### PR TITLE
core: Migrate to new OpenCensus method & status tags

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -26,7 +26,8 @@ dependencies {
             project(':grpc-api').sourceSets.test.output,
             project(':grpc-testing'),
             project(':grpc-grpclb'),
-            libraries.guava_testlib
+            libraries.guava_testlib,
+            libraries.opencensus_impl
 
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"

--- a/core/src/main/java/io/grpc/internal/CensusStatsModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusStatsModule.java
@@ -356,7 +356,7 @@ public final class CensusStatsModule {
       this.parentCtx = checkNotNull(parentCtx);
       TagValue methodTag = TagValue.create(fullMethodName);
       this.startCtx = module.tagger.toBuilder(parentCtx)
-          .putLocal(DeprecatedCensusConstants.RPC_METHOD, methodTag)
+          .putLocal(RpcMeasureConstants.GRPC_CLIENT_METHOD, methodTag)
           .build();
       this.stopwatch = module.stopwatchSupplier.get().start();
       if (module.recordStartedRpcs) {
@@ -442,7 +442,7 @@ public final class CensusStatsModule {
           module
               .tagger
               .toBuilder(startCtx)
-              .putLocal(DeprecatedCensusConstants.RPC_STATUS, statusTag)
+              .putLocal(RpcMeasureConstants.GRPC_CLIENT_STATUS, statusTag)
               .build());
     }
   }
@@ -647,7 +647,7 @@ public final class CensusStatsModule {
           module
               .tagger
               .toBuilder(parentCtx)
-              .putLocal(DeprecatedCensusConstants.RPC_STATUS, statusTag)
+              .putLocal(RpcMeasureConstants.GRPC_SERVER_STATUS, statusTag)
               .build());
     }
 
@@ -672,7 +672,7 @@ public final class CensusStatsModule {
       parentCtx =
           tagger
               .toBuilder(parentCtx)
-              .putLocal(DeprecatedCensusConstants.RPC_METHOD, methodTag)
+              .putLocal(RpcMeasureConstants.GRPC_SERVER_METHOD, methodTag)
               .build();
       return new ServerTracer(CensusStatsModule.this, parentCtx);
     }

