### PR TITLE
api, core: add ClientCallTracer API for accessing Census span/trace ID on ClientCall

### DIFF
--- a/api/src/main/java/io/grpc/CallOptions.java
+++ b/api/src/main/java/io/grpc/CallOptions.java
@@ -66,6 +66,9 @@ public final class CallOptions {
   // Unmodifiable list
   private List<ClientStreamTracer.Factory> streamTracerFactories = Collections.emptyList();
 
+  // Unmodifiable list
+  private List<ClientCallTracer> clientCallTracers = Collections.emptyList();
+
   /**
    * Opposite to fail fast.
    */
@@ -234,6 +237,32 @@ public final class CallOptions {
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2861")
   public List<ClientStreamTracer.Factory> getStreamTracerFactories() {
     return streamTracerFactories;
+  }
+
+  /**
+   * Returns a new {@code CallOptions} with a {@link ClientCallTracer} in addition to the existing
+   * client call tracers.
+   *
+   * <p>This method doesn't replace or try to de-duplicate existing client call tracers.
+   *
+   * @since 1.24.0
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/6080")
+  public CallOptions withClientCallTracer(ClientCallTracer tracer) {
+    CallOptions newOptions = new CallOptions(this);
+    List<ClientCallTracer> newList = new ArrayList<>(clientCallTracers.size() + 1);
+    newList.addAll(clientCallTracers);
+    newList.add(tracer);
+    newOptions.clientCallTracers = Collections.unmodifiableList(newList);
+    return newOptions;
+  }
+
+  /**
+   * Returns an immutable list of {@link ClientCallTracer}s.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/6080")
+  public List<ClientCallTracer> getClientCallTracers() {
+    return clientCallTracers;
   }
 
   /**
@@ -432,6 +461,7 @@ public final class CallOptions {
     maxInboundMessageSize = other.maxInboundMessageSize;
     maxOutboundMessageSize = other.maxOutboundMessageSize;
     streamTracerFactories = other.streamTracerFactories;
+    clientCallTracers = other.clientCallTracers;
   }
 
   @Override
@@ -447,6 +477,7 @@ public final class CallOptions {
         .add("maxInboundMessageSize", maxInboundMessageSize)
         .add("maxOutboundMessageSize", maxOutboundMessageSize)
         .add("streamTracerFactories", streamTracerFactories)
+        .add("clientCallTracers", clientCallTracers)
         .toString();
   }
 }

--- a/api/src/main/java/io/grpc/ClientCall.java
+++ b/api/src/main/java/io/grpc/ClientCall.java
@@ -279,4 +279,16 @@ public abstract class ClientCall<ReqT, RespT> {
   public Attributes getAttributes() {
     return Attributes.EMPTY;
   }
+
+  /**
+   * Returns tracer specific properties (if any) attached by tracing components via
+   * {@link ClientCallTracer}. Tracer properties are available as soon as the call is created.
+   *
+   * @return non-{@code null} attributes
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/6080")
+  @Grpc.TracerAttr
+  public Attributes getTracerAttributes() {
+    return Attributes.EMPTY;
+  }
 }

--- a/api/src/main/java/io/grpc/ClientCallTracer.java
+++ b/api/src/main/java/io/grpc/ClientCallTracer.java
@@ -32,5 +32,5 @@ public abstract class ClientCallTracer extends ClientStreamTracer.Factory {
    *
    * @param builder receiver of tracer information.
    */
-  public void getTracerAttributes(Attributes.Builder builder) {}
+  public void getTracerAttributes(@Grpc.TracerAttr Attributes.Builder builder) {}
 }

--- a/api/src/main/java/io/grpc/ClientCallTracer.java
+++ b/api/src/main/java/io/grpc/ClientCallTracer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Client side RPC tracer, with exposure of tracer properties.
+ *
+ * @since 1.24.0
+ */
+@ThreadSafe
+public abstract class ClientCallTracer extends ClientStreamTracer.Factory {
+
+  /**
+   * Puts tracer specific information as attributes to the provided builder. Tracer attributes are
+   * implementation specific.
+   *
+   * @param builder receiver of tracer information.
+   */
+  public void getTracerAttributes(Attributes.Builder builder) {}
+}

--- a/api/src/main/java/io/grpc/Grpc.java
+++ b/api/src/main/java/io/grpc/Grpc.java
@@ -67,7 +67,7 @@ public final class Grpc {
    * Annotation for tracer attributes. It follows the annotation semantics defined by
    * {@link Attributes}.
    */
-  @ExperimentalApi("")
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4972")
   @Retention(RetentionPolicy.SOURCE)
   @Documented
   public @interface TracerAttr {}

--- a/api/src/main/java/io/grpc/Grpc.java
+++ b/api/src/main/java/io/grpc/Grpc.java
@@ -62,4 +62,13 @@ public final class Grpc {
   @Retention(RetentionPolicy.SOURCE)
   @Documented
   public @interface TransportAttr {}
+
+  /**
+   * Annotation for tracer attributes. It follows the annotation semantics defined by
+   * {@link Attributes}.
+   */
+  @ExperimentalApi("")
+  @Retention(RetentionPolicy.SOURCE)
+  @Documented
+  public @interface TracerAttr {}
 }

--- a/api/src/main/java/io/grpc/PartialForwardingClientCall.java
+++ b/api/src/main/java/io/grpc/PartialForwardingClientCall.java
@@ -60,6 +60,11 @@ abstract class PartialForwardingClientCall<ReqT, RespT> extends ClientCall<ReqT,
   }
 
   @Override
+  public Attributes getTracerAttributes() {
+    return delegate().getTracerAttributes();
+  }
+
+  @Override
   public String toString() {
     return MoreObjects.toStringHelper(this).add("delegate", delegate()).toString();
   }

--- a/api/src/test/java/io/grpc/CallOptionsTest.java
+++ b/api/src/test/java/io/grpc/CallOptionsTest.java
@@ -237,6 +237,36 @@ public class CallOptionsTest {
   }
 
   @Test
+  public void withClientCallTracer() {
+    ClientCallTracer tracer1 = mock(ClientCallTracer.class);
+    ClientCallTracer tracer2 = mock(ClientCallTracer.class);
+
+    CallOptions opts1 = CallOptions.DEFAULT.withClientCallTracer(tracer1);
+    CallOptions opts2 = opts1.withClientCallTracer(tracer2);
+    CallOptions opts3 = opts2.withClientCallTracer(tracer2);
+
+    assertThat(opts1.getClientCallTracers()).containsExactly(tracer1);
+    assertThat(opts2.getClientCallTracers()).containsExactly(tracer1, tracer2)
+        .inOrder();
+    assertThat(opts3.getClientCallTracers())
+        .containsExactly(tracer1, tracer2, tracer2).inOrder();
+
+    try {
+      CallOptions.DEFAULT.getClientCallTracers().add(tracer1);
+      fail("Should have thrown. The list should be unmodifiable.");
+    } catch (UnsupportedOperationException e) {
+      // Expected
+    }
+
+    try {
+      opts2.getClientCallTracers().clear();
+      fail("Should have thrown. The list should be unmodifiable.");
+    } catch (UnsupportedOperationException e) {
+      // Expected
+    }
+  }
+
+  @Test
   public void getWaitForReady() {
     assertNull(CallOptions.DEFAULT.getWaitForReady());
     assertSame(CallOptions.DEFAULT.withWaitForReady().getWaitForReady(), Boolean.TRUE);

--- a/core/src/main/java/io/grpc/internal/CensusStatsModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusStatsModule.java
@@ -138,12 +138,12 @@ public final class CensusStatsModule {
   }
 
   /**
-   * Creates a {@link ClientCallTracer} for a new call.
+   * Creates a {@link ClientCallFullLifecycleTracer} for a new call.
    */
   @VisibleForTesting
-  ClientCallTracer newClientCallTracer(
+  ClientCallFullLifecycleTracer newClientCallTracer(
       TagContext parentCtx, String fullMethodName) {
-    return new ClientCallTracer(this, parentCtx, fullMethodName);
+    return new ClientCallFullLifecycleTracer(this, parentCtx, fullMethodName);
   }
 
   /**
@@ -314,12 +314,13 @@ public final class CensusStatsModule {
   }
 
   @VisibleForTesting
-  static final class ClientCallTracer extends ClientStreamTracer.Factory {
+  static final class ClientCallFullLifecycleTracer extends ClientStreamTracer.Factory {
     @Nullable
-    private static final AtomicReferenceFieldUpdater<ClientCallTracer, ClientTracer>
+    private static final AtomicReferenceFieldUpdater<ClientCallFullLifecycleTracer, ClientTracer>
         streamTracerUpdater;
 
-    @Nullable private static final AtomicIntegerFieldUpdater<ClientCallTracer> callEndedUpdater;
+    @Nullable
+    private static final AtomicIntegerFieldUpdater<ClientCallFullLifecycleTracer> callEndedUpdater;
 
     /**
      * When using Atomic*FieldUpdater, some Samsung Android 5.0.x devices encounter a bug in their
@@ -327,14 +328,15 @@ public final class CensusStatsModule {
      * (potentially racy) direct updates of the volatile variables.
      */
     static {
-      AtomicReferenceFieldUpdater<ClientCallTracer, ClientTracer> tmpStreamTracerUpdater;
-      AtomicIntegerFieldUpdater<ClientCallTracer> tmpCallEndedUpdater;
+      AtomicReferenceFieldUpdater<ClientCallFullLifecycleTracer,
+          ClientTracer> tmpStreamTracerUpdater;
+      AtomicIntegerFieldUpdater<ClientCallFullLifecycleTracer> tmpCallEndedUpdater;
       try {
         tmpStreamTracerUpdater =
             AtomicReferenceFieldUpdater.newUpdater(
-                ClientCallTracer.class, ClientTracer.class, "streamTracer");
+                ClientCallFullLifecycleTracer.class, ClientTracer.class, "streamTracer");
         tmpCallEndedUpdater =
-            AtomicIntegerFieldUpdater.newUpdater(ClientCallTracer.class, "callEnded");
+            AtomicIntegerFieldUpdater.newUpdater(ClientCallFullLifecycleTracer.class, "callEnded");
       } catch (Throwable t) {
         logger.log(Level.SEVERE, "Creating atomic field updaters failed", t);
         tmpStreamTracerUpdater = null;
@@ -351,7 +353,8 @@ public final class CensusStatsModule {
     private final TagContext parentCtx;
     private final TagContext startCtx;
 
-    ClientCallTracer(CensusStatsModule module, TagContext parentCtx, String fullMethodName) {
+    ClientCallFullLifecycleTracer(CensusStatsModule module, TagContext parentCtx,
+        String fullMethodName) {
       this.module = checkNotNull(module);
       this.parentCtx = checkNotNull(parentCtx);
       TagValue methodTag = TagValue.create(fullMethodName);
@@ -685,7 +688,7 @@ public final class CensusStatsModule {
         MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
       // New RPCs on client-side inherit the tag context from the current Context.
       TagContext parentCtx = tagger.getCurrentTagContext();
-      final ClientCallTracer tracerFactory =
+      final ClientCallFullLifecycleTracer tracerFactory =
           newClientCallTracer(parentCtx, method.getFullMethodName());
       ClientCall<ReqT, RespT> call =
           next.newCall(method, callOptions.withStreamTracerFactory(tracerFactory));

--- a/core/src/main/java/io/grpc/internal/CensusTracingModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusTracingModule.java
@@ -29,6 +29,7 @@ import io.grpc.ClientStreamTracer;
 import io.grpc.Context;
 import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
 import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
+import io.grpc.Grpc;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerStreamTracer;
@@ -65,10 +66,12 @@ final class CensusTracingModule {
   private static final Logger logger = Logger.getLogger(CensusTracingModule.class.getName());
 
   @VisibleForTesting
+  @Grpc.TracerAttr
   static final Attributes.Key<SpanId> SPAN_ID_ATTRIBUTES_KEY = Attributes.Key
       .create("census-span-id");
 
   @VisibleForTesting
+  @Grpc.TracerAttr
   static final Attributes.Key<TraceId> TRACE_ID_ATTRIBUTES_KEY = Attributes.Key
       .create("census-trace-id");
 

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -33,6 +33,7 @@ import com.google.common.base.MoreObjects;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
+import io.grpc.ClientCallTracer;
 import io.grpc.Codec;
 import io.grpc.Compressor;
 import io.grpc.CompressorRegistry;
@@ -504,6 +505,15 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
       return stream.getAttributes();
     }
     return Attributes.EMPTY;
+  }
+
+  @Override
+  public Attributes getTracerAttributes() {
+    Attributes.Builder attrsBuilder = Attributes.newBuilder();
+    for (ClientCallTracer tracer : callOptions.getClientCallTracers()) {
+      tracer.getTracerAttributes(attrsBuilder);
+    }
+    return attrsBuilder.build();
   }
 
   private void closeObserver(Listener<RespT> observer, Status status, Metadata trailers) {

--- a/core/src/main/java/io/grpc/internal/StatsTraceContext.java
+++ b/core/src/main/java/io/grpc/internal/StatsTraceContext.java
@@ -49,7 +49,9 @@ public final class StatsTraceContext {
    */
   public static StatsTraceContext newClientContext(
       final CallOptions callOptions, final Attributes transportAttrs, Metadata headers) {
-    List<ClientStreamTracer.Factory> factories = callOptions.getStreamTracerFactories();
+    List<ClientStreamTracer.Factory> factories =
+        new ArrayList<>(callOptions.getStreamTracerFactories());
+    factories.addAll(callOptions.getClientCallTracers());
     if (factories.isEmpty()) {
       return NOOP;
     }


### PR DESCRIPTION
Introducing `ClientCallTracer` to expose client side tracer properties through `ClientCall#getTracerAttributes()`.

Implementation of #6048.

This approach involves fewer API changes and performance impact (see https://github.com/grpc/grpc-java/pull/6081#discussion_r316374752) than #6081.

Introduced a new annotation for tracer component attributes, `Grpc.TracerAttr`. Added tracking link to #4972.

TODO: 
- We should migrate existing `ClientStreamTracer.Factory` implementations to `ClientCallTracer` and deprecate `CallOptions#withStreamTracerFactory(...)`.
- As mentioned in https://github.com/grpc/grpc-java/pull/6081#discussion_r316359181, we need an accessor class for Census attributes keys for external framework/user's usage.