### PR TITLE
api, core: add ClientCallTracer APIs for tracing components with capability to expose tracer properties to external frameworks

### DIFF
--- a/api/src/main/java/io/grpc/ClientCall.java
+++ b/api/src/main/java/io/grpc/ClientCall.java
@@ -279,4 +279,13 @@ public abstract class ClientCall<ReqT, RespT> {
   public Attributes getAttributes() {
     return Attributes.EMPTY;
   }
+
+  /**
+   * Returns tracer specific properties (if any) attached by tracing components.
+   *
+   * @return non-{@code null} attributes
+   */
+  public Attributes getTracerAttributes() {
+    return Attributes.EMPTY;
+  }
 }

--- a/api/src/main/java/io/grpc/ClientCall.java
+++ b/api/src/main/java/io/grpc/ClientCall.java
@@ -285,6 +285,7 @@ public abstract class ClientCall<ReqT, RespT> {
    *
    * @return non-{@code null} attributes
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/6080")
   public Attributes getTracerAttributes() {
     return Attributes.EMPTY;
   }

--- a/api/src/main/java/io/grpc/ClientCallTracer.java
+++ b/api/src/main/java/io/grpc/ClientCallTracer.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Traces {@link ClientCall} events.
+ *
+ * <p>Implementers use this class to trace events on {@link ClientCall} layer. As it extends {@link
+ * ClientStreamTracer.Factory}, implementers can supply a {@link ClientStreamTracer} for tracing
+ * events on client stream layer as well.
+ *
+ * <p>Similar functionality can be achieved with a {@link ClientInterceptor} that intercepts the
+ * {@link Channel} by installing a {@link ClientStreamTracer.Factory} to {@link ClientCall}s it
+ * creates. But this mechanism allows implementers to expose direct access to tracing attributes to
+ * external components, such as {@link ClientInterceptor}s.
+ *
+ * @since 1.24.0
+ */
+@ThreadSafe
+public abstract class ClientCallTracer extends ClientStreamTracer.Factory {
+
+  /**
+   * Put tracer specific information as attributes to the provided builder. Tracer attributes are
+   * implementation specific.
+   *
+   * @param builder receiver of tracer information.
+   */
+  public void getTracerAttributes(Attributes.Builder builder) {}
+
+  /**
+   * A request message has been sent to the server. May be called zero or more times depending on
+   * how many messages the server is willing to accept for the operation.
+   *
+   * <p>This is called in {@link ClientCall#sendMessage(Object)}.
+   *
+   * @param message to be sent to the server.
+   */
+  public void outboundMessage(Object message) {}
+
+  /**
+   * A response message has been received. May be called zero or more times depending on whether the
+   * call response is empty, a single message or a stream of messages.
+   *
+   * <p>This is called in {@link ClientCall.Listener#onMessage(Object)}, which is invoked in call
+   * executor.
+   *
+   * @param message returned by the server
+   */
+  public void inboundMessage(Object message) {}
+
+  /**
+   * The {@link ClientCall} has been closed.
+   *
+   * <p>This is called in {@link ClientCall.Listener#onClose(Status, Metadata)}, which is invoked in
+   * call executor.
+   *
+   * @param status the result of the remote call.
+   */
+  public void callEnded(Status status) {}
+
+  /**
+   * Factory class for {@link ClientCallTracer}.
+   *
+   * @since 1.24.0
+   */
+  public interface Factory {
+
+    /**
+     * Creates a {@link ClientCallTracer} for a new {@link ClientCall}. This is called inside the
+     * channel when it's creating a client call.
+     *
+     * @param method information about the stream
+     * @param callOptions the effective CallOptions of the call
+     */
+    ClientCallTracer newClientCallTracer(MethodDescriptor<?, ?> method, CallOptions callOptions);
+  }
+}

--- a/api/src/main/java/io/grpc/ClientCallTracer.java
+++ b/api/src/main/java/io/grpc/ClientCallTracer.java
@@ -32,6 +32,7 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * @since 1.24.0
  */
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/6080")
 @ThreadSafe
 public abstract class ClientCallTracer extends ClientStreamTracer.Factory {
 

--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -84,6 +84,12 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
   }
 
   @Override
+  public T clientCallTracerFactories(ClientCallTracer.Factory... factories) {
+    delegate().clientCallTracerFactories(factories);
+    return thisT();
+  }
+
+  @Override
   public T userAgent(String userAgent) {
     delegate().userAgent(userAgent);
     return thisT();

--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -128,6 +128,17 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   public abstract T intercept(ClientInterceptor... interceptors);
 
   /**
+   * Adds {@link ClientCallTracer.Factory}s with each of which will create a {@link
+   * ClientCallTracer} (which is also {@link ClientStreamTracer.Factory}) for each {@link
+   * ClientCall} the channel creates.
+   * Instantiated {@link ClientStreamTracer}s run in the same order as their factories are added.
+   *
+   * @return this
+   * @since 1.24.0
+   */
+  public abstract T clientCallTracerFactories(ClientCallTracer.Factory... factories);
+
+  /**
    * Provides a custom {@code User-Agent} for the application.
    *
    * <p>It's an optional parameter. The library will provide a user agent independent of this

--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -136,6 +136,7 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * @return this
    * @since 1.24.0
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/6080")
   public abstract T clientCallTracerFactories(ClientCallTracer.Factory... factories);
 
   /**

--- a/api/src/main/java/io/grpc/PartialForwardingClientCall.java
+++ b/api/src/main/java/io/grpc/PartialForwardingClientCall.java
@@ -60,6 +60,11 @@ abstract class PartialForwardingClientCall<ReqT, RespT> extends ClientCall<ReqT,
   }
 
   @Override
+  public Attributes getTracerAttributes() {
+    return delegate().getTracerAttributes();
+  }
+
+  @Override
   public String toString() {
     return MoreObjects.toStringHelper(this).add("delegate", delegate()).toString();
   }

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -26,6 +26,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
+import io.grpc.ClientCallTracer;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.Context;
@@ -194,6 +195,7 @@ final class OobChannel extends ManagedChannel implements InternalInstrumented<Ch
     return new ClientCallImpl<>(methodDescriptor,
         callOptions.getExecutor() == null ? executor : callOptions.getExecutor(),
         callOptions, transportProvider, deadlineCancellationExecutor, channelCallsTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */);
   }
 

