### PR TITLE
repositories.bzl: Fix typo in maven_install override_targets (v1.24.x backport)

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -26,7 +26,7 @@ IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS = {
     "io.grpc:grpc-api": "@io_grpc_grpc_java//api",
     "io.grpc:grpc-auth": "@io_grpc_grpc_java//auth",
     "io.grpc:grpc-context": "@io_grpc_grpc_java//context",
-    "io.grpc:grpc-core": "@io_grpc_grpc_java//core_maven",
+    "io.grpc:grpc-core": "@io_grpc_grpc_java//core:core_maven",
     "io.grpc:grpc-grpclb": "@io_grpc_grpc_java//grpclb",
     "io.grpc:grpc-netty": "@io_grpc_grpc_java//netty",
     "io.grpc:grpc-netty-shaded": "@io_grpc_grpc_java//netty:shaded_maven",


### PR DESCRIPTION
The typo was present in the initial version added in 9d6f532

This is a backport of #6224