### PR TITLE
xds: implement a server interceptor for taking server application metrics and sending to client side in ORCA format

### DIFF
--- a/services/src/main/java/io/grpc/services/InternalCallMetricRecorder.java
+++ b/services/src/main/java/io/grpc/services/InternalCallMetricRecorder.java
@@ -16,6 +16,7 @@
 
 package io.grpc.services;
 
+import io.grpc.Context;
 import io.grpc.Internal;
 import java.util.Map;
 
@@ -26,8 +27,14 @@ import java.util.Map;
 @Internal
 public final class InternalCallMetricRecorder {
 
+  public static final Context.Key<CallMetricRecorder> CONTEXT_KEY = CallMetricRecorder.CONTEXT_KEY;
+
   // Prevent instantiation.
   private InternalCallMetricRecorder() {
+  }
+
+  public static CallMetricRecorder newCallMetricRecorder() {
+    return new CallMetricRecorder();
   }
 
   public static Map<String, Double> finalizeAndDump(CallMetricRecorder recorder) {

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -25,7 +25,8 @@ description = "gRPC: XDS plugin"
 dependencies {
     compile project(':grpc-protobuf'),
             project(':grpc-stub'),
-            project(':grpc-core')
+            project(':grpc-core'),
+            project(':grpc-services')
     compile (libraries.protobuf_util) {
         // prefer 26.0-android from libraries instead of 20.0
         exclude group: 'com.google.guava', module: 'guava'
@@ -36,6 +37,7 @@ dependencies {
     compileOnly libraries.javax_annotation
     
     testCompile project(':grpc-testing'), 
+            project(':grpc-testing-proto'),
             libraries.guava_testlib
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
 }

--- a/xds/src/main/java/io/grpc/xds/OrcaMetricReportingServerInterceptor.java
+++ b/xds/src/main/java/io/grpc/xds/OrcaMetricReportingServerInterceptor.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.envoyproxy.udpa.data.orca.v1.OrcaLoadReport;
 import io.grpc.Context;
 import io.grpc.Contexts;
+import io.grpc.ExperimentalApi;
 import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
@@ -37,7 +38,10 @@ import java.util.Map;
  * handling under a {@link Context} that records custom per-request metrics provided by server
  * applications and sends to client side along with the response in the format of Open Request
  * Cost Aggregation (ORCA).
+ *
+ * @since 1.23.0
  */
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/6021")
 public final class OrcaMetricReportingServerInterceptor implements ServerInterceptor {
 
   private static final OrcaMetricReportingServerInterceptor INSTANCE =

--- a/xds/src/main/java/io/grpc/xds/OrcaMetricReportingServerInterceptor.java
+++ b/xds/src/main/java/io/grpc/xds/OrcaMetricReportingServerInterceptor.java
@@ -38,13 +38,24 @@ import java.util.Map;
  * applications and sends to client side along with the response in the format of Open Request
  * Cost Aggregation (ORCA).
  */
-final class OrcaMetricReportingServerInterceptor implements ServerInterceptor {
+public final class OrcaMetricReportingServerInterceptor implements ServerInterceptor {
+
+  private static final OrcaMetricReportingServerInterceptor INSTANCE =
+      new OrcaMetricReportingServerInterceptor();
 
   @VisibleForTesting
   static final Metadata.Key<OrcaLoadReport> ORCA_ENDPOINT_LOAD_METRICS_KEY =
       Metadata.Key.of(
           "x-endpoint-load-metrics-bin",
           ProtoUtils.metadataMarshaller(OrcaLoadReport.getDefaultInstance()));
+
+  @VisibleForTesting
+  OrcaMetricReportingServerInterceptor() {
+  }
+
+  public static OrcaMetricReportingServerInterceptor getInstance() {
+    return INSTANCE;
+  }
 
   @Override
   public <ReqT, RespT> Listener<ReqT> interceptCall(

--- a/xds/src/main/java/io/grpc/xds/OrcaMetricReportingServerInterceptor.java
+++ b/xds/src/main/java/io/grpc/xds/OrcaMetricReportingServerInterceptor.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.envoyproxy.udpa.data.orca.v1.OrcaLoadReport;
+import io.grpc.Context;
+import io.grpc.Contexts;
+import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import io.grpc.protobuf.ProtoUtils;
+import io.grpc.services.CallMetricRecorder;
+import io.grpc.services.InternalCallMetricRecorder;
+import java.util.Map;
+
+/**
+ * A {@link ServerInterceptor} that intercepts a {@link ServerCall} by running server-side RPC
+ * handling under a {@link Context} that records custom per-request metrics provided by server
+ * applications and sends to client side along with the response in the format of Open Request
+ * Cost Aggregation (ORCA).
+ */
+final class OrcaMetricReportingServerInterceptor implements ServerInterceptor {
+
+  @VisibleForTesting
+  static final Metadata.Key<OrcaLoadReport> ORCA_ENDPOINT_LOAD_METRICS_KEY =
+      Metadata.Key.of(
+          "x-endpoint-load-metrics-bin",
+          ProtoUtils.metadataMarshaller(OrcaLoadReport.getDefaultInstance()));
+
+  @Override
+  public <ReqT, RespT> Listener<ReqT> interceptCall(
+      ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+    ServerCall<ReqT, RespT> trailerAttachingCall =
+        new SimpleForwardingServerCall<ReqT, RespT>(call) {
+          @Override
+          public void close(Status status, Metadata trailers) {
+            Map<String, Double> metricValues =
+                InternalCallMetricRecorder.finalizeAndDump(CallMetricRecorder.getCurrent());
+            // Only attach a metric report if there are some metric values to be reported.
+            if (!metricValues.isEmpty()) {
+              OrcaLoadReport report =
+                  OrcaLoadReport.newBuilder().putAllRequestCost(metricValues).build();
+              trailers.put(ORCA_ENDPOINT_LOAD_METRICS_KEY, report);
+            }
+            super.close(status, trailers);
+          }
+        };
+    final CallMetricRecorder recorder = InternalCallMetricRecorder.newCallMetricRecorder();
+    return Contexts.interceptCall(
+        Context.current().withValue(InternalCallMetricRecorder.CONTEXT_KEY, recorder),
+        trailerAttachingCall,
+        headers,
+        next);
+  }
+}

--- a/xds/src/test/java/io/grpc/xds/OrcaMetricReportingServerInterceptorTest.java
+++ b/xds/src/test/java/io/grpc/xds/OrcaMetricReportingServerInterceptorTest.java
@@ -44,7 +44,6 @@ import io.grpc.testing.protobuf.SimpleServiceGrpc;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -70,7 +69,6 @@ public class OrcaMetricReportingServerInterceptorTest {
 
   private final AtomicReference<Metadata> trailersCapture = new AtomicReference<>();
 
-  private ManagedChannel baseChannel;
   private Channel channelToUse;
 
   @Before
@@ -100,15 +98,11 @@ public class OrcaMetricReportingServerInterceptorTest {
                 ServerInterceptors.intercept(simpleServiceImpl, metricReportingServerInterceptor))
             .build().start());
 
-    baseChannel = InProcessChannelBuilder.forName(serverName).build();
+    ManagedChannel baseChannel =
+        grpcCleanupRule.register(InProcessChannelBuilder.forName(serverName).build());
     channelToUse =
         ClientInterceptors.intercept(
             baseChannel, new TrailersCapturingClientInterceptor(trailersCapture));
-  }
-
-  @After
-  public void tearDown() {
-    baseChannel.shutdown();
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/OrcaMetricReportingServerInterceptorTest.java
+++ b/xds/src/test/java/io/grpc/xds/OrcaMetricReportingServerInterceptorTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.envoyproxy.udpa.data.orca.v1.OrcaLoadReport;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
+import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerInterceptors;
+import io.grpc.Status;
+import io.grpc.services.CallMetricRecorder;
+import io.grpc.stub.ClientCalls;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcServerRule;
+import io.grpc.testing.protobuf.SimpleRequest;
+import io.grpc.testing.protobuf.SimpleResponse;
+import io.grpc.testing.protobuf.SimpleServiceGrpc;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link OrcaMetricReportingServerInterceptor}.
+ */
+@RunWith(JUnit4.class)
+public class OrcaMetricReportingServerInterceptorTest {
+
+  @Rule public final GrpcServerRule grpcServerRule = new GrpcServerRule().directExecutor();
+
+  private final MethodDescriptor<SimpleRequest, SimpleResponse> simpleMethod =
+      SimpleServiceGrpc.getUnaryRpcMethod();
+
+  private final SimpleRequest request =
+      SimpleRequest.newBuilder().setRequestMessage("Simple request").build();
+
+  private final Map<String, Double> applicationMetrics = new HashMap<>();
+
+  private final AtomicReference<Metadata> trailersCapture = new AtomicReference<>();
+
+  private ManagedChannel baseChannel;
+  private Channel channelToUse;
+
+  @Before
+  public void setUp() {
+    SimpleServiceGrpc.SimpleServiceImplBase simpleServiceImpl =
+        new SimpleServiceGrpc.SimpleServiceImplBase() {
+          @Override
+          public void unaryRpc(
+              SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            for (Map.Entry<String, Double> entry : applicationMetrics.entrySet()) {
+              CallMetricRecorder.getCurrent().recordCallMetric(entry.getKey(), entry.getValue());
+            }
+            SimpleResponse response =
+                SimpleResponse.newBuilder().setResponseMessage("Simple response").build();
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+          }
+        };
+
+    ServerInterceptor metricReportingServerInterceptor = new OrcaMetricReportingServerInterceptor();
+    grpcServerRule
+        .getServiceRegistry()
+        .addService(
+            ServerInterceptors.intercept(simpleServiceImpl, metricReportingServerInterceptor));
+
+    baseChannel = grpcServerRule.getChannel();
+    channelToUse =
+        ClientInterceptors.intercept(
+            baseChannel, new TrailersCapturingClientInterceptor(trailersCapture));
+  }
+
+  @After
+  public void tearDown() {
+    baseChannel.shutdown();
+  }
+
+  @Test
+  public void noTrailerReportIfNoRecordedMetrics() {
+    ClientCalls.blockingUnaryCall(channelToUse, simpleMethod, CallOptions.DEFAULT, request);
+    Metadata receivedTrailers = trailersCapture.get();
+    assertThat(
+        receivedTrailers.get(OrcaMetricReportingServerInterceptor.ORCA_ENDPOINT_LOAD_METRICS_KEY))
+        .isNull();
+  }
+
+  @Test
+  public void responseTrailersContainAllReportedMetrics() {
+    applicationMetrics.put("cost1", 1231.4543);
+    applicationMetrics.put("cost2", 0.1367);
+    applicationMetrics.put("cost3", 7614.145);
+    ClientCalls.blockingUnaryCall(channelToUse, simpleMethod, CallOptions.DEFAULT, request);
+    Metadata receivedTrailers = trailersCapture.get();
+    OrcaLoadReport report =
+        receivedTrailers.get(OrcaMetricReportingServerInterceptor.ORCA_ENDPOINT_LOAD_METRICS_KEY);
+    assertThat(report.getRequestCostMap())
+        .containsExactly("cost1", 1231.4543, "cost2", 0.1367, "cost3", 7614.145);
+  }
+
+  private static final class TrailersCapturingClientInterceptor implements ClientInterceptor {
+    final AtomicReference<Metadata> trailersCapture;
+
+    TrailersCapturingClientInterceptor(AtomicReference<Metadata> trailersCapture) {
+      this.trailersCapture = trailersCapture;
+    }
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+      return new TrailersCapturingClientCall<>(next.newCall(method, callOptions));
+    }
+
+    private final class TrailersCapturingClientCall<ReqT, RespT>
+        extends SimpleForwardingClientCall<ReqT, RespT> {
+
+      TrailersCapturingClientCall(ClientCall<ReqT, RespT> call) {
+        super(call);
+      }
+
+      @Override
+      public void start(Listener<RespT> responseListener, Metadata headers) {
+        trailersCapture.set(null);
+        super.start(new TrailersCapturingClientCallListener(responseListener), headers);
+      }
+
+      private final class TrailersCapturingClientCallListener
+          extends SimpleForwardingClientCallListener<RespT> {
+        TrailersCapturingClientCallListener(ClientCall.Listener<RespT> responseListener) {
+          super(responseListener);
+        }
+
+        @Override
+        public void onClose(Status status, Metadata trailers) {
+          trailersCapture.set(trailers);
+          super.onClose(status, trailers);
+        }
+      }
+    }
+  }
+}

--- a/xds/src/test/java/io/grpc/xds/OrcaMetricReportingServerInterceptorTest.java
+++ b/xds/src/test/java/io/grpc/xds/OrcaMetricReportingServerInterceptorTest.java
@@ -60,10 +60,10 @@ public class OrcaMetricReportingServerInterceptorTest {
   @Rule
   public final GrpcCleanupRule grpcCleanupRule = new GrpcCleanupRule();
 
-  private final MethodDescriptor<SimpleRequest, SimpleResponse> simpleMethod =
+  private static final MethodDescriptor<SimpleRequest, SimpleResponse> SIMPLE_METHOD =
       SimpleServiceGrpc.getUnaryRpcMethod();
 
-  private final SimpleRequest request =
+  private static final SimpleRequest REQUEST =
       SimpleRequest.newBuilder().setRequestMessage("Simple request").build();
 
   private final Map<String, Double> applicationMetrics = new HashMap<>();
@@ -113,7 +113,7 @@ public class OrcaMetricReportingServerInterceptorTest {
 
   @Test
   public void noTrailerReportIfNoRecordedMetrics() {
-    ClientCalls.blockingUnaryCall(channelToUse, simpleMethod, CallOptions.DEFAULT, request);
+    ClientCalls.blockingUnaryCall(channelToUse, SIMPLE_METHOD, CallOptions.DEFAULT, REQUEST);
     Metadata receivedTrailers = trailersCapture.get();
     assertThat(
         receivedTrailers.get(OrcaMetricReportingServerInterceptor.ORCA_ENDPOINT_LOAD_METRICS_KEY))
@@ -125,7 +125,7 @@ public class OrcaMetricReportingServerInterceptorTest {
     applicationMetrics.put("cost1", 1231.4543);
     applicationMetrics.put("cost2", 0.1367);
     applicationMetrics.put("cost3", 7614.145);
-    ClientCalls.blockingUnaryCall(channelToUse, simpleMethod, CallOptions.DEFAULT, request);
+    ClientCalls.blockingUnaryCall(channelToUse, SIMPLE_METHOD, CallOptions.DEFAULT, REQUEST);
     Metadata receivedTrailers = trailersCapture.get();
     OrcaLoadReport report =
         receivedTrailers.get(OrcaMetricReportingServerInterceptor.ORCA_ENDPOINT_LOAD_METRICS_KEY);


### PR DESCRIPTION
`ServerInterceptor` for intercepting server calls with context of holding a `CallMetricRecorder` and attaching saved metric values in RPC trailers in ORCA format.

PS: let me know if missing any important test cases.
