### PR TITLE
netty,okhttp: log FINE level for pure IOExceptions when transport terminated (v1.25.x backport)

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
@@ -19,7 +19,6 @@ package io.grpc.netty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.InternalChannelz.SocketStats;
@@ -50,11 +49,6 @@ class NettyServerTransport implements ServerTransport {
   // connectionLog is for connection related messages only
   private static final Logger connectionLog = Logger.getLogger(
       String.format("%s.connections", NettyServerTransport.class.getName()));
-  // Some exceptions are not very useful and add too much noise to the log
-  private static final ImmutableList<String> QUIET_ERRORS = ImmutableList.of(
-      "Connection reset by peer",
-      "An existing connection was forcibly closed by the remote host",
-      "An established connection was aborted by the software in your host machine");
 
   private final InternalLogId logId;
   private final Channel channel;
@@ -184,12 +178,8 @@ class NettyServerTransport implements ServerTransport {
    */
   @VisibleForTesting
   static Level getLogLevel(Throwable t) {
-    if (t instanceof IOException && t.getMessage() != null) {
-      for (String msg : QUIET_ERRORS) {
-        if (t.getMessage().contains(msg)) {
-          return Level.FINE;
-        }
-      }
+    if (t.getClass().equals(IOException.class)) {
+      return Level.FINE;
     }
     return Level.INFO;
   }

--- a/netty/src/test/java/io/grpc/netty/NettyServerTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerTransportTest.java
@@ -16,6 +16,7 @@
 
 package io.grpc.netty;
 
+import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.netty.NettyServerTransport.getLogLevel;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -34,27 +35,25 @@ public class NettyServerTransportTest {
   }
 
   @Test
-  public void quiet() {
+  public void ioException() {
     assertEquals(Level.FINE, getLogLevel(new IOException("Connection reset by peer")));
     assertEquals(Level.FINE, getLogLevel(new IOException(
         "An existing connection was forcibly closed by the remote host")));
   }
 
   @Test
-  public void quiet_prefixed() {
-    assertEquals(Level.FINE, getLogLevel(new IOException(
-        "syscall:read(..) failed: Connection reset by peer")));
-  }
-
-  @Test
-  public void nonquiet() {
-    assertEquals(Level.INFO, getLogLevel(new IOException("foo")));
-  }
-
-  @Test
-  public void nullMessage() {
+  public void ioException_nullMessage() {
     IOException e = new IOException();
     assertNull(e.getMessage());
-    assertEquals(Level.INFO, getLogLevel(e));
+    assertEquals(Level.FINE, getLogLevel(e));
+  }
+
+  @Test
+  public void extendedIoException() {
+    class ExtendedIoException extends IOException {}
+
+    ExtendedIoException e = new ExtendedIoException();
+    assertThat(e.getMessage()).isNull();
+    assertThat(getLogLevel(e)).isEqualTo(Level.INFO);
   }
 }

--- a/okhttp/src/main/java/io/grpc/okhttp/ExceptionHandlingFrameWriter.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/ExceptionHandlingFrameWriter.java
@@ -25,11 +25,7 @@ import io.grpc.okhttp.internal.framed.FrameWriter;
 import io.grpc.okhttp.internal.framed.Header;
 import io.grpc.okhttp.internal.framed.Settings;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import okio.Buffer;
@@ -38,10 +34,6 @@ import okio.ByteString;
 final class ExceptionHandlingFrameWriter implements FrameWriter {
 
   private static final Logger log = Logger.getLogger(OkHttpClientTransport.class.getName());
-
-  // Some exceptions are not very useful and add too much noise to the log
-  private static final Set<String> QUIET_ERRORS =
-      Collections.unmodifiableSet(new HashSet<>(Arrays.asList("Socket closed")));
 
   private final TransportExceptionHandler transportExceptionHandler;
 
@@ -231,9 +223,7 @@ final class ExceptionHandlingFrameWriter implements FrameWriter {
    */
   @VisibleForTesting
   static Level getLogLevel(Throwable t) {
-    if (t instanceof IOException
-        && t.getMessage() != null
-        && QUIET_ERRORS.contains(t.getMessage())) {
+    if (t.getClass().equals(IOException.class)) {
       return Level.FINE;
     }
     return Level.INFO;

--- a/okhttp/src/test/java/io/grpc/okhttp/ExceptionHandlingFrameWriterTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/ExceptionHandlingFrameWriterTest.java
@@ -71,18 +71,22 @@ public class ExceptionHandlingFrameWriterTest {
   }
 
   @Test
-  public void quiet() {
+  public void ioException() {
     assertThat(getLogLevel(new IOException("Socket closed"))).isEqualTo(Level.FINE);
   }
 
   @Test
-  public void nonquiet() {
-    assertThat(getLogLevel(new IOException("foo"))).isEqualTo(Level.INFO);
+  public void ioException_nullMessage() {
+    IOException e = new IOException();
+    assertThat(e.getMessage()).isNull();
+    assertThat(getLogLevel(e)).isEqualTo(Level.FINE);
   }
 
   @Test
-  public void nullMessage() {
-    IOException e = new IOException();
+  public void extendedIoException() {
+    class ExtendedIoException extends IOException {}
+
+    ExtendedIoException e = new ExtendedIoException();
     assertThat(e.getMessage()).isNull();
     assertThat(getLogLevel(e)).isEqualTo(Level.INFO);
   }


### PR DESCRIPTION
backport of #6334 related to #6322