### PR TITLE
core: Set jndi connection timeout and retires to default.

### DIFF
--- a/core/src/main/java/io/grpc/internal/JndiResourceResolverFactory.java
+++ b/core/src/main/java/io/grpc/internal/JndiResourceResolverFactory.java
@@ -249,12 +249,7 @@ final class JndiResourceResolverFactory implements DnsNameResolver.ResourceResol
       checkAvailable();
       String[] rrType = new String[]{recordType};
       List<String> records = new ArrayList<>();
-
-      @SuppressWarnings("JdkObsolete")
-      Hashtable<String, String> env = new Hashtable<>();
-      env.put("com.sun.jndi.dns.timeout.initial", "1000");
-      env.put("com.sun.jndi.dns.timeout.retries", "4");
-      DirContext dirContext = new InitialDirContext(env);
+      DirContext dirContext = new InitialDirContext();
 
       try {
         javax.naming.directory.Attributes attrs = dirContext.getAttributes(name, rrType);

--- a/core/src/main/java/io/grpc/internal/JndiResourceResolverFactory.java
+++ b/core/src/main/java/io/grpc/internal/JndiResourceResolverFactory.java
@@ -252,8 +252,8 @@ final class JndiResourceResolverFactory implements DnsNameResolver.ResourceResol
 
       @SuppressWarnings("JdkObsolete")
       Hashtable<String, String> env = new Hashtable<>();
-      env.put("com.sun.jndi.ldap.connect.timeout", "5000");
-      env.put("com.sun.jndi.ldap.read.timeout", "5000");
+      env.put("com.sun.jndi.dns.timeout.initial", "1000");
+      env.put("com.sun.jndi.dns.timeout.retries", "4");
       DirContext dirContext = new InitialDirContext(env);
 
       try {


### PR DESCRIPTION
The current DirContext properties are for LDAP and does not affect the
actual DNS settings. This surfaces the actual properties for tuning
connection timeout and retries. Values are set to the default in
[openJDK](https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/master/src/jdk.naming.dns/share/classes/com/sun/jndi/dns/DnsContext.java#L70)