### PR TITLE
xds: move XdsLoadBalancer.XdsConfig to XdsLoadBalancerProvider

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
@@ -24,7 +24,6 @@ import static io.grpc.xds.XdsLoadBalancerProvider.XDS_POLICY_NAME;
 import static java.util.logging.Level.FINEST;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import io.grpc.Attributes;
@@ -47,6 +46,7 @@ import io.grpc.xds.LoadReportClient.LoadReportCallback;
 import io.grpc.xds.LoadReportClientImpl.LoadReportClientFactory;
 import io.grpc.xds.LocalityStore.LocalityStoreImpl;
 import io.grpc.xds.XdsComms.AdsStreamCallback;
+import io.grpc.xds.XdsLoadBalancerProvider.XdsConfig;
 import io.grpc.xds.XdsSubchannelPickers.ErrorPicker;
 import java.util.List;
 import java.util.Map;
@@ -476,47 +476,4 @@ final class XdsLoadBalancer extends LoadBalancer {
     }
   }
 
-  /**
-   * Represents a successfully parsed and validated LoadBalancingConfig for XDS.
-   */
-  static final class XdsConfig {
-    private final String newBalancerName;
-    // TODO(carl-mastrangelo): make these Object's containing the fully parsed child configs.
-    @Nullable
-    private final LbConfig childPolicy;
-    @Nullable
-    private final LbConfig fallbackPolicy;
-
-    XdsConfig(
-        String newBalancerName, @Nullable LbConfig childPolicy, @Nullable LbConfig fallbackPolicy) {
-      this.newBalancerName = checkNotNull(newBalancerName, "newBalancerName");
-      this.childPolicy = childPolicy;
-      this.fallbackPolicy = fallbackPolicy;
-    }
-
-    @Override
-    public String toString() {
-      return MoreObjects.toStringHelper(this)
-          .add("newBalancerName", newBalancerName)
-          .add("childPolicy", childPolicy)
-          .add("fallbackPolicy", fallbackPolicy)
-          .toString();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-      if (!(obj instanceof XdsConfig)) {
-        return false;
-      }
-      XdsConfig that = (XdsConfig) obj;
-      return Objects.equal(this.newBalancerName, that.newBalancerName)
-          && Objects.equal(this.childPolicy, that.childPolicy)
-          && Objects.equal(this.fallbackPolicy, that.fallbackPolicy);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hashCode(newBalancerName, childPolicy, fallbackPolicy);
-    }
-  }
 }

