### PR TITLE
netty,okhttp,cronet: add option to use get/put when methods are safe/idempotent

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -144,6 +144,17 @@ public abstract class AbstractManagedChannelImplBuilder
 
   private int maxInboundMessageSize = GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 
+  /**
+   * If true, indicates that the transport may use the GET method for RPCs, and may include the
+   * request body in the query params.
+   */
+  boolean useGetForSafeMethods;
+
+  /**
+   * If true, indicates that the transport may use the PUT method for RPCs.
+   */
+  boolean usePutForIdempotentMethods;
+
   @Nullable
   BinaryLog binlog;
 
@@ -557,6 +568,14 @@ public abstract class AbstractManagedChannelImplBuilder
    */
   protected int getDefaultPort() {
     return GrpcUtil.DEFAULT_PORT_SSL;
+  }
+
+  protected final boolean useGetForSafeMethods() {
+    return useGetForSafeMethods;
+  }
+
+  protected final boolean usePutForIdempotentMethods() {
+    return usePutForIdempotentMethods;
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -144,17 +144,6 @@ public abstract class AbstractManagedChannelImplBuilder
 
   private int maxInboundMessageSize = GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 
-  /**
-   * If true, indicates that the transport may use the GET method for RPCs, and may include the
-   * request body in the query params.
-   */
-  boolean useGetForSafeMethods;
-
-  /**
-   * If true, indicates that the transport may use the PUT method for RPCs.
-   */
-  boolean usePutForIdempotentMethods;
-
   @Nullable
   BinaryLog binlog;
 
@@ -568,14 +557,6 @@ public abstract class AbstractManagedChannelImplBuilder
    */
   protected int getDefaultPort() {
     return GrpcUtil.DEFAULT_PORT_SSL;
-  }
-
-  protected final boolean useGetForSafeMethods() {
-    return useGetForSafeMethods;
-  }
-
-  protected final boolean usePutForIdempotentMethods() {
-    return usePutForIdempotentMethods;
   }
 
   /**

--- a/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
@@ -194,7 +194,9 @@ public final class CronetChannelBuilder extends
         scheduledExecutorService,
         maxMessageSize,
         alwaysUsePut,
-        transportTracerFactory.create());
+        transportTracerFactory.create(),
+        useGetForSafeMethods(),
+        usePutForIdempotentMethods());
   }
 
   @VisibleForTesting
@@ -206,6 +208,8 @@ public final class CronetChannelBuilder extends
     private final StreamBuilderFactory streamFactory;
     private final TransportTracer transportTracer;
     private final boolean usingSharedScheduler;
+    private final boolean useGetForSafeMethods;
+    private final boolean usePutForIdempotentMethods;
 
     private CronetTransportFactory(
         StreamBuilderFactory streamFactory,
@@ -213,7 +217,9 @@ public final class CronetChannelBuilder extends
         @Nullable ScheduledExecutorService timeoutService,
         int maxMessageSize,
         boolean alwaysUsePut,
-        TransportTracer transportTracer) {
+        TransportTracer transportTracer,
+        boolean useGetForSafeMethods,
+        boolean usePutForIdempotentMethods) {
       usingSharedScheduler = timeoutService == null;
       this.timeoutService = usingSharedScheduler
           ? SharedResourceHolder.get(GrpcUtil.TIMER_SERVICE) : timeoutService;
@@ -222,6 +228,8 @@ public final class CronetChannelBuilder extends
       this.streamFactory = streamFactory;
       this.executor = Preconditions.checkNotNull(executor, "executor");
       this.transportTracer = Preconditions.checkNotNull(transportTracer, "transportTracer");
+      this.useGetForSafeMethods = useGetForSafeMethods;
+      this.usePutForIdempotentMethods = usePutForIdempotentMethods;
     }
 
     @Override
@@ -230,7 +238,7 @@ public final class CronetChannelBuilder extends
       InetSocketAddress inetSocketAddr = (InetSocketAddress) addr;
       return new CronetClientTransport(streamFactory, inetSocketAddr, options.getAuthority(),
           options.getUserAgent(), options.getEagAttributes(), executor, maxMessageSize,
-          alwaysUsePut, transportTracer);
+          alwaysUsePut, transportTracer, useGetForSafeMethods, usePutForIdempotentMethods);
     }
 
     @Override

--- a/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
@@ -86,6 +86,17 @@ public final class CronetChannelBuilder extends
 
   private int maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
 
+  /**
+   * If true, indicates that the transport may use the GET method for RPCs, and may include the
+   * request body in the query params.
+   */
+  private final boolean useGetForSafeMethods;
+
+  /**
+   * If true, indicates that the transport may use the PUT method for RPCs.
+   */
+  private final boolean usePutForIdempotentMethods;
+
   private boolean trafficStatsTagSet;
   private int trafficStatsTag;
   private boolean trafficStatsUidSet;
@@ -195,8 +206,8 @@ public final class CronetChannelBuilder extends
         maxMessageSize,
         alwaysUsePut,
         transportTracerFactory.create(),
-        useGetForSafeMethods(),
-        usePutForIdempotentMethods());
+        useGetForSafeMethods,
+        usePutForIdempotentMethods);
   }
 
   @VisibleForTesting

