### PR TITLE
xds: Use GracefulSwitchLoadBalancer for XdsLbState

### DIFF
--- a/core/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
@@ -159,4 +159,10 @@ public final class GracefulSwitchLoadBalancer extends ForwardingLoadBalancer {
     pendingLb.shutdown();
     currentLb.shutdown();
   }
+
+  @VisibleForTesting
+  @Nullable
+  String getCurrentPolicyForTest() {
+    return currentPolicyName;
+  }
 }

--- a/core/src/test/java/io/grpc/util/GracefulSwitchLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/util/GracefulSwitchLoadBalancerTest.java
@@ -43,6 +43,7 @@ import java.net.SocketAddress;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -77,6 +78,11 @@ public class GracefulSwitchLoadBalancerTest {
       lbProviders.put(lbPolicy, lbProvider);
       lbRegistry.register(lbProvider);
     }
+  }
+
+  @Nullable
+  public static String getCurrentPolicyForTest(GracefulSwitchLoadBalancer gracefulSwitchLb) {
+    return gracefulSwitchLb.getCurrentPolicyForTest();
   }
 
   @Test

--- a/xds/src/main/java/io/grpc/xds/XdsComms.java
+++ b/xds/src/main/java/io/grpc/xds/XdsComms.java
@@ -421,10 +421,9 @@ final class XdsComms {
   }
 
   // run in SynchronizationContext
-  // TODO: Change method name to shutdown or shutdownXdsComms if that gives better semantics (
-  //  cancel LB RPC and clean up retry timer).
-  void shutdownLbRpc(String message) {
-    adsStream.cancelRpc(message, null);
+  /** Cancels LB RPC and cleans up retry timer.*/
+  void shutdownXdsComms() {
+    adsStream.cancelRpc("shutdown", null);
     cancelRetryTimer();
   }
 

--- a/xds/src/test/java/io/grpc/xds/XdsCommsTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsCommsTest.java
@@ -202,15 +202,15 @@ public class XdsCommsTest {
 
   @Test
   public void shutdownLbRpc_verifyChannelNotShutdown() throws Exception {
-    xdsComms.shutdownLbRpc("shutdown msg1");
+    xdsComms.shutdownXdsComms();
     assertTrue(streamRecorder.awaitCompletion(1, TimeUnit.SECONDS));
     assertEquals(Status.Code.CANCELLED, Status.fromThrowable(streamRecorder.getError()).getCode());
     assertFalse(channel.isShutdown());
   }
 
   @Test
-  public void cancel() throws Exception {
-    xdsComms.shutdownLbRpc("cause1");
+  public void shutdownXdsCommsWillCancelAdsStream() throws Exception {
+    xdsComms.shutdownXdsComms();
     assertTrue(streamRecorder.awaitCompletion(1, TimeUnit.SECONDS));
     assertEquals(Status.Code.CANCELLED, Status.fromThrowable(streamRecorder.getError()).getCode());
   }
@@ -332,7 +332,7 @@ public class XdsCommsTest {
     assertThat(localityEndpointsMappingCaptor.getValue()).containsExactly(
         locality2, localityInfo2, locality1, localityInfo1).inOrder();
 
-    xdsComms.shutdownLbRpc("End test");
+    xdsComms.shutdownXdsComms();
   }
 
   @Test
@@ -468,7 +468,7 @@ public class XdsCommsTest {
     assertThat(localityEndpointsMappingCaptor.getValue()).containsExactly(
         locality2, localityInfo2, locality1, localityInfo1).inOrder();
 
-    xdsComms.shutdownLbRpc("End test");
+    xdsComms.shutdownXdsComms();
   }
 
   @Test
@@ -650,7 +650,7 @@ public class XdsCommsTest {
     assertEquals(1, fakeClock.numPendingTasks(LB_RPC_RETRY_TASK_FILTER));
 
     // Shutdown cancels retry
-    xdsComms.shutdownLbRpc("shutdown");
+    xdsComms.shutdownXdsComms();
     assertEquals(0, fakeClock.numPendingTasks(LB_RPC_RETRY_TASK_FILTER));
   }
 
@@ -663,6 +663,6 @@ public class XdsCommsTest {
     xdsComms.refreshAdsStream();
     assertEquals(0, fakeClock.numPendingTasks(LB_RPC_RETRY_TASK_FILTER));
 
-    xdsComms.shutdownLbRpc("End test");
+    xdsComms.shutdownXdsComms();
   }
 }

--- a/xds/src/test/java/io/grpc/xds/XdsLbStateTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLbStateTest.java
@@ -126,23 +126,22 @@ public class XdsLbStateTest {
     doReturn(channel).when(helper).createResolvingOobChannel(BALANCER_NAME);
 
     xdsLbState = new XdsLbState(
-        BALANCER_NAME, null, helper, localityStore, channel, adsStreamCallback,
-        backoffPolicyProvider);
+        helper, localityStore, channel, adsStreamCallback, backoffPolicyProvider);
   }
 
   @Test
   public void shutdownResetsLocalityStore() {
-    xdsLbState.shutdownAndReleaseChannel("Client shutdown");
+    xdsLbState.shutdown();
     verify(localityStore).reset();
   }
 
   @Test
   public void shutdownDoesNotTearDownChannel() {
-    ManagedChannel lbChannel = xdsLbState.shutdownAndReleaseChannel("Client shutdown");
-    assertThat(lbChannel).isSameInstanceAs(channel);
+    xdsLbState.shutdown();
     assertThat(channel.isShutdown()).isFalse();
   }
 
+  @Deprecated
   @Test
   public void handleResolvedAddressGroupsTriggerEds() throws Exception {
     xdsLbState.handleResolvedAddressGroups(
@@ -151,6 +150,6 @@ public class XdsLbStateTest {
     assertThat(streamRecorder.firstValue().get().getTypeUrl())
         .isEqualTo("type.googleapis.com/envoy.api.v2.ClusterLoadAssignment");
 
-    xdsLbState.shutdownAndReleaseChannel("End test");
+    xdsLbState.shutdown();
   }
 }


### PR DESCRIPTION
- `XdsLbState` now extends `LoadBalancer` (Fixes #5679) (I'm open to refactor its name), in parallel with fallback balancer in `XdsLoadBalancer`.
```
      XdsLoadBalancer
        /         \
xdsLbState   fallbackBalancer
  /...|...\
{lb_with_childPolicy_each_locality}
```
 
- use `GracefulSwitchLoadBalancer`, and then can not use `shutdownAndReleaseChannel()`, so add a field `lbChannel` in `XdsLoadBalancer` to keep track the channel instead.