### PR TITLE
[aborted] xds: implement XdsClient with retry and basic EDS

### DIFF
--- a/xds/src/main/java/io/grpc/xds/AdsLifecycleManager.java
+++ b/xds/src/main/java/io/grpc/xds/AdsLifecycleManager.java
@@ -127,9 +127,9 @@ final class AdsLifecycleManager {
 
     long delayNanos;
     if (firstResponseReceived) {
-      // Reset the backoff sequence if balancer has sent the initial response
+      // Reset the backoff sequence if balancer has sent the initial response.
       adsRpcRetryPolicy = backoffPolicyProvider.get();
-      // Retry immediately
+      // Retry immediately.
       delayNanos = 0;
     } else {
       delayNanos = Math.max(

--- a/xds/src/main/java/io/grpc/xds/AdsLifecycleManager.java
+++ b/xds/src/main/java/io/grpc/xds/AdsLifecycleManager.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.base.Supplier;
+import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
+import io.envoyproxy.envoy.service.discovery.v2.AggregatedDiscoveryServiceGrpc.AggregatedDiscoveryServiceStub;
+import io.grpc.Status;
+import io.grpc.SynchronizationContext;
+import io.grpc.SynchronizationContext.ScheduledHandle;
+import io.grpc.internal.BackoffPolicy;
+import io.grpc.stub.StreamObserver;
+import io.grpc.xds.XdsClientImpl.EndpointWatchers;
+import io.grpc.xds.XdsResponseReader.StreamActivityWatcher;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import javax.annotation.CheckForNull;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * Manages ADS RPC lifecycle events and retry.
+ */
+@NotThreadSafe // Must be properly synchronized in SynchronizationContext.
+final class AdsLifecycleManager {
+
+  private final AggregatedDiscoveryServiceStub stub;
+  private final EndpointWatchers endpointWatchers;
+  private final SynchronizationContext syncCtx;
+  private final ScheduledExecutorService timerService;
+  private final Supplier<Stopwatch> stopwatchSupplier;
+  private final BackoffPolicy.Provider backoffPolicyProvider;
+
+  private boolean firstResponseReceived;
+  private boolean isStreamActive;
+  @CheckForNull
+  private ScheduledHandle adsRpcRetryTimer;
+  private Stopwatch retryStopwatch;
+  @CheckForNull
+  private StreamObserver<DiscoveryRequest> xdsRequestWriter;
+  // never null
+  private BackoffPolicy adsRpcRetryPolicy;
+
+  AdsLifecycleManager(
+      AggregatedDiscoveryServiceStub stub,
+      EndpointWatchers endpointWatchers,
+      SynchronizationContext syncCtx,
+      ScheduledExecutorService timerService,
+      Supplier<Stopwatch> stopwatchSupplier,
+      BackoffPolicy.Provider backoffPolicyProvider) {
+    this.stub = stub;
+    this.endpointWatchers = endpointWatchers;
+    this.syncCtx = syncCtx;
+    this.timerService = timerService;
+    this.stopwatchSupplier = stopwatchSupplier;
+    this.backoffPolicyProvider = backoffPolicyProvider;
+    this.adsRpcRetryPolicy = backoffPolicyProvider.get();
+  }
+
+  void start() {
+    isStreamActive = true;
+    firstResponseReceived = false;
+    retryStopwatch = stopwatchSupplier.get().start();
+
+    StreamActivityWatcher streamActivityWatcher = new StreamActivityWatcher() {
+      @Override
+      public void responseReceived() {
+        firstResponseReceived = true;
+      }
+
+      @Override
+      public void streamClosed() {
+        if (!isStreamActive) {
+          return;
+        }
+        isStreamActive = false;
+        endpointWatchers.seizeRequestEndpoints();
+        scheduleRetry();
+      }
+    };
+
+    xdsRequestWriter = stub.streamAggregatedResources(
+        new XdsResponseReader(streamActivityWatcher, endpointWatchers, syncCtx));
+
+    // EDS request will be sent only if there is any EndpointWatcher added.
+    endpointWatchers.requestEndpoints(xdsRequestWriter);
+  }
+
+  void shutdown() {
+    isStreamActive = false;
+    if (adsRpcRetryTimer != null) {
+      adsRpcRetryTimer.cancel();
+      adsRpcRetryTimer = null;
+    }
+    xdsRequestWriter.onError(
+        Status.CANCELLED.withDescription("XdsClient is shutdown").asRuntimeException());
+  }
+
+  private void scheduleRetry() {
+    checkState(
+        adsRpcRetryTimer == null, "Scheduling retry while a retry is already pending");
+
+    class AdsRpcRetryTask implements Runnable {
+      @Override
+      public void run() {
+        adsRpcRetryTimer = null;
+        start();
+      }
+    }
+
+    long delayNanos;
+    if (firstResponseReceived) {
+      // Reset the backoff sequence if balancer has sent the initial response
+      adsRpcRetryPolicy = backoffPolicyProvider.get();
+      // Retry immediately
+      delayNanos = 0;
+    } else {
+      delayNanos = Math.max(
+          adsRpcRetryPolicy.nextBackoffNanos() - retryStopwatch.elapsed(TimeUnit.NANOSECONDS), 0);
+    }
+
+    XdsClientImpl.logger.log(Level.FINE, "XdsClient stream closed, retry in {0} ns", delayNanos);
+    adsRpcRetryTimer = syncCtx.schedule(
+        new AdsRpcRetryTask(),
+        delayNanos,
+        TimeUnit.NANOSECONDS,
+        timerService);
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -16,7 +16,9 @@
 
 package io.grpc.xds;
 
+import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment;
 import io.grpc.Status;
+import java.util.Objects;
 
 /**
  * An {@link XdsClient} instance encapsulates all of the logic for communicating with the xDS
@@ -48,7 +50,7 @@ abstract class XdsClient {
     }
 
     static final class Builder {
-      private ConfigUpdate base;
+      private final ConfigUpdate base;
 
       private Builder() {
         base = new ConfigUpdate();
@@ -81,9 +83,44 @@ abstract class XdsClient {
    * configurations for traffic control such as drop overloads, inter-cluster load balancing
    * policy and etc.
    */
-  // TODO(zdapeng): content TBD.
   static final class EndpointUpdate {
+    private ClusterLoadAssignment clusterLoadAssignment;
 
+    static Builder newBuilder() {
+      return new Builder();
+    }
+
+    static final class Builder {
+      private final EndpointUpdate base = new EndpointUpdate();
+
+      private Builder() {}
+
+      Builder setClusterLoadAssignment(ClusterLoadAssignment clusterLoadAssignment) {
+        base.clusterLoadAssignment = clusterLoadAssignment;
+        return this;
+      }
+
+      EndpointUpdate build() {
+        return base;
+      }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      EndpointUpdate that = (EndpointUpdate) o;
+      return Objects.equals(clusterLoadAssignment, that.clusterLoadAssignment);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(clusterLoadAssignment);
+    }
   }
 
   /**

--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Stopwatch;
+import com.google.common.base.Supplier;
+import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment;
+import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
+import io.envoyproxy.envoy.api.v2.core.Node;
+import io.envoyproxy.envoy.service.discovery.v2.AggregatedDiscoveryServiceGrpc;
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.SynchronizationContext;
+import io.grpc.internal.BackoffPolicy;
+import io.grpc.stub.StreamObserver;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.CheckForNull;
+
+final class XdsClientImpl extends XdsClient {
+  static final Logger logger = Logger.getLogger(XdsClientImpl.class.getName());
+  static final String EDS_TYPE_URL =
+      "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment";
+
+  private final ManagedChannel channel;
+  private final Node xdsNode;
+  private final String authority;
+  private final EndpointWatchers endpointWatchers;
+  private final AdsLifecycleManager adsLifecycleManager;
+
+  XdsClientImpl(
+      ManagedChannel channel,
+      SynchronizationContext syncCtx,
+      ScheduledExecutorService timerService,
+      BackoffPolicy.Provider backoffPolicyProvider,
+      Supplier<Stopwatch> stopwatchSupplier,
+      Node xdsNode,
+      final String authority) {
+    this.channel = checkNotNull(channel, "channel");
+    this.xdsNode = checkNotNull(xdsNode, "xdsNode");
+    this.authority = checkNotNull(authority, "authority");
+    this.endpointWatchers = new EndpointWatchers(xdsNode);
+    this.adsLifecycleManager = new AdsLifecycleManager(
+        AggregatedDiscoveryServiceGrpc.newStub(channel).withWaitForReady(),
+        endpointWatchers,
+        syncCtx,
+        checkNotNull(timerService, "timerService"),
+        checkNotNull(stopwatchSupplier, "stopwatchSupplier"),
+        checkNotNull(backoffPolicyProvider, "backoffPolicyProvider"));
+  }
+
+  @Override
+  void start() {
+    logger.log(Level.INFO, "Starting XdsClient {0}", XdsClientImpl.this);
+    adsLifecycleManager.start();
+  }
+
+  @Override
+  void shutdown() {
+    channel.shutdown();
+    adsLifecycleManager.shutdown();
+  }
+
+  @Override
+  void watchEndpointData(String cluster, EndpointWatcher endpointWatcher) {
+    endpointWatchers.addWatcher(cluster, endpointWatcher);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("xdsNode", xdsNode).add("authority", authority).toString();
+  }
+
+  /**
+   * Keeps track of all the endpoinWaters that have been added.
+   */
+  static final class EndpointWatchers {
+    private final Map<String, Collection<EndpointWatcher>> endpointWatchers = new LinkedHashMap<>();
+    private final Node xdsNode;
+
+    @CheckForNull // It is null during backoff period.
+    private StreamObserver<DiscoveryRequest> xdsRequestWriter;
+
+    EndpointWatchers(Node xdsNode) {
+      this.xdsNode = xdsNode;
+    }
+
+    void addWatcher(String cluster, EndpointWatcher endpointWatcher) {
+      if (!endpointWatchers.containsKey(cluster)) {
+        endpointWatchers.put(cluster, new ArrayList<EndpointWatcher>());
+      }
+      endpointWatchers.get(cluster).add(endpointWatcher);
+
+      if (xdsRequestWriter != null) {
+        requestEndpoints(xdsRequestWriter);
+      }
+    }
+
+    void onError(Status error) {
+      for (Collection<EndpointWatcher> watcherCollection : endpointWatchers.values()) {
+        for (EndpointWatcher endpointWatcher : watcherCollection) {
+          endpointWatcher.onError(error);
+        }
+      }
+    }
+
+    void onEndpointUpdate(ClusterLoadAssignment clusterLoadAssignment) {
+      String cluster = clusterLoadAssignment.getClusterName();
+      if (endpointWatchers.containsKey(cluster)) {
+        for (EndpointWatcher endpointWatcher : endpointWatchers.get(cluster)) {
+          endpointWatcher.onEndpointChanged(
+              EndpointUpdate.newBuilder().setClusterLoadAssignment(clusterLoadAssignment).build());
+        }
+      }
+    }
+
+    /**
+     * Sends an EDS request if there is any EndpointWatcher added, otherwise will delay EDS request
+     * until a new EndpointWatcher is added.
+     */
+    void requestEndpoints(StreamObserver<DiscoveryRequest> xdsRequestWriter) {
+      this.xdsRequestWriter = checkNotNull(xdsRequestWriter, "xdsRequestWriter");
+      if (!endpointWatchers.isEmpty()) {
+        DiscoveryRequest edsRequest =
+            DiscoveryRequest.newBuilder()
+                .setNode(xdsNode)
+                .setTypeUrl(EDS_TYPE_URL)
+                .addAllResourceNames(endpointWatchers.keySet())
+                .build();
+        logger.log(Level.FINE, "Sending EDS request {0}", edsRequest);
+        xdsRequestWriter.onNext(edsRequest);
+      }
+    }
+
+    /**
+     * Will not send EDS request until the next requestEndpoints(xdsRequestWriter) is called.
+     */
+    void seizeRequestEndpoints() {
+      xdsRequestWriter = null;
+    }
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/XdsResponseReader.java
+++ b/xds/src/main/java/io/grpc/xds/XdsResponseReader.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment;
+import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
+import io.grpc.Status;
+import io.grpc.SynchronizationContext;
+import io.grpc.stub.StreamObserver;
+import io.grpc.xds.XdsClientImpl.EndpointWatchers;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+final class XdsResponseReader implements StreamObserver<DiscoveryResponse> {
+  private static final Logger logger = XdsClientImpl.logger;
+
+  private final StreamActivityWatcher streamActivityWatcher;
+  private final EndpointWatchers endpointWatchers;
+  private final SynchronizationContext syncCtx;
+
+  XdsResponseReader(
+      StreamActivityWatcher streamActivityWatcher,
+      EndpointWatchers endpointWatchers,
+      SynchronizationContext syncCtx) {
+    this.streamActivityWatcher = streamActivityWatcher;
+    this.endpointWatchers = endpointWatchers;
+    this.syncCtx = syncCtx;
+  }
+
+  @Override
+  public void onNext(final DiscoveryResponse value) {
+
+    class HandleResponseRunnable implements Runnable {
+      @Override
+      public void run() {
+        streamActivityWatcher.responseReceived();
+
+        String typeUrl = value.getTypeUrl();
+        if (XdsClientImpl.EDS_TYPE_URL.equals(typeUrl)) {
+          handleEdsResponse(value);
+        }
+      }
+    }
+
+    syncCtx.execute(new HandleResponseRunnable());
+  }
+
+  @Override
+  public void onError(final Throwable t) {
+    logger.log(Level.INFO, "XdsClient received an error", t);
+
+    syncCtx.execute(
+        new Runnable() {
+          @Override
+          public void run() {
+            handleStreamClosed(Status.fromThrowable(t));
+          }
+        });
+  }
+
+  @Override
+  public void onCompleted() {
+    final String errMsg = "Traffic director closed the ADS stream";
+    logger.log(Level.INFO, errMsg);
+    syncCtx.execute(
+        new Runnable() {
+          @Override
+          public void run() {
+            handleStreamClosed(Status.UNAVAILABLE.withDescription(errMsg));
+          }
+        });
+  }
+
+  private void handleEdsResponse(DiscoveryResponse value) {
+    List<ClusterLoadAssignment> clusterLoadAssignments = new ArrayList<>(value.getResourcesCount());
+    try {
+      // maybe better to run this deserialization task out of syncContext?
+      for (Any any : value.getResourcesList()) {
+        clusterLoadAssignments.add(any.unpack(ClusterLoadAssignment.class));
+      }
+    } catch (InvalidProtocolBufferException | RuntimeException e) {
+      if (logger.isLoggable(Level.INFO)) {
+        logger.log(
+            Level.INFO,
+            "Unable to extract clusterLoadAssignment from EDS response: " + value,
+            e);
+      }
+      // TODO(zdapeng): NACK
+      return;
+    }
+
+    logger.log(
+        Level.FINE, "Received an EDS response: {0}", clusterLoadAssignments);
+
+    // TODO(zdapeng): ACK (but if endpointWatchers is empty then send NACK?)
+    for (ClusterLoadAssignment clusterLoadAssignment : clusterLoadAssignments) {
+      endpointWatchers.onEndpointUpdate(clusterLoadAssignment);
+    }
+  }
+
+  // Must run in SynchronizationContext
+  private void handleStreamClosed(Status error) {
+    checkArgument(!error.isOk(), "unexpected OK status");
+
+    endpointWatchers.onError(error);
+    streamActivityWatcher.streamClosed();
+  }
+
+  interface StreamActivityWatcher {
+    void responseReceived();
+
+    void streamClosed();
+  }
+}

--- a/xds/src/test/java/io/grpc/xds/AdsLifecycleManagerTest.java
+++ b/xds/src/test/java/io/grpc/xds/AdsLifecycleManagerTest.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.grpc.xds.XdsClientImpl.EDS_TYPE_URL;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.UInt32Value;
+import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment;
+import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
+import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
+import io.envoyproxy.envoy.api.v2.core.Address;
+import io.envoyproxy.envoy.api.v2.core.Locality;
+import io.envoyproxy.envoy.api.v2.core.Node;
+import io.envoyproxy.envoy.api.v2.core.SocketAddress;
+import io.envoyproxy.envoy.api.v2.endpoint.Endpoint;
+import io.envoyproxy.envoy.api.v2.endpoint.LbEndpoint;
+import io.envoyproxy.envoy.api.v2.endpoint.LocalityLbEndpoints;
+import io.envoyproxy.envoy.service.discovery.v2.AggregatedDiscoveryServiceGrpc;
+import io.envoyproxy.envoy.service.discovery.v2.AggregatedDiscoveryServiceGrpc.AggregatedDiscoveryServiceImplBase;
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.SynchronizationContext;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.internal.BackoffPolicy;
+import io.grpc.internal.FakeClock;
+import io.grpc.internal.testing.StreamRecorder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+import io.grpc.xds.XdsClient.EndpointWatcher;
+import io.grpc.xds.XdsClientImpl.EndpointWatchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Tests for {@link AdsLifecycleManager}.
+ */
+public class AdsLifecycleManagerTest {
+  @Rule
+  public final GrpcCleanupRule cleanupRule = new GrpcCleanupRule();
+
+  private static final FakeClock.TaskFilter LB_RPC_RETRY_TASK_FILTER =
+      new FakeClock.TaskFilter() {
+        @Override
+        public boolean shouldAccept(Runnable command) {
+          return command.toString().contains("AdsRpcRetryTask");
+        }
+      };
+  private final FakeClock fakeClock = new FakeClock();
+  private final SynchronizationContext syncContext = new SynchronizationContext(
+      new Thread.UncaughtExceptionHandler() {
+        @Override
+        public void uncaughtException(Thread t, Throwable e) {
+          throw new AssertionError(e);
+        }
+      });
+
+  @Mock
+  private BackoffPolicy.Provider backoffPolicyProvider;
+  @Mock
+  private BackoffPolicy backoffPolicy1;
+  @Mock
+  private BackoffPolicy backoffPolicy2;
+  @Mock
+  private EndpointWatcher endpointWatcher;
+
+  private StreamRecorder<DiscoveryRequest> streamRecorder;
+  private StreamObserver<DiscoveryResponse> responseWriter;
+  private AdsLifecycleManager adsLifecycleManager;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    doReturn(backoffPolicy1, backoffPolicy2).when(backoffPolicyProvider).get();
+    doReturn(10L, 100L).when(backoffPolicy1).nextBackoffNanos();
+    doReturn(20L, 200L).when(backoffPolicy2).nextBackoffNanos();
+
+    String serverName = InProcessServerBuilder.generateName();
+
+    AggregatedDiscoveryServiceImplBase serviceImpl = new AggregatedDiscoveryServiceImplBase() {
+      @Override
+      public StreamObserver<DiscoveryRequest> streamAggregatedResources(
+          final StreamObserver<DiscoveryResponse> responseObserver) {
+        responseWriter = responseObserver;
+        streamRecorder = StreamRecorder.create();
+
+        return new StreamObserver<DiscoveryRequest>() {
+
+          @Override
+          public void onNext(DiscoveryRequest value) {
+            streamRecorder.onNext(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            streamRecorder.onError(t);
+          }
+
+          @Override
+          public void onCompleted() {
+            streamRecorder.onCompleted();
+          }
+        };
+      }
+    };
+
+    cleanupRule.register(
+        InProcessServerBuilder
+            .forName(serverName)
+            .addService(serviceImpl)
+            .directExecutor()
+            .build()
+            .start());
+    ManagedChannel channel =
+        cleanupRule.register(InProcessChannelBuilder.forName(serverName).directExecutor().build());
+    AggregatedDiscoveryServiceGrpc.AggregatedDiscoveryServiceStub stub =
+        AggregatedDiscoveryServiceGrpc.newStub(channel);
+    EndpointWatchers endpointWatchers =
+        new EndpointWatchers(Node.newBuilder().setCluster("xdsNode").build());
+    endpointWatchers.addWatcher("cluster1", endpointWatcher);
+    adsLifecycleManager = new AdsLifecycleManager(
+        stub, endpointWatchers, syncContext, fakeClock.getScheduledExecutorService(),
+        fakeClock.getStopwatchSupplier(), backoffPolicyProvider);
+  }
+
+  @Test
+  public void start_retries_shutdownCancelsRetry() {
+    assertThat(streamRecorder).isNull();
+
+    adsLifecycleManager.start();
+
+    StreamRecorder<DiscoveryRequest> currentStreamRecorder = streamRecorder;
+    assertThat(currentStreamRecorder.getValues()).hasSize(1);
+    verify(backoffPolicyProvider).get();
+    assertThat(fakeClock.getPendingTasks(LB_RPC_RETRY_TASK_FILTER)).isEmpty();
+
+    // The 1st ADS RPC fails  without receiving initial response.
+    responseWriter.onError(new Exception("fake error"));
+    verify(endpointWatcher).onError(any(Status.class));
+
+    // Will start backoff sequence 1 (10ns).
+    verify(backoffPolicy1).nextBackoffNanos();
+    assertThat(fakeClock.getPendingTasks(LB_RPC_RETRY_TASK_FILTER)).hasSize(1);
+
+    // Fast-forward to a moment before the retry.
+    fakeClock.forwardNanos(9);
+    assertThat(fakeClock.getPendingTasks(LB_RPC_RETRY_TASK_FILTER)).hasSize(1);
+    assertSame(streamRecorder, currentStreamRecorder);
+
+    // Then time for retry
+    fakeClock.forwardNanos(1);
+    assertThat(fakeClock.getPendingTasks(LB_RPC_RETRY_TASK_FILTER)).isEmpty();
+    assertNotSame(currentStreamRecorder, streamRecorder);
+    currentStreamRecorder = streamRecorder;
+    assertThat(currentStreamRecorder.getValues()).hasSize(1);
+
+    // Fail the retry after spending 4ns.
+    fakeClock.forwardNanos(4);
+    // The 2nd RPC fails with response observer onError() without receiving initial response.
+    responseWriter.onError(new Exception("fake error"));
+    verify(endpointWatcher, times(2)).onError(any(Status.class));
+
+    // Will start backoff sequence 2 (100ns)
+    verify(backoffPolicy1, times(2)).nextBackoffNanos();
+    assertThat(fakeClock.getPendingTasks(LB_RPC_RETRY_TASK_FILTER)).hasSize(1);
+    // Fast-forward to a moment before the retry, the time spent in the last try is deducted.
+    fakeClock.forwardNanos(100 - 4 - 1);
+    assertThat(fakeClock.getPendingTasks(LB_RPC_RETRY_TASK_FILTER)).hasSize(1);
+    assertSame(streamRecorder, currentStreamRecorder);
+
+    // Then time for retry
+    fakeClock.forwardNanos(1);
+    assertThat(fakeClock.getPendingTasks(LB_RPC_RETRY_TASK_FILTER)).isEmpty();
+    assertNotSame(currentStreamRecorder, streamRecorder);
+    currentStreamRecorder = streamRecorder;
+    assertThat(currentStreamRecorder.getValues()).hasSize(1);
+
+    // Fail the retry after spending 5ns
+    fakeClock.forwardNanos(5);
+    // The 3rd PRC receives an initial response.
+    Locality localityProto1 = Locality.newBuilder()
+        .setRegion("region1").setZone("zone1").setSubZone("subzone1").build();
+    LbEndpoint endpoint11 = LbEndpoint.newBuilder()
+        .setEndpoint(Endpoint.newBuilder()
+            .setAddress(Address.newBuilder()
+                .setSocketAddress(SocketAddress.newBuilder()
+                    .setAddress("addr11").setPortValue(11))))
+        .setLoadBalancingWeight(UInt32Value.of(11))
+        .build();
+    DiscoveryResponse validEdsResponse = DiscoveryResponse.newBuilder()
+        .addResources(Any.pack(ClusterLoadAssignment.newBuilder()
+            .setClusterName("cluster1")
+            .addEndpoints(LocalityLbEndpoints.newBuilder()
+                .setLocality(localityProto1)
+                .addLbEndpoints(endpoint11)
+                .setLoadBalancingWeight(UInt32Value.of(1)))
+            .build()))
+        .setTypeUrl(EDS_TYPE_URL)
+        .build();
+    responseWriter.onNext(validEdsResponse);
+
+    verify(backoffPolicyProvider, times(1)).get(); // still called once
+    verify(backoffPolicy2, never()).nextBackoffNanos();
+    assertThat(fakeClock.getPendingTasks(LB_RPC_RETRY_TASK_FILTER)).isEmpty();
+
+    // The 3rd RPC then fails
+    fakeClock.forwardNanos(7);
+    responseWriter.onError(new Exception("fake error"));
+    verify(endpointWatcher, times(3)).onError(any(Status.class));
+
+    // Will reset the retry sequence and retry immediately, because balancer has responded.
+    verify(backoffPolicyProvider, times(2)).get();
+    fakeClock.runDueTasks();
+    assertThat(fakeClock.getPendingTasks(LB_RPC_RETRY_TASK_FILTER)).isEmpty();
+    assertNotSame(currentStreamRecorder, streamRecorder);
+    currentStreamRecorder = streamRecorder;
+    assertThat(currentStreamRecorder.getValues()).hasSize(1);
+
+    // The 4th RPC fails with response observer onError() without receiving initial response
+    fakeClock.forwardNanos(8);
+    responseWriter.onError(new Exception("fake error"));
+    verify(endpointWatcher, times(4)).onError(any(Status.class));
+
+    // Will start backoff sequence 1 (20ns)
+    verify(backoffPolicy2).nextBackoffNanos();
+    assertThat(fakeClock.getPendingTasks(LB_RPC_RETRY_TASK_FILTER)).hasSize(1);
+    // Fast-forward to a moment before the retry, the time spent in the last try is deducted.
+    fakeClock.forwardNanos(20 - 8 - 1);
+    assertThat(fakeClock.getPendingTasks(LB_RPC_RETRY_TASK_FILTER)).hasSize(1);
+    assertSame(streamRecorder, currentStreamRecorder);
+
+    // Then time for retry
+    fakeClock.forwardNanos(1);
+    assertThat(fakeClock.getPendingTasks(LB_RPC_RETRY_TASK_FILTER)).isEmpty();
+    assertNotSame(currentStreamRecorder, streamRecorder);
+    currentStreamRecorder = streamRecorder;
+    assertThat(currentStreamRecorder.getValues()).hasSize(1);
+    assertThat(currentStreamRecorder.getError()).isNull();
+
+    // Wrapping up
+    verify(backoffPolicyProvider, times(2)).get();
+    verify(backoffPolicy1, times(2)).nextBackoffNanos(); // for 2nd, 3rd
+    verify(backoffPolicy2, times(1)).nextBackoffNanos(); // for 5th RPC
+
+    // The 5th RPC fails with response observer onError() without receiving initial response
+    responseWriter.onError(new Exception("fake error"));
+    verify(endpointWatcher, times(5)).onError(any(Status.class));
+
+    // Retry is scheduled
+    assertThat(fakeClock.getPendingTasks(LB_RPC_RETRY_TASK_FILTER)).hasSize(1);
+    verify(backoffPolicy2, times(2)).nextBackoffNanos();
+
+    // Shutdown cancels retry
+    adsLifecycleManager.shutdown();
+    assertThat(fakeClock.getPendingTasks(LB_RPC_RETRY_TASK_FILTER)).isEmpty();
+  }
+
+  @Test
+  public void shutdownCancelsRpc() {
+    adsLifecycleManager.start();
+
+    StreamRecorder<DiscoveryRequest> currentStreamRecorder = streamRecorder;
+    assertThat(currentStreamRecorder.getValues()).hasSize(1);
+
+    adsLifecycleManager.shutdown();
+    assertThat(streamRecorder).isSameInstanceAs(currentStreamRecorder);
+    assertThat(streamRecorder.getError()).isNotNull();
+    assertThat(Status.fromThrowable(streamRecorder.getError()).getCode())
+        .isEqualTo(Status.Code.CANCELLED);
+  }
+}

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.grpc.xds.XdsClientImpl.EDS_TYPE_URL;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.collect.Iterables;
+import com.google.protobuf.Any;
+import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment;
+import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment.Policy;
+import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
+import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
+import io.envoyproxy.envoy.api.v2.core.Node;
+import io.envoyproxy.envoy.service.discovery.v2.AggregatedDiscoveryServiceGrpc.AggregatedDiscoveryServiceImplBase;
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.SynchronizationContext;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.internal.BackoffPolicy;
+import io.grpc.internal.FakeClock;
+import io.grpc.internal.testing.StreamRecorder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+import io.grpc.xds.XdsClient.EndpointUpdate;
+import io.grpc.xds.XdsClient.EndpointWatcher;
+import java.util.Arrays;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Tests for {@link XdsClientImpl}.
+ */
+@RunWith(JUnit4.class)
+public class XdsClientImplTest {
+
+  @Rule
+  public final GrpcCleanupRule cleanupRule = new GrpcCleanupRule();
+
+  private final FakeClock fakeClock = new FakeClock();
+  private final SynchronizationContext syncContext = new SynchronizationContext(
+      new Thread.UncaughtExceptionHandler() {
+        @Override
+        public void uncaughtException(Thread t, Throwable e) {
+          throw new AssertionError(e);
+        }
+      });
+  private final Node xdsNode = Node.newBuilder().setCluster("xdsNode").build();
+
+  private final BackoffPolicy.Provider backoffPolicyProvider = new BackoffPolicy.Provider() {
+    final BackoffPolicy backoffPolicy = new BackoffPolicy() {
+      @Override
+      public long nextBackoffNanos() {
+        return 1234567;
+      }
+    };
+
+    @Override
+    public BackoffPolicy get() {
+      return backoffPolicy;
+    }
+  };
+
+  @Mock
+  private EndpointWatcher endpointWatcher1;
+  @Mock
+  private EndpointWatcher endpointWatcher2;
+
+  private StreamRecorder<DiscoveryRequest> streamRecorder;
+  private StreamObserver<DiscoveryResponse> responseWriter;
+  private XdsClientImpl xdsClient;
+  private ManagedChannel channel;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+
+    String serverName = InProcessServerBuilder.generateName();
+
+    AggregatedDiscoveryServiceImplBase serviceImpl = new AggregatedDiscoveryServiceImplBase() {
+      @Override
+      public StreamObserver<DiscoveryRequest> streamAggregatedResources(
+          final StreamObserver<DiscoveryResponse> responseObserver) {
+        responseWriter = responseObserver;
+        streamRecorder = StreamRecorder.create();
+
+        return new StreamObserver<DiscoveryRequest>() {
+
+          @Override
+          public void onNext(DiscoveryRequest value) {
+            streamRecorder.onNext(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            streamRecorder.onError(t);
+          }
+
+          @Override
+          public void onCompleted() {
+            streamRecorder.onCompleted();
+          }
+        };
+      }
+    };
+
+    cleanupRule.register(
+        InProcessServerBuilder
+            .forName(serverName)
+            .addService(serviceImpl)
+            .directExecutor()
+            .build()
+            .start());
+    channel =
+        cleanupRule.register(InProcessChannelBuilder.forName(serverName).directExecutor().build());
+
+    xdsClient = new XdsClientImpl(
+        channel, syncContext, fakeClock.getScheduledExecutorService(), backoffPolicyProvider,
+        fakeClock.getStopwatchSupplier(), xdsNode, "fakeAuthority");
+
+    assertThat(streamRecorder).isNull();
+    xdsClient.start();
+    assertThat(streamRecorder).isNotNull();
+  }
+
+  @After
+  public void tearDown() {
+    xdsClient.shutdown();
+    assertThat(fakeClock.getPendingTasks()).isEmpty();
+    assertThat(channel.isShutdown()).isTrue();
+  }
+
+  @Test
+  public void addEndpointWatcher_edsRequestSent_endpointWatcherUpdateOnEdsResponse() {
+    StreamRecorder<DiscoveryRequest> currentStreamRecorder = streamRecorder;
+    assertThat(currentStreamRecorder.getValues()).isEmpty();
+
+    xdsClient.watchEndpointData("cluster1", endpointWatcher1);
+    assertThat(currentStreamRecorder.getValues()).hasSize(1);
+    DiscoveryRequest requestReceived = Iterables.getOnlyElement(currentStreamRecorder.getValues());
+    assertThat(requestReceived.getTypeUrl()).isEqualTo(EDS_TYPE_URL);
+    assertThat(requestReceived.getResourceNamesList()).containsExactly("cluster1");
+
+    ClusterLoadAssignment clusterLoadAssignment1A =
+        ClusterLoadAssignment.newBuilder().setClusterName("cluster1").build();
+    ClusterLoadAssignment clusterLoadAssignment2A =
+        ClusterLoadAssignment.newBuilder().setClusterName("cluster2").build();
+    ClusterLoadAssignment clusterLoadAssignment3 =
+        ClusterLoadAssignment.newBuilder().setClusterName("cluster3").build();
+    DiscoveryResponse edsResponse = DiscoveryResponse.newBuilder()
+        .addAllResources(Arrays.asList(
+            Any.pack(clusterLoadAssignment1A),
+            Any.pack(clusterLoadAssignment2A),
+            Any.pack(clusterLoadAssignment3)))
+        .setTypeUrl(EDS_TYPE_URL)
+        .setNonce("A")
+        .build();
+    responseWriter.onNext(edsResponse);
+    verify(endpointWatcher1).onEndpointChanged(
+        EndpointUpdate.newBuilder().setClusterLoadAssignment(clusterLoadAssignment1A).build());
+    verify(endpointWatcher2, never()).onEndpointChanged(any(EndpointUpdate.class));
+
+    xdsClient.watchEndpointData("cluster2", endpointWatcher2);
+    assertThat(currentStreamRecorder.getValues()).hasSize(2);
+    DiscoveryRequest requestReceived2 = Iterables.getLast(currentStreamRecorder.getValues());
+    assertThat(requestReceived2.getTypeUrl()).isEqualTo(EDS_TYPE_URL);
+    assertThat(requestReceived2.getResourceNamesList()).containsExactly("cluster1", "cluster2");
+
+    ClusterLoadAssignment clusterLoadAssignment1B = ClusterLoadAssignment
+        .newBuilder().setClusterName("cluster1").setPolicy(Policy.getDefaultInstance()).build();
+    ClusterLoadAssignment clusterLoadAssignment2B = ClusterLoadAssignment
+        .newBuilder().setClusterName("cluster2").setPolicy(Policy.getDefaultInstance()).build();
+    edsResponse = DiscoveryResponse.newBuilder()
+        .addAllResources(Arrays.asList(
+            Any.pack(clusterLoadAssignment1B),
+            Any.pack(clusterLoadAssignment2B),
+            Any.pack(clusterLoadAssignment3)))
+        .setTypeUrl(EDS_TYPE_URL)
+        .setNonce("B")
+        .build();
+    responseWriter.onNext(edsResponse);
+    verify(endpointWatcher1).onEndpointChanged(
+        eq(EndpointUpdate.newBuilder().setClusterLoadAssignment(clusterLoadAssignment1B).build()));
+    verify(endpointWatcher2).onEndpointChanged(
+        eq(EndpointUpdate.newBuilder().setClusterLoadAssignment(clusterLoadAssignment2B).build()));
+  }
+
+  @Test
+  public void addEndpointWatcher_rpcFailure_endpointWatcherOnError() {
+    xdsClient.watchEndpointData("cluster2", endpointWatcher2);
+
+    responseWriter.onError(Status.UNAVAILABLE.asException());
+
+    verify(endpointWatcher1, never()).onError(any(Status.class));
+    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(null);
+    verify(endpointWatcher2).onError(statusCaptor.capture());
+    assertThat(statusCaptor.getValue().getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+  }
+}

--- a/xds/src/test/java/io/grpc/xds/XdsResponseReaderTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsResponseReaderTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.grpc.xds.XdsClientImpl.EDS_TYPE_URL;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.UInt32Value;
+import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment;
+import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
+import io.envoyproxy.envoy.api.v2.core.Address;
+import io.envoyproxy.envoy.api.v2.core.Locality;
+import io.envoyproxy.envoy.api.v2.core.Node;
+import io.envoyproxy.envoy.api.v2.core.SocketAddress;
+import io.envoyproxy.envoy.api.v2.endpoint.Endpoint;
+import io.envoyproxy.envoy.api.v2.endpoint.LbEndpoint;
+import io.envoyproxy.envoy.api.v2.endpoint.LocalityLbEndpoints;
+import io.grpc.Status;
+import io.grpc.SynchronizationContext;
+import io.grpc.xds.XdsClient.EndpointUpdate;
+import io.grpc.xds.XdsClient.EndpointWatcher;
+import io.grpc.xds.XdsClientImpl.EndpointWatchers;
+import io.grpc.xds.XdsResponseReader.StreamActivityWatcher;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Tests for {@link XdsResponseReader}.
+ */
+@RunWith(JUnit4.class)
+public class XdsResponseReaderTest {
+  private XdsResponseReader xdsResponseReader;
+  @Mock
+  private StreamActivityWatcher streamActivityWatcher;
+  @Mock
+  private EndpointWatcher endpointWatcher1;
+  @Mock
+  private EndpointWatcher endpointWatcher2;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+
+    EndpointWatchers endpointWatchers = new EndpointWatchers(Node.getDefaultInstance());
+    endpointWatchers.addWatcher("cluster1", endpointWatcher1);
+    endpointWatchers.addWatcher("cluster2", endpointWatcher2);
+
+    xdsResponseReader = new XdsResponseReader(
+        streamActivityWatcher,
+        endpointWatchers,
+        new SynchronizationContext(
+            new Thread.UncaughtExceptionHandler() {
+              @Override
+              public void uncaughtException(Thread t, Throwable e) {
+                throw new AssertionError(e);
+              }
+            }));
+  }
+
+  @Test
+  public void onResponse() {
+    xdsResponseReader.onNext(DiscoveryResponse.getDefaultInstance());
+
+    verify(streamActivityWatcher).responseReceived();
+    verify(endpointWatcher1, never()).onEndpointChanged(any(EndpointUpdate.class));
+    verify(endpointWatcher2, never()).onEndpointChanged(any(EndpointUpdate.class));
+  }
+
+  @Test
+  public void onEdsResponse() {
+    Locality localityProto1 = Locality.newBuilder()
+        .setRegion("region1").setZone("zone1").setSubZone("subzone1").build();
+    LbEndpoint endpoint11 = LbEndpoint.newBuilder()
+        .setEndpoint(Endpoint.newBuilder()
+            .setAddress(Address.newBuilder()
+                .setSocketAddress(SocketAddress.newBuilder()
+                    .setAddress("addr11").setPortValue(11))))
+        .setLoadBalancingWeight(UInt32Value.of(11))
+        .build();
+    ClusterLoadAssignment clusterLoadAssignment = ClusterLoadAssignment.newBuilder()
+        // only cluster2
+        .setClusterName("cluster2")
+        .addEndpoints(LocalityLbEndpoints.newBuilder()
+            .setLocality(localityProto1)
+            .addLbEndpoints(endpoint11)
+            .setLoadBalancingWeight(UInt32Value.of(1)))
+        .build();
+    DiscoveryResponse edsResponse = DiscoveryResponse.newBuilder()
+        .addResources(Any.pack(clusterLoadAssignment))
+        .setTypeUrl(EDS_TYPE_URL)
+        .build();
+    xdsResponseReader.onNext(edsResponse);
+
+    verify(streamActivityWatcher).responseReceived();
+    verify(endpointWatcher2).onEndpointChanged(
+        eq(EndpointUpdate.newBuilder().setClusterLoadAssignment(clusterLoadAssignment).build()));
+    verify(endpointWatcher1, never()).onEndpointChanged(any(EndpointUpdate.class));
+  }
+
+  @Test
+  public void onError() {
+    Exception fakeException = new Exception("fake exception");
+    xdsResponseReader.onError(fakeException);
+
+    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(null);
+    verify(endpointWatcher1).onError(statusCaptor.capture());
+    assertThat(statusCaptor.getValue().getCause()).isEqualTo(fakeException);
+    verify(endpointWatcher2).onError(statusCaptor.capture());
+    assertThat(statusCaptor.getValue().getCause()).isEqualTo(fakeException);
+
+    verify(streamActivityWatcher).streamClosed();
+  }
+}


### PR DESCRIPTION
- EDS ACK/NACK not implemented.
- XdsClient.cancelEndpointDataWatch() not implemented. (Will see what need be done when swapping other than just removing the watcher)