### PR TITLE
xds: Priority failover

### DIFF
--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -502,7 +502,6 @@ interface LocalityStore {
           updatePicker(overallState, childPickers);
           if (overallState == READY) {
             cancelFailOverTimer();
-            goToPriority(priority);
           } else if (overallState == TRANSIENT_FAILURE) {
             cancelFailOverTimer();
             failOver();
@@ -512,7 +511,15 @@ interface LocalityStore {
         } else if (overallState == READY) {
           updatePicker(overallState, childPickers);
           cancelFailOverTimer();
-          goToPriority(priority);
+          currentPriority = priority;
+        }
+
+        if (overallState == READY) {
+          for (int p = priority + 1; p < priorityTable.size(); p++) {
+            for (XdsLocality xdsLocality : priorityTable.get(p)) {
+              deactivate(xdsLocality);
+            }
+          }
         }
       }
 
@@ -593,15 +600,6 @@ interface LocalityStore {
                     .setAddresses(localityInfo.eags).build());
           }
         });
-      }
-
-      private void goToPriority(int priority) {
-        currentPriority = priority;
-        for (int p = priority + 1; p < priorityTable.size(); p++) {
-          for (XdsLocality xdsLocality : priorityTable.get(p)) {
-            deactivate(xdsLocality);
-          }
-        }
       }
     }
   }

