### PR TITLE
cronet: move call options APIs into an internal accessor class

### DIFF
--- a/cronet/src/main/java/io/grpc/cronet/CronetCallOptions.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetCallOptions.java
@@ -17,9 +17,6 @@
 package io.grpc.cronet;
 
 import io.grpc.CallOptions;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 
 /** Call options for use with the Cronet transport. */
 public final class CronetCallOptions {
@@ -36,7 +33,7 @@ public final class CronetCallOptions {
    */
   @Deprecated
   public static final CallOptions.Key<Object> CRONET_ANNOTATION_KEY =
-      CallOptions.Key.create("cronet-annotation");
+      CronetClientStream.CRONET_ANNOTATION_KEY;
 
   /**
    * Returns a copy of {@code callOptions} with {@code annotation} included as one of the Cronet
@@ -48,18 +45,6 @@ public final class CronetCallOptions {
    * @param annotation the object to attach to the Cronet stream
    */
   public static CallOptions withAnnotation(CallOptions callOptions, Object annotation) {
-    Collection<Object> existingAnnotations = callOptions.getOption(CRONET_ANNOTATIONS_KEY);
-    ArrayList<Object> newAnnotations;
-    if (existingAnnotations == null) {
-      newAnnotations = new ArrayList<>();
-    } else {
-      newAnnotations = new ArrayList<>(existingAnnotations);
-    }
-    newAnnotations.add(annotation);
-    return callOptions.withOption(
-        CronetCallOptions.CRONET_ANNOTATIONS_KEY, Collections.unmodifiableList(newAnnotations));
+    return CronetClientStream.withAnnotation(callOptions, annotation);
   }
-
-  static final CallOptions.Key<Collection<Object>> CRONET_ANNOTATIONS_KEY =
-      CallOptions.Key.create("cronet-annotations");
 }

--- a/cronet/src/main/java/io/grpc/cronet/InternalCronetCallOptions.java
+++ b/cronet/src/main/java/io/grpc/cronet/InternalCronetCallOptions.java
@@ -27,17 +27,10 @@ import io.grpc.Internal;
 @Internal
 public final class InternalCronetCallOptions {
 
-  /**
-   * @deprecated Use {@link #withAnnotation} instead.
-   */
-  @Deprecated
-  public static final CallOptions.Key<Object> CRONET_ANNOTATION_KEY =
-      CronetClientStream.CRONET_ANNOTATION_KEY;
+  // Prevent instantiation
+  private InternalCronetCallOptions() {}
 
   public static CallOptions withAnnotation(CallOptions callOptions, Object annotation) {
     return CronetClientStream.withAnnotation(callOptions, annotation);
   }
-
-  // Prevent instantiation
-  private InternalCronetCallOptions() {}
 }

--- a/cronet/src/main/java/io/grpc/cronet/InternalCronetCallOptions.java
+++ b/cronet/src/main/java/io/grpc/cronet/InternalCronetCallOptions.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.cronet;
+
+import io.grpc.CallOptions;
+import io.grpc.Internal;
+
+/**
+ * Internal accessor class for call options using with the Cronet transport. This is intended for
+ * usage internal to the gRPC team. If you *really* think you need to use this, contact the gRPC
+ * team first.
+ */
+@Internal
+public final class InternalCronetCallOptions {
+
+  /**
+   * @deprecated Use {@link #withAnnotation} instead.
+   */
+  @Deprecated
+  public static final CallOptions.Key<Object> CRONET_ANNOTATION_KEY =
+      CronetClientStream.CRONET_ANNOTATION_KEY;
+
+  public static CallOptions withAnnotation(CallOptions callOptions, Object annotation) {
+    return CronetClientStream.withAnnotation(callOptions, annotation);
+  }
+
+  // Prevent instantiation
+  private InternalCronetCallOptions() {}
+}

--- a/cronet/src/test/java/io/grpc/cronet/CronetClientStreamTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientStreamTest.java
@@ -587,7 +587,7 @@ public final class CronetClientStreamTest {
             false /* alwaysUsePut */,
             method,
             StatsTraceContext.NOOP,
-            CallOptions.DEFAULT.withOption(CronetCallOptions.CRONET_ANNOTATION_KEY, annotation),
+            CallOptions.DEFAULT.withOption(CronetClientStream.CRONET_ANNOTATION_KEY, annotation),
             transportTracer);
     callback.setStream(stream);
     when(factory.newBidirectionalStreamBuilder(


### PR DESCRIPTION
Implementations in `CronetCallOptions` are moved into `CronetClientStream`, only keep indirections to them in `CronetCallOptions`. 

Created an `InternalCronetCallOptions` accessor class for restricting internal usages of those APIs.

After all internal usages are migrated to the internal accessor, `CronetCallOptions` will be deleted.