### PR TITLE
gradle: Use absolute path with checkstyle fileTree

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -246,11 +246,11 @@ subprojects {
         }
 
         checkstyleMain {
-            source = fileTree(dir: "src/main", include: "**/*.java")
+            source = fileTree(dir: "$projectDir/src/main", include: "**/*.java")
         }
 
         checkstyleTest {
-            source = fileTree(dir: "src/test", include: "**/*.java")
+            source = fileTree(dir: "$projectDir/src/test", include: "**/*.java")
         }
 
         // At a test failure, log the stack trace to the console so that we don't

--- a/xds/src/main/java/io/grpc/xds/XdsAttributes.java
+++ b/xds/src/main/java/io/grpc/xds/XdsAttributes.java
@@ -21,7 +21,7 @@ import io.grpc.Attributes;
 import io.grpc.Grpc;
 
 /**
- * Special attributes that are only useful to gRPC in the XDS context
+ * Special attributes that are only useful to gRPC in the XDS context.
  */
 final class XdsAttributes {
   /**


### PR DESCRIPTION
The fileTree is supposed to be relative to the current project, which in
this case would be the child project, but apparently it isn't. Poked
around but couldn't find out why. In any case this fixes a regression
introduced in 4215b80b where checkstyle would no longer file any Java
files and thus it would not notice any failures.

CC @sanjaypujare 