### PR TITLE
(WIP) xds: use fully qualified name for io.envoyproxy.envoy.api.v2.core.Node in gRPC's logic

### DIFF
--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -21,8 +21,6 @@ import com.google.protobuf.ListValue;
 import com.google.protobuf.NullValue;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
-import io.envoyproxy.envoy.api.v2.core.Locality;
-import io.envoyproxy.envoy.api.v2.core.Node;
 import io.grpc.internal.JsonParser;
 import io.grpc.internal.JsonUtil;
 import java.io.IOException;
@@ -121,7 +119,8 @@ abstract class Bootstrapper {
       throw new IOException("Invalid bootstrap: 'node' does not exist.");
     }
     // Fields in "node" are not checked.
-    Node.Builder nodeBuilder = Node.newBuilder();
+    io.envoyproxy.envoy.api.v2.core.Node.Builder nodeBuilder =
+        io.envoyproxy.envoy.api.v2.core.Node.newBuilder();
     String id = JsonUtil.getString(rawNode, "id");
     if (id != null) {
       nodeBuilder.setId(id);
@@ -140,7 +139,8 @@ abstract class Bootstrapper {
     }
     Map<String, ?> rawLocality = JsonUtil.getObject(rawNode, "locality");
     if (rawLocality != null) {
-      Locality.Builder localityBuilder = Locality.newBuilder();
+      io.envoyproxy.envoy.api.v2.core.Locality.Builder localityBuilder =
+          io.envoyproxy.envoy.api.v2.core.Locality.newBuilder();
       String region = JsonUtil.getString(rawLocality, "region");
       if (region == null) {
         throw new IOException("Invalid bootstrap: malformed 'node : locality'.");
@@ -235,10 +235,11 @@ abstract class Bootstrapper {
   static class BootstrapInfo {
     private final String serverUri;
     private final List<ChannelCreds> channelCredsList;
-    private final Node node;
+    private final io.envoyproxy.envoy.api.v2.core.Node node;
 
     @VisibleForTesting
-    BootstrapInfo(String serverUri, List<ChannelCreds> channelCredsList, Node node) {
+    BootstrapInfo(String serverUri, List<ChannelCreds> channelCredsList,
+        io.envoyproxy.envoy.api.v2.core.Node node) {
       this.serverUri = serverUri;
       this.channelCredsList = channelCredsList;
       this.node = node;
@@ -254,7 +255,7 @@ abstract class Bootstrapper {
     /**
      * Returns the node identifier to be included in xDS requests.
      */
-    Node getNode() {
+    io.envoyproxy.envoy.api.v2.core.Node getNode() {
       return node;
     }
 

--- a/xds/src/test/java/io/grpc/xds/BootstrapperTest.java
+++ b/xds/src/test/java/io/grpc/xds/BootstrapperTest.java
@@ -20,8 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
-import io.envoyproxy.envoy.api.v2.core.Locality;
-import io.envoyproxy.envoy.api.v2.core.Node;
 import io.grpc.xds.Bootstrapper.BootstrapInfo;
 import java.io.IOException;
 import org.junit.Rule;
@@ -65,11 +63,11 @@ public class BootstrapperTest {
     assertThat(info.getChannelCredentials().get(1).getType()).isEqualTo("LOAS");
     assertThat(info.getChannelCredentials().get(1).getConfig()).isNull();
     assertThat(info.getNode()).isEqualTo(
-        Node.newBuilder()
+        io.envoyproxy.envoy.api.v2.core.Node.newBuilder()
             .setId("ENVOY_NODE_ID")
             .setCluster("ENVOY_CLUSTER")
             .setLocality(
-                Locality.newBuilder()
+                io.envoyproxy.envoy.api.v2.core.Locality.newBuilder()
                     .setRegion("ENVOY_REGION").setZone("ENVOY_ZONE").setSubZone("ENVOY_SUBZONE"))
             .setMetadata(
                 Struct.newBuilder()
@@ -100,7 +98,7 @@ public class BootstrapperTest {
 
     BootstrapInfo info = Bootstrapper.parseConfig(rawData);
     assertThat(info.getServerUri()).isEqualTo("trafficdirector.googleapis.com:443");
-    assertThat(info.getNode()).isEqualTo(Node.getDefaultInstance());
+    assertThat(info.getNode()).isEqualTo(io.envoyproxy.envoy.api.v2.core.Node.getDefaultInstance());
   }
 
   @Test


### PR DESCRIPTION
This is a cleanup change follows what we modify in #6361. In the future, we will not carry envoy's proto message in gRPC's logic. `io.envoyproxy.envoy.api.v2.core.Node` is an exception (as mentioned in https://github.com/grpc/grpc-java/pull/6361#issue-334544375). To avoid ambiguity, we use fully qualified name for it.