### PR TITLE
protobuf: StatusProto#fromStatusAndTrailers fall-back use status

### DIFF
--- a/protobuf/src/main/java/io/grpc/protobuf/StatusProto.java
+++ b/protobuf/src/main/java/io/grpc/protobuf/StatusProto.java
@@ -148,7 +148,8 @@ public final class StatusProto {
 
   /**
    * Extracts the google.rpc.Status from trailers, and makes sure they match the gRPC
-   * {@code status}.
+   * {@code status}. If the trailers doesn't contain status entry, it uses {@code status} param to
+   * generate status.
    *
    * @return the embedded google.rpc.Status or {@code null} if it is not present.
    * @since 1.11.0
@@ -163,6 +164,15 @@ public final class StatusProto {
             "com.google.rpc.Status code must match gRPC status code");
         return statusProto;
       }
+    }
+    // fall-back to status, this is useful if the error is local. e.g. Server is unavailable.
+    if (status != null) {
+      com.google.rpc.Status.Builder statusBuilder = com.google.rpc.Status.newBuilder()
+          .setCode(status.getCode().value());
+      if (status.getDescription() != null) {
+        statusBuilder.setMessage(status.getDescription());
+      }
+      return statusBuilder.build();
     }
     return null;
   }

--- a/protobuf/src/main/java/io/grpc/protobuf/StatusProto.java
+++ b/protobuf/src/main/java/io/grpc/protobuf/StatusProto.java
@@ -151,11 +151,12 @@ public final class StatusProto {
    * {@code status}. If the trailers do not contain a {@code google.rpc.Status}, it uses
    * {@code status} param to generate a {@code google.rpc.Status}.
    *
-   * @return the embedded google.rpc.Status or {@code null} if it is not present.
+   * @return the embedded google.rpc.Status
    * @since 1.11.0
    */
-  @Nullable
-  public static com.google.rpc.Status fromStatusAndTrailers(Status status, Metadata trailers) {
+  public static com.google.rpc.Status fromStatusAndTrailers(
+      Status status, @Nullable Metadata trailers) {
+    checkNotNull(status, "status");
     if (trailers != null) {
       com.google.rpc.Status statusProto = trailers.get(STATUS_DETAILS_KEY);
       if (statusProto != null) {
@@ -166,14 +167,11 @@ public final class StatusProto {
       }
     }
     // fall-back to status, this is useful if the error is local. e.g. Server is unavailable.
-    if (status != null) {
-      com.google.rpc.Status.Builder statusBuilder = com.google.rpc.Status.newBuilder()
-          .setCode(status.getCode().value());
-      if (status.getDescription() != null) {
-        statusBuilder.setMessage(status.getDescription());
-      }
-      return statusBuilder.build();
+    com.google.rpc.Status.Builder statusBuilder = com.google.rpc.Status.newBuilder()
+        .setCode(status.getCode().value());
+    if (status.getDescription() != null) {
+      statusBuilder.setMessage(status.getDescription());
     }
-    return null;
+    return statusBuilder.build();
   }
 }

--- a/protobuf/src/main/java/io/grpc/protobuf/StatusProto.java
+++ b/protobuf/src/main/java/io/grpc/protobuf/StatusProto.java
@@ -147,9 +147,9 @@ public final class StatusProto {
   }
 
   /**
-   * Extracts the google.rpc.Status from trailers, and makes sure they match the gRPC
-   * {@code status}. If the trailers doesn't contain status entry, it uses {@code status} param to
-   * generate status.
+   * Extracts the {@code google.rpc.Status} from trailers, and makes sure they match the gRPC
+   * {@code status}. If the trailers do not contain a {@code google.rpc.Status}, it uses
+   * {@code status} param to generate a {@code google.rpc.Status}.
    *
    * @return the embedded google.rpc.Status or {@code null} if it is not present.
    * @since 1.11.0

--- a/protobuf/src/test/java/io/grpc/protobuf/StatusProtoTest.java
+++ b/protobuf/src/test/java/io/grpc/protobuf/StatusProtoTest.java
@@ -126,20 +126,25 @@ public class StatusProtoTest {
   }
 
   @Test
-  public void fromThrowable_shouldReturnNullIfTrailersAreNull() {
-    Status status = Status.fromCodeValue(0);
+  public void fromThrowable_runtimeException_shouldReturnDerivedStatusIfTrailersAreNull() {
+    Status status = Status.UNAVAILABLE.withDescription("not available");
 
-    assertNull(StatusProto.fromThrowable(status.asRuntimeException()));
-    assertNull(StatusProto.fromThrowable(status.asException()));
+    com.google.rpc.Status statusFromThrowable =
+        StatusProto.fromThrowable(status.asRuntimeException());
+
+    assertEquals(statusFromThrowable.getCode(), status.getCode().value());
+    assertEquals(statusFromThrowable.getMessage(), status.getDescription());
   }
 
   @Test
-  public void fromThrowable_shouldReturnNullIfStatusDetailsKeyIsMissing() {
-    Status status = Status.fromCodeValue(0);
-    Metadata emptyMetadata = new Metadata();
+  public void fromThrowable_exception_shouldReturnDerivedStatusIfTrailersAreNull() {
+    Status status = Status.UNAVAILABLE.withDescription("not available");
 
-    assertNull(StatusProto.fromThrowable(status.asRuntimeException(emptyMetadata)));
-    assertNull(StatusProto.fromThrowable(status.asException(emptyMetadata)));
+    com.google.rpc.Status statusFromThrowable =
+        StatusProto.fromThrowable(status.asException());
+
+    assertEquals(statusFromThrowable.getCode(), status.getCode().value());
+    assertEquals(statusFromThrowable.getMessage(), status.getDescription());
   }
 
   @Test


### PR DESCRIPTION

the original intention was only generating Status proto from trailers. In actual use cases requires to handle null and derive the Status proto from status. The main reason is there are few cases when the server doesn't send trailers such as server UNREACHABLE, UNAVAILABLE or DEADLINE_EXCEEDED.