### PR TITLE
api, core: make channel logger accessible through NameResolver.Args

### DIFF
--- a/api/src/main/java/io/grpc/NameResolver.java
+++ b/api/src/main/java/io/grpc/NameResolver.java
@@ -474,6 +474,7 @@ public abstract class NameResolver {
      *
      * @since 1.26.0
      */
+    @ExperimentalApi("https://github.com/grpc/grpc-java/issues/6438")
     public ChannelLogger getChannelLogger() {
       if (channelLogger == null) {
         throw new IllegalStateException("ChannelLogger is not set in Builder");
@@ -591,6 +592,7 @@ public abstract class NameResolver {
        *
        * @since 1.26.0
        */
+      @ExperimentalApi("https://github.com/grpc/grpc-java/issues/6438")
       public Builder setChannelLogger(ChannelLogger channelLogger) {
         this.channelLogger = checkNotNull(channelLogger);
         return this;

--- a/api/src/main/java/io/grpc/NameResolver.java
+++ b/api/src/main/java/io/grpc/NameResolver.java
@@ -588,7 +588,7 @@ public abstract class NameResolver {
       }
 
       /**
-       * See {@link Args#getChannelLogger}. This is a required field.
+       * See {@link Args#getChannelLogger}.
        *
        * @since 1.26.0
        */

--- a/api/src/main/java/io/grpc/NameResolver.java
+++ b/api/src/main/java/io/grpc/NameResolver.java
@@ -408,21 +408,11 @@ public abstract class NameResolver {
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1770")
   public static final class Args {
-    private static final ChannelLogger NOOP_CHANNEL_LOGGER = new ChannelLogger() {
-      @Override
-      public void log(ChannelLogLevel level, String message) {
-      }
-
-      @Override
-      public void log(ChannelLogLevel level, String messageFormat, Object... args) {
-      }
-    };
-
     private final int defaultPort;
     private final ProxyDetector proxyDetector;
     private final SynchronizationContext syncContext;
     private final ServiceConfigParser serviceConfigParser;
-    private final ChannelLogger channelLogger;
+    @Nullable private final ChannelLogger channelLogger;
     @Nullable private final Executor executor;
 
     Args(
@@ -436,11 +426,7 @@ public abstract class NameResolver {
       this.proxyDetector = checkNotNull(proxyDetector, "proxyDetector not set");
       this.syncContext = checkNotNull(syncContext, "syncContext not set");
       this.serviceConfigParser = checkNotNull(serviceConfigParser, "serviceConfigParser not set");
-      if (channelLogger == null) {
-        this.channelLogger = NOOP_CHANNEL_LOGGER;
-      } else {
-        this.channelLogger = channelLogger;
-      }
+      this.channelLogger = channelLogger;
       this.executor = executor;
     }
 
@@ -489,6 +475,9 @@ public abstract class NameResolver {
      * @since 1.26.0
      */
     public ChannelLogger getChannelLogger() {
+      if (channelLogger == null) {
+        throw new IllegalStateException("ChannelLogger is not set in Builder");
+      }
       return channelLogger;
     }
 
@@ -598,7 +587,7 @@ public abstract class NameResolver {
       }
 
       /**
-       * See {@link Args#getChannelLogger}. This is an optional field.
+       * See {@link Args#getChannelLogger}. This is a required field.
        *
        * @since 1.26.0
        */

--- a/api/src/test/java/io/grpc/NameResolverRegistryTest.java
+++ b/api/src/test/java/io/grpc/NameResolverRegistryTest.java
@@ -39,6 +39,7 @@ public class NameResolverRegistryTest {
       .setProxyDetector(mock(ProxyDetector.class))
       .setSynchronizationContext(new SynchronizationContext(mock(UncaughtExceptionHandler.class)))
       .setServiceConfigParser(mock(ServiceConfigParser.class))
+      .setChannelLogger(mock(ChannelLogger.class))
       .build();
 
   @Test

--- a/api/src/test/java/io/grpc/NameResolverTest.java
+++ b/api/src/test/java/io/grpc/NameResolverTest.java
@@ -45,6 +45,7 @@ public class NameResolverTest {
   private final SynchronizationContext syncContext =
       new SynchronizationContext(mock(UncaughtExceptionHandler.class));
   private final ServiceConfigParser parser = mock(ServiceConfigParser.class);
+  private final ChannelLogger channelLogger = mock(ChannelLogger.class);
   private final Executor executor = Executors.newSingleThreadExecutor();
   private URI uri;
   private final NameResolver nameResolver = mock(NameResolver.class);
@@ -61,6 +62,7 @@ public class NameResolverTest {
     assertThat(args.getProxyDetector()).isSameInstanceAs(proxyDetector);
     assertThat(args.getSynchronizationContext()).isSameInstanceAs(syncContext);
     assertThat(args.getServiceConfigParser()).isSameInstanceAs(parser);
+    assertThat(args.getChannelLogger()).isSameInstanceAs(channelLogger);
     assertThat(args.getOffloadExecutor()).isSameInstanceAs(executor);
 
     NameResolver.Args args2 = args.toBuilder().build();
@@ -68,6 +70,7 @@ public class NameResolverTest {
     assertThat(args2.getProxyDetector()).isSameInstanceAs(proxyDetector);
     assertThat(args2.getSynchronizationContext()).isSameInstanceAs(syncContext);
     assertThat(args2.getServiceConfigParser()).isSameInstanceAs(parser);
+    assertThat(args2.getChannelLogger()).isSameInstanceAs(channelLogger);
     assertThat(args2.getOffloadExecutor()).isSameInstanceAs(executor);
 
     assertThat(args2).isNotSameInstanceAs(args);
@@ -251,6 +254,7 @@ public class NameResolverTest {
         .setProxyDetector(proxyDetector)
         .setSynchronizationContext(syncContext)
         .setServiceConfigParser(parser)
+        .setChannelLogger(channelLogger)
         .setOffloadExecutor(executor)
         .build();
   }

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverProviderTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverProviderTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.mock;
 
+import io.grpc.ChannelLogger;
 import io.grpc.NameResolver;
 import io.grpc.NameResolver.ServiceConfigParser;
 import io.grpc.SynchronizationContext;
@@ -47,6 +48,7 @@ public class DnsNameResolverProviderTest {
       .setProxyDetector(GrpcUtil.DEFAULT_PROXY_DETECTOR)
       .setSynchronizationContext(syncContext)
       .setServiceConfigParser(mock(ServiceConfigParser.class))
+      .setChannelLogger(mock(ChannelLogger.class))
       .build();
 
   private DnsNameResolverProvider provider = new DnsNameResolverProvider();

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.net.InetAddresses;
 import com.google.common.testing.FakeTicker;
+import io.grpc.ChannelLogger;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.HttpConnectProxiedSocketAddress;
 import io.grpc.NameResolver;
@@ -115,6 +116,7 @@ public class DnsNameResolverTest {
       .setProxyDetector(GrpcUtil.DEFAULT_PROXY_DETECTOR)
       .setSynchronizationContext(syncContext)
       .setServiceConfigParser(mock(ServiceConfigParser.class))
+      .setChannelLogger(mock(ChannelLogger.class))
       .build();
 
   private final DnsNameResolverProvider provider = new DnsNameResolverProvider();
@@ -175,6 +177,7 @@ public class DnsNameResolverTest {
             .setProxyDetector(proxyDetector)
             .setSynchronizationContext(syncContext)
             .setServiceConfigParser(mock(ServiceConfigParser.class))
+            .setChannelLogger(mock(ChannelLogger.class))
             .build();
     return newResolver(name, stopwatch, isAndroid, args);
   }
@@ -331,6 +334,7 @@ public class DnsNameResolverTest {
             .setProxyDetector(GrpcUtil.NOOP_PROXY_DETECTOR)
             .setSynchronizationContext(syncContext)
             .setServiceConfigParser(mock(ServiceConfigParser.class))
+            .setChannelLogger(mock(ChannelLogger.class))
             .setOffloadExecutor(
                 new Executor() {
                   @Override

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
+import io.grpc.ChannelLogger;
 import io.grpc.NameResolver;
 import io.grpc.NameResolver.Factory;
 import io.grpc.NameResolver.ServiceConfigParser;
@@ -40,6 +41,7 @@ public class ManagedChannelImplGetNameResolverTest {
       .setProxyDetector(mock(ProxyDetector.class))
       .setSynchronizationContext(new SynchronizationContext(mock(UncaughtExceptionHandler.class)))
       .setServiceConfigParser(mock(ServiceConfigParser.class))
+      .setChannelLogger(mock(ChannelLogger.class))
       .build();
 
   @Test

--- a/core/src/test/java/io/grpc/internal/OverrideAuthorityNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/OverrideAuthorityNameResolverTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.grpc.ChannelLogger;
 import io.grpc.NameResolver;
 import io.grpc.NameResolver.ServiceConfigParser;
 import io.grpc.ProxyDetector;
@@ -41,6 +42,7 @@ public class OverrideAuthorityNameResolverTest {
       .setProxyDetector(mock(ProxyDetector.class))
       .setSynchronizationContext(new SynchronizationContext(mock(UncaughtExceptionHandler.class)))
       .setServiceConfigParser(mock(ServiceConfigParser.class))
+      .setChannelLogger(mock(ChannelLogger.class))
       .build();
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverProviderTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
+import io.grpc.ChannelLogger;
 import io.grpc.InternalServiceProviders;
 import io.grpc.NameResolver;
 import io.grpc.NameResolver.ServiceConfigParser;
@@ -46,6 +47,7 @@ public class XdsNameResolverProviderTest {
       .setProxyDetector(GrpcUtil.NOOP_PROXY_DETECTOR)
       .setSynchronizationContext(syncContext)
       .setServiceConfigParser(mock(ServiceConfigParser.class))
+      .setChannelLogger(mock(ChannelLogger.class))
       .build();
 
   private XdsNameResolverProvider provider = new XdsNameResolverProvider();

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import io.envoyproxy.envoy.api.v2.core.Node;
+import io.grpc.ChannelLogger;
 import io.grpc.NameResolver;
 import io.grpc.NameResolver.ResolutionResult;
 import io.grpc.NameResolver.ServiceConfigParser;
@@ -69,6 +70,7 @@ public class XdsNameResolverTest {
           .setProxyDetector(GrpcUtil.NOOP_PROXY_DETECTOR)
           .setSynchronizationContext(syncContext)
           .setServiceConfigParser(mock(ServiceConfigParser.class))
+          .setChannelLogger(mock(ChannelLogger.class))
           .build();
 
   private final XdsNameResolverProvider provider = new XdsNameResolverProvider();


### PR DESCRIPTION
~TODO: create tracking issue for `NameResolver.Args.getChannelLogger()` API.~