### PR TITLE
Revert "buildscripts: android.sh to clean the build when building HEAD^"

### DIFF
--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -86,7 +86,6 @@ new_apk_size="$(stat --printf=%s $HELLO_WORLD_OUTPUT_DIR/apk/release/app-release
 
 cd $BASE_DIR/github/grpc-java
 git checkout HEAD^
-./gradlew clean
 ./gradlew publishToMavenLocal
 cd examples/android/helloworld/
 ../../gradlew build


### PR DESCRIPTION
This reverts commit c240f270773a49eb9c78ad7bcf7ef33c09aa5094.

Fixing #6146 in v1.24.x branch.