### PR TITLE
Revert "all: remove deprecated usePlaintext(boolean)"

### DIFF
--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -95,6 +95,16 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
     return thisT();
   }
 
+  /**
+   * @deprecated use {@link #usePlaintext()} instead.
+   */
+  @Override
+  @Deprecated
+  public T usePlaintext(boolean skipNegotiation) {
+    delegate().usePlaintext(skipNegotiation);
+    return thisT();
+  }
+
   @Override
   public T usePlaintext() {
     delegate().usePlaintext();

--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -157,6 +157,27 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * <p>Should only be used for testing or for APIs where the use of such API or the data
    * exchanged is not sensitive.
    *
+   * @param skipNegotiation @{code true} if there is a priori knowledge that the endpoint supports
+   *                        plaintext, {@code false} if plaintext use must be negotiated.
+   * @deprecated Use {@link #usePlaintext()} instead.
+   *
+   * @throws UnsupportedOperationException if plaintext mode is not supported.
+   * @return this
+   * @since 1.0.0
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1772")
+  @Deprecated
+  public T usePlaintext(boolean skipNegotiation) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Use of a plaintext connection to the server. By default a secure connection mechanism
+   * such as TLS will be used.
+   *
+   * <p>Should only be used for testing or for APIs where the use of such API or the data
+   * exchanged is not sensitive.
+   *
    * <p>This assumes prior knowledge that the target of this channel is using plaintext.  It will
    * not perform HTTP/1.1 upgrades.
    *

--- a/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -96,6 +96,17 @@ public final class InProcessChannelBuilder extends
 
   /**
    * Does nothing.
+   *
+   * @deprecated use {@link #usePlaintext()} instead.
+   */
+  @Override
+  @Deprecated
+  public InProcessChannelBuilder usePlaintext(boolean skipNegotiation) {
+    return this;
+  }
+
+  /**
+   * Does nothing.
    */
   @Override
   public InProcessChannelBuilder usePlaintext() {

--- a/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
@@ -128,6 +128,14 @@ public final class CronetChannelBuilder extends
   }
 
   /**
+   * Not supported for building cronet channel.
+   */
+  @Override
+  public final CronetChannelBuilder usePlaintext(boolean skipNegotiation) {
+    throw new IllegalArgumentException("Plaintext not currently supported");
+  }
+
+  /**
    * Sets {@link android.net.TrafficStats} tag to use when accounting socket traffic caused by this
    * channel. See {@link android.net.TrafficStats} for more information. If no tag is set (e.g. this
    * method isn't called), then Android accounts for the socket traffic caused by this channel as if

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -286,6 +286,23 @@ public final class NettyChannelBuilder
   }
 
   /**
+   * Equivalent to using {@link #negotiationType(NegotiationType)} with {@code PLAINTEXT} or
+   * {@code PLAINTEXT_UPGRADE}.
+   *
+   * @deprecated use {@link #usePlaintext()} instead.
+   */
+  @Override
+  @Deprecated
+  public NettyChannelBuilder usePlaintext(boolean skipNegotiation) {
+    if (skipNegotiation) {
+      negotiationType(NegotiationType.PLAINTEXT);
+    } else {
+      negotiationType(NegotiationType.PLAINTEXT_UPGRADE);
+    }
+    return this;
+  }
+
+  /**
    * Equivalent to using {@link #negotiationType(NegotiationType)} with {@code PLAINTEXT}.
    */
   @Override

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -305,6 +305,22 @@ public class OkHttpChannelBuilder extends
     return this;
   }
 
+  /**
+   * Equivalent to using {@link #negotiationType} with {@code PLAINTEXT}.
+   *
+   * @deprecated use {@link #usePlaintext()} instead.
+   */
+  @Override
+  @Deprecated
+  public final OkHttpChannelBuilder usePlaintext(boolean skipNegotiation) {
+    if (skipNegotiation) {
+      negotiationType(io.grpc.okhttp.NegotiationType.PLAINTEXT);
+    } else {
+      throw new IllegalArgumentException("Plaintext negotiation not currently supported");
+    }
+    return this;
+  }
+
   /** Sets the negotiation type for the HTTP/2 connection to plaintext. */
   @Override
   public final OkHttpChannelBuilder usePlaintext() {


### PR DESCRIPTION
This reverts commit 296857b4e7a5bb6b5fe367ca6e9ac401dc134a38.

Revert because there are still some internal usages.