### PR TITLE
xds: refactor gRPC's data types for envoy proto messages

### DIFF
--- a/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
@@ -193,12 +193,14 @@ final class EnvoyProtoData {
   static final class LbEndpoint {
     private final EquivalentAddressGroup eag;
     private final int loadBalancingWeight;
+    private final boolean isHealthy;
 
     /** Must only be used for testing. */
     @VisibleForTesting
-    LbEndpoint(EquivalentAddressGroup eag, int loadBalancingWeight) {
+    LbEndpoint(EquivalentAddressGroup eag, int loadBalancingWeight, boolean isHealthy) {
       this.eag = eag;
       this.loadBalancingWeight = loadBalancingWeight;
+      this.isHealthy = isHealthy;
     }
 
     static LbEndpoint fromEnvoyProtoLbEndpoint(
@@ -211,7 +213,10 @@ final class EnvoyProtoData {
                   ImmutableList.<java.net.SocketAddress>of(
                       new InetSocketAddress(socketAddress.getAddress(),
                           socketAddress.getPortValue()))),
-              proto.getLoadBalancingWeight().getValue());
+              proto.getLoadBalancingWeight().getValue(),
+              proto.getHealthStatus() == io.envoyproxy.envoy.api.v2.core.HealthStatus.HEALTHY
+                  || proto.getHealthStatus() == io.envoyproxy.envoy.api.v2.core.HealthStatus.UNKNOWN
+              );
     }
 
     EquivalentAddressGroup getAddress() {
@@ -232,12 +237,13 @@ final class EnvoyProtoData {
       }
       LbEndpoint that = (LbEndpoint) o;
       return loadBalancingWeight == that.loadBalancingWeight
-          && Objects.equal(eag, that.eag);
+          && Objects.equal(eag, that.eag)
+          && isHealthy == that.isHealthy;
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(eag, loadBalancingWeight);
+      return Objects.hashCode(eag, loadBalancingWeight, isHealthy);
     }
 
     @Override
@@ -245,6 +251,7 @@ final class EnvoyProtoData {
       return MoreObjects.toStringHelper(this)
           .add("eag", eag)
           .add("loadBalancingWeight", loadBalancingWeight)
+          .add("isHealthy", isHealthy)
           .toString();
     }
   }

--- a/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
@@ -29,9 +29,20 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Contains data types for ClusterLoadAssignment.
+ * Defines gRPC data types for Envoy protobuf messages used in xDS protocol. Each data type has
+ * the same name as Envoy's corresponding protobuf message, but only with fields used by gRPC.
+ *
+ * <p>Each data type should define a {@code fromEnvoyProtoXXX} static method to convert an Envoy
+ * proto message to an instance of that data type.
+ *
+ * <p>For data types that need to be sent as protobuf messages, a {@code toEnvoyProtoXXX} instance
+ * method is defined to convert an instance to Envoy proto message.
  */
