### PR TITLE
xds: redesign client load recording and backend metrics receiving interface

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
+++ b/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
@@ -339,7 +339,7 @@ final class ClientLoadCounter {
    * instrumenting purposes.
    */
   @VisibleForTesting
-  abstract static class StreamInstrumentedSubchannelPicker extends SubchannelPicker {
+  abstract static class TracerWrappingSubchannelPicker extends SubchannelPicker {
 
     private static final ClientStreamTracer NOOP_CLIENT_STREAM_TRACER =
         new ClientStreamTracer() {
@@ -387,7 +387,7 @@ final class ClientLoadCounter {
    * ClientLoadCounter}.
    */
   @ThreadSafe
-  static final class LoadRecordingSubchannelPicker extends StreamInstrumentedSubchannelPicker {
+  static final class LoadRecordingSubchannelPicker extends TracerWrappingSubchannelPicker {
 
     private final ClientLoadCounter counter;
     private final SubchannelPicker delegate;
@@ -415,7 +415,7 @@ final class ClientLoadCounter {
    * with the logic of registering the listener for observing backend metrics.
    */
   @ThreadSafe
-  static final class MetricsObservingSubchannelPicker extends StreamInstrumentedSubchannelPicker {
+  static final class MetricsObservingSubchannelPicker extends TracerWrappingSubchannelPicker {
 
     private final OrcaPerRequestReportListener listener;
     private final SubchannelPicker delegate;

--- a/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
+++ b/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
@@ -259,17 +259,18 @@ final class ClientLoadCounter {
   }
 
   /**
-   * An {@link ClientLoadRecorder} instance records and aggregates client-side load data into an
-   * {@link ClientLoadCounter} object.
+   * An {@link LoadRecordingStreamTracerFactory} instance records and aggregates client-side load
+   * data into an {@link ClientLoadCounter} object.
    */
   @ThreadSafe
   @VisibleForTesting
-  static final class ClientLoadRecorder extends ClientStreamTracer.Factory {
+  static final class LoadRecordingStreamTracerFactory extends ClientStreamTracer.Factory {
 
     private final ClientStreamTracer.Factory delegate;
     private final ClientLoadCounter counter;
 
-    ClientLoadRecorder(ClientLoadCounter counter, ClientStreamTracer.Factory delegate) {
+    LoadRecordingStreamTracerFactory(ClientLoadCounter counter,
+        ClientStreamTracer.Factory delegate) {
       this.counter = checkNotNull(counter, "counter");
       this.delegate = checkNotNull(delegate, "delegate");
     }
@@ -404,7 +405,7 @@ final class ClientLoadCounter {
     @Override
     protected ClientStreamTracer.Factory wrapTracerFactory(
         ClientStreamTracer.Factory originFactory) {
-      return new ClientLoadRecorder(counter, originFactory);
+      return new LoadRecordingStreamTracerFactory(counter, originFactory);
     }
   }
 

--- a/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
+++ b/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
@@ -371,6 +371,11 @@ final class ClientLoadCounter {
       }
       return PickResult.withSubchannel(result.getSubchannel(), wrapTracerFactory(originFactory));
     }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this).add("delegate", delegate()).toString();
+    }
   }
 
   /**

--- a/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
+++ b/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
@@ -259,17 +259,17 @@ final class ClientLoadCounter {
   }
 
   /**
-   * An {@link XdsClientLoadRecorder} instance records and aggregates client-side load data into an
+   * An {@link ClientLoadRecorder} instance records and aggregates client-side load data into an
    * {@link ClientLoadCounter} object.
    */
   @ThreadSafe
   @VisibleForTesting
-  static final class XdsClientLoadRecorder extends ClientStreamTracer.Factory {
+  static final class ClientLoadRecorder extends ClientStreamTracer.Factory {
 
     private final ClientStreamTracer.Factory delegate;
     private final ClientLoadCounter counter;
 
-    XdsClientLoadRecorder(ClientLoadCounter counter, ClientStreamTracer.Factory delegate) {
+    ClientLoadRecorder(ClientLoadCounter counter, ClientStreamTracer.Factory delegate) {
       this.counter = checkNotNull(counter, "counter");
       this.delegate = checkNotNull(delegate, "delegate");
     }
@@ -399,7 +399,7 @@ final class ClientLoadCounter {
     @Override
     protected ClientStreamTracer.Factory wrapTracerFactory(
         ClientStreamTracer.Factory originFactory) {
-      return new XdsClientLoadRecorder(counter, originFactory);
+      return new ClientLoadRecorder(counter, originFactory);
     }
   }
 

--- a/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
+++ b/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
@@ -299,15 +299,16 @@ final class ClientLoadCounter {
   }
 
   /**
-   * Listener implementation to receive backend metrics with locality-level aggregation.
+   * Listener implementation to receive backend metrics and record metric values in the provided
+   * {@link ClientLoadCounter}.
    */
   @ThreadSafe
-  static final class LocalityMetricsListener implements OrcaPerRequestReportListener,
-      OrcaOobReportListener {
+  static final class MetricsRecordingListener
+      implements OrcaPerRequestReportListener, OrcaOobReportListener {
 
     private final ClientLoadCounter counter;
 
-    LocalityMetricsListener(ClientLoadCounter counter) {
+    MetricsRecordingListener(ClientLoadCounter counter) {
       this.counter = checkNotNull(counter, "counter");
     }
 

--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -393,17 +393,9 @@ interface LocalityStore {
 
         currentChildState = newState;
         currentChildPicker =
-            new SubchannelPicker() {
-              SubchannelPicker instance =
-                  new LoadRecordingSubchannelPicker(counter,
-                      new MetricsObservingSubchannelPicker(
-                          new MetricsRecordingListener(counter), newPicker, orcaPerRequestUtil));
-
-              @Override
-              public PickResult pickSubchannel(PickSubchannelArgs args) {
-                return instance.pickSubchannel(args);
-              }
-            };
+            new LoadRecordingSubchannelPicker(counter,
+                new MetricsObservingSubchannelPicker(new MetricsRecordingListener(counter),
+                    newPicker, orcaPerRequestUtil));
 
         // delegate to parent helper
         updateChildState(locality, newState, currentChildPicker);

--- a/xds/src/main/java/io/grpc/xds/StatsStore.java
+++ b/xds/src/main/java/io/grpc/xds/StatsStore.java
@@ -17,7 +17,6 @@
 package io.grpc.xds;
 
 import io.envoyproxy.envoy.api.v2.endpoint.ClusterStats;
-import io.grpc.LoadBalancer.PickResult;
 import javax.annotation.Nullable;
 
 /**
@@ -59,15 +58,6 @@ interface StatsStore {
    * returned by {@link XdsLoadBalancer.Helper#getSynchronizationContext}.
    */
   void removeLocality(XdsLocality locality);
-
-  /**
-   * Applies client side load recording to {@link PickResult}s picked by the intra-locality picker
-   * for the provided locality. If the provided locality is not tracked, the original
-   * {@link PickResult} will be returned.
-   *
-   * <p>This method is thread-safe.
-   */
-  PickResult interceptPickResult(PickResult pickResult, XdsLocality locality);
 
   /**
    * Returns the {@link ClientLoadCounter} that does locality level stats aggregation for the

--- a/xds/src/test/java/io/grpc/xds/ClientLoadCounterTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClientLoadCounterTest.java
@@ -34,8 +34,8 @@ import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.xds.ClientLoadCounter.ClientLoadSnapshot;
 import io.grpc.xds.ClientLoadCounter.LoadRecordingSubchannelPicker;
-import io.grpc.xds.ClientLoadCounter.LocalityMetricsListener;
 import io.grpc.xds.ClientLoadCounter.MetricValue;
+import io.grpc.xds.ClientLoadCounter.MetricsRecordingListener;
 import io.grpc.xds.ClientLoadCounter.XdsClientLoadRecorder;
 import java.util.concurrent.ThreadLocalRandom;
 import org.junit.Before;
@@ -150,8 +150,8 @@ public class ClientLoadCounterTest {
   }
 
   @Test
-  public void metricListener_backendMetricsAggregation() {
-    LocalityMetricsListener listener1 = new LocalityMetricsListener(counter);
+  public void metricsRecordingListener_backendMetricsAggregation() {
+    MetricsRecordingListener listener1 = new MetricsRecordingListener(counter);
     OrcaLoadReport report =
         OrcaLoadReport.newBuilder()
             .setCpuUtilization(0.5345)
@@ -184,7 +184,7 @@ public class ClientLoadCounterTest {
     snapshot = counter.snapshot();
     assertThat(snapshot.getMetricValues()).isEmpty();
 
-    LocalityMetricsListener listener2 = new LocalityMetricsListener(counter);
+    MetricsRecordingListener listener2 = new MetricsRecordingListener(counter);
     report =
         OrcaLoadReport.newBuilder()
             .setCpuUtilization(0.3423)

--- a/xds/src/test/java/io/grpc/xds/ClientLoadCounterTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClientLoadCounterTest.java
@@ -39,7 +39,7 @@ import io.grpc.xds.ClientLoadCounter.LoadRecordingSubchannelPicker;
 import io.grpc.xds.ClientLoadCounter.MetricValue;
 import io.grpc.xds.ClientLoadCounter.MetricsObservingSubchannelPicker;
 import io.grpc.xds.ClientLoadCounter.MetricsRecordingListener;
-import io.grpc.xds.ClientLoadCounter.StreamInstrumentedSubchannelPicker;
+import io.grpc.xds.ClientLoadCounter.TracerWrappingSubchannelPicker;
 import io.grpc.xds.OrcaPerRequestUtil.OrcaPerRequestReportListener;
 import java.util.concurrent.ThreadLocalRandom;
 import org.junit.Before;
@@ -215,9 +215,9 @@ public class ClientLoadCounterTest {
   }
 
   @Test
-  public void streamInstrSubchannelPicker_interceptPickResult_invalidPickResultNotIntercepted() {
+  public void tracerWrappingSubchannelPicker_interceptPickResult_invalidPickResultNotIntercepted() {
     final SubchannelPicker picker = mock(SubchannelPicker.class);
-    SubchannelPicker streamInstrSubchannelPicker = new StreamInstrumentedSubchannelPicker() {
+    SubchannelPicker streamInstrSubchannelPicker = new TracerWrappingSubchannelPicker() {
       @Override
       protected SubchannelPicker delegate() {
         return picker;

--- a/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
@@ -51,7 +51,7 @@ import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.SynchronizationContext;
-import io.grpc.xds.ClientLoadCounter.ClientLoadRecorder;
+import io.grpc.xds.ClientLoadCounter.LoadRecordingStreamTracerFactory;
 import io.grpc.xds.ClientLoadCounter.MetricsRecordingListener;
 import io.grpc.xds.InterLocalityPicker.WeightedChildPicker;
 import io.grpc.xds.LocalityStore.LocalityStoreImpl;
@@ -274,11 +274,13 @@ public class LocalityStoreTest {
     MetricsRecordingListener listener1 = (MetricsRecordingListener) listenerCaptor1.getValue();
     assertThat(listener1.getCounter())
         .isSameInstanceAs(fakeLoadStatsStore.localityCounters.get(locality1));
-    assertThat(pickResult1.getStreamTracerFactory()).isInstanceOf(ClientLoadRecorder.class);
-    ClientLoadRecorder recorder1 = (ClientLoadRecorder) pickResult1.getStreamTracerFactory();
-    assertThat(recorder1.getCounter())
+    assertThat(pickResult1.getStreamTracerFactory())
+        .isInstanceOf(LoadRecordingStreamTracerFactory.class);
+    LoadRecordingStreamTracerFactory factory1 =
+        (LoadRecordingStreamTracerFactory) pickResult1.getStreamTracerFactory();
+    assertThat(factory1.getCounter())
         .isSameInstanceAs(fakeLoadStatsStore.localityCounters.get(locality1));
-    assertThat(recorder1.delegate()).isSameInstanceAs(metricsRecorder1);
+    assertThat(factory1.delegate()).isSameInstanceAs(metricsRecorder1);
 
     pickerFactory.nextIndex = 1;
     PickResult pickResult2 = interLocalityPicker.pickSubchannel(pickSubchannelArgs);
@@ -290,11 +292,13 @@ public class LocalityStoreTest {
     MetricsRecordingListener listener2 = (MetricsRecordingListener) listenerCaptor2.getValue();
     assertThat(listener2.getCounter())
         .isSameInstanceAs(fakeLoadStatsStore.localityCounters.get(locality2));
-    assertThat(pickResult2.getStreamTracerFactory()).isInstanceOf(ClientLoadRecorder.class);
-    ClientLoadRecorder recorder2 = (ClientLoadRecorder) pickResult2.getStreamTracerFactory();
-    assertThat(recorder2.getCounter())
+    assertThat(pickResult2.getStreamTracerFactory())
+        .isInstanceOf(LoadRecordingStreamTracerFactory.class);
+    LoadRecordingStreamTracerFactory factory2 =
+        (LoadRecordingStreamTracerFactory) pickResult2.getStreamTracerFactory();
+    assertThat(factory2.getCounter())
         .isSameInstanceAs(fakeLoadStatsStore.localityCounters.get(locality2));
-    assertThat(recorder2.delegate()).isSameInstanceAs(metricsRecorder2);
+    assertThat(factory2.delegate()).isSameInstanceAs(metricsRecorder2);
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
@@ -51,8 +51,8 @@ import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.SynchronizationContext;
+import io.grpc.xds.ClientLoadCounter.ClientLoadRecorder;
 import io.grpc.xds.ClientLoadCounter.MetricsRecordingListener;
-import io.grpc.xds.ClientLoadCounter.XdsClientLoadRecorder;
 import io.grpc.xds.InterLocalityPicker.WeightedChildPicker;
 import io.grpc.xds.LocalityStore.LocalityStoreImpl;
 import io.grpc.xds.LocalityStore.LocalityStoreImpl.PickerFactory;
@@ -274,8 +274,8 @@ public class LocalityStoreTest {
     MetricsRecordingListener listener1 = (MetricsRecordingListener) listenerCaptor1.getValue();
     assertThat(listener1.getCounter())
         .isSameInstanceAs(fakeLoadStatsStore.localityCounters.get(locality1));
-    assertThat(pickResult1.getStreamTracerFactory()).isInstanceOf(XdsClientLoadRecorder.class);
-    XdsClientLoadRecorder recorder1 = (XdsClientLoadRecorder) pickResult1.getStreamTracerFactory();
+    assertThat(pickResult1.getStreamTracerFactory()).isInstanceOf(ClientLoadRecorder.class);
+    ClientLoadRecorder recorder1 = (ClientLoadRecorder) pickResult1.getStreamTracerFactory();
     assertThat(recorder1.getCounter())
         .isSameInstanceAs(fakeLoadStatsStore.localityCounters.get(locality1));
     assertThat(recorder1.delegate()).isSameInstanceAs(metricsRecorder1);
@@ -290,8 +290,8 @@ public class LocalityStoreTest {
     MetricsRecordingListener listener2 = (MetricsRecordingListener) listenerCaptor2.getValue();
     assertThat(listener2.getCounter())
         .isSameInstanceAs(fakeLoadStatsStore.localityCounters.get(locality2));
-    assertThat(pickResult2.getStreamTracerFactory()).isInstanceOf(XdsClientLoadRecorder.class);
-    XdsClientLoadRecorder recorder2 = (XdsClientLoadRecorder) pickResult2.getStreamTracerFactory();
+    assertThat(pickResult2.getStreamTracerFactory()).isInstanceOf(ClientLoadRecorder.class);
+    ClientLoadRecorder recorder2 = (ClientLoadRecorder) pickResult2.getStreamTracerFactory();
     assertThat(recorder2.getCounter())
         .isSameInstanceAs(fakeLoadStatsStore.localityCounters.get(locality2));
     assertThat(recorder2.delegate()).isSameInstanceAs(metricsRecorder2);

--- a/xds/src/test/java/io/grpc/xds/XdsLbStateTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLbStateTest.java
@@ -17,9 +17,6 @@
 package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.AdditionalAnswers.returnsFirstArg;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -32,7 +29,6 @@ import io.grpc.Attributes;
 import io.grpc.ChannelLogger;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer.Helper;
-import io.grpc.LoadBalancer.PickResult;
 import io.grpc.ManagedChannel;
 import io.grpc.SynchronizationContext;
 import io.grpc.inprocess.InProcessChannelBuilder;
@@ -63,8 +59,6 @@ public class XdsLbStateTest {
   @Mock
   private AdsStreamCallback adsStreamCallback;
   @Mock
-  private StatsStore statsStore;
-  @Mock
   private LocalityStore localityStore;
 
   private final FakeClock fakeClock = new FakeClock();
@@ -89,8 +83,6 @@ public class XdsLbStateTest {
     doReturn(fakeClock.getScheduledExecutorService()).when(helper).getScheduledExecutorService();
     doReturn("fake_authority").when(helper).getAuthority();
     doReturn(mock(ChannelLogger.class)).when(helper).getChannelLogger();
-    doAnswer(returnsFirstArg())
-        .when(statsStore).interceptPickResult(any(PickResult.class), any(XdsLocality.class));
 
     String serverName = InProcessServerBuilder.generateName();
 


### PR DESCRIPTION
Previously we have `StatsStore#interceptPickResult()` for applying client load recording logic to `PickResult` returned by original `SubchannelPicker`. However, we need to do another layer of wrapping for applying another `ClientStreamTracer.Factory` to receive backend metrics, and we did not have method in `StatsStore` to do that. This becomes weird as one interception is done via calling a method in `StatsStore` and the other is on-the-fly.

Therefore, I removed `interceptPickResult()` method from `StatsStore` interface. Instead, provide two `SubchannelPicker` wrapper classes, `LoadRecordingSubchannelPicker` and `MetricsObservingSubchannelPicker`. xDS load balancer wraps its pickers with these two wrapper classes to enable both load and backend metrics recording.

Tests in xDS load balancer's `LocalityStore` verify that the eventual `PickResult`s are intercepted with both load and backend metrics recording logics.

More about the idea can be found in [this conversation](https://github.com/grpc/grpc-java/pull/5878#discussion_r295034857).

This PR replaces #5888 and #5878.