--- a/core/src/main/java/io/grpc/internal/SubchannelChannel.java
+++ b/core/src/main/java/io/grpc/internal/SubchannelChannel.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
+import io.grpc.ClientCallTracer;
 import io.grpc.Context;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
 import io.grpc.Metadata;
@@ -29,7 +30,7 @@ import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.internal.ClientCallImpl.ClientTransportProvider;
 import io.grpc.internal.ClientStreamListener.RpcProgress;
-import io.grpc.internal.GrpcUtil;
+import java.util.Collections;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -109,7 +110,9 @@ final class SubchannelChannel extends Channel {
     return new ClientCallImpl<>(methodDescriptor,
         effectiveExecutor,
         callOptions.withOption(GrpcUtil.CALL_OPTIONS_RPC_OWNED_BY_BALANCER, Boolean.TRUE),
-        transportProvider, deadlineCancellationExecutor, callsTracer, false /* retryEnabled */);
+        transportProvider, deadlineCancellationExecutor, callsTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
+        false /* retryEnabled */);
   }
 
   @Override

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -30,6 +30,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
@@ -37,6 +38,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
@@ -44,6 +46,7 @@ import io.grpc.Attributes;
 import io.grpc.Attributes.Key;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
+import io.grpc.ClientCallTracer;
 import io.grpc.ClientStreamTracer;
 import io.grpc.Codec;
 import io.grpc.Context;
@@ -54,12 +57,15 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.Status;
+import io.grpc.StringMarshaller;
 import io.grpc.internal.ClientCallImpl.ClientTransportProvider;
 import io.grpc.internal.testing.SingleMessageProducer;
 import io.grpc.testing.TestMethodDescriptors;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
@@ -165,6 +171,7 @@ public class ClientCallImplTest {
         provider,
         deadlineCancellationExecutor,
         channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */);
     call.start(callListener, new Metadata());
     verify(stream).start(listenerArgumentCaptor.capture());
@@ -187,6 +194,7 @@ public class ClientCallImplTest {
         provider,
         deadlineCancellationExecutor,
         channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */);
     call.start(callListener, new Metadata());
     verify(stream).start(listenerArgumentCaptor.capture());
