### PR TITLE
xds: add APIs for initiating LRS in XdsClient

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -352,4 +352,18 @@ abstract class XdsClient {
    */
   void cancelEndpointDataWatch(String clusterName, EndpointWatcher watcher) {
   }
+
+  /**
+   * Starts reporting client load stats to a remote server for the given cluster.
+   *
+   * @param loadStatsStore  a in-memory data store containing loads recorded by gRPC client.
+   */
+  void reportClientStats(String clusterName, String serverUri, LoadStatsStore loadStatsStore) {
+  }
+
+  /**
+   * Stops reporting client load stats to the remote server for the given cluster.
+   */
+  void cancelClientStatsReport(String clusterName) {
+  }
 }


### PR DESCRIPTION
Prerequisite for integrating LRS in XdsClient. 


[C++'s implementation](https://github.com/grpc/grpc/blob/970f703337ecc19017a737cc4eb831cd50fd0fec/src/core/ext/filters/client_channel/xds/xds_client.h#L104-L107) has similar APIs.