--- a/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
@@ -90,12 +90,12 @@ public final class CronetChannelBuilder extends
    * If true, indicates that the transport may use the GET method for RPCs, and may include the
    * request body in the query params.
    */
-  private final boolean useGetForSafeMethods;
+  private final boolean useGetForSafeMethods = false;
 
   /**
    * If true, indicates that the transport may use the PUT method for RPCs.
    */
-  private final boolean usePutForIdempotentMethods;
+  private final boolean usePutForIdempotentMethods = false;
 
   private boolean trafficStatsTagSet;
   private int trafficStatsTag;

--- a/cronet/src/main/java/io/grpc/cronet/CronetClientStream.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetClientStream.java
@@ -107,10 +107,12 @@ class CronetClientStream extends AbstractClientStream {
       MethodDescriptor<?, ?> method,
       StatsTraceContext statsTraceCtx,
       CallOptions callOptions,
-      TransportTracer transportTracer) {
+      TransportTracer transportTracer,
+      boolean useGetForSafeMethods,
+      boolean usePutForIdempotentMethods) {
     super(
         new CronetWritableBufferAllocator(), statsTraceCtx, transportTracer, headers, callOptions,
-        method.isSafe());
+        useGetForSafeMethods && method.isSafe());
     this.url = Preconditions.checkNotNull(url, "url");
     this.userAgent = Preconditions.checkNotNull(userAgent, "userAgent");
     this.statsTraceCtx = Preconditions.checkNotNull(statsTraceCtx, "statsTraceCtx");
@@ -118,7 +120,7 @@ class CronetClientStream extends AbstractClientStream {
     this.headers = Preconditions.checkNotNull(headers, "headers");
     this.transport = Preconditions.checkNotNull(transport, "transport");
     this.startCallback = Preconditions.checkNotNull(startCallback, "startCallback");
-    this.idempotent = method.isIdempotent() || alwaysUsePut;
+    this.idempotent = (usePutForIdempotentMethods && method.isIdempotent()) || alwaysUsePut;
     // Only delay flushing header for unary rpcs.
     this.delayRequestHeader = (method.getType() == MethodDescriptor.MethodType.UNARY);
     this.annotation = callOptions.getOption(CRONET_ANNOTATION_KEY);

--- a/cronet/src/test/java/io/grpc/cronet/CronetClientStreamTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientStreamTest.java
@@ -119,7 +119,9 @@ public final class CronetClientStreamTest {
             method,
             StatsTraceContext.NOOP,
             CallOptions.DEFAULT,
-            transportTracer);
+            transportTracer,
+            false,
+            false);
     callback.setStream(clientStream);
     when(factory.newBidirectionalStreamBuilder(
             any(String.class), any(BidirectionalStream.Callback.class), any(Executor.class)))
