### PR TITLE
xds: refactor EDS policy to use ObjectPool<XdsClient> with error handling fixes

### DIFF
--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -267,6 +267,7 @@ final class LookasideLb extends LoadBalancer {
           return;
         }
 
+        // TODO(zdapeng): First try to get loadStatsStore from XdsAttributes.LOAD_STATS_STORE_REF.
         LoadStatsStore loadStatsStore = new LoadStatsStoreImpl();
         localityStore = localityStoreFactory.newLocalityStore(
             helper, lbRegistry, loadStatsStore);
@@ -379,6 +380,8 @@ final class LookasideLb extends LoadBalancer {
         cachedXdsClientRef = xdsClientRef;
 
         xdsClient = xdsClientRef.getObject();
+        // TODO(zdapeng): Call xdsClient.reportClientStats() and xdsClient.cancelClientStatsReport()
+        // based on if lrsServerName is null instead of using lrsClient.
         EndpointWatcher newEndpointWatcher =
             new EndpointWatcherImpl(lrsClient, lrsCallback, localityStore);
         xdsClient.watchEndpointData(xdsConfig.edsServiceName, newEndpointWatcher);

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -115,6 +115,8 @@ final class LookasideLb extends LoadBalancer {
 
   @Override
   public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    channelLogger.log(ChannelLogLevel.DEBUG, "Received ResolvedAddresses '%s'", resolvedAddresses);
+
     // In the future, xdsConfig can be gotten directly by
     // resolvedAddresses.getLoadBalancingPolicyConfig().
     Attributes attributes = resolvedAddresses.getAttributes();
@@ -431,6 +433,8 @@ final class LookasideLb extends LoadBalancer {
 
     @Override
     public void onEndpointChanged(EndpointUpdate endpointUpdate) {
+      channelLogger.log(ChannelLogLevel.DEBUG, "Received an EDS update: '%s'",  endpointUpdate);
+
       if (!firstEdsUpdateReceived) {
         firstEdsUpdateReceived = true;
         edsUpdateCallback.onWorking();
@@ -464,6 +468,7 @@ final class LookasideLb extends LoadBalancer {
 
     @Override
     public void onError(Status error) {
+      channelLogger.log(ChannelLogLevel.ERROR, "Received an EDS error: '%s'",  error);
       edsUpdateCallback.onError();
     }
   }

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -297,7 +297,7 @@ final class LookasideLb extends LoadBalancer {
 
   private final class ClusterEndpointsBalancerProvider extends LoadBalancerProvider {
     final String edsServiceName;
-    @Nullable // not null if oldEndpointWatcher is not null
+    @Nullable
     final String oldEdsServiceName;
     @Nullable
     final EndpointWatcher oldEndpointWatcher;

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -72,11 +72,13 @@ final class LookasideLb extends LoadBalancer {
   private final LoadReportClientFactory loadReportClientFactory;
   private final Bootstrapper bootstrapper;
 
-  /** Most recent XdsConfig. */
-  @Nullable // Becomes non-null once handleResolvedAddresses() successfully.
+  // Most recent XdsConfig.
+  // Becomes non-null once handleResolvedAddresses() successfully.
+  @Nullable
   private XdsConfig xdsConfig;
-  /** Most recent EndpointWatcher. */
-  @Nullable // Becomes non-null once handleResolvedAddresses() successfully.
+  // Most recent EndpointWatcher.
+  // Becomes non-null once handleResolvedAddresses() successfully.
+  @Nullable
   private EndpointWatcher endpointWatcher;
 
   @Nullable
@@ -114,7 +116,7 @@ final class LookasideLb extends LoadBalancer {
   @Override
   public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     // In the future, xdsConfig can be gotten directly by
-    // resolvedAddresses.getLoadBalancingPolicyConfig()
+    // resolvedAddresses.getLoadBalancingPolicyConfig().
     Attributes attributes = resolvedAddresses.getAttributes();
     final ObjectPool<XdsClient> xdsClientRefFromResolver =
         resolvedAddresses.getAttributes().get(XdsAttributes.XDS_CLIENT_REF);
@@ -174,7 +176,7 @@ final class LookasideLb extends LoadBalancer {
     try {
       channel = helper.createResolvingOobChannel(balancerName);
     } catch (UnsupportedOperationException uoe) {
-      // Temporary solution until createResolvingOobChannel is implemented
+      // Temporary solution until createResolvingOobChannel is implemented.
       // FIXME (https://github.com/grpc/grpc-java/issues/5495)
       Logger logger = Logger.getLogger(LookasideLb.class.getName());
       if (logger.isLoggable(FINEST)) {
@@ -272,7 +274,7 @@ final class LookasideLb extends LoadBalancer {
               };
 
           if (xdsConfig.balancerName != null) {
-            // The is to handle the legacy usecase that requires balancerName from xds config.
+            // This to handle the legacy usecase that requires balancerName from xds config.
 
             String oldBalancerName = oldXdsConfig == null ? null : oldXdsConfig.balancerName;
             if (!xdsConfig.balancerName.equals(oldBalancerName)) {

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -226,8 +226,7 @@ final class LookasideLb extends LoadBalancer {
       return 5;
     }
 
-    // A synthetic policy name identified by xds config. The implementation detail doesn't
-    // matter.
+    // A synthetic policy name identified by xds config.
     @Override
     public String getPolicyName() {
       return "xds_policy__balancer_name_" + xdsConfig.balancerName

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -22,8 +22,6 @@ import static java.util.logging.Level.FINEST;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.protobuf.Struct;
-import com.google.protobuf.Value;
 import io.envoyproxy.envoy.api.v2.core.Node;
 import io.grpc.Attributes;
 import io.grpc.ChannelLogger;
@@ -299,12 +297,6 @@ final class LookasideLb extends LoadBalancer {
           if (oldXdsConfig == null || !xdsConfig.balancerName.equals(oldXdsConfig.balancerName)) {
             final ManagedChannel channel = initLbChannel(
                 helper, xdsConfig.balancerName, Collections.<ChannelCreds>emptyList());
-            final Node node = Node.newBuilder()
-                .setMetadata(Struct.newBuilder()
-                    .putFields(
-                        "endpoints_required",
-                        Value.newBuilder().setBoolValue(true).build()))
-                .build();
             // TODO(zdapeng): Use XdsClient to do Lrs directly.
             lrsClient = loadReportClientFactory.createLoadReportClient(
                 channel, helper, new ExponentialBackoffPolicy.Provider(), loadStatsStore);
@@ -313,7 +305,7 @@ final class LookasideLb extends LoadBalancer {
               XdsClient createXdsClient() {
                 return new XdsComms2(
                     channel, helper, new ExponentialBackoffPolicy.Provider(),
-                    GrpcUtil.STOPWATCH_SUPPLIER, node);
+                    GrpcUtil.STOPWATCH_SUPPLIER, Node.getDefaultInstance());
               }
             });
           } else {

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -145,7 +145,7 @@ final class LookasideLb extends LoadBalancer {
 
   @Override
   public void handleNameResolutionError(Status error) {
-    channelLogger.log(ChannelLogLevel.DEBUG, "Name resolution error: '%s'", error);
+    channelLogger.log(ChannelLogLevel.ERROR, "Name resolution error: '%s'", error);
     switchingLoadBalancer.handleNameResolutionError(error);
   }
 
@@ -279,6 +279,7 @@ final class LookasideLb extends LoadBalancer {
 
         // There are three usecases:
         // 1. The EDS-only legacy usecase that requires balancerName from xds config.
+        //    TODO(zdapeng): Remove the legacy case.
         // 2. The EDS-only with bootstrap usecase:
         //    The name resolver resolves a ResolvedAddresses with an XdsConfig without balancerName
         //    field. Use the bootstrap information to create a channel.
@@ -360,6 +361,7 @@ final class LookasideLb extends LoadBalancer {
               xdsClientRef = new RefCountedXdsClientObjectPool(new XdsClientFactory() {
                 @Override
                 XdsClient createXdsClient() {
+                  // TODO(zdapeng): Replace XdsComms2 with XdsClientImpl.
                   return new XdsComms2(
                       channel, helper, new ExponentialBackoffPolicy.Provider(),
                       GrpcUtil.STOPWATCH_SUPPLIER, bootstrapInfo.getNode());

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -127,6 +127,7 @@ final class LookasideLb extends LoadBalancer {
           TRANSIENT_FAILURE,
           new ErrorPicker(
               Status.UNAVAILABLE.withDescription("ATTR_LOAD_BALANCING_CONFIG not available")));
+      return;
     }
     ConfigOrError cfg =
         XdsLoadBalancerProvider.parseLoadBalancingConfigPolicy(newRawLbConfig, lbRegistry);
@@ -134,6 +135,7 @@ final class LookasideLb extends LoadBalancer {
       // This will not happen when the service config error handling is implemented.
       // For now simply go to TRANSIENT_FAILURE.
       lookasideLbHelper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(cfg.getError()));
+      return;
     }
     final XdsConfig newXdsConfig = (XdsConfig) cfg.getConfig();
 

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -242,7 +242,7 @@ final class LookasideLb extends LoadBalancer {
       return new LoadBalancer() {
 
         // All fields become non-null once handleResolvedAddresses() successfully.
-        // All fields are assigned at most once .
+        // All fields are assigned at most once.
         @Nullable
         ObjectPool<XdsClient> xdsClientRef;
         @Nullable
@@ -298,6 +298,8 @@ final class LookasideLb extends LoadBalancer {
                 }
               });
             } else {
+              // The balancerName is unchanged, so the channel is unchanged.
+              // Use the cached lrsClient and xdsClientRef, which are using the existing channel.
               lrsClient = cachedLrsClient;
               xdsClientRef = cachedXdsClientRef;
             }
@@ -330,6 +332,9 @@ final class LookasideLb extends LoadBalancer {
             });
           } else {
             // This is the XdsResolver or non EDS-only usecase.
+            // XDS_CLIENT_REF attribute is available from ResolvedAddresses, and already cached.
+            // Use the cached xdsClientRef.
+            xdsClientRef = cachedXdsClientRef;
 
             // FIXME(zdapeng): Use XdsClient to do Lrs directly.
             // No-op for now.
@@ -340,9 +345,10 @@ final class LookasideLb extends LoadBalancer {
               @Override
               public void stopLoadReporting() {}
             };
-            xdsClientRef = cachedXdsClientRef;
           }
 
+          // Now the lrsClient and xdsClientRef are assigned in all usecase, cache them for later
+          // use.
           cachedLrsClient = lrsClient;
           cachedXdsClientRef = xdsClientRef;
 

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -290,8 +290,7 @@ final class LookasideLb extends LoadBalancer {
         if (xdsConfig.balancerName != null) {
           // This is the EDS-only legacy usecase that requires balancerName from xds config.
 
-          String oldBalancerName = oldXdsConfig == null ? null : oldXdsConfig.balancerName;
-          if (!xdsConfig.balancerName.equals(oldBalancerName)) {
+          if (oldXdsConfig == null || !xdsConfig.balancerName.equals(oldXdsConfig.balancerName)) {
             final ManagedChannel channel = initLbChannel(
                 helper, xdsConfig.balancerName, Collections.<ChannelCreds>emptyList());
             final Node node = Node.newBuilder()

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -348,7 +348,6 @@ final class LookasideLb extends LoadBalancer {
                 helper.updateBalancingState(
                     ConnectivityState.TRANSIENT_FAILURE,
                     new ErrorPicker(Status.UNAVAILABLE.withCause(e)));
-                LookasideLb.this.endpointWatcher = null;
                 return;
               }
               final ManagedChannel channel = initLbChannel(

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -61,7 +61,7 @@ import java.util.Map;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
-/** Lookaside load balancer that handles balancer name changes. */
+/** Lookaside load balancer that handles EDS config. */
 final class LookasideLb extends LoadBalancer {
 
   private final ChannelLogger channelLogger;

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -16,6 +16,7 @@
 
 package io.grpc.xds;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 import static java.util.logging.Level.FINEST;
 
@@ -94,8 +95,8 @@ final class LookasideLb extends LoadBalancer {
 
   LookasideLb(Helper lookasideLbHelper, EndpointUpdateCallback endpointUpdateCallback) {
     this(
-        lookasideLbHelper,
-        endpointUpdateCallback,
+        checkNotNull(lookasideLbHelper, "lookasideLbHelper"),
+        checkNotNull(endpointUpdateCallback, "endpointUpdateCallback"),
         LoadBalancerRegistry.getDefaultRegistry(),
         LocalityStoreFactory.getInstance(),
         LoadReportClientFactory.getInstance(),

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -310,14 +310,15 @@ final class LookasideLb extends LoadBalancer {
               }
             });
           } else {
-            // The balancerName is unchanged, so the channel is unchanged.
+            // The balancerName is unchanged, no need to create new channel.
             // Use the cached lrsClient and xdsClientRef, which are using the existing channel.
             lrsClient = cachedLrsClient;
             xdsClientRef = cachedXdsClientRef;
           }
         } else if (cachedXdsClientRef == null) {
-          // This is to handle EDS-only with bootstrap usecase: the name resolver resolves
-          // a ResolvedAddresses with an XdsConfig without balancerName field.
+          // This is to handle EDS-only with bootstrap usecase: The name resolver resolves
+          // a ResolvedAddresses with an XdsConfig without balancerName field. Use the bootstrap
+          // information to create a channel.
           final BootstrapInfo bootstrapInfo;
           try {
             bootstrapInfo = bootstrapper.readBootstrap();
@@ -343,7 +344,7 @@ final class LookasideLb extends LoadBalancer {
             }
           });
         } else {
-          // This is the XdsResolver or non EDS-only usecase.
+          // This is the XdsNameResolver or non EDS-only usecase.
           // XDS_CLIENT_REF attribute is available from ResolvedAddresses, and already cached.
           // Use the cached xdsClientRef.
           xdsClientRef = cachedXdsClientRef;
@@ -359,7 +360,7 @@ final class LookasideLb extends LoadBalancer {
           };
         }
 
-        // Now the lrsClient and xdsClientRef are assigned in all usecase, cache them for later
+        // Now the lrsClient and xdsClientRef are assigned in all usecases, cache them for later
         // use.
         cachedLrsClient = lrsClient;
         cachedXdsClientRef = xdsClientRef;

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -183,12 +183,8 @@ final class LookasideLb extends LoadBalancer {
             @Override
             public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
               if (xdsClientRef != null) {
-                checkState(
-                    xdsClient != null, "Bug: xdsClient = xdsClientRef.getObject() not called");
                 return;
               }
-              checkState(
-                  xdsClient == null, "Bug: xdsClient is not null while xdsClientRef is null.");
 
               localityStore = localityStoreFactory.newLocalityStore(helper, lbRegistry);
               final LoadReportCallback lrsCallback =

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -205,8 +205,6 @@ final class LookasideLb extends LoadBalancer {
       xdsClient = xdsClientRef.getObject();
     }
 
-    // TODO(zdapeng): If lrsServerName in XdsConfig is changed, call xdsClient.reportClientStats()
-    //     and/or xdsClient.cancelClientStatsReport().
     // Note: balancerName change is unsupported and ignored.
     // TODO(zdapeng): Remove support for balancerName.
     // Note: childPolicy change will be handled in LocalityStore, to be implemented.
@@ -232,6 +230,9 @@ final class LookasideLb extends LoadBalancer {
         .setLoadBalancingPolicyConfig(newXdsConfig)
         .build();
     switchingLoadBalancer.handleResolvedAddresses(resolvedAddresses);
+
+    // TODO(zdapeng): If lrsServerName in XdsConfig is changed, call xdsClient.reportClientStats()
+    //     and/or xdsClient.cancelClientStatsReport().
   }
 
   @Override
@@ -374,7 +375,6 @@ final class LookasideLb extends LoadBalancer {
           return;
         }
 
-        // TODO(zdapeng): First try to get loadStatsStore from XdsAttributes.LOAD_STATS_STORE_REF.
         LoadStatsStore loadStatsStore = new LoadStatsStoreImpl();
         localityStore = localityStoreFactory.newLocalityStore(helper, lbRegistry, loadStatsStore);
         LoadReportCallback lrsCallback =

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -17,8 +17,7 @@
 package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.grpc.xds.XdsNameResolver.XDS_CHANNEL_CREDS_LIST;
-import static io.grpc.xds.XdsNameResolver.XDS_NODE;
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.logging.Level.FINEST;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -28,6 +27,7 @@ import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import io.envoyproxy.envoy.api.v2.core.Node;
 import io.grpc.Attributes;
+import io.grpc.ConnectivityState;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
@@ -38,8 +38,10 @@ import io.grpc.Status;
 import io.grpc.alts.GoogleDefaultChannelBuilder;
 import io.grpc.internal.ExponentialBackoffPolicy;
 import io.grpc.internal.GrpcUtil;
+import io.grpc.internal.ObjectPool;
 import io.grpc.util.ForwardingLoadBalancer;
 import io.grpc.util.GracefulSwitchLoadBalancer;
+import io.grpc.xds.Bootstrapper.BootstrapInfo;
 import io.grpc.xds.Bootstrapper.ChannelCreds;
 import io.grpc.xds.EnvoyProtoData.DropOverload;
 import io.grpc.xds.EnvoyProtoData.Locality;
@@ -49,7 +51,10 @@ import io.grpc.xds.LoadReportClientImpl.LoadReportClientFactory;
 import io.grpc.xds.LocalityStore.LocalityStoreFactory;
 import io.grpc.xds.XdsClient.EndpointUpdate;
 import io.grpc.xds.XdsClient.EndpointWatcher;
+import io.grpc.xds.XdsClient.RefCountedXdsClientObjectPool;
+import io.grpc.xds.XdsClient.XdsClientFactory;
 import io.grpc.xds.XdsLoadBalancerProvider.XdsConfig;
+import io.grpc.xds.XdsSubchannelPickers.ErrorPicker;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -60,12 +65,23 @@ import javax.annotation.Nullable;
 final class LookasideLb extends ForwardingLoadBalancer {
 
   private final EdsUpdateCallback edsUpdateCallback;
-  private final GracefulSwitchLoadBalancer lookasideChannelLb;
+  private final GracefulSwitchLoadBalancer switchingLoadBalancer;
   private final LoadBalancerRegistry lbRegistry;
   private final LocalityStoreFactory localityStoreFactory;
   private final LoadReportClientFactory loadReportClientFactory;
+  private final Bootstrapper bootstrapper;
 
-  private String balancerName;
+  /** Most recent XdsConfig. */
+  @Nullable // Becomes non-null once handleResolvedAddresses() successfully.
+  private XdsConfig xdsConfig;
+  /** Most recent EndpointWatcher. */
+  @Nullable // Becomes non-null once handleResolvedAddresses() successfully.
+  private EndpointWatcher endpointWatcher;
+
+  @Nullable
+  private ObjectPool<XdsClient> cachedXdsClientRef; // Cached for optimization.
+  @Nullable
+  private LoadReportClient cachedLrsClient; // Cached for optimization.
 
   LookasideLb(Helper lookasideLbHelper, EdsUpdateCallback edsUpdateCallback) {
     this(
@@ -73,7 +89,8 @@ final class LookasideLb extends ForwardingLoadBalancer {
         edsUpdateCallback,
         LoadBalancerRegistry.getDefaultRegistry(),
         LocalityStoreFactory.getInstance(),
-        LoadReportClientFactory.getInstance());
+        LoadReportClientFactory.getInstance(),
+        Bootstrapper.getInstance());
   }
 
   @VisibleForTesting
@@ -82,17 +99,19 @@ final class LookasideLb extends ForwardingLoadBalancer {
       EdsUpdateCallback edsUpdateCallback,
       LoadBalancerRegistry lbRegistry,
       LocalityStoreFactory localityStoreFactory,
-      LoadReportClientFactory loadReportClientFactory) {
+      LoadReportClientFactory loadReportClientFactory,
+      Bootstrapper bootstrapper) {
     this.edsUpdateCallback = edsUpdateCallback;
     this.lbRegistry = lbRegistry;
-    this.lookasideChannelLb = new GracefulSwitchLoadBalancer(lookasideLbHelper);
+    this.switchingLoadBalancer = new GracefulSwitchLoadBalancer(lookasideLbHelper);
     this.localityStoreFactory = localityStoreFactory;
     this.loadReportClientFactory = loadReportClientFactory;
+    this.bootstrapper = bootstrapper;
   }
 
   @Override
   protected LoadBalancer delegate() {
-    return lookasideChannelLb;
+    return switchingLoadBalancer;
   }
 
   @Override
@@ -100,6 +119,11 @@ final class LookasideLb extends ForwardingLoadBalancer {
     // In the future, xdsConfig can be gotten directly by
     // resolvedAddresses.getLoadBalancingPolicyConfig()
     Attributes attributes = resolvedAddresses.getAttributes();
+    final ObjectPool<XdsClient> xdsClientRefFromResolver =
+        resolvedAddresses.getAttributes().get(XdsAttributes.XDS_CLIENT_REF);
+    if (xdsClientRefFromResolver != null) {
+      cachedXdsClientRef = xdsClientRefFromResolver;
+    }
     Map<String, ?> newRawLbConfig = checkNotNull(
         attributes.get(ATTR_LOAD_BALANCING_CONFIG), "ATTR_LOAD_BALANCING_CONFIG not available");
     ConfigOrError cfg =
@@ -107,35 +131,16 @@ final class LookasideLb extends ForwardingLoadBalancer {
     if (cfg.getError() != null) {
       throw cfg.getError().asRuntimeException();
     }
-    XdsConfig xdsConfig = (XdsConfig) cfg.getConfig();
+    final XdsConfig newXdsConfig = (XdsConfig) cfg.getConfig();
 
-    final String newBalancerName = xdsConfig.balancerName;
+    // If XdsConfig is changed, do a graceful switch.
+    if (!newXdsConfig.equals(xdsConfig)) {
+      final XdsConfig oldXdsConfig = xdsConfig;
+      final EndpointWatcher oldEndpointWatcher = endpointWatcher;
+      xdsConfig = newXdsConfig;
 
-    // The is to handle the legacy usecase that requires balancerName from xds config.
-    if (!newBalancerName.equals(balancerName)) {
-      balancerName = newBalancerName; // cache the name and check next time for optimization
-      Node nodeFromResolvedAddresses = resolvedAddresses.getAttributes().get(XDS_NODE);
-      final Node node;
-      if (nodeFromResolvedAddresses == null) {
-        node = Node.newBuilder()
-            .setMetadata(Struct.newBuilder()
-                .putFields(
-                    "endpoints_required",
-                    Value.newBuilder().setBoolValue(true).build()))
-            .build();
-      } else {
-        node = nodeFromResolvedAddresses;
-      }
-      List<ChannelCreds> channelCredsListFromResolvedAddresses =
-          resolvedAddresses.getAttributes().get(XDS_CHANNEL_CREDS_LIST);
-      final List<ChannelCreds> channelCredsList;
-      if (channelCredsListFromResolvedAddresses == null) {
-        channelCredsList = Collections.emptyList();
-      } else {
-        channelCredsList = channelCredsListFromResolvedAddresses;
-      }
-
-      LoadBalancerProvider childBalancerProvider = new LoadBalancerProvider() {
+      // Provides a load balancer with the fixed XdsConfig: newXdsConfig.
+      LoadBalancerProvider fixedXdsConfigBalancer = new LoadBalancerProvider() {
         @Override
         public boolean isAvailable() {
           return true;
@@ -147,17 +152,26 @@ final class LookasideLb extends ForwardingLoadBalancer {
         }
 
         /**
-         * A synthetic policy name identified by balancerName. The implementation detail doesn't
+         * A synthetic policy name identified by xds config. The implementation detail doesn't
          * matter.
          */
         @Override
         public String getPolicyName() {
-          return "xds_child_policy_balancer_name_" + newBalancerName;
+          return "xds_policy__balancer_name_" + newXdsConfig.balancerName
+              + "__childPolicy_" + newXdsConfig.childPolicy
+              + "__fallbackPolicy_" + newXdsConfig.fallbackPolicy
+              + "__edsServiceName_" + newXdsConfig.edsServiceName
+              + "__lrsServerName_" + newXdsConfig.lrsServerName;
         }
 
         @Override
         public LoadBalancer newLoadBalancer(final Helper helper) {
           return new LoadBalancer() {
+
+            // All fields become non-null once handleResolvedAddresses() successfully.
+            // All fields are assigned at most once .
+            @Nullable
+            ObjectPool<XdsClient> xdsClientRef;
             @Nullable
             XdsClient xdsClient;
             @Nullable
@@ -170,46 +184,123 @@ final class LookasideLb extends ForwardingLoadBalancer {
 
             @Override
             public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-              if (xdsClient == null) {
-                ManagedChannel channel = initLbChannel(helper, newBalancerName, channelCredsList);
-                xdsClient  = new XdsComms2(
-                    channel, helper, new ExponentialBackoffPolicy.Provider(),
-                    GrpcUtil.STOPWATCH_SUPPLIER, node);
-                localityStore = localityStoreFactory.newLocalityStore(helper, lbRegistry);
+              if (xdsClientRef != null) {
+                checkState(
+                    xdsClient != null, "Bug: xdsClient = xdsClientRef.getObject() not called");
+                return;
+              }
+              checkState(
+                  xdsClient == null, "Bug: xdsClient is not null while xdsClientRef is null.");
+
+              localityStore = localityStoreFactory.newLocalityStore(helper, lbRegistry);
+              final LoadReportCallback lrsCallback =
+                  new LoadReportCallback() {
+                    @Override
+                    public void onReportResponse(long reportIntervalNano) {
+                      localityStore.updateOobMetricsReportInterval(reportIntervalNano);
+                    }
+                  };
+
+              if (newXdsConfig.balancerName != null) {
+                // The is to handle the legacy usecase that requires balancerName from xds config.
+
+                String oldBalancerName = oldXdsConfig == null ? null : oldXdsConfig.balancerName;
+                if (!newXdsConfig.balancerName.equals(oldBalancerName)) {
+                  final ManagedChannel channel = initLbChannel(
+                      helper, newXdsConfig.balancerName, Collections.<ChannelCreds>emptyList());
+                  final Node node = Node.newBuilder()
+                      .setMetadata(Struct.newBuilder()
+                          .putFields(
+                              "endpoints_required",
+                              Value.newBuilder().setBoolValue(true).build()))
+                      .build();
+                  // TODO(zdapeng): Use XdsClient to do Lrs directly.
+                  lrsClient = loadReportClientFactory.createLoadReportClient(
+                      channel, helper, new ExponentialBackoffPolicy.Provider(),
+                      localityStore.getLoadStatsStore());
+                  xdsClientRef = new RefCountedXdsClientObjectPool(new XdsClientFactory() {
+                    @Override
+                    XdsClient createXdsClient() {
+                      return new XdsComms2(
+                          channel, helper, new ExponentialBackoffPolicy.Provider(),
+                          GrpcUtil.STOPWATCH_SUPPLIER, node);
+                    }
+                  });
+                } else {
+                  lrsClient = cachedLrsClient;
+                  xdsClientRef = cachedXdsClientRef;
+                }
+              } else if (cachedXdsClientRef == null) {
+                // This is to handle EDS-only with bootstrap usecase.
+                final BootstrapInfo bootstrapInfo;
+                try {
+                  bootstrapInfo = bootstrapper.readBootstrap();
+                } catch (Exception e) {
+                  helper.updateBalancingState(
+                      ConnectivityState.TRANSIENT_FAILURE,
+                      new ErrorPicker(Status.UNAVAILABLE.withCause(e)));
+                  return;
+                }
+                final ManagedChannel channel = initLbChannel(
+                    helper, bootstrapInfo.getServerUri(),
+                    bootstrapInfo.getChannelCredentials());
                 // TODO(zdapeng): Use XdsClient to do Lrs directly.
                 lrsClient = loadReportClientFactory.createLoadReportClient(
                     channel, helper, new ExponentialBackoffPolicy.Provider(),
                     localityStore.getLoadStatsStore());
-                final LoadReportCallback lrsCallback =
-                    new LoadReportCallback() {
-                      @Override
-                      public void onReportResponse(long reportIntervalNano) {
-                        localityStore.updateOobMetricsReportInterval(reportIntervalNano);
-                      }
-                    };
+                xdsClientRef = new RefCountedXdsClientObjectPool(new XdsClientFactory() {
+                  @Override
+                  XdsClient createXdsClient() {
+                    return new XdsComms2(
+                        channel, helper, new ExponentialBackoffPolicy.Provider(),
+                        GrpcUtil.STOPWATCH_SUPPLIER, bootstrapInfo.getNode());
+                  }
+                });
+              } else {
+                // This is the XdsResolver or non EDS-only usecase.
 
-                EndpointWatcher endpointWatcher =
-                    new EndpointWatcherImpl(lrsClient, lrsCallback, localityStore);
-                xdsClient.watchEndpointData(node.getCluster(), endpointWatcher);
+                // FIXME(zdapeng): Use XdsClient to do Lrs directly.
+                // No-op for now.
+                lrsClient = new LoadReportClient() {
+                  @Override
+                  public void startLoadReporting(LoadReportCallback callback) {}
+
+                  @Override
+                  public void stopLoadReporting() {}
+                };
+                xdsClientRef = cachedXdsClientRef;
               }
+
+              cachedLrsClient = lrsClient;
+              cachedXdsClientRef = xdsClientRef;
+
+              xdsClient = xdsClientRef.getObject();
+              EndpointWatcher newEndpointWatcher =
+                  new EndpointWatcherImpl(lrsClient, lrsCallback, localityStore);
+              xdsClient.watchEndpointData(newXdsConfig.edsServiceName, newEndpointWatcher);
+              if (oldEndpointWatcher != null) {
+                xdsClient.cancelEndpointDataWatch(
+                    oldXdsConfig.edsServiceName, oldEndpointWatcher);
+              }
+              endpointWatcher = newEndpointWatcher;
             }
 
             @Override
             public void shutdown() {
-              if (xdsClient != null) {
+              if (xdsClientRef != null) {
                 lrsClient.stopLoadReporting();
                 localityStore.reset();
-                xdsClient.shutdown();
+                xdsClientRef.returnObject(xdsClient);
               }
             }
           };
         }
       };
 
-      lookasideChannelLb.switchTo(childBalancerProvider);
+      switchingLoadBalancer.switchTo(fixedXdsConfigBalancer);
     }
 
-    lookasideChannelLb.handleResolvedAddresses(resolvedAddresses);
+    switchingLoadBalancer.handleResolvedAddresses(resolvedAddresses);
   }
 
   private static ManagedChannel initLbChannel(

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -214,7 +214,8 @@ final class LookasideLb extends LoadBalancer {
         || !Objects.equals(newXdsConfig.edsServiceName, xdsConfig.edsServiceName)) {
       String edsServiceName = newXdsConfig.edsServiceName;
 
-      // Just in case edsServiceName is null, in the future this shouldn't be allowed.
+      // The edsServiceName field is null in legacy gRPC client with EDS: use target authority for
+      // querying endpoints, but in the future we expect this to be explicitly given by EDS config.
       // We assume if edsServiceName is null, it will always be null in later resolver updates;
       // and if edsServiceName is not null, it will always be not null.
       if (edsServiceName == null) {

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -262,6 +262,8 @@ final class LookasideLb extends LoadBalancer {
       @Override
       public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
         if (xdsClientRef != null) {
+          // handleResolvedAddresses() already called, so no-op here, because the config is fixed in
+          // this balancer.
           return;
         }
 

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -235,6 +235,7 @@ final class LookasideLb extends LoadBalancer {
         .setLoadBalancingPolicyConfig(newXdsConfig)
         .build();
     switchingLoadBalancer.handleResolvedAddresses(resolvedAddresses);
+    this.xdsConfig = newXdsConfig;
 
     // TODO(zdapeng): If lrsServerName in XdsConfig is changed, call xdsClient.reportClientStats()
     //     and/or xdsClient.cancelClientStatsReport().
@@ -411,7 +412,6 @@ final class LookasideLb extends LoadBalancer {
           xdsClient.cancelEndpointDataWatch(oldEdsServiceName, oldEndpointWatcher);
         }
         LookasideLb.this.endpointWatcher = endpointWatcher;
-        LookasideLb.this.xdsConfig = xdsConfig;
       }
 
       @Override

--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancer2.java
@@ -27,7 +27,7 @@ import io.grpc.LoadBalancer;
 import io.grpc.Status;
 import io.grpc.SynchronizationContext.ScheduledHandle;
 import io.grpc.util.ForwardingLoadBalancerHelper;
-import io.grpc.xds.LookasideLb.EdsUpdateCallback;
+import io.grpc.xds.LookasideLb.EndpointUpdateCallback;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
@@ -46,7 +46,7 @@ final class XdsLoadBalancer2 extends LoadBalancer {
   private final Helper helper;
   private final LoadBalancer lookasideLb;
   private final LoadBalancer.Factory fallbackLbFactory;
-  private final EdsUpdateCallback edsUpdateCallback = new EdsUpdateCallback() {
+  private final EndpointUpdateCallback edsUpdateCallback = new EndpointUpdateCallback() {
     @Override
     public void onWorking() {
       if (childPolicyHasBeenReady) {
@@ -247,13 +247,13 @@ final class XdsLoadBalancer2 extends LoadBalancer {
   /** Factory of a look-aside load balancer. The interface itself is for convenience in test. */
   @VisibleForTesting
   interface LookasideLbFactory {
-    LoadBalancer newLoadBalancer(Helper helper, EdsUpdateCallback edsUpdateCallback);
+    LoadBalancer newLoadBalancer(Helper helper, EndpointUpdateCallback edsUpdateCallback);
   }
 
   private static final class LookasideLbFactoryImpl implements LookasideLbFactory {
     @Override
     public LoadBalancer newLoadBalancer(
-        Helper lookasideLbHelper, EdsUpdateCallback edsUpdateCallback) {
+        Helper lookasideLbHelper, EndpointUpdateCallback edsUpdateCallback) {
       return new LookasideLb(lookasideLbHelper, edsUpdateCallback);
     }
   }

--- a/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
+++ b/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
@@ -504,8 +504,11 @@ public class LookasideLbTest {
 
     assertThat(helpers).hasSize(1);
     assertThat(localityStores).hasSize(1);
+    ArgumentCaptor<EndpointWatcher> endpointWatcherCaptor =
+        ArgumentCaptor.forClass(EndpointWatcher.class);
     verify(xdsClientFromResolver).watchEndpointData(
-        eq("edsServiceName1"), any(EndpointWatcher.class));
+        eq("edsServiceName1"), endpointWatcherCaptor.capture());
+    EndpointWatcher endpointWatcher = endpointWatcherCaptor.getValue();
 
     Helper helper1 = helpers.peekLast();
     SubchannelPicker picker = mock(SubchannelPicker.class);
@@ -516,6 +519,7 @@ public class LookasideLbTest {
     xdsClientRef.returnObject(xdsClientFromResolver);
     verify(xdsClientFromResolver, never()).shutdown();
     lookasideLb.shutdown();
+    verify(xdsClientFromResolver).cancelEndpointDataWatch("edsServiceName1", endpointWatcher);
     verify(xdsClientFromResolver).shutdown();
   }
 

--- a/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
+++ b/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
@@ -25,7 +25,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -483,8 +482,7 @@ public class LookasideLbTest {
 
     verify(helper, never()).createResolvingOobChannel(anyString());
     lookasideLb.handleResolvedAddresses(resolvedAddresses);
-    // Channel is created twice for ADS and LRS.
-    verify(helper, atLeastOnce()).createResolvingOobChannel("dns:///balancer1.example.com:8080");
+    verify(helper).createResolvingOobChannel("dns:///balancer1.example.com:8080");
 
     lookasideLb.shutdown();
   }

--- a/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
+++ b/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
@@ -260,6 +260,11 @@ public class LookasideLbTest {
         .build();
   }
 
+  @Test
+  public void canHandleEmptyAddressListFromNameResolution() {
+    assertThat(lookasideLb.canHandleEmptyAddressListFromNameResolution()).isTrue();
+  }
+
   @SuppressWarnings("unchecked")
   @Test
   public void handleChildPolicyChangeThenBalancerNameChangeThenChildPolicyChange_swtichGracefully()

--- a/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
+++ b/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
@@ -80,7 +80,7 @@ import io.grpc.xds.EnvoyProtoData.LocalityLbEndpoints;
 import io.grpc.xds.LoadReportClient.LoadReportCallback;
 import io.grpc.xds.LoadReportClientImpl.LoadReportClientFactory;
 import io.grpc.xds.LocalityStore.LocalityStoreFactory;
-import io.grpc.xds.LookasideLb.EdsUpdateCallback;
+import io.grpc.xds.LookasideLb.EndpointUpdateCallback;
 import io.grpc.xds.XdsClient.EndpointUpdate;
 import io.grpc.xds.XdsClient.EndpointWatcher;
 import io.grpc.xds.XdsClient.RefCountedXdsClientObjectPool;
@@ -137,7 +137,7 @@ public class LookasideLbTest {
   @Mock
   private Helper helper;
   @Mock
-  private EdsUpdateCallback edsUpdateCallback;
+  private EndpointUpdateCallback edsUpdateCallback;
   @Mock
   private Bootstrapper bootstrapper;
   @Captor
@@ -475,7 +475,7 @@ public class LookasideLbTest {
   public void handleResolvedAddress_createLbChannel()
       throws Exception {
     // Test balancer created with the default real LookasideChannelLbFactory
-    lookasideLb = new LookasideLb(helper, mock(EdsUpdateCallback.class));
+    lookasideLb = new LookasideLb(helper, mock(EndpointUpdateCallback.class));
     String lbConfigRaw = "{'balancerName' : 'dns:///balancer1.example.com:8080'}"
         .replace("'", "\"");
     @SuppressWarnings("unchecked")

--- a/xds/src/test/java/io/grpc/xds/XdsLoadBalancer2Test.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadBalancer2Test.java
@@ -40,7 +40,7 @@ import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.Status;
 import io.grpc.SynchronizationContext;
 import io.grpc.internal.FakeClock;
-import io.grpc.xds.LookasideLb.EdsUpdateCallback;
+import io.grpc.xds.LookasideLb.EndpointUpdateCallback;
 import io.grpc.xds.XdsLoadBalancer2.LookasideLbFactory;
 import java.util.ArrayList;
 import java.util.List;
@@ -75,7 +75,7 @@ public class XdsLoadBalancer2Test {
   @Mock
   private Helper helper;
   private LoadBalancer xdsLoadBalancer;
-  private EdsUpdateCallback edsUpdateCallback;
+  private EndpointUpdateCallback edsUpdateCallback;
 
   private Helper lookasideLbHelper;
   private final List<LoadBalancer> lookasideLbs = new ArrayList<>();
@@ -90,7 +90,7 @@ public class XdsLoadBalancer2Test {
     LookasideLbFactory lookasideLbFactory = new LookasideLbFactory() {
       @Override
       public LoadBalancer newLoadBalancer(
-          Helper helper, EdsUpdateCallback edsUpdateCallback) {
+          Helper helper, EndpointUpdateCallback edsUpdateCallback) {
         // just return a mock and record the input and output
         lookasideLbHelper = helper;
         XdsLoadBalancer2Test.this.edsUpdateCallback = edsUpdateCallback;


### PR DESCRIPTION
- Support `XdsConfig` without `balancerName` field, either get `XdsClient` instance from ResolvedAddresses attributes (XdsNameResolver case) or create one from bootstrap (EDS only case) (Not using `XdsClientImpl` for now because it does not handle EdsUpdate yet).

- The deprecated XdsConfig with `balancerName` field case is still supported for now but unsupported `balancerName` change in XdsConfig due to the extra complexity over things that are going to be entirely deleted.

- Whenever `XdsConfig` is changed (any field is changed), will create a new `EndpointWatcher` with a new `localityStore` and do a graceful switch.