### PR TITLE
Expose Safe and Idempotent on Protobuf descriptors

### DIFF
--- a/api/src/main/java/io/grpc/MethodDescriptor.java
+++ b/api/src/main/java/io/grpc/MethodDescriptor.java
@@ -352,7 +352,6 @@ public final class MethodDescriptor<ReqT, RespT> {
    *
    * @since 1.0.0
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1775")
   public boolean isIdempotent() {
     return idempotent;
   }
@@ -364,7 +363,6 @@ public final class MethodDescriptor<ReqT, RespT> {
    *
    * @since 1.1.0
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1775")
   public boolean isSafe() {
     return safe;
   }
@@ -540,7 +538,6 @@ public final class MethodDescriptor<ReqT, RespT> {
      *
      * @since 1.1.0
      */
-    @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1775")
     public Builder<ReqT, RespT> setIdempotent(boolean idempotent) {
       this.idempotent = idempotent;
       return this;
@@ -552,7 +549,6 @@ public final class MethodDescriptor<ReqT, RespT> {
      *
      * @since 1.1.0
      */
-    @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1775")
     public Builder<ReqT, RespT> setSafe(boolean safe) {
       this.safe = safe;
       return this;

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -410,7 +410,22 @@ static void PrintMethodFields(
         "        $service_class_name$.$method_new_field_name$ = $method_new_field_name$ =\n"
         "            $MethodDescriptor$.<$input_type$, $output_type$>newBuilder()\n"
         "            .setType($MethodType$.$method_type$)\n"
-        "            .setFullMethodName(generateFullMethodName(SERVICE_NAME, \"$method_name$\"))\n"
+        "            .setFullMethodName(generateFullMethodName(SERVICE_NAME, \"$method_name$\"))\n");
+        
+    bool safe = method->options().idempotency_level()
+        == google::protobuf::MethodOptions_IdempotencyLevel_NO_SIDE_EFFECTS;
+    if (safe) {
+      p->Print(*vars, "            .setSafe(true)\n");
+    } else {
+      bool idempotent = method->options().idempotency_level()
+          == google::protobuf::MethodOptions_IdempotencyLevel_IDEMPOTENT;
+      if (idempotent) {
+        p->Print(*vars, "            .setIdempotent(true)\n");
+      }
+    }
+        
+    p->Print(
+        *vars,
         "            .setSampledToLocalTracing(true)\n"
         "            .setRequestMarshaller($ProtoUtils$.marshaller(\n"
         "                $input_type$.getDefaultInstance()))\n"

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -216,6 +216,70 @@ public final class TestServiceGrpc {
     return getImportMethod;
   }
 
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.compiler.Test.SimpleRequest,
+      io.grpc.testing.compiler.Test.SimpleResponse> getSafeCallMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SafeCall",
+      requestType = io.grpc.testing.compiler.Test.SimpleRequest.class,
+      responseType = io.grpc.testing.compiler.Test.SimpleResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<io.grpc.testing.compiler.Test.SimpleRequest,
+      io.grpc.testing.compiler.Test.SimpleResponse> getSafeCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.compiler.Test.SimpleRequest, io.grpc.testing.compiler.Test.SimpleResponse> getSafeCallMethod;
+    if ((getSafeCallMethod = TestServiceGrpc.getSafeCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getSafeCallMethod = TestServiceGrpc.getSafeCallMethod) == null) {
+          TestServiceGrpc.getSafeCallMethod = getSafeCallMethod =
+              io.grpc.MethodDescriptor.<io.grpc.testing.compiler.Test.SimpleRequest, io.grpc.testing.compiler.Test.SimpleResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "SafeCall"))
+              .setSafe(true)
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.compiler.Test.SimpleRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.compiler.Test.SimpleResponse.getDefaultInstance()))
+              .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("SafeCall"))
+              .build();
+        }
+      }
+    }
+    return getSafeCallMethod;
+  }
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.compiler.Test.SimpleRequest,
+      io.grpc.testing.compiler.Test.SimpleResponse> getIdempotentCallMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "IdempotentCall",
+      requestType = io.grpc.testing.compiler.Test.SimpleRequest.class,
+      responseType = io.grpc.testing.compiler.Test.SimpleResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<io.grpc.testing.compiler.Test.SimpleRequest,
+      io.grpc.testing.compiler.Test.SimpleResponse> getIdempotentCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.compiler.Test.SimpleRequest, io.grpc.testing.compiler.Test.SimpleResponse> getIdempotentCallMethod;
+    if ((getIdempotentCallMethod = TestServiceGrpc.getIdempotentCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getIdempotentCallMethod = TestServiceGrpc.getIdempotentCallMethod) == null) {
+          TestServiceGrpc.getIdempotentCallMethod = getIdempotentCallMethod =
+              io.grpc.MethodDescriptor.<io.grpc.testing.compiler.Test.SimpleRequest, io.grpc.testing.compiler.Test.SimpleResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "IdempotentCall"))
+              .setIdempotent(true)
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.compiler.Test.SimpleRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.compiler.Test.SimpleResponse.getDefaultInstance()))
+              .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("IdempotentCall"))
+              .build();
+        }
+      }
+    }
+    return getIdempotentCallMethod;
+  }
+
   /**
    * Creates a new async stub that supports all call types for the service
    */
