### PR TITLE
netty: Use await instead of sync

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServer.java
@@ -284,7 +284,7 @@ class NettyServer implements InternalServer, InternalWithLogId {
       }
     });
     try {
-      channel.closeFuture().sync();
+      channel.closeFuture().await();
     } catch (InterruptedException e) {
       log.log(Level.FINE, "Interrupted while shutting down", e);
       Thread.currentThread().interrupt();


### PR DESCRIPTION
We only care about when closing is done, not whether it is successful or not.
If there's a failure, we're already going to log a warning. Use await to avoid
throwing unexpectedly.

------

Noticed this when double-checking that it was different methods that wait uninterruptably.