### PR TITLE
Make //compiler:grpc_java_plugin publicly visible again

### DIFF
--- a/compiler/BUILD.bazel
+++ b/compiler/BUILD.bazel
@@ -10,6 +10,7 @@ cc_binary(
     deps = [
         "@com_google_protobuf//:protoc_lib",
     ],
+    visibility = ["//visibility:public"],
 )
 
 java_library(


### PR DESCRIPTION
Fixes #5942

Prior to 745aa0a2f570d74e7d7fe0c72334c24e21b8ab17, this target was visible publicly and is useful for external projects that depend on the protoc plugin.