### PR TITLE
xds: add CdsLoadBalancer

### DIFF
--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
@@ -16,10 +16,10 @@
 
 package io.grpc.xds;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import io.grpc.ChannelLogger;
 import io.grpc.ChannelLogger.ChannelLogLevel;
@@ -47,7 +47,7 @@ public final class CdsLoadBalancer extends LoadBalancer {
 
   // The following fields become non-null once handleResolvedAddresses() successfully.
 
-  // Most recent XdsConfig.
+  // Most recent CdsConfig.
   @Nullable
   private CdsConfig cdsConfig;
   // Most recent ClusterWatcher.
@@ -73,7 +73,7 @@ public final class CdsLoadBalancer extends LoadBalancer {
   public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     channelLogger.log(ChannelLogLevel.DEBUG, "Received ResolvedAddresses '%s'", resolvedAddresses);
     Object lbConfig = resolvedAddresses.getLoadBalancingPolicyConfig();
-    Preconditions.checkArgument(
+    checkArgument(
         lbConfig instanceof CdsConfig,
         "Expecting a CDS LB config, but the actual LB config is '%s'",
         lbConfig);
@@ -188,6 +188,8 @@ public final class CdsLoadBalancer extends LoadBalancer {
             }
             CdsLoadBalancer.this.clusterWatcher = clusterWatcher;
           }
+          // Else handleResolvedAddresses() already called, so no-op here because the config is
+          // fixed in this balancer.
         }
       };
     }
