### PR TITLE
netty,interop-testing: increase timeouts on tests for TSAN

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -190,7 +190,7 @@ public abstract class AbstractInteropTest {
    * Constructor for tests.
    */
   public AbstractInteropTest() {
-    TestRule timeout = Timeout.seconds(30);
+    TestRule timeout = Timeout.seconds(60);
     try {
       timeout = new DisableOnDebug(timeout);
     } catch (Throwable t) {

--- a/interop-testing/src/test/java/io/grpc/testing/integration/ConcurrencyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/ConcurrencyTest.java
@@ -61,7 +61,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ConcurrencyTest {
 
-  @Rule public final Timeout globalTimeout = Timeout.seconds(10);
+  @Rule public final Timeout globalTimeout = Timeout.seconds(60);
   
   /**
    * A response observer that signals a {@code CountDownLatch} when the proper number of responses

--- a/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
+++ b/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
@@ -113,7 +113,7 @@ public class ProtocolNegotiatorsTest {
     @Override public void run() {}
   };
 
-  private static final int TIMEOUT_SECONDS = 5;
+  private static final int TIMEOUT_SECONDS = 60;
   @Rule public final TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(TIMEOUT_SECONDS));
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
@@ -645,9 +645,9 @@ public class ProtocolNegotiatorsTest {
     ChannelFuture write = c.writeAndFlush(NettyClientHandler.NOOP_MESSAGE);
     c.connect(addr);
 
-    boolean completed = gh.negotiated.await(5, TimeUnit.SECONDS);
+    boolean completed = gh.negotiated.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
     if (!completed) {
-      assertTrue("failed to negotiated", write.await(1, TimeUnit.SECONDS));
+      assertTrue("failed to negotiated", write.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
       // sync should fail if we are in this block.
       write.sync();
       throw new AssertionError("neither wrote nor negotiated");
@@ -708,9 +708,9 @@ public class ProtocolNegotiatorsTest {
     ChannelFuture write = channel.writeAndFlush(NettyClientHandler.NOOP_MESSAGE);
     channel.connect(serverChannel.localAddress());
 
-    boolean completed = gh.negotiated.await(5, TimeUnit.SECONDS);
+    boolean completed = gh.negotiated.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
     if (!completed) {
-      assertTrue("failed to negotiated", write.await(1, TimeUnit.SECONDS));
+      assertTrue("failed to negotiated", write.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
       // sync should fail if we are in this block.
       write.sync();
       throw new AssertionError("neither wrote nor negotiated");

--- a/netty/src/test/java/io/grpc/netty/WriteQueueTest.java
+++ b/netty/src/test/java/io/grpc/netty/WriteQueueTest.java
@@ -48,7 +48,7 @@ import org.mockito.stubbing.Answer;
 public class WriteQueueTest {
 
   @Rule
-  public final Timeout globalTimeout = Timeout.seconds(10);
+  public final Timeout globalTimeout = Timeout.seconds(60);
 
   private final Object lock = new Object();
 


### PR DESCRIPTION
These tests don't really need such a high deadline, but when running under TSAN they do.   