### PR TITLE
Make grpc-xds dependent on grpc-netty 

### DIFF
--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     compile project(':grpc-protobuf'),
             project(':grpc-stub'),
             project(':grpc-core'),
+            project(':grpc-netty'),
             project(':grpc-services'),
             project(':grpc-auth')
     compile (libraries.pgv) {
@@ -73,6 +74,8 @@ shadowJar {
     relocate 'com.github.udpa', 'io.grpc.xds.shaded.com.github.udpa'
     relocate 'com.google.protobuf.GoGoProtos', 'io.grpc.xds.shaded.gogoproto.GoGoProtos'
     relocate 'io.envoyproxy', 'io.grpc.xds.shaded.io.envoyproxy'
+    relocate 'io.grpc.netty', 'io.grpc.netty.shaded.io.grpc.netty'
+    relocate 'io.netty', 'io.grpc.netty.shaded.io.netty'
     exclude "**/*.proto"
 }
 
@@ -81,6 +84,17 @@ publishing {
         maven(MavenPublication) {
             artifact shadowJar
             artifacts.removeAll { it.classifier == 'original' }
+
+            pom.withXml {
+                // Swap our dependency to grpc-netty-shaded. Projects depending on this via
+                // project(':grpc-xds') will still be using the non-shaded form.
+                asNode().dependencies.'*'.findAll() { dep ->
+                    dep.artifactId.text() == 'grpc-netty'
+                }.each() { netty ->
+                    netty.artifactId*.value = 'grpc-netty-shaded'
+                    netty.version*.value = "[" + netty.version.text() + "]"
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
For SDS, we need the ProtocolNegotiator definitions for custom implementations in grpc-xds (as discussed offline)