### PR TITLE
auth: fix builder invocation for converting Google service account to Jwt access credential (backport 1.22.x)

### DIFF
--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -296,8 +296,8 @@ final class GoogleAuthLibraryCallCredentials extends io.grpc.CallCredentials2 {
         methodPairs.add(new MethodPair(getter, setter));
       }
       {
-        Method getter = serviceAccountClass.getMethod("getPrivateKey");
-        Method setter = builderClass.getMethod("setPrivateKey", getter.getReturnType());
+        Method getter = serviceAccountClass.getMethod("getPrivateKeyId");
+        Method setter = builderClass.getMethod("setPrivateKeyId", getter.getReturnType());
         methodPairs.add(new MethodPair(getter, setter));
       }
     }


### PR DESCRIPTION
Resolves #6105 .

Backport of #6106.