### PR TITLE
xds: implement bootstrapping for xDS load balancer for alpha release

### DIFF
--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -26,10 +26,17 @@ dependencies {
     compile project(':grpc-protobuf'),
             project(':grpc-stub'),
             project(':grpc-core'),
-            project(':grpc-services')
+            project(':grpc-services'),
+            project(':grpc-auth')
     compile (libraries.protobuf_util) {
         // prefer 26.0-android from libraries instead of 20.0
         exclude group: 'com.google.guava', module: 'guava'
+    }
+    compile (libraries.google_auth_oauth2_http) {
+        // prefer 26.0-android from libraries instead of 25.1-android
+        exclude group: 'com.google.guava', module: 'guava'
+        // prefer 0.19.2 from libraries instead of 0.18.0
+        exclude group: 'io.opencensus', module: 'opencensus-api'
     }
 
     testCompile project(':grpc-core').sourceSets.test.output

--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import com.google.auth.oauth2.ComputeEngineCredentials;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.util.JsonFormat;
+import io.envoyproxy.envoy.api.v2.core.ApiConfigSource;
+import io.envoyproxy.envoy.api.v2.core.ApiConfigSource.ApiType;
+import io.envoyproxy.envoy.api.v2.core.Node;
+import io.grpc.CallCredentials;
+import io.grpc.auth.MoreCallCredentials;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * Loads configuration information to bootstrap xDS load balancer.
+ */
+@NotThreadSafe
+abstract class Bootstrapper {
+
+  private static final String BOOTSTRAP_PATH_SYS_ENV_VAR = "GRPC_XDS_BOOTSTRAP";
+  private static final Logger log = Logger.getLogger(Bootstrapper.class.getName());
+  private static RuntimeException failToBootstrapException;
+  private static Bootstrapper DEFAULT_INSTANCE;
+
+  static Bootstrapper getInstance() {
+    if (DEFAULT_INSTANCE == null && failToBootstrapException == null) {
+      try {
+        DEFAULT_INSTANCE = new FileBasedBootstrapper();
+      } catch (RuntimeException e) {
+        failToBootstrapException = e;
+      }
+    }
+    if (DEFAULT_INSTANCE == null) {
+      throw failToBootstrapException;
+    }
+    return DEFAULT_INSTANCE;
+  }
+
+  @Nullable
+  private static ConfigReader createConfigReaderOrNull() {
+    String filePath = System.getenv(BOOTSTRAP_PATH_SYS_ENV_VAR);
+    ConfigReader reader = null;
+    if (filePath != null) {
+      try {
+        reader = new ConfigReader(Paths.get(filePath));
+      } catch (Exception e) {
+        log.warning("Unable to read bootstrap file: " + e.getMessage());
+      }
+    } else {
+      log.warning("Environment variable " + BOOTSTRAP_PATH_SYS_ENV_VAR + " not found.");
+    }
+    return reader;
+  }
+
+  /**
+   * Returns the canonical name of the traffic director to be connected to.
+   */
+  abstract String getBalancerName();
+
+  /**
+   * Returns a {@link Node} message with project/network metadata in it to be included in
+   * xDS requests.
+   */
+  abstract Node getNode();
+
+  /**
+   * Returns the credentials to use when communicating with the xDS server.
+   */
+  abstract CallCredentials getCallCredentials();
+
+  @VisibleForTesting
+  static final class FileBasedBootstrapper extends Bootstrapper {
+
+    private final String balancerName;
+    private final Node node;
+    // TODO(chengyuanzhang): Add configuration for call credentials loaded from bootstrap file.
+    //  hard-coded for alpha release.
+
+    private FileBasedBootstrapper() {
+      this(createConfigReaderOrNull());
+    }
+
+    @VisibleForTesting
+    FileBasedBootstrapper(@Nullable ConfigReader reader) {
+      if (reader == null) {
+        throw new RuntimeException("Failed to bootstrap from config file.");
+      }
+      balancerName = reader.getServerConfig().getGrpcServices(0).getGoogleGrpc().getTargetUri();
+      node = reader.getNode();
+    }
+
+    @Override
+    String getBalancerName() {
+      return balancerName;
+    }
+    
+    @Override
+    Node getNode() {
+      return node;
+    }
+
+    @Override
+    CallCredentials getCallCredentials() {
+      return MoreCallCredentials.from(ComputeEngineCredentials.create());
+    }
+  }
+
+  @VisibleForTesting
+  static final class ConfigReader {
+    private final Node node;
+    private final ApiConfigSource serverConfig;
+
+    private ConfigReader(Path path) throws IOException {
+      this(new String(Files.readAllBytes(path), Charset.defaultCharset()));
+    }
+
+    ConfigReader(String data) throws IOException {
+      Bootstrap.Builder bootstrapBuilder = Bootstrap.newBuilder();
+      JsonFormat.parser().merge(data, bootstrapBuilder);
+      node = bootstrapBuilder.getNode();
+      serverConfig = bootstrapBuilder.getXdsServer();
+      if (!serverConfig.getApiType().equals(ApiType.GRPC)) {
+        throw new RuntimeException("Unexpected api type: " + serverConfig.getApiType().toString());
+      }
+      if (serverConfig.getGrpcServicesCount() != 1) {
+        throw new RuntimeException(
+            "Unexpected number of gRPC services: expected: 1, actual: "
+                + serverConfig.getGrpcServicesCount());
+      }
+    }
+
+    private Node getNode() {
+      return node;
+    }
+
+    private ApiConfigSource getServerConfig() {
+      return serverConfig;
+    }
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancerProvider.java
@@ -67,7 +67,7 @@ public final class XdsLoadBalancerProvider extends LoadBalancerProvider {
   @Override
   public LoadBalancer newLoadBalancer(Helper helper) {
     return new XdsLoadBalancer(helper, LoadBalancerRegistry.getDefaultRegistry(),
-        new ExponentialBackoffPolicy.Provider());
+        new ExponentialBackoffPolicy.Provider(), false);
   }
 
   @Override

--- a/xds/src/main/proto/bootstrap.proto
+++ b/xds/src/main/proto/bootstrap.proto
@@ -1,0 +1,39 @@
+// Copyright 2019 The gRPC Authors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// An integration test service that covers all the method signature permutations
+// of unary/streaming requests/responses.
+
+syntax = "proto3";
+
+package io.grpc.xds;
+
+option java_outer_classname = "BootstrapProto";
+option java_multiple_files = true;
+option java_package = "io.grpc.xds";
+
+import "envoy/api/v2/core/base.proto";
+import "envoy/api/v2/core/config_source.proto";
+
+// Configurations containing the information needed for xDS load balancer to bootstrap its
+// communication with the xDS server.
+// This proto message is defined for the convenience of parsing JSON bootstrap file in xDS load
+// balancing policy only. It should not be used for any other purposes.
+message Bootstrap {
+  // Metadata to be added to the Node message in xDS requests.
+  envoy.api.v2.core.Node node = 1;
+
+  // Configurations including the name of the xDS server to contact, the credentials to use, etc.
+  envoy.api.v2.core.ApiConfigSource xds_server = 2;
+}

--- a/xds/src/test/java/io/grpc/xds/BootstrapperTest.java
+++ b/xds/src/test/java/io/grpc/xds/BootstrapperTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import io.envoyproxy.envoy.api.v2.core.Locality;
+import io.envoyproxy.envoy.api.v2.core.Node;
+import io.grpc.xds.Bootstrapper.ConfigReader;
+import io.grpc.xds.Bootstrapper.FileBasedBootstrapper;
+import java.io.IOException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link Bootstrapper}. */
+@RunWith(JUnit4.class)
+public class BootstrapperTest {
+
+  @Test
+  public void validBootstrap() throws IOException {
+    String bootstrapData = "{"
+        + "\"node\": {"
+        + "\"id\": \"ENVOY_NODE_ID\","
+        + "\"locality\": {"
+        + "\"zone\": \"ENVOY_ZONE\"},"
+        + "\"metadata\": {"
+        + "\"TRAFFICDIRECTOR_INTERCEPTION_PORT\": \"ENVOY_PORT\", "
+        + "\"TRAFFICDIRECTOR_NETWORK_NAME\": \"VPC_NETWORK_NAME\""
+        + "}"
+        + "},"
+        + "\"xds_server\": {"
+        + "\"api_type\": \"GRPC\","
+        + "\"grpc_services\": "
+        + "[ {\"google_grpc\": {\"target_uri\": \"trafficdirector.googleapis.com:443\"} } ]"
+        + "} "
+        + "}";
+
+    ConfigReader reader = new ConfigReader(bootstrapData);
+    Bootstrapper bootstrapper =
+        new FileBasedBootstrapper(reader);
+    assertThat(bootstrapper.getBalancerName()).isEqualTo("trafficdirector.googleapis.com:443");
+    assertThat(bootstrapper.getNode())
+        .isEqualTo(
+            Node.newBuilder()
+                .setId("ENVOY_NODE_ID")
+                .setLocality(Locality.newBuilder().setZone("ENVOY_ZONE").build())
+                .setMetadata(
+                    Struct.newBuilder()
+                        .putFields("TRAFFICDIRECTOR_INTERCEPTION_PORT",
+                            Value.newBuilder().setStringValue("ENVOY_PORT").build())
+                        .putFields("TRAFFICDIRECTOR_NETWORK_NAME",
+                            Value.newBuilder().setStringValue("VPC_NETWORK_NAME").build())
+                        .build()).build());
+  }
+
+  @Test
+  public void failToBootstrap() {
+    try {
+      new FileBasedBootstrapper(null);
+      fail("RuntimeException should have been thrown");
+    } catch (RuntimeException e) {
+      // Expected.
+      assertThat(e.getMessage()).isEqualTo("Failed to bootstrap from config file.");
+    }
+  }
+
+  @Test
+  public void configReader_emptyFile() {
+    String bootstrapData = "";
+    try {
+      new ConfigReader(bootstrapData);
+      fail("IOException should have been thrown");
+    } catch (IOException e) {
+      // Expected.
+    }
+  }
+
+  @Test
+  public void configReader_invalidNodeProto() {
+    String bootstrapData = "{"
+        + "\"node\": {"
+        + "\"id\": \"ENVOY_NODE_ID\","
+        + "\"bad_field\": \"bad_value\""
+        + "\"locality\": {"
+        + "\"zone\": \"ENVOY_ZONE\"},"
+        + "\"metadata\": {"
+        + "\"TRAFFICDIRECTOR_INTERCEPTION_PORT\": \"ENVOY_PORT\", "
+        + "\"TRAFFICDIRECTOR_NETWORK_NAME\": \"VPC_NETWORK_NAME\""
+        + "}"
+        + "},"
+        + "\"xds_server\": {"
+        + "\"api_type\": \"GRPC\","
+        + "\"grpc_services\": "
+        + "[ {\"google_grpc\": {\"target_uri\": \"trafficdirector.googleapis.com:443\"} } ]"
+        + "} "
+        + "}";
+    try {
+      new ConfigReader(bootstrapData);
+      fail("IOException should have been thrown");
+    } catch (IOException e) {
+      // Expected.
+    }
+  }
+
+  @Test
+  public void configReader_invalidApiConfigSourceProto() {
+    String bootstrapData = "{"
+        + "\"node\": {"
+        + "\"id\": \"ENVOY_NODE_ID\","
+        + "\"locality\": {"
+        + "\"zone\": \"ENVOY_ZONE\"},"
+        + "\"metadata\": {"
+        + "\"TRAFFICDIRECTOR_INTERCEPTION_PORT\": \"ENVOY_PORT\", "
+        + "\"TRAFFICDIRECTOR_NETWORK_NAME\": \"VPC_NETWORK_NAME\""
+        + "}"
+        + "},"
+        + "\"xds_server\": {"
+        + "\"api_type\": \"GRPC\","
+        + "\"bad_field\": \"bad_value\""
+        + "\"grpc_services\": "
+        + "[ {\"google_grpc\": {\"target_uri\": \"trafficdirector.googleapis.com:443\"} } ]"
+        + "} "
+        + "}";
+    try {
+      new ConfigReader(bootstrapData);
+      fail("IOException should have been thrown");
+    } catch (IOException e) {
+      // Expected.
+    }
+  }
+
+  @Test
+  public void configReader_tooManyGrpcServices() throws IOException {
+    String bootstrapData = "{"
+        + "\"node\": {"
+        + "\"id\": \"ENVOY_NODE_ID\","
+        + "\"locality\": {"
+        + "\"zone\": \"ENVOY_ZONE\"},"
+        + "\"metadata\": {"
+        + "\"TRAFFICDIRECTOR_INTERCEPTION_PORT\": \"ENVOY_PORT\", "
+        + "\"TRAFFICDIRECTOR_NETWORK_NAME\": \"VPC_NETWORK_NAME\""
+        + "}"
+        + "},"
+        + "\"xds_server\": {"
+        + "\"api_type\": \"GRPC\","
+        + "\"grpc_services\": "
+        + "[ {\"google_grpc\": {\"target_uri\": \"trafficdirector.googleapis.com:443\"} },"
+        + "{\"google_grpc\": {\"target_uri\": \"foobar.googleapis.com:443\"} } ]"
+        + "} "
+        + "}";
+    try {
+      new ConfigReader(bootstrapData);
+      fail("RuntimeException should have been thrown");
+    } catch (RuntimeException e) {
+      // Expected.
+      assertThat(e.getMessage())
+          .isEqualTo("Unexpected number of gRPC services: expected: 1, actual: 2");
+    }
+  }
+
+  @Test
+  public void configReader_invalidApiType() throws IOException {
+    String bootstrapData = "{"
+        + "\"node\": {"
+        + "\"id\": \"ENVOY_NODE_ID\","
+        + "\"locality\": {"
+        + "\"zone\": \"ENVOY_ZONE\"},"
+        + "\"metadata\": {"
+        + "\"TRAFFICDIRECTOR_INTERCEPTION_PORT\": \"ENVOY_PORT\", "
+        + "\"TRAFFICDIRECTOR_NETWORK_NAME\": \"VPC_NETWORK_NAME\""
+        + "}"
+        + "},"
+        + "\"xds_server\": {"
+        + "\"api_type\": \"REST\","
+        + "\"grpc_services\": "
+        + "[ {\"google_grpc\": {\"target_uri\": \"trafficdirector.googleapis.com:443\"} } ]"
+        + "} "
+        + "}";
+    try {
+      new ConfigReader(bootstrapData);
+      fail("RuntimeException should have been thrown");
+    } catch (RuntimeException e) {
+      // Expected.
+      assertThat(e.getMessage()).isEqualTo("Unexpected api type: REST");
+    }
+  }
+}

--- a/xds/src/test/java/io/grpc/xds/XdsLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadBalancerTest.java
@@ -227,7 +227,7 @@ public class XdsLoadBalancerTest {
     lbRegistry.register(lbProvider1);
     lbRegistry.register(lbProvider2);
     lbRegistry.register(roundRobin);
-    lb = new XdsLoadBalancer(helper, lbRegistry, backoffPolicyProvider);
+    lb = new XdsLoadBalancer(helper, lbRegistry, backoffPolicyProvider, false);
     doReturn(syncContext).when(helper).getSynchronizationContext();
     doReturn(fakeClock.getScheduledExecutorService()).when(helper).getScheduledExecutorService();
     doReturn(mock(ChannelLogger.class)).when(helper).getChannelLogger();

--- a/xds/src/test/java/io/grpc/xds/XdsLoadBalancerWithLrsTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadBalancerWithLrsTest.java
@@ -224,7 +224,7 @@ public class XdsLoadBalancerWithLrsTest {
         any(BackoffPolicy.Provider.class), any(LoadStatsStore.class))).thenReturn(lrsClient);
 
     xdsLoadBalancer =
-        new XdsLoadBalancer(helper, lbRegistry, backoffPolicyProvider, lrsClientFactory,
+        new XdsLoadBalancer(helper, lbRegistry, backoffPolicyProvider, false, lrsClientFactory,
             new FallbackManager(helper, lbRegistry), localityStore);
   }
 


### PR DESCRIPTION
A bootstrap class that reads a local JSON file to populate information needed for xDS load balancer communicating with traffic director. 

More specifically, it populates balancer name (aka, traffic director name) and a `Node` message to be included in xDS requests.

We have not figured out how we should use channel/call credentials from bootstrap. For now, it's hard-coded to `ComputeEngineCredentials`, which can be easily applied to LB `stub`.

xDS load balancer is undergoing restructuring and code refactoring. We will apply configurations populated by bootstrapper to xDS communications once that is done.