### PR TITLE
interop-testing,benchmarks: publish tar, zip (backport of #6369 to 1.24.x)

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -96,3 +96,12 @@ applicationDistribution.into("bin") {
     from(benchmark_worker)
     fileMode = 0755
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifact distZip
+            artifact distTar
+        }
+    }
+}

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -116,3 +116,12 @@ applicationDistribution.into("bin") {
     from(grpclb_long_lived_affinity_test_client)
     fileMode = 0755
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifact distZip
+            artifact distTar
+        }
+    }
+}


### PR DESCRIPTION
backport of #6369 related to #6365