### PR TITLE
xds: add an Attributes for XdsClient reference

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsAttributes.java
+++ b/xds/src/main/java/io/grpc/xds/XdsAttributes.java
@@ -26,7 +26,7 @@ import io.grpc.Attributes;
 import io.grpc.Grpc;
 import io.grpc.Internal;
 import io.grpc.NameResolver;
-import io.grpc.xds.XdsClient.RefCountedXdsClientObjectPool;
+import io.grpc.internal.ObjectPool;
 
 /**
  * Special attributes that are only useful to gRPC in the XDS context.
@@ -76,7 +76,7 @@ public final class XdsAttributes {
       Attributes.Key.create("io.grpc.xds.XdsAttributes.downstreamTlsContext");
 
   @NameResolver.ResolutionResultAttr
-  static final Attributes.Key<RefCountedXdsClientObjectPool> XDS_CLIENT_REF =
+  static final Attributes.Key<ObjectPool<XdsClient>> XDS_CLIENT_REF =
       Attributes.Key.create("io.grpc.xds.XdsAttributes.xdsClientRef");
 
   private XdsAttributes() {}

--- a/xds/src/main/java/io/grpc/xds/XdsAttributes.java
+++ b/xds/src/main/java/io/grpc/xds/XdsAttributes.java
@@ -25,6 +25,8 @@ import io.envoyproxy.envoy.api.v2.auth.UpstreamTlsContext;
 import io.grpc.Attributes;
 import io.grpc.Grpc;
 import io.grpc.Internal;
+import io.grpc.NameResolver;
+import io.grpc.xds.XdsClient.RefCountedXdsClientObjectPool;
 
 /**
  * Special attributes that are only useful to gRPC in the XDS context.
@@ -72,6 +74,10 @@ public final class XdsAttributes {
   @Grpc.TransportAttr
   public static final Attributes.Key<DownstreamTlsContext> ATTR_DOWNSTREAM_TLS_CONTEXT =
       Attributes.Key.create("io.grpc.xds.XdsAttributes.downstreamTlsContext");
+
+  @NameResolver.ResolutionResultAttr
+  static final Attributes.Key<RefCountedXdsClientObjectPool> XDS_CLIENT_REF =
+      Attributes.Key.create("io.grpc.xds.XdsAttributes.xdsClientRef");
 
   private XdsAttributes() {}
 }

--- a/xds/src/test/java/io/grpc/xds/XdsClientTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientTest.java
@@ -86,6 +86,23 @@ public class XdsClientTest {
   }
 
   @Test
+  public void refCountedXdsClientObjectPool_returnWrongObjectShouldThrow() {
+    XdsClientFactory xdsClientFactory = new XdsClientFactory() {
+      @Override
+      XdsClient createXdsClient() {
+        return mock(XdsClient.class);
+      }
+    };
+    RefCountedXdsClientObjectPool xdsClientRef =
+        new RefCountedXdsClientObjectPool(xdsClientFactory);
+
+    xdsClientRef.getObject();
+
+    thrown.expect(IllegalStateException.class);
+    xdsClientRef.returnObject(mock(XdsClient.class));
+  }
+
+  @Test
   public void refCountedXdsClientObjectPool_getObjectCreatesNewInstanceIfAlreadyShutdown() {
     XdsClientFactory xdsClientFactory = new XdsClientFactory() {
       @Override


### PR DESCRIPTION
There are multiple choices on the type of the attribute key based on an offline discussion with @ejona86 . I'm now leaning to take the ObjectPool approach. The benefit of it could be:

Because both `XdsNameResolver` (The LDS path) and xds load balancer (The EDS-only path) can create XdsClient instance. The ObjectPool approach
- does not rely on the assumption that when shutting down the name resolver, all the balancers created by the name resolver (indirectly) will also be shutdown, although the assumption is true currently.

- does not rely on the order of shutdown events of resolver and any balancers. The xdsClient will be shutdown only once all the balancers and resolver using it are shutdown. No need to worry that `XdsClient` is not usable in any one of the reolver or balancers if other parties were shutdown.

- C-core is also using refcount approach, so we will have similar implementation.