### PR TITLE
core: make libraries.android_annotations compileOnly

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -27,6 +27,7 @@ dependencies {
             project(':grpc-api').sourceSets.test.output,
             project(':grpc-testing'),
             project(':grpc-grpclb'),
+            libraries.android_annotations,
             libraries.guava_testlib
 
     signature "org.codehaus.mojo.signature:java17:1.0@signature"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -3,7 +3,6 @@ description = 'gRPC: Core'
 dependencies {
     compile project(':grpc-api'),
             libraries.gson,
-            libraries.android_annotations,
             libraries.perfmark
     compile (libraries.opencensus_api) {
         // prefer 3.0.2 from libraries instead of 3.0.1
@@ -21,6 +20,8 @@ dependencies {
         // prefer 20.0 from libraries instead of 19.0
         exclude group: 'com.google.guava', module: 'guava'
     }
+    
+    compileOnly libraries.android_annotations
 
     testCompile project(':grpc-context').sourceSets.test.output,
             project(':grpc-api').sourceSets.test.output,

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -149,6 +149,7 @@ def com_google_android_annotations():
         server_urls = ["http://central.maven.org/maven2"],
         artifact_sha256 = "ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15",
         licenses = ["notice"],  # Apache 2.0
+        neverlink = True,
     )
 
 def com_google_api_grpc_google_common_protos():


### PR DESCRIPTION
This will not add 
```
    <dependency>
      <groupId>com.google.android</groupId>
      <artifactId>annotations</artifactId>
      <version>4.1.1.4</version>
      <scope>compile</scope>
    </dependency>
```

into `/grpc-core-version.pom`.

Tested by commenting on `@SuppressLint` and off in `JndiResourceResolverFactory` then `gradlew :app:lintDebug` for `examples/android/helloworld`, still works.