### PR TITLE
xds: clean up some ImmutableMaps

### DIFF
--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -54,6 +54,7 @@ import io.grpc.xds.XdsSubchannelPickers.ErrorPicker;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -306,13 +307,9 @@ interface LocalityStore {
         public void run() {
           localityLbInfo.shutdown();
 
-          ImmutableMap.Builder<XdsLocality, LocalityLbInfo> builder = ImmutableMap.builder();
-          for (Map.Entry<XdsLocality, LocalityLbInfo> entry : localityMap.entrySet()) {
-            if (!entry.getKey().equals(locality)) {
-              builder.put(entry);
-            }
-          }
-          localityMap = builder.build();
+          Map<XdsLocality, LocalityLbInfo> copy = new LinkedHashMap<>(localityMap);
+          copy.remove(locality);
+          localityMap = ImmutableMap.copyOf(copy);
         }
       }
 

--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -92,7 +92,7 @@ interface LocalityStore {
     private final OrcaPerRequestUtil orcaPerRequestUtil;
     private final OrcaOobUtil orcaOobUtil;
 
-    private Map<XdsLocality, LocalityLbInfo> localityMap = ImmutableMap.of();
+    private final Map<XdsLocality, LocalityLbInfo> localityMap = new LinkedHashMap<>();
     private Map<XdsLocality, LocalityInfo> edsResponsLocalityInfo = ImmutableMap.of();
     private ImmutableList<DropOverload> dropOverloads = ImmutableList.of();
     private long metricsReportIntervalNano = -1;
@@ -188,7 +188,7 @@ interface LocalityStore {
       for (XdsLocality locality : localityMap.keySet()) {
         localityMap.get(locality).shutdown();
       }
-      localityMap = ImmutableMap.of();
+      localityMap.clear();
       for (XdsLocality locality : edsResponsLocalityInfo.keySet()) {
         loadStatsStore.removeLocality(locality);
       }
@@ -199,7 +199,7 @@ interface LocalityStore {
     public void updateLocalityStore(Map<XdsLocality, LocalityInfo> localityInfoMap) {
       Set<XdsLocality> oldLocalities = localityMap.keySet();
       Set<XdsLocality> newLocalities = localityInfoMap.keySet();
-      ImmutableMap.Builder<XdsLocality, LocalityLbInfo> updatedLocalityMap = ImmutableMap.builder();
+      Map<XdsLocality, LocalityLbInfo> updatedLocalityMap = new LinkedHashMap<>();
 
       for (XdsLocality oldLocality : oldLocalities) {
         if (!newLocalities.contains(oldLocality)) {
@@ -264,7 +264,8 @@ interface LocalityStore {
           updatedLocalityMap.put(locality, localityMap.get(locality));
         }
       }
-      localityMap = updatedLocalityMap.build();
+      localityMap.clear();
+      localityMap.putAll(updatedLocalityMap);
 
       final Set<XdsLocality> toBeRemovedFromStatsStore = new HashSet<>();
       // There is a race between picking a subchannel and updating localities, which leads to
@@ -306,10 +307,7 @@ interface LocalityStore {
         @Override
         public void run() {
           localityLbInfo.shutdown();
-
-          Map<XdsLocality, LocalityLbInfo> copy = new LinkedHashMap<>(localityMap);
-          copy.remove(locality);
-          localityMap = ImmutableMap.copyOf(copy);
+          localityMap.remove(locality);
         }
       }
 

--- a/xds/src/main/java/io/grpc/xds/XdsComms.java
+++ b/xds/src/main/java/io/grpc/xds/XdsComms.java
@@ -26,6 +26,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
@@ -50,9 +51,7 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.CheckForNull;
 
@@ -239,7 +238,8 @@ final class XdsComms {
                   localityStore.updateDropPercentage(dropOverloads);
 
                   List<LocalityLbEndpoints> localities = clusterLoadAssignment.getEndpointsList();
-                  Map<XdsLocality, LocalityInfo> localityEndpointsMapping = new LinkedHashMap<>();
+                  ImmutableMap.Builder<XdsLocality, LocalityInfo> localityEndpointsMappingBuilder =
+                      ImmutableMap.builder();
                   for (LocalityLbEndpoints localityLbEndpoints : localities) {
                     io.envoyproxy.envoy.api.v2.core.Locality localityProto =
                         localityLbEndpoints.getLocality();
@@ -252,14 +252,12 @@ final class XdsComms {
                     int localityWeight = localityLbEndpoints.getLoadBalancingWeight().getValue();
 
                     if (localityWeight != 0) {
-                      localityEndpointsMapping.put(
+                      localityEndpointsMappingBuilder.put(
                           locality, new LocalityInfo(lbEndPoints, localityWeight));
                     }
                   }
 
-                  localityEndpointsMapping = Collections.unmodifiableMap(localityEndpointsMapping);
-
-                  localityStore.updateLocalityStore(localityEndpointsMapping);
+                  localityStore.updateLocalityStore(localityEndpointsMappingBuilder.build());
                 }
               }
             }

--- a/xds/src/main/java/io/grpc/xds/XdsComms.java
+++ b/xds/src/main/java/io/grpc/xds/XdsComms.java
@@ -52,7 +52,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.CheckForNull;
 
@@ -201,65 +200,64 @@ final class XdsComms {
                 if (EDS_TYPE_URL.equals(typeUrl)) {
                   // Assuming standard mode.
 
-                  Map<XdsLocality, LocalityInfo> localityInfoMap;
+                  ClusterLoadAssignment clusterLoadAssignment;
                   try {
-                    // Maybe better to run this deserialization task out of syncContext?
-                    ClusterLoadAssignment clusterLoadAssignment =
+                    // maybe better to run this deserialization task out of syncContext?
+                    clusterLoadAssignment =
                         value.getResources(0).unpack(ClusterLoadAssignment.class);
-
-                    helper.getChannelLogger().log(
-                        ChannelLogLevel.DEBUG,
-                        "Received an EDS response: {0}", clusterLoadAssignment);
-                    if (!firstEdsResponseReceived) {
-                      firstEdsResponseReceived = true;
-                      adsStreamCallback.onWorking();
-                    }
-
-                    List<ClusterLoadAssignment.Policy.DropOverload> dropOverloadsProto =
-                        clusterLoadAssignment.getPolicy().getDropOverloadsList();
-                    ImmutableList.Builder<DropOverload> dropOverloadsBuilder
-                        = ImmutableList.builder();
-                    for (ClusterLoadAssignment.Policy.DropOverload dropOverload
-                        : dropOverloadsProto) {
-                      int rateInMillion = rateInMillion(dropOverload.getDropPercentage());
-                      dropOverloadsBuilder.add(new DropOverload(
-                          dropOverload.getCategory(), rateInMillion));
-                      if (rateInMillion == 1000_000) {
-                        adsStreamCallback.onAllDrop();
-                        break;
-                      }
-                    }
-                    ImmutableList<DropOverload> dropOverloads = dropOverloadsBuilder.build();
-                    localityStore.updateDropPercentage(dropOverloads);
-
-                    List<LocalityLbEndpoints> localities = clusterLoadAssignment.getEndpointsList();
-                    ImmutableMap.Builder<XdsLocality, LocalityInfo> localityInfoMapBuilder =
-                        ImmutableMap.builder();
-                    for (LocalityLbEndpoints localityLbEndpoints : localities) {
-                      io.envoyproxy.envoy.api.v2.core.Locality localityProto =
-                          localityLbEndpoints.getLocality();
-                      XdsLocality locality = XdsLocality.fromLocalityProto(localityProto);
-                      List<LbEndpoint> lbEndPoints = new ArrayList<>();
-                      for (io.envoyproxy.envoy.api.v2.endpoint.LbEndpoint lbEndpoint
-                          : localityLbEndpoints.getLbEndpointsList()) {
-                        lbEndPoints.add(new LbEndpoint(lbEndpoint));
-                      }
-                      int localityWeight = localityLbEndpoints.getLoadBalancingWeight().getValue();
-
-                      if (localityWeight != 0) {
-                        localityInfoMapBuilder.put(
-                            locality, new LocalityInfo(lbEndPoints, localityWeight));
-                      }
-                    }
-
-                    localityInfoMap = localityInfoMapBuilder.build();
                   } catch (InvalidProtocolBufferException | RuntimeException e) {
                     cancelRpc("Received invalid EDS response", e);
                     adsStreamCallback.onError();
                     scheduleRetry();
                     return;
                   }
-                  localityStore.updateLocalityStore(localityInfoMap);
+
+                  helper.getChannelLogger().log(
+                      ChannelLogLevel.DEBUG,
+                      "Received an EDS response: {0}", clusterLoadAssignment);
+                  if (!firstEdsResponseReceived) {
+                    firstEdsResponseReceived = true;
+                    adsStreamCallback.onWorking();
+                  }
+
+                  List<ClusterLoadAssignment.Policy.DropOverload> dropOverloadsProto =
+                      clusterLoadAssignment.getPolicy().getDropOverloadsList();
+                  ImmutableList.Builder<DropOverload> dropOverloadsBuilder
+                      = ImmutableList.builder();
+                  for (ClusterLoadAssignment.Policy.DropOverload dropOverload
+                      : dropOverloadsProto) {
+                    int rateInMillion = rateInMillion(dropOverload.getDropPercentage());
+                    dropOverloadsBuilder.add(new DropOverload(
+                        dropOverload.getCategory(), rateInMillion));
+                    if (rateInMillion == 1000_000) {
+                      adsStreamCallback.onAllDrop();
+                      break;
+                    }
+                  }
+                  ImmutableList<DropOverload> dropOverloads = dropOverloadsBuilder.build();
+                  localityStore.updateDropPercentage(dropOverloads);
+
+                  List<LocalityLbEndpoints> localities = clusterLoadAssignment.getEndpointsList();
+                  ImmutableMap.Builder<XdsLocality, LocalityInfo> localityEndpointsMappingBuilder =
+                      ImmutableMap.builder();
+                  for (LocalityLbEndpoints localityLbEndpoints : localities) {
+                    io.envoyproxy.envoy.api.v2.core.Locality localityProto =
+                        localityLbEndpoints.getLocality();
+                    XdsLocality locality = XdsLocality.fromLocalityProto(localityProto);
+                    List<LbEndpoint> lbEndPoints = new ArrayList<>();
+                    for (io.envoyproxy.envoy.api.v2.endpoint.LbEndpoint lbEndpoint
+                        : localityLbEndpoints.getLbEndpointsList()) {
+                      lbEndPoints.add(new LbEndpoint(lbEndpoint));
+                    }
+                    int localityWeight = localityLbEndpoints.getLoadBalancingWeight().getValue();
+
+                    if (localityWeight != 0) {
+                      localityEndpointsMappingBuilder.put(
+                          locality, new LocalityInfo(lbEndPoints, localityWeight));
+                    }
+                  }
+
+                  localityStore.updateLocalityStore(localityEndpointsMappingBuilder.build());
                 }
               }
             }


### PR DESCRIPTION
Change
```java
          ImmutableMap.Builder<XdsLocality, LocalityLbInfo> builder = ImmutableMap.builder();
          for (Map.Entry<XdsLocality, LocalityLbInfo> entry : localityMap.entrySet()) {
            if (!entry.getKey().equals(locality)) {
              builder.put(entry);
            }
          }
          localityMap = builder.build();
```

into
```java
          Map<XdsLocality, LocalityLbInfo> copy = new LinkedHashMap<>(localityMap);
          copy.remove(locality);
          localityMap = ImmutableMap.copyOf(copy);
```

The performance is almost the same, unless we use the beta API `ImmutableMap.builderWithExpectedSize()`. But the latter has much better readability.