### PR TITLE
core: move generic Json util methods out of ServiceConfigUtil

### DIFF
--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -461,7 +461,7 @@ final class DnsNameResolver extends NameResolver {
     if (!serviceConfigChoice.containsKey(SERVICE_CONFIG_CHOICE_PERCENTAGE_KEY)) {
       return null;
     }
-    return ServiceConfigUtil.getDouble(serviceConfigChoice, SERVICE_CONFIG_CHOICE_PERCENTAGE_KEY);
+    return JsonUtil.getDouble(serviceConfigChoice, SERVICE_CONFIG_CHOICE_PERCENTAGE_KEY);
   }
 
   @Nullable
@@ -471,7 +471,7 @@ final class DnsNameResolver extends NameResolver {
       return null;
     }
     return ServiceConfigUtil.checkStringList(
-        ServiceConfigUtil.getList(serviceConfigChoice, SERVICE_CONFIG_CHOICE_CLIENT_LANGUAGE_KEY));
+        JsonUtil.getList(serviceConfigChoice, SERVICE_CONFIG_CHOICE_CLIENT_LANGUAGE_KEY));
   }
 
   @Nullable
@@ -480,7 +480,7 @@ final class DnsNameResolver extends NameResolver {
       return null;
     }
     return ServiceConfigUtil.checkStringList(
-        ServiceConfigUtil.getList(serviceConfigChoice, SERVICE_CONFIG_CHOICE_CLIENT_HOSTNAME_KEY));
+        JsonUtil.getList(serviceConfigChoice, SERVICE_CONFIG_CHOICE_CLIENT_HOSTNAME_KEY));
   }
 
   /**
@@ -559,7 +559,7 @@ final class DnsNameResolver extends NameResolver {
       }
     }
     Map<String, ?> sc =
-        ServiceConfigUtil.getObject(choice, SERVICE_CONFIG_CHOICE_SERVICE_CONFIG_KEY);
+        JsonUtil.getObject(choice, SERVICE_CONFIG_CHOICE_SERVICE_CONFIG_KEY);
     if (sc == null) {
       throw new VerifyException(String.format(
           "key '%s' missing in '%s'", choice, SERVICE_CONFIG_CHOICE_SERVICE_CONFIG_KEY));

--- a/core/src/main/java/io/grpc/internal/JsonUtil.java
+++ b/core/src/main/java/io/grpc/internal/JsonUtil.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Helper utility to work with JSON values in Java types.
+ */
+public class JsonUtil {
+  /**
+   * Gets a list from an object for the given key.  If the key is not present, this returns null.
+   * If the value is not a List, throws an exception.
+   */
+  @SuppressWarnings("unchecked")
+  @Nullable
+  public static List<?> getList(Map<String, ?> obj, String key) {
+    assert key != null;
+    if (!obj.containsKey(key)) {
+      return null;
+    }
+    Object value = obj.get(key);
+    if (!(value instanceof List)) {
+      throw new ClassCastException(
+          String.format("value '%s' for key '%s' in '%s' is not List", value, key, obj));
+    }
+    return (List<?>) value;
+  }
+
+  /**
+   * Gets an object from an object for the given key.  If the key is not present, this returns null.
+   * If the value is not a Map, throws an exception.
+   */
+  @SuppressWarnings("unchecked")
+  @Nullable
+  public static Map<String, ?> getObject(Map<String, ?> obj, String key) {
+    assert key != null;
+    if (!obj.containsKey(key)) {
+      return null;
+    }
+    Object value = obj.get(key);
+    if (!(value instanceof Map)) {
+      throw new ClassCastException(
+          String.format("value '%s' for key '%s' in '%s' is not object", value, key, obj));
+    }
+    return (Map<String, ?>) value;
+  }
+
+  /**
+   * Gets a double from an object for the given key.  If the key is not present, this returns null.
+   * If the value is not a Double, throws an exception.
+   */
+  @Nullable
+  public static Double getDouble(Map<String, ?> obj, String key) {
+    assert key != null;
+    if (!obj.containsKey(key)) {
+      return null;
+    }
+    Object value = obj.get(key);
+    if (!(value instanceof Double)) {
+      throw new ClassCastException(
+          String.format("value '%s' for key '%s' in '%s' is not Double", value, key, obj));
+    }
+    return (Double) value;
+  }
+
+  /**
+   * Gets a string from an object for the given key.  If the key is not present, this returns null.
+   * If the value is not a String, throws an exception.
+   */
+  @Nullable
+  public static String getString(Map<String, ?> obj, String key) {
+    assert key != null;
+    if (!obj.containsKey(key)) {
+      return null;
+    }
+    Object value = obj.get(key);
+    if (!(value instanceof String)) {
+      throw new ClassCastException(
+          String.format("value '%s' for key '%s' in '%s' is not String", value, key, obj));
+    }
+    return (String) value;
+  }
+
+  /**
+   * Gets a boolean from an object for the given key.  If the key is not present, this returns null.
+   * If the value is not a Boolean, throws an exception.
+   */
+  @Nullable
+  public static Boolean getBoolean(Map<String, ?> obj, String key) {
+    assert key != null;
+    if (!obj.containsKey(key)) {
+      return null;
+    }
+    Object value = obj.get(key);
+    if (!(value instanceof Boolean)) {
+      throw new ClassCastException(
+          String.format("value '%s' for key '%s' in '%s' is not Boolean", value, key, obj));
+    }
+    return (Boolean) value;
+  }
+}