--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
@@ -196,7 +196,7 @@ final class XdsLoadBalancer extends LoadBalancer {
   }
 
   private void handleNewConfig(XdsConfig xdsConfig) {
-    String newBalancerName = xdsConfig.newBalancerName;
+    String newBalancerName = xdsConfig.balancerName;
     LbConfig childPolicy = xdsConfig.childPolicy;
     ManagedChannel lbChannel;
     if (xdsLbState == null) {

--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancerProvider.java
@@ -128,7 +128,7 @@ public final class XdsLoadBalancerProvider extends LoadBalancerProvider {
    * Represents a successfully parsed and validated LoadBalancingConfig for XDS.
    */
   static final class XdsConfig {
-    final String newBalancerName;
+    final String balancerName;
     // TODO(carl-mastrangelo): make these Object's containing the fully parsed child configs.
     @Nullable
     final LbConfig childPolicy;
@@ -136,8 +136,8 @@ public final class XdsLoadBalancerProvider extends LoadBalancerProvider {
     final LbConfig fallbackPolicy;
 
     XdsConfig(
-        String newBalancerName, @Nullable LbConfig childPolicy, @Nullable LbConfig fallbackPolicy) {
-      this.newBalancerName = checkNotNull(newBalancerName, "newBalancerName");
+        String balancerName, @Nullable LbConfig childPolicy, @Nullable LbConfig fallbackPolicy) {
+      this.balancerName = checkNotNull(balancerName, "balancerName");
       this.childPolicy = childPolicy;
       this.fallbackPolicy = fallbackPolicy;
     }
@@ -145,7 +145,7 @@ public final class XdsLoadBalancerProvider extends LoadBalancerProvider {
     @Override
     public String toString() {
       return MoreObjects.toStringHelper(this)
-          .add("newBalancerName", newBalancerName)
+          .add("balancerName", balancerName)
           .add("childPolicy", childPolicy)
           .add("fallbackPolicy", fallbackPolicy)
           .toString();
@@ -157,14 +157,14 @@ public final class XdsLoadBalancerProvider extends LoadBalancerProvider {
         return false;
       }
       XdsConfig that = (XdsConfig) obj;
-      return Objects.equal(this.newBalancerName, that.newBalancerName)
+      return Objects.equal(this.balancerName, that.balancerName)
           && Objects.equal(this.childPolicy, that.childPolicy)
           && Objects.equal(this.fallbackPolicy, that.fallbackPolicy);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(newBalancerName, childPolicy, fallbackPolicy);
+      return Objects.hashCode(balancerName, childPolicy, fallbackPolicy);
     }
   }
 }

--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancerProvider.java
@@ -16,7 +16,11 @@
 
 package io.grpc.xds;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import io.grpc.Internal;
 import io.grpc.LoadBalancer;
@@ -28,7 +32,6 @@ import io.grpc.Status;
 import io.grpc.internal.ExponentialBackoffPolicy;
 import io.grpc.internal.ServiceConfigUtil;
 import io.grpc.internal.ServiceConfigUtil.LbConfig;
-import io.grpc.xds.XdsLoadBalancer.XdsConfig;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -119,5 +122,49 @@ public final class XdsLoadBalancerProvider extends LoadBalancerProvider {
       }
     }
     return null;
+  }
+
+  /**
+   * Represents a successfully parsed and validated LoadBalancingConfig for XDS.
+   */
+  static final class XdsConfig {
+    final String newBalancerName;
+    // TODO(carl-mastrangelo): make these Object's containing the fully parsed child configs.
+    @Nullable
+    final LbConfig childPolicy;
+    @Nullable
+    final LbConfig fallbackPolicy;
+
+    XdsConfig(
+        String newBalancerName, @Nullable LbConfig childPolicy, @Nullable LbConfig fallbackPolicy) {
+      this.newBalancerName = checkNotNull(newBalancerName, "newBalancerName");
+      this.childPolicy = childPolicy;
+      this.fallbackPolicy = fallbackPolicy;
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("newBalancerName", newBalancerName)
+          .add("childPolicy", childPolicy)
+          .add("fallbackPolicy", fallbackPolicy)
+          .toString();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (!(obj instanceof XdsConfig)) {
+        return false;
+      }
+      XdsConfig that = (XdsConfig) obj;
+      return Objects.equal(this.newBalancerName, that.newBalancerName)
+          && Objects.equal(this.childPolicy, that.childPolicy)
+          && Objects.equal(this.fallbackPolicy, that.fallbackPolicy);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(newBalancerName, childPolicy, fallbackPolicy);
+    }
   }
 }

--- a/xds/src/test/java/io/grpc/xds/XdsLoadBalancerProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadBalancerProviderTest.java
@@ -27,7 +27,7 @@ import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.internal.JsonParser;
 import io.grpc.internal.ServiceConfigUtil;
 import io.grpc.internal.ServiceConfigUtil.LbConfig;
-import io.grpc.xds.XdsLoadBalancer.XdsConfig;
+import io.grpc.xds.XdsLoadBalancerProvider.XdsConfig;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Rule;


### PR DESCRIPTION
`XdsLoadBalancer` will be replaced by `XdsLoadBalancer2`, and `XdsConfig` is better fit in `XdsLoadBalancerProvider`.