### PR TITLE
api: Rename blockingExecutor to offloadExecutor (v1.25.x backport)

### DIFF
--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -72,6 +72,13 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
   }
 
   @Override
+  public T offloadExecutor(Executor executor) {
+    delegate().offloadExecutor(executor);
+    return thisT();
+  }
+
+  @Deprecated
+  @Override
   public T blockingExecutor(Executor executor) {
     delegate().blockingExecutor(executor);
     return thisT();

--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -104,7 +104,7 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   public abstract T executor(Executor executor);
 
   /**
-   * Provides a custom executor that will be used for operations that block.
+   * Provides a custom executor that will be used for operations that block or are expensive.
    *
    * <p>It's an optional parameter. If the user has not provided an executor when the channel is
    * built, the builder will use a static cached thread pool.
@@ -117,8 +117,14 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * @since 1.25.0
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/6279")
-  public T blockingExecutor(Executor executor) {
+  public T offloadExecutor(Executor executor) {
     throw new UnsupportedOperationException();
+  }
+
+  @Deprecated
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/6279")
+  public T blockingExecutor(Executor executor) {
+    return offloadExecutor(executor);
   }
 
   /**

--- a/api/src/main/java/io/grpc/NameResolver.java
+++ b/api/src/main/java/io/grpc/NameResolver.java
@@ -474,7 +474,7 @@ public abstract class NameResolver {
      */
     @Nullable
     @ExperimentalApi("https://github.com/grpc/grpc-java/issues/6279")
-    public Executor getBlockingExecutor() {
+    public Executor getOffloadExecutor() {
       return executor;
     }
 
@@ -500,7 +500,7 @@ public abstract class NameResolver {
       builder.setProxyDetector(proxyDetector);
       builder.setSynchronizationContext(syncContext);
       builder.setServiceConfigParser(serviceConfigParser);
-      builder.setBlockingExecutor(executor);
+      builder.setOffloadExecutor(executor);
       return builder;
     }
 
@@ -569,12 +569,12 @@ public abstract class NameResolver {
       }
 
       /**
-       * See {@link Args#getBlockingExecutor}. This is an optional field.
+       * See {@link Args#getOffloadExecutor}. This is an optional field.
        *
        * @since 1.25.0
        */
       @ExperimentalApi("https://github.com/grpc/grpc-java/issues/6279")
-      public Builder setBlockingExecutor(Executor executor) {
+      public Builder setOffloadExecutor(Executor executor) {
         this.executor = executor;
         return this;
       }

--- a/api/src/test/java/io/grpc/NameResolverTest.java
+++ b/api/src/test/java/io/grpc/NameResolverTest.java
@@ -61,14 +61,14 @@ public class NameResolverTest {
     assertThat(args.getProxyDetector()).isSameInstanceAs(proxyDetector);
     assertThat(args.getSynchronizationContext()).isSameInstanceAs(syncContext);
     assertThat(args.getServiceConfigParser()).isSameInstanceAs(parser);
-    assertThat(args.getBlockingExecutor()).isSameInstanceAs(executor);
+    assertThat(args.getOffloadExecutor()).isSameInstanceAs(executor);
 
     NameResolver.Args args2 = args.toBuilder().build();
     assertThat(args2.getDefaultPort()).isEqualTo(defaultPort);
     assertThat(args2.getProxyDetector()).isSameInstanceAs(proxyDetector);
     assertThat(args2.getSynchronizationContext()).isSameInstanceAs(syncContext);
     assertThat(args2.getServiceConfigParser()).isSameInstanceAs(parser);
-    assertThat(args2.getBlockingExecutor()).isSameInstanceAs(executor);
+    assertThat(args2.getOffloadExecutor()).isSameInstanceAs(executor);
 
     assertThat(args2).isNotSameInstanceAs(args);
     assertThat(args2).isNotEqualTo(args);
@@ -251,7 +251,7 @@ public class NameResolverTest {
         .setProxyDetector(proxyDetector)
         .setSynchronizationContext(syncContext)
         .setServiceConfigParser(parser)
-        .setBlockingExecutor(executor)
+        .setOffloadExecutor(executor)
         .build();
   }
 }

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -95,7 +95,7 @@ public abstract class AbstractManagedChannelImplBuilder
 
   ObjectPool<? extends Executor> executorPool = DEFAULT_EXECUTOR_POOL;
 
-  ObjectPool<? extends Executor> blockingExecutorPool = DEFAULT_EXECUTOR_POOL;
+  ObjectPool<? extends Executor> offloadExecutorPool = DEFAULT_EXECUTOR_POOL;
 
   private final List<ClientInterceptor> interceptors = new ArrayList<>();
   final NameResolverRegistry nameResolverRegistry = NameResolverRegistry.getDefaultRegistry();
@@ -220,11 +220,11 @@ public abstract class AbstractManagedChannelImplBuilder
   }
 
   @Override
-  public final T blockingExecutor(Executor executor) {
+  public final T offloadExecutor(Executor executor) {
     if (executor != null) {
-      this.blockingExecutorPool = new FixedObjectPool<>(executor);
+      this.offloadExecutorPool = new FixedObjectPool<>(executor);
     } else {
-      this.blockingExecutorPool = DEFAULT_EXECUTOR_POOL;
+      this.offloadExecutorPool = DEFAULT_EXECUTOR_POOL;
     }
     return thisT();
   }

--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -185,7 +185,7 @@ final class DnsNameResolver extends NameResolver {
     this.stopwatch = Preconditions.checkNotNull(stopwatch, "stopwatch");
     this.syncContext =
         Preconditions.checkNotNull(args.getSynchronizationContext(), "syncContext");
-    this.executor = args.getBlockingExecutor();
+    this.executor = args.getOffloadExecutor();
     this.usingExecutorResource = executor == null;
     this.enableSrv = enableSrv;
   }

--- a/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
@@ -100,18 +100,18 @@ public class AbstractManagedChannelImplBuilderTest {
   }
 
   @Test
-  public void blockingExecutor_normal() {
+  public void offloadExecutor_normal() {
     Executor executor = mock(Executor.class);
-    assertEquals(builder, builder.blockingExecutor(executor));
-    assertEquals(executor, builder.blockingExecutorPool.getObject());
+    assertEquals(builder, builder.offloadExecutor(executor));
+    assertEquals(executor, builder.offloadExecutorPool.getObject());
   }
 
   @Test
-  public void blockingExecutor_null() {
-    ObjectPool<? extends Executor> defaultValue = builder.blockingExecutorPool;
-    builder.blockingExecutor(mock(Executor.class));
-    assertEquals(builder, builder.blockingExecutor(null));
-    assertEquals(defaultValue, builder.blockingExecutorPool);
+  public void offloadExecutor_null() {
+    ObjectPool<? extends Executor> defaultValue = builder.offloadExecutorPool;
+    builder.offloadExecutor(mock(Executor.class));
+    assertEquals(builder, builder.offloadExecutor(null));
+    assertEquals(defaultValue, builder.offloadExecutorPool);
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -331,7 +331,7 @@ public class DnsNameResolverTest {
             .setProxyDetector(GrpcUtil.NOOP_PROXY_DETECTOR)
             .setSynchronizationContext(syncContext)
             .setServiceConfigParser(mock(ServiceConfigParser.class))
-            .setBlockingExecutor(
+            .setOffloadExecutor(
                 new Executor() {
                   @Override
                   public void execute(Runnable command) {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -266,7 +266,7 @@ public class ManagedChannelImplTest {
   @Mock
   private CallCredentials creds;
   @Mock
-  private Executor blockingExecutor;
+  private Executor offloadExecutor;
   private ChannelBuilder channelBuilder;
   private boolean requestConnection = true;
   private BlockingQueue<MockClientTransportInfo> transports;
@@ -328,7 +328,7 @@ public class ManagedChannelImplTest {
             .userAgent(USER_AGENT)
             .idleTimeout(
                 AbstractManagedChannelImplBuilder.IDLE_MODE_MAX_TIMEOUT_DAYS, TimeUnit.DAYS)
-            .blockingExecutor(blockingExecutor);
+            .offloadExecutor(offloadExecutor);
     channelBuilder.executorPool = executorPool;
     channelBuilder.binlog = null;
     channelBuilder.channelz = channelz;
@@ -3588,14 +3588,14 @@ public class ManagedChannelImplTest {
     assertThat(args.getDefaultPort()).isEqualTo(DEFAULT_PORT);
     assertThat(args.getProxyDetector()).isSameInstanceAs(neverProxy);
 
-    verify(blockingExecutor, never()).execute(any(Runnable.class));
-    args.getBlockingExecutor()
+    verify(offloadExecutor, never()).execute(any(Runnable.class));
+    args.getOffloadExecutor()
         .execute(
             new Runnable() {
               @Override
               public void run() {}
             });
-    verify(blockingExecutor, times(1)).execute(any(Runnable.class));
+    verify(offloadExecutor, times(1)).execute(any(Runnable.class));
   }
 
   @Test


### PR DESCRIPTION
The API review for #6279 came up with a more meaningful name that
better explains the intent. A setter for the old name was left in
ManagedChannelBuilder to ease migration to the new name by current
users.

This is a backport of #6389 

CC @zhangkun83 