### PR TITLE
netty: Implicitly enable Conscrypt when it is available (and share some code)

### DIFF
--- a/core/src/main/java/io/grpc/internal/ConscryptLoader.java
+++ b/core/src/main/java/io/grpc/internal/ConscryptLoader.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.security.Provider;
+
+/**
+ * Utility to load dynamically Conscrypt when it is available.
+ */
+public final class ConscryptLoader {
+  private static final Method NEW_PROVIDER_METHOD;
+  private static final Method IS_CONSCRYPT_METHOD;
+
+  static {
+    Method newProvider;
+    Method isConscrypt;
+    try {
+      Class<?> conscryptClass = Class.forName("org.conscrypt.Conscrypt");
+      newProvider = conscryptClass.getMethod("newProvider");
+      isConscrypt = conscryptClass.getMethod("isConscrypt", Provider.class);
+    } catch (ClassNotFoundException ex) {
+      newProvider = null;
+      isConscrypt = null;
+    } catch (NoSuchMethodException ex) {
+      throw new AssertionError(ex);
+    }
+    NEW_PROVIDER_METHOD = newProvider;
+    IS_CONSCRYPT_METHOD = isConscrypt;
+  }
+
+  /**
+   * Returns {@code true} when the Conscrypt Java classes are available. Does not imply it actually
+   * works on this platform.
+   */
+  public static boolean isPresent() {
+    return NEW_PROVIDER_METHOD != null;
+  }
+
+  /** Same as {@code Conscrypt.isConscrypt(Provider)}. */
+  public static boolean isConscrypt(Provider provider) {
+    if (!isPresent()) {
+      return false;
+    }
+    try {
+      return (Boolean) IS_CONSCRYPT_METHOD.invoke(null, provider);
+    } catch (IllegalAccessException ex) {
+      throw new AssertionError(ex);
+    } catch (InvocationTargetException ex) {
+      throw new AssertionError(ex);
+    }
+  }
+
+  /** Same as {@code Conscrypt.newProvider()}. */
+  public static Provider newProvider() throws Throwable {
+    if (!isPresent()) {
+      Class.forName("org.conscrypt.Conscrypt");
+      throw new AssertionError("Unexpected failure referencing Conscrypt class");
+    }
+    // Exceptions here probably mean something's wrong with the JNI loading. Maybe the platform is
+    // not supported. It's an error, but it may occur in some environments as part of normal
+    // operation. It's too hard to distinguish "normal" from "abnormal" failures here.
+    return (Provider) NEW_PROVIDER_METHOD.invoke(null);
+  }
+}

--- a/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
@@ -18,9 +18,9 @@ package io.grpc.netty;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.base.Throwables;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.grpc.ExperimentalApi;
+import io.grpc.internal.ConscryptLoader;
 import io.netty.handler.codec.http2.Http2SecurityUtil;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
@@ -32,8 +32,6 @@ import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import java.io.File;
 import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.security.Provider;
 import java.security.Security;
 import java.util.Arrays;
@@ -95,20 +93,6 @@ public class GrpcSslContexts {
       NEXT_PROTOCOL_VERSIONS);
 
   private static final String SUN_PROVIDER_NAME = "SunJSSE";
