### PR TITLE
travis: Upgrade from trusty to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,10 @@ after_success:
 os:
   - linux
 
-dist: trusty
+dist: xenial
 
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk11
 
 notifications:


### PR DESCRIPTION
In 97cb0554 we pinned ourselves to trusty to workaround temporary Java 8
issues. Oracle JDK 8 is "dead" across the ecosystem because Oracle
removed download links to it, so we swap to openjdk 8 as we have done
elsewhere.  OpenJDK 8 is supported with xenial, so we can upgrade.

Unfortunately bionic on Travis does not include openjdk8, so we will be
unable to easily upgrade to newer versions of the distro unless we drop
JDK 8 compilation or we figure out a way to get it working. For example,
in may be possible to install the openjdk-8-jdk package.