### PR TITLE
xds: refactor Bootstrapper implementation to be more use friendly

### DIFF
--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -37,7 +37,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * Loads configuration information to bootstrap xDS load balancer.
+ * Loads configuration information to bootstrap gRPC's integration of xDS protocol.
  */
 abstract class Bootstrapper {
 

--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -81,7 +81,7 @@ abstract class Bootstrapper {
         }
       }
       if (failToBootstrapException != null) {
-        throw failToBootstrapException;
+        throw new RuntimeException(failToBootstrapException);
       }
       return bootstrapInfo;
     }

--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -43,7 +43,7 @@ abstract class Bootstrapper {
 
   private static final String BOOTSTRAP_PATH_SYS_ENV_VAR = "GRPC_XDS_BOOTSTRAP";
 
-  static Bootstrapper getInstance() {
+  static Bootstrapper newInsatnce() {
     return new FileBasedBootstrapper();
   }
 

--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -39,85 +39,49 @@ import javax.annotation.concurrent.Immutable;
 /**
  * Loads configuration information to bootstrap xDS load balancer.
  */
-@Immutable
 abstract class Bootstrapper {
 
   private static final String BOOTSTRAP_PATH_SYS_ENV_VAR = "GRPC_XDS_BOOTSTRAP";
 
-  static Bootstrapper getInstance() throws Exception {
-    if (FileBasedBootstrapper.defaultInstance == null) {
-      throw FileBasedBootstrapper.failToBootstrapException;
-    }
-    return FileBasedBootstrapper.defaultInstance;
+  static Bootstrapper getInstance() {
+    return new FileBasedBootstrapper();
   }
 
   /**
-   * Returns the URI the traffic director to be connected to.
+   * Returns configurations from bootstrap.
    */
-  abstract String getServerUri();
+  abstract BootstrapInfo readBootstrap() throws Exception;
 
-  /**
-   * Returns a {@link Node} message with project/network metadata in it to be included in
-   * xDS requests.
-   */
-  abstract Node getNode();
+  private static final class FileBasedBootstrapper extends Bootstrapper {
 
-  /**
-   * Returns the credentials to use when communicating with the xDS server.
-   */
-  abstract List<ChannelCreds> getChannelCredentials();
+    private static Exception failToBootstrapException;
+    private static BootstrapInfo bootstrapInfo;
 
-  @VisibleForTesting
-  static final class FileBasedBootstrapper extends Bootstrapper {
-
-    private static final Exception failToBootstrapException;
-    private static final Bootstrapper defaultInstance;
-
-    private final String serverUri;
-    private final Node node;
-    private final List<ChannelCreds> channelCredsList;
-
-    static {
-      Bootstrapper instance = null;
-      Exception exception = null;
-      try {
-        instance = new FileBasedBootstrapper(Bootstrapper.readConfig());
-      } catch (Exception e) {
-        exception = e;
+    @Override
+    BootstrapInfo readBootstrap() throws Exception {
+      if (bootstrapInfo != null) {
+        return bootstrapInfo;
       }
-      defaultInstance = instance;
-      failToBootstrapException = exception;
+      if (failToBootstrapException != null) {
+        throw failToBootstrapException;
+      }
+      try {
+        String filePath = System.getenv(BOOTSTRAP_PATH_SYS_ENV_VAR);
+        if (filePath == null) {
+          throw
+              new IOException("Environment variable " + BOOTSTRAP_PATH_SYS_ENV_VAR + " not found.");
+        }
+        bootstrapInfo =
+            parseConfig(new String(Files.readAllBytes(Paths.get(filePath)),
+                StandardCharsets.UTF_8));
+      } catch (Exception e) {
+        failToBootstrapException = e;
+      }
+      if (failToBootstrapException != null) {
+        throw failToBootstrapException;
+      }
+      return bootstrapInfo;
     }
-
-    @VisibleForTesting
-    FileBasedBootstrapper(BootstrapInfo bootstrapInfo) {
-      this.serverUri = bootstrapInfo.serverConfig.uri;
-      this.node = bootstrapInfo.node;
-      this.channelCredsList = bootstrapInfo.serverConfig.channelCredsList;
-    }
-
-    @Override
-    String getServerUri() {
-      return serverUri;
-    }
-    
-    @Override
-    Node getNode() {
-      return node;
-    }
-
-    @Override
-    List<ChannelCreds> getChannelCredentials() {
-      return Collections.unmodifiableList(channelCredsList);
-    }
-  }
-
-  private static BootstrapInfo readConfig() throws IOException {
-    String filePath = System.getenv(BOOTSTRAP_PATH_SYS_ENV_VAR);
-    if (filePath == null) {
-      throw new IOException("Environment variable " + BOOTSTRAP_PATH_SYS_ENV_VAR + " not found.");
-    }
-    return parseConfig(new String(Files.readAllBytes(Paths.get(filePath)), StandardCharsets.UTF_8));
   }
 
   @VisibleForTesting
@@ -148,7 +112,6 @@ abstract class Bootstrapper {
         channelCredsOptions.add(creds);
       }
     }
-    ServerConfig serverConfig = new ServerConfig(serverUri, channelCredsOptions);
 
     Map<String, ?> rawNode = JsonUtil.getObject(rawBootstrap, "node");
     if (rawNode == null) {
@@ -193,7 +156,7 @@ abstract class Bootstrapper {
       nodeBuilder.setBuildVersion(buildVersion);
     }
 
-    return new BootstrapInfo(serverConfig, nodeBuilder.build());
+    return new BootstrapInfo(serverUri, channelCredsOptions, nodeBuilder.build());
   }
 
   /**
@@ -233,7 +196,11 @@ abstract class Bootstrapper {
     return valueBuilder.build();
   }
 
+  /**
+   * Data class containing channel credentials configurations for xDS protocol communication.
+   */
   // TODO(chengyuanzhang): May need more complex structure for channel creds config representation.
+  @Immutable
   static class ChannelCreds {
     private final String type;
     @Nullable
@@ -251,31 +218,48 @@ abstract class Bootstrapper {
 
     @Nullable
     Map<String, ?> getConfig() {
-      return config;
+      if (config != null) {
+        return Collections.unmodifiableMap(config);
+      }
+      return null;
     }
   }
 
-  @VisibleForTesting
+  /**
+   * Data class containing the results of reading bootstrap.
+   */
+  @Immutable
   static class BootstrapInfo {
-    final ServerConfig serverConfig;
-    final Node node;
+    private final String serverUri;
+    private final List<ChannelCreds> channelCredsList;
+    private final Node node;
 
     @VisibleForTesting
-    BootstrapInfo(ServerConfig serverConfig, Node node) {
-      this.serverConfig = serverConfig;
+    BootstrapInfo(String serverUri, List<ChannelCreds> channelCredsList, Node node) {
+      this.serverUri = serverUri;
+      this.channelCredsList = channelCredsList;
       this.node = node;
     }
-  }
 
-  @VisibleForTesting
-  static class ServerConfig {
-    final String uri;
-    final List<ChannelCreds> channelCredsList;
+    /**
+     * Returns the URI the traffic director to be connected to.
+     */
+    String getServerUri() {
+      return serverUri;
+    }
 
-    @VisibleForTesting
-    ServerConfig(String uri, List<ChannelCreds> channelCredsList) {
-      this.uri = uri;
-      this.channelCredsList = channelCredsList;
+    /**
+     * Returns the node identifier to be included in xDS requests.
+     */
+    Node getNode() {
+      return node;
+    }
+
+    /**
+     * Returns the credentials to use when communicating with the xDS server.
+     */
+    List<ChannelCreds> getChannelCredentials() {
+      return Collections.unmodifiableList(channelCredsList);
     }
   }
 }

--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -62,7 +62,7 @@ abstract class Bootstrapper {
     @Override
     BootstrapInfo readBootstrap() throws Exception {
       if (bootstrapInfo == null && failToBootstrapException == null) {
-        synchronized (Bootstrapper.FileBasedBootstrapper.class) {
+        synchronized (FileBasedBootstrapper.class) {
           if (bootstrapInfo == null && failToBootstrapException == null) {
             try {
               String filePath = System.getenv(BOOTSTRAP_PATH_SYS_ENV_VAR);

--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -35,10 +35,12 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Loads configuration information to bootstrap gRPC's integration of xDS protocol.
  */
+@ThreadSafe
 abstract class Bootstrapper {
 
   private static final String BOOTSTRAP_PATH_SYS_ENV_VAR = "GRPC_XDS_BOOTSTRAP";

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -77,7 +77,7 @@ final class XdsNameResolver extends NameResolver {
     try {
       bootstrapInfo = bootstrapper.readBootstrap();
     } catch (Exception e) {
-      listener.onError(Status.UNKNOWN.withDescription("Failed to bootstrap").withCause(e));
+      listener.onError(Status.UNAVAILABLE.withDescription("Failed to bootstrap").withCause(e));
       return;
     }
 

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -52,7 +52,7 @@ final class XdsNameResolver extends NameResolver {
   private final Bootstrapper bootstrapper;
 
   XdsNameResolver(String name) {
-    this(name, Bootstrapper.getInstance());
+    this(name, Bootstrapper.newInsatnce());
   }
 
   @VisibleForTesting

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -27,13 +27,11 @@ import io.grpc.NameResolver;
 import io.grpc.Status;
 import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.JsonParser;
+import io.grpc.xds.Bootstrapper.BootstrapInfo;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import javax.annotation.Nullable;
 
 /**
  * A {@link NameResolver} for resolving gRPC target names with "xds-experimental" scheme.
@@ -46,61 +44,25 @@ import javax.annotation.Nullable;
  */
 final class XdsNameResolver extends NameResolver {
 
-  private static final Logger logger = Logger.getLogger(XdsNameResolver.class.getName());
-
+  // TODO(chengyuanzhang): delete this later, it was a workaround for demo.
   @NameResolver.ResolutionResultAttr
   static final Attributes.Key<Node> XDS_NODE = Attributes.Key.create("xds-node");
 
-  private static final String SERVICE_CONFIG_HARDCODED = "{"
-          + "\"loadBalancingConfig\": ["
-          + "{\"xds_experimental\" : {"
-          + "\"childPolicy\" : [{\"round_robin\" : {}}]"
-          + "}}"
-          + "]}";
-
   private final String authority;
-  private final String serviceConfig;
-  private final Node node;
+  private final Bootstrapper bootstrapper;
 
   XdsNameResolver(String name) {
-    this(name, createBootstrapper());
+    this(name, Bootstrapper.getInstance());
   }
 
   @VisibleForTesting
-  XdsNameResolver(String name, @Nullable Bootstrapper bootstrapper) {
+  XdsNameResolver(String name, Bootstrapper bootstrapper) {
     URI nameUri = URI.create("//" + checkNotNull(name, "name"));
     Preconditions.checkArgument(nameUri.getHost() != null, "Invalid hostname: %s", name);
     authority =
         Preconditions.checkNotNull(
             nameUri.getAuthority(), "nameUri (%s) doesn't have an authority", nameUri);
-
-    String serviceConfig = SERVICE_CONFIG_HARDCODED;
-    Node node = Node.getDefaultInstance();
-
-    if (bootstrapper != null) {
-      String serverUri = bootstrapper.getServerUri();
-      node = bootstrapper.getNode();
-      serviceConfig = "{"
-          + "\"loadBalancingConfig\": ["
-          + "{\"xds_experimental\" : {"
-          + "\"balancerName\" : \"" + serverUri + "\","
-          + "\"childPolicy\" : [{\"round_robin\" : {}}]"
-          + "}}"
-          + "]}";
-    }
-
-    this.serviceConfig = serviceConfig;
-    this.node = node;
-  }
-
-  @Nullable
-  private static Bootstrapper createBootstrapper() {
-    try {
-      return Bootstrapper.getInstance();
-    } catch (Exception e) {
-      logger.log(Level.FINE, "Unable to load XDS bootstrap config", e);
-    }
-    return null;
+    this.bootstrapper = Preconditions.checkNotNull(bootstrapper, "bootstrapper");
   }
 
   @Override
@@ -111,7 +73,21 @@ final class XdsNameResolver extends NameResolver {
   @SuppressWarnings("unchecked")
   @Override
   public void start(final Listener2 listener) {
+    BootstrapInfo bootstrapInfo = null;
+    try {
+      bootstrapInfo = bootstrapper.readBootstrap();
+    } catch (Exception e) {
+      listener.onError(Status.UNKNOWN.withDescription("Failed to bootstrap").withCause(e));
+      return;
+    }
 
+    String serviceConfig = "{"
+        + "\"loadBalancingConfig\": ["
+        + "{\"xds_experimental\" : {"
+        + "\"balancerName\" : \"" + bootstrapInfo.getServerUri() + "\","
+        + "\"childPolicy\" : [{\"round_robin\" : {}}]"
+        + "}}"
+        + "]}";
     Map<String, ?> config;
     try {
       config = (Map<String, ?>) JsonParser.parse(serviceConfig);
@@ -123,7 +99,7 @@ final class XdsNameResolver extends NameResolver {
     Attributes attrs =
         Attributes.newBuilder()
             .set(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG, config)
-            .set(XDS_NODE, node)
+            .set(XDS_NODE, bootstrapInfo.getNode())
             .build();
     ResolutionResult result =
         ResolutionResult.newBuilder()

--- a/xds/src/test/java/io/grpc/xds/BootstrapperTest.java
+++ b/xds/src/test/java/io/grpc/xds/BootstrapperTest.java
@@ -18,17 +18,12 @@ package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import io.envoyproxy.envoy.api.v2.core.Locality;
 import io.envoyproxy.envoy.api.v2.core.Node;
 import io.grpc.xds.Bootstrapper.BootstrapInfo;
-import io.grpc.xds.Bootstrapper.ChannelCreds;
-import io.grpc.xds.Bootstrapper.FileBasedBootstrapper;
-import io.grpc.xds.Bootstrapper.ServerConfig;
 import java.io.IOException;
-import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -40,56 +35,6 @@ import org.junit.runners.JUnit4;
 public class BootstrapperTest {
 
   @Rule public ExpectedException thrown = ExpectedException.none();
-
-  @Test
-  public void validBootstrap() {
-    List<ChannelCreds> channelCredsList =
-        ImmutableList.of(new ChannelCreds("TLS", null), new ChannelCreds("LOAS", null));
-    ServerConfig serverConfig =
-        new ServerConfig("trafficdirector.googleapis.com:443", channelCredsList);
-
-    Node node =
-        Node.newBuilder()
-            .setId("ENVOY_NODE_ID")
-            .setCluster("ENVOY_CLUSTER")
-            .setLocality(
-                Locality.newBuilder()
-                    .setRegion("ENVOY_REGION").setZone("ENVOY_ZONE").setSubZone("ENVOY_SUBZONE"))
-            .setMetadata(
-                Struct.newBuilder()
-                    .putFields("TRAFFICDIRECTOR_INTERCEPTION_PORT",
-                        Value.newBuilder().setStringValue("ENVOY_PORT").build())
-                    .putFields("TRAFFICDIRECTOR_NETWORK_NAME",
-                        Value.newBuilder().setStringValue("VPC_NETWORK_NAME").build()))
-            .build();
-
-    BootstrapInfo config = new BootstrapInfo(serverConfig, node);
-    Bootstrapper bootstrapper = new FileBasedBootstrapper(config);
-    assertThat(bootstrapper.getServerUri()).isEqualTo("trafficdirector.googleapis.com:443");
-    assertThat(bootstrapper.getNode())
-        .isEqualTo(
-            Node.newBuilder()
-                .setId("ENVOY_NODE_ID")
-                .setCluster("ENVOY_CLUSTER")
-                .setLocality(
-                    Locality.newBuilder()
-                        .setRegion("ENVOY_REGION")
-                        .setZone("ENVOY_ZONE")
-                        .setSubZone("ENVOY_SUBZONE"))
-                .setMetadata(
-                    Struct.newBuilder()
-                        .putFields("TRAFFICDIRECTOR_INTERCEPTION_PORT",
-                            Value.newBuilder().setStringValue("ENVOY_PORT").build())
-                        .putFields("TRAFFICDIRECTOR_NETWORK_NAME",
-                            Value.newBuilder().setStringValue("VPC_NETWORK_NAME").build())
-                        .build())
-                .build());
-    assertThat(bootstrapper.getChannelCredentials()).hasSize(2);
-    assertThat(bootstrapper.getChannelCredentials().get(0).getType()).isEqualTo("TLS");
-    assertThat(bootstrapper.getChannelCredentials().get(0).getConfig()).isNull();
-    assertThat(bootstrapper.getChannelCredentials().get(1).getType()).isEqualTo("LOAS");
-    assertThat(bootstrapper.getChannelCredentials().get(1).getConfig()).isNull();
-  }
 
   @Test
   public void parseBootstrap_validData() throws IOException {
@@ -113,13 +58,13 @@ public class BootstrapperTest {
         + "}";
 
     BootstrapInfo info = Bootstrapper.parseConfig(rawData);
-    assertThat(info.serverConfig.uri).isEqualTo("trafficdirector.googleapis.com:443");
-    assertThat(info.serverConfig.channelCredsList).hasSize(2);
-    assertThat(info.serverConfig.channelCredsList.get(0).getType()).isEqualTo("TLS");
-    assertThat(info.serverConfig.channelCredsList.get(0).getConfig()).isNull();
-    assertThat(info.serverConfig.channelCredsList.get(1).getType()).isEqualTo("LOAS");
-    assertThat(info.serverConfig.channelCredsList.get(1).getConfig()).isNull();
-    assertThat(info.node).isEqualTo(
+    assertThat(info.getServerUri()).isEqualTo("trafficdirector.googleapis.com:443");
+    assertThat(info.getChannelCredentials()).hasSize(2);
+    assertThat(info.getChannelCredentials().get(0).getType()).isEqualTo("TLS");
+    assertThat(info.getChannelCredentials().get(0).getConfig()).isNull();
+    assertThat(info.getChannelCredentials().get(1).getType()).isEqualTo("LOAS");
+    assertThat(info.getChannelCredentials().get(1).getConfig()).isNull();
+    assertThat(info.getNode()).isEqualTo(
         Node.newBuilder()
             .setId("ENVOY_NODE_ID")
             .setCluster("ENVOY_CLUSTER")
@@ -154,8 +99,8 @@ public class BootstrapperTest {
         + "}";
 
     BootstrapInfo info = Bootstrapper.parseConfig(rawData);
-    assertThat(info.serverConfig.uri).isEqualTo("trafficdirector.googleapis.com:443");
-    assertThat(info.node).isEqualTo(Node.getDefaultInstance());
+    assertThat(info.getServerUri()).isEqualTo("trafficdirector.googleapis.com:443");
+    assertThat(info.getNode()).isEqualTo(Node.getDefaultInstance());
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -17,10 +17,8 @@
 package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
-import static io.grpc.xds.XdsNameResolver.XDS_NODE;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.google.common.collect.ImmutableList;
@@ -29,9 +27,11 @@ import io.envoyproxy.envoy.api.v2.core.Node;
 import io.grpc.NameResolver;
 import io.grpc.NameResolver.ResolutionResult;
 import io.grpc.NameResolver.ServiceConfigParser;
+import io.grpc.Status;
 import io.grpc.SynchronizationContext;
 import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.GrpcUtil;
+import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
@@ -41,7 +41,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -73,7 +72,6 @@ public class XdsNameResolverTest {
   private final XdsNameResolverProvider provider = new XdsNameResolverProvider();
 
   @Mock private NameResolver.Listener2 mockListener;
-  @Captor private ArgumentCaptor<ResolutionResult> resultCaptor;
 
   @Test
   public void validName_withAuthority() {
@@ -103,81 +101,56 @@ public class XdsNameResolverTest {
   }
 
   @Test
-  public void resolve_hardcodedResult() {
-    XdsNameResolver resolver = new XdsNameResolver("foo.googleapis.com", null);
-    resolver.start(mockListener);
-    verify(mockListener).onResult(resultCaptor.capture());
-    assertHardCodedServiceConfig(resultCaptor.getValue());
-
-    resolver = new XdsNameResolver("bar.googleapis.com", null);
-    resolver.start(mockListener);
-    verify(mockListener, times(2)).onResult(resultCaptor.capture());
-    assertHardCodedServiceConfig(resultCaptor.getValue());
-  }
-
-  @Test
   public void resolve_bootstrapResult() {
     Bootstrapper bootstrapper = new Bootstrapper() {
       @Override
-      String getServerUri() {
-        return "fake_server_uri";
+      BootstrapInfo readBootstrap() {
+        return new BootstrapInfo("trafficdirector.googleapis.com",
+            ImmutableList.<ChannelCreds>of(), FAKE_BOOTSTRAP_NODE);
       }
+    };
+    XdsNameResolver resolver = new XdsNameResolver("foo.googleapis.com", bootstrapper);
+    resolver.start(mockListener);
+    ArgumentCaptor<ResolutionResult> resultCaptor = ArgumentCaptor.forClass(null);
+    verify(mockListener).onResult(resultCaptor.capture());
+    ResolutionResult result = resultCaptor.getValue();
+    assertThat(result.getAddresses()).isEmpty();
 
-      @Override
-      Node getNode() {
-        return FAKE_BOOTSTRAP_NODE;
-      }
+    Map<String, ?> serviceConfig =
+        result.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
+    @SuppressWarnings("unchecked")
+    List<Map<String, ?>> rawLbConfigs =
+        (List<Map<String, ?>>) serviceConfig.get("loadBalancingConfig");
+    Map<String, ?> xdsLbConfig = Iterables.getOnlyElement(rawLbConfigs);
+    assertThat(xdsLbConfig.keySet()).containsExactly("xds_experimental");
+    @SuppressWarnings("unchecked")
+    Map<String, ?> rawConfigValues = (Map<String, ?>) xdsLbConfig.get("xds_experimental");
+    assertThat(rawConfigValues)
+        .containsExactly(
+            "balancerName",
+            "trafficdirector.googleapis.com",
+            "childPolicy",
+            Collections.singletonList(
+                Collections.singletonMap("round_robin", Collections.EMPTY_MAP)));
+    assertThat(result.getAttributes().get(XdsNameResolver.XDS_NODE)).isEqualTo(FAKE_BOOTSTRAP_NODE);
+  }
 
+  @Test
+  public void resolve_failToBootstrap() {
+    Bootstrapper bootstrapper = new Bootstrapper() {
       @Override
-      List<ChannelCreds> getChannelCredentials() {
-        return ImmutableList.of();
+      BootstrapInfo readBootstrap() throws Exception {
+        throw new IOException("Fail to read bootstrap file");
       }
     };
 
     XdsNameResolver resolver = new XdsNameResolver("foo.googleapis.com", bootstrapper);
     resolver.start(mockListener);
-    verify(mockListener).onResult(resultCaptor.capture());
-    assertBootstrapServiceConfig(resultCaptor.getValue());
-
-    resolver = new XdsNameResolver("bar.googleapis.com", bootstrapper);
-    resolver.start(mockListener);
-    verify(mockListener, times(2)).onResult(resultCaptor.capture());
-    assertBootstrapServiceConfig(resultCaptor.getValue());
-  }
-
-  @SuppressWarnings("unchecked")
-  private static void assertHardCodedServiceConfig(ResolutionResult actualResult) {
-    assertThat(actualResult.getAddresses()).isEmpty();
-    Map<String, ?> serviceConfig =
-        actualResult.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
-    List<Map<String, ?>> rawLbConfigs =
-        (List<Map<String, ?>>) serviceConfig.get("loadBalancingConfig");
-    Map<String, ?> xdsLbConfig = Iterables.getOnlyElement(rawLbConfigs);
-    assertThat(xdsLbConfig.keySet()).containsExactly("xds_experimental");
-    Map<String, ?> rawConfigValues = (Map<String, ?>) xdsLbConfig.get("xds_experimental");
-    assertThat(rawConfigValues)
-        .containsExactly("childPolicy",
-            Collections.singletonList(
-                Collections.singletonMap("round_robin", Collections.EMPTY_MAP)));
-  }
-
-  @SuppressWarnings("unchecked")
-  private static void assertBootstrapServiceConfig(ResolutionResult actualResult) {
-    assertThat(actualResult.getAddresses()).isEmpty();
-    Map<String, ?> serviceConfig =
-        actualResult.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
-    List<Map<String, ?>> rawLbConfigs =
-        (List<Map<String, ?>>) serviceConfig.get("loadBalancingConfig");
-    Map<String, ?> xdsLbConfig = Iterables.getOnlyElement(rawLbConfigs);
-    assertThat(xdsLbConfig.keySet()).containsExactly("xds_experimental");
-    Map<String, ?> rawConfigValues = (Map<String, ?>) xdsLbConfig.get("xds_experimental");
-    assertThat(rawConfigValues)
-        .containsExactly(
-            "balancerName",
-            "fake_server_uri",
-            "childPolicy",
-            Collections.singletonList(
-                Collections.singletonMap("round_robin", Collections.EMPTY_MAP)));
-    assertThat(actualResult.getAttributes().get(XDS_NODE)).isEqualTo(FAKE_BOOTSTRAP_NODE);
+    ArgumentCaptor<Status> errorCaptor = ArgumentCaptor.forClass(null);
+    verify(mockListener).onError(errorCaptor.capture());
+    Status error = errorCaptor.getValue();
+    assertThat(error.getCode()).isEqualTo(Status.Code.UNKNOWN);
+    assertThat(error.getDescription()).isEqualTo("Failed to bootstrap");
+    assertThat(error.getCause()).hasMessageThat().isEqualTo("Fail to read bootstrap file");
   }
 }

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -28,6 +28,7 @@ import io.grpc.NameResolver;
 import io.grpc.NameResolver.ResolutionResult;
 import io.grpc.NameResolver.ServiceConfigParser;
 import io.grpc.Status;
+import io.grpc.Status.Code;
 import io.grpc.SynchronizationContext;
 import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.GrpcUtil;
@@ -149,7 +150,7 @@ public class XdsNameResolverTest {
     ArgumentCaptor<Status> errorCaptor = ArgumentCaptor.forClass(null);
     verify(mockListener).onError(errorCaptor.capture());
     Status error = errorCaptor.getValue();
-    assertThat(error.getCode()).isEqualTo(Status.Code.UNKNOWN);
+    assertThat(error.getCode()).isEqualTo(Code.UNAVAILABLE);
     assertThat(error.getDescription()).isEqualTo("Failed to bootstrap");
     assertThat(error.getCause()).hasMessageThat().isEqualTo("Fail to read bootstrap file");
   }


### PR DESCRIPTION
Existing `Bootstrapper` implementation reads bootstrap file statically at the first time getting an instance. This is not friendly for usage in resolver, especially for error propagation.

The resolver is doing the work at `NameResolver#start(Listener2)`, which passes resolution results or error to channel through the listener. With the existing `Bootstrapper` implementation, we would need to instantiate a `Bootstrapper` instance in `NameResolver#start(...)` in order to have correct error propagation. But this introduces difficulty for testing. This makes #6240 very awkward.

This PR restructures the implementation of `Bootstrapper`, which adds a `Bootstrapper#readBootstrap()` method that does the work of reading/parsing bootstrap. The bootstrapping result is saved in a static field so that we will only bootstrap at most once.

Simplified usage:
`BootstrapInfo` is a data class that contains everything gRPC client needs for xDS.
`Bootstrapper#readBootstrap()` returns a `BootstrapInfo` instance.