@@ -213,7 +215,7 @@ public final class CdsLoadBalancer extends LoadBalancer {
 
     @Override
     public void onClusterChanged(ClusterUpdate newUpdate) {
-      Preconditions.checkArgument(
+      checkArgument(
           newUpdate.getLbPolicy().equals("round_robin"),
           "The load balancing policy in ClusterUpdate '%s' is not supported", newUpdate);
 
@@ -252,7 +254,7 @@ public final class CdsLoadBalancer extends LoadBalancer {
     final String name;
 
     CdsConfig(String name) {
-      Preconditions.checkArgument(name != null && !name.isEmpty(), "name is null or empty");
+      checkArgument(name != null && !name.isEmpty(), "name is null or empty");
       this.name = name;
     }
 

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import io.grpc.ChannelLogger;
+import io.grpc.ChannelLogger.ChannelLogLevel;
+import io.grpc.LoadBalancer;
+import io.grpc.LoadBalancerProvider;
+import io.grpc.LoadBalancerRegistry;
+import io.grpc.Status;
+import io.grpc.internal.ObjectPool;
+import io.grpc.internal.ServiceConfigUtil.LbConfig;
+import io.grpc.util.GracefulSwitchLoadBalancer;
+import io.grpc.xds.XdsClient.ClusterUpdate;
+import io.grpc.xds.XdsClient.ClusterWatcher;
+import io.grpc.xds.XdsLoadBalancerProvider.XdsConfig;
+import io.grpc.xds.XdsSubchannelPickers.ErrorPicker;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Load balancer for experimental_cds LB policy.
+ */
+public final class CdsLoadBalancer extends LoadBalancer {
+  private final ChannelLogger channelLogger;
+  private final LoadBalancerRegistry lbRegistry;
+  private final GracefulSwitchLoadBalancer switchingLoadBalancer;
+
+  // The following fields become non-null once handleResolvedAddresses() successfully.
+  /** Most recent XdsConfig. */
+  @Nullable
+  private CdsConfig cdsConfig;
+  /** Most recent ClusterWatcher. */
+  @Nullable
+  private ClusterWatcher clusterWatcher;
+  @Nullable
+  private ObjectPool<XdsClient> xdsClientRef;
+  @Nullable
+  private XdsClient xdsClient;
+
+  CdsLoadBalancer(Helper helper) {
+    this(helper, LoadBalancerRegistry.getDefaultRegistry());
+  }
+
+  @VisibleForTesting
+  CdsLoadBalancer(Helper helper, LoadBalancerRegistry lbRegistry) {
+    this.channelLogger = helper.getChannelLogger();
+    this.lbRegistry = lbRegistry;
+    this.switchingLoadBalancer = new GracefulSwitchLoadBalancer(helper);
+  }
+
+  @Override
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    channelLogger.log(ChannelLogLevel.DEBUG, "Received ResolvedAddresses '%s'", resolvedAddresses);
+    Object lbConfig = resolvedAddresses.getLoadBalancingPolicyConfig();
+    Preconditions.checkArgument(
+        lbConfig != null && CdsConfig.class.isAssignableFrom(lbConfig.getClass()),
+        "Expecting a CDS LB config, but the actual LB config is '%s'",
+        lbConfig);
+
+    if (xdsClientRef == null) {
+      xdsClientRef = resolvedAddresses.getAttributes().get(XdsAttributes.XDS_CLIENT_REF);
+
+      if (xdsClientRef == null) {
+        // TODO(zdapeng): create a new xdsClient from bootstrap if no one exists.
+        throw new UnsupportedOperationException(
+            "XDS_CLIENT_REF attributes not available in resolvedAddresses " + resolvedAddresses);
+      }
+
+      xdsClient = xdsClientRef.getObject();
+    }
+
+    final CdsConfig newCdsConfig = (CdsConfig) lbConfig;
+    // If CdsConfig is changed, do a graceful switch.
+    if (!newCdsConfig.equals(cdsConfig)) {
+      final CdsConfig oldCdsConfig = cdsConfig;
+      final ClusterWatcher oldClusterWatcher = clusterWatcher;
+      // Provides a load balancer with the fixed CdsConfig: newCdsConfig.
+      LoadBalancerProvider fixedCdsConfigBalancer = new LoadBalancerProvider() {
+        ClusterWatcherImpl clusterWatcher;
+
+        @Override
+        public boolean isAvailable() {
+          return true;
+        }
+
+        @Override
+        public int getPriority() {
+          return 5;
+        }
+
+        /**
+         * A synthetic policy name identified by CDS config. The implementation detail doesn't
+         * matter.
+         */
+        @Override
+        public String getPolicyName() {
+          return "cds_policy__cluster_name_" + newCdsConfig.name;
+        }
+
+        @Override
+        public LoadBalancer newLoadBalancer(final Helper helper) {
+          return new LoadBalancer() {
+            @Override
+            public void handleNameResolutionError(Status error) {}
+
+            @Override
+            public void shutdown() {
+              clusterWatcher.edsBalancer.shutdown();
+            }
+
+            @Override
+            public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+              if (clusterWatcher == null) {
+                clusterWatcher = new ClusterWatcherImpl(helper, resolvedAddresses);
+                xdsClient.watchClusterData(newCdsConfig.name, clusterWatcher);
+                if (oldCdsConfig != null) {
+                  xdsClient.cancelClusterDataWatch(oldCdsConfig.name, oldClusterWatcher);
+                }
+                CdsLoadBalancer.this.clusterWatcher = clusterWatcher;
+              }
+            }
+          };
+        }
+      };
+
+      switchingLoadBalancer.switchTo(fixedCdsConfigBalancer);
+    }
+
+    switchingLoadBalancer.handleResolvedAddresses(resolvedAddresses);
+
+    // clusterWatcher is also updated after switchingLoadBalancer.handleResolvedAddresses
+    cdsConfig = newCdsConfig;
+  }
+
+  @Override
+  public void handleNameResolutionError(Status error) {
+    channelLogger.log(ChannelLogLevel.DEBUG, "Name resolution error: '%s'", error);
+  }
+
+  @Override
+  public boolean canHandleEmptyAddressListFromNameResolution() {
+    return true;
+  }
+
+  @Override
+  public void shutdown() {
+    channelLogger.log(ChannelLogLevel.DEBUG, "CDS load balancer is shutting down");
+
+    switchingLoadBalancer.shutdown();
+    if (xdsClientRef != null) {
+      xdsClientRef.returnObject(xdsClient);
+    }
+  }
+
+  private final class ClusterWatcherImpl implements ClusterWatcher {
+
+    final LoadBalancer edsBalancer;
+    final Helper helper;
+    final ResolvedAddresses resolvedAddresses;
+
+    ClusterWatcherImpl(Helper helper, ResolvedAddresses resolvedAddresses) {
+      this.helper = helper;
+      this.resolvedAddresses = resolvedAddresses;
+      this.edsBalancer = lbRegistry.getProvider("xds_experimental").newLoadBalancer(helper);
+    }
+
+    @Override
+    public void onClusterChanged(ClusterUpdate update) {
+      Preconditions.checkArgument(
+          update.getLbPolicy().equals("round_robin"),
+          "The lbPolicy in ClusterUpdate '%s' is not 'round_robin'", update);
+
+      final XdsConfig edsConfig = new XdsConfig(
+          /* balancerName = */ null,
+          new LbConfig(update.getLbPolicy(), ImmutableMap.<String, Object>of()),
+          /* fallbackPolicy = */ null,
+          /* edsServiceName = */ update.getEdsServiceName(),
+          /* lrsServerName = */ update.getLrsServerName());
+
+      LoadStatsStore loadStatsStore = new LoadStatsStoreImpl();
+      if (update.isEnableLrs()) {
+        xdsClient.reportClientStats(
+            update.getClusterName(), update.getLrsServerName(), loadStatsStore);
+      }
+      edsBalancer.handleResolvedAddresses(
+          resolvedAddresses.toBuilder()
+              .setAttributes(
+                  resolvedAddresses.getAttributes().toBuilder()
+                      .discard(ATTR_LOAD_BALANCING_CONFIG)
+                      .set(XdsAttributes.LOAD_STATS_STORE_REF, loadStatsStore)
+                      .build())
+              .setLoadBalancingPolicyConfig(edsConfig)
+          .build());
+    }
+
+    @Override
+    public void onError(Status error) {
+      helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(error));
+    }
+  }
+
+  static final class CdsConfig {
+
+    /**
+     * Name of cluster to query CDS for.
+     */
+    final String name;
+
+    CdsConfig(String name) {
+      Preconditions.checkArgument(name != null && !name.isEmpty(), "name is null or empty");
+      this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      CdsConfig cdsConfig = (CdsConfig) o;
+      return Objects.equals(name, cdsConfig.name);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name);
+    }
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
@@ -225,8 +225,6 @@ public final class CdsLoadBalancer extends LoadBalancer {
             }
             CdsLoadBalancer.this.clusterWatcher = clusterWatcher;
           }
-          // Else handleResolvedAddresses() already called, so no-op here because the config is
-          // fixed in this balancer.
         }
       };
     }

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
@@ -34,12 +34,12 @@ import io.grpc.Status;
 import io.grpc.internal.ObjectPool;
 import io.grpc.internal.ServiceConfigUtil.LbConfig;
 import io.grpc.util.GracefulSwitchLoadBalancer;
