### PR TITLE
Protono

### DIFF
--- a/netty/src/main/java/io/grpc/netty/InternalProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/InternalProtocolNegotiators.java
@@ -19,6 +19,7 @@ package io.grpc.netty;
 import io.grpc.ChannelLogger;
 import io.grpc.netty.ProtocolNegotiators.ClientTlsHandler;
 import io.grpc.netty.ProtocolNegotiators.GrpcNegotiationHandler;
+import io.grpc.netty.ProtocolNegotiators.ProtocolNegotiationHandler;
 import io.grpc.netty.ProtocolNegotiators.WaitUntilActiveHandler;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -98,5 +99,17 @@ public final class InternalProtocolNegotiators {
   public static ChannelHandler clientTlsHandler(
       ChannelHandler next, SslContext sslContext, String authority) {
     return new ClientTlsHandler(next, sslContext, authority);
+  }
+
+  public static class ProtocolNegotiationHandler
+      extends ProtocolNegotiators.ProtocolNegotiationHandler {
+
+    protected ProtocolNegotiationHandler(ChannelHandler next, String negotiatorName) {
+      super(next, negotiatorName);
+    }
+
+    protected ProtocolNegotiationHandler(ChannelHandler next) {
+      super(next);
+    }
   }
 }

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -22,6 +22,7 @@ import static io.grpc.netty.GrpcSslContexts.NEXT_PROTOCOL_VERSIONS;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.errorprone.annotations.ForOverride;
 import io.grpc.Attributes;
 import io.grpc.ChannelLogger;
 import io.grpc.ChannelLogger.ChannelLogLevel;
@@ -851,54 +852,109 @@ final class ProtocolNegotiators {
    * subsequent handlers to assume the channel is active and ready to send.  Additionally, this a
    * {@link ProtocolNegotiationEvent}, with the connection addresses.
    */
-  static final class WaitUntilActiveHandler extends ChannelInboundHandlerAdapter {
-    private final ChannelHandler next;
-    private ProtocolNegotiationEvent pne;
+  static final class WaitUntilActiveHandler extends ProtocolNegotiationHandler {
 
-    public WaitUntilActiveHandler(ChannelHandler next) {
-      this.next = checkNotNull(next, "next");
-    }
+    boolean protocolNegotiationEventReceived;
 
-    @Override
-    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
-      negotiationLogger(ctx).log(ChannelLogLevel.INFO, "WaitUntilActive started");
-      // This should be a noop, but just in case...
-      super.handlerAdded(ctx);
+    WaitUntilActiveHandler(ChannelHandler next) {
+      super(next);
     }
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception {
+      if (protocolNegotiationEventReceived) {
+        replaceOnActive(ctx);
+        fireProtocolNegotiationEvent(ctx);
+      }
       // Still propagate channelActive to the new handler.
       super.channelActive(ctx);
-      if (pne != null) {
+    }
+
+    @Override
+    protected void protocolNegotiationEventTriggered(ChannelHandlerContext ctx) {
+      protocolNegotiationEventReceived = true;
+      if (ctx.channel().isActive()) {
+        replaceOnActive(ctx);
         fireProtocolNegotiationEvent(ctx);
       }
     }
 
-    @Override
-    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-      if (evt instanceof ProtocolNegotiationEvent) {
-        checkState(pne == null, "negotiation already started");
-        pne = (ProtocolNegotiationEvent) evt;
-        if (ctx.channel().isActive()) {
-          fireProtocolNegotiationEvent(ctx);
-        }
-      } else {
-        super.userEventTriggered(ctx, evt);
-      }
-    }
-
-    private void fireProtocolNegotiationEvent(ChannelHandlerContext ctx) {
-      checkState(pne != null, "negotiation not yet complete");
-      negotiationLogger(ctx).log(ChannelLogLevel.INFO, "WaitUntilActive finished");
-      ctx.pipeline().replace(ctx.name(), /* newName= */ null, next);
-      Attributes attrs = pne.getAttributes().toBuilder()
+    private void replaceOnActive(ChannelHandlerContext ctx) {
+      ProtocolNegotiationEvent existingPne = getProtocolNegotiationEvent();
+      Attributes attrs = existingPne.getAttributes().toBuilder()
           .set(Grpc.TRANSPORT_ATTR_LOCAL_ADDR, ctx.channel().localAddress())
           .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, ctx.channel().remoteAddress())
           // Later handlers are expected to overwrite this.
           .set(GrpcAttributes.ATTR_SECURITY_LEVEL, SecurityLevel.NONE)
           .build();
-      ctx.fireUserEventTriggered(pne.withAttributes(attrs));
+      replaceProtocolNegotiationEvent(existingPne.withAttributes(attrs));
+    }
+  }
+
+  static class ProtocolNegotiationHandler extends ChannelDuplexHandler {
+
+    private final ChannelHandler next;
+    private final String negotiatorName;
+    private ProtocolNegotiationEvent pne;
+
+    protected ProtocolNegotiationHandler(ChannelHandler next, String negotiatorName) {
+      this.next = checkNotNull(next, "next");
+      this.negotiatorName = negotiatorName;
+    }
+
+    protected ProtocolNegotiationHandler(ChannelHandler next) {
+      this.next = checkNotNull(next, "next");
+      this.negotiatorName = getClass().getSimpleName().replace("Handler", "");
+    }
+
+    @Override
+    public final void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+      InternalProtocolNegotiators.negotiationLogger(ctx)
+          .log(ChannelLogLevel.DEBUG, negotiatorName + " started");
+      handlerAdded0(ctx);
+    }
+
+    @ForOverride
+    protected void handlerAdded0(ChannelHandlerContext ctx) throws Exception {
+      super.handlerAdded(ctx);
+    }
+
+    @Override
+    public final void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+      if (evt instanceof ProtocolNegotiationEvent) {
+        checkState(pne == null, "pre-existing negotiation: %s < %s", pne, evt);
+        pne = (ProtocolNegotiationEvent) evt;
+        protocolNegotiationEventTriggered(ctx);
+      } else {
+        userEventTriggered0(ctx, evt);
+      }
+    }
+
+    protected void userEventTriggered0(ChannelHandlerContext ctx, Object evt) throws Exception {
+      super.userEventTriggered(ctx, evt);
+    }
+
+    @ForOverride
+    protected void protocolNegotiationEventTriggered(ChannelHandlerContext ctx) {
+      // no-op
+    }
+
+    protected final ProtocolNegotiationEvent getProtocolNegotiationEvent() {
+      checkState(pne != null, "previous protocol negotiation event hasn't triggered");
+      return pne;
+    }
+
+    protected final void replaceProtocolNegotiationEvent(ProtocolNegotiationEvent pne) {
+      checkState(this.pne != null, "previous protocol negotiation event hasn't triggered");
+      this.pne = checkNotNull(pne);
+    }
+
+    protected final void fireProtocolNegotiationEvent(ChannelHandlerContext ctx) {
+      checkState(pne != null, "previous protocol negotiation event hasn't triggered");
+      InternalProtocolNegotiators.negotiationLogger(ctx)
+          .log(ChannelLogLevel.INFO, negotiatorName + " completed");
+      ctx.pipeline().replace(ctx.name(), /* newName= */ null, next);
+      ctx.fireUserEventTriggered(pne);
     }
   }
 }


### PR DESCRIPTION
Upstream ProtocolNegotiatiorHandler, and swap the appropriate classes to it.

ALTS is not switched yet, since it is shared between client and server.  Once the server is changed to use WBAEH, it can be moved too.