### PR TITLE
alts: Use Conscrypt when available

### DIFF
--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -19,7 +19,8 @@ dependencies {
             project(':grpc-protobuf'),
             project(':grpc-stub'),
             libraries.lang,
-            libraries.protobuf
+            libraries.protobuf,
+            libraries.conscrypt
     compile (libraries.google_auth_oauth2_http) {
         // prefer 26.0-android from libraries instead of 25.1-android
         exclude group: 'com.google.guava', module: 'guava'
@@ -36,8 +37,7 @@ dependencies {
             libraries.mockito,
             libraries.truth
     testRuntime libraries.netty_tcnative,
-            libraries.netty_epoll,
-            libraries.conscrypt
+            libraries.netty_epoll
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/alts/src/main/java/io/grpc/alts/internal/AesGcmAeadCrypter.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AesGcmAeadCrypter.java
@@ -18,8 +18,13 @@ package io.grpc.alts.internal;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
+import java.security.Provider;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
@@ -27,12 +32,15 @@ import javax.crypto.spec.SecretKeySpec;
 
 /** AES128-GCM implementation of {@link AeadCrypter} that uses default JCE provider. */
 final class AesGcmAeadCrypter implements AeadCrypter {
+  private static final Logger logger = Logger.getLogger(AesGcmAeadCrypter.class.getName());
   private static final int KEY_LENGTH = 16;
   private static final int TAG_LENGTH = 16;
   static final int NONCE_LENGTH = 12;
 
   private static final String AES = "AES";
   private static final String AES_GCM = AES + "/GCM/NoPadding";
+  // Conscrypt if available, otherwise null. Conscrypt is much faster than Java 8's JSSE
+  private static final Provider CONSCRYPT = getConscrypt();
 
   private final byte[] key;
   private final Cipher cipher;
@@ -40,7 +48,11 @@ final class AesGcmAeadCrypter implements AeadCrypter {
   AesGcmAeadCrypter(byte[] key) throws GeneralSecurityException {
     checkArgument(key.length == KEY_LENGTH);
     this.key = key;
-    cipher = Cipher.getInstance(AES_GCM);
+    if (CONSCRYPT != null) {
+      cipher = Cipher.getInstance(AES_GCM, CONSCRYPT);
+    } else {
+      cipher = Cipher.getInstance(AES_GCM);
+    }
   }
 
   private int encryptAad(
@@ -97,5 +109,54 @@ final class AesGcmAeadCrypter implements AeadCrypter {
 
   static int getKeyLength() {
     return KEY_LENGTH;
+  }
+
+  private static Provider getConscrypt() {
+    // This is equivalent to if (Conscrypt.isAvailable()) return Conscrypt.newProvider();
+
+    // Conscrypt 2.1.0 or later is required. If an older version is used, it will fail with these
+    // sorts of errors:
+    //     "The underlying Cipher implementation does not support this method"
+    //     "error:1e000067:Cipher functions:OPENSSL_internal:BUFFER_TOO_SMALL"
+    //
+    // While we could use Conscrypt.version() to check compatibility, that is _very_ verbose via
+    // reflection. In practice, old conscrypts are probably not much of a problem.
+    Class<?> conscryptClass;
+    try {
+      conscryptClass = Class.forName("org.conscrypt.Conscrypt");
+    } catch (ClassNotFoundException ex) {
+      logger.log(Level.FINE, "Could not find Conscrypt", ex);
+      return null;
+    }
+    Method method;
+    try {
+      method = conscryptClass.getMethod("newProvider");
+    } catch (SecurityException ex) {
+      logger.log(Level.FINE, "Could not find Conscrypt factory method", ex);
+      return null;
+    } catch (NoSuchMethodException ex) {
+      logger.log(Level.WARNING, "Could not find Conscrypt factory method", ex);
+      return null;
+    }
+    Object provider;
+    try {
+      provider = method.invoke(null);
+    } catch (IllegalAccessException ex) {
+      logger.log(Level.WARNING, "Could not call Conscrypt factory method", ex);
+      return null;
+    } catch (Throwable ex) {
+      // This is probably an InvocationTargetException, which means something's wrong with the JNI
+      // loading. Maybe the platform is not supported. We could have used Conscrypt.isAvailable(),
+      // but it just catches Throwable as well
+      logger.log(Level.WARNING, "Failed calling Conscrypt factory method", ex);
+      return null;
+    }
+    if (!(provider instanceof Provider)) {
+      logger.log(
+          Level.WARNING, "Could not load Conscrypt. Returned provider was not a Provider: {0}",
+          provider.getClass().getName());
+      return null;
+    }
+    return (Provider) provider;
   }
 }

--- a/alts/src/main/java/io/grpc/alts/internal/AesGcmAeadCrypter.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AesGcmAeadCrypter.java
@@ -18,7 +18,6 @@ package io.grpc.alts.internal;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;

--- a/alts/src/test/java/io/grpc/alts/internal/ChannelCrypterNettyTestBase.java
+++ b/alts/src/test/java/io/grpc/alts/internal/ChannelCrypterNettyTestBase.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 
 /** Abstract class for unit tests of {@link ChannelCrypterNetty}. */
 public abstract class ChannelCrypterNettyTestBase {
-  private static final String DECRYPTION_FAILURE_MESSAGE = "Tag mismatch";
+  private static final String DECRYPTION_FAILURE_MESSAGE_RE = "Tag mismatch|BAD_DECRYPT";
 
   protected final List<ReferenceCounted> references = new ArrayList<>();
   public ChannelCrypterNetty client;
@@ -169,7 +169,7 @@ public abstract class ChannelCrypterNettyTestBase {
       client.decrypt(frameDecrypt.out, frameDecrypt.tag, frameDecrypt.ciphertext);
       fail("Exception expected");
     } catch (AEADBadTagException ex) {
-      assertThat(ex).hasMessageThat().contains(DECRYPTION_FAILURE_MESSAGE);
+      assertThat(ex).hasMessageThat().containsMatch(DECRYPTION_FAILURE_MESSAGE_RE);
     }
   }
 
@@ -186,7 +186,7 @@ public abstract class ChannelCrypterNettyTestBase {
       client.decrypt(frameDecrypt.out, frameDecrypt.tag, frameDecrypt.ciphertext);
       fail("Exception expected");
     } catch (AEADBadTagException ex) {
-      assertThat(ex).hasMessageThat().contains(DECRYPTION_FAILURE_MESSAGE);
+      assertThat(ex).hasMessageThat().containsMatch(DECRYPTION_FAILURE_MESSAGE_RE);
     }
   }
 
@@ -202,7 +202,7 @@ public abstract class ChannelCrypterNettyTestBase {
       client.decrypt(frameDecrypt.out, frameDecrypt.tag, frameDecrypt.ciphertext);
       fail("Exception expected");
     } catch (AEADBadTagException ex) {
-      assertThat(ex).hasMessageThat().contains(DECRYPTION_FAILURE_MESSAGE);
+      assertThat(ex).hasMessageThat().containsMatch(DECRYPTION_FAILURE_MESSAGE_RE);
     }
   }
 
@@ -220,7 +220,7 @@ public abstract class ChannelCrypterNettyTestBase {
       server.decrypt(frameDecrypt2.out, frameDecrypt2.tag, frameDecrypt2.ciphertext);
       fail("Exception expected");
     } catch (AEADBadTagException ex) {
-      assertThat(ex).hasMessageThat().contains(DECRYPTION_FAILURE_MESSAGE);
+      assertThat(ex).hasMessageThat().containsMatch(DECRYPTION_FAILURE_MESSAGE_RE);
     }
   }
 }

--- a/alts/src/test/java/io/grpc/alts/internal/TsiTest.java
+++ b/alts/src/test/java/io/grpc/alts/internal/TsiTest.java
@@ -35,7 +35,7 @@ import javax.crypto.AEADBadTagException;
 
 /** Utility class that provides tests for implementations of @{link TsiHandshaker}. */
 public final class TsiTest {
-  private static final String DECRYPTION_FAILURE_RE = "Tag mismatch!";
+  private static final String DECRYPTION_FAILURE_RE = "Tag mismatch!|BAD_DECRYPT";
 
   private TsiTest() {}
 
@@ -282,7 +282,7 @@ public final class TsiTest {
       receiver.unprotect(protect, unprotectOut, alloc);
       fail("Exception expected");
     } catch (AEADBadTagException ex) {
-      assertThat(ex).hasMessageThat().contains(DECRYPTION_FAILURE_RE);
+      assertThat(ex).hasMessageThat().containsMatch(DECRYPTION_FAILURE_RE);
     }
 
     sender.destroy();
@@ -321,7 +321,7 @@ public final class TsiTest {
       receiver.unprotect(protect, unprotectOut, alloc);
       fail("Exception expected");
     } catch (AEADBadTagException ex) {
-      assertThat(ex).hasMessageThat().contains(DECRYPTION_FAILURE_RE);
+      assertThat(ex).hasMessageThat().containsMatch(DECRYPTION_FAILURE_RE);
     }
 
     sender.destroy();
@@ -360,7 +360,7 @@ public final class TsiTest {
       receiver.unprotect(protect, unprotectOut, alloc);
       fail("Exception expected");
     } catch (AEADBadTagException ex) {
-      assertThat(ex).hasMessageThat().contains(DECRYPTION_FAILURE_RE);
+      assertThat(ex).hasMessageThat().containsMatch(DECRYPTION_FAILURE_RE);
     }
 
     sender.destroy();
@@ -396,7 +396,7 @@ public final class TsiTest {
       sender.unprotect(protect.slice(), unprotectOut, alloc);
       fail("Exception expected");
     } catch (AEADBadTagException ex) {
-      assertThat(ex).hasMessageThat().contains(DECRYPTION_FAILURE_RE);
+      assertThat(ex).hasMessageThat().containsMatch(DECRYPTION_FAILURE_RE);
     }
 
     sender.destroy();

--- a/build.gradle
+++ b/build.gradle
@@ -150,7 +150,7 @@ subprojects {
             // examples/example-tls/pom.xml
             netty_tcnative: 'io.netty:netty-tcnative-boringssl-static:2.0.25.Final',
 
-            conscrypt: 'org.conscrypt:conscrypt-openjdk-uber:1.0.1',
+            conscrypt: 'org.conscrypt:conscrypt-openjdk-uber:2.2.1',
             re2j: 'com.google.re2j:re2j:1.2',
 
             // Test dependencies.


### PR DESCRIPTION
We depend on Conscrypt to help ensure Conscrypt 2.1.0 or newer is used.
It's not 100% clear this is the best approach, but it is the simplest at
present. If Conscrypt is not available then we will just use the JDK's
slower implementation of AES-GCM.

Fixes #6213