### PR TITLE
Remove missing pattern from glob

### DIFF
--- a/netty/BUILD.bazel
+++ b/netty/BUILD.bazel
@@ -2,7 +2,6 @@ java_library(
     name = "netty",
     srcs = glob([
         "src/main/java/**/*.java",
-        "third_party/netty/java/**/*.java",
     ]),
     resources = glob([
         "src/main/resources/**",


### PR DESCRIPTION
There's no third_party directory.
This change makes the repository compatible with
Bazel change --incompatible_disallow_empty_glob.