### PR TITLE
xds: only check authority not host for xds name resolver

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -16,10 +16,7 @@
 
 package io.grpc.xds;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import io.envoyproxy.envoy.api.v2.core.Node;
 import io.grpc.Attributes;
 import io.grpc.EquivalentAddressGroup;
@@ -28,7 +25,6 @@ import io.grpc.Status;
 import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.JsonParser;
 import java.io.IOException;
-import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
 import java.util.logging.Level;
@@ -62,17 +58,13 @@ final class XdsNameResolver extends NameResolver {
   private final String serviceConfig;
   private final Node node;
 
-  XdsNameResolver(String name) {
-    this(name, createBootstrapper());
+  XdsNameResolver(String authority) {
+    this(authority, createBootstrapper());
   }
 
   @VisibleForTesting
-  XdsNameResolver(String name, @Nullable Bootstrapper bootstrapper) {
-    URI nameUri = URI.create("//" + checkNotNull(name, "name"));
-    authority =
-        Preconditions.checkNotNull(
-            nameUri.getAuthority(), "nameUri (%s) doesn't have an authority", nameUri);
-
+  XdsNameResolver(String authority, @Nullable Bootstrapper bootstrapper) {
+    this.authority = authority;
     String serviceConfig = SERVICE_CONFIG_HARDCODED;
     Node node = Node.getDefaultInstance();
 

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -69,7 +69,6 @@ final class XdsNameResolver extends NameResolver {
   @VisibleForTesting
   XdsNameResolver(String name, @Nullable Bootstrapper bootstrapper) {
     URI nameUri = URI.create("//" + checkNotNull(name, "name"));
-    Preconditions.checkArgument(nameUri.getHost() != null, "Invalid hostname: %s", name);
     authority =
         Preconditions.checkNotNull(
             nameUri.getAuthority(), "nameUri (%s) doesn't have an authority", nameUri);

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
@@ -16,8 +16,6 @@
 
 package io.grpc.xds;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.base.Preconditions;
 import io.grpc.NameResolver.Args;
 import io.grpc.NameResolverProvider;
@@ -41,7 +39,7 @@ public final class XdsNameResolverProvider extends NameResolverProvider {
   @Override
   public XdsNameResolver newNameResolver(URI targetUri, Args args) {
     if (SCHEME.equals(targetUri.getScheme())) {
-      String targetPath = checkNotNull(targetUri.getPath(), "targetPath");
+      String targetPath = Preconditions.checkNotNull(targetUri.getPath(), "targetPath");
       Preconditions.checkArgument(
           targetPath.startsWith("/"),
           "the path component (%s) of the target (%s) must start with '/'",

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
@@ -16,6 +16,8 @@
 
 package io.grpc.xds;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.base.Preconditions;
 import io.grpc.NameResolver.Args;
 import io.grpc.NameResolverProvider;
@@ -39,14 +41,14 @@ public final class XdsNameResolverProvider extends NameResolverProvider {
   @Override
   public XdsNameResolver newNameResolver(URI targetUri, Args args) {
     if (SCHEME.equals(targetUri.getScheme())) {
-      String targetPath = Preconditions.checkNotNull(targetUri.getPath(), "targetPath");
+      String targetPath = checkNotNull(targetUri.getPath(), "targetPath");
       Preconditions.checkArgument(
           targetPath.startsWith("/"),
           "the path component (%s) of the target (%s) must start with '/'",
           targetPath,
           targetUri);
-      String name = targetPath.substring(1);
-      return new XdsNameResolver(name);
+      String authority = targetPath.substring(1);
+      return new XdsNameResolver(authority);
     }
     return null;
   }

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -31,6 +31,7 @@ import io.grpc.NameResolver.ServiceConfigParser;
 import io.grpc.SynchronizationContext;
 import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.GrpcUtil;
+import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -72,6 +73,23 @@ public class XdsNameResolverTest {
 
   @Mock private NameResolver.Listener2 mockListener;
   @Captor private ArgumentCaptor<ResolutionResult> resultCaptor;
+
+  @Test
+  public void validName_withAuthority() {
+    XdsNameResolver resolver =
+        provider.newNameResolver(
+            URI.create("xds-experimental://trafficdirector.google.com/foo.googleapis.com"), args);
+    assertThat(resolver).isNotNull();
+    assertThat(resolver.getServiceAuthority()).isEqualTo("foo.googleapis.com");
+  }
+
+  @Test
+  public void validName_noAuthority() {
+    XdsNameResolver resolver =
+        provider.newNameResolver(URI.create("xds-experimental:///foo.googleapis.com"), args);
+    assertThat(resolver).isNotNull();
+    assertThat(resolver.getServiceAuthority()).isEqualTo("foo.googleapis.com");
+  }
 
   @Test
   public void resolve_hardcodedResult() {

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -31,7 +31,6 @@ import io.grpc.NameResolver.ServiceConfigParser;
 import io.grpc.SynchronizationContext;
 import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.GrpcUtil;
-import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -73,23 +72,6 @@ public class XdsNameResolverTest {
 
   @Mock private NameResolver.Listener2 mockListener;
   @Captor private ArgumentCaptor<ResolutionResult> resultCaptor;
-
-  @Test
-  public void validName_withAuthority() {
-    XdsNameResolver resolver =
-        provider.newNameResolver(
-            URI.create("xds-experimental://trafficdirector.google.com/foo.googleapis.com"), args);
-    assertThat(resolver).isNotNull();
-    assertThat(resolver.getServiceAuthority()).isEqualTo("foo.googleapis.com");
-  }
-
-  @Test
-  public void validName_noAuthority() {
-    XdsNameResolver resolver =
-        provider.newNameResolver(URI.create("xds-experimental:///foo.googleapis.com"), args);
-    assertThat(resolver).isNotNull();
-    assertThat(resolver.getServiceAuthority()).isEqualTo("foo.googleapis.com");
-  }
 
   @Test
   public void resolve_hardcodedResult() {

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -18,7 +18,6 @@ package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.xds.XdsNameResolver.XDS_NODE;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -90,16 +89,6 @@ public class XdsNameResolverTest {
         provider.newNameResolver(URI.create("xds-experimental:///foo.googleapis.com"), args);
     assertThat(resolver).isNotNull();
     assertThat(resolver.getServiceAuthority()).isEqualTo("foo.googleapis.com");
-  }
-
-  @Test
-  public void invalidName_hostnameContainsUnderscore() {
-    try {
-      provider.newNameResolver(URI.create("xds-experimental:///foo_bar.googleapis.com"), args);
-      fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) {
-      // Expected
-    }
   }
 
   @Test


### PR DESCRIPTION
Our backend address used in the demo env on GCP does not have a valid host value, all we need seems a valid authority.