@@ -225,6 +233,7 @@ public class ClientCallImplTest {
         provider,
         deadlineCancellationExecutor,
         channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */);
     call.start(callListener, new Metadata());
     verify(stream).start(listenerArgumentCaptor.capture());
@@ -261,6 +270,7 @@ public class ClientCallImplTest {
         provider,
         deadlineCancellationExecutor,
         channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */);
     call.start(callListener, new Metadata());
     verify(stream).start(listenerArgumentCaptor.capture());
@@ -296,6 +306,7 @@ public class ClientCallImplTest {
         provider,
         deadlineCancellationExecutor,
         channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */)
             .setDecompressorRegistry(decompressorRegistry);
 
@@ -320,6 +331,7 @@ public class ClientCallImplTest {
         provider,
         deadlineCancellationExecutor,
         channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */)
             .setDecompressorRegistry(decompressorRegistry);
 
@@ -337,6 +349,7 @@ public class ClientCallImplTest {
         provider,
         deadlineCancellationExecutor,
         channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */)
         .setDecompressorRegistry(decompressorRegistry);
     final Metadata metadata = new Metadata();
@@ -356,6 +369,7 @@ public class ClientCallImplTest {
         provider,
         deadlineCancellationExecutor,
         channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */)
             .setDecompressorRegistry(decompressorRegistry);
 
@@ -527,6 +541,7 @@ public class ClientCallImplTest {
         provider,
         deadlineCancellationExecutor,
         channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */)
             .setDecompressorRegistry(decompressorRegistry);
 
@@ -605,6 +620,7 @@ public class ClientCallImplTest {
         provider,
         deadlineCancellationExecutor,
         channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */)
             .setDecompressorRegistry(decompressorRegistry);
 
@@ -635,6 +651,7 @@ public class ClientCallImplTest {
         provider,
         deadlineCancellationExecutor,
         channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */)
         .setDecompressorRegistry(decompressorRegistry);
 
@@ -680,6 +697,7 @@ public class ClientCallImplTest {
         provider,
         deadlineCancellationExecutor,
         channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */)
             .setDecompressorRegistry(decompressorRegistry);
     call.start(callListener, new Metadata());
@@ -705,6 +723,7 @@ public class ClientCallImplTest {
         provider,
         deadlineCancellationExecutor,
         channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */);
     call.start(callListener, new Metadata());
 
@@ -730,6 +749,7 @@ public class ClientCallImplTest {
         provider,
         deadlineCancellationExecutor,
         channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */);
     call.start(callListener, new Metadata());
 
@@ -755,6 +775,7 @@ public class ClientCallImplTest {
         provider,
         deadlineCancellationExecutor,
         channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */);
     call.start(callListener, new Metadata());
 
@@ -776,6 +797,7 @@ public class ClientCallImplTest {
         provider,
         deadlineCancellationExecutor,
         channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */);
     call.start(callListener, new Metadata());
 
@@ -794,6 +816,7 @@ public class ClientCallImplTest {
         provider,
         deadlineCancellationExecutor,
         channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */);
     call.start(callListener, new Metadata());
 
@@ -812,6 +835,7 @@ public class ClientCallImplTest {
         provider,
         deadlineCancellationExecutor,
         channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */);
 
     call.start(callListener, new Metadata());
@@ -839,6 +863,7 @@ public class ClientCallImplTest {
         provider,
         deadlineCancellationExecutor,
         channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */);
 
     context.detach(origContext);
@@ -863,6 +888,7 @@ public class ClientCallImplTest {
         provider,
         deadlineCancellationExecutor,
         channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */);
     call.start(callListener, new Metadata());
     call.cancel("canceled", null);
@@ -888,6 +914,7 @@ public class ClientCallImplTest {
         provider,
         deadlineCancellationExecutor,
         channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */);
 
     Metadata headers = new Metadata();
@@ -906,6 +933,7 @@ public class ClientCallImplTest {
         provider,
         deadlineCancellationExecutor,
         channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */);
     final Exception cause = new Exception();
     ClientCall.Listener<Void> callListener =
@@ -944,6 +972,7 @@ public class ClientCallImplTest {
         provider,
         deadlineCancellationExecutor,
         channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
         false /* retryEnabled */)
             .setDecompressorRegistry(decompressorRegistry);
 
