### PR TITLE
all: Bump perfmark to 0.19.0 (backport to v1.22.x)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -185,7 +185,7 @@ subprojects {
         libraries = [
             android_annotations: "com.google.android:annotations:4.1.1.4",
             animalsniffer_annotations: "org.codehaus.mojo:animal-sniffer-annotations:1.17",
-            errorprone: "com.google.errorprone:error_prone_annotations:2.3.2",
+            errorprone: "com.google.errorprone:error_prone_annotations:2.3.3",
             gson: "com.google.code.gson:gson:2.7",
             guava: "com.google.guava:guava:${guavaVersion}",
             hpack: 'com.twitter:hpack:0.10.1',
@@ -202,6 +202,7 @@ subprojects {
             opencensus_impl_lite: "io.opencensus:opencensus-impl-lite:${opencensusVersion}",
             instrumentation_api: 'com.google.instrumentation:instrumentation-api:0.4.3',
             perfmark: 'io.perfmark:perfmark-api:0.16.0',
+            perfmark: 'io.perfmark:perfmark-api:0.19.0',
             protobuf: "com.google.protobuf:protobuf-java:${protobufVersion}",
             protobuf_lite: "com.google.protobuf:protobuf-lite:3.0.1",
             protoc_lite: "com.google.protobuf:protoc-gen-javalite:3.0.0",

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -63,6 +63,11 @@
       <version>${protobuf.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+      <version>2.3.3</version> <!-- prefer to use 2.3.3 or later -->
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/grpclb/build.gradle
+++ b/grpclb/build.gradle
@@ -16,6 +16,8 @@ dependencies {
     compile (libraries.protobuf_util) {
         // prefer 26.0-android from libraries instead of 20.0
         exclude group: 'com.google.guava', module: 'guava'
+        // prefer 2.3.3 from libraries instead of 2.3.2
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }
     compileOnly libraries.javax_annotation
     testCompile libraries.truth,

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -408,9 +408,9 @@ def io_opencensus_grpc_metrics():
 def io_perfmark():
     jvm_maven_import_external(
         name = "io_perfmark_perfmark_api",
-        artifact = "io.perfmark:perfmark-api:0.16.0",
+        artifact = "io.perfmark:perfmark-api:0.19.0",
         server_urls = ["http://central.maven.org/maven2"],
-        artifact_sha256 = "a93667875ea9d10315177768739a18d6c667df041c982d2841645ae8558d0af0",
+        artifact_sha256 = "b734ba2149712409a44eabdb799f64768578fee0defe1418bb108fe32ea43e1a",
         licenses = ["notice"],  # Apache 2.0
     )
 

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -24,6 +24,8 @@ dependencies {
     compile (libraries.protobuf_util) {
         // prefer 26.0-android from libraries instead of 20.0
         exclude group: 'com.google.guava', module: 'guava'
+        // prefer 2.3.3 from libraries instead of 2.3.2
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }
 
     compileOnly libraries.javax_annotation

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     compile (libraries.protobuf_util) {
         // prefer 26.0-android from libraries instead of 20.0
         exclude group: 'com.google.guava', module: 'guava'
+        // prefer 2.3.3 from libraries instead of 2.3.2
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }
 
     testCompile project(':grpc-core').sourceSets.test.output


### PR DESCRIPTION
Resolves #6217