### PR TITLE
core: delay attaching cancellation listener to context on server-side.

### DIFF
--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -498,7 +498,7 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
       final StatsTraceContext statsTraceCtx = Preconditions.checkNotNull(
           stream.statsTraceContext(), "statsTraceCtx not present from stream");
 
-      final Context.CancellableContext context = createContext(stream, headers, statsTraceCtx);
+      final Context.CancellableContext context = createContext(headers, statsTraceCtx);
       final Executor wrappedExecutor;
       // This is a performance optimization that avoids the synchronization and queuing overhead
       // that comes with SerializingExecutor.
@@ -553,8 +553,23 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
               context.cancel(null);
               return;
             }
-            listener =
-                startCall(stream, methodName, method, headers, context, statsTraceCtx, tag);
+            listener = startCall(stream, methodName, method, headers, context, statsTraceCtx, tag);
+
+            // Delay cancellation to after startCall().
+            // related issue: https://github.com/grpc/grpc-java/issues/6300
+            final class ServerStreamCancellationListener implements Context.CancellationListener {
+              @Override
+              public void cancelled(Context context) {
+                Status status = statusFromCancelled(context);
+                if (DEADLINE_EXCEEDED.getCode().equals(status.getCode())) {
+                  // This should rarely get run, since the client will likely cancel the stream before
+                  // the timeout is reached.
+                  stream.cancel(status);
+                }
+              }
+            }
+
+            context.addListener(new ServerStreamCancellationListener(), directExecutor());
           } catch (RuntimeException e) {
             stream.close(Status.fromThrowable(e), new Metadata());
             context.cancel(null);
@@ -573,7 +588,7 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
     }
 
     private Context.CancellableContext createContext(
-        final ServerStream stream, Metadata headers, StatsTraceContext statsTraceCtx) {
+        Metadata headers, StatsTraceContext statsTraceCtx) {
       Long timeoutNanos = headers.get(TIMEOUT_KEY);
 
       Context baseContext = statsTraceCtx.serverFilterContext(rootContext);
@@ -586,19 +601,6 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
           baseContext.withDeadline(
               Deadline.after(timeoutNanos, NANOSECONDS, ticker),
               transport.getScheduledExecutorService());
-      final class ServerStreamCancellationListener implements Context.CancellationListener {
-        @Override
-        public void cancelled(Context context) {
-          Status status = statusFromCancelled(context);
-          if (DEADLINE_EXCEEDED.getCode().equals(status.getCode())) {
-            // This should rarely get run, since the client will likely cancel the stream before
-            // the timeout is reached.
-            stream.cancel(status);
-          }
-        }
-      }
-
-      context.addListener(new ServerStreamCancellationListener(), directExecutor());
 
       return context;
     }

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -585,6 +585,7 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
         }
       }
 
+
       wrappedExecutor.execute(new StreamCreated());
     }
 

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -562,8 +562,8 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
               public void cancelled(Context context) {
                 Status status = statusFromCancelled(context);
                 if (DEADLINE_EXCEEDED.getCode().equals(status.getCode())) {
-                  // This should rarely get run, since the client will likely cancel the stream before
-                  // the timeout is reached.
+                  // This should rarely get run, since the client will likely cancel the stream
+                  // before the timeout is reached.
                   stream.cancel(status);
                 }
               }

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -585,7 +585,6 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
         }
       }
 
-
       wrappedExecutor.execute(new StreamCreated());
     }
 

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -566,9 +566,9 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
             jumpListener.setListener(listener);
           }
 
-          // An extremely short deadline may expire before the stream listener is set. This causes
-          // NPE as in issue: https://github.com/grpc/grpc-java/issues/6300
-          // Delay the setting of listener will fix the NPE.
+          // An extremely short deadline may expire before stream.setListener(jumpListener).
+          // This causes NPE as in issue: https://github.com/grpc/grpc-java/issues/6300
+          // Delay of setting cancellationListener to context will fix the issue.
           final class ServerStreamCancellationListener implements Context.CancellationListener {
             @Override
             public void cancelled(Context context) {

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -1037,20 +1037,18 @@ public class ServerImplTest {
       throws Exception {
     AtomicBoolean contextCancelled = new AtomicBoolean(false);
     AtomicReference<Context> context = new AtomicReference<>();
-    AtomicReference<ServerCall<String, Integer>> callReference
-        = new AtomicReference<>();
+    AtomicReference<ServerCall<String, Integer>> callReference = new AtomicReference<>();
 
-    testStreamClose_setup(callReference,
-        context, contextCancelled, 0L);
+    testStreamClose_setup(callReference, context, contextCancelled, 0L);
 
-    // This assert that stream.setListener() is called before stream.cancel(), which avoid every
-    // short deadlines causing NPEs.
+    // This assert that stream.setListener(jumpListener) is called before stream.cancel(), which
+    // prevents extremely short deadlines causing NPEs.
     InOrder inOrder = inOrder(stream);
     inOrder.verify(stream).setListener(any(ServerStreamListener.class));
     inOrder.verify(stream).cancel(statusCaptor.capture());
 
-    assertThat(
-        statusCaptor.getValue().asException()).hasMessageThat().contains("context timed out");
+    assertThat(statusCaptor.getValue().asException())
+        .hasMessageThat().contains("context timed out");
     assertTrue(callReference.get().isCancelled());
   }
 
@@ -1058,8 +1056,7 @@ public class ServerImplTest {
   public void testStreamClose_clientCancelTriggersImmediateCancellation() throws Exception {
     AtomicBoolean contextCancelled = new AtomicBoolean(false);
     AtomicReference<Context> context = new AtomicReference<>();
-    AtomicReference<ServerCall<String, Integer>> callReference
-        = new AtomicReference<>();
+    AtomicReference<ServerCall<String, Integer>> callReference = new AtomicReference<>();
 
     ServerStreamListener streamListener = testStreamClose_setup(callReference,
         context, contextCancelled, null);
@@ -1081,8 +1078,7 @@ public class ServerImplTest {
   public void testStreamClose_clientOkTriggersDelayedCancellation() throws Exception {
     AtomicBoolean contextCancelled = new AtomicBoolean(false);
     AtomicReference<Context> context = new AtomicReference<>();
-    AtomicReference<ServerCall<String, Integer>> callReference
-        = new AtomicReference<>();
+    AtomicReference<ServerCall<String, Integer>> callReference = new AtomicReference<>();
 
     ServerStreamListener streamListener = testStreamClose_setup(callReference,
         context, contextCancelled, null);
@@ -1105,8 +1101,7 @@ public class ServerImplTest {
   public void testStreamClose_deadlineExceededTriggersImmediateCancellation() throws Exception {
     AtomicBoolean contextCancelled = new AtomicBoolean(false);
     AtomicReference<Context> context = new AtomicReference<>();
-    AtomicReference<ServerCall<String, Integer>> callReference
-        = new AtomicReference<>();
+    AtomicReference<ServerCall<String, Integer>> callReference = new AtomicReference<>();
 
     testStreamClose_setup(callReference, context, contextCancelled, 50L);
 


### PR DESCRIPTION
fixes: https://github.com/grpc/grpc-java/issues/6300

With these change, it passes the reproducer in that issue.