### PR TITLE
android-interop-testing: remove settings for using GET via setting MethodDescriptor to safe

### DIFF
--- a/android-interop-testing/app/src/main/java/io/grpc/android/integrationtest/InteropTask.java
+++ b/android-interop-testing/app/src/main/java/io/grpc/android/integrationtest/InteropTask.java
@@ -18,13 +18,11 @@ package io.grpc.android.integrationtest;
 
 import android.os.AsyncTask;
 import android.util.Log;
-import io.grpc.ClientInterceptor;
 import io.grpc.ManagedChannel;
 import io.grpc.testing.integration.AbstractInteropTest;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.ref.WeakReference;
-import java.util.List;
 import org.junit.AssumptionViolatedException;
 
 /** AsyncTask for interop test cases. */
@@ -44,11 +42,10 @@ final class InteropTask extends AsyncTask<Void, Void, String> {
   InteropTask(
       Listener listener,
       ManagedChannel channel,
-      List<ClientInterceptor> interceptors,
       String testCase) {
     this.listenerReference = new WeakReference<Listener>(listener);
     this.testCase = testCase;
-    this.tester = new Tester(channel, interceptors);
+    this.tester = new Tester(channel);
   }
 
   @Override
@@ -149,21 +146,14 @@ final class InteropTask extends AsyncTask<Void, Void, String> {
 
   private static class Tester extends AbstractInteropTest {
     private final ManagedChannel channel;
-    private final List<ClientInterceptor> interceptors;
 
-    private Tester(ManagedChannel channel, List<ClientInterceptor> interceptors) {
+    private Tester(ManagedChannel channel) {
       this.channel = channel;
-      this.interceptors = interceptors;
     }
 
     @Override
     protected ManagedChannel createChannel() {
       return channel;
-    }
-
-    @Override
-    protected ClientInterceptor[] getAdditionalInterceptors() {
-      return interceptors.toArray(new ClientInterceptor[0]);
     }
 
     @Override

--- a/android-interop-testing/app/src/main/res/layout/activity_tester.xml
+++ b/android-interop-testing/app/src/main/res/layout/activity_tester.xml
@@ -33,11 +33,6 @@
       android:layout_height="wrap_content"
       android:orientation="horizontal"
       >
-    <CheckBox android:id="@+id/get_checkbox"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/use_get"
-        />
     <CheckBox android:id="@+id/test_cert_checkbox"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/android-interop-testing/app/src/main/res/values/strings.xml
+++ b/android-interop-testing/app/src/main/res/values/strings.xml
@@ -1,4 +1,3 @@
 <resources>
     <string name="app_name">gRPC Integration Test</string>
-    <string name="use_get">Use GET</string>
 </resources>


### PR DESCRIPTION
Resolves #6195.