### PR TITLE
cronet: do not expose setTrafficStats* as public APIs

### DIFF
--- a/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
@@ -136,7 +136,7 @@ public final class CronetChannelBuilder extends
    *     application.
    * @return the builder to facilitate chaining.
    */
-  public final CronetChannelBuilder setTrafficStatsTag(int tag) {
+  final CronetChannelBuilder setTrafficStatsTag(int tag) {
     trafficStatsTagSet = true;
     trafficStatsTag = tag;
     return this;
@@ -157,7 +157,7 @@ public final class CronetChannelBuilder extends
    * @param uid the UID to attribute socket traffic caused by this channel.
    * @return the builder to facilitate chaining.
    */
-  public final CronetChannelBuilder setTrafficStatsUid(int uid) {
+  final CronetChannelBuilder setTrafficStatsUid(int uid) {
     trafficStatsUidSet = true;
     trafficStatsUid = uid;
     return this;

--- a/cronet/src/main/java/io/grpc/cronet/InternalCronetChannelBuilder.java
+++ b/cronet/src/main/java/io/grpc/cronet/InternalCronetChannelBuilder.java
@@ -23,7 +23,10 @@ import io.grpc.Internal;
  * team. If you *really* think you need to use this, contact the gRPC team first.
  */
 @Internal
-public class InternalCronetChannelBuilder {
+public final class InternalCronetChannelBuilder {
+
+  // Prevent instantiation
+  private InternalCronetChannelBuilder() {}
 
   /**
    * Sets {@link android.net.TrafficStats} tag to use when accounting socket traffic caused by this


### PR DESCRIPTION
All Internal usages have been migrated through an accessor class.

TODO: we may also want to hide `CronetCallOptions#withAnnotation(..)` from external users. If we are going to do that, need to restrict internal usages first (there are a couple).