@@ -588,7 +590,9 @@ public final class CronetClientStreamTest {
             method,
             StatsTraceContext.NOOP,
             CallOptions.DEFAULT.withOption(CronetClientStream.CRONET_ANNOTATION_KEY, annotation),
-            transportTracer);
+            transportTracer,
+            false,
+            false);
     callback.setStream(stream);
     when(factory.newBidirectionalStreamBuilder(
             any(String.class), any(BidirectionalStream.Callback.class), any(Executor.class)))
@@ -621,7 +625,9 @@ public final class CronetClientStreamTest {
             method,
             StatsTraceContext.NOOP,
             callOptions,
-            transportTracer);
+            transportTracer,
+            false,
+            false);
     callback.setStream(stream);
     when(factory.newBidirectionalStreamBuilder(
             any(String.class), any(BidirectionalStream.Callback.class), any(Executor.class)))
@@ -659,7 +665,9 @@ public final class CronetClientStreamTest {
             getMethod,
             StatsTraceContext.NOOP,
             CallOptions.DEFAULT,
-            transportTracer);
+            transportTracer,
+            true,
+            false);
     callback.setStream(stream);
     ExperimentalBidirectionalStream.Builder getBuilder =
         mock(ExperimentalBidirectionalStream.Builder.class);
@@ -714,7 +722,9 @@ public final class CronetClientStreamTest {
             idempotentMethod,
             StatsTraceContext.NOOP,
             CallOptions.DEFAULT,
-            transportTracer);
+            transportTracer,
+            true,
+            true);
     callback.setStream(stream);
     ExperimentalBidirectionalStream.Builder builder =
         mock(ExperimentalBidirectionalStream.Builder.class);
@@ -744,7 +754,9 @@ public final class CronetClientStreamTest {
             method,
             StatsTraceContext.NOOP,
             CallOptions.DEFAULT,
-            transportTracer);
+            transportTracer,
+            true,
+            true);
     callback.setStream(stream);
     ExperimentalBidirectionalStream.Builder builder =
         mock(ExperimentalBidirectionalStream.Builder.class);
@@ -782,7 +794,9 @@ public final class CronetClientStreamTest {
             method,
             StatsTraceContext.NOOP,
             CallOptions.DEFAULT,
-            transportTracer);
+            transportTracer,
+            false,
+            false);
     callback.setStream(stream);
     ExperimentalBidirectionalStream.Builder builder =
         mock(ExperimentalBidirectionalStream.Builder.class);

