### PR TITLE
java_grpc_library.bzl: Work with proto_library rules using strip_import_prefix / import_prefix

### DIFF
--- a/java_grpc_library.bzl
+++ b/java_grpc_library.bzl
@@ -62,7 +62,20 @@ java_rpc_toolchain = rule(
 def _path_ignoring_repository(f):
     if len(f.owner.workspace_root) == 0:
         return f.short_path
-    return f.path[f.path.find(f.owner.workspace_root) + len(f.owner.workspace_root) + 1:]
+
+    # Bazel creates a _virtual_imports directory in case the .proto source files
+    # need to a accessed at a path that's different from their source path:
+    # https://github.com/bazelbuild/bazel/blob/0.27.1/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoCommon.java#L289
+    #
+    # In that case, the import path of the .proto file is the path relative to
+    # the virtual imports directory of the rule in question.
+    virtual_imports = "/_virtual_imports/"
+    if virtual_imports in f.path:
+        return f.path.split(virtual_imports)[1].split("/", 1)[1]
+    else:
+        # If |f| is a generated file, it will have "bazel-out/*/genfiles" prefix
+        # before "external/workspace", so we need to add the starting index of "external/workspace"
+        return f.path[f.path.find(f.owner.workspace_root) + len(f.owner.workspace_root) + 1:]
 
 def _java_rpc_library_impl(ctx):
     if len(ctx.attr.srcs) != 1:


### PR DESCRIPTION
In addition to this welcome functionality, this change also makes it
possible to fix http://github.com/bazelbuild/bazel/issues/7157 by
tolerating proto_library rules using a virtual import directory.

CC @lberki @mjduijn

This is an export of cl/256951455.

-------

@mjduijn, you may be interested to test with this. Medium/long-term, @lberki mentioned that proto_common will be receiving a function for us to use to avoid calling protoc directly.