--- a/core/src/main/java/io/grpc/internal/DeprecatedCensusConstants.java
+++ b/core/src/main/java/io/grpc/internal/DeprecatedCensusConstants.java
@@ -26,10 +26,6 @@ import io.opencensus.tags.TagKey;
 @SuppressWarnings("deprecation")
 @VisibleForTesting
 public final class DeprecatedCensusConstants {
-
-  public static final TagKey RPC_STATUS = RpcMeasureConstants.RPC_STATUS;
-  public static final TagKey RPC_METHOD = RpcMeasureConstants.RPC_METHOD;
-
   public static final MeasureLong RPC_CLIENT_ERROR_COUNT =
       RpcMeasureConstants.RPC_CLIENT_ERROR_COUNT;
   public static final MeasureDouble RPC_CLIENT_REQUEST_BYTES =

--- a/core/src/main/java/io/grpc/internal/DeprecatedCensusConstants.java
+++ b/core/src/main/java/io/grpc/internal/DeprecatedCensusConstants.java
@@ -20,7 +20,6 @@ import com.google.common.annotations.VisibleForTesting;
 import io.opencensus.contrib.grpc.metrics.RpcMeasureConstants;
 import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.Measure.MeasureLong;
-import io.opencensus.tags.TagKey;
 
 /** Holder class for the deprecated OpenCensus constants. */
 @SuppressWarnings("deprecation")

--- a/core/src/test/java/io/grpc/internal/CensusModulesTest.java
+++ b/core/src/test/java/io/grpc/internal/CensusModulesTest.java
@@ -288,8 +288,8 @@ public class CensusModulesTest {
 
     StatsTestUtils.MetricsRecord record = statsRecorder.pollRecord();
     assertNotNull(record);
-    TagValue methodTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
-    assertEquals(method.getFullMethodName(), methodTagOld.asString());
+    TagValue methodTag = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
+    assertEquals(method.getFullMethodName(), methodTag.asString());
     if (nonDefaultContext) {
       TagValue extraTag = record.tags.get(StatsTestUtils.EXTRA_TAG);
       assertEquals("extra value", extraTag.asString());
@@ -322,10 +322,10 @@ public class CensusModulesTest {
     // The intercepting listener calls callEnded() on ClientCallTracer, which records to Census.
     record = statsRecorder.pollRecord();
     assertNotNull(record);
-    methodTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
-    assertEquals(method.getFullMethodName(), methodTagOld.asString());
-    TagValue statusTagOld = record.tags.get(DeprecatedCensusConstants.RPC_STATUS);
-    assertEquals(Status.Code.PERMISSION_DENIED.toString(), statusTagOld.asString());
+    methodTag = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
+    assertEquals(method.getFullMethodName(), methodTag.asString());
+    TagValue statusTag = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_STATUS);
+    assertEquals(Status.Code.PERMISSION_DENIED.toString(), statusTag.asString());
     if (nonDefaultContext) {
       TagValue extraTag = record.tags.get(StatsTestUtils.EXTRA_TAG);
       assertEquals("extra value", extraTag.asString());
@@ -384,8 +384,8 @@ public class CensusModulesTest {
       assertNotNull(record);
       assertNoServerContent(record);
       assertEquals(1, record.tags.size());
-      TagValue methodTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
-      assertEquals(method.getFullMethodName(), methodTagOld.asString());
+      TagValue methodTag = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
+      assertEquals(method.getFullMethodName(), methodTag.asString());
       assertEquals(
           1, record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_STARTED_COUNT));
     } else {
@@ -446,10 +446,10 @@ public class CensusModulesTest {
       StatsTestUtils.MetricsRecord record = statsRecorder.pollRecord();
       assertNotNull(record);
       assertNoServerContent(record);
-      TagValue methodTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
-      assertEquals(method.getFullMethodName(), methodTagOld.asString());
-      TagValue statusTagOld = record.tags.get(DeprecatedCensusConstants.RPC_STATUS);
-      assertEquals(Status.Code.OK.toString(), statusTagOld.asString());
+      TagValue methodTag = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
+      assertEquals(method.getFullMethodName(), methodTag.asString());
+      TagValue statusTag = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_STATUS);
+      assertEquals(Status.Code.OK.toString(), statusTag.asString());
       assertEquals(
           1, record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_FINISHED_COUNT));
       assertNull(record.getMetric(DeprecatedCensusConstants.RPC_CLIENT_ERROR_COUNT));
@@ -488,11 +488,16 @@ public class CensusModulesTest {
     assertNotNull(record);
     if (clientSide) {
       assertNoServerContent(record);
+
+      TagValue methodTag = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
+      assertEquals(method.getFullMethodName(), methodTag.asString());
     } else {
       assertNoClientContent(record);
+
+      TagValue methodTag = record.tags.get(RpcMeasureConstants.GRPC_SERVER_METHOD);
+      assertEquals(method.getFullMethodName(), methodTag.asString());
     }
-    TagValue methodTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
-    assertEquals(method.getFullMethodName(), methodTagOld.asString());
+
     assertEquals(expectedValue, record.getMetricAsLongOrFail(measure));
   }
 
@@ -564,8 +569,8 @@ public class CensusModulesTest {
     assertNotNull(record);
     assertNoServerContent(record);
     assertEquals(1, record.tags.size());
-    TagValue methodTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
-    assertEquals(method.getFullMethodName(), methodTagOld.asString());
+    TagValue methodTag = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
+    assertEquals(method.getFullMethodName(), methodTag.asString());
     assertEquals(
         1,
         record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_STARTED_COUNT));
@@ -574,10 +579,10 @@ public class CensusModulesTest {
     record = statsRecorder.pollRecord();
     assertNotNull(record);
     assertNoServerContent(record);
-    methodTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
-    assertEquals(method.getFullMethodName(), methodTagOld.asString());
-    TagValue statusTagOld = record.tags.get(DeprecatedCensusConstants.RPC_STATUS);
-    assertEquals(Status.Code.DEADLINE_EXCEEDED.toString(), statusTagOld.asString());
+    methodTag = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
+    assertEquals(method.getFullMethodName(), methodTag.asString());
+    TagValue statusTag = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_STATUS);
+    assertEquals(Status.Code.DEADLINE_EXCEEDED.toString(), statusTag.asString());
     assertEquals(
         1,
         record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_FINISHED_COUNT));
@@ -668,8 +673,8 @@ public class CensusModulesTest {
       assertNotNull(clientRecord);
       assertNoServerContent(clientRecord);
       assertEquals(2, clientRecord.tags.size());
-      TagValue clientMethodTagOld = clientRecord.tags.get(DeprecatedCensusConstants.RPC_METHOD);
-      assertEquals(method.getFullMethodName(), clientMethodTagOld.asString());
+      TagValue clientMethodTag = clientRecord.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
+      assertEquals(method.getFullMethodName(), clientMethodTag.asString());
       TagValue clientPropagatedTag = clientRecord.tags.get(StatsTestUtils.EXTRA_TAG);
       assertEquals("extra-tag-value-897", clientPropagatedTag.asString());
     }
@@ -690,7 +695,7 @@ public class CensusModulesTest {
     assertEquals(
         tagger.toBuilder(clientCtx)
             .putLocal(
-                DeprecatedCensusConstants.RPC_METHOD,
+                RpcMeasureConstants.GRPC_SERVER_METHOD,
                 TagValue.create(method.getFullMethodName()))
             .build(),
         io.opencensus.tags.unsafe.ContextUtils.getValue(serverContext));
@@ -704,8 +709,8 @@ public class CensusModulesTest {
       assertNotNull(serverRecord);
       assertNoClientContent(serverRecord);
       assertEquals(2, serverRecord.tags.size());
-      TagValue serverMethodTagOld = serverRecord.tags.get(DeprecatedCensusConstants.RPC_METHOD);
-      assertEquals(method.getFullMethodName(), serverMethodTagOld.asString());
+      TagValue serverMethodTag = serverRecord.tags.get(RpcMeasureConstants.GRPC_SERVER_METHOD);
+      assertEquals(method.getFullMethodName(), serverMethodTag.asString());
       TagValue serverPropagatedTag = serverRecord.tags.get(StatsTestUtils.EXTRA_TAG);
       assertEquals("extra-tag-value-897", serverPropagatedTag.asString());
 
@@ -713,10 +718,10 @@ public class CensusModulesTest {
       serverRecord = statsRecorder.pollRecord();
       assertNotNull(serverRecord);
       assertNoClientContent(serverRecord);
-      serverMethodTagOld = serverRecord.tags.get(DeprecatedCensusConstants.RPC_METHOD);
-      assertEquals(method.getFullMethodName(), serverMethodTagOld.asString());
-      TagValue serverStatusTagOld = serverRecord.tags.get(DeprecatedCensusConstants.RPC_STATUS);
-      assertEquals(Status.Code.OK.toString(), serverStatusTagOld.asString());
+      serverMethodTag = serverRecord.tags.get(RpcMeasureConstants.GRPC_SERVER_METHOD);
+      assertEquals(method.getFullMethodName(), serverMethodTag.asString());
+      TagValue serverStatusTag = serverRecord.tags.get(RpcMeasureConstants.GRPC_SERVER_STATUS);
+      assertEquals(Status.Code.OK.toString(), serverStatusTag.asString());
       assertNull(serverRecord.getMetric(DeprecatedCensusConstants.RPC_SERVER_ERROR_COUNT));
       serverPropagatedTag = serverRecord.tags.get(StatsTestUtils.EXTRA_TAG);
       assertEquals("extra-tag-value-897", serverPropagatedTag.asString());
@@ -731,10 +736,10 @@ public class CensusModulesTest {
       StatsTestUtils.MetricsRecord clientRecord = statsRecorder.pollRecord();
       assertNotNull(clientRecord);
       assertNoServerContent(clientRecord);
-      TagValue clientMethodTagOld = clientRecord.tags.get(DeprecatedCensusConstants.RPC_METHOD);
-      assertEquals(method.getFullMethodName(), clientMethodTagOld.asString());
-      TagValue clientStatusTagOld = clientRecord.tags.get(DeprecatedCensusConstants.RPC_STATUS);
-      assertEquals(Status.Code.OK.toString(), clientStatusTagOld.asString());
+      TagValue clientMethodTag = clientRecord.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
+      assertEquals(method.getFullMethodName(), clientMethodTag.asString());
+      TagValue clientStatusTag = clientRecord.tags.get(RpcMeasureConstants.GRPC_CLIENT_STATUS);
+      assertEquals(Status.Code.OK.toString(), clientStatusTag.asString());
       assertNull(clientRecord.getMetric(DeprecatedCensusConstants.RPC_CLIENT_ERROR_COUNT));
       TagValue clientPropagatedTag = clientRecord.tags.get(StatsTestUtils.EXTRA_TAG);
       assertEquals("extra-tag-value-897", clientPropagatedTag.asString());
@@ -911,8 +916,8 @@ public class CensusModulesTest {
       assertNotNull(record);
       assertNoClientContent(record);
       assertEquals(1, record.tags.size());
-      TagValue methodTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
-      assertEquals(method.getFullMethodName(), methodTagOld.asString());
+      TagValue methodTag = record.tags.get(RpcMeasureConstants.GRPC_SERVER_METHOD);
+      assertEquals(method.getFullMethodName(), methodTag.asString());
       assertEquals(
           1,
           record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_SERVER_STARTED_COUNT));
@@ -926,7 +931,7 @@ public class CensusModulesTest {
         tagger
             .emptyBuilder()
             .putLocal(
-                DeprecatedCensusConstants.RPC_METHOD,
+                RpcMeasureConstants.GRPC_SERVER_METHOD,
                 TagValue.create(method.getFullMethodName()))
             .build(),
         statsCtx);
@@ -980,10 +985,10 @@ public class CensusModulesTest {
       StatsTestUtils.MetricsRecord record = statsRecorder.pollRecord();
       assertNotNull(record);
       assertNoClientContent(record);
-      TagValue methodTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
-      assertEquals(method.getFullMethodName(), methodTagOld.asString());
-      TagValue statusTagOld = record.tags.get(DeprecatedCensusConstants.RPC_STATUS);
-      assertEquals(Status.Code.CANCELLED.toString(), statusTagOld.asString());
+      TagValue methodTag = record.tags.get(RpcMeasureConstants.GRPC_SERVER_METHOD);
+      assertEquals(method.getFullMethodName(), methodTag.asString());
+      TagValue statusTag = record.tags.get(RpcMeasureConstants.GRPC_SERVER_STATUS);
+      assertEquals(Status.Code.CANCELLED.toString(), statusTag.asString());
       assertEquals(
           1, record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_SERVER_FINISHED_COUNT));
       assertEquals(

--- a/core/src/test/java/io/grpc/internal/CensusModulesTest.java
+++ b/core/src/test/java/io/grpc/internal/CensusModulesTest.java
@@ -1167,7 +1167,7 @@ public class CensusModulesTest {
     assertNull(record.getMetric(DeprecatedCensusConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES));
   }
 
-  @SuppressWarnings("deprecation")
+  @Deprecated
   @Test
   public void newTagsPopulateOldViews() throws InterruptedException {
     StatsComponent localStats = new StatsComponentImpl();
@@ -1212,7 +1212,7 @@ public class CensusModulesTest {
         .isEqualTo(1);
   }
 
-  @SuppressWarnings("deprecation")
+  @Deprecated
   private long getAggregationValueAsLong(StatsComponent localStats, View view,
       List<TagValue> dimension) {
     AggregationData aggregationData = localStats.getViewManager()

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -91,6 +91,7 @@ import io.grpc.testing.integration.Messages.StreamingInputCallRequest;
 import io.grpc.testing.integration.Messages.StreamingInputCallResponse;
 import io.grpc.testing.integration.Messages.StreamingOutputCallRequest;
 import io.grpc.testing.integration.Messages.StreamingOutputCallResponse;
+import io.opencensus.contrib.grpc.metrics.RpcMeasureConstants;
 import io.opencensus.tags.TagKey;
 import io.opencensus.tags.TagValue;
 import io.opencensus.trace.Span;
@@ -796,14 +797,14 @@ public abstract class AbstractInteropTest {
 
     if (metricsExpected()) {
       MetricsRecord clientStartRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
-      checkStartTags(clientStartRecord, "grpc.testing.TestService/StreamingInputCall");
+      checkStartTags(clientStartRecord, "grpc.testing.TestService/StreamingInputCall", true);
       // CensusStreamTracerModule record final status in the interceptor, thus is guaranteed to be
       // recorded.  The tracer stats rely on the stream being created, which is not always the case
       // in this test.  Therefore we don't check the tracer stats.
       MetricsRecord clientEndRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
       checkEndTags(
           clientEndRecord, "grpc.testing.TestService/StreamingInputCall",
-          Status.CANCELLED.getCode());
+          Status.CANCELLED.getCode(), true);
       // Do not check server-side metrics, because the status on the server side is undetermined.
     }
   }
@@ -1117,12 +1118,12 @@ public abstract class AbstractInteropTest {
       // stats.
       MetricsRecord clientStartRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
       checkStartTags(
-          clientStartRecord, "grpc.testing.TestService/StreamingOutputCall");
+          clientStartRecord, "grpc.testing.TestService/StreamingOutputCall", true);
       MetricsRecord clientEndRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
       checkEndTags(
           clientEndRecord,
           "grpc.testing.TestService/StreamingOutputCall",
-          Status.Code.DEADLINE_EXCEEDED);
+          Status.Code.DEADLINE_EXCEEDED, true);
       // Do not check server-side metrics, because the status on the server side is undetermined.
     }
   }
@@ -1153,12 +1154,12 @@ public abstract class AbstractInteropTest {
       // stats.
       MetricsRecord clientStartRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
       checkStartTags(
-          clientStartRecord, "grpc.testing.TestService/StreamingOutputCall");
+          clientStartRecord, "grpc.testing.TestService/StreamingOutputCall", true);
       MetricsRecord clientEndRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
       checkEndTags(
           clientEndRecord,
           "grpc.testing.TestService/StreamingOutputCall",
-          Status.Code.DEADLINE_EXCEEDED);
+          Status.Code.DEADLINE_EXCEEDED, true);
       // Do not check server-side metrics, because the status on the server side is undetermined.
     }
   }
@@ -1182,11 +1183,11 @@ public abstract class AbstractInteropTest {
     // deadline is exceeded before the call is created. Therefore we don't check the tracer stats.
     if (metricsExpected()) {
       MetricsRecord clientStartRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
-      checkStartTags(clientStartRecord, "grpc.testing.TestService/EmptyCall");
+      checkStartTags(clientStartRecord, "grpc.testing.TestService/EmptyCall", true);
       MetricsRecord clientEndRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
       checkEndTags(
           clientEndRecord, "grpc.testing.TestService/EmptyCall",
-          Status.DEADLINE_EXCEEDED.getCode());
+          Status.DEADLINE_EXCEEDED.getCode(), true);
     }
 
     // warm up the channel
@@ -1204,11 +1205,11 @@ public abstract class AbstractInteropTest {
     assertStatsTrace("grpc.testing.TestService/EmptyCall", Status.Code.OK);
     if (metricsExpected()) {
       MetricsRecord clientStartRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
-      checkStartTags(clientStartRecord, "grpc.testing.TestService/EmptyCall");
+      checkStartTags(clientStartRecord, "grpc.testing.TestService/EmptyCall", true);
       MetricsRecord clientEndRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
       checkEndTags(
           clientEndRecord, "grpc.testing.TestService/EmptyCall",
-          Status.DEADLINE_EXCEEDED.getCode());
+          Status.DEADLINE_EXCEEDED.getCode(), true);
     }
   }
 
@@ -1644,12 +1645,12 @@ public abstract class AbstractInteropTest {
       // recorded.  The tracer stats rely on the stream being created, which is not always the case
       // in this test, thus we will not check that.
       MetricsRecord clientStartRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
-      checkStartTags(clientStartRecord, "grpc.testing.TestService/FullDuplexCall");
+      checkStartTags(clientStartRecord, "grpc.testing.TestService/FullDuplexCall", true);
       MetricsRecord clientEndRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
       checkEndTags(
           clientEndRecord,
           "grpc.testing.TestService/FullDuplexCall",
-          Status.DEADLINE_EXCEEDED.getCode());
+          Status.DEADLINE_EXCEEDED.getCode(), true);
     }
   }
 
