### PR TITLE
netty: Deflake WriteBufferingAndExceptionHandlerTest

### DIFF
--- a/netty/src/test/java/io/grpc/netty/WriteBufferingAndExceptionHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/WriteBufferingAndExceptionHandlerTest.java
@@ -41,6 +41,7 @@ import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalServerChannel;
 import java.net.ConnectException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -69,14 +70,14 @@ public class WriteBufferingAndExceptionHandlerTest {
   private Channel server;
 
   @After
-  public void tearDown() {
+  public void tearDown() throws InterruptedException {
     if (server != null) {
-      server.close();
+      server.close().sync();
     }
     if (chan != null) {
-      chan.close();
+      chan.close().sync();
     }
-    group.shutdownGracefully();
+    group.shutdownGracefully(0, 10, TimeUnit.SECONDS).sync();
   }
 
   @Test


### PR DESCRIPTION
It appears the problem is that server.close() was missing sync(), so the
event loop was still processing the closure when the next test started.

This change is more aggressive than it needs to be, but should make it
less bug-prone.

Fixes #5574