### PR TITLE
[On hold] xds: add EdsLoadBalancer

### DIFF
--- a/xds/src/main/java/io/grpc/xds/EdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/EdsLoadBalancer.java
@@ -136,9 +136,7 @@ final class EdsLoadBalancer extends LoadBalancer {
     }
 
     if (xdsClient != null) {
-      Preconditions.checkState(
-          xdsClient == xdsClientRef.get(),
-          "The XdsClient is changed");
+      Preconditions.checkState(xdsClient == xdsClientRef.get(), "The XdsClient is changed");
     } else {
       xdsClient = xdsClientRef.get();
     }

--- a/xds/src/main/java/io/grpc/xds/EdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/EdsLoadBalancer.java
@@ -106,7 +106,7 @@ final class EdsLoadBalancer extends LoadBalancer {
     this.helper = checkNotNull(helper, "helper");
     this.xdsClient = checkNotNull(xdsClient, "xdsClient");
     this.channelLogger = helper.getChannelLogger();
-    // TODO(zdapeng): Allow it be null when enableLrs from ClusterUpdate is false.
+    // TODO(zdapeng): TBD: handle enableLrs from ClusterUpdate is false/changed.
     this.loadStatsStore = checkNotNull(loadStatsStore, "loadStatsStore");
 
     // The following fields are injected for testing

--- a/xds/src/main/java/io/grpc/xds/EdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/EdsLoadBalancer.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.grpc.ChannelLogger;
+import io.grpc.ChannelLogger.ChannelLogLevel;
+import io.grpc.LoadBalancer;
+import io.grpc.LoadBalancerRegistry;
+import io.grpc.Status;
+import io.grpc.xds.LocalityStore.LocalityStoreImpl;
+import io.grpc.xds.XdsClient.EndpointUpdate;
+import io.grpc.xds.XdsClient.EndpointWatcher;
+import javax.annotation.CheckForNull;
+
+/**
+ * Load balancer for experimental_eds LB policy.
+ */
+final class EdsLoadBalancer extends LoadBalancer {
+
+  private final String clusterName;
+  // TODO(zdapeng): merge LocalityStore implementation inside this class after migration to
+  // XdsClient is done.
+  private final LocalityStore localityStore;
+  private final XdsClient xdsClient;
+  private final ChannelLogger channelLogger;
+
+  @CheckForNull
+  private EndpointWatcher endpointWatcher;
+
+  EdsLoadBalancer(String clusterName, Helper helper, XdsClient xdsClient) {
+    this(
+        clusterName,
+        new LocalityStoreImpl(
+            checkNotNull(helper, "helper"), LoadBalancerRegistry.getDefaultRegistry()),
+        xdsClient,
+        helper.getChannelLogger());
+  }
+
+  @VisibleForTesting
+  EdsLoadBalancer(
+      String clusterName, LocalityStore localityStore, XdsClient xdsClient,
+      ChannelLogger channelLogger) {
+    this.clusterName = checkNotNull(clusterName, "clusterName");
+    this.localityStore = checkNotNull(localityStore, "localityStore");
+    this.xdsClient = checkNotNull(xdsClient, "xdsClient");
+    this.channelLogger = checkNotNull(channelLogger, "channelLogger");
+  }
+
+  @Override
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    channelLogger.log(ChannelLogLevel.DEBUG, "Received ResolvedAddresses '%s'", resolvedAddresses);
+
+    Object lbConfig = resolvedAddresses.getLoadBalancingPolicyConfig();
+    checkArgument(
+        lbConfig != null && EdsConfig.class.isAssignableFrom(lbConfig.getClass()),
+        "Expecting an EDS LB config, but the actual LB config is '%s'",
+        lbConfig);
+
+    EdsConfig edsConfig = (EdsConfig) lbConfig;
+
+    checkArgument(
+        clusterName.equals(edsConfig.name),
+        "The cluster name '%s' from EDS LB config does not match the name '%s' provided by CDS",
+        edsConfig.name,
+        clusterName);
+
+    // TODO(zdapeng): if localityPickingPolicy is changed for the same cluster, swap to new policy.
+    // Right now we have only one default localityPickingPolicy (hardcoded in LocalityStore),
+    // so ignoring localityPickingPolicy for now.
+    if (endpointWatcher == null) {
+      endpointWatcher = new EndpointWatcherImpl(localityStore);
+      xdsClient.watchEndpointData(clusterName, endpointWatcher);
+    }
+  }
+
+  @Override
+  public void handleNameResolutionError(Status error) {
+    channelLogger.log(ChannelLogLevel.DEBUG, "Name resolution error: '%s'", error);
+    // NO-OP?
+  }
+
+  @Override
+  public boolean canHandleEmptyAddressListFromNameResolution() {
+    return true;
+  }
+
+  @Override
+  public void shutdown() {
+    channelLogger.log(ChannelLogLevel.DEBUG, "EDS load balancer is shutting down");
+
+    if (endpointWatcher != null) {
+      xdsClient.cancelEndpointDataWatch(endpointWatcher);
+    }
+    localityStore.reset();
+  }
+
+  static final class EdsConfig {
+
+    /**
+     * Name of cluster to query EDS for.
+     */
+    final String name;
+
+    final Object localityPickingPolicy;
+
+    public EdsConfig(String name, Object localityPickingPolicy) {
+      this.name = checkNotNull(name, "name");
+      this.localityPickingPolicy = checkNotNull(localityPickingPolicy);
+    }
+  }
+
+  static final class EndpointWatcherImpl implements EndpointWatcher {
+
+    private final LocalityStore localityStore;
+
+    EndpointWatcherImpl(LocalityStore localityStore) {
+      this.localityStore = localityStore;
+    }
+
+    @Override
+    public void onEndpointChanged(EndpointUpdate update) {
+      checkNotNull(update, "update");
+
+      localityStore.updateLocalityStore(ImmutableMap.copyOf(update.localityInfoMap));
+      localityStore.updateDropPercentage(ImmutableList.copyOf(update.dropOverloads));
+    }
+
+    @Override
+    public void onError(Status error) {
+      // ADS stream error, no known endpoint specific error yet.
+    }
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/EdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/EdsLoadBalancer.java
@@ -207,7 +207,7 @@ final class EdsLoadBalancer extends LoadBalancer {
     private final Map<Locality, LocalityLbInfo> localityMap = new HashMap<>();
     // Most current set of localities instructed by traffic director
     private Set<Locality> localities = ImmutableSet.of();
-    private ImmutableList<DropOverload> dropOverloads = ImmutableList.of();
+    private List<DropOverload> dropOverloads = ImmutableList.of();
     private long metricsReportIntervalNano = -1;
 
     EndpointWatcherImpl(
@@ -260,7 +260,7 @@ final class EdsLoadBalancer extends LoadBalancer {
 
     // This is triggered by EDS response.
     private void updateLocalityStore(
-        final ImmutableMap<Locality, LocalityLbEndpoints> localityInfoMap) {
+        final Map<Locality, LocalityLbEndpoints> localityInfoMap) {
 
       Set<Locality> newLocalities = localityInfoMap.keySet();
       // TODO: put endPointWeights into attributes for WRR.
@@ -320,7 +320,7 @@ final class EdsLoadBalancer extends LoadBalancer {
       }
     }
 
-    private void updateDropPercentage(ImmutableList<DropOverload> dropOverloads) {
+    private void updateDropPercentage(List<DropOverload> dropOverloads) {
       this.dropOverloads = checkNotNull(dropOverloads, "dropOverloads");
     }
 
@@ -409,13 +409,13 @@ final class EdsLoadBalancer extends LoadBalancer {
 
     private static final class DroppablePicker extends SubchannelPicker {
 
-      final ImmutableList<DropOverload> dropOverloads;
+      final List<DropOverload> dropOverloads;
       final SubchannelPicker delegate;
       final ThreadSafeRandom random;
       final LoadStatsStore loadStatsStore;
 
       DroppablePicker(
-          ImmutableList<DropOverload> dropOverloads, SubchannelPicker delegate,
+          List<DropOverload> dropOverloads, SubchannelPicker delegate,
           ThreadSafeRandom random, LoadStatsStore loadStatsStore) {
         this.dropOverloads = dropOverloads;
         this.delegate = delegate;

--- a/xds/src/main/java/io/grpc/xds/EdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/EdsLoadBalancer.java
@@ -239,7 +239,9 @@ final class EdsLoadBalancer extends LoadBalancer {
 
     @Override
     public void onError(Status error) {
-      // ADS stream error, no known endpoint specific error yet.
+      reset();
+      helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(error));
+
     }
 
     private void reset() {

--- a/xds/src/main/java/io/grpc/xds/EdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/EdsLoadBalancer.java
@@ -286,22 +286,9 @@ final class EdsLoadBalancer extends LoadBalancer {
       // TODO: put endPointWeights into attributes for WRR.
       for (Locality locality : newLocalities) {
         if (localityMap.containsKey(locality)) {
-          final LocalityLbInfo localityLbInfo = localityMap.get(locality);
-          LocalityLbEndpoints localityInfo = localityInfoMap.get(locality);
-          final List<EquivalentAddressGroup> eags = new ArrayList<>();
-          for (LbEndpoint endpoint: localityInfo.getEndpoints()) {
-            eags.add(endpoint.getAddress());
-          }
-          // In extreme case handleResolvedAddresses() may trigger updateBalancingState()
-          // immediately, so execute handleResolvedAddresses() after all the setup in this method is
-          // complete.
-          helper.getSynchronizationContext().execute(new Runnable() {
-            @Override
-            public void run() {
-              localityLbInfo.childBalancer.handleResolvedAddresses(
-                  ResolvedAddresses.newBuilder().setAddresses(eags).build());
-            }
-          });
+          LocalityLbInfo localityLbInfo = localityMap.get(locality);
+          LocalityLbEndpoints localityLbEndpoints = localityInfoMap.get(locality);
+          handleEagsOnChildBalancer(helper, localityLbInfo, localityLbEndpoints, locality);
         }
       }
 
@@ -707,29 +694,44 @@ final class EdsLoadBalancer extends LoadBalancer {
         ChildHelper childHelper =
             new ChildHelper(locality, loadStatsStore.getLocalityCounter(locality),
                 orcaOobUtil);
-        final LocalityLbInfo localityLbInfo =
+        LocalityLbInfo localityLbInfo =
             new LocalityLbInfo(
                 loadBalancerProvider.newLoadBalancer(childHelper),
                 childHelper);
         localityMap.put(locality, localityLbInfo);
+        LocalityLbEndpoints localityLbEndpoints = localityInfoMap.get(locality);
+        handleEagsOnChildBalancer(childHelper, localityLbInfo, localityLbEndpoints, locality);
+      }
+    }
 
-        LocalityLbEndpoints localityInfo = localityInfoMap.get(locality);
-        final List<EquivalentAddressGroup> eags = new ArrayList<>();
-        for (LbEndpoint endpoint: localityInfo.getEndpoints()) {
+    private static void handleEagsOnChildBalancer(
+        Helper childHelper, final LocalityLbInfo localityLbInfo,
+        final LocalityLbEndpoints localityLbEndpoints, final Locality locality) {
+      final List<EquivalentAddressGroup> eags = new ArrayList<>();
+      for (LbEndpoint endpoint: localityLbEndpoints.getEndpoints()) {
+        if (endpoint.isHealthy()) {
           eags.add(endpoint.getAddress());
         }
-        // In extreme case handleResolvedAddresses() may trigger updateBalancingState() immediately,
-        // so execute handleResolvedAddresses() after all the setup in the caller is complete.
-        helper.getSynchronizationContext().execute(new Runnable() {
-          @Override
-          public void run() {
-            // TODO: put endPointWeights into attributes for WRR.
+      }
+      // In extreme case handleResolvedAddresses() may trigger updateBalancingState()
+      // immediately, so execute handleResolvedAddresses() after all the setup in the caller is
+      // complete.
+      childHelper.getSynchronizationContext().execute(new Runnable() {
+        @Override
+        public void run() {
+          if (eags.isEmpty()
+              && !localityLbInfo.childBalancer.canHandleEmptyAddressListFromNameResolution()) {
+            localityLbInfo.childBalancer.handleNameResolutionError(
+                Status.UNAVAILABLE.withDescription(
+                    "No healthy address available from EDS update '" + localityLbEndpoints
+                        + "' for locality '" + locality + "'"));
+          } else {
             localityLbInfo.childBalancer
                 .handleResolvedAddresses(ResolvedAddresses.newBuilder()
                     .setAddresses(eags).build());
           }
-        });
-      }
+        }
+      });
     }
   }
 }

--- a/xds/src/main/java/io/grpc/xds/EdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/EdsLoadBalancer.java
@@ -18,18 +18,48 @@ package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.grpc.ConnectivityState.CONNECTING;
+import static io.grpc.ConnectivityState.IDLE;
+import static io.grpc.ConnectivityState.READY;
+import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.grpc.ChannelLogger;
 import io.grpc.ChannelLogger.ChannelLogLevel;
+import io.grpc.ConnectivityState;
+import io.grpc.ConnectivityStateInfo;
+import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
+import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.Status;
-import io.grpc.xds.LocalityStore.LocalityStoreImpl;
+import io.grpc.SynchronizationContext.ScheduledHandle;
+import io.grpc.util.ForwardingLoadBalancerHelper;
+import io.grpc.xds.ClientLoadCounter.LoadRecordingSubchannelPicker;
+import io.grpc.xds.ClientLoadCounter.MetricsObservingSubchannelPicker;
+import io.grpc.xds.ClientLoadCounter.MetricsRecordingListener;
+import io.grpc.xds.EnvoyProtoData.DropOverload;
+import io.grpc.xds.EnvoyProtoData.LbEndpoint;
+import io.grpc.xds.EnvoyProtoData.Locality;
+import io.grpc.xds.EnvoyProtoData.LocalityLbEndpoints;
+import io.grpc.xds.InterLocalityPicker.WeightedChildPicker;
+import io.grpc.xds.OrcaOobUtil.OrcaReportingConfig;
+import io.grpc.xds.OrcaOobUtil.OrcaReportingHelperWrapper;
 import io.grpc.xds.XdsClient.EndpointUpdate;
 import io.grpc.xds.XdsClient.EndpointWatcher;
+import io.grpc.xds.XdsSubchannelPickers.ErrorPicker;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
@@ -38,32 +68,58 @@ import javax.annotation.Nullable;
  */
 final class EdsLoadBalancer extends LoadBalancer {
 
-  // TODO(zdapeng): merge LocalityStore implementation inside this class after migration to
-  // XdsClient is done.
-  private final LocalityStore localityStore;
+  private static final EndpointWatcherImpl.PickerFactory pickerFactoryImpl =
+      new EndpointWatcherImpl.PickerFactory() {
+        @Override
+        public SubchannelPicker picker(List<WeightedChildPicker> childPickers) {
+          return new InterLocalityPicker(childPickers);
+        }
+      };
+
+  private final Helper helper;
   private final XdsClient xdsClient;
   private final ChannelLogger channelLogger;
+
+  private final EndpointWatcherImpl.PickerFactory pickerFactory;
+  private final LoadBalancerRegistry lbRegistry;
+  private final ThreadSafeRandom random;
+  private final LoadStatsStore loadStatsStore;
+  private final OrcaPerRequestUtil orcaPerRequestUtil;
+  private final OrcaOobUtil orcaOobUtil;
+
 
   @Nullable
   private String edsServiceName;
 
   @CheckForNull
-  private EndpointWatcher endpointWatcher;
+  private EndpointWatcherImpl endpointWatcher;
 
   EdsLoadBalancer(Helper helper, XdsClient xdsClient) {
-    this(
-        new LocalityStoreImpl(
-            checkNotNull(helper, "helper"), LoadBalancerRegistry.getDefaultRegistry()),
-        xdsClient,
-        helper.getChannelLogger());
+    this(helper, xdsClient, pickerFactoryImpl, LoadBalancerRegistry.getDefaultRegistry(),
+        ThreadSafeRandom.ThreadSafeRandomImpl.instance, new LoadStatsStoreImpl(),
+        OrcaPerRequestUtil.getInstance(), OrcaOobUtil.getInstance());
   }
 
   @VisibleForTesting
   EdsLoadBalancer(
-      LocalityStore localityStore, XdsClient xdsClient, ChannelLogger channelLogger) {
-    this.localityStore = checkNotNull(localityStore, "localityStore");
+      Helper helper,
+      XdsClient xdsClient,
+      EndpointWatcherImpl.PickerFactory pickerFactory,
+      LoadBalancerRegistry lbRegistry,
+      ThreadSafeRandom random,
+      LoadStatsStore loadStatsStore,
+      OrcaPerRequestUtil orcaPerRequestUtil,
+      OrcaOobUtil orcaOobUtil) {
+    this.helper = checkNotNull(helper, "helper");
     this.xdsClient = checkNotNull(xdsClient, "xdsClient");
-    this.channelLogger = checkNotNull(channelLogger, "channelLogger");
+    this.channelLogger = helper.getChannelLogger();
+
+    this.pickerFactory = checkNotNull(pickerFactory, "pickerFactory");
+    this.lbRegistry = checkNotNull(lbRegistry, "lbRegistry");
+    this.random = checkNotNull(random, "random");
+    this.loadStatsStore = checkNotNull(loadStatsStore, "loadStatsStore");
+    this.orcaPerRequestUtil = checkNotNull(orcaPerRequestUtil, "orcaPerRequestUtil");
+    this.orcaOobUtil = checkNotNull(orcaOobUtil, "orcaOobUtil");
   }
 
   @Override
@@ -87,9 +143,12 @@ final class EdsLoadBalancer extends LoadBalancer {
       if (endpointWatcher != null) {
         // TODO(zdapeng): Maybe gracefully swap until the localities for the new watcher is READY?
         xdsClient.cancelEndpointDataWatch(endpointWatcher);
+        endpointWatcher.reset();
       }
-      endpointWatcher = new EndpointWatcherImpl(localityStore);
-      xdsClient.watchEndpointData(edsServiceName, endpointWatcher);
+      endpointWatcher = new EndpointWatcherImpl(
+          helper, pickerFactory, lbRegistry, random, loadStatsStore, orcaPerRequestUtil,
+          orcaOobUtil);
+      xdsClient.watchEndpointData(edsServiceName, endpointWatcher);;
       this.edsServiceName = edsServiceName;
     }
   }
@@ -111,8 +170,8 @@ final class EdsLoadBalancer extends LoadBalancer {
 
     if (endpointWatcher != null) {
       xdsClient.cancelEndpointDataWatch(endpointWatcher);
+      endpointWatcher.reset();
     }
-    localityStore.reset();
   }
 
   static final class EdsConfig {
@@ -124,7 +183,7 @@ final class EdsLoadBalancer extends LoadBalancer {
 
     final Object localityPickingPolicy;
 
-    public EdsConfig(String name, Object localityPickingPolicy) {
+    EdsConfig(String name, Object localityPickingPolicy) {
       this.name = checkNotNull(name, "name");
       this.localityPickingPolicy = checkNotNull(localityPickingPolicy);
     }
@@ -132,23 +191,529 @@ final class EdsLoadBalancer extends LoadBalancer {
 
   static final class EndpointWatcherImpl implements EndpointWatcher {
 
-    private final LocalityStore localityStore;
+    private static final String ROUND_ROBIN = "round_robin";
+    private static final long DELAYED_DELETION_TIMEOUT_MINUTES = 15L;
 
-    EndpointWatcherImpl(LocalityStore localityStore) {
-      this.localityStore = localityStore;
+    private final Helper helper;
+    private final PickerFactory pickerFactory;
+    private final LoadBalancerProvider loadBalancerProvider;
+    private final ThreadSafeRandom random;
+    private final LoadStatsStore loadStatsStore;
+    private final OrcaPerRequestUtil orcaPerRequestUtil;
+    private final OrcaOobUtil orcaOobUtil;
+    private final PriorityManager priorityManager = new PriorityManager();
+    private final Map<Locality, LocalityLbInfo> localityMap = new HashMap<>();
+    // Most current set of localities instructed by traffic director
+    private Set<Locality> localities = ImmutableSet.of();
+    private ImmutableList<DropOverload> dropOverloads = ImmutableList.of();
+    private long metricsReportIntervalNano = -1;
+
+    EndpointWatcherImpl(
+        Helper helper,
+        PickerFactory pickerFactory,
+        LoadBalancerRegistry lbRegistry,
+        ThreadSafeRandom random,
+        LoadStatsStore loadStatsStore,
+        OrcaPerRequestUtil orcaPerRequestUtil,
+        OrcaOobUtil orcaOobUtil) {
+      this.helper = checkNotNull(helper, "helper");
+      this.pickerFactory = checkNotNull(pickerFactory, "pickerFactory");
+      loadBalancerProvider = checkNotNull(
+          lbRegistry.getProvider(ROUND_ROBIN),
+          "Unable to find '%s' LoadBalancer", ROUND_ROBIN);
+      this.random = checkNotNull(random, "random");
+      this.loadStatsStore = checkNotNull(loadStatsStore, "loadStatsStore");
+      this.orcaPerRequestUtil = checkNotNull(orcaPerRequestUtil, "orcaPerRequestUtil");
+      this.orcaOobUtil = checkNotNull(orcaOobUtil, "orcaOobUtil");
     }
 
     @Override
     public void onEndpointChanged(EndpointUpdate update) {
       checkNotNull(update, "update");
 
-      localityStore.updateLocalityStore(ImmutableMap.copyOf(update.localityInfoMap));
-      localityStore.updateDropPercentage(ImmutableList.copyOf(update.dropOverloads));
+      updateDropPercentage(ImmutableList.copyOf(update.dropOverloads));
+      updateLocalityStore(ImmutableMap.copyOf(update.localityInfoMap));
     }
 
     @Override
     public void onError(Status error) {
       // ADS stream error, no known endpoint specific error yet.
+    }
+
+    // This is triggered by xdsLoadbalancer.handleSubchannelState
+    public void handleSubchannelState(Subchannel subchannel, ConnectivityStateInfo newState) {
+      // delegate to the childBalancer who manages this subchannel
+      for (LocalityLbInfo localityLbInfo : localityMap.values()) {
+        // This will probably trigger childHelper.updateBalancingState
+        localityLbInfo.childBalancer.handleSubchannelState(subchannel, newState);
+      }
+    }
+
+    public void reset() {
+      for (Locality locality : localityMap.keySet()) {
+        localityMap.get(locality).shutdown();
+      }
+      localityMap.clear();
+
+      for (Locality locality : localities) {
+        loadStatsStore.removeLocality(locality);
+      }
+      localities = ImmutableSet.of();
+
+      priorityManager.reset();
+    }
+
+    // This is triggered by EDS response.
+    public void updateLocalityStore(
+        final ImmutableMap<Locality, LocalityLbEndpoints> localityInfoMap) {
+
+      Set<Locality> newLocalities = localityInfoMap.keySet();
+      // TODO: put endPointWeights into attributes for WRR.
+      for (Locality locality : newLocalities) {
+        if (localityMap.containsKey(locality)) {
+          final LocalityLbInfo localityLbInfo = localityMap.get(locality);
+          LocalityLbEndpoints localityInfo = localityInfoMap.get(locality);
+          final List<EquivalentAddressGroup> eags = new ArrayList<>();
+          for (LbEndpoint endpoint: localityInfo.getEndpoints()) {
+            eags.add(endpoint.getAddress());
+          }
+          // In extreme case handleResolvedAddresses() may trigger updateBalancingState()
+          // immediately, so execute handleResolvedAddresses() after all the setup in this method is
+          // complete.
+          helper.getSynchronizationContext().execute(new Runnable() {
+            @Override
+            public void run() {
+              localityLbInfo.childBalancer.handleResolvedAddresses(
+                  ResolvedAddresses.newBuilder().setAddresses(eags).build());
+            }
+          });
+        }
+      }
+
+      for (Locality newLocality : newLocalities) {
+        if (!localities.contains(newLocality)) {
+          loadStatsStore.addLocality(newLocality);
+        }
+      }
+      final Set<Locality> toBeRemovedFromStatsStore = new HashSet<>();
+      // There is a race between picking a subchannel and updating localities, which leads to
+      // the possibility that RPCs will be sent to a removed locality. As a result, those RPC
+      // loads will not be recorded. We consider this to be natural. By removing locality counters
+      // after updating subchannel pickers, we eliminate the race and conservatively record loads
+      // happening in that period.
+      for (Locality oldLocality : localities) {
+        if (!localityInfoMap.containsKey(oldLocality)) {
+          toBeRemovedFromStatsStore.add(oldLocality);
+        }
+      }
+      helper.getSynchronizationContext().execute(new Runnable() {
+        @Override
+        public void run() {
+          for (Locality locality : toBeRemovedFromStatsStore) {
+            loadStatsStore.removeLocality(locality);
+          }
+        }
+      });
+      localities = newLocalities;
+
+      priorityManager.updateLocalities(localityInfoMap);
+
+      for (Locality oldLocality : localityMap.keySet()) {
+        if (!newLocalities.contains(oldLocality)) {
+          deactivate(oldLocality);
+        }
+      }
+    }
+
+    public void updateDropPercentage(ImmutableList<DropOverload> dropOverloads) {
+      this.dropOverloads = checkNotNull(dropOverloads, "dropOverloads");
+    }
+
+    private void deactivate(final Locality locality) {
+      if (!localityMap.containsKey(locality) || localityMap.get(locality).isDeactivated()) {
+        return;
+      }
+
+      final LocalityLbInfo localityLbInfo = localityMap.get(locality);
+      class DeletionTask implements Runnable {
+
+        @Override
+        public void run() {
+          localityLbInfo.shutdown();
+          localityMap.remove(locality);
+        }
+
+        @Override
+        public String toString() {
+          return "DeletionTask: locality=" + locality;
+        }
+      }
+
+      localityLbInfo.delayedDeletionTimer = helper.getSynchronizationContext().schedule(
+          new DeletionTask(), DELAYED_DELETION_TIMEOUT_MINUTES,
+          TimeUnit.MINUTES, helper.getScheduledExecutorService());
+    }
+
+    public LoadStatsStore getLoadStatsStore() {
+      return loadStatsStore;
+    }
+
+    public void updateOobMetricsReportInterval(long reportIntervalNano) {
+      metricsReportIntervalNano = reportIntervalNano;
+      for (LocalityLbInfo lbInfo : localityMap.values()) {
+        lbInfo.childHelper.updateMetricsReportInterval(reportIntervalNano);
+      }
+    }
+
+    @Nullable
+    private static ConnectivityState aggregateState(
+        @Nullable ConnectivityState overallState, ConnectivityState childState) {
+      if (overallState == null) {
+        return childState;
+      }
+      if (overallState == READY || childState == READY) {
+        return READY;
+      }
+      if (overallState == CONNECTING || childState == CONNECTING) {
+        return CONNECTING;
+      }
+      if (overallState == IDLE || childState == IDLE) {
+        return IDLE;
+      }
+      return overallState;
+    }
+
+    private void updatePicker(
+        @Nullable ConnectivityState state,  List<WeightedChildPicker> childPickers) {
+      childPickers = Collections.unmodifiableList(childPickers);
+      SubchannelPicker picker;
+      if (childPickers.isEmpty()) {
+        if (state == TRANSIENT_FAILURE) {
+          picker = new ErrorPicker(Status.UNAVAILABLE); // TODO: more details in status
+        } else {
+          picker = XdsSubchannelPickers.BUFFER_PICKER;
+        }
+      } else {
+        picker = pickerFactory.picker(childPickers);
+      }
+
+      if (!dropOverloads.isEmpty()) {
+        picker = new DroppablePicker(dropOverloads, picker, random, loadStatsStore);
+      }
+
+      if (state != null) {
+        helper.updateBalancingState(state, picker);
+      }
+    }
+
+    @VisibleForTesting // Introduced for testing only.
+    interface PickerFactory {
+      SubchannelPicker picker(List<WeightedChildPicker> childPickers);
+    }
+
+    private static final class DroppablePicker extends SubchannelPicker {
+
+      final ImmutableList<DropOverload> dropOverloads;
+      final SubchannelPicker delegate;
+      final ThreadSafeRandom random;
+      final LoadStatsStore loadStatsStore;
+
+      DroppablePicker(
+          ImmutableList<DropOverload> dropOverloads, SubchannelPicker delegate,
+          ThreadSafeRandom random, LoadStatsStore loadStatsStore) {
+        this.dropOverloads = dropOverloads;
+        this.delegate = delegate;
+        this.random = random;
+        this.loadStatsStore = loadStatsStore;
+      }
+
+      @Override
+      public PickResult pickSubchannel(PickSubchannelArgs args) {
+        for (DropOverload dropOverload : dropOverloads) {
+          int rand = random.nextInt(1000_000);
+          if (rand < dropOverload.getDropsPerMillion()) {
+            loadStatsStore.recordDroppedRequest(dropOverload.getCategory());
+            return PickResult.withDrop(Status.UNAVAILABLE.withDescription(
+                "dropped by loadbalancer: " + dropOverload.toString()));
+          }
+        }
+        return delegate.pickSubchannel(args);
+      }
+
+      @Override
+      public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("dropOverloads", dropOverloads)
+            .add("delegate", delegate)
+            .toString();
+      }
+    }
+
+    /**
+     * State of a single Locality.
+     */
+    // TODO(zdapeng): rename it to LocalityLbState
+    static final class LocalityLbInfo {
+
+      final LoadBalancer childBalancer;
+      final ChildHelper childHelper;
+
+      @Nullable
+      private ScheduledHandle delayedDeletionTimer;
+
+      LocalityLbInfo(
+          LoadBalancer childBalancer, ChildHelper childHelper) {
+        this.childBalancer = checkNotNull(childBalancer, "childBalancer");
+        this.childHelper = checkNotNull(childHelper, "childHelper");
+      }
+
+      void shutdown() {
+        if (delayedDeletionTimer != null) {
+          delayedDeletionTimer.cancel();
+          delayedDeletionTimer = null;
+        }
+        childBalancer.shutdown();
+      }
+
+      void reactivate() {
+        if (delayedDeletionTimer != null) {
+          delayedDeletionTimer.cancel();
+          delayedDeletionTimer = null;
+        }
+      }
+
+      boolean isDeactivated() {
+        return delayedDeletionTimer != null;
+      }
+    }
+
+    class ChildHelper extends ForwardingLoadBalancerHelper {
+
+      private final OrcaReportingHelperWrapper orcaReportingHelperWrapper;
+
+      private SubchannelPicker currentChildPicker = XdsSubchannelPickers.BUFFER_PICKER;
+      private ConnectivityState currentChildState = CONNECTING;
+
+      ChildHelper(final Locality locality, final ClientLoadCounter counter,
+          OrcaOobUtil orcaOobUtil) {
+        checkNotNull(locality, "locality");
+        checkNotNull(counter, "counter");
+        checkNotNull(orcaOobUtil, "orcaOobUtil");
+        Helper delegate = new ForwardingLoadBalancerHelper() {
+          @Override
+          protected Helper delegate() {
+            return helper;
+          }
+
+          @Override
+          public void updateBalancingState(ConnectivityState newState,
+              final SubchannelPicker newPicker) {
+            checkNotNull(newState, "newState");
+            checkNotNull(newPicker, "newPicker");
+
+            currentChildState = newState;
+            currentChildPicker =
+                new LoadRecordingSubchannelPicker(counter,
+                    new MetricsObservingSubchannelPicker(new MetricsRecordingListener(counter),
+                        newPicker, orcaPerRequestUtil));
+
+            // delegate to parent helper
+            priorityManager.updatePriorityState(priorityManager.getPriority(locality));
+          }
+
+          @Override
+          public String toString() {
+            return MoreObjects.toStringHelper(this).add("locality", locality).toString();
+          }
+
+          @Override
+          public String getAuthority() {
+            //FIXME: This should be a new proposed field of Locality, locality_name
+            return locality.getSubzone();
+          }
+        };
+        orcaReportingHelperWrapper =
+            checkNotNull(orcaOobUtil, "orcaOobUtil")
+                .newOrcaReportingHelperWrapper(delegate, new MetricsRecordingListener(counter));
+
+        if (metricsReportIntervalNano > 0) {
+          updateMetricsReportInterval(metricsReportIntervalNano);
+        }
+      }
+
+      void updateMetricsReportInterval(long intervalNanos) {
+        orcaReportingHelperWrapper
+            .setReportingConfig(OrcaReportingConfig.newBuilder()
+                .setReportInterval(intervalNanos, TimeUnit.NANOSECONDS).build());
+      }
+
+      @Override
+      protected Helper delegate() {
+        return orcaReportingHelperWrapper.asHelper();
+      }
+    }
+
+    private final class PriorityManager {
+
+      private final List<List<Locality>> priorityTable = new ArrayList<>();
+      private Map<Locality, LocalityLbEndpoints> localityInfoMap = ImmutableMap.of();
+      private int currentPriority = -1;
+      private ScheduledHandle failOverTimer;
+
+      /**
+       * Updates the priority ordering of localities with the given collection of localities.
+       * Recomputes the current ready localities to be used.
+       */
+      void updateLocalities(Map<Locality, LocalityLbEndpoints> localityInfoMap) {
+        this.localityInfoMap = localityInfoMap;
+        priorityTable.clear();
+        for (Locality newLocality : localityInfoMap.keySet()) {
+          int priority = localityInfoMap.get(newLocality).getPriority();
+          while (priorityTable.size() <= priority) {
+            priorityTable.add(new ArrayList<Locality>());
+          }
+          priorityTable.get(priority).add(newLocality);
+        }
+
+        currentPriority = -1;
+        failOver();
+      }
+
+      /**
+       * Refreshes the group of localities with the given priority. Recomputes the current ready
+       * localities to be used.
+       */
+      void updatePriorityState(int priority) {
+        if (priority == -1 || priority > currentPriority) {
+          return;
+        }
+        List<WeightedChildPicker> childPickers = new ArrayList<>();
+
+        ConnectivityState overallState = null;
+        for (Locality l : priorityTable.get(priority)) {
+          if (!localityMap.containsKey(l)) {
+            initLocality(l);
+          }
+          LocalityLbInfo localityLbInfo = localityMap.get(l);
+          localityLbInfo.reactivate();
+          ConnectivityState childState = localityLbInfo.childHelper.currentChildState;
+          SubchannelPicker childPicker = localityLbInfo.childHelper.currentChildPicker;
+
+          overallState = aggregateState(overallState, childState);
+
+          if (READY == childState) {
+            childPickers.add(
+                new WeightedChildPicker(localityInfoMap.get(l).getLocalityWeight(), childPicker));
+          }
+        }
+
+        if (priority == currentPriority) {
+          updatePicker(overallState, childPickers);
+          if (overallState == READY) {
+            cancelFailOverTimer();
+          } else if (overallState == TRANSIENT_FAILURE) {
+            cancelFailOverTimer();
+            failOver();
+          } else if (failOverTimer == null) {
+            failOver();
+          } // else, still connecting and failOverTimer not expired yet, noop
+        } else if (overallState == READY) {
+          updatePicker(overallState, childPickers);
+          cancelFailOverTimer();
+          currentPriority = priority;
+        }
+
+        if (overallState == READY) {
+          for (int p = priority + 1; p < priorityTable.size(); p++) {
+            for (Locality xdsLocality : priorityTable.get(p)) {
+              deactivate(xdsLocality);
+            }
+          }
+        }
+      }
+
+      int getPriority(Locality locality) {
+        if (localityInfoMap.containsKey(locality)) {
+          return localityInfoMap.get(locality).getPriority();
+        }
+        return -1;
+      }
+
+      void reset() {
+        cancelFailOverTimer();
+        priorityTable.clear();
+        localityInfoMap = ImmutableMap.of();
+        currentPriority = -1;
+      }
+
+      private void cancelFailOverTimer() {
+        if (failOverTimer != null) {
+          failOverTimer.cancel();
+          failOverTimer = null;
+        }
+      }
+
+      private void failOver() {
+        if (currentPriority == priorityTable.size() - 1) {
+          return;
+        }
+
+        currentPriority++;
+
+        List<Locality> localities = priorityTable.get(currentPriority);
+        boolean initializedBefore = false;
+        for (Locality locality : localities) {
+          if (localityMap.containsKey(locality)) {
+            initializedBefore = true;
+            localityMap.get(locality).reactivate();
+          } else {
+            initLocality(locality);
+          }
+        }
+
+        if (!initializedBefore) {
+          class FailOverTask implements Runnable {
+            @Override
+            public void run() {
+              failOverTimer = null;
+              failOver();
+            }
+          }
+
+          failOverTimer = helper.getSynchronizationContext().schedule(
+              new FailOverTask(), 10, TimeUnit.SECONDS, helper.getScheduledExecutorService());
+        }
+
+        updatePriorityState(currentPriority);
+      }
+
+      private void initLocality(final Locality locality) {
+        ChildHelper childHelper =
+            new ChildHelper(locality, loadStatsStore.getLocalityCounter(locality),
+                orcaOobUtil);
+        final LocalityLbInfo localityLbInfo =
+            new LocalityLbInfo(
+                loadBalancerProvider.newLoadBalancer(childHelper),
+                childHelper);
+        localityMap.put(locality, localityLbInfo);
+
+        LocalityLbEndpoints localityInfo = localityInfoMap.get(locality);
+        final List<EquivalentAddressGroup> eags = new ArrayList<>();
+        for (LbEndpoint endpoint: localityInfo.getEndpoints()) {
+          eags.add(endpoint.getAddress());
+        }
+        // In extreme case handleResolvedAddresses() may trigger updateBalancingState() immediately,
+        // so execute handleResolvedAddresses() after all the setup in the caller is complete.
+        helper.getSynchronizationContext().execute(new Runnable() {
+          @Override
+          public void run() {
+            // TODO: put endPointWeights into attributes for WRR.
+            localityLbInfo.childBalancer
+                .handleResolvedAddresses(ResolvedAddresses.newBuilder()
+                    .setAddresses(eags).build());
+          }
+        });
+      }
     }
   }
 }

--- a/xds/src/main/java/io/grpc/xds/XdsAttributes.java
+++ b/xds/src/main/java/io/grpc/xds/XdsAttributes.java
@@ -25,6 +25,9 @@ import io.envoyproxy.envoy.api.v2.auth.UpstreamTlsContext;
 import io.grpc.Attributes;
 import io.grpc.Grpc;
 import io.grpc.Internal;
+import io.grpc.NameResolver;
+
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Special attributes that are only useful to gRPC in the XDS context.
@@ -72,6 +75,10 @@ public final class XdsAttributes {
   @Grpc.TransportAttr
   public static final Attributes.Key<DownstreamTlsContext> ATTR_DOWNSTREAM_TLS_CONTEXT =
       Attributes.Key.create("io.grpc.xds.XdsAttributes.downstreamTlsContext");
+
+  @NameResolver.ResolutionResultAttr
+  static final Attributes.Key<AtomicReference<XdsClient>> XDS_CLIENT_REF =
+          Attributes.Key.create("io.grpc.xds.XdsAttributes.xdsClientRef");
 
   private XdsAttributes() {}
 }

--- a/xds/src/main/java/io/grpc/xds/XdsAttributes.java
+++ b/xds/src/main/java/io/grpc/xds/XdsAttributes.java
@@ -26,7 +26,6 @@ import io.grpc.Attributes;
 import io.grpc.Grpc;
 import io.grpc.Internal;
 import io.grpc.NameResolver;
-
 import java.util.concurrent.atomic.AtomicReference;
 
 /**

--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -17,6 +17,8 @@
 package io.grpc.xds;
 
 import io.grpc.Status;
+import java.util.List;
+import java.util.Map;
 
 /**
  * An {@link XdsClient} instance encapsulates all of the logic for communicating with the xDS
@@ -83,7 +85,9 @@ abstract class XdsClient {
    */
   // TODO(zdapeng): content TBD.
   static final class EndpointUpdate {
-
+    // TODO(zdapeng): merge with @voidzcy's integration of EDS into XdsClient.
+    Map<EnvoyProtoData.Locality, EnvoyProtoData.LocalityLbEndpoints> localityInfoMap;
+    List<EnvoyProtoData.DropOverload> dropOverloads;
   }
 
   /**

--- a/xds/src/test/java/io/grpc/xds/EdsLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/EdsLoadBalancerTest.java
@@ -16,23 +16,78 @@
 
 package io.grpc.xds;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.Truth.assertThat;
+import static io.grpc.ConnectivityState.CONNECTING;
+import static io.grpc.ConnectivityState.READY;
+import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
+import static io.grpc.Status.UNAVAILABLE;
+import static io.grpc.xds.XdsSubchannelPickers.BUFFER_PICKER;
+import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import io.envoyproxy.envoy.api.v2.endpoint.ClusterStats;
 import io.grpc.ChannelLogger;
+import io.grpc.ClientStreamTracer;
+import io.grpc.ConnectivityState;
 import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancer;
+import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancer.PickResult;
+import io.grpc.LoadBalancer.PickSubchannelArgs;
 import io.grpc.LoadBalancer.ResolvedAddresses;
+import io.grpc.LoadBalancer.Subchannel;
+import io.grpc.LoadBalancer.SubchannelPicker;
+import io.grpc.LoadBalancerProvider;
+import io.grpc.LoadBalancerRegistry;
+import io.grpc.SynchronizationContext;
+import io.grpc.internal.FakeClock;
+import io.grpc.internal.FakeClock.ScheduledTask;
+import io.grpc.internal.FakeClock.TaskFilter;
+import io.grpc.xds.ClientLoadCounter.LoadRecordingStreamTracerFactory;
+import io.grpc.xds.ClientLoadCounter.MetricsRecordingListener;
 import io.grpc.xds.EdsLoadBalancer.EdsConfig;
+import io.grpc.xds.EdsLoadBalancer.EndpointWatcherImpl;
+import io.grpc.xds.EdsLoadBalancer.EndpointWatcherImpl.PickerFactory;
+import io.grpc.xds.EnvoyProtoData.DropOverload;
+import io.grpc.xds.EnvoyProtoData.LbEndpoint;
+import io.grpc.xds.EnvoyProtoData.Locality;
+import io.grpc.xds.EnvoyProtoData.LocalityLbEndpoints;
+import io.grpc.xds.InterLocalityPicker.WeightedChildPicker;
+import io.grpc.xds.OrcaOobUtil.OrcaOobReportListener;
+import io.grpc.xds.OrcaOobUtil.OrcaReportingConfig;
+import io.grpc.xds.OrcaOobUtil.OrcaReportingHelperWrapper;
+import io.grpc.xds.OrcaPerRequestUtil.OrcaPerRequestReportListener;
 import io.grpc.xds.XdsClient.EndpointUpdate;
 import io.grpc.xds.XdsClient.EndpointWatcher;
+import io.grpc.xds.XdsSubchannelPickers.ErrorPicker;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,8 +95,13 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
+import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.stubbing.Answer;
 
 /**
  * Tests for {@link EdsLoadBalancer}.
@@ -53,19 +113,157 @@ public class EdsLoadBalancerTest {
   public final ExpectedException thrown = ExpectedException.none();
 
   @Mock
-  private LocalityStore localityStore;
-  @Mock
   private XdsClient xdsClient;
-  @Mock
-  private ChannelLogger channelLogger;
 
   private EdsLoadBalancer edsLoadBalancer;
 
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  private static final class FakePickerFactory implements PickerFactory {
+    int totalReadyLocalities;
+    int nextIndex;
+    List<WeightedChildPicker> perLocalitiesPickers;
+
+    @Override
+    public SubchannelPicker picker(final List<WeightedChildPicker> childPickers) {
+      totalReadyLocalities = childPickers.size();
+      perLocalitiesPickers = Collections.unmodifiableList(childPickers);
+
+      return new SubchannelPicker() {
+        @Override
+        public PickResult pickSubchannel(PickSubchannelArgs args) {
+          return childPickers.get(nextIndex).getPicker().pickSubchannel(args);
+        }
+      };
+    }
+  }
+
+  private final SynchronizationContext syncContext = new SynchronizationContext(
+      new Thread.UncaughtExceptionHandler() {
+        @Override
+        public void uncaughtException(Thread t, Throwable e) {
+          throw new AssertionError(e);
+        }
+      });
+
+  private final LoadBalancerRegistry lbRegistry = new LoadBalancerRegistry();
+  private final Map<String, LoadBalancer> loadBalancers = new HashMap<>();
+  private final Map<String, Helper> childHelpers = new HashMap<>();
+  private final Map<String, FakeOrcaReportingHelperWrapper> childHelperWrappers = new HashMap<>();
+  private final FakeClock fakeClock = new FakeClock();
+
+  private final TaskFilter deactivationTaskFilter = new TaskFilter() {
+    @Override
+    public boolean shouldAccept(Runnable runnable) {
+      return runnable.toString().contains("DeletionTask");
+    }
+  };
+
+  private final TaskFilter failOverTaskFilter = new TaskFilter() {
+    @Override
+    public boolean shouldAccept(Runnable runnable) {
+      return runnable.toString().contains("FailOverTask");
+    }
+  };
+
+  private final LoadBalancerProvider lbProvider = new LoadBalancerProvider() {
+
+    @Override
+    public boolean isAvailable() {
+      return true;
+    }
+
+    @Override
+    public int getPriority() {
+      return 0;
+    }
+
+    @Override
+    public String getPolicyName() {
+      return "round_robin";
+    }
+
+    @Override
+    public LoadBalancer newLoadBalancer(Helper helper) {
+      LoadBalancer fakeLb = mock(LoadBalancer.class);
+      loadBalancers.put(helper.getAuthority(), fakeLb);
+      childHelpers.put(helper.getAuthority(), helper);
+      return fakeLb;
+    }
+  };
+
+  private final FakePickerFactory pickerFactory = new FakePickerFactory();
+
+  private final Locality locality1 = new Locality("r1", "z1", "sz1");
+  private final Locality locality2 = new Locality("r2", "z2", "sz2");
+  private final Locality locality3 = new Locality("r3", "z3", "sz3");
+  private final Locality locality4 = new Locality("r4", "z4", "sz4");
+
+  private final EquivalentAddressGroup eag11 =
+      new EquivalentAddressGroup(new InetSocketAddress("addr11", 11));
+  private final EquivalentAddressGroup eag12 =
+      new EquivalentAddressGroup(new InetSocketAddress("addr12", 12));
+  private final EquivalentAddressGroup eag21 =
+      new EquivalentAddressGroup(new InetSocketAddress("addr21", 21));
+  private final EquivalentAddressGroup eag22 =
+      new EquivalentAddressGroup(new InetSocketAddress("addr22", 22));
+  private final EquivalentAddressGroup eag31 =
+      new EquivalentAddressGroup(new InetSocketAddress("addr31", 31));
+  private final EquivalentAddressGroup eag32 =
+      new EquivalentAddressGroup(new InetSocketAddress("addr32", 32));
+  private final EquivalentAddressGroup eag41 =
+      new EquivalentAddressGroup(new InetSocketAddress("addr41", 41));
+  private final EquivalentAddressGroup eag42 =
+      new EquivalentAddressGroup(new InetSocketAddress("addr42", 42));
+
+  private final LbEndpoint lbEndpoint11 = new LbEndpoint(eag11, 11);
+  private final LbEndpoint lbEndpoint12 = new LbEndpoint(eag12, 12);
+  private final LbEndpoint lbEndpoint21 = new LbEndpoint(eag21, 21);
+  private final LbEndpoint lbEndpoint22 = new LbEndpoint(eag22, 22);
+  private final LbEndpoint lbEndpoint31 = new LbEndpoint(eag31, 31);
+  private final LbEndpoint lbEndpoint32 = new LbEndpoint(eag32, 32);
+  private final LbEndpoint lbEndpoint41 = new LbEndpoint(eag41, 41);
+  private final LbEndpoint lbEndpoint42 = new LbEndpoint(eag42, 42);
+
+  private final Map<String, Locality> namedLocalities
+      = ImmutableMap.of("sz1", locality1, "sz2", locality2, "sz3", locality3, "sz4", locality4);
+
+  @Mock
+  private Helper helper;
+  @Mock
+  private PickSubchannelArgs pickSubchannelArgs;
+  @Mock
+  private ThreadSafeRandom random;
+  @Mock
+  private OrcaPerRequestUtil orcaPerRequestUtil;
+  @Mock
+  private OrcaOobUtil orcaOobUtil;
+  private final FakeLoadStatsStore fakeLoadStatsStore = new FakeLoadStatsStore();
+  private final LoadStatsStore loadStatsStore =
+      mock(LoadStatsStore.class, delegatesTo(fakeLoadStatsStore));
+
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
-
-    edsLoadBalancer = new EdsLoadBalancer(localityStore, xdsClient, channelLogger);
+    doReturn(mock(ChannelLogger.class)).when(helper).getChannelLogger();
+    doReturn(syncContext).when(helper).getSynchronizationContext();
+    doReturn(fakeClock.getScheduledExecutorService()).when(helper).getScheduledExecutorService();
+    when(orcaOobUtil.newOrcaReportingHelperWrapper(any(Helper.class),
+        any(OrcaOobReportListener.class)))
+        .thenAnswer(new Answer<OrcaReportingHelperWrapper>() {
+          @Override
+          public OrcaReportingHelperWrapper answer(InvocationOnMock invocation) {
+            Helper h = invocation.getArgument(0);
+            FakeOrcaReportingHelperWrapper res =
+                new FakeOrcaReportingHelperWrapper(h);
+            childHelperWrappers.put(h.getAuthority(), res);
+            return res;
+          }
+        });
+    lbRegistry.register(lbProvider);
+    edsLoadBalancer =
+        new EdsLoadBalancer(helper, xdsClient, pickerFactory, lbRegistry, random, loadStatsStore,
+            orcaPerRequestUtil, orcaOobUtil);
   }
 
   @Test
@@ -124,13 +322,9 @@ public class EdsLoadBalancerTest {
     endpointUpdate.dropOverloads = dropOverloads;
     endpointWatcherCaptor.getValue().onEndpointChanged(endpointUpdate);
 
-    verify(localityStore).updateLocalityStore(localityInfoMap);
-    verify(localityStore).updateDropPercentage(dropOverloads);
-
     // shutdown
     edsLoadBalancer.shutdown();
     verify(xdsClient).cancelEndpointDataWatch(endpointWatcherCaptor.getValue());
-    verify(localityStore).reset();
   }
 
   @Test
@@ -168,9 +362,1236 @@ public class EdsLoadBalancerTest {
   }
 
   @Test
-  public void shutdown() {
+  @SuppressWarnings("unchecked")
+  public void updateLocalityStore_updateStatsStoreLocalityTracking() {
+    ResolvedAddresses resolvedAddresses = ResolvedAddresses.newBuilder()
+        .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
+        .setLoadBalancingPolicyConfig(new EdsConfig("edsService1", new Object()))
+        .build();
+
+    edsLoadBalancer.handleResolvedAddresses(resolvedAddresses);
+
+    ArgumentCaptor<EndpointWatcher> endpointWatcherCaptor = ArgumentCaptor.forClass(null);
+    verify(xdsClient).watchEndpointData(eq("edsService1"), endpointWatcherCaptor.capture());
+    EndpointWatcher endpointWatcher1 = endpointWatcherCaptor.getValue();
+
+    Map<Locality, LocalityLbEndpoints> localityInfoMap = new HashMap<>();
+    localityInfoMap
+        .put(locality1,
+            new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0));
+    localityInfoMap
+        .put(locality2,
+            new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0));
+
+    EndpointUpdate endpointUpdate1 = new EndpointUpdate();
+    endpointUpdate1.localityInfoMap = localityInfoMap;
+    endpointUpdate1.dropOverloads = new ArrayList<>();
+    endpointWatcher1.onEndpointChanged(endpointUpdate1);
+
+    verify(loadStatsStore).addLocality(locality1);
+    verify(loadStatsStore).addLocality(locality2);
+
+    localityInfoMap
+        .put(locality3,
+            new LocalityLbEndpoints(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0));
+    endpointWatcher1.onEndpointChanged(endpointUpdate1);
+    verify(loadStatsStore).addLocality(locality3);
+
+    endpointUpdate1.localityInfoMap = ImmutableMap
+        .of(locality4,
+            new LocalityLbEndpoints(ImmutableList.of(lbEndpoint41, lbEndpoint42), 4, 0));
+    endpointWatcher1.onEndpointChanged(endpointUpdate1);
+    verify(loadStatsStore).removeLocality(locality1);
+    verify(loadStatsStore).removeLocality(locality2);
+    verify(loadStatsStore).removeLocality(locality3);
+    verify(loadStatsStore).addLocality(locality4);
+
+    endpointUpdate1.localityInfoMap = Collections.EMPTY_MAP;
+    endpointWatcher1.onEndpointChanged(endpointUpdate1);
+    verify(loadStatsStore).removeLocality(locality4);
+  }
+
+  @Test
+  public void updateLocalityStore_pickResultInterceptedForLoadRecordingWhenSubchannelReady() {
+    ResolvedAddresses resolvedAddresses = ResolvedAddresses.newBuilder()
+        .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
+        .setLoadBalancingPolicyConfig(new EdsConfig("edsService1", new Object()))
+        .build();
+
+    edsLoadBalancer.handleResolvedAddresses(resolvedAddresses);
+
+    ArgumentCaptor<EndpointWatcher> endpointWatcherCaptor = ArgumentCaptor.forClass(null);
+    verify(xdsClient).watchEndpointData(eq("edsService1"), endpointWatcherCaptor.capture());
+    EndpointWatcher endpointWatcher1 = endpointWatcherCaptor.getValue();
+
+    // Simulate receiving two localities.
+    LocalityLbEndpoints localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    LocalityLbEndpoints localityInfo2 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
+
+    EndpointUpdate endpointUpdate1 = new EndpointUpdate();
+    endpointUpdate1.localityInfoMap = ImmutableMap.of(
+        locality1, localityInfo1, locality2, localityInfo2);
+    endpointUpdate1.dropOverloads = new ArrayList<>();
+    endpointWatcher1.onEndpointChanged(endpointUpdate1);
+
+    // Two child balancers are created.
+    assertThat(loadBalancers).hasSize(2);
+    assertThat(pickerFactory.totalReadyLocalities).isEqualTo(0);
+
+    ClientStreamTracer.Factory metricsTracingFactory1 = mock(ClientStreamTracer.Factory.class);
+    ClientStreamTracer.Factory metricsTracingFactory2 = mock(ClientStreamTracer.Factory.class);
+    when(orcaPerRequestUtil.newOrcaClientStreamTracerFactory(any(ClientStreamTracer.Factory.class),
+        any(OrcaPerRequestReportListener.class)))
+        .thenReturn(metricsTracingFactory1, metricsTracingFactory2);
+
+    Subchannel subchannel1 = mock(Subchannel.class);
+    Subchannel subchannel2 = mock(Subchannel.class);
+    final PickResult result1 = PickResult.withSubchannel(subchannel1);
+    final PickResult result2 =
+        PickResult.withSubchannel(subchannel2, mock(ClientStreamTracer.Factory.class));
+    SubchannelPicker subchannelPicker1 = mock(SubchannelPicker.class);
+    SubchannelPicker subchannelPicker2 = mock(SubchannelPicker.class);
+    when(subchannelPicker1.pickSubchannel(any(PickSubchannelArgs.class)))
+        .thenReturn(result1);
+    when(subchannelPicker2.pickSubchannel(any(PickSubchannelArgs.class)))
+        .thenReturn(result2);
+
+    // Simulate picker updates for the two localities with dummy pickers.
+    childHelpers.get("sz1").updateBalancingState(READY, subchannelPicker1);
+    childHelpers.get("sz2").updateBalancingState(READY, subchannelPicker2);
+
+    assertThat(pickerFactory.totalReadyLocalities).isEqualTo(2);
+    ArgumentCaptor<SubchannelPicker> interLocalityPickerCaptor = ArgumentCaptor.forClass(null);
+    verify(helper, times(2)).updateBalancingState(eq(READY), interLocalityPickerCaptor.capture());
+    SubchannelPicker interLocalityPicker = interLocalityPickerCaptor.getValue();
+
+    // Verify each PickResult picked is intercepted with client stream tracer factory for
+    // recording load and backend metrics.
+    Map<Subchannel, Locality> localitiesBySubchannel
+        = ImmutableMap.of(subchannel1, locality1, subchannel2, locality2);
+    Map<Subchannel, ClientStreamTracer.Factory> metricsTracingFactoriesBySubchannel
+        = ImmutableMap.of(subchannel1, metricsTracingFactory1, subchannel2, metricsTracingFactory2);
+    for (int i = 0; i < pickerFactory.totalReadyLocalities; i++) {
+      pickerFactory.nextIndex = i;
+      PickResult pickResult = interLocalityPicker.pickSubchannel(pickSubchannelArgs);
+      Subchannel expectedSubchannel = pickResult.getSubchannel();
+      Locality expectedLocality = localitiesBySubchannel.get(expectedSubchannel);
+      ArgumentCaptor<OrcaPerRequestReportListener> listenerCaptor = ArgumentCaptor.forClass(null);
+      verify(orcaPerRequestUtil, times(i + 1))
+          .newOrcaClientStreamTracerFactory(any(ClientStreamTracer.Factory.class),
+              listenerCaptor.capture());
+      assertThat(listenerCaptor.getValue()).isInstanceOf(MetricsRecordingListener.class);
+      MetricsRecordingListener listener = (MetricsRecordingListener) listenerCaptor.getValue();
+      assertThat(listener.getCounter())
+          .isSameInstanceAs(fakeLoadStatsStore.localityCounters.get(expectedLocality));
+      assertThat(pickResult.getStreamTracerFactory())
+          .isInstanceOf(LoadRecordingStreamTracerFactory.class);
+      LoadRecordingStreamTracerFactory loadRecordingFactory =
+          (LoadRecordingStreamTracerFactory) pickResult.getStreamTracerFactory();
+      assertThat(loadRecordingFactory.getCounter())
+          .isSameInstanceAs(fakeLoadStatsStore.localityCounters.get(expectedLocality));
+      assertThat(loadRecordingFactory.delegate())
+          .isSameInstanceAs(metricsTracingFactoriesBySubchannel.get(expectedSubchannel));
+    }
+  }
+
+  @Test
+  public void childLbPerformOobBackendMetricsAggregation() {
+    ResolvedAddresses resolvedAddresses = ResolvedAddresses.newBuilder()
+        .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
+        .setLoadBalancingPolicyConfig(new EdsConfig("edsService1", new Object()))
+        .build();
+
+    edsLoadBalancer.handleResolvedAddresses(resolvedAddresses);
+
+    ArgumentCaptor<EndpointWatcher> endpointWatcherCaptor = ArgumentCaptor.forClass(null);
+    verify(xdsClient).watchEndpointData(eq("edsService1"), endpointWatcherCaptor.capture());
+    EndpointWatcher endpointWatcher1 = endpointWatcherCaptor.getValue();
+
+    // Simulate receiving two localities.
+    LocalityLbEndpoints localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    LocalityLbEndpoints localityInfo2 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
+
+    EndpointUpdate endpointUpdate1 = new EndpointUpdate();
+    endpointUpdate1.localityInfoMap = ImmutableMap.of(
+        locality1, localityInfo1, locality2, localityInfo2);
+    endpointUpdate1.dropOverloads = new ArrayList<>();
+    endpointWatcher1.onEndpointChanged(endpointUpdate1);
+
+    // Two child balancers are created.
+    assertThat(loadBalancers).hasSize(2);
+    assertThat(childHelperWrappers).hasSize(2);
+
+    class HelperMatcher implements ArgumentMatcher<Helper> {
+
+      private final String authority;
+
+      private HelperMatcher(String authority) {
+        this.authority = checkNotNull(authority, "authority");
+      }
+
+      @Override
+      public boolean matches(Helper argument) {
+        return authority.equals(argument.getAuthority());
+      }
+    }
+
+    Map<String, Locality> localities = ImmutableMap.of("sz1", locality1, "sz2", locality2);
+    for (Helper h : childHelpers.values()) {
+      ArgumentCaptor<OrcaOobReportListener> listenerCaptor = ArgumentCaptor.forClass(null);
+      verify(orcaOobUtil)
+          .newOrcaReportingHelperWrapper(argThat(new HelperMatcher(h.getAuthority())),
+              listenerCaptor.capture());
+      assertThat(listenerCaptor.getValue()).isInstanceOf(MetricsRecordingListener.class);
+      MetricsRecordingListener listener = (MetricsRecordingListener) listenerCaptor.getValue();
+      assertThat(listener.getCounter())
+          .isSameInstanceAs(fakeLoadStatsStore
+              .localityCounters.get(localities.get(h.getAuthority())));
+    }
+
+    // Simulate receiving updates for backend metrics reporting interval.
+    ((EndpointWatcherImpl) endpointWatcher1).updateOobMetricsReportInterval(1952);
+    for (FakeOrcaReportingHelperWrapper orcaWrapper : childHelperWrappers.values()) {
+      assertThat(orcaWrapper.reportIntervalNanos).isEqualTo(1952);
+    }
+
+    ((EndpointWatcherImpl) endpointWatcher1).updateOobMetricsReportInterval(9251);
+    for (FakeOrcaReportingHelperWrapper orcaWrapper : childHelperWrappers.values()) {
+      assertThat(orcaWrapper.reportIntervalNanos).isEqualTo(9251);
+    }
+  }
+
+  @Test
+  public void updateOobMetricsReportIntervalBeforeChildLbCreated() {
+    ResolvedAddresses resolvedAddresses = ResolvedAddresses.newBuilder()
+        .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
+        .setLoadBalancingPolicyConfig(new EdsConfig("edsService1", new Object()))
+        .build();
+
+    edsLoadBalancer.handleResolvedAddresses(resolvedAddresses);
+
+    ArgumentCaptor<EndpointWatcher> endpointWatcherCaptor = ArgumentCaptor.forClass(null);
+    verify(xdsClient).watchEndpointData(eq("edsService1"), endpointWatcherCaptor.capture());
+    EndpointWatcher endpointWatcher1 = endpointWatcherCaptor.getValue();
+
+    // Simulate receiving update for backend metrics reporting interval.
+    ((EndpointWatcherImpl) endpointWatcher1).updateOobMetricsReportInterval(1952);
+
+    assertThat(loadBalancers).isEmpty();
+
+    // Simulate receiving two localities.
+    LocalityLbEndpoints localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    LocalityLbEndpoints localityInfo2 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
+
+    EndpointUpdate endpointUpdate1 = new EndpointUpdate();
+    endpointUpdate1.localityInfoMap = ImmutableMap.of(
+        locality1, localityInfo1, locality2, localityInfo2);
+    endpointUpdate1.dropOverloads = new ArrayList<>();
+    endpointWatcher1.onEndpointChanged(endpointUpdate1);
+
+    // Two child balancers are created.
+    assertThat(loadBalancers).hasSize(2);
+    assertThat(childHelperWrappers).hasSize(2);
+
+    for (FakeOrcaReportingHelperWrapper orcaWrapper : childHelperWrappers.values()) {
+      assertThat(orcaWrapper.reportIntervalNanos).isEqualTo(1952);
+    }
+  }
+
+  @Test
+  public void updateLoaclityStore_withEmptyDropList() {
+    ResolvedAddresses resolvedAddresses = ResolvedAddresses.newBuilder()
+        .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
+        .setLoadBalancingPolicyConfig(new EdsConfig("edsService1", new Object()))
+        .build();
+
+    edsLoadBalancer.handleResolvedAddresses(resolvedAddresses);
+
+    ArgumentCaptor<EndpointWatcher> endpointWatcherCaptor = ArgumentCaptor.forClass(null);
+    verify(xdsClient).watchEndpointData(eq("edsService1"), endpointWatcherCaptor.capture());
+    EndpointWatcher endpointWatcher1 = endpointWatcherCaptor.getValue();
+
+    LocalityLbEndpoints localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    LocalityLbEndpoints localityInfo2 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
+    LocalityLbEndpoints localityInfo3 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
+    ImmutableMap<Locality, LocalityLbEndpoints> localityInfoMap = ImmutableMap.of(
+        locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
+
+    EndpointUpdate endpointUpdate1 = new EndpointUpdate();
+    endpointUpdate1.localityInfoMap = localityInfoMap;
+    endpointUpdate1.dropOverloads = new ArrayList<>();
+    endpointWatcher1.onEndpointChanged(endpointUpdate1);
+
+    verify(helper).updateBalancingState(CONNECTING, BUFFER_PICKER);
+
+    assertThat(loadBalancers).hasSize(3);
+    assertThat(loadBalancers.keySet()).containsExactly("sz1", "sz2", "sz3");
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor1 =
+        ArgumentCaptor.forClass(ResolvedAddresses.class);
+    verify(loadBalancers.get("sz1")).handleResolvedAddresses(resolvedAddressesCaptor1.capture());
+    assertThat(resolvedAddressesCaptor1.getValue().getAddresses()).containsExactly(eag11, eag12);
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor2 =
+        ArgumentCaptor.forClass(ResolvedAddresses.class);
+    verify(loadBalancers.get("sz2")).handleResolvedAddresses(resolvedAddressesCaptor2.capture());
+    assertThat(resolvedAddressesCaptor2.getValue().getAddresses()).containsExactly(eag21, eag22);
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor3 =
+        ArgumentCaptor.forClass(ResolvedAddresses.class);
+    verify(loadBalancers.get("sz3")).handleResolvedAddresses(resolvedAddressesCaptor3.capture());
+    assertThat(resolvedAddressesCaptor3.getValue().getAddresses()).containsExactly(eag31, eag32);
+    assertThat(pickerFactory.totalReadyLocalities).isEqualTo(0);
+    // verify no more updateBalancingState except the initial CONNECTING state
+    verify(helper, times(1)).updateBalancingState(
+        any(ConnectivityState.class), any(SubchannelPicker.class));
+
+    // subchannel12 goes to CONNECTING
+    final Subchannel subchannel12 = mock(Subchannel.class);
+    SubchannelPicker subchannelPicker12 = new SubchannelPicker() {
+      @Override
+      public PickResult pickSubchannel(PickSubchannelArgs args) {
+        return PickResult.withSubchannel(subchannel12);
+      }
+    };
+    childHelpers.get("sz1").updateBalancingState(CONNECTING, subchannelPicker12);
+    ArgumentCaptor<SubchannelPicker> subchannelPickerCaptor12 =
+        ArgumentCaptor.forClass(SubchannelPicker.class);
+    verify(helper, times(2)).updateBalancingState(
+        same(CONNECTING), subchannelPickerCaptor12.capture());
+    assertThat(pickerFactory.totalReadyLocalities).isEqualTo(0);
+    assertThat(subchannelPickerCaptor12.getValue().pickSubchannel(pickSubchannelArgs))
+        .isEqualTo(PickResult.withNoResult());
+
+    // subchannel31 goes to READY
+    final Subchannel subchannel31 = mock(Subchannel.class);
+    SubchannelPicker subchannelPicker31 = new SubchannelPicker() {
+      @Override
+      public PickResult pickSubchannel(PickSubchannelArgs args) {
+        return PickResult.withSubchannel(subchannel31);
+      }
+    };
+    childHelpers.get("sz3").updateBalancingState(READY, subchannelPicker31);
+    ArgumentCaptor<SubchannelPicker> subchannelPickerCaptor =
+        ArgumentCaptor.forClass(null);
+    verify(helper).updateBalancingState(same(READY), subchannelPickerCaptor.capture());
+    assertThat(pickerFactory.totalReadyLocalities).isEqualTo(1);
+    pickerFactory.nextIndex = 0;
+    assertThat(subchannelPickerCaptor.getValue().pickSubchannel(pickSubchannelArgs).getSubchannel())
+        .isEqualTo(subchannel31);
+
+    // subchannel12 goes to READY
+    childHelpers.get("sz1").updateBalancingState(READY, subchannelPicker12);
+    verify(helper, times(2)).updateBalancingState(same(READY), subchannelPickerCaptor.capture());
+    assertThat(pickerFactory.totalReadyLocalities).isEqualTo(2);
+
+    SubchannelPicker interLocalityPicker = subchannelPickerCaptor.getValue();
+    Set<Subchannel> pickedReadySubchannels = new HashSet<>();
+    for (int i = 0; i < pickerFactory.totalReadyLocalities; i++) {
+      pickerFactory.nextIndex = i;
+      PickResult result = interLocalityPicker.pickSubchannel(pickSubchannelArgs);
+      pickedReadySubchannels.add(result.getSubchannel());
+    }
+    assertThat(pickedReadySubchannels).containsExactly(subchannel31, subchannel12);
+
+    // update with new addresses
+    localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11), 1, 0);
+    LocalityLbEndpoints localityInfo4 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint41, lbEndpoint42), 4, 0);
+    localityInfoMap = ImmutableMap.of(
+        locality2, localityInfo2, locality4, localityInfo4, locality1, localityInfo1);
+    endpointUpdate1.localityInfoMap = localityInfoMap;
+    endpointWatcher1.onEndpointChanged(endpointUpdate1);
+
+    assertThat(loadBalancers).hasSize(4);
+    verify(loadBalancers.get("sz2"), times(2))
+        .handleResolvedAddresses(resolvedAddressesCaptor2.capture());
+    assertThat(resolvedAddressesCaptor2.getValue().getAddresses()).containsExactly(eag21, eag22);
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor4 =
+        ArgumentCaptor.forClass(ResolvedAddresses.class);
+    verify(loadBalancers.get("sz4")).handleResolvedAddresses(resolvedAddressesCaptor4.capture());
+    assertThat(resolvedAddressesCaptor4.getValue().getAddresses()).containsExactly(eag41, eag42);
+    verify(loadBalancers.get("sz1"), times(2))
+        .handleResolvedAddresses(resolvedAddressesCaptor1.capture());
+    assertThat(resolvedAddressesCaptor1.getValue().getAddresses()).containsExactly(eag11);
+    assertThat(pickerFactory.totalReadyLocalities).isEqualTo(1);
+
+    fakeClock.forwardTime(14, TimeUnit.MINUTES);
+    verify(loadBalancers.get("sz3"), never()).shutdown();
+    fakeClock.forwardTime(1, TimeUnit.MINUTES);
+    verify(loadBalancers.get("sz3")).shutdown();
+
+    verify(random, never()).nextInt(1000_000);
+  }
+
+  @Test
+  public void updateLoaclityStore_deactivateAndReactivate() {
+    ResolvedAddresses resolvedAddresses = ResolvedAddresses.newBuilder()
+        .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
+        .setLoadBalancingPolicyConfig(new EdsConfig("edsService1", new Object()))
+        .build();
+
+    edsLoadBalancer.handleResolvedAddresses(resolvedAddresses);
+
+    ArgumentCaptor<EndpointWatcher> endpointWatcherCaptor = ArgumentCaptor.forClass(null);
+    verify(xdsClient).watchEndpointData(eq("edsService1"), endpointWatcherCaptor.capture());
+    EndpointWatcher endpointWatcher1 = endpointWatcherCaptor.getValue();
+
+    LocalityLbEndpoints localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    LocalityLbEndpoints localityInfo2 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
+    LocalityLbEndpoints localityInfo3 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
+    ImmutableMap<Locality, LocalityLbEndpoints> localityInfoMap = ImmutableMap.of(
+        locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
+
+    EndpointUpdate endpointUpdate1 = new EndpointUpdate();
+    endpointUpdate1.localityInfoMap = localityInfoMap;
+    endpointUpdate1.dropOverloads = new ArrayList<>();
+    endpointWatcher1.onEndpointChanged(endpointUpdate1);
+
+    assertThat(loadBalancers.keySet()).containsExactly("sz1", "sz2", "sz3");
+
+    LoadBalancer lb1 = loadBalancers.get("sz1");
+    LoadBalancer lb2 = loadBalancers.get("sz2");
+    LoadBalancer lb3 = loadBalancers.get("sz3");
+
+    final Subchannel subchannel1 = mock(Subchannel.class);
+    SubchannelPicker subchannelPicker1 = new SubchannelPicker() {
+      @Override
+      public PickResult pickSubchannel(PickSubchannelArgs args) {
+        return PickResult.withSubchannel(subchannel1);
+      }
+    };
+    childHelpers.get("sz1").updateBalancingState(READY, subchannelPicker1);
+    final Subchannel subchannel3 = mock(Subchannel.class);
+    SubchannelPicker subchannelPicker3 = new SubchannelPicker() {
+      @Override
+      public PickResult pickSubchannel(PickSubchannelArgs args) {
+        return PickResult.withSubchannel(subchannel3);
+      }
+    };
+    childHelpers.get("sz3").updateBalancingState(READY, subchannelPicker3);
+
+    // update localities, removing sz1, sz2, keeping sz3, and adding sz4
+    LocalityLbEndpoints localityInfo4 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint41, lbEndpoint42), 4, 0);
+    localityInfoMap = ImmutableMap.of(locality3, localityInfo3, locality4, localityInfo4);
+
+
+    endpointUpdate1.localityInfoMap = localityInfoMap;
+    endpointWatcher1.onEndpointChanged(endpointUpdate1);
+
+    assertThat(loadBalancers.keySet()).containsExactly("sz1", "sz2", "sz3", "sz4");
+
+    LoadBalancer lb4 = loadBalancers.get("sz4");
+
+    ArgumentCaptor<SubchannelPicker> subchannelPickerCaptor = ArgumentCaptor.forClass(null);
+    // helper updated multiple times. Don't care how many times, just capture the latest picker
+    verify(helper, atLeastOnce()).updateBalancingState(
+        same(READY), subchannelPickerCaptor.capture());
+    assertThat(pickerFactory.totalReadyLocalities).isEqualTo(1);
+    pickerFactory.nextIndex = 0;
+    assertThat(subchannelPickerCaptor.getValue().pickSubchannel(pickSubchannelArgs).getSubchannel())
+        .isEqualTo(subchannel3);
+
+    // verify no traffic will go to deactivated locality
+    final Subchannel subchannel2 = mock(Subchannel.class);
+    SubchannelPicker subchannelPicker2 = new SubchannelPicker() {
+      @Override
+      public PickResult pickSubchannel(PickSubchannelArgs args) {
+        return PickResult.withSubchannel(subchannel2);
+      }
+    };
+    childHelpers.get("sz2").updateBalancingState(READY, subchannelPicker2);
+    verify(helper, atLeastOnce()).updateBalancingState(
+        same(READY), subchannelPickerCaptor.capture());
+    assertThat(pickerFactory.totalReadyLocalities).isEqualTo(1);
+    pickerFactory.nextIndex = 0;
+    assertThat(subchannelPickerCaptor.getValue().pickSubchannel(pickSubchannelArgs).getSubchannel())
+        .isEqualTo(subchannel3);
+
+    // update localities, reactivating sz1
+    localityInfoMap = ImmutableMap.of(
+        locality1, localityInfo1, locality3, localityInfo3, locality4, localityInfo4);
+
+    endpointUpdate1.localityInfoMap = localityInfoMap;
+    endpointWatcher1.onEndpointChanged(endpointUpdate1);
+    verify(helper, atLeastOnce()).updateBalancingState(
+        same(READY), subchannelPickerCaptor.capture());
+    assertThat(pickerFactory.totalReadyLocalities).isEqualTo(2);
+    pickerFactory.nextIndex = 0;
+    assertThat(subchannelPickerCaptor.getValue().pickSubchannel(pickSubchannelArgs).getSubchannel())
+        .isEqualTo(subchannel1);
+    pickerFactory.nextIndex = 1;
+    assertThat(subchannelPickerCaptor.getValue().pickSubchannel(pickSubchannelArgs).getSubchannel())
+        .isEqualTo(subchannel3);
+
+    verify(lb2, never()).shutdown();
+    // delayed deletion timer expires, no reactivation
+    fakeClock.forwardTime(15, TimeUnit.MINUTES);
+    verify(lb1, never()).shutdown();
+    verify(lb2).shutdown();
+    // update localities, re-adding sz2, keeping sz1, and removing sz3, sz4
+    localityInfoMap = ImmutableMap.of(
+        locality1, localityInfo1, locality2, localityInfo2);
+
+    endpointUpdate1.localityInfoMap = localityInfoMap;
+    endpointUpdate1.dropOverloads = new ArrayList<>();
+    endpointWatcher1.onEndpointChanged(endpointUpdate1);
+
+    LoadBalancer newLb2 = loadBalancers.get("sz2");
+    assertThat(newLb2).isNotSameInstanceAs(lb2);
+
+    verify(helper, atLeastOnce()).updateBalancingState(
+        same(READY), subchannelPickerCaptor.capture());
+    assertThat(pickerFactory.totalReadyLocalities).isEqualTo(1);
+    pickerFactory.nextIndex = 0;
+    assertThat(subchannelPickerCaptor.getValue().pickSubchannel(pickSubchannelArgs).getSubchannel())
+        .isEqualTo(subchannel1);
+    // sz3, sz4 pending removal
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).hasSize(2);
+
+    // verify lb1, lb3, and lb4 never shutdown and never changed since created
+    verify(lb1, never()).shutdown();
+    verify(newLb2, never()).shutdown();
+    verify(lb3, never()).shutdown();
+    verify(lb4, never()).shutdown();
+    assertThat(loadBalancers.get("sz1")).isSameInstanceAs(lb1);
+    assertThat(loadBalancers.get("sz2")).isSameInstanceAs(newLb2);
+    assertThat(loadBalancers.get("sz3")).isSameInstanceAs(lb3);
+    assertThat(loadBalancers.get("sz4")).isSameInstanceAs(lb4);
+
     edsLoadBalancer.shutdown();
-    verify(localityStore).reset();
-    verify(xdsClient, never()).cancelEndpointDataWatch(any(EndpointWatcher.class));
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).isEmpty();
+    verify(lb1).shutdown();
+    verify(newLb2).shutdown();
+    verify(lb3).shutdown();
+    verify(lb4).shutdown();
+  }
+
+  @Test
+  public void updateLoaclityStore_withDrop() {
+    ResolvedAddresses resolvedAddresses = ResolvedAddresses.newBuilder()
+        .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
+        .setLoadBalancingPolicyConfig(new EdsConfig("edsService1", new Object()))
+        .build();
+
+    edsLoadBalancer.handleResolvedAddresses(resolvedAddresses);
+
+    ArgumentCaptor<EndpointWatcher> endpointWatcherCaptor = ArgumentCaptor.forClass(null);
+    verify(xdsClient).watchEndpointData(eq("edsService1"), endpointWatcherCaptor.capture());
+    EndpointWatcher endpointWatcher1 = endpointWatcherCaptor.getValue();
+
+    LocalityLbEndpoints localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    LocalityLbEndpoints localityInfo2 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
+    LocalityLbEndpoints localityInfo3 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
+    ImmutableMap<Locality, LocalityLbEndpoints> localityInfoMap = ImmutableMap.of(
+        locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
+
+    EndpointUpdate endpointUpdate1 = new EndpointUpdate();
+    endpointUpdate1.localityInfoMap = localityInfoMap;
+    endpointUpdate1.dropOverloads = ImmutableList.of(
+        new DropOverload("throttle", 365),
+        new DropOverload("lb", 1234));
+    endpointWatcher1.onEndpointChanged(endpointUpdate1);
+
+    assertThat(loadBalancers).hasSize(3);
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor1 =
+        ArgumentCaptor.forClass(ResolvedAddresses.class);
+    verify(loadBalancers.get("sz1")).handleResolvedAddresses(resolvedAddressesCaptor1.capture());
+    assertThat(resolvedAddressesCaptor1.getValue().getAddresses()).containsExactly(eag11, eag12);
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor2 =
+        ArgumentCaptor.forClass(ResolvedAddresses.class);
+    verify(loadBalancers.get("sz2")).handleResolvedAddresses(resolvedAddressesCaptor2.capture());
+    assertThat(resolvedAddressesCaptor2.getValue().getAddresses()).containsExactly(eag21, eag22);
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor3 =
+        ArgumentCaptor.forClass(ResolvedAddresses.class);
+    verify(loadBalancers.get("sz3")).handleResolvedAddresses(resolvedAddressesCaptor3.capture());
+    assertThat(resolvedAddressesCaptor3.getValue().getAddresses()).containsExactly(eag31, eag32);
+    assertThat(pickerFactory.totalReadyLocalities).isEqualTo(0);
+    ArgumentCaptor<SubchannelPicker> subchannelPickerCaptor =
+        ArgumentCaptor.forClass(SubchannelPicker.class);
+    verify(helper).updateBalancingState(same(CONNECTING), subchannelPickerCaptor.capture());
+
+    int times = 0;
+    InOrder inOrder = inOrder(loadStatsStore);
+    doReturn(365, 1234).when(random).nextInt(1000_000);
+    assertThat(subchannelPickerCaptor.getValue().pickSubchannel(pickSubchannelArgs))
+        .isEqualTo(PickResult.withNoResult());
+    verify(random, times(times += 2)).nextInt(1000_000);
+    inOrder.verify(loadStatsStore, never()).recordDroppedRequest(anyString());
+
+    doReturn(366, 1235).when(random).nextInt(1000_000);
+    assertThat(subchannelPickerCaptor.getValue().pickSubchannel(pickSubchannelArgs))
+        .isEqualTo(PickResult.withNoResult());
+    verify(random, times(times += 2)).nextInt(1000_000);
+    inOrder.verify(loadStatsStore, never()).recordDroppedRequest(anyString());
+
+    doReturn(364, 1234).when(random).nextInt(1000_000);
+    assertThat(subchannelPickerCaptor.getValue().pickSubchannel(pickSubchannelArgs).isDrop())
+        .isTrue();
+    verify(random, times(times += 1)).nextInt(1000_000);
+    inOrder.verify(loadStatsStore).recordDroppedRequest(eq("throttle"));
+
+    doReturn(365, 1233).when(random).nextInt(1000_000);
+    assertThat(subchannelPickerCaptor.getValue().pickSubchannel(pickSubchannelArgs).isDrop())
+        .isTrue();
+    verify(random, times(times += 2)).nextInt(1000_000);
+    inOrder.verify(loadStatsStore).recordDroppedRequest(eq("lb"));
+
+    // subchannel12 goes to READY
+    final Subchannel subchannel12 = mock(Subchannel.class);
+    SubchannelPicker subchannelPicker12 = new SubchannelPicker() {
+      @Override
+      public PickResult pickSubchannel(PickSubchannelArgs args) {
+        return PickResult.withSubchannel(subchannel12);
+      }
+    };
+    childHelpers.get("sz1").updateBalancingState(READY, subchannelPicker12);
+    ArgumentCaptor<SubchannelPicker> subchannelPickerCaptor12 =
+        ArgumentCaptor.forClass(SubchannelPicker.class);
+    verify(helper).updateBalancingState(same(READY), subchannelPickerCaptor12.capture());
+
+    doReturn(365, 1234).when(random).nextInt(1000_000);
+    assertThat(subchannelPickerCaptor12.getValue().pickSubchannel(pickSubchannelArgs)
+        .getSubchannel()).isEqualTo(subchannel12);
+    verify(random, times(times += 2)).nextInt(1000_000);
+    inOrder.verify(loadStatsStore, never()).recordDroppedRequest(anyString());
+
+    doReturn(366, 1235).when(random).nextInt(1000_000);
+    assertThat(subchannelPickerCaptor12.getValue().pickSubchannel(pickSubchannelArgs)
+        .getSubchannel()).isEqualTo(subchannel12);
+    verify(random, times(times += 2)).nextInt(1000_000);
+    inOrder.verify(loadStatsStore, never()).recordDroppedRequest(anyString());
+
+    doReturn(364, 1234).when(random).nextInt(1000_000);
+    assertThat(subchannelPickerCaptor12.getValue().pickSubchannel(pickSubchannelArgs).isDrop())
+        .isTrue();
+    verify(random, times(times += 1)).nextInt(1000_000);
+    inOrder.verify(loadStatsStore).recordDroppedRequest(eq("throttle"));
+
+    doReturn(365, 1233).when(random).nextInt(1000_000);
+    assertThat(subchannelPickerCaptor12.getValue().pickSubchannel(pickSubchannelArgs).isDrop())
+        .isTrue();
+    verify(random, times(times + 2)).nextInt(1000_000);
+    inOrder.verify(loadStatsStore).recordDroppedRequest(eq("lb"));
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void updateLoaclityStore_withAllDropBeforeLocalityUpdateConnectivityState() {
+    ResolvedAddresses resolvedAddresses = ResolvedAddresses.newBuilder()
+        .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
+        .setLoadBalancingPolicyConfig(new EdsConfig("edsService1", new Object()))
+        .build();
+    edsLoadBalancer.handleResolvedAddresses(resolvedAddresses);
+
+    ArgumentCaptor<EndpointWatcher> endpointWatcherCaptor = ArgumentCaptor.forClass(null);
+    verify(xdsClient).watchEndpointData(eq("edsService1"), endpointWatcherCaptor.capture());
+    EndpointWatcher endpointWatcher1 = endpointWatcherCaptor.getValue();
+
+    LocalityLbEndpoints localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    LocalityLbEndpoints localityInfo2 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
+    LocalityLbEndpoints localityInfo3 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
+    ImmutableMap<Locality, LocalityLbEndpoints> localityInfoMap = ImmutableMap.of(
+        locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
+    EndpointUpdate endpointUpdate1 = new EndpointUpdate();
+    endpointUpdate1.localityInfoMap = localityInfoMap;
+    endpointUpdate1.dropOverloads = ImmutableList.of(
+        new DropOverload("throttle", 365),
+        new DropOverload("lb", 1000_000));
+    endpointWatcher1.onEndpointChanged(endpointUpdate1);
+
+    ArgumentCaptor<SubchannelPicker> subchannelPickerCaptor =
+        ArgumentCaptor.forClass(SubchannelPicker.class);
+    verify(helper).updateBalancingState(same(CONNECTING), subchannelPickerCaptor.capture());
+    doReturn(999_999).when(random).nextInt(1000_000);
+    assertThat(subchannelPickerCaptor.getValue().pickSubchannel(pickSubchannelArgs).isDrop())
+        .isTrue();
+    verify(random, times(2)).nextInt(1000_000);
+  }
+
+  @Test
+  public void updateLocalityStore_OnlyUpdatingWeightsStillUpdatesPicker() {
+    ResolvedAddresses resolvedAddresses = ResolvedAddresses.newBuilder()
+        .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
+        .setLoadBalancingPolicyConfig(new EdsConfig("edsService1", new Object()))
+        .build();
+    edsLoadBalancer.handleResolvedAddresses(resolvedAddresses);
+
+    ArgumentCaptor<EndpointWatcher> endpointWatcherCaptor = ArgumentCaptor.forClass(null);
+    verify(xdsClient).watchEndpointData(eq("edsService1"), endpointWatcherCaptor.capture());
+    EndpointWatcher endpointWatcher1 = endpointWatcherCaptor.getValue();
+
+    LocalityLbEndpoints localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    LocalityLbEndpoints localityInfo2 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
+    LocalityLbEndpoints localityInfo3 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
+    ImmutableMap<Locality, LocalityLbEndpoints> localityInfoMap = ImmutableMap.of(
+        locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
+    EndpointUpdate endpointUpdate1 = new EndpointUpdate();
+    endpointUpdate1.localityInfoMap = localityInfoMap;
+    endpointUpdate1.dropOverloads = new ArrayList<>();
+    endpointWatcher1.onEndpointChanged(endpointUpdate1);
+    assertThat(loadBalancers).hasSize(3);
+    assertThat(loadBalancers.keySet()).containsExactly("sz1", "sz2", "sz3");
+    assertThat(pickerFactory.totalReadyLocalities).isEqualTo(0);
+
+    // Update locality weights before any subchannel becomes READY.
+    localityInfo1 = new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 4, 0);
+    localityInfo2 = new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 5, 0);
+    localityInfo3 = new LocalityLbEndpoints(ImmutableList.of(lbEndpoint31, lbEndpoint32), 6, 0);
+    localityInfoMap = ImmutableMap.of(
+        locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
+    endpointUpdate1.localityInfoMap = localityInfoMap;
+    endpointWatcher1.onEndpointChanged(endpointUpdate1);
+
+    assertThat(pickerFactory.totalReadyLocalities).isEqualTo(0);
+
+    final Map<Subchannel, Locality> localitiesBySubchannel = new HashMap<>();
+    for (final Helper h : childHelpers.values()) {
+      h.updateBalancingState(READY, new SubchannelPicker() {
+        @Override
+        public PickResult pickSubchannel(PickSubchannelArgs args) {
+          Subchannel subchannel = mock(Subchannel.class);
+          localitiesBySubchannel.put(subchannel, namedLocalities.get(h.getAuthority()));
+          return PickResult.withSubchannel(subchannel);
+        }
+      });
+    }
+
+    assertThat(pickerFactory.totalReadyLocalities).isEqualTo(3);
+    for (int i = 0; i < pickerFactory.totalReadyLocalities; i++) {
+      WeightedChildPicker weightedChildPicker
+          = pickerFactory.perLocalitiesPickers.get(i);
+      Subchannel subchannel
+          = weightedChildPicker.getPicker().pickSubchannel(pickSubchannelArgs).getSubchannel();
+      assertThat(weightedChildPicker.getWeight())
+          .isEqualTo(
+              localityInfoMap.get(localitiesBySubchannel.get(subchannel)).getLocalityWeight());
+    }
+  }
+
+  @Test
+  public void reset() {
+    ResolvedAddresses resolvedAddresses = ResolvedAddresses.newBuilder()
+        .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
+        .setLoadBalancingPolicyConfig(new EdsConfig("edsService1", new Object()))
+        .build();
+    edsLoadBalancer.handleResolvedAddresses(resolvedAddresses);
+
+    ArgumentCaptor<EndpointWatcher> endpointWatcherCaptor = ArgumentCaptor.forClass(null);
+    verify(xdsClient).watchEndpointData(eq("edsService1"), endpointWatcherCaptor.capture());
+    EndpointWatcher endpointWatcher1 = endpointWatcherCaptor.getValue();
+
+    LocalityLbEndpoints localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    LocalityLbEndpoints localityInfo2 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
+    ImmutableMap<Locality, LocalityLbEndpoints> localityInfoMap = ImmutableMap.of(
+        locality1, localityInfo1, locality2, localityInfo2);
+    EndpointUpdate endpointUpdate1 = new EndpointUpdate();
+    endpointUpdate1.localityInfoMap = localityInfoMap;
+    endpointUpdate1.dropOverloads = new ArrayList<>();
+    endpointWatcher1.onEndpointChanged(endpointUpdate1);
+
+    assertThat(loadBalancers).hasSize(2);
+
+    edsLoadBalancer.shutdown();
+
+    verify(loadBalancers.get("sz1")).shutdown();
+    verify(loadBalancers.get("sz2")).shutdown();
+    verify(loadStatsStore).removeLocality(locality1);
+    verify(loadStatsStore).removeLocality(locality2);
+  }
+
+  /**
+   * Tests the scenario of the following sequence of events.
+   * (In the format of "event detail - expected state", with abbreviations C for CONNECTING,
+   * F for TRANSIENT_FAILURE, R for READ, and D for deactivated etc.)
+   * EDS update: P0 sz1; P1 sz2; P2 sz3; P3 sz4 - P0 C, P1 N/A, P2 N/A, P3 N/A
+   * 10 secs passes P0 still CONNECTING - P0 C, P1 C, P2 N/A, P3 N/A
+   * 5 secs passes P1 in TRANSIENT_FAILURE - P0 C, P1 F, P2 C, P3 N/A
+   * 4 secs passes P2 READY - P0 C, P1 F, P2 R, P3 N/A
+   * P0 gets READY - P0 R, P1 F&D, P2 R&D, P3 N/A
+   * P1 gets READY - P0 R, P1 R&D, P2 R&D, P3 N/A
+   * 10 min passes P0 in TRANSIENT_FAILURE - P0 F, P1 R, P2 R&D, P3 N/A
+   * 5 min passes - P0 F, P1 R, P2 N/A, P3 N/A
+   * P1 in TRANSIENT_FAILURE - P0 F, P1 F, P2 C, P3 N/A
+   * 10 secs passes - P0 F, P1 F, P2 C, P3 C
+   * P1, P3 gets READY - P0 F, P1 R, P2 C&D, P3 R&D
+   * EDS update, localities moved: P0 sz1, sz3; P1 sz4; P2 sz2 - P0 C, P1 R, P2 R&D
+   * 15 min passes - P0 C, P1 R, P2 N/A
+   * EDS update, locality removed: P0 sz1, sz3, - P0 C, P1 N/A, sz4 R&D
+   * sz3 gets READY - P0 R, P1 N/A, sz4 R&D
+   * EDS update, locality comes back and another removed: P0 sz1, P1 sz4 - P0 C, P1 R, sz3 R&D
+   *
+   * <p>Should also verify that when locality store is updated with new EDS data, state of all
+   * localities should be updated before the child balancer of each locality handles new addresses.
+   */
+  @Test
+  public void multipriority() {
+    ResolvedAddresses resolvedAddresses = ResolvedAddresses.newBuilder()
+        .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
+        .setLoadBalancingPolicyConfig(new EdsConfig("edsService1", new Object()))
+        .build();
+    edsLoadBalancer.handleResolvedAddresses(resolvedAddresses);
+
+    ArgumentCaptor<EndpointWatcher> endpointWatcherCaptor = ArgumentCaptor.forClass(null);
+    verify(xdsClient).watchEndpointData(eq("edsService1"), endpointWatcherCaptor.capture());
+    final EndpointWatcher endpointWatcher1 = endpointWatcherCaptor.getValue();
+
+    // EDS update: P0 sz1; P1 sz2; P2 sz3; P3 sz4 - P0 C, P1 N/A, P2 N/A, P3 N/A
+    LocalityLbEndpoints localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    LocalityLbEndpoints localityInfo2 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 1);
+    LocalityLbEndpoints localityInfo3 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 2);
+    LocalityLbEndpoints localityInfo4 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint41, lbEndpoint42), 3, 3);
+    ImmutableMap<Locality, LocalityLbEndpoints> localityInfoMap = ImmutableMap.of(
+        locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3, locality4,
+        localityInfo4);
+    final EndpointUpdate endpointUpdate1 = new EndpointUpdate();
+    endpointUpdate1.localityInfoMap = localityInfoMap;
+    endpointUpdate1.dropOverloads = new ArrayList<>();
+
+    syncContext.execute(new Runnable() {
+      @Override
+      public void run() {
+        endpointWatcher1.onEndpointChanged(endpointUpdate1);
+      }
+    });
+    assertThat(loadBalancers.keySet()).containsExactly("sz1");
+    LoadBalancer lb1 = loadBalancers.get("sz1");
+    InOrder inOrder = inOrder(lb1, helper);
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor1 = ArgumentCaptor.forClass(null);
+    inOrder.verify(helper).updateBalancingState(CONNECTING, BUFFER_PICKER);
+    inOrder.verify(lb1).handleResolvedAddresses(resolvedAddressesCaptor1.capture());
+    assertThat(resolvedAddressesCaptor1.getValue().getAddresses()).containsExactly(eag11, eag12);
+
+    // 10 sec passes P0 still CONNECTING - P0 C, P1 C, P2 N/A, P3 N/A
+    fakeClock.forwardTime(9, TimeUnit.SECONDS);
+    assertThat(loadBalancers.keySet()).containsExactly("sz1");
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).hasSize(1);
+    ScheduledTask failOverTask =
+        Iterables.getOnlyElement(fakeClock.getPendingTasks(failOverTaskFilter));
+    fakeClock.forwardTime(1, TimeUnit.SECONDS);
+    assertThat(failOverTask.isCancelled()).isFalse();
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).doesNotContain(failOverTask);
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).hasSize(1);
+    failOverTask = Iterables.getOnlyElement(fakeClock.getPendingTasks(failOverTaskFilter));
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).isEmpty();
+    assertThat(loadBalancers.keySet()).containsExactly("sz1", "sz2");
+    LoadBalancer lb2 = loadBalancers.get("sz2");
+    inOrder = inOrder(lb1, lb2, helper);
+    inOrder.verify(helper).updateBalancingState(CONNECTING, BUFFER_PICKER);
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor2 = ArgumentCaptor.forClass(null);
+    inOrder.verify(lb2).handleResolvedAddresses(resolvedAddressesCaptor2.capture());
+    assertThat(resolvedAddressesCaptor2.getValue().getAddresses()).containsExactly(eag21, eag22);
+
+    // 5 secs passes P1 in TRANSIENT_FAILURE - P0 C, P1 F, P2 C, P3 N/A
+    fakeClock.forwardTime(5, TimeUnit.SECONDS);
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).containsExactly(failOverTask);
+    final Helper helper2 = childHelpers.get("sz2");
+    helper.getSynchronizationContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        helper2.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(UNAVAILABLE));
+      }
+    });
+    assertThat(failOverTask.isCancelled()).isTrue();
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).doesNotContain(failOverTask);
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).hasSize(1);
+    failOverTask = Iterables.getOnlyElement(fakeClock.getPendingTasks(failOverTaskFilter));
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).isEmpty();
+    assertThat(loadBalancers.keySet()).containsExactly("sz1", "sz2", "sz3");
+    LoadBalancer lb3 = loadBalancers.get("sz3");
+    inOrder = inOrder(lb3, helper);
+    // The order of the following two updateBalancingState() does not matter. We want to verify
+    // lb3.handleResolvedAddresses() is after them.
+    inOrder.verify(helper).updateBalancingState(same(TRANSIENT_FAILURE), isA(ErrorPicker.class));
+    inOrder.verify(helper).updateBalancingState(CONNECTING, BUFFER_PICKER);
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor3 = ArgumentCaptor.forClass(null);
+    inOrder.verify(lb3).handleResolvedAddresses(resolvedAddressesCaptor3.capture());
+    assertThat(resolvedAddressesCaptor3.getValue().getAddresses()).containsExactly(eag31, eag32);
+
+    // 5 secs passes P2 READY - P0 C, P1 F, P2 R, P3 N/A
+    fakeClock.forwardTime(4, TimeUnit.SECONDS);
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).containsExactly(failOverTask);
+    final Helper helper3 = childHelpers.get("sz3");
+    final Subchannel mockSubchannel3 = mock(Subchannel.class);
+    helper.getSynchronizationContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        helper3.updateBalancingState(
+            READY,
+            new SubchannelPicker() {
+              @Override
+              public PickResult pickSubchannel(PickSubchannelArgs args) {
+                return PickResult.withSubchannel(mockSubchannel3);
+              }
+            });
+      }
+    });
+    assertThat(failOverTask.isCancelled()).isTrue();
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).isEmpty();
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).isEmpty();
+    ArgumentCaptor<SubchannelPicker> subchannelPickerCaptor = ArgumentCaptor.forClass(null);
+    inOrder.verify(helper).updateBalancingState(same(READY), subchannelPickerCaptor.capture());
+    assertThat(subchannelPickerCaptor.getValue()
+        .pickSubchannel(mock(PickSubchannelArgs.class))
+        .getSubchannel())
+        .isSameInstanceAs(mockSubchannel3);
+
+    // P0 gets READY - P0 R, P1 F&D, P2 R&D, P3 N/A
+    final Helper helper1 = childHelpers.get("sz1");
+    final Subchannel mockSubchannel1 = mock(Subchannel.class);
+    helper.getSynchronizationContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        helper1.updateBalancingState(
+            READY,
+            new SubchannelPicker() {
+              @Override
+              public PickResult pickSubchannel(PickSubchannelArgs args) {
+                return PickResult.withSubchannel(mockSubchannel1);
+              }
+            });
+      }
+    });
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).isEmpty();
+    Collection<ScheduledTask> deactivationTasks = fakeClock.getPendingTasks(deactivationTaskFilter);
+    assertThat(deactivationTasks).hasSize(2);
+    inOrder.verify(helper).updateBalancingState(same(READY), subchannelPickerCaptor.capture());
+    assertThat(subchannelPickerCaptor.getValue()
+        .pickSubchannel(mock(PickSubchannelArgs.class))
+        .getSubchannel())
+        .isSameInstanceAs(mockSubchannel1);
+
+    // P1 gets READY - P0 R, P1 R&D, P2 R&D, P3 N/A
+    final Subchannel mockSubchannel2 = mock(Subchannel.class);
+    helper.getSynchronizationContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        helper2.updateBalancingState(
+            READY,
+            new SubchannelPicker() {
+              @Override
+              public PickResult pickSubchannel(PickSubchannelArgs args) {
+                return PickResult.withSubchannel(mockSubchannel2);
+              }
+            });
+      }
+    });
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).isEmpty();
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).hasSize(2);
+    inOrder.verify(helper, never())
+        .updateBalancingState(any(ConnectivityState.class), any(SubchannelPicker.class));
+
+    // 10 min passes P0 in TRANSIENT_FAILURE - P0 F, P1 R, P2 R&D, P3 N/A
+    fakeClock.forwardTime(10, TimeUnit.MINUTES);
+    helper.getSynchronizationContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        helper1.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(UNAVAILABLE));
+      }
+    });
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).isEmpty();
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).hasSize(1);
+    ScheduledTask deactivationTask =
+        Iterables.getOnlyElement(fakeClock.getPendingTasks(deactivationTaskFilter));
+    assertThat(deactivationTask).isSameInstanceAs(Iterables.get(deactivationTasks, 1));
+    assertThat(Iterables.get(deactivationTasks, 0).isCancelled()).isTrue();
+    inOrder.verify(helper, never())
+        .updateBalancingState(CONNECTING, BUFFER_PICKER);
+
+
+    // 5 min passes - P0 F, P1 R, P2 N/A, P3 N/A
+    verify(lb3, never()).shutdown();
+    fakeClock.forwardTime(5, TimeUnit.MINUTES);
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).isEmpty();
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).isEmpty();
+    verify(lb3).shutdown();
+
+    // P1 in TRANSIENT_FAILURE - P0 F, P1 F, P2 C, P3 N/A
+    helper.getSynchronizationContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        helper2.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(UNAVAILABLE));
+      }
+    });
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).hasSize(1);
+    failOverTask = Iterables.getOnlyElement(fakeClock.getPendingTasks(failOverTaskFilter));
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).isEmpty();
+    // The order of the following two updateBalancingState() does not matter. We only want to verify
+    // these are the latest tow updateBalancingState().
+    inOrder.verify(helper).updateBalancingState(same(TRANSIENT_FAILURE), isA(ErrorPicker.class));
+    inOrder.verify(helper).updateBalancingState(CONNECTING, BUFFER_PICKER);
+    assertThat(loadBalancers.keySet()).containsExactly("sz1", "sz2", "sz3");
+    assertThat(loadBalancers.get("sz3")).isNotSameInstanceAs(lb3);
+    lb3 = loadBalancers.get("sz3");
+    assertThat(childHelpers.get("sz3")).isNotSameInstanceAs(helper3);
+
+    // 10 secs passes - P0 F, P1 F, P2 C, P3 C
+    fakeClock.forwardTime(10, TimeUnit.SECONDS);
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).hasSize(1);
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).doesNotContain(failOverTask);
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).isEmpty();
+    assertThat(loadBalancers.keySet()).containsExactly("sz1", "sz2", "sz3", "sz4");
+    LoadBalancer lb4 = loadBalancers.get("sz4");
+    inOrder = inOrder(lb1, lb2, lb3, lb4, helper);
+    inOrder.verify(helper).updateBalancingState(CONNECTING, BUFFER_PICKER);
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor4 = ArgumentCaptor.forClass(null);
+    inOrder.verify(lb4).handleResolvedAddresses(resolvedAddressesCaptor4.capture());
+    assertThat(resolvedAddressesCaptor4.getValue().getAddresses()).containsExactly(eag41, eag42);
+
+    // P1, P3 gets READY - P0 F, P1 R, P2 C&D, P3 R&D
+    final Subchannel mockSubchannel22 = mock(Subchannel.class);
+    final Subchannel mockSubchannel4 = mock(Subchannel.class);
+    final Helper helper4 = childHelpers.get("sz4");
+    helper.getSynchronizationContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        helper2.updateBalancingState(
+            READY,
+            new SubchannelPicker() {
+              @Override
+              public PickResult pickSubchannel(PickSubchannelArgs args) {
+                return PickResult.withSubchannel(mockSubchannel22);
+              }
+            });
+        helper4.updateBalancingState(
+            READY,
+            new SubchannelPicker() {
+              @Override
+              public PickResult pickSubchannel(PickSubchannelArgs args) {
+                return PickResult.withSubchannel(mockSubchannel4);
+              }
+            });
+      }
+    });
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).isEmpty();
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).hasSize(2);
+    inOrder.verify(helper).updateBalancingState(same(READY), subchannelPickerCaptor.capture());
+    assertThat(subchannelPickerCaptor.getValue()
+        .pickSubchannel(mock(PickSubchannelArgs.class))
+        .getSubchannel())
+        .isSameInstanceAs(mockSubchannel22);
+
+    // EDS update, localities moved: P0 sz1, sz3; P1 sz4; P2 sz2 - P0 C, P1 R, P2 R&D
+    localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint12), 1, 0);
+    localityInfo2 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint22), 2, 2);
+    localityInfo3 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint32), 3, 0);
+    localityInfo4 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint42), 4, 1);
+    ImmutableMap<Locality, LocalityLbEndpoints> localityInfoMap2 = ImmutableMap.of(
+        locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3, locality4,
+        localityInfo4);
+
+    final EndpointUpdate endpointUpdate2 = new EndpointUpdate();
+    endpointUpdate2.localityInfoMap = localityInfoMap2;
+    endpointUpdate2.dropOverloads = new ArrayList<>();
+    syncContext.execute(new Runnable() {
+      @Override
+      public void run() {
+        endpointWatcher1.onEndpointChanged(endpointUpdate2);
+      }
+    });
+    assertThat(loadBalancers.keySet()).containsExactly("sz1", "sz2", "sz3", "sz4");
+    assertThat(loadBalancers.values()).containsExactly(lb1, lb2, lb3, lb4);
+    inOrder.verify(helper).updateBalancingState(same(READY), subchannelPickerCaptor.capture());
+    assertThat(subchannelPickerCaptor.getValue()
+        .pickSubchannel(mock(PickSubchannelArgs.class))
+        .getSubchannel())
+        .isSameInstanceAs(mockSubchannel4);
+    // The order of the following four handleResolvedAddresses() does not matter. We want to verify
+    // they are after helper.updateBalancingState()
+    inOrder.verify(lb1).handleResolvedAddresses(resolvedAddressesCaptor1.capture());
+    assertThat(resolvedAddressesCaptor1.getValue().getAddresses()).containsExactly(eag12);
+    inOrder.verify(lb2).handleResolvedAddresses(resolvedAddressesCaptor2.capture());
+    assertThat(resolvedAddressesCaptor2.getValue().getAddresses()).containsExactly(eag22);
+    inOrder.verify(lb3).handleResolvedAddresses(resolvedAddressesCaptor3.capture());
+    assertThat(resolvedAddressesCaptor3.getValue().getAddresses()).containsExactly(eag32);
+    inOrder.verify(lb4).handleResolvedAddresses(resolvedAddressesCaptor4.capture());
+    assertThat(resolvedAddressesCaptor4.getValue().getAddresses()).containsExactly(eag42);
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).isEmpty();
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).hasSize(1);
+
+    // 15 min passes - P0 C, P1 R, P2 N/A
+    verify(lb2, never()).shutdown();
+    fakeClock.forwardTime(15, TimeUnit.MINUTES);
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).isEmpty();
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).isEmpty();
+    inOrder.verify(lb2).shutdown();
+    inOrder.verifyNoMoreInteractions();
+
+    // EDS update, locality removed: P0 sz1, sz3, - P0 C, P1 N/A, sz4 R&D
+    localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11), 1, 0);
+    localityInfo3 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint31), 3, 0);
+    ImmutableMap<Locality, LocalityLbEndpoints> localityInfoMap3 = ImmutableMap.of(
+        locality1, localityInfo1,locality3, localityInfo3);
+    final EndpointUpdate endpointUpdate3 = new EndpointUpdate();
+    endpointUpdate3.localityInfoMap = localityInfoMap3;
+    endpointUpdate3.dropOverloads = new ArrayList<>();
+    syncContext.execute(new Runnable() {
+      @Override
+      public void run() {
+        endpointWatcher1.onEndpointChanged(endpointUpdate3);
+      }
+    });
+    inOrder.verify(helper).updateBalancingState(CONNECTING, BUFFER_PICKER);
+    // The order of the following two handleResolvedAddresses() does not matter. We want to verify
+    // they are after helper.updateBalancingState()
+    inOrder.verify(lb1).handleResolvedAddresses(resolvedAddressesCaptor1.capture());
+    assertThat(resolvedAddressesCaptor1.getValue().getAddresses()).containsExactly(eag11);
+    inOrder.verify(lb3).handleResolvedAddresses(resolvedAddressesCaptor3.capture());
+    assertThat(resolvedAddressesCaptor3.getValue().getAddresses()).containsExactly(eag31);
+    inOrder.verifyNoMoreInteractions();
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).isEmpty();
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).hasSize(1);
+
+    // sz3 gets READY - P0 R, P1 N/A, sz4 R&D
+    final Helper newHelper3 = childHelpers.get("sz3");
+    final Subchannel newMockSubchannel3 = mock(Subchannel.class);
+    syncContext.execute(new Runnable() {
+      @Override
+      public void run() {
+        newHelper3.updateBalancingState(
+            READY,
+            new SubchannelPicker() {
+              @Override
+              public PickResult pickSubchannel(PickSubchannelArgs args) {
+                return PickResult.withSubchannel(newMockSubchannel3);
+              }
+            }
+        );
+      }
+    });
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).isEmpty();
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).hasSize(1);
+    inOrder.verify(helper).updateBalancingState(same(READY), subchannelPickerCaptor.capture());
+    assertThat(subchannelPickerCaptor.getValue()
+        .pickSubchannel(mock(PickSubchannelArgs.class))
+        .getSubchannel())
+        .isSameInstanceAs(newMockSubchannel3);
+    inOrder.verifyNoMoreInteractions();
+
+    // EDS update, locality comes back and another removed: P0 sz1, P1 sz4 - P0 C, P1 R, sz3 R&D
+    localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11), 1, 0);
+    localityInfo4 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint41), 4, 1);
+    ImmutableMap<Locality, LocalityLbEndpoints> localityInfoMap4 = ImmutableMap.of(
+        locality1, localityInfo1,locality4, localityInfo4);
+    final EndpointUpdate endpointUpdate4 = new EndpointUpdate();
+    endpointUpdate4.localityInfoMap = localityInfoMap4;
+    endpointUpdate4.dropOverloads = new ArrayList<>();
+    syncContext.execute(new Runnable() {
+      @Override
+      public void run() {
+        endpointWatcher1.onEndpointChanged(endpointUpdate4);
+      }
+    });
+    inOrder.verify(helper, atLeastOnce()).updateBalancingState(
+        same(READY), subchannelPickerCaptor.capture());
+    assertThat(subchannelPickerCaptor.getValue()
+        .pickSubchannel(mock(PickSubchannelArgs.class))
+        .getSubchannel())
+        .isSameInstanceAs(mockSubchannel4);
+    // The order of the following two handleResolvedAddresses() does not matter. We want to verify
+    // they are after helper.updateBalancingState()
+    inOrder.verify(lb1).handleResolvedAddresses(resolvedAddressesCaptor1.capture());
+    assertThat(resolvedAddressesCaptor1.getValue().getAddresses()).containsExactly(eag11);
+    inOrder.verify(lb4).handleResolvedAddresses(resolvedAddressesCaptor4.capture());
+    assertThat(resolvedAddressesCaptor4.getValue().getAddresses()).containsExactly(eag41);
+    inOrder.verifyNoMoreInteractions();
+    assertThat(fakeClock.getPendingTasks(failOverTaskFilter)).isEmpty();
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).hasSize(1);
+
+    verify(lb1, never()).shutdown();
+    verify(lb3, never()).shutdown();
+    verify(lb4, never()).shutdown();
+    edsLoadBalancer.shutdown();
+    assertThat(fakeClock.getPendingTasks(deactivationTaskFilter)).isEmpty();
+    verify(lb1).shutdown();
+    verify(lb3).shutdown();
+    verify(lb4).shutdown();
+  }
+
+  private static final class FakeLoadStatsStore implements LoadStatsStore {
+
+    Map<Locality, ClientLoadCounter> localityCounters = new HashMap<>();
+
+    @Override
+    public ClusterStats generateLoadReport() {
+      throw new AssertionError("Should not be called");
+    }
+
+    @Override
+    public void addLocality(Locality locality) {
+      assertThat(localityCounters).doesNotContainKey(locality);
+      localityCounters.put(locality, new ClientLoadCounter());
+    }
+
+    @Override
+    public void removeLocality(Locality locality) {
+      assertThat(localityCounters).containsKey(locality);
+      localityCounters.remove(locality);
+    }
+
+    @Nullable
+    @Override
+    public ClientLoadCounter getLocalityCounter(Locality locality) {
+      return localityCounters.get(locality);
+    }
+
+    @Override
+    public void recordDroppedRequest(String category) {
+      // NO-OP, verify by invocations.
+    }
+  }
+
+  private static final class FakeOrcaReportingHelperWrapper extends OrcaReportingHelperWrapper {
+
+    final Helper delegate;
+    long reportIntervalNanos = -1;
+
+    FakeOrcaReportingHelperWrapper(Helper delegate) {
+      this.delegate = checkNotNull(delegate, "delegate");
+    }
+
+    @Override
+    public void setReportingConfig(OrcaReportingConfig config) {
+      reportIntervalNanos = config.getReportIntervalNanos();
+    }
+
+    @Override
+    public Helper asHelper() {
+      return delegate;
+    }
   }
 }

