### PR TITLE
xds: remove invalid srcDir third_party/protoc-gen-validate/src/main/proto

### DIFF
--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -50,7 +50,6 @@ sourceSets {
         proto {
             srcDir 'third_party/envoy/src/main/proto'
             srcDir 'third_party/gogoproto/src/main/proto'
-            srcDir 'third_party/protoc-gen-validate/src/main/proto'
             srcDir 'third_party/udpa/src/main/proto'
         }
     }


### PR DESCRIPTION
The directory third_party/protoc-gen-validate/src/main/proto was removed in #6177.