### PR TITLE
Make //compiler:grpc_java_plugin publicly visible again (1.22 backport)

### DIFF
--- a/compiler/BUILD.bazel
+++ b/compiler/BUILD.bazel
@@ -10,6 +10,7 @@ cc_binary(
     deps = [
         "@com_google_protobuf//:protoc_lib",
     ],
+    visibility = ["//visibility:public"],
 )
 
 java_library(

--- a/compiler/BUILD.bazel
+++ b/compiler/BUILD.bazel
@@ -1,5 +1,6 @@
 load("//:java_grpc_library.bzl", "java_rpc_toolchain")
 
+# This should not generally be referenced. Users should use java_grpc_library
 cc_binary(
     name = "grpc_java_plugin",
     srcs = [


### PR DESCRIPTION
Backport of #5947 and #5952

CC @aaliddell 