@@ -315,6 +379,26 @@ public final class TestServiceGrpc {
       return asyncUnimplementedStreamingCall(getImportMethod(), responseObserver);
     }
 
+    /**
+     * <pre>
+     * A unary call that is Safe.
+     * </pre>
+     */
+    public void safeCall(io.grpc.testing.compiler.Test.SimpleRequest request,
+        io.grpc.stub.StreamObserver<io.grpc.testing.compiler.Test.SimpleResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getSafeCallMethod(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * A unary call that is Idempotent.
+     * </pre>
+     */
+    public void idempotentCall(io.grpc.testing.compiler.Test.SimpleRequest request,
+        io.grpc.stub.StreamObserver<io.grpc.testing.compiler.Test.SimpleResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getIdempotentCallMethod(), responseObserver);
+    }
+
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
@@ -359,6 +443,20 @@ public final class TestServiceGrpc {
                 io.grpc.testing.compiler.Test.StreamingInputCallRequest,
                 io.grpc.testing.compiler.Test.StreamingInputCallResponse>(
                   this, METHODID_IMPORT)))
+          .addMethod(
+            getSafeCallMethod(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                io.grpc.testing.compiler.Test.SimpleRequest,
+                io.grpc.testing.compiler.Test.SimpleResponse>(
+                  this, METHODID_SAFE_CALL)))
+          .addMethod(
+            getIdempotentCallMethod(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                io.grpc.testing.compiler.Test.SimpleRequest,
+                io.grpc.testing.compiler.Test.SimpleResponse>(
+                  this, METHODID_IDEMPOTENT_CALL)))
           .build();
     }
   }
@@ -458,6 +556,28 @@ public final class TestServiceGrpc {
       return asyncBidiStreamingCall(
           getChannel().newCall(getImportMethod(), getCallOptions()), responseObserver);
     }
