### PR TITLE
api,core: Adds an Executor field to NameResolver.Args.

### DIFF
--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -72,8 +72,8 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
   }
 
   @Override
-  public T nameResolverExecutor(Executor executor) {
-    delegate().nameResolverExecutor(executor);
+  public T blockingExecutor(Executor executor) {
+    delegate().blockingExecutor(executor);
     return thisT();
   }
 

--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -72,6 +72,12 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
   }
 
   @Override
+  public T nameResolverExecutor(Executor executor) {
+    delegate().nameResolverExecutor(executor);
+    return thisT();
+  }
+
+  @Override
   public T intercept(List<ClientInterceptor> interceptors) {
     delegate().intercept(interceptors);
     return thisT();

--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -112,8 +112,8 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * <p>The channel won't take ownership of the given executor. It's caller's responsibility to shut
    * down the executor when it's desired.
    *
-   * @throws UnsupportedOperationException if unsupported
    * @return this
+   * @throws UnsupportedOperationException if unsupported
    * @since 1.25.0
    */
   public T nameResolverExecutor(Executor executor) {

--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -104,6 +104,23 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   public abstract T executor(Executor executor);
 
   /**
+   * Provides a custom executor that will be passed to the {@link NameResolver}.
+   *
+   * <p>It's an optional parameter. If the user has not provided an executor when the channel is
+   * built, the builder will use a static cached thread pool.
+   *
+   * <p>The channel won't take ownership of the given executor. It's caller's responsibility to shut
+   * down the executor when it's desired.
+   *
+   * @throws UnsupportedOperationException if unsupported
+   * @return this
+   * @since 1.25.0
+   */
+  public T nameResolverExecutor(Executor executor) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Adds interceptors that will be called before the channel performs its real work. This is
    * functionally equivalent to using {@link ClientInterceptors#intercept(Channel, List)}, but while
    * still having access to the original {@code ManagedChannel}. Interceptors run in the reverse

--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -104,7 +104,7 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   public abstract T executor(Executor executor);
 
   /**
-   * Provides a custom executor that will be passed to the {@link NameResolver}.
+   * Provides a custom executor that will be used for operations that block.
    *
    * <p>It's an optional parameter. If the user has not provided an executor when the channel is
    * built, the builder will use a static cached thread pool.
@@ -116,7 +116,7 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * @throws UnsupportedOperationException if unsupported
    * @since 1.25.0
    */
-  public T nameResolverExecutor(Executor executor) {
+  public T blockingExecutor(Executor executor) {
     throw new UnsupportedOperationException();
   }
 

--- a/api/src/main/java/io/grpc/NameResolver.java
+++ b/api/src/main/java/io/grpc/NameResolver.java
@@ -473,7 +473,7 @@ public abstract class NameResolver {
      * @since 1.25.0
      */
     @Nullable
-    public Executor getExecutor() {
+    public Executor getBlockingExecutor() {
       return executor;
     }
 
@@ -499,7 +499,7 @@ public abstract class NameResolver {
       builder.setProxyDetector(proxyDetector);
       builder.setSynchronizationContext(syncContext);
       builder.setServiceConfigParser(serviceConfigParser);
-      builder.setExecutor(executor);
+      builder.setBlockingExecutor(executor);
       return builder;
     }
 
@@ -568,11 +568,11 @@ public abstract class NameResolver {
       }
 
       /**
-       * See {@link Args#getExecutor}. This is an optional field.
+       * See {@link Args#getBlockingExecutor}. This is an optional field.
        *
        * @since 1.25.0
        */
-      public Builder setExecutor(Executor executor) {
+      public Builder setBlockingExecutor(Executor executor) {
         this.executor = executor;
         return this;
       }

--- a/api/src/main/java/io/grpc/NameResolver.java
+++ b/api/src/main/java/io/grpc/NameResolver.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -411,13 +412,19 @@ public abstract class NameResolver {
     private final ProxyDetector proxyDetector;
     private final SynchronizationContext syncContext;
     private final ServiceConfigParser serviceConfigParser;
+    @Nullable private final Executor executor;
 
-    Args(Integer defaultPort, ProxyDetector proxyDetector,
-        SynchronizationContext syncContext, ServiceConfigParser serviceConfigParser) {
+    Args(
+        Integer defaultPort,
+        ProxyDetector proxyDetector,
+        SynchronizationContext syncContext,
+        ServiceConfigParser serviceConfigParser,
+        @Nullable Executor executor) {
       this.defaultPort = checkNotNull(defaultPort, "defaultPort not set");
       this.proxyDetector = checkNotNull(proxyDetector, "proxyDetector not set");
       this.syncContext = checkNotNull(syncContext, "syncContext not set");
       this.serviceConfigParser = checkNotNull(serviceConfigParser, "serviceConfigParser not set");
+      this.executor = executor;
     }
 
     /**
@@ -459,6 +466,17 @@ public abstract class NameResolver {
       return serviceConfigParser;
     }
 
+    /**
+     * Returns the Executor on which this resolver should execute long-running or I/O bound work.
+     * Null if no Executor was set.
+     *
+     * @since 1.25.0
+     */
+    @Nullable
+    public Executor getExecutor() {
+      return executor;
+    }
+
     @Override
     public String toString() {
       return MoreObjects.toStringHelper(this)
@@ -466,6 +484,7 @@ public abstract class NameResolver {
           .add("proxyDetector", proxyDetector)
           .add("syncContext", syncContext)
           .add("serviceConfigParser", serviceConfigParser)
+          .add("executor", executor)
           .toString();
     }
 
@@ -480,6 +499,7 @@ public abstract class NameResolver {
       builder.setProxyDetector(proxyDetector);
       builder.setSynchronizationContext(syncContext);
       builder.setServiceConfigParser(serviceConfigParser);
+      builder.setExecutor(executor);
       return builder;
     }
 
@@ -502,6 +522,7 @@ public abstract class NameResolver {
       private ProxyDetector proxyDetector;
       private SynchronizationContext syncContext;
       private ServiceConfigParser serviceConfigParser;
+      private Executor executor;
 
       Builder() {
       }
@@ -547,12 +568,22 @@ public abstract class NameResolver {
       }
 
       /**
+       * See {@link Args#getExecutor}. This is an optional field.
+       *
+       * @since 1.25.0
+       */
+      public Builder setExecutor(Executor executor) {
+        this.executor = executor;
+        return this;
+      }
+
+      /**
        * Builds an {@link Args}.
        *
        * @since 1.21.0
        */
       public Args build() {
-        return new Args(defaultPort, proxyDetector, syncContext, serviceConfigParser);
+        return new Args(defaultPort, proxyDetector, syncContext, serviceConfigParser, executor);
       }
     }
   }

--- a/api/src/test/java/io/grpc/NameResolverTest.java
+++ b/api/src/test/java/io/grpc/NameResolverTest.java
@@ -29,6 +29,8 @@ import java.lang.Thread.UncaughtExceptionHandler;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,6 +45,7 @@ public class NameResolverTest {
   private final SynchronizationContext syncContext =
       new SynchronizationContext(mock(UncaughtExceptionHandler.class));
   private final ServiceConfigParser parser = mock(ServiceConfigParser.class);
+  private final Executor executor = Executors.newSingleThreadExecutor();
   private URI uri;
   private final NameResolver nameResolver = mock(NameResolver.class);
 
@@ -58,12 +61,14 @@ public class NameResolverTest {
     assertThat(args.getProxyDetector()).isSameInstanceAs(proxyDetector);
     assertThat(args.getSynchronizationContext()).isSameInstanceAs(syncContext);
     assertThat(args.getServiceConfigParser()).isSameInstanceAs(parser);
+    assertThat(args.getExecutor()).isSameInstanceAs(executor);
 
     NameResolver.Args args2 = args.toBuilder().build();
     assertThat(args2.getDefaultPort()).isEqualTo(defaultPort);
     assertThat(args2.getProxyDetector()).isSameInstanceAs(proxyDetector);
     assertThat(args2.getSynchronizationContext()).isSameInstanceAs(syncContext);
     assertThat(args2.getServiceConfigParser()).isSameInstanceAs(parser);
+    assertThat(args2.getExecutor()).isSameInstanceAs(executor);
 
     assertThat(args2).isNotSameInstanceAs(args);
     assertThat(args2).isNotEqualTo(args);
@@ -246,6 +251,7 @@ public class NameResolverTest {
         .setProxyDetector(proxyDetector)
         .setSynchronizationContext(syncContext)
         .setServiceConfigParser(parser)
+        .setExecutor(executor)
         .build();
   }
 }

--- a/api/src/test/java/io/grpc/NameResolverTest.java
+++ b/api/src/test/java/io/grpc/NameResolverTest.java
@@ -61,14 +61,14 @@ public class NameResolverTest {
     assertThat(args.getProxyDetector()).isSameInstanceAs(proxyDetector);
     assertThat(args.getSynchronizationContext()).isSameInstanceAs(syncContext);
     assertThat(args.getServiceConfigParser()).isSameInstanceAs(parser);
-    assertThat(args.getExecutor()).isSameInstanceAs(executor);
+    assertThat(args.getBlockingExecutor()).isSameInstanceAs(executor);
 
     NameResolver.Args args2 = args.toBuilder().build();
     assertThat(args2.getDefaultPort()).isEqualTo(defaultPort);
     assertThat(args2.getProxyDetector()).isSameInstanceAs(proxyDetector);
     assertThat(args2.getSynchronizationContext()).isSameInstanceAs(syncContext);
     assertThat(args2.getServiceConfigParser()).isSameInstanceAs(parser);
-    assertThat(args2.getExecutor()).isSameInstanceAs(executor);
+    assertThat(args2.getBlockingExecutor()).isSameInstanceAs(executor);
 
     assertThat(args2).isNotSameInstanceAs(args);
     assertThat(args2).isNotEqualTo(args);
@@ -251,7 +251,7 @@ public class NameResolverTest {
         .setProxyDetector(proxyDetector)
         .setSynchronizationContext(syncContext)
         .setServiceConfigParser(parser)
-        .setExecutor(executor)
+        .setBlockingExecutor(executor)
         .build();
   }
 }

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -95,7 +95,7 @@ public abstract class AbstractManagedChannelImplBuilder
 
   ObjectPool<? extends Executor> executorPool = DEFAULT_EXECUTOR_POOL;
 
-  ObjectPool<? extends Executor> nameResolverExecutorPool = DEFAULT_EXECUTOR_POOL;
+  ObjectPool<? extends Executor> blockingExecutorPool = DEFAULT_EXECUTOR_POOL;
 
   private final List<ClientInterceptor> interceptors = new ArrayList<>();
   final NameResolverRegistry nameResolverRegistry = NameResolverRegistry.getDefaultRegistry();
@@ -220,11 +220,11 @@ public abstract class AbstractManagedChannelImplBuilder
   }
 
   @Override
-  public final T nameResolverExecutor(Executor executor) {
+  public final T blockingExecutor(Executor executor) {
     if (executor != null) {
-      this.nameResolverExecutorPool = new FixedObjectPool<>(executor);
+      this.blockingExecutorPool = new FixedObjectPool<>(executor);
     } else {
-      this.nameResolverExecutorPool = DEFAULT_EXECUTOR_POOL;
+      this.blockingExecutorPool = DEFAULT_EXECUTOR_POOL;
     }
     return thisT();
   }

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -95,6 +95,8 @@ public abstract class AbstractManagedChannelImplBuilder
 
   ObjectPool<? extends Executor> executorPool = DEFAULT_EXECUTOR_POOL;
 
+  ObjectPool<? extends Executor> nameResolverExecutorPool = DEFAULT_EXECUTOR_POOL;
+
   private final List<ClientInterceptor> interceptors = new ArrayList<>();
   final NameResolverRegistry nameResolverRegistry = NameResolverRegistry.getDefaultRegistry();
 
@@ -213,6 +215,16 @@ public abstract class AbstractManagedChannelImplBuilder
       this.executorPool = new FixedObjectPool<>(executor);
     } else {
       this.executorPool = DEFAULT_EXECUTOR_POOL;
+    }
+    return thisT();
+  }
+
+  @Override
+  public final T nameResolverExecutor(Executor executor) {
+    if (executor != null) {
+      this.nameResolverExecutorPool = new FixedObjectPool<>(executor);
+    } else {
+      this.nameResolverExecutorPool = DEFAULT_EXECUTOR_POOL;
     }
     return thisT();
   }

--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -182,7 +182,7 @@ final class DnsNameResolver extends NameResolver {
     this.stopwatch = Preconditions.checkNotNull(stopwatch, "stopwatch");
     this.syncContext =
         Preconditions.checkNotNull(args.getSynchronizationContext(), "syncContext");
-    this.executor = args.getExecutor();
+    this.executor = args.getBlockingExecutor();
     this.usingExecutorResource = executor == null;
   }
 
@@ -194,7 +194,7 @@ final class DnsNameResolver extends NameResolver {
   @Override
   public void start(Listener2 listener) {
     Preconditions.checkState(this.listener == null, "already started");
-    if (executor == null) {
+    if (usingExecutorResource) {
       executor = SharedResourceHolder.get(executorResource);
     }
     this.listener = Preconditions.checkNotNull(listener, "listener");

--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -138,6 +138,8 @@ final class DnsNameResolver extends NameResolver {
   private final String authority;
   private final String host;
   private final int port;
+
+  /** Executor that will be used if an Executor is not provide via {@link NameResolver.Args}. */
   private final Resource<Executor> executorResource;
   private final long cacheTtlNanos;
   private final SynchronizationContext syncContext;
@@ -147,6 +149,10 @@ final class DnsNameResolver extends NameResolver {
   private ResolutionResults cachedResolutionResults;
   private boolean shutdown;
   private Executor executor;
+
+  /** True if using an executor resource that should be released after use. */
+  private final boolean usingExecutorResource;
+
   private boolean resolving;
 
   // The field must be accessed from syncContext, although the methods on an Listener2 can be called
@@ -176,6 +182,8 @@ final class DnsNameResolver extends NameResolver {
     this.stopwatch = Preconditions.checkNotNull(stopwatch, "stopwatch");
     this.syncContext =
         Preconditions.checkNotNull(args.getSynchronizationContext(), "syncContext");
+    this.executor = args.getExecutor();
+    this.usingExecutorResource = executor == null;
   }
 
   @Override
@@ -186,7 +194,9 @@ final class DnsNameResolver extends NameResolver {
   @Override
   public void start(Listener2 listener) {
     Preconditions.checkState(this.listener == null, "already started");
-    executor = SharedResourceHolder.get(executorResource);
+    if (executor == null) {
+      executor = SharedResourceHolder.get(executorResource);
+    }
     this.listener = Preconditions.checkNotNull(listener, "listener");
     resolve();
   }
@@ -361,7 +371,7 @@ final class DnsNameResolver extends NameResolver {
       return;
     }
     shutdown = true;
-    if (executor != null) {
+    if (executor != null && usingExecutorResource) {
       executor = SharedResourceHolder.release(executorResource, executor);
     }
   }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -581,7 +581,14 @@ final class ManagedChannelImpl extends ManagedChannel implements
                     builder.maxRetryAttempts,
                     builder.maxHedgedAttempts,
                     loadBalancerFactory))
-            .setBlockingExecutor(builder.blockingExecutorPool.getObject())
+            .setBlockingExecutor(
+                // Avoid creating the blockingExecutor until it is first used
+                new Executor() {
+                  @Override
+                  public void execute(Runnable command) {
+                    blockingExecutorHolder.getExecutor().execute(command);
+                  }
+                })
             .build();
     this.nameResolver = getNameResolver(target, nameResolverFactory, nameResolverArgs);
     this.timeProvider = checkNotNull(timeProvider, "timeProvider");

--- a/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
@@ -100,18 +100,18 @@ public class AbstractManagedChannelImplBuilderTest {
   }
 
   @Test
-  public void nameResolverExecutor_normal() {
+  public void blockingExecutor_normal() {
     Executor executor = mock(Executor.class);
-    assertEquals(builder, builder.nameResolverExecutor(executor));
-    assertEquals(executor, builder.nameResolverExecutorPool.getObject());
+    assertEquals(builder, builder.blockingExecutor(executor));
+    assertEquals(executor, builder.blockingExecutorPool.getObject());
   }
 
   @Test
-  public void nameResolverExecutor_null() {
-    ObjectPool<? extends Executor> defaultValue = builder.nameResolverExecutorPool;
-    builder.nameResolverExecutor(mock(Executor.class));
-    assertEquals(builder, builder.nameResolverExecutor(null));
-    assertEquals(defaultValue, builder.nameResolverExecutorPool);
+  public void blockingExecutor_null() {
+    ObjectPool<? extends Executor> defaultValue = builder.blockingExecutorPool;
+    builder.blockingExecutor(mock(Executor.class));
+    assertEquals(builder, builder.blockingExecutor(null));
+    assertEquals(defaultValue, builder.blockingExecutorPool);
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
@@ -100,6 +100,21 @@ public class AbstractManagedChannelImplBuilderTest {
   }
 
   @Test
+  public void nameResolverExecutor_normal() {
+    Executor executor = mock(Executor.class);
+    assertEquals(builder, builder.nameResolverExecutor(executor));
+    assertEquals(executor, builder.nameResolverExecutorPool.getObject());
+  }
+
+  @Test
+  public void nameResolverExecutor_null() {
+    ObjectPool<? extends Executor> defaultValue = builder.nameResolverExecutorPool;
+    builder.nameResolverExecutor(mock(Executor.class));
+    assertEquals(builder, builder.nameResolverExecutor(null));
+    assertEquals(defaultValue, builder.nameResolverExecutorPool);
+  }
+
+  @Test
   public void nameResolverFactory_default() {
     assertNotNull(builder.getNameResolverFactory());
   }

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -330,7 +330,7 @@ public class DnsNameResolverTest {
             .setProxyDetector(GrpcUtil.NOOP_PROXY_DETECTOR)
             .setSynchronizationContext(syncContext)
             .setServiceConfigParser(mock(ServiceConfigParser.class))
-            .setExecutor(
+            .setBlockingExecutor(
                 new Executor() {
                   @Override
                   public void execute(Runnable command) {

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -70,6 +70,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -120,17 +121,20 @@ public class DnsNameResolverTest {
   private final FakeClock fakeClock = new FakeClock();
   private final FakeClock fakeExecutor = new FakeClock();
 
-  private final Resource<Executor> fakeExecutorResource =
-      new Resource<Executor>() {
-        @Override
-        public Executor create() {
-          return fakeExecutor.getScheduledExecutorService();
-        }
+  private final FakeExecutorResource fakeExecutorResource = new FakeExecutorResource();
 
-        @Override
-        public void close(Executor instance) {
-        }
-      };
+  private final class FakeExecutorResource implements Resource<Executor> {
+    private final AtomicInteger createCount = new AtomicInteger();
+
+    @Override
+    public Executor create() {
+      createCount.incrementAndGet();
+      return fakeExecutor.getScheduledExecutorService();
+    }
+
+    @Override
+    public void close(Executor instance) {}
+  }
 
   @Mock
   private NameResolver.Listener2 mockListener;
@@ -165,18 +169,20 @@ public class DnsNameResolverTest {
       final ProxyDetector proxyDetector,
       Stopwatch stopwatch,
       boolean isAndroid) {
-    DnsNameResolver dnsResolver = new DnsNameResolver(
-        null,
-        name,
+    NameResolver.Args args =
         NameResolver.Args.newBuilder()
             .setDefaultPort(defaultPort)
             .setProxyDetector(proxyDetector)
             .setSynchronizationContext(syncContext)
             .setServiceConfigParser(mock(ServiceConfigParser.class))
-            .build(),
-        fakeExecutorResource,
-        stopwatch,
-        isAndroid);
+            .build();
+    return newResolver(name, stopwatch, isAndroid, args);
+  }
+
+  private DnsNameResolver newResolver(
+      String name, Stopwatch stopwatch, boolean isAndroid, NameResolver.Args args) {
+    DnsNameResolver dnsResolver =
+        new DnsNameResolver(null, name, args, fakeExecutorResource, stopwatch, isAndroid);
     // By default, using the mocked ResourceResolver to avoid I/O
     dnsResolver.setResourceResolver(new JndiResourceResolver(recordFetcher));
     return dnsResolver;
@@ -291,6 +297,65 @@ public class DnsNameResolverTest {
     resolver.shutdown();
 
     verify(mockResolver, times(2)).resolveAddress(anyString());
+  }
+
+  @Test
+  public void testExecutor_default() throws Exception {
+    final List<InetAddress> answer = createAddressList(2);
+
+    DnsNameResolver resolver = newResolver("foo.googleapis.com", 81);
+    AddressResolver mockResolver = mock(AddressResolver.class);
+    when(mockResolver.resolveAddress(anyString())).thenReturn(answer);
+    resolver.setAddressResolver(mockResolver);
+
+    resolver.start(mockListener);
+    assertEquals(1, fakeExecutor.runDueTasks());
+    verify(mockListener).onResult(resultCaptor.capture());
+    assertAnswerMatches(answer, 81, resultCaptor.getValue());
+    assertEquals(0, fakeClock.numPendingTasks());
+
+    resolver.shutdown();
+
+    assertThat(fakeExecutorResource.createCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void testExecutor_custom() throws Exception {
+    final List<InetAddress> answer = createAddressList(2);
+    final AtomicInteger executions = new AtomicInteger();
+
+    NameResolver.Args args =
+        NameResolver.Args.newBuilder()
+            .setDefaultPort(81)
+            .setProxyDetector(GrpcUtil.NOOP_PROXY_DETECTOR)
+            .setSynchronizationContext(syncContext)
+            .setServiceConfigParser(mock(ServiceConfigParser.class))
+            .setExecutor(
+                new Executor() {
+                  @Override
+                  public void execute(Runnable command) {
+                    executions.incrementAndGet();
+                    command.run();
+                  }
+                })
+            .build();
+
+    DnsNameResolver resolver =
+        newResolver("foo.googleapis.com", Stopwatch.createUnstarted(), false, args);
+    AddressResolver mockResolver = mock(AddressResolver.class);
+    when(mockResolver.resolveAddress(anyString())).thenReturn(answer);
+    resolver.setAddressResolver(mockResolver);
+
+    resolver.start(mockListener);
+    assertEquals(0, fakeExecutor.runDueTasks());
+    verify(mockListener).onResult(resultCaptor.capture());
+    assertAnswerMatches(answer, 81, resultCaptor.getValue());
+    assertEquals(0, fakeClock.numPendingTasks());
+
+    resolver.shutdown();
+
+    assertThat(fakeExecutorResource.createCount.get()).isEqualTo(0);
+    assertThat(executions.get()).isEqualTo(1);
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -265,6 +265,8 @@ public class ManagedChannelImplTest {
   private ObjectPool<Executor> balancerRpcExecutorPool;
   @Mock
   private CallCredentials creds;
+  @Mock
+  private Executor nameResolverExecutor;
   private ChannelBuilder channelBuilder;
   private boolean requestConnection = true;
   private BlockingQueue<MockClientTransportInfo> transports;
@@ -319,11 +321,14 @@ public class ManagedChannelImplTest {
     when(balancerRpcExecutorPool.getObject())
         .thenReturn(balancerRpcExecutor.getScheduledExecutorService());
 
-    channelBuilder = new ChannelBuilder()
-        .nameResolverFactory(new FakeNameResolverFactory.Builder(expectedUri).build())
-        .defaultLoadBalancingPolicy(MOCK_POLICY_NAME)
-        .userAgent(USER_AGENT)
-        .idleTimeout(AbstractManagedChannelImplBuilder.IDLE_MODE_MAX_TIMEOUT_DAYS, TimeUnit.DAYS);
+    channelBuilder =
+        new ChannelBuilder()
+            .nameResolverFactory(new FakeNameResolverFactory.Builder(expectedUri).build())
+            .defaultLoadBalancingPolicy(MOCK_POLICY_NAME)
+            .userAgent(USER_AGENT)
+            .idleTimeout(
+                AbstractManagedChannelImplBuilder.IDLE_MODE_MAX_TIMEOUT_DAYS, TimeUnit.DAYS)
+            .nameResolverExecutor(nameResolverExecutor);
     channelBuilder.executorPool = executorPool;
     channelBuilder.binlog = null;
     channelBuilder.channelz = channelz;
@@ -3582,6 +3587,7 @@ public class ManagedChannelImplTest {
     assertThat(args).isNotNull();
     assertThat(args.getDefaultPort()).isEqualTo(DEFAULT_PORT);
     assertThat(args.getProxyDetector()).isSameInstanceAs(neverProxy);
+    assertThat(args.getExecutor()).isSameInstanceAs(nameResolverExecutor);
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -266,7 +266,7 @@ public class ManagedChannelImplTest {
   @Mock
   private CallCredentials creds;
   @Mock
-  private Executor nameResolverExecutor;
+  private Executor blockingExecutor;
   private ChannelBuilder channelBuilder;
   private boolean requestConnection = true;
   private BlockingQueue<MockClientTransportInfo> transports;
@@ -328,7 +328,7 @@ public class ManagedChannelImplTest {
             .userAgent(USER_AGENT)
             .idleTimeout(
                 AbstractManagedChannelImplBuilder.IDLE_MODE_MAX_TIMEOUT_DAYS, TimeUnit.DAYS)
-            .nameResolverExecutor(nameResolverExecutor);
+            .blockingExecutor(blockingExecutor);
     channelBuilder.executorPool = executorPool;
     channelBuilder.binlog = null;
     channelBuilder.channelz = channelz;
@@ -3587,7 +3587,7 @@ public class ManagedChannelImplTest {
     assertThat(args).isNotNull();
     assertThat(args.getDefaultPort()).isEqualTo(DEFAULT_PORT);
     assertThat(args.getProxyDetector()).isSameInstanceAs(neverProxy);
-    assertThat(args.getExecutor()).isSameInstanceAs(nameResolverExecutor);
+    assertThat(args.getBlockingExecutor()).isSameInstanceAs(blockingExecutor);
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -3587,7 +3587,15 @@ public class ManagedChannelImplTest {
     assertThat(args).isNotNull();
     assertThat(args.getDefaultPort()).isEqualTo(DEFAULT_PORT);
     assertThat(args.getProxyDetector()).isSameInstanceAs(neverProxy);
-    assertThat(args.getBlockingExecutor()).isSameInstanceAs(blockingExecutor);
+
+    verify(blockingExecutor, never()).execute(any(Runnable.class));
+    args.getBlockingExecutor()
+        .execute(
+            new Runnable() {
+              @Override
+              public void run() {}
+            });
+    verify(blockingExecutor, times(1)).execute(any(Runnable.class));
   }
 
   @Test


### PR DESCRIPTION
Adds an Executor field to NameResolver.Args, which is optionally set on ManagedChannelBuilder. This allows NameResolver implementations to avoid creating their own thread pools if the application already manages its own pools. 

Addresses #3703.