### PR TITLE
Fix java path separator bug on Windows

### DIFF
--- a/java_grpc_library.bzl
+++ b/java_grpc_library.bzl
@@ -93,7 +93,7 @@ def _java_rpc_library_impl(ctx):
     args = ctx.actions.args()
     args.add(toolchain.plugin, format = "--plugin=protoc-gen-rpc-plugin=%s")
     args.add("--rpc-plugin_out={0}:{1}".format(toolchain.plugin_arg, srcjar.path))
-    args.add_joined("--descriptor_set_in", descriptor_set_in, join_with = ":")
+    args.add_joined("--descriptor_set_in", descriptor_set_in, join_with = ctx.host_configuration.host_path_separator)
     args.add_all(srcs, map_each = _path_ignoring_repository)
 
     ctx.actions.run(


### PR DESCRIPTION
`java_grpc_library` targets based on `java_proto_library` targets with more than one `proto_library` dependency can't be built on Windows, starting somewhere before 1.22. A minimal reproducing example is available on https://github.com/Xjs/bazel-grpc-java-win-repro (see `README.md` there for output on my machine as well as steps to reproduce). 

The issue stems from `protoc` [configuring a different path separator for Windows at compile time](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/compiler/command_line_interface.cc#L767) in combination with `java_grpc_library` [always using `:`](https://github.com/grpc/grpc-java/blob/master/java_grpc_library.bzl#L96).

This PR uses the path separator available from the bazel context's host_configuration to resolve the issue.