### PR TITLE
okhttp: add PerfMark tracing for okhttp transport

### DIFF
--- a/okhttp/BUILD.bazel
+++ b/okhttp/BUILD.bazel
@@ -16,5 +16,6 @@ java_library(
         "@com_google_j2objc_j2objc_annotations//jar",
         "@com_squareup_okhttp_okhttp//jar",
         "@com_squareup_okio_okio//jar",
+        "@io_perfmark_perfmark_api//jar",
     ],
 )

--- a/okhttp/src/main/java/io/grpc/okhttp/AsyncSink.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/AsyncSink.java
@@ -80,24 +80,36 @@ final class AsyncSink implements Sink {
     if (closed) {
       throw new IOException("closed");
     }
-    synchronized (lock) {
-      buffer.write(source, byteCount);
-      if (writeEnqueued || flushEnqueued || buffer.completeSegmentByteCount() <= 0) {
-        return;
-      }
-      writeEnqueued = true;
-    }
-    serializingExecutor.execute(new WriteRunnable() {
-      @Override
-      public void doRun() throws IOException {
-        Buffer buf = new Buffer();
-        synchronized (lock) {
-          buf.write(buffer, buffer.completeSegmentByteCount());
-          writeEnqueued = false;
+    PerfMark.startTask("AsyncSink.write");
+    try {
+      synchronized (lock) {
+        buffer.write(source, byteCount);
+        if (writeEnqueued || flushEnqueued || buffer.completeSegmentByteCount() <= 0) {
+          return;
         }
-        sink.write(buf, buf.size());
+        writeEnqueued = true;
       }
-    });
+      serializingExecutor.execute(new WriteRunnable() {
+        final Link link = PerfMark.linkOut();
+        @Override
+        public void doRun() throws IOException {
+          PerfMark.startTask("WriteRunnable.runWrite");
+          PerfMark.linkIn(link);
+          Buffer buf = new Buffer();
+          try {
+            synchronized (lock) {
+              buf.write(buffer, buffer.completeSegmentByteCount());
+              writeEnqueued = false;
+            }
+            sink.write(buf, buf.size());
+          } finally {
+            PerfMark.stopTask("WriteRunnable.runWrite");
+          }
+        }
+      });
+    } finally {
+      PerfMark.stopTask("AsyncSink.write");
+    }
   }
 
   @Override
@@ -105,24 +117,36 @@ final class AsyncSink implements Sink {
     if (closed) {
       throw new IOException("closed");
     }
-    synchronized (lock) {
-      if (flushEnqueued) {
-        return;
-      }
-      flushEnqueued = true;
-    }
-    serializingExecutor.execute(new WriteRunnable() {
-      @Override
-      public void doRun() throws IOException {
-        Buffer buf = new Buffer();
-        synchronized (lock) {
-          buf.write(buffer, buffer.size());
-          flushEnqueued = false;
+    PerfMark.startTask("AsyncSink.flush");
+    try {
+      synchronized (lock) {
+        if (flushEnqueued) {
+          return;
         }
-        sink.write(buf, buf.size());
-        sink.flush();
+        flushEnqueued = true;
       }
-    });
+      serializingExecutor.execute(new WriteRunnable() {
+        final Link link = PerfMark.linkOut();
+        @Override
+        public void doRun() throws IOException {
+          PerfMark.startTask("WriteRunnable.runFlush");
+          PerfMark.linkIn(link);
+          Buffer buf = new Buffer();
+          try {
+            synchronized (lock) {
+              buf.write(buffer, buffer.size());
+              flushEnqueued = false;
+            }
+            sink.write(buf, buf.size());
+            sink.flush();
+          } finally {
+            PerfMark.stopTask("WriteRunnable.runFlush");
+          }
+        }
+      });
+    } finally {
+      PerfMark.stopTask("AsyncSink.flush");
+    }
   }
 
   @Override
@@ -159,17 +183,8 @@ final class AsyncSink implements Sink {
   }
 
   private abstract class WriteRunnable implements Runnable {
-
-    private final Link link;
-
-    WriteRunnable() {
-      this.link = PerfMark.linkOut();
-    }
-
     @Override
     public final void run() {
-      PerfMark.startTask("WriteRunnable.run");
-      PerfMark.linkIn(link);
       try {
         if (sink == null) {
           throw new IOException("Unable to perform write due to unavailable sink.");
@@ -177,8 +192,6 @@ final class AsyncSink implements Sink {
         doRun();
       } catch (Exception e) {
         transportExceptionHandler.onException(e);
-      } finally {
-        PerfMark.stopTask("WriteRunnable.run");
       }
     }
 

--- a/okhttp/src/main/java/io/grpc/okhttp/AsyncSink.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/AsyncSink.java
@@ -21,6 +21,8 @@ import static com.google.common.base.Preconditions.checkState;
 
 import io.grpc.internal.SerializingExecutor;
 import io.grpc.okhttp.ExceptionHandlingFrameWriter.TransportExceptionHandler;
+import io.perfmark.Link;
+import io.perfmark.PerfMark;
 import java.io.IOException;
 import java.net.Socket;
 import javax.annotation.Nullable;
@@ -157,8 +159,17 @@ final class AsyncSink implements Sink {
   }
 
   private abstract class WriteRunnable implements Runnable {
+
+    private final Link link;
+
+    WriteRunnable() {
+      this.link = PerfMark.linkOut();
+    }
+
     @Override
     public final void run() {
+      PerfMark.startTask("WriteRunnable.run");
+      PerfMark.linkIn(link);
       try {
         if (sink == null) {
           throw new IOException("Unable to perform write due to unavailable sink.");
@@ -166,6 +177,8 @@ final class AsyncSink implements Sink {
         doRun();
       } catch (Exception e) {
         transportExceptionHandler.onException(e);
+      } finally {
+        PerfMark.stopTask("WriteRunnable.run");
       }
     }
 

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -233,7 +233,7 @@ class OkHttpClientStream extends AbstractClientStream {
     /** True iff neither {@link #cancel} nor {@link #start(int)} have been called. */
     @GuardedBy("lock")
     private boolean canStart = true;
-    private Tag tag;
+    private final Tag tag;
 
     public TransportState(
         int maxMessageSize,

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -33,6 +33,8 @@ import io.grpc.internal.TransportTracer;
 import io.grpc.internal.WritableBuffer;
 import io.grpc.okhttp.internal.framed.ErrorCode;
 import io.grpc.okhttp.internal.framed.Header;
+import io.perfmark.PerfMark;
+import io.perfmark.Tag;
 import java.util.List;
 import javax.annotation.concurrent.GuardedBy;
 import okio.Buffer;
@@ -96,7 +98,8 @@ class OkHttpClientStream extends AbstractClientStream {
             frameWriter,
             outboundFlow,
             transport,
-            initialWindowSize);
+            initialWindowSize,
+            method.getFullMethodName());
   }
 
   @Override
@@ -141,19 +144,25 @@ class OkHttpClientStream extends AbstractClientStream {
   class Sink implements AbstractClientStream.Sink {
     @Override
     public void writeHeaders(Metadata metadata, byte[] payload) {
+      PerfMark.startTask("OkHttpClientStream$Sink.writeHeaders");
       String defaultPath = "/" + method.getFullMethodName();
       if (payload != null) {
         useGet = true;
         defaultPath += "?" + BaseEncoding.base64().encode(payload);
       }
-      synchronized (state.lock) {
-        state.streamReady(metadata, defaultPath);
+      try {
+        synchronized (state.lock) {
+          state.streamReady(metadata, defaultPath);
+        }
+      } finally {
+        PerfMark.stopTask("OkHttpClientStream$Sink.writeHeaders");
       }
     }
 
     @Override
     public void writeFrame(
         WritableBuffer frame, boolean endOfStream, boolean flush, int numMessages) {
+      PerfMark.startTask("OkHttpClientStream$Sink.writeFrame");
       Buffer buffer;
       if (frame == null) {
         buffer = EMPTY_BUFFER;
@@ -165,23 +174,37 @@ class OkHttpClientStream extends AbstractClientStream {
         }
       }
 
-      synchronized (state.lock) {
-        state.sendBuffer(buffer, endOfStream, flush);
-        getTransportTracer().reportMessageSent(numMessages);
+      try {
+        synchronized (state.lock) {
+          state.sendBuffer(buffer, endOfStream, flush);
+          getTransportTracer().reportMessageSent(numMessages);
+        }
+      } finally {
+        PerfMark.stopTask("OkHttpClientStream$Sink.writeFrame");
       }
     }
 
     @Override
     public void request(final int numMessages) {
-      synchronized (state.lock) {
-        state.requestMessagesFromDeframer(numMessages);
+      PerfMark.startTask("OkHttpClientStream$Sink.request");
+      try {
+        synchronized (state.lock) {
+          state.requestMessagesFromDeframer(numMessages);
+        }
+      } finally {
+        PerfMark.stopTask("OkHttpClientStream$Sink.request");
       }
     }
 
     @Override
     public void cancel(Status reason) {
-      synchronized (state.lock) {
-        state.cancel(reason, true, null);
+      PerfMark.startTask("OkHttpClientStream$Sink.cancel");
+      try {
+        synchronized (state.lock) {
+          state.cancel(reason, true, null);
+        }
+      } finally {
+        PerfMark.stopTask("OkHttpClientStream$Sink.cancel");
       }
     }
   }
@@ -210,6 +233,7 @@ class OkHttpClientStream extends AbstractClientStream {
     /** True iff neither {@link #cancel} nor {@link #start(int)} have been called. */
     @GuardedBy("lock")
     private boolean canStart = true;
+    private Tag tag;
 
     public TransportState(
         int maxMessageSize,
@@ -218,7 +242,8 @@ class OkHttpClientStream extends AbstractClientStream {
         ExceptionHandlingFrameWriter frameWriter,
         OutboundFlowController outboundFlow,
         OkHttpClientTransport transport,
-        int initialWindowSize) {
+        int initialWindowSize,
+        String methodName) {
       super(maxMessageSize, statsTraceCtx, OkHttpClientStream.this.getTransportTracer());
       this.lock = checkNotNull(lock, "lock");
       this.frameWriter = frameWriter;
@@ -227,6 +252,7 @@ class OkHttpClientStream extends AbstractClientStream {
       this.window = initialWindowSize;
       this.processedWindow = initialWindowSize;
       this.initialWindowSize = initialWindowSize;
+      tag = PerfMark.createTag(methodName);
     }
 
     @GuardedBy("lock")
@@ -383,6 +409,10 @@ class OkHttpClientStream extends AbstractClientStream {
     private void streamReady(Metadata metadata, String path) {
       requestHeaders = Headers.createRequestHeaders(metadata, path, authority, userAgent, useGet);
       transport.streamReadyToStart(OkHttpClientStream.this);
+    }
+
+    Tag tag() {
+      return tag;
     }
   }
 

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -67,6 +67,7 @@ import io.grpc.okhttp.internal.framed.HeadersMode;
 import io.grpc.okhttp.internal.framed.Http2;
 import io.grpc.okhttp.internal.framed.Settings;
 import io.grpc.okhttp.internal.framed.Variant;
+import io.perfmark.PerfMark;
 import java.io.EOFException;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -1127,6 +1128,8 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
 
         Buffer buf = new Buffer();
         buf.write(in.buffer(), length);
+        PerfMark.event("OkHttpClientTransport$ClientFrameHandler.data",
+            stream.transportState().tag());
         synchronized (lock) {
           stream.transportState().transportDataReceived(buf, inFinished);
         }
@@ -1176,6 +1179,8 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
           }
         } else {
           if (failedStatus == null) {
+            PerfMark.event("OkHttpClientTransport$ClientFrameHandler.headers",
+                stream.transportState().tag());
             stream.transportState().transportHeadersReceived(headerBlock, inFinished);
           } else {
             if (!inFinished) {
@@ -1208,10 +1213,17 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
       Status status = toGrpcStatus(errorCode).augmentDescription("Rst Stream");
       boolean stopDelivery =
           (status.getCode() == Code.CANCELLED || status.getCode() == Code.DEADLINE_EXCEEDED);
-      finishStream(
-          streamId, status,
-          errorCode == ErrorCode.REFUSED_STREAM ? RpcProgress.REFUSED : RpcProgress.PROCESSED,
-          stopDelivery, null, null);
+      synchronized (lock) {
+        OkHttpClientStream stream = streams.get(streamId);
+        if (stream != null) {
+          PerfMark.event("OkHttpClientTransport$ClientFrameHandler.rstStream",
+              stream.transportState().tag());
+          finishStream(
+              streamId, status,
+              errorCode == ErrorCode.REFUSED_STREAM ? RpcProgress.REFUSED : RpcProgress.PROCESSED,
+              stopDelivery, null, null);
+        }
+      }
     }
 
     @Override


### PR DESCRIPTION
Did not find a proper approach to incorporate stream IDs/RPC method names as tags for tracing tasks running on Okio side (Netty's io happens in terms of a set of commands, each of which is associated with `TransportState` containing the tag. But Okhttp transport dumps bytes to `AsyncSink`, in which we do not keep track of what those bytes are).