### PR TITLE
xds: rename SecretProvider to SslContextProvider and make it non-generic

### DIFF
--- a/xds/src/main/java/io/grpc/xds/sds/SecretVolumeSslContextProvider.java
+++ b/xds/src/main/java/io/grpc/xds/sds/SecretVolumeSslContextProvider.java
@@ -45,10 +45,10 @@ import javax.annotation.Nullable;
  * An SslContext provider that uses file-based secrets (secret volume). Used for both server and
  * client SslContexts
  */
-final class SslContextSecretVolumeSecretProvider implements SecretProvider<SslContext> {
+final class SecretVolumeSslContextProvider implements SslContextProvider {
 
   private static final Logger logger =
-      Logger.getLogger(SslContextSecretVolumeSecretProvider.class.getName());
+      Logger.getLogger(SecretVolumeSslContextProvider.class.getName());
 
   private final boolean server;
   @Nullable private final String privateKey;
@@ -56,7 +56,7 @@ final class SslContextSecretVolumeSecretProvider implements SecretProvider<SslCo
   @Nullable private final String certificateChain;
   @Nullable private final CertificateValidationContext certContext;
 
-  private SslContextSecretVolumeSecretProvider(
+  private SecretVolumeSslContextProvider(
       @Nullable String privateKey,
       @Nullable String privateKeyPassword,
       @Nullable String certificateChain,
@@ -106,7 +106,7 @@ final class SslContextSecretVolumeSecretProvider implements SecretProvider<SslCo
     return tlsCertificate;
   }
 
-  static SslContextSecretVolumeSecretProvider getProviderForServer(
+  static SecretVolumeSslContextProvider getProviderForServer(
       DownstreamTlsContext downstreamTlsContext) {
     checkNotNull(downstreamTlsContext, "downstreamTlsContext");
     CommonTlsContext commonTlsContext = downstreamTlsContext.getCommonTlsContext();
@@ -125,7 +125,7 @@ final class SslContextSecretVolumeSecretProvider implements SecretProvider<SslCo
     }
     String privateKeyPassword =
         tlsCertificate.hasPassword() ? tlsCertificate.getPassword().getInlineString() : null;
-    return new SslContextSecretVolumeSecretProvider(
+    return new SecretVolumeSslContextProvider(
         tlsCertificate.getPrivateKey().getFilename(),
         privateKeyPassword,
         tlsCertificate.getCertificateChain().getFilename(),
@@ -133,7 +133,7 @@ final class SslContextSecretVolumeSecretProvider implements SecretProvider<SslCo
         /* server= */ true);
   }
 
-  static SslContextSecretVolumeSecretProvider getProviderForClient(
+  static SecretVolumeSslContextProvider getProviderForClient(
       UpstreamTlsContext upstreamTlsContext) {
     checkNotNull(upstreamTlsContext, "upstreamTlsContext");
     CommonTlsContext commonTlsContext = upstreamTlsContext.getCommonTlsContext();
@@ -159,7 +159,7 @@ final class SslContextSecretVolumeSecretProvider implements SecretProvider<SslCo
       }
       certificateChain = tlsCertificate.getCertificateChain().getFilename();
     }
-    return new SslContextSecretVolumeSecretProvider(
+    return new SecretVolumeSslContextProvider(
         privateKey,
         privateKeyPassword,
         certificateChain,
@@ -181,7 +181,7 @@ final class SslContextSecretVolumeSecretProvider implements SecretProvider<SslCo
   }
 
   @Override
-  public void addCallback(final Callback<SslContext> callback, Executor executor) {
+  public void addCallback(final Callback callback, Executor executor) {
     checkNotNull(callback, "callback");
     checkNotNull(executor, "executor");
     executor.execute(

--- a/xds/src/main/java/io/grpc/xds/sds/SslContextProvider.java
+++ b/xds/src/main/java/io/grpc/xds/sds/SslContextProvider.java
@@ -17,28 +17,30 @@
 package io.grpc.xds.sds;
 
 import io.grpc.Internal;
+import io.netty.handler.ssl.SslContext;
+
 import java.util.concurrent.Executor;
 
 /**
- * A SecretProvider is a "container" or provider of a secret. This is used by gRPC-xds to access
- * secrets, so is not part of the public API of gRPC. This "container" may represent a stream that
- * is receiving the requested secret(s) or it could represent file-system based secret(s) that are
- * dynamic.
+ * A SslContextProvider is a "container" or provider of SslContext. This is used by gRPC-xds to
+ * obtain an SslContext, so is not part of the public API of gRPC. This "container" may represent
+ * a stream that is receiving the requested secret(s) or it could represent file-system based
+ * secret(s) that are dynamic.
  */
 @Internal
-public interface SecretProvider<T> {
+public interface SslContextProvider {
 
-  interface Callback<T> {
-    /** Informs callee of new/updated secret. */
-    void updateSecret(T secret);
+  interface Callback {
+    /** Informs callee of new/updated SslContext. */
+    void updateSecret(SslContext sslContext);
 
     /** Informs callee of an exception that was generated. */
     void onException(Throwable throwable);
   }
 
   /**
-   * Registers a callback on the given executor. The callback will run when secret becomes available
-   * or immediately if the result is already available.
+   * Registers a callback on the given executor. The callback will run when SslContext becomes
+   * available or immediately if the result is already available.
    */
-  void addCallback(Callback<T> callback, Executor executor);
+  void addCallback(Callback callback, Executor executor);
 }

--- a/xds/src/main/java/io/grpc/xds/sds/TlsContextManager.java
+++ b/xds/src/main/java/io/grpc/xds/sds/TlsContextManager.java
@@ -19,13 +19,12 @@ package io.grpc.xds.sds;
 import io.envoyproxy.envoy.api.v2.auth.DownstreamTlsContext;
 import io.envoyproxy.envoy.api.v2.auth.UpstreamTlsContext;
 import io.grpc.Internal;
-import io.netty.handler.ssl.SslContext;
 
 /**
  * Class to manage secrets used to create SSL contexts - this effectively manages SSL contexts
  * (aka TlsContexts) based on inputs we get from xDS. This is used by gRPC-xds to access the
  * SSL contexts/secrets and is not public API.
- * Currently it just creates a new SecretProvider for each call.
+ * Currently it just creates a new SslContextProvider for each call.
  */
 // TODO(sanjaypujare): implement a Map and ref-counting
 @Internal
@@ -43,15 +42,15 @@ public final class TlsContextManager {
     return instance;
   }
 
-  /** Creates a SecretProvider. Used for retrieving a server-side SslContext. */
-  public SecretProvider<SslContext> findOrCreateServerSslContextProvider(
+  /** Creates a SslContextProvider. Used for retrieving a server-side SslContext. */
+  public SslContextProvider findOrCreateServerSslContextProvider(
       DownstreamTlsContext downstreamTlsContext) {
-    return SslContextSecretVolumeSecretProvider.getProviderForServer(downstreamTlsContext);
+    return SecretVolumeSslContextProvider.getProviderForServer(downstreamTlsContext);
   }
 
-  /** Creates a SecretProvider. Used for retrieving a client-side SslContext. */
-  public SecretProvider<SslContext> findOrCreateClientSslContextProvider(
+  /** Creates a SslContextProvider. Used for retrieving a client-side SslContext. */
+  public SslContextProvider findOrCreateClientSslContextProvider(
       UpstreamTlsContext upstreamTlsContext) {
-    return SslContextSecretVolumeSecretProvider.getProviderForClient(upstreamTlsContext);
+    return SecretVolumeSslContextProvider.getProviderForClient(upstreamTlsContext);
   }
 }

--- a/xds/src/main/java/io/grpc/xds/sds/internal/SdsProtocolNegotiators.java
+++ b/xds/src/main/java/io/grpc/xds/sds/internal/SdsProtocolNegotiators.java
@@ -29,7 +29,7 @@ import io.grpc.netty.InternalProtocolNegotiator;
 import io.grpc.netty.InternalProtocolNegotiator.ProtocolNegotiator;
 import io.grpc.netty.InternalProtocolNegotiators;
 import io.grpc.netty.NettyChannelBuilder;
-import io.grpc.xds.sds.SecretProvider;
+import io.grpc.xds.sds.SslContextProvider;
 import io.grpc.xds.sds.TlsContextManager;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerAdapter;
@@ -192,11 +192,11 @@ public final class SdsProtocolNegotiators {
       final BufferReadsHandler bufferReads = new BufferReadsHandler();
       ctx.pipeline().addBefore(ctx.name(), null, bufferReads);
 
-      SecretProvider<SslContext> sslContextProvider =
+      SslContextProvider sslContextProvider =
           TlsContextManager.getInstance().findOrCreateClientSslContextProvider(upstreamTlsContext);
 
       sslContextProvider.addCallback(
-          new SecretProvider.Callback<SslContext>() {
+          new SslContextProvider.Callback() {
 
             @Override
             public void updateSecret(SslContext sslContext) {
@@ -277,12 +277,12 @@ public final class SdsProtocolNegotiators {
       final BufferReadsHandler bufferReads = new BufferReadsHandler();
       ctx.pipeline().addBefore(ctx.name(), null, bufferReads);
 
-      SecretProvider<SslContext> sslContextProvider =
+      SslContextProvider sslContextProvider =
           TlsContextManager.getInstance()
               .findOrCreateServerSslContextProvider(downstreamTlsContext);
 
       sslContextProvider.addCallback(
-          new SecretProvider.Callback<SslContext>() {
+          new SslContextProvider.Callback() {
 
             @Override
             public void updateSecret(SslContext sslContext) {

--- a/xds/src/test/java/io/grpc/xds/sds/SecretVolumeSslContextProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/sds/SecretVolumeSslContextProviderTest.java
@@ -39,9 +39,9 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link SslContextSecretVolumeSecretProvider}. */
+/** Unit tests for {@link SecretVolumeSslContextProvider}. */
 @RunWith(JUnit4.class)
-public class SslContextSecretVolumeSecretProviderTest {
+public class SecretVolumeSslContextProviderTest {
 
   private static final String SERVER_1_PEM_FILE = "server1.pem";
   private static final String SERVER_1_KEY_FILE = "server1.key";
@@ -55,7 +55,7 @@ public class SslContextSecretVolumeSecretProviderTest {
   public void validateCertificateContext_nullAndNotOptional_throwsException() {
     // expect exception when certContext is null and not optional
     try {
-      SslContextSecretVolumeSecretProvider.validateCertificateContext(
+      SecretVolumeSslContextProvider.validateCertificateContext(
           /* certContext= */ null, /* optional= */ false);
       Assert.fail("no exception thrown");
     } catch (IllegalArgumentException expected) {
@@ -68,7 +68,7 @@ public class SslContextSecretVolumeSecretProviderTest {
     // expect exception when certContext has no CA and not optional
     CertificateValidationContext certContext = CertificateValidationContext.getDefaultInstance();
     try {
-      SslContextSecretVolumeSecretProvider.validateCertificateContext(
+      SecretVolumeSslContextProvider.validateCertificateContext(
           certContext, /* optional= */ false);
       Assert.fail("no exception thrown");
     } catch (IllegalArgumentException expected) {
@@ -80,7 +80,7 @@ public class SslContextSecretVolumeSecretProviderTest {
   public void validateCertificateContext_nullAndOptional() {
     // certContext argument can be null when optional
     CertificateValidationContext certContext =
-        SslContextSecretVolumeSecretProvider.validateCertificateContext(
+        SecretVolumeSslContextProvider.validateCertificateContext(
             /* certContext= */ null, /* optional= */ true);
     assertThat(certContext).isNull();
   }
@@ -90,7 +90,7 @@ public class SslContextSecretVolumeSecretProviderTest {
     // certContext argument can have missing CA when optional
     CertificateValidationContext certContext = CertificateValidationContext.getDefaultInstance();
     assertThat(
-            SslContextSecretVolumeSecretProvider.validateCertificateContext(
+            SecretVolumeSslContextProvider.validateCertificateContext(
                 certContext, /* optional= */ true))
         .isNull();
   }
@@ -103,7 +103,7 @@ public class SslContextSecretVolumeSecretProviderTest {
             .setTrustedCa(DataSource.newBuilder().setInlineString("foo"))
             .build();
     try {
-      SslContextSecretVolumeSecretProvider.validateCertificateContext(
+      SecretVolumeSslContextProvider.validateCertificateContext(
           certContext, /* optional= */ false);
       Assert.fail("no exception thrown");
     } catch (IllegalArgumentException expected) {
@@ -119,7 +119,7 @@ public class SslContextSecretVolumeSecretProviderTest {
             .setTrustedCa(DataSource.newBuilder().setFilename("bar"))
             .build();
     assertThat(
-            SslContextSecretVolumeSecretProvider.validateCertificateContext(
+            SecretVolumeSslContextProvider.validateCertificateContext(
                 certContext, /* optional= */ false))
         .isSameInstanceAs(certContext);
   }
@@ -128,7 +128,7 @@ public class SslContextSecretVolumeSecretProviderTest {
   public void validateTlsCertificate_nullAndNotOptional_throwsException() {
     // expect exception when tlsCertificate is null and not optional
     try {
-      SslContextSecretVolumeSecretProvider.validateTlsCertificate(
+      SecretVolumeSslContextProvider.validateTlsCertificate(
           /* tlsCertificate= */ null, /* optional= */ false);
       Assert.fail("no exception thrown");
     } catch (IllegalArgumentException expected) {
@@ -139,7 +139,7 @@ public class SslContextSecretVolumeSecretProviderTest {
   @Test
   public void validateTlsCertificate_nullOptional() {
     assertThat(
-            SslContextSecretVolumeSecretProvider.validateTlsCertificate(
+            SecretVolumeSslContextProvider.validateTlsCertificate(
                 /* tlsCertificate= */ null, /* optional= */ true))
         .isNull();
   }
@@ -149,7 +149,7 @@ public class SslContextSecretVolumeSecretProviderTest {
     // tlsCertificate is not null but has no value (default instance): expect null
     TlsCertificate tlsCert = TlsCertificate.getDefaultInstance();
     assertThat(
-            SslContextSecretVolumeSecretProvider.validateTlsCertificate(
+            SecretVolumeSslContextProvider.validateTlsCertificate(
                 tlsCert, /* optional= */ true))
         .isNull();
   }
@@ -162,7 +162,7 @@ public class SslContextSecretVolumeSecretProviderTest {
             .setPrivateKey(DataSource.newBuilder().setInlineString("foo"))
             .build();
     try {
-      SslContextSecretVolumeSecretProvider.validateTlsCertificate(tlsCert, /* optional= */ false);
+      SecretVolumeSslContextProvider.validateTlsCertificate(tlsCert, /* optional= */ false);
       Assert.fail("no exception thrown");
     } catch (IllegalArgumentException expected) {
       assertThat(expected).hasMessageThat().isEqualTo("filename expected");
@@ -177,7 +177,7 @@ public class SslContextSecretVolumeSecretProviderTest {
             .setPrivateKey(DataSource.newBuilder().setInlineString("foo"))
             .build();
     try {
-      SslContextSecretVolumeSecretProvider.validateTlsCertificate(tlsCert, /* optional= */ true);
+      SecretVolumeSslContextProvider.validateTlsCertificate(tlsCert, /* optional= */ true);
       Assert.fail("no exception thrown");
     } catch (IllegalArgumentException expected) {
       assertThat(expected).hasMessageThat().isEqualTo("filename expected");
@@ -192,7 +192,7 @@ public class SslContextSecretVolumeSecretProviderTest {
             .setCertificateChain(DataSource.newBuilder().setInlineString("foo"))
             .build();
     try {
-      SslContextSecretVolumeSecretProvider.validateTlsCertificate(tlsCert, /* optional= */ false);
+      SecretVolumeSslContextProvider.validateTlsCertificate(tlsCert, /* optional= */ false);
       Assert.fail("no exception thrown");
     } catch (IllegalArgumentException expected) {
       assertThat(expected).hasMessageThat().isEqualTo("filename expected");
@@ -207,7 +207,7 @@ public class SslContextSecretVolumeSecretProviderTest {
             .setCertificateChain(DataSource.newBuilder().setInlineString("foo"))
             .build();
     try {
-      SslContextSecretVolumeSecretProvider.validateTlsCertificate(tlsCert, /* optional= */ true);
+      SecretVolumeSslContextProvider.validateTlsCertificate(tlsCert, /* optional= */ true);
       Assert.fail("no exception thrown");
     } catch (IllegalArgumentException expected) {
       assertThat(expected).hasMessageThat().isEqualTo("filename expected");
@@ -222,7 +222,7 @@ public class SslContextSecretVolumeSecretProviderTest {
             .setPrivateKey(DataSource.newBuilder().setFilename("bar"))
             .build();
     assertThat(
-            SslContextSecretVolumeSecretProvider.validateTlsCertificate(
+            SecretVolumeSslContextProvider.validateTlsCertificate(
                 tlsCert, /* optional= */ true))
         .isSameInstanceAs(tlsCert);
   }
@@ -235,7 +235,7 @@ public class SslContextSecretVolumeSecretProviderTest {
             .setPrivateKey(DataSource.newBuilder().setFilename("bar"))
             .build();
     assertThat(
-            SslContextSecretVolumeSecretProvider.validateTlsCertificate(
+            SecretVolumeSslContextProvider.validateTlsCertificate(
                 tlsCert, /* optional= */ false))
         .isSameInstanceAs(tlsCert);
   }
@@ -249,7 +249,7 @@ public class SslContextSecretVolumeSecretProviderTest {
             .setPrivateKey(DataSource.newBuilder().setFilename("bar"))
             .build();
     try {
-      SslContextSecretVolumeSecretProvider.validateTlsCertificate(tlsCert, /* optional= */ true);
+      SecretVolumeSslContextProvider.validateTlsCertificate(tlsCert, /* optional= */ true);
       Assert.fail("no exception thrown");
     } catch (IllegalArgumentException expected) {
       assertThat(expected).hasMessageThat().isEqualTo("filename expected");
@@ -265,7 +265,7 @@ public class SslContextSecretVolumeSecretProviderTest {
             .setCertificateChain(DataSource.newBuilder().setFilename("bar"))
             .build();
     try {
-      SslContextSecretVolumeSecretProvider.validateTlsCertificate(tlsCert, /* optional= */ true);
+      SecretVolumeSslContextProvider.validateTlsCertificate(tlsCert, /* optional= */ true);
       Assert.fail("no exception thrown");
     } catch (IllegalArgumentException expected) {
       assertThat(expected).hasMessageThat().isEqualTo("filename expected");
@@ -276,7 +276,7 @@ public class SslContextSecretVolumeSecretProviderTest {
   public void getProviderForServer_defaultTlsCertificate_throwsException() {
     TlsCertificate tlsCert = TlsCertificate.getDefaultInstance();
     try {
-      SslContextSecretVolumeSecretProvider.getProviderForServer(
+      SecretVolumeSslContextProvider.getProviderForServer(
           buildDownstreamTlsContext(getCommonTlsContext(tlsCert, /* certContext= */ null)));
       Assert.fail("no exception thrown");
     } catch (IllegalArgumentException expected) {
@@ -296,7 +296,7 @@ public class SslContextSecretVolumeSecretProviderTest {
             .setTrustedCa(DataSource.newBuilder().setInlineString("foo"))
             .build();
     try {
-      SslContextSecretVolumeSecretProvider.getProviderForServer(
+      SecretVolumeSslContextProvider.getProviderForServer(
           buildDownstreamTlsContext(getCommonTlsContext(tlsCert, certContext)));
       Assert.fail("no exception thrown");
     } catch (IllegalArgumentException expected) {
@@ -308,7 +308,7 @@ public class SslContextSecretVolumeSecretProviderTest {
   public void getProviderForClient_defaultCertContext_throwsException() {
     CertificateValidationContext certContext = CertificateValidationContext.getDefaultInstance();
     try {
-      SslContextSecretVolumeSecretProvider.getProviderForClient(
+      SecretVolumeSslContextProvider.getProviderForClient(
           buildUpstreamTlsContext(getCommonTlsContext(/* tlsCertificate= */ null, certContext)));
       Assert.fail("no exception thrown");
     } catch (IllegalArgumentException expected) {
@@ -328,7 +328,7 @@ public class SslContextSecretVolumeSecretProviderTest {
             .setTrustedCa(DataSource.newBuilder().setFilename("foo"))
             .build();
     try {
-      SslContextSecretVolumeSecretProvider.getProviderForClient(
+      SecretVolumeSslContextProvider.getProviderForClient(
           buildUpstreamTlsContext(getCommonTlsContext(tlsCert, certContext)));
       Assert.fail("no exception thrown");
     } catch (IllegalArgumentException expected) {
@@ -348,7 +348,7 @@ public class SslContextSecretVolumeSecretProviderTest {
             .setTrustedCa(DataSource.newBuilder().setFilename("foo"))
             .build();
     try {
-      SslContextSecretVolumeSecretProvider.getProviderForClient(
+      SecretVolumeSslContextProvider.getProviderForClient(
           buildUpstreamTlsContext(getCommonTlsContext(tlsCert, certContext)));
       Assert.fail("no exception thrown");
     } catch (IllegalArgumentException expected) {
@@ -360,8 +360,8 @@ public class SslContextSecretVolumeSecretProviderTest {
     return TestUtils.loadCert(resFile).getAbsolutePath();
   }
 
-  /** Helper method to build SslContextSecretVolumeSecretProvider from given files. */
-  private static SslContextSecretVolumeSecretProvider getSslContextSecretVolumeSecretProvider(
+  /** Helper method to build SecretVolumeSslContextProvider from given files. */
+  private static SecretVolumeSslContextProvider getSslContextSecretVolumeSecretProvider(
       boolean server, String certChainFilename, String privateKeyFilename, String trustedCaFilename)
       throws IOException {
 
@@ -376,22 +376,22 @@ public class SslContextSecretVolumeSecretProviderTest {
       trustedCaFilename = getTempFileNameForResourcesFile(trustedCaFilename);
     }
     return server
-        ? SslContextSecretVolumeSecretProvider.getProviderForServer(
+        ? SecretVolumeSslContextProvider.getProviderForServer(
         buildDownstreamTlsContextFromFilenames(
             privateKeyFilename, certChainFilename, trustedCaFilename))
-        : SslContextSecretVolumeSecretProvider.getProviderForClient(
+        : SecretVolumeSslContextProvider.getProviderForClient(
             buildUpstreamTlsContextFromFilenames(
                 privateKeyFilename, certChainFilename, trustedCaFilename));
   }
 
   /**
-   * Helper method to build SslContextSecretVolumeSecretProvider, call buildSslContext on it and
+   * Helper method to build SecretVolumeSslContextProvider, call buildSslContext on it and
    * check returned SslContext.
    */
   private static void sslContextForEitherWithBothCertAndTrust(
       boolean server, String pemFile, String keyFile, String caFile)
       throws IOException, CertificateException, CertStoreException {
-    SslContextSecretVolumeSecretProvider provider =
+    SecretVolumeSslContextProvider provider =
         getSslContextSecretVolumeSecretProvider(server, pemFile, keyFile, caFile);
 
     SslContext sslContext = provider.buildSslContextFromSecrets();
@@ -511,14 +511,14 @@ public class SslContextSecretVolumeSecretProviderTest {
     }
   }
 
-  static class TestCallback<T> implements SecretProvider.Callback<T> {
+  static class TestCallback implements SslContextProvider.Callback {
 
-    T updatedSecret;
+    SslContext updatedSslContext;
     Throwable updatedThrowable;
 
     @Override
-    public void updateSecret(T secret) {
-      updatedSecret = secret;
+    public void updateSecret(SslContext sslContext) {
+      updatedSslContext = sslContext;
     }
 
     @Override
@@ -531,41 +531,41 @@ public class SslContextSecretVolumeSecretProviderTest {
    * Helper method to get the value thru directExecutor callback. Because of directExecutor this is
    * a synchronous callback - so need to provide a listener.
    */
-  private static TestCallback<SslContext> getValueThruCallback(
-      SecretProvider<SslContext> provider) {
-    TestCallback<SslContext> testCallback = new TestCallback<>();
+  private static TestCallback getValueThruCallback(
+      SslContextProvider provider) {
+    TestCallback testCallback = new TestCallback();
     provider.addCallback(testCallback, MoreExecutors.directExecutor());
     return testCallback;
   }
 
   @Test
   public void getProviderForServer_both_callsback() throws IOException {
-    SslContextSecretVolumeSecretProvider provider =
+    SecretVolumeSslContextProvider provider =
         getSslContextSecretVolumeSecretProvider(
             true, SERVER_1_PEM_FILE, SERVER_1_KEY_FILE, CA_PEM_FILE);
 
-    TestCallback<SslContext> testCallback = getValueThruCallback(provider);
-    doChecksOnSslContext(true, testCallback.updatedSecret);
+    TestCallback testCallback = getValueThruCallback(provider);
+    doChecksOnSslContext(true, testCallback.updatedSslContext);
   }
 
   @Test
   public void getProviderForClient_both_callsback() throws IOException {
-    SslContextSecretVolumeSecretProvider provider =
+    SecretVolumeSslContextProvider provider =
         getSslContextSecretVolumeSecretProvider(
             false, CLIENT_PEM_FILE, CLIENT_KEY_FILE, CA_PEM_FILE);
 
-    TestCallback<SslContext> testCallback = getValueThruCallback(provider);
-    doChecksOnSslContext(false, testCallback.updatedSecret);
+    TestCallback testCallback = getValueThruCallback(provider);
+    doChecksOnSslContext(false, testCallback.updatedSslContext);
   }
 
   // note this test generates stack-trace but can be safely ignored
   @Test
   public void getProviderForClient_both_callsback_setException() throws IOException {
-    SslContextSecretVolumeSecretProvider provider =
+    SecretVolumeSslContextProvider provider =
         getSslContextSecretVolumeSecretProvider(
             false, CLIENT_PEM_FILE, CLIENT_PEM_FILE, CA_PEM_FILE);
-    TestCallback<SslContext> testCallback = getValueThruCallback(provider);
-    assertThat(testCallback.updatedSecret).isNull();
+    TestCallback testCallback = getValueThruCallback(provider);
+    assertThat(testCallback.updatedSslContext).isNull();
     assertThat(testCallback.updatedThrowable).isInstanceOf(IllegalArgumentException.class);
     assertThat(testCallback.updatedThrowable).hasMessageThat()
         .contains("File does not contain valid private key");

--- a/xds/src/test/java/io/grpc/xds/sds/TlsContextManagerTest.java
+++ b/xds/src/test/java/io/grpc/xds/sds/TlsContextManagerTest.java
@@ -20,7 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import io.envoyproxy.envoy.api.v2.auth.DownstreamTlsContext;
 import io.envoyproxy.envoy.api.v2.auth.UpstreamTlsContext;
-import io.netty.handler.ssl.SslContext;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -36,10 +35,10 @@ public class TlsContextManagerTest {
   @Test
   public void createServerSslContextProvider() {
     DownstreamTlsContext downstreamTlsContext =
-        SslContextSecretVolumeSecretProviderTest.buildDownstreamTlsContextFromFilenames(
+        SecretVolumeSslContextProviderTest.buildDownstreamTlsContextFromFilenames(
             SERVER_1_KEY_FILE, SERVER_1_PEM_FILE, /* trustCa= */ null);
 
-    SecretProvider<SslContext> serverSecretProvider =
+    SslContextProvider serverSecretProvider =
         TlsContextManager.getInstance().findOrCreateServerSslContextProvider(downstreamTlsContext);
     assertThat(serverSecretProvider).isNotNull();
   }
@@ -47,10 +46,10 @@ public class TlsContextManagerTest {
   @Test
   public void createClientSslContextProvider() {
     UpstreamTlsContext upstreamTlsContext =
-        SslContextSecretVolumeSecretProviderTest.buildUpstreamTlsContextFromFilenames(
+        SecretVolumeSslContextProviderTest.buildUpstreamTlsContextFromFilenames(
             /* privateKey= */ null, /* certChain= */ null, CA_PEM_FILE);
 
-    SecretProvider<SslContext> serverSecretProvider =
+    SslContextProvider serverSecretProvider =
         TlsContextManager.getInstance().findOrCreateClientSslContextProvider(upstreamTlsContext);
     assertThat(serverSecretProvider).isNotNull();
   }


### PR DESCRIPTION
We don't need SecretProvider for generic secrets - so rename appropriately