@@ -957,7 +986,9 @@ public class ClientCallImplTest {
   public void getAttributes() {
     ClientCallImpl<Void, Void> call = new ClientCallImpl<>(
         method, MoreExecutors.directExecutor(), baseCallOptions, provider,
-        deadlineCancellationExecutor, channelCallTracer, false /* retryEnabled */);
+        deadlineCancellationExecutor, channelCallTracer,
+        Collections.<ClientCallTracer>emptyList() /* clientCallTracers */,
+        false /* retryEnabled */);
     Attributes attrs =
         Attributes.newBuilder().set(Key.<String>create("fake key"), "fake value").build();
     when(stream.getAttributes()).thenReturn(attrs);
@@ -967,6 +998,48 @@ public class ClientCallImplTest {
     call.start(callListener, new Metadata());
 
     assertEquals(attrs, call.getAttributes());
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void callEventsPropagateToClientCallTracer() {
+    MethodDescriptor<String, String> method = MethodDescriptor.<String, String>newBuilder()
+        .setType(MethodType.UNARY)
+        .setFullMethodName("service/method")
+        .setRequestMarshaller(StringMarshaller.INSTANCE)
+        .setResponseMarshaller(StringMarshaller.INSTANCE)
+        .build();
+
+    ClientCallTracer clientCallTracer = mock(ClientCallTracer.class);
+
+    ClientCallImpl<String, String> call =
+        new ClientCallImpl<>(
+            method,
+            MoreExecutors.directExecutor(),
+            baseCallOptions,
+            provider,
+            deadlineCancellationExecutor,
+            channelCallTracer,
+            ImmutableList.of(clientCallTracer),
+            false /* retryEnabled */);
+
+    ClientCall.Listener<String> listener = mock(ClientCall.Listener.class);
+    call.start(listener, new Metadata());
+    verify(stream).start(listenerArgumentCaptor.capture());
+    ClientStreamListener streamListener = listenerArgumentCaptor.getValue();
+
+    String request = "request message";
+    String response = "response message";
+    call.sendMessage(request);
+    verify(clientCallTracer).outboundMessage(request);
+
+    streamListener.messagesAvailable(
+        new SingleMessageProducer(
+            new ByteArrayInputStream(response.getBytes(Charset.defaultCharset()))));
+    streamListener.closed(Status.OK, new Metadata());
+
+    verify(clientCallTracer).inboundMessage(response);
+    verify(clientCallTracer).callEnded(Status.OK);
   }
 
   private static void assertTimeoutBetween(long timeout, long from, long to) {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -37,6 +37,7 @@ import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ChannelLogger;
 import io.grpc.ClientCall;
+import io.grpc.ClientCallTracer;
 import io.grpc.ClientInterceptor;
 import io.grpc.ConnectivityState;
 import io.grpc.EquivalentAddressGroup;
@@ -182,6 +183,7 @@ public class ManagedChannelImplIdlenessTest {
         builder, mockTransportFactory, new FakeBackoffPolicyProvider(),
         oobExecutorPool, timer.getStopwatchSupplier(),
         Collections.<ClientInterceptor>emptyList(),
+        Collections.<ClientCallTracer.Factory>emptyList(),
         TimeProvider.SYSTEM_TIME_PROVIDER);
     newTransports = TestUtils.captureTransports(mockTransportFactory);
 


### PR DESCRIPTION
New API class `ClientCallTracer`/`ClientCallTracer.Factory`.

- `ClientCallTracer` traces `ClientCall` events and allow callers to populate tracer properties through `ClientCallTracer#getTracerAttributes(...)`. Those attributes are further populated up to `ClientCall` interface for external access.

- Users attach `ClientCallTracer.Factory` instances to `Channel` via `ManagedChannelBuilder#clientCallTracerFactories(...)`. , which creates and attach a new `ClientCallTracer` instance to each new `ClientCall` it creates.

- `ClientCallImpl` invokes callback methods defined in `ClientCallTracer` at each call events.


Implementation of #6080. 

`CensusTracingModule` is the first usage of this API. It transits from `ClientInterceptor` to `ClientCallTracer` to give access to Census SpanId and TraceId to external users/frameworks.
