### PR TITLE
android: fix Javadoc symbol/class not found errors

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 
 task javadocs(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    classpath += files(android.getBootClasspath())
     options {
         // Disable JavaDoc doclint on Java 8.
         if (JavaVersion.current().isJava8Compatible()) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -68,7 +68,7 @@ task javadocs(type: Javadoc) {
 
 afterEvaluate {
     javadocs.classpath += files(android.libraryVariants.collect { variant ->
-        variant.javaCompile.classpath
+        variant.javaCompileProvider.get().classpath
     })
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,14 +57,19 @@ dependencies {
 
 task javadocs(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
-    // TODO(ericgribkoff) Fix javadoc errors
-    failOnError false
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
     options {
         // Disable JavaDoc doclint on Java 8.
         if (JavaVersion.current().isJava8Compatible()) {
             addStringOption('Xdoclint:none', '-quiet')
         }
     }
+}
+
+afterEvaluate {
+    javadocs.classpath += files(android.libraryVariants.collect { variant ->
+        variant.javaCompile.classpath
+    })
 }
 
 task javadocJar(type: Jar, dependsOn: javadocs) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,11 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     lintOptions { abortOnError false }
+    libraryVariants.all { variant ->
+        javadocs {
+            classpath += variant.javaCompileProvider.get().classpath
+        }
+    }
 }
 
 repositories {
@@ -64,12 +69,6 @@ task javadocs(type: Javadoc) {
             addStringOption('Xdoclint:none', '-quiet')
         }
     }
-}
-
-afterEvaluate {
-    javadocs.classpath += files(android.libraryVariants.collect { variant ->
-        variant.javaCompileProvider.get().classpath
-    })
 }
 
 task javadocJar(type: Jar, dependsOn: javadocs) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,11 +34,6 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     lintOptions { abortOnError false }
-    libraryVariants.all { variant ->
-        javadocs {
-            classpath += variant.javaCompileProvider.get().classpath
-        }
-    }
 }
 
 repositories {
@@ -63,6 +58,11 @@ dependencies {
 task javadocs(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
     classpath += files(android.getBootClasspath())
+    classpath += files({
+        android.libraryVariants.collect { variant ->
+            variant.javaCompileProvider.get().classpath
+        }
+    })
     options {
         // Disable JavaDoc doclint on Java 8.
         if (JavaVersion.current().isJava8Compatible()) {


### PR DESCRIPTION
The issue is dependencies are not in the classpath that `javadoc` uses to resolve type references in the source code.

We have to use `afterEvaluate` to fill `javadocs` task's `classpath` after android tasks have been executed.