### PR TITLE
docs: Update the maven plugins in the project readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ For protobuf-based codegen integrated with the Maven build system, you can use
     <extension>
       <groupId>kr.motd.maven</groupId>
       <artifactId>os-maven-plugin</artifactId>
-      <version>1.5.0.Final</version>
+      <version>1.6.2.Final</version>
     </extension>
   </extensions>
   <plugins>
     <plugin>
       <groupId>org.xolstice.maven.plugins</groupId>
       <artifactId>protobuf-maven-plugin</artifactId>
-      <version>0.5.1</version>
+      <version>0.6.1</version>
       <configuration>
         <protocArtifact>com.google.protobuf:protoc:3.9.0:exe:${os.detected.classifier}</protocArtifact>
         <pluginId>grpc-java</pluginId>

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ For protobuf-based codegen integrated with the Maven build system, you can use
     <extension>
       <groupId>kr.motd.maven</groupId>
       <artifactId>os-maven-plugin</artifactId>
-      <version>1.6.2.Final</version>
+      <version>1.6.2</version>
     </extension>
   </extensions>
   <plugins>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -151,7 +151,7 @@ the dependency.
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.5.0.Final</version>
+        <version>1.6.2.Final</version>
       </extension>
     </extensions>
     <plugins>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -151,7 +151,7 @@ the dependency.
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.6.2.Final</version>
+        <version>1.6.2</version>
       </extension>
     </extensions>
     <plugins>

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -94,7 +94,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.6.2.Final</version>
+        <version>1.6.2</version>
       </extension>
     </extensions>
     <plugins>

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -94,7 +94,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.5.0.Final</version>
+        <version>1.6.2.Final</version>
       </extension>
     </extensions>
     <plugins>

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -64,14 +64,14 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.5.0.Final</version>
+        <version>1.6.2.Final</version>
       </extension>
     </extensions>
     <plugins>
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
-        <version>0.5.1</version>
+        <version>0.6.1</version>
         <configuration>
           <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -64,7 +64,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.6.2.Final</version>
+        <version>1.6.2</version>
       </extension>
     </extensions>
     <plugins>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -81,14 +81,14 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.5.0.Final</version>
+        <version>1.6.2.Final</version>
       </extension>
     </extensions>
     <plugins>
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
-        <version>0.5.1</version>
+        <version>0.6.1</version>
         <configuration>
           <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -81,7 +81,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.6.2.Final</version>
+        <version>1.6.2</version>
       </extension>
     </extensions>
     <plugins>


### PR DESCRIPTION
There are a few improvements available in the plugin updates and we should point to the latest version in our readme.

https://github.com/xolstice/protobuf-maven-plugin/compare/protobuf-maven-plugin-0.5.1...protobuf-maven-plugin-0.6.1?expand=1

* Mainly documentation improvements, but also some bugfixes (including Fixed Zip Slip(?))

https://github.com/trustin/os-maven-plugin/releases

* Improved/extended OS detection, better eclipse integration

I use the updated plugins myself and didn't encounter any problems with them yet.