### PR TITLE
xds: Fix bug of locality store not update weights for existing localities

### DIFF
--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -217,7 +217,8 @@ interface LocalityStore {
           LocalityLbInfo oldLocalityLbInfo = localityMap.get(newLocality);
           childHelper = oldLocalityLbInfo.childHelper;
           localityLbInfo =
-              new LocalityLbInfo(oldLocalityLbInfo.localityWeight,
+              new LocalityLbInfo(
+                  localityInfoMap.get(newLocality).localityWeight,
                   oldLocalityLbInfo.childBalancer,
                   childHelper);
         } else {


### PR DESCRIPTION
As discussed in https://github.com/grpc/grpc-java/pull/5973#discussion_r302289849, this PR fixed the bug and added test coverage without modifying `WeightChildPicker` implementation.