### PR TITLE
auth: verify information in decoded JWT token instead of comparing encoded hash values

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -3,7 +3,8 @@ dependencies {
     compile project(':grpc-api'),
             libraries.google_auth_credentials
     testCompile project(':grpc-testing'),
-            libraries.google_auth_oauth2_http
+            libraries.google_auth_oauth2_http,
+            libraries.jwt
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -191,6 +191,7 @@ subprojects {
             hpack: 'com.twitter:hpack:0.10.1',
             javax_annotation: 'javax.annotation:javax.annotation-api:1.2',
             jsr305: 'com.google.code.findbugs:jsr305:3.0.2',
+            jwt: 'com.auth0:java-jwt:3.8.2',
             google_api_protos: 'com.google.api.grpc:proto-google-common-protos:1.12.0',
             google_auth_credentials: "com.google.auth:google-auth-library-credentials:${googleauthVersion}",
             google_auth_oauth2_http: "com.google.auth:google-auth-library-oauth2-http:${googleauthVersion}",


### PR DESCRIPTION
Resolves #6129 

Previous we compare encoded JWT tokens to verify that service account information is correctly used for converting `ServiceAccountCredentials` to `ServiceAccountJwtAccessCredentials`. The encoded JWT payload contains issue/expiration information, which causes the test to be flaky when comparing two hashes that generated at slightly different time.

This change uses `java-jwt` to decode the token and verify if it contains our original information for test.