### PR TITLE
Refactor top-level build.gradle to avoid enabling unhelpful plugins

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -1,14 +1,8 @@
-apply plugin: 'com.github.kt3k.coveralls'
+plugins {
+    id "com.github.kt3k.coveralls"
+}
 
 description = "gRPC: All"
-
-buildscript {
-    repositories {
-        maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
-    }
-    dependencies { classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.0.1' }
-}
 
 def subprojects = [
     project(':grpc-api'),

--- a/all/build.gradle
+++ b/all/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "java"
     id "maven-publish"
 
     id "com.github.kt3k.coveralls"

--- a/all/build.gradle
+++ b/all/build.gradle
@@ -1,4 +1,6 @@
 plugins {
+    id "maven-publish"
+
     id "com.github.kt3k.coveralls"
 }
 

--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
     id "com.github.johnrengelman.shadow"
     id "com.google.protobuf"
+    id "ru.vyarus.animalsniffer"
 }
 
 description = "gRPC: ALTS"

--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "java"
     id "maven-publish"
 
     id "com.github.johnrengelman.shadow"

--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -1,4 +1,6 @@
 plugins {
+    id "maven-publish"
+
     id "com.github.johnrengelman.shadow"
     id "com.google.protobuf"
 }

--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -1,22 +1,12 @@
-buildscript {
-    repositories { jcenter() }
-    dependencies { classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.4' }
+plugins {
+    id "com.github.johnrengelman.shadow"
+    id "com.google.protobuf"
 }
-
-apply plugin: 'com.github.johnrengelman.shadow'
 
 description = "gRPC: ALTS"
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
-
-buildscript {
-    repositories {
-        maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
-    }
-    dependencies { classpath libraries.protobuf_plugin }
-}
 
 dependencies {
     compile project(':grpc-auth'),

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "java"
     id "maven-publish"
 
     id "me.champeau.gradle.jmh"

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "me.champeau.gradle.jmh"
+}
+
 description = 'gRPC: API'
 
 dependencies {

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id "maven-publish"
 
     id "me.champeau.gradle.jmh"
+    id "ru.vyarus.animalsniffer"
 }
 
 description = 'gRPC: API'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,4 +1,6 @@
 plugins {
+    id "maven-publish"
+
     id "me.champeau.gradle.jmh"
 }
 

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"
+    id "ru.vyarus.animalsniffer"
 }
 
 description = "gRPC: Auth"

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -1,5 +1,7 @@
 plugins {
     id "maven-publish"
+
+    id "me.champeau.gradle.japicmp"
 }
 
 description = "gRPC: Auth"

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "maven-publish"
+}
+
 description = "gRPC: Auth"
 dependencies {
     compile project(':grpc-api'),

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "java"
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "application"
+    id "maven-publish"
 
     id "com.google.protobuf"
     id "me.champeau.gradle.jmh"

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id "application"
 
     id "com.google.protobuf"
+    id "me.champeau.gradle.jmh"
 }
 
 description = "grpc Benchmarks"

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -18,6 +18,10 @@ jmh {
     includeTests = true
 }
 
+configurations {
+    alpnagent
+}
+
 dependencies {
     compile project(':grpc-core'),
             project(':grpc-netty'),
@@ -32,6 +36,7 @@ dependencies {
             libraries.netty_epoll,
             libraries.math
     compileOnly libraries.javax_annotation
+    alpnagent libraries.jetty_alpn_agent
 }
 
 import net.ltgt.gradle.errorprone.CheckSeverity

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "application"
+    id "java"
     id "maven-publish"
 
     id "com.google.protobuf"

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -1,12 +1,8 @@
-buildscript {
-    repositories {
-        maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
-    }
-    dependencies { classpath libraries.protobuf_plugin }
-}
+plugins {
+    id "application"
 
-apply plugin: 'application'
+    id "com.google.protobuf"
+}
 
 description = "grpc Benchmarks"
 

--- a/bom/build.gradle
+++ b/bom/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "maven-publish"
+}
+
 description = 'gRPC: BOM'
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "com.google.osdetector" apply false
     id "me.champeau.gradle.japicmp" apply false
-    id "me.champeau.gradle.jmh" apply false
     id "net.ltgt.errorprone" apply false
     id "ru.vyarus.animalsniffer" apply false
 }
