### PR TITLE
xds: update envoy proto version to f709434b37e9ff74666d5b854aa11fb2f1ec37f3

### DIFF
--- a/xds/third_party/envoy/NOTICE
+++ b/xds/third_party/envoy/NOTICE
@@ -1,4 +1,4 @@
 Envoy
-Copyright 2016-2018 Envoy Project Authors
+Copyright 2016-2019 Envoy Project Authors
 
 Licensed under Apache License 2.0.  See LICENSE for terms.

--- a/xds/third_party/envoy/import.sh
+++ b/xds/third_party/envoy/import.sh
@@ -18,7 +18,7 @@
 set -e
 BRANCH=master
 # import VERSION from one of the google internal CLs
-VERSION=6ff0bce8ff417a252cde4d04dfb9cba2bab463d8
+VERSION=f709434b37e9ff74666d5b854aa11fb2f1ec37f3
 GIT_REPO="https://github.com/envoyproxy/envoy.git"
 GIT_BASE_DIR=envoy
 SOURCE_PROTO_BASE_DIR=envoy/api

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/auth/cert.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/auth/cert.proto
@@ -5,7 +5,6 @@ package envoy.api.v2.auth;
 option java_outer_classname = "CertProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.api.v2.auth";
-option go_package = "auth";
 
 import "envoy/api/v2/core/base.proto";
 import "envoy/api/v2/core/config_source.proto";
@@ -15,9 +14,6 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Common TLS configuration]
 
@@ -40,11 +36,11 @@ message TlsParameters {
   }
 
   // Minimum TLS protocol version. By default, it's ``TLSv1_0``.
-  TlsProtocol tls_minimum_protocol_version = 1 [(validate.rules).enum.defined_only = true];
+  TlsProtocol tls_minimum_protocol_version = 1 [(validate.rules).enum = {defined_only: true}];
 
   // Maximum TLS protocol version. By default, it's ``TLSv1_3`` for servers in non-FIPS builds, and
   // ``TLSv1_2`` for clients and for servers using :ref:`BoringSSL FIPS <arch_overview_ssl_fips>`.
-  TlsProtocol tls_maximum_protocol_version = 2 [(validate.rules).enum.defined_only = true];
+  TlsProtocol tls_maximum_protocol_version = 2 [(validate.rules).enum = {defined_only: true}];
 
   // If specified, the TLS listener will only support the specified `cipher list
   // <https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#Cipher-suite-configuration>`_
