### PR TITLE
core: ClientStream.getAttributes() can be called at any time.

### DIFF
--- a/core/src/main/java/io/grpc/internal/ClientStream.java
+++ b/core/src/main/java/io/grpc/internal/ClientStream.java
@@ -94,7 +94,8 @@ public interface ClientStream extends Stream {
   void setDeadline(@Nonnull Deadline deadline);
 
   /**
-   * Attributes that the stream holds at the current moment.
+   * Attributes that the stream holds at the current moment.  Thread-safe and can be called at any
+   * time, although some attributes are there only after a certain point.
    */
   Attributes getAttributes();
 }

--- a/core/src/main/java/io/grpc/internal/DelayedStream.java
+++ b/core/src/main/java/io/grpc/internal/DelayedStream.java
@@ -213,8 +213,15 @@ class DelayedStream implements ClientStream {
 
   @Override
   public Attributes getAttributes() {
-    checkState(passThrough, "Called getAttributes before attributes are ready");
-    return realStream.getAttributes();
+    ClientStream savedRealStream;
+    synchronized (this) {
+      savedRealStream = realStream;
+    }
+    if (savedRealStream != null) {
+      return savedRealStream.getAttributes();
+    } else {
+      return Attributes.EMPTY;
+    }
   }
 
   @Override

--- a/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
@@ -19,7 +19,6 @@ package io.grpc.internal;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
@@ -186,12 +185,7 @@ public class DelayedStreamTest {
 
     stream.start(listener);
 
-    try {
-      stream.getAttributes(); // expect to throw IllegalStateException, otherwise fail()
-      fail();
-    } catch (IllegalStateException expected) {
-      // ignore
-    }
+    assertEquals(Attributes.EMPTY, stream.getAttributes());
 
     stream.setStream(realStream);
     assertEquals(attributes, stream.getAttributes());


### PR DESCRIPTION
In #5892 getAttributes() is called without any regard of timing.
Currently DelayedStream.getAttributes() wil throw if called before
passThrough was set.  Just to be safe, we are removing that
restriction and making it clear on the javadoc.

On the other hand, we intend to keep the timing restriction on
ClientCall.getAttributes().