--- a/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
@@ -78,7 +78,9 @@ public final class CronetClientTransportTest {
             executor,
             5000,
             false,
-            TransportTracer.getDefaultFactory().create());
+            TransportTracer.getDefaultFactory().create(),
+            false,
+            false);
     Runnable callback = transport.start(clientTransportListener);
     assertTrue(callback != null);
     callback.run();

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -371,6 +371,8 @@ public abstract class AbstractInteropTest {
 
   /** Sends a cacheable unary rpc using GET. Requires that the server is behind a caching proxy. */
   public void cacheableUnary() {
+    // THIS TEST IS BROKEN. Enabling safe just on the MethodDescriptor does nothing by itself. This
+    // test would need to enable GET on the channel.
     // Set safe to true.
     MethodDescriptor<SimpleRequest, SimpleResponse> safeCacheableUnaryCallMethod =
         TestServiceGrpc.getCacheableUnaryCallMethod().toBuilder().setSafe(true).build();
@@ -405,6 +407,7 @@ public abstract class AbstractInteropTest {
 
     assertEquals(response1, response2);
     assertNotEquals(response1, response3);
+    // THIS TEST IS BROKEN. See comment at start of method.
   }
 
   @Test

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -91,6 +91,12 @@ public final class NettyChannelBuilder
   private LocalSocketPicker localSocketPicker;
 
   /**
+   * If true, indicates that the transport may use the GET method for RPCs, and may include the
+   * request body in the query params.
+   */
+  private final boolean useGetForSafeMethods = false;
+
+  /**
    * Creates a new builder with the given server address. This factory method is primarily intended
    * for using Netty Channel types other than SocketChannel. {@link #forAddress(String, int)} should
    * generally be preferred over this method, since that API permits delaying DNS lookups and
@@ -415,7 +421,7 @@ public final class NettyChannelBuilder
         negotiator, channelFactory, channelOptions,
         eventLoopGroupPool, flowControlWindow, maxInboundMessageSize(),
         maxHeaderListSize, keepAliveTimeNanos, keepAliveTimeoutNanos, keepAliveWithoutCalls,
-        transportTracerFactory, localSocketPicker, useGetForSafeMethods());
+        transportTracerFactory, localSocketPicker, useGetForSafeMethods);
   }
 
   @VisibleForTesting

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -415,7 +415,7 @@ public final class NettyChannelBuilder
         negotiator, channelFactory, channelOptions,
         eventLoopGroupPool, flowControlWindow, maxInboundMessageSize(),
         maxHeaderListSize, keepAliveTimeNanos, keepAliveTimeoutNanos, keepAliveWithoutCalls,
-        transportTracerFactory, localSocketPicker);
+        transportTracerFactory, localSocketPicker, useGetForSafeMethods());
   }
 
   @VisibleForTesting
@@ -536,6 +536,7 @@ public final class NettyChannelBuilder
     private final boolean keepAliveWithoutCalls;
     private final TransportTracer.Factory transportTracerFactory;
     private final LocalSocketPicker localSocketPicker;
+    private final boolean useGetForSafeMethods;
 
     private boolean closed;
 
@@ -544,7 +545,8 @@ public final class NettyChannelBuilder
         Map<ChannelOption<?>, ?> channelOptions, ObjectPool<? extends EventLoopGroup> groupPool,
         int flowControlWindow, int maxMessageSize, int maxHeaderListSize,
         long keepAliveTimeNanos, long keepAliveTimeoutNanos, boolean keepAliveWithoutCalls,
-        TransportTracer.Factory transportTracerFactory, LocalSocketPicker localSocketPicker) {
+        TransportTracer.Factory transportTracerFactory, LocalSocketPicker localSocketPicker,
+        boolean useGetForSafeMethods) {
       this.protocolNegotiator = checkNotNull(protocolNegotiator, "protocolNegotiator");
       this.channelFactory = channelFactory;
       this.channelOptions = new HashMap<ChannelOption<?>, Object>(channelOptions);
@@ -559,6 +561,7 @@ public final class NettyChannelBuilder
       this.transportTracerFactory = transportTracerFactory;
       this.localSocketPicker =
           localSocketPicker != null ? localSocketPicker : new LocalSocketPicker();
+      this.useGetForSafeMethods = useGetForSafeMethods;
     }
 
     @Override
@@ -592,7 +595,7 @@ public final class NettyChannelBuilder
           maxMessageSize, maxHeaderListSize, keepAliveTimeNanosState.get(), keepAliveTimeoutNanos,
           keepAliveWithoutCalls, options.getAuthority(), options.getUserAgent(),
           tooManyPingsRunnable, transportTracerFactory.create(), options.getEagAttributes(),
-          localSocketPicker, channelLogger);
+          localSocketPicker, channelLogger, useGetForSafeMethods);
       return transport;
     }
 

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -75,14 +75,15 @@ class NettyClientStream extends AbstractClientStream {
       AsciiString userAgent,
       StatsTraceContext statsTraceCtx,
       TransportTracer transportTracer,
-      CallOptions callOptions) {
+      CallOptions callOptions,
+      boolean useGetForSafeMethods) {
     super(
         new NettyWritableBufferAllocator(channel.alloc()),
         statsTraceCtx,
         transportTracer,
         headers,
         callOptions,
-        useGet(method));
+        useGetForSafeMethods && method.isSafe());
     this.state = checkNotNull(state, "transportState");
     this.writeQueue = state.handler.getWriteQueue();
     this.method = checkNotNull(method, "method");
@@ -110,10 +111,6 @@ class NettyClientStream extends AbstractClientStream {
   @Override
   public Attributes getAttributes() {
     return state.handler.getAttributes();
-  }
-
-  private static boolean useGet(MethodDescriptor<?, ?> method) {
-    return method.isSafe();
   }
 
   private class Sink implements AbstractClientStream.Sink {

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -100,6 +100,7 @@ class NettyClientTransport implements ConnectionClientTransport {
   private final Attributes eagAttributes;
   private final LocalSocketPicker localSocketPicker;
   private final ChannelLogger channelLogger;
+  private final boolean useGetForSafeMethods;
 
   NettyClientTransport(
       SocketAddress address, ChannelFactory<? extends Channel> channelFactory,
@@ -108,7 +109,8 @@ class NettyClientTransport implements ConnectionClientTransport {
       int maxHeaderListSize, long keepAliveTimeNanos, long keepAliveTimeoutNanos,
       boolean keepAliveWithoutCalls, String authority, @Nullable String userAgent,
       Runnable tooManyPingsRunnable, TransportTracer transportTracer, Attributes eagAttributes,
-      LocalSocketPicker localSocketPicker, ChannelLogger channelLogger) {
+      LocalSocketPicker localSocketPicker, ChannelLogger channelLogger,
+      boolean useGetForSafeMethods) {
     this.negotiator = Preconditions.checkNotNull(negotiator, "negotiator");
     this.negotiationScheme = this.negotiator.scheme();
     this.remoteAddress = Preconditions.checkNotNull(address, "address");
@@ -131,6 +133,7 @@ class NettyClientTransport implements ConnectionClientTransport {
     this.localSocketPicker = Preconditions.checkNotNull(localSocketPicker, "localSocketPicker");
     this.logId = InternalLogId.allocate(getClass(), remoteAddress.toString());
     this.channelLogger = Preconditions.checkNotNull(channelLogger, "channelLogger");
+    this.useGetForSafeMethods = useGetForSafeMethods;
   }
 
   @Override
@@ -191,7 +194,8 @@ class NettyClientTransport implements ConnectionClientTransport {
         userAgent,
         statsTraceCtx,
         transportTracer,
-        callOptions);
+        callOptions,
+        useGetForSafeMethods);
   }
 
   @SuppressWarnings("unchecked")

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -420,7 +420,8 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
         AsciiString.of("agent"),
         StatsTraceContext.NOOP,
         transportTracer,
-        CallOptions.DEFAULT);
+        CallOptions.DEFAULT,
+        false);
     stream.start(listener);
     stream().transportState().setId(STREAM_ID);
     verify(listener, never()).onReady();
@@ -450,7 +451,8 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
         AsciiString.of("good agent"),
         StatsTraceContext.NOOP,
         transportTracer,
-        CallOptions.DEFAULT);
+        CallOptions.DEFAULT,
+        false);
     stream.start(listener);
 
     ArgumentCaptor<CreateStreamCommand> cmdCap = ArgumentCaptor.forClass(CreateStreamCommand.class);
@@ -480,7 +482,8 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
         AsciiString.of("agent"),
         StatsTraceContext.NOOP,
         transportTracer,
-        CallOptions.DEFAULT);
+        CallOptions.DEFAULT,
+        true);
     stream.start(listener);
     stream.transportState().setId(STREAM_ID);
     stream.transportState().setHttp2Stream(http2Stream);
@@ -513,7 +516,8 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
         AsciiString.of("agent"),
         StatsTraceContext.NOOP,
         transportTracer,
-        CallOptions.DEFAULT);
+        CallOptions.DEFAULT,
+        false);
     stream.start(listener);
     stream.transportState().setHttp2Stream(http2Stream);
     reset(listener);

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -193,7 +193,7 @@ public class NettyClientTransportTest {
         newNegotiator(), DEFAULT_WINDOW_SIZE, DEFAULT_MAX_MESSAGE_SIZE,
         GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE, KEEPALIVE_TIME_NANOS_DISABLED, 1L, false, authority,
         null /* user agent */, tooManyPingsRunnable, new TransportTracer(), Attributes.EMPTY,
-        new SocketPicker(), new FakeChannelLogger());
+        new SocketPicker(), new FakeChannelLogger(), false);
     transports.add(transport);
     callMeMaybe(transport.start(clientTransportListener));
 
