### PR TITLE
xds: fix a bug locality reset not fully clean up

### DIFF
--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -192,6 +192,7 @@ interface LocalityStore {
       for (XdsLocality locality : edsResponsLocalityInfo.keySet()) {
         loadStatsStore.removeLocality(locality);
       }
+      edsResponsLocalityInfo = ImmutableMap.of();
     }
 
     // This is triggered by EDS response.

--- a/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
@@ -831,6 +831,15 @@ public class LocalityStoreTest {
     verify(loadBalancers.get("sz2")).shutdown();
     verify(loadStatsStore).removeLocality(locality1);
     verify(loadStatsStore).removeLocality(locality2);
+
+    // Regression test for same locality added back.
+    localityStore.updateLocalityStore(localityInfoMap);
+    assertThat(loadBalancers).hasSize(2);
+    localityStore.reset();
+    verify(loadBalancers.get("sz1")).shutdown();
+    verify(loadBalancers.get("sz2")).shutdown();
+    verify(loadStatsStore, times(2)).removeLocality(locality1);
+    verify(loadStatsStore, times(2)).removeLocality(locality2);
   }
 
   private static final class FakeLoadStatsStore implements LoadStatsStore {


### PR DESCRIPTION
There is a bug in `LocalityStore.reset()` found during import cc @ejona86 