### PR TITLE
xds: plumbing restructured xds loadbalancer

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancer2.java
@@ -83,7 +83,10 @@ final class XdsLoadBalancer2 extends LoadBalancer {
   private boolean adsWorked;
   private boolean childPolicyHasBeenReady;
 
-  // TODO(zdapeng): Add XdsLoadBalancer2(Helper helper) with default factories
+  XdsLoadBalancer2(Helper helper) {
+    this(helper, new LookasideLbFactoryImpl(), new FallbackLbFactory());
+  }
+
   @VisibleForTesting
   XdsLoadBalancer2(
       Helper helper,
@@ -244,5 +247,19 @@ final class XdsLoadBalancer2 extends LoadBalancer {
   @VisibleForTesting
   interface LookasideLbFactory {
     LoadBalancer newLoadBalancer(Helper helper, AdsStreamCallback adsCallback);
+  }
+
+  private static final class LookasideLbFactoryImpl implements LookasideLbFactory {
+    @Override
+    public LoadBalancer newLoadBalancer(Helper lookasideLbHelper, AdsStreamCallback adsCallback) {
+      return new LookasideLb(lookasideLbHelper, adsCallback);
+    }
+  }
+
+  private static final class FallbackLbFactory extends LoadBalancer.Factory {
+    @Override
+    public LoadBalancer newLoadBalancer(Helper helper) {
+      return new FallbackLb(helper);
+    }
   }
 }

--- a/xds/src/test/java/io/grpc/xds/LookasideChannelLbTest.java
+++ b/xds/src/test/java/io/grpc/xds/LookasideChannelLbTest.java
@@ -78,7 +78,6 @@ import org.mockito.junit.MockitoRule;
 @RunWith(JUnit4.class)
 public class LookasideChannelLbTest {
 
-  private static final String BALANCER_NAME = "fakeBalancerName";
   private static final String SERVICE_AUTHORITY = "test authority";
 
   @Rule
@@ -163,16 +162,13 @@ public class LookasideChannelLbTest {
             .directExecutor()
             .build());
 
-    doReturn(channel).when(helper).createResolvingOobChannel(BALANCER_NAME);
     doReturn(SERVICE_AUTHORITY).when(helper).getAuthority();
     doReturn(syncContext).when(helper).getSynchronizationContext();
     doReturn(mock(ChannelLogger.class)).when(helper).getChannelLogger();
     doReturn(loadStatsStore).when(localityStore).getLoadStatsStore();
 
     lookasideChannelLb = new LookasideChannelLb(
-        helper, adsStreamCallback, BALANCER_NAME, loadReportClient, localityStore);
-
-    verify(helper).createResolvingOobChannel(BALANCER_NAME);
+        helper, adsStreamCallback, channel, loadReportClient, localityStore);
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
+++ b/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
@@ -160,7 +160,7 @@ public class LookasideLbTest {
   }
 
   @Test
-  public void handleAddress_verifyTryToCreateLbChannelToBalancerName()
+  public void handleResolvedAddress_createLbChannel()
       throws Exception {
     // Test balancer created with the default real LookasideChannelLbFactory
     lookasideLb = new LookasideLb(helper, mock(AdsStreamCallback.class));

--- a/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
+++ b/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
@@ -19,6 +19,7 @@ package io.grpc.xds;
 import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.ConnectivityState.CONNECTING;
 import static io.grpc.LoadBalancer.ATTR_LOAD_BALANCING_CONFIG;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -156,5 +157,28 @@ public class LookasideLbTest {
     verify(balancer2, never()).shutdown();
     lookasideLb.shutdown();
     verify(balancer2).shutdown();
+  }
+
+  @Test
+  public void handleAddress_verifyTryToCreateLbChannelToBalancerName()
+      throws Exception {
+    // Test balancer created with the default real LookasideChannelLbFactory
+    lookasideLb = new LookasideLb(helper, mock(AdsStreamCallback.class));
+    String lbConfigRaw11 = "{'balancerName' : 'dns:///balancer1.example.com:8080'}"
+        .replace("'", "\"");
+    @SuppressWarnings("unchecked")
+    Map<String, ?> lbConfig11 = (Map<String, ?>) JsonParser.parse(lbConfigRaw11);
+    ResolvedAddresses resolvedAddresses = ResolvedAddresses.newBuilder()
+        .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
+        .setAttributes(Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig11).build())
+        .build();
+
+    verify(helper, never()).createResolvingOobChannel(anyString());
+    try {
+      lookasideLb.handleResolvedAddresses(resolvedAddresses);
+    } catch (RuntimeException e) {
+      // Expected because helper is a mock and helper.createResolvingOobChannel() returns null.
+    }
+    verify(helper).createResolvingOobChannel("dns:///balancer1.example.com:8080");
   }
 }


### PR DESCRIPTION
Moved `ManagedChannel initLbChannel(Helper helper, String balancerName)` out of `LookasideChannelLb` because `LoadReportClientImpl` need channel be initialized already. 

Migration will be in an upcoming PR.