### PR TITLE
bazel: Support --incompatible_load_proto_rules_from_bzl

### DIFF
--- a/alts/BUILD.bazel
+++ b/alts/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("//:java_grpc_library.bzl", "java_grpc_library")
 
 java_library(

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
 
 proto_library(
@@ -71,7 +72,7 @@ java_library(
         ":route_guide_java_proto",
         "@com_google_api_grpc_proto_google_common_protos//jar",
         "@com_google_code_findbugs_jsr305//jar",
-        "@com_google_code_gson_gson//:com_google_code_gson_gson",
+        "@com_google_code_gson_gson",
         "@com_google_guava_guava//jar",
         "@com_google_protobuf//:protobuf_java",
         "@com_google_protobuf//:protobuf_java_util",

--- a/examples/example-alts/BUILD.bazel
+++ b/examples/example-alts/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
 
 proto_library(

--- a/examples/example-tls/BUILD.bazel
+++ b/examples/example-tls/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
 
 proto_library(

--- a/grpclb/BUILD.bazel
+++ b/grpclb/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("//:java_grpc_library.bzl", "java_grpc_library")
 
 java_library(

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -316,9 +316,9 @@ def com_squareup_okio():
 def io_grpc_grpc_proto():
     http_archive(
         name = "io_grpc_grpc_proto",
-        sha256 = "873f3fdec7ed052f899aef83fc897926729713d96d7ccdb2df22843dc702ef3a",
-        strip_prefix = "grpc-proto-96ecba6941c67b1da2af598330c60cf9b0336051",
-        urls = ["https://github.com/grpc/grpc-proto/archive/96ecba6941c67b1da2af598330c60cf9b0336051.zip"],
+        sha256 = "9d96f861f01ed9e3d805024e72a6b218b626da2114c69c1cad5d0e967c8e23be",
+        strip_prefix = "grpc-proto-435d723289d348e1bc420d420b364369d565182a",
+        urls = ["https://github.com/grpc/grpc-proto/archive/435d723289d348e1bc420d420b364369d565182a.zip"],
     )
 
 def io_netty_buffer():

--- a/services/src/main/proto/grpc/channelz/v1/channelz.proto
+++ b/services/src/main/proto/grpc/channelz/v1/channelz.proto
@@ -165,7 +165,7 @@ message ChannelRef {
   reserved 3, 4, 5, 6, 7, 8;
 }
 
-// ChannelRef is a reference to a Subchannel.
+// SubchannelRef is a reference to a Subchannel.
 message SubchannelRef {
   // The globally unique id for this subchannel.  Must be a positive number.
   int64 subchannel_id = 7;


### PR DESCRIPTION
This flag will be enabled by default in Bazel 1.0

Since I changed the grpc-proto repo version for Bazel, I also synced the
protos.