### PR TITLE
android: delete deprecated API methods

### DIFF
--- a/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
+++ b/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
@@ -37,12 +37,9 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.MethodDescriptor;
 import io.grpc.internal.GrpcUtil;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
-import javax.net.ssl.SSLSocketFactory;
 
 /**
  * Builds a {@link ManagedChannel} that, when provided with a {@link Context}, will automatically
@@ -137,62 +134,6 @@ public final class AndroidChannelBuilder extends ForwardingChannelBuilder<Androi
   public AndroidChannelBuilder context(Context context) {
     this.context = context;
     return this;
-  }
-
-  /**
-   * Set the delegate channel builder's transportExecutor.
-   *
-   * @deprecated Use {@link #usingBuilder(ManagedChannelBuilder)} with a pre-configured
-   *     ManagedChannelBuilder instead.
-   */
-  @Deprecated
-  public AndroidChannelBuilder transportExecutor(@Nullable Executor transportExecutor) {
-    try {
-      OKHTTP_CHANNEL_BUILDER_CLASS
-          .getMethod("transportExecutor", Executor.class)
-          .invoke(delegateBuilder, transportExecutor);
-      return this;
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to invoke transportExecutor on delegate builder", e);
-    }
-  }
-
-  /**
-   * Set the delegate channel builder's sslSocketFactory.
-   *
-   * @deprecated Use {@link #usingBuilder(ManagedChannelBuilder)} with a pre-configured
-   *     ManagedChannelBuilder instead.
-   */
-  @Deprecated
-  public AndroidChannelBuilder sslSocketFactory(SSLSocketFactory factory) {
-    try {
-      OKHTTP_CHANNEL_BUILDER_CLASS
-          .getMethod("sslSocketFactory", SSLSocketFactory.class)
-          .invoke(delegateBuilder, factory);
-      return this;
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to invoke sslSocketFactory on delegate builder", e);
-    }
-  }
-
-  /**
-   * Set the delegate channel builder's scheduledExecutorService.
-   *
-   * @deprecated Use {@link #usingBuilder(ManagedChannelBuilder)} with a pre-configured
-   *     ManagedChannelBuilder instead.
-   */
-  @Deprecated
-  public AndroidChannelBuilder scheduledExecutorService(
-      ScheduledExecutorService scheduledExecutorService) {
-    try {
-      OKHTTP_CHANNEL_BUILDER_CLASS
-          .getMethod("scheduledExecutorService", ScheduledExecutorService.class)
-          .invoke(delegateBuilder, scheduledExecutorService);
-      return this;
-    } catch (Exception e) {
-      throw new RuntimeException(
-          "Failed to invoke scheduledExecutorService on delegate builder", e);
-    }
   }
 
   @Override

--- a/android/src/test/java/io/grpc/android/AndroidChannelBuilderTest.java
+++ b/android/src/test/java/io/grpc/android/AndroidChannelBuilderTest.java
@@ -36,12 +36,10 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLSocketFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -98,27 +96,6 @@ public final class AndroidChannelBuilderTest {
     OkHttpChannelBuilder wrappedBuilder = OkHttpChannelBuilder.forTarget("target");
     AndroidChannelBuilder androidBuilder = AndroidChannelBuilder.usingBuilder(wrappedBuilder);
     assertThat(androidBuilder.delegate()).isSameInstanceAs(wrappedBuilder);
-  }
-
-  @Test
-  public void transportExecutor() {
-    AndroidChannelBuilder.forTarget("target")
-        .transportExecutor(
-            new Executor() {
-              @Override
-              public void execute(Runnable r) {}
-            });
-  }
-
-  @Test
-  public void sslSocketFactory() {
-    AndroidChannelBuilder.forTarget("target")
-        .sslSocketFactory((SSLSocketFactory) SSLSocketFactory.getDefault());
-  }
-
-  @Test
-  public void scheduledExecutorService() {
-    AndroidChannelBuilder.forTarget("target").scheduledExecutorService(new ScheduledExecutorImpl());
   }
 
   @Test


### PR DESCRIPTION
All internal usages cleared. Delete deprecated methods. `fromBuilder` has only been deprecated recently, leave it for a while for external-import user migration (see https://github.com/grpc/grpc-java/issues/6043#issuecomment-523216599). 