### PR TITLE
core: fix terminated status check in TransportListener

### DIFF
--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -494,6 +494,7 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
   private class TransportListener implements ManagedClientTransport.Listener {
     final ConnectionClientTransport transport;
     final SocketAddress address;
+    boolean shutdownInitiated = false;
 
     TransportListener(ConnectionClientTransport transport, SocketAddress address) {
       this.transport = transport;
@@ -530,6 +531,7 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
     public void transportShutdown(final Status s) {
       channelLogger.log(
           ChannelLogLevel.INFO, "{0} SHUTDOWN with {1}", transport.getLogId(), printShortStatus(s));
+      shutdownInitiated = true;
       syncContext.execute(new Runnable() {
         @Override
         public void run() {
@@ -573,7 +575,7 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
           }
         }
       });
-      Preconditions.checkState(activeTransport != transport,
+      Preconditions.checkState(shutdownInitiated || activeTransport != transport,
           "activeTransport still points to this transport. "
           + "Seems transportShutdown() was not called.");
     }

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -563,9 +563,8 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
 
     @Override
     public void transportTerminated() {
-      Preconditions.checkState(shutdownInitiated,
-          "activeTransport still points to this transport. "
-          + "Seems transportShutdown() was not called.");
+      Preconditions.checkState(
+          shutdownInitiated, "transportShutdown() must be called before transportTerminated().");
 
       channelLogger.log(ChannelLogLevel.INFO, "{0} Terminated", transport.getLogId());
       channelz.removeClientSocket(transport);

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -563,6 +563,10 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
 
     @Override
     public void transportTerminated() {
+      Preconditions.checkState(shutdownInitiated,
+          "activeTransport still points to this transport. "
+          + "Seems transportShutdown() was not called.");
+
       channelLogger.log(ChannelLogLevel.INFO, "{0} Terminated", transport.getLogId());
       channelz.removeClientSocket(transport);
       handleTransportInUseState(transport, false);
@@ -575,9 +579,6 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
           }
         }
       });
-      Preconditions.checkState(shutdownInitiated || activeTransport != transport,
-          "activeTransport still points to this transport. "
-          + "Seems transportShutdown() was not called.");
     }
   }
 

--- a/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
+++ b/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
@@ -1145,9 +1145,9 @@ public class InternalSubchannelTest {
     internalSubchannel.obtainActiveTransport();
 
     MockClientTransportInfo t0 = transports.poll();
+    t0.listener.transportReady();
     assertTrue(channelz.containsClientSocket(t0.transport.getLogId()));
     t0.listener.transportShutdown(Status.RESOURCE_EXHAUSTED);
-    fakeClock.forwardNanos(10);
     t0.listener.transportTerminated();
     assertFalse(channelz.containsClientSocket(t0.transport.getLogId()));
   }

--- a/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
+++ b/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
@@ -839,6 +839,7 @@ public class InternalSubchannelTest {
     internalSubchannel.shutdown(SHUTDOWN_REASON);
     verify(transportInfo.transport).shutdown(same(SHUTDOWN_REASON));
     assertExactCallbackInvokes("onStateChange:SHUTDOWN");
+    transportInfo.listener.transportShutdown(SHUTDOWN_REASON);
 
     transportInfo.listener.transportTerminated();
     assertExactCallbackInvokes("onTerminated");
@@ -1145,6 +1146,8 @@ public class InternalSubchannelTest {
 
     MockClientTransportInfo t0 = transports.poll();
     assertTrue(channelz.containsClientSocket(t0.transport.getLogId()));
+    t0.listener.transportShutdown(Status.RESOURCE_EXHAUSTED);
+    fakeClock.forwardNanos(10);
     t0.listener.transportTerminated();
     assertFalse(channelz.containsClientSocket(t0.transport.getLogId()));
   }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -521,8 +521,10 @@ public class ManagedChannelImplTest {
     MockClientTransportInfo transportInfo = transports.poll();
     assertNotNull(transportInfo);
     assertTrue(channelz.containsClientSocket(transportInfo.transport.getLogId()));
+    transportInfo.listener.transportReady();
 
     // terminate transport
+    transportInfo.listener.transportShutdown(Status.CANCELLED);
     transportInfo.listener.transportTerminated();
     assertFalse(channelz.containsClientSocket(transportInfo.transport.getLogId()));
 
@@ -564,6 +566,7 @@ public class ManagedChannelImplTest {
     assertTrue(channelz.containsClientSocket(transportInfo.transport.getLogId()));
 
     // terminate transport
+    transportInfo.listener.transportShutdown(Status.INTERNAL);
     transportInfo.listener.transportTerminated();
     assertFalse(channelz.containsClientSocket(transportInfo.transport.getLogId()));
 
@@ -3270,6 +3273,7 @@ public class ManagedChannelImplTest {
     verify(mockLoadBalancer).shutdown();
     // simulating the shutdown of load balancer triggers the shutdown of subchannel
     shutdownSafely(helper, subchannel);
+    transportInfo.listener.transportShutdown(Status.INTERNAL);
     transportInfo.listener.transportTerminated(); // simulating transport terminated
     assertTrue(
         "channel.isTerminated() is expected to be true but was false",
@@ -3369,7 +3373,9 @@ public class ManagedChannelImplTest {
     verify(mockLoadBalancer).shutdown();
     // simulating the shutdown of load balancer triggers the shutdown of subchannel
     shutdownSafely(helper, subchannel);
-    transportInfo.listener.transportTerminated(); // simulating transport terminated
+    // simulating transport shutdown & terminated
+    transportInfo.listener.transportShutdown(Status.INTERNAL);
+    transportInfo.listener.transportTerminated();
     assertTrue(
         "channel.isTerminated() is expected to be true but was false",
         channel.isTerminated());


### PR DESCRIPTION
when we queue and execute the runnable in transport terminated, it may not be drained immediately if there's a already drain is running on the other thread. 
Adding a boolean to check shutdown is called before terminated.