### PR TITLE
protobuf: Exclude new javalite artifact name

### DIFF
--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     }
 
     compile (project(':grpc-protobuf-lite')) {
-        exclude group: 'com.google.protobuf', module: 'protobuf-lite'
+        exclude group: 'com.google.protobuf', module: 'protobuf-javalite'
     }
 
     signature "org.codehaus.mojo.signature:java17:1.0@signature"


### PR DESCRIPTION
In 48929c4 the protobuf lite artifact name changed from protobuf-lite to
protobuf-javalite. However, the exclusion in grpc-protobuf was missed in the
update, allowing protobuf lite to leak into the classpath. This restores the
previous behavior of only having one protobuf implementation on the classpath.