### PR TITLE
github: wrap non-title content into comment blocks.

### DIFF
--- a/.github/ISSUE_TEMPLATE/ask_question.md
+++ b/.github/ISSUE_TEMPLATE/ask_question.md
@@ -4,9 +4,9 @@ about: Asking a question related gRPC-Java
 labels: question
 ---
 
-<!--For questions not directly related to gRPC-Java, please use [stackoverflow](https://stackoverflow.com/questions/tagged/grpc-java).
+<!-- For questions not directly related to gRPC-Java, please use [stackoverflow](https://stackoverflow.com/questions/tagged/grpc-java).
 Also, if question is not gRPC-Java implementation specific, consider using [grpc.io](https://groups.google.com/forum/#!forum/grpc-io).
 
-Make sure you include information that can help us understand your question.-->
+Make sure you include information that can help us understand your question. -->
 
 <!-- Your question below this line. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,11 +4,12 @@ about: Create a bug report to help us improve
 labels: bug
 ---
 
-Please answer these questions before submitting a bug report.
+<!-- Please answer these questions before submitting a bug report. -->
 
-### What version of gRPC are you using?
+### What version of gRPC-Java are you using?
 
-### What operating system (Linux, Windows,...) and version?
+### What is your environment?
+<!-- operating system (Linux, Windows,...) and version, jdk version, etc. -->
 
 ### What did you expect to see?
 
@@ -16,4 +17,4 @@ Please answer these questions before submitting a bug report.
 
 ### Steps to reproduce the bug
 
-Make sure you include information that can help us debug (full error message, exception listing, stack trace, logs).
+<!-- Make sure you include information that can help us debug (full error message, exception listing, stack trace, logs). -->

--- a/.github/ISSUE_TEMPLATE/feature_report.md
+++ b/.github/ISSUE_TEMPLATE/feature_report.md
@@ -4,14 +4,16 @@ about: Suggest an enhancement for gRPC
 labels: enhancement
 ---
 
-### Is your feature request related to a problem? Please describe.
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!-- Please answer these questions before submitting a feature request. -->
+
+### Is your feature request related to a problem?
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 ### Describe the solution you'd like
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
 
 ### Describe alternatives you've considered
-A clear and concise description of any alternative solutions or features you've considered.
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
 ### Additional context
-Add any other context about the feature request here.
+<!-- Add any other context about the feature request here. -->


### PR DESCRIPTION
Hide all descriptive content when issue is filed. Issue like 6330 can looks confusing if we do not hide those things.