@@ -439,7 +439,7 @@ public class NettyClientTransportTest {
         newNegotiator(), DEFAULT_WINDOW_SIZE, DEFAULT_MAX_MESSAGE_SIZE,
         GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE, KEEPALIVE_TIME_NANOS_DISABLED, 1, false, authority,
         null, tooManyPingsRunnable, new TransportTracer(), Attributes.EMPTY, new SocketPicker(),
-        new FakeChannelLogger());
+        new FakeChannelLogger(), false);
     transports.add(transport);
 
     // Should not throw
@@ -709,7 +709,7 @@ public class NettyClientTransportTest {
         negotiator, DEFAULT_WINDOW_SIZE, maxMsgSize, maxHeaderListSize,
         keepAliveTimeNano, keepAliveTimeoutNano,
         false, authority, userAgent, tooManyPingsRunnable,
-        new TransportTracer(), eagAttributes, new SocketPicker(), new FakeChannelLogger());
+        new TransportTracer(), eagAttributes, new SocketPicker(), new FakeChannelLogger(), false);
     transports.add(transport);
     return transport;
   }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -129,6 +129,12 @@ public class OkHttpChannelBuilder extends
   private boolean keepAliveWithoutCalls;
   private int maxInboundMetadataSize = Integer.MAX_VALUE;
 
