### PR TITLE
netty: make unexpected reads fail negotiation, and log close failures

### DIFF
--- a/netty/src/main/java/io/grpc/netty/WriteBufferingAndExceptionHandler.java
+++ b/netty/src/main/java/io/grpc/netty/WriteBufferingAndExceptionHandler.java
@@ -82,7 +82,7 @@ final class WriteBufferingAndExceptionHandler extends ChannelDuplexHandler {
   }
 
   @Override
-  public void exceptionCaught(ChannelHandlerContext ctx, final Throwable cause) {
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
     assert cause != null;
     Throwable previousFailure = failCause;
     Status status = Utils.statusFromThrowable(cause);

--- a/netty/src/main/java/io/grpc/netty/WriteBufferingAndExceptionHandler.java
+++ b/netty/src/main/java/io/grpc/netty/WriteBufferingAndExceptionHandler.java
@@ -156,13 +156,14 @@ final class WriteBufferingAndExceptionHandler extends ChannelDuplexHandler {
       Object loggedMsg = msg instanceof ByteBuf ? ByteBufUtil.hexDump((ByteBuf) msg) : msg;
       logger.log(
           Level.FINE,
-          "Unexpected read {0} reached end of pipeline {1}",
+          "Unexpected channelRead()->{0} reached end of pipeline {1}",
           new Object[] {loggedMsg, ctx.pipeline().names()});
     }
     ReferenceCountUtil.safeRelease(msg);
     exceptionCaught(
         ctx,
-        Status.INTERNAL.withDescription("read() missed by ProtocolNegotiator handler")
+        Status.INTERNAL.withDescription(
+            "channelRead() missed by ProtocolNegotiator handler: " + msg.getClass())
             .asRuntimeException());
   }
 

--- a/netty/src/main/java/io/grpc/netty/WriteBufferingAndExceptionHandler.java
+++ b/netty/src/main/java/io/grpc/netty/WriteBufferingAndExceptionHandler.java
@@ -100,7 +100,7 @@ final class WriteBufferingAndExceptionHandler extends ChannelDuplexHandler {
     if (ctx.channel().isActive() && previousFailure == null) {
       final class LogOnFailure implements ChannelFutureListener {
         @Override
-        public void operationComplete(ChannelFuture future) throws Exception {
+        public void operationComplete(ChannelFuture future) {
           if (!future.isSuccess()) {
             logger.log(Level.FINE, "Failed closing channel", future.cause());
           }

--- a/netty/src/test/java/io/grpc/netty/WriteBufferingAndExceptionHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/WriteBufferingAndExceptionHandlerTest.java
@@ -27,6 +27,7 @@ import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelFuture;
@@ -344,5 +345,39 @@ public class WriteBufferingAndExceptionHandlerTest {
     assertThat(write.get().getClass()).isSameInstanceAs(Object.class);
     assertTrue(flush.get());
     assertThat(chan.pipeline()).doesNotContain(handler);
+  }
+
+  @Test
+  public void uncaughtReadFails() throws Exception {
+    WriteBufferingAndExceptionHandler handler =
+        new WriteBufferingAndExceptionHandler(new ChannelHandlerAdapter() {});
+    LocalAddress addr = new LocalAddress("local");
+    ChannelFuture cf = new Bootstrap()
+        .channel(LocalChannel.class)
+        .handler(handler)
+        .group(group)
+        .register();
+    chan = cf.channel();
+    cf.sync();
+    ChannelFuture sf = new ServerBootstrap()
+        .channel(LocalServerChannel.class)
+        .childHandler(new ChannelHandlerAdapter() {})
+        .group(group)
+        .bind(addr);
+    server = sf.channel();
+    sf.sync();
+
+    ChannelFuture wf = chan.writeAndFlush(new Object());
+    chan.connect(addr);
+    chan.pipeline().fireChannelRead(Unpooled.copiedBuffer(new byte[] {'a'}));
+
+    try {
+      wf.sync();
+      fail();
+    } catch (Exception e) {
+      Status status = Status.fromThrowable(e);
+      assertThat(status.getCode()).isEqualTo(Code.INTERNAL);
+      assertThat(status.getDescription()).contains("read() missed");
+    }
   }
 }

--- a/netty/src/test/java/io/grpc/netty/WriteBufferingAndExceptionHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/WriteBufferingAndExceptionHandlerTest.java
@@ -377,7 +377,7 @@ public class WriteBufferingAndExceptionHandlerTest {
     } catch (Exception e) {
       Status status = Status.fromThrowable(e);
       assertThat(status.getCode()).isEqualTo(Code.INTERNAL);
-      assertThat(status.getDescription()).contains("read() missed");
+      assertThat(status.getDescription()).contains("channelRead() missed");
     }
   }
 }


### PR DESCRIPTION
Incase a negotiating handler misses a read, and it reaches the WBAEH, it should cause a failure.  Also, if closing the channel fails while handling another error, log the second failure.