-final class ClusterLoadAssignmentData {
+final class EnvoyProtoData {
+
+  // Prevent instantiation.
+  private EnvoyProtoData() {
+  }
 
   /**
    * An {@code XdsLocality} object is simply a POJO representation for {@link

--- a/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
@@ -45,31 +45,29 @@ final class EnvoyProtoData {
   }
 
   /**
-   * An {@code XdsLocality} object is simply a POJO representation for {@link
-   * io.envoyproxy.envoy.api.v2.core.Locality}, with only details needed for {@link
-   * XdsLoadBalancer2}.
+   * See corresponding Envoy proto message {@link io.envoyproxy.envoy.api.v2.core.Locality}.
    */
-  static final class XdsLocality {
+  static final class Locality {
     private final String region;
     private final String zone;
     private final String subzone;
 
     /** Must only be used for testing. */
     @VisibleForTesting
-    XdsLocality(String region, String zone, String subzone) {
+    Locality(String region, String zone, String subzone) {
       this.region = region;
       this.zone = zone;
       this.subzone = subzone;
     }
 
-    static XdsLocality fromLocalityProto(io.envoyproxy.envoy.api.v2.core.Locality locality) {
-      return new XdsLocality(
+    static Locality fromEnvoyProtoLocality(io.envoyproxy.envoy.api.v2.core.Locality locality) {
+      return new Locality(
           /* region = */ locality.getRegion(),
           /* zone = */ locality.getZone(),
           /* subzone = */ locality.getSubZone());
     }
 
-    io.envoyproxy.envoy.api.v2.core.Locality toLocalityProto() {
+    io.envoyproxy.envoy.api.v2.core.Locality toEnvoyProtoLocality() {
       return io.envoyproxy.envoy.api.v2.core.Locality.newBuilder()
           .setRegion(region)
           .setZone(zone)
@@ -97,7 +95,7 @@ final class EnvoyProtoData {
       if (o == null || getClass() != o.getClass()) {
         return false;
       }
-      XdsLocality locality = (XdsLocality) o;
+      Locality locality = (Locality) o;
       return Objects.equal(region, locality.region)
           && Objects.equal(zone, locality.zone)
           && Objects.equal(subzone, locality.subzone);

--- a/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
@@ -196,8 +196,14 @@ final class EnvoyProtoData {
     private final boolean isHealthy;
 
     /** Must only be used for testing. */
+    // TODO(chengyuanzhang): migrate tests to use LbEndpoint(EquivalentAddressGroup, int, boolean)
+    //  and should add tests for LB policies dealing with unhealthy endpoints.
     @VisibleForTesting
-    LbEndpoint(EquivalentAddressGroup eag, int loadBalancingWeight, boolean isHealthy) {
+    LbEndpoint(EquivalentAddressGroup eag, int loadBalancingWeight) {
+      this(eag, loadBalancingWeight, true);
+    }
+
+    private LbEndpoint(EquivalentAddressGroup eag, int loadBalancingWeight, boolean isHealthy) {
       this.eag = eag;
       this.loadBalancingWeight = loadBalancingWeight;
       this.isHealthy = isHealthy;

--- a/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
@@ -227,6 +227,10 @@ final class EnvoyProtoData {
       return loadBalancingWeight;
     }
 
+    boolean isHealthy() {
+      return isHealthy;
+    }
+
     @Override
     public boolean equals(Object o) {
       if (this == o) {

--- a/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
@@ -213,12 +213,11 @@ final class EnvoyProtoData {
         io.envoyproxy.envoy.api.v2.endpoint.LbEndpoint proto) {
       io.envoyproxy.envoy.api.v2.core.SocketAddress socketAddress =
           proto.getEndpoint().getAddress().getSocketAddress();
+      InetSocketAddress addr =
+          new InetSocketAddress(socketAddress.getAddress(), socketAddress.getPortValue());
       return
           new LbEndpoint(
-              new EquivalentAddressGroup(
-                  ImmutableList.<java.net.SocketAddress>of(
-                      new InetSocketAddress(socketAddress.getAddress(),
-                          socketAddress.getPortValue()))),
+              new EquivalentAddressGroup(ImmutableList.<java.net.SocketAddress>of(addr)),
               proto.getLoadBalancingWeight().getValue(),
               proto.getHealthStatus() == io.envoyproxy.envoy.api.v2.core.HealthStatus.HEALTHY
                   || proto.getHealthStatus() == io.envoyproxy.envoy.api.v2.core.HealthStatus.UNKNOWN

--- a/xds/src/main/java/io/grpc/xds/LoadStatsStore.java
+++ b/xds/src/main/java/io/grpc/xds/LoadStatsStore.java
@@ -17,7 +17,7 @@
 package io.grpc.xds;
 
 import io.envoyproxy.envoy.api.v2.endpoint.ClusterStats;
-import io.grpc.xds.ClusterLoadAssignmentData.XdsLocality;
+import io.grpc.xds.EnvoyProtoData.Locality;
 import javax.annotation.Nullable;
 
 /**
@@ -32,11 +32,11 @@ import javax.annotation.Nullable;
  *
  * <ol>
  *   <li>Let {@link LoadStatsStore} track the locality newly exposed by traffic director by
- *       calling {@link #addLocality(XdsLocality)}.
- *   <li>Use the locality counter returned by {@link #getLocalityCounter(XdsLocality)} to record
+ *       calling {@link #addLocality(Locality)}.
+ *   <li>Use the locality counter returned by {@link #getLocalityCounter(Locality)} to record
  *       load stats for the corresponding locality.
  *   <li>Tell {@link LoadStatsStore} to stop tracking the locality no longer exposed by traffic
- *       director by calling {@link #removeLocality(XdsLocality)}.
+ *       director by calling {@link #removeLocality(Locality)}.
  * </ol>
  *
  * <p>No locality information is needed for recording dropped calls since they are aggregated in
@@ -75,7 +75,7 @@ interface LoadStatsStore {
    * <p>This method is not thread-safe and should be called from the same synchronized context
    * returned by {@link XdsLoadBalancer2.Helper#getSynchronizationContext}.
    */
-  void addLocality(XdsLocality locality);
+  void addLocality(Locality locality);
 
   /**
    * Stops tracking load stats for endpoints in the provided locality. gRPC clients are expected not
@@ -90,7 +90,7 @@ interface LoadStatsStore {
    * <p>This method is not thread-safe and should be called from the same synchronized context
    * returned by {@link XdsLoadBalancer2.Helper#getSynchronizationContext}.
    */
-  void removeLocality(XdsLocality locality);
+  void removeLocality(Locality locality);
 
   /**
    * Returns the locality counter that does locality level stats aggregation for the provided
@@ -99,7 +99,7 @@ interface LoadStatsStore {
    * <p>This method is thread-safe.
    */
   @Nullable
-  ClientLoadCounter getLocalityCounter(XdsLocality locality);
+  ClientLoadCounter getLocalityCounter(Locality locality);
 
   /**
    * Records a drop decision made by a {@link io.grpc.LoadBalancer.SubchannelPicker} instance

--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -148,8 +148,8 @@ interface LocalityStore {
       public PickResult pickSubchannel(PickSubchannelArgs args) {
         for (DropOverload dropOverload : dropOverloads) {
           int rand = random.nextInt(1000_000);
-          if (rand < dropOverload.dropsPerMillion) {
-            loadStatsStore.recordDroppedRequest(dropOverload.category);
+          if (rand < dropOverload.getDropsPerMillion()) {
+            loadStatsStore.recordDroppedRequest(dropOverload.getCategory());
             return PickResult.withDrop(Status.UNAVAILABLE.withDescription(
                 "dropped by loadbalancer: " + dropOverload.toString()));
           }

--- a/xds/src/main/java/io/grpc/xds/LookasideChannelLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideChannelLb.java
@@ -31,10 +31,10 @@ import io.grpc.ManagedChannel;
 import io.grpc.Status;
 import io.grpc.internal.ExponentialBackoffPolicy;
 import io.grpc.internal.GrpcUtil;
-import io.grpc.xds.ClusterLoadAssignmentData.DropOverload;
-import io.grpc.xds.ClusterLoadAssignmentData.LbEndpoint;
-import io.grpc.xds.ClusterLoadAssignmentData.LocalityInfo;
-import io.grpc.xds.ClusterLoadAssignmentData.XdsLocality;
+import io.grpc.xds.EnvoyProtoData.DropOverload;
+import io.grpc.xds.EnvoyProtoData.LbEndpoint;
+import io.grpc.xds.EnvoyProtoData.Locality;
+import io.grpc.xds.EnvoyProtoData.LocalityInfo;
 import io.grpc.xds.LoadReportClient.LoadReportCallback;
 import io.grpc.xds.XdsComms2.AdsStreamCallback;
 import java.util.ArrayList;
@@ -167,12 +167,12 @@ final class LookasideChannelLb extends LoadBalancer {
       localityStore.updateDropPercentage(dropOverloads);
 
       List<LocalityLbEndpoints> localities = clusterLoadAssignment.getEndpointsList();
-      ImmutableMap.Builder<XdsLocality, LocalityInfo> localityEndpointsMapping =
+      ImmutableMap.Builder<Locality, LocalityInfo> localityEndpointsMapping =
           new ImmutableMap.Builder<>();
       for (LocalityLbEndpoints localityLbEndpoints : localities) {
         io.envoyproxy.envoy.api.v2.core.Locality localityProto =
             localityLbEndpoints.getLocality();
-        XdsLocality locality = XdsLocality.fromLocalityProto(localityProto);
+        Locality locality = Locality.fromEnvoyProtoLocality(localityProto);
         List<LbEndpoint> lbEndPoints = new ArrayList<>();
         for (io.envoyproxy.envoy.api.v2.endpoint.LbEndpoint lbEndpoint
             : localityLbEndpoints.getLbEndpointsList()) {

--- a/xds/src/main/java/io/grpc/xds/LookasideChannelLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideChannelLb.java
@@ -176,7 +176,7 @@ final class LookasideChannelLb extends LoadBalancer {
         List<LbEndpoint> lbEndPoints = new ArrayList<>();
         for (io.envoyproxy.envoy.api.v2.endpoint.LbEndpoint lbEndpoint
             : localityLbEndpoints.getLbEndpointsList()) {
-          lbEndPoints.add(new LbEndpoint(lbEndpoint));
+          lbEndPoints.add(LbEndpoint.fromEnvoyProtoLbEndpoint(lbEndpoint));
         }
         int localityWeight = localityLbEndpoints.getLoadBalancingWeight().getValue();
         int priority = localityLbEndpoints.getPriority();

--- a/xds/src/test/java/io/grpc/xds/ClusterLoadAssignmentDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterLoadAssignmentDataTest.java
@@ -19,32 +19,31 @@ package io.grpc.xds;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import io.envoyproxy.envoy.api.v2.core.Locality;
-import io.grpc.xds.ClusterLoadAssignmentData.XdsLocality;
+import io.grpc.xds.EnvoyProtoData.Locality;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /**
- * Unit tests for {@link ClusterLoadAssignmentData}.
+ * Unit tests for {@link EnvoyProtoData}.
  */
 @RunWith(JUnit4.class)
 public class ClusterLoadAssignmentDataTest {
 
   @Test
   public void xdsLocality_convertToAndFromLocalityProto() {
-    Locality locality =
-        Locality.newBuilder()
+    io.envoyproxy.envoy.api.v2.core.Locality locality =
+        io.envoyproxy.envoy.api.v2.core.Locality.newBuilder()
             .setRegion("test_region")
             .setZone("test_zone")
             .setSubZone("test_subzone")
             .build();
-    XdsLocality xdsLocality = XdsLocality.fromLocalityProto(locality);
+    Locality xdsLocality = Locality.fromEnvoyProtoLocality(locality);
     assertThat(xdsLocality.getRegion()).isEqualTo("test_region");
     assertThat(xdsLocality.getZone()).isEqualTo("test_zone");
     assertThat(xdsLocality.getSubzone()).isEqualTo("test_subzone");
 
-    Locality convertedLocality = xdsLocality.toLocalityProto();
+    io.envoyproxy.envoy.api.v2.core.Locality convertedLocality = xdsLocality.toEnvoyProtoLocality();
     assertThat(convertedLocality.getRegion()).isEqualTo("test_region");
     assertThat(convertedLocality.getZone()).isEqualTo("test_zone");
     assertThat(convertedLocality.getSubZone()).isEqualTo("test_subzone");
@@ -54,20 +53,20 @@ public class ClusterLoadAssignmentDataTest {
   public void xdsLocality_equal() {
     new EqualsTester()
         .addEqualityGroup(
-            new XdsLocality("region-a", "zone-a", "subzone-a"),
-            new XdsLocality("region-a", "zone-a", "subzone-a"))
+            new Locality("region-a", "zone-a", "subzone-a"),
+            new Locality("region-a", "zone-a", "subzone-a"))
         .addEqualityGroup(
-            new XdsLocality("region", "zone", "subzone")
+            new Locality("region", "zone", "subzone")
         )
         .addEqualityGroup(
-            new XdsLocality("", "", ""),
-            new XdsLocality("", "", ""))
+            new Locality("", "", ""),
+            new Locality("", "", ""))
         .testEquals();
   }
 
   @Test
   public void xdsLocality_hash() {
-    assertThat(new XdsLocality("region", "zone", "subzone").hashCode())
-        .isEqualTo(new XdsLocality("region", "zone","subzone").hashCode());
+    assertThat(new Locality("region", "zone", "subzone").hashCode())
+        .isEqualTo(new Locality("region", "zone","subzone").hashCode());
   }
 }

--- a/xds/src/test/java/io/grpc/xds/EnvoyProtoDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/EnvoyProtoDataTest.java
@@ -28,10 +28,10 @@ import org.junit.runners.JUnit4;
  * Unit tests for {@link EnvoyProtoData}.
  */
 @RunWith(JUnit4.class)
-public class ClusterLoadAssignmentDataTest {
+public class EnvoyProtoDataTest {
 
   @Test
-  public void xdsLocality_convertToAndFromLocalityProto() {
+  public void locality_convertToAndFromLocalityProto() {
     io.envoyproxy.envoy.api.v2.core.Locality locality =
         io.envoyproxy.envoy.api.v2.core.Locality.newBuilder()
             .setRegion("test_region")
@@ -50,7 +50,7 @@ public class ClusterLoadAssignmentDataTest {
   }
 
   @Test
-  public void xdsLocality_equal() {
+  public void locality_equal() {
     new EqualsTester()
         .addEqualityGroup(
             new Locality("region-a", "zone-a", "subzone-a"),
@@ -65,8 +65,10 @@ public class ClusterLoadAssignmentDataTest {
   }
 
   @Test
-  public void xdsLocality_hash() {
+  public void locality_hash() {
     assertThat(new Locality("region", "zone", "subzone").hashCode())
         .isEqualTo(new Locality("region", "zone","subzone").hashCode());
   }
+
+  // TODO(chengyuanzhang): add test for other data types.
 }

--- a/xds/src/test/java/io/grpc/xds/LoadStatsStoreImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/LoadStatsStoreImplTest.java
@@ -24,7 +24,7 @@ import io.envoyproxy.envoy.api.v2.endpoint.ClusterStats.DroppedRequests;
 import io.envoyproxy.envoy.api.v2.endpoint.EndpointLoadMetricStats;
 import io.envoyproxy.envoy.api.v2.endpoint.UpstreamLocalityStats;
 import io.grpc.xds.ClientLoadCounter.MetricValue;
-import io.grpc.xds.ClusterLoadAssignmentData.XdsLocality;
+import io.grpc.xds.EnvoyProtoData.Locality;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -44,11 +44,11 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link LoadStatsStore}. */
 @RunWith(JUnit4.class)
 public class LoadStatsStoreImplTest {
-  private static final XdsLocality LOCALITY1 =
-      new XdsLocality("test_region1", "test_zone", "test_subzone");
-  private static final XdsLocality LOCALITY2 =
-      new XdsLocality("test_region2", "test_zone", "test_subzone");
-  private ConcurrentMap<XdsLocality, ClientLoadCounter> localityLoadCounters;
+  private static final Locality LOCALITY1 =
+      new Locality("test_region1", "test_zone", "test_subzone");
+  private static final Locality LOCALITY2 =
+      new Locality("test_region2", "test_zone", "test_subzone");
+  private ConcurrentMap<Locality, ClientLoadCounter> localityLoadCounters;
   private ConcurrentMap<String, AtomicLong> dropCounters;
   private LoadStatsStore loadStatsStore;
 
@@ -73,7 +73,7 @@ public class LoadStatsStoreImplTest {
   }
 
   private static UpstreamLocalityStats buildUpstreamLocalityStats(
-      XdsLocality locality,
+      Locality locality,
       long callsSucceed,
       long callsInProgress,
       long callsFailed,
@@ -81,7 +81,7 @@ public class LoadStatsStoreImplTest {
       @Nullable List<EndpointLoadMetricStats> metrics) {
     UpstreamLocalityStats.Builder builder =
         UpstreamLocalityStats.newBuilder()
-            .setLocality(locality.toLocalityProto())
+            .setLocality(locality.toEnvoyProtoLocality())
             .setTotalSuccessfulRequests(callsSucceed)
             .setTotalErrorRequests(callsFailed)
             .setTotalRequestsInProgress(callsInProgress)

--- a/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
@@ -65,7 +65,7 @@ import io.grpc.xds.ClientLoadCounter.MetricsRecordingListener;
 import io.grpc.xds.EnvoyProtoData.DropOverload;
 import io.grpc.xds.EnvoyProtoData.LbEndpoint;
 import io.grpc.xds.EnvoyProtoData.Locality;
-import io.grpc.xds.EnvoyProtoData.LocalityInfo;
+import io.grpc.xds.EnvoyProtoData.LocalityLbEndpoints;
 import io.grpc.xds.InterLocalityPicker.WeightedChildPicker;
 import io.grpc.xds.LocalityStore.LocalityStoreImpl;
 import io.grpc.xds.LocalityStore.LocalityStoreImpl.PickerFactory;
@@ -257,22 +257,26 @@ public class LocalityStoreTest {
   @Test
   @SuppressWarnings("unchecked")
   public void updateLocalityStore_updateStatsStoreLocalityTracking() {
-    Map<Locality, LocalityInfo> localityInfoMap = new HashMap<>();
+    Map<Locality, LocalityLbEndpoints> localityInfoMap = new HashMap<>();
     localityInfoMap
-        .put(locality1, new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0));
+        .put(locality1,
+            new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0));
     localityInfoMap
-        .put(locality2, new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0));
+        .put(locality2,
+            new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0));
     localityStore.updateLocalityStore(ImmutableMap.copyOf(localityInfoMap));
     verify(loadStatsStore).addLocality(locality1);
     verify(loadStatsStore).addLocality(locality2);
 
     localityInfoMap
-        .put(locality3, new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0));
+        .put(locality3,
+            new LocalityLbEndpoints(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0));
     localityStore.updateLocalityStore(ImmutableMap.copyOf(localityInfoMap));
     verify(loadStatsStore).addLocality(locality3);
 
     localityInfoMap = ImmutableMap
-        .of(locality4, new LocalityInfo(ImmutableList.of(lbEndpoint41, lbEndpoint42), 4, 0));
+        .of(locality4,
+            new LocalityLbEndpoints(ImmutableList.of(lbEndpoint41, lbEndpoint42), 4, 0));
     localityStore.updateLocalityStore(ImmutableMap.copyOf(localityInfoMap));
     verify(loadStatsStore).removeLocality(locality1);
     verify(loadStatsStore).removeLocality(locality2);
@@ -286,10 +290,10 @@ public class LocalityStoreTest {
   @Test
   public void updateLocalityStore_pickResultInterceptedForLoadRecordingWhenSubchannelReady() {
     // Simulate receiving two localities.
-    LocalityInfo localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
-    LocalityInfo localityInfo2 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
+    LocalityLbEndpoints localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    LocalityLbEndpoints localityInfo2 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
     localityStore.updateLocalityStore(ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2));
 
@@ -357,10 +361,10 @@ public class LocalityStoreTest {
   @Test
   public void childLbPerformOobBackendMetricsAggregation() {
     // Simulate receiving two localities.
-    LocalityInfo localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
-    LocalityInfo localityInfo2 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
+    LocalityLbEndpoints localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    LocalityLbEndpoints localityInfo2 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
     localityStore.updateLocalityStore(ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2));
 
@@ -415,10 +419,10 @@ public class LocalityStoreTest {
     assertThat(loadBalancers).isEmpty();
 
     // Simulate receiving two localities.
-    LocalityInfo localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
-    LocalityInfo localityInfo2 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
+    LocalityLbEndpoints localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    LocalityLbEndpoints localityInfo2 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
     localityStore.updateLocalityStore(ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2));
 
@@ -434,13 +438,13 @@ public class LocalityStoreTest {
   @Test
   public void updateLoaclityStore_withEmptyDropList() {
     localityStore.updateDropPercentage(ImmutableList.<DropOverload>of());
-    LocalityInfo localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
-    LocalityInfo localityInfo2 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
-    LocalityInfo localityInfo3 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
-    ImmutableMap<Locality, LocalityInfo> localityInfoMap = ImmutableMap.of(
+    LocalityLbEndpoints localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    LocalityLbEndpoints localityInfo2 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
+    LocalityLbEndpoints localityInfo3 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
+    ImmutableMap<Locality, LocalityLbEndpoints> localityInfoMap = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
     localityStore.updateLocalityStore(localityInfoMap);
     verify(helper).updateBalancingState(CONNECTING, BUFFER_PICKER);
@@ -514,9 +518,9 @@ public class LocalityStoreTest {
 
     // update with new addresses
     localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint11), 1, 0);
-    LocalityInfo localityInfo4 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint41, lbEndpoint42), 4, 0);
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11), 1, 0);
+    LocalityLbEndpoints localityInfo4 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint41, lbEndpoint42), 4, 0);
     localityInfoMap = ImmutableMap.of(
         locality2, localityInfo2, locality4, localityInfo4, locality1, localityInfo1);
     localityStore.updateLocalityStore(localityInfoMap);
@@ -544,13 +548,13 @@ public class LocalityStoreTest {
 
   @Test
   public void updateLoaclityStore_deactivateAndReactivate() {
-    LocalityInfo localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
-    LocalityInfo localityInfo2 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
-    LocalityInfo localityInfo3 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
-    ImmutableMap<Locality, LocalityInfo> localityInfoMap = ImmutableMap.of(
+    LocalityLbEndpoints localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    LocalityLbEndpoints localityInfo2 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
+    LocalityLbEndpoints localityInfo3 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
+    ImmutableMap<Locality, LocalityLbEndpoints> localityInfoMap = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
     localityStore.updateLocalityStore(localityInfoMap);
 
@@ -578,8 +582,8 @@ public class LocalityStoreTest {
     childHelpers.get("sz3").updateBalancingState(READY, subchannelPicker3);
 
     // update localities, removing sz1, sz2, keeping sz3, and adding sz4
-    LocalityInfo localityInfo4 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint41, lbEndpoint42), 4, 0);
+    LocalityLbEndpoints localityInfo4 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint41, lbEndpoint42), 4, 0);
     localityInfoMap = ImmutableMap.of(locality3, localityInfo3, locality4, localityInfo4);
     localityStore.updateLocalityStore(localityInfoMap);
 
@@ -671,13 +675,13 @@ public class LocalityStoreTest {
     localityStore.updateDropPercentage(ImmutableList.of(
         new DropOverload("throttle", 365),
         new DropOverload("lb", 1234)));
-    LocalityInfo localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
-    LocalityInfo localityInfo2 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
-    LocalityInfo localityInfo3 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
-    ImmutableMap<Locality, LocalityInfo> localityInfoMap = ImmutableMap.of(
+    LocalityLbEndpoints localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    LocalityLbEndpoints localityInfo2 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
+    LocalityLbEndpoints localityInfo3 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
+    ImmutableMap<Locality, LocalityLbEndpoints> localityInfoMap = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
     localityStore.updateLocalityStore(localityInfoMap);
 
@@ -769,13 +773,13 @@ public class LocalityStoreTest {
     localityStore.updateDropPercentage(ImmutableList.of(
         new DropOverload("throttle", 365),
         new DropOverload("lb", 1000_000)));
-    LocalityInfo localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
-    LocalityInfo localityInfo2 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
-    LocalityInfo localityInfo3 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
-    ImmutableMap<Locality, LocalityInfo> localityInfoMap = ImmutableMap.of(
+    LocalityLbEndpoints localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    LocalityLbEndpoints localityInfo2 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
+    LocalityLbEndpoints localityInfo3 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
+    ImmutableMap<Locality, LocalityLbEndpoints> localityInfoMap = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
     localityStore.updateLocalityStore(localityInfoMap);
 
@@ -790,13 +794,13 @@ public class LocalityStoreTest {
 
   @Test
   public void updateLocalityStore_OnlyUpdatingWeightsStillUpdatesPicker() {
-    LocalityInfo localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
-    LocalityInfo localityInfo2 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
-    LocalityInfo localityInfo3 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
-    ImmutableMap<Locality, LocalityInfo> localityInfoMap = ImmutableMap.of(
+    LocalityLbEndpoints localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    LocalityLbEndpoints localityInfo2 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
+    LocalityLbEndpoints localityInfo3 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
+    ImmutableMap<Locality, LocalityLbEndpoints> localityInfoMap = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
     localityStore.updateLocalityStore(localityInfoMap);
 
@@ -805,9 +809,9 @@ public class LocalityStoreTest {
     assertThat(pickerFactory.totalReadyLocalities).isEqualTo(0);
 
     // Update locality weights before any subchannel becomes READY.
-    localityInfo1 = new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 4, 0);
-    localityInfo2 = new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 5, 0);
-    localityInfo3 = new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 6, 0);
+    localityInfo1 = new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 4, 0);
+    localityInfo2 = new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 5, 0);
+    localityInfo3 = new LocalityLbEndpoints(ImmutableList.of(lbEndpoint31, lbEndpoint32), 6, 0);
     localityInfoMap = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
     localityStore.updateLocalityStore(localityInfoMap);
@@ -833,17 +837,18 @@ public class LocalityStoreTest {
       Subchannel subchannel
           = weightedChildPicker.getPicker().pickSubchannel(pickSubchannelArgs).getSubchannel();
       assertThat(weightedChildPicker.getWeight())
-          .isEqualTo(localityInfoMap.get(localitiesBySubchannel.get(subchannel)).localityWeight);
+          .isEqualTo(
+              localityInfoMap.get(localitiesBySubchannel.get(subchannel)).getLocalityWeight());
     }
   }
 
   @Test
   public void reset() {
-    LocalityInfo localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
-    LocalityInfo localityInfo2 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
-    ImmutableMap<Locality, LocalityInfo> localityInfoMap = ImmutableMap.of(
+    LocalityLbEndpoints localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    LocalityLbEndpoints localityInfo2 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
+    ImmutableMap<Locality, LocalityLbEndpoints> localityInfoMap = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2);
     localityStore.updateLocalityStore(localityInfoMap);
 
@@ -893,15 +898,15 @@ public class LocalityStoreTest {
   @Test
   public void multipriority() {
     // EDS update: P0 sz1; P1 sz2; P2 sz3; P3 sz4 - P0 C, P1 N/A, P2 N/A, P3 N/A
-    LocalityInfo localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
-    LocalityInfo localityInfo2 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 1);
-    LocalityInfo localityInfo3 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 2);
-    LocalityInfo localityInfo4 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint41, lbEndpoint42), 3, 3);
-    final ImmutableMap<Locality, LocalityInfo> localityInfoMap = ImmutableMap.of(
+    LocalityLbEndpoints localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    LocalityLbEndpoints localityInfo2 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 1);
+    LocalityLbEndpoints localityInfo3 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 2);
+    LocalityLbEndpoints localityInfo4 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint41, lbEndpoint42), 3, 3);
+    final ImmutableMap<Locality, LocalityLbEndpoints> localityInfoMap = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3, locality4,
         localityInfo4);
     syncContext.execute(new Runnable() {
@@ -1129,14 +1134,14 @@ public class LocalityStoreTest {
 
     // EDS update, localities moved: P0 sz1, sz3; P1 sz4; P2 sz2 - P0 C, P1 R, P2 R&D
     localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint12), 1, 0);
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint12), 1, 0);
     localityInfo2 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint22), 2, 2);
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint22), 2, 2);
     localityInfo3 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint32), 3, 0);
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint32), 3, 0);
     localityInfo4 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint42), 4, 1);
-    final ImmutableMap<Locality, LocalityInfo> localityInfoMap2 = ImmutableMap.of(
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint42), 4, 1);
+    final ImmutableMap<Locality, LocalityLbEndpoints> localityInfoMap2 = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3, locality4,
         localityInfo4);
     syncContext.execute(new Runnable() {
@@ -1175,10 +1180,10 @@ public class LocalityStoreTest {
 
     // EDS update, locality removed: P0 sz1, sz3, - P0 C, P1 N/A, sz4 R&D
     localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint11), 1, 0);
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11), 1, 0);
     localityInfo3 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint31), 3, 0);
-    final ImmutableMap<Locality, LocalityInfo> localityInfoMap3 = ImmutableMap.of(
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint31), 3, 0);
+    final ImmutableMap<Locality, LocalityLbEndpoints> localityInfoMap3 = ImmutableMap.of(
         locality1, localityInfo1,locality3, localityInfo3);
     syncContext.execute(new Runnable() {
       @Override
@@ -1225,10 +1230,10 @@ public class LocalityStoreTest {
 
     // EDS update, locality comes back and another removed: P0 sz1, P1 sz4 - P0 C, P1 R, sz3 R&D
     localityInfo1 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint11), 1, 0);
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11), 1, 0);
     localityInfo4 =
