### PR TITLE
all: upgrade to Mockito 2.28.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,7 @@ subprojects {
 
             // Test dependencies.
             junit: 'junit:junit:4.12',
-            mockito: 'org.mockito:mockito-core:2.25.1',
+            mockito: 'org.mockito:mockito-core:2.28.2',
             truth: 'com.google.truth:truth:1.0',
             guava_testlib: "com.google.guava:guava-testlib:${guavaVersion}",
 

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     testImplementation 'org.chromium.net:cronet-embedded:66.3359.158'
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.25.1'
+    testImplementation 'org.mockito:mockito-core:2.28.2'
     testImplementation "org.robolectric:robolectric:3.5.1"
 }
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 
     testImplementation "io.grpc:grpc-testing:${grpcVersion}"
     testImplementation "junit:junit:4.12"
-    testImplementation "org.mockito:mockito-core:2.25.1"
+    testImplementation "org.mockito:mockito-core:2.28.2"
 }
 
 protobuf {

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.25.1</version>
+      <version>2.28.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/example-kotlin/build.gradle
+++ b/examples/example-kotlin/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 
     testImplementation "io.grpc:grpc-testing:${grpcVersion}" // gRCP testing utilities
     testImplementation "junit:junit:4.12"
-    testImplementation "org.mockito:mockito-core:2.25.1"
+    testImplementation "org.mockito:mockito-core:2.28.2"
 }
 
 protobuf {

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.25.1</version>
+      <version>2.28.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
[Mockito 2.28.2 ](https://search.maven.org/artifact/org.mockito/mockito-core/2.28.2/jar) is the latest in its 2.X versions.

Grep result for mockito in build.gradle:

There's no 2.25.1 any more:

```
suztomo@suxtomo24:~/grpc-java$ grep -ilr 2.25.1 ./
suztomo@suxtomo24:~/grpc-java$ 
```

Last mockito version upgrade https://github.com/grpc/grpc-java/commit/d35fbd7eee072854c20b61ea7fcf7c70a8e8cb8e modified the 6 files.