### PR TITLE
bazel: Add comment for public protoc plugin

### DIFF
--- a/compiler/BUILD.bazel
+++ b/compiler/BUILD.bazel
@@ -1,5 +1,6 @@
 load("//:java_grpc_library.bzl", "java_rpc_toolchain")
 
+# This should not generally be referenced. Users should use java_grpc_library
 cc_binary(
     name = "grpc_java_plugin",
     srcs = [


### PR DESCRIPTION
The 3rd-party rules_proto project is referencing our compiler directly
and not using our java_grpc_library. This target is fine for them to
use (although we'd prefer using our java_grpc_library), but most users
shouldn't be touching it.
    
Related to #5942 and #5947