### PR TITLE
Upgrade to protobuf lite 3.10

### DIFF
--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -41,14 +41,15 @@ android {
 protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.10.0' }
     plugins {
-        javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.26.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
         all().each { task ->
+            task.builtins {
+              java { option 'lite' }
+            }
             task.plugins {
-                javalite {}
                 grpc {
                     // Options added to --grpc_out
                     option 'lite'
@@ -76,9 +77,6 @@ dependencies {
     implementation 'io.grpc:grpc-protobuf-lite:1.26.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'io.grpc:grpc-stub:1.26.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'io.grpc:grpc-testing:1.26.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-
-    // workaround for https://github.com/google/protobuf/issues/1889
-    protobuf 'com.google.protobuf:protobuf-java:3.0.2'
 
     androidTestImplementation 'androidx.test:rules:1.1.0-alpha1'
     androidTestImplementation 'androidx.test:runner:1.1.0-alpha1'

--- a/build.gradle
+++ b/build.gradle
@@ -105,11 +105,6 @@ subprojects {
             }
 
             tasks.withType(JavaCompile) {
-                // Protobuf-generated code produces some warnings.
-                // https://github.com/google/protobuf/issues/2718
-                it.options.compilerArgs += [
-                    "-Xlint:-cast",
-                ]
                 it.options.errorprone.excludedPaths = ".*/src/generated/[^/]+/java/.*" +
                         "|.*/build/generated/source/proto/[^/]+/java/.*"
             }

--- a/build.gradle
+++ b/build.gradle
@@ -137,8 +137,7 @@ subprojects {
             perfmark: 'io.perfmark:perfmark-api:0.19.0',
             pgv: 'io.envoyproxy.protoc-gen-validate:pgv-java-stub:0.2.0',
             protobuf: "com.google.protobuf:protobuf-java:${protobufVersion}",
-            protobuf_lite: "com.google.protobuf:protobuf-lite:3.0.1",
-            protoc_lite: "com.google.protobuf:protoc-gen-javalite:3.0.0",
+            protobuf_lite: "com.google.protobuf:protobuf-javalite:${protobufVersion}",
             protobuf_util: "com.google.protobuf:protobuf-java-util:${protobufVersion}",
             lang: "org.apache.commons:commons-lang3:3.5",
 

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -147,12 +147,6 @@ compileTestJava {
 
 compileTestLiteJava {
     options.compilerArgs = compileTestJava.options.compilerArgs
-    // Protobuf-generated Lite produces quite a few warnings.
-    options.compilerArgs += [
-        "-Xlint:-rawtypes",
-        "-Xlint:-unchecked",
-        "-Xlint:-fallthrough"
-    ]
     options.errorprone.excludedPaths = ".*/build/generated/source/proto/.*"
 }
 
@@ -165,13 +159,6 @@ protobuf {
         }
     }
     plugins {
-        javalite {
-            if (project.hasProperty('protoc-gen-javalite')) {
-                path = project['protoc-gen-javalite']
-            } else {
-                artifact = libraries.protoc_lite
-            }
-        }
         grpc { path = javaPluginPath }
     }
     generateProtoTasks {
@@ -181,9 +168,10 @@ protobuf {
         }
         ofSourceSet('test')*.plugins { grpc {} }
         ofSourceSet('testLite')*.each { task ->
-            task.builtins { remove java }
+            task.builtins {
+                java { option 'lite' }
+            }
             task.plugins {
-                javalite {}
                 grpc { option 'lite' }
             }
         }

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -139,9 +139,6 @@ sourceSets {
 }
 
 compileTestJava {
-    options.compilerArgs += [
-        "-Xlint:-cast"
-    ]
     options.errorprone.excludedPaths = ".*/build/generated/source/proto/.*"
 }
 

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -144,6 +144,9 @@ compileTestJava {
 
 compileTestLiteJava {
     options.compilerArgs = compileTestJava.options.compilerArgs
+    options.compilerArgs += [
+        "-Xlint:-cast"
+    ]
     options.errorprone.excludedPaths = ".*/build/generated/source/proto/.*"
 }
 

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -28,16 +28,17 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.4.0' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.10.0' }
     plugins {
-        javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.26.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
         all().each { task ->
+            task.builtins {
+                java { option 'lite' }
+            }
             task.plugins {
-                javalite {}
                 grpc { // Options added to --grpc_out
                     option 'lite' }
             }

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -29,14 +29,15 @@ android {
 protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.10.0' }
     plugins {
-        javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.26.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
         all().each { task ->
+            task.builtins {
+                java { option 'lite' }
+            }
             task.plugins {
-                javalite {}
                 grpc { // Options added to --grpc_out
                     option 'lite' }
             }

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -28,14 +28,15 @@ android {
 protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.10.0' }
     plugins {
-        javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.26.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
         all().each { task ->
+            task.builtins {
+                java { option 'lite' }
+            }
             task.plugins {
-                javalite {}
                 grpc { // Options added to --grpc_out
                     option 'lite' }
             }

--- a/examples/android/strictmode/app/build.gradle
+++ b/examples/android/strictmode/app/build.gradle
@@ -29,14 +29,15 @@ android {
 protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.10.0' }
     plugins {
-        javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.26.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
         all().each { task ->
+            task.builtins {
+                java { option 'lite' }
+            }
             task.plugins {
-                javalite {}
                 grpc { // Options added to --grpc_out
                     option 'lite' }
             }

--- a/examples/example-kotlin/android/helloworld/app/build.gradle
+++ b/examples/example-kotlin/android/helloworld/app/build.gradle
@@ -51,14 +51,15 @@ android {
 protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.10.0' }
     plugins {
-        javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.26.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
         all().each { task ->
+            task.builtins {
+                java { option 'lite' }
+            }
             task.plugins {
-                javalite {}
                 grpc { // Options added to --grpc_out
                     option 'lite' }
             }

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -28,6 +28,9 @@ dependencies {
 }
 
 compileTestJava {
+    options.compilerArgs += [
+        "-Xlint:-cast"
+    ]
     options.errorprone.excludedPaths = ".*/build/generated/source/proto/.*"
 }
 

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -29,11 +29,8 @@ dependencies {
 }
 
 compileTestJava {
-    // Protobuf-generated Lite produces quite a few warnings.
     options.compilerArgs += [
-        "-Xlint:-rawtypes",
-        "-Xlint:-unchecked",
-        "-Xlint:-fallthrough"
+        "-Xlint:-cast"
     ]
     options.errorprone.excludedPaths = ".*/build/generated/source/proto/.*"
 }
@@ -46,19 +43,11 @@ protobuf {
             artifact = "com.google.protobuf:protoc:${protocVersion}"
         }
     }
-    plugins {
-        javalite {
-            if (project.hasProperty('protoc-gen-javalite')) {
-                path = project['protoc-gen-javalite']
-            } else {
-                artifact = libraries.protoc_lite
-            }
-        }
-    }
     generateProtoTasks {
         ofSourceSet('test')*.each { task ->
-            task.builtins { remove java }
-            task.plugins { javalite {} }
+            task.builtins {
+                java { option 'lite' }
+            }
         }
     }
 }

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -22,16 +22,12 @@ dependencies {
     }
 
     testCompile project(':grpc-core')
-    testProtobuf libraries.protobuf
 
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }
 
 compileTestJava {
-    options.compilerArgs += [
-        "-Xlint:-cast"
-    ]
     options.errorprone.excludedPaths = ".*/build/generated/source/proto/.*"
 }
 


### PR DESCRIPTION
This finally brings lite into version number sync with full proto.

-----

This was a change I made in September for proto 3.9. We have since upgraded to 3.10 and the commit message was no longer correct, but it seems the code didn't need to change at all. (You can see my branch name is lite-3.9 :-) )

Fixes #6405 

CC @liusheng, @kiwik, @rafi-kamal, @bubenheimer

See also protocolbuffers/protobuf#6867