### PR TITLE
xds: fix lint warning for throwing RuntimeException

### DIFF
--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -56,11 +56,11 @@ abstract class Bootstrapper {
 
   private static final class FileBasedBootstrapper extends Bootstrapper {
 
-    private static volatile IOException failToBootstrapException;
+    private static volatile Exception failToBootstrapException;
     private static volatile BootstrapInfo bootstrapInfo;
 
     @Override
-    BootstrapInfo readBootstrap() throws IOException {
+    BootstrapInfo readBootstrap() throws Exception {
       if (bootstrapInfo == null && failToBootstrapException == null) {
         synchronized (FileBasedBootstrapper.class) {
           if (bootstrapInfo == null && failToBootstrapException == null) {
@@ -74,7 +74,7 @@ abstract class Bootstrapper {
               bootstrapInfo =
                   parseConfig(new String(Files.readAllBytes(Paths.get(filePath)),
                       StandardCharsets.UTF_8));
-            } catch (IOException e) {
+            } catch (Exception e) {
               failToBootstrapException = e;
               throw e;
             }

--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -76,16 +76,12 @@ abstract class Bootstrapper {
                       StandardCharsets.UTF_8));
             } catch (Exception e) {
               failToBootstrapException = e;
-              throw e;
             }
           }
         }
       }
       if (failToBootstrapException != null) {
-        throw new IOException(
-            "Failed to read bootstrap. A previous attempt has failed. See the cause for the "
-                + "original failure",
-            failToBootstrapException);
+        throw new IOException(failToBootstrapException);
       }
       return bootstrapInfo;
     }

--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -56,11 +56,11 @@ abstract class Bootstrapper {
 
   private static final class FileBasedBootstrapper extends Bootstrapper {
 
-    private static volatile Exception failToBootstrapException;
+    private static volatile IOException failToBootstrapException;
     private static volatile BootstrapInfo bootstrapInfo;
 
     @Override
-    BootstrapInfo readBootstrap() throws Exception {
+    BootstrapInfo readBootstrap() throws IOException {
       if (bootstrapInfo == null && failToBootstrapException == null) {
         synchronized (FileBasedBootstrapper.class) {
           if (bootstrapInfo == null && failToBootstrapException == null) {
@@ -74,14 +74,18 @@ abstract class Bootstrapper {
               bootstrapInfo =
                   parseConfig(new String(Files.readAllBytes(Paths.get(filePath)),
                       StandardCharsets.UTF_8));
-            } catch (Exception e) {
+            } catch (IOException e) {
               failToBootstrapException = e;
+              throw e;
             }
           }
         }
       }
       if (failToBootstrapException != null) {
-        throw new RuntimeException(failToBootstrapException);
+        throw new IOException(
+            "Failed to read bootstrap. A previous attempt has failed. See the cause for the "
+                + "original failure",
+            failToBootstrapException);
       }
       return bootstrapInfo;
     }


### PR DESCRIPTION
A lint warning is found during the import. http://go/java-practices/exceptions#abstract_throwables