### PR TITLE
Upstream changes

### DIFF
--- a/java_grpc_library.bzl
+++ b/java_grpc_library.bzl
@@ -149,7 +149,7 @@ _java_lite_grpc_library = rule(
         "srcs": attr.label_list(
             mandatory = True,
             allow_empty = False,
-            providers = ["proto"],
+            providers = ["ProtoInfo"],
         ),
         "deps": attr.label_list(
             mandatory = True,


### PR DESCRIPTION
Migrate the provider containing information about protocol buffers from the old-style 'dep.proto' pattern to the new-style 'dep[ProtoInfo]' one.