### PR TITLE
services: add even more (context-related) test cases for CallMetricRecorder

### DIFF
--- a/services/src/main/java/io/grpc/services/CallMetricRecorder.java
+++ b/services/src/main/java/io/grpc/services/CallMetricRecorder.java
@@ -16,6 +16,7 @@
 
 package io.grpc.services;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.grpc.Context;
 import io.grpc.ExperimentalApi;
 import java.util.Collections;
@@ -94,6 +95,11 @@ public final class CallMetricRecorder {
       return Collections.emptyMap();
     }
     return Collections.unmodifiableMap(savedMetrics);
+  }
+
+  @VisibleForTesting
+  boolean isDisabled() {
+    return disabled;
   }
 
   /**

--- a/services/src/test/java/io/grpc/services/CallMetricRecorderTest.java
+++ b/services/src/test/java/io/grpc/services/CallMetricRecorderTest.java
@@ -18,6 +18,7 @@ package io.grpc.services;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import io.grpc.Context;
 import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -62,5 +63,29 @@ public class CallMetricRecorderTest {
     Map<String, Double> dump = recorder.finalizeAndDump();
     assertThat(dump)
         .containsExactly("cost1", 4654.67, "cost2", 75.83);
+  }
+
+  @Test
+  public void getCurrent_sameEnabledInstance() {
+    CallMetricRecorder recorder = new CallMetricRecorder();
+    Context ctx = Context.ROOT.withValue(CallMetricRecorder.CONTEXT_KEY, recorder);
+    Context origCtx = ctx.attach();
+    try {
+      assertThat(CallMetricRecorder.getCurrent()).isSameInstanceAs(recorder);
+      assertThat(recorder.isDisabled()).isFalse();
+    } finally {
+      ctx.detach(origCtx);
+    }
+  }
+
+  @Test
+  public void getCurrent_blankContext() {
+    Context blankCtx = Context.ROOT;
+    Context origCtx = blankCtx.attach();
+    try {
+      assertThat(CallMetricRecorder.getCurrent().isDisabled()).isTrue();
+    } finally {
+      blankCtx.detach(origCtx);
+    }
   }
 }


### PR DESCRIPTION
The internal implementation of `CallMetricRecorder` will be deleted. Found another two test methods used to exist in the old version.