+  /**
+   * If true, indicates that the transport may use the GET method for RPCs, and may include the
+   * request body in the query params.
+   */
+  private final boolean useGetForSafeMethods = true;
+
   protected OkHttpChannelBuilder(String host, int port) {
     this(GrpcUtil.authorityFromHostAndPort(host, port));
   }
@@ -392,7 +398,7 @@ public class OkHttpChannelBuilder extends
         keepAliveWithoutCalls,
         maxInboundMetadataSize,
         transportTracerFactory,
-        useGetForSafeMethods());
+        useGetForSafeMethods);
   }
 
   @Override

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -391,7 +391,8 @@ public class OkHttpChannelBuilder extends
         flowControlWindow,
         keepAliveWithoutCalls,
         maxInboundMetadataSize,
-        transportTracerFactory);
+        transportTracerFactory,
+        useGetForSafeMethods());
   }
 
   @Override
@@ -449,6 +450,7 @@ public class OkHttpChannelBuilder extends
     private final boolean keepAliveWithoutCalls;
     private final int maxInboundMetadataSize;
     private final ScheduledExecutorService timeoutService;
+    private final boolean useGetForSafeMethods;
     private boolean closed;
 
     private OkHttpTransportFactory(
@@ -465,7 +467,8 @@ public class OkHttpChannelBuilder extends
         int flowControlWindow,
         boolean keepAliveWithoutCalls,
         int maxInboundMetadataSize,
-        TransportTracer.Factory transportTracerFactory) {
+        TransportTracer.Factory transportTracerFactory,
+        boolean useGetForSafeMethods) {
       usingSharedScheduler = timeoutService == null;
       this.timeoutService = usingSharedScheduler
           ? SharedResourceHolder.get(GrpcUtil.TIMER_SERVICE) : timeoutService;
@@ -480,6 +483,7 @@ public class OkHttpChannelBuilder extends
       this.flowControlWindow = flowControlWindow;
       this.keepAliveWithoutCalls = keepAliveWithoutCalls;
       this.maxInboundMetadataSize = maxInboundMetadataSize;
+      this.useGetForSafeMethods = useGetForSafeMethods;
 
       usingSharedExecutor = executor == null;
       this.transportTracerFactory =
@@ -522,7 +526,8 @@ public class OkHttpChannelBuilder extends
           options.getHttpConnectProxiedSocketAddress(),
           tooManyPingsRunnable,
           maxInboundMetadataSize,
-          transportTracerFactory.create());
+          transportTracerFactory.create(),
+          useGetForSafeMethods);
       if (enableKeepAlive) {
         transport.enableKeepAlive(
             true, keepAliveTimeNanosState.get(), keepAliveTimeoutNanos, keepAliveWithoutCalls);

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -74,14 +74,15 @@ class OkHttpClientStream extends AbstractClientStream {
       String userAgent,
       StatsTraceContext statsTraceCtx,
       TransportTracer transportTracer,
-      CallOptions callOptions) {
+      CallOptions callOptions,
+      boolean useGetForSafeMethods) {
     super(
         new OkHttpWritableBufferAllocator(),
         statsTraceCtx,
         transportTracer,
         headers,
         callOptions,
-        method.isSafe());
+        useGetForSafeMethods && method.isSafe());
     this.statsTraceCtx = checkNotNull(statsTraceCtx, "statsTraceCtx");
     this.method = method;
     this.authority = authority;

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -198,6 +198,7 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
   private boolean keepAliveWithoutCalls;
   private final Runnable tooManyPingsRunnable;
   private final int maxInboundMetadataSize;
+  private final boolean useGetForSafeMethods;
   @GuardedBy("lock")
   private final TransportTracer transportTracer;
   @GuardedBy("lock")
@@ -239,7 +240,8 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
       @Nullable HttpConnectProxiedSocketAddress proxiedAddr,
       Runnable tooManyPingsRunnable,
       int maxInboundMetadataSize,
-      TransportTracer transportTracer) {
+      TransportTracer transportTracer,
+      boolean useGetForSafeMethods) {
     this.address = Preconditions.checkNotNull(address, "address");
     this.defaultAuthority = authority;
     this.maxMessageSize = maxMessageSize;
@@ -263,6 +265,7 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
     this.logId = InternalLogId.allocate(getClass(), address.toString());
     this.attributes = Attributes.newBuilder()
         .set(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS, eagAttrs).build();
+    this.useGetForSafeMethods = useGetForSafeMethods;
     initTransportTracer();
   }
 
