### PR TITLE
Add support for cross-compiling for aarch64 platform

### DIFF
--- a/buildscripts/build_artifacts_in_docker.sh
+++ b/buildscripts/build_artifacts_in_docker.sh
@@ -3,6 +3,6 @@ set -exu -o pipefail
 
 # Runs all the tests and builds mvn artifacts.
 # mvn artifacts are stored in grpc-java/mvn-artifacts/
-ALL_ARTIFACTS=true ARCH=64 "$(dirname $0)"/kokoro/unix.sh
+ALL_ARTIFACTS=true ARCH=x86_64 "$(dirname $0)"/kokoro/unix.sh
 # Already ran tests the first time, so skip tests this time
-SKIP_TESTS=true ARCH=32 "$(dirname $0)"/kokoro/unix.sh
+SKIP_TESTS=true ARCH=x86_32 "$(dirname $0)"/kokoro/unix.sh

--- a/buildscripts/kokoro/linux_artifacts.sh
+++ b/buildscripts/kokoro/linux_artifacts.sh
@@ -36,4 +36,4 @@ cp -r "$LOCAL_MVN_TEMP"/* "$MVN_ARTIFACT_DIR"/
 
 # for aarch64 platform
 sudo apt-get install -y g++-aarch64-linux-gnu
-SKIP_TESTS=true ARCH=aarch_64 ./buildscripts/kokoro/unix.sh
+SKIP_TESTS=true ARCH=aarch_64 "$GRPC_JAVA_DIR"/buildscripts/kokoro/unix.sh

--- a/buildscripts/kokoro/linux_artifacts.sh
+++ b/buildscripts/kokoro/linux_artifacts.sh
@@ -35,12 +35,5 @@ mkdir -p "$MVN_ARTIFACT_DIR"
 cp -r "$LOCAL_MVN_TEMP"/* "$MVN_ARTIFACT_DIR"/
 
 # for aarch64 platform
-apt-get install -y wget autoconf automake libtool g++-aarch64-linux-gnu g++ make
-
-apt-get install software-properties-common -y
-add-apt-repository ppa:openjdk-r/ppa -y
-apt-get update
-apt install openjdk-8-jdk -y
-export JAVA_HOME=`dirname $(dirname $(update-alternatives --list javac |grep java-8))`
-update-ca-certificates -f
+sudo apt-get install -y g++-aarch64-linux-gnu
 SKIP_TESTS=true ARCH=aarch_64 ./buildscripts/kokoro/unix.sh

--- a/buildscripts/kokoro/linux_artifacts.sh
+++ b/buildscripts/kokoro/linux_artifacts.sh
@@ -33,3 +33,14 @@ popd
 readonly MVN_ARTIFACT_DIR="${MVN_ARTIFACT_DIR:-$GRPC_JAVA_DIR/mvn-artifacts}"
 mkdir -p "$MVN_ARTIFACT_DIR"
 cp -r "$LOCAL_MVN_TEMP"/* "$MVN_ARTIFACT_DIR"/
+
+# for aarch64 platform
+apt-get install -y wget autoconf automake libtool g++-aarch64-linux-gnu g++ make
+
+apt-get install software-properties-common -y
+add-apt-repository ppa:openjdk-r/ppa -y
+apt-get update
+apt install openjdk-8-jdk -y
+export JAVA_HOME=`dirname $(dirname $(update-alternatives --list javac |grep java-8))`
+update-ca-certificates -f
+SKIP_TESTS=true ARCH=aarch_64 ./buildscripts/kokoro/unix.sh

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -72,6 +72,11 @@ fi
 LOCAL_MVN_TEMP=$(mktemp -d)
 # Note that this disables parallel=true from GRADLE_FLAGS
 if [[ -z "${ALL_ARTIFACTS:-}" ]]; then
+  if [[ $ARCH == "aarch_64" ]]; then
+    GRADLE_FLAGS+=" -x grpc-compiler:generateTestProto -x grpc-compiler:generateTestLiteProto"
+    GRADLE_FLAGS+=" -x grpc-compiler:testGolden -x grpc-compiler:testLiteGolden"
+    GRADLE_FLAGS+=" -x grpc-compiler:testDeprecatedGolden -x grpc-compiler:testDeprecatedLiteGolden"
+  fi
   ./gradlew grpc-compiler:build grpc-compiler:publish $GRADLE_FLAGS \
     -Dorg.gradle.parallel=false -PrepositoryDir=$LOCAL_MVN_TEMP
 else

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -5,8 +5,10 @@
 # the correct environment for releases.
 # To run locally:
 #  ./buildscripts/kokoro/unix.sh
-# For 32 bit:
-#  ARCH=32 ./buildscripts/kokoro/unix.sh
+# For x86 32 arch:
+#  ARCH=x86_32 ./buildscripts/kokoro/unix.sh
+# For aarch64 arch:
+#  ARCH=aarch_64 ./buildscripts/kokoro/unix.sh
 
 # This script assumes `set -e`. Removing it may lead to undefined behavior.
 set -exu -o pipefail
@@ -23,14 +25,14 @@ cd $(dirname $0)/../..
 
 # TODO(zpencer): always make sure we are using Oracle jdk8
 
-# ARCH is 64 bit unless otherwise specified.
-ARCH="${ARCH:-64}"
+# ARCH is x86_64 unless otherwise specified.
+ARCH="${ARCH:-x86_64}"
 
 ARCH="$ARCH" buildscripts/make_dependencies.sh
 
 # Set properties via flags, do not pollute gradle.properties
 GRADLE_FLAGS="${GRADLE_FLAGS:-}"
-GRADLE_FLAGS+=" -PtargetArch=x86_$ARCH"
+GRADLE_FLAGS+=" -PtargetArch=$ARCH"
 GRADLE_FLAGS+=" -Pcheckstyle.ignoreFailures=false"
 GRADLE_FLAGS+=" -PfailOnWarnings=true"
 GRADLE_FLAGS+=" -PerrorProne=true"

--- a/buildscripts/kokoro/upload_artifacts.sh
+++ b/buildscripts/kokoro/upload_artifacts.sh
@@ -27,6 +27,9 @@ LOCAL_MVN_ARTIFACTS="$KOKORO_GFILE_DIR"/github/grpc-java/mvn-artifacts/
 [[ "$(find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'protoc-gen-grpc-java-*-linux-x86_64.exe' | wc -l)" != '0' ]]
 [[ "$(find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'protoc-gen-grpc-java-*-linux-x86_32.exe' | wc -l)" != '0' ]]
 
+# for linux aarch64 platform
+[[ "$(find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'protoc-gen-grpc-java-*-linux-aarch_64.exe' | wc -l)" != '0' ]]
+
 # from macos job:
 [[ "$(find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'protoc-gen-grpc-java-*-osx-x86_64.exe' | wc -l)" != '0' ]]
 

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -5,10 +5,10 @@ set -evux -o pipefail
 
 PROTOBUF_VERSION=3.10.0
 
-# ARCH is 64 bit unless otherwise specified.
-ARCH="${ARCH:-64}"
+# ARCH is x86_64 bit unless otherwise specified.
+ARCH="${ARCH:-x86_64}"
 DOWNLOAD_DIR=/tmp/source
-INSTALL_DIR="/tmp/protobuf-cache/$PROTOBUF_VERSION/$(uname -s)-$(uname -p)-x86_$ARCH"
+INSTALL_DIR="/tmp/protobuf-cache/$PROTOBUF_VERSION/$(uname -s)-$ARCH"
 mkdir -p $DOWNLOAD_DIR
 
 # Start with a sane default
@@ -31,8 +31,12 @@ else
   fi
   pushd $DOWNLOAD_DIR/protobuf-${PROTOBUF_VERSION}
   # install here so we don't need sudo
-  ./configure CFLAGS=-m"$ARCH" CXXFLAGS=-m"$ARCH" --disable-shared \
-    --prefix="$INSTALL_DIR"
+  if [[ "$ARCH" == x86* ]]; then
+    ./configure CFLAGS=-m${ARCH#*_} CXXFLAGS=-m${ARCH#*_} --disable-shared \
+      --prefix="$INSTALL_DIR"
+  elif [[ "$ARCH" == aarch* ]]; then
+    ./configure --disable-shared --host=aarch64-linux-gnu --prefix="$INSTALL_DIR"
+  fi
   # the same source dir is used for 32 and 64 bit builds, so we need to clean stale data first
   make clean
   make V=0 -j$NUM_CPU

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -51,7 +51,10 @@ model {
         }
         gcc(Gcc) {
             target("ppcle_64")
-            target("aarch_64")
+            target("aarch_64") {
+                cppCompiler.executable = 'aarch64-linux-gnu-g++'
+                linker.executable = 'aarch64-linux-gnu-g++'
+            }
             target("s390_64")
         }
         clang(Clang) {

--- a/compiler/check-artifact.sh
+++ b/compiler/check-artifact.sh
@@ -59,6 +59,8 @@ checkArch ()
         assertEq "$format" "elf32-i386" $LINENO
       elif [[ "$ARCH" == x86_64 ]]; then
         assertEq "$format" "elf64-x86-64" $LINENO
+      elif [[ "$ARCH" == aarch_64 ]]; then
+        assertEq "$format" "elf64-little" $LINENO
       else
         fail "Unsupported arch: $ARCH"
       fi
@@ -103,6 +105,10 @@ checkDependencies ()
       white_list="linux-gate\.so\.1\|libpthread\.so\.0\|libm\.so\.6\|libc\.so\.6\|ld-linux\.so\.2"
     elif [[ "$ARCH" == x86_64 ]]; then
       white_list="linux-vdso\.so\.1\|libpthread\.so\.0\|libm\.so\.6\|libc\.so\.6\|ld-linux-x86-64\.so\.2"
+    fi
+    elif [[ "$ARCH" == aarch_64 ]]; then
+      dump_cmd='aarch64-linux-gnu-objdump -x '"$1"' |grep "NEEDED"'
+      white_list="linux-vdso\.so\.1\|libpthread\.so\.0\|libm\.so\.6\|libc\.so\.6\|ld-linux-aarch64\.so\.1"
     fi
   elif [[ "$OS" == osx ]]; then
     dump_cmd='otool -L '"$1"' | fgrep dylib'

--- a/compiler/check-artifact.sh
+++ b/compiler/check-artifact.sh
@@ -105,7 +105,6 @@ checkDependencies ()
       white_list="linux-gate\.so\.1\|libpthread\.so\.0\|libm\.so\.6\|libc\.so\.6\|ld-linux\.so\.2"
     elif [[ "$ARCH" == x86_64 ]]; then
       white_list="linux-vdso\.so\.1\|libpthread\.so\.0\|libm\.so\.6\|libc\.so\.6\|ld-linux-x86-64\.so\.2"
-    fi
     elif [[ "$ARCH" == aarch_64 ]]; then
       dump_cmd='aarch64-linux-gnu-objdump -x '"$1"' |grep "NEEDED"'
       white_list="linux-vdso\.so\.1\|libpthread\.so\.0\|libm\.so\.6\|libc\.so\.6\|ld-linux-aarch64\.so\.1"


### PR DESCRIPTION
This change modified the building scripts to support cross compile
grpc-java for aarch64 platform

For grpc/grpc-java#6364