### PR TITLE
grpclb: cancel stream instead of halfClose when balancer shutdown

### DIFF
--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -279,7 +279,7 @@ final class GrpclbState {
 
   private void shutdownLbRpc() {
     if (lbStream != null) {
-      lbStream.close(null);
+      lbStream.close(Status.CANCELLED.withDescription("balancer shutdown").asException());
       // lbStream will be set to null in LbStream.cleanup()
     }
   }
@@ -668,17 +668,13 @@ final class GrpclbState {
       helper.refreshNameResolution();
     }
 
-    void close(@Nullable Exception error) {
+    void close(Exception error) {
       if (closed) {
         return;
       }
       closed = true;
       cleanUp();
-      if (error == null) {
-        lbRequestWriter.onCompleted();
-      } else {
-        lbRequestWriter.onError(error);
-      }
+      lbRequestWriter.onError(error);
     }
 
     private void cleanUp() {

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -65,6 +65,7 @@ import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.Status;
+import io.grpc.Status.Code;
 import io.grpc.SynchronizationContext;
 import io.grpc.grpclb.GrpclbState.BackendEntry;
 import io.grpc.grpclb.GrpclbState.DropEntry;
@@ -1835,7 +1836,10 @@ public class GrpclbLoadBalancerTest {
 
     verify(requestObserver, never()).onCompleted();
     balancer.shutdown();
-    verify(requestObserver).onCompleted();
+    ArgumentCaptor<Throwable> throwableCaptor = ArgumentCaptor.forClass(Throwable.class);
+    verify(requestObserver).onError(throwableCaptor.capture());
+    assertThat(Status.fromThrowable(throwableCaptor.getValue()).getCode())
+        .isEqualTo(Code.CANCELLED);
   }
 
   @SuppressWarnings("deprecation")


### PR DESCRIPTION
Previously, if the remote balancer doesn't close the stream after receiving the half-close, the OOB channel will hang there forever. It's safer to always cancel on the client-side so that the OOB channel can be cleaned up timely, regardless of what the remote balancer does.