### PR TITLE
xds: use order-deterministic locality map for preserving most recent locality update to eliminate test flakiness

### DIFF
--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -26,6 +26,7 @@ import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
@@ -83,7 +84,7 @@ interface LocalityStore {
     private final StatsStore statsStore;
     private final OrcaPerRequestUtil orcaPerRequestUtil;
 
-    private Map<XdsLocality, LocalityLbInfo> localityMap = new LinkedHashMap<>();
+    private Map<XdsLocality, LocalityLbInfo> localityMap = ImmutableMap.of();
     private ImmutableList<DropOverload> dropOverloads = ImmutableList.of();
 
     LocalityStoreImpl(Helper helper, LoadBalancerRegistry lbRegistry) {
@@ -176,7 +177,7 @@ interface LocalityStore {
         localityMap.get(locality).shutdown();
         statsStore.removeLocality(locality);
       }
-      localityMap = new LinkedHashMap<>();
+      localityMap = ImmutableMap.of();
     }
 
     // This is triggered by EDS response.
@@ -233,7 +234,7 @@ interface LocalityStore {
         }
         newState = aggregateState(newState, childHelper.currentChildState);
       }
-      localityMap = updatedLocalityMap;
+      localityMap = Collections.unmodifiableMap(updatedLocalityMap);
 
       updatePicker(newState, childPickers);
 


### PR DESCRIPTION
`LocalityStore` has clear-box tests such that inter-locality subchannel picking relies on the order of most recent locality update. Existing implementation loses the ordering when localities are stored in a `HashMap`, the order of `WeightedChildPicker`s (which are wrapped inter-localityo pickers) in `InterLocalityPicker` become indeterministic. This would cause test flakiness as the list of `WeightedChildPicker` passed into `FakePickerFactory#picker(...)` does not reflect the order of localities in most recent locality update.