### PR TITLE
Bump PerfMark to 0.17.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,7 +201,7 @@ subprojects {
             opencensus_impl: "io.opencensus:opencensus-impl:${opencensusVersion}",
             opencensus_impl_lite: "io.opencensus:opencensus-impl-lite:${opencensusVersion}",
             instrumentation_api: 'com.google.instrumentation:instrumentation-api:0.4.3',
-            perfmark: 'io.perfmark:perfmark-api:0.16.0',
+            perfmark: 'io.perfmark:perfmark-api:0.17.0',
             protobuf: "com.google.protobuf:protobuf-java:${protobufVersion}",
             protobuf_lite: "com.google.protobuf:protobuf-lite:3.0.1",
             protoc_lite: "com.google.protobuf:protoc-gen-javalite:3.0.0",

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -526,7 +526,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
     @Override
     public void headersRead(final Metadata headers) {
       PerfMark.startTask("ClientStreamListener.headersRead", tag);
-      final Link link = PerfMark.link();
+      final Link link = PerfMark.linkOut();
 
       final class HeadersRead extends ContextRunnable {
         HeadersRead() {
@@ -536,7 +536,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
         @Override
         public void runInContext() {
           PerfMark.startTask("ClientCall$Listener.headersRead", tag);
-          link.link();
+          PerfMark.linkIn(link);
           try {
             runInternal();
           } finally {
@@ -569,7 +569,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
     @Override
     public void messagesAvailable(final MessageProducer producer) {
       PerfMark.startTask("ClientStreamListener.messagesAvailable", tag);
-      final Link link = PerfMark.link();
+      final Link link = PerfMark.linkOut();
 
       final class MessagesAvailable extends ContextRunnable {
         MessagesAvailable() {
@@ -579,7 +579,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
         @Override
         public void runInContext() {
           PerfMark.startTask("ClientCall$Listener.messagesAvailable", tag);
-          link.link();
+          PerfMark.linkIn(link);
           try {
             runInternal();
           } finally {
@@ -667,7 +667,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
       }
       final Status savedStatus = status;
       final Metadata savedTrailers = trailers;
-      final Link link = PerfMark.link();
+      final Link link = PerfMark.linkOut();
       final class StreamClosed extends ContextRunnable {
         StreamClosed() {
           super(context);
@@ -676,7 +676,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
         @Override
         public void runInContext() {
           PerfMark.startTask("ClientCall$Listener.onClose", tag);
-          link.link();
+          PerfMark.linkIn(link);
           try {
             runInternal();
           } finally {
@@ -703,7 +703,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
       }
 
       PerfMark.startTask("ClientStreamListener.onReady", tag);
-      final Link link = PerfMark.link();
+      final Link link = PerfMark.linkOut();
 
       final class StreamOnReady extends ContextRunnable {
         StreamOnReady() {
@@ -713,7 +713,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
         @Override
         public void runInContext() {
           PerfMark.startTask("ClientCall$Listener.onReady", tag);
-          link.link();
+          PerfMark.linkIn(link);
           try {
             runInternal();
           } finally {

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -504,7 +504,7 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
         wrappedExecutor = new SerializingExecutor(executor);
       }
 
-      final Link link = PerfMark.link();
+      final Link link = PerfMark.linkOut();
 
       final JumpToApplicationThreadServerStreamListener jumpListener
           = new JumpToApplicationThreadServerStreamListener(
@@ -522,7 +522,7 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
         @Override
         public void runInContext() {
           PerfMark.startTask("ServerTransportListener$StreamCreated.startCall", tag);
-          link.link();
+          PerfMark.linkIn(link);
           try {
             runInternal();
           } finally {
@@ -757,7 +757,7 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
     @Override
     public void messagesAvailable(final MessageProducer producer) {
       PerfMark.startTask("ServerStreamListener.messagesAvailable", tag);
-      final Link link = PerfMark.link();
+      final Link link = PerfMark.linkOut();
 
       final class MessagesAvailable extends ContextRunnable {
 
@@ -768,7 +768,7 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
         @Override
         public void runInContext() {
           PerfMark.startTask("ServerCallListener(app).messagesAvailable", tag);
-          link.link();
+          PerfMark.linkIn(link);
           try {
             getListener().messagesAvailable(producer);
           } catch (RuntimeException e) {
@@ -793,7 +793,7 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
     @Override
     public void halfClosed() {
       PerfMark.startTask("ServerStreamListener.halfClosed", tag);
-      final Link link = PerfMark.link();
+      final Link link = PerfMark.linkOut();
 
       final class HalfClosed extends ContextRunnable {
         HalfClosed() {
@@ -803,7 +803,7 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
         @Override
         public void runInContext() {
           PerfMark.startTask("ServerCallListener(app).halfClosed", tag);
-          link.link();
+          PerfMark.linkIn(link);
           try {
             getListener().halfClosed();
           } catch (RuntimeException e) {
@@ -843,7 +843,7 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
         // is not serializing.
         cancelExecutor.execute(new ContextCloser(context, status.getCause()));
       }
-      final Link link = PerfMark.link();
+      final Link link = PerfMark.linkOut();
 
       final class Closed extends ContextRunnable {
         Closed() {
@@ -853,7 +853,7 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
         @Override
         public void runInContext() {
           PerfMark.startTask("ServerCallListener(app).closed", tag);
-          link.link();
+          PerfMark.linkIn(link);
           try {
             getListener().closed(status);
           } finally {
@@ -868,7 +868,7 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
     @Override
     public void onReady() {
       PerfMark.startTask("ServerStreamListener.onReady", tag);
-      final Link link = PerfMark.link();
+      final Link link = PerfMark.linkOut();
       final class OnReady extends ContextRunnable {
         OnReady() {
           super(context);
@@ -877,7 +877,7 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
         @Override
         public void runInContext() {
           PerfMark.startTask("ServerCallListener(app).onReady", tag);
-          link.link();
+          PerfMark.linkIn(link);
           try {
             getListener().onReady();
           } catch (RuntimeException e) {

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -549,7 +549,7 @@ class NettyClientHandler extends AbstractNettyHandler {
     stream.setId(streamId);
 
     PerfMark.startTask("NettyClientHandler.createStream", stream.tag());
-    command.getLink().link();
+    PerfMark.linkIn(command.getLink());
     try {
       createStreamTraced(
           streamId, stream, headers, command.isGet(), command.shouldBeCountedForInUse(), promise);
@@ -618,7 +618,7 @@ class NettyClientHandler extends AbstractNettyHandler {
       ChannelPromise promise) {
     NettyClientStream.TransportState stream = cmd.stream();
     PerfMark.startTask("NettyClientHandler.cancelStream", stream.tag());
-    cmd.getLink().link();
+    PerfMark.linkIn(cmd.getLink());
     try {
       Status reason = cmd.reason();
       if (reason != null) {
@@ -640,7 +640,7 @@ class NettyClientHandler extends AbstractNettyHandler {
   private void sendGrpcFrame(ChannelHandlerContext ctx, SendGrpcFrameCommand cmd,
       ChannelPromise promise) {
     PerfMark.startTask("NettyClientHandler.sendGrpcFrame", cmd.stream().tag());
-    cmd.getLink().link();
+    PerfMark.linkIn(cmd.getLink());
     try {
       // Call the base class to write the HTTP/2 DATA frame.
       // Note: no need to flush since this is handled by the outbound flow controller.
@@ -653,7 +653,7 @@ class NettyClientHandler extends AbstractNettyHandler {
   private void sendPingFrame(ChannelHandlerContext ctx, SendPingCommand msg,
       ChannelPromise promise) {
     PerfMark.startTask("NettyClientHandler.sendPingFrame");
-    msg.getLink().link();
+    PerfMark.linkIn(msg.getLink());
     try {
       sendPingFrameTraced(ctx, msg, promise);
     } finally {
@@ -737,7 +737,7 @@ class NettyClientHandler extends AbstractNettyHandler {
         NettyClientStream.TransportState clientStream = clientStream(stream);
         Tag tag = clientStream != null ? clientStream.tag() : PerfMark.createTag();
         PerfMark.startTask("NettyClientHandler.forcefulClose", tag);
-        msg.getLink().link();
+        PerfMark.linkIn(msg.getLink());
         try {
           if (clientStream != null) {
             clientStream.transportReportStatus(msg.getStatus(), true, new Metadata());

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -217,13 +217,13 @@ class NettyClientStream extends AbstractClientStream {
         transportState().requestMessagesFromDeframer(numMessages);
       } else {
         channel.eventLoop().execute(new Runnable() {
-          final Link link = PerfMark.link();
+          final Link link = PerfMark.linkOut();
           @Override
           public void run() {
             PerfMark.startTask(
                 "NettyClientStream$Sink.requestMessagesFromDeframer",
                 transportState().tag());
-            link.link();
+            PerfMark.linkIn(link);
             try {
               transportState().requestMessagesFromDeframer(numMessages);
             } finally {

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -649,7 +649,7 @@ class NettyServerHandler extends AbstractNettyHandler {
   private void sendGrpcFrame(ChannelHandlerContext ctx, SendGrpcFrameCommand cmd,
       ChannelPromise promise) throws Http2Exception {
     PerfMark.startTask("NettyServerHandler.sendGrpcFrame", cmd.stream().tag());
-    cmd.getLink().link();
+    PerfMark.linkIn(cmd.getLink());
     try {
       if (cmd.endStream()) {
         closeStreamWhenDone(promise, cmd.stream().id());
@@ -667,7 +667,7 @@ class NettyServerHandler extends AbstractNettyHandler {
   private void sendResponseHeaders(ChannelHandlerContext ctx, SendResponseHeadersCommand cmd,
       ChannelPromise promise) throws Http2Exception {
     PerfMark.startTask("NettyServerHandler.sendResponseHeaders", cmd.stream().tag());
-    cmd.getLink().link();
+    PerfMark.linkIn(cmd.getLink());
     try {
       // TODO(carl-mastrangelo): remove this check once https://github.com/netty/netty/issues/6296
       // is fixed.
@@ -689,7 +689,7 @@ class NettyServerHandler extends AbstractNettyHandler {
   private void cancelStream(ChannelHandlerContext ctx, CancelServerStreamCommand cmd,
       ChannelPromise promise) {
     PerfMark.startTask("NettyServerHandler.cancelStream", cmd.stream().tag());
-    cmd.getLink().link();
+    PerfMark.linkIn(cmd.getLink());
     try {
       // Notify the listener if we haven't already.
       cmd.stream().transportReportStatus(cmd.reason());
@@ -709,7 +709,7 @@ class NettyServerHandler extends AbstractNettyHandler {
         NettyServerStream.TransportState serverStream = serverStream(stream);
         if (serverStream != null) {
           PerfMark.startTask("NettyServerHandler.forcefulClose", serverStream.tag());
-          msg.getLink().link();
+          PerfMark.linkIn(msg.getLink());
           try {
             serverStream.transportReportStatus(msg.getStatus());
             resetStream(ctx, stream.id(), Http2Error.CANCEL.code(), ctx.newPromise());

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -100,14 +100,14 @@ class NettyServerStream extends AbstractServerStream {
         // Processing data read in the event loop so can call into the deframer immediately
         transportState().requestMessagesFromDeframer(numMessages);
       } else {
-        final Link link = PerfMark.link();
+        final Link link = PerfMark.linkOut();
         channel.eventLoop().execute(new Runnable() {
           @Override
           public void run() {
             PerfMark.startTask(
                 "NettyServerStream$Sink.requestMessagesFromDeframer",
                 transportState().tag());
-            link.link();
+            PerfMark.linkIn(link);
             try {
               transportState().requestMessagesFromDeframer(numMessages);
             } finally {

--- a/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
+++ b/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
@@ -38,7 +38,7 @@ final class SendGrpcFrameCommand extends DefaultByteBufHolder implements WriteQu
     super(content);
     this.stream = stream;
     this.endStream = endStream;
-    this.link = PerfMark.link();
+    this.link = PerfMark.linkOut();
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/netty/WriteQueue.java
+++ b/netty/src/main/java/io/grpc/netty/WriteQueue.java
@@ -151,7 +151,7 @@ class WriteQueue {
     private final Link link;
 
     public RunnableCommand(Runnable runnable) {
-      this.link = PerfMark.link();
+      this.link = PerfMark.linkOut();
       this.runnable = runnable;
     }
 
@@ -182,7 +182,7 @@ class WriteQueue {
     private final Link link;
 
     AbstractQueuedCommand() {
-      this.link = PerfMark.link();
+      this.link = PerfMark.linkOut();
     }
 
     @Override

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -408,9 +408,9 @@ def io_opencensus_grpc_metrics():
 def io_perfmark():
     jvm_maven_import_external(
         name = "io_perfmark_perfmark_api",
-        artifact = "io.perfmark:perfmark-api:0.16.0",
+        artifact = "io.perfmark:perfmark-api:0.17.0",
         server_urls = ["http://central.maven.org/maven2"],
-        artifact_sha256 = "a93667875ea9d10315177768739a18d6c667df041c982d2841645ae8558d0af0",
+        artifact_sha256 = "816c11409b8a0c6c9ce1cda14bed526e7b4da0e772da67c5b7b88eefd41520f9",
         licenses = ["notice"],  # Apache 2.0
     )
 


### PR DESCRIPTION
The main changes how linking is done.  Linking is now always done
through the `PerfMark` entry class.   This is for two reasons:

1.  It make instrumenting the linking calls *much* easier.
2.  It follows the API pattern of "verbNoun()".  Previous callsites
    would have `Link link = PerfMark.link(); link.link()`.  This
    stuttering is not quick to follow.

Generated using:

```
find -name \*.java -exec sed -i 's#link = PerfMark.link();#link = PerfMark.linkOut();#g' {} \;
find -name \*.java -exec sed -i 's#link.link();#PerfMark.linkIn(link);#g' {} \;
find -name \*.java -exec sed -i 's#command.getLink().link();#PerfMark.linkIn(command.getLink());#g' {} \;
find -name \*.java -exec sed -i 's#cmd.getLink().link();#PerfMark.linkIn(cmd.getLink());#g' {} \;
find -name \*.java -exec sed -i 's#msg.getLink().link();#PerfMark.linkIn(msg.getLink());#g' {} \;
```

Since the deprecated link methods are also `@DoNotCall`, the same
sed calls will need to be used on import.