### PR TITLE
alts: add close to TsiHandshaker to avoid resource leak for some impls

### DIFF
--- a/alts/src/main/java/io/grpc/alts/internal/AltsTsiHandshaker.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsTsiHandshaker.java
@@ -192,4 +192,8 @@ public final class AltsTsiHandshaker implements TsiHandshaker {
   public TsiFrameProtector createFrameProtector(ByteBufAllocator alloc) {
     return createFrameProtector(AltsTsiFrameProtector.getMaxAllowedFrameBytes(), alloc);
   }
+
+  public void close() {
+    handshaker.close();
+  }
 }

--- a/alts/src/main/java/io/grpc/alts/internal/AltsTsiHandshaker.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsTsiHandshaker.java
@@ -193,6 +193,7 @@ public final class AltsTsiHandshaker implements TsiHandshaker {
     return createFrameProtector(AltsTsiFrameProtector.getMaxAllowedFrameBytes(), alloc);
   }
 
+  @Override
   public void close() {
     handshaker.close();
   }

--- a/alts/src/main/java/io/grpc/alts/internal/NettyTsiHandshaker.java
+++ b/alts/src/main/java/io/grpc/alts/internal/NettyTsiHandshaker.java
@@ -149,4 +149,8 @@ public final class NettyTsiHandshaker {
     unwrapper = null;
     return internalHandshaker.createFrameProtector(alloc);
   }
+
+  void close() {
+    internalHandshaker.close();
+  }
 }

--- a/alts/src/main/java/io/grpc/alts/internal/TsiHandshakeHandler.java
+++ b/alts/src/main/java/io/grpc/alts/internal/TsiHandshakeHandler.java
@@ -185,4 +185,9 @@ public final class TsiHandshakeHandler extends ByteToMessageDecoder {
       }
     }
   }
+
+  @Override
+  protected void handlerRemoved0(ChannelHandlerContext ctx) throws Exception {
+    handshaker.close();
+  }
 }

--- a/alts/src/main/java/io/grpc/alts/internal/TsiHandshaker.java
+++ b/alts/src/main/java/io/grpc/alts/internal/TsiHandshaker.java
@@ -106,4 +106,9 @@ public interface TsiHandshaker {
    * @return a new TsiFrameProtector.
    */
   TsiFrameProtector createFrameProtector(ByteBufAllocator alloc);
+
+  /**
+   * Closes resources.
+   */
+  void close();
 }

--- a/alts/src/test/java/io/grpc/alts/internal/AltsProtocolNegotiatorTest.java
+++ b/alts/src/test/java/io/grpc/alts/internal/AltsProtocolNegotiatorTest.java
@@ -479,6 +479,11 @@ public class AltsProtocolNegotiatorTest {
       protectors.add(protector);
       return protector;
     }
+
+    @Override
+    public void close() {
+      delegate.close();
+    }
   }
 
   private static class InterceptingProtector implements TsiFrameProtector {

--- a/alts/src/test/java/io/grpc/alts/internal/FakeTsiHandshaker.java
+++ b/alts/src/test/java/io/grpc/alts/internal/FakeTsiHandshaker.java
@@ -226,4 +226,9 @@ public class FakeTsiHandshaker implements TsiHandshaker {
   public TsiFrameProtector createFrameProtector(ByteBufAllocator alloc) {
     return createFrameProtector(AltsTsiFrameProtector.getMaxAllowedFrameBytes(), alloc);
   }
+
+  @Override
+  public void close() {
+    // No-op
+  }
 }


### PR DESCRIPTION
Some handshaker implementation has internal closable resources. It only works if everything goes well (current implementation relying on the internal resource closes itself).

 In failure case, it may cause leak depends on the implementation of tsi handshaker. Having close in TsiHandshaker and TsiHandshakeHandler explicitly close the handshaker should avoid such leak; less error prone.