### PR TITLE
xds: do not globally cache results of reading bootstrap file

### DIFF
--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -35,57 +35,34 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
-import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Loads configuration information to bootstrap gRPC's integration of xDS protocol.
  */
-@ThreadSafe
 abstract class Bootstrapper {
 
   private static final String BOOTSTRAP_PATH_SYS_ENV_VAR = "GRPC_XDS_BOOTSTRAP";
 
-  static Bootstrapper newInsatnce() {
-    return new FileBasedBootstrapper();
+  private static final Bootstrapper DEFAULT_INSTANCE = new Bootstrapper() {
+    @Override
+    BootstrapInfo readBootstrap() throws IOException {
+      String filePath = System.getenv(BOOTSTRAP_PATH_SYS_ENV_VAR);
+      if (filePath == null) {
+        throw new IOException("Environment variable " + BOOTSTRAP_PATH_SYS_ENV_VAR + " not found.");
+      }
+      return parseConfig(
+          new String(Files.readAllBytes(Paths.get(filePath)), StandardCharsets.UTF_8));
+    }
+  };
+
+  static Bootstrapper newInstance() {
+    return DEFAULT_INSTANCE;
   }
 
   /**
    * Returns configurations from bootstrap.
    */
   abstract BootstrapInfo readBootstrap() throws Exception;
-
-  private static final class FileBasedBootstrapper extends Bootstrapper {
-
-    private static volatile Exception failToBootstrapException;
-    private static volatile BootstrapInfo bootstrapInfo;
-
-    @Override
-    BootstrapInfo readBootstrap() throws Exception {
-      if (bootstrapInfo == null && failToBootstrapException == null) {
-        synchronized (FileBasedBootstrapper.class) {
-          if (bootstrapInfo == null && failToBootstrapException == null) {
-            try {
-              String filePath = System.getenv(BOOTSTRAP_PATH_SYS_ENV_VAR);
-              if (filePath == null) {
-                throw
-                    new IOException("Environment variable " + BOOTSTRAP_PATH_SYS_ENV_VAR
-                        + " not found.");
-              }
-              bootstrapInfo =
-                  parseConfig(new String(Files.readAllBytes(Paths.get(filePath)),
-                      StandardCharsets.UTF_8));
-            } catch (Exception e) {
-              failToBootstrapException = e;
-            }
-          }
-        }
-      }
-      if (failToBootstrapException != null) {
-        throw new IOException(failToBootstrapException);
-      }
-      return bootstrapInfo;
-    }
-  }
 
   @VisibleForTesting
   static BootstrapInfo parseConfig(String rawData) throws IOException {

--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -55,7 +55,7 @@ abstract class Bootstrapper {
     }
   };
 
-  static Bootstrapper newInstance() {
+  static Bootstrapper getInstance() {
     return DEFAULT_INSTANCE;
   }
 

--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -48,7 +48,8 @@ abstract class Bootstrapper {
     BootstrapInfo readBootstrap() throws IOException {
       String filePath = System.getenv(BOOTSTRAP_PATH_SYS_ENV_VAR);
       if (filePath == null) {
-        throw new IOException("Environment variable " + BOOTSTRAP_PATH_SYS_ENV_VAR + " not found.");
+        throw
+            new IOException("Environment variable " + BOOTSTRAP_PATH_SYS_ENV_VAR + " not defined.");
       }
       return parseConfig(
           new String(Files.readAllBytes(Paths.get(filePath)), StandardCharsets.UTF_8));

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -34,7 +34,6 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 
 /**
  * A {@link NameResolver} for resolving gRPC target names with "xds-experimental" scheme.
@@ -60,9 +59,6 @@ final class XdsNameResolver extends NameResolver {
   private final String authority;
   private final Bootstrapper bootstrapper;
 
-  @Nullable
-  private BootstrapInfo bootstrapInfo;
-
   XdsNameResolver(String name) {
     this(name, Bootstrapper.getInstance());
   }
@@ -85,13 +81,12 @@ final class XdsNameResolver extends NameResolver {
   @SuppressWarnings("unchecked")
   @Override
   public void start(final Listener2 listener) {
-    if (bootstrapInfo == null) {
-      try {
-        bootstrapInfo = bootstrapper.readBootstrap();
-      } catch (Exception e) {
-        listener.onError(Status.UNAVAILABLE.withDescription("Failed to bootstrap").withCause(e));
-        return;
-      }
+    BootstrapInfo bootstrapInfo = null;
+    try {
+      bootstrapInfo = bootstrapper.readBootstrap();
+    } catch (Exception e) {
+      listener.onError(Status.UNAVAILABLE.withDescription("Failed to bootstrap").withCause(e));
+      return;
     }
 
     String serviceConfig = "{"

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -64,7 +64,7 @@ final class XdsNameResolver extends NameResolver {
   private BootstrapInfo bootstrapInfo;
 
   XdsNameResolver(String name) {
-    this(name, Bootstrapper.newInstance());
+    this(name, Bootstrapper.getInstance());
   }
 
   @VisibleForTesting

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -102,73 +102,6 @@ public class XdsNameResolverTest {
     }
   }
 
-  /**
-   * Each resolver explicitly triggers reading bootstrap configurations.
-   */
-  @Test
-  public void eachResolverReadsBootstrapSeparately() {
-    final ChannelCreds loasCreds = new ChannelCreds("loas2", null);
-    final ChannelCreds googleDefaultCreds = new ChannelCreds("google_default", null);
-    Bootstrapper bootstrapper1 = new Bootstrapper() {
-      @Override
-      BootstrapInfo readBootstrap() throws Exception {
-        return new BootstrapInfo("trafficdirector-foo.googleapis.com",
-            ImmutableList.of(googleDefaultCreds), FAKE_BOOTSTRAP_NODE);
-      }
-    };
-    Bootstrapper bootstrapper2 = new Bootstrapper() {
-      @Override
-      BootstrapInfo readBootstrap() throws Exception {
-        return new BootstrapInfo("trafficdirector-bar.googleapis.com",
-            ImmutableList.of(loasCreds), FAKE_BOOTSTRAP_NODE);
-      }
-    };
-
-    XdsNameResolver resolver1 = new XdsNameResolver("service-foo.googleapis.com", bootstrapper1);
-    XdsNameResolver resolver2 = new XdsNameResolver("service-bar.googleapis.com", bootstrapper2);
-    NameResolver.Listener2 listener1 = mock(NameResolver.Listener2.class);
-    NameResolver.Listener2 listener2 = mock(NameResolver.Listener2.class);
-    ArgumentCaptor<ResolutionResult> resultCaptor = ArgumentCaptor.forClass(null);
-
-    resolver1.start(listener1);
-    verify(listener1).onResult(resultCaptor.capture());
-    ResolutionResult result1 = resultCaptor.getValue();
-    assertThat(result1.getAddresses()).isEmpty();
-    Map<String, ?> serviceConfig1 =
-        result1.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
-    Map<String, ?> xdsLbConfig1 = extractXdsLoadBalancingConfigFromServiceConfig(serviceConfig1);
-    assertThat(xdsLbConfig1)
-        .containsExactly(
-            "balancerName",
-            "trafficdirector-foo.googleapis.com",
-            "childPolicy",
-            Collections.singletonList(
-                Collections.singletonMap("round_robin", Collections.EMPTY_MAP)));
-    assertThat(result1.getAttributes().get(XdsNameResolver.XDS_NODE))
-        .isEqualTo(FAKE_BOOTSTRAP_NODE);
-    assertThat(result1.getAttributes().get(XdsNameResolver.XDS_CHANNEL_CREDS_LIST))
-        .containsExactly(googleDefaultCreds);
-
-    resolver2.start(listener2);
-    verify(listener2).onResult(resultCaptor.capture());
-    ResolutionResult result2 = resultCaptor.getValue();
-    assertThat(result2.getAddresses()).isEmpty();
-    Map<String, ?> serviceConfig2 =
-        result2.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
-    Map<String, ?> xdsLbConfig2 = extractXdsLoadBalancingConfigFromServiceConfig(serviceConfig2);
-    assertThat(xdsLbConfig2)
-        .containsExactly(
-            "balancerName",
-            "trafficdirector-bar.googleapis.com",
-            "childPolicy",
-            Collections.singletonList(
-                Collections.singletonMap("round_robin", Collections.EMPTY_MAP)));
-    assertThat(result2.getAttributes().get(XdsNameResolver.XDS_NODE))
-        .isEqualTo(FAKE_BOOTSTRAP_NODE);
-    assertThat(result2.getAttributes().get(XdsNameResolver.XDS_CHANNEL_CREDS_LIST))
-        .containsExactly(loasCreds);
-  }
-
   @Test
   public void resolve_bootstrapResult() {
     final ChannelCreds loasCreds = new ChannelCreds("loas2", null);
@@ -189,7 +122,13 @@ public class XdsNameResolverTest {
 
     Map<String, ?> serviceConfig =
         result.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
-    Map<String, ?> rawConfigValues = extractXdsLoadBalancingConfigFromServiceConfig(serviceConfig);
+    @SuppressWarnings("unchecked")
+    List<Map<String, ?>> rawLbConfigs =
+        (List<Map<String, ?>>) serviceConfig.get("loadBalancingConfig");
+    Map<String, ?> xdsLbConfig = Iterables.getOnlyElement(rawLbConfigs);
+    assertThat(xdsLbConfig.keySet()).containsExactly("xds_experimental");
+    @SuppressWarnings("unchecked")
+    Map<String, ?> rawConfigValues = (Map<String, ?>) xdsLbConfig.get("xds_experimental");
     assertThat(rawConfigValues)
         .containsExactly(
             "balancerName",
@@ -219,16 +158,5 @@ public class XdsNameResolverTest {
     assertThat(error.getCode()).isEqualTo(Code.UNAVAILABLE);
     assertThat(error.getDescription()).isEqualTo("Failed to bootstrap");
     assertThat(error.getCause()).hasMessageThat().isEqualTo("Fail to read bootstrap file");
-  }
-
-  @SuppressWarnings("unchecked")
-  private static Map<String, ?> extractXdsLoadBalancingConfigFromServiceConfig(
-      Map<String, ?> serviceConfig) {
-    List<Map<String, ?>> rawLbConfigs =
-        (List<Map<String, ?>>) serviceConfig.get("loadBalancingConfig");
-    Map<String, ?> xdsLbConfig = Iterables.getOnlyElement(rawLbConfigs);
-    assertThat(xdsLbConfig.keySet()).containsExactly("xds_experimental");
-
-    return (Map<String, ?>) xdsLbConfig.get("xds_experimental");
   }
 }

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -167,7 +167,6 @@ public class XdsNameResolverTest {
         .isEqualTo(FAKE_BOOTSTRAP_NODE);
     assertThat(result2.getAttributes().get(XdsNameResolver.XDS_CHANNEL_CREDS_LIST))
         .containsExactly(loasCreds);
-
   }
 
   @Test


### PR DESCRIPTION
Each channel should trigger reading bootstrap file separately, instead of reading it once per JVM. It's not required to cache results of reading bootstrap file. 