@@ -285,6 +288,7 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
       int initialWindowSize,
       Runnable tooManyPingsRunnable,
       TransportTracer transportTracer) {
+    useGetForSafeMethods = false;
     address = null;
     this.maxMessageSize = maxMessageSize;
     this.initialWindowSize = initialWindowSize;
@@ -397,7 +401,8 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
           userAgent,
           statsTraceCtx,
           transportTracer,
-          callOptions);
+          callOptions,
+          useGetForSafeMethods);
     }
   }
 

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
@@ -99,7 +99,8 @@ public class OkHttpClientStreamTest {
         "userAgent",
         StatsTraceContext.NOOP,
         transportTracer,
-        CallOptions.DEFAULT);
+        CallOptions.DEFAULT,
+        false);
   }
 
   @Test
@@ -158,7 +159,7 @@ public class OkHttpClientStreamTest {
     metaData.put(GrpcUtil.USER_AGENT_KEY, "misbehaving-application");
     stream = new OkHttpClientStream(methodDescriptor, metaData, frameWriter, transport,
         flowController, lock, MAX_MESSAGE_SIZE, INITIAL_WINDOW_SIZE, "localhost",
-        "good-application", StatsTraceContext.NOOP, transportTracer, CallOptions.DEFAULT);
+        "good-application", StatsTraceContext.NOOP, transportTracer, CallOptions.DEFAULT, false);
     stream.start(new BaseClientStreamListener());
     stream.transportState().start(3);
 
@@ -174,7 +175,7 @@ public class OkHttpClientStreamTest {
     metaData.put(GrpcUtil.USER_AGENT_KEY, "misbehaving-application");
     stream = new OkHttpClientStream(methodDescriptor, metaData, frameWriter, transport,
         flowController, lock, MAX_MESSAGE_SIZE, INITIAL_WINDOW_SIZE, "localhost",
-        "good-application", StatsTraceContext.NOOP, transportTracer, CallOptions.DEFAULT);
+        "good-application", StatsTraceContext.NOOP, transportTracer, CallOptions.DEFAULT, false);
     stream.start(new BaseClientStreamListener());
     stream.transportState().start(3);
 
