### PR TITLE
xds: ignore endpoints with health_status != HEALTHY or UNKNOWN

### DIFF
--- a/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
@@ -195,15 +195,8 @@ final class EnvoyProtoData {
     private final int loadBalancingWeight;
     private final boolean isHealthy;
 
-    /** Must only be used for testing. */
-    // TODO(chengyuanzhang): migrate tests to use LbEndpoint(EquivalentAddressGroup, int, boolean)
-    //  and should add tests for LB policies dealing with unhealthy endpoints.
     @VisibleForTesting
-    LbEndpoint(EquivalentAddressGroup eag, int loadBalancingWeight) {
-      this(eag, loadBalancingWeight, true);
-    }
-
-    private LbEndpoint(EquivalentAddressGroup eag, int loadBalancingWeight, boolean isHealthy) {
+    LbEndpoint(EquivalentAddressGroup eag, int loadBalancingWeight, boolean isHealthy) {
       this.eag = eag;
       this.loadBalancingWeight = loadBalancingWeight;
       this.isHealthy = isHealthy;

--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -597,7 +597,7 @@ interface LocalityStore {
         }
       }
       // In extreme case handleResolvedAddresses() may trigger updateBalancingState()
-      // immediately, so execute handleResolvedAddresses() after all the setup in this method is
+      // immediately, so execute handleResolvedAddresses() after all the setup in the caller is
       // complete.
       childHelper.getSynchronizationContext().execute(new Runnable() {
         @Override

--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -224,14 +224,16 @@ interface LocalityStore {
           helper.getSynchronizationContext().execute(new Runnable() {
             @Override
             public void run() {
-              if (eags.isEmpty()) {
+              if (eags.isEmpty()
+                  && !localityLbInfo.childBalancer.canHandleEmptyAddressListFromNameResolution()) {
                 localityLbInfo.childBalancer.handleNameResolutionError(
                     Status.UNAVAILABLE.withDescription(
                         "No healthy address available from EDS update '" + localityInfo
                             + "' for locality '" + locality + "'"));
+              } else {
+                localityLbInfo.childBalancer.handleResolvedAddresses(
+                    ResolvedAddresses.newBuilder().setAddresses(eags).build());
               }
-              localityLbInfo.childBalancer.handleResolvedAddresses(
-                  ResolvedAddresses.newBuilder().setAddresses(eags).build());
             }
           });
         }


### PR DESCRIPTION
Let child balancer (currently is Round Robin) handle the address list with only healthy addresses for its locality. If no healthy address available, let the child balancer `handleNameResolutionError`.

@voidzcy @zhangkun83 How do you think the approach?