@@ -1916,9 +1917,9 @@ public abstract class AbstractInteropTest {
       // CensusStreamTracerModule records final status in interceptor, which is guaranteed to be
       // done before application receives status.
       MetricsRecord clientStartRecord = clientStatsRecorder.pollRecord();
-      checkStartTags(clientStartRecord, method);
+      checkStartTags(clientStartRecord, method, true);
       MetricsRecord clientEndRecord = clientStatsRecorder.pollRecord();
-      checkEndTags(clientEndRecord, method, code);
+      checkEndTags(clientEndRecord, method, code, true);
 
       if (requests != null && responses != null) {
         checkCensus(clientEndRecord, false, requests, responses);
@@ -1951,8 +1952,8 @@ public abstract class AbstractInteropTest {
       }
       assertNotNull(serverStartRecord);
       assertNotNull(serverEndRecord);
-      checkStartTags(serverStartRecord, method);
-      checkEndTags(serverEndRecord, method, code);
+      checkStartTags(serverStartRecord, method, false);
+      checkEndTags(serverEndRecord, method, code, false);
       if (requests != null && responses != null) {
         checkCensus(serverEndRecord, true, requests, responses);
       }
@@ -1976,22 +1977,34 @@ public abstract class AbstractInteropTest {
     }
   }
 
-  private static void checkStartTags(MetricsRecord record, String methodName) {
+  private static void checkStartTags(MetricsRecord record, String methodName, boolean clientSide) {
     assertNotNull("record is not null", record);
-    TagValue methodNameTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
-    assertNotNull("method name tagged", methodNameTagOld);
-    assertEquals("method names match", methodName, methodNameTagOld.asString());
+
+    TagKey methodNameTagKey = clientSide
+        ? RpcMeasureConstants.GRPC_CLIENT_METHOD
+        : RpcMeasureConstants.GRPC_SERVER_METHOD;
+    TagValue methodNameTag = record.tags.get(methodNameTagKey);
+    assertNotNull("method name tagged", methodNameTag);
+    assertEquals("method names match", methodName, methodNameTag.asString());
   }
 
   private static void checkEndTags(
-      MetricsRecord record, String methodName, Status.Code status) {
+      MetricsRecord record, String methodName, Status.Code status, boolean clientSide) {
     assertNotNull("record is not null", record);
-    TagValue methodNameTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
-    assertNotNull("method name tagged", methodNameTagOld);
-    assertEquals("method names match", methodName, methodNameTagOld.asString());
-    TagValue statusTagOld = record.tags.get(DeprecatedCensusConstants.RPC_STATUS);
-    assertNotNull("status tagged", statusTagOld);
-    assertEquals(status.toString(), statusTagOld.asString());
+
+    TagKey methodNameTagKey = clientSide
+        ? RpcMeasureConstants.GRPC_CLIENT_METHOD
+        : RpcMeasureConstants.GRPC_SERVER_METHOD;
+    TagValue methodNameTag = record.tags.get(methodNameTagKey);
+    assertNotNull("method name tagged", methodNameTag);
+    assertEquals("method names match", methodName, methodNameTag.asString());
+
+    TagKey statusTagKey = clientSide
+        ? RpcMeasureConstants.GRPC_CLIENT_STATUS
+        : RpcMeasureConstants.GRPC_SERVER_STATUS;
+    TagValue statusTag = record.tags.get(statusTagKey);
+    assertNotNull("status tagged", statusTag);
+    assertEquals(status.toString(), statusTag.asString());
   }
 
   /**


### PR DESCRIPTION
Fixes #5593 and supersedes #5601

Now that https://github.com/census-instrumentation/opencensus-java/pull/1854 has been merged & released as 0.21.0. We can start using the method & status tags.

Background:
Opencensus introduced new tags for status and method (https://github.com/census-instrumentation/opencensus-java/pull/1115). The old views that used those tags were deprecated and new views were created that used the new tags. However grpc-java wasn't updated to use the new tags due to concern of breaking existing metrics. This resulted in the old views being deprecated while the new views were broken (goomics <span>#</span>50).

https://github.com/census-instrumentation/opencensus-java/pull/1854 added a compatibility layer to opencensus that would remap new tags to old tags for old views. This should unblock grpc to switching to the new tags while allowing old views to still be populated. That commit was released as part of opencensus 0.21, which grpc currently uses.