### PR TITLE
Revert "xds: bootstrap xDS load balancer with xDS name resolver"

### DIFF
--- a/xds/src/main/java/io/grpc/xds/LookasideChannelLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideChannelLb.java
@@ -22,7 +22,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment;
-import io.envoyproxy.envoy.api.v2.core.Node;
 import io.envoyproxy.envoy.api.v2.endpoint.LocalityLbEndpoints;
 import io.envoyproxy.envoy.type.FractionalPercent;
 import io.envoyproxy.envoy.type.FractionalPercent.DenominatorType;
@@ -53,7 +52,7 @@ final class LookasideChannelLb extends LoadBalancer {
 
   LookasideChannelLb(
       Helper helper, LookasideChannelCallback lookasideChannelCallback, ManagedChannel lbChannel,
-      LocalityStore localityStore, Node node) {
+      LocalityStore localityStore) {
     this(
         helper,
         lookasideChannelCallback,
@@ -61,8 +60,7 @@ final class LookasideChannelLb extends LoadBalancer {
         new LoadReportClientImpl(
             lbChannel, helper, GrpcUtil.STOPWATCH_SUPPLIER, new ExponentialBackoffPolicy.Provider(),
             localityStore.getLoadStatsStore()),
-        localityStore,
-        node);
+        localityStore);
   }
 
   @VisibleForTesting
@@ -71,8 +69,7 @@ final class LookasideChannelLb extends LoadBalancer {
       LookasideChannelCallback lookasideChannelCallback,
       ManagedChannel lbChannel,
       LoadReportClient lrsClient,
-      final LocalityStore localityStore,
-      Node node) {
+      final LocalityStore localityStore) {
     this.lbChannel = lbChannel;
     LoadReportCallback lrsCallback =
         new LoadReportCallback() {
@@ -87,7 +84,7 @@ final class LookasideChannelLb extends LoadBalancer {
         lookasideChannelCallback, lrsClient, lrsCallback, localityStore) ;
     xdsComms2 = new XdsComms2(
         lbChannel, helper, adsCallback, new ExponentialBackoffPolicy.Provider(),
-        GrpcUtil.STOPWATCH_SUPPLIER, node);
+        GrpcUtil.STOPWATCH_SUPPLIER);
   }
 
   private static int rateInMillion(FractionalPercent fractionalPercent) {

--- a/xds/src/main/java/io/grpc/xds/XdsComms2.java
+++ b/xds/src/main/java/io/grpc/xds/XdsComms2.java
@@ -22,6 +22,8 @@ import static com.google.common.base.Preconditions.checkState;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
 import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment;
 import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
 import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
@@ -47,8 +49,6 @@ final class XdsComms2 {
   private final Helper helper;
   private final BackoffPolicy.Provider backoffPolicyProvider;
   private final Supplier<Stopwatch> stopwatchSupplier;
-  // Metadata to be included in every xDS request.
-  private final Node node;
 
   @CheckForNull
   private ScheduledHandle adsRpcRetryTimer;
@@ -177,7 +177,11 @@ final class XdsComms2 {
       // Assuming standard mode, and send EDS request only
       DiscoveryRequest edsRequest =
           DiscoveryRequest.newBuilder()
-              .setNode(node)
+              .setNode(Node.newBuilder()
+                  .setMetadata(Struct.newBuilder()
+                      .putFields(
+                          "endpoints_required",
+                          Value.newBuilder().setBoolValue(true).build())))
               .setTypeUrl(EDS_TYPE_URL)
               // In the future, the right resource name can be obtained from CDS response.
               .addResourceNames(helper.getAuthority()).build();
@@ -205,12 +209,10 @@ final class XdsComms2 {
    */
   XdsComms2(
       ManagedChannel channel, Helper helper, AdsStreamCallback adsStreamCallback,
-      BackoffPolicy.Provider backoffPolicyProvider, Supplier<Stopwatch> stopwatchSupplier,
-      Node node) {
+      BackoffPolicy.Provider backoffPolicyProvider, Supplier<Stopwatch> stopwatchSupplier) {
     this.channel = checkNotNull(channel, "channel");
     this.helper = checkNotNull(helper, "helper");
     this.stopwatchSupplier = checkNotNull(stopwatchSupplier, "stopwatchSupplier");
-    this.node = node;
     this.adsStream = new AdsStream(
         checkNotNull(adsStreamCallback, "adsStreamCallback"));
     this.backoffPolicyProvider = checkNotNull(backoffPolicyProvider, "backoffPolicyProvider");

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -18,9 +18,7 @@ package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import io.envoyproxy.envoy.api.v2.core.Node;
 import io.grpc.Attributes;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.NameResolver;
@@ -31,9 +29,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import javax.annotation.Nullable;
 
 /**
  * A {@link NameResolver} for resolving gRPC target names with "xds-experimental" scheme.
@@ -46,11 +41,6 @@ import javax.annotation.Nullable;
  */
 final class XdsNameResolver extends NameResolver {
 
-  private static final Logger logger = Logger.getLogger(XdsNameResolver.class.getName());
-
-  @NameResolver.ResolutionResultAttr
-  static final Attributes.Key<Node> XDS_NODE = Attributes.Key.create("xds-node");
-
   private static final String SERVICE_CONFIG_HARDCODED = "{"
           + "\"loadBalancingConfig\": ["
           + "{\"xds_experimental\" : {"
@@ -59,48 +49,13 @@ final class XdsNameResolver extends NameResolver {
           + "]}";
 
   private final String authority;
-  private final String serviceConfig;
-  private final Node node;
 
   XdsNameResolver(String name) {
-    this(name, createBootstrapper());
-  }
-
-  @VisibleForTesting
-  XdsNameResolver(String name, @Nullable Bootstrapper bootstrapper) {
     URI nameUri = URI.create("//" + checkNotNull(name, "name"));
     Preconditions.checkArgument(nameUri.getHost() != null, "Invalid hostname: %s", name);
     authority =
         Preconditions.checkNotNull(
             nameUri.getAuthority(), "nameUri (%s) doesn't have an authority", nameUri);
-
-    String serviceConfig = SERVICE_CONFIG_HARDCODED;
-    Node node = Node.getDefaultInstance();
-
-    if (bootstrapper != null) {
-      String serverUri = bootstrapper.getServerUri();
-      node = bootstrapper.getNode();
-      serviceConfig = "{"
-          + "\"loadBalancingConfig\": ["
-          + "{\"xds_experimental\" : {"
-          + "\"balancerName\" : \"" + serverUri + "\","
-          + "\"childPolicy\" : [{\"round_robin\" : {}}]"
-          + "}}"
-          + "]}";
-    }
-
-    this.serviceConfig = serviceConfig;
-    this.node = node;
-  }
-
-  @Nullable
-  private static Bootstrapper createBootstrapper() {
-    try {
-      return Bootstrapper.getInstance();
-    } catch (Exception e) {
-      logger.log(Level.FINE, "Unable to load XDS bootstrap config", e);
-    }
-    return null;
   }
 
   @Override
@@ -111,10 +66,9 @@ final class XdsNameResolver extends NameResolver {
   @SuppressWarnings("unchecked")
   @Override
   public void start(final Listener2 listener) {
-
     Map<String, ?> config;
     try {
-      config = (Map<String, ?>) JsonParser.parse(serviceConfig);
+      config = (Map<String, ?>) JsonParser.parse(SERVICE_CONFIG_HARDCODED);
     } catch (IOException e) {
       listener.onError(
           Status.UNKNOWN.withDescription("Invalid service config").withCause(e));
@@ -123,7 +77,6 @@ final class XdsNameResolver extends NameResolver {
     Attributes attrs =
         Attributes.newBuilder()
             .set(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG, config)
-            .set(XDS_NODE, node)
             .build();
     ResolutionResult result =
         ResolutionResult.newBuilder()

--- a/xds/src/test/java/io/grpc/xds/LookasideChannelLbTest.java
+++ b/xds/src/test/java/io/grpc/xds/LookasideChannelLbTest.java
@@ -38,7 +38,6 @@ import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
 import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
 import io.envoyproxy.envoy.api.v2.core.Address;
 import io.envoyproxy.envoy.api.v2.core.Locality;
-import io.envoyproxy.envoy.api.v2.core.Node;
 import io.envoyproxy.envoy.api.v2.core.SocketAddress;
 import io.envoyproxy.envoy.api.v2.endpoint.Endpoint;
 import io.envoyproxy.envoy.api.v2.endpoint.LbEndpoint;
@@ -170,8 +169,7 @@ public class LookasideChannelLbTest {
     doReturn(loadStatsStore).when(localityStore).getLoadStatsStore();
 
     lookasideChannelLb = new LookasideChannelLb(
-        helper, lookasideChannelCallback, channel, loadReportClient, localityStore,
-        Node.getDefaultInstance());
+        helper, lookasideChannelCallback, channel, loadReportClient, localityStore);
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
+++ b/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.google.common.collect.ImmutableList;
-import io.envoyproxy.envoy.api.v2.core.Node;
 import io.grpc.Attributes;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
@@ -56,13 +55,11 @@ public class LookasideLbTest {
       new LookasideChannelLbFactory() {
         @Override
         public LoadBalancer newLoadBalancer(
-            Helper helper, LookasideChannelCallback lookasideChannelCallback, String balancerName,
-            Node node) {
+            Helper helper, LookasideChannelCallback lookasideChannelCallback, String balancerName) {
           // just return a mock and record helper and balancer.
           helpers.add(helper);
           LoadBalancer balancer = mock(LoadBalancer.class);
           balancers.add(balancer);
-          assertThat(node).isNotNull();
           return balancer;
         }
       };

--- a/xds/src/test/java/io/grpc/xds/XdsCommsTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsCommsTest.java
@@ -37,7 +37,6 @@ import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
 import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
 import io.envoyproxy.envoy.api.v2.core.Address;
 import io.envoyproxy.envoy.api.v2.core.Locality;
-import io.envoyproxy.envoy.api.v2.core.Node;
 import io.envoyproxy.envoy.api.v2.core.SocketAddress;
 import io.envoyproxy.envoy.api.v2.endpoint.Endpoint;
 import io.envoyproxy.envoy.api.v2.endpoint.LbEndpoint;
@@ -185,7 +184,7 @@ public class XdsCommsTest {
     doReturn(20L, 200L).when(backoffPolicy2).nextBackoffNanos();
     xdsComms = new XdsComms2(
         channel, helper, adsStreamCallback, backoffPolicyProvider,
-        fakeClock.getStopwatchSupplier(), Node.getDefaultInstance());
+        fakeClock.getStopwatchSupplier());
   }
 
   @Test
@@ -208,6 +207,9 @@ public class XdsCommsTest {
     assertThat(streamRecorder.getValues()).hasSize(1);
     DiscoveryRequest request = streamRecorder.getValues().get(0);
     assertThat(request.getTypeUrl()).isEqualTo(EDS_TYPE_URL);
+    assertThat(
+            request.getNode().getMetadata().getFieldsOrThrow("endpoints_required").getBoolValue())
+        .isTrue();
     assertThat(request.getResourceNamesList()).hasSize(1);
 
     Locality localityProto1 = Locality.newBuilder()

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -17,15 +17,12 @@
 package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
-import static io.grpc.xds.XdsNameResolver.XDS_NODE;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import io.envoyproxy.envoy.api.v2.core.Node;
 import io.grpc.NameResolver;
 import io.grpc.NameResolver.ResolutionResult;
 import io.grpc.NameResolver.ServiceConfigParser;
@@ -49,8 +46,6 @@ import org.mockito.junit.MockitoRule;
 /** Unit tests for {@link XdsNameResolver}. */
 @RunWith(JUnit4.class)
 public class XdsNameResolverTest {
-  private static final Node FAKE_BOOTSTRAP_NODE =
-      Node.newBuilder().setBuildVersion("fakeVer").build();
 
   @Rule public final MockitoRule mocks = MockitoJUnit.rule();
   
@@ -104,45 +99,15 @@ public class XdsNameResolverTest {
 
   @Test
   public void resolve_hardcodedResult() {
-    XdsNameResolver resolver = new XdsNameResolver("foo.googleapis.com", null);
+    XdsNameResolver resolver = newResolver("foo.googleapis.com");
     resolver.start(mockListener);
     verify(mockListener).onResult(resultCaptor.capture());
     assertHardCodedServiceConfig(resultCaptor.getValue());
 
-    resolver = new XdsNameResolver("bar.googleapis.com", null);
+    resolver = newResolver("bar.googleapis.com");
     resolver.start(mockListener);
     verify(mockListener, times(2)).onResult(resultCaptor.capture());
     assertHardCodedServiceConfig(resultCaptor.getValue());
-  }
-
-  @Test
-  public void resolve_bootstrapResult() {
-    Bootstrapper bootstrapper = new Bootstrapper() {
-      @Override
-      String getServerUri() {
-        return "fake_server_uri";
-      }
-
-      @Override
-      Node getNode() {
-        return FAKE_BOOTSTRAP_NODE;
-      }
-
-      @Override
-      List<ChannelCreds> getChannelCredentials() {
-        return ImmutableList.of();
-      }
-    };
-
-    XdsNameResolver resolver = new XdsNameResolver("foo.googleapis.com", bootstrapper);
-    resolver.start(mockListener);
-    verify(mockListener).onResult(resultCaptor.capture());
-    assertBootstrapServiceConfig(resultCaptor.getValue());
-
-    resolver = new XdsNameResolver("bar.googleapis.com", bootstrapper);
-    resolver.start(mockListener);
-    verify(mockListener, times(2)).onResult(resultCaptor.capture());
-    assertBootstrapServiceConfig(resultCaptor.getValue());
   }
 
   @SuppressWarnings("unchecked")
@@ -161,23 +126,8 @@ public class XdsNameResolverTest {
                 Collections.singletonMap("round_robin", Collections.EMPTY_MAP)));
   }
 
-  @SuppressWarnings("unchecked")
-  private static void assertBootstrapServiceConfig(ResolutionResult actualResult) {
-    assertThat(actualResult.getAddresses()).isEmpty();
-    Map<String, ?> serviceConfig =
-        actualResult.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
-    List<Map<String, ?>> rawLbConfigs =
-        (List<Map<String, ?>>) serviceConfig.get("loadBalancingConfig");
-    Map<String, ?> xdsLbConfig = Iterables.getOnlyElement(rawLbConfigs);
-    assertThat(xdsLbConfig.keySet()).containsExactly("xds_experimental");
-    Map<String, ?> rawConfigValues = (Map<String, ?>) xdsLbConfig.get("xds_experimental");
-    assertThat(rawConfigValues)
-        .containsExactly(
-            "balancerName",
-            "fake_server_uri",
-            "childPolicy",
-            Collections.singletonList(
-                Collections.singletonMap("round_robin", Collections.EMPTY_MAP)));
-    assertThat(actualResult.getAttributes().get(XDS_NODE)).isEqualTo(FAKE_BOOTSTRAP_NODE);
+
+  private XdsNameResolver newResolver(String name) {
+    return new XdsNameResolver(name);
   }
 }


### PR DESCRIPTION
This reverts commit 31b1da5a8d4503881449a6395c236aca55b7422f.

Bootstrap file should be read in `XdsClient`. To keep existing integration test (which does not trigger xds resolver) working, xDS load balancer can creates a `XdsClient` instance. This requires moving xDS communication logic into `XdsClient`.