### PR TITLE
Add Executor When Creating SslContext

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -627,4 +627,11 @@ public abstract class AbstractManagedChannelImplBuilder
     T thisT = (T) this;
     return thisT;
   }
+
+  /**
+   * Returns the internal offload executor pool for offloading tasks.
+   */
+  protected ObjectPool<? extends Executor> getOffloadExecutorPool() {
+    return this.offloadExecutorPool;
+  }
 }

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -297,4 +297,11 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
       return null;
     }
   }
+
+  /**
+   * Returns the internal ExecutorPool for offloading tasks.
+   */
+  protected ObjectPool<? extends Executor> getExecutorPool() {
+    return this.executorPool;
+  }
 }

--- a/netty/src/main/java/io/grpc/netty/InternalProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/InternalProtocolNegotiators.java
@@ -159,7 +159,7 @@ public final class InternalProtocolNegotiators {
 
   public static ChannelHandler clientTlsHandler(
       ChannelHandler next, SslContext sslContext, String authority) {
-    return new ClientTlsHandler(next, sslContext, authority);
+    return new ClientTlsHandler(next, sslContext, authority, null);
   }
 
   public static class ProtocolNegotiationHandler

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -51,6 +51,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.CheckReturnValue;
@@ -398,7 +399,8 @@ public final class NettyChannelBuilder
           throw new RuntimeException(ex);
         }
       }
-      negotiator = createProtocolNegotiatorByType(negotiationType, localSslContext);
+      negotiator = createProtocolNegotiatorByType(negotiationType, localSslContext,
+          this.getOffloadExecutorPool());
     }
 
     return new NettyTransportFactory(
@@ -441,14 +443,15 @@ public final class NettyChannelBuilder
   @CheckReturnValue
   static ProtocolNegotiator createProtocolNegotiatorByType(
       NegotiationType negotiationType,
-      SslContext sslContext) {
+      SslContext sslContext,
+      ObjectPool<? extends Executor> executorPool) {
     switch (negotiationType) {
       case PLAINTEXT:
         return ProtocolNegotiators.plaintext();
       case PLAINTEXT_UPGRADE:
         return ProtocolNegotiators.plaintextUpgrade();
       case TLS:
-        return ProtocolNegotiators.tls(sslContext);
+        return ProtocolNegotiators.tls(sslContext, executorPool);
       default:
         throw new IllegalArgumentException("Unsupported negotiationType: " + negotiationType);
     }

--- a/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
@@ -533,8 +533,9 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
 
     ProtocolNegotiator negotiator = protocolNegotiator;
     if (negotiator == null) {
-      negotiator = sslContext != null ? ProtocolNegotiators.serverTls(sslContext) :
-          ProtocolNegotiators.serverPlaintext();
+      negotiator = sslContext != null
+          ? ProtocolNegotiators.serverTls(sslContext, this.getExecutorPool())
+          : ProtocolNegotiators.serverPlaintext();
     }
 
     List<NettyServer> transportServers = new ArrayList<>(listenAddresses.size());

--- a/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
+++ b/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
@@ -246,7 +246,7 @@ public class ProtocolNegotiatorsTest {
 
   @Test
   public void tlsHandler_handlerAddedAddsSslHandler() throws Exception {
-    ChannelHandler handler = new ServerTlsHandler(grpcHandler, sslContext);
+    ChannelHandler handler = new ServerTlsHandler(grpcHandler, sslContext, null);
 
     pipeline.addLast(handler);
 
@@ -255,7 +255,7 @@ public class ProtocolNegotiatorsTest {
 
   @Test
   public void tlsHandler_userEventTriggeredNonSslEvent() throws Exception {
-    ChannelHandler handler = new ServerTlsHandler(grpcHandler, sslContext);
+    ChannelHandler handler = new ServerTlsHandler(grpcHandler, sslContext, null);
     pipeline.addLast(handler);
     channelHandlerCtx = pipeline.context(handler);
     Object nonSslEvent = new Object();
@@ -276,7 +276,7 @@ public class ProtocolNegotiatorsTest {
       }
     };
 
-    ChannelHandler handler = new ServerTlsHandler(grpcHandler, sslContext);
+    ChannelHandler handler = new ServerTlsHandler(grpcHandler, sslContext, null);
     pipeline.addLast(handler);
 
     final AtomicReference<Throwable> error = new AtomicReference<>();
@@ -303,7 +303,7 @@ public class ProtocolNegotiatorsTest {
 
   @Test
   public void tlsHandler_userEventTriggeredSslEvent_handshakeFailure() throws Exception {
-    ChannelHandler handler = new ServerTlsHandler(grpcHandler, sslContext);
+    ChannelHandler handler = new ServerTlsHandler(grpcHandler, sslContext, null);
     pipeline.addLast(handler);
     channelHandlerCtx = pipeline.context(handler);
     Object sslEvent = new SslHandshakeCompletionEvent(new RuntimeException("bad"));
@@ -335,7 +335,7 @@ public class ProtocolNegotiatorsTest {
       }
     };
 
-    ChannelHandler handler = new ServerTlsHandler(grpcHandler, sslContext);
+    ChannelHandler handler = new ServerTlsHandler(grpcHandler, sslContext, null);
     pipeline.addLast(handler);
 
     pipeline.replace(SslHandler.class, null, goodSslHandler);
@@ -358,7 +358,7 @@ public class ProtocolNegotiatorsTest {
       }
     };
 
-    ChannelHandler handler = new ServerTlsHandler(grpcHandler, sslContext);
+    ChannelHandler handler = new ServerTlsHandler(grpcHandler, sslContext, null);
     pipeline.addLast(handler);
 
     pipeline.replace(SslHandler.class, null, goodSslHandler);
@@ -374,7 +374,7 @@ public class ProtocolNegotiatorsTest {
 
   @Test
   public void engineLog() {
-    ChannelHandler handler = new ServerTlsHandler(grpcHandler, sslContext);
+    ChannelHandler handler = new ServerTlsHandler(grpcHandler, sslContext, null);
     pipeline.addLast(handler);
     channelHandlerCtx = pipeline.context(handler);
 
@@ -618,8 +618,7 @@ public class ProtocolNegotiatorsTest {
     SslContext serverSslContext =
         GrpcSslContexts.configure(SslContextBuilder.forServer(cert.key(), cert.cert())).build();
     FakeGrpcHttp2ConnectionHandler gh = FakeGrpcHttp2ConnectionHandler.newHandler();
-
-    ClientTlsProtocolNegotiator pn = new ClientTlsProtocolNegotiator(clientSslContext);
+    ClientTlsProtocolNegotiator pn = new ClientTlsProtocolNegotiator(clientSslContext, null);
     WriteBufferingAndExceptionHandler clientWbaeh =
         new WriteBufferingAndExceptionHandler(pn.newHandler(gh));
 
@@ -656,6 +655,7 @@ public class ProtocolNegotiatorsTest {
     }
     c.close();
     s.close();
+    pn.close();
 
     assertThat(gh.securityInfo).isNotNull();
     assertThat(gh.securityInfo.tls).isNotNull();


### PR DESCRIPTION
This PR is to add one more Executor parameter when creating the SslContext.
In Netty, we already have this implementation for passing Executor when creating SslContext: https://github.com/netty/netty/pull/8847. This extra Executor is used to take some time-consuming tasks when doing SSL handshake. However, in current gRPC implementation, we are not using this API. 

In this PR, the relevant changes are:

- get the executorPool from ChannelBuilder or ServerBuilder

- pass the executorPool all the way down to ClientTlsHandler

- fill executorPool in when creating SslHandler