-  private static final Method IS_CONSCRYPT_PROVIDER;
-
-  static {
-    Method method = null;
-    try {
-      Class<?> conscryptClass = Class.forName("org.conscrypt.Conscrypt");
-      method = conscryptClass.getMethod("isConscrypt", Provider.class);
-    } catch (ClassNotFoundException ex) {
-      logger.log(Level.FINE, "Conscrypt class not found. Not using Conscrypt", ex);
-    } catch (NoSuchMethodException ex) {
-      throw new AssertionError(ex);
-    }
-    IS_CONSCRYPT_PROVIDER = method;
-  }
 
   /**
    * Creates an SslContextBuilder with ciphers and APN appropriate for gRPC.
@@ -223,9 +207,9 @@ public class GrpcSslContexts {
         apc = ALPN;
       } else {
         throw new IllegalArgumentException(
-            SUN_PROVIDER_NAME + " selected, but Jetty NPN/ALPN unavailable");
+            SUN_PROVIDER_NAME + " selected, but Java 9+ and Jetty NPN/ALPN unavailable");
       }
-    } else if (isConscrypt(jdkProvider)) {
+    } else if (ConscryptLoader.isConscrypt(jdkProvider)) {
       apc = ALPN;
     } else {
       throw new IllegalArgumentException("Unknown provider; can't configure: " + jdkProvider);
@@ -250,9 +234,11 @@ public class GrpcSslContexts {
       logger.log(Level.FINE, "Selecting JDK with provider {0}", provider);
       return SslProvider.JDK;
     }
+    logger.log(Level.INFO, "Java 9 ALPN API unavailable (this may be normal)");
     logger.log(Level.INFO, "netty-tcnative unavailable (this may be normal)",
         OpenSsl.unavailabilityCause());
-    logger.log(Level.INFO, "Conscrypt not found (this may be normal)");
+    logger.log(Level.INFO, "Conscrypt not found (this may be normal)",
+        ConscryptHolder.UNAVAILABILITY_CAUSE);
     logger.log(Level.INFO, "Jetty ALPN unavailable (this may be normal)",
         JettyTlsUtil.getJettyAlpnUnavailabilityCause());
     throw new IllegalStateException(
@@ -268,28 +254,14 @@ public class GrpcSslContexts {
             || JettyTlsUtil.isJava9AlpnAvailable()) {
           return provider;
         }
-      } else if (isConscrypt(provider)) {
+      } else if (ConscryptLoader.isConscrypt(provider)) {
         return provider;
       }
     }
+    if (ConscryptHolder.PROVIDER != null) {
+      return ConscryptHolder.PROVIDER;
+    }
     return null;
-  }
-
-  private static boolean isConscrypt(Provider provider) {
-    if (IS_CONSCRYPT_PROVIDER == null) {
-      return false;
-    }
-    try {
-      return (Boolean) IS_CONSCRYPT_PROVIDER.invoke(null, provider);
-    } catch (IllegalAccessException ex) {
-      throw new AssertionError(ex);
-    } catch (InvocationTargetException ex) {
-      if (ex.getCause() != null) {
-        Throwables.throwIfUnchecked(ex.getCause());
-        // If checked, just wrap up everything.
-      }
-      throw new AssertionError(ex);
-    }
   }
 
   @SuppressWarnings("deprecation")
@@ -303,5 +275,24 @@ public class GrpcSslContexts {
         "This ALPN config does not support HTTP/2. Expected %s, but got %s'.",
         HTTP2_VERSION,
         alpnNegotiator.protocols());
+  }
+
+  private static class ConscryptHolder {
+    static final Provider PROVIDER;
+    static final Throwable UNAVAILABILITY_CAUSE;
+
+    static {
+      Provider provider;
+      Throwable cause;
+      try {
+        provider = ConscryptLoader.newProvider();
+        cause = null;
+      } catch (Throwable t) {
+        provider = null;
+        cause = t;
+      }
+      PROVIDER = provider;
+      UNAVAILABILITY_CAUSE = cause;
+    }
   }
 }

--- a/testing/src/main/java/io/grpc/internal/testing/TestUtils.java
+++ b/testing/src/main/java/io/grpc/internal/testing/TestUtils.java
@@ -17,6 +17,7 @@
 package io.grpc.internal.testing;
 
 import com.google.common.base.Throwables;
+import io.grpc.internal.ConscryptLoader;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -25,8 +26,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -163,33 +162,22 @@ public class TestUtils {
       conscryptInstallAttempted = true;
       return;
     }
-    Class<?> conscrypt;
-    try {
-      conscrypt = Class.forName("org.conscrypt.Conscrypt");
-    } catch (ClassNotFoundException ex) {
+    if (!ConscryptLoader.isPresent()) {
       conscryptInstallAttempted = true;
       return;
     }
-    Method newProvider;
-    try {
-      newProvider = conscrypt.getMethod("newProvider");
-    } catch (NoSuchMethodException ex) {
-      throw new RuntimeException("Could not find newProvider method on Conscrypt", ex);
-    }
     Provider provider;
     try {
-      provider = (Provider) newProvider.invoke(null);
-    } catch (IllegalAccessException ex) {
-      throw new RuntimeException("Could not invoke Conscrypt.newProvider", ex);
-    } catch (InvocationTargetException ex) {
-      Throwable root = Throwables.getRootCause(ex);
+      provider = ConscryptLoader.newProvider();
+    } catch (Throwable t) {
+      Throwable root = Throwables.getRootCause(t);
       // Conscrypt uses a newer version of glibc than available on RHEL 6
       if (root instanceof UnsatisfiedLinkError && root.getMessage() != null
           && root.getMessage().contains("GLIBC_2.14")) {
         conscryptInstallAttempted = true;
         return;
       }
-      throw new RuntimeException("Could not invoke Conscrypt.newProvider", ex);
+      throw new RuntimeException("Could not create Conscrypt provider", t);
     }
     Security.addProvider(provider);
     conscryptInstallAttempted = true;


### PR DESCRIPTION
This implicit loading is more conservative than the loading for
tcnative, as Conscrypt will only be implicitly loaded if there are no
other options. This means the Java 9+ JSSE is preferred over Conscrypt
without explicit user configuration.

While we would generally prefer Conscrypt over JSSE, we want to allow
the user to configure their security providers. There wasn't a good way
to do that with netty-tcnative and the performance of JSSE at the time
was abysmal.

While generally being a good way to allow adopting Conscrypt, this also
allows easily using App Engine Java 8's provided Conscrypt which can
substantially reduce binary size.

See googleapis/google-cloud-java#6425

-------

I plan to preserve the two commits when merging.