### PR TITLE
xds: Fix bug of locality store does not update weights for existing localities

### DIFF
--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -217,7 +217,8 @@ interface LocalityStore {
           LocalityLbInfo oldLocalityLbInfo = localityMap.get(newLocality);
           childHelper = oldLocalityLbInfo.childHelper;
           localityLbInfo =
-              new LocalityLbInfo(oldLocalityLbInfo.localityWeight,
+              new LocalityLbInfo(
+                  localityInfoMap.get(newLocality).localityWeight,
                   oldLocalityLbInfo.childBalancer,
                   childHelper);
         } else {

--- a/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
@@ -55,7 +55,7 @@ import io.grpc.LoadBalancerRegistry;
 import io.grpc.SynchronizationContext;
 import io.grpc.xds.ClientLoadCounter.LoadRecordingStreamTracerFactory;
 import io.grpc.xds.ClientLoadCounter.MetricsRecordingListener;
-import io.grpc.xds.InterLocalityPicker.WeightedChildPicker;
+import io.grpc.xds.InterLocalityPicker.IntraLocalityPicker;
 import io.grpc.xds.LocalityStore.LocalityStoreImpl;
 import io.grpc.xds.LocalityStore.LocalityStoreImpl.PickerFactory;
 import io.grpc.xds.OrcaOobUtil.OrcaOobReportListener;
@@ -98,13 +98,13 @@ public class LocalityStoreTest {
     int nextIndex;
 
     @Override
-    public SubchannelPicker picker(final List<WeightedChildPicker> childPickers) {
-      totalReadyLocalities = childPickers.size();
+    public SubchannelPicker picker(final List<IntraLocalityPicker> intraLocalityPickers) {
+      totalReadyLocalities = intraLocalityPickers.size();
 
       return new SubchannelPicker() {
         @Override
         public PickResult pickSubchannel(PickSubchannelArgs args) {
-          return childPickers.get(nextIndex).getPicker().pickSubchannel(args);
+          return intraLocalityPickers.get(nextIndex).pickSubchannel(args);
         }
       };
     }


### PR DESCRIPTION
The primary goal of this PR is to fix the bug introduced in #5921 for https://github.com/grpc/grpc-java/blob/d974bea4b169b68662111b31f33307ac3378894e/xds/src/main/java/io/grpc/xds/LocalityStore.java#L220, with weights for existing localities are not updated.

To add unit test coverage for locality weight update, I changed `WeightedChildPicker` to `IntraLocalityPicker`, which contains a `locality` field. So `InterLocalityPicker` is composited with a list of `IntraLocalityPicker`s. In test, we are able to check the weight for each locality in the `InterLocalityPicker` spawned by `LocalityStore`.