--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -446,11 +446,9 @@ interface LocalityStore {
 
     private final class PriorityManager {
 
-      private static final int INVALID_PRIORITY = -1;
-
       private final List<List<XdsLocality>> priorityTable = new ArrayList<>();
       private Map<XdsLocality, LocalityInfo> localityInfoMap = ImmutableMap.of();
-      private int currentPriority = INVALID_PRIORITY;
+      private int currentPriority = -1;
       private ScheduledHandle failOverTimer;
 
       /**
@@ -472,7 +470,7 @@ interface LocalityStore {
           currentPriority = priorityTable.size() - 1;
         }
 
-        if (currentPriority == INVALID_PRIORITY) {
+        if (currentPriority == -1) {
           failOver();
           return;
         }
@@ -487,7 +485,7 @@ interface LocalityStore {
        * localities to be used.
        */
       void updatePriorityState(int priority) {
-        if (priority == INVALID_PRIORITY || priority > currentPriority) {
+        if (priority == -1 || priority > currentPriority) {
           return;
         }
         List<WeightedChildPicker> childPickers = new ArrayList<>();
@@ -529,14 +527,14 @@ interface LocalityStore {
         if (localityInfoMap.containsKey(locality)) {
           return localityInfoMap.get(locality).priority;
         }
-        return INVALID_PRIORITY;
+        return -1;
       }
 
       void reset() {
         cancelFailOverTimer();
         priorityTable.clear();
         localityInfoMap = ImmutableMap.of();
-        currentPriority = INVALID_PRIORITY;
+        currentPriority = -1;
       }
 
       private void cancelFailOverTimer() {

--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -459,7 +459,11 @@ interface LocalityStore {
         this.localityInfoMap = ImmutableMap.copyOf(localityInfoMap);
         priorityTable.clear();
         for (XdsLocality newLocality : localityInfoMap.keySet()) {
-          addLocality(localityInfoMap.get(newLocality).priority, newLocality);
+          int priority = localityInfoMap.get(newLocality).priority;
+          while (priorityTable.size() <= priority) {
+            priorityTable.add(new ArrayList<XdsLocality>());
+          }
+          priorityTable.get(priority).add(newLocality);
         }
 
         if (currentPriority >= priorityTable.size()) {
@@ -474,13 +478,6 @@ interface LocalityStore {
         for (int p = 0; p < priorityTable.size(); p++) {
           updatePriorityState(p);
         }
-      }
-
-      private void addLocality(int priority, XdsLocality locality) {
-        while (priorityTable.size() <= priority) {
-          priorityTable.add(new ArrayList<XdsLocality>());
-        }
-        priorityTable.get(priority).add(locality);
       }
 
       /**

--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -245,7 +245,7 @@ interface LocalityStore {
           }
         }
       });
-      localities = ImmutableSet.copyOf(newLocalities);
+      localities = newLocalities;
 
       priorityManager.updateLocalities(localityInfoMap);
 

--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -16,7 +16,6 @@
 
 package io.grpc.xds;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.grpc.ConnectivityState.CONNECTING;
 import static io.grpc.ConnectivityState.IDLE;
@@ -29,7 +28,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
-import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.PickResult;
@@ -53,8 +51,8 @@ import io.grpc.xds.XdsComms.LocalityInfo;
 import io.grpc.xds.XdsSubchannelPickers.ErrorPicker;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -91,8 +89,8 @@ interface LocalityStore {
     private final LoadStatsStore loadStatsStore;
     private final OrcaPerRequestUtil orcaPerRequestUtil;
     private final OrcaOobUtil orcaOobUtil;
-
-    private final Map<XdsLocality, LocalityLbInfo> localityMap = new LinkedHashMap<>();
+    private final PriorityManager priorityManager = new PriorityManager();
+    private final Map<XdsLocality, LocalityLbInfo> localityMap = new HashMap<>();
     private Map<XdsLocality, LocalityInfo> edsResponsLocalityInfo = ImmutableMap.of();
     private ImmutableList<DropOverload> dropOverloads = ImmutableList.of();
     private long metricsReportIntervalNano = -1;
@@ -192,78 +190,37 @@ interface LocalityStore {
       for (XdsLocality locality : edsResponsLocalityInfo.keySet()) {
         loadStatsStore.removeLocality(locality);
       }
+      priorityManager.cancelFailOverTimer();
     }
 
     // This is triggered by EDS response.
     @Override
-    public void updateLocalityStore(Map<XdsLocality, LocalityInfo> localityInfoMap) {
-      Set<XdsLocality> oldLocalities = localityMap.keySet();
-      Set<XdsLocality> newLocalities = localityInfoMap.keySet();
-      Map<XdsLocality, LocalityLbInfo> updatedLocalityMap = new LinkedHashMap<>();
+    public void updateLocalityStore(final Map<XdsLocality, LocalityInfo> localityInfoMap) {
 
-      for (XdsLocality oldLocality : oldLocalities) {
-        if (!newLocalities.contains(oldLocality)) {
-          deactivate(oldLocality);
+      // TODO: put endPointWeights into attributes for WRR.
+      for (XdsLocality locality : localityInfoMap.keySet()) {
+        if (localityMap.containsKey(locality)) {
+          final LocalityLbInfo localityLbInfo = localityMap.get(locality);
+          final LocalityInfo localityInfo = localityInfoMap.get(locality);
+          // In extreme case handleResolvedAddresses() may trigger updateBalancingState()
+          // immediately, so execute handleResolvedAddresses() after all the setup in this method is
+          // complete.
+          helper.getSynchronizationContext().execute(new Runnable() {
+            @Override
+            public void run() {
+              localityLbInfo.childBalancer.handleResolvedAddresses(
+                  ResolvedAddresses.newBuilder().setAddresses(localityInfo.eags).build());
+            }
+          });
         }
       }
 
+      Set<XdsLocality> newLocalities = localityInfoMap.keySet();
       for (XdsLocality newLocality : newLocalities) {
-
         if (!edsResponsLocalityInfo.containsKey(newLocality)) {
           loadStatsStore.addLocality(newLocality);
         }
-
-        // Assuming standard mode only (EDS response with a list of endpoints) for now.
-        final List<EquivalentAddressGroup> newEags = localityInfoMap.get(newLocality).eags;
-        final LocalityLbInfo localityLbInfo;
-        ChildHelper childHelper;
-        if (oldLocalities.contains(newLocality)) {
-          LocalityLbInfo oldLocalityLbInfo = localityMap.get(newLocality);
-
-          oldLocalityLbInfo.reactivate();
-
-          childHelper = oldLocalityLbInfo.childHelper;
-          localityLbInfo =
-              new LocalityLbInfo(
-                  localityInfoMap.get(newLocality).localityWeight,
-                  oldLocalityLbInfo.childBalancer,
-                  childHelper);
-        } else {
-          childHelper =
-              new ChildHelper(newLocality, loadStatsStore.getLocalityCounter(newLocality),
-                  orcaOobUtil);
-          localityLbInfo =
-              new LocalityLbInfo(
-                  localityInfoMap.get(newLocality).localityWeight,
-                  loadBalancerProvider.newLoadBalancer(childHelper),
-                  childHelper);
-          if (metricsReportIntervalNano > 0) {
-            localityLbInfo.childHelper.updateMetricsReportInterval(metricsReportIntervalNano);
-          }
-        }
-        updatedLocalityMap.put(newLocality, localityLbInfo);
-
-        // In extreme case handleResolvedAddresses() may trigger updateBalancingState() immediately,
-        // so execute handleResolvedAddresses() after all the setup in this method is complete.
-        helper.getSynchronizationContext().execute(new Runnable() {
-          @Override
-          public void run() {
-            // TODO: put endPointWeights into attributes for WRR.
-            localityLbInfo.childBalancer
-                .handleResolvedAddresses(
-                    ResolvedAddresses.newBuilder().setAddresses(newEags).build());
-          }
-        });
       }
-
-      // Add deactivated localities to localityMap to keep track of them.
-      for (XdsLocality locality : oldLocalities) {
-        if (localityMap.get(locality).isDeactivated()) {
-          updatedLocalityMap.put(locality, localityMap.get(locality));
-        }
-      }
-      localityMap.clear();
-      localityMap.putAll(updatedLocalityMap);
 
       final Set<XdsLocality> toBeRemovedFromStatsStore = new HashSet<>();
       // There is a race between picking a subchannel and updating localities, which leads to
@@ -286,7 +243,13 @@ interface LocalityStore {
       });
 
       edsResponsLocalityInfo = ImmutableMap.copyOf(localityInfoMap);
-      onChildStateUpdated();
+      priorityManager.updateLocalityStore();
+
+      for (XdsLocality oldLocality : localityMap.keySet()) {
+        if (!newLocalities.contains(oldLocality)) {
+          deactivate(oldLocality);
+        }
+      }
     }
 
     @Override
@@ -307,13 +270,16 @@ interface LocalityStore {
           localityLbInfo.shutdown();
           localityMap.remove(locality);
         }
+
+        @Override
+        public String toString() {
+          return "DeletionTask: locality=" + locality;
+        }
       }
 
       localityLbInfo.delayedDeletionTimer = helper.getSynchronizationContext().schedule(
           new DeletionTask(), DELAYED_DELETION_TIMEOUT_MINUTES,
           TimeUnit.MINUTES, helper.getScheduledExecutorService());
-
-      onChildStateUpdated();
     }
 
     @Override
@@ -347,29 +313,6 @@ interface LocalityStore {
       return overallState;
     }
 
-    private void onChildStateUpdated() {
-      List<WeightedChildPicker> childPickers = new ArrayList<>();
-
-      ConnectivityState overallState = null;
-      for (XdsLocality l : localityMap.keySet()) {
-        if (localityMap.get(l).isDeactivated()) {
-          continue;
-        }
-        LocalityLbInfo localityLbInfo = localityMap.get(l);
-        ConnectivityState childState = localityLbInfo.childHelper.currentChildState;
-        SubchannelPicker childPicker = localityLbInfo.childHelper.currentChildPicker;
-
-        overallState = aggregateState(overallState, childState);
-
-        if (READY == childState) {
-          childPickers.add(
-              new WeightedChildPicker(localityLbInfo.localityWeight, childPicker));
-        }
-      }
-
-      updatePicker(overallState, childPickers);
-    }
-
     private void updatePicker(
         @Nullable ConnectivityState state,  List<WeightedChildPicker> childPickers) {
       childPickers = Collections.unmodifiableList(childPickers);
@@ -398,7 +341,6 @@ interface LocalityStore {
      */
     static final class LocalityLbInfo {
 
-      final int localityWeight;
       final LoadBalancer childBalancer;
       final ChildHelper childHelper;
 
@@ -406,9 +348,7 @@ interface LocalityStore {
       private ScheduledHandle delayedDeletionTimer;
 
       LocalityLbInfo(
-          int localityWeight, LoadBalancer childBalancer, ChildHelper childHelper) {
-        checkArgument(localityWeight >= 0, "localityWeight must be non-negative");
-        this.localityWeight = localityWeight;
+          LoadBalancer childBalancer, ChildHelper childHelper) {
         this.childBalancer = checkNotNull(childBalancer, "childBalancer");
         this.childHelper = checkNotNull(childHelper, "childHelper");
       }
@@ -425,8 +365,6 @@ interface LocalityStore {
         if (delayedDeletionTimer != null) {
           delayedDeletionTimer.cancel();
           delayedDeletionTimer = null;
-          childHelper.updateBalancingState(
-              childHelper.currentChildState, childHelper.currentChildPicker);
         }
       }
 
@@ -466,7 +404,9 @@ interface LocalityStore {
                         newPicker, orcaPerRequestUtil));
 
             // delegate to parent helper
-            onChildStateUpdated();
+            if (edsResponsLocalityInfo.containsKey(locality)) {
+              priorityManager.onChildStateUpdated(edsResponsLocalityInfo.get(locality).priority);
+            }
           }
 
           @Override
@@ -483,6 +423,10 @@ interface LocalityStore {
         orcaReportingHelperWrapper =
             checkNotNull(orcaOobUtil, "orcaOobUtil")
                 .newOrcaReportingHelperWrapper(delegate, new MetricsRecordingListener(counter));
+
+        if (metricsReportIntervalNano > 0) {
+          updateMetricsReportInterval(metricsReportIntervalNano);
+        }
       }
 
       void updateMetricsReportInterval(long intervalNanos) {
@@ -494,6 +438,162 @@ interface LocalityStore {
       @Override
       protected Helper delegate() {
         return orcaReportingHelperWrapper.asHelper();
+      }
+    }
+
+    class PriorityManager {
+
+      private final List<List<XdsLocality>> priorityTable = new ArrayList<>();
+      private int priorityLevel = -1;
+      private ScheduledHandle failOverTimer;
+
+      void updateLocalityStore() {
+        priorityTable.clear();
+        for (XdsLocality newLocality : edsResponsLocalityInfo.keySet()) {
+          addLocality(edsResponsLocalityInfo.get(newLocality).priority, newLocality);
+        }
+
+        if (priorityLevel >= priorityTable.size()) {
+          priorityLevel = priorityTable.size() - 1;
+        }
+
+        if (priorityLevel == -1) {
+          failOver();
+          return;
+        }
+
+        for (int p = 0; p < priorityTable.size(); p++) {
+          onChildStateUpdated(p);
+        }
+      }
+
+      private void addLocality(int priority, XdsLocality locality) {
+        while (priorityTable.size() <= priority) {
+          priorityTable.add(new ArrayList<XdsLocality>());
+        }
+        priorityTable.get(priority).add(locality);
+      }
+
+      /**
+       * Load balancing state of localities at the given priority has changed.
+       */
+      void onChildStateUpdated(int priority) {
+        if (priority > priorityLevel) {
+          return;
+        }
+        List<WeightedChildPicker> childPickers = new ArrayList<>();
+
+        ConnectivityState overallState = null;
+        for (XdsLocality l : priorityTable.get(priority)) {
+          if (!localityMap.containsKey(l)) {
+            initLocality(l);
+          }
+          LocalityLbInfo localityLbInfo = localityMap.get(l);
+          localityLbInfo.reactivate();
+          ConnectivityState childState = localityLbInfo.childHelper.currentChildState;
+          SubchannelPicker childPicker = localityLbInfo.childHelper.currentChildPicker;
+
+          overallState = aggregateState(overallState, childState);
+
+          if (READY == childState) {
+            childPickers.add(
+                new WeightedChildPicker(edsResponsLocalityInfo.get(l).localityWeight, childPicker));
+          }
+        }
+
+        if (priority == priorityLevel || overallState == READY) {
+          updatePicker(overallState, childPickers);
+        }
+
+        if (overallState == READY || overallState == TRANSIENT_FAILURE) {
+          cancelFailOverTimer();
+        }
+
+        if (priority == priorityLevel && overallState != READY) {
+          failOver();
+        } else if (priority <= priorityLevel && overallState == READY) {
+          goToPriority(priority);
+        }
+      }
+
+      private void startFailOverTimer() {
+        class FailOverTask implements Runnable {
+          @Override
+          public void run() {
+            failOverTimer = null;
+            failOver();
+          }
+        }
+
+        failOverTimer = helper.getSynchronizationContext().schedule(
+            new FailOverTask(), 10, TimeUnit.SECONDS, helper.getScheduledExecutorService());
+      }
+
+      void cancelFailOverTimer() {
+        if (failOverTimer != null) {
+          failOverTimer.cancel();
+          failOverTimer = null;
+        }
+      }
+
+      private void failOver() {
+        if (failOverTimer != null) {
+          // still CONNECTING
+          return;
+        }
+        if (priorityTable.size() > priorityLevel + 1) {
+          priorityLevel++;
+
+          List<XdsLocality> localities = priorityTable.get(priorityLevel);
+          boolean initializedBefore = false;
+          for (XdsLocality locality : localities) {
+            if (localityMap.containsKey(locality)) {
+              initializedBefore = true;
+              localityMap.get(locality).reactivate();
+            } else {
+              initLocality(locality);
+            }
+          }
+
+          if (!initializedBefore) {
+            startFailOverTimer();
+          }
+
+          onChildStateUpdated(priorityLevel);
+        }
+      }
+
+      private void initLocality(final XdsLocality locality) {
+        ChildHelper childHelper =
+            new ChildHelper(locality, loadStatsStore.getLocalityCounter(locality),
+                orcaOobUtil);
+        final LocalityLbInfo localityLbInfo =
+            new LocalityLbInfo(
+                loadBalancerProvider.newLoadBalancer(childHelper),
+                childHelper);
+        localityMap.put(locality, localityLbInfo);
+
+        final LocalityInfo localityInfo = edsResponsLocalityInfo.get(locality);
+        // In extreme case handleResolvedAddresses() may trigger updateBalancingState() immediately,
+        // so execute handleResolvedAddresses() after all the setup in the caller is complete.
+        helper.getSynchronizationContext().execute(new Runnable() {
+          @Override
+          public void run() {
+            // TODO: put endPointWeights into attributes for WRR.
+            localityLbInfo.childBalancer
+                .handleResolvedAddresses(ResolvedAddresses.newBuilder()
+                    .setAddresses(localityInfo.eags).build());
+          }
+        });
+      }
+
+      private void goToPriority(int priority) {
+        priorityLevel = priority;
+        for (int p = priority + 1; p < priorityTable.size(); p++) {
+          for (XdsLocality xdsLocality : priorityTable.get(p)) {
+            deactivate(xdsLocality);
+          }
+        }
       }
     }
   }

--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -472,7 +472,7 @@ interface LocalityStore {
           currentPriority = priorityTable.size() - 1;
         }
 
-        if (currentPriority == -1) {
+        if (currentPriority == INVALID_PRIORITY) {
           failOver();
           return;
         }
@@ -536,7 +536,7 @@ interface LocalityStore {
         cancelFailOverTimer();
         priorityTable.clear();
         localityInfoMap = ImmutableMap.of();
-        currentPriority = -1;
+        currentPriority = INVALID_PRIORITY;
       }
 
       private void cancelFailOverTimer() {

--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -69,7 +69,7 @@ interface LocalityStore {
 
   void reset();
 
-  void updateLocalityStore(Map<XdsLocality, LocalityInfo> localityInfoMap);
+  void updateLocalityStore(ImmutableMap<XdsLocality, LocalityInfo> localityInfoMap);
 
   void updateDropPercentage(ImmutableList<DropOverload> dropOverloads);
 
@@ -200,7 +200,7 @@ interface LocalityStore {
 
     // This is triggered by EDS response.
     @Override
-    public void updateLocalityStore(final Map<XdsLocality, LocalityInfo> localityInfoMap) {
+    public void updateLocalityStore(final ImmutableMap<XdsLocality, LocalityInfo> localityInfoMap) {
 
       Set<XdsLocality> newLocalities = localityInfoMap.keySet();
       // TODO: put endPointWeights into attributes for WRR.
@@ -456,7 +456,7 @@ interface LocalityStore {
        * Recomputes the current ready localities to be used.
        */
       void updateLocalities(Map<XdsLocality, LocalityInfo> localityInfoMap) {
-        this.localityInfoMap = ImmutableMap.copyOf(localityInfoMap);
+        this.localityInfoMap = localityInfoMap;
         priorityTable.clear();
         for (XdsLocality newLocality : localityInfoMap.keySet()) {
           int priority = localityInfoMap.get(newLocality).priority;

--- a/xds/src/main/java/io/grpc/xds/XdsComms.java
+++ b/xds/src/main/java/io/grpc/xds/XdsComms.java
@@ -76,6 +76,7 @@ final class XdsComms {
   /**
    * Information about the locality from EDS response.
    */
+  // TODO(zdapeng): move this class out.
   static final class LocalityInfo {
     final List<EquivalentAddressGroup> eags;
     final List<Integer> endPointWeights;

--- a/xds/src/main/java/io/grpc/xds/XdsComms.java
+++ b/xds/src/main/java/io/grpc/xds/XdsComms.java
@@ -26,6 +26,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
@@ -50,9 +51,7 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.CheckForNull;
 
@@ -243,7 +242,8 @@ final class XdsComms {
                   localityStore.updateDropPercentage(dropOverloads);
 
                   List<LocalityLbEndpoints> localities = clusterLoadAssignment.getEndpointsList();
-                  Map<XdsLocality, LocalityInfo> localityEndpointsMapping = new LinkedHashMap<>();
+                  ImmutableMap.Builder<XdsLocality, LocalityInfo> localityEndpointsMapping =
+                      new ImmutableMap.Builder<>();
                   for (LocalityLbEndpoints localityLbEndpoints : localities) {
                     io.envoyproxy.envoy.api.v2.core.Locality localityProto =
                         localityLbEndpoints.getLocality();
@@ -262,9 +262,7 @@ final class XdsComms {
                     }
                   }
 
-                  localityEndpointsMapping = Collections.unmodifiableMap(localityEndpointsMapping);
-
-                  localityStore.updateLocalityStore(localityEndpointsMapping);
+                  localityStore.updateLocalityStore(localityEndpointsMapping.build());
                 }
               }
             }

--- a/xds/src/main/java/io/grpc/xds/XdsComms.java
+++ b/xds/src/main/java/io/grpc/xds/XdsComms.java
@@ -80,8 +80,9 @@ final class XdsComms {
     final List<EquivalentAddressGroup> eags;
     final List<Integer> endPointWeights;
     final int localityWeight;
+    final int priority;
 
-    LocalityInfo(Collection<LbEndpoint> lbEndPoints, int localityWeight) {
+    LocalityInfo(Collection<LbEndpoint> lbEndPoints, int localityWeight, int priority) {
       List<EquivalentAddressGroup> eags = new ArrayList<>(lbEndPoints.size());
       List<Integer> endPointWeights = new ArrayList<>(lbEndPoints.size());
       for (LbEndpoint lbEndPoint : lbEndPoints) {
@@ -91,6 +92,7 @@ final class XdsComms {
       this.eags = Collections.unmodifiableList(eags);
       this.endPointWeights = Collections.unmodifiableList(new ArrayList<>(endPointWeights));
       this.localityWeight = localityWeight;
+      this.priority = priority;
     }
 
     @Override
@@ -103,13 +105,14 @@ final class XdsComms {
       }
       LocalityInfo that = (LocalityInfo) o;
       return localityWeight == that.localityWeight
+          && priority == that.priority
           && Objects.equal(eags, that.eags)
           && Objects.equal(endPointWeights, that.endPointWeights);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(eags, endPointWeights, localityWeight);
+      return Objects.hashCode(eags, endPointWeights, localityWeight, priority);
     }
   }
 
@@ -250,10 +253,11 @@ final class XdsComms {
                       lbEndPoints.add(new LbEndpoint(lbEndpoint));
                     }
                     int localityWeight = localityLbEndpoints.getLoadBalancingWeight().getValue();
+                    int priority = localityLbEndpoints.getPriority();
 
                     if (localityWeight != 0) {
                       localityEndpointsMapping.put(
-                          locality, new LocalityInfo(lbEndPoints, localityWeight));
+                          locality, new LocalityInfo(lbEndPoints, localityWeight, priority));
                     }
                   }
 

--- a/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
@@ -236,20 +236,20 @@ public class LocalityStoreTest {
   public void updateLocalityStore_updateStatsStoreLocalityTracking() {
     Map<XdsLocality, LocalityInfo> localityInfoMap = new HashMap<>();
     localityInfoMap
-        .put(locality1, new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1));
+        .put(locality1, new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0));
     localityInfoMap
-        .put(locality2, new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2));
+        .put(locality2, new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0));
     localityStore.updateLocalityStore(localityInfoMap);
     verify(loadStatsStore).addLocality(locality1);
     verify(loadStatsStore).addLocality(locality2);
 
     localityInfoMap
-        .put(locality3, new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3));
+        .put(locality3, new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0));
     localityStore.updateLocalityStore(localityInfoMap);
     verify(loadStatsStore).addLocality(locality3);
 
     localityInfoMap = ImmutableMap
-        .of(locality4, new LocalityInfo(ImmutableList.of(lbEndpoint41, lbEndpoint42), 4));
+        .of(locality4, new LocalityInfo(ImmutableList.of(lbEndpoint41, lbEndpoint42), 4, 0));
     localityStore.updateLocalityStore(localityInfoMap);
     verify(loadStatsStore).removeLocality(locality1);
     verify(loadStatsStore).removeLocality(locality2);
@@ -264,9 +264,9 @@ public class LocalityStoreTest {
   public void updateLocalityStore_pickResultInterceptedForLoadRecordingWhenSubchannelReady() {
     // Simulate receiving two localities.
     LocalityInfo localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1);
+        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
     LocalityInfo localityInfo2 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2);
+        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
     localityStore.updateLocalityStore(ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2));
 
@@ -335,9 +335,9 @@ public class LocalityStoreTest {
   public void childLbPerformOobBackendMetricsAggregation() {
     // Simulate receiving two localities.
     LocalityInfo localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1);
+        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
     LocalityInfo localityInfo2 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2);
+        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
     localityStore.updateLocalityStore(ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2));
 
@@ -393,9 +393,9 @@ public class LocalityStoreTest {
 
     // Simulate receiving two localities.
     LocalityInfo localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1);
+        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
     LocalityInfo localityInfo2 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2);
+        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
     localityStore.updateLocalityStore(ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2));
 
@@ -412,11 +412,11 @@ public class LocalityStoreTest {
   public void updateLoaclityStore_withEmptyDropList() {
     localityStore.updateDropPercentage(ImmutableList.<DropOverload>of());
     LocalityInfo localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1);
+        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
     LocalityInfo localityInfo2 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2);
+        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
     LocalityInfo localityInfo3 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3);
+        new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
     Map<XdsLocality, LocalityInfo> localityInfoMap = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
     localityStore.updateLocalityStore(localityInfoMap);
@@ -491,9 +491,9 @@ public class LocalityStoreTest {
 
     // update with new addresses
     localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint11), 1);
+        new LocalityInfo(ImmutableList.of(lbEndpoint11), 1, 0);
     LocalityInfo localityInfo4 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint41, lbEndpoint42), 4);
+        new LocalityInfo(ImmutableList.of(lbEndpoint41, lbEndpoint42), 4, 0);
     localityInfoMap = ImmutableMap.of(
         locality2, localityInfo2, locality4, localityInfo4, locality1, localityInfo1);
     localityStore.updateLocalityStore(localityInfoMap);
@@ -522,11 +522,11 @@ public class LocalityStoreTest {
   @Test
   public void updateLoaclityStore_deactivateAndReactivate() {
     LocalityInfo localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1);
+        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
     LocalityInfo localityInfo2 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2);
+        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
     LocalityInfo localityInfo3 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3);
+        new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
     Map<XdsLocality, LocalityInfo> localityInfoMap = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
     localityStore.updateLocalityStore(localityInfoMap);
@@ -556,7 +556,7 @@ public class LocalityStoreTest {
 
     // update localities, removing sz1, sz2, keeping sz3, and adding sz4
     LocalityInfo localityInfo4 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint41, lbEndpoint42), 4);
+        new LocalityInfo(ImmutableList.of(lbEndpoint41, lbEndpoint42), 4, 0);
     localityInfoMap = ImmutableMap.of(locality3, localityInfo3, locality4, localityInfo4);
     localityStore.updateLocalityStore(localityInfoMap);
 
@@ -648,11 +648,11 @@ public class LocalityStoreTest {
         new DropOverload("throttle", 365),
         new DropOverload("lb", 1234)));
     LocalityInfo localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1);
