### PR TITLE
cronet: add grpc-cronet artifact publishing configurations

### DIFF
--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -1,21 +1,31 @@
 apply plugin: 'com.android.library'
 
+group = "io.grpc"
+version = "1.24.0-SNAPSHOT" // CURRENT_GRPC_VERSION
 description = "gRPC: Cronet Android"
 
 buildscript {
     repositories {
         google()
         jcenter()
+        mavenCentral()
+        maven { url "https://plugins.gradle.org/m2/" }
     }
-    dependencies { classpath 'com.android.tools.build:gradle:3.3.0' }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'digital.wup:android-maven-publish:3.6.2'
+    }
 }
 
-allprojects {
-    repositories {
-        google()
-        jcenter()
-        mavenLocal()
-    }
+apply plugin: "maven-publish"
+apply plugin: "digital.wup.android-maven-publish"
+apply plugin: "signing"
+
+repositories {
+    google()
+    jcenter()
+    mavenCentral()
+    mavenLocal()
 }
 
 android {
@@ -47,4 +57,111 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.25.1'
     testImplementation "org.robolectric:robolectric:3.5.1"
+}
+
+task javadocs(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    classpath += files(android.getBootClasspath())
+    classpath += files({
+        android.libraryVariants.collect { variant ->
+            variant.javaCompileProvider.get().classpath
+        }
+    })
+    options {
+        // Disable JavaDoc doclint on Java 8.
+        if (JavaVersion.current().isJava8Compatible()) {
+            addStringOption('Xdoclint:none', '-quiet')
+        }
+    }
+}
+
+task javadocJar(type: Jar, dependsOn: javadocs) {
+    classifier = 'javadoc'
+    from javadocs.destinationDir
+}
+
+task sourcesJar(type: Jar) {
+    classifier = 'sources'
+    from android.sourceSets.main.java.srcDirs
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.android
+
+            artifact javadocJar
+            artifact sourcesJar
+
+            pom {
+                name = project.group + ":" + project.name
+                url = 'https://github.com/grpc/grpc-java'
+                afterEvaluate {
+                    // description is not available until evaluated.
+                    description = project.description
+                }
+
+                scm {
+                    connection = 'scm:git:https://github.com/grpc/grpc-java.git'
+                    developerConnection = 'scm:git:git@github.com:grpc/grpc-java.git'
+                    url = 'https://github.com/grpc/grpc-java'
+                }
+
+                licenses {
+                    license {
+                        name = 'Apache 2.0'
+                        url = 'https://opensource.org/licenses/Apache-2.0'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = "grpc.io"
+                        name = "gRPC Contributors"
+                        email = "grpc-io@googlegroups.com"
+                        url = "https://grpc.io/"
+                        organization = "gRPC Authors"
+                        organizationUrl = "https://www.google.com"
+                    }
+                }
+
+                withXml {
+                    asNode().dependencies.'*'.findAll() { dep ->
+                        dep.artifactId.text() in ['grpc-api', 'grpc-core']
+                    }.each() { core ->
+                        core.version*.value = "[" + core.version.text() + "]"
+                    }
+                }
+            }
+        }
+    }
+    repositories {
+        maven {
+            if (rootProject.hasProperty('repositoryDir')) {
+                url = new File(rootProject.repositoryDir).toURI()
+            } else {
+                String stagingUrl
+                if (rootProject.hasProperty('repositoryId')) {
+                    stagingUrl = 'https://oss.sonatype.org/service/local/staging/deployByRepositoryId/' +
+                            rootProject.repositoryId
+                } else {
+                    stagingUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+                }
+                credentials {
+                    if (rootProject.hasProperty('ossrhUsername') && rootProject.hasProperty('ossrhPassword')) {
+                        username = rootProject.ossrhUsername
+                        password = rootProject.ossrhPassword
+                    }
+                }
+                def releaseUrl = stagingUrl
+                def snapshotUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+                url = version.endsWith('SNAPSHOT') ? snapshotUrl : releaseUrl
+            }
+        }
+    }
+}
+
+signing {
+    required false
+    sign publishing.publications.maven
 }

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -52,7 +52,8 @@ dependencies {
     implementation 'io.grpc:grpc-core:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     testImplementation 'io.grpc:grpc-testing:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 
-    implementation "org.chromium.net:cronet-embedded:66.3359.158"
+    implementation 'org.chromium.net:cronet-api:76.3809.111'
+    testImplementation 'org.chromium.net:cronet-embedded:66.3359.158'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.25.1'

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -13,11 +13,13 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.8.1'
         classpath 'digital.wup:android-maven-publish:3.6.2'
     }
 }
 
 apply plugin: "maven-publish"
+apply plugin: "net.ltgt.errorprone"
 apply plugin: "digital.wup.android-maven-publish"
 apply plugin: "signing"
 
@@ -49,6 +51,9 @@ android {
 }
 
 dependencies {
+    errorprone 'com.google.errorprone:error_prone_core:2.3.3'
+    errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
+
     implementation 'io.grpc:grpc-core:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     testImplementation 'io.grpc:grpc-testing:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -31,7 +31,7 @@ repositories {
 android {
     compileSdkVersion 27
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
- Added maven publish plugin and configurations.
- Changed grpc-cronet minSdkVersion to 16 as cronet dependency requires so.
- Changed cronet dependency configuration, `grpc-cronet` now only has dependency on [`cronet-api`](https://mvnrepository.com/artifact/org.chromium.net/cronet-api), which contains only the API layer of cronet without implementation providers. Cronet implementation is still needed for tests.