### PR TITLE
gitignore: Intellij filebased import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ bazel-testlogs
 # IntelliJ IDEA
 .idea
 *.iml
+*.ipr
+*.iws
 
 # Eclipse
 .classpath


### PR DESCRIPTION
For Intellij there are two ways to import a project: file based and directory based. *.ipr and *.iws need to be ignore for file based project.