### PR TITLE
build: update modules to wait until dependent sourceSet is available

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -8,6 +8,8 @@ plugins {
 
 description = 'gRPC: API'
 
+evaluationDependsOn(project(':grpc-context').path)
+
 dependencies {
     compile project(':grpc-context'),
             libraries.errorprone,

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -13,6 +13,8 @@ configurations {
     alpnagent
 }
 
+evaluationDependsOn(project(':grpc-context').path)
+
 dependencies {
     compile project(':grpc-alts'),
             project(':grpc-auth'),

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -13,6 +13,8 @@ configurations {
     alpnagent
 }
 
+evaluationDependsOn(project(':grpc-core').path)
+
 dependencies {
     compile project(':grpc-core'),
             libraries.netty,

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -8,6 +8,8 @@ plugins {
 
 description = "gRPC: OkHttp"
 
+evaluationDependsOn(project(':grpc-core').path)
+
 dependencies {
     compile project(':grpc-core'),
             libraries.okio

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -16,6 +16,8 @@ description = "gRPC: Services"
     ]
 }
 
+evaluationDependsOn(project(':grpc-core').path)
+
 dependencies {
     compile project(':grpc-protobuf'),
             project(':grpc-stub'),

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -7,6 +7,8 @@ plugins {
 
 description = "gRPC: Testing"
 
+evaluationDependsOn(project(':grpc-core').path)
+
 dependencies {
     compile project(':grpc-core'),
             project(':grpc-stub'),

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -16,6 +16,8 @@ description = "gRPC: XDS plugin"
     ]
 }
 
+evaluationDependsOn(project(':grpc-core').path)
+
 dependencies {
     compile project(':grpc-protobuf'),
             project(':grpc-stub'),


### PR DESCRIPTION
motivation: when I am running some test case often gradle fails. IIRC this can be environment specific (level of parallelism etc), but there is no real down side of doing it.

```
> % ./gradlew grpc-netty:cleanTest grpc-netty:test --tests "io.grpc.netty.ProtocolNegotiatorsTest.httpProxy_500"
Configuration on demand is an incubating feature.

FAILURE: Build failed with an exception.

* Where:
Build file '${MY_SECRET_HOME:~}/git/grpc-java/netty/build.gradle' line: 22

* What went wrong:
A problem occurred evaluating project ':grpc-netty'.
> Could not get unknown property 'sourceSets' for project ':grpc-core' of type org.gradle.api.Project.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1s
```

with this change it will always able to run the tests