+
+    /**
+     * <pre>
+     * A unary call that is Safe.
+     * </pre>
+     */
+    public void safeCall(io.grpc.testing.compiler.Test.SimpleRequest request,
+        io.grpc.stub.StreamObserver<io.grpc.testing.compiler.Test.SimpleResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getSafeCallMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * A unary call that is Idempotent.
+     * </pre>
+     */
+    public void idempotentCall(io.grpc.testing.compiler.Test.SimpleRequest request,
+        io.grpc.stub.StreamObserver<io.grpc.testing.compiler.Test.SimpleResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getIdempotentCallMethod(), getCallOptions()), request, responseObserver);
+    }
   }
 
   /**
@@ -503,6 +623,26 @@ public final class TestServiceGrpc {
       return blockingServerStreamingCall(
           getChannel(), getStreamingOutputCallMethod(), getCallOptions(), request);
     }
+
+    /**
+     * <pre>
+     * A unary call that is Safe.
+     * </pre>
+     */
+    public io.grpc.testing.compiler.Test.SimpleResponse safeCall(io.grpc.testing.compiler.Test.SimpleRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getSafeCallMethod(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * A unary call that is Idempotent.
+     * </pre>
+     */
+    public io.grpc.testing.compiler.Test.SimpleResponse idempotentCall(io.grpc.testing.compiler.Test.SimpleRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getIdempotentCallMethod(), getCallOptions(), request);
+    }
   }
 
   /**
@@ -537,14 +677,38 @@ public final class TestServiceGrpc {
       return futureUnaryCall(
           getChannel().newCall(getUnaryCallMethod(), getCallOptions()), request);
     }
+
+    /**
+     * <pre>
+     * A unary call that is Safe.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.compiler.Test.SimpleResponse> safeCall(
+        io.grpc.testing.compiler.Test.SimpleRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getSafeCallMethod(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * A unary call that is Idempotent.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.compiler.Test.SimpleResponse> idempotentCall(
+        io.grpc.testing.compiler.Test.SimpleRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getIdempotentCallMethod(), getCallOptions()), request);
+    }
   }
 
   private static final int METHODID_UNARY_CALL = 0;
   private static final int METHODID_STREAMING_OUTPUT_CALL = 1;
-  private static final int METHODID_STREAMING_INPUT_CALL = 2;
-  private static final int METHODID_FULL_BIDI_CALL = 3;
-  private static final int METHODID_HALF_BIDI_CALL = 4;
-  private static final int METHODID_IMPORT = 5;
+  private static final int METHODID_SAFE_CALL = 2;
+  private static final int METHODID_IDEMPOTENT_CALL = 3;
+  private static final int METHODID_STREAMING_INPUT_CALL = 4;
+  private static final int METHODID_FULL_BIDI_CALL = 5;
+  private static final int METHODID_HALF_BIDI_CALL = 6;
+  private static final int METHODID_IMPORT = 7;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -570,6 +734,14 @@ public final class TestServiceGrpc {
         case METHODID_STREAMING_OUTPUT_CALL:
           serviceImpl.streamingOutputCall((io.grpc.testing.compiler.Test.StreamingOutputCallRequest) request,
               (io.grpc.stub.StreamObserver<io.grpc.testing.compiler.Test.StreamingOutputCallResponse>) responseObserver);
+          break;
+        case METHODID_SAFE_CALL:
+          serviceImpl.safeCall((io.grpc.testing.compiler.Test.SimpleRequest) request,
+              (io.grpc.stub.StreamObserver<io.grpc.testing.compiler.Test.SimpleResponse>) responseObserver);
+          break;
+        case METHODID_IDEMPOTENT_CALL:
+          serviceImpl.idempotentCall((io.grpc.testing.compiler.Test.SimpleRequest) request,
+              (io.grpc.stub.StreamObserver<io.grpc.testing.compiler.Test.SimpleResponse>) responseObserver);
           break;
         default:
           throw new AssertionError();
@@ -650,6 +822,8 @@ public final class TestServiceGrpc {
               .addMethod(getFullBidiCallMethod())
               .addMethod(getHalfBidiCallMethod())
               .addMethod(getImportMethod())
+              .addMethod(getSafeCallMethod())
+              .addMethod(getIdempotentCallMethod())
               .build();
         }
       }

--- a/compiler/src/test/proto/grpc/testing/compiler/test.proto
+++ b/compiler/src/test/proto/grpc/testing/compiler/test.proto
@@ -70,6 +70,16 @@ service TestService {
   // An RPC method whose Java name collides with a keyword, and whose generated
   // method should have a '_' appended.
   rpc Import(stream StreamingInputCallRequest) returns (stream StreamingInputCallResponse);
+
+  // A unary call that is Safe.
+  rpc SafeCall(SimpleRequest) returns (SimpleResponse) {
+      option idempotency_level = NO_SIDE_EFFECTS;
+  }
+
+  // A unary call that is Idempotent.
+  rpc IdempotentCall(SimpleRequest) returns (SimpleResponse) {
+      option idempotency_level = IDEMPOTENT;
+  }
 }
 
 // Test service that has been deprecated and should generate with Java's @Deprecated annotation

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -210,6 +210,68 @@ public final class TestServiceGrpc {
     return getImportMethod;
   }
 
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.compiler.Test.SimpleRequest,
+      io.grpc.testing.compiler.Test.SimpleResponse> getSafeCallMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SafeCall",
+      requestType = io.grpc.testing.compiler.Test.SimpleRequest.class,
+      responseType = io.grpc.testing.compiler.Test.SimpleResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<io.grpc.testing.compiler.Test.SimpleRequest,
+      io.grpc.testing.compiler.Test.SimpleResponse> getSafeCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.compiler.Test.SimpleRequest, io.grpc.testing.compiler.Test.SimpleResponse> getSafeCallMethod;
+    if ((getSafeCallMethod = TestServiceGrpc.getSafeCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getSafeCallMethod = TestServiceGrpc.getSafeCallMethod) == null) {
+          TestServiceGrpc.getSafeCallMethod = getSafeCallMethod =
+              io.grpc.MethodDescriptor.<io.grpc.testing.compiler.Test.SimpleRequest, io.grpc.testing.compiler.Test.SimpleResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "SafeCall"))
+              .setSafe(true)
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
+                  io.grpc.testing.compiler.Test.SimpleRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
+                  io.grpc.testing.compiler.Test.SimpleResponse.getDefaultInstance()))
+              .build();
+        }
+      }
+    }
+    return getSafeCallMethod;
+  }
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.compiler.Test.SimpleRequest,
+      io.grpc.testing.compiler.Test.SimpleResponse> getIdempotentCallMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "IdempotentCall",
+      requestType = io.grpc.testing.compiler.Test.SimpleRequest.class,
+      responseType = io.grpc.testing.compiler.Test.SimpleResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<io.grpc.testing.compiler.Test.SimpleRequest,
+      io.grpc.testing.compiler.Test.SimpleResponse> getIdempotentCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.compiler.Test.SimpleRequest, io.grpc.testing.compiler.Test.SimpleResponse> getIdempotentCallMethod;
+    if ((getIdempotentCallMethod = TestServiceGrpc.getIdempotentCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getIdempotentCallMethod = TestServiceGrpc.getIdempotentCallMethod) == null) {
+          TestServiceGrpc.getIdempotentCallMethod = getIdempotentCallMethod =
+              io.grpc.MethodDescriptor.<io.grpc.testing.compiler.Test.SimpleRequest, io.grpc.testing.compiler.Test.SimpleResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "IdempotentCall"))
+              .setIdempotent(true)
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
+                  io.grpc.testing.compiler.Test.SimpleRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
+                  io.grpc.testing.compiler.Test.SimpleResponse.getDefaultInstance()))
+              .build();
+        }
+      }
+    }
+    return getIdempotentCallMethod;
+  }
+
   /**
    * Creates a new async stub that supports all call types for the service
    */