+import io.grpc.xds.CdsLoadBalancerProvider.CdsConfig;
 import io.grpc.xds.XdsClient.ClusterUpdate;
 import io.grpc.xds.XdsClient.ClusterWatcher;
 import io.grpc.xds.XdsLoadBalancerProvider.XdsConfig;
 import io.grpc.xds.XdsSubchannelPickers.ErrorPicker;
 import java.util.Map;
-import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
@@ -267,33 +267,4 @@ public final class CdsLoadBalancer extends LoadBalancer {
     }
   }
 
-  static final class CdsConfig {
-
-    /**
-     * Name of cluster to query CDS for.
-     */
-    final String name;
-
-    CdsConfig(String name) {
-      checkArgument(name != null && !name.isEmpty(), "name is null or empty");
-      this.name = name;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      CdsConfig cdsConfig = (CdsConfig) o;
-      return Objects.equals(name, cdsConfig.name);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(name);
-    }
-  }
 }

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
@@ -179,8 +179,10 @@ public final class CdsLoadBalancer extends LoadBalancer {
 
         @Override
         public void shutdown() {
-          if (clusterWatcher != null && clusterWatcher.edsBalancer != null) {
-            clusterWatcher.edsBalancer.shutdown();
+          if (clusterWatcher != null) {
+            if (clusterWatcher.edsBalancer != null) {
+              clusterWatcher.edsBalancer.shutdown();
+            }
             xdsClient.cancelClusterDataWatch(cdsConfig.name, clusterWatcher);
           }
         }

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
@@ -73,7 +73,7 @@ public final class CdsLoadBalancer extends LoadBalancer {
     channelLogger.log(ChannelLogLevel.DEBUG, "Received ResolvedAddresses '%s'", resolvedAddresses);
     Object lbConfig = resolvedAddresses.getLoadBalancingPolicyConfig();
     Preconditions.checkArgument(
-        lbConfig != null && CdsConfig.class.isAssignableFrom(lbConfig.getClass()),
+        lbConfig instanceof CdsConfig,
         "Expecting a CDS LB config, but the actual LB config is '%s'",
         lbConfig);
 

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
@@ -18,6 +18,7 @@ package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
+import static io.grpc.xds.XdsLoadBalancerProvider.XDS_POLICY_NAME;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
@@ -235,7 +236,7 @@ public final class CdsLoadBalancer extends LoadBalancer {
         loadStatsStore = new LoadStatsStoreImpl();
       }
       if (edsBalancer == null) {
-        edsBalancer = lbRegistry.getProvider("xds_experimental").newLoadBalancer(helper);
+        edsBalancer = lbRegistry.getProvider(XDS_POLICY_NAME).newLoadBalancer(helper);
       }
       edsBalancer.handleResolvedAddresses(
           resolvedAddresses.toBuilder()

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
@@ -106,7 +106,7 @@ public final class CdsLoadBalancer extends LoadBalancer {
 
   @Override
   public void handleNameResolutionError(Status error) {
-    channelLogger.log(ChannelLogLevel.DEBUG, "Name resolution error: '%s'", error);
+    channelLogger.log(ChannelLogLevel.ERROR, "Name resolution error: '%s'", error);
   }
 
   @Override
@@ -219,6 +219,7 @@ public final class CdsLoadBalancer extends LoadBalancer {
 
     @Override
     public void onClusterChanged(ClusterUpdate newUpdate) {
+      channelLogger.log(ChannelLogLevel.DEBUG, "Received a CDS update: '%s'",  newUpdate);
       checkArgument(
           newUpdate.getLbPolicy().equals("round_robin"),
           "The load balancing policy in ClusterUpdate '%s' is not supported", newUpdate);
@@ -249,6 +250,8 @@ public final class CdsLoadBalancer extends LoadBalancer {
 
     @Override
     public void onError(Status error) {
+      channelLogger.log(ChannelLogLevel.ERROR, "Received a CDS error: '%s'",  error);
+
       // Go into TRANSIENT_FAILURE if we have not yet created the child
       // policy (i.e., we have not yet received valid data for the cluster). Otherwise,
       // we keep running with the data we had previously.

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
@@ -17,7 +17,6 @@
 package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 import static io.grpc.xds.XdsLoadBalancerProvider.XDS_POLICY_NAME;
 
@@ -244,12 +243,6 @@ public final class CdsLoadBalancer extends LoadBalancer {
     @Nullable
     LoadBalancer edsBalancer;
 
-    // LoadStatsStore for the cluster.
-    // Becomes non-null once handleResolvedAddresses() successfully.
-    // Assigned at most once.
-    @Nullable
-    LoadStatsStore loadStatsStore;
-
     ClusterWatcherImpl(Helper helper, ResolvedAddresses resolvedAddresses) {
       this.helper = helper;
       this.resolvedAddresses = resolvedAddresses;
@@ -269,10 +262,6 @@ public final class CdsLoadBalancer extends LoadBalancer {
           /* fallbackPolicy = */ null,
           /* edsServiceName = */ newUpdate.getEdsServiceName(),
           /* lrsServerName = */ newUpdate.getLrsServerName());
-
-      if (loadStatsStore == null) {
-        loadStatsStore = new LoadStatsStoreImpl();
-      }
       if (edsBalancer == null) {
         edsBalancer = lbRegistry.getProvider(XDS_POLICY_NAME).newLoadBalancer(helper);
       }
@@ -281,7 +270,6 @@ public final class CdsLoadBalancer extends LoadBalancer {
               .setAttributes(
                   resolvedAddresses.getAttributes().toBuilder()
                       .discard(ATTR_LOAD_BALANCING_CONFIG)
-                      .set(XdsAttributes.LOAD_STATS_STORE_REF, loadStatsStore)
                       .build())
               .setLoadBalancingPolicyConfig(edsConfig)
           .build());

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
@@ -181,6 +181,7 @@ public final class CdsLoadBalancer extends LoadBalancer {
         public void shutdown() {
           if (clusterWatcher != null && clusterWatcher.edsBalancer != null) {
             clusterWatcher.edsBalancer.shutdown();
+            xdsClient.cancelClusterDataWatch(cdsConfig.name, clusterWatcher);
           }
         }
 

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancerProvider.java
@@ -16,6 +16,8 @@
 
 package io.grpc.xds;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import io.grpc.Internal;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
@@ -23,8 +25,8 @@ import io.grpc.LoadBalancerProvider;
 import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.Status;
 import io.grpc.internal.JsonUtil;
-import io.grpc.xds.CdsLoadBalancer.CdsConfig;
 import java.util.Map;
+import java.util.Objects;
 
 @Internal
 public class CdsLoadBalancerProvider extends LoadBalancerProvider {
@@ -70,6 +72,39 @@ public class CdsLoadBalancerProvider extends LoadBalancerProvider {
     } catch (RuntimeException e) {
       return ConfigOrError.fromError(
           Status.UNKNOWN.withDescription("Failed to parse config " + e.getMessage()).withCause(e));
+    }
+  }
+
+  /**
+   * Represents a successfully parsed and validated LoadBalancingConfig for CDS.
+   */
+  static final class CdsConfig {
+
+    /**
+     * Name of cluster to query CDS for.
+     */
+    final String name;
+
+    CdsConfig(String name) {
+      checkArgument(name != null && !name.isEmpty(), "name is null or empty");
+      this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      CdsConfig cdsConfig = (CdsConfig) o;
+      return Objects.equals(name, cdsConfig.name);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name);
     }
   }
 }

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancerProvider.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import io.grpc.Internal;
+import io.grpc.LoadBalancer;
+import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancerProvider;
+import io.grpc.NameResolver.ConfigOrError;
+import io.grpc.Status;
+import io.grpc.internal.JsonUtil;
+import io.grpc.xds.CdsLoadBalancer.CdsConfig;
+import java.util.Map;
+
+@Internal
+public class CdsLoadBalancerProvider extends LoadBalancerProvider {
+
+  static final String CDS_POLICY_NAME = "experimental_cds";
+  private static final String CLUSTER_KEY = "cluster";
+
+  @Override
+  public boolean isAvailable() {
+    return true;
+  }
+
+  @Override
+  public int getPriority() {
+    return 5;
+  }
+
+  @Override
+  public String getPolicyName() {
+    return CDS_POLICY_NAME;
+  }
+
+  @Override
+  public LoadBalancer newLoadBalancer(Helper helper) {
+    return new CdsLoadBalancer(helper);
+  }
+
+  @Override
+  public ConfigOrError parseLoadBalancingPolicyConfig(
+      Map<String, ?> rawLoadBalancingPolicyConfig) {
+    return parseLoadBalancingConfigPolicy(rawLoadBalancingPolicyConfig);
+  }
+
+  /**
+   * Parses raw load balancing config and returns a {@link ConfigOrError} that contains a
+   * {@link CdsConfig} if parsing is successful.
+   */
+  static ConfigOrError parseLoadBalancingConfigPolicy(Map<String, ?> rawLoadBalancingPolicyConfig) {
+    try {
+      String cluster =
+          JsonUtil.getString(rawLoadBalancingPolicyConfig, CLUSTER_KEY);
+      return ConfigOrError.fromConfig(new CdsConfig(cluster));
+    } catch (RuntimeException e) {
+      return ConfigOrError.fromError(
+          Status.UNKNOWN.withDescription("Failed to parse config " + e.getMessage()).withCause(e));
+    }
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancerProvider.java
@@ -28,6 +28,11 @@ import io.grpc.internal.JsonUtil;
 import java.util.Map;
 import java.util.Objects;
 
+/**
+ * The provider for the "cds" balancing policy.  This class should not be directly referenced in
+ * code.  The policy should be accessed through {@link io.grpc.LoadBalancerRegistry#getProvider}
+ * with the name "cds" (currently "experimental_cds").
+ */
 @Internal
 public class CdsLoadBalancerProvider extends LoadBalancerProvider {
 

--- a/xds/src/main/java/io/grpc/xds/XdsAttributes.java
+++ b/xds/src/main/java/io/grpc/xds/XdsAttributes.java
@@ -79,5 +79,9 @@ public final class XdsAttributes {
   static final Attributes.Key<ObjectPool<XdsClient>> XDS_CLIENT_REF =
       Attributes.Key.create("io.grpc.xds.XdsAttributes.xdsClientRef");
 
+  @NameResolver.ResolutionResultAttr
+  static final Attributes.Key<LoadStatsStore> LOAD_STATS_STORE_REF =
+      Attributes.Key.create("io.grpc.xds.XdsAttributes.loadStatsStoreRef");
+
   private XdsAttributes() {}
 }

--- a/xds/src/main/java/io/grpc/xds/XdsAttributes.java
+++ b/xds/src/main/java/io/grpc/xds/XdsAttributes.java
@@ -79,9 +79,5 @@ public final class XdsAttributes {
   static final Attributes.Key<ObjectPool<XdsClient>> XDS_CLIENT_REF =
       Attributes.Key.create("io.grpc.xds.XdsAttributes.xdsClientRef");
 
-  @NameResolver.ResolutionResultAttr
-  static final Attributes.Key<LoadStatsStore> LOAD_STATS_STORE_REF =
-      Attributes.Key.create("io.grpc.xds.XdsAttributes.loadStatsStoreRef");
-
   private XdsAttributes() {}
 }

--- a/xds/src/main/resources/META-INF/services/io.grpc.LoadBalancerProvider
+++ b/xds/src/main/resources/META-INF/services/io.grpc.LoadBalancerProvider
@@ -1,1 +1,2 @@
+io.grpc.xds.CdsLoadBalancerProvider
 io.grpc.xds.XdsLoadBalancerProvider

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancerTest.java
@@ -18,6 +18,7 @@ package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
+import static io.grpc.xds.XdsLoadBalancerProvider.XDS_POLICY_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -109,7 +110,7 @@ public class CdsLoadBalancerTest {
 
       @Override
       public String getPolicyName() {
-        return "xds_experimental";
+        return XDS_POLICY_NAME;
       }
 
       @Override

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancerTest.java
@@ -290,7 +290,7 @@ public class CdsLoadBalancerTest {
   }
 
   @Test
-  public void clusterWatcherOnErrorBeforeAndAfteronClusterChanged() {
+  public void clusterWatcher_onErrorCalledBeforeAndAfterOnClusterChanged() {
     CdsConfig cdsConfig1 = new CdsConfig("foo.googleapis.com");
     ResolvedAddresses resolvedAddresses1 = ResolvedAddresses.newBuilder()
         .setAddresses(ImmutableList.<EquivalentAddressGroup>of())

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancerTest.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.grpc.Attributes;
+import io.grpc.ChannelLogger;
+import io.grpc.ConnectivityState;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancer;
+import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancer.ResolvedAddresses;
+import io.grpc.LoadBalancer.SubchannelPicker;
+import io.grpc.LoadBalancerProvider;
+import io.grpc.LoadBalancerRegistry;
+import io.grpc.internal.ServiceConfigUtil.LbConfig;
+import io.grpc.xds.CdsLoadBalancer.CdsConfig;
+import io.grpc.xds.XdsClient.ClusterUpdate;
+import io.grpc.xds.XdsClient.ClusterWatcher;
+import io.grpc.xds.XdsClient.RefCountedXdsClientObjectPool;
+import io.grpc.xds.XdsClient.XdsClientFactory;
+import io.grpc.xds.XdsLoadBalancerProvider.XdsConfig;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Tests for {@link CdsLoadBalancer}.
+ */
+@RunWith(JUnit4.class)
+public class CdsLoadBalancerTest {
+
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  private final RefCountedXdsClientObjectPool xdsClientRef = new RefCountedXdsClientObjectPool(
+      new XdsClientFactory() {
+        @Override
+        XdsClient createXdsClient() {
+          xdsClient = mock(XdsClient.class);
+          return xdsClient;
+        }
+      }
+  );
+  private Deque<LoadBalancer> edsLoadBalancers = new ArrayDeque<>();
+  private Deque<Helper> edsLbHelpers = new ArrayDeque<>();
+
+  @Mock
+  private Helper helper;
+  @Mock
+  private ChannelLogger channelLogger;
+
+  private LoadBalancer cdsLoadBalancer;
+  private XdsClient xdsClient;
+
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+
+    doReturn(channelLogger).when(helper).getChannelLogger();
+
+    LoadBalancerRegistry lbRegistry = new LoadBalancerRegistry();
+    lbRegistry.register(new LoadBalancerProvider() {
+      @Override
+      public boolean isAvailable() {
+        return true;
+      }
+
+      @Override
+      public int getPriority() {
+        return 5;
+      }
+
+      @Override
+      public String getPolicyName() {
+        return "xds_experimental";
+      }
+
+      @Override
+      public LoadBalancer newLoadBalancer(Helper helper) {
+        edsLbHelpers.add(helper);
+        LoadBalancer edsLoadBalancer = mock(LoadBalancer.class);
+        edsLoadBalancers.add(edsLoadBalancer);
+        return edsLoadBalancer;
+      }
+    });
+
+    cdsLoadBalancer = new CdsLoadBalancer(helper, lbRegistry);
+  }
+
+  @Test
+  public void canHandleEmptyAddressListFromNameResolution() {
+    assertThat(cdsLoadBalancer.canHandleEmptyAddressListFromNameResolution()).isTrue();
+  }
+
+  @Test
+  public void missingCdsConfig() {
+    ResolvedAddresses resolvedAddresses = ResolvedAddresses.newBuilder()
+        .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
+        .setAttributes(Attributes.newBuilder()
+            .set(XdsAttributes.XDS_CLIENT_REF, xdsClientRef).build())
+        .build();
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Expecting a CDS LB config, but the actual LB config is 'null'");
+    cdsLoadBalancer.handleResolvedAddresses(resolvedAddresses);
+  }
+
+  @Test
+  public void invalidConfigType() {
+    Object invalidConfig = new Object();
+    ResolvedAddresses resolvedAddresses = ResolvedAddresses.newBuilder()
+        .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
+        .setAttributes(Attributes.newBuilder()
+            .set(XdsAttributes.XDS_CLIENT_REF, xdsClientRef).build())
+        .setLoadBalancingPolicyConfig(invalidConfig)
+        .build();
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Expecting a CDS LB config, but the actual LB config is '"
+        + invalidConfig + "'");
+    cdsLoadBalancer.handleResolvedAddresses(resolvedAddresses);
+  }
+
+  @Test
+  public void handleCdsConfigs() {
+    assertThat(xdsClient).isNull();
+
+    CdsConfig cdsConfig1 = new CdsConfig("foo.googleapis.com");
+    ResolvedAddresses resolvedAddresses1 = ResolvedAddresses.newBuilder()
+        .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
+        .setAttributes(Attributes.newBuilder()
+            .set(XdsAttributes.XDS_CLIENT_REF, xdsClientRef).build())
+        .setLoadBalancingPolicyConfig(cdsConfig1)
+        .build();
+    cdsLoadBalancer.handleResolvedAddresses(resolvedAddresses1);
+
+    ArgumentCaptor<ClusterWatcher> clusterWatcherCaptor1 = ArgumentCaptor.forClass(null);
+    verify(xdsClient).watchClusterData(eq("foo.googleapis.com"), clusterWatcherCaptor1.capture());
+    assertThat(edsLbHelpers).hasSize(1);
+    assertThat(edsLoadBalancers).hasSize(1);
+    Helper edsLbHelper1 = edsLbHelpers.poll();
+    LoadBalancer edsLoadBalancer1 = edsLoadBalancers.poll();
+
+    ClusterWatcher clusterWatcher1 = clusterWatcherCaptor1.getValue();
+    clusterWatcher1.onClusterChanged(
+        ClusterUpdate.newBuilder()
+            .setClusterName("foo.googleapis.com")
+            .setEdsServiceName("edsServiceFoo.googleapis.com")
+            .setLbPolicy("round_robin")
+            .setEnableLrs(false)
+            .build());
+
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor1 = ArgumentCaptor.forClass(null);
+    verify(edsLoadBalancer1).handleResolvedAddresses(resolvedAddressesCaptor1.capture());
+    XdsConfig expectedXdsConfig = new XdsConfig(
+        null,
+        new LbConfig("round_robin", ImmutableMap.<String, Object>of()),
+        null,
+        "edsServiceFoo.googleapis.com",
+        null);
+    ResolvedAddresses resolvedAddressesFoo = resolvedAddressesCaptor1.getValue();
+    assertThat(resolvedAddressesFoo.getLoadBalancingPolicyConfig()).isEqualTo(expectedXdsConfig);
+    assertThat(resolvedAddressesFoo.getAttributes().get(XdsAttributes.XDS_CLIENT_REF))
+        .isSameInstanceAs(xdsClientRef);
+    assertThat(resolvedAddressesFoo.getAttributes().get(XdsAttributes.LOAD_STATS_STORE_REF))
+        .isNotNull();
+    verify(xdsClient, never()).reportClientStats(
+        anyString(), anyString(), any(LoadStatsStore.class));
+
+    SubchannelPicker picker1 = mock(SubchannelPicker.class);
+    edsLbHelper1.updateBalancingState(ConnectivityState.READY, picker1);
+    verify(helper).updateBalancingState(ConnectivityState.READY, picker1);
+
+    CdsConfig cdsConfig2 = new CdsConfig("bar.googleapis.com");
+    ResolvedAddresses resolvedAddresses2 = ResolvedAddresses.newBuilder()
+        .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
+        .setAttributes(Attributes.newBuilder()
+            .set(XdsAttributes.XDS_CLIENT_REF, xdsClientRef).build())
+        .setLoadBalancingPolicyConfig(cdsConfig2)
+        .build();
+    cdsLoadBalancer.handleResolvedAddresses(resolvedAddresses2);
+
+    ArgumentCaptor<ClusterWatcher> clusterWatcherCaptor2 = ArgumentCaptor.forClass(null);
+    verify(xdsClient).watchClusterData(eq("bar.googleapis.com"), clusterWatcherCaptor2.capture());
+    assertThat(edsLbHelpers).hasSize(1);
+    assertThat(edsLoadBalancers).hasSize(1);
+    Helper edsLbHelper2 = edsLbHelpers.poll();
+    LoadBalancer edsLoadBalancer2 = edsLoadBalancers.poll();
+
+    ClusterWatcher clusterWatcher2 = clusterWatcherCaptor2.getValue();
+    clusterWatcher2.onClusterChanged(
+        ClusterUpdate.newBuilder()
+            .setClusterName("bar.googleapis.com")
+            .setEdsServiceName("edsServiceBar.googleapis.com")
+            .setLbPolicy("round_robin")
+            .setEnableLrs(true)
+            .setLrsServerName("lrsBar.googleapis.com")
+            .build());
+
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor2 = ArgumentCaptor.forClass(null);
+    verify(edsLoadBalancer2).handleResolvedAddresses(resolvedAddressesCaptor2.capture());
+    expectedXdsConfig = new XdsConfig(
+        null,
+        new LbConfig("round_robin", ImmutableMap.<String, Object>of()),
+        null,
+        "edsServiceBar.googleapis.com",
+        "lrsBar.googleapis.com");
+    ResolvedAddresses resolvedAddressesBar = resolvedAddressesCaptor2.getValue();
+    assertThat(resolvedAddressesBar.getLoadBalancingPolicyConfig()).isEqualTo(expectedXdsConfig);
+    assertThat(resolvedAddressesBar.getAttributes().get(XdsAttributes.XDS_CLIENT_REF))
+        .isSameInstanceAs(xdsClientRef);
+    LoadStatsStore loadStatsStore = resolvedAddressesBar.getAttributes()
+        .get(XdsAttributes.LOAD_STATS_STORE_REF);
+    verify(xdsClient).reportClientStats(
+        "bar.googleapis.com", "lrsBar.googleapis.com", loadStatsStore);
+
+    SubchannelPicker picker2 = mock(SubchannelPicker.class);
+    edsLbHelper2.updateBalancingState(ConnectivityState.CONNECTING, picker2);
+    verify(helper, never()).updateBalancingState(ConnectivityState.CONNECTING, picker2);
+    verify(edsLoadBalancer1, never()).shutdown();
+
+    picker2 = mock(SubchannelPicker.class);
+    edsLbHelper2.updateBalancingState(ConnectivityState.READY, picker2);
+    verify(helper).updateBalancingState(ConnectivityState.READY, picker2);
+    verify(edsLoadBalancer1).shutdown();
+
+    cdsLoadBalancer.shutdown();
+    verify(edsLoadBalancer2).shutdown();
+    assertThat(xdsClientRef.xdsClient).isNull();
+  }
+}

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancerTest.java
@@ -261,10 +261,6 @@ public class CdsLoadBalancerTest {
     verify(helper).updateBalancingState(ConnectivityState.READY, picker2);
     verify(edsLoadBalancer1).shutdown();
 
-    cdsLoadBalancer.shutdown();
-    verify(edsLoadBalancer2).shutdown();
-    assertThat(xdsClientRef.xdsClient).isNull();
-
     clusterWatcher2.onClusterChanged(
         ClusterUpdate.newBuilder()
             .setClusterName("bar.googleapis.com")
@@ -285,6 +281,11 @@ public class CdsLoadBalancerTest {
         .get(XdsAttributes.LOAD_STATS_STORE_REF);
     // LoadStatsStore should be reused for the same cluster.
     assertThat(loadStatsStoreBar2).isSameInstanceAs(loadStatsStoreBar);
+
+    cdsLoadBalancer.shutdown();
+    verify(edsLoadBalancer2).shutdown();
+    verify(xdsClient).cancelClusterDataWatch("bar.googleapis.com", clusterWatcher2);
+    assertThat(xdsClientRef.xdsClient).isNull();
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancerTest.java
@@ -216,6 +216,7 @@ public class CdsLoadBalancerTest {
 
     ArgumentCaptor<ClusterWatcher> clusterWatcherCaptor2 = ArgumentCaptor.forClass(null);
     verify(xdsClient).watchClusterData(eq("bar.googleapis.com"), clusterWatcherCaptor2.capture());
+    verify(xdsClient).cancelClusterDataWatch("foo.googleapis.com", clusterWatcher1);
     assertThat(edsLbHelpers).hasSize(1);
     assertThat(edsLoadBalancers).hasSize(1);
     Helper edsLbHelper2 = edsLbHelpers.poll();


### PR DESCRIPTION
- Contains `ClusterWatcher` implementation. On cluster update, `ClusterWatcherImpl` spawns an EDS child balancer if not created, then based on the ClusterUpdate data, it sends an edsConfig to the EDS child balancer.
- `CdsLoadBalancer` reads `XdsClientRef` and `CdsConfig` from `resolvedAddresses`. Base on `resolvedAddresses`, it register a `ClusterWatcherImpl` to `XdsClient`.
- For a different cluster resource name in CdsConfig when `handleResolvedAddresses()`, `CdsLoadBalancer` will gracefully switch to the new cluster.
