### PR TITLE
android: clean up AndroidChannelBuilder APIs

### DIFF
--- a/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
+++ b/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
@@ -95,7 +95,7 @@ public final class AndroidChannelBuilder extends ForwardingChannelBuilder<Androi
    */
   @Deprecated
   public static AndroidChannelBuilder fromBuilder(ManagedChannelBuilder<?> builder) {
-    return new AndroidChannelBuilder(builder);
+    return usingBuilder(builder);
   }
 
   /**

--- a/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
+++ b/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
@@ -101,8 +101,10 @@ public final class AndroidChannelBuilder extends ForwardingChannelBuilder<Androi
   /**
    * Creates a new builder, which delegates to the given ManagedChannelBuilder.
    *
-   * <p>The builder being delegated to can still be modified and configuration changes will
-   * propagate to the channel built by this builder.
+   * <p>The provided {@code builder} becomes "owned" by AndroidChannelBuilder. The caller should
+   * not modify the provided builder and AndroidChannelBuilder may modify it. That implies reusing
+   * the provided builder to build another channel may result with unexpected configurations. That
+   * usage should be discouraged.
    *
    * @since 1.24.0
    */

--- a/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
+++ b/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
@@ -54,7 +54,7 @@ import javax.net.ssl.SSLSocketFactory;
  *
  * @since 1.12.0
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/4056")
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/6043")
 public final class AndroidChannelBuilder extends ForwardingChannelBuilder<AndroidChannelBuilder> {
 
   private static final String LOG_TAG = "AndroidChannelBuilder";
@@ -73,15 +73,40 @@ public final class AndroidChannelBuilder extends ForwardingChannelBuilder<Androi
 
   @Nullable private Context context;
 
+  /**
+   * Creates a new builder with the given target string that will be resolved by
+   * {@link io.grpc.NameResolver}.
+   */
   public static final AndroidChannelBuilder forTarget(String target) {
     return new AndroidChannelBuilder(target);
   }
 
+  /**
+   * Creates a new builder with the given host and port.
+   */
   public static AndroidChannelBuilder forAddress(String name, int port) {
     return forTarget(GrpcUtil.authorityFromHostAndPort(name, port));
   }
 
+  /**
+   * Creates a new builder, which delegates to the given ManagedChannelBuilder.
+   *
+   * @deprecated Use {@link #usingBuilder(ManagedChannelBuilder)} instead.
+   */
+  @Deprecated
   public static AndroidChannelBuilder fromBuilder(ManagedChannelBuilder<?> builder) {
+    return new AndroidChannelBuilder(builder);
+  }
+
+  /**
+   * Creates a new builder, which delegates to the given ManagedChannelBuilder.
+   *
+   * <p>The builder being delegated to can still be modified and configuration changes will
+   * propagate to the channel built by this builder.
+   *
+   * @since 1.24.0
+   */
+  public static AndroidChannelBuilder usingBuilder(ManagedChannelBuilder<?> builder) {
     return new AndroidChannelBuilder(builder);
   }
 
@@ -104,7 +129,9 @@ public final class AndroidChannelBuilder extends ForwardingChannelBuilder<Androi
     this.delegateBuilder = Preconditions.checkNotNull(delegateBuilder, "delegateBuilder");
   }
 
-  /** Enables automatic monitoring of the device's network state. */
+  /**
+   * Enables automatic monitoring of the device's network state.
+   */
   public AndroidChannelBuilder context(Context context) {
     this.context = context;
     return this;
@@ -113,7 +140,7 @@ public final class AndroidChannelBuilder extends ForwardingChannelBuilder<Androi
   /**
    * Set the delegate channel builder's transportExecutor.
    *
-   * @deprecated Use {@link #fromBuilder(ManagedChannelBuilder)} with a pre-configured
+   * @deprecated Use {@link #usingBuilder(ManagedChannelBuilder)} with a pre-configured
    *     ManagedChannelBuilder instead.
    */
   @Deprecated
@@ -131,7 +158,7 @@ public final class AndroidChannelBuilder extends ForwardingChannelBuilder<Androi
   /**
    * Set the delegate channel builder's sslSocketFactory.
    *
-   * @deprecated Use {@link #fromBuilder(ManagedChannelBuilder)} with a pre-configured
+   * @deprecated Use {@link #usingBuilder(ManagedChannelBuilder)} with a pre-configured
    *     ManagedChannelBuilder instead.
    */
   @Deprecated
@@ -149,7 +176,7 @@ public final class AndroidChannelBuilder extends ForwardingChannelBuilder<Androi
   /**
    * Set the delegate channel builder's scheduledExecutorService.
    *
-   * @deprecated Use {@link #fromBuilder(ManagedChannelBuilder)} with a pre-configured
+   * @deprecated Use {@link #usingBuilder(ManagedChannelBuilder)} with a pre-configured
    *     ManagedChannelBuilder instead.
    */
   @Deprecated
@@ -171,6 +198,9 @@ public final class AndroidChannelBuilder extends ForwardingChannelBuilder<Androi
     return delegateBuilder;
   }
 
+  /**
+   * Builds a channel with current configurations.
+   */
   @Override
   public ManagedChannel build() {
     return new AndroidChannel(delegateBuilder.build(), context);

--- a/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
+++ b/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
@@ -61,7 +61,7 @@ public final class AndroidChannelBuilder extends ForwardingChannelBuilder<Androi
 
   @Nullable private static final Class<?> OKHTTP_CHANNEL_BUILDER_CLASS = findOkHttp();
 
-  private static final Class<?> findOkHttp() {
+  private static Class<?> findOkHttp() {
     try {
       return Class.forName("io.grpc.okhttp.OkHttpChannelBuilder");
     } catch (ClassNotFoundException e) {
@@ -77,7 +77,7 @@ public final class AndroidChannelBuilder extends ForwardingChannelBuilder<Androi
    * Creates a new builder with the given target string that will be resolved by
    * {@link io.grpc.NameResolver}.
    */
-  public static final AndroidChannelBuilder forTarget(String target) {
+  public static AndroidChannelBuilder forTarget(String target) {
     return new AndroidChannelBuilder(target);
   }
 

--- a/android/src/test/java/io/grpc/android/AndroidChannelBuilderTest.java
+++ b/android/src/test/java/io/grpc/android/AndroidChannelBuilderTest.java
@@ -94,9 +94,9 @@ public final class AndroidChannelBuilderTest {
   }
 
   @Test
-  public void fromBuilderConstructor() {
+  public void usingBuilderConstructor() {
     OkHttpChannelBuilder wrappedBuilder = OkHttpChannelBuilder.forTarget("target");
-    AndroidChannelBuilder androidBuilder = AndroidChannelBuilder.fromBuilder(wrappedBuilder);
+    AndroidChannelBuilder androidBuilder = AndroidChannelBuilder.usingBuilder(wrappedBuilder);
     assertThat(androidBuilder.delegate()).isSameInstanceAs(wrappedBuilder);
   }
 


### PR DESCRIPTION
TODO: delete deprecated method after migrating all internal usages.