@@ -309,6 +371,26 @@ public final class TestServiceGrpc {
       return asyncUnimplementedStreamingCall(getImportMethod(), responseObserver);
     }
 
+    /**
+     * <pre>
+     * A unary call that is Safe.
+     * </pre>
+     */
+    public void safeCall(io.grpc.testing.compiler.Test.SimpleRequest request,
+        io.grpc.stub.StreamObserver<io.grpc.testing.compiler.Test.SimpleResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getSafeCallMethod(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * A unary call that is Idempotent.
+     * </pre>
+     */
+    public void idempotentCall(io.grpc.testing.compiler.Test.SimpleRequest request,
+        io.grpc.stub.StreamObserver<io.grpc.testing.compiler.Test.SimpleResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getIdempotentCallMethod(), responseObserver);
+    }
+
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
@@ -353,6 +435,20 @@ public final class TestServiceGrpc {
                 io.grpc.testing.compiler.Test.StreamingInputCallRequest,
                 io.grpc.testing.compiler.Test.StreamingInputCallResponse>(
                   this, METHODID_IMPORT)))
+          .addMethod(
+            getSafeCallMethod(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                io.grpc.testing.compiler.Test.SimpleRequest,
+                io.grpc.testing.compiler.Test.SimpleResponse>(
+                  this, METHODID_SAFE_CALL)))
+          .addMethod(
+            getIdempotentCallMethod(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                io.grpc.testing.compiler.Test.SimpleRequest,
+                io.grpc.testing.compiler.Test.SimpleResponse>(
+                  this, METHODID_IDEMPOTENT_CALL)))
           .build();
     }
   }
@@ -452,6 +548,28 @@ public final class TestServiceGrpc {
       return asyncBidiStreamingCall(
           getChannel().newCall(getImportMethod(), getCallOptions()), responseObserver);
     }
