### PR TITLE
buildscripts: android.sh to clean the build when building HEAD^

### DIFF
--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -86,6 +86,7 @@ new_apk_size="$(stat --printf=%s $HELLO_WORLD_OUTPUT_DIR/apk/release/app-release
 
 cd $BASE_DIR/github/grpc-java
 git checkout HEAD^
+./gradlew clean
 ./gradlew publishToMavenLocal
 cd examples/android/helloworld/
 ../../gradlew build


### PR DESCRIPTION
A gradle plugin [issue](google/protobuf-gradle-plugin#331) was seen for https://github.com/grpc/grpc-java/pull/6099. This PR tries to workaround it.