### PR TITLE
xds: build channel to xDS server with GoogleDefaultChannelBuilder if bootstrap file specifies so

### DIFF
--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -23,7 +23,8 @@ dependencies {
             project(':grpc-stub'),
             project(':grpc-core'),
             project(':grpc-netty'),
-            project(':grpc-services')
+            project(':grpc-services'),
+            project(':grpc-alts')
     
     compile (libraries.pgv) {
         // PGV depends on com.google.protobuf:protobuf-java 3.6.1 conflicting with :grpc-protobuf

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -17,6 +17,7 @@
 package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.grpc.xds.XdsNameResolver.XDS_CHANNEL_CREDS_LIST;
 import static io.grpc.xds.XdsNameResolver.XDS_NODE;
 import static java.util.logging.Level.FINEST;
 
@@ -31,11 +32,15 @@ import io.grpc.LoadBalancerRegistry;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.NameResolver.ConfigOrError;
+import io.grpc.alts.GoogleDefaultChannelBuilder;
 import io.grpc.util.ForwardingLoadBalancer;
 import io.grpc.util.GracefulSwitchLoadBalancer;
+import io.grpc.xds.Bootstrapper.ChannelCreds;
 import io.grpc.xds.LocalityStore.LocalityStoreImpl;
 import io.grpc.xds.LookasideChannelLb.LookasideChannelCallback;
 import io.grpc.xds.XdsLoadBalancerProvider.XdsConfig;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
@@ -98,13 +103,19 @@ final class LookasideLb extends ForwardingLoadBalancer {
                     Value.newBuilder().setBoolValue(true).build()))
             .build();
       }
