### PR TITLE
xds: add fields for EDS server and LRS server in XdsConfig

### DIFF
--- a/core/src/main/java/io/grpc/internal/ServiceConfigUtil.java
+++ b/core/src/main/java/io/grpc/internal/ServiceConfigUtil.java
@@ -48,9 +48,12 @@ public final class ServiceConfigUtil {
   private static final String SERVICE_CONFIG_METHOD_CONFIG_KEY = "methodConfig";
   private static final String SERVICE_CONFIG_LOAD_BALANCING_POLICY_KEY = "loadBalancingPolicy";
   private static final String SERVICE_CONFIG_LOAD_BALANCING_CONFIG_KEY = "loadBalancingConfig";
+  // TODO(chengyuanzhang): delete this key after shifting to use bootstrap.
   private static final String XDS_CONFIG_BALANCER_NAME_KEY = "balancerName";
   private static final String XDS_CONFIG_CHILD_POLICY_KEY = "childPolicy";
   private static final String XDS_CONFIG_FALLBACK_POLICY_KEY = "fallbackPolicy";
+  private static final String XDS_CONFIG_EDS_SERVICE_NAME = "edsServiceName";
+  private static final String XDS_CONFIG_LRS_SERVER_NAME = "lrsLoadReportingServerName";
   private static final String SERVICE_CONFIG_STICKINESS_METADATA_KEY = "stickinessMetadataKey";
   private static final String METHOD_CONFIG_NAME_KEY = "name";
   private static final String METHOD_CONFIG_TIMEOUT_KEY = "timeout";
@@ -423,8 +426,25 @@ public final class ServiceConfigUtil {
   /**
    * Extracts the loadbalancer name from xds loadbalancer config.
    */
+  // TODO(chengyuanzhang): delete after shifting to use bootstrap.
   public static String getBalancerNameFromXdsConfig(Map<String, ?> rawXdsConfig) {
     return JsonUtil.getString(rawXdsConfig, XDS_CONFIG_BALANCER_NAME_KEY);
+  }
+
+  /**
+   * Extract the server name to use in EDS query.
+   */
+  @Nullable
+  public static String getEdsServiceNameFromXdsConfig(Map<String, ?> rawXdsConfig) {
+    return JsonUtil.getString(rawXdsConfig, XDS_CONFIG_EDS_SERVICE_NAME);
+  }
+
+  /**
+   * Extract the LRS server name to send load reports to.
+   */
+  @Nullable
+  public static String getLrsServerNameFromXdsConfig(Map<String, ?> rawXdsConfig) {
+    return JsonUtil.getString(rawXdsConfig, XDS_CONFIG_LRS_SERVER_NAME);
   }
 
   /**

--- a/core/src/test/java/io/grpc/internal/ServiceConfigUtilTest.java
+++ b/core/src/test/java/io/grpc/internal/ServiceConfigUtilTest.java
@@ -107,6 +107,60 @@ public class ServiceConfigUtilTest {
   }
 
   @Test
+  public void getEdsServiceNameFromXdsConfig() throws Exception {
+    String rawLbConfig = "{"
+        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
+        + "\"childPolicy\" : [{\"round_robin\" : {}}, {\"lbPolicy2\" : {\"key\" : \"val\"}}],"
+        + "\"fallbackPolicy\" : [{\"lbPolicy3\" : {\"key\" : \"val\"}}, {\"lbPolicy4\" : {}}],"
+        + "\"edsServiceName\" : \"dns:///eds.service.com:8080\""
+        + "}";
+
+    String edsServiceName = ServiceConfigUtil.getEdsServiceNameFromXdsConfig(
+        checkObject(JsonParser.parse(rawLbConfig)));
+    assertThat(edsServiceName).isEqualTo("dns:///eds.service.com:8080");
+  }
+
+  @Test
+  public void getEdsServiceNameFromXdsConfig_null() throws Exception {
+    String rawLbConfig = "{"
+        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
+        + "\"childPolicy\" : [{\"round_robin\" : {}}, {\"lbPolicy2\" : {\"key\" : \"val\"}}],"
+        + "\"fallbackPolicy\" : [{\"lbPolicy3\" : {\"key\" : \"val\"}}, {\"lbPolicy4\" : {}}]"
+        + "}";
+
+    String edsServiceName = ServiceConfigUtil.getEdsServiceNameFromXdsConfig(
+        checkObject(JsonParser.parse(rawLbConfig)));
+    assertThat(edsServiceName).isNull();
+  }
+
+  @Test
+  public void getLrsServerNameFromXdsConfig() throws Exception {
+    String rawLbConfig = "{"
+        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
+        + "\"childPolicy\" : [{\"round_robin\" : {}}, {\"lbPolicy2\" : {\"key\" : \"val\"}}],"
+        + "\"fallbackPolicy\" : [{\"lbPolicy3\" : {\"key\" : \"val\"}}, {\"lbPolicy4\" : {}}],"
+        + "\"lrsLoadReportingServerName\" : \"dns:///lrs.service.com:8080\""
+        + "}";
+
+    String lrsServerName = ServiceConfigUtil.getLrsServerNameFromXdsConfig(
+        checkObject(JsonParser.parse(rawLbConfig)));
+    assertThat(lrsServerName).isEqualTo("dns:///lrs.service.com:8080");
+  }
+
+  @Test
+  public void getLrsServerNameFromXdsConfig_null() throws Exception {
+    String rawLbConfig = "{"
+        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
+        + "\"childPolicy\" : [{\"round_robin\" : {}}, {\"lbPolicy2\" : {\"key\" : \"val\"}}],"
+        + "\"fallbackPolicy\" : [{\"lbPolicy3\" : {\"key\" : \"val\"}}, {\"lbPolicy4\" : {}}]"
+        + "}";
+
+    String lrsServerName = ServiceConfigUtil.getLrsServerNameFromXdsConfig(
+        checkObject(JsonParser.parse(rawLbConfig)));
+    assertThat(lrsServerName).isNull();
+  }
+
+  @Test
   public void unwrapLoadBalancingConfig() throws Exception {
     String lbConfig = "{\"xds_experimental\" : { "
         + "\"balancerName\" : \"dns:///balancer.example.com:8080\","

--- a/xds/src/test/java/io/grpc/xds/XdsLoadBalancerProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadBalancerProviderTest.java
@@ -161,7 +161,9 @@ public class XdsLoadBalancerProviderTest {
         + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
         + "\"childPolicy\" : [{\"lbPolicy3\" : {\"key\" : \"val\"}}, {\"supported_1\" : {}}],"
         + "\"fallbackPolicy\" : [{\"unsupported\" : {}}, {\"round_robin\" : {\"key\" : \"val\"}},"
-        + "{\"supported_2\" : {\"key\" : \"val\"}}]"
+        + "{\"supported_2\" : {\"key\" : \"val\"}}],"
+        + "\"edsServiceName\" : \"dns:///eds.service.com:8080\","
+        + "\"lrsLoadReportingServerName\" : \"dns:///lrs.service.com:8080\""
         + "}";
     Map<String, ?> rawlbConfigMap = checkObject(JsonParser.parse(rawLbConfig));
     ConfigOrError configOrError =
@@ -175,7 +177,9 @@ public class XdsLoadBalancerProviderTest {
             ServiceConfigUtil.unwrapLoadBalancingConfig(
                 checkObject(JsonParser.parse("{\"supported_1\" : {}}"))),
             ServiceConfigUtil.unwrapLoadBalancingConfig(
-                checkObject(JsonParser.parse("{\"round_robin\" : {\"key\" : \"val\"}}"))))
+                checkObject(JsonParser.parse("{\"round_robin\" : {\"key\" : \"val\"}}"))),
+            "dns:///eds.service.com:8080",
+            "dns:///lrs.service.com:8080")
     );
   }
 


### PR DESCRIPTION
Based on changed in cl/273761393. xDS LB policy config proto will contain two new fields:

- `eds_service_name` field, so that the CDS policy can tell the EDS
  policy what name to use in the EDS query.  (For backward
  compatibility, if this field is not set, it will default to the server
  name from the channel's target URI.)

- `lrs_load_reporting_server_name` field to indicate whether LRS load
  reporting should be enabled.

TODO: shift to use bootstrap (even though `xdsClient` has not been implemented, internal integration test is ready) and remove `balancer_name` field from `XdsConfig`.

TODO: add `CdsConfig` message for cds policy.