### PR TITLE
interop-testing: fix race in CascadingTest

### DIFF
--- a/interop-testing/src/test/java/io/grpc/testing/integration/CascadingTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/CascadingTest.java
@@ -295,7 +295,9 @@ public class CascadingTest {
                       Context.currentContextExecutor(otherWork).execute(new Runnable() {
                         @Override
                         public void run() {
-                          call.close(Status.ABORTED, new Metadata());
+                          synchronized (call) {
+                            call.close(Status.ABORTED, new Metadata());
+                          }
                         }
                       });
                     } else if (req.getResponseSize() != 0) {
@@ -316,7 +318,9 @@ public class CascadingTest {
                                 }
                                 // Propagate closure upwards.
                                 try {
-                                  call.close(status, new Metadata());
+                                  synchronized (call) {
+                                    call.close(status, new Metadata());
+                                  }
                                 } catch (IllegalStateException t2) {
                                   // Ignore error if already closed.
                                 }


### PR DESCRIPTION
ServerCall.close() is meant to only be accessed from a single thread, but in the test it is accessed from the callbacks of several client calls.  Synchronize access to sate TSAN.