### PR TITLE
core:  use Sharded Executor by default

### DIFF
--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -545,7 +545,8 @@ public final class GrpcUtil {
                 int.class, fjpwtfClz, UncaughtExceptionHandler.class, boolean.class);
             return (Executor) ctor.newInstance(
                 Runtime.getRuntime().availableProcessors(),
-                fjpwtf, Thread.currentThread().getUncaughtExceptionHandler(),
+                fjpwtf,
+                Thread.currentThread().getUncaughtExceptionHandler(),
                 /* async=*/ true);
 
           } catch (ClassNotFoundException e) {


### PR DESCRIPTION
This tries to reflectively load FJP and use it as the default executor.   The largest risk associated with this is that the interrupted status of the Thread is not cleared before running the callbacks, which is a subtle behavior change.

The second risk is that I am not certain what happens when all threads are in blocking operations.  I think it spawns a new thread, but am not sure.