### PR TITLE
xds: remove getLoadStatsStore method from LocalityStore

### DIFF
--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -175,11 +175,13 @@ final class LookasideLb extends ForwardingLoadBalancer {
                 xdsClient  = new XdsComms2(
                     channel, helper, new ExponentialBackoffPolicy.Provider(),
                     GrpcUtil.STOPWATCH_SUPPLIER, node);
-                localityStore = localityStoreFactory.newLocalityStore(helper, lbRegistry);
+                LoadStatsStore loadStatsStore = new LoadStatsStoreImpl();
+                localityStore = localityStoreFactory.newLocalityStore(
+                    helper, lbRegistry, loadStatsStore);
                 // TODO(zdapeng): Use XdsClient to do Lrs directly.
                 lrsClient = loadReportClientFactory.createLoadReportClient(
                     channel, helper, new ExponentialBackoffPolicy.Provider(),
-                    localityStore.getLoadStatsStore());
+                    loadStatsStore);
                 final LoadReportCallback lrsCallback =
                     new LoadReportCallback() {
                       @Override

--- a/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
+++ b/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
@@ -194,11 +194,10 @@ public class LookasideLbTest {
 
     localityStoreFactory = new LocalityStoreFactory() {
       @Override
-      public LocalityStore newLocalityStore(Helper helper, LoadBalancerRegistry lbRegistry) {
+      public LocalityStore newLocalityStore(
+          Helper helper, LoadBalancerRegistry lbRegistry, LoadStatsStore loadStatsStore) {
         helpers.add(helper);
         LocalityStore localityStore = mock(LocalityStore.class);
-        LoadStatsStore loadStatsStore = mock(LoadStatsStore.class);
-        doReturn(loadStatsStore).when(localityStore).getLoadStatsStore();
         localityStores.add(localityStore);
         return localityStore;
       }


### PR DESCRIPTION
Currently `LoadStatsStore` is create by `LocalityStore` and `LoadReportClient` retrieves `LoadStatsStore` from `LocalityStore.getLoadStatsStore()`.

But `LocalityStore` is create by EDS policy, whereas `LoadReportClient` and `LoadStatsStore` should be created by CDS (if not EDS-only), before `LocalityStore` is created. If `LoadReportClient` is embedded in `XdsClientImpl`, it need a `LoadStatsStore` which shouldn't be created by `LocalityStore`.

Instead, `LoadStatsStore` should be create before `LocalityStore` is created, and be passed to `LocalityStore`'s constructor. A getter is not needed.