### PR TITLE
interop-testing,core: add interop test to get remote address attributes

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -122,6 +122,8 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
     this.attributes = Attributes.newBuilder()
         .set(GrpcAttributes.ATTR_SECURITY_LEVEL, SecurityLevel.PRIVACY_AND_INTEGRITY)
         .set(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS, eagAttrs)
+        .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, new InProcessSocketAddress(name))
+        .set(Grpc.TRANSPORT_ATTR_LOCAL_ADDR, new InProcessSocketAddress(name))
         .build();
     logId = InternalLogId.allocate(getClass(), name);
   }
@@ -783,7 +785,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
 
       @Override
       public Attributes getAttributes() {
-        return Attributes.EMPTY;
+        return attributes;
       }
 
       @Override

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
@@ -89,7 +89,7 @@ public class Http2NettyTest extends AbstractInteropTest {
 
   @Test
   public void localAddr() throws Exception {
-    InetSocketAddress isa = (InetSocketAddress) obtainLocalClientAddr();
+    InetSocketAddress isa = (InetSocketAddress) obtainLocalServerAddr();
     assertEquals(InetAddress.getLoopbackAddress(), isa.getAddress());
     assertEquals(((InetSocketAddress) getListenAddress()).getPort(), isa.getPort());
   }


### PR DESCRIPTION
Adding interop-test for getting remote server address from client interceptor. Also added this feature to inprocess transport.