+        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
     LocalityInfo localityInfo2 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2);
+        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
     LocalityInfo localityInfo3 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3);
+        new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
     Map<XdsLocality, LocalityInfo> localityInfoMap = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
     localityStore.updateLocalityStore(localityInfoMap);
@@ -746,11 +746,11 @@ public class LocalityStoreTest {
         new DropOverload("throttle", 365),
         new DropOverload("lb", 1000_000)));
     LocalityInfo localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1);
+        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
     LocalityInfo localityInfo2 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2);
+        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
     LocalityInfo localityInfo3 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3);
+        new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
     Map<XdsLocality, LocalityInfo> localityInfoMap = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
     localityStore.updateLocalityStore(localityInfoMap);
@@ -767,11 +767,11 @@ public class LocalityStoreTest {
   @Test
   public void updateLocalityStore_OnlyUpdatingWeightsStillUpdatesPicker() {
     LocalityInfo localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1);
+        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
     LocalityInfo localityInfo2 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2);
+        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
     LocalityInfo localityInfo3 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3);
+        new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
     Map<XdsLocality, LocalityInfo> localityInfoMap = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
     localityStore.updateLocalityStore(localityInfoMap);
@@ -781,9 +781,9 @@ public class LocalityStoreTest {
     assertThat(pickerFactory.totalReadyLocalities).isEqualTo(0);
 
     // Update locality weights before any subchannel becomes READY.
-    localityInfo1 = new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 4);
-    localityInfo2 = new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 5);
-    localityInfo3 = new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 6);
+    localityInfo1 = new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 4, 0);
+    localityInfo2 = new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 5, 0);
+    localityInfo3 = new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 6, 0);
     localityInfoMap = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
     localityStore.updateLocalityStore(localityInfoMap);
