### PR TITLE
Roll-forward of stub,compiler: generated stub extends Abstract{Async,…

### DIFF
--- a/alts/src/generated/main/grpc/io/grpc/alts/internal/HandshakerServiceGrpc.java
+++ b/alts/src/generated/main/grpc/io/grpc/alts/internal/HandshakerServiceGrpc.java
@@ -62,7 +62,14 @@ public final class HandshakerServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static HandshakerServiceStub newStub(io.grpc.Channel channel) {
-    return new HandshakerServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<HandshakerServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<HandshakerServiceStub>() {
+        @java.lang.Override
+        public HandshakerServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new HandshakerServiceStub(channel, callOptions);
+        }
+      };
+    return HandshakerServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -70,7 +77,14 @@ public final class HandshakerServiceGrpc {
    */
   public static HandshakerServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new HandshakerServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<HandshakerServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<HandshakerServiceBlockingStub>() {
+        @java.lang.Override
+        public HandshakerServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new HandshakerServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return HandshakerServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -78,7 +92,14 @@ public final class HandshakerServiceGrpc {
    */
   public static HandshakerServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new HandshakerServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<HandshakerServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<HandshakerServiceFutureStub>() {
+        @java.lang.Override
+        public HandshakerServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new HandshakerServiceFutureStub(channel, callOptions);
+        }
+      };
+    return HandshakerServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -115,19 +136,15 @@ public final class HandshakerServiceGrpc {
 
   /**
    */
-  public static final class HandshakerServiceStub extends io.grpc.stub.AbstractStub<HandshakerServiceStub> {
-    private HandshakerServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private HandshakerServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class HandshakerServiceStub extends io.grpc.stub.AbstractAsyncStub<HandshakerServiceStub> {
+    private HandshakerServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected HandshakerServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected HandshakerServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new HandshakerServiceStub(channel, callOptions);
     }
 
@@ -150,38 +167,30 @@ public final class HandshakerServiceGrpc {
 
   /**
    */
-  public static final class HandshakerServiceBlockingStub extends io.grpc.stub.AbstractStub<HandshakerServiceBlockingStub> {
-    private HandshakerServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private HandshakerServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class HandshakerServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<HandshakerServiceBlockingStub> {
+    private HandshakerServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected HandshakerServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected HandshakerServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new HandshakerServiceBlockingStub(channel, callOptions);
     }
   }
 
   /**
    */
-  public static final class HandshakerServiceFutureStub extends io.grpc.stub.AbstractStub<HandshakerServiceFutureStub> {
-    private HandshakerServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private HandshakerServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class HandshakerServiceFutureStub extends io.grpc.stub.AbstractFutureStub<HandshakerServiceFutureStub> {
+    private HandshakerServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected HandshakerServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected HandshakerServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new HandshakerServiceFutureStub(channel, callOptions);
     }
   }

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
@@ -186,7 +186,14 @@ public final class BenchmarkServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static BenchmarkServiceStub newStub(io.grpc.Channel channel) {
-    return new BenchmarkServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<BenchmarkServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<BenchmarkServiceStub>() {
+        @java.lang.Override
+        public BenchmarkServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new BenchmarkServiceStub(channel, callOptions);
+        }
+      };
+    return BenchmarkServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -194,7 +201,14 @@ public final class BenchmarkServiceGrpc {
    */
   public static BenchmarkServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new BenchmarkServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<BenchmarkServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<BenchmarkServiceBlockingStub>() {
+        @java.lang.Override
+        public BenchmarkServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new BenchmarkServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return BenchmarkServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -202,7 +216,14 @@ public final class BenchmarkServiceGrpc {
    */
   public static BenchmarkServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new BenchmarkServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<BenchmarkServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<BenchmarkServiceFutureStub>() {
+        @java.lang.Override
+        public BenchmarkServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new BenchmarkServiceFutureStub(channel, callOptions);
+        }
+      };
+    return BenchmarkServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -308,19 +329,15 @@ public final class BenchmarkServiceGrpc {
 
   /**
    */
-  public static final class BenchmarkServiceStub extends io.grpc.stub.AbstractStub<BenchmarkServiceStub> {
-    private BenchmarkServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private BenchmarkServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class BenchmarkServiceStub extends io.grpc.stub.AbstractAsyncStub<BenchmarkServiceStub> {
+    private BenchmarkServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected BenchmarkServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected BenchmarkServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new BenchmarkServiceStub(channel, callOptions);
     }
 
@@ -388,19 +405,15 @@ public final class BenchmarkServiceGrpc {
 
   /**
    */
-  public static final class BenchmarkServiceBlockingStub extends io.grpc.stub.AbstractStub<BenchmarkServiceBlockingStub> {
-    private BenchmarkServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private BenchmarkServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class BenchmarkServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<BenchmarkServiceBlockingStub> {
+    private BenchmarkServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected BenchmarkServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected BenchmarkServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new BenchmarkServiceBlockingStub(channel, callOptions);
     }
 
@@ -430,19 +443,15 @@ public final class BenchmarkServiceGrpc {
 
   /**
    */
-  public static final class BenchmarkServiceFutureStub extends io.grpc.stub.AbstractStub<BenchmarkServiceFutureStub> {
-    private BenchmarkServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private BenchmarkServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class BenchmarkServiceFutureStub extends io.grpc.stub.AbstractFutureStub<BenchmarkServiceFutureStub> {
+    private BenchmarkServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected BenchmarkServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected BenchmarkServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new BenchmarkServiceFutureStub(channel, callOptions);
     }
 

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/ReportQpsScenarioServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/ReportQpsScenarioServiceGrpc.java
@@ -62,7 +62,14 @@ public final class ReportQpsScenarioServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static ReportQpsScenarioServiceStub newStub(io.grpc.Channel channel) {
-    return new ReportQpsScenarioServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ReportQpsScenarioServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ReportQpsScenarioServiceStub>() {
+        @java.lang.Override
+        public ReportQpsScenarioServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ReportQpsScenarioServiceStub(channel, callOptions);
+        }
+      };
+    return ReportQpsScenarioServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -70,7 +77,14 @@ public final class ReportQpsScenarioServiceGrpc {
    */
   public static ReportQpsScenarioServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new ReportQpsScenarioServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ReportQpsScenarioServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ReportQpsScenarioServiceBlockingStub>() {
+        @java.lang.Override
+        public ReportQpsScenarioServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ReportQpsScenarioServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return ReportQpsScenarioServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -78,7 +92,14 @@ public final class ReportQpsScenarioServiceGrpc {
    */
   public static ReportQpsScenarioServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new ReportQpsScenarioServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ReportQpsScenarioServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ReportQpsScenarioServiceFutureStub>() {
+        @java.lang.Override
+        public ReportQpsScenarioServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ReportQpsScenarioServiceFutureStub(channel, callOptions);
+        }
+      };
+    return ReportQpsScenarioServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -110,19 +131,15 @@ public final class ReportQpsScenarioServiceGrpc {
 
   /**
    */
-  public static final class ReportQpsScenarioServiceStub extends io.grpc.stub.AbstractStub<ReportQpsScenarioServiceStub> {
-    private ReportQpsScenarioServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ReportQpsScenarioServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ReportQpsScenarioServiceStub extends io.grpc.stub.AbstractAsyncStub<ReportQpsScenarioServiceStub> {
+    private ReportQpsScenarioServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ReportQpsScenarioServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ReportQpsScenarioServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ReportQpsScenarioServiceStub(channel, callOptions);
     }
 
@@ -140,19 +157,15 @@ public final class ReportQpsScenarioServiceGrpc {
 
   /**
    */
-  public static final class ReportQpsScenarioServiceBlockingStub extends io.grpc.stub.AbstractStub<ReportQpsScenarioServiceBlockingStub> {
-    private ReportQpsScenarioServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ReportQpsScenarioServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ReportQpsScenarioServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<ReportQpsScenarioServiceBlockingStub> {
+    private ReportQpsScenarioServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ReportQpsScenarioServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ReportQpsScenarioServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ReportQpsScenarioServiceBlockingStub(channel, callOptions);
     }
 
@@ -169,19 +182,15 @@ public final class ReportQpsScenarioServiceGrpc {
 
   /**
    */
-  public static final class ReportQpsScenarioServiceFutureStub extends io.grpc.stub.AbstractStub<ReportQpsScenarioServiceFutureStub> {
-    private ReportQpsScenarioServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ReportQpsScenarioServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ReportQpsScenarioServiceFutureStub extends io.grpc.stub.AbstractFutureStub<ReportQpsScenarioServiceFutureStub> {
+    private ReportQpsScenarioServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ReportQpsScenarioServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ReportQpsScenarioServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ReportQpsScenarioServiceFutureStub(channel, callOptions);
     }
 

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
@@ -155,7 +155,14 @@ public final class WorkerServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static WorkerServiceStub newStub(io.grpc.Channel channel) {
-    return new WorkerServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<WorkerServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<WorkerServiceStub>() {
+        @java.lang.Override
+        public WorkerServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new WorkerServiceStub(channel, callOptions);
+        }
+      };
+    return WorkerServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -163,7 +170,14 @@ public final class WorkerServiceGrpc {
    */
   public static WorkerServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new WorkerServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<WorkerServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<WorkerServiceBlockingStub>() {
+        @java.lang.Override
+        public WorkerServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new WorkerServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return WorkerServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -171,7 +185,14 @@ public final class WorkerServiceGrpc {
    */
   public static WorkerServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new WorkerServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<WorkerServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<WorkerServiceFutureStub>() {
+        @java.lang.Override
+        public WorkerServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new WorkerServiceFutureStub(channel, callOptions);
+        }
+      };
+    return WorkerServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -264,19 +285,15 @@ public final class WorkerServiceGrpc {
 
   /**
    */
-  public static final class WorkerServiceStub extends io.grpc.stub.AbstractStub<WorkerServiceStub> {
-    private WorkerServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private WorkerServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class WorkerServiceStub extends io.grpc.stub.AbstractAsyncStub<WorkerServiceStub> {
+    private WorkerServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected WorkerServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected WorkerServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new WorkerServiceStub(channel, callOptions);
     }
 
@@ -337,19 +354,15 @@ public final class WorkerServiceGrpc {
 
   /**
    */
-  public static final class WorkerServiceBlockingStub extends io.grpc.stub.AbstractStub<WorkerServiceBlockingStub> {
-    private WorkerServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private WorkerServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class WorkerServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<WorkerServiceBlockingStub> {
+    private WorkerServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected WorkerServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected WorkerServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new WorkerServiceBlockingStub(channel, callOptions);
     }
 
@@ -376,19 +389,15 @@ public final class WorkerServiceGrpc {
 
   /**
    */
-  public static final class WorkerServiceFutureStub extends io.grpc.stub.AbstractStub<WorkerServiceFutureStub> {
-    private WorkerServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private WorkerServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class WorkerServiceFutureStub extends io.grpc.stub.AbstractFutureStub<WorkerServiceFutureStub> {
+    private WorkerServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected WorkerServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected WorkerServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new WorkerServiceFutureStub(channel, callOptions);
     }
 

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -489,6 +489,37 @@ static void PrintBindServiceMethodBody(const ServiceDescriptor* service,
                                    std::map<string, string>* vars,
                                    Printer* p);
 
+// Prints a StubFactory for given service / stub type.
+static void PrintStubFactory(
+    const ServiceDescriptor* service,
+    std::map<string, string>* vars,
+    Printer* p, StubType type) {
+  string stub_type_name;
+  switch (type) {
+    case ASYNC_CLIENT_IMPL:
+      stub_type_name = "";
+      break;
+    case FUTURE_CLIENT_IMPL:
+      stub_type_name = "Future";
+      break;
+    case BLOCKING_CLIENT_IMPL:
+      stub_type_name = "Blocking";
+      break;
+    default:
+      GRPC_CODEGEN_FAIL << "Cannot generate StubFactory for StubType: " << type;
+  }
+  (*vars)["stub_full_name"] = (*vars)["service_name"] + stub_type_name + "Stub";
+  p->Print(
+    *vars,
+    "$StubFactory$<$stub_full_name$> factory =\n"
+    "  new $StubFactory$<$stub_full_name$>() {\n"
+    "    @$Override$\n"
+    "    public $stub_full_name$ newStub($Channel$ channel, $CallOptions$ callOptions) {\n"
+    "      return new $stub_full_name$(channel, callOptions);\n"
+    "    }\n"
+    "  };\n");
+}
+
 // Prints a client interface or implementation class, or a server interface.
 static void PrintStub(
     const ServiceDescriptor* service,
@@ -499,6 +530,7 @@ static void PrintStub(
   (*vars)["abstract_name"] = service_name + "ImplBase";
   string stub_name = service_name;
   string client_name = service_name;
+  string stub_base_class_name = "AbstractStub";
   CallType call_type;
   bool impl_base = false;
   bool interface = false;
@@ -510,6 +542,7 @@ static void PrintStub(
     case ASYNC_CLIENT_IMPL:
       call_type = ASYNC_CALL;
       stub_name += "Stub";
+      stub_base_class_name = "AbstractAsyncStub";
       break;
     case BLOCKING_CLIENT_INTERFACE:
       interface = true;
@@ -518,6 +551,7 @@ static void PrintStub(
       call_type = BLOCKING_CALL;
       stub_name += "BlockingStub";
       client_name += "BlockingClient";
+      stub_base_class_name = "AbstractBlockingStub";
       break;
     case FUTURE_CLIENT_INTERFACE:
       interface = true;
@@ -526,16 +560,20 @@ static void PrintStub(
       call_type = FUTURE_CALL;
       stub_name += "FutureStub";
       client_name += "FutureClient";
+      stub_base_class_name = "AbstractFutureStub";
       break;
     case ASYNC_INTERFACE:
       call_type = ASYNC_CALL;
       interface = true;
+      stub_name += "Stub";
+      stub_base_class_name = "AbstractAsyncStub";
       break;
     default:
       GRPC_CODEGEN_FAIL << "Cannot determine class name for StubType: " << type;
   }
   (*vars)["stub_name"] = stub_name;
   (*vars)["client_name"] = client_name;
+  (*vars)["stub_base_class_name"] = (*vars)[stub_base_class_name];
 
   // Class head
   if (!interface) {
@@ -549,11 +587,13 @@ static void PrintStub(
   if (impl_base) {
     p->Print(
         *vars,
-        "public static abstract class $abstract_name$ implements $BindableService$ {\n");
+        "public static abstract class $abstract_name$"
+        " implements $BindableService$ {\n");
   } else {
     p->Print(
         *vars,
-        "public static final class $stub_name$ extends $AbstractStub$<$stub_name$> {\n");
+        "public static final class $stub_name$"
+        " extends $stub_base_class_name$<$stub_name$> {\n");
   }
   p->Indent();
 
@@ -561,15 +601,9 @@ static void PrintStub(
   if (!impl_base && !interface) {
     p->Print(
         *vars,
-        "private $stub_name$($Channel$ channel) {\n");
-    p->Indent();
-    p->Print("super(channel);\n");
-    p->Outdent();
-    p->Print("}\n\n");
-    p->Print(
-        *vars,
-        "private $stub_name$($Channel$ channel,\n"
-        "    $CallOptions$ callOptions) {\n");
+        "private $stub_name$(\n"
+        "    $Channel$ channel, $CallOptions$ callOptions) {"
+        "\n");
     p->Indent();
     p->Print("super(channel, callOptions);\n");
     p->Outdent();
@@ -577,8 +611,9 @@ static void PrintStub(
     p->Print(
         *vars,
         "@$Override$\n"
-        "protected $stub_name$ build($Channel$ channel,\n"
-        "    $CallOptions$ callOptions) {\n");
+        "protected $stub_name$ build(\n"
+        "    $Channel$ channel, $CallOptions$ callOptions) {"
+        "\n");
     p->Indent();
     p->Print(
         *vars,
@@ -1076,9 +1111,8 @@ static void PrintService(const ServiceDescriptor* service,
       *vars,
       "public static $service_name$Stub newStub($Channel$ channel) {\n");
   p->Indent();
-  p->Print(
-      *vars,
-      "return new $service_name$Stub(channel);\n");
+  PrintStubFactory(service, vars, p, ASYNC_CLIENT_IMPL);
+  p->Print(*vars, "return $service_name$Stub.newStub(factory, channel);\n");
   p->Outdent();
   p->Print("}\n\n");
 
@@ -1090,9 +1124,10 @@ static void PrintService(const ServiceDescriptor* service,
       "public static $service_name$BlockingStub newBlockingStub(\n"
       "    $Channel$ channel) {\n");
   p->Indent();
+  PrintStubFactory(service, vars, p, BLOCKING_CLIENT_IMPL);
   p->Print(
       *vars,
-      "return new $service_name$BlockingStub(channel);\n");
+      "return $service_name$BlockingStub.newStub(factory, channel);\n");
   p->Outdent();
   p->Print("}\n\n");
 
@@ -1104,9 +1139,10 @@ static void PrintService(const ServiceDescriptor* service,
       "public static $service_name$FutureStub newFutureStub(\n"
       "    $Channel$ channel) {\n");
   p->Indent();
+  PrintStubFactory(service, vars, p, FUTURE_CLIENT_IMPL);
   p->Print(
       *vars,
-      "return new $service_name$FutureStub(channel);\n");
+      "return $service_name$FutureStub.newStub(factory, channel);\n");
   p->Outdent();
   p->Print("}\n\n");
 
@@ -1180,6 +1216,10 @@ void GenerateService(const ServiceDescriptor* service,
   vars["ProtoMethodDescriptorSupplier"] =
       "io.grpc.protobuf.ProtoMethodDescriptorSupplier";
   vars["AbstractStub"] = "io.grpc.stub.AbstractStub";
+  vars["AbstractAsyncStub"] = "io.grpc.stub.AbstractAsyncStub";
+  vars["AbstractFutureStub"] = "io.grpc.stub.AbstractFutureStub";
+  vars["AbstractBlockingStub"] = "io.grpc.stub.AbstractBlockingStub";
+  vars["StubFactory"] = "io.grpc.stub.AbstractStub.StubFactory";
   vars["RpcMethod"] = "io.grpc.stub.annotations.RpcMethod";
   vars["MethodDescriptor"] = "io.grpc.MethodDescriptor";
   vars["StreamObserver"] = "io.grpc.stub.StreamObserver";

--- a/compiler/src/test/golden/TestDeprecatedService.java.txt
+++ b/compiler/src/test/golden/TestDeprecatedService.java.txt
@@ -66,7 +66,14 @@ public final class TestDeprecatedServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static TestDeprecatedServiceStub newStub(io.grpc.Channel channel) {
-    return new TestDeprecatedServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<TestDeprecatedServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<TestDeprecatedServiceStub>() {
+        @java.lang.Override
+        public TestDeprecatedServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new TestDeprecatedServiceStub(channel, callOptions);
+        }
+      };
+    return TestDeprecatedServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -74,7 +81,14 @@ public final class TestDeprecatedServiceGrpc {
    */
   public static TestDeprecatedServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new TestDeprecatedServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<TestDeprecatedServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<TestDeprecatedServiceBlockingStub>() {
+        @java.lang.Override
+        public TestDeprecatedServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new TestDeprecatedServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return TestDeprecatedServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -82,7 +96,14 @@ public final class TestDeprecatedServiceGrpc {
    */
   public static TestDeprecatedServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new TestDeprecatedServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<TestDeprecatedServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<TestDeprecatedServiceFutureStub>() {
+        @java.lang.Override
+        public TestDeprecatedServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new TestDeprecatedServiceFutureStub(channel, callOptions);
+        }
+      };
+    return TestDeprecatedServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -123,19 +144,15 @@ public final class TestDeprecatedServiceGrpc {
    * </pre>
    */
   @java.lang.Deprecated
-  public static final class TestDeprecatedServiceStub extends io.grpc.stub.AbstractStub<TestDeprecatedServiceStub> {
-    private TestDeprecatedServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private TestDeprecatedServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class TestDeprecatedServiceStub extends io.grpc.stub.AbstractAsyncStub<TestDeprecatedServiceStub> {
+    private TestDeprecatedServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected TestDeprecatedServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected TestDeprecatedServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new TestDeprecatedServiceStub(channel, callOptions);
     }
 
@@ -158,19 +175,15 @@ public final class TestDeprecatedServiceGrpc {
    * </pre>
    */
   @java.lang.Deprecated
-  public static final class TestDeprecatedServiceBlockingStub extends io.grpc.stub.AbstractStub<TestDeprecatedServiceBlockingStub> {
-    private TestDeprecatedServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private TestDeprecatedServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class TestDeprecatedServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<TestDeprecatedServiceBlockingStub> {
+    private TestDeprecatedServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected TestDeprecatedServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected TestDeprecatedServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new TestDeprecatedServiceBlockingStub(channel, callOptions);
     }
 
@@ -192,19 +205,15 @@ public final class TestDeprecatedServiceGrpc {
    * </pre>
    */
   @java.lang.Deprecated
-  public static final class TestDeprecatedServiceFutureStub extends io.grpc.stub.AbstractStub<TestDeprecatedServiceFutureStub> {
-    private TestDeprecatedServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private TestDeprecatedServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class TestDeprecatedServiceFutureStub extends io.grpc.stub.AbstractFutureStub<TestDeprecatedServiceFutureStub> {
+    private TestDeprecatedServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected TestDeprecatedServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected TestDeprecatedServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new TestDeprecatedServiceFutureStub(channel, callOptions);
     }
 

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -284,7 +284,14 @@ public final class TestServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static TestServiceStub newStub(io.grpc.Channel channel) {
-    return new TestServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<TestServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<TestServiceStub>() {
+        @java.lang.Override
+        public TestServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new TestServiceStub(channel, callOptions);
+        }
+      };
+    return TestServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -292,7 +299,14 @@ public final class TestServiceGrpc {
    */
   public static TestServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new TestServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<TestServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<TestServiceBlockingStub>() {
+        @java.lang.Override
+        public TestServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new TestServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return TestServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -300,7 +314,14 @@ public final class TestServiceGrpc {
    */
   public static TestServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new TestServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<TestServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<TestServiceFutureStub>() {
+        @java.lang.Override
+        public TestServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new TestServiceFutureStub(channel, callOptions);
+        }
+      };
+    return TestServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -466,19 +487,15 @@ public final class TestServiceGrpc {
    * Test service that supports all call types.
    * </pre>
    */
-  public static final class TestServiceStub extends io.grpc.stub.AbstractStub<TestServiceStub> {
-    private TestServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private TestServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class TestServiceStub extends io.grpc.stub.AbstractAsyncStub<TestServiceStub> {
+    private TestServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected TestServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected TestServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new TestServiceStub(channel, callOptions);
     }
 
@@ -585,19 +602,15 @@ public final class TestServiceGrpc {
    * Test service that supports all call types.
    * </pre>
    */
-  public static final class TestServiceBlockingStub extends io.grpc.stub.AbstractStub<TestServiceBlockingStub> {
-    private TestServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private TestServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class TestServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<TestServiceBlockingStub> {
+    private TestServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected TestServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected TestServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new TestServiceBlockingStub(channel, callOptions);
     }
 
@@ -650,19 +663,15 @@ public final class TestServiceGrpc {
    * Test service that supports all call types.
    * </pre>
    */
-  public static final class TestServiceFutureStub extends io.grpc.stub.AbstractStub<TestServiceFutureStub> {
-    private TestServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private TestServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class TestServiceFutureStub extends io.grpc.stub.AbstractFutureStub<TestServiceFutureStub> {
+    private TestServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected TestServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected TestServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new TestServiceFutureStub(channel, callOptions);
     }
 

--- a/compiler/src/testLite/golden/TestDeprecatedService.java.txt
+++ b/compiler/src/testLite/golden/TestDeprecatedService.java.txt
@@ -65,7 +65,14 @@ public final class TestDeprecatedServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static TestDeprecatedServiceStub newStub(io.grpc.Channel channel) {
-    return new TestDeprecatedServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<TestDeprecatedServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<TestDeprecatedServiceStub>() {
+        @java.lang.Override
+        public TestDeprecatedServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new TestDeprecatedServiceStub(channel, callOptions);
+        }
+      };
+    return TestDeprecatedServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -73,7 +80,14 @@ public final class TestDeprecatedServiceGrpc {
    */
   public static TestDeprecatedServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new TestDeprecatedServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<TestDeprecatedServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<TestDeprecatedServiceBlockingStub>() {
+        @java.lang.Override
+        public TestDeprecatedServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new TestDeprecatedServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return TestDeprecatedServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -81,7 +95,14 @@ public final class TestDeprecatedServiceGrpc {
    */
   public static TestDeprecatedServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new TestDeprecatedServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<TestDeprecatedServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<TestDeprecatedServiceFutureStub>() {
+        @java.lang.Override
+        public TestDeprecatedServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new TestDeprecatedServiceFutureStub(channel, callOptions);
+        }
+      };
+    return TestDeprecatedServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -122,19 +143,15 @@ public final class TestDeprecatedServiceGrpc {
    * </pre>
    */
   @java.lang.Deprecated
-  public static final class TestDeprecatedServiceStub extends io.grpc.stub.AbstractStub<TestDeprecatedServiceStub> {
-    private TestDeprecatedServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private TestDeprecatedServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class TestDeprecatedServiceStub extends io.grpc.stub.AbstractAsyncStub<TestDeprecatedServiceStub> {
+    private TestDeprecatedServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected TestDeprecatedServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected TestDeprecatedServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new TestDeprecatedServiceStub(channel, callOptions);
     }
 
@@ -157,19 +174,15 @@ public final class TestDeprecatedServiceGrpc {
    * </pre>
    */
   @java.lang.Deprecated
-  public static final class TestDeprecatedServiceBlockingStub extends io.grpc.stub.AbstractStub<TestDeprecatedServiceBlockingStub> {
-    private TestDeprecatedServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private TestDeprecatedServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class TestDeprecatedServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<TestDeprecatedServiceBlockingStub> {
+    private TestDeprecatedServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected TestDeprecatedServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected TestDeprecatedServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new TestDeprecatedServiceBlockingStub(channel, callOptions);
     }
 
@@ -191,19 +204,15 @@ public final class TestDeprecatedServiceGrpc {
    * </pre>
    */
   @java.lang.Deprecated
-  public static final class TestDeprecatedServiceFutureStub extends io.grpc.stub.AbstractStub<TestDeprecatedServiceFutureStub> {
-    private TestDeprecatedServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private TestDeprecatedServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class TestDeprecatedServiceFutureStub extends io.grpc.stub.AbstractFutureStub<TestDeprecatedServiceFutureStub> {
+    private TestDeprecatedServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected TestDeprecatedServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected TestDeprecatedServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new TestDeprecatedServiceFutureStub(channel, callOptions);
     }
 

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -276,7 +276,14 @@ public final class TestServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static TestServiceStub newStub(io.grpc.Channel channel) {
-    return new TestServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<TestServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<TestServiceStub>() {
+        @java.lang.Override
+        public TestServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new TestServiceStub(channel, callOptions);
+        }
+      };
+    return TestServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -284,7 +291,14 @@ public final class TestServiceGrpc {
    */
   public static TestServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new TestServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<TestServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<TestServiceBlockingStub>() {
+        @java.lang.Override
+        public TestServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new TestServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return TestServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -292,7 +306,14 @@ public final class TestServiceGrpc {
    */
   public static TestServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new TestServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<TestServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<TestServiceFutureStub>() {
+        @java.lang.Override
+        public TestServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new TestServiceFutureStub(channel, callOptions);
+        }
+      };
+    return TestServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -458,19 +479,15 @@ public final class TestServiceGrpc {
    * Test service that supports all call types.
    * </pre>
    */
-  public static final class TestServiceStub extends io.grpc.stub.AbstractStub<TestServiceStub> {
-    private TestServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private TestServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class TestServiceStub extends io.grpc.stub.AbstractAsyncStub<TestServiceStub> {
+    private TestServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected TestServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected TestServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new TestServiceStub(channel, callOptions);
     }
 
@@ -577,19 +594,15 @@ public final class TestServiceGrpc {
    * Test service that supports all call types.
    * </pre>
    */
-  public static final class TestServiceBlockingStub extends io.grpc.stub.AbstractStub<TestServiceBlockingStub> {
-    private TestServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private TestServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class TestServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<TestServiceBlockingStub> {
+    private TestServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected TestServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected TestServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new TestServiceBlockingStub(channel, callOptions);
     }
 
@@ -642,19 +655,15 @@ public final class TestServiceGrpc {
    * Test service that supports all call types.
    * </pre>
    */
-  public static final class TestServiceFutureStub extends io.grpc.stub.AbstractStub<TestServiceFutureStub> {
-    private TestServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private TestServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class TestServiceFutureStub extends io.grpc.stub.AbstractFutureStub<TestServiceFutureStub> {
+    private TestServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected TestServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected TestServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new TestServiceFutureStub(channel, callOptions);
     }
 

--- a/grpclb/src/generated/main/grpc/io/grpc/lb/v1/LoadBalancerGrpc.java
+++ b/grpclb/src/generated/main/grpc/io/grpc/lb/v1/LoadBalancerGrpc.java
@@ -62,7 +62,14 @@ public final class LoadBalancerGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static LoadBalancerStub newStub(io.grpc.Channel channel) {
-    return new LoadBalancerStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<LoadBalancerStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<LoadBalancerStub>() {
+        @java.lang.Override
+        public LoadBalancerStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new LoadBalancerStub(channel, callOptions);
+        }
+      };
+    return LoadBalancerStub.newStub(factory, channel);
   }
 
   /**
@@ -70,7 +77,14 @@ public final class LoadBalancerGrpc {
    */
   public static LoadBalancerBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new LoadBalancerBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<LoadBalancerBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<LoadBalancerBlockingStub>() {
+        @java.lang.Override
+        public LoadBalancerBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new LoadBalancerBlockingStub(channel, callOptions);
+        }
+      };
+    return LoadBalancerBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -78,7 +92,14 @@ public final class LoadBalancerGrpc {
    */
   public static LoadBalancerFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new LoadBalancerFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<LoadBalancerFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<LoadBalancerFutureStub>() {
+        @java.lang.Override
+        public LoadBalancerFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new LoadBalancerFutureStub(channel, callOptions);
+        }
+      };
+    return LoadBalancerFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -110,19 +131,15 @@ public final class LoadBalancerGrpc {
 
   /**
    */
-  public static final class LoadBalancerStub extends io.grpc.stub.AbstractStub<LoadBalancerStub> {
-    private LoadBalancerStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private LoadBalancerStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class LoadBalancerStub extends io.grpc.stub.AbstractAsyncStub<LoadBalancerStub> {
+    private LoadBalancerStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected LoadBalancerStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected LoadBalancerStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new LoadBalancerStub(channel, callOptions);
     }
 
@@ -140,38 +157,30 @@ public final class LoadBalancerGrpc {
 
   /**
    */
-  public static final class LoadBalancerBlockingStub extends io.grpc.stub.AbstractStub<LoadBalancerBlockingStub> {
-    private LoadBalancerBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private LoadBalancerBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class LoadBalancerBlockingStub extends io.grpc.stub.AbstractBlockingStub<LoadBalancerBlockingStub> {
+    private LoadBalancerBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected LoadBalancerBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected LoadBalancerBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new LoadBalancerBlockingStub(channel, callOptions);
     }
   }
 
   /**
    */
-  public static final class LoadBalancerFutureStub extends io.grpc.stub.AbstractStub<LoadBalancerFutureStub> {
-    private LoadBalancerFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private LoadBalancerFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class LoadBalancerFutureStub extends io.grpc.stub.AbstractFutureStub<LoadBalancerFutureStub> {
+    private LoadBalancerFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected LoadBalancerFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected LoadBalancerFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new LoadBalancerFutureStub(channel, callOptions);
     }
   }

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -93,7 +93,14 @@ public final class MetricsServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static MetricsServiceStub newStub(io.grpc.Channel channel) {
-    return new MetricsServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<MetricsServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<MetricsServiceStub>() {
+        @java.lang.Override
+        public MetricsServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new MetricsServiceStub(channel, callOptions);
+        }
+      };
+    return MetricsServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -101,7 +108,14 @@ public final class MetricsServiceGrpc {
    */
   public static MetricsServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new MetricsServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<MetricsServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<MetricsServiceBlockingStub>() {
+        @java.lang.Override
+        public MetricsServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new MetricsServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return MetricsServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -109,7 +123,14 @@ public final class MetricsServiceGrpc {
    */
   public static MetricsServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new MetricsServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<MetricsServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<MetricsServiceFutureStub>() {
+        @java.lang.Override
+        public MetricsServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new MetricsServiceFutureStub(channel, callOptions);
+        }
+      };
+    return MetricsServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -159,19 +180,15 @@ public final class MetricsServiceGrpc {
 
   /**
    */
-  public static final class MetricsServiceStub extends io.grpc.stub.AbstractStub<MetricsServiceStub> {
-    private MetricsServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private MetricsServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class MetricsServiceStub extends io.grpc.stub.AbstractAsyncStub<MetricsServiceStub> {
+    private MetricsServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected MetricsServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected MetricsServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new MetricsServiceStub(channel, callOptions);
     }
 
@@ -201,19 +218,15 @@ public final class MetricsServiceGrpc {
 
   /**
    */
-  public static final class MetricsServiceBlockingStub extends io.grpc.stub.AbstractStub<MetricsServiceBlockingStub> {
-    private MetricsServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private MetricsServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class MetricsServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<MetricsServiceBlockingStub> {
+    private MetricsServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected MetricsServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected MetricsServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new MetricsServiceBlockingStub(channel, callOptions);
     }
 
@@ -242,19 +255,15 @@ public final class MetricsServiceGrpc {
 
   /**
    */
-  public static final class MetricsServiceFutureStub extends io.grpc.stub.AbstractStub<MetricsServiceFutureStub> {
-    private MetricsServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private MetricsServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class MetricsServiceFutureStub extends io.grpc.stub.AbstractFutureStub<MetricsServiceFutureStub> {
+    private MetricsServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected MetricsServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected MetricsServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new MetricsServiceFutureStub(channel, callOptions);
     }
 

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -96,7 +96,14 @@ public final class ReconnectServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static ReconnectServiceStub newStub(io.grpc.Channel channel) {
-    return new ReconnectServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ReconnectServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ReconnectServiceStub>() {
+        @java.lang.Override
+        public ReconnectServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ReconnectServiceStub(channel, callOptions);
+        }
+      };
+    return ReconnectServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -104,7 +111,14 @@ public final class ReconnectServiceGrpc {
    */
   public static ReconnectServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new ReconnectServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ReconnectServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ReconnectServiceBlockingStub>() {
+        @java.lang.Override
+        public ReconnectServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ReconnectServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return ReconnectServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -112,7 +126,14 @@ public final class ReconnectServiceGrpc {
    */
   public static ReconnectServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new ReconnectServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ReconnectServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ReconnectServiceFutureStub>() {
+        @java.lang.Override
+        public ReconnectServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ReconnectServiceFutureStub(channel, callOptions);
+        }
+      };
+    return ReconnectServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -161,19 +182,15 @@ public final class ReconnectServiceGrpc {
    * A service used to control reconnect server.
    * </pre>
    */
-  public static final class ReconnectServiceStub extends io.grpc.stub.AbstractStub<ReconnectServiceStub> {
-    private ReconnectServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ReconnectServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ReconnectServiceStub extends io.grpc.stub.AbstractAsyncStub<ReconnectServiceStub> {
+    private ReconnectServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ReconnectServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ReconnectServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ReconnectServiceStub(channel, callOptions);
     }
 
@@ -199,19 +216,15 @@ public final class ReconnectServiceGrpc {
    * A service used to control reconnect server.
    * </pre>
    */
-  public static final class ReconnectServiceBlockingStub extends io.grpc.stub.AbstractStub<ReconnectServiceBlockingStub> {
-    private ReconnectServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ReconnectServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ReconnectServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<ReconnectServiceBlockingStub> {
+    private ReconnectServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ReconnectServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ReconnectServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ReconnectServiceBlockingStub(channel, callOptions);
     }
 
@@ -235,19 +248,15 @@ public final class ReconnectServiceGrpc {
    * A service used to control reconnect server.
    * </pre>
    */
-  public static final class ReconnectServiceFutureStub extends io.grpc.stub.AbstractStub<ReconnectServiceFutureStub> {
-    private ReconnectServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ReconnectServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ReconnectServiceFutureStub extends io.grpc.stub.AbstractFutureStub<ReconnectServiceFutureStub> {
+    private ReconnectServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ReconnectServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ReconnectServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ReconnectServiceFutureStub(channel, callOptions);
     }
 

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -283,7 +283,14 @@ public final class TestServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static TestServiceStub newStub(io.grpc.Channel channel) {
-    return new TestServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<TestServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<TestServiceStub>() {
+        @java.lang.Override
+        public TestServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new TestServiceStub(channel, callOptions);
+        }
+      };
+    return TestServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -291,7 +298,14 @@ public final class TestServiceGrpc {
    */
   public static TestServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new TestServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<TestServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<TestServiceBlockingStub>() {
+        @java.lang.Override
+        public TestServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new TestServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return TestServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -299,7 +313,14 @@ public final class TestServiceGrpc {
    */
   public static TestServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new TestServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<TestServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<TestServiceFutureStub>() {
+        @java.lang.Override
+        public TestServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new TestServiceFutureStub(channel, callOptions);
+        }
+      };
+    return TestServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -468,19 +489,15 @@ public final class TestServiceGrpc {
    * performance with various types of payload.
    * </pre>
    */
-  public static final class TestServiceStub extends io.grpc.stub.AbstractStub<TestServiceStub> {
-    private TestServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private TestServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class TestServiceStub extends io.grpc.stub.AbstractAsyncStub<TestServiceStub> {
+    private TestServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected TestServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected TestServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new TestServiceStub(channel, callOptions);
     }
 
@@ -589,19 +606,15 @@ public final class TestServiceGrpc {
    * performance with various types of payload.
    * </pre>
    */
-  public static final class TestServiceBlockingStub extends io.grpc.stub.AbstractStub<TestServiceBlockingStub> {
-    private TestServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private TestServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class TestServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<TestServiceBlockingStub> {
+    private TestServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected TestServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected TestServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new TestServiceBlockingStub(channel, callOptions);
     }
 
@@ -667,19 +680,15 @@ public final class TestServiceGrpc {
    * performance with various types of payload.
    * </pre>
    */
-  public static final class TestServiceFutureStub extends io.grpc.stub.AbstractStub<TestServiceFutureStub> {
-    private TestServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private TestServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class TestServiceFutureStub extends io.grpc.stub.AbstractFutureStub<TestServiceFutureStub> {
+    private TestServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected TestServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected TestServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new TestServiceFutureStub(channel, callOptions);
     }
 

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -66,7 +66,14 @@ public final class UnimplementedServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static UnimplementedServiceStub newStub(io.grpc.Channel channel) {
-    return new UnimplementedServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<UnimplementedServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<UnimplementedServiceStub>() {
+        @java.lang.Override
+        public UnimplementedServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new UnimplementedServiceStub(channel, callOptions);
+        }
+      };
+    return UnimplementedServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -74,7 +81,14 @@ public final class UnimplementedServiceGrpc {
    */
   public static UnimplementedServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new UnimplementedServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<UnimplementedServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<UnimplementedServiceBlockingStub>() {
+        @java.lang.Override
+        public UnimplementedServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new UnimplementedServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return UnimplementedServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -82,7 +96,14 @@ public final class UnimplementedServiceGrpc {
    */
   public static UnimplementedServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new UnimplementedServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<UnimplementedServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<UnimplementedServiceFutureStub>() {
+        @java.lang.Override
+        public UnimplementedServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new UnimplementedServiceFutureStub(channel, callOptions);
+        }
+      };
+    return UnimplementedServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -122,19 +143,15 @@ public final class UnimplementedServiceGrpc {
    * that case.
    * </pre>
    */
-  public static final class UnimplementedServiceStub extends io.grpc.stub.AbstractStub<UnimplementedServiceStub> {
-    private UnimplementedServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private UnimplementedServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class UnimplementedServiceStub extends io.grpc.stub.AbstractAsyncStub<UnimplementedServiceStub> {
+    private UnimplementedServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected UnimplementedServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected UnimplementedServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new UnimplementedServiceStub(channel, callOptions);
     }
 
@@ -156,19 +173,15 @@ public final class UnimplementedServiceGrpc {
    * that case.
    * </pre>
    */
-  public static final class UnimplementedServiceBlockingStub extends io.grpc.stub.AbstractStub<UnimplementedServiceBlockingStub> {
-    private UnimplementedServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private UnimplementedServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class UnimplementedServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<UnimplementedServiceBlockingStub> {
+    private UnimplementedServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected UnimplementedServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected UnimplementedServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new UnimplementedServiceBlockingStub(channel, callOptions);
     }
 
@@ -189,19 +202,15 @@ public final class UnimplementedServiceGrpc {
    * that case.
    * </pre>
    */
-  public static final class UnimplementedServiceFutureStub extends io.grpc.stub.AbstractStub<UnimplementedServiceFutureStub> {
-    private UnimplementedServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private UnimplementedServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class UnimplementedServiceFutureStub extends io.grpc.stub.AbstractFutureStub<UnimplementedServiceFutureStub> {
+    private UnimplementedServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected UnimplementedServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected UnimplementedServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new UnimplementedServiceFutureStub(channel, callOptions);
     }
 

--- a/services/src/generated/main/grpc/io/grpc/channelz/v1/ChannelzGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/channelz/v1/ChannelzGrpc.java
@@ -252,7 +252,14 @@ public final class ChannelzGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static ChannelzStub newStub(io.grpc.Channel channel) {
-    return new ChannelzStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ChannelzStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ChannelzStub>() {
+        @java.lang.Override
+        public ChannelzStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ChannelzStub(channel, callOptions);
+        }
+      };
+    return ChannelzStub.newStub(factory, channel);
   }
 
   /**
@@ -260,7 +267,14 @@ public final class ChannelzGrpc {
    */
   public static ChannelzBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new ChannelzBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ChannelzBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ChannelzBlockingStub>() {
+        @java.lang.Override
+        public ChannelzBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ChannelzBlockingStub(channel, callOptions);
+        }
+      };
+    return ChannelzBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -268,7 +282,14 @@ public final class ChannelzGrpc {
    */
   public static ChannelzFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new ChannelzFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ChannelzFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ChannelzFutureStub>() {
+        @java.lang.Override
+        public ChannelzFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ChannelzFutureStub(channel, callOptions);
+        }
+      };
+    return ChannelzFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -411,19 +432,15 @@ public final class ChannelzGrpc {
    * information.
    * </pre>
    */
-  public static final class ChannelzStub extends io.grpc.stub.AbstractStub<ChannelzStub> {
-    private ChannelzStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ChannelzStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ChannelzStub extends io.grpc.stub.AbstractAsyncStub<ChannelzStub> {
+    private ChannelzStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ChannelzStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ChannelzStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ChannelzStub(channel, callOptions);
     }
 
@@ -512,19 +529,15 @@ public final class ChannelzGrpc {
    * information.
    * </pre>
    */
-  public static final class ChannelzBlockingStub extends io.grpc.stub.AbstractStub<ChannelzBlockingStub> {
-    private ChannelzBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ChannelzBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ChannelzBlockingStub extends io.grpc.stub.AbstractBlockingStub<ChannelzBlockingStub> {
+    private ChannelzBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ChannelzBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ChannelzBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ChannelzBlockingStub(channel, callOptions);
     }
 
@@ -606,19 +619,15 @@ public final class ChannelzGrpc {
    * information.
    * </pre>
    */
-  public static final class ChannelzFutureStub extends io.grpc.stub.AbstractStub<ChannelzFutureStub> {
-    private ChannelzFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ChannelzFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ChannelzFutureStub extends io.grpc.stub.AbstractFutureStub<ChannelzFutureStub> {
+    private ChannelzFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ChannelzFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ChannelzFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ChannelzFutureStub(channel, callOptions);
     }
 

--- a/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
@@ -93,7 +93,14 @@ public final class HealthGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static HealthStub newStub(io.grpc.Channel channel) {
-    return new HealthStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<HealthStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<HealthStub>() {
+        @java.lang.Override
+        public HealthStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new HealthStub(channel, callOptions);
+        }
+      };
+    return HealthStub.newStub(factory, channel);
   }
 
   /**
@@ -101,7 +108,14 @@ public final class HealthGrpc {
    */
   public static HealthBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new HealthBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<HealthBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<HealthBlockingStub>() {
+        @java.lang.Override
+        public HealthBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new HealthBlockingStub(channel, callOptions);
+        }
+      };
+    return HealthBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -109,7 +123,14 @@ public final class HealthGrpc {
    */
   public static HealthFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new HealthFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<HealthFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<HealthFutureStub>() {
+        @java.lang.Override
+        public HealthFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new HealthFutureStub(channel, callOptions);
+        }
+      };
+    return HealthFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -171,19 +192,15 @@ public final class HealthGrpc {
 
   /**
    */
-  public static final class HealthStub extends io.grpc.stub.AbstractStub<HealthStub> {
-    private HealthStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private HealthStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class HealthStub extends io.grpc.stub.AbstractAsyncStub<HealthStub> {
+    private HealthStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected HealthStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected HealthStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new HealthStub(channel, callOptions);
     }
 
@@ -225,19 +242,15 @@ public final class HealthGrpc {
 
   /**
    */
-  public static final class HealthBlockingStub extends io.grpc.stub.AbstractStub<HealthBlockingStub> {
-    private HealthBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private HealthBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class HealthBlockingStub extends io.grpc.stub.AbstractBlockingStub<HealthBlockingStub> {
+    private HealthBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected HealthBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected HealthBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new HealthBlockingStub(channel, callOptions);
     }
 
@@ -278,19 +291,15 @@ public final class HealthGrpc {
 
   /**
    */
-  public static final class HealthFutureStub extends io.grpc.stub.AbstractStub<HealthFutureStub> {
-    private HealthFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private HealthFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class HealthFutureStub extends io.grpc.stub.AbstractFutureStub<HealthFutureStub> {
+    private HealthFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected HealthFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected HealthFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new HealthFutureStub(channel, callOptions);
     }
 

--- a/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
@@ -62,7 +62,14 @@ public final class ServerReflectionGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static ServerReflectionStub newStub(io.grpc.Channel channel) {
-    return new ServerReflectionStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ServerReflectionStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ServerReflectionStub>() {
+        @java.lang.Override
+        public ServerReflectionStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ServerReflectionStub(channel, callOptions);
+        }
+      };
+    return ServerReflectionStub.newStub(factory, channel);
   }
 
   /**
@@ -70,7 +77,14 @@ public final class ServerReflectionGrpc {
    */
   public static ServerReflectionBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new ServerReflectionBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ServerReflectionBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ServerReflectionBlockingStub>() {
+        @java.lang.Override
+        public ServerReflectionBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ServerReflectionBlockingStub(channel, callOptions);
+        }
+      };
+    return ServerReflectionBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -78,7 +92,14 @@ public final class ServerReflectionGrpc {
    */
   public static ServerReflectionFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new ServerReflectionFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ServerReflectionFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ServerReflectionFutureStub>() {
+        @java.lang.Override
+        public ServerReflectionFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ServerReflectionFutureStub(channel, callOptions);
+        }
+      };
+    return ServerReflectionFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -111,19 +132,15 @@ public final class ServerReflectionGrpc {
 
   /**
    */
-  public static final class ServerReflectionStub extends io.grpc.stub.AbstractStub<ServerReflectionStub> {
-    private ServerReflectionStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ServerReflectionStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ServerReflectionStub extends io.grpc.stub.AbstractAsyncStub<ServerReflectionStub> {
+    private ServerReflectionStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ServerReflectionStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ServerReflectionStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ServerReflectionStub(channel, callOptions);
     }
 
@@ -142,38 +159,30 @@ public final class ServerReflectionGrpc {
 
   /**
    */
-  public static final class ServerReflectionBlockingStub extends io.grpc.stub.AbstractStub<ServerReflectionBlockingStub> {
-    private ServerReflectionBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ServerReflectionBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ServerReflectionBlockingStub extends io.grpc.stub.AbstractBlockingStub<ServerReflectionBlockingStub> {
+    private ServerReflectionBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ServerReflectionBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ServerReflectionBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ServerReflectionBlockingStub(channel, callOptions);
     }
   }
 
   /**
    */
-  public static final class ServerReflectionFutureStub extends io.grpc.stub.AbstractStub<ServerReflectionFutureStub> {
-    private ServerReflectionFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ServerReflectionFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ServerReflectionFutureStub extends io.grpc.stub.AbstractFutureStub<ServerReflectionFutureStub> {
+    private ServerReflectionFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ServerReflectionFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ServerReflectionFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ServerReflectionFutureStub(channel, callOptions);
     }
   }

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/AnotherDynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/AnotherDynamicServiceGrpc.java
@@ -65,7 +65,14 @@ public final class AnotherDynamicServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static AnotherDynamicServiceStub newStub(io.grpc.Channel channel) {
-    return new AnotherDynamicServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AnotherDynamicServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<AnotherDynamicServiceStub>() {
+        @java.lang.Override
+        public AnotherDynamicServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new AnotherDynamicServiceStub(channel, callOptions);
+        }
+      };
+    return AnotherDynamicServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -73,7 +80,14 @@ public final class AnotherDynamicServiceGrpc {
    */
   public static AnotherDynamicServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new AnotherDynamicServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AnotherDynamicServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<AnotherDynamicServiceBlockingStub>() {
+        @java.lang.Override
+        public AnotherDynamicServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new AnotherDynamicServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return AnotherDynamicServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -81,7 +95,14 @@ public final class AnotherDynamicServiceGrpc {
    */
   public static AnotherDynamicServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new AnotherDynamicServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AnotherDynamicServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<AnotherDynamicServiceFutureStub>() {
+        @java.lang.Override
+        public AnotherDynamicServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new AnotherDynamicServiceFutureStub(channel, callOptions);
+        }
+      };
+    return AnotherDynamicServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -119,19 +140,15 @@ public final class AnotherDynamicServiceGrpc {
    * AnotherDynamicService
    * </pre>
    */
-  public static final class AnotherDynamicServiceStub extends io.grpc.stub.AbstractStub<AnotherDynamicServiceStub> {
-    private AnotherDynamicServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private AnotherDynamicServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class AnotherDynamicServiceStub extends io.grpc.stub.AbstractAsyncStub<AnotherDynamicServiceStub> {
+    private AnotherDynamicServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected AnotherDynamicServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected AnotherDynamicServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new AnotherDynamicServiceStub(channel, callOptions);
     }
 
@@ -152,19 +169,15 @@ public final class AnotherDynamicServiceGrpc {
    * AnotherDynamicService
    * </pre>
    */
-  public static final class AnotherDynamicServiceBlockingStub extends io.grpc.stub.AbstractStub<AnotherDynamicServiceBlockingStub> {
-    private AnotherDynamicServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private AnotherDynamicServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class AnotherDynamicServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<AnotherDynamicServiceBlockingStub> {
+    private AnotherDynamicServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected AnotherDynamicServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected AnotherDynamicServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new AnotherDynamicServiceBlockingStub(channel, callOptions);
     }
 
@@ -184,19 +197,15 @@ public final class AnotherDynamicServiceGrpc {
    * AnotherDynamicService
    * </pre>
    */
-  public static final class AnotherDynamicServiceFutureStub extends io.grpc.stub.AbstractStub<AnotherDynamicServiceFutureStub> {
-    private AnotherDynamicServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private AnotherDynamicServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class AnotherDynamicServiceFutureStub extends io.grpc.stub.AbstractFutureStub<AnotherDynamicServiceFutureStub> {
+    private AnotherDynamicServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected AnotherDynamicServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected AnotherDynamicServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new AnotherDynamicServiceFutureStub(channel, callOptions);
     }
 

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
@@ -65,7 +65,14 @@ public final class DynamicServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static DynamicServiceStub newStub(io.grpc.Channel channel) {
-    return new DynamicServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<DynamicServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<DynamicServiceStub>() {
+        @java.lang.Override
+        public DynamicServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new DynamicServiceStub(channel, callOptions);
+        }
+      };
+    return DynamicServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -73,7 +80,14 @@ public final class DynamicServiceGrpc {
    */
   public static DynamicServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new DynamicServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<DynamicServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<DynamicServiceBlockingStub>() {
+        @java.lang.Override
+        public DynamicServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new DynamicServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return DynamicServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -81,7 +95,14 @@ public final class DynamicServiceGrpc {
    */
   public static DynamicServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new DynamicServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<DynamicServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<DynamicServiceFutureStub>() {
+        @java.lang.Override
+        public DynamicServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new DynamicServiceFutureStub(channel, callOptions);
+        }
+      };
+    return DynamicServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -119,19 +140,15 @@ public final class DynamicServiceGrpc {
    * A DynamicService
    * </pre>
    */
-  public static final class DynamicServiceStub extends io.grpc.stub.AbstractStub<DynamicServiceStub> {
-    private DynamicServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private DynamicServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class DynamicServiceStub extends io.grpc.stub.AbstractAsyncStub<DynamicServiceStub> {
+    private DynamicServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected DynamicServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected DynamicServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new DynamicServiceStub(channel, callOptions);
     }
 
@@ -152,19 +169,15 @@ public final class DynamicServiceGrpc {
    * A DynamicService
    * </pre>
    */
-  public static final class DynamicServiceBlockingStub extends io.grpc.stub.AbstractStub<DynamicServiceBlockingStub> {
-    private DynamicServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private DynamicServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class DynamicServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<DynamicServiceBlockingStub> {
+    private DynamicServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected DynamicServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected DynamicServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new DynamicServiceBlockingStub(channel, callOptions);
     }
 
@@ -184,19 +197,15 @@ public final class DynamicServiceGrpc {
    * A DynamicService
    * </pre>
    */
-  public static final class DynamicServiceFutureStub extends io.grpc.stub.AbstractStub<DynamicServiceFutureStub> {
-    private DynamicServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private DynamicServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class DynamicServiceFutureStub extends io.grpc.stub.AbstractFutureStub<DynamicServiceFutureStub> {
+    private DynamicServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected DynamicServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected DynamicServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new DynamicServiceFutureStub(channel, callOptions);
     }
 

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
@@ -62,7 +62,14 @@ public final class ReflectableServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static ReflectableServiceStub newStub(io.grpc.Channel channel) {
-    return new ReflectableServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ReflectableServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ReflectableServiceStub>() {
+        @java.lang.Override
+        public ReflectableServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ReflectableServiceStub(channel, callOptions);
+        }
+      };
+    return ReflectableServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -70,7 +77,14 @@ public final class ReflectableServiceGrpc {
    */
   public static ReflectableServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new ReflectableServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ReflectableServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ReflectableServiceBlockingStub>() {
+        @java.lang.Override
+        public ReflectableServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ReflectableServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return ReflectableServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -78,7 +92,14 @@ public final class ReflectableServiceGrpc {
    */
   public static ReflectableServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new ReflectableServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ReflectableServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ReflectableServiceFutureStub>() {
+        @java.lang.Override
+        public ReflectableServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ReflectableServiceFutureStub(channel, callOptions);
+        }
+      };
+    return ReflectableServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -107,19 +128,15 @@ public final class ReflectableServiceGrpc {
 
   /**
    */
-  public static final class ReflectableServiceStub extends io.grpc.stub.AbstractStub<ReflectableServiceStub> {
-    private ReflectableServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ReflectableServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ReflectableServiceStub extends io.grpc.stub.AbstractAsyncStub<ReflectableServiceStub> {
+    private ReflectableServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ReflectableServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ReflectableServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ReflectableServiceStub(channel, callOptions);
     }
 
@@ -134,19 +151,15 @@ public final class ReflectableServiceGrpc {
 
   /**
    */
-  public static final class ReflectableServiceBlockingStub extends io.grpc.stub.AbstractStub<ReflectableServiceBlockingStub> {
-    private ReflectableServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ReflectableServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ReflectableServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<ReflectableServiceBlockingStub> {
+    private ReflectableServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ReflectableServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ReflectableServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ReflectableServiceBlockingStub(channel, callOptions);
     }
 
@@ -160,19 +173,15 @@ public final class ReflectableServiceGrpc {
 
   /**
    */
-  public static final class ReflectableServiceFutureStub extends io.grpc.stub.AbstractStub<ReflectableServiceFutureStub> {
-    private ReflectableServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ReflectableServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ReflectableServiceFutureStub extends io.grpc.stub.AbstractFutureStub<ReflectableServiceFutureStub> {
+    private ReflectableServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ReflectableServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ReflectableServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ReflectableServiceFutureStub(channel, callOptions);
     }
 

--- a/stub/src/main/java/io/grpc/stub/AbstractAsyncStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractAsyncStub.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.stub;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.stub.ClientCalls.StubType;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Stub implementations for async stubs.
+ *
+ * <p>DO NOT MOCK: Customizing options doesn't work properly in mocks. Use InProcessChannelBuilder
+ * to create a real channel suitable for testing. It is also possible to mock Channel instead.
+ *
+ * @since 1.25.0
+ */
+@ThreadSafe
+@CheckReturnValue
+public abstract class AbstractAsyncStub<S extends AbstractAsyncStub<S>> extends AbstractStub<S> {
+
+  protected AbstractAsyncStub(Channel channel, CallOptions callOptions) {
+      super(channel, callOptions);
+  }
+
+  /**
+   * Returns a new async stub with the given channel for the provided method configurations.
+   *
+   * @since 1.25.0
+   * @param factory the factory to create an async stub
+   * @param channel the channel that this stub will use to do communications
+   */
+  public static <T extends AbstractStub<T>> T newStub(
+      StubFactory<T> factory, Channel channel) {
+    return newStub(factory, channel, CallOptions.DEFAULT);
+  }
+
+  /**
+   * Returns a new async stub with the given channel for the provided method configurations.
+   *
+   * @since 1.25.0
+   * @param factory the factory to create an async stub
+   * @param channel the channel that this stub will use to do communications
+   * @param callOptions the runtime call options to be applied to every call on this stub
+   */
+  public static <T extends AbstractStub<T>> T newStub(
+      StubFactory<T> factory, Channel channel, CallOptions callOptions) {
+    T stub = factory.newStub(
+        channel, callOptions.withOption(ClientCalls.STUB_TYPE_OPTION, StubType.ASYNC));
+    assert stub instanceof AbstractAsyncStub
+        : String.format("Expected AbstractAsyncStub, but got %s.", stub.getClass());
+    return stub;
+  }
+}

--- a/stub/src/main/java/io/grpc/stub/AbstractBlockingStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractBlockingStub.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.stub;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.stub.ClientCalls.StubType;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Stub implementations for blocking stubs.
+ *
+ * <p>DO NOT MOCK: Customizing options doesn't work properly in mocks. Use InProcessChannelBuilder
+ * to create a real channel suitable for testing. It is also possible to mock Channel instead.
+ *
+ * @since 1.25.0
+ */
+@ThreadSafe
+@CheckReturnValue
+public abstract class AbstractBlockingStub<S extends AbstractBlockingStub<S>>
+    extends AbstractStub<S> {
+
+  protected AbstractBlockingStub(Channel channel, CallOptions callOptions) {
+    super(channel, callOptions);
+  }
+
+  /**
+   * Returns a new blocking stub with the given channel for the provided method configurations.
+   *
+   * @since 1.25.0
+   * @param factory the factory to create a blocking stub
+   * @param channel the channel that this stub will use to do communications
+   */
+  public static <T extends AbstractStub<T>> T newStub(
+      StubFactory<T> factory, Channel channel) {
+    return newStub(factory, channel, CallOptions.DEFAULT);
+  }
+
+  /**
+   * Returns a new blocking stub with the given channel for the provided method configurations.
+   *
+   * @since 1.25.0
+   * @param factory the factory to create a blocking stub
+   * @param channel the channel that this stub will use to do communications
+   * @param callOptions the runtime call options to be applied to every call on this stub
+   */
+  public static <T extends AbstractStub<T>> T newStub(
+      StubFactory<T> factory, Channel channel, CallOptions callOptions) {
+    T stub = factory.newStub(
+        channel, callOptions.withOption(ClientCalls.STUB_TYPE_OPTION, StubType.BLOCKING));
+    assert stub instanceof AbstractBlockingStub
+        : String.format("Expected AbstractBlockingStub, but got %s.", stub.getClass());
+    return stub;
+  }
+}

--- a/stub/src/main/java/io/grpc/stub/AbstractFutureStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractFutureStub.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.stub;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.stub.ClientCalls.StubType;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Stub implementations for future stubs.
+ *
+ * <p>DO NOT MOCK: Customizing options doesn't work properly in mocks. Use InProcessChannelBuilder
+ * to create a real channel suitable for testing. It is also possible to mock Channel instead.
+ *
+ * @since 1.25.0
+ */
+@ThreadSafe
+@CheckReturnValue
+public abstract class AbstractFutureStub<S extends AbstractFutureStub<S>> extends AbstractStub<S> {
+
+  protected AbstractFutureStub(Channel channel, CallOptions callOptions) {
+    super(channel, callOptions);
+  }
+
+  /**
+   * Returns a new future stub with the given channel for the provided method configurations.
+   *
+   * @since 1.25.0
+   * @param factory the factory to create a future stub
+   * @param channel the channel that this stub will use to do communications
+   */
+  public static <T extends AbstractStub<T>> T newStub(
+      StubFactory<T> factory, Channel channel) {
+    return newStub(factory, channel, CallOptions.DEFAULT);
+  }
+
+  /**
+   * Returns a new future stub with the given channel for the provided method configurations.
+   *
+   * @since 1.25.0
+   * @param factory the factory to create a future stub
+   * @param channel the channel that this stub will use to do communications
+   * @param callOptions the runtime call options to be applied to every call on this stub
+   * @return a future stub
+   */
+  public static <T extends AbstractStub<T>> T newStub(
+      StubFactory<T> factory, Channel channel, CallOptions callOptions) {
+    T stub = factory.newStub(
+        channel, callOptions.withOption(ClientCalls.STUB_TYPE_OPTION, StubType.FUTURE));
+    assert stub instanceof AbstractFutureStub
+        : String.format("Expected AbstractFutureStub, but got %s.", stub.getClass());
+    return stub;
+  }
+}

--- a/stub/src/main/java/io/grpc/stub/AbstractStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractStub.java
@@ -102,6 +102,31 @@ public abstract class AbstractStub<S extends AbstractStub<S>> {
   protected abstract S build(Channel channel, CallOptions callOptions);
 
   /**
+   * Returns a new stub with the given channel for the provided method configurations.
+   *
+   * @since 1.25.0
+   * @param factory the factory to create a stub
+   * @param channel the channel that this stub will use to do communications
+   */
+  public static <T extends AbstractStub<T>> T newStub(
+      StubFactory<T> factory, Channel channel) {
+    return newStub(factory, channel, CallOptions.DEFAULT);
+  }
+
+  /**
+   * Returns a new stub with the given channel for the provided method configurations.
+   *
+   * @since 1.25.0
+   * @param factory the factory to create a stub
+   * @param channel the channel that this stub will use to do communications
+   * @param callOptions the runtime call options to be applied to every call on this stub
+   */
+  public static <T extends AbstractStub<T>> T newStub(
+      StubFactory<T> factory, Channel channel, CallOptions callOptions) {
+    return factory.newStub(channel, callOptions);
+  }
+
+  /**
    * Returns a new stub with an absolute deadline.
    *
    * <p>This is mostly used for propagating an existing deadline. {@link #withDeadlineAfter} is the
@@ -223,5 +248,14 @@ public abstract class AbstractStub<S extends AbstractStub<S>> {
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2563")
   public final S withMaxOutboundMessageSize(int maxSize) {
     return build(channel, callOptions.withMaxOutboundMessageSize(maxSize));
+  }
+
+  /**
+   * A factory class for stub.
+   *
+   * @since 1.25.0
+   */
+  public interface StubFactory<T extends AbstractStub<T>> {
+    T newStub(Channel channel, CallOptions callOptions);
   }
 }

--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -706,4 +706,14 @@ public final class ClientCalls {
       LockSupport.unpark(waiter); // no-op if null
     }
   }
+
+  enum StubType {
+    BLOCKING, FUTURE, ASYNC
+  }
+
+  /**
+   * Internal {@link CallOptions.Key} to indicate stub types.
+   */
+  static final CallOptions.Key<StubType> STUB_TYPE_OPTION =
+      CallOptions.Key.create("internal-stub-type");
 }

--- a/stub/src/main/java/io/grpc/stub/InternalClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/InternalClientCalls.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.stub;
+
+import io.grpc.CallOptions;
+import io.grpc.Internal;
+
+/**
+ * Internal {@link ClientCalls} accessor.  This is intended for usage internal to the gRPC
+ * team.  If you *really* think you need to use this, contact the gRPC team first.
+ */
+@Internal
+public final class InternalClientCalls {
+
+  /** Internal accessor for {@link ClientCalls#STUB_TYPE_OPTION}. */
+  public static CallOptions.Key<ClientCalls.StubType> getStubTypeOption() {
+    return ClientCalls.STUB_TYPE_OPTION;
+  }
+
+  /** Returns {@link StubType} from call options. */
+  public static StubType getStubType(CallOptions callOptions) {
+    return StubType.of(callOptions.getOption(ClientCalls.STUB_TYPE_OPTION));
+  }
+
+  /** Companion enum for internal enum {@link ClientCalls.StubType}. */
+  public enum StubType {
+    BLOCKING(ClientCalls.StubType.BLOCKING),
+    ASYNC(ClientCalls.StubType.ASYNC),
+    FUTURE(ClientCalls.StubType.FUTURE);
+
+    private final ClientCalls.StubType internalType;
+
+    StubType(ClientCalls.StubType internalType) {
+      this.internalType = internalType;
+    }
+
+    /** Returns companion enum value of passed internal enum equivalent. */
+    public static StubType of(ClientCalls.StubType internal) {
+      for (StubType value : StubType.values()) {
+        if (value.internalType == internal) {
+          return value;
+        }
+      }
+      throw new AssertionError("Unknown StubType: " + internal.name());
+    }
+  }
+}

--- a/stub/src/test/java/io/grpc/stub/AbstractAsyncStubTest.java
+++ b/stub/src/test/java/io/grpc/stub/AbstractAsyncStubTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.stub;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.stub.AbstractAsyncStubTest.NoopAsyncStub;
+import io.grpc.stub.AbstractBlockingStubTest.NoopBlockingStub;
+import io.grpc.stub.AbstractFutureStubTest.NoopFutureStub;
+import io.grpc.stub.AbstractStub.StubFactory;
+import io.grpc.stub.ClientCalls.StubType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class AbstractAsyncStubTest extends BaseAbstractStubTest<NoopAsyncStub> {
+
+  @Override
+  NoopAsyncStub create(Channel channel, CallOptions callOptions) {
+    return new NoopAsyncStub(channel, callOptions);
+  }
+
+  @Test
+  public void defaultCallOptions() {
+    NoopAsyncStub stub = NoopAsyncStub.newStub(new StubFactory<NoopAsyncStub>() {
+      @Override
+      public NoopAsyncStub newStub(Channel channel, CallOptions callOptions) {
+        return create(channel, callOptions);
+      }
+    }, channel, CallOptions.DEFAULT);
+
+    assertThat(stub.getCallOptions().getOption(ClientCalls.STUB_TYPE_OPTION))
+        .isEqualTo(StubType.ASYNC);
+  }
+
+  @Test
+  @SuppressWarnings("AssertionFailureIgnored")
+  public void newStub_futureStub_throwsException() {
+    try {
+      NoopFutureStub unused = NoopAsyncStub.newStub(new StubFactory<NoopFutureStub>() {
+        @Override
+        public NoopFutureStub newStub(Channel channel, CallOptions callOptions) {
+          return new NoopFutureStub(channel, callOptions);
+        }
+      }, channel, CallOptions.DEFAULT);
+      fail("should not reach here");
+    } catch (AssertionError e) {
+      assertThat(e).hasMessageThat().startsWith("Expected AbstractAsyncStub");
+    }
+  }
+
+  @Test
+  @SuppressWarnings("AssertionFailureIgnored")
+  public void newStub_blockingStub_throwsException() {
+    try {
+      NoopBlockingStub unused = NoopAsyncStub.newStub(new StubFactory<NoopBlockingStub>() {
+        @Override
+        public NoopBlockingStub newStub(Channel channel, CallOptions callOptions) {
+          return new NoopBlockingStub(channel, callOptions);
+        }
+      }, channel, CallOptions.DEFAULT);
+      fail("should not reach here");
+    } catch (AssertionError e) {
+      assertThat(e).hasMessageThat().startsWith("Expected AbstractAsyncStub");
+    }
+  }
+
+  static class NoopAsyncStub extends AbstractAsyncStub<NoopAsyncStub> {
+
+    NoopAsyncStub(Channel channel, CallOptions options) {
+      super(channel, options);
+    }
+
+    @Override
+    protected NoopAsyncStub build(Channel channel, CallOptions callOptions) {
+      return new NoopAsyncStub(channel, callOptions);
+    }
+  }
+}

--- a/stub/src/test/java/io/grpc/stub/AbstractBlockingStubTest.java
+++ b/stub/src/test/java/io/grpc/stub/AbstractBlockingStubTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.stub;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.stub.AbstractAsyncStubTest.NoopAsyncStub;
+import io.grpc.stub.AbstractBlockingStubTest.NoopBlockingStub;
+import io.grpc.stub.AbstractFutureStubTest.NoopFutureStub;
+import io.grpc.stub.AbstractStub.StubFactory;
+import io.grpc.stub.ClientCalls.StubType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class AbstractBlockingStubTest extends BaseAbstractStubTest<NoopBlockingStub> {
+
+  @Override
+  NoopBlockingStub create(Channel channel, CallOptions callOptions) {
+    return new NoopBlockingStub(channel, callOptions);
+  }
+
+  @Test
+  public void defaultCallOptions() {
+    NoopBlockingStub stub = NoopBlockingStub.newStub(new StubFactory<NoopBlockingStub>() {
+      @Override
+      public NoopBlockingStub newStub(Channel channel, CallOptions callOptions) {
+        return create(channel, callOptions);
+      }
+    }, channel, CallOptions.DEFAULT);
+
+    assertThat(stub.getCallOptions().getOption(ClientCalls.STUB_TYPE_OPTION))
+        .isEqualTo(StubType.BLOCKING);
+  }
+
+  @Test
+  @SuppressWarnings("AssertionFailureIgnored")
+  public void newStub_asyncStub_throwsException() {
+    try {
+      NoopAsyncStub unused = NoopBlockingStub.newStub(new StubFactory<NoopAsyncStub>() {
+        @Override
+        public NoopAsyncStub newStub(Channel channel, CallOptions callOptions) {
+          return new NoopAsyncStub(channel, callOptions);
+        }
+      }, channel, CallOptions.DEFAULT);
+      fail("should not reach here");
+    } catch (AssertionError e) {
+      assertThat(e).hasMessageThat().startsWith("Expected AbstractBlockingStub");
+    }
+  }
+
+  @Test
+  @SuppressWarnings("AssertionFailureIgnored")
+  public void newStub_futureStub_throwsException() {
+    try {
+      NoopFutureStub unused = NoopBlockingStub.newStub(new StubFactory<NoopFutureStub>() {
+        @Override
+        public NoopFutureStub newStub(Channel channel, CallOptions callOptions) {
+          return new NoopFutureStub(channel, callOptions);
+        }
+      }, channel, CallOptions.DEFAULT);
+      fail("should not reach here");
+    } catch (AssertionError e) {
+      assertThat(e).hasMessageThat().startsWith("Expected AbstractBlockingStub");
+    }
+  }
+
+  static class NoopBlockingStub extends AbstractBlockingStub<NoopBlockingStub> {
+
+    NoopBlockingStub(Channel channel, CallOptions options) {
+      super(channel, options);
+    }
+
+    @Override
+    protected NoopBlockingStub build(Channel channel, CallOptions callOptions) {
+      return new NoopBlockingStub(channel, callOptions);
+    }
+  }
+}

--- a/stub/src/test/java/io/grpc/stub/AbstractFutureStubTest.java
+++ b/stub/src/test/java/io/grpc/stub/AbstractFutureStubTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.stub;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.stub.AbstractAsyncStubTest.NoopAsyncStub;
+import io.grpc.stub.AbstractBlockingStubTest.NoopBlockingStub;
+import io.grpc.stub.AbstractFutureStubTest.NoopFutureStub;
+import io.grpc.stub.AbstractStub.StubFactory;
+import io.grpc.stub.ClientCalls.StubType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class AbstractFutureStubTest extends BaseAbstractStubTest<NoopFutureStub> {
+
+  @Override
+  NoopFutureStub create(Channel channel, CallOptions callOptions) {
+    return new NoopFutureStub(channel, callOptions);
+  }
+
+  @Test
+  public void defaultCallOptions() {
+    NoopFutureStub stub = NoopFutureStub.newStub(new StubFactory<NoopFutureStub>() {
+      @Override
+      public NoopFutureStub newStub(Channel channel, CallOptions callOptions) {
+        return create(channel, callOptions);
+      }
+    }, channel, CallOptions.DEFAULT);
+
+    assertThat(stub.getCallOptions().getOption(ClientCalls.STUB_TYPE_OPTION))
+        .isEqualTo(StubType.FUTURE);
+  }
+
+  @Test
+  @SuppressWarnings("AssertionFailureIgnored")
+  public void newStub_asyncStub_throwsException() {
+    try {
+      NoopAsyncStub unused = NoopFutureStub.newStub(new StubFactory<NoopAsyncStub>() {
+        @Override
+        public NoopAsyncStub newStub(Channel channel, CallOptions callOptions) {
+          return new NoopAsyncStub(channel, callOptions);
+        }
+      }, channel, CallOptions.DEFAULT);
+      fail("should not reach here");
+    } catch (AssertionError e) {
+      assertThat(e).hasMessageThat().startsWith("Expected AbstractFutureStub");
+    }
+  }
+
+  @Test
+  @SuppressWarnings("AssertionFailureIgnored")
+  public void newStub_blockingStub_throwsException() {
+    try {
+      NoopBlockingStub unused = NoopFutureStub.newStub(new StubFactory<NoopBlockingStub>() {
+        @Override
+        public NoopBlockingStub newStub(Channel channel, CallOptions callOptions) {
+          return new NoopBlockingStub(channel, callOptions);
+        }
+      }, channel, CallOptions.DEFAULT);
+      fail("should not reach here");
+    } catch (AssertionError e) {
+      assertThat(e).hasMessageThat().startsWith("Expected AbstractFutureStub");
+    }
+  }
+
+  static class NoopFutureStub extends AbstractFutureStub<NoopFutureStub> {
+
+    NoopFutureStub(Channel channel, CallOptions options) {
+      super(channel, options);
+    }
+
+    @Override
+    protected NoopFutureStub build(Channel channel, CallOptions callOptions) {
+      return new NoopFutureStub(channel, callOptions);
+    }
+  }
+}

--- a/stub/src/test/java/io/grpc/stub/AbstractStubTest.java
+++ b/stub/src/test/java/io/grpc/stub/AbstractStubTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The gRPC Authors
+ * Copyright 2019 The gRPC Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,64 +16,38 @@
 
 package io.grpc.stub;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
+import static com.google.common.truth.Truth.assertThat;
 
 import io.grpc.CallOptions;
 import io.grpc.Channel;
-import java.util.concurrent.Executor;
-import org.junit.Before;
+import io.grpc.stub.AbstractStub.StubFactory;
+import io.grpc.stub.AbstractStubTest.NoopStub;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
-public class AbstractStubTest {
+public class AbstractStubTest extends BaseAbstractStubTest<NoopStub> {
 
-  @Mock
-  Channel channel;
-
-  @Before
-  public void setup() {
-    MockitoAnnotations.initMocks(this);
+  @Override
+  NoopStub create(Channel channel, CallOptions callOptions) {
+    return new NoopStub(channel, callOptions);
   }
 
-  @Test(expected = NullPointerException.class)
-  public void channelMustNotBeNull() {
-    new NoopStub(null);
-  }
+  @Test
+  public void defaultCallOptions() {
+    NoopStub stub = NoopStub.newStub(new StubFactory<NoopStub>() {
+      @Override
+      public NoopStub newStub(Channel channel, CallOptions callOptions) {
+        return create(channel, callOptions);
+      }
+    }, channel, CallOptions.DEFAULT);
 
-  @Test(expected = NullPointerException.class)
-  public void callOptionsMustNotBeNull() {
-    new NoopStub(channel, null);
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void channelMustNotBeNull2() {
-    new NoopStub(null, CallOptions.DEFAULT);
-  }
-
-  @Test()
-  public void withWaitForReady() {
-    NoopStub stub = new NoopStub(channel);
-    CallOptions callOptions = stub.getCallOptions();
-    assertFalse(callOptions.isWaitForReady());
-
-    stub = stub.withWaitForReady();
-    callOptions = stub.getCallOptions();
-    assertTrue(callOptions.isWaitForReady());
+    assertThat(stub.getCallOptions().getOption(ClientCalls.STUB_TYPE_OPTION))
+        .isNull();
   }
 
   class NoopStub extends AbstractStub<NoopStub> {
-
-    NoopStub(Channel channel) {
-      super(channel);
-    }
 
     NoopStub(Channel channel, CallOptions options) {
       super(channel, options);
@@ -84,18 +58,5 @@ public class AbstractStubTest {
       return new NoopStub(channel, callOptions);
     }
   }
-
-  @Test
-  public void withExecutor() {
-    NoopStub stub = new NoopStub(channel);
-    CallOptions callOptions = stub.getCallOptions();
-
-    assertNull(callOptions.getExecutor());
-
-    Executor executor = mock(Executor.class);
-    stub = stub.withExecutor(executor);
-    callOptions = stub.getCallOptions();
-
-    assertEquals(callOptions.getExecutor(), executor);
-  }
 }
+

--- a/stub/src/test/java/io/grpc/stub/BaseAbstractStubTest.java
+++ b/stub/src/test/java/io/grpc/stub/BaseAbstractStubTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2016 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.stub;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import java.util.concurrent.Executor;
+import javax.annotation.Nullable;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** Standard unit tests for AbstractStub and its subclasses. */
+abstract class BaseAbstractStubTest<T extends AbstractStub<T>> {
+
+  @Mock
+  Channel channel;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  T create(Channel channel) {
+    return create(channel, CallOptions.DEFAULT);
+  }
+
+  abstract T create(@Nullable Channel channel, @Nullable CallOptions callOptions);
+
+  @Test
+  public void callOptionsMustNotBeNull() {
+    try {
+      create(channel, null);
+      fail("NullPointerException expected");
+    } catch (NullPointerException npe) {
+      // expected
+    }
+  }
+
+  @Test
+  public void channelMustNotBeNull2() {
+    try {
+      create(null, CallOptions.DEFAULT);
+      fail("NullPointerException expected");
+    } catch (NullPointerException npe) {
+      // expected
+    }
+  }
+
+  @Test
+  public void withWaitForReady() {
+    T stub = create(channel);
+    CallOptions callOptions = stub.getCallOptions();
+    assertFalse(callOptions.isWaitForReady());
+
+    stub = stub.withWaitForReady();
+    callOptions = stub.getCallOptions();
+    assertTrue(callOptions.isWaitForReady());
+  }
+
+  @Test
+  public void withExecutor() {
+    T stub = create(channel);
+    CallOptions callOptions = stub.getCallOptions();
+
+    assertNull(callOptions.getExecutor());
+
+    Executor executor = mock(Executor.class);
+    stub = stub.withExecutor(executor);
+    callOptions = stub.getCallOptions();
+
+    assertEquals(callOptions.getExecutor(), executor);
+  }
+}

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/protobuf/SimpleServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/protobuf/SimpleServiceGrpc.java
@@ -158,7 +158,14 @@ public final class SimpleServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static SimpleServiceStub newStub(io.grpc.Channel channel) {
-    return new SimpleServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SimpleServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<SimpleServiceStub>() {
+        @java.lang.Override
+        public SimpleServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new SimpleServiceStub(channel, callOptions);
+        }
+      };
+    return SimpleServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -166,7 +173,14 @@ public final class SimpleServiceGrpc {
    */
   public static SimpleServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new SimpleServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SimpleServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<SimpleServiceBlockingStub>() {
+        @java.lang.Override
+        public SimpleServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new SimpleServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return SimpleServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -174,7 +188,14 @@ public final class SimpleServiceGrpc {
    */
   public static SimpleServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new SimpleServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SimpleServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<SimpleServiceFutureStub>() {
+        @java.lang.Override
+        public SimpleServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new SimpleServiceFutureStub(channel, callOptions);
+        }
+      };
+    return SimpleServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -263,19 +284,15 @@ public final class SimpleServiceGrpc {
    * A simple service for test.
    * </pre>
    */
-  public static final class SimpleServiceStub extends io.grpc.stub.AbstractStub<SimpleServiceStub> {
-    private SimpleServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private SimpleServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class SimpleServiceStub extends io.grpc.stub.AbstractAsyncStub<SimpleServiceStub> {
+    private SimpleServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected SimpleServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected SimpleServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new SimpleServiceStub(channel, callOptions);
     }
 
@@ -329,19 +346,15 @@ public final class SimpleServiceGrpc {
    * A simple service for test.
    * </pre>
    */
-  public static final class SimpleServiceBlockingStub extends io.grpc.stub.AbstractStub<SimpleServiceBlockingStub> {
-    private SimpleServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private SimpleServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class SimpleServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<SimpleServiceBlockingStub> {
+    private SimpleServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected SimpleServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected SimpleServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new SimpleServiceBlockingStub(channel, callOptions);
     }
 
@@ -372,19 +385,15 @@ public final class SimpleServiceGrpc {
    * A simple service for test.
    * </pre>
    */
-  public static final class SimpleServiceFutureStub extends io.grpc.stub.AbstractStub<SimpleServiceFutureStub> {
-    private SimpleServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private SimpleServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class SimpleServiceFutureStub extends io.grpc.stub.AbstractFutureStub<SimpleServiceFutureStub> {
+    private SimpleServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected SimpleServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected SimpleServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new SimpleServiceFutureStub(channel, callOptions);
     }
 

--- a/xds/src/generated/main/grpc/com/github/udpa/udpa/service/orca/v1/OpenRcaServiceGrpc.java
+++ b/xds/src/generated/main/grpc/com/github/udpa/udpa/service/orca/v1/OpenRcaServiceGrpc.java
@@ -72,7 +72,14 @@ public final class OpenRcaServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static OpenRcaServiceStub newStub(io.grpc.Channel channel) {
-    return new OpenRcaServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<OpenRcaServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<OpenRcaServiceStub>() {
+        @java.lang.Override
+        public OpenRcaServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new OpenRcaServiceStub(channel, callOptions);
+        }
+      };
+    return OpenRcaServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -80,7 +87,14 @@ public final class OpenRcaServiceGrpc {
    */
   public static OpenRcaServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new OpenRcaServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<OpenRcaServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<OpenRcaServiceBlockingStub>() {
+        @java.lang.Override
+        public OpenRcaServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new OpenRcaServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return OpenRcaServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -88,7 +102,14 @@ public final class OpenRcaServiceGrpc {
    */
   public static OpenRcaServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new OpenRcaServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<OpenRcaServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<OpenRcaServiceFutureStub>() {
+        @java.lang.Override
+        public OpenRcaServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new OpenRcaServiceFutureStub(channel, callOptions);
+        }
+      };
+    return OpenRcaServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -137,19 +158,15 @@ public final class OpenRcaServiceGrpc {
    * a new call to change backend reporting frequency.
    * </pre>
    */
-  public static final class OpenRcaServiceStub extends io.grpc.stub.AbstractStub<OpenRcaServiceStub> {
-    private OpenRcaServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private OpenRcaServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class OpenRcaServiceStub extends io.grpc.stub.AbstractAsyncStub<OpenRcaServiceStub> {
+    private OpenRcaServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected OpenRcaServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected OpenRcaServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new OpenRcaServiceStub(channel, callOptions);
     }
 
@@ -174,19 +191,15 @@ public final class OpenRcaServiceGrpc {
    * a new call to change backend reporting frequency.
    * </pre>
    */
-  public static final class OpenRcaServiceBlockingStub extends io.grpc.stub.AbstractStub<OpenRcaServiceBlockingStub> {
-    private OpenRcaServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private OpenRcaServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class OpenRcaServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<OpenRcaServiceBlockingStub> {
+    private OpenRcaServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected OpenRcaServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected OpenRcaServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new OpenRcaServiceBlockingStub(channel, callOptions);
     }
 
@@ -211,19 +224,15 @@ public final class OpenRcaServiceGrpc {
    * a new call to change backend reporting frequency.
    * </pre>
    */
-  public static final class OpenRcaServiceFutureStub extends io.grpc.stub.AbstractStub<OpenRcaServiceFutureStub> {
-    private OpenRcaServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private OpenRcaServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class OpenRcaServiceFutureStub extends io.grpc.stub.AbstractFutureStub<OpenRcaServiceFutureStub> {
+    private OpenRcaServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected OpenRcaServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected OpenRcaServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new OpenRcaServiceFutureStub(channel, callOptions);
     }
   }

--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/ClusterDiscoveryServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/ClusterDiscoveryServiceGrpc.java
@@ -127,7 +127,14 @@ public final class ClusterDiscoveryServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static ClusterDiscoveryServiceStub newStub(io.grpc.Channel channel) {
-    return new ClusterDiscoveryServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ClusterDiscoveryServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ClusterDiscoveryServiceStub>() {
+        @java.lang.Override
+        public ClusterDiscoveryServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ClusterDiscoveryServiceStub(channel, callOptions);
+        }
+      };
+    return ClusterDiscoveryServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -135,7 +142,14 @@ public final class ClusterDiscoveryServiceGrpc {
    */
   public static ClusterDiscoveryServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new ClusterDiscoveryServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ClusterDiscoveryServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ClusterDiscoveryServiceBlockingStub>() {
+        @java.lang.Override
+        public ClusterDiscoveryServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ClusterDiscoveryServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return ClusterDiscoveryServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -143,7 +157,14 @@ public final class ClusterDiscoveryServiceGrpc {
    */
   public static ClusterDiscoveryServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new ClusterDiscoveryServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ClusterDiscoveryServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ClusterDiscoveryServiceFutureStub>() {
+        @java.lang.Override
+        public ClusterDiscoveryServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ClusterDiscoveryServiceFutureStub(channel, callOptions);
+        }
+      };
+    return ClusterDiscoveryServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -206,19 +227,15 @@ public final class ClusterDiscoveryServiceGrpc {
    * Return list of all clusters this proxy will load balance to.
    * </pre>
    */
-  public static final class ClusterDiscoveryServiceStub extends io.grpc.stub.AbstractStub<ClusterDiscoveryServiceStub> {
-    private ClusterDiscoveryServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ClusterDiscoveryServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ClusterDiscoveryServiceStub extends io.grpc.stub.AbstractAsyncStub<ClusterDiscoveryServiceStub> {
+    private ClusterDiscoveryServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ClusterDiscoveryServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ClusterDiscoveryServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ClusterDiscoveryServiceStub(channel, callOptions);
     }
 
@@ -252,19 +269,15 @@ public final class ClusterDiscoveryServiceGrpc {
    * Return list of all clusters this proxy will load balance to.
    * </pre>
    */
-  public static final class ClusterDiscoveryServiceBlockingStub extends io.grpc.stub.AbstractStub<ClusterDiscoveryServiceBlockingStub> {
-    private ClusterDiscoveryServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ClusterDiscoveryServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ClusterDiscoveryServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<ClusterDiscoveryServiceBlockingStub> {
+    private ClusterDiscoveryServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ClusterDiscoveryServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ClusterDiscoveryServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ClusterDiscoveryServiceBlockingStub(channel, callOptions);
     }
 
@@ -281,19 +294,15 @@ public final class ClusterDiscoveryServiceGrpc {
    * Return list of all clusters this proxy will load balance to.
    * </pre>
    */
-  public static final class ClusterDiscoveryServiceFutureStub extends io.grpc.stub.AbstractStub<ClusterDiscoveryServiceFutureStub> {
-    private ClusterDiscoveryServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ClusterDiscoveryServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ClusterDiscoveryServiceFutureStub extends io.grpc.stub.AbstractFutureStub<ClusterDiscoveryServiceFutureStub> {
+    private ClusterDiscoveryServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ClusterDiscoveryServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ClusterDiscoveryServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ClusterDiscoveryServiceFutureStub(channel, callOptions);
     }
 

--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/EndpointDiscoveryServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/EndpointDiscoveryServiceGrpc.java
@@ -124,7 +124,14 @@ public final class EndpointDiscoveryServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static EndpointDiscoveryServiceStub newStub(io.grpc.Channel channel) {
-    return new EndpointDiscoveryServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<EndpointDiscoveryServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<EndpointDiscoveryServiceStub>() {
+        @java.lang.Override
+        public EndpointDiscoveryServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new EndpointDiscoveryServiceStub(channel, callOptions);
+        }
+      };
+    return EndpointDiscoveryServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -132,7 +139,14 @@ public final class EndpointDiscoveryServiceGrpc {
    */
   public static EndpointDiscoveryServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new EndpointDiscoveryServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<EndpointDiscoveryServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<EndpointDiscoveryServiceBlockingStub>() {
+        @java.lang.Override
+        public EndpointDiscoveryServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new EndpointDiscoveryServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return EndpointDiscoveryServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -140,7 +154,14 @@ public final class EndpointDiscoveryServiceGrpc {
    */
   public static EndpointDiscoveryServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new EndpointDiscoveryServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<EndpointDiscoveryServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<EndpointDiscoveryServiceFutureStub>() {
+        @java.lang.Override
+        public EndpointDiscoveryServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new EndpointDiscoveryServiceFutureStub(channel, callOptions);
+        }
+      };
+    return EndpointDiscoveryServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -201,19 +222,15 @@ public final class EndpointDiscoveryServiceGrpc {
 
   /**
    */
-  public static final class EndpointDiscoveryServiceStub extends io.grpc.stub.AbstractStub<EndpointDiscoveryServiceStub> {
-    private EndpointDiscoveryServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private EndpointDiscoveryServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class EndpointDiscoveryServiceStub extends io.grpc.stub.AbstractAsyncStub<EndpointDiscoveryServiceStub> {
+    private EndpointDiscoveryServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected EndpointDiscoveryServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected EndpointDiscoveryServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new EndpointDiscoveryServiceStub(channel, callOptions);
     }
 
@@ -248,19 +265,15 @@ public final class EndpointDiscoveryServiceGrpc {
 
   /**
    */
-  public static final class EndpointDiscoveryServiceBlockingStub extends io.grpc.stub.AbstractStub<EndpointDiscoveryServiceBlockingStub> {
-    private EndpointDiscoveryServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private EndpointDiscoveryServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class EndpointDiscoveryServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<EndpointDiscoveryServiceBlockingStub> {
+    private EndpointDiscoveryServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected EndpointDiscoveryServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected EndpointDiscoveryServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new EndpointDiscoveryServiceBlockingStub(channel, callOptions);
     }
 
@@ -274,19 +287,15 @@ public final class EndpointDiscoveryServiceGrpc {
 
   /**
    */
-  public static final class EndpointDiscoveryServiceFutureStub extends io.grpc.stub.AbstractStub<EndpointDiscoveryServiceFutureStub> {
-    private EndpointDiscoveryServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private EndpointDiscoveryServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class EndpointDiscoveryServiceFutureStub extends io.grpc.stub.AbstractFutureStub<EndpointDiscoveryServiceFutureStub> {
+    private EndpointDiscoveryServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected EndpointDiscoveryServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected EndpointDiscoveryServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new EndpointDiscoveryServiceFutureStub(channel, callOptions);
     }
 

--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/ListenerDiscoveryServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/ListenerDiscoveryServiceGrpc.java
@@ -130,7 +130,14 @@ public final class ListenerDiscoveryServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static ListenerDiscoveryServiceStub newStub(io.grpc.Channel channel) {
-    return new ListenerDiscoveryServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ListenerDiscoveryServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ListenerDiscoveryServiceStub>() {
+        @java.lang.Override
+        public ListenerDiscoveryServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ListenerDiscoveryServiceStub(channel, callOptions);
+        }
+      };
+    return ListenerDiscoveryServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -138,7 +145,14 @@ public final class ListenerDiscoveryServiceGrpc {
    */
   public static ListenerDiscoveryServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new ListenerDiscoveryServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ListenerDiscoveryServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ListenerDiscoveryServiceBlockingStub>() {
+        @java.lang.Override
+        public ListenerDiscoveryServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ListenerDiscoveryServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return ListenerDiscoveryServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -146,7 +160,14 @@ public final class ListenerDiscoveryServiceGrpc {
    */
   public static ListenerDiscoveryServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new ListenerDiscoveryServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ListenerDiscoveryServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ListenerDiscoveryServiceFutureStub>() {
+        @java.lang.Override
+        public ListenerDiscoveryServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ListenerDiscoveryServiceFutureStub(channel, callOptions);
+        }
+      };
+    return ListenerDiscoveryServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -215,19 +236,15 @@ public final class ListenerDiscoveryServiceGrpc {
    * allowed to drain from listeners that are no longer present.
    * </pre>
    */
-  public static final class ListenerDiscoveryServiceStub extends io.grpc.stub.AbstractStub<ListenerDiscoveryServiceStub> {
-    private ListenerDiscoveryServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ListenerDiscoveryServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ListenerDiscoveryServiceStub extends io.grpc.stub.AbstractAsyncStub<ListenerDiscoveryServiceStub> {
+    private ListenerDiscoveryServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ListenerDiscoveryServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ListenerDiscoveryServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ListenerDiscoveryServiceStub(channel, callOptions);
     }
 
@@ -264,19 +281,15 @@ public final class ListenerDiscoveryServiceGrpc {
    * allowed to drain from listeners that are no longer present.
    * </pre>
    */
-  public static final class ListenerDiscoveryServiceBlockingStub extends io.grpc.stub.AbstractStub<ListenerDiscoveryServiceBlockingStub> {
-    private ListenerDiscoveryServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ListenerDiscoveryServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ListenerDiscoveryServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<ListenerDiscoveryServiceBlockingStub> {
+    private ListenerDiscoveryServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ListenerDiscoveryServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ListenerDiscoveryServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ListenerDiscoveryServiceBlockingStub(channel, callOptions);
     }
 
@@ -296,19 +309,15 @@ public final class ListenerDiscoveryServiceGrpc {
    * allowed to drain from listeners that are no longer present.
    * </pre>
    */
-  public static final class ListenerDiscoveryServiceFutureStub extends io.grpc.stub.AbstractStub<ListenerDiscoveryServiceFutureStub> {
-    private ListenerDiscoveryServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ListenerDiscoveryServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ListenerDiscoveryServiceFutureStub extends io.grpc.stub.AbstractFutureStub<ListenerDiscoveryServiceFutureStub> {
+    private ListenerDiscoveryServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ListenerDiscoveryServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ListenerDiscoveryServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ListenerDiscoveryServiceFutureStub(channel, callOptions);
     }
 

--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/RouteDiscoveryServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/RouteDiscoveryServiceGrpc.java
@@ -131,7 +131,14 @@ public final class RouteDiscoveryServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static RouteDiscoveryServiceStub newStub(io.grpc.Channel channel) {
-    return new RouteDiscoveryServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<RouteDiscoveryServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<RouteDiscoveryServiceStub>() {
+        @java.lang.Override
+        public RouteDiscoveryServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new RouteDiscoveryServiceStub(channel, callOptions);
+        }
+      };
+    return RouteDiscoveryServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -139,7 +146,14 @@ public final class RouteDiscoveryServiceGrpc {
    */
   public static RouteDiscoveryServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new RouteDiscoveryServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<RouteDiscoveryServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<RouteDiscoveryServiceBlockingStub>() {
+        @java.lang.Override
+        public RouteDiscoveryServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new RouteDiscoveryServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return RouteDiscoveryServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -147,7 +161,14 @@ public final class RouteDiscoveryServiceGrpc {
    */
   public static RouteDiscoveryServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new RouteDiscoveryServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<RouteDiscoveryServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<RouteDiscoveryServiceFutureStub>() {
+        @java.lang.Override
+        public RouteDiscoveryServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new RouteDiscoveryServiceFutureStub(channel, callOptions);
+        }
+      };
+    return RouteDiscoveryServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -218,19 +239,15 @@ public final class RouteDiscoveryServiceGrpc {
    * a route table via this identifier.
    * </pre>
    */
-  public static final class RouteDiscoveryServiceStub extends io.grpc.stub.AbstractStub<RouteDiscoveryServiceStub> {
-    private RouteDiscoveryServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private RouteDiscoveryServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class RouteDiscoveryServiceStub extends io.grpc.stub.AbstractAsyncStub<RouteDiscoveryServiceStub> {
+    private RouteDiscoveryServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected RouteDiscoveryServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected RouteDiscoveryServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new RouteDiscoveryServiceStub(channel, callOptions);
     }
 
@@ -268,19 +285,15 @@ public final class RouteDiscoveryServiceGrpc {
    * a route table via this identifier.
    * </pre>
    */
-  public static final class RouteDiscoveryServiceBlockingStub extends io.grpc.stub.AbstractStub<RouteDiscoveryServiceBlockingStub> {
-    private RouteDiscoveryServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private RouteDiscoveryServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class RouteDiscoveryServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<RouteDiscoveryServiceBlockingStub> {
+    private RouteDiscoveryServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected RouteDiscoveryServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected RouteDiscoveryServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new RouteDiscoveryServiceBlockingStub(channel, callOptions);
     }
 
@@ -301,19 +314,15 @@ public final class RouteDiscoveryServiceGrpc {
    * a route table via this identifier.
    * </pre>
    */
-  public static final class RouteDiscoveryServiceFutureStub extends io.grpc.stub.AbstractStub<RouteDiscoveryServiceFutureStub> {
-    private RouteDiscoveryServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private RouteDiscoveryServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class RouteDiscoveryServiceFutureStub extends io.grpc.stub.AbstractFutureStub<RouteDiscoveryServiceFutureStub> {
+    private RouteDiscoveryServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected RouteDiscoveryServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected RouteDiscoveryServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new RouteDiscoveryServiceFutureStub(channel, callOptions);
     }
 

--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/ScopedRoutesDiscoveryServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/ScopedRoutesDiscoveryServiceGrpc.java
@@ -135,7 +135,14 @@ public final class ScopedRoutesDiscoveryServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static ScopedRoutesDiscoveryServiceStub newStub(io.grpc.Channel channel) {
-    return new ScopedRoutesDiscoveryServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ScopedRoutesDiscoveryServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ScopedRoutesDiscoveryServiceStub>() {
+        @java.lang.Override
+        public ScopedRoutesDiscoveryServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ScopedRoutesDiscoveryServiceStub(channel, callOptions);
+        }
+      };
+    return ScopedRoutesDiscoveryServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -143,7 +150,14 @@ public final class ScopedRoutesDiscoveryServiceGrpc {
    */
   public static ScopedRoutesDiscoveryServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new ScopedRoutesDiscoveryServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ScopedRoutesDiscoveryServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ScopedRoutesDiscoveryServiceBlockingStub>() {
+        @java.lang.Override
+        public ScopedRoutesDiscoveryServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ScopedRoutesDiscoveryServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return ScopedRoutesDiscoveryServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -151,7 +165,14 @@ public final class ScopedRoutesDiscoveryServiceGrpc {
    */
   public static ScopedRoutesDiscoveryServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new ScopedRoutesDiscoveryServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ScopedRoutesDiscoveryServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<ScopedRoutesDiscoveryServiceFutureStub>() {
+        @java.lang.Override
+        public ScopedRoutesDiscoveryServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new ScopedRoutesDiscoveryServiceFutureStub(channel, callOptions);
+        }
+      };
+    return ScopedRoutesDiscoveryServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -230,19 +251,15 @@ public final class ScopedRoutesDiscoveryServiceGrpc {
    * HTTP request.
    * </pre>
    */
-  public static final class ScopedRoutesDiscoveryServiceStub extends io.grpc.stub.AbstractStub<ScopedRoutesDiscoveryServiceStub> {
-    private ScopedRoutesDiscoveryServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ScopedRoutesDiscoveryServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ScopedRoutesDiscoveryServiceStub extends io.grpc.stub.AbstractAsyncStub<ScopedRoutesDiscoveryServiceStub> {
+    private ScopedRoutesDiscoveryServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ScopedRoutesDiscoveryServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ScopedRoutesDiscoveryServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ScopedRoutesDiscoveryServiceStub(channel, callOptions);
     }
 
@@ -284,19 +301,15 @@ public final class ScopedRoutesDiscoveryServiceGrpc {
    * HTTP request.
    * </pre>
    */
-  public static final class ScopedRoutesDiscoveryServiceBlockingStub extends io.grpc.stub.AbstractStub<ScopedRoutesDiscoveryServiceBlockingStub> {
-    private ScopedRoutesDiscoveryServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ScopedRoutesDiscoveryServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ScopedRoutesDiscoveryServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<ScopedRoutesDiscoveryServiceBlockingStub> {
+    private ScopedRoutesDiscoveryServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ScopedRoutesDiscoveryServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ScopedRoutesDiscoveryServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ScopedRoutesDiscoveryServiceBlockingStub(channel, callOptions);
     }
 
@@ -321,19 +334,15 @@ public final class ScopedRoutesDiscoveryServiceGrpc {
    * HTTP request.
    * </pre>
    */
-  public static final class ScopedRoutesDiscoveryServiceFutureStub extends io.grpc.stub.AbstractStub<ScopedRoutesDiscoveryServiceFutureStub> {
-    private ScopedRoutesDiscoveryServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private ScopedRoutesDiscoveryServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class ScopedRoutesDiscoveryServiceFutureStub extends io.grpc.stub.AbstractFutureStub<ScopedRoutesDiscoveryServiceFutureStub> {
+    private ScopedRoutesDiscoveryServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected ScopedRoutesDiscoveryServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected ScopedRoutesDiscoveryServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new ScopedRoutesDiscoveryServiceFutureStub(channel, callOptions);
     }
 

--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/VirtualHostDiscoveryServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/VirtualHostDiscoveryServiceGrpc.java
@@ -74,7 +74,14 @@ public final class VirtualHostDiscoveryServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static VirtualHostDiscoveryServiceStub newStub(io.grpc.Channel channel) {
-    return new VirtualHostDiscoveryServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<VirtualHostDiscoveryServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<VirtualHostDiscoveryServiceStub>() {
+        @java.lang.Override
+        public VirtualHostDiscoveryServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new VirtualHostDiscoveryServiceStub(channel, callOptions);
+        }
+      };
+    return VirtualHostDiscoveryServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -82,7 +89,14 @@ public final class VirtualHostDiscoveryServiceGrpc {
    */
   public static VirtualHostDiscoveryServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new VirtualHostDiscoveryServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<VirtualHostDiscoveryServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<VirtualHostDiscoveryServiceBlockingStub>() {
+        @java.lang.Override
+        public VirtualHostDiscoveryServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new VirtualHostDiscoveryServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return VirtualHostDiscoveryServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -90,7 +104,14 @@ public final class VirtualHostDiscoveryServiceGrpc {
    */
   public static VirtualHostDiscoveryServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new VirtualHostDiscoveryServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<VirtualHostDiscoveryServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<VirtualHostDiscoveryServiceFutureStub>() {
+        @java.lang.Override
+        public VirtualHostDiscoveryServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new VirtualHostDiscoveryServiceFutureStub(channel, callOptions);
+        }
+      };
+    return VirtualHostDiscoveryServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -143,19 +164,15 @@ public final class VirtualHostDiscoveryServiceGrpc {
    * from the routing table associated with the RouteConfiguration.
    * </pre>
    */
-  public static final class VirtualHostDiscoveryServiceStub extends io.grpc.stub.AbstractStub<VirtualHostDiscoveryServiceStub> {
-    private VirtualHostDiscoveryServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private VirtualHostDiscoveryServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class VirtualHostDiscoveryServiceStub extends io.grpc.stub.AbstractAsyncStub<VirtualHostDiscoveryServiceStub> {
+    private VirtualHostDiscoveryServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected VirtualHostDiscoveryServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected VirtualHostDiscoveryServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new VirtualHostDiscoveryServiceStub(channel, callOptions);
     }
 
@@ -182,19 +199,15 @@ public final class VirtualHostDiscoveryServiceGrpc {
    * from the routing table associated with the RouteConfiguration.
    * </pre>
    */
-  public static final class VirtualHostDiscoveryServiceBlockingStub extends io.grpc.stub.AbstractStub<VirtualHostDiscoveryServiceBlockingStub> {
-    private VirtualHostDiscoveryServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private VirtualHostDiscoveryServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class VirtualHostDiscoveryServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<VirtualHostDiscoveryServiceBlockingStub> {
+    private VirtualHostDiscoveryServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected VirtualHostDiscoveryServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected VirtualHostDiscoveryServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new VirtualHostDiscoveryServiceBlockingStub(channel, callOptions);
     }
   }
@@ -213,19 +226,15 @@ public final class VirtualHostDiscoveryServiceGrpc {
    * from the routing table associated with the RouteConfiguration.
    * </pre>
    */
-  public static final class VirtualHostDiscoveryServiceFutureStub extends io.grpc.stub.AbstractStub<VirtualHostDiscoveryServiceFutureStub> {
-    private VirtualHostDiscoveryServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private VirtualHostDiscoveryServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class VirtualHostDiscoveryServiceFutureStub extends io.grpc.stub.AbstractFutureStub<VirtualHostDiscoveryServiceFutureStub> {
+    private VirtualHostDiscoveryServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected VirtualHostDiscoveryServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected VirtualHostDiscoveryServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new VirtualHostDiscoveryServiceFutureStub(channel, callOptions);
     }
   }

--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/discovery/v2/AggregatedDiscoveryServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/discovery/v2/AggregatedDiscoveryServiceGrpc.java
@@ -101,7 +101,14 @@ public final class AggregatedDiscoveryServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static AggregatedDiscoveryServiceStub newStub(io.grpc.Channel channel) {
-    return new AggregatedDiscoveryServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AggregatedDiscoveryServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<AggregatedDiscoveryServiceStub>() {
+        @java.lang.Override
+        public AggregatedDiscoveryServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new AggregatedDiscoveryServiceStub(channel, callOptions);
+        }
+      };
+    return AggregatedDiscoveryServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -109,7 +116,14 @@ public final class AggregatedDiscoveryServiceGrpc {
    */
   public static AggregatedDiscoveryServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new AggregatedDiscoveryServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AggregatedDiscoveryServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<AggregatedDiscoveryServiceBlockingStub>() {
+        @java.lang.Override
+        public AggregatedDiscoveryServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new AggregatedDiscoveryServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return AggregatedDiscoveryServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -117,7 +131,14 @@ public final class AggregatedDiscoveryServiceGrpc {
    */
   public static AggregatedDiscoveryServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new AggregatedDiscoveryServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AggregatedDiscoveryServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<AggregatedDiscoveryServiceFutureStub>() {
+        @java.lang.Override
+        public AggregatedDiscoveryServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new AggregatedDiscoveryServiceFutureStub(channel, callOptions);
+        }
+      };
+    return AggregatedDiscoveryServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -179,19 +200,15 @@ public final class AggregatedDiscoveryServiceGrpc {
    * the multiplexed singleton APIs at the Envoy instance and management server.
    * </pre>
    */
-  public static final class AggregatedDiscoveryServiceStub extends io.grpc.stub.AbstractStub<AggregatedDiscoveryServiceStub> {
-    private AggregatedDiscoveryServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private AggregatedDiscoveryServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class AggregatedDiscoveryServiceStub extends io.grpc.stub.AbstractAsyncStub<AggregatedDiscoveryServiceStub> {
+    private AggregatedDiscoveryServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected AggregatedDiscoveryServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected AggregatedDiscoveryServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new AggregatedDiscoveryServiceStub(channel, callOptions);
     }
 
@@ -225,19 +242,15 @@ public final class AggregatedDiscoveryServiceGrpc {
    * the multiplexed singleton APIs at the Envoy instance and management server.
    * </pre>
    */
-  public static final class AggregatedDiscoveryServiceBlockingStub extends io.grpc.stub.AbstractStub<AggregatedDiscoveryServiceBlockingStub> {
-    private AggregatedDiscoveryServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private AggregatedDiscoveryServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class AggregatedDiscoveryServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<AggregatedDiscoveryServiceBlockingStub> {
+    private AggregatedDiscoveryServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected AggregatedDiscoveryServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected AggregatedDiscoveryServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new AggregatedDiscoveryServiceBlockingStub(channel, callOptions);
     }
   }
@@ -252,19 +265,15 @@ public final class AggregatedDiscoveryServiceGrpc {
    * the multiplexed singleton APIs at the Envoy instance and management server.
    * </pre>
    */
-  public static final class AggregatedDiscoveryServiceFutureStub extends io.grpc.stub.AbstractStub<AggregatedDiscoveryServiceFutureStub> {
-    private AggregatedDiscoveryServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private AggregatedDiscoveryServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class AggregatedDiscoveryServiceFutureStub extends io.grpc.stub.AbstractFutureStub<AggregatedDiscoveryServiceFutureStub> {
+    private AggregatedDiscoveryServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected AggregatedDiscoveryServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected AggregatedDiscoveryServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new AggregatedDiscoveryServiceFutureStub(channel, callOptions);
     }
   }

--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/discovery/v2/SecretDiscoveryServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/discovery/v2/SecretDiscoveryServiceGrpc.java
@@ -124,7 +124,14 @@ public final class SecretDiscoveryServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static SecretDiscoveryServiceStub newStub(io.grpc.Channel channel) {
-    return new SecretDiscoveryServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SecretDiscoveryServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<SecretDiscoveryServiceStub>() {
+        @java.lang.Override
+        public SecretDiscoveryServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new SecretDiscoveryServiceStub(channel, callOptions);
+        }
+      };
+    return SecretDiscoveryServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -132,7 +139,14 @@ public final class SecretDiscoveryServiceGrpc {
    */
   public static SecretDiscoveryServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new SecretDiscoveryServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SecretDiscoveryServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<SecretDiscoveryServiceBlockingStub>() {
+        @java.lang.Override
+        public SecretDiscoveryServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new SecretDiscoveryServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return SecretDiscoveryServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -140,7 +154,14 @@ public final class SecretDiscoveryServiceGrpc {
    */
   public static SecretDiscoveryServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new SecretDiscoveryServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SecretDiscoveryServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<SecretDiscoveryServiceFutureStub>() {
+        @java.lang.Override
+        public SecretDiscoveryServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new SecretDiscoveryServiceFutureStub(channel, callOptions);
+        }
+      };
+    return SecretDiscoveryServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -197,19 +218,15 @@ public final class SecretDiscoveryServiceGrpc {
 
   /**
    */
-  public static final class SecretDiscoveryServiceStub extends io.grpc.stub.AbstractStub<SecretDiscoveryServiceStub> {
-    private SecretDiscoveryServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private SecretDiscoveryServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class SecretDiscoveryServiceStub extends io.grpc.stub.AbstractAsyncStub<SecretDiscoveryServiceStub> {
+    private SecretDiscoveryServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected SecretDiscoveryServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected SecretDiscoveryServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new SecretDiscoveryServiceStub(channel, callOptions);
     }
 
@@ -240,19 +257,15 @@ public final class SecretDiscoveryServiceGrpc {
 
   /**
    */
-  public static final class SecretDiscoveryServiceBlockingStub extends io.grpc.stub.AbstractStub<SecretDiscoveryServiceBlockingStub> {
-    private SecretDiscoveryServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private SecretDiscoveryServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class SecretDiscoveryServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<SecretDiscoveryServiceBlockingStub> {
+    private SecretDiscoveryServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected SecretDiscoveryServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected SecretDiscoveryServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new SecretDiscoveryServiceBlockingStub(channel, callOptions);
     }
 
@@ -266,19 +279,15 @@ public final class SecretDiscoveryServiceGrpc {
 
   /**
    */
-  public static final class SecretDiscoveryServiceFutureStub extends io.grpc.stub.AbstractStub<SecretDiscoveryServiceFutureStub> {
-    private SecretDiscoveryServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private SecretDiscoveryServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class SecretDiscoveryServiceFutureStub extends io.grpc.stub.AbstractFutureStub<SecretDiscoveryServiceFutureStub> {
+    private SecretDiscoveryServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected SecretDiscoveryServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected SecretDiscoveryServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new SecretDiscoveryServiceFutureStub(channel, callOptions);
     }
 

--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/load_stats/v2/LoadReportingServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/load_stats/v2/LoadReportingServiceGrpc.java
@@ -62,7 +62,14 @@ public final class LoadReportingServiceGrpc {
    * Creates a new async stub that supports all call types for the service
    */
   public static LoadReportingServiceStub newStub(io.grpc.Channel channel) {
-    return new LoadReportingServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<LoadReportingServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<LoadReportingServiceStub>() {
+        @java.lang.Override
+        public LoadReportingServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new LoadReportingServiceStub(channel, callOptions);
+        }
+      };
+    return LoadReportingServiceStub.newStub(factory, channel);
   }
 
   /**
@@ -70,7 +77,14 @@ public final class LoadReportingServiceGrpc {
    */
   public static LoadReportingServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new LoadReportingServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<LoadReportingServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<LoadReportingServiceBlockingStub>() {
+        @java.lang.Override
+        public LoadReportingServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new LoadReportingServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return LoadReportingServiceBlockingStub.newStub(factory, channel);
   }
 
   /**
@@ -78,7 +92,14 @@ public final class LoadReportingServiceGrpc {
    */
   public static LoadReportingServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
-    return new LoadReportingServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<LoadReportingServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<LoadReportingServiceFutureStub>() {
+        @java.lang.Override
+        public LoadReportingServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new LoadReportingServiceFutureStub(channel, callOptions);
+        }
+      };
+    return LoadReportingServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -136,19 +157,15 @@ public final class LoadReportingServiceGrpc {
 
   /**
    */
-  public static final class LoadReportingServiceStub extends io.grpc.stub.AbstractStub<LoadReportingServiceStub> {
-    private LoadReportingServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private LoadReportingServiceStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class LoadReportingServiceStub extends io.grpc.stub.AbstractAsyncStub<LoadReportingServiceStub> {
+    private LoadReportingServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected LoadReportingServiceStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected LoadReportingServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new LoadReportingServiceStub(channel, callOptions);
     }
 
@@ -192,38 +209,30 @@ public final class LoadReportingServiceGrpc {
 
   /**
    */
-  public static final class LoadReportingServiceBlockingStub extends io.grpc.stub.AbstractStub<LoadReportingServiceBlockingStub> {
-    private LoadReportingServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private LoadReportingServiceBlockingStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class LoadReportingServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<LoadReportingServiceBlockingStub> {
+    private LoadReportingServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected LoadReportingServiceBlockingStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected LoadReportingServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new LoadReportingServiceBlockingStub(channel, callOptions);
     }
   }
 
   /**
    */
-  public static final class LoadReportingServiceFutureStub extends io.grpc.stub.AbstractStub<LoadReportingServiceFutureStub> {
-    private LoadReportingServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
-    private LoadReportingServiceFutureStub(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+  public static final class LoadReportingServiceFutureStub extends io.grpc.stub.AbstractFutureStub<LoadReportingServiceFutureStub> {
+    private LoadReportingServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected LoadReportingServiceFutureStub build(io.grpc.Channel channel,
-        io.grpc.CallOptions callOptions) {
+    protected LoadReportingServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new LoadReportingServiceFutureStub(channel, callOptions);
     }
   }


### PR DESCRIPTION
Roll-forward of stub,compiler: generated stub extends Abstract{Async, Future,Blocking}Stub #6196

This reverts commit 2eb3f8c34e58b2371cafa0728ae1ba1feec121da (#6317).

internal blocking issue is resolved (b/143656392)