-        new LocalityInfo(ImmutableList.of(lbEndpoint41), 4, 1);
-    final ImmutableMap<Locality, LocalityInfo> localityInfoMap4 = ImmutableMap.of(
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint41), 4, 1);
+    final ImmutableMap<Locality, LocalityLbEndpoints> localityInfoMap4 = ImmutableMap.of(
         locality1, localityInfo1,locality4, localityInfo4);
     syncContext.execute(new Runnable() {
       @Override

--- a/xds/src/test/java/io/grpc/xds/LookasideChannelLbTest.java
+++ b/xds/src/test/java/io/grpc/xds/LookasideChannelLbTest.java
@@ -41,7 +41,6 @@ import io.envoyproxy.envoy.api.v2.core.Node;
 import io.envoyproxy.envoy.api.v2.core.SocketAddress;
 import io.envoyproxy.envoy.api.v2.endpoint.Endpoint;
 import io.envoyproxy.envoy.api.v2.endpoint.LbEndpoint;
-import io.envoyproxy.envoy.api.v2.endpoint.LocalityLbEndpoints;
 import io.envoyproxy.envoy.service.discovery.v2.AggregatedDiscoveryServiceGrpc.AggregatedDiscoveryServiceImplBase;
 import io.envoyproxy.envoy.type.FractionalPercent;
 import io.envoyproxy.envoy.type.FractionalPercent.DenominatorType;
@@ -57,7 +56,7 @@ import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
 import io.grpc.xds.EnvoyProtoData.DropOverload;
 import io.grpc.xds.EnvoyProtoData.Locality;
-import io.grpc.xds.EnvoyProtoData.LocalityInfo;
+import io.grpc.xds.EnvoyProtoData.LocalityLbEndpoints;
 import io.grpc.xds.LoadReportClient.LoadReportCallback;
 import io.grpc.xds.LookasideChannelLb.LookasideChannelCallback;
 import org.junit.Before;
@@ -116,7 +115,8 @@ public class LookasideChannelLbTest {
   private StreamObserver<DiscoveryResponse> serverResponseWriter;
 
   @Captor
-  private ArgumentCaptor<ImmutableMap<Locality, LocalityInfo>> localityEndpointsMappingCaptor;
+  private ArgumentCaptor<ImmutableMap<Locality, LocalityLbEndpoints>>
+      localityEndpointsMappingCaptor;
 
   private LookasideChannelLb lookasideChannelLb;
 
@@ -341,17 +341,17 @@ public class LookasideChannelLbTest {
         .setLoadBalancingWeight(UInt32Value.of(31))
         .build();
     ClusterLoadAssignment clusterLoadAssignment = ClusterLoadAssignment.newBuilder()
-            .addEndpoints(LocalityLbEndpoints.newBuilder()
+            .addEndpoints(io.envoyproxy.envoy.api.v2.endpoint.LocalityLbEndpoints.newBuilder()
                 .setLocality(localityProto1)
                 .addLbEndpoints(endpoint11)
                 .addLbEndpoints(endpoint12)
                 .setLoadBalancingWeight(UInt32Value.of(1)))
-            .addEndpoints(LocalityLbEndpoints.newBuilder()
+            .addEndpoints(io.envoyproxy.envoy.api.v2.endpoint.LocalityLbEndpoints.newBuilder()
                 .setLocality(localityProto2)
                 .addLbEndpoints(endpoint21)
                 .addLbEndpoints(endpoint22)
                 .setLoadBalancingWeight(UInt32Value.of(2)))
-            .addEndpoints(LocalityLbEndpoints.newBuilder()
+            .addEndpoints(io.envoyproxy.envoy.api.v2.endpoint.LocalityLbEndpoints.newBuilder()
                 .setLocality(localityProto3)
                 .addLbEndpoints(endpoint3)
                 .setLoadBalancingWeight(UInt32Value.of(0)))
@@ -363,12 +363,12 @@ public class LookasideChannelLbTest {
             .build());
 
     Locality locality1 = Locality.fromEnvoyProtoLocality(localityProto1);
-    LocalityInfo localityInfo1 = new LocalityInfo(
+    LocalityLbEndpoints localityInfo1 = new LocalityLbEndpoints(
         ImmutableList.of(
             EnvoyProtoData.LbEndpoint.fromEnvoyProtoLbEndpoint(endpoint11),
             EnvoyProtoData.LbEndpoint.fromEnvoyProtoLbEndpoint(endpoint12)),
         1, 0);
-    LocalityInfo localityInfo2 = new LocalityInfo(
+    LocalityLbEndpoints localityInfo2 = new LocalityLbEndpoints(
         ImmutableList.of(
             EnvoyProtoData.LbEndpoint.fromEnvoyProtoLbEndpoint(endpoint21),
             EnvoyProtoData.LbEndpoint.fromEnvoyProtoLbEndpoint(endpoint22)),

--- a/xds/src/test/java/io/grpc/xds/LookasideChannelLbTest.java
+++ b/xds/src/test/java/io/grpc/xds/LookasideChannelLbTest.java
@@ -37,7 +37,6 @@ import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment.Policy;
 import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
 import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
 import io.envoyproxy.envoy.api.v2.core.Address;
-import io.envoyproxy.envoy.api.v2.core.Locality;
 import io.envoyproxy.envoy.api.v2.core.Node;
 import io.envoyproxy.envoy.api.v2.core.SocketAddress;
 import io.envoyproxy.envoy.api.v2.endpoint.Endpoint;
@@ -56,9 +55,9 @@ import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.internal.testing.StreamRecorder;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
-import io.grpc.xds.ClusterLoadAssignmentData.DropOverload;
-import io.grpc.xds.ClusterLoadAssignmentData.LocalityInfo;
-import io.grpc.xds.ClusterLoadAssignmentData.XdsLocality;
+import io.grpc.xds.EnvoyProtoData.DropOverload;
+import io.grpc.xds.EnvoyProtoData.Locality;
+import io.grpc.xds.EnvoyProtoData.LocalityInfo;
 import io.grpc.xds.LoadReportClient.LoadReportCallback;
 import io.grpc.xds.LookasideChannelLb.LookasideChannelCallback;
 import org.junit.Before;
@@ -117,7 +116,7 @@ public class LookasideChannelLbTest {
   private StreamObserver<DiscoveryResponse> serverResponseWriter;
 
   @Captor
-  private ArgumentCaptor<ImmutableMap<XdsLocality, LocalityInfo>> localityEndpointsMappingCaptor;
+  private ArgumentCaptor<ImmutableMap<Locality, LocalityInfo>> localityEndpointsMappingCaptor;
 
   private LookasideChannelLb lookasideChannelLb;
 
@@ -285,8 +284,13 @@ public class LookasideChannelLbTest {
 
   @Test
   public void handleLocalityAssignmentUpdates() {
-    Locality localityProto1 = Locality.newBuilder()
-        .setRegion("region1").setZone("zone1").setSubZone("subzone1").build();
+    io.envoyproxy.envoy.api.v2.core.Locality localityProto1 =
+        io.envoyproxy.envoy.api.v2.core.Locality
+            .newBuilder()
+            .setRegion("region1")
+            .setZone("zone1")
+            .setSubZone("subzone1")
+            .build();
     LbEndpoint endpoint11 = LbEndpoint.newBuilder()
         .setEndpoint(Endpoint.newBuilder()
             .setAddress(Address.newBuilder()
@@ -301,8 +305,13 @@ public class LookasideChannelLbTest {
                     .setAddress("addr12").setPortValue(12))))
         .setLoadBalancingWeight(UInt32Value.of(12))
         .build();
-    Locality localityProto2 = Locality.newBuilder()
-        .setRegion("region2").setZone("zone2").setSubZone("subzone2").build();
+    io.envoyproxy.envoy.api.v2.core.Locality localityProto2 =
+        io.envoyproxy.envoy.api.v2.core.Locality
+            .newBuilder()
+            .setRegion("region2")
+            .setZone("zone2")
+            .setSubZone("subzone2")
+            .build();
     LbEndpoint endpoint21 = LbEndpoint.newBuilder()
         .setEndpoint(Endpoint.newBuilder()
             .setAddress(Address.newBuilder()
@@ -317,8 +326,13 @@ public class LookasideChannelLbTest {
                     .setAddress("addr22").setPortValue(22))))
         .setLoadBalancingWeight(UInt32Value.of(22))
         .build();
-    Locality localityProto3 = Locality.newBuilder()
-        .setRegion("region3").setZone("zone3").setSubZone("subzone3").build();
+    io.envoyproxy.envoy.api.v2.core.Locality localityProto3 =
+        io.envoyproxy.envoy.api.v2.core.Locality
+            .newBuilder()
+            .setRegion("region3")
+            .setZone("zone3")
+            .setSubZone("subzone3")
+            .build();
     LbEndpoint endpoint3 = LbEndpoint.newBuilder()
         .setEndpoint(Endpoint.newBuilder()
             .setAddress(Address.newBuilder()
@@ -348,18 +362,18 @@ public class LookasideChannelLbTest {
             .setTypeUrl("type.googleapis.com/envoy.api.v2.ClusterLoadAssignment")
             .build());
 
-    XdsLocality locality1 = XdsLocality.fromLocalityProto(localityProto1);
+    Locality locality1 = Locality.fromEnvoyProtoLocality(localityProto1);
     LocalityInfo localityInfo1 = new LocalityInfo(
         ImmutableList.of(
-            new ClusterLoadAssignmentData.LbEndpoint(endpoint11),
-            new ClusterLoadAssignmentData.LbEndpoint(endpoint12)),
+            new EnvoyProtoData.LbEndpoint(endpoint11),
+            new EnvoyProtoData.LbEndpoint(endpoint12)),
         1, 0);
     LocalityInfo localityInfo2 = new LocalityInfo(
         ImmutableList.of(
-            new ClusterLoadAssignmentData.LbEndpoint(endpoint21),
-            new ClusterLoadAssignmentData.LbEndpoint(endpoint22)),
+            new EnvoyProtoData.LbEndpoint(endpoint21),
+            new EnvoyProtoData.LbEndpoint(endpoint22)),
         2, 0);
-    XdsLocality locality2 = XdsLocality.fromLocalityProto(localityProto2);
+    Locality locality2 = Locality.fromEnvoyProtoLocality(localityProto2);
 
     InOrder inOrder = inOrder(localityStore);
     inOrder.verify(localityStore).updateDropPercentage(ImmutableList.<DropOverload>of());

--- a/xds/src/test/java/io/grpc/xds/LookasideChannelLbTest.java
+++ b/xds/src/test/java/io/grpc/xds/LookasideChannelLbTest.java
@@ -365,13 +365,13 @@ public class LookasideChannelLbTest {
     Locality locality1 = Locality.fromEnvoyProtoLocality(localityProto1);
     LocalityInfo localityInfo1 = new LocalityInfo(
         ImmutableList.of(
-            new EnvoyProtoData.LbEndpoint(endpoint11),
-            new EnvoyProtoData.LbEndpoint(endpoint12)),
+            EnvoyProtoData.LbEndpoint.fromEnvoyProtoLbEndpoint(endpoint11),
+            EnvoyProtoData.LbEndpoint.fromEnvoyProtoLbEndpoint(endpoint12)),
         1, 0);
     LocalityInfo localityInfo2 = new LocalityInfo(
         ImmutableList.of(
-            new EnvoyProtoData.LbEndpoint(endpoint21),
-            new EnvoyProtoData.LbEndpoint(endpoint22)),
+            EnvoyProtoData.LbEndpoint.fromEnvoyProtoLbEndpoint(endpoint21),
+            EnvoyProtoData.LbEndpoint.fromEnvoyProtoLbEndpoint(endpoint22)),
         2, 0);
     Locality locality2 = Locality.fromEnvoyProtoLocality(localityProto2);
 


### PR DESCRIPTION
`EnvoyProtoData.java` defines gRPC's data types for proto messages used in xDS protocol. In gRPC's LB logic, we should only carry gRPC's data type around instead of envoy proto messages.

This provides benefits:
- All xDS communication logic is encapsulated in `XdsClient` (in the future) and `LrsClient` (which is also a component of `XdsClient`), they pass gRPC's own data types to LB policies.
- Since gRPC only uses a subset of envoy's API, most fields in envoy's proto messages are not used. Processing envoy's proto message in gRPC's logic is verbose and can mistakenly touch unused fields. Data types in `EnvoyProtoData` only contains the fields used by gRPC.

For better use experience, please follow the convention of using gRPC's data type in gRPC's logic, only convert to envoy's proto messages when they needs to be sent in RPC.

Note: `io.envoyproxy.envoy.api.v2.core.Node` is an exception. This is read from bootstrap file and  included in xDS requests, it is opaque to gRPC. So we should not convert it to our own data type and should carry it around in its original form.

To avoid ambiguity, always declare envoy's proto message with fully qualified names (e.g., `io.envoyproxy.envoy.api.v2.core.Node node = ...`). 

TODO: [`LoadStatsStore#generateLoadReport()`](https://github.com/grpc/grpc-java/blob/4048716795ec60f43736fe3dab42cb30b6a65bc9/xds/src/main/java/io/grpc/xds/LoadStatsStore.java#L66) still carries envoy's proto message directly (and there may be other places but for now we focuses on the main xDS).

TODO: we may want add tests for all data types in `EnvoyProtoDataTest.java` (trivial).