@@ -816,9 +816,9 @@ public class LocalityStoreTest {
   @Test
   public void reset() {
     LocalityInfo localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1);
+        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
     LocalityInfo localityInfo2 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2);
+        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
     Map<XdsLocality, LocalityInfo> localityInfoMap = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2);
     localityStore.updateLocalityStore(localityInfoMap);

--- a/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
@@ -20,12 +20,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.ConnectivityState.CONNECTING;
 import static io.grpc.ConnectivityState.READY;
+import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
+import static io.grpc.Status.UNAVAILABLE;
 import static io.grpc.xds.XdsSubchannelPickers.BUFFER_PICKER;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
@@ -38,6 +41,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import io.envoyproxy.envoy.api.v2.endpoint.ClusterStats;
 import io.grpc.ChannelLogger;
 import io.grpc.ClientStreamTracer;
@@ -54,6 +58,8 @@ import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.SynchronizationContext;
 import io.grpc.internal.FakeClock;
+import io.grpc.internal.FakeClock.ScheduledTask;
+import io.grpc.internal.FakeClock.TaskFilter;
 import io.grpc.xds.ClientLoadCounter.LoadRecordingStreamTracerFactory;
 import io.grpc.xds.ClientLoadCounter.MetricsRecordingListener;
 import io.grpc.xds.InterLocalityPicker.WeightedChildPicker;
@@ -66,7 +72,9 @@ import io.grpc.xds.OrcaPerRequestUtil.OrcaPerRequestReportListener;
 import io.grpc.xds.XdsComms.DropOverload;
 import io.grpc.xds.XdsComms.LbEndpoint;
 import io.grpc.xds.XdsComms.LocalityInfo;
