### PR TITLE
alts: fix ComputeEngineChannelBuilder class signature (backport v1.21.x)

### DIFF
--- a/alts/src/main/java/io/grpc/alts/ComputeEngineChannelBuilder.java
+++ b/alts/src/main/java/io/grpc/alts/ComputeEngineChannelBuilder.java
@@ -44,7 +44,7 @@ import javax.net.ssl.SSLException;
  * using ALTS if applicable and using TLS as fallback.
  */
 public final class ComputeEngineChannelBuilder
-    extends ForwardingChannelBuilder<GoogleDefaultChannelBuilder> {
+    extends ForwardingChannelBuilder<ComputeEngineChannelBuilder> {
 
   private final NettyChannelBuilder delegate;
   private GoogleDefaultProtocolNegotiator negotiatorForTest;


### PR DESCRIPTION
#6367