-      lookasideChannelLb.switchTo(newLookasideChannelLbProvider(newBalancerName, node));
+      List<ChannelCreds> channelCredsList =
+          resolvedAddresses.getAttributes().get(XDS_CHANNEL_CREDS_LIST);
+      if (channelCredsList == null) {
+        channelCredsList = Collections.emptyList();
+      }
+      lookasideChannelLb.switchTo(newLookasideChannelLbProvider(
+          newBalancerName, node, channelCredsList));
     }
     lookasideChannelLb.handleResolvedAddresses(resolvedAddresses);
   }
 
   private LoadBalancerProvider newLookasideChannelLbProvider(
-      final String balancerName, final Node node) {
+      final String balancerName, final Node node, final List<ChannelCreds> channelCredsList) {
     return new LoadBalancerProvider() {
       @Override
       public boolean isAvailable() {
@@ -128,7 +139,7 @@ final class LookasideLb extends ForwardingLoadBalancer {
       @Override
       public LoadBalancer newLoadBalancer(Helper helper) {
         return lookasideChannelLbFactory.newLoadBalancer(
-            helper, lookasideChannelCallback, balancerName, node);
+            helper, lookasideChannelCallback, balancerName, node, channelCredsList);
       }
     };
   }
@@ -137,7 +148,7 @@ final class LookasideLb extends ForwardingLoadBalancer {
   interface LookasideChannelLbFactory {
     LoadBalancer newLoadBalancer(
         Helper helper, LookasideChannelCallback lookasideChannelCallback, String balancerName,
-        Node node);
+        Node node, List<ChannelCreds> channelCredsList);
   }
 
   private static final class LookasideChannelLbFactoryImpl implements LookasideChannelLbFactory {
@@ -145,15 +156,18 @@ final class LookasideLb extends ForwardingLoadBalancer {
     @Override
     public LoadBalancer newLoadBalancer(
         Helper helper, LookasideChannelCallback lookasideChannelCallback, String balancerName,
-        Node node) {
+        Node node, List<ChannelCreds> channelCredsList) {
       return new LookasideChannelLb(
-          helper, lookasideChannelCallback, initLbChannel(helper, balancerName),
+          helper, lookasideChannelCallback, initLbChannel(helper, balancerName, channelCredsList),
           new LocalityStoreImpl(helper, LoadBalancerRegistry.getDefaultRegistry()),
           node);
     }
 
-    private static ManagedChannel initLbChannel(Helper helper, String balancerName) {
-      ManagedChannel channel;
+    private static ManagedChannel initLbChannel(
+        Helper helper,
+        String balancerName,
+        List<ChannelCreds> channelCredsList) {
+      ManagedChannel channel = null;
       try {
         channel = helper.createResolvingOobChannel(balancerName);
       } catch (UnsupportedOperationException uoe) {
@@ -167,10 +181,20 @@ final class LookasideLb extends ForwardingLoadBalancer {
               uoe);
           logger.log(
               FINEST,
-              "creating oob channel for target {0} using default ManagedChannelBuilder",
+              "creating oob channel for target {0} normally",
               balancerName);
         }
-        channel = ManagedChannelBuilder.forTarget(balancerName).build();
+
+        // Use the first supported channel credentials configuration.
+        // Currently, only "google_default" is supported.
+        for (ChannelCreds creds : channelCredsList) {
+          if (creds.getType().equals("google_default")) {
+            channel = GoogleDefaultChannelBuilder.forTarget(balancerName).build();
+          }
+        }
+        if (channel == null) {
+          channel = ManagedChannelBuilder.forTarget(balancerName).build();
+        }
       }
       return channel;
     }

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -179,10 +179,7 @@ final class LookasideLb extends ForwardingLoadBalancer {
               FINEST,
               "createResolvingOobChannel() not supported by the helper: " + helper,
               uoe);
-          logger.log(
-              FINEST,
-              "creating oob channel for target {0} normally",
-              balancerName);
+          logger.log(FINEST, "creating oob channel for target {0}", balancerName);
         }
 
         // Use the first supported channel credentials configuration.

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -184,10 +184,10 @@ final class LookasideLb extends ForwardingLoadBalancer {
 
         // Use the first supported channel credentials configuration.
         // Currently, only "google_default" is supported.
-        // TODO(chengyuanzhang): make "google_default" a reserved keyword.
         for (ChannelCreds creds : channelCredsList) {
           if (creds.getType().equals("google_default")) {
             channel = GoogleDefaultChannelBuilder.forTarget(balancerName).build();
+            break;
           }
         }
         if (channel == null) {

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -184,6 +184,7 @@ final class LookasideLb extends ForwardingLoadBalancer {
 
         // Use the first supported channel credentials configuration.
         // Currently, only "google_default" is supported.
+        // TODO(chengyuanzhang): make "google_default" a reserved keyword.
         for (ChannelCreds creds : channelCredsList) {
           if (creds.getType().equals("google_default")) {
             channel = GoogleDefaultChannelBuilder.forTarget(balancerName).build();

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -28,9 +28,11 @@ import io.grpc.Status;
 import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.JsonParser;
 import io.grpc.xds.Bootstrapper.BootstrapInfo;
+import io.grpc.xds.Bootstrapper.ChannelCreds;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -47,6 +49,12 @@ final class XdsNameResolver extends NameResolver {
   // TODO(chengyuanzhang): delete this later, it was a workaround for demo.
   @NameResolver.ResolutionResultAttr
   static final Attributes.Key<Node> XDS_NODE = Attributes.Key.create("xds-node");
+  // TODO(chengyuanzhang): delete this later, XdsClient (to be implemented) constructed here
+  //  should take channel credentials config. This workaround is passing channel credentials
+  //  config to xDS load balancer, which is doing the xDS RPC communication for now.
+  @NameResolver.ResolutionResultAttr
+  static final Attributes.Key<List<ChannelCreds>> XDS_CHANNEL_CREDS_LIST =
+      Attributes.Key.create("xds-channel-creds-list");
 
   private final String authority;
   private final Bootstrapper bootstrapper;
@@ -100,6 +108,7 @@ final class XdsNameResolver extends NameResolver {
         Attributes.newBuilder()
             .set(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG, config)
             .set(XDS_NODE, bootstrapInfo.getNode())
+            .set(XDS_CHANNEL_CREDS_LIST, bootstrapInfo.getChannelCredentials())
             .build();
     ResolutionResult result =
         ResolutionResult.newBuilder()

--- a/xds/src/test/java/io/grpc/xds/BootstrapperTest.java
+++ b/xds/src/test/java/io/grpc/xds/BootstrapperTest.java
@@ -53,17 +53,19 @@ public class BootstrapperTest {
         + "\"xds_server\": {"
         + "\"server_uri\": \"trafficdirector.googleapis.com:443\","
         + "\"channel_creds\": "
-        + "[ {\"type\": \"TLS\"}, {\"type\": \"LOAS\"} ]"
+        + "[ {\"type\": \"tls\"}, {\"type\": \"loas\"}, {\"type\": \"google_default\"} ]"
         + "} "
         + "}";
 
     BootstrapInfo info = Bootstrapper.parseConfig(rawData);
     assertThat(info.getServerUri()).isEqualTo("trafficdirector.googleapis.com:443");
-    assertThat(info.getChannelCredentials()).hasSize(2);
-    assertThat(info.getChannelCredentials().get(0).getType()).isEqualTo("TLS");
+    assertThat(info.getChannelCredentials()).hasSize(3);
+    assertThat(info.getChannelCredentials().get(0).getType()).isEqualTo("tls");
     assertThat(info.getChannelCredentials().get(0).getConfig()).isNull();
-    assertThat(info.getChannelCredentials().get(1).getType()).isEqualTo("LOAS");
+    assertThat(info.getChannelCredentials().get(1).getType()).isEqualTo("loas");
     assertThat(info.getChannelCredentials().get(1).getConfig()).isNull();
+    assertThat(info.getChannelCredentials().get(2).getType()).isEqualTo("google_default");
+    assertThat(info.getChannelCredentials().get(2).getConfig()).isNull();
     assertThat(info.getNode()).isEqualTo(
         Node.newBuilder()
             .setId("ENVOY_NODE_ID")
@@ -109,7 +111,7 @@ public class BootstrapperTest {
         + "\"xds_server\": {"
         + "\"server_uri\": \"trafficdirector.googleapis.com:443\","
         + "\"channel_creds\": "
-        + "[ {\"type\": \"TLS\"}, {\"type\": \"LOAS\"} ]"
+        + "[ {\"type\": \"tls\"}, {\"type\": \"loas\"} ]"
         + "} "
         + "}";
 
@@ -155,7 +157,7 @@ public class BootstrapperTest {
         + "},"
         + "\"xds_server\": {"
         + "\"channel_creds\": "
-        + "[ {\"type\": \"TLS\"}, {\"type\": \"LOAS\"} ]"
+        + "[ {\"type\": \"tls\"}, {\"type\": \"loas\"} ]"
         + "} "
         + "}";
 

--- a/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
+++ b/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
@@ -34,6 +34,7 @@ import io.grpc.LoadBalancer.ResolvedAddresses;
 import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.internal.JsonParser;
+import io.grpc.xds.Bootstrapper.ChannelCreds;
 import io.grpc.xds.LookasideChannelLb.LookasideChannelCallback;
 import io.grpc.xds.LookasideLb.LookasideChannelLbFactory;
 import java.util.ArrayList;
@@ -57,7 +58,7 @@ public class LookasideLbTest {
         @Override
         public LoadBalancer newLoadBalancer(
             Helper helper, LookasideChannelCallback lookasideChannelCallback, String balancerName,
-            Node node) {
+            Node node, List<ChannelCreds> channelCredsList) {
           // just return a mock and record helper and balancer.
           helpers.add(helper);
           LoadBalancer balancer = mock(LoadBalancer.class);


### PR DESCRIPTION
The `XdsNameResolver` reads the bootstrap file and pass channel creds configuration in `ResolutionResult.Attributes` to `XdsLoadBalancer`. LB implementation populates the channel creds configurations and build channel to xDS resolver based on it.

Note: same as the hack for `Node`, this solution is temporary. We do not need to pass node and channel creds config in `ResolutionResult.Attributes` once we encapsulate logic for xDS communication into `XdsClient`. I know it's a bit messy now, but we are migrating to `XdsClient`. Things will be significantly cleaned up after that.