### PR TITLE
core: allow setting custom Deadline.Ticker to InProcessServerBuilder

### DIFF
--- a/context/src/main/java/io/grpc/Deadline.java
+++ b/context/src/main/java/io/grpc/Deadline.java
@@ -169,6 +169,11 @@ public final class Deadline implements Comparable<Deadline> {
 
   /**
    * Schedule a task to be run when the deadline expires.
+   *
+   * <p>Note if this deadline was created with a custom {@link Ticker}, the {@code scheduler}'s
+   * underlying clock should be synchronized with that Ticker.  Otherwise the task won't be run at
+   * the expected point of time.
+   *
    * @param task to run on expiration
    * @param scheduler used to execute the task
    * @return {@link ScheduledFuture} which can be used to cancel execution of the task
@@ -195,7 +200,7 @@ public final class Deadline implements Comparable<Deadline> {
     }
     buf.append("s from now");
     if (ticker != SYSTEM_TICKER) {
-      buf.append("(ticker=" + ticker + ")");
+      buf.append(" (ticker=" + ticker + ")");
     }
     return buf.toString();
   }
@@ -219,6 +224,10 @@ public final class Deadline implements Comparable<Deadline> {
 
   /**
    * Time source representing nanoseconds since fixed but arbitrary point in time.
+   *
+   * <p>DO NOT use custom {@link Ticker} implementations in production, because deadlines created
+   * with custom tickers are incompatible with those created with the system ticker.  Always use
+   * the {@link #getSystemTicker system ticker} whenever you need to provide one in production code.
    *
    * <p>This is <strong>EXPERIMENTAL</strong> API and may subject to change.  If you'd like it to be
    * stabilized or have any feedback, please

--- a/context/src/main/java/io/grpc/Deadline.java
+++ b/context/src/main/java/io/grpc/Deadline.java
@@ -261,7 +261,7 @@ public final class Deadline implements Comparable<Deadline> {
     if (ticker != other.ticker) {
       throw new AssertionError(
           "Tickers (" + ticker + " and " + other.ticker + ") don't match."
-          + " Custom Ticker should only be used in  tests!");
+          + " Custom Ticker should only be used in tests!");
     }
   }
 }

--- a/context/src/test/java/io/grpc/DeadlineTest.java
+++ b/context/src/test/java/io/grpc/DeadlineTest.java
@@ -17,6 +17,7 @@
 package io.grpc;
 
 import static com.google.common.truth.Truth.assertAbout;
+import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.testing.DeadlineSubject.deadline;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -209,9 +210,15 @@ public class DeadlineTest {
   }
 
   @Test
+  public void toString_systemTickerNotShown() {
+    Deadline d = Deadline.after(0, TimeUnit.MILLISECONDS);
+    assertThat(d.toString()).endsWith("s from now");
+  }
+
+  @Test
   public void toString_exact() {
     Deadline d = Deadline.after(0, TimeUnit.MILLISECONDS, ticker);
-    assertEquals("0s from now", d.toString());
+    assertEquals("0s from now (ticker=FAKE_TICKER)", d.toString());
   }
 
   @Test
@@ -219,17 +226,17 @@ public class DeadlineTest {
     Deadline d;
 
     d = Deadline.after(-1, TimeUnit.MINUTES, ticker);
-    assertEquals("-60s from now", d.toString());
+    assertEquals("-60s from now (ticker=FAKE_TICKER)", d.toString());
     d = Deadline.after(-1, TimeUnit.MILLISECONDS, ticker);
-    assertEquals("-0.001000000s from now", d.toString());
+    assertEquals("-0.001000000s from now (ticker=FAKE_TICKER)", d.toString());
     d = Deadline.after(-500, TimeUnit.MILLISECONDS, ticker);
-    assertEquals("-0.500000000s from now", d.toString());
+    assertEquals("-0.500000000s from now (ticker=FAKE_TICKER)", d.toString());
     d = Deadline.after(-1000, TimeUnit.MILLISECONDS, ticker);
-    assertEquals("-1s from now", d.toString());
+    assertEquals("-1s from now (ticker=FAKE_TICKER)", d.toString());
     d = Deadline.after(-1500, TimeUnit.MILLISECONDS, ticker);
-    assertEquals("-1.500000000s from now", d.toString());
+    assertEquals("-1.500000000s from now (ticker=FAKE_TICKER)", d.toString());
     d = Deadline.after(-1023456789, TimeUnit.NANOSECONDS, ticker);
-    assertEquals("-1.023456789s from now", d.toString());
+    assertEquals("-1.023456789s from now (ticker=FAKE_TICKER)", d.toString());
   }
 
   @Test
@@ -278,6 +285,11 @@ public class DeadlineTest {
         throw new IllegalArgumentException();
       }
       this.time += unit.toNanos(period);
+    }
+
+    @Override
+    public String toString() {
+      return "FAKE_TICKER";
     }
   }
 }

--- a/context/src/test/java/io/grpc/DeadlineTest.java
+++ b/context/src/test/java/io/grpc/DeadlineTest.java
@@ -70,6 +70,18 @@ public class DeadlineTest {
   }
 
   @Test
+  public void minimum() {
+    Deadline d1 = Deadline.after(1, TimeUnit.MINUTES, ticker);
+    Deadline d2 = Deadline.after(2, TimeUnit.MINUTES, ticker);
+    Deadline d3 = Deadline.after(3, TimeUnit.MINUTES, ticker);
+
+    assertThat(d1.minimum(d2)).isSameInstanceAs(d1);
+    assertThat(d2.minimum(d1)).isSameInstanceAs(d1);
+    assertThat(d3.minimum(d2)).isSameInstanceAs(d2);
+    assertThat(d2.minimum(d3)).isSameInstanceAs(d2);
+  }
+
+  @Test
   public void timeCanOverflow() {
     ticker.reset(Long.MAX_VALUE);
     Deadline d = Deadline.after(10, TimeUnit.DAYS, ticker);
@@ -263,9 +275,39 @@ public class DeadlineTest {
   }
 
   @Test
+  public void tickersDontMatch() {
+    Deadline d1 = Deadline.after(10, TimeUnit.SECONDS);
+    Deadline d2 = Deadline.after(10, TimeUnit.SECONDS, ticker);
+    boolean success = false;
+    try {
+      d1.compareTo(d2);
+      success = true;
+    } catch (AssertionError e) {
+      // Expected
+    }
+    assertFalse(success);
+
+    try {
+      d1.minimum(d2);
+      success = true;
+    } catch (AssertionError e) {
+      // Expected
+    }
+    assertFalse(success);
+
+    try {
+      d1.isBefore(d2);
+      success = true;
+    } catch (AssertionError e) {
+      // Expected
+    }
+    assertFalse(success);
+  }
+
+  @Test
   public void toString_before() {
     Deadline d = Deadline.after(12, TimeUnit.MICROSECONDS, ticker);
-    assertEquals("0.000012000s from now", d.toString());
+    assertEquals("0.000012000s from now (ticker=FAKE_TICKER)", d.toString());
   }
 
   private static class FakeTicker extends Deadline.Ticker {

--- a/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
@@ -19,6 +19,7 @@ package io.grpc.inprocess;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Preconditions;
+import io.grpc.Deadline;
 import io.grpc.ExperimentalApi;
 import io.grpc.ServerStreamTracer;
 import io.grpc.internal.AbstractServerImplBuilder;
@@ -122,6 +123,24 @@ public final class InProcessServerBuilder
       ScheduledExecutorService scheduledExecutorService) {
     schedulerPool = new FixedObjectPool<>(
         checkNotNull(scheduledExecutorService, "scheduledExecutorService"));
+    return this;
+  }
+
+  /**
+   * Provides a custom deadline ticker that this server will use to create incoming {@link
+   * Deadline}s.
+   *
+   * <p>This intended for unit tests that fake out the clock.  You should also have a fake {@link
+   * ScheduledExecutorService} whose clock is synchronized with this ticker and set it to {@link
+   * #scheduledExecutorService}. DO NOT use this in production.
+   *
+   * @return this
+   * @see Deadline#create(long, TimeUnit, Deadline.Ticker)
+   *
+   * @since 1.24.0
+   */
+  public InProcessServerBuilder deadlineTicker(Deadline.Ticker ticker) {
+    setDeadlineTicker(ticker);
     return this;
   }
 

--- a/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
@@ -130,12 +130,12 @@ public final class InProcessServerBuilder
    * Provides a custom deadline ticker that this server will use to create incoming {@link
    * Deadline}s.
    *
-   * <p>This intended for unit tests that fake out the clock.  You should also have a fake {@link
+   * <p>This is intended for unit tests that fake out the clock.  You should also have a fake {@link
    * ScheduledExecutorService} whose clock is synchronized with this ticker and set it to {@link
    * #scheduledExecutorService}. DO NOT use this in production.
    *
    * @return this
-   * @see Deadline#create(long, TimeUnit, Deadline.Ticker)
+   * @see Deadline#after(long, TimeUnit, Deadline.Ticker)
    *
    * @since 1.24.0
    */

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -25,6 +25,7 @@ import io.grpc.BinaryLog;
 import io.grpc.BindableService;
 import io.grpc.CompressorRegistry;
 import io.grpc.Context;
+import io.grpc.Deadline;
 import io.grpc.DecompressorRegistry;
 import io.grpc.HandlerRegistry;
 import io.grpc.InternalChannelz;
@@ -78,6 +79,7 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
   DecompressorRegistry decompressorRegistry = DEFAULT_DECOMPRESSOR_REGISTRY;
   CompressorRegistry compressorRegistry = DEFAULT_COMPRESSOR_REGISTRY;
   long handshakeTimeoutMillis = DEFAULT_HANDSHAKE_TIMEOUT_MILLIS;
+  Deadline.Ticker ticker = Deadline.getSystemTicker();
   @Nullable private CensusStatsModule censusStatsOverride;
   private boolean statsEnabled = true;
   private boolean recordStartedRpcs = true;
@@ -214,6 +216,13 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
    */
   protected void setTracingEnabled(boolean value) {
     tracingEnabled = value;
+  }
+
+  /**
+   * Sets a custom deadline ticker.  This should only be called from InProcessServerBuilder.
+   */
+  protected void setDeadlineTicker(Deadline.Ticker ticker) {
+    this.ticker = checkNotNull(ticker, "ticker");
   }
 
   @Override

--- a/core/src/test/java/io/grpc/inprocess/InProcessServerBuilderTest.java
+++ b/core/src/test/java/io/grpc/inprocess/InProcessServerBuilderTest.java
@@ -89,4 +89,15 @@ public class InProcessServerBuilderTest {
 
     scheduledExecutorServicePool.returnObject(scheduledExecutorService);
   }
+
+  @Test
+  public void customDeadlineTicker() {
+    MethodDescriptor<String, Integer> method = MethodDescriptor.<String, Integer>newBuilder()
+        .setType(MethodDescriptor.MethodType.UNKNOWN)
+        .setFullMethodName("Waiter/serve")
+        .setRequestMarshaller(IntegerMarshaller.INSTANCE)
+        .setResponseMarshaller(StringMarshaller.INSTANCE)
+        .build();
+    InProcessServerBuilder builder = InProcessServerBuilder.forName("foo");
+  }
 }

--- a/core/src/test/java/io/grpc/inprocess/InProcessServerBuilderTest.java
+++ b/core/src/test/java/io/grpc/inprocess/InProcessServerBuilderTest.java
@@ -89,15 +89,4 @@ public class InProcessServerBuilderTest {
 
     scheduledExecutorServicePool.returnObject(scheduledExecutorService);
   }
-
-  @Test
-  public void customDeadlineTicker() {
-    MethodDescriptor<String, Integer> method = MethodDescriptor.<String, Integer>newBuilder()
-        .setType(MethodDescriptor.MethodType.UNKNOWN)
-        .setFullMethodName("Waiter/serve")
-        .setRequestMarshaller(IntegerMarshaller.INSTANCE)
-        .setResponseMarshaller(StringMarshaller.INSTANCE)
-        .build();
-    InProcessServerBuilder builder = InProcessServerBuilder.forName("foo");
-  }
 }

--- a/core/src/test/java/io/grpc/internal/FakeClock.java
+++ b/core/src/test/java/io/grpc/internal/FakeClock.java
@@ -20,6 +20,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
 import com.google.common.base.Ticker;
 import com.google.common.util.concurrent.AbstractFuture;
+import io.grpc.Deadline;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -57,6 +58,13 @@ public final class FakeClock {
   private final Ticker ticker =
       new Ticker() {
         @Override public long read() {
+          return currentTimeNanos;
+        }
+      };
+
+  private final Deadline.Ticker deadlineTicker =
+      new Deadline.Ticker() {
+        @Override public long nanoTime() {
           return currentTimeNanos;
         }
       };
@@ -227,6 +235,13 @@ public final class FakeClock {
    */
   public Ticker getTicker() {
     return ticker;
+  }
+
+  /**
+   * Deadline ticker of the FakeClock.
+   */
+  public Deadline.Ticker getDeadlineTicker() {
+    return deadlineTicker;
   }
 
   /**

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -19,6 +19,7 @@ package io.grpc.internal;
 import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.InternalChannelz.id;
 import static io.grpc.internal.GrpcUtil.MESSAGE_ENCODING_KEY;
+import static io.grpc.internal.GrpcUtil.TIMEOUT_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -199,6 +200,7 @@ public class ServerImplTest {
   public void startUp() throws IOException {
     MockitoAnnotations.initMocks(this);
     builder.channelz = channelz;
+    builder.ticker = timer.getDeadlineTicker();
     streamTracerFactories = Arrays.asList(streamTracerFactory);
     when(executorPool.getObject()).thenReturn(executor.getScheduledExecutorService());
     when(streamTracerFactory.newServerStreamTracer(anyString(), any(Metadata.class)))
@@ -977,10 +979,11 @@ public class ServerImplTest {
     verify(stream, times(0)).close(isA(Status.class), ArgumentMatchers.<Metadata>isNotNull());
   }
 
-  private ServerStreamListener testClientClose_setup(
+  private ServerStreamListener testStreamClose_setup(
       final AtomicReference<ServerCall<String, Integer>> callReference,
       final AtomicReference<Context> context,
-      final AtomicBoolean contextCancelled) throws Exception {
+      final AtomicBoolean contextCancelled,
+      @Nullable Long timeoutNanos) throws Exception {
     createAndStartServer();
     callListener = new ServerCall.Listener<String>() {
       @Override
@@ -1011,6 +1014,9 @@ public class ServerImplTest {
         = transportServer.registerNewServerTransport(new SimpleServerTransport());
     transportListener.transportReady(Attributes.EMPTY);
     Metadata requestHeaders = new Metadata();
+    if (timeoutNanos != null) {
+      requestHeaders.put(TIMEOUT_KEY, timeoutNanos);
+    }
     StatsTraceContext statsTraceCtx =
         StatsTraceContext.newServerContext(streamTracerFactories, "Waitier/serve", requestHeaders);
     when(stream.statsTraceContext()).thenReturn(statsTraceCtx);
@@ -1025,14 +1031,14 @@ public class ServerImplTest {
   }
 
   @Test
-  public void testClientClose_cancelTriggersImmediateCancellation() throws Exception {
+  public void testStreamClose_clientCancelTriggersImmediateCancellation() throws Exception {
     AtomicBoolean contextCancelled = new AtomicBoolean(false);
     AtomicReference<Context> context = new AtomicReference<>();
     AtomicReference<ServerCall<String, Integer>> callReference
         = new AtomicReference<>();
 
-    ServerStreamListener streamListener = testClientClose_setup(callReference,
-        context, contextCancelled);
+    ServerStreamListener streamListener = testStreamClose_setup(callReference,
+        context, contextCancelled, null);
 
     // For close status being non OK:
     // isCancelled is expected to be true immediately after calling closed(), without needing
@@ -1048,14 +1054,14 @@ public class ServerImplTest {
   }
 
   @Test
-  public void testClientClose_OkTriggersDelayedCancellation() throws Exception {
+  public void testStreamClose_clientOkTriggersDelayedCancellation() throws Exception {
     AtomicBoolean contextCancelled = new AtomicBoolean(false);
     AtomicReference<Context> context = new AtomicReference<>();
     AtomicReference<ServerCall<String, Integer>> callReference
         = new AtomicReference<>();
 
-    ServerStreamListener streamListener = testClientClose_setup(callReference,
-        context, contextCancelled);
+    ServerStreamListener streamListener = testStreamClose_setup(callReference,
+        context, contextCancelled, null);
 
     // For close status OK:
     // isCancelled is expected to be true after all pending work is done
@@ -1066,6 +1072,27 @@ public class ServerImplTest {
     assertFalse(context.get().isCancelled());
 
     assertEquals(1, executor.runDueTasks());
+    assertTrue(callReference.get().isCancelled());
+    assertTrue(context.get().isCancelled());
+    assertTrue(contextCancelled.get());
+  }
+
+  @Test
+  public void testStreamClose_deadlineExceededTriggersImmediateCancellation() throws Exception {
+    AtomicBoolean contextCancelled = new AtomicBoolean(false);
+    AtomicReference<Context> context = new AtomicReference<>();
+    AtomicReference<ServerCall<String, Integer>> callReference
+        = new AtomicReference<>();
+
+    testStreamClose_setup(callReference, context, contextCancelled, 50L);
+
+    timer.forwardNanos(49);
+
+    assertFalse(callReference.get().isCancelled());
+    assertFalse(context.get().isCancelled());
+
+    assertEquals(1, timer.forwardNanos(1));
+    
     assertTrue(callReference.get().isCancelled());
     assertTrue(context.get().isCancelled());
     assertTrue(contextCancelled.get());


### PR DESCRIPTION
`ServerImpl` uses that ticker to create incoming `Deadline`s. This feature is specifically restricted to in-process, as it can also customize `ScheduledExecutorService`, and them together can fake out the clock which is useful in tests. On the other hand, a fake `Ticker` won't work with Netty's `ScheduledExecutorService`.

Also improved mismatch detection, documentation and tests in `Deadline`.

Resolves #2531