--- a/core/src/main/java/io/grpc/internal/ServiceConfigUtil.java
+++ b/core/src/main/java/io/grpc/internal/ServiceConfigUtil.java
@@ -96,11 +96,11 @@ public final class ServiceConfigUtil {
       }
     }
     */
-    Map<String, ?> healthCheck = getObject(serviceConfig, healthCheckKey);
+    Map<String, ?> healthCheck = JsonUtil.getObject(serviceConfig, healthCheckKey);
     if (!healthCheck.containsKey(serviceNameKey)) {
       return null;
     }
-    return getString(healthCheck, "serviceName");
+    return JsonUtil.getString(healthCheck, "serviceName");
   }
 
   @Nullable
@@ -129,11 +129,11 @@ public final class ServiceConfigUtil {
     }
     */
 
-    Map<String, ?> throttling = getObject(serviceConfig, retryThrottlingKey);
+    Map<String, ?> throttling = JsonUtil.getObject(serviceConfig, retryThrottlingKey);
 
     // TODO(dapengzhang0): check if this is null.
-    float maxTokens = getDouble(throttling, "maxTokens").floatValue();
-    float tokenRatio = getDouble(throttling, "tokenRatio").floatValue();
+    float maxTokens = JsonUtil.getDouble(throttling, "maxTokens").floatValue();
+    float tokenRatio = JsonUtil.getDouble(throttling, "tokenRatio").floatValue();
     checkState(maxTokens > 0f, "maxToken should be greater than zero");
     checkState(tokenRatio > 0f, "tokenRatio should be greater than zero");
     return new Throttle(maxTokens, tokenRatio);
@@ -144,7 +144,7 @@ public final class ServiceConfigUtil {
     if (!retryPolicy.containsKey(RETRY_POLICY_MAX_ATTEMPTS_KEY)) {
       return null;
     }
-    return getDouble(retryPolicy, RETRY_POLICY_MAX_ATTEMPTS_KEY).intValue();
+    return JsonUtil.getDouble(retryPolicy, RETRY_POLICY_MAX_ATTEMPTS_KEY).intValue();
   }
 
   @Nullable