+import io.grpc.xds.XdsSubchannelPickers.ErrorPicker;
 import java.net.InetSocketAddress;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -129,6 +137,20 @@ public class LocalityStoreTest {
   private final Map<String, Helper> childHelpers = new HashMap<>();
   private final Map<String, FakeOrcaReportingHelperWrapper> childHelperWrappers = new HashMap<>();
   private final FakeClock fakeClock = new FakeClock();
+
+  private final TaskFilter deactivationTaskFilter = new TaskFilter() {
+    @Override
+    public boolean shouldAccept(Runnable runnable) {
+      return runnable.toString().contains("DeletionTask");
+    }
+  };
+
+  private final TaskFilter failOverTaskFilter = new TaskFilter() {
+    @Override
+    public boolean shouldAccept(Runnable runnable) {
+      return runnable.toString().contains("FailOverTask");
+    }
+  };
 
   private final LoadBalancerProvider lbProvider = new LoadBalancerProvider() {
 
@@ -622,7 +644,8 @@ public class LocalityStoreTest {
     pickerFactory.nextIndex = 0;
     assertThat(subchannelPickerCaptor.getValue().pickSubchannel(pickSubchannelArgs).getSubchannel())
         .isEqualTo(subchannel1);
-    assertThat(fakeClock.getPendingTasks()).hasSize(2); // sz3, sz4 pending removal
+    // sz3, sz4 pending removal
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).hasSize(2);
 
     // verify lb1, lb3, and lb4 never shutdown and never changed since created
     verify(lb1, never()).shutdown();
@@ -635,7 +658,7 @@ public class LocalityStoreTest {
     assertThat(loadBalancers.get("sz4")).isSameInstanceAs(lb4);
 
     localityStore.reset();
-    assertThat(fakeClock.getPendingTasks()).isEmpty();
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).isEmpty();
     verify(lb1).shutdown();
     verify(newLb2).shutdown();
     verify(lb3).shutdown();
@@ -831,6 +854,393 @@ public class LocalityStoreTest {
     verify(loadBalancers.get("sz2")).shutdown();
     verify(loadStatsStore).removeLocality(locality1);
     verify(loadStatsStore).removeLocality(locality2);
+  }
+
+  /**
+   * Tests the scenario of the following sequence of events.
+   * (In the format of "event detail - expected state", with abbreviations C for CONNECTING,
+   * F for TRANSIENT_FAILURE, R for READ, and D for deactivated etc.)
+   * EDS update: P0 sz1; P1 sz2; P2 sz3; P3 sz4 - P0 C, P1 N/A, P2 N/A, P3 N/A
+   * 10 secs passes P0 still CONNECTING - P0 C, P1 C, P2 N/A, P3 N/A
+   * 5 secs passes P1 in TRANSIENT_FAILURE - P0 C, P1 F, P2 C, P3 N/A
+   * 4 secs passes P2 READY - P0 C, P1 F, P2 R, P3 N/A
+   * P0 gets READY - P0 R, P1 F&D, P2 R&D, P3 N/A
+   * P1 gets READY - P0 R, P1 R&D, P2 R&D, P3 N/A
+   * 10 min passes P0 in TRANSIENT_FAILURE - P0 F, P1 R, P2 R&D, P3 N/A
+   * 5 min passes - P0 F, P1 R, P2 N/A, P3 N/A
+   * P1 in TRANSIENT_FAILURE - P0 F, P1 F, P2 C, P3 N/A
+   * 10 secs passes - P0 F, P1 F, P2 C, P3 C
+   * P1, P3 gets READY - P0 F, P1 R, P2 C&D, P3 R&D
+   * EDS update, localities moved: P0 sz1, sz3; P1 sz4; P2 sz2 - P0 C, P1 R, P2 R&D
+   * 15 min passes - P0 C, P1 R, P2 N/A
+   * EDS update, locality removed: P0 sz1, sz3, - P0 C, P1 N/A, sz4 R&D
+   * sz3 gets READY - P0 R, P1 N/A, sz4 R&D
+   * EDS update, locality comes back and another removed: P0 sz1, P1 sz4 - P0 C, P1 R, sz3 R&D
+   */
+  @Test
+  public void multipriority() {
+    // EDS update: P0 sz1; P1 sz2; P2 sz3; P3 sz4 - P0 C, P1 N/A, P2 N/A, P3 N/A
+    LocalityInfo localityInfo1 =
+        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    LocalityInfo localityInfo2 =
+        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 1);
+    LocalityInfo localityInfo3 =
+        new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 2);
+    LocalityInfo localityInfo4 =
+        new LocalityInfo(ImmutableList.of(lbEndpoint41, lbEndpoint42), 3, 3);
+    final Map<XdsLocality, LocalityInfo> localityInfoMap = ImmutableMap.of(
+        locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3, locality4,
+        localityInfo4);
+    syncContext.execute(new Runnable() {
+      @Override
+      public void run() {
+        localityStore.updateLocalityStore(localityInfoMap);
+      }
+    });
+    assertThat(loadBalancers.keySet()).containsExactly("sz1");
+    LoadBalancer lb1 = loadBalancers.get("sz1");
+    InOrder inOrder = inOrder(lb1, helper);
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor1 =
+        ArgumentCaptor.forClass(ResolvedAddresses.class);
+    inOrder.verify(helper).updateBalancingState(CONNECTING, BUFFER_PICKER);
+    inOrder.verify(lb1).handleResolvedAddresses(resolvedAddressesCaptor1.capture());
+    assertThat(resolvedAddressesCaptor1.getValue().getAddresses()).containsExactly(eag11, eag12);
+
+    // 10 sec passes P0 still CONNECTING - P0 C, P1 C, P2 N/A, P3 N/A
+    fakeClock.forwardTime(9, TimeUnit.SECONDS);
+    assertThat(loadBalancers.keySet()).containsExactly("sz1");
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).hasSize(1);
+    ScheduledTask failOverTask =
+        Iterables.getOnlyElement(fakeClock.getPendingTasks(failOverTaskFilter));
+    fakeClock.forwardTime(1, TimeUnit.SECONDS);
+    assertThat(failOverTask.isCancelled()).isFalse();
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).doesNotContain(failOverTask);
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).hasSize(1);
+    failOverTask = Iterables.getOnlyElement(fakeClock.getPendingTasks(failOverTaskFilter));
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).isEmpty();
+    assertThat(loadBalancers.keySet()).containsExactly("sz1", "sz2");
+    LoadBalancer lb2 = loadBalancers.get("sz2");
+    inOrder = inOrder(lb1, lb2, helper);
+    inOrder.verify(helper).updateBalancingState(CONNECTING, BUFFER_PICKER);
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor2 =
+        ArgumentCaptor.forClass(ResolvedAddresses.class);
+    inOrder.verify(lb2).handleResolvedAddresses(resolvedAddressesCaptor2.capture());
+    assertThat(resolvedAddressesCaptor2.getValue().getAddresses()).containsExactly(eag21, eag22);
+
+    // 5 secs passes P1 in TRANSIENT_FAILURE - P0 C, P1 F, P2 C, P3 N/A
+    fakeClock.forwardTime(5, TimeUnit.SECONDS);
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).containsExactly(failOverTask);
+    final Helper helper2 = childHelpers.get("sz2");
+    helper.getSynchronizationContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        helper2.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(UNAVAILABLE));
+      }
+    });
+    assertThat(failOverTask.isCancelled()).isTrue();
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).doesNotContain(failOverTask);
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).hasSize(1);
+    failOverTask = Iterables.getOnlyElement(fakeClock.getPendingTasks(failOverTaskFilter));
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).isEmpty();
+    assertThat(loadBalancers.keySet()).containsExactly("sz1", "sz2", "sz3");
+    LoadBalancer lb3 = loadBalancers.get("sz3");
+    inOrder = inOrder(lb1, lb2, lb3, helper);
+    inOrder.verify(helper).updateBalancingState(same(TRANSIENT_FAILURE), isA(ErrorPicker.class));
+    inOrder.verify(helper).updateBalancingState(CONNECTING, BUFFER_PICKER);
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor3 =
+        ArgumentCaptor.forClass(ResolvedAddresses.class);
+    inOrder.verify(lb3).handleResolvedAddresses(resolvedAddressesCaptor3.capture());
+    assertThat(resolvedAddressesCaptor3.getValue().getAddresses()).containsExactly(eag31, eag32);
+
+    // 5 secs passes P2 READY - P0 C, P1 F, P2 R, P3 N/A
+    fakeClock.forwardTime(4, TimeUnit.SECONDS);
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).containsExactly(failOverTask);
+    final Helper helper3 = childHelpers.get("sz3");
+    final Subchannel mockSubchannel3 = mock(Subchannel.class);
+    helper.getSynchronizationContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        helper3.updateBalancingState(
+            READY,
+            new SubchannelPicker() {
+              @Override
+              public PickResult pickSubchannel(PickSubchannelArgs args) {
+                return PickResult.withSubchannel(mockSubchannel3);
+              }
+            });
+      }
+    });
+    assertThat(failOverTask.isCancelled()).isTrue();
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).isEmpty();
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).isEmpty();
+    ArgumentCaptor<SubchannelPicker> subchannelPickerCaptor = ArgumentCaptor.forClass(null);
+    inOrder.verify(helper).updateBalancingState(same(READY), subchannelPickerCaptor.capture());
+    assertThat(subchannelPickerCaptor.getValue()
+            .pickSubchannel(mock(PickSubchannelArgs.class))
+            .getSubchannel())
+        .isSameInstanceAs(mockSubchannel3);
+
+    // P0 gets READY - P0 R, P1 F&D, P2 R&D, P3 N/A
+    final Helper helper1 = childHelpers.get("sz1");
+    final Subchannel mockSubchannel1 = mock(Subchannel.class);
+    helper.getSynchronizationContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        helper1.updateBalancingState(
+            READY,
+            new SubchannelPicker() {
+              @Override
+              public PickResult pickSubchannel(PickSubchannelArgs args) {
+                return PickResult.withSubchannel(mockSubchannel1);
+              }
+            });
+      }
+    });
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).isEmpty();
+    Collection<ScheduledTask> deactivationTasks = fakeClock.getPendingTasks(deactivationTaskFilter);
+    assertThat(deactivationTasks).hasSize(2);
+    inOrder.verify(helper).updateBalancingState(same(READY), subchannelPickerCaptor.capture());
+    assertThat(subchannelPickerCaptor.getValue()
+            .pickSubchannel(mock(PickSubchannelArgs.class))
+            .getSubchannel())
+        .isSameInstanceAs(mockSubchannel1);
+
+    // P1 gets READY - P0 R, P1 R&D, P2 R&D, P3 N/A
+    final Subchannel mockSubchannel2 = mock(Subchannel.class);
+    helper.getSynchronizationContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        helper2.updateBalancingState(
+            READY,
+            new SubchannelPicker() {
+              @Override
+              public PickResult pickSubchannel(PickSubchannelArgs args) {
+                return PickResult.withSubchannel(mockSubchannel2);
+              }
+            });
+      }
+    });
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).isEmpty();
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).hasSize(2);
+    inOrder.verify(helper, never())
+        .updateBalancingState(any(ConnectivityState.class), any(SubchannelPicker.class));
+
+    // 10 min passes P0 in TRANSIENT_FAILURE - P0 F, P1 R, P2 R&D, P3 N/A
+    fakeClock.forwardTime(10, TimeUnit.MINUTES);
+    helper.getSynchronizationContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        helper1.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(UNAVAILABLE));
+      }
+    });
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).isEmpty();
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).hasSize(1);
+    ScheduledTask deactivationTask =
+        Iterables.getOnlyElement(fakeClock.getPendingTasks(deactivationTaskFilter));
+    assertThat(deactivationTask).isSameInstanceAs(Iterables.get(deactivationTasks, 1));
+    assertThat(Iterables.get(deactivationTasks, 0).isCancelled()).isTrue();
+    inOrder.verify(helper, never())
+        .updateBalancingState(CONNECTING, BUFFER_PICKER);
+
+
+    // 5 min passes - P0 F, P1 R, P2 N/A, P3 N/A
+    verify(lb3, never()).shutdown();
+    fakeClock.forwardTime(5, TimeUnit.MINUTES);
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).isEmpty();
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).isEmpty();
+    inOrder.verify(lb3).shutdown();
+
+    // P1 in TRANSIENT_FAILURE - P0 F, P1 F, P2 C, P3 N/A
+    helper.getSynchronizationContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        helper2.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(UNAVAILABLE));
+      }
+    });
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).hasSize(1);
+    failOverTask = Iterables.getOnlyElement(fakeClock.getPendingTasks(failOverTaskFilter));
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).isEmpty();
+    inOrder.verify(helper).updateBalancingState(same(TRANSIENT_FAILURE), isA(ErrorPicker.class));
+    inOrder.verify(helper).updateBalancingState(CONNECTING, BUFFER_PICKER);
+    assertThat(loadBalancers.keySet()).containsExactly("sz1", "sz2", "sz3");
+    assertThat(loadBalancers.get("sz3")).isNotSameInstanceAs(lb3);
+    lb3 = loadBalancers.get("sz3");
+    assertThat(childHelpers.get("sz3")).isNotSameInstanceAs(helper3);
+
+    // 10 secs passes - P0 F, P1 F, P2 C, P3 C
+    fakeClock.forwardTime(10, TimeUnit.SECONDS);
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).hasSize(1);
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).doesNotContain(failOverTask);
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).isEmpty();
+    assertThat(loadBalancers.keySet()).containsExactly("sz1", "sz2", "sz3", "sz4");
+    LoadBalancer lb4 = loadBalancers.get("sz4");
+    inOrder = inOrder(lb1, lb2, lb3, lb4, helper);
+    inOrder.verify(helper).updateBalancingState(CONNECTING, BUFFER_PICKER);
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor4 =
+        ArgumentCaptor.forClass(ResolvedAddresses.class);
+    inOrder.verify(lb4).handleResolvedAddresses(resolvedAddressesCaptor4.capture());
+    assertThat(resolvedAddressesCaptor4.getValue().getAddresses()).containsExactly(eag41, eag42);
+
+    // P1, P3 gets READY - P0 F, P1 R, P2 C&D, P3 R&D
+    final Subchannel mockSubchannel22 = mock(Subchannel.class);
+    final Subchannel mockSubchannel4 = mock(Subchannel.class);
+    final Helper helper4 = childHelpers.get("sz4");
+    helper.getSynchronizationContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        helper2.updateBalancingState(
+            READY,
+            new SubchannelPicker() {
+              @Override
+              public PickResult pickSubchannel(PickSubchannelArgs args) {
+                return PickResult.withSubchannel(mockSubchannel22);
+              }
+            });
+        helper4.updateBalancingState(
+            READY,
+            new SubchannelPicker() {
+              @Override
+              public PickResult pickSubchannel(PickSubchannelArgs args) {
+                return PickResult.withSubchannel(mockSubchannel4);
+              }
+            });
+      }
+    });
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).isEmpty();
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).hasSize(2);
+    inOrder.verify(helper).updateBalancingState(same(READY), subchannelPickerCaptor.capture());
+    assertThat(subchannelPickerCaptor.getValue()
+            .pickSubchannel(mock(PickSubchannelArgs.class))
+            .getSubchannel())
+        .isSameInstanceAs(mockSubchannel22);
+
+    // EDS update, localities moved: P0 sz1, sz3; P1 sz4; P2 sz2 - P0 C, P1 R, P2 R&D
+    localityInfo1 =
+        new LocalityInfo(ImmutableList.of(lbEndpoint12), 1, 0);
+    localityInfo2 =
+        new LocalityInfo(ImmutableList.of(lbEndpoint22), 2, 2);
+    localityInfo3 =
+        new LocalityInfo(ImmutableList.of(lbEndpoint32), 3, 0);
+    localityInfo4 =
+        new LocalityInfo(ImmutableList.of(lbEndpoint42), 4, 1);
+    final Map<XdsLocality, LocalityInfo> localityInfoMap2 = ImmutableMap.of(
+        locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3, locality4,
+        localityInfo4);
+    syncContext.execute(new Runnable() {
+      @Override
+      public void run() {
+        localityStore.updateLocalityStore(localityInfoMap2);
+      }
+    });
+    assertThat(loadBalancers.keySet()).containsExactly("sz1", "sz2", "sz3", "sz4");
+    assertThat(loadBalancers.values()).containsExactly(lb1, lb2, lb3, lb4);
+    inOrder.verify(helper).updateBalancingState(same(READY), subchannelPickerCaptor.capture());
+    assertThat(subchannelPickerCaptor.getValue()
+            .pickSubchannel(mock(PickSubchannelArgs.class))
+            .getSubchannel())
+        .isSameInstanceAs(mockSubchannel4);
+    inOrder.verify(lb1).handleResolvedAddresses(resolvedAddressesCaptor1.capture());
+    assertThat(resolvedAddressesCaptor1.getValue().getAddresses()).containsExactly(eag12);
+    inOrder.verify(lb2).handleResolvedAddresses(resolvedAddressesCaptor2.capture());
+    assertThat(resolvedAddressesCaptor2.getValue().getAddresses()).containsExactly(eag22);
+    inOrder.verify(lb3).handleResolvedAddresses(resolvedAddressesCaptor3.capture());
+    assertThat(resolvedAddressesCaptor3.getValue().getAddresses()).containsExactly(eag32);
+    inOrder.verify(lb4).handleResolvedAddresses(resolvedAddressesCaptor4.capture());
+    assertThat(resolvedAddressesCaptor4.getValue().getAddresses()).containsExactly(eag42);
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).isEmpty();
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).hasSize(1);
+
+    // 15 min passes - P0 C, P1 R, P2 N/A
+    verify(lb2, never()).shutdown();
+    fakeClock.forwardTime(15, TimeUnit.MINUTES);
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).isEmpty();
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).isEmpty();
+    inOrder.verify(lb2).shutdown();
+    inOrder.verifyNoMoreInteractions();
+
+    // EDS update, locality removed: P0 sz1, sz3, - P0 C, P1 N/A, sz4 R&D
+    localityInfo1 =
+        new LocalityInfo(ImmutableList.of(lbEndpoint11), 1, 0);
+    localityInfo3 =
+        new LocalityInfo(ImmutableList.of(lbEndpoint31), 3, 0);
+    final Map<XdsLocality, LocalityInfo> localityInfoMap3 = ImmutableMap.of(
+        locality1, localityInfo1,locality3, localityInfo3);
+    syncContext.execute(new Runnable() {
+      @Override
+      public void run() {
+        localityStore.updateLocalityStore(localityInfoMap3);
+      }
+    });
+    inOrder.verify(helper).updateBalancingState(CONNECTING, BUFFER_PICKER);
+    inOrder.verify(lb1).handleResolvedAddresses(resolvedAddressesCaptor1.capture());
+    assertThat(resolvedAddressesCaptor1.getValue().getAddresses()).containsExactly(eag11);
+    inOrder.verify(lb3).handleResolvedAddresses(resolvedAddressesCaptor3.capture());
+    assertThat(resolvedAddressesCaptor3.getValue().getAddresses()).containsExactly(eag31);
+    inOrder.verifyNoMoreInteractions();
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).isEmpty();
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).hasSize(1);
+
+    // sz3 gets READY - P0 R, P1 N/A, sz4 R&D
+    final Helper newHelper3 = childHelpers.get("sz3");
+    final Subchannel newMockSubchannel3 = mock(Subchannel.class);
+    syncContext.execute(new Runnable() {
+      @Override
+      public void run() {
+        newHelper3.updateBalancingState(
+            READY,
+            new SubchannelPicker() {
+              @Override
+              public PickResult pickSubchannel(PickSubchannelArgs args) {
+                return PickResult.withSubchannel(newMockSubchannel3);
+              }
+            }
+        );
+      }
+    });
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).isEmpty();
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).hasSize(1);
+    inOrder.verify(helper).updateBalancingState(same(READY), subchannelPickerCaptor.capture());
+    assertThat(subchannelPickerCaptor.getValue()
+            .pickSubchannel(mock(PickSubchannelArgs.class))
+            .getSubchannel())
+        .isSameInstanceAs(newMockSubchannel3);
+    inOrder.verifyNoMoreInteractions();
+
+    // EDS update, locality comes back and another removed: P0 sz1, P1 sz4 - P0 C, P1 R, sz3 R&D
+    localityInfo1 =
+        new LocalityInfo(ImmutableList.of(lbEndpoint11), 1, 0);
+    localityInfo4 =
+        new LocalityInfo(ImmutableList.of(lbEndpoint41), 4, 1);
+    final Map<XdsLocality, LocalityInfo> localityInfoMap4 = ImmutableMap.of(
+        locality1, localityInfo1,locality4, localityInfo4);
+    syncContext.execute(new Runnable() {
+      @Override
+      public void run() {
+        localityStore.updateLocalityStore(localityInfoMap4);
+      }
+    });
+    inOrder.verify(helper, atLeastOnce()).updateBalancingState(
+        same(READY), subchannelPickerCaptor.capture());
+    assertThat(subchannelPickerCaptor.getValue()
+        .pickSubchannel(mock(PickSubchannelArgs.class))
+        .getSubchannel())
+        .isSameInstanceAs(mockSubchannel4);
+    inOrder.verify(lb1).handleResolvedAddresses(resolvedAddressesCaptor1.capture());
+    assertThat(resolvedAddressesCaptor1.getValue().getAddresses()).containsExactly(eag11);
+    inOrder.verify(lb4).handleResolvedAddresses(resolvedAddressesCaptor4.capture());
+    assertThat(resolvedAddressesCaptor4.getValue().getAddresses()).containsExactly(eag41);
+    inOrder.verifyNoMoreInteractions();
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).isEmpty();
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).hasSize(1);
+
+    verify(lb1, never()).shutdown();
+    verify(lb3, never()).shutdown();
+    verify(lb4, never()).shutdown();
+    localityStore.reset();
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).isEmpty();
+    verify(lb1).shutdown();
+    verify(lb3).shutdown();
+    verify(lb4).shutdown();
   }
 
   private static final class FakeLoadStatsStore implements LoadStatsStore {

--- a/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
@@ -909,8 +909,7 @@ public class LocalityStoreTest {
     assertThat(loadBalancers.keySet()).containsExactly("sz1");
     LoadBalancer lb1 = loadBalancers.get("sz1");
     InOrder inOrder = inOrder(lb1, helper);
-    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor1 =
-        ArgumentCaptor.forClass(ResolvedAddresses.class);
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor1 = ArgumentCaptor.forClass(null);
     inOrder.verify(helper).updateBalancingState(CONNECTING, BUFFER_PICKER);
     inOrder.verify(lb1).handleResolvedAddresses(resolvedAddressesCaptor1.capture());
     assertThat(resolvedAddressesCaptor1.getValue().getAddresses()).containsExactly(eag11, eag12);
@@ -931,8 +930,7 @@ public class LocalityStoreTest {
     LoadBalancer lb2 = loadBalancers.get("sz2");
     inOrder = inOrder(lb1, lb2, helper);
     inOrder.verify(helper).updateBalancingState(CONNECTING, BUFFER_PICKER);
-    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor2 =
-        ArgumentCaptor.forClass(ResolvedAddresses.class);
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor2 = ArgumentCaptor.forClass(null);
     inOrder.verify(lb2).handleResolvedAddresses(resolvedAddressesCaptor2.capture());
     assertThat(resolvedAddressesCaptor2.getValue().getAddresses()).containsExactly(eag21, eag22);
 
@@ -956,8 +954,7 @@ public class LocalityStoreTest {
     inOrder = inOrder(lb1, lb2, lb3, helper);
     inOrder.verify(helper).updateBalancingState(same(TRANSIENT_FAILURE), isA(ErrorPicker.class));
     inOrder.verify(helper).updateBalancingState(CONNECTING, BUFFER_PICKER);
-    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor3 =
-        ArgumentCaptor.forClass(ResolvedAddresses.class);
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor3 = ArgumentCaptor.forClass(null);
     inOrder.verify(lb3).handleResolvedAddresses(resolvedAddressesCaptor3.capture());
     assertThat(resolvedAddressesCaptor3.getValue().getAddresses()).containsExactly(eag31, eag32);
 
@@ -1085,8 +1082,7 @@ public class LocalityStoreTest {
     LoadBalancer lb4 = loadBalancers.get("sz4");
     inOrder = inOrder(lb1, lb2, lb3, lb4, helper);
     inOrder.verify(helper).updateBalancingState(CONNECTING, BUFFER_PICKER);
-    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor4 =
-        ArgumentCaptor.forClass(ResolvedAddresses.class);
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor4 = ArgumentCaptor.forClass(null);
     inOrder.verify(lb4).handleResolvedAddresses(resolvedAddressesCaptor4.capture());
     assertThat(resolvedAddressesCaptor4.getValue().getAddresses()).containsExactly(eag41, eag42);
 

--- a/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
@@ -261,24 +261,24 @@ public class LocalityStoreTest {
         .put(locality1, new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0));
     localityInfoMap
         .put(locality2, new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0));
-    localityStore.updateLocalityStore(localityInfoMap);
+    localityStore.updateLocalityStore(ImmutableMap.copyOf(localityInfoMap));
     verify(loadStatsStore).addLocality(locality1);
     verify(loadStatsStore).addLocality(locality2);
 
     localityInfoMap
         .put(locality3, new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0));
-    localityStore.updateLocalityStore(localityInfoMap);
+    localityStore.updateLocalityStore(ImmutableMap.copyOf(localityInfoMap));
     verify(loadStatsStore).addLocality(locality3);
 
     localityInfoMap = ImmutableMap
         .of(locality4, new LocalityInfo(ImmutableList.of(lbEndpoint41, lbEndpoint42), 4, 0));
-    localityStore.updateLocalityStore(localityInfoMap);
+    localityStore.updateLocalityStore(ImmutableMap.copyOf(localityInfoMap));
     verify(loadStatsStore).removeLocality(locality1);
     verify(loadStatsStore).removeLocality(locality2);
     verify(loadStatsStore).removeLocality(locality3);
     verify(loadStatsStore).addLocality(locality4);
 
-    localityStore.updateLocalityStore(Collections.EMPTY_MAP);
+    localityStore.updateLocalityStore(ImmutableMap.copyOf(Collections.EMPTY_MAP));
     verify(loadStatsStore).removeLocality(locality4);
   }
 
@@ -439,7 +439,7 @@ public class LocalityStoreTest {
         new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
     LocalityInfo localityInfo3 =
         new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
-    Map<XdsLocality, LocalityInfo> localityInfoMap = ImmutableMap.of(
+    ImmutableMap<XdsLocality, LocalityInfo> localityInfoMap = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
     localityStore.updateLocalityStore(localityInfoMap);
     verify(helper).updateBalancingState(CONNECTING, BUFFER_PICKER);
@@ -549,7 +549,7 @@ public class LocalityStoreTest {
         new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
     LocalityInfo localityInfo3 =
         new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
-    Map<XdsLocality, LocalityInfo> localityInfoMap = ImmutableMap.of(
+    ImmutableMap<XdsLocality, LocalityInfo> localityInfoMap = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
     localityStore.updateLocalityStore(localityInfoMap);
 
@@ -676,7 +676,7 @@ public class LocalityStoreTest {
         new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
     LocalityInfo localityInfo3 =
         new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
-    Map<XdsLocality, LocalityInfo> localityInfoMap = ImmutableMap.of(
+    ImmutableMap<XdsLocality, LocalityInfo> localityInfoMap = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
     localityStore.updateLocalityStore(localityInfoMap);
 
@@ -774,7 +774,7 @@ public class LocalityStoreTest {
         new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
     LocalityInfo localityInfo3 =
         new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
-    Map<XdsLocality, LocalityInfo> localityInfoMap = ImmutableMap.of(
+    ImmutableMap<XdsLocality, LocalityInfo> localityInfoMap = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
     localityStore.updateLocalityStore(localityInfoMap);
 
@@ -795,7 +795,7 @@ public class LocalityStoreTest {
         new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
     LocalityInfo localityInfo3 =
         new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
-    Map<XdsLocality, LocalityInfo> localityInfoMap = ImmutableMap.of(
+    ImmutableMap<XdsLocality, LocalityInfo> localityInfoMap = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
     localityStore.updateLocalityStore(localityInfoMap);
 
@@ -842,7 +842,7 @@ public class LocalityStoreTest {
         new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
     LocalityInfo localityInfo2 =
         new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
-    Map<XdsLocality, LocalityInfo> localityInfoMap = ImmutableMap.of(
+    ImmutableMap<XdsLocality, LocalityInfo> localityInfoMap = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2);
     localityStore.updateLocalityStore(localityInfoMap);
 
@@ -900,7 +900,7 @@ public class LocalityStoreTest {
         new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 2);
     LocalityInfo localityInfo4 =
         new LocalityInfo(ImmutableList.of(lbEndpoint41, lbEndpoint42), 3, 3);
-    final Map<XdsLocality, LocalityInfo> localityInfoMap = ImmutableMap.of(
+    final ImmutableMap<XdsLocality, LocalityInfo> localityInfoMap = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3, locality4,
         localityInfo4);
     syncContext.execute(new Runnable() {
@@ -1135,7 +1135,7 @@ public class LocalityStoreTest {
         new LocalityInfo(ImmutableList.of(lbEndpoint32), 3, 0);
     localityInfo4 =
         new LocalityInfo(ImmutableList.of(lbEndpoint42), 4, 1);
-    final Map<XdsLocality, LocalityInfo> localityInfoMap2 = ImmutableMap.of(
+    final ImmutableMap<XdsLocality, LocalityInfo> localityInfoMap2 = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3, locality4,
         localityInfo4);
     syncContext.execute(new Runnable() {
@@ -1177,7 +1177,7 @@ public class LocalityStoreTest {
         new LocalityInfo(ImmutableList.of(lbEndpoint11), 1, 0);
     localityInfo3 =
         new LocalityInfo(ImmutableList.of(lbEndpoint31), 3, 0);
-    final Map<XdsLocality, LocalityInfo> localityInfoMap3 = ImmutableMap.of(
+    final ImmutableMap<XdsLocality, LocalityInfo> localityInfoMap3 = ImmutableMap.of(
         locality1, localityInfo1,locality3, localityInfo3);
     syncContext.execute(new Runnable() {
       @Override
@@ -1227,7 +1227,7 @@ public class LocalityStoreTest {
         new LocalityInfo(ImmutableList.of(lbEndpoint11), 1, 0);
     localityInfo4 =
         new LocalityInfo(ImmutableList.of(lbEndpoint41), 4, 1);
-    final Map<XdsLocality, LocalityInfo> localityInfoMap4 = ImmutableMap.of(
+    final ImmutableMap<XdsLocality, LocalityInfo> localityInfoMap4 = ImmutableMap.of(
         locality1, localityInfo1,locality4, localityInfo4);
     syncContext.execute(new Runnable() {
       @Override

--- a/xds/src/test/java/io/grpc/xds/XdsCommsTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsCommsTest.java
@@ -293,12 +293,14 @@ public class XdsCommsTest {
         ImmutableList.of(
             new XdsComms.LbEndpoint(endpoint11),
             new XdsComms.LbEndpoint(endpoint12)),
-        1);
+        1,
+        0);
     LocalityInfo localityInfo2 = new LocalityInfo(
         ImmutableList.of(
             new XdsComms.LbEndpoint(endpoint21),
             new XdsComms.LbEndpoint(endpoint22)),
-        2);
+        2,
+        0);
     XdsLocality locality2 = XdsLocality.fromLocalityProto(localityProto2);
 
     InOrder inOrder = inOrder(localityStore);
@@ -405,9 +407,9 @@ public class XdsCommsTest {
 
     XdsLocality locality1 = XdsLocality.fromLocalityProto(localityProto1);
     LocalityInfo localityInfo1 = new LocalityInfo(
-        ImmutableList.of(new XdsComms.LbEndpoint(endpoint11)), 1);
+        ImmutableList.of(new XdsComms.LbEndpoint(endpoint11)), 1, 0);
     LocalityInfo localityInfo2 = new LocalityInfo(
-        ImmutableList.of(new XdsComms.LbEndpoint(endpoint21)), 2);
+        ImmutableList.of(new XdsComms.LbEndpoint(endpoint21)), 2, 0);
     XdsLocality locality2 = XdsLocality.fromLocalityProto(localityProto2);
     assertThat(localityEndpointsMappingCaptor.getValue()).containsExactly(
         locality2, localityInfo2, locality1, localityInfo1).inOrder();

--- a/xds/src/test/java/io/grpc/xds/XdsCommsTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsCommsTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Any;
 import com.google.protobuf.UInt32Value;
 import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment;
@@ -64,7 +65,6 @@ import io.grpc.testing.GrpcCleanupRule;
 import io.grpc.xds.XdsComms.AdsStreamCallback;
 import io.grpc.xds.XdsComms.DropOverload;
 import io.grpc.xds.XdsComms.LocalityInfo;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Rule;
@@ -107,7 +107,7 @@ public class XdsCommsTest {
   @Mock
   private BackoffPolicy backoffPolicy2;
   @Captor
-  private ArgumentCaptor<Map<XdsLocality, LocalityInfo>> localityEndpointsMappingCaptor;
+  private ArgumentCaptor<ImmutableMap<XdsLocality, LocalityInfo>> localityEndpointsMappingCaptor;
 
   private final FakeClock fakeClock = new FakeClock();
   private final SynchronizationContext syncContext = new SynchronizationContext(


### PR DESCRIPTION
- Implementing [priority failover](https://docs.google.com/document/d/1fAfdllHJ3JaaKVIdrrBaMnZSHxGAnlx4BhABMQQOn_4/view?pli=1#heading=h.krx7r69l2drb)
- Removed `localityWeight` field from `LocalityLbInfo` because this is always available and up to date in `edsResponsLocalityInfo`, otherwise need to create a new instance of `LocalityLbInfo` each time weight is updated.
- Introduced `PriorityManager` that manages all the priority failover logic.
