### PR TITLE
xds: bootstrap xDS load balancer with xDS name resolver

### DIFF
--- a/xds/src/main/java/io/grpc/xds/LookasideChannelLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideChannelLb.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment;
+import io.envoyproxy.envoy.api.v2.core.Node;
 import io.envoyproxy.envoy.api.v2.endpoint.LocalityLbEndpoints;
 import io.envoyproxy.envoy.type.FractionalPercent;
 import io.envoyproxy.envoy.type.FractionalPercent.DenominatorType;
@@ -52,7 +53,7 @@ final class LookasideChannelLb extends LoadBalancer {
 
   LookasideChannelLb(
       Helper helper, LookasideChannelCallback lookasideChannelCallback, ManagedChannel lbChannel,
-      LocalityStore localityStore) {
+      LocalityStore localityStore, Node node) {
     this(
         helper,
         lookasideChannelCallback,
@@ -60,7 +61,8 @@ final class LookasideChannelLb extends LoadBalancer {
         new LoadReportClientImpl(
             lbChannel, helper, GrpcUtil.STOPWATCH_SUPPLIER, new ExponentialBackoffPolicy.Provider(),
             localityStore.getLoadStatsStore()),
-        localityStore);
+        localityStore,
+        node);
   }
 
   @VisibleForTesting
@@ -69,7 +71,8 @@ final class LookasideChannelLb extends LoadBalancer {
       LookasideChannelCallback lookasideChannelCallback,
       ManagedChannel lbChannel,
       LoadReportClient lrsClient,
-      final LocalityStore localityStore) {
+      final LocalityStore localityStore,
+      Node node) {
     this.lbChannel = lbChannel;
     LoadReportCallback lrsCallback =
         new LoadReportCallback() {
@@ -84,7 +87,7 @@ final class LookasideChannelLb extends LoadBalancer {
         lookasideChannelCallback, lrsClient, lrsCallback, localityStore) ;
     xdsComms2 = new XdsComms2(
         lbChannel, helper, adsCallback, new ExponentialBackoffPolicy.Provider(),
-        GrpcUtil.STOPWATCH_SUPPLIER);
+        GrpcUtil.STOPWATCH_SUPPLIER, node);
   }
 
   private static int rateInMillion(FractionalPercent fractionalPercent) {

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -17,9 +17,13 @@
 package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.grpc.xds.XdsNameResolver.XDS_NODE;
 import static java.util.logging.Level.FINEST;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import io.envoyproxy.envoy.api.v2.core.Node;
 import io.grpc.Attributes;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancerProvider;
@@ -85,12 +89,22 @@ final class LookasideLb extends ForwardingLoadBalancer {
     String newBalancerName = xdsConfig.balancerName;
     if (!newBalancerName.equals(balancerName)) {
       balancerName = newBalancerName; // cache the name and check next time for optimization
-      lookasideChannelLb.switchTo(newLookasideChannelLbProvider(newBalancerName));
+      Node node = resolvedAddresses.getAttributes().get(XDS_NODE);
+      if (node == null) {
+        node = Node.newBuilder()
+            .setMetadata(Struct.newBuilder()
+                .putFields(
+                    "endpoints_required",
+                    Value.newBuilder().setBoolValue(true).build()))
+            .build();
+      }
+      lookasideChannelLb.switchTo(newLookasideChannelLbProvider(newBalancerName, node));
     }
     lookasideChannelLb.handleResolvedAddresses(resolvedAddresses);
   }
 
-  private LoadBalancerProvider newLookasideChannelLbProvider(final String balancerName) {
+  private LoadBalancerProvider newLookasideChannelLbProvider(
+      final String balancerName, final Node node) {
     return new LoadBalancerProvider() {
       @Override
       public boolean isAvailable() {
@@ -114,7 +128,7 @@ final class LookasideLb extends ForwardingLoadBalancer {
       @Override
       public LoadBalancer newLoadBalancer(Helper helper) {
         return lookasideChannelLbFactory.newLoadBalancer(
-            helper, lookasideChannelCallback, balancerName);
+            helper, lookasideChannelCallback, balancerName, node);
       }
     };
   }
@@ -122,17 +136,20 @@ final class LookasideLb extends ForwardingLoadBalancer {
   @VisibleForTesting
   interface LookasideChannelLbFactory {
     LoadBalancer newLoadBalancer(
-        Helper helper, LookasideChannelCallback lookasideChannelCallback, String balancerName);
+        Helper helper, LookasideChannelCallback lookasideChannelCallback, String balancerName,
+        Node node);
   }
 
   private static final class LookasideChannelLbFactoryImpl implements LookasideChannelLbFactory {
 
     @Override
     public LoadBalancer newLoadBalancer(
-        Helper helper, LookasideChannelCallback lookasideChannelCallback, String balancerName) {
+        Helper helper, LookasideChannelCallback lookasideChannelCallback, String balancerName,
+        Node node) {
       return new LookasideChannelLb(
           helper, lookasideChannelCallback, initLbChannel(helper, balancerName),
-          new LocalityStoreImpl(helper, LoadBalancerRegistry.getDefaultRegistry()));
+          new LocalityStoreImpl(helper, LoadBalancerRegistry.getDefaultRegistry()),
+          node);
     }
 
     private static ManagedChannel initLbChannel(Helper helper, String balancerName) {

--- a/xds/src/main/java/io/grpc/xds/XdsComms2.java
+++ b/xds/src/main/java/io/grpc/xds/XdsComms2.java
@@ -22,8 +22,6 @@ import static com.google.common.base.Preconditions.checkState;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.Struct;
-import com.google.protobuf.Value;
 import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment;
 import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
 import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
@@ -49,6 +47,7 @@ final class XdsComms2 {
   private final Helper helper;
   private final BackoffPolicy.Provider backoffPolicyProvider;
   private final Supplier<Stopwatch> stopwatchSupplier;
+  private final Node node;
 
   @CheckForNull
   private ScheduledHandle adsRpcRetryTimer;
@@ -177,11 +176,7 @@ final class XdsComms2 {
       // Assuming standard mode, and send EDS request only
       DiscoveryRequest edsRequest =
           DiscoveryRequest.newBuilder()
-              .setNode(Node.newBuilder()
-                  .setMetadata(Struct.newBuilder()
-                      .putFields(
-                          "endpoints_required",
-                          Value.newBuilder().setBoolValue(true).build())))
+              .setNode(node)
               .setTypeUrl(EDS_TYPE_URL)
               // In the future, the right resource name can be obtained from CDS response.
               .addResourceNames(helper.getAuthority()).build();
@@ -209,10 +204,12 @@ final class XdsComms2 {
    */
   XdsComms2(
       ManagedChannel channel, Helper helper, AdsStreamCallback adsStreamCallback,
-      BackoffPolicy.Provider backoffPolicyProvider, Supplier<Stopwatch> stopwatchSupplier) {
+      BackoffPolicy.Provider backoffPolicyProvider, Supplier<Stopwatch> stopwatchSupplier,
+      Node node) {
     this.channel = checkNotNull(channel, "channel");
     this.helper = checkNotNull(helper, "helper");
     this.stopwatchSupplier = checkNotNull(stopwatchSupplier, "stopwatchSupplier");
+    this.node = node;
     this.adsStream = new AdsStream(
         checkNotNull(adsStreamCallback, "adsStreamCallback"));
     this.backoffPolicyProvider = checkNotNull(backoffPolicyProvider, "backoffPolicyProvider");

--- a/xds/src/main/java/io/grpc/xds/XdsComms2.java
+++ b/xds/src/main/java/io/grpc/xds/XdsComms2.java
@@ -47,6 +47,7 @@ final class XdsComms2 {
   private final Helper helper;
   private final BackoffPolicy.Provider backoffPolicyProvider;
   private final Supplier<Stopwatch> stopwatchSupplier;
+  // Metadata to be included in every xDS request.
   private final Node node;
 
   @CheckForNull

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -20,8 +20,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.protobuf.Struct;
-import com.google.protobuf.Value;
 import io.envoyproxy.envoy.api.v2.core.Node;
 import io.grpc.Attributes;
 import io.grpc.EquivalentAddressGroup;

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -49,7 +49,6 @@ final class XdsNameResolver extends NameResolver {
 
   private static final Logger logger = Logger.getLogger(XdsNameResolver.class.getName());
 
-  // This is temporary and is for demo purpose only.
   @NameResolver.ResolutionResultAttr
   static final Attributes.Key<Node> XDS_NODE = Attributes.Key.create("xds-node");
 
@@ -73,8 +72,6 @@ final class XdsNameResolver extends NameResolver {
             nameUri.getAuthority(), "nameUri (%s) doesn't have an authority", nameUri);
   }
 
-  // It's hard to make bootstrapper a final field and pass Bootstrapper.getInstance() to the
-  // constructor argument because Bootstrapper.getInstance() throws.
   void setBootstrapperForTest(Bootstrapper bootstrapper) {
     this.bootstrapper = bootstrapper;
   }
@@ -105,9 +102,6 @@ final class XdsNameResolver extends NameResolver {
     if (bootstrapper != null) {
       String serverUri = bootstrapper.getServerUri();
       node = bootstrapper.getNode();
-      // This is temporary and is for demo purpose only.
-      // The balancer_name is actually not needed in the future, serverUri will be used to create
-      // XdsClient directly.
       serviceConfig = "{"
           + "\"loadBalancingConfig\": ["
           + "{\"xds_experimental\" : {"
@@ -128,7 +122,6 @@ final class XdsNameResolver extends NameResolver {
     Attributes attrs =
         Attributes.newBuilder()
             .set(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG, config)
-            // This is temporary and is for demo purpose only.
             .set(XDS_NODE, node)
             .build();
     ResolutionResult result =

--- a/xds/src/test/java/io/grpc/xds/LookasideChannelLbTest.java
+++ b/xds/src/test/java/io/grpc/xds/LookasideChannelLbTest.java
@@ -38,6 +38,7 @@ import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
 import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
 import io.envoyproxy.envoy.api.v2.core.Address;
 import io.envoyproxy.envoy.api.v2.core.Locality;
+import io.envoyproxy.envoy.api.v2.core.Node;
 import io.envoyproxy.envoy.api.v2.core.SocketAddress;
 import io.envoyproxy.envoy.api.v2.endpoint.Endpoint;
 import io.envoyproxy.envoy.api.v2.endpoint.LbEndpoint;
@@ -169,7 +170,8 @@ public class LookasideChannelLbTest {
     doReturn(loadStatsStore).when(localityStore).getLoadStatsStore();
 
     lookasideChannelLb = new LookasideChannelLb(
-        helper, lookasideChannelCallback, channel, loadReportClient, localityStore);
+        helper, lookasideChannelCallback, channel, loadReportClient, localityStore,
+        Node.getDefaultInstance());
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
+++ b/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.google.common.collect.ImmutableList;
+import io.envoyproxy.envoy.api.v2.core.Node;
 import io.grpc.Attributes;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
@@ -55,11 +56,13 @@ public class LookasideLbTest {
       new LookasideChannelLbFactory() {
         @Override
         public LoadBalancer newLoadBalancer(
-            Helper helper, LookasideChannelCallback lookasideChannelCallback, String balancerName) {
+            Helper helper, LookasideChannelCallback lookasideChannelCallback, String balancerName,
+            Node node) {
           // just return a mock and record helper and balancer.
           helpers.add(helper);
           LoadBalancer balancer = mock(LoadBalancer.class);
           balancers.add(balancer);
+          assertThat(node).isNotNull();
           return balancer;
         }
       };

--- a/xds/src/test/java/io/grpc/xds/XdsCommsTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsCommsTest.java
@@ -37,6 +37,7 @@ import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
 import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
 import io.envoyproxy.envoy.api.v2.core.Address;
 import io.envoyproxy.envoy.api.v2.core.Locality;
+import io.envoyproxy.envoy.api.v2.core.Node;
 import io.envoyproxy.envoy.api.v2.core.SocketAddress;
 import io.envoyproxy.envoy.api.v2.endpoint.Endpoint;
 import io.envoyproxy.envoy.api.v2.endpoint.LbEndpoint;
@@ -184,7 +185,7 @@ public class XdsCommsTest {
     doReturn(20L, 200L).when(backoffPolicy2).nextBackoffNanos();
     xdsComms = new XdsComms2(
         channel, helper, adsStreamCallback, backoffPolicyProvider,
-        fakeClock.getStopwatchSupplier());
+        fakeClock.getStopwatchSupplier(), Node.getDefaultInstance());
   }
 
   @Test
@@ -207,9 +208,6 @@ public class XdsCommsTest {
     assertThat(streamRecorder.getValues()).hasSize(1);
     DiscoveryRequest request = streamRecorder.getValues().get(0);
     assertThat(request.getTypeUrl()).isEqualTo(EDS_TYPE_URL);
-    assertThat(
-            request.getNode().getMetadata().getFieldsOrThrow("endpoints_required").getBoolValue())
-        .isTrue();
     assertThat(request.getResourceNamesList()).hasSize(1);
 
     Locality localityProto1 = Locality.newBuilder()

--- a/xds/src/test/java/io/grpc/xds/XdsNamResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNamResolverTest.java
@@ -49,6 +49,8 @@ import org.mockito.junit.MockitoRule;
 /** Unit tests for {@link XdsNameResolver}. */
 @RunWith(JUnit4.class)
 public class XdsNamResolverTest {
+  private static final Node FAKE_BOOTSTRAP_NODE =
+      Node.newBuilder().setBuildVersion("fakeVer").build();
 
   @Rule public final MockitoRule mocks = MockitoJUnit.rule();
   
@@ -69,7 +71,6 @@ public class XdsNamResolverTest {
           .build();
 
   private final XdsNameResolverProvider provider = new XdsNameResolverProvider();
-  private static final Node bootstrapNode = Node.newBuilder().setBuildVersion("fakeVer").build();
 
   @Mock private NameResolver.Listener2 mockListener;
   @Captor private ArgumentCaptor<ResolutionResult> resultCaptor;
@@ -124,7 +125,7 @@ public class XdsNamResolverTest {
 
       @Override
       Node getNode() {
-        return bootstrapNode;
+        return FAKE_BOOTSTRAP_NODE;
       }
 
       @Override
@@ -177,6 +178,6 @@ public class XdsNamResolverTest {
             "childPolicy",
             Collections.singletonList(
                 Collections.singletonMap("round_robin", Collections.EMPTY_MAP)));
-    assertThat(actualResult.getAttributes().get(XDS_NODE)).isEqualTo(bootstrapNode);
+    assertThat(actualResult.getAttributes().get(XDS_NODE)).isEqualTo(FAKE_BOOTSTRAP_NODE);
   }
 }

--- a/xds/src/test/java/io/grpc/xds/XdsNamResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNamResolverTest.java
@@ -69,7 +69,7 @@ public class XdsNamResolverTest {
           .build();
 
   private final XdsNameResolverProvider provider = new XdsNameResolverProvider();
-  private static final Node bootstrapNode = Node.newBuilder().build();
+  private static final Node bootstrapNode = Node.newBuilder().setBuildVersion("fakeVer").build();
   private static final Bootstrapper bootstrapper = new Bootstrapper() {
     @Override
     String getServerUri() {

--- a/xds/src/test/java/io/grpc/xds/XdsNamResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNamResolverTest.java
@@ -70,22 +70,6 @@ public class XdsNamResolverTest {
 
   private final XdsNameResolverProvider provider = new XdsNameResolverProvider();
   private static final Node bootstrapNode = Node.newBuilder().setBuildVersion("fakeVer").build();
-  private static final Bootstrapper bootstrapper = new Bootstrapper() {
-    @Override
-    String getServerUri() {
-      return "fake_server_uri";
-    }
-
-    @Override
-    Node getNode() {
-      return bootstrapNode;
-    }
-
-    @Override
-    List<ChannelCreds> getChannelCredentials() {
-      return ImmutableList.of();
-    }
-  };
 
   @Mock private NameResolver.Listener2 mockListener;
   @Captor private ArgumentCaptor<ResolutionResult> resultCaptor;
@@ -132,6 +116,23 @@ public class XdsNamResolverTest {
 
   @Test
   public void resolve_bootstrapResult() {
+    Bootstrapper bootstrapper = new Bootstrapper() {
+      @Override
+      String getServerUri() {
+        return "fake_server_uri";
+      }
+
+      @Override
+      Node getNode() {
+        return bootstrapNode;
+      }
+
+      @Override
+      List<ChannelCreds> getChannelCredentials() {
+        return ImmutableList.of();
+      }
+    };
+
     XdsNameResolver resolver = new XdsNameResolver("foo.googleapis.com", bootstrapper);
     resolver.start(mockListener);
     verify(mockListener).onResult(resultCaptor.capture());

--- a/xds/src/test/java/io/grpc/xds/XdsNamResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNamResolverTest.java
@@ -176,6 +176,6 @@ public class XdsNamResolverTest {
             "childPolicy",
             Collections.singletonList(
                 Collections.singletonMap("round_robin", Collections.EMPTY_MAP)));
-    assertThat(actualResult.getAttributes().get(XDS_NODE)).isSameInstanceAs(bootstrapNode);
+    assertThat(actualResult.getAttributes().get(XDS_NODE)).isEqualTo(bootstrapNode);
   }
 }

--- a/xds/src/test/java/io/grpc/xds/XdsNamResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNamResolverTest.java
@@ -119,12 +119,12 @@ public class XdsNamResolverTest {
 
   @Test
   public void resolve_hardcodedResult() {
-    XdsNameResolver resolver = newResolver("foo.googleapis.com");
+    XdsNameResolver resolver = new XdsNameResolver("foo.googleapis.com", null);
     resolver.start(mockListener);
     verify(mockListener).onResult(resultCaptor.capture());
     assertHardCodedServiceConfig(resultCaptor.getValue());
 
-    resolver = newResolver("bar.googleapis.com");
+    resolver = new XdsNameResolver("bar.googleapis.com", null);
     resolver.start(mockListener);
     verify(mockListener, times(2)).onResult(resultCaptor.capture());
     assertHardCodedServiceConfig(resultCaptor.getValue());
@@ -132,14 +132,12 @@ public class XdsNamResolverTest {
 
   @Test
   public void resolve_bootstrapResult() {
-    XdsNameResolver resolver = newResolver("foo.googleapis.com");
-    resolver.setBootstrapperForTest(bootstrapper);
+    XdsNameResolver resolver = new XdsNameResolver("foo.googleapis.com", bootstrapper);
     resolver.start(mockListener);
     verify(mockListener).onResult(resultCaptor.capture());
     assertBootstrapServiceConfig(resultCaptor.getValue());
 
-    resolver = newResolver("bar.googleapis.com");
-    resolver.setBootstrapperForTest(bootstrapper);
+    resolver = new XdsNameResolver("bar.googleapis.com", bootstrapper);
     resolver.start(mockListener);
     verify(mockListener, times(2)).onResult(resultCaptor.capture());
     assertBootstrapServiceConfig(resultCaptor.getValue());
@@ -179,9 +177,5 @@ public class XdsNamResolverTest {
             Collections.singletonList(
                 Collections.singletonMap("round_robin", Collections.EMPTY_MAP)));
     assertThat(actualResult.getAttributes().get(XDS_NODE)).isSameInstanceAs(bootstrapNode);
-  }
-
-  private XdsNameResolver newResolver(String name) {
-    return new XdsNameResolver(name);
   }
 }


### PR DESCRIPTION
`XdsNameResolver` will load bootstrap file and populate `Node` reference to the `XdsLoadBalancer` through attributes of `ResolvedAddresses`. This is only for demo purpose until `XdsClient` is available, whence `XdsNameResolver` will populate `XdsClient` reference to `XdsLoadBalancer` through attributes instead.