@@ -152,7 +152,7 @@ public final class ServiceConfigUtil {
     if (!retryPolicy.containsKey(RETRY_POLICY_INITIAL_BACKOFF_KEY)) {
       return null;
     }
-    String rawInitialBackoff = getString(retryPolicy, RETRY_POLICY_INITIAL_BACKOFF_KEY);
+    String rawInitialBackoff = JsonUtil.getString(retryPolicy, RETRY_POLICY_INITIAL_BACKOFF_KEY);
     try {
       return parseDuration(rawInitialBackoff);
     } catch (ParseException e) {
@@ -165,7 +165,7 @@ public final class ServiceConfigUtil {
     if (!retryPolicy.containsKey(RETRY_POLICY_MAX_BACKOFF_KEY)) {
       return null;
     }
-    String rawMaxBackoff = getString(retryPolicy, RETRY_POLICY_MAX_BACKOFF_KEY);
+    String rawMaxBackoff = JsonUtil.getString(retryPolicy, RETRY_POLICY_MAX_BACKOFF_KEY);
     try {
       return parseDuration(rawMaxBackoff);
     } catch (ParseException e) {
@@ -178,7 +178,7 @@ public final class ServiceConfigUtil {
     if (!retryPolicy.containsKey(RETRY_POLICY_BACKOFF_MULTIPLIER_KEY)) {
       return null;
     }
-    return getDouble(retryPolicy, RETRY_POLICY_BACKOFF_MULTIPLIER_KEY);
+    return JsonUtil.getDouble(retryPolicy, RETRY_POLICY_BACKOFF_MULTIPLIER_KEY);
   }
 
   private static Set<Status.Code> getStatusCodesFromList(List<?> statuses) {
@@ -212,7 +212,8 @@ public final class ServiceConfigUtil {
         retryPolicy.containsKey(RETRY_POLICY_RETRYABLE_STATUS_CODES_KEY),
         "%s is required in retry policy", RETRY_POLICY_RETRYABLE_STATUS_CODES_KEY);
     Set<Status.Code> codes =
-        getStatusCodesFromList(getList(retryPolicy, RETRY_POLICY_RETRYABLE_STATUS_CODES_KEY));
+        getStatusCodesFromList(
+            JsonUtil.getList(retryPolicy, RETRY_POLICY_RETRYABLE_STATUS_CODES_KEY));
     verify(!codes.isEmpty(), "%s must not be empty", RETRY_POLICY_RETRYABLE_STATUS_CODES_KEY);
     verify(
         !codes.contains(Status.Code.OK),
@@ -225,7 +226,7 @@ public final class ServiceConfigUtil {
     if (!hedgingPolicy.containsKey(HEDGING_POLICY_MAX_ATTEMPTS_KEY)) {
       return null;
     }
-    return getDouble(hedgingPolicy, HEDGING_POLICY_MAX_ATTEMPTS_KEY).intValue();
+    return JsonUtil.getDouble(hedgingPolicy, HEDGING_POLICY_MAX_ATTEMPTS_KEY).intValue();
   }
 
   @Nullable
@@ -233,7 +234,7 @@ public final class ServiceConfigUtil {
     if (!hedgingPolicy.containsKey(HEDGING_POLICY_HEDGING_DELAY_KEY)) {
       return null;
     }
-    String rawHedgingDelay = getString(hedgingPolicy, HEDGING_POLICY_HEDGING_DELAY_KEY);
+    String rawHedgingDelay = JsonUtil.getString(hedgingPolicy, HEDGING_POLICY_HEDGING_DELAY_KEY);
     try {
       return parseDuration(rawHedgingDelay);
     } catch (ParseException e) {
@@ -246,7 +247,8 @@ public final class ServiceConfigUtil {
       return Collections.unmodifiableSet(EnumSet.noneOf(Status.Code.class));
     }
     Set<Status.Code> codes =
-        getStatusCodesFromList(getList(hedgingPolicy, HEDGING_POLICY_NON_FATAL_STATUS_CODES_KEY));
+        getStatusCodesFromList(
+            JsonUtil.getList(hedgingPolicy, HEDGING_POLICY_NON_FATAL_STATUS_CODES_KEY));
     verify(
         !codes.contains(Status.Code.OK),
         "%s must not contain OK", HEDGING_POLICY_NON_FATAL_STATUS_CODES_KEY);
@@ -258,7 +260,7 @@ public final class ServiceConfigUtil {
     if (!name.containsKey(NAME_SERVICE_KEY)) {
       return null;
     }
-    return getString(name, NAME_SERVICE_KEY);
+    return JsonUtil.getString(name, NAME_SERVICE_KEY);
   }
 
   @Nullable
@@ -266,7 +268,7 @@ public final class ServiceConfigUtil {
     if (!name.containsKey(NAME_METHOD_KEY)) {
       return null;
     }
-    return getString(name, NAME_METHOD_KEY);
+    return JsonUtil.getString(name, NAME_METHOD_KEY);
   }
 
   @Nullable
@@ -274,7 +276,7 @@ public final class ServiceConfigUtil {
     if (!methodConfig.containsKey(METHOD_CONFIG_RETRY_POLICY_KEY)) {
       return null;
     }
-    return getObject(methodConfig, METHOD_CONFIG_RETRY_POLICY_KEY);
+    return JsonUtil.getObject(methodConfig, METHOD_CONFIG_RETRY_POLICY_KEY);
   }
 
   @Nullable
@@ -282,7 +284,7 @@ public final class ServiceConfigUtil {
     if (!methodConfig.containsKey(METHOD_CONFIG_HEDGING_POLICY_KEY)) {
       return null;
     }
-    return getObject(methodConfig, METHOD_CONFIG_HEDGING_POLICY_KEY);
+    return JsonUtil.getObject(methodConfig, METHOD_CONFIG_HEDGING_POLICY_KEY);
   }
 
   @Nullable
@@ -291,7 +293,7 @@ public final class ServiceConfigUtil {
     if (!methodConfig.containsKey(METHOD_CONFIG_NAME_KEY)) {
       return null;
     }
-    return checkObjectList(getList(methodConfig, METHOD_CONFIG_NAME_KEY));
+    return checkObjectList(JsonUtil.getList(methodConfig, METHOD_CONFIG_NAME_KEY));
   }
 
   /**
@@ -304,7 +306,7 @@ public final class ServiceConfigUtil {
     if (!methodConfig.containsKey(METHOD_CONFIG_TIMEOUT_KEY)) {
       return null;
     }
-    String rawTimeout = getString(methodConfig, METHOD_CONFIG_TIMEOUT_KEY);
+    String rawTimeout = JsonUtil.getString(methodConfig, METHOD_CONFIG_TIMEOUT_KEY);
     try {
       return parseDuration(rawTimeout);
     } catch (ParseException e) {
@@ -317,7 +319,7 @@ public final class ServiceConfigUtil {
     if (!methodConfig.containsKey(METHOD_CONFIG_WAIT_FOR_READY_KEY)) {
       return null;
     }
-    return getBoolean(methodConfig, METHOD_CONFIG_WAIT_FOR_READY_KEY);
+    return JsonUtil.getBoolean(methodConfig, METHOD_CONFIG_WAIT_FOR_READY_KEY);
   }
 
   @Nullable
@@ -325,7 +327,7 @@ public final class ServiceConfigUtil {
     if (!methodConfig.containsKey(METHOD_CONFIG_MAX_REQUEST_MESSAGE_BYTES_KEY)) {
       return null;
     }
-    return getDouble(methodConfig, METHOD_CONFIG_MAX_REQUEST_MESSAGE_BYTES_KEY).intValue();
+    return JsonUtil.getDouble(methodConfig, METHOD_CONFIG_MAX_REQUEST_MESSAGE_BYTES_KEY).intValue();
   }
 
   @Nullable
@@ -333,7 +335,8 @@ public final class ServiceConfigUtil {
     if (!methodConfig.containsKey(METHOD_CONFIG_MAX_RESPONSE_MESSAGE_BYTES_KEY)) {
       return null;
     }
-    return getDouble(methodConfig, METHOD_CONFIG_MAX_RESPONSE_MESSAGE_BYTES_KEY).intValue();
+    return JsonUtil.getDouble(methodConfig, METHOD_CONFIG_MAX_RESPONSE_MESSAGE_BYTES_KEY)
+        .intValue();
   }
 
   @Nullable
@@ -342,7 +345,7 @@ public final class ServiceConfigUtil {
     if (!serviceConfig.containsKey(SERVICE_CONFIG_METHOD_CONFIG_KEY)) {
       return null;
     }
-    return checkObjectList(getList(serviceConfig, SERVICE_CONFIG_METHOD_CONFIG_KEY));
+    return checkObjectList(JsonUtil.getList(serviceConfig, SERVICE_CONFIG_METHOD_CONFIG_KEY));
   }
 
   /**
@@ -369,7 +372,7 @@ public final class ServiceConfigUtil {
     */
     List<Map<String, ?>> lbConfigs = new ArrayList<>();
     if (serviceConfig.containsKey(SERVICE_CONFIG_LOAD_BALANCING_CONFIG_KEY)) {
-      List<?> configs = getList(serviceConfig, SERVICE_CONFIG_LOAD_BALANCING_CONFIG_KEY);
+      List<?> configs = JsonUtil.getList(serviceConfig, SERVICE_CONFIG_LOAD_BALANCING_CONFIG_KEY);
       for (Map<String, ?> config : checkObjectList(configs)) {
         lbConfigs.add(config);
       }
@@ -378,7 +381,7 @@ public final class ServiceConfigUtil {
       // No LoadBalancingConfig found.  Fall back to the deprecated LoadBalancingPolicy
       if (serviceConfig.containsKey(SERVICE_CONFIG_LOAD_BALANCING_POLICY_KEY)) {
         // TODO(zhangkun83): check if this is null.
-        String policy = getString(serviceConfig, SERVICE_CONFIG_LOAD_BALANCING_POLICY_KEY);
+        String policy = JsonUtil.getString(serviceConfig, SERVICE_CONFIG_LOAD_BALANCING_POLICY_KEY);
         // Convert the policy to a config, so that the caller can handle them in the same way.
         policy = policy.toLowerCase(Locale.ROOT);
         Map<String, ?> fakeConfig = Collections.singletonMap(policy, Collections.emptyMap());
@@ -401,7 +404,7 @@ public final class ServiceConfigUtil {
           + " is expected. Config=" + lbConfig);
     }
     String key = lbConfig.entrySet().iterator().next().getKey();
-    return new LbConfig(key, getObject(lbConfig, key));
+    return new LbConfig(key, JsonUtil.getObject(lbConfig, key));
   }
 
   /**
@@ -420,7 +423,7 @@ public final class ServiceConfigUtil {
    * Extracts the loadbalancer name from xds loadbalancer config.
    */
   public static String getBalancerNameFromXdsConfig(Map<String, ?> rawXdsConfig) {
-    return getString(rawXdsConfig, XDS_CONFIG_BALANCER_NAME_KEY);
+    return JsonUtil.getString(rawXdsConfig, XDS_CONFIG_BALANCER_NAME_KEY);
   }
 
   /**
@@ -428,7 +431,7 @@ public final class ServiceConfigUtil {
    */
   @Nullable
   public static List<LbConfig> getChildPolicyFromXdsConfig(Map<String, ?> rawXdsConfig) {
-    List<?> rawChildPolicies = getList(rawXdsConfig, XDS_CONFIG_CHILD_POLICY_KEY);
+    List<?> rawChildPolicies = JsonUtil.getList(rawXdsConfig, XDS_CONFIG_CHILD_POLICY_KEY);
     if (rawChildPolicies != null) {
       return unwrapLoadBalancingConfigList(checkObjectList(rawChildPolicies));
     }
@@ -440,7 +443,7 @@ public final class ServiceConfigUtil {
    */
   @Nullable
   public static List<LbConfig> getFallbackPolicyFromXdsConfig(Map<String, ?> rawXdsConfig) {
-    List<?> rawFallbackPolicies = getList(rawXdsConfig, XDS_CONFIG_FALLBACK_POLICY_KEY);
+    List<?> rawFallbackPolicies = JsonUtil.getList(rawXdsConfig, XDS_CONFIG_FALLBACK_POLICY_KEY);
     if (rawFallbackPolicies != null) {
       return unwrapLoadBalancingConfigList(checkObjectList(rawFallbackPolicies));
     }
@@ -456,99 +459,7 @@ public final class ServiceConfigUtil {
     if (!serviceConfig.containsKey(SERVICE_CONFIG_STICKINESS_METADATA_KEY)) {
       return null;
     }
-    return getString(serviceConfig, SERVICE_CONFIG_STICKINESS_METADATA_KEY);
-  }
-
-  /**
-   * Gets a list from an object for the given key.  If the key is not present, this returns null.
-   * If the value is not a List, throws an exception.
-   */
-  @SuppressWarnings("unchecked")
-  @Nullable
-  static List<?> getList(Map<String, ?> obj, String key) {
-    assert key != null;
-    if (!obj.containsKey(key)) {
-      return null;
-    }
-    Object value = obj.get(key);
-    if (!(value instanceof List)) {
-      throw new ClassCastException(
-          String.format("value '%s' for key '%s' in '%s' is not List", value, key, obj));
-    }
-    return (List<?>) value;
-  }
-
-  /**
-   * Gets an object from an object for the given key.  If the key is not present, this returns null.
-   * If the value is not a List, throws an exception.
-   */
-  @SuppressWarnings("unchecked")
-  @Nullable
-  static Map<String, ?> getObject(Map<String, ?> obj, String key) {
-    assert key != null;
-    if (!obj.containsKey(key)) {
-      return null;
-    }
-    Object value = obj.get(key);
-    if (!(value instanceof Map)) {
-      throw new ClassCastException(
-          String.format("value '%s' for key '%s' in '%s' is not object", value, key, obj));
-    }
-    return (Map<String, ?>) value;
-  }
-
-  /**
-   * Gets a double from an object for the given key.  If the key is not present, this returns null.
-   * If the value is not a Double, throws an exception.
-   */
-  @Nullable
-  static Double getDouble(Map<String, ?> obj, String key) {
-    assert key != null;
-    if (!obj.containsKey(key)) {
-      return null;
-    }
-    Object value = obj.get(key);
-    if (!(value instanceof Double)) {
-      throw new ClassCastException(
-          String.format("value '%s' for key '%s' in '%s' is not Double", value, key, obj));
-    }
-    return (Double) value;
-  }
-
-  /**
-   * Gets a string from an object for the given key.  If the key is not present, this returns null.
-   * If the value is not a String, throws an exception.
-   */
-  @Nullable
-  static String getString(Map<String, ?> obj, String key) {
-    assert key != null;
-    if (!obj.containsKey(key)) {
-      return null;
-    }
-    Object value = obj.get(key);
-    if (!(value instanceof String)) {
-      throw new ClassCastException(
-          String.format("value '%s' for key '%s' in '%s' is not String", value, key, obj));
-    }
-    return (String) value;
-  }
-
-  /**
-   * Gets a boolean from an object for the given key.  If the key is not present, this returns null.
-   * If the value is not a Boolean, throws an exception.
-   */
-  @Nullable
-  static Boolean getBoolean(Map<String, ?> obj, String key) {
-    assert key != null;
-    if (!obj.containsKey(key)) {
-      return null;
-    }
-    Object value = obj.get(key);
-    if (!(value instanceof Boolean)) {
-      throw new ClassCastException(
-          String.format("value '%s' for key '%s' in '%s' is not Boolean", value, key, obj));
-    }
-    return (Boolean) value;
+    return JsonUtil.getString(serviceConfig, SERVICE_CONFIG_STICKINESS_METADATA_KEY);
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
As discussed in https://github.com/grpc/grpc-java/pull/6201#discussion_r329135169, other packages may want to use those Json utility methods.