### PR TITLE
xds: integrate receiving and reporting OOB backend metrics in xDS load balancer

### DIFF
--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -45,6 +45,8 @@ import io.grpc.xds.ClientLoadCounter.LoadRecordingSubchannelPicker;
 import io.grpc.xds.ClientLoadCounter.MetricsObservingSubchannelPicker;
 import io.grpc.xds.ClientLoadCounter.MetricsRecordingListener;
 import io.grpc.xds.InterLocalityPicker.WeightedChildPicker;
+import io.grpc.xds.OrcaOobUtil.OrcaReportingConfig;
+import io.grpc.xds.OrcaOobUtil.OrcaReportingHelperWrapper;
 import io.grpc.xds.XdsComms.DropOverload;
 import io.grpc.xds.XdsComms.LocalityInfo;
 import io.grpc.xds.XdsSubchannelPickers.ErrorPicker;
@@ -55,6 +57,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
@@ -72,6 +75,8 @@ interface LocalityStore {
 
   void handleSubchannelState(Subchannel subchannel, ConnectivityStateInfo newState);
 
+  void updateOobMetricsReportInterval(long reportIntervalNano);
+
   StatsStore getStatsStore();
 
   final class LocalityStoreImpl implements LocalityStore {
@@ -83,13 +88,15 @@ interface LocalityStore {
     private final ThreadSafeRandom random;
     private final StatsStore statsStore;
     private final OrcaPerRequestUtil orcaPerRequestUtil;
+    private final OrcaOobUtil orcaOobUtil;
 
     private Map<XdsLocality, LocalityLbInfo> localityMap = ImmutableMap.of();
     private ImmutableList<DropOverload> dropOverloads = ImmutableList.of();
+    private long metricsReportIntervalNano = -1;
 
     LocalityStoreImpl(Helper helper, LoadBalancerRegistry lbRegistry) {
       this(helper, pickerFactoryImpl, lbRegistry, ThreadSafeRandom.ThreadSafeRandomImpl.instance,
-          new XdsLoadStatsStore(), OrcaPerRequestUtil.getInstance());
+          new XdsLoadStatsStore(), OrcaPerRequestUtil.getInstance(), OrcaOobUtil.getInstance());
     }
 
     @VisibleForTesting
@@ -99,7 +106,8 @@ interface LocalityStore {
         LoadBalancerRegistry lbRegistry,
         ThreadSafeRandom random,
         StatsStore statsStore,
-        OrcaPerRequestUtil orcaPerRequestUtil) {
+        OrcaPerRequestUtil orcaPerRequestUtil,
+        OrcaOobUtil orcaOobUtil) {
       this.helper = checkNotNull(helper, "helper");
       this.pickerFactory = checkNotNull(pickerFactory, "pickerFactory");
       loadBalancerProvider = checkNotNull(
@@ -108,6 +116,7 @@ interface LocalityStore {
       this.random = checkNotNull(random, "random");
       this.statsStore = checkNotNull(statsStore, "statsStore");
       this.orcaPerRequestUtil = checkNotNull(orcaPerRequestUtil, "orcaPerRequestUtil");
+      this.orcaOobUtil = checkNotNull(orcaOobUtil, "orcaOobUtil");
     }
 
     @VisibleForTesting // Introduced for testing only.
@@ -213,12 +222,17 @@ interface LocalityStore {
                   childHelper);
         } else {
           statsStore.addLocality(newLocality);
-          childHelper = new ChildHelper(newLocality, statsStore.getLocalityCounter(newLocality));
+          childHelper =
+              new ChildHelper(newLocality, statsStore.getLocalityCounter(newLocality), orcaOobUtil);
           localityLbInfo =
               new LocalityLbInfo(
                   localityInfoMap.get(newLocality).localityWeight,
                   loadBalancerProvider.newLoadBalancer(childHelper),
                   childHelper);
+          if (metricsReportIntervalNano > 0) {
+            localityLbInfo.childHelper.updateMetricsReportInterval(metricsReportIntervalNano);
+          }
+          localityMap.put(newLocality, localityLbInfo);
         }
         updatedLocalityMap.put(newLocality, localityLbInfo);
         // TODO: put endPointWeights into attributes for WRR.
@@ -261,6 +275,14 @@ interface LocalityStore {
     @Override
     public StatsStore getStatsStore() {
       return statsStore;
+    }
+
+    @Override
+    public void updateOobMetricsReportInterval(long reportIntervalNano) {
+      metricsReportIntervalNano = reportIntervalNano;
+      for (LocalityLbInfo lbInfo : localityMap.values()) {
+        lbInfo.childHelper.updateMetricsReportInterval(reportIntervalNano);
+      }
     }
 
     @Nullable
@@ -362,48 +384,63 @@ interface LocalityStore {
 
     class ChildHelper extends ForwardingLoadBalancerHelper {
 
-      private final XdsLocality locality;
-      private final ClientLoadCounter counter;
+      private final OrcaReportingHelperWrapper orcaReportingHelperWrapper;
 
       private SubchannelPicker currentChildPicker = XdsSubchannelPickers.BUFFER_PICKER;
       private ConnectivityState currentChildState = null;
 
-      ChildHelper(XdsLocality locality, ClientLoadCounter counter) {
-        this.locality = checkNotNull(locality, "locality");
-        this.counter = checkNotNull(counter, "counter");
+      ChildHelper(final XdsLocality locality, final ClientLoadCounter counter,
+          OrcaOobUtil orcaOobUtil) {
+        checkNotNull(locality, "locality");
+        checkNotNull(counter, "counter");
+        checkNotNull(orcaOobUtil, "orcaOobUtil");
+        Helper delegate = new ForwardingLoadBalancerHelper() {
+          @Override
+          protected Helper delegate() {
+            return helper;
+          }
+
+          @Override
+          public void updateBalancingState(ConnectivityState newState,
+              final SubchannelPicker newPicker) {
+            checkNotNull(newState, "newState");
+            checkNotNull(newPicker, "newPicker");
+
+            currentChildState = newState;
+            currentChildPicker =
+                new LoadRecordingSubchannelPicker(counter,
+                    new MetricsObservingSubchannelPicker(new MetricsRecordingListener(counter),
+                        newPicker, orcaPerRequestUtil));
+
+            // delegate to parent helper
+            updateChildState(locality, newState, currentChildPicker);
+          }
+
+          @Override
+          public String toString() {
+            return MoreObjects.toStringHelper(this).add("locality", locality).toString();
+          }
+
+          @Override
+          public String getAuthority() {
+            //FIXME: This should be a new proposed field of Locality, locality_name
+            return locality.getSubzone();
+          }
+        };
+        orcaReportingHelperWrapper =
+            checkNotNull(orcaOobUtil, "orcaOobUtil")
+                .newOrcaReportingHelperWrapper(delegate, new MetricsRecordingListener(counter));
+      }
+
+      void updateMetricsReportInterval(long intervalNanos) {
+        orcaReportingHelperWrapper
+            .setReportingConfig(OrcaReportingConfig.newBuilder()
+                .setReportInterval(intervalNanos, TimeUnit.NANOSECONDS).build());
       }
 
       @Override
       protected Helper delegate() {
-        return helper;
-      }
-
-      // This is triggered by child balancer
-      @Override
-      public void updateBalancingState(ConnectivityState newState,
-          final SubchannelPicker newPicker) {
-        checkNotNull(newState, "newState");
-        checkNotNull(newPicker, "newPicker");
-
-        currentChildState = newState;
-        currentChildPicker =
-            new LoadRecordingSubchannelPicker(counter,
-                new MetricsObservingSubchannelPicker(new MetricsRecordingListener(counter),
-                    newPicker, orcaPerRequestUtil));
-
-        // delegate to parent helper
-        updateChildState(locality, newState, currentChildPicker);
-      }
-
-      @Override
-      public String toString() {
-        return MoreObjects.toStringHelper(this).add("locality", locality).toString();
-      }
-
-      @Override
-      public String getAuthority() {
-        //FIXME: This should be a new proposed field of Locality, locality_name
-        return locality.getSubzone();
+        return orcaReportingHelperWrapper.asHelper();
       }
     }
   }

--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -232,7 +232,6 @@ interface LocalityStore {
           if (metricsReportIntervalNano > 0) {
             localityLbInfo.childHelper.updateMetricsReportInterval(metricsReportIntervalNano);
           }
-          localityMap.put(newLocality, localityLbInfo);
         }
         updatedLocalityMap.put(newLocality, localityLbInfo);
         // TODO: put endPointWeights into attributes for WRR.

--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
@@ -45,6 +45,7 @@ import io.grpc.internal.ServiceConfigUtil.LbConfig;
 import io.grpc.util.ForwardingLoadBalancerHelper;
 import io.grpc.xds.LocalityStore.LocalityStoreImpl;
 import io.grpc.xds.XdsComms.AdsStreamCallback;
+import io.grpc.xds.XdsLoadReportClientImpl.XdsLoadReportCallback;
 import io.grpc.xds.XdsLoadReportClientImpl.XdsLoadReportClientFactory;
 import io.grpc.xds.XdsSubchannelPickers.ErrorPicker;
 import java.util.List;
@@ -80,7 +81,7 @@ final class XdsLoadBalancer extends LoadBalancer {
       }
 
       fallbackManager.childBalancerWorked = true;
-      lrsClient.startLoadReporting();
+      lrsClient.startLoadReporting(lrsCallback);
     }
 
     @Override
@@ -98,6 +99,15 @@ final class XdsLoadBalancer extends LoadBalancer {
       fallbackManager.cancelFallback();
     }
   };
+
+  private final XdsLoadReportCallback lrsCallback =
+      new XdsLoadReportCallback() {
+
+        @Override
+        public void onReportResponse(long reportIntervalNano) {
+          localityStore.updateOobMetricsReportInterval(reportIntervalNano);
+        }
+      };
 
   private LbConfig fallbackPolicy;
 

--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
@@ -45,7 +45,7 @@ import io.grpc.internal.ServiceConfigUtil.LbConfig;
 import io.grpc.util.ForwardingLoadBalancerHelper;
 import io.grpc.xds.LocalityStore.LocalityStoreImpl;
 import io.grpc.xds.XdsComms.AdsStreamCallback;
-import io.grpc.xds.XdsLoadReportClientImpl.XdsLoadReportCallback;
+import io.grpc.xds.XdsLoadReportClient.XdsLoadReportCallback;
 import io.grpc.xds.XdsLoadReportClientImpl.XdsLoadReportClientFactory;
 import io.grpc.xds.XdsSubchannelPickers.ErrorPicker;
 import java.util.List;

--- a/xds/src/main/java/io/grpc/xds/XdsLoadReportClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadReportClient.java
@@ -16,6 +16,7 @@
 
 package io.grpc.xds;
 
+import io.grpc.xds.XdsLoadReportClientImpl.XdsLoadReportCallback;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -33,8 +34,11 @@ interface XdsLoadReportClient {
    *
    * <p>This method is not thread-safe and should be called from the same synchronized context
    * returned by {@link XdsLoadBalancer.Helper#getSynchronizationContext}.
+   *
+   * @param callback containing methods to be invoked for passing information received from load
+   *                 reporting responses to xDS load balancer.
    */
-  void startLoadReporting();
+  void startLoadReporting(XdsLoadReportCallback callback);
 
   /**
    * Terminates load reporting. Calling this method on an already stopped

--- a/xds/src/main/java/io/grpc/xds/XdsLoadReportClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadReportClient.java
@@ -16,7 +16,6 @@
 
 package io.grpc.xds;
 
-import io.grpc.xds.XdsLoadReportClientImpl.XdsLoadReportCallback;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -48,4 +47,21 @@ interface XdsLoadReportClient {
    * returned by {@link XdsLoadBalancer.Helper#getSynchronizationContext}.
    */
   void stopLoadReporting();
+
+  /**
+   * Callbacks for passing information received from client load reporting responses to xDS load
+   * balancer, such as the load reporting interval requested by the traffic director.
+   *
+   * <p>Implementations are not required to be thread-safe as callbacks will be invoked in xDS load
+   * balancer's {@link io.grpc.SynchronizationContext}.
+   */
+  interface XdsLoadReportCallback {
+
+    /**
+     * The load reporting interval has been received.
+     *
+     * @param reportIntervalNano load reporting interval requested by remote traffic director.
+     */
+    void onReportResponse(long reportIntervalNano);
+  }
 }

--- a/xds/src/main/java/io/grpc/xds/XdsLoadReportClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadReportClientImpl.java
@@ -346,23 +346,6 @@ final class XdsLoadReportClientImpl implements XdsLoadReportClient {
     }
   }
 
-  /**
-   * Callbacks for passing information received from client load reporting responses to xDS load
-   * balancer, such as the load reporting interval requested by the traffic director.
-   *
-   * <p>Implementations are not required to be thread-safe as callbacks will be invoked in xDS load
-   * balancer's {@link SynchronizationContext}.
-   */
-  interface XdsLoadReportCallback {
-
-    /**
-     * The load reporting interval has been received.
-     *
-     * @param reportIntervalNano load reporting interval requested by remote traffic director.
-     */
-    void onReportResponse(long reportIntervalNano);
-  }
-
   abstract static class XdsLoadReportClientFactory {
 
     private static final XdsLoadReportClientFactory DEFAULT_INSTANCE =

--- a/xds/src/test/java/io/grpc/xds/XdsLoadBalancerWithLrsTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadBalancerWithLrsTest.java
@@ -55,7 +55,7 @@ import io.grpc.internal.testing.StreamRecorder;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
 import io.grpc.xds.XdsLoadBalancer.FallbackManager;
-import io.grpc.xds.XdsLoadReportClientImpl.XdsLoadReportCallback;
+import io.grpc.xds.XdsLoadReportClient.XdsLoadReportCallback;
 import io.grpc.xds.XdsLoadReportClientImpl.XdsLoadReportClientFactory;
 import java.util.Collections;
 import java.util.Map;

--- a/xds/src/test/java/io/grpc/xds/XdsLoadBalancerWithLrsTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadBalancerWithLrsTest.java
@@ -55,6 +55,7 @@ import io.grpc.internal.testing.StreamRecorder;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
 import io.grpc.xds.XdsLoadBalancer.FallbackManager;
+import io.grpc.xds.XdsLoadReportClientImpl.XdsLoadReportCallback;
 import io.grpc.xds.XdsLoadReportClientImpl.XdsLoadReportClientFactory;
 import java.util.Collections;
 import java.util.Map;
@@ -65,6 +66,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -254,11 +256,13 @@ public class XdsLoadBalancerWithLrsTest {
     fakeClock.forwardTime(10, TimeUnit.SECONDS);
     assertThat(fallBackLbHelper).isNotNull();
 
-    verify(lrsClient, never()).startLoadReporting();
+    verify(lrsClient, never()).startLoadReporting(any(XdsLoadReportCallback.class));
 
     // Simulates a syntactically incorrect EDS response.
     serverResponseWriter.onNext(DiscoveryResponse.getDefaultInstance());
-    verify(lrsClient, never()).startLoadReporting();
+    verify(lrsClient, never()).startLoadReporting(any(XdsLoadReportCallback.class));
+
+    ArgumentCaptor<XdsLoadReportCallback> lrsCallbackCaptor = ArgumentCaptor.forClass(null);
 
     // Simulate a syntactically correct EDS response.
     DiscoveryResponse edsResponse =
@@ -267,7 +271,9 @@ public class XdsLoadBalancerWithLrsTest {
             .setTypeUrl("type.googleapis.com/envoy.api.v2.ClusterLoadAssignment")
             .build();
     serverResponseWriter.onNext(edsResponse);
-    verify(lrsClient).startLoadReporting();
+    verify(lrsClient).startLoadReporting(lrsCallbackCaptor.capture());
+    lrsCallbackCaptor.getValue().onReportResponse(19543);
+    verify(localityStore).updateOobMetricsReportInterval(19543);
 
     // Simulate another EDS response from the same remote balancer.
     serverResponseWriter.onNext(edsResponse);
@@ -299,7 +305,7 @@ public class XdsLoadBalancerWithLrsTest {
         .createLoadReportClient(same(oobChannel1), same(helper), same(backoffPolicyProvider),
             same(statsStore));
     assertThat(streamRecorder.getValues()).hasSize(1);
-    inOrder.verify(lrsClient, never()).startLoadReporting();
+    inOrder.verify(lrsClient, never()).startLoadReporting(any(XdsLoadReportCallback.class));
 
     // Simulate receiving a new service config with balancer name changed before xDS protocol is
     // established.
@@ -326,7 +332,7 @@ public class XdsLoadBalancerWithLrsTest {
             .setTypeUrl("type.googleapis.com/envoy.api.v2.ClusterLoadAssignment")
             .build();
     serverResponseWriter.onNext(edsResponse);
-    inOrder.verify(lrsClient).startLoadReporting();
+    inOrder.verify(lrsClient).startLoadReporting(any(XdsLoadReportCallback.class));
 
     // Simulate receiving a new service config with balancer name changed.
     newLbConfig = (Map<String, ?>) JsonParser.parse(
@@ -346,7 +352,7 @@ public class XdsLoadBalancerWithLrsTest {
             same(statsStore));
 
     serverResponseWriter.onNext(edsResponse);
-    inOrder.verify(lrsClient).startLoadReporting();
+    inOrder.verify(lrsClient).startLoadReporting(any(XdsLoadReportCallback.class));
 
     inOrder.verifyNoMoreInteractions();
   }
@@ -374,7 +380,7 @@ public class XdsLoadBalancerWithLrsTest {
             .setTypeUrl("type.googleapis.com/envoy.api.v2.ClusterLoadAssignment")
             .build();
     serverResponseWriter.onNext(edsResponse);
-    verify(lrsClient).startLoadReporting();
+    verify(lrsClient).startLoadReporting(any(XdsLoadReportCallback.class));
 
     // Simulate receiving a new service config with child policy changed.
     @SuppressWarnings("unchecked")

--- a/xds/src/test/java/io/grpc/xds/XdsLoadReportClientImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadReportClientImplTest.java
@@ -53,6 +53,7 @@ import io.grpc.internal.BackoffPolicy;
 import io.grpc.internal.FakeClock;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
+import io.grpc.xds.XdsLoadReportClientImpl.XdsLoadReportCallback;
 import java.text.MessageFormat;
 import java.util.ArrayDeque;
 import java.util.concurrent.ThreadLocalRandom;
@@ -148,6 +149,8 @@ public class XdsLoadReportClientImplTest {
   private BackoffPolicy backoffPolicy2;
   @Mock
   private StatsStore statsStore;
+  @Mock
+  private XdsLoadReportCallback callback;
 
   private static ClusterStats buildEmptyClusterStats(long loadReportIntervalNanos) {
     return ClusterStats.newBuilder()
@@ -203,7 +206,7 @@ public class XdsLoadReportClientImplTest {
         new XdsLoadReportClientImpl(channel, helper, fakeClock.getStopwatchSupplier(),
             backoffPolicyProvider,
             statsStore);
-    lrsClient.startLoadReporting();
+    lrsClient.startLoadReporting(callback);
   }
 
   @After
@@ -251,9 +254,9 @@ public class XdsLoadReportClientImplTest {
     assertThat(lrsRequestObservers).hasSize(1);
     StreamObserver<LoadStatsRequest> requestObserver = lrsRequestObservers.peek();
     verify(requestObserver).onNext(EXPECTED_INITIAL_REQ);
-    lrsClient.startLoadReporting();
+    lrsClient.startLoadReporting(callback);
     assertThat(lrsRequestObservers).hasSize(1);
-    lrsClient.startLoadReporting();
+    lrsClient.startLoadReporting(callback);
     assertThat(lrsRequestObservers).hasSize(1);
     verifyNoMoreInteractions(requestObserver);
 
@@ -263,7 +266,7 @@ public class XdsLoadReportClientImplTest {
     lrsClient.stopLoadReporting();
     verifyNoMoreInteractions(requestObserver);
 
-    lrsClient.startLoadReporting();
+    lrsClient.startLoadReporting(callback);
     verify(mockLoadReportingService, times(2)).streamLoadStats(lrsResponseObserverCaptor.capture());
     assertThat(lrsRequestObservers).hasSize(2);
   }
@@ -284,6 +287,7 @@ public class XdsLoadReportClientImplTest {
     assertThat(logs).containsExactly(
         "DEBUG: Received LRS initial response: " + buildLrsResponse(1453));
     assertNextReport(inOrder, requestObserver, buildEmptyClusterStats(1453));
+    verify(callback).onReportResponse(1453);
   }
 
   @Test
@@ -305,12 +309,14 @@ public class XdsLoadReportClientImplTest {
         "DEBUG: Received LRS initial response: " + buildLrsResponse(1362));
     logs.poll();
     assertNextReport(inOrder, requestObserver, buildEmptyClusterStats(1362));
+    verify(callback).onReportResponse(1362);
 
     responseObserver.onNext(buildLrsResponse(2183345));
     assertThat(logs).containsExactly(
         "DEBUG: Received an LRS response: " + buildLrsResponse(2183345));
     // Updated load reporting interval becomes effective immediately.
     assertNextReport(inOrder, requestObserver, buildEmptyClusterStats(2183345));
+    verify(callback).onReportResponse(2183345);
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/XdsLoadReportClientImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadReportClientImplTest.java
@@ -53,7 +53,7 @@ import io.grpc.internal.BackoffPolicy;
 import io.grpc.internal.FakeClock;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
-import io.grpc.xds.XdsLoadReportClientImpl.XdsLoadReportCallback;
+import io.grpc.xds.XdsLoadReportClient.XdsLoadReportCallback;
 import java.text.MessageFormat;
 import java.util.ArrayDeque;
 import java.util.concurrent.ThreadLocalRandom;


### PR DESCRIPTION
To integrate reporting OOB backend metrics, we wrap each xDS's child load balancer helper with `OrcaReportingHelperWrapper`, which invokes the registered `OrcaOobReportListener#onLoadReport(...)` upon receiving backend metrics reports. Client side aggregation happens naturally via creating the `OrcaOobReportListener` instance with the locality counter the child helper belongs to.

The interval for receiving backend metrics reports is set to be the same as the client side load reporting, which is received from traffic director in [load reporting response](https://github.com/grpc/grpc-java/blob/44bbccff79d108baf90f55226a4fbc62fcbcaab4/xds/third_party/envoy/src/main/proto/envoy/service/load_stats/v2/lrs.proto#L77). We pass this interval to each child helper through `XdsLoadReportCallback`, which calls `LocalityStore#updateOobMetricsReportInterval(...)`, each time the `XdsLoadReportClient` received a load reporting response.