### PR TITLE
buildscripts: increase android gradle build JVM metaspace size

### DIFF
--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -10,7 +10,7 @@ BASE_DIR="$(pwd)"
 
 cd "$BASE_DIR/github/grpc-java"
 
-export GRADLE_OPTS=-Xmx512m
+export GRADLE_OPTS=(-Xmx512m -XX:MaxMetaspaceSize=512m)
 export LDFLAGS=-L/tmp/protobuf/lib
 export CXXFLAGS=-I/tmp/protobuf/include
 export LD_LIBRARY_PATH=/tmp/protobuf/lib


### PR DESCRIPTION
We recently saw Android CI fails frequently due to gradle build running out of memory. This started to occur after we made the change of doing a clean build in #6103. Gradle 5 uses 256 MB as the maximum limit fo  build process (see [this](https://stackoverflow.com/questions/54045132/after-upgrading-to-gradle-5-and-android-plugin-3-3-my-build-fails-with-metaspa)). This PR increase the limit to 512 GB.