### PR TITLE
re-add the grpc-netty dependency

### DIFF
--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     compile project(':grpc-protobuf'),
             project(':grpc-stub'),
             project(':grpc-core'),
+            project(':grpc-netty'),
             project(':grpc-services')
     
     compile (libraries.pgv) {


### PR DESCRIPTION
accidentally removed in a previous PR