### PR TITLE
[README] Add mention of missing dep running on JDK version >8

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ https://search.maven.org/search?q=g:io.grpc%20AND%20v:1.21.0
 Development snapshots are available in [Sonatypes's snapshot
 repository](https://oss.sonatype.org/content/repositories/snapshots/).
 
+If you're running on a JDK version newer than than JDK 8, you'll also need to
+explicitly add the dependency `javax.annotation:javax.annotation-api`
+
+[javax.annotation.api]: https://mvnrepository.com/artifact/javax.annotation/javax.annotation-api
+
 Generated Code
 --------------
 
@@ -172,7 +177,7 @@ We recommend using the
 [grpc-java-api-checker](https://github.com/grpc/grpc-java-api-checker)
 (an [Error Prone](https://github.com/google/error-prone) plugin)
 to check for usages of `@ExperimentalApi` and `@Internal` in any library code
-that depends on gRPC. It may also be used to check for `@Internal` usage or 
+that depends on gRPC. It may also be used to check for `@Internal` usage or
 unintended `@ExperimentalApi` consumption in non-library code.
 
 How to Build


### PR DESCRIPTION
Following the instructions on the README results in a compile error on JDK versions >8 because of a missing dep on javax.annotation-api

While a bit of searching around eventually points you to a few GitHub issues where the solution exists, it should probably be mentioned in the README.