@@ -203,7 +204,7 @@ public class OkHttpClientStreamTest {
         .build();
     stream = new OkHttpClientStream(getMethod, new Metadata(), frameWriter, transport,
         flowController, lock, MAX_MESSAGE_SIZE, INITIAL_WINDOW_SIZE, "localhost",
-        "good-application", StatsTraceContext.NOOP, transportTracer, CallOptions.DEFAULT);
+        "good-application", StatsTraceContext.NOOP, transportTracer, CallOptions.DEFAULT, true);
     stream.start(new BaseClientStreamListener());
 
     // GET streams send headers after halfClose is called.

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -264,7 +264,8 @@ public class OkHttpClientTransportTest {
         NO_PROXY,
         tooManyPingsRunnable,
         DEFAULT_MAX_INBOUND_METADATA_SIZE,
-        transportTracer);
+        transportTracer,
+        false);
     String s = clientTransport.toString();
     assertTrue("Unexpected: " + s, s.contains("OkHttpClientTransport"));
     assertTrue("Unexpected: " + s, s.contains(address.toString()));
@@ -1664,7 +1665,8 @@ public class OkHttpClientTransportTest {
         NO_PROXY,
         tooManyPingsRunnable,
         DEFAULT_MAX_INBOUND_METADATA_SIZE,
-        transportTracer);
+        transportTracer,
+        false);
 
     String host = clientTransport.getOverridenHost();
     int port = clientTransport.getOverridenPort();
@@ -1690,7 +1692,8 @@ public class OkHttpClientTransportTest {
         NO_PROXY,
         tooManyPingsRunnable,
         DEFAULT_MAX_INBOUND_METADATA_SIZE,
-        new TransportTracer());
+        new TransportTracer(),
+        false);
 
     ManagedClientTransport.Listener listener = mock(ManagedClientTransport.Listener.class);
     clientTransport.start(listener);
@@ -1727,7 +1730,8 @@ public class OkHttpClientTransportTest {
             NO_PROXY,
             tooManyPingsRunnable,
             DEFAULT_MAX_INBOUND_METADATA_SIZE,
-            new TransportTracer());
+            new TransportTracer(),
+            false);
 
     ManagedClientTransport.Listener listener = mock(ManagedClientTransport.Listener.class);
     clientTransport.start(listener);
@@ -1759,7 +1763,8 @@ public class OkHttpClientTransportTest {
             .setProxyAddress(serverSocket.getLocalSocketAddress()).build(),
         tooManyPingsRunnable,
         DEFAULT_MAX_INBOUND_METADATA_SIZE,
-        transportTracer);
+        transportTracer,
+        false);
     clientTransport.start(transportListener);
 
     Socket sock = serverSocket.accept();
@@ -1815,7 +1820,8 @@ public class OkHttpClientTransportTest {
             .setProxyAddress(serverSocket.getLocalSocketAddress()).build(),
         tooManyPingsRunnable,
         DEFAULT_MAX_INBOUND_METADATA_SIZE,
-        transportTracer);
+        transportTracer,
+        false);
     clientTransport.start(transportListener);
 
     Socket sock = serverSocket.accept();
@@ -1870,7 +1876,8 @@ public class OkHttpClientTransportTest {
             .setProxyAddress(serverSocket.getLocalSocketAddress()).build(),
         tooManyPingsRunnable,
         DEFAULT_MAX_INBOUND_METADATA_SIZE,
-        transportTracer);
+        transportTracer,
+        false);
     clientTransport.start(transportListener);
 
     Socket sock = serverSocket.accept();


### PR DESCRIPTION
This change adds two booleans to AbstractManagedChannelBuilderImpl to
allow transports to use get and put.   These are currently defaulted to
on, but unset on the method descriptors.   This change is 1/2 that will
allow the safe / idempotent bits to be set on generated proto code.
Part 2/2 will actually enable it.

The use case for this is for interceptors that implement caching logic.
They need to be able to access the safe/idempotent bits on the MD in
order to decide to how to handle the request, even if gRPC doesn't use
GET / PUT HTTP methods.