@@ -110,7 +106,7 @@ message TlsParameters {
 message PrivateKeyProvider {
   // Private key method provider name. The name must match a
   // supported private key method provider type.
-  string provider_name = 1 [(validate.rules).string.min_bytes = 1];
+  string provider_name = 1 [(validate.rules).string = {min_bytes: 1}];
 
   // Private key method provider specific configuration.
   oneof config_type {
@@ -171,7 +167,7 @@ message TlsSessionTicketKeys {
   //   * Keep the session ticket keys at least as secure as your TLS certificate private keys
   //   * Rotate session ticket keys at least daily, and preferably hourly
   //   * Always generate keys using a cryptographically-secure random data source
-  repeated core.DataSource keys = 1 [(validate.rules).repeated .min_items = 1];
+  repeated core.DataSource keys = 1 [(validate.rules).repeated = {min_items: 1}];
 }
 
 message CertificateValidationContext {
@@ -205,9 +201,9 @@ message CertificateValidationContext {
   //
   // .. code-block:: bash
   //
-  //   $ openssl x509 -in path/to/client.crt -noout -pubkey \
-  //     | openssl pkey -pubin -outform DER \
-  //     | openssl dgst -sha256 -binary \
+  //   $ openssl x509 -in path/to/client.crt -noout -pubkey
+  //     | openssl pkey -pubin -outform DER
+  //     | openssl dgst -sha256 -binary
   //     | openssl enc -base64
   //   NvqYIYSbgK2vCJpQhObf77vv+bQWtc5ek5RIOwPiC9A=
   //
@@ -227,7 +223,7 @@ message CertificateValidationContext {
   //   because SPKI is tied to a private key, so it doesn't change when the certificate
   //   is renewed using the same private key.
   repeated string verify_certificate_spki = 3
-      [(validate.rules).repeated .items.string = {min_bytes: 44, max_bytes: 44}];
+      [(validate.rules).repeated = {items {string {min_bytes: 44 max_bytes: 44}}}];
 
   // An optional list of hex-encoded SHA-256 hashes. If specified, Envoy will verify that
   // the SHA-256 of the DER-encoded presented certificate matches one of the specified values.
@@ -256,7 +252,7 @@ message CertificateValidationContext {
   // <envoy_api_field_auth.CertificateValidationContext.verify_certificate_spki>` are specified,
   // a hash matching value from either of the lists will result in the certificate being accepted.
   repeated string verify_certificate_hash = 2
-      [(validate.rules).repeated .items.string = {min_bytes: 64, max_bytes: 95}];
+      [(validate.rules).repeated = {items {string {min_bytes: 64 max_bytes: 95}}}];
 
   // An optional list of Subject Alternative Names. If specified, Envoy will verify that the
   // Subject Alternative Name of the presented certificate matches one of the specified values.
@@ -287,6 +283,18 @@ message CertificateValidationContext {
 
 // TLS context shared by both client and server TLS contexts.
 message CommonTlsContext {
+  message CombinedCertificateValidationContext {
+    // How to validate peer certificates.
+    CertificateValidationContext default_validation_context = 1
+        [(validate.rules).message = {required: true}];
+
+    // Config for fetching validation context via SDS API.
+    SdsSecretConfig validation_context_sds_secret_config = 2
+        [(validate.rules).message = {required: true}];
+  }
+
+  reserved 5;
+
   // TLS protocol versions, cipher suites etc.
   TlsParameters tls_params = 1;
 
@@ -300,17 +308,7 @@ message CommonTlsContext {
 
   // Configs for fetching TLS certificates via SDS API.
   repeated SdsSecretConfig tls_certificate_sds_secret_configs = 6
-      [(validate.rules).repeated .max_items = 1];
-
-  message CombinedCertificateValidationContext {
-    // How to validate peer certificates.
-    CertificateValidationContext default_validation_context = 1
-        [(validate.rules).message.required = true];
-
-    // Config for fetching validation context via SDS API.
-    SdsSecretConfig validation_context_sds_secret_config = 2
-        [(validate.rules).message.required = true];
-  };
+      [(validate.rules).repeated = {max_items: 1}];
 
   oneof validation_context_type {
     // How to validate peer certificates.
@@ -340,8 +338,6 @@ message CommonTlsContext {
   //
   // There is no default for this parameter. If empty, Envoy will not expose ALPN.
   repeated string alpn_protocols = 4;
-
-  reserved 5;
 }
 
 message UpstreamTlsContext {
@@ -349,7 +345,7 @@ message UpstreamTlsContext {
   CommonTlsContext common_tls_context = 1;
 
   // SNI string to use when creating TLS backend connections.
-  string sni = 2 [(validate.rules).string.max_bytes = 255];
+  string sni = 2 [(validate.rules).string = {max_bytes: 255}];
 
   // If true, server-initiated TLS renegotiation will be allowed.
   //
@@ -386,22 +382,25 @@ message DownstreamTlsContext {
   }
 }
 
-// [#proto-status: experimental]
 message SdsSecretConfig {
   // Name (FQDN, UUID, SPKI, SHA256, etc.) by which the secret can be uniquely referred to.
   // When both name and config are specified, then secret can be fetched and/or reloaded via SDS.
-  // When only name is specified, then secret will be loaded from static resources [V2-API-DIFF].
+  // When only name is specified, then secret will be loaded from static
+  // resources.
   string name = 1;
+
   core.ConfigSource sds_config = 2;
 }
 
-// [#proto-status: experimental]
 message Secret {
   // Name (FQDN, UUID, SPKI, SHA256, etc.) by which the secret can be uniquely referred to.
   string name = 1;
+
   oneof type {
     TlsCertificate tls_certificate = 2;
+
     TlsSessionTicketKeys session_ticket_keys = 3;
+
     CertificateValidationContext validation_context = 4;
   }
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/address.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/address.proto
@@ -11,9 +11,6 @@ import "envoy/api/v2/core/base.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Network addresses]
 
@@ -22,17 +19,19 @@ message Pipe {
   // abstract namespace. The starting '@' is replaced by a null byte by Envoy.
   // Paths starting with '@' will result in an error in environments other than
   // Linux.
-  string path = 1 [(validate.rules).string.min_bytes = 1];
+  string path = 1 [(validate.rules).string = {min_bytes: 1}];
 }
 
 message SocketAddress {
   enum Protocol {
-    option (gogoproto.goproto_enum_prefix) = false;
     TCP = 0;
+
     // [#not-implemented-hide:]
     UDP = 1;
   }
-  Protocol protocol = 1 [(validate.rules).enum.defined_only = true];
+
+  Protocol protocol = 1 [(validate.rules).enum = {defined_only: true}];
+
   // The address for this socket. :ref:`Listeners <config_listeners>` will bind
   // to the address. An empty address is not allowed. Specify ``0.0.0.0`` or ``::``
   // to bind to any address. [#comment:TODO(zuercher) reinstate when implemented:
@@ -44,15 +43,19 @@ message SocketAddress {
   // address must be an IP (*STATIC* or *EDS* clusters) or a hostname resolved by DNS
   // (*STRICT_DNS* or *LOGICAL_DNS* clusters). Address resolution can be customized
   // via :ref:`resolver_name <envoy_api_field_core.SocketAddress.resolver_name>`.
-  string address = 2 [(validate.rules).string.min_bytes = 1];
+  string address = 2 [(validate.rules).string = {min_bytes: 1}];
+
   oneof port_specifier {
     option (validate.required) = true;
-    uint32 port_value = 3 [(validate.rules).uint32.lte = 65535];
+
+    uint32 port_value = 3 [(validate.rules).uint32 = {lte: 65535}];
+
     // This is only valid if :ref:`resolver_name
     // <envoy_api_field_core.SocketAddress.resolver_name>` is specified below and the
     // named resolver is capable of named port resolution.
     string named_port = 4;
   }
+
   // The name of the custom resolver. This must have been registered with Envoy. If
   // this is empty, a context dependent default applies. If the address is a concrete
   // IP address, no resolution will occur. If address is a hostname this
@@ -72,10 +75,12 @@ message TcpKeepalive {
   // the connection is dead. Default is to use the OS level configuration (unless
   // overridden, Linux defaults to 9.)
   google.protobuf.UInt32Value keepalive_probes = 1;
+
   // The number of seconds a connection needs to be idle before keep-alive probes
   // start being sent. Default is to use the OS level configuration (unless
   // overridden, Linux defaults to 7200s (ie 2 hours.)
   google.protobuf.UInt32Value keepalive_time = 2;
+
   // The number of seconds between keep-alive probes. Default is to use the OS
   // level configuration (unless overridden, Linux defaults to 75s.)
   google.protobuf.UInt32Value keepalive_interval = 3;
@@ -83,7 +88,7 @@ message TcpKeepalive {
 
 message BindConfig {
   // The address to bind to when creating a socket.
-  SocketAddress source_address = 1 [(validate.rules).message.required = true];
+  SocketAddress source_address = 1 [(validate.rules).message = {required: true}];
 
   // Whether to set the *IP_FREEBIND* option when creating the socket. When this
   // flag is set to true, allows the :ref:`source_address
@@ -107,6 +112,7 @@ message Address {
     option (validate.required) = true;
 
     SocketAddress socket_address = 1;
+
     Pipe pipe = 2;
   }
 }
@@ -115,7 +121,8 @@ message Address {
 // the subnet mask for a `CIDR <https://tools.ietf.org/html/rfc4632>`_ range.
 message CidrRange {
   // IPv4 or IPv6 address, e.g. ``192.0.0.0`` or ``2001:db8::``.
-  string address_prefix = 1 [(validate.rules).string.min_bytes = 1];
+  string address_prefix = 1 [(validate.rules).string = {min_bytes: 1}];
+
   // Length of prefix, e.g. 0, 32.
-  google.protobuf.UInt32Value prefix_len = 2 [(validate.rules).uint32.lte = 128];
+  google.protobuf.UInt32Value prefix_len = 2 [(validate.rules).uint32 = {lte: 128}];
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/base.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/base.proto
@@ -5,23 +5,55 @@ package envoy.api.v2.core;
 option java_outer_classname = "BaseProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.api.v2.core";
-option go_package = "core";
 
 import "envoy/api/v2/core/http_uri.proto";
+import "envoy/type/percent.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-import "envoy/type/percent.proto";
-
-option (gogoproto.equal_all) = true;
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: Common types]
+
+// Envoy supports :ref:`upstream priority routing
+// <arch_overview_http_routing_priority>` both at the route and the virtual
+// cluster level. The current priority implementation uses different connection
+// pool and circuit breaking settings for each priority level. This means that
+// even for HTTP/2 requests, two physical connections will be used to an
+// upstream host. In the future Envoy will likely support true HTTP/2 priority
+// over a single upstream connection.
+enum RoutingPriority {
+  DEFAULT = 0;
+  HIGH = 1;
+}
+
+// HTTP request method.
+enum RequestMethod {
+  METHOD_UNSPECIFIED = 0;
+  GET = 1;
+  HEAD = 2;
+  POST = 3;
+  PUT = 4;
+  DELETE = 5;
+  CONNECT = 6;
+  OPTIONS = 7;
+  TRACE = 8;
+  PATCH = 9;
+}
+
+// Identifies the direction of the traffic relative to the local Envoy.
+enum TrafficDirection {
+  // Default option is unspecified.
+  UNSPECIFIED = 0;
+
+  // The transport is used for incoming traffic.
+  INBOUND = 1;
+
+  // The transport is used for outgoing traffic.
+  OUTBOUND = 2;
+}
 
 // Identifies location of where either Envoy runs or where upstream hosts run.
 message Locality {
@@ -115,53 +147,26 @@ message RuntimeUInt32 {
   uint32 default_value = 2;
 
   // Runtime key to get value for comparison. This value is used if defined.
-  string runtime_key = 3 [(validate.rules).string.min_bytes = 1];
-}
-
-// Envoy supports :ref:`upstream priority routing
-// <arch_overview_http_routing_priority>` both at the route and the virtual
-// cluster level. The current priority implementation uses different connection
-// pool and circuit breaking settings for each priority level. This means that
-// even for HTTP/2 requests, two physical connections will be used to an
-// upstream host. In the future Envoy will likely support true HTTP/2 priority
-// over a single upstream connection.
-enum RoutingPriority {
-  DEFAULT = 0;
-  HIGH = 1;
-}
-
-// HTTP request method.
-enum RequestMethod {
-  option (gogoproto.goproto_enum_prefix) = false;
-  METHOD_UNSPECIFIED = 0;
-  GET = 1;
-  HEAD = 2;
-  POST = 3;
-  PUT = 4;
-  DELETE = 5;
-  CONNECT = 6;
-  OPTIONS = 7;
-  TRACE = 8;
-  PATCH = 9;
+  string runtime_key = 3 [(validate.rules).string = {min_bytes: 1}];
 }
 
 // Header name/value pair.
 message HeaderValue {
   // Header name.
-  string key = 1 [(validate.rules).string = {min_bytes: 1, max_bytes: 16384}];
+  string key = 1 [(validate.rules).string = {min_bytes: 1 max_bytes: 16384}];
 
   // Header value.
   //
   // The same :ref:`format specifier <config_access_log_format>` as used for
   // :ref:`HTTP access logging <config_access_log>` applies here, however
   // unknown header values are replaced with the empty string instead of `-`.
-  string value = 2 [(validate.rules).string.max_bytes = 16384];
+  string value = 2 [(validate.rules).string = {max_bytes: 16384}];
 }
 
 // Header name/value pair plus option to control append behavior.
 message HeaderValueOption {
   // Header name/value pair that this option applies to.
-  HeaderValue header = 1 [(validate.rules).message.required = true];
+  HeaderValue header = 1 [(validate.rules).message = {required: true}];
 
   // Should the value be appended? If true (default), the value is appended to
   // existing values.
@@ -179,23 +184,23 @@ message DataSource {
     option (validate.required) = true;
 
     // Local filesystem data source.
-    string filename = 1 [(validate.rules).string.min_bytes = 1];
+    string filename = 1 [(validate.rules).string = {min_bytes: 1}];
 
     // Bytes inlined in the configuration.
-    bytes inline_bytes = 2 [(validate.rules).bytes.min_len = 1];
+    bytes inline_bytes = 2 [(validate.rules).bytes = {min_len: 1}];
 
     // String inlined in the configuration.
-    string inline_string = 3 [(validate.rules).string.min_bytes = 1];
+    string inline_string = 3 [(validate.rules).string = {min_bytes: 1}];
   }
 }
 
 // The message specifies how to fetch data from remote and how to verify it.
 message RemoteDataSource {
   // The HTTP URI to fetch the remote data.
-  HttpUri http_uri = 1 [(validate.rules).message.required = true];
+  HttpUri http_uri = 1 [(validate.rules).message = {required: true}];
 
   // SHA256 string for verifying data.
-  string sha256 = 2 [(validate.rules).string.min_bytes = 1];
+  string sha256 = 2 [(validate.rules).string = {min_bytes: 1}];
 }
 
 // Async data source which support async data fetch.
@@ -218,7 +223,7 @@ message AsyncDataSource {
 message TransportSocket {
   // The name of the transport socket to instantiate. The name must match a supported transport
   // socket implementation.
-  string name = 1 [(validate.rules).string.min_bytes = 1];
+  string name = 1 [(validate.rules).string = {min_bytes: 1}];
 
   // Implementation specific configuration which depends on the implementation being instantiated.
   // See the supported transport socket implementations for further documentation.
@@ -232,40 +237,47 @@ message TransportSocket {
 // Generic socket option message. This would be used to set socket options that
 // might not exist in upstream kernels or precompiled Envoy binaries.
 message SocketOption {
+  enum SocketState {
+    // Socket options are applied after socket creation but before binding the socket to a port
+    STATE_PREBIND = 0;
+
+    // Socket options are applied after binding the socket to a port but before calling listen()
+    STATE_BOUND = 1;
+
+    // Socket options are applied after calling listen()
+    STATE_LISTENING = 2;
+  }
+
   // An optional name to give this socket option for debugging, etc.
   // Uniqueness is not required and no special meaning is assumed.
   string description = 1;
+
   // Corresponding to the level value passed to setsockopt, such as IPPROTO_TCP
   int64 level = 2;
+
   // The numeric name as passed to setsockopt
   int64 name = 3;
+
   oneof value {
     option (validate.required) = true;
 
     // Because many sockopts take an int value.
     int64 int_value = 4;
+
     // Otherwise it's a byte buffer.
     bytes buf_value = 5;
   }
-  enum SocketState {
-    option (gogoproto.goproto_enum_prefix) = false;
-    // Socket options are applied after socket creation but before binding the socket to a port
-    STATE_PREBIND = 0;
-    // Socket options are applied after binding the socket to a port but before calling listen()
-    STATE_BOUND = 1;
-    // Socket options are applied after calling listen()
-    STATE_LISTENING = 2;
-  }
+
   // The state in which the option will be applied. When used in BindConfig
   // STATE_PREBIND is currently the only valid value.
-  SocketState state = 6 [(validate.rules).enum.defined_only = true];
+  SocketState state = 6 [(validate.rules).enum = {defined_only: true}];
 }
 
 // Runtime derived FractionalPercent with defaults for when the numerator or denominator is not
 // specified via a runtime key.
 message RuntimeFractionalPercent {
   // Default value if the runtime value's for the numerator/denominator keys are not available.
-  envoy.type.FractionalPercent default_value = 1 [(validate.rules).message.required = true];
+  type.FractionalPercent default_value = 1 [(validate.rules).message = {required: true}];
 
   // Runtime key for a YAML representation of a FractionalPercent.
   string runtime_key = 2;
@@ -277,16 +289,4 @@ message ControlPlane {
   // of control plane. This can be used to identify which control plane instance,
   // the Envoy is connected to.
   string identifier = 1;
-}
-
-// Identifies the direction of the traffic relative to the local Envoy.
-enum TrafficDirection {
-  // Default option is unspecified.
-  UNSPECIFIED = 0;
-
-  // The transport is used for incoming traffic.
-  INBOUND = 1;
-
-  // The transport is used for outgoing traffic.
-  OUTBOUND = 2;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/config_source.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/config_source.proto
@@ -12,9 +12,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Configuration sources]
 
@@ -26,12 +23,15 @@ message ApiConfigSource {
     // Ideally this would be 'reserved 0' but one can't reserve the default
     // value. Instead we throw an exception if this is ever used.
     UNSUPPORTED_REST_LEGACY = 0 [deprecated = true];
+
     // REST-JSON v2 API. The `canonical JSON encoding
     // <https://developers.google.com/protocol-buffers/docs/proto3#json>`_ for
     // the v2 protos is used.
     REST = 1;
+
     // gRPC v2 API.
     GRPC = 2;
+
     // Using the delta xDS gRPC service, i.e. DeltaDiscovery{Request,Response}
     // rather than Discovery{Request,Response}. Rather than sending Envoy the entire state
     // with every update, the xDS server only sends what has changed since the last update.
@@ -40,7 +40,9 @@ message ApiConfigSource {
     // Do not use for other xDSes. TODO(fredlas) update/remove this warning when appropriate.
     DELTA_GRPC = 3;
   }
-  ApiType api_type = 1 [(validate.rules).enum.defined_only = true];
+
+  ApiType api_type = 1 [(validate.rules).enum = {defined_only: true}];
+
   // Cluster names should be used only with REST. If > 1
   // cluster is defined, clusters will be cycled through if any kind of failure
   // occurs.
@@ -56,11 +58,10 @@ message ApiConfigSource {
   repeated GrpcService grpc_services = 4;
 
   // For REST APIs, the delay between successive polls.
-  google.protobuf.Duration refresh_delay = 3 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration refresh_delay = 3;
 
   // For REST APIs, the request timeout. If not set, a default value of 1s will be used.
-  google.protobuf.Duration request_timeout = 5
-      [(validate.rules).duration.gt.seconds = 0, (gogoproto.stdduration) = true];
+  google.protobuf.Duration request_timeout = 5 [(validate.rules).duration = {gt {}}];
 
   // For GRPC APIs, the rate limit settings. If present, discovery requests made by Envoy will be
   // rate limited.
@@ -76,6 +77,13 @@ message ApiConfigSource {
 message AggregatedConfigSource {
 }
 
+// [#not-implemented-hide:]
+// Self-referencing config source options. This is currently empty, but when
+// set in :ref:`ConfigSource <envoy_api_msg_core.ConfigSource>` can be used to
+// specify that other data can be obtained from the same server.
+message SelfConfigSource {
+}
+
 // Rate Limit settings to be applied for discovery requests made by Envoy.
 message RateLimitSettings {
   // Maximum number of tokens to be used for rate limiting discovery request calls. If not set, a
@@ -84,7 +92,7 @@ message RateLimitSettings {
 
   // Rate at which tokens will be filled per second. If not set, a default fill rate of 10 tokens
   // per second will be used.
-  google.protobuf.DoubleValue fill_rate = 2 [(validate.rules).double.gt = 0.0];
+  google.protobuf.DoubleValue fill_rate = 2 [(validate.rules).double = {gt: 0.0}];
 }
 
 // Configuration for :ref:`listeners <config_listeners>`, :ref:`clusters
@@ -93,9 +101,11 @@ message RateLimitSettings {
 // <arch_overview_service_discovery>` etc. may either be sourced from the
 // filesystem or from an xDS API source. Filesystem configs are watched with
 // inotify for updates.
+// [#comment:next free field: 6]
 message ConfigSource {
   oneof config_source_specifier {
     option (validate.required) = true;
+
     // Path on the filesystem to source and watch for configuration updates.
     //
     // .. note::
@@ -108,11 +118,26 @@ message ConfigSource {
     //   are atomic. The same method of swapping files as is demonstrated in the
     //   :ref:`runtime documentation <config_runtime_symbolic_link_swap>` can be used here also.
     string path = 1;
+
     // API configuration source.
     ApiConfigSource api_config_source = 2;
+
     // When set, ADS will be used to fetch resources. The ADS API configuration
     // source in the bootstrap configuration is used.
     AggregatedConfigSource ads = 3;
+
+    // [#not-implemented-hide:]
+    // When set, the client will access the resources from the same server it got the
+    // ConfigSource from, although not necessarily from the same stream. This is similar to the
+    // :ref:`ads<envoy_api_field.ConfigSource.ads>` field, except that the client may use a
+    // different stream to the same server. As a result, this field can be used for things
+    // like LRS that cannot be sent on an ADS stream. It can also be used to link from (e.g.)
+    // LDS to RDS on the same server without requiring the management server to know its name
+    // or required credentials.
+    // [#next-major-version: In xDS v3, consider replacing the ads field with this one, since
+    // this field can implicitly mean to use the same stream in the case where the ConfigSource
+    // is provided via ADS and the specified data can also be obtained via ADS.]
+    SelfConfigSource self = 5;
   }
 
   // When this timeout is specified, Envoy will wait no longer than the specified time for first

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/grpc_service.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/grpc_service.proto
@@ -10,13 +10,10 @@ import "envoy/api/v2/core/base.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/empty.proto";
+import "google/protobuf/struct.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: gRPC services]
 
@@ -27,16 +24,10 @@ message GrpcService {
     // The name of the upstream gRPC cluster. SSL credentials will be supplied
     // in the :ref:`Cluster <envoy_api_msg_Cluster>` :ref:`tls_context
     // <envoy_api_field_Cluster.tls_context>`.
-    string cluster_name = 1 [(validate.rules).string.min_bytes = 1];
+    string cluster_name = 1 [(validate.rules).string = {min_bytes: 1}];
   }
 
-  // [#proto-status: draft]
   message GoogleGrpc {
-    // The target URI when using the `Google C++ gRPC client
-    // <https://github.com/grpc/grpc>`_. SSL credentials will be supplied in
-    // :ref:`channel_credentials <envoy_api_field_core.GrpcService.GoogleGrpc.channel_credentials>`.
-    string target_uri = 1 [(validate.rules).string.min_bytes = 1];
-
     // See https://grpc.io/grpc/cpp/structgrpc_1_1_ssl_credentials_options.html.
     message SslCredentials {
       // PEM encoded server root certificates.
@@ -59,6 +50,7 @@ message GrpcService {
     message ChannelCredentials {
       oneof credential_specifier {
         option (validate.required) = true;
+
         SslCredentials ssl_credentials = 1;
 
         // https://grpc.io/grpc/cpp/namespacegrpc.html#a6beb3ac70ff94bd2ebbd89b8f21d1f61
@@ -68,21 +60,22 @@ message GrpcService {
       }
     }
 
-    ChannelCredentials channel_credentials = 2;
-
     message CallCredentials {
       message ServiceAccountJWTAccessCredentials {
         string json_key = 1;
+
         uint64 token_lifetime_seconds = 2;
       }
 
       message GoogleIAMCredentials {
         string authorization_token = 1;
+
         string authority_selector = 2;
       }
 
       message MetadataCredentialsFromPlugin {
         string name = 1;
+
         oneof config_type {
           google.protobuf.Struct config = 2;
 
@@ -120,6 +113,13 @@ message GrpcService {
       }
     }
 
+    // The target URI when using the `Google C++ gRPC client
+    // <https://github.com/grpc/grpc>`_. SSL credentials will be supplied in
+    // :ref:`channel_credentials <envoy_api_field_core.GrpcService.GoogleGrpc.channel_credentials>`.
+    string target_uri = 1 [(validate.rules).string = {min_bytes: 1}];
+
+    ChannelCredentials channel_credentials = 2;
+
     // A set of call credentials that can be composed with `channel credentials
     // <https://grpc.io/docs/guides/auth.html#credential-types>`_.
     repeated CallCredentials call_credentials = 3;
@@ -133,7 +133,7 @@ message GrpcService {
     //
     //    streams_total, Counter, Total number of streams opened
     //    streams_closed_<gRPC status code>, Counter, Total streams closed with <gRPC status code>
-    string stat_prefix = 4 [(validate.rules).string.min_bytes = 1];
+    string stat_prefix = 4 [(validate.rules).string = {min_bytes: 1}];
 
     // The name of the Google gRPC credentials factory to use. This must have been registered with
     // Envoy. If this is empty, a default credentials factory will be used that sets up channel
@@ -144,6 +144,8 @@ message GrpcService {
     // gRPC library.
     google.protobuf.Struct config = 6;
   }
+
+  reserved 4;
 
   oneof target_specifier {
     option (validate.required) = true;
@@ -162,9 +164,6 @@ message GrpcService {
   // The timeout for the gRPC request. This is the timeout for a specific
   // request.
   google.protobuf.Duration timeout = 3;
-
-  // Field 4 reserved due to moving credentials inside the GoogleGrpc message
-  reserved 4;
 
   // Additional metadata to include in streams initiated to the GrpcService.
   // This can be used for scenarios in which additional ad hoc authorization

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/health_check.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/health_check.proto
@@ -15,75 +15,46 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Health check]
 // * Health checking :ref:`architecture overview <arch_overview_health_checking>`.
 // * If health checking is configured for a cluster, additional statistics are emitted. They are
 //   documented :ref:`here <config_cluster_manager_cluster_stats>`.
 
+// Endpoint health status.
+enum HealthStatus {
+  // The health status is not known. This is interpreted by Envoy as *HEALTHY*.
+  UNKNOWN = 0;
+
+  // Healthy.
+  HEALTHY = 1;
+
+  // Unhealthy.
+  UNHEALTHY = 2;
+
+  // Connection draining in progress. E.g.,
+  // `<https://aws.amazon.com/blogs/aws/elb-connection-draining-remove-instances-from-service-with-care/>`_
+  // or
+  // `<https://cloud.google.com/compute/docs/load-balancing/enabling-connection-draining>`_.
+  // This is interpreted by Envoy as *UNHEALTHY*.
+  DRAINING = 3;
+
+  // Health check timed out. This is part of HDS and is interpreted by Envoy as
+  // *UNHEALTHY*.
+  TIMEOUT = 4;
+
+  // Degraded.
+  DEGRADED = 5;
+}
+
 message HealthCheck {
-  // The time to wait for a health check response. If the timeout is reached the
-  // health check attempt will be considered a failure.
-  google.protobuf.Duration timeout = 1 [
-    (validate.rules).duration = {
-      required: true,
-      gt: {seconds: 0}
-    },
-    (gogoproto.stdduration) = true
-  ];
-
-  // The interval between health checks.
-  google.protobuf.Duration interval = 2 [
-    (validate.rules).duration = {
-      required: true,
-      gt: {seconds: 0}
-    },
-    (gogoproto.stdduration) = true
-  ];
-
-  // An optional jitter amount in milliseconds. If specified, Envoy will start health
-  // checking after for a random time in ms between 0 and initial_jitter. This only
-  // applies to the first health check.
-  google.protobuf.Duration initial_jitter = 20;
-
-  // An optional jitter amount in milliseconds. If specified, during every
-  // interval Envoy will add interval_jitter to the wait time.
-  google.protobuf.Duration interval_jitter = 3;
-
-  // An optional jitter amount as a percentage of interval_ms. If specified,
-  // during every interval Envoy will add interval_ms *
-  // interval_jitter_percent / 100 to the wait time.
-  //
-  // If interval_jitter_ms and interval_jitter_percent are both set, both of
-  // them will be used to increase the wait time.
-  uint32 interval_jitter_percent = 18;
-
-  // The number of unhealthy health checks required before a host is marked
-  // unhealthy. Note that for *http* health checking if a host responds with 503
-  // this threshold is ignored and the host is considered unhealthy immediately.
-  google.protobuf.UInt32Value unhealthy_threshold = 4;
-
-  // The number of healthy health checks required before a host is marked
-  // healthy. Note that during startup, only a single successful health check is
-  // required to mark a host healthy.
-  google.protobuf.UInt32Value healthy_threshold = 5;
-
-  // [#not-implemented-hide:] Non-serving port for health checking.
-  google.protobuf.UInt32Value alt_port = 6;
-
-  // Reuse health check connection between health checks. Default is true.
-  google.protobuf.BoolValue reuse_connection = 7;
-
   // Describes the encoding of the payload bytes in the payload.
   message Payload {
     oneof payload {
       option (validate.required) = true;
 
       // Hex encoded payload. E.g., "000000FF".
-      string text = 1 [(validate.rules).string.min_bytes = 1];
+      string text = 1 [(validate.rules).string = {min_bytes: 1}];
 
       // [#not-implemented-hide:] Binary payload.
       bytes binary = 2;
@@ -99,7 +70,7 @@ message HealthCheck {
 
     // Specifies the HTTP path that will be requested during health checking. For example
     // */healthcheck*.
-    string path = 2 [(validate.rules).string.min_bytes = 1];
+    string path = 2 [(validate.rules).string = {min_bytes: 1}];
 
     // [#not-implemented-hide:] HTTP specific payload.
     Payload send = 3;
@@ -116,8 +87,8 @@ message HealthCheck {
     // health checked cluster. For more information, including details on header value syntax, see
     // the documentation on :ref:`custom request headers
     // <config_http_conn_man_headers_custom_request_headers>`.
-    repeated core.HeaderValueOption request_headers_to_add = 6
-        [(validate.rules).repeated .max_items = 1000];
+    repeated HeaderValueOption request_headers_to_add = 6
+        [(validate.rules).repeated = {max_items: 1000}];
 
     // Specifies a list of HTTP headers that should be removed from each request that is sent to the
     // health checked cluster.
@@ -129,7 +100,7 @@ message HealthCheck {
     // Specifies a list of HTTP response statuses considered healthy. If provided, replaces default
     // 200-only policy - 200 must be included explicitly as needed. Ranges follow half-open
     // semantics of :ref:`Int64Range <envoy_api_msg_type.Int64Range>`.
-    repeated envoy.type.Int64Range expected_statuses = 9;
+    repeated type.Int64Range expected_statuses = 9;
   }
 
   message TcpHealthCheck {
@@ -171,7 +142,7 @@ message HealthCheck {
   // Custom health check.
   message CustomHealthCheck {
     // The registered name of the custom health checker.
-    string name = 1 [(validate.rules).string.min_bytes = 1];
+    string name = 1 [(validate.rules).string = {min_bytes: 1}];
 
     // A custom health checker specific configuration which depends on the custom health checker
     // being instantiated. See :api:`envoy/config/health_checker` for reference.
@@ -181,6 +152,54 @@ message HealthCheck {
       google.protobuf.Any typed_config = 3;
     }
   }
+
+  reserved 10;
+
+  // The time to wait for a health check response. If the timeout is reached the
+  // health check attempt will be considered a failure.
+  google.protobuf.Duration timeout = 1 [(validate.rules).duration = {
+    required: true
+    gt {}
+  }];
+
+  // The interval between health checks.
+  google.protobuf.Duration interval = 2 [(validate.rules).duration = {
+    required: true
+    gt {}
+  }];
+
+  // An optional jitter amount in milliseconds. If specified, Envoy will start health
+  // checking after for a random time in ms between 0 and initial_jitter. This only
+  // applies to the first health check.
+  google.protobuf.Duration initial_jitter = 20;
+
+  // An optional jitter amount in milliseconds. If specified, during every
+  // interval Envoy will add interval_jitter to the wait time.
+  google.protobuf.Duration interval_jitter = 3;
+
+  // An optional jitter amount as a percentage of interval_ms. If specified,
+  // during every interval Envoy will add interval_ms *
+  // interval_jitter_percent / 100 to the wait time.
+  //
+  // If interval_jitter_ms and interval_jitter_percent are both set, both of
+  // them will be used to increase the wait time.
+  uint32 interval_jitter_percent = 18;
+
+  // The number of unhealthy health checks required before a host is marked
+  // unhealthy. Note that for *http* health checking if a host responds with 503
+  // this threshold is ignored and the host is considered unhealthy immediately.
+  google.protobuf.UInt32Value unhealthy_threshold = 4;
+
+  // The number of healthy health checks required before a host is marked
+  // healthy. Note that during startup, only a single successful health check is
+  // required to mark a host healthy.
+  google.protobuf.UInt32Value healthy_threshold = 5;
+
+  // [#not-implemented-hide:] Non-serving port for health checking.
+  google.protobuf.UInt32Value alt_port = 6;
+
+  // Reuse health check connection between health checks. Default is true.
+  google.protobuf.BoolValue reuse_connection = 7;
 
   oneof health_checker {
     option (validate.required) = true;
@@ -198,10 +217,6 @@ message HealthCheck {
     CustomHealthCheck custom_health_check = 13;
   }
 
-  reserved 10; // redis_health_check is deprecated by :ref:`custom_health_check
-               // <envoy_api_field_core.HealthCheck.custom_health_check>`
-  reserved "redis_health_check";
-
   // The "no traffic interval" is a special health check interval that is used when a cluster has
   // never had traffic routed to it. This lower interval allows cluster information to be kept up to
   // date, without sending a potentially large amount of active health checking traffic for no
@@ -210,14 +225,14 @@ message HealthCheck {
   // any other.
   //
   // The default value for "no traffic interval" is 60 seconds.
-  google.protobuf.Duration no_traffic_interval = 12 [(validate.rules).duration.gt = {}];
+  google.protobuf.Duration no_traffic_interval = 12 [(validate.rules).duration = {gt {}}];
 
   // The "unhealthy interval" is a health check interval that is used for hosts that are marked as
   // unhealthy. As soon as the host is marked as healthy, Envoy will shift back to using the
   // standard health check interval that is defined.
   //
   // The default value for "unhealthy interval" is the same as "interval".
-  google.protobuf.Duration unhealthy_interval = 14 [(validate.rules).duration.gt = {}];
+  google.protobuf.Duration unhealthy_interval = 14 [(validate.rules).duration = {gt {}}];
 
   // The "unhealthy edge interval" is a special health check interval that is used for the first
   // health check right after a host is marked as unhealthy. For subsequent health checks
@@ -225,14 +240,14 @@ message HealthCheck {
   // check interval that is defined.
   //
   // The default value for "unhealthy edge interval" is the same as "unhealthy interval".
-  google.protobuf.Duration unhealthy_edge_interval = 15 [(validate.rules).duration.gt = {}];
+  google.protobuf.Duration unhealthy_edge_interval = 15 [(validate.rules).duration = {gt {}}];
 
   // The "healthy edge interval" is a special health check interval that is used for the first
   // health check right after a host is marked as healthy. For subsequent health checks
   // Envoy will shift back to using the standard health check interval that is defined.
   //
   // The default value for "healthy edge interval" is the same as the default interval.
-  google.protobuf.Duration healthy_edge_interval = 16 [(validate.rules).duration.gt = {}];
+  google.protobuf.Duration healthy_edge_interval = 16 [(validate.rules).duration = {gt {}}];
 
   // Specifies the path to the :ref:`health check event log <arch_overview_health_check_logging>`.
   // If empty, no event log will be written.
@@ -242,30 +257,4 @@ message HealthCheck {
   // initial health check failure event will be logged.
   // The default value is false.
   bool always_log_health_check_failures = 19;
-}
-
-// Endpoint health status.
-enum HealthStatus {
-  // The health status is not known. This is interpreted by Envoy as *HEALTHY*.
-  UNKNOWN = 0;
-
-  // Healthy.
-  HEALTHY = 1;
-
-  // Unhealthy.
-  UNHEALTHY = 2;
-
-  // Connection draining in progress. E.g.,
-  // `<https://aws.amazon.com/blogs/aws/elb-connection-draining-remove-instances-from-service-with-care/>`_
-  // or
-  // `<https://cloud.google.com/compute/docs/load-balancing/enabling-connection-draining>`_.
-  // This is interpreted by Envoy as *UNHEALTHY*.
-  DRAINING = 3;
-
-  // Health check timed out. This is part of HDS and is interpreted by Envoy as
-  // *UNHEALTHY*.
-  TIMEOUT = 4;
-
-  // Degraded.
-  DEGRADED = 5;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/http_uri.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/http_uri.proto
@@ -7,11 +7,8 @@ option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.api.v2.core";
 
 import "google/protobuf/duration.proto";
-import "gogoproto/gogo.proto";
 
 import "validate/validate.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: HTTP Service URI ]
 
@@ -25,7 +22,7 @@ message HttpUri {
   //
   //    uri: https://www.googleapis.com/oauth2/v1/certs
   //
-  string uri = 1 [(validate.rules).string.min_bytes = 1];
+  string uri = 1 [(validate.rules).string = {min_bytes: 1}];
 
   // Specify how `uri` is to be fetched. Today, this requires an explicit
   // cluster, but in the future we may support dynamic cluster creation or
@@ -33,6 +30,7 @@ message HttpUri {
   // <https://github.com/envoyproxy/envoy/issues/1606>`_.
   oneof http_upstream_type {
     option (validate.required) = true;
+
     // A cluster is created in the Envoy "cluster_manager" config
     // section. This field specifies the cluster name.
     //
@@ -42,13 +40,12 @@ message HttpUri {
     //
     //    cluster: jwks_cluster
     //
-    string cluster = 2 [(validate.rules).string.min_bytes = 1];
+    string cluster = 2 [(validate.rules).string = {min_bytes: 1}];
   }
 
   // Sets the maximum duration in milliseconds that a response can take to arrive upon request.
-  google.protobuf.Duration timeout = 3 [
-    (validate.rules).duration.gte = {},
-    (validate.rules).duration.required = true,
-    (gogoproto.stdduration) = true
-  ];
+  google.protobuf.Duration timeout = 3 [(validate.rules).duration = {
+    required: true
+    gte {}
+  }];
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/discovery.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/discovery.proto
@@ -5,16 +5,11 @@ package envoy.api.v2;
 option java_outer_classname = "DiscoveryProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.api.v2";
-option go_package = "v2";
 
 import "envoy/api/v2/core/base.proto";
 
 import "google/protobuf/any.proto";
 import "google/rpc/status.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: Common discovery API components]
 
@@ -49,8 +44,9 @@ message DiscoveryRequest {
 
   // nonce corresponding to DiscoveryResponse being ACK/NACKed. See above
   // discussion on version_info and the DiscoveryResponse nonce comment. This
-  // may be empty if no nonce is available, e.g. at startup or for non-stream
-  // xDS implementations.
+  // may be empty only if 1) this is a non-persistent-stream xDS such as HTTP,
+  // or 2) the client has not yet accepted an update in this xDS stream (unlike
+  // delta, where it is populated only for new explicit ACKs).
   string response_nonce = 5;
 
   // This is populated when the previous :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>`
@@ -181,7 +177,7 @@ message DeltaDiscoveryRequest {
   // When the DeltaDiscoveryRequest is a ACK or NACK message in response
   // to a previous DeltaDiscoveryResponse, the response_nonce must be the
   // nonce in the DeltaDiscoveryResponse.
-  // Otherwise response_nonce must be omitted.
+  // Otherwise (unlike in DiscoveryRequest) response_nonce must be omitted.
   string response_nonce = 6;
 
   // This is populated when the previous :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>`

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/eds.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/eds.proto
@@ -5,7 +5,6 @@ package envoy.api.v2;
 option java_outer_classname = "EdsProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.api.v2";
-
 option java_generic_services = true;
 
 import "envoy/api/v2/discovery.proto";
@@ -13,14 +12,10 @@ import "envoy/api/v2/endpoint/endpoint.proto";
 import "envoy/type/percent.proto";
 
 import "google/api/annotations.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-import "google/protobuf/wrappers.proto";
-import "google/protobuf/duration.proto";
-
-option (gogoproto.equal_all) = true;
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: EDS]
 // Endpoint discovery :ref:`architecture overview <arch_overview_service_discovery_types_eds>`
@@ -52,29 +47,18 @@ service EndpointDiscoveryService {
 // load_balancing_weight of its locality. First, a locality will be selected,
 // then an endpoint within that locality will be chose based on its weight.
 message ClusterLoadAssignment {
-  // Name of the cluster. This will be the :ref:`service_name
-  // <envoy_api_field_Cluster.EdsClusterConfig.service_name>` value if specified
-  // in the cluster :ref:`EdsClusterConfig
-  // <envoy_api_msg_Cluster.EdsClusterConfig>`.
-  string cluster_name = 1 [(validate.rules).string.min_bytes = 1];
-
-  // List of endpoints to load balance to.
-  repeated endpoint.LocalityLbEndpoints endpoints = 2;
-
-  // Map of named endpoints that can be referenced in LocalityLbEndpoints.
-  map<string, endpoint.Endpoint> named_endpoints = 5;
-
   // Load balancing policy settings.
   message Policy {
-    reserved 1;
-
     message DropOverload {
       // Identifier for the policy specifying the drop.
-      string category = 1 [(validate.rules).string.min_bytes = 1];
+      string category = 1 [(validate.rules).string = {min_bytes: 1}];
 
       // Percentage of traffic that should be dropped for the category.
-      envoy.type.FractionalPercent drop_percentage = 2;
+      type.FractionalPercent drop_percentage = 2;
     }
+
+    reserved 1;
+
     // Action to trim the overall incoming traffic to protect the upstream
     // hosts. This action allows protection in case the hosts are unable to
     // recover from an outage, or unable to autoscale or unable to handle
@@ -110,14 +94,37 @@ message ClusterLoadAssignment {
     //
     // Read more at :ref:`priority levels <arch_overview_load_balancing_priority_levels>` and
     // :ref:`localities <arch_overview_load_balancing_locality_weighted_lb>`.
-    google.protobuf.UInt32Value overprovisioning_factor = 3 [(validate.rules).uint32.gt = 0];
+    google.protobuf.UInt32Value overprovisioning_factor = 3 [(validate.rules).uint32 = {gt: 0}];
 
     // The max time until which the endpoints from this assignment can be used.
     // If no new assignments are received before this time expires the endpoints
     // are considered stale and should be marked unhealthy.
     // Defaults to 0 which means endpoints never go stale.
-    google.protobuf.Duration endpoint_stale_after = 4 [(validate.rules).duration.gt.seconds = 0];
+    google.protobuf.Duration endpoint_stale_after = 4 [(validate.rules).duration = {gt {}}];
+
+    // The flag to disable overprovisioning. If it is set to true,
+    // :ref:`overprovisioning factor
+    // <arch_overview_load_balancing_overprovisioning_factor>` will be ignored
+    // and Envoy will not perform graceful failover between priority levels or
+    // localities as endpoints become unhealthy. Otherwise Envoy will perform
+    // graceful failover as :ref:`overprovisioning factor
+    // <arch_overview_load_balancing_overprovisioning_factor>` suggests.
+    // [#next-major-version: Unify with overprovisioning config as a single message.]
+    // [#not-implemented-hide:]
+    bool disable_overprovisioning = 5;
   }
+
+  // Name of the cluster. This will be the :ref:`service_name
+  // <envoy_api_field_Cluster.EdsClusterConfig.service_name>` value if specified
+  // in the cluster :ref:`EdsClusterConfig
+  // <envoy_api_msg_Cluster.EdsClusterConfig>`.
+  string cluster_name = 1 [(validate.rules).string = {min_bytes: 1}];
+
+  // List of endpoints to load balance to.
+  repeated endpoint.LocalityLbEndpoints endpoints = 2;
+
+  // Map of named endpoints that can be referenced in LocalityLbEndpoints.
+  map<string, endpoint.Endpoint> named_endpoints = 5;
 
   // Load balancing policy settings.
   Policy policy = 4;

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/endpoint/endpoint.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/endpoint/endpoint.proto
@@ -5,7 +5,6 @@ package envoy.api.v2.endpoint;
 option java_outer_classname = "EndpointProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.api.v2.endpoint";
-option go_package = "endpoint";
 
 import "envoy/api/v2/core/address.proto";
 import "envoy/api/v2/core/base.proto";
@@ -14,14 +13,22 @@ import "envoy/api/v2/core/health_check.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Endpoints]
 
 // Upstream host identifier.
 message Endpoint {
+  // The optional health check configuration.
+  message HealthCheckConfig {
+    // Optional alternative health check port value.
+    //
+    // By default the health check address port of an upstream host is the same
+    // as the host's serving address port. This provides an alternative health
+    // check port. Setting this with a non-zero value allows an upstream host
+    // to have different health check address port.
+    uint32 port_value = 1 [(validate.rules).uint32 = {lte: 65535}];
+  }
+
   // The upstream host address.
   //
   // .. attention::
@@ -32,17 +39,6 @@ message Endpoint {
   //   in the Address). For LOGICAL or STRICT DNS, it is expected to be hostname,
   //   and will be resolved via DNS.
   core.Address address = 1;
-
-  // The optional health check configuration.
-  message HealthCheckConfig {
-    // Optional alternative health check port value.
-    //
-    // By default the health check address port of an upstream host is the same
-    // as the host's serving address port. This provides an alternative health
-    // check port. Setting this with a non-zero value allows an upstream host
-    // to have different health check address port.
-    uint32 port_value = 1 [(validate.rules).uint32.lte = 65535];
-  }
 
   // The optional health check configuration is used as configuration for the
   // health checker to contact the health checked host.
@@ -59,6 +55,7 @@ message LbEndpoint {
   // Upstream host identifier or a named reference.
   oneof host_identifier {
     Endpoint endpoint = 1;
+
     string endpoint_name = 5;
   }
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/endpoint/load_report.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/endpoint/load_report.proto
@@ -13,7 +13,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // These are stats Envoy reports to GLB every so often. Report frequency is
 // defined by

--- a/xds/third_party/envoy/src/main/proto/envoy/service/discovery/v2/ads.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/service/discovery/v2/ads.proto
@@ -5,15 +5,9 @@ package envoy.service.discovery.v2;
 option java_outer_classname = "AdsProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.service.discovery.v2";
-option go_package = "v2";
 option java_generic_services = true;
 
 import "envoy/api/v2/discovery.proto";
-
-// [#not-implemented-hide:] Not configuration. Workaround c++ protobuf issue with importing
-// services: https://github.com/google/protobuf/issues/4221
-message AdsDummy {
-}
 
 // [#not-implemented-hide:] Discovery services for endpoints, clusters, routes,
 // and listeners are retained in the package `envoy.api.v2` for backwards
@@ -28,11 +22,16 @@ message AdsDummy {
 // the multiplexed singleton APIs at the Envoy instance and management server.
 service AggregatedDiscoveryService {
   // This is a gRPC-only API.
-  rpc StreamAggregatedResources(stream envoy.api.v2.DiscoveryRequest)
-      returns (stream envoy.api.v2.DiscoveryResponse) {
+  rpc StreamAggregatedResources(stream api.v2.DiscoveryRequest)
+      returns (stream api.v2.DiscoveryResponse) {
   }
 
-  rpc DeltaAggregatedResources(stream envoy.api.v2.DeltaDiscoveryRequest)
-      returns (stream envoy.api.v2.DeltaDiscoveryResponse) {
+  rpc DeltaAggregatedResources(stream api.v2.DeltaDiscoveryRequest)
+      returns (stream api.v2.DeltaDiscoveryResponse) {
   }
+}
+
+// [#not-implemented-hide:] Not configuration. Workaround c++ protobuf issue with importing
+// services: https://github.com/google/protobuf/issues/4221
+message AdsDummy {
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/service/load_stats/v2/lrs.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/service/load_stats/v2/lrs.proto
@@ -5,7 +5,6 @@ package envoy.service.load_stats.v2;
 option java_outer_classname = "LrsProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.service.load_stats.v2";
-option go_package = "v2";
 option java_generic_services = true;
 
 import "envoy/api/v2/core/base.proto";

--- a/xds/third_party/envoy/src/main/proto/envoy/type/percent.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/percent.proto
@@ -7,15 +7,12 @@ option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.type";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Percent]
 
 // Identifies a percentage, in the range [0.0, 100.0].
 message Percent {
-  double value = 1 [(validate.rules).double = {gte: 0, lte: 100}];
+  double value = 1 [(validate.rules).double = {lte: 100.0 gte: 0.0}];
 }
 
 // A fractional percentage is used in cases in which for performance reasons performing floating
@@ -25,9 +22,6 @@ message Percent {
 // * **Example**: 1/100 = 1%.
 // * **Example**: 3/10000 = 0.03%.
 message FractionalPercent {
-  // Specifies the numerator. Defaults to 0.
-  uint32 numerator = 1;
-
   // Fraction percentages support several fixed denominator values.
   enum DenominatorType {
     // 100.
@@ -46,7 +40,10 @@ message FractionalPercent {
     MILLION = 2;
   }
 
+  // Specifies the numerator. Defaults to 0.
+  uint32 numerator = 1;
+
   // Specifies the denominator. If the denominator specified is less than the numerator, the final
   // fractional percentage is capped at 1 (100%).
-  DenominatorType denominator = 2 [(validate.rules).enum.defined_only = true];
+  DenominatorType denominator = 2 [(validate.rules).enum = {defined_only: true}];
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/type/range.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/range.proto
@@ -5,11 +5,6 @@ package envoy.type;
 option java_outer_classname = "RangeProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.type";
-option go_package = "envoy_type";
-
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Range]
 


### PR DESCRIPTION
Time to update envoy proto version. Corresponding internal import is cl/274202414.

This unblocks us from bringing in `cds.proto`, `lds.proto`, `rds.proto` etc, as there was a bugfix in https://github.com/envoyproxy/envoy/issues/8287, which breaks proto compilation.