@@ -17,7 +16,6 @@ subprojects {
     apply plugin: "signing"
     apply plugin: "jacoco"
 
-    apply plugin: "me.champeau.gradle.jmh"
     apply plugin: "com.google.osdetector"
     // The plugin only has an effect if a signature is specified
     apply plugin: "ru.vyarus.animalsniffer"
@@ -53,11 +51,7 @@ subprojects {
         mavenLocal()
     }
 
-    [
-        compileJava,
-        compileTestJava,
-        compileJmhJava
-    ].each() {
+    tasks.withType(JavaCompile) {
         it.options.compilerArgs += [
             "-Xlint:all",
             "-Xlint:-options",
@@ -160,11 +154,7 @@ subprojects {
                 }
             }
 
-            [
-                compileJava,
-                compileTestJava,
-                compileJmhJava
-            ].each() {
+            tasks.withType(JavaCompile) {
                 // Protobuf-generated code produces some warnings.
                 // https://github.com/google/protobuf/issues/2718
                 it.options.compilerArgs += [
@@ -253,9 +243,6 @@ subprojects {
 
         // Configuration for modules that use Jetty ALPN agent
         alpnagent libraries.jetty_alpn_agent
-
-        jmh 'org.openjdk.jmh:jmh-core:1.19',
-                'org.openjdk.jmh:jmh-generator-bytecode:1.19'
     }
 
     // Disable JavaDoc doclint on Java 8. It's annoying.
@@ -295,20 +282,26 @@ subprojects {
         source = fileTree(dir: "src/test", include: "**/*.java")
     }
 
-    // invoke jmh on a single benchmark class like so:
-    //   ./gradlew -PjmhIncludeSingleClass=StatsTraceContextBenchmark clean :grpc-core:jmh
-    jmh {
-        warmupIterations = 10
-        iterations = 10
-        fork = 1
-        // None of our benchmarks need the tests, and we have pseudo-circular
-        // dependencies that break when including them. (context's testCompile
-        // depends on core; core's testCompile depends on testing)
-        includeTests = false
-        if (project.hasProperty('jmhIncludeSingleClass')) {
-            include = [
-                project.property('jmhIncludeSingleClass')
-            ]
+    plugins.withId("me.champeau.gradle.jmh") {
+        dependencies {
+            jmh 'org.openjdk.jmh:jmh-core:1.19',
+                    'org.openjdk.jmh:jmh-generator-bytecode:1.19'
+        }
+        // invoke jmh on a single benchmark class like so:
+        //   ./gradlew -PjmhIncludeSingleClass=StatsTraceContextBenchmark clean :grpc-core:jmh
+        jmh {
+            warmupIterations = 10
+            iterations = 10
+            fork = 1
+            // None of our benchmarks need the tests, and we have pseudo-circular
+            // dependencies that break when including them. (context's testCompile
+            // depends on core; core's testCompile depends on testing)
+            includeTests = false
+            if (project.hasProperty('jmhIncludeSingleClass')) {
+                include = [
+                    project.property('jmhIncludeSingleClass')
+                ]
+            }
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ subprojects {
     apply plugin: "checkstyle"
     apply plugin: "java"
     apply plugin: "maven"
-    apply plugin: "maven-publish"
     apply plugin: "idea"
     apply plugin: "signing"
     apply plugin: "jacoco"
@@ -305,109 +304,107 @@ subprojects {
         }
     }
 
-    task javadocJar(type: Jar) {
-        classifier = 'javadoc'
-        from javadoc
-    }
+    plugins.withId("maven-publish") {
+        task javadocJar(type: Jar) {
+            classifier = 'javadoc'
+            from javadoc
+        }
 
-    task sourcesJar(type: Jar) {
-        classifier = 'sources'
-        from sourceSets.main.allSource
-    }
+        task sourcesJar(type: Jar) {
+            classifier = 'sources'
+            from sourceSets.main.allSource
+        }
 
-    publishing {
-        publications {
-            // do not use mavenJava, as java plugin will modify it via "magic"
-            maven(MavenPublication) {
-                if (project.name != 'grpc-netty-shaded') {
-                    from components.java
-                }
-
-                artifact javadocJar
-                artifact sourcesJar
-
-                pom {
-                    name = project.group + ":" + project.name
-                    url = 'https://github.com/grpc/grpc-java'
-                    afterEvaluate {
-                        // description is not available until evaluated.
-                        description = project.description
+        publishing {
+            publications {
+                // do not use mavenJava, as java plugin will modify it via "magic"
+                maven(MavenPublication) {
+                    if (project.name != 'grpc-netty-shaded') {
+                        from components.java
                     }
 
-                    scm {
-                        connection = 'scm:git:https://github.com/grpc/grpc-java.git'
-                        developerConnection = 'scm:git:git@github.com:grpc/grpc-java.git'
+                    artifact javadocJar
+                    artifact sourcesJar
+
+                    pom {
+                        name = project.group + ":" + project.name
                         url = 'https://github.com/grpc/grpc-java'
-                    }
-
-                    licenses {
-                        license {
-                            name = 'Apache 2.0'
-                            url = 'https://opensource.org/licenses/Apache-2.0'
+                        afterEvaluate {
+                            // description is not available until evaluated.
+                            description = project.description
                         }
-                    }
 
-                    developers {
-                        developer {
-                            id = "grpc.io"
-                            name = "gRPC Contributors"
-                            email = "grpc-io@googlegroups.com"
-                            url = "https://grpc.io/"
-                            organization = "gRPC Authors"
-                            organizationUrl = "https://www.google.com"
+                        scm {
+                            connection = 'scm:git:https://github.com/grpc/grpc-java.git'
+                            developerConnection = 'scm:git:git@github.com:grpc/grpc-java.git'
+                            url = 'https://github.com/grpc/grpc-java'
                         }
-                    }
 
-                    withXml {
-                        if (!(project.name in
-                        [
-                            "grpc-stub",
-                            "grpc-protobuf",
-                            "grpc-protobuf-lite",
-                        ])) {
-                            asNode().dependencies.'*'.findAll() { dep ->
-                                dep.artifactId.text() in ['grpc-api', 'grpc-core']
-                            }.each() { core ->
-                                core.version*.value = "[" + core.version.text() + "]"
+                        licenses {
+                            license {
+                                name = 'Apache 2.0'
+                                url = 'https://opensource.org/licenses/Apache-2.0'
+                            }
+                        }
+
+                        developers {
+                            developer {
+                                id = "grpc.io"
+                                name = "gRPC Contributors"
+                                email = "grpc-io@googlegroups.com"
+                                url = "https://grpc.io/"
+                                organization = "gRPC Authors"
+                                organizationUrl = "https://www.google.com"
+                            }
+                        }
+
+                        withXml {
+                            if (!(project.name in
+                            [
+                                "grpc-stub",
+                                "grpc-protobuf",
+                                "grpc-protobuf-lite",
+                            ])) {
+                                asNode().dependencies.'*'.findAll() { dep ->
+                                    dep.artifactId.text() in ['grpc-api', 'grpc-core']
+                                }.each() { core ->
+                                    core.version*.value = "[" + core.version.text() + "]"
+                                }
                             }
                         }
                     }
                 }
             }
-        }
-        repositories {
-            maven {
-	        if (rootProject.hasProperty('repositoryDir')) {
-                    url = new File(rootProject.repositoryDir).toURI()
-                } else {
-                    String stagingUrl
-                    if (rootProject.hasProperty('repositoryId')) {
-                        stagingUrl = 'https://oss.sonatype.org/service/local/staging/deployByRepositoryId/' +
-                                rootProject.repositoryId
+            repositories {
+                maven {
+                    if (rootProject.hasProperty('repositoryDir')) {
+                        url = new File(rootProject.repositoryDir).toURI()
                     } else {
-                        stagingUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-                    }
-                    credentials {
-                        if (rootProject.hasProperty('ossrhUsername') && rootProject.hasProperty('ossrhPassword')) {
-                            username = rootProject.ossrhUsername
-                            password = rootProject.ossrhPassword
+                        String stagingUrl
+                        if (rootProject.hasProperty('repositoryId')) {
+                            stagingUrl = 'https://oss.sonatype.org/service/local/staging/deployByRepositoryId/' +
+                                    rootProject.repositoryId
+                        } else {
+                            stagingUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
                         }
+                        credentials {
+                            if (rootProject.hasProperty('ossrhUsername') && rootProject.hasProperty('ossrhPassword')) {
+                                username = rootProject.ossrhUsername
+                                password = rootProject.ossrhPassword
+                            }
+                        }
+                        def releaseUrl = stagingUrl
+                        def snapshotUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+                        url = version.endsWith('SNAPSHOT') ? snapshotUrl : releaseUrl
                     }
-                    def releaseUrl = stagingUrl
-                    def snapshotUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
-                    url = version.endsWith('SNAPSHOT') ? snapshotUrl : releaseUrl
-		}
+                }
             }
         }
-    }
 
-    signing {
-        required false
-        sign publishing.publications.maven
-    }
-
-    [publishMavenPublicationToMavenRepository, publishMavenPublicationToMavenLocal]*.onlyIf {
-        !name.contains("grpc-gae-interop-testing") && !name.contains("grpc-xds")
+        signing {
+            required false
+            sign publishing.publications.maven
+        }
     }
 
     // At a test failure, log the stack trace to the console so that we don't

--- a/build.gradle
+++ b/build.gradle
@@ -220,8 +220,6 @@ subprojects {
 
     // Define a separate configuration for managing the dependency on Jetty ALPN agent.
     configurations {
-        alpnagent
-
         compile {
             // Detect Maven Enforcer's dependencyConvergence failures. We only
             // care for artifacts used as libraries by others.
@@ -239,9 +237,6 @@ subprojects {
         testCompile libraries.junit,
                 libraries.mockito,
                 libraries.truth
-
-        // Configuration for modules that use Jetty ALPN agent
-        alpnagent libraries.jetty_alpn_agent
     }
 
     // Disable JavaDoc doclint on Java 8. It's annoying.

--- a/build.gradle
+++ b/build.gradle
@@ -413,30 +413,10 @@ subprojects {
         }
         maxHeapSize = '1500m'
     }
-}
 
-// Run with: ./gradlew japicmp --continue
-def baselineGrpcVersion = '1.6.1'
-def publicApiSubprojects = [
-    // TODO: uncomment after grpc-alts, grpc-bom artifact is published.
-    // ':grpc-alts',
-    //':grpc-api',
-    ':grpc-auth',
-    //':grpc-bom',
-    ':grpc-context',
-    ':grpc-core',
-    ':grpc-grpclb',
-    ':grpc-netty',
-    ':grpc-okhttp',
-    ':grpc-protobuf',
-    ':grpc-protobuf-lite',
-    ':grpc-stub',
-    ':grpc-testing',
-]
-
-publicApiSubprojects.each { name ->
-    project(":$name") {
-        apply plugin: 'me.champeau.gradle.japicmp'
+    // Run with: ./gradlew japicmp --continue
+    plugins.withId("me.champeau.gradle.japicmp") {
+        def baselineGrpcVersion = '1.6.1'
 
         // Get the baseline version's jar for this subproject
         File baselineArtifact = null

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id "com.google.osdetector" apply false
     id "me.champeau.gradle.japicmp" apply false
     id "net.ltgt.errorprone" apply false
-    id "ru.vyarus.animalsniffer" apply false
 }
 
 import net.ltgt.gradle.errorprone.CheckSeverity
@@ -15,9 +14,6 @@ subprojects {
     apply plugin: "jacoco"
 
     apply plugin: "com.google.osdetector"
-    // The plugin only has an effect if a signature is specified
-    apply plugin: "ru.vyarus.animalsniffer"
-
     apply plugin: "net.ltgt.errorprone"
 
     group = "io.grpc"

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,9 @@
-buildscript {
-    repositories {
-        mavenLocal()
-        maven { url "https://plugins.gradle.org/m2/" }
-    }
-    dependencies {
-        classpath 'com.google.gradle:osdetector-gradle-plugin:1.4.0'
-        classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.5.0'
-        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.8.1'
-        classpath "me.champeau.gradle:jmh-gradle-plugin:0.4.5"
-        classpath 'me.champeau.gradle:japicmp-gradle-plugin:0.2.5'
-    }
+plugins {
+    id "com.google.osdetector" apply false
+    id "me.champeau.gradle.japicmp" apply false
+    id "me.champeau.gradle.jmh" apply false
+    id "net.ltgt.errorprone" apply false
+    id "ru.vyarus.animalsniffer" apply false
 }
 
 import net.ltgt.gradle.errorprone.CheckSeverity
@@ -115,7 +109,6 @@ subprojects {
 
         configureProtoCompilation = {
             String generatedSourcePath = "${projectDir}/src/generated"
-            project.apply plugin: 'com.google.protobuf'
             project.protobuf {
                 protoc {
                     if (project.hasProperty('protoc')) {
@@ -205,7 +198,6 @@ subprojects {
             protobuf: "com.google.protobuf:protobuf-java:${protobufVersion}",
             protobuf_lite: "com.google.protobuf:protobuf-lite:3.0.1",
             protoc_lite: "com.google.protobuf:protoc-gen-javalite:3.0.0",
-            protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.8.8',
             protobuf_util: "com.google.protobuf:protobuf-java-util:${protobufVersion}",
             lang: "org.apache.commons:commons-lang3:3.5",
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ import net.ltgt.gradle.errorprone.CheckSeverity
 
 subprojects {
     apply plugin: "checkstyle"
-    apply plugin: "java"
     apply plugin: "maven"
     apply plugin: "idea"
     apply plugin: "signing"
@@ -20,29 +19,9 @@ subprojects {
     apply plugin: "ru.vyarus.animalsniffer"
 
     apply plugin: "net.ltgt.errorprone"
-    if (rootProject.properties.get('errorProne', true)) {
-        dependencies {
-            errorprone 'com.google.errorprone:error_prone_core:2.3.3'
-            errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
-
-            annotationProcessor 'com.google.guava:guava-beta-checker:1.0'
-        }
-    } else {
-        // Disable Error Prone
-        allprojects {
-            afterEvaluate { project ->
-                project.tasks.withType(JavaCompile) {
-                    options.errorprone.enabled = false
-                }
-            }
-        }
-    }
 
     group = "io.grpc"
     version = "1.24.0-SNAPSHOT" // CURRENT_GRPC_VERSION
-
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.7
 
     repositories {
         maven { // The google mirror is less flaky than mavenCentral()
@@ -61,31 +40,6 @@ subprojects {
         if (rootProject.hasProperty('failOnWarnings') && rootProject.failOnWarnings.toBoolean()) {
             it.options.compilerArgs += ["-Werror"]
         }
-    }
-
-    compileTestJava {
-        // serialVersionUID is basically guaranteed to be useless in our tests
-        options.compilerArgs += [
-            "-Xlint:-serial"
-        ]
-        // LinkedList doesn't hurt much in tests and has lots of usages
-        options.errorprone.check("JdkObsolete", CheckSeverity.OFF)
-    }
-
-    jar.manifest {
-        attributes('Implementation-Title': name,
-        'Implementation-Version': version,
-        'Built-By': System.getProperty('user.name'),
-        'Built-JDK': System.getProperty('java.version'),
-        'Source-Compatibility': sourceCompatibility,
-        'Target-Compatibility': targetCompatibility)
-    }
-
-    javadoc.options {
-        encoding = 'UTF-8'
-        use = true
-        links 'https://docs.oracle.com/javase/8/docs/api/'
-        source = "8"
     }
 
     ext {
@@ -233,12 +187,6 @@ subprojects {
         }
     }
 
-    dependencies {
-        testCompile libraries.junit,
-                libraries.mockito,
-                libraries.truth
-    }
-
     // Disable JavaDoc doclint on Java 8. It's annoying.
     if (JavaVersion.current().isJava8Compatible()) {
         allprojects {
@@ -268,12 +216,81 @@ subprojects {
         }
     }
 
-    checkstyleMain {
-        source = fileTree(dir: "src/main", include: "**/*.java")
-    }
+    plugins.withId("java") {
+        sourceCompatibility = 1.7
+        targetCompatibility = 1.7
 
-    checkstyleTest {
-        source = fileTree(dir: "src/test", include: "**/*.java")
+        dependencies {
+            testCompile libraries.junit,
+                    libraries.mockito,
+                    libraries.truth
+        }
+
+        compileTestJava {
+            // serialVersionUID is basically guaranteed to be useless in our tests
+            options.compilerArgs += [
+                "-Xlint:-serial"
+            ]
+        }
+
+        jar.manifest {
+            attributes('Implementation-Title': name,
+            'Implementation-Version': version,
+            'Built-By': System.getProperty('user.name'),
+            'Built-JDK': System.getProperty('java.version'),
+            'Source-Compatibility': sourceCompatibility,
+            'Target-Compatibility': targetCompatibility)
+        }
+
+        javadoc.options {
+            encoding = 'UTF-8'
+            use = true
+            links 'https://docs.oracle.com/javase/8/docs/api/'
+            source = "8"
+        }
+
+        checkstyleMain {
+            source = fileTree(dir: "src/main", include: "**/*.java")
+        }
+
+        checkstyleTest {
+            source = fileTree(dir: "src/test", include: "**/*.java")
+        }
+
+        // At a test failure, log the stack trace to the console so that we don't
+        // have to open the HTML in a browser.
+        test {
+            testLogging {
+                exceptionFormat = 'full'
+                showExceptions true
+                showCauses true
+                showStackTraces true
+            }
+            maxHeapSize = '1500m'
+        }
+
+        if (rootProject.properties.get('errorProne', true)) {
+            dependencies {
+                errorprone 'com.google.errorprone:error_prone_core:2.3.3'
+                errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
+
+                annotationProcessor 'com.google.guava:guava-beta-checker:1.0'
+            }
+        } else {
+            // Disable Error Prone
+            allprojects {
+                afterEvaluate { project ->
+                    project.tasks.withType(JavaCompile) {
+                        options.errorprone.enabled = false
+                    }
+                }
+            }
+        }
+
+        compileTestJava {
+            // LinkedList doesn't hurt much in tests and has lots of usages
+            options.errorprone.check("JdkObsolete", CheckSeverity.OFF)
+        }
     }
 
     plugins.withId("me.champeau.gradle.jmh") {
@@ -300,27 +317,10 @@ subprojects {
     }
 
     plugins.withId("maven-publish") {
-        task javadocJar(type: Jar) {
-            classifier = 'javadoc'
-            from javadoc
-        }
-
-        task sourcesJar(type: Jar) {
-            classifier = 'sources'
-            from sourceSets.main.allSource
-        }
-
         publishing {
             publications {
                 // do not use mavenJava, as java plugin will modify it via "magic"
                 maven(MavenPublication) {
-                    if (project.name != 'grpc-netty-shaded') {
-                        from components.java
-                    }
-
-                    artifact javadocJar
-                    artifact sourcesJar
-
                     pom {
                         name = project.group + ":" + project.name
                         url = 'https://github.com/grpc/grpc-java'
@@ -400,18 +400,31 @@ subprojects {
             required false
             sign publishing.publications.maven
         }
-    }
 
-    // At a test failure, log the stack trace to the console so that we don't
-    // have to open the HTML in a browser.
-    test {
-        testLogging {
-            exceptionFormat = 'full'
-            showExceptions true
-            showCauses true
-            showStackTraces true
+        plugins.withId("java") {
+            task javadocJar(type: Jar) {
+                classifier = 'javadoc'
+                from javadoc
+            }
+
+            task sourcesJar(type: Jar) {
+                classifier = 'sources'
+                from sourceSets.main.allSource
+            }
+
+            publishing {
+                publications {
+                    maven {
+                        if (project.name != 'grpc-netty-shaded') {
+                            from components.java
+                        }
+
+                        artifact javadocJar
+                        artifact sourcesJar
+                    }
+                }
+            }
         }
-        maxHeapSize = '1500m'
     }
 
     // Run with: ./gradlew japicmp --continue

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "cpp"
+    id "maven-publish"
 
     id "com.google.protobuf"
 }

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "cpp"
+    id "java"
     id "maven-publish"
 
     id "com.google.protobuf"

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -1,16 +1,10 @@
-apply plugin: "cpp"
-apply plugin: "com.google.protobuf"
+plugins {
+    id "cpp"
+
+    id "com.google.protobuf"
+}
 
 description = 'The protoc plugin for gRPC Java'
-
-buildscript {
-    repositories {
-        maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
-        mavenLocal()
-    }
-    dependencies { classpath libraries.protobuf_plugin }
-}
 
 def artifactStagingPath = "$buildDir/artifacts" as File
 // Adds space-delimited arguments from the environment variable env to the

--- a/context/build.gradle
+++ b/context/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "maven-publish"
 
+    id "me.champeau.gradle.japicmp"
     id "me.champeau.gradle.jmh"
 }
 

--- a/context/build.gradle
+++ b/context/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
     id "me.champeau.gradle.japicmp"
     id "me.champeau.gradle.jmh"
+    id "ru.vyarus.animalsniffer"
 }
 
 description = 'gRPC: Context'

--- a/context/build.gradle
+++ b/context/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "me.champeau.gradle.jmh"
+}
+
 description = 'gRPC: Context'
 
 dependencies {

--- a/context/build.gradle
+++ b/context/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "java"
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"

--- a/context/build.gradle
+++ b/context/build.gradle
@@ -1,4 +1,6 @@
 plugins {
+    id "maven-publish"
+
     id "me.champeau.gradle.jmh"
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "java"
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"
@@ -6,6 +7,9 @@ plugins {
 }
 
 description = 'gRPC: Core'
+
+evaluationDependsOn(project(':grpc-context').path)
+evaluationDependsOn(project(':grpc-api').path)
 
 dependencies {
     compile project(':grpc-api'),

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "maven-publish"
 
+    id "me.champeau.gradle.japicmp"
     id "me.champeau.gradle.jmh"
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
     id "me.champeau.gradle.japicmp"
     id "me.champeau.gradle.jmh"
+    id "ru.vyarus.animalsniffer"
 }
 
 description = 'gRPC: Core'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "me.champeau.gradle.jmh"
+}
+
 description = 'gRPC: Core'
 
 dependencies {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,4 +1,6 @@
 plugins {
+    id "maven-publish"
+
     id "me.champeau.gradle.jmh"
 }
 

--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -11,7 +11,6 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-description = 'gRPC: gae interop testing (jdk8)'
 
 buildscript {
     // Configuration for building
@@ -26,6 +25,13 @@ buildscript {
     }
 }
 
+plugins {
+    id "java"
+    id "war"
+}
+
+description = 'gRPC: gae interop testing (jdk8)'
+
 repositories {
     // repositories for Jar's you access in your code
     mavenLocal()
@@ -34,8 +40,6 @@ repositories {
     jcenter()
 }
 
-apply plugin: 'java'                              // standard Java tasks
-apply plugin: 'war'                               // standard Web Archive plugin
 apply plugin: 'com.google.cloud.tools.appengine'  // App Engine tasks
 
 dependencies {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/grpclb/build.gradle
+++ b/grpclb/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "java"
     id "maven-publish"
 
     id "com.google.protobuf"
@@ -6,6 +7,8 @@ plugins {
 }
 
 description = "gRPC: GRPCLB LoadBalancer plugin"
+
+evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
     compile project(':grpc-core'),

--- a/grpclb/build.gradle
+++ b/grpclb/build.gradle
@@ -1,12 +1,8 @@
-description = "gRPC: GRPCLB LoadBalancer plugin"
-
-buildscript {
-    repositories {
-        maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
-    }
-    dependencies { classpath libraries.protobuf_plugin }
+plugins {
+    id "com.google.protobuf"
 }
+
+description = "gRPC: GRPCLB LoadBalancer plugin"
 
 dependencies {
     compile project(':grpc-core'),

--- a/grpclb/build.gradle
+++ b/grpclb/build.gradle
@@ -1,4 +1,6 @@
 plugins {
+    id "maven-publish"
+
     id "com.google.protobuf"
 }
 

--- a/grpclb/build.gradle
+++ b/grpclb/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id "maven-publish"
 
     id "com.google.protobuf"
+    id "me.champeau.gradle.japicmp"
 }
 
 description = "gRPC: GRPCLB LoadBalancer plugin"

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "application"
+    id "maven-publish"
 
     id "com.google.protobuf"
 }

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "application"
+    id "java"
     id "maven-publish"
 
     id "com.google.protobuf"

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -8,6 +8,10 @@ plugins {
 description = "gRPC: Integration Testing"
 startScripts.enabled = false
 
+configurations {
+    alpnagent
+}
+
 dependencies {
     compile project(':grpc-alts'),
             project(':grpc-auth'),
@@ -26,6 +30,7 @@ dependencies {
             project(':grpc-grpclb')
     testCompile project(':grpc-context').sourceSets.test.output,
             libraries.mockito
+    alpnagent libraries.jetty_alpn_agent
 }
 
 configureProtoCompilation()

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -1,16 +1,11 @@
-apply plugin: 'application'
+plugins {
+    id "application"
+
+    id "com.google.protobuf"
+}
 
 description = "gRPC: Integration Testing"
 startScripts.enabled = false
-
-// Add dependency on the protobuf plugin
-buildscript {
-    repositories {
-        maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
-    }
-    dependencies { classpath libraries.protobuf_plugin }
-}
 
 dependencies {
     compile project(':grpc-alts'),

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "maven-publish"
 
+    id "me.champeau.gradle.japicmp"
     id "me.champeau.gradle.jmh"
 }
 

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "me.champeau.gradle.jmh"
+}
+
 description = "gRPC: Netty"
 dependencies {
     compile project(':grpc-core'),

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -5,6 +5,11 @@ plugins {
 }
 
 description = "gRPC: Netty"
+
+configurations {
+    alpnagent
+}
+
 dependencies {
     compile project(':grpc-core'),
             libraries.netty,
@@ -18,6 +23,7 @@ dependencies {
             libraries.conscrypt,
             libraries.netty_epoll
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
+    alpnagent libraries.jetty_alpn_agent
 }
 
 import net.ltgt.gradle.errorprone.CheckSeverity

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
     id "me.champeau.gradle.japicmp"
     id "me.champeau.gradle.jmh"
+    id "ru.vyarus.animalsniffer"
 }
 
 description = "gRPC: Netty"

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "java"
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -1,4 +1,6 @@
 plugins {
+    id "maven-publish"
+
     id "me.champeau.gradle.jmh"
 }
 

--- a/netty/shaded/build.gradle
+++ b/netty/shaded/build.gradle
@@ -1,4 +1,6 @@
 plugins {
+    id "maven-publish"
+
     id "com.github.johnrengelman.shadow"
 }
 

--- a/netty/shaded/build.gradle
+++ b/netty/shaded/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "java"
     id "maven-publish"
 
     id "com.github.johnrengelman.shadow"

--- a/netty/shaded/build.gradle
+++ b/netty/shaded/build.gradle
@@ -1,9 +1,6 @@
-buildscript {
-    repositories { jcenter() }
-    dependencies { classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.4' }
+plugins {
+    id "com.github.johnrengelman.shadow"
 }
-
-apply plugin: 'com.github.johnrengelman.shadow'
 
 description = "gRPC: Netty Shaded"
 

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"
+    id "ru.vyarus.animalsniffer"
 }
 
 description = "gRPC: OkHttp"

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -1,5 +1,7 @@
 plugins {
     id "maven-publish"
+
+    id "me.champeau.gradle.japicmp"
 }
 
 description = "gRPC: OkHttp"

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "java"
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "maven-publish"
+}
+
 description = "gRPC: OkHttp"
 
 dependencies {

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "java"
     id "maven-publish"
 
     id "com.google.protobuf"

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id "maven-publish"
 
     id "com.google.protobuf"
+    id "me.champeau.gradle.japicmp"
 }
 
 description = 'gRPC: Protobuf Lite'

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
     id "com.google.protobuf"
     id "me.champeau.gradle.japicmp"
+    id "ru.vyarus.animalsniffer"
 }
 
 description = 'gRPC: Protobuf Lite'

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -1,13 +1,6 @@
-buildscript {
-    repositories {
-        maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
-        mavenLocal()
-    }
-    dependencies { classpath libraries.protobuf_plugin }
+plugins {
+    id "com.google.protobuf"
 }
-
-apply plugin: 'com.google.protobuf'
 
 description = 'gRPC: Protobuf Lite'
 

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -1,4 +1,6 @@
 plugins {
+    id "maven-publish"
+
     id "com.google.protobuf"
 }
 

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id "maven-publish"
 
     id "com.google.protobuf"
+    id "me.champeau.gradle.japicmp"
 }
 
 description = 'gRPC: Protobuf'

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
     id "com.google.protobuf"
     id "me.champeau.gradle.japicmp"
+    id "ru.vyarus.animalsniffer"
 }
 
 description = 'gRPC: Protobuf'

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "java"
     id "maven-publish"
 
     id "com.google.protobuf"

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -1,4 +1,6 @@
 plugins {
+    id "maven-publish"
+
     id "com.google.protobuf"
 }
 

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -1,12 +1,8 @@
-description = 'gRPC: Protobuf'
-
-buildscript {
-    repositories {
-        maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
-    }
-    dependencies { classpath libraries.protobuf_plugin }
+plugins {
+    id "com.google.protobuf"
 }
+
+description = 'gRPC: Protobuf'
 
 dependencies {
     compile project(':grpc-api'),

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id "maven-publish"
 
     id "com.google.protobuf"
+    id "ru.vyarus.animalsniffer"
 }
 
 description = "gRPC: Services"

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "java"
     id "maven-publish"
 
     id "com.google.protobuf"

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -1,10 +1,5 @@
-// Add dependency on the protobuf plugin
-buildscript {
-    repositories {
-        maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
-    }
-    dependencies { classpath libraries.protobuf_plugin }
+plugins {
+    id "com.google.protobuf"
 }
 
 description = "gRPC: Services"

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -1,4 +1,6 @@
 plugins {
+    id "maven-publish"
+
     id "com.google.protobuf"
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,16 @@
+pluginManagement {
+    plugins {
+        id "com.github.johnrengelman.shadow" version "2.0.4"
+        id "com.github.kt3k.coveralls" version "2.0.1"
+        id "com.google.osdetector" version "1.4.0"
+        id "com.google.protobuf" version "0.8.8"
+        id "me.champeau.gradle.japicmp" version "0.2.5"
+        id "me.champeau.gradle.jmh" version "0.4.5"
+        id "net.ltgt.errorprone" version "0.8.1"
+        id "ru.vyarus.animalsniffer" version "1.5.0"
+    }
+}
+
 rootProject.name = "grpc"
 include ":grpc-api"
 include ":grpc-core"

--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"
+    id "ru.vyarus.animalsniffer"
 }
 
 description = "gRPC: Stub"

--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "maven-publish"
+}
+
 description = "gRPC: Stub"
 dependencies {
     compile project(':grpc-api')

--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "java"
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"

--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -1,5 +1,7 @@
 plugins {
     id "maven-publish"
+
+    id "me.champeau.gradle.japicmp"
 }
 
 description = "gRPC: Stub"

--- a/testing-proto/build.gradle
+++ b/testing-proto/build.gradle
@@ -1,13 +1,8 @@
-description = "gRPC: Testing Protos"
-
-// Add dependency on the protobuf plugin
-buildscript {
-    repositories {
-        maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
-    }
-    dependencies { classpath libraries.protobuf_plugin }
+plugins {
+    id "com.google.protobuf"
 }
+
+description = "gRPC: Testing Protos"
 
 dependencies {
     compile project(':grpc-protobuf'),

--- a/testing-proto/build.gradle
+++ b/testing-proto/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "java"
     id "maven-publish"
 
     id "com.google.protobuf"

--- a/testing-proto/build.gradle
+++ b/testing-proto/build.gradle
@@ -1,4 +1,6 @@
 plugins {
+    id "maven-publish"
+
     id "com.google.protobuf"
 }
 

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -1,5 +1,7 @@
 plugins {
     id "maven-publish"
+
+    id "me.champeau.gradle.japicmp"
 }
 
 description = "gRPC: Testing"

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "maven-publish"
+}
+
 description = "gRPC: Testing"
 
 dependencies {

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "java"
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -1,17 +1,7 @@
-// Add dependency on the protobuf plugin
-buildscript {
-    repositories {
-        maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
-        gradlePluginPortal()
-    }
-    dependencies {
-        classpath libraries.protobuf_plugin
-        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.4'
-    }
+plugins {
+    id "com.github.johnrengelman.shadow"
+    id "com.google.protobuf"
 }
-
-apply plugin: 'com.github.johnrengelman.shadow'
 
 description = "gRPC: XDS plugin"
 
@@ -42,7 +32,6 @@ dependencies {
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
 }
 
-apply plugin: 'com.google.protobuf'
 sourceSets {
     main {
         proto {

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -1,4 +1,6 @@
 plugins {
+    id "maven-publish"
+
     id "com.github.johnrengelman.shadow"
     id "com.google.protobuf"
 }
@@ -68,3 +70,4 @@ publishing {
         }
     }
 }
+[publishMavenPublicationToMavenRepository, publishMavenPublicationToMavenLocal]*.onlyIf { false }

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "java"
     id "maven-publish"
 
     id "com.github.johnrengelman.shadow"

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
     id "com.github.johnrengelman.shadow"
     id "com.google.protobuf"
+    id "ru.vyarus.animalsniffer"
 }
 
 description = "gRPC: XDS plugin"


### PR DESCRIPTION
This is a long patch series that looks intimidating. But it is split up into atomic comics that apply to one piece at a time. I spent effort to avoid changing existing behavior or to further simplify, so most large code movements have no differences within their body. The exception is cases where we had ifs checking which project we were processing; those were mostly removed in favor of triggering the behavior only if a project uses specific plugins.

This is in no way "complete." There's still plenty of other improvements available.

There were several objectives: 1) get the build file into stronger shape where related code is together, 2) allow more independence in projects (e.g., we shouldn't be forced to migrate all projects to java-library at once) and 3) allow Android to be part of our main build. Actually adding Android projects was not included (see #6132), since that is a riskier addition.

Parts of this may be more conservative than you may hope, like I did not update the examples to the new plugin syntax. That should not be seen as a problem; we can do further changes later.

When merging, I will leave the commits separate.