+
+    /**
+     * <pre>
+     * A unary call that is Safe.
+     * </pre>
+     */
+    public void safeCall(io.grpc.testing.compiler.Test.SimpleRequest request,
+        io.grpc.stub.StreamObserver<io.grpc.testing.compiler.Test.SimpleResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getSafeCallMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * A unary call that is Idempotent.
+     * </pre>
+     */
+    public void idempotentCall(io.grpc.testing.compiler.Test.SimpleRequest request,
+        io.grpc.stub.StreamObserver<io.grpc.testing.compiler.Test.SimpleResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getIdempotentCallMethod(), getCallOptions()), request, responseObserver);
+    }
   }
 
   /**
@@ -497,6 +615,26 @@ public final class TestServiceGrpc {
       return blockingServerStreamingCall(
           getChannel(), getStreamingOutputCallMethod(), getCallOptions(), request);
     }
+
+    /**
+     * <pre>
+     * A unary call that is Safe.
+     * </pre>
+     */
+    public io.grpc.testing.compiler.Test.SimpleResponse safeCall(io.grpc.testing.compiler.Test.SimpleRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getSafeCallMethod(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * A unary call that is Idempotent.
+     * </pre>
+     */
+    public io.grpc.testing.compiler.Test.SimpleResponse idempotentCall(io.grpc.testing.compiler.Test.SimpleRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getIdempotentCallMethod(), getCallOptions(), request);
+    }
   }
 
   /**
@@ -531,14 +669,38 @@ public final class TestServiceGrpc {
       return futureUnaryCall(
           getChannel().newCall(getUnaryCallMethod(), getCallOptions()), request);
     }
+
+    /**
+     * <pre>
+     * A unary call that is Safe.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.compiler.Test.SimpleResponse> safeCall(
+        io.grpc.testing.compiler.Test.SimpleRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getSafeCallMethod(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * A unary call that is Idempotent.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.compiler.Test.SimpleResponse> idempotentCall(
+        io.grpc.testing.compiler.Test.SimpleRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getIdempotentCallMethod(), getCallOptions()), request);
+    }
   }
 
   private static final int METHODID_UNARY_CALL = 0;
   private static final int METHODID_STREAMING_OUTPUT_CALL = 1;
-  private static final int METHODID_STREAMING_INPUT_CALL = 2;
-  private static final int METHODID_FULL_BIDI_CALL = 3;
-  private static final int METHODID_HALF_BIDI_CALL = 4;
-  private static final int METHODID_IMPORT = 5;
+  private static final int METHODID_SAFE_CALL = 2;
+  private static final int METHODID_IDEMPOTENT_CALL = 3;
+  private static final int METHODID_STREAMING_INPUT_CALL = 4;
+  private static final int METHODID_FULL_BIDI_CALL = 5;
+  private static final int METHODID_HALF_BIDI_CALL = 6;
+  private static final int METHODID_IMPORT = 7;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -564,6 +726,14 @@ public final class TestServiceGrpc {
         case METHODID_STREAMING_OUTPUT_CALL:
           serviceImpl.streamingOutputCall((io.grpc.testing.compiler.Test.StreamingOutputCallRequest) request,
               (io.grpc.stub.StreamObserver<io.grpc.testing.compiler.Test.StreamingOutputCallResponse>) responseObserver);
+          break;
+        case METHODID_SAFE_CALL:
+          serviceImpl.safeCall((io.grpc.testing.compiler.Test.SimpleRequest) request,
+              (io.grpc.stub.StreamObserver<io.grpc.testing.compiler.Test.SimpleResponse>) responseObserver);
+          break;
+        case METHODID_IDEMPOTENT_CALL:
+          serviceImpl.idempotentCall((io.grpc.testing.compiler.Test.SimpleRequest) request,
+              (io.grpc.stub.StreamObserver<io.grpc.testing.compiler.Test.SimpleResponse>) responseObserver);
           break;
         default:
           throw new AssertionError();
@@ -608,6 +778,8 @@ public final class TestServiceGrpc {
               .addMethod(getFullBidiCallMethod())
               .addMethod(getHalfBidiCallMethod())
               .addMethod(getImportMethod())
+              .addMethod(getSafeCallMethod())
+              .addMethod(getIdempotentCallMethod())
               .build();
         }
       }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -133,7 +133,7 @@ public class OkHttpChannelBuilder extends
    * If true, indicates that the transport may use the GET method for RPCs, and may include the
    * request body in the query params.
    */
-  private final boolean useGetForSafeMethods = true;
+  private final boolean useGetForSafeMethods = false;
 
   protected OkHttpChannelBuilder(String host, int port) {
     this(GrpcUtil.authorityFromHostAndPort(host, port));


### PR DESCRIPTION
This PR is split into two commits, one to stabilize the MethodDescriptors, and the other to update the generated code.    

PTAL @ejona86 


Updates https://github.com/grpc/grpc-java/issues/1775