--- a/xds/src/test/java/io/grpc/xds/EdsLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/EdsLoadBalancerTest.java
@@ -57,6 +57,7 @@ import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
+import io.grpc.Status;
 import io.grpc.SynchronizationContext;
 import io.grpc.internal.FakeClock;
 import io.grpc.internal.FakeClock.ScheduledTask;
@@ -224,14 +225,14 @@ public class EdsLoadBalancerTest {
   private final EquivalentAddressGroup eag42 =
       new EquivalentAddressGroup(new InetSocketAddress("addr42", 42));
 
-  private final LbEndpoint lbEndpoint11 = new LbEndpoint(eag11, 11);
-  private final LbEndpoint lbEndpoint12 = new LbEndpoint(eag12, 12);
-  private final LbEndpoint lbEndpoint21 = new LbEndpoint(eag21, 21);
-  private final LbEndpoint lbEndpoint22 = new LbEndpoint(eag22, 22);
-  private final LbEndpoint lbEndpoint31 = new LbEndpoint(eag31, 31);
-  private final LbEndpoint lbEndpoint32 = new LbEndpoint(eag32, 32);
-  private final LbEndpoint lbEndpoint41 = new LbEndpoint(eag41, 41);
-  private final LbEndpoint lbEndpoint42 = new LbEndpoint(eag42, 42);
+  private final LbEndpoint lbEndpoint11 = new LbEndpoint(eag11, 11, true);
+  private final LbEndpoint lbEndpoint12 = new LbEndpoint(eag12, 12, true);
+  private final LbEndpoint lbEndpoint21 = new LbEndpoint(eag21, 21, true);
+  private final LbEndpoint lbEndpoint22 = new LbEndpoint(eag22, 22, true);
+  private final LbEndpoint lbEndpoint31 = new LbEndpoint(eag31, 31, true);
+  private final LbEndpoint lbEndpoint32 = new LbEndpoint(eag32, 32, true);
+  private final LbEndpoint lbEndpoint41 = new LbEndpoint(eag41, 41, true);
+  private final LbEndpoint lbEndpoint42 = new LbEndpoint(eag42, 42, true);
 
   private final Map<String, Locality> namedLocalities
       = ImmutableMap.of("sz1", locality1, "sz2", locality2, "sz3", locality3, "sz4", locality4);
@@ -1074,6 +1075,117 @@ public class EdsLoadBalancerTest {
     assertThat(subchannelPickerCaptor.getValue().pickSubchannel(pickSubchannelArgs).isDrop())
         .isTrue();
     verify(random, times(2)).nextInt(1000_000);
+  }
+
+  @Test
+  public void updateLoaclityStore_withUnHealthyEndPoints() {
+    edsLoadBalancer.handleResolvedAddresses(defaultResolvedAddresses);
+
+    ArgumentCaptor<EndpointWatcher> endpointWatcherCaptor = ArgumentCaptor.forClass(null);
+    verify(xdsClient).watchEndpointData(eq("edsService1"), endpointWatcherCaptor.capture());
+    EndpointWatcher endpointWatcher1 = endpointWatcherCaptor.getValue();
+
+    LbEndpoint lbEndpoint11 = new LbEndpoint(eag11, 11, true);
+    LbEndpoint lbEndpoint12 = new LbEndpoint(eag12, 12, true);
+    LbEndpoint lbEndpoint21 = new LbEndpoint(eag21, 21, false); // unhealthy
+    LbEndpoint lbEndpoint22 = new LbEndpoint(eag22, 22, true);
+    LbEndpoint lbEndpoint31 = new LbEndpoint(eag31, 31, false); // unhealthy
+    LbEndpoint lbEndpoint32 = new LbEndpoint(eag32, 32, false); // unhealthy
+    LbEndpoint lbEndpoint41 = new LbEndpoint(eag41, 41, true);
+    LbEndpoint lbEndpoint42 = new LbEndpoint(eag42, 42, true);
+    LocalityLbEndpoints localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    LocalityLbEndpoints localityInfo2 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
+    LocalityLbEndpoints localityInfo3 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
+    LocalityLbEndpoints localityInfo4 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint41, lbEndpoint42), 4, 0);
+    ImmutableMap<Locality, LocalityLbEndpoints> localityInfoMap = ImmutableMap.of(
+        locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3,
+        locality4, localityInfo4);
+    EndpointUpdate endpointUpdate1 = new EndpointUpdate(
+        "edsService1", localityInfoMap, new ArrayList<DropOverload>());
+    endpointWatcher1.onEndpointChanged(endpointUpdate1);
+    verify(helper).updateBalancingState(CONNECTING, BUFFER_PICKER);
+
+    assertThat(loadBalancers).hasSize(4);
+    assertThat(loadBalancers.keySet()).containsExactly("sz1", "sz2", "sz3", "sz4");
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor1 =
+        ArgumentCaptor.forClass(ResolvedAddresses.class);
+    verify(loadBalancers.get("sz1")).handleResolvedAddresses(resolvedAddressesCaptor1.capture());
+    assertThat(resolvedAddressesCaptor1.getValue().getAddresses()).containsExactly(eag11, eag12);
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor2 =
+        ArgumentCaptor.forClass(ResolvedAddresses.class);
+    verify(loadBalancers.get("sz2")).handleResolvedAddresses(resolvedAddressesCaptor2.capture());
+    assertThat(resolvedAddressesCaptor2.getValue().getAddresses()).containsExactly(eag22);
+    verify(loadBalancers.get("sz3"), never()).handleResolvedAddresses(any(ResolvedAddresses.class));
+    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
+    verify(loadBalancers.get("sz3")).handleNameResolutionError(statusCaptor.capture());
+    assertThat(statusCaptor.getValue().getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor4 =
+        ArgumentCaptor.forClass(ResolvedAddresses.class);
+    verify(loadBalancers.get("sz4")).handleResolvedAddresses(resolvedAddressesCaptor4.capture());
+    assertThat(resolvedAddressesCaptor4.getValue().getAddresses()).containsExactly(eag41, eag42);
+    // verify no more updateBalancingState except the initial CONNECTING state
+    verify(helper, times(1)).updateBalancingState(
+        any(ConnectivityState.class), any(SubchannelPicker.class));
+
+    // update with different healthy status
+    lbEndpoint11 = new LbEndpoint(eag11, 11, false); // unhealthy
+    lbEndpoint12 = new LbEndpoint(eag12, 12, false); // unhealthy
+    lbEndpoint21 = new LbEndpoint(eag21, 21, true);
+    lbEndpoint22 = new LbEndpoint(eag22, 22, false); // unhealthy
+    lbEndpoint31 = new LbEndpoint(eag31, 31, true);
+    lbEndpoint32 = new LbEndpoint(eag32, 32, false); // unhealthy
+    localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    localityInfo2 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0);
+    localityInfo3 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
+    localityInfoMap = ImmutableMap.of(
+        locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
+    EndpointUpdate endpointUpdate2 = new EndpointUpdate(
+        "edsService1", localityInfoMap, new ArrayList<DropOverload>());
+    endpointWatcher1.onEndpointChanged(endpointUpdate2);
+
+    verify(loadBalancers.get("sz1"), times(1))
+        .handleResolvedAddresses(any(ResolvedAddresses.class));
+    verify(loadBalancers.get("sz1"), times(1)).handleNameResolutionError(statusCaptor.capture());
+    assertThat(statusCaptor.getValue().getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+    verify(loadBalancers.get("sz2"), times(2))
+        .handleResolvedAddresses(resolvedAddressesCaptor2.capture());
+    assertThat(resolvedAddressesCaptor2.getValue().getAddresses()).containsExactly(eag21);
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor3 =
+        ArgumentCaptor.forClass(ResolvedAddresses.class);
+    verify(loadBalancers.get("sz3")).handleResolvedAddresses(resolvedAddressesCaptor3.capture());
+    assertThat(resolvedAddressesCaptor3.getValue().getAddresses()).containsExactly(eag31);
+    verify(helper, times(2)).updateBalancingState(CONNECTING, BUFFER_PICKER);
+
+    // update with all endpoints unhealthy
+    lbEndpoint11 = new LbEndpoint(eag11, 11, false); // unhealthy
+    lbEndpoint12 = new LbEndpoint(eag12, 12, false); // unhealthy
+    lbEndpoint31 = new LbEndpoint(eag31, 31, false); // unhealthy
+    lbEndpoint32 = new LbEndpoint(eag32, 32, false); // unhealthy
+    localityInfo1 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0);
+    localityInfo3 =
+        new LocalityLbEndpoints(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0);
+    localityInfoMap = ImmutableMap.of(locality1, localityInfo1, locality3, localityInfo3);
+    EndpointUpdate endpointUpdate3 = new EndpointUpdate(
+        "edsService1", localityInfoMap, new ArrayList<DropOverload>());
+    endpointWatcher1.onEndpointChanged(endpointUpdate3);
+
+    verify(loadBalancers.get("sz1"), times(2)).handleNameResolutionError(statusCaptor.capture());
+    assertThat(statusCaptor.getValue().getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+    verify(loadBalancers.get("sz3"), times(2)).handleNameResolutionError(statusCaptor.capture());
+    assertThat(statusCaptor.getValue().getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+
+    // mimic child balancers update subchannels to TRANSIENT_FAILURE after handleNameResolutionError
+    childHelpers.get("sz1").updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(UNAVAILABLE));
+    childHelpers.get("sz3").updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(UNAVAILABLE));
+    verify(helper).updateBalancingState(eq(TRANSIENT_FAILURE), any(SubchannelPicker.class));
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/EdsLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/EdsLoadBalancerTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.grpc.ChannelLogger;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancer.ResolvedAddresses;
+import io.grpc.xds.EdsLoadBalancer.EdsConfig;
+import io.grpc.xds.XdsClient.EndpointUpdate;
+import io.grpc.xds.XdsClient.EndpointWatcher;
+import java.util.ArrayList;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Tests for {@link EdsLoadBalancer}.
+ */
+@RunWith(JUnit4.class)
+public class EdsLoadBalancerTest {
+  private static final String FAKE_CLUSTER_NAME = "cluster1";
+
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Mock
+  private LocalityStore localityStore;
+  @Mock
+  private XdsClient xdsClient;
+  @Mock
+  private ChannelLogger channelLogger;
+
+  private EdsLoadBalancer edsLoadBalancer;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+
+    edsLoadBalancer = new EdsLoadBalancer(
+        FAKE_CLUSTER_NAME, localityStore, xdsClient, channelLogger);
+  }
+
+  @Test
+  public void canHandleEmptyAddressListFromNameResolution() {
+    assertThat(edsLoadBalancer.canHandleEmptyAddressListFromNameResolution()).isTrue();
+  }
+
+  @Test
+  public void missingEdsConfig() {
+    ResolvedAddresses resolvedAddresses = ResolvedAddresses.newBuilder()
+        .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
+        .build();
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Expecting an EDS LB config, but the actual LB config is 'null'");
+    edsLoadBalancer.handleResolvedAddresses(resolvedAddresses);
+  }
+
+  @Test
+  public void invalidConfigType() {
+    Object invalidConfig = new Object();
+    ResolvedAddresses resolvedAddresses = ResolvedAddresses.newBuilder()
+        .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
+        .setLoadBalancingPolicyConfig(invalidConfig)
+        .build();
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Expecting an EDS LB config, but the actual LB config is '"
+        + invalidConfig + "'");
+    edsLoadBalancer.handleResolvedAddresses(resolvedAddresses);
+  }
+
+  @Test
+  public void invalidClusterNameInEdsConfig() {
+    ResolvedAddresses resolvedAddresses = ResolvedAddresses.newBuilder()
+        .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
+        .setLoadBalancingPolicyConfig(new EdsConfig("wrongCluster", new Object()))
+        .build();
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(
+        "The cluster name 'wrongCluster' from EDS LB config does not match the name '"
+            + FAKE_CLUSTER_NAME + "' provided by CDS");
+    edsLoadBalancer.handleResolvedAddresses(resolvedAddresses);
+  }
+
+  @Test
+  public void validEdsConfig_watcherUpdate_shutdown() {
+    // handle valid EdsConfig
+    ResolvedAddresses resolvedAddresses = ResolvedAddresses.newBuilder()
+        .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
+        .setLoadBalancingPolicyConfig(new EdsConfig(FAKE_CLUSTER_NAME, new Object()))
+        .build();
+    edsLoadBalancer.handleResolvedAddresses(resolvedAddresses);
+
+    ArgumentCaptor<EndpointWatcher> endpointWatcherCaptor = ArgumentCaptor.forClass(null);
+    verify(xdsClient).watchEndpointData(eq(FAKE_CLUSTER_NAME), endpointWatcherCaptor.capture());
+
+    // watcher receives EndpointUpdate
+    EnvoyProtoData.Locality xdsLocality =
+        new EnvoyProtoData.Locality("region1", "zone1", "subzone1");
+    EnvoyProtoData.LocalityLbEndpoints localityLbEndpoints =
+        new EnvoyProtoData.LocalityLbEndpoints(new ArrayList<EnvoyProtoData.LbEndpoint>(), 3, 0);
+    ImmutableMap<EnvoyProtoData.Locality, EnvoyProtoData.LocalityLbEndpoints> localityInfoMap =
+        ImmutableMap.of(xdsLocality, localityLbEndpoints);
+    ImmutableList<EnvoyProtoData.DropOverload> dropOverloads =
+        ImmutableList.of(new EnvoyProtoData.DropOverload("cat1", 10));
+    EndpointUpdate endpointUpdate = new EndpointUpdate();
+    endpointUpdate.localityInfoMap = localityInfoMap;
+    endpointUpdate.dropOverloads = dropOverloads;
+    endpointWatcherCaptor.getValue().onEndpointChanged(endpointUpdate);
+
+    verify(localityStore).updateLocalityStore(localityInfoMap);
+    verify(localityStore).updateDropPercentage(dropOverloads);
+
+    // shutdown
+    edsLoadBalancer.shutdown();
+    verify(xdsClient).cancelEndpointDataWatch(endpointWatcherCaptor.getValue());
+    verify(localityStore).reset();
+  }
+
+  @Test
+  public void shutdown() {
+    edsLoadBalancer.shutdown();
+    verify(localityStore).reset();
+    verify(xdsClient, never()).cancelEndpointDataWatch(any(EndpointWatcher.class));
+  }
+}


### PR DESCRIPTION
This does nothing nontrivial, just reusing the existing `LocalityStore` logic. The implementation of `LocalityStore` is copied into `EdsLoadBalancer`, and tests in `LocalityStoreTest` are copied into `EdsLoadBalancerTest`.

No change on LoadReport related stuffs in `LocalityStore` is made. Just keep them as-is.