### PR TITLE
xds: fix wrong json key balancerName

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -83,7 +83,7 @@ final class XdsNameResolver extends NameResolver {
       serviceConfig = "{"
           + "\"loadBalancingConfig\": ["
           + "{\"xds_experimental\" : {"
-          + "\"balancer_name\" : \"" + serverUri + "\","
+          + "\"balancerName\" : \"" + serverUri + "\","
           + "\"childPolicy\" : [{\"round_robin\" : {}}]"
           + "}}"
           + "]}";

--- a/xds/src/test/java/io/grpc/xds/XdsNamResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNamResolverTest.java
@@ -173,7 +173,7 @@ public class XdsNamResolverTest {
     Map<String, ?> rawConfigValues = (Map<String, ?>) xdsLbConfig.get("xds_experimental");
     assertThat(rawConfigValues)
         .containsExactly(
-            "balancer_name",
+            "balancerName",
             "fake_server_uri",
             "childPolicy",
             Collections.singletonList(

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -48,7 +48,7 @@ import org.mockito.junit.MockitoRule;
 
 /** Unit tests for {@link XdsNameResolver}. */
 @RunWith(JUnit4.class)
-public class XdsNamResolverTest {
+public class XdsNameResolverTest {
   private static final Node FAKE_BOOTSTRAP_NODE =
       Node.newBuilder().setBuildVersion("fakeVer").build();
 


### PR DESCRIPTION
The protobuf key balancer_name is corresponding to balancerName in json.