### PR TITLE
xds: import third party envoy proto

### DIFF
--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/EndpointDiscoveryServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/EndpointDiscoveryServiceGrpc.java
@@ -59,6 +59,38 @@ public final class EndpointDiscoveryServiceGrpc {
      return getStreamEndpointsMethod;
   }
 
+  private static volatile io.grpc.MethodDescriptor<io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest,
+      io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse> getDeltaEndpointsMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeltaEndpoints",
+      requestType = io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest.class,
+      responseType = io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+  public static io.grpc.MethodDescriptor<io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest,
+      io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse> getDeltaEndpointsMethod() {
+    io.grpc.MethodDescriptor<io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest, io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse> getDeltaEndpointsMethod;
+    if ((getDeltaEndpointsMethod = EndpointDiscoveryServiceGrpc.getDeltaEndpointsMethod) == null) {
+      synchronized (EndpointDiscoveryServiceGrpc.class) {
+        if ((getDeltaEndpointsMethod = EndpointDiscoveryServiceGrpc.getDeltaEndpointsMethod) == null) {
+          EndpointDiscoveryServiceGrpc.getDeltaEndpointsMethod = getDeltaEndpointsMethod = 
+              io.grpc.MethodDescriptor.<io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest, io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "envoy.api.v2.EndpointDiscoveryService", "DeltaEndpoints"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new EndpointDiscoveryServiceMethodDescriptorSupplier("DeltaEndpoints"))
+                  .build();
+          }
+        }
+     }
+     return getDeltaEndpointsMethod;
+  }
+
   private static volatile io.grpc.MethodDescriptor<io.envoyproxy.envoy.api.v2.DiscoveryRequest,
       io.envoyproxy.envoy.api.v2.DiscoveryResponse> getFetchEndpointsMethod;
 
@@ -131,6 +163,13 @@ public final class EndpointDiscoveryServiceGrpc {
 
     /**
      */
+    public io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest> deltaEndpoints(
+        io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse> responseObserver) {
+      return asyncUnimplementedStreamingCall(getDeltaEndpointsMethod(), responseObserver);
+    }
+
+    /**
+     */
     public void fetchEndpoints(io.envoyproxy.envoy.api.v2.DiscoveryRequest request,
         io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.DiscoveryResponse> responseObserver) {
       asyncUnimplementedUnaryCall(getFetchEndpointsMethod(), responseObserver);
@@ -145,6 +184,13 @@ public final class EndpointDiscoveryServiceGrpc {
                 io.envoyproxy.envoy.api.v2.DiscoveryRequest,
                 io.envoyproxy.envoy.api.v2.DiscoveryResponse>(
                   this, METHODID_STREAM_ENDPOINTS)))
+          .addMethod(
+            getDeltaEndpointsMethod(),
+            asyncBidiStreamingCall(
+              new MethodHandlers<
+                io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest,
+                io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse>(
+                  this, METHODID_DELTA_ENDPOINTS)))
           .addMethod(
             getFetchEndpointsMethod(),
             asyncUnaryCall(
@@ -184,6 +230,14 @@ public final class EndpointDiscoveryServiceGrpc {
         io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.DiscoveryResponse> responseObserver) {
       return asyncBidiStreamingCall(
           getChannel().newCall(getStreamEndpointsMethod(), getCallOptions()), responseObserver);
+    }
+
+    /**
+     */
+    public io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest> deltaEndpoints(
+        io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse> responseObserver) {
+      return asyncBidiStreamingCall(
+          getChannel().newCall(getDeltaEndpointsMethod(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -250,6 +304,7 @@ public final class EndpointDiscoveryServiceGrpc {
 
   private static final int METHODID_FETCH_ENDPOINTS = 0;
   private static final int METHODID_STREAM_ENDPOINTS = 1;
+  private static final int METHODID_DELTA_ENDPOINTS = 2;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -285,6 +340,9 @@ public final class EndpointDiscoveryServiceGrpc {
         case METHODID_STREAM_ENDPOINTS:
           return (io.grpc.stub.StreamObserver<Req>) serviceImpl.streamEndpoints(
               (io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.DiscoveryResponse>) responseObserver);
+        case METHODID_DELTA_ENDPOINTS:
+          return (io.grpc.stub.StreamObserver<Req>) serviceImpl.deltaEndpoints(
+              (io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse>) responseObserver);
         default:
           throw new AssertionError();
       }
@@ -337,6 +395,7 @@ public final class EndpointDiscoveryServiceGrpc {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new EndpointDiscoveryServiceFileDescriptorSupplier())
               .addMethod(getStreamEndpointsMethod())
+              .addMethod(getDeltaEndpointsMethod())
               .addMethod(getFetchEndpointsMethod())
               .build();
         }

--- a/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
+++ b/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
@@ -322,7 +322,10 @@ final class ClientLoadCounter {
     public void onLoadReport(OrcaLoadReport report) {
       counter.recordMetric("cpu_utilization", report.getCpuUtilization());
       counter.recordMetric("mem_utilization", report.getMemUtilization());
-      for (Map.Entry<String, Double> entry : report.getRequestCostOrUtilizationMap().entrySet()) {
+      for (Map.Entry<String, Double> entry : report.getRequestCostMap().entrySet()) {
+        counter.recordMetric(entry.getKey(), entry.getValue());
+      }
+      for (Map.Entry<String, Double> entry : report.getUtilizationMap().entrySet()) {
         counter.recordMetric(entry.getKey(), entry.getValue());
       }
     }

--- a/xds/src/test/java/io/grpc/xds/ClientLoadCounterTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClientLoadCounterTest.java
@@ -161,8 +161,8 @@ public class ClientLoadCounterTest {
         OrcaLoadReport.newBuilder()
             .setCpuUtilization(0.5345)
             .setMemUtilization(0.647)
-            .putRequestCostOrUtilization("named-cost-or-utilization-1", 3453.3525)
-            .putRequestCostOrUtilization("named-cost-or-utilization-2", 532543.14234)
+            .putRequestCost("named-cost-1", 3453.3525)
+            .putRequestCost("named-cost-2", 532543.14234)
             .build();
     listener1.onLoadReport(report);
 
@@ -178,11 +178,11 @@ public class ClientLoadCounterTest {
     assertThat(memMetric.getNumReports()).isEqualTo(2);
     assertThat(memMetric.getTotalValue()).isEqualTo(0.647);
 
-    MetricValue namedMetric1 = snapshot.getMetricValues().get("named-cost-or-utilization-1");
+    MetricValue namedMetric1 = snapshot.getMetricValues().get("named-cost-1");
     assertThat(namedMetric1.getNumReports()).isEqualTo(1);
     assertThat(namedMetric1.getTotalValue()).isEqualTo(3453.3525);
 
-    MetricValue namedMetric2 = snapshot.getMetricValues().get("named-cost-or-utilization-2");
+    MetricValue namedMetric2 = snapshot.getMetricValues().get("named-cost-2");
     assertThat(namedMetric2.getNumReports()).isEqualTo(1);
     assertThat(namedMetric2.getTotalValue()).isEqualTo(532543.14234);
 
@@ -194,7 +194,7 @@ public class ClientLoadCounterTest {
         OrcaLoadReport.newBuilder()
             .setCpuUtilization(0.3423)
             .setMemUtilization(0.654)
-            .putRequestCostOrUtilization("named-cost-or-utilization", 3534.0)
+            .putUtilization("named-utilization", 0.7563)
             .build();
     // Two listeners with the same counter aggregate metrics together.
     listener1.onLoadReport(report);
@@ -209,9 +209,9 @@ public class ClientLoadCounterTest {
     assertThat(memMetric.getNumReports()).isEqualTo(2);
     assertThat(memMetric.getTotalValue()).isEqualTo(0.654 + 0.654);
 
-    MetricValue namedMetric = snapshot.getMetricValues().get("named-cost-or-utilization");
+    MetricValue namedMetric = snapshot.getMetricValues().get("named-utilization");
     assertThat(namedMetric.getNumReports()).isEqualTo(2);
-    assertThat(namedMetric.getTotalValue()).isEqualTo(3534.0 + 3534.0);
+    assertThat(namedMetric.getTotalValue()).isEqualTo(0.7563 + 0.7563);
   }
 
   @Test

--- a/xds/third_party/envoy/import.sh
+++ b/xds/third_party/envoy/import.sh
@@ -20,7 +20,7 @@
 set -e
 BRANCH=master
 # import VERSION from one of the google internal CLs
-VERSION=228a963d1308eb1b06e2e8b7387e0bfa72fe77ea
+VERSION=eefcd0e6fcbeba446454bd5396a34c69348338eb
 GIT_REPO="https://github.com/envoyproxy/envoy.git"
 GIT_BASE_DIR=envoy
 SOURCE_PROTO_BASE_DIR=envoy/api

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/auth/cert.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/auth/cert.proto
@@ -13,9 +13,9 @@ import "envoy/api/v2/core/config_source.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
-option (gogoproto.equal_all) = true;
+
+
 
 // [#protodoc-title: Common TLS configuration]
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/cds.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/cds.proto
@@ -27,10 +27,10 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
-option (gogoproto.equal_all) = true;
-option (gogoproto.stable_marshaler_all) = true;
+
+
+
 
 // Return list of all clusters this proxy will load balance to.
 service ClusterDiscoveryService {
@@ -127,9 +127,7 @@ message Cluster {
 
   // The timeout for new network connections to hosts in the cluster.
   google.protobuf.Duration connect_timeout = 4 [
-    (validate.rules).duration.gt = {},
-    (gogoproto.stdduration) = true,
-    (gogoproto.nullable) = false
+    (validate.rules).duration.gt = {}
   ];
 
   // Soft limit on size of the cluster’s connections read and write buffers. If
@@ -139,7 +137,6 @@ message Cluster {
   // Refer to :ref:`load balancer type <arch_overview_load_balancing_types>` architecture
   // overview section for information on each type.
   enum LbPolicy {
-
     // Refer to the :ref:`round robin load balancing
     // policy<arch_overview_load_balancing_types_round_robin>`
     // for an explanation.
@@ -168,6 +165,11 @@ message Cluster {
     // Refer to the :ref:`Maglev load balancing policy<arch_overview_load_balancing_types_maglev>`
     // for an explanation.
     MAGLEV = 5;
+
+    // This load balancer type must be specified if the configured cluster provides a cluster
+    // specific load balancer. Consult the configured cluster's documentation for whether to set
+    // this option or not.
+    CLUSTER_PROVIDED = 6;
   }
   // The :ref:`load balancer type <arch_overview_load_balancing_types>` to use
   // when picking a host in the cluster.
@@ -268,7 +270,7 @@ message Cluster {
   // and :ref:`LOGICAL_DNS<envoy_api_enum_value_Cluster.DiscoveryType.LOGICAL_DNS>`
   // this setting is ignored.
   google.protobuf.Duration dns_refresh_rate = 16
-      [(validate.rules).duration.gt = {}, (gogoproto.stdduration) = true];
+      [(validate.rules).duration.gt = {}];
 
   // When V4_ONLY is selected, the DNS resolver will only perform a lookup for
   // addresses in the IPv4 family. If V6_ONLY is selected, the DNS resolver will
@@ -322,7 +324,7 @@ message Cluster {
   // :ref:`ORIGINAL_DST<envoy_api_enum_value_Cluster.DiscoveryType.ORIGINAL_DST>`
   // this setting is ignored.
   google.protobuf.Duration cleanup_interval = 20
-      [(validate.rules).duration.gt = {}, (gogoproto.stdduration) = true];
+      [(validate.rules).duration.gt = {}];
 
   // Optional configuration used to bind newly established upstream connections.
   // This overrides any bind_config specified in the bootstrap proto.
@@ -363,6 +365,24 @@ message Cluster {
     message LbSubsetSelector {
       // List of keys to match with the weighted cluster metadata.
       repeated string keys = 1;
+      // The behavior used when no endpoint subset matches the selected route's
+      // metadata.
+      LbSubsetSelectorFallbackPolicy fallback_policy = 2
+          [(validate.rules).enum.defined_only = true];
+
+      // Allows to override top level fallback policy per selector.
+      enum LbSubsetSelectorFallbackPolicy {
+        // If NOT_DEFINED top level config fallback policy is used instead.
+        NOT_DEFINED = 0;
+        // If NO_FALLBACK is selected, a result equivalent to no healthy hosts is reported.
+        NO_FALLBACK = 1;
+        // If ANY_ENDPOINT is selected, any cluster endpoint may be returned
+        // (subject to policy, health checks, etc).
+        ANY_ENDPOINT = 2;
+        // If DEFAULT_SUBSET is selected, load balancing is performed over the
+        // endpoints matching the values from the default_subset field.
+        DEFAULT_SUBSET = 3;
+      }
     }
 
     // For each entry, LbEndpoint.Metadata's
@@ -406,6 +426,11 @@ message Cluster {
     // subset might become empty. With this option enabled, if that happens the LB will attempt
     // to select a host from the entire cluster.
     bool panic_mode_any = 6;
+
+    // If true, metadata specified for a metadata key will be matched against the corresponding
+    // endpoint metadata if the endpoint metadata matches the value exactly OR it is a list value
+    // and any of the elements in the list matches the criteria.
+    bool list_as_any = 7;
   }
 
   // Configuration for load balancing subsetting.

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/cluster/circuit_breaker.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/cluster/circuit_breaker.proto
@@ -7,14 +7,15 @@ option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.api.v2.cluster";
 option go_package = "cluster";
 option csharp_namespace = "Envoy.Api.V2.ClusterNS";
+option ruby_package = "Envoy.Api.V2.ClusterNS";
 
 import "envoy/api/v2/core/base.proto";
 
 import "google/protobuf/wrappers.proto";
 
-import "gogoproto/gogo.proto";
 
-option (gogoproto.equal_all) = true;
+
+
 
 // [#protodoc-title: Circuit breakers]
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/cluster/outlier_detection.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/cluster/outlier_detection.proto
@@ -6,14 +6,15 @@ option java_outer_classname = "OutlierDetectionProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.api.v2.cluster";
 option csharp_namespace = "Envoy.Api.V2.ClusterNS";
+option ruby_package = "Envoy.Api.V2.ClusterNS";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
-option (gogoproto.equal_all) = true;
+
+
 
 // [#protodoc-title: Outlier detection]
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/address.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/address.proto
@@ -11,9 +11,9 @@ import "envoy/api/v2/core/base.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
-option (gogoproto.equal_all) = true;
+
+
 
 // [#protodoc-title: Network addresses]
 
@@ -27,7 +27,6 @@ message Pipe {
 
 message SocketAddress {
   enum Protocol {
-    option (gogoproto.goproto_enum_prefix) = false;
     TCP = 0;
     // [#not-implemented-hide:]
     UDP = 1;
@@ -84,7 +83,7 @@ message TcpKeepalive {
 message BindConfig {
   // The address to bind to when creating a socket.
   SocketAddress source_address = 1
-      [(validate.rules).message.required = true, (gogoproto.nullable) = false];
+      [(validate.rules).message.required = true];
 
   // Whether to set the *IP_FREEBIND* option when creating the socket. When this
   // flag is set to true, allows the :ref:`source_address

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/base.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/base.proto
@@ -12,12 +12,12 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
+
 
 import "envoy/type/percent.proto";
 
-option (gogoproto.equal_all) = true;
-option (gogoproto.stable_marshaler_all) = true;
+
+
 
 // [#protodoc-title: Common types]
 
@@ -130,7 +130,7 @@ enum RoutingPriority {
 
 // HTTP request method.
 enum RequestMethod {
-  option (gogoproto.goproto_enum_prefix) = false;
+  
   METHOD_UNSPECIFIED = 0;
   GET = 1;
   HEAD = 2;
@@ -140,6 +140,7 @@ enum RequestMethod {
   CONNECT = 6;
   OPTIONS = 7;
   TRACE = 8;
+  PATCH = 9;
 }
 
 // Header name/value pair.
@@ -223,7 +224,6 @@ message SocketOption {
     bytes buf_value = 5;
   }
   enum SocketState {
-    option (gogoproto.goproto_enum_prefix) = false;
     // Socket options are applied after socket creation but before binding the socket to a port
     STATE_PREBIND = 0;
     // Socket options are applied after binding the socket to a port but before calling listen()

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/config_source.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/config_source.proto
@@ -12,9 +12,9 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
-option (gogoproto.equal_all) = true;
+
+
 
 // [#protodoc-title: Configuration sources]
 
@@ -56,11 +56,11 @@ message ApiConfigSource {
   repeated GrpcService grpc_services = 4;
 
   // For REST APIs, the delay between successive polls.
-  google.protobuf.Duration refresh_delay = 3 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration refresh_delay = 3;
 
   // For REST APIs, the request timeout. If not set, a default value of 1s will be used.
   google.protobuf.Duration request_timeout = 5
-      [(validate.rules).duration.gt.seconds = 0, (gogoproto.stdduration) = true];
+      [(validate.rules).duration.gt.seconds = 0];
 
   // For GRPC APIs, the rate limit settings. If present, discovery requests made by Envoy will be
   // rate limited.

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/grpc_service.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/grpc_service.proto
@@ -14,9 +14,9 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/empty.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
-option (gogoproto.equal_all) = true;
+
+
 
 // [#protodoc-title: gRPC services]
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/health_check.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/health_check.proto
@@ -15,9 +15,9 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
-option (gogoproto.equal_all) = true;
+
+
 
 // [#protodoc-title: Health check]
 // * Health checking :ref:`architecture overview <arch_overview_health_checking>`.
@@ -31,8 +31,7 @@ message HealthCheck {
     (validate.rules).duration = {
       required: true,
       gt: {seconds: 0}
-    },
-    (gogoproto.stdduration) = true
+    }
   ];
 
   // The interval between health checks.
@@ -40,8 +39,7 @@ message HealthCheck {
     (validate.rules).duration = {
       required: true,
       gt: {seconds: 0}
-    },
-    (gogoproto.stdduration) = true
+    }
   ];
 
   // An optional jitter amount in milliseconds. If specified, Envoy will start health

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/protocol.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/protocol.proto
@@ -12,9 +12,9 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
-option (gogoproto.equal_all) = true;
+
+
 
 // [#protodoc-title: Protocol options]
 
@@ -27,7 +27,7 @@ message HttpProtocolOptions {
   // period in which there are no active requests. If not set, there is no idle timeout. When the
   // idle timeout is reached the connection will be closed. Note that request based timeouts mean
   // that HTTP/2 PINGs will not keep the connection alive.
-  google.protobuf.Duration idle_timeout = 1 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration idle_timeout = 1;
 }
 
 message Http1ProtocolOptions {

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/discovery.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/discovery.proto
@@ -11,10 +11,10 @@ import "envoy/api/v2/core/base.proto";
 
 import "google/protobuf/any.proto";
 import "google/rpc/status.proto";
-import "gogoproto/gogo.proto";
 
-option (gogoproto.equal_all) = true;
-option (gogoproto.stable_marshaler_all) = true;
+
+
+
 
 // [#protodoc-title: Common discovery API components]
 
@@ -65,7 +65,7 @@ message DiscoveryResponse {
   string version_info = 1;
 
   // The response resources. These resources are typed and depend on the API being called.
-  repeated google.protobuf.Any resources = 2 [(gogoproto.nullable) = false];
+  repeated google.protobuf.Any resources = 2;
 
   // [#not-implemented-hide:]
   // Canary is used to support two Envoy command line flags:
@@ -83,9 +83,8 @@ message DiscoveryResponse {
   //   validated via a dry run.
   bool canary = 3;
 
-  // Type URL for resources. This must be consistent with the type_url in the
-  // Any messages for resources if resources is non-empty. This effectively
-  // identifies the xDS API when muxing over ADS.
+  // Type URL for resources. Identifies the xDS API when muxing over ADS.
+  // Must be consistent with the type_url in the 'resources' repeated Any (if non-empty).
   string type_url = 4;
 
   // For gRPC based subscriptions, the nonce provides a way to explicitly ack a
@@ -109,7 +108,7 @@ message DiscoveryResponse {
 // With Delta xDS, the DeltaDiscoveryResponses do not need to include a full
 // snapshot of the tracked resources. Instead, DeltaDiscoveryResponses are a
 // diff to the state of a xDS client.
-// In Delta XDS there are per resource versions, which allow tracking state at
+// In Delta XDS there are per-resource versions, which allow tracking state at
 // the resource granularity.
 // An xDS Delta session is always in the context of a gRPC bidirectional
 // stream. This allows the xDS server to keep track of the state of xDS clients
@@ -120,22 +119,27 @@ message DiscoveryResponse {
 // Optionally, a response message level system_version_info is present for
 // debugging purposes only.
 //
-// DeltaDiscoveryRequest can be sent in 3 situations:
-//   1. Initial message in a xDS bidirectional gRPC stream.
-//   2. As a ACK or NACK response to a previous DeltaDiscoveryResponse.
-//      In this case the response_nonce is set to the nonce value in the Response.
-//      ACK or NACK is determined by the absence or presence of error_detail.
-//   3. Spontaneous DeltaDiscoveryRequest from the client.
-//      This can be done to dynamically add or remove elements from the tracked
-//      resource_names set. In this case response_nonce must be omitted.
+// DeltaDiscoveryRequest plays two independent roles. Any DeltaDiscoveryRequest
+// can be either or both of: [1] informing the server of what resources the
+// client has gained/lost interest in (using resource_names_subscribe and
+// resource_names_unsubscribe), or [2] (N)ACKing an earlier resource update from
+// the server (using response_nonce, with presence of error_detail making it a NACK).
+// Additionally, the first message (for a given type_url) of a reconnected gRPC stream
+// has a third role: informing the server of the resources (and their versions)
+// that the client already possesses, using the initial_resource_versions field.
+//
+// As with state-of-the-world, when multiple resource types are multiplexed (ADS),
+// all requests/acknowledgments/updates are logically walled off by type_url:
+// a Cluster ACK exists in a completely separate world from a prior Route NACK.
+// In particular, initial_resource_versions being sent at the "start" of every
+// gRPC stream actually entails a message for each type_url, each with its own
+// initial_resource_versions.
 message DeltaDiscoveryRequest {
   // The node making the request.
   core.Node node = 1;
 
   // Type of the resource that is being requested, e.g.
-  // "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment". This is implicit
-  // in requests made via singleton xDS APIs such as CDS, LDS, etc. but is
-  // required for ADS.
+  // "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment".
   string type_url = 2;
 
   // DeltaDiscoveryRequests allow the client to add or remove individual
@@ -143,19 +147,20 @@ message DeltaDiscoveryRequest {
   // All resource names in the resource_names_subscribe list are added to the
   // set of tracked resources and all resource names in the resource_names_unsubscribe
   // list are removed from the set of tracked resources.
-  // Unlike in state-of-the-world xDS, an empty resource_names_subscribe or
+  //
+  // *Unlike* state-of-the-world xDS, an empty resource_names_subscribe or
   // resource_names_unsubscribe list simply means that no resources are to be
   // added or removed to the resource list.
-  // The xDS server must send updates for all tracked resources but can also
-  // send updates for resources the client has not subscribed to. This behavior
-  // is similar to state-of-the-world xDS.
-  // These two fields can be set for all types of DeltaDiscoveryRequests
-  // (initial, ACK/NACK or spontaneous).
+  // *Like* state-of-the-world xDS, the server must send updates for all tracked
+  // resources, but can also send updates for resources the client has not subscribed to.
   //
   // NOTE: the server must respond with all resources listed in resource_names_subscribe,
   // even if it believes the client has the most recent version of them. The reason:
   // the client may have dropped them, but then regained interest before it had a chance
   // to send the unsubscribe message. See DeltaSubscriptionStateTest.RemoveThenAdd.
+  //
+  // These two fields can be set in any DeltaDiscoveryRequest, including ACKs
+  // and initial_resource_versions.
   //
   // A list of Resource names to add to the list of tracked resources.
   repeated string resource_names_subscribe = 3;
@@ -163,12 +168,14 @@ message DeltaDiscoveryRequest {
   // A list of Resource names to remove from the list of tracked resources.
   repeated string resource_names_unsubscribe = 4;
 
-  // This map must be populated when the DeltaDiscoveryRequest is the
-  // first in a stream (assuming there are any resources - this field's purpose is to enable
-  // a session to continue in a reconnected gRPC stream, and so will not be used in the very
-  // first stream of a session). The keys are the resources names of the xDS resources
-  // known to the xDS client. The values in the map are the associated resource
-  // level version info.
+  // Informs the server of the versions of the resources the xDS client knows of, to enable the
+  // client to continue the same logical xDS session even in the face of gRPC stream reconnection.
+  // It will not be populated: [1] in the very first stream of a session, since the client will
+  // not yet have any resources,  [2] in any message after the first in a stream (for a given
+  // type_url), since the server will already be correctly tracking the client's state.
+  // (In ADS, the first message *of each type_url* of a reconnected stream populates this map.)
+  // The map's keys are names of xDS resources known to the xDS client.
+  // The map's values are opaque resource versions.
   map<string, string> initial_resource_versions = 5;
 
   // When the DeltaDiscoveryRequest is a ACK or NACK message in response
@@ -187,16 +194,22 @@ message DeltaDiscoveryResponse {
   // The version of the response data (used for debugging).
   string system_version_info = 1;
 
-  // The response resources. These are typed resources that match the type url
-  // in the DeltaDiscoveryRequest.
-  repeated Resource resources = 2 [(gogoproto.nullable) = false];
+  // The response resources. These are typed resources, whose types must match
+  // the type_url field.
+  repeated Resource resources = 2;
+
+  // field id 3 IS available!
+
+  // Type URL for resources. Identifies the xDS API when muxing over ADS.
+  // Must be consistent with the type_url in the Any within 'resources' if 'resources' is non-empty.
+  string type_url = 4;
 
   // Resources names of resources that have be deleted and to be removed from the xDS Client.
   // Removed resources for missing resources can be ignored.
   repeated string removed_resources = 6;
 
   // The nonce provides a way for DeltaDiscoveryRequests to uniquely
-  // reference a DeltaDiscoveryResponse. The nonce is required.
+  // reference a DeltaDiscoveryResponse when (N)ACKing. The nonce is required.
   string nonce = 5;
 }
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/eds.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/eds.proto
@@ -15,12 +15,12 @@ import "envoy/type/percent.proto";
 import "google/api/annotations.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
+
 import "google/protobuf/wrappers.proto";
 import "google/protobuf/duration.proto";
 
-option (gogoproto.equal_all) = true;
-option (gogoproto.stable_marshaler_all) = true;
+
+
 
 // [#protodoc-title: EDS]
 // Endpoint discovery :ref:`architecture overview <arch_overview_service_discovery_types_eds>`
@@ -29,6 +29,9 @@ service EndpointDiscoveryService {
   // The resource_names field in DiscoveryRequest specifies a list of clusters
   // to subscribe to updates for.
   rpc StreamEndpoints(stream DiscoveryRequest) returns (stream DiscoveryResponse) {
+  }
+
+  rpc DeltaEndpoints(stream DeltaDiscoveryRequest) returns (stream DeltaDiscoveryResponse) {
   }
 
   rpc FetchEndpoints(DiscoveryRequest) returns (DiscoveryResponse) {
@@ -56,7 +59,7 @@ message ClusterLoadAssignment {
   string cluster_name = 1 [(validate.rules).string.min_bytes = 1];
 
   // List of endpoints to load balance to.
-  repeated endpoint.LocalityLbEndpoints endpoints = 2 [(gogoproto.nullable) = false];
+  repeated endpoint.LocalityLbEndpoints endpoints = 2;
 
   // Map of named endpoints that can be referenced in LocalityLbEndpoints.
   map<string, endpoint.Endpoint> named_endpoints = 5;

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/endpoint/endpoint.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/endpoint/endpoint.proto
@@ -14,9 +14,9 @@ import "envoy/api/v2/core/health_check.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
-option (gogoproto.equal_all) = true;
+
+
 
 // [#protodoc-title: Endpoints]
 
@@ -101,7 +101,7 @@ message LocalityLbEndpoints {
   core.Locality locality = 1;
 
   // The group of endpoints belonging to the locality specified.
-  repeated LbEndpoint lb_endpoints = 2 [(gogoproto.nullable) = false];
+  repeated LbEndpoint lb_endpoints = 2;
 
   // Optional: Per priority/region/zone/sub_zone weight - range 1-128. The load
   // balancing weight for a locality is divided by the sum of the weights of all

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/endpoint/load_report.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/endpoint/load_report.proto
@@ -13,7 +13,7 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
+
 
 // These are stats Envoy reports to GLB every so often. Report frequency is
 // defined by

--- a/xds/third_party/envoy/src/main/proto/envoy/type/percent.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/percent.proto
@@ -7,9 +7,9 @@ option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.type";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
-option (gogoproto.equal_all) = true;
+
+
 
 // [#protodoc-title: Percent]
 

--- a/xds/third_party/envoy/src/main/proto/envoy/type/range.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/range.proto
@@ -7,9 +7,9 @@ option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.type";
 option go_package = "envoy_type";
 
-import "gogoproto/gogo.proto";
 
-option (gogoproto.equal_all) = true;
+
+
 
 // [#protodoc-title: Range]
 

--- a/xds/third_party/envoy/src/main/proto/udpa/data/orca/v1/orca_load_report.proto
+++ b/xds/third_party/envoy/src/main/proto/udpa/data/orca/v1/orca_load_report.proto
@@ -14,22 +14,23 @@ import "validate/validate.proto";
 
 message OrcaLoadReport {
   // CPU utilization expressed as a fraction of available CPU resources. This
-  // should be derived from a sample or measurement taken during the request.
+  // should be derived from the latest sample or measurement.
   double cpu_utilization = 1 [(validate.rules).double.gte = 0, (validate.rules).double.lte = 1];
 
   // Memory utilization expressed as a fraction of available memory
-  // resources. This should be derived from a sample or measurement taken
-  // during the request.
+  // resources. This should be derived from the latest sample or measurement.
   double mem_utilization = 2 [(validate.rules).double.gte = 0, (validate.rules).double.lte = 1];
 
   // Total RPS being served by an endpoint. This should cover all services that an endpoint is
   // responsible for.
   uint64 rps = 3;
 
-  // Application specific requests costs. Each value may be an absolute cost (e.g.
-  // 3487 bytes of storage) or utilization associated with the request,
-  // expressed as a fraction of total resources available. Utilization
-  // metrics should be derived from a sample or measurement taken
-  // during the request.
-  map<string, double> request_cost_or_utilization = 4;
+  // Application specific requests costs. Each value is an absolute cost (e.g. 3487 bytes of
+  // storage) associated with the request.
+  map<string, double> request_cost = 4;
+
+  // Resource utilization values. Each value is expressed as a fraction of total resources
+  // available, derived from the latest sample or measurement.
+  map<string, double> utilization = 5
+      [(validate.rules).map.values.double.gte = 0, (validate.rules).map.values.double.lte = 1];
 }


### PR DESCRIPTION
One breaking change:
- The field `request_cost_or_utilization` in `OrcaLoadReport` is split into `request_cost` and `utilization` separately.
- This changes how gRPC backend metrics listener record received metrics.

DO NOT MERGE until envoy commit `3be027b1a661136ed2d9597f2e00ce035b6e3f1b` has been brought into Google internal and change our import again to match that.

**To patch this in google3:**
```
$ g4d && cd third_party/java_src/grpc
$ patch -p1 < <(curl -L https://github.com/grpc/grpc-java/pull/5929.diff)
```

**Then skip the generated Grpc classes:**
```
can't find file to patch at input line 5
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|diff --git a/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/EndpointDiscoveryServiceGrpc.java b/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/EndpointDiscoveryServiceGrpc.java
|index c930f6ef37..694cd7b3c2 100644
|--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/EndpointDiscoveryServiceGrpc.java
|+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/EndpointDiscoveryServiceGrpc.java
--------------------------
File to patch:  [Enter]
Skip this patch? [y]
```