### PR TITLE
alts: fix ComputeEngineChannelBuilder class signature (backport v1.24.x)

### DIFF
--- a/alts/src/main/java/io/grpc/alts/ComputeEngineChannelBuilder.java
+++ b/alts/src/main/java/io/grpc/alts/ComputeEngineChannelBuilder.java
@@ -39,7 +39,7 @@ import javax.net.ssl.SSLException;
  * using ALTS if applicable and using TLS as fallback.
  */
 public final class ComputeEngineChannelBuilder
-    extends ForwardingChannelBuilder<GoogleDefaultChannelBuilder> {
+    extends ForwardingChannelBuilder<ComputeEngineChannelBuilder> {
 
   private final NettyChannelBuilder delegate;
 


### PR DESCRIPTION
#6367