### PR TITLE
xds: refactor xds policy to use XdsClient

### DIFF
--- a/xds/src/main/java/io/grpc/xds/LookasideChannelLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideChannelLb.java
@@ -16,21 +16,13 @@
 
 package io.grpc.xds;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment;
-import io.envoyproxy.envoy.api.v2.core.Node;
 import io.grpc.LoadBalancer;
-import io.grpc.ManagedChannel;
 import io.grpc.Status;
-import io.grpc.internal.ExponentialBackoffPolicy;
-import io.grpc.internal.GrpcUtil;
 import io.grpc.xds.EnvoyProtoData.DropOverload;
-import io.grpc.xds.EnvoyProtoData.Locality;
-import io.grpc.xds.EnvoyProtoData.LocalityLbEndpoints;
 import io.grpc.xds.LoadReportClient.LoadReportCallback;
-import io.grpc.xds.XdsComms2.AdsStreamCallback;
+import io.grpc.xds.XdsClient.EndpointUpdate;
+import io.grpc.xds.XdsClient.EndpointWatcher;
 import java.util.List;
 
 /**
@@ -40,33 +32,16 @@ import java.util.List;
  */
 final class LookasideChannelLb extends LoadBalancer {
 
-  private final ManagedChannel lbChannel;
   private final LoadReportClient lrsClient;
-  private final XdsComms2 xdsComms2;
+  private final XdsClient xdsClient;
 
   LookasideChannelLb(
-      Helper helper, LookasideChannelCallback lookasideChannelCallback, ManagedChannel lbChannel,
-      LocalityStore localityStore, Node node) {
-    this(
-        helper,
-        lookasideChannelCallback,
-        lbChannel,
-        new LoadReportClientImpl(
-            lbChannel, helper, GrpcUtil.STOPWATCH_SUPPLIER, new ExponentialBackoffPolicy.Provider(),
-            localityStore.getLoadStatsStore()),
-        localityStore,
-        node);
-  }
-
-  @VisibleForTesting
-  LookasideChannelLb(
-      Helper helper,
+      String edsServiceName,
       LookasideChannelCallback lookasideChannelCallback,
-      ManagedChannel lbChannel,
+      XdsClient xdsClient,
       LoadReportClient lrsClient,
-      final LocalityStore localityStore,
-      Node node) {
-    this.lbChannel = lbChannel;
+      final LocalityStore localityStore) {
+    this.xdsClient = xdsClient;
     LoadReportCallback lrsCallback =
         new LoadReportCallback() {
           @Override
@@ -76,11 +51,9 @@ final class LookasideChannelLb extends LoadBalancer {
         };
     this.lrsClient = lrsClient;
 
-    AdsStreamCallback adsCallback = new AdsStreamCallbackImpl(
+    XdsClient.EndpointWatcher endpointWatcher = new EndpointWatcherImpl(
         lookasideChannelCallback, lrsClient, lrsCallback, localityStore) ;
-    xdsComms2 = new XdsComms2(
-        lbChannel, helper, adsCallback, new ExponentialBackoffPolicy.Provider(),
-        GrpcUtil.STOPWATCH_SUPPLIER, node);
+    xdsClient.watchEndpointData(edsServiceName, endpointWatcher);
   }
 
   @Override
@@ -91,11 +64,10 @@ final class LookasideChannelLb extends LoadBalancer {
   @Override
   public void shutdown() {
     lrsClient.stopLoadReporting();
-    xdsComms2.shutdownLbRpc();
-    lbChannel.shutdown();
+    xdsClient.shutdown();
   }
 
-  private static final class AdsStreamCallbackImpl implements AdsStreamCallback {
+  private static final class EndpointWatcherImpl implements EndpointWatcher {
 
     final LookasideChannelCallback lookasideChannelCallback;
     final LoadReportClient lrsClient;
@@ -103,7 +75,7 @@ final class LookasideChannelLb extends LoadBalancer {
     final LocalityStore localityStore;
     boolean firstEdsResponseReceived;
 
-    AdsStreamCallbackImpl(
+    EndpointWatcherImpl(
         LookasideChannelCallback lookasideChannelCallback, LoadReportClient lrsClient,
         LoadReportCallback lrsCallback, LocalityStore localityStore) {
       this.lookasideChannelCallback = lookasideChannelCallback;
@@ -113,47 +85,28 @@ final class LookasideChannelLb extends LoadBalancer {
     }
 
     @Override
-    public void onEdsResponse(ClusterLoadAssignment clusterLoadAssignment) {
+    public void onEndpointChanged(EndpointUpdate endpointUpdate) {
       if (!firstEdsResponseReceived) {
         firstEdsResponseReceived = true;
         lookasideChannelCallback.onWorking();
         lrsClient.startLoadReporting(lrsCallback);
       }
 
-      List<ClusterLoadAssignment.Policy.DropOverload> dropOverloadsProto =
-          clusterLoadAssignment.getPolicy().getDropOverloadsList();
+      List<DropOverload> dropOverloads = endpointUpdate.getDropPolicies();
       ImmutableList.Builder<DropOverload> dropOverloadsBuilder = ImmutableList.builder();
-      for (ClusterLoadAssignment.Policy.DropOverload drop : dropOverloadsProto) {
-        DropOverload dropOverload = DropOverload.fromEnvoyProtoDropOverload(drop);
+      for (DropOverload dropOverload : dropOverloads) {
         dropOverloadsBuilder.add(dropOverload);
         if (dropOverload.getDropsPerMillion() == 1_000_000) {
           lookasideChannelCallback.onAllDrop();
           break;
         }
       }
-      ImmutableList<DropOverload> dropOverloads = dropOverloadsBuilder.build();
-      localityStore.updateDropPercentage(dropOverloads);
-
-      List<io.envoyproxy.envoy.api.v2.endpoint.LocalityLbEndpoints> localities =
-          clusterLoadAssignment.getEndpointsList();
-      ImmutableMap.Builder<Locality, LocalityLbEndpoints> localityEndpointsMapping =
-          new ImmutableMap.Builder<>();
-      for (io.envoyproxy.envoy.api.v2.endpoint.LocalityLbEndpoints localityLbEndpoints
-          : localities) {
-        Locality locality = Locality.fromEnvoyProtoLocality(localityLbEndpoints.getLocality());
-        int localityWeight = localityLbEndpoints.getLoadBalancingWeight().getValue();
-
-        if (localityWeight != 0) {
-          localityEndpointsMapping.put(
-              locality, LocalityLbEndpoints.fromEnvoyProtoLocalityLbEndpoints(localityLbEndpoints));
-        }
-      }
-
-      localityStore.updateLocalityStore(localityEndpointsMapping.build());
+      localityStore.updateDropPercentage(dropOverloadsBuilder.build());
+      localityStore.updateLocalityStore(endpointUpdate.getLocalityLbEndpointsMap());
     }
 
     @Override
-    public void onError() {
+    public void onError(Status error) {
       lookasideChannelCallback.onError();
     }
   }

--- a/xds/src/main/java/io/grpc/xds/LookasideChannelLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideChannelLb.java
@@ -55,7 +55,7 @@ final class LookasideChannelLb extends LoadBalancer {
         };
     this.lrsClient = lrsClient;
 
-    XdsClient.EndpointWatcher endpointWatcher = new EndpointWatcherImpl(
+    EndpointWatcher endpointWatcher = new EndpointWatcherImpl(
         lookasideChannelCallback, lrsClient, lrsCallback, localityStore) ;
     xdsClient.watchEndpointData(edsServiceName, endpointWatcher);
   }

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -95,7 +95,7 @@ final class LookasideLb extends ForwardingLoadBalancer {
 
     String newBalancerName = xdsConfig.balancerName;
 
-    // Legacy path.
+    // The is to handle the legacy usecase that requires balancerName from xds config.
     if (!newBalancerName.equals(balancerName)) {
       balancerName = newBalancerName; // cache the name and check next time for optimization
       Node node = resolvedAddresses.getAttributes().get(XDS_NODE);
@@ -116,7 +116,6 @@ final class LookasideLb extends ForwardingLoadBalancer {
           newBalancerName, node, channelCredsList));
     }
 
-    // New path.
     if (newBalancerName == null) {
       // TODO(zdapeng): load XdsClient from Attributes. If null create XdsClient from bootstrap
       // lookasideChannelLb = new LookasideChannelLb(

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -116,12 +116,6 @@ final class LookasideLb extends ForwardingLoadBalancer {
           newBalancerName, node, channelCredsList));
     }
 
-    if (newBalancerName == null) {
-      // TODO(zdapeng): load XdsClient from Attributes. If null create XdsClient from bootstrap
-      // lookasideChannelLb = new LookasideChannelLb(
-      //     edsServiceName, lookasideChannelCallback, xdsClient, localityStore);
-    }
-
     lookasideChannelLb.handleResolvedAddresses(resolvedAddresses);
   }
 

--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
@@ -229,6 +230,25 @@ abstract class XdsClient {
      */
     List<DropOverload> getDropPolicies() {
       return Collections.unmodifiableList(dropPolicies);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      EndpointUpdate that = (EndpointUpdate) o;
+      return clusterName.equals(that.clusterName)
+          && localityLbEndpointsMap.equals(that.localityLbEndpointsMap)
+          && dropPolicies.equals(that.dropPolicies);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(clusterName, localityLbEndpointsMap, dropPolicies);
     }
 
     static final class Builder {

--- a/xds/src/main/java/io/grpc/xds/XdsComms2.java
+++ b/xds/src/main/java/io/grpc/xds/XdsComms2.java
@@ -255,7 +255,9 @@ final class XdsComms2 extends XdsClient {
 
   @Override
   void shutdown() {
-    adsStream.cancelRpc("shutdown", null);
+    if (adsStream != null) {
+      adsStream.cancelRpc("shutdown", null);
+    }
     cancelRetryTimer();
     channel.shutdown();
   }

--- a/xds/src/main/java/io/grpc/xds/XdsComms2.java
+++ b/xds/src/main/java/io/grpc/xds/XdsComms2.java
@@ -23,9 +23,11 @@ import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment;
+import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment.Policy.DropOverload;
 import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
 import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
 import io.envoyproxy.envoy.api.v2.core.Node;
+import io.envoyproxy.envoy.api.v2.endpoint.LocalityLbEndpoints;
 import io.envoyproxy.envoy.service.discovery.v2.AggregatedDiscoveryServiceGrpc;
 import io.grpc.ChannelLogger.ChannelLogLevel;
 import io.grpc.LoadBalancer.Helper;
@@ -42,7 +44,7 @@ import javax.annotation.CheckForNull;
  */
 // TODO(zdapeng): This is a temporary and easy refactor of XdsComms, will be replaced by XdsClient.
 // Tests are deferred in XdsClientTest, otherwise it's just a refactor of XdsCommsTest.
-final class XdsComms2 {
+final class XdsComms2 extends XdsClient {
   private final ManagedChannel channel;
   private final Helper helper;
   private final BackoffPolicy.Provider backoffPolicyProvider;
@@ -62,7 +64,7 @@ final class XdsComms2 {
     static final String EDS_TYPE_URL =
         "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment";
 
-    final AdsStreamCallback adsStreamCallback;
+    final XdsClient.EndpointWatcher endpointWatcher;
     final StreamObserver<DiscoveryRequest> xdsRequestWriter;
     final Stopwatch retryStopwatch = stopwatchSupplier.get().start();
 
@@ -89,7 +91,7 @@ final class XdsComms2 {
                         value.getResources(0).unpack(ClusterLoadAssignment.class);
                   } catch (InvalidProtocolBufferException | RuntimeException e) {
                     cancelRpc("Received invalid EDS response", e);
-                    adsStreamCallback.onError();
+                    endpointWatcher.onError(Status.fromThrowable(e));
                     scheduleRetry();
                     return;
                   }
@@ -98,7 +100,26 @@ final class XdsComms2 {
                       ChannelLogLevel.DEBUG,
                       "Received an EDS response: {0}", clusterLoadAssignment);
                   firstEdsResponseReceived = true;
-                  adsStreamCallback.onEdsResponse(clusterLoadAssignment);
+                  EndpointUpdate.Builder endpointUpdateBuilder = EndpointUpdate.newBuilder();
+                  endpointUpdateBuilder.setClusterName(clusterLoadAssignment.getClusterName());
+                  for (DropOverload dropOverload :
+                      clusterLoadAssignment.getPolicy().getDropOverloadsList()) {
+                    endpointUpdateBuilder.addDropPolicy(
+                        EnvoyProtoData.DropOverload.fromEnvoyProtoDropOverload(dropOverload));
+                  }
+                  for (LocalityLbEndpoints localityLbEndpoints :
+                      clusterLoadAssignment.getEndpointsList()) {
+                    if (localityLbEndpoints.getLoadBalancingWeight().getValue() == 0) {
+                      continue;
+                    }
+                    endpointUpdateBuilder.addLocalityLbEndpoints(
+                        EnvoyProtoData.Locality.fromEnvoyProtoLocality(
+                            localityLbEndpoints.getLocality()),
+                        EnvoyProtoData.LocalityLbEndpoints.fromEnvoyProtoLocalityLbEndpoints(
+                            localityLbEndpoints));
+
+                  }
+                  endpointWatcher.onEndpointChanged(endpointUpdateBuilder.build());
                 }
               }
             }
@@ -107,7 +128,7 @@ final class XdsComms2 {
           }
 
           @Override
-          public void onError(Throwable t) {
+          public void onError(final Throwable t) {
             helper.getSynchronizationContext().execute(
                 new Runnable() {
                   @Override
@@ -116,7 +137,7 @@ final class XdsComms2 {
                     if (cancelled) {
                       return;
                     }
-                    adsStreamCallback.onError();
+                    endpointWatcher.onError(Status.fromThrowable(t));
                     scheduleRetry();
                   }
                 });
@@ -124,7 +145,7 @@ final class XdsComms2 {
 
           @Override
           public void onCompleted() {
-            onError(Status.INTERNAL.withDescription("Server closed the ADS streaming RPC")
+            onError(Status.UNAVAILABLE.withDescription("Server closed the ADS streaming RPC")
                 .asException());
           }
 
@@ -168,8 +189,8 @@ final class XdsComms2 {
     boolean cancelled;
     boolean closed;
 
-    AdsStream(AdsStreamCallback adsStreamCallback) {
-      this.adsStreamCallback = adsStreamCallback;
+    AdsStream(XdsClient.EndpointWatcher endpointWatcher) {
+      this.endpointWatcher = endpointWatcher;
       this.xdsRequestWriter = AggregatedDiscoveryServiceGrpc.newStub(channel).withWaitForReady()
           .streamAggregatedResources(xdsResponseReader);
 
@@ -186,7 +207,7 @@ final class XdsComms2 {
     }
 
     AdsStream(AdsStream adsStream) {
-      this(adsStream.adsStreamCallback);
+      this(adsStream.endpointWatcher);
     }
 
     // run in SynchronizationContext
@@ -204,15 +225,13 @@ final class XdsComms2 {
    * Starts a new ADS streaming RPC.
    */
   XdsComms2(
-      ManagedChannel channel, Helper helper, AdsStreamCallback adsStreamCallback,
+      ManagedChannel channel, Helper helper,
       BackoffPolicy.Provider backoffPolicyProvider, Supplier<Stopwatch> stopwatchSupplier,
       Node node) {
     this.channel = checkNotNull(channel, "channel");
     this.helper = checkNotNull(helper, "helper");
     this.stopwatchSupplier = checkNotNull(stopwatchSupplier, "stopwatchSupplier");
     this.node = node;
-    this.adsStream = new AdsStream(
-        checkNotNull(adsStreamCallback, "adsStreamCallback"));
     this.backoffPolicyProvider = checkNotNull(backoffPolicyProvider, "backoffPolicyProvider");
     this.adsRpcRetryPolicy = backoffPolicyProvider.get();
   }
@@ -227,12 +246,18 @@ final class XdsComms2 {
     }
   }
 
-  // run in SynchronizationContext
-  // TODO: Change method name to shutdown or shutdownXdsComms if that gives better semantics (
-  //  cancel LB RPC and clean up retry timer).
-  void shutdownLbRpc() {
+  @Override
+  void watchEndpointData(String clusterName, EndpointWatcher watcher) {
+    if (adsStream == null) {
+      adsStream = new AdsStream(watcher);
+    }
+  }
+
+  @Override
+  void shutdown() {
     adsStream.cancelRpc("shutdown", null);
     cancelRetryTimer();
+    channel.shutdown();
   }
 
   // run in SynchronizationContext
@@ -241,15 +266,5 @@ final class XdsComms2 {
       adsRpcRetryTimer.cancel();
       adsRpcRetryTimer = null;
     }
-  }
-
-  /**
-   * Callback on ADS stream events. The callback methods should be called in a proper {@link
-   * io.grpc.SynchronizationContext}.
-   */
-  interface AdsStreamCallback {
-    void onEdsResponse(ClusterLoadAssignment clusterLoadAssignment);
-
-    void onError();
   }
 }

--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancerProvider.java
@@ -16,8 +16,6 @@
 
 package io.grpc.xds;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
@@ -133,6 +131,7 @@ public final class XdsLoadBalancerProvider extends LoadBalancerProvider {
    */
   static final class XdsConfig {
     // TODO(chengyuanzhang): delete after shifting to use bootstrap.
+    @Nullable
     final String balancerName;
     // TODO(carl-mastrangelo): make these Object's containing the fully parsed child configs.
     @Nullable
@@ -150,9 +149,10 @@ public final class XdsLoadBalancerProvider extends LoadBalancerProvider {
     final String lrsServerName;
 
     XdsConfig(
-        String balancerName, @Nullable LbConfig childPolicy, @Nullable LbConfig fallbackPolicy,
-        @Nullable String edsServiceName, @Nullable String lrsServerName) {
-      this.balancerName = checkNotNull(balancerName, "balancerName");
+        @Nullable String balancerName, @Nullable LbConfig childPolicy,
+        @Nullable LbConfig fallbackPolicy, @Nullable String edsServiceName,
+        @Nullable String lrsServerName) {
+      this.balancerName = balancerName;
       this.childPolicy = childPolicy;
       this.fallbackPolicy = fallbackPolicy;
       this.edsServiceName = edsServiceName;

--- a/xds/src/test/java/io/grpc/xds/LookasideChannelLbTest.java
+++ b/xds/src/test/java/io/grpc/xds/LookasideChannelLbTest.java
@@ -51,6 +51,8 @@ import io.grpc.Status;
 import io.grpc.SynchronizationContext;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.internal.ExponentialBackoffPolicy;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.testing.StreamRecorder;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
@@ -168,9 +170,11 @@ public class LookasideChannelLbTest {
     doReturn(mock(ChannelLogger.class)).when(helper).getChannelLogger();
     doReturn(loadStatsStore).when(localityStore).getLoadStatsStore();
 
+    XdsClient xdsClient = new XdsComms2(
+        channel, helper, new ExponentialBackoffPolicy.Provider(),
+        GrpcUtil.STOPWATCH_SUPPLIER, Node.getDefaultInstance());
     lookasideChannelLb = new LookasideChannelLb(
-        helper, lookasideChannelCallback, channel, loadReportClient, localityStore,
-        Node.getDefaultInstance());
+        "cluster1", lookasideChannelCallback, xdsClient, loadReportClient, localityStore);
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/XdsCommsTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsCommsTest.java
@@ -278,7 +278,7 @@ public class XdsCommsTest {
     responseWriter.onNext(edsResponse);
 
     verify(endpointWatcher).onEndpointChanged(
-        endPointUpdatefromClusterAssignment(clusterLoadAssignment));
+        endpointUpdatefromClusterAssignment(clusterLoadAssignment));
 
     ClusterLoadAssignment clusterLoadAssignment2 = ClusterLoadAssignment.newBuilder()
         .addEndpoints(LocalityLbEndpoints.newBuilder()
@@ -299,7 +299,7 @@ public class XdsCommsTest {
     responseWriter.onNext(edsResponse);
 
     verify(endpointWatcher).onEndpointChanged(
-        endPointUpdatefromClusterAssignment(clusterLoadAssignment2));
+        endpointUpdatefromClusterAssignment(clusterLoadAssignment2));
     verifyNoMoreInteractions(endpointWatcher);
 
     xdsComms.shutdown();
@@ -502,7 +502,7 @@ public class XdsCommsTest {
     xdsComms.shutdown();
   }
 
-  private static XdsClient.EndpointUpdate endPointUpdatefromClusterAssignment(
+  private static XdsClient.EndpointUpdate endpointUpdatefromClusterAssignment(
       ClusterLoadAssignment clusterLoadAssignment) {
     EndpointUpdate.Builder endpointUpdateBuilder = EndpointUpdate.newBuilder();
     endpointUpdateBuilder.setClusterName(clusterLoadAssignment.getClusterName());


### PR DESCRIPTION
This is a refactor of the existing xds policy to use XdsClient. It does neither create a copy of EDS policy as in #6371 nor re-implement an EDS policy. This should be similar to the idea of https://github.com/grpc/grpc/pull/20368 in C-core. 

Here it refactors `XdsComms2` to an implementation of `XdsClient`, which can be drop-in replaced by `XdsClientImp` when it's available.

I will add handling `XdsClientRef` in Attributes of `ResolvedAddresses` in after this refactor PR.