### PR TITLE
Upgrade gradle-errorprone-plugin to 0.8.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.0'
-        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.6"
+        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.8.1"
         classpath "digital.wup:android-maven-publish:3.6.2"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     dependencies {
         classpath 'com.google.gradle:osdetector-gradle-plugin:1.4.0'
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.5.0'
-        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.6'
+        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.8.1'
         classpath "me.champeau.gradle:jmh-gradle-plugin:0.4.5"
         classpath 'me.champeau.gradle:japicmp-gradle-plugin:0.2.5'
     }


### PR DESCRIPTION
This fixes the following warning when building grpc-android:
WARNING: API 'variant.getJavaCompiler()' is obsolete and has been replaced with 'variant.getJavaCompileProvider()'.
It will be removed at the end of 2019.
For more information, see https://d.android.com/r/tools/task-configuration-avoidance.
To determine what is calling variant.getJavaCompiler(), use -Pandroid.debug.obsoleteApi=true on the command line to display a stack trace.

CC @dapengzhang0 