### PR TITLE
Update protobuf to 3.11.0 and gson to 2.8.6

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -42,7 +42,7 @@ The codegen plugin is C++ code and requires protobuf 3.0.0 or later.
 
 For Linux, Mac and MinGW:
 ```
-$ PROTOBUF_VERSION=3.10.0
+$ PROTOBUF_VERSION=3.11.0
 $ curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protobuf-all-$PROTOBUF_VERSION.tar.gz
 $ tar xzf protobuf-all-$PROTOBUF_VERSION.tar.gz
 $ cd protobuf-$PROTOBUF_VERSION
@@ -75,16 +75,16 @@ When building on Windows and VC++, you need to specify project properties for
 Gradle to find protobuf:
 ```
 .\gradlew publishToMavenLocal ^
-    -PvcProtobufInclude=C:\path\to\protobuf-3.10.0\src ^
-    -PvcProtobufLibs=C:\path\to\protobuf-3.10.0\vsprojects\Release ^
+    -PvcProtobufInclude=C:\path\to\protobuf-3.11.0\src ^
+    -PvcProtobufLibs=C:\path\to\protobuf-3.11.0\vsprojects\Release ^
     -PtargetArch=x86_32
 ```
 
 Since specifying those properties every build is bothersome, you can instead
 create ``<project-root>\gradle.properties`` with contents like:
 ```
-vcProtobufInclude=C:\\path\\to\\protobuf-3.10.0\\src
-vcProtobufLibs=C:\\path\\to\\protobuf-3.10.0\\vsprojects\\Release
+vcProtobufInclude=C:\\path\\to\\protobuf-3.11.0\\src
+vcProtobufLibs=C:\\path\\to\\protobuf-3.11.0\\vsprojects\\Release
 targetArch=x86_32
 ```
 

--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -39,7 +39,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.10.0' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.11.0' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.26.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ subprojects {
         nettyVersion = '4.1.42.Final'
         guavaVersion = '28.1-android'
         googleauthVersion = '0.18.0'
-        protobufVersion = '3.10.0'
+        protobufVersion = '3.11.0'
         protocVersion = protobufVersion
         opencensusVersion = '0.24.0'
 
@@ -114,7 +114,7 @@ subprojects {
             android_annotations: "com.google.android:annotations:4.1.1.4",
             animalsniffer_annotations: "org.codehaus.mojo:animal-sniffer-annotations:1.17",
             errorprone: "com.google.errorprone:error_prone_annotations:2.3.3",
-            gson: "com.google.code.gson:gson:2.8.5",
+            gson: "com.google.code.gson:gson:2.8.6",
             guava: "com.google.guava:guava:${guavaVersion}",
             hpack: 'com.twitter:hpack:0.10.1',
             javax_annotation: 'javax.annotation:javax.annotation-api:1.2',

--- a/buildscripts/build_docker.sh
+++ b/buildscripts/build_docker.sh
@@ -2,7 +2,7 @@
 set -eu -o pipefail
 
 readonly proto_dir="$(mktemp -d --tmpdir protobuf.XXXXXX)"
-wget -O - https://github.com/google/protobuf/archive/v3.10.0.tar.gz | tar xz -C "$proto_dir"
+wget -O - https://github.com/google/protobuf/archive/v3.11.0.tar.gz | tar xz -C "$proto_dir"
 
-docker build -t protoc-artifacts "$proto_dir"/protobuf-3.10.0/protoc-artifacts
+docker build -t protoc-artifacts "$proto_dir"/protobuf-3.11.0/protoc-artifacts
 rm -r "$proto_dir"

--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -1,4 +1,4 @@
-set PROTOBUF_VER=3.10.0
+set PROTOBUF_VER=3.11.0
 set CMAKE_NAME=cmake-3.3.2-win32-x86
 
 if not exist "protobuf-%PROTOBUF_VER%\cmake\build\Release\" (

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -3,7 +3,7 @@
 # Build protoc
 set -evux -o pipefail
 
-PROTOBUF_VERSION=3.10.0
+PROTOBUF_VERSION=3.11.0
 
 # ARCH is 64 bit unless otherwise specified.
 ARCH="${ARCH:-64}"

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -28,7 +28,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.10.0' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.11.0' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.26.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -27,7 +27,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.10.0' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.11.0' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.26.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -26,7 +26,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.10.0' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.11.0' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.26.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/android/strictmode/app/build.gradle
+++ b/examples/android/strictmode/app/build.gradle
@@ -27,7 +27,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.10.0' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.11.0' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.26.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -23,7 +23,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.26.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.10.0'
+def protobufVersion = '3.11.0'
 def protocVersion = protobufVersion
 
 dependencies {

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -23,7 +23,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.26.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.10.0'
+def protocVersion = '3.11.0'
 
 dependencies {
     // grpc-alts transitively depends on grpc-netty-shaded, grpc-protobuf, and grpc-stub

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.26.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.10.0'
+def protobufVersion = '3.11.0'
 def protocVersion = protobufVersion
 
 

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.26.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.10.0</protobuf.version>
+    <protobuf.version>3.11.0</protobuf.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/examples/example-kotlin/android/helloworld/app/build.gradle
+++ b/examples/example-kotlin/android/helloworld/app/build.gradle
@@ -49,7 +49,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.10.0' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.11.0' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.26.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/example-kotlin/build.gradle
+++ b/examples/example-kotlin/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.10.0' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.11.0' }
     plugins {
         grpc { artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}" }
     }

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -25,7 +25,7 @@ targetCompatibility = 1.7
 // updating the version in our release process.
 def grpcVersion = '1.26.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 def nettyTcNativeVersion = '2.0.26.Final'
-def protocVersion = '3.10.0'
+def protocVersion = '3.11.0'
 
 dependencies {
     implementation "io.grpc:grpc-netty:${grpcVersion}"

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.26.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protoc.version>3.10.0</protoc.version>
+    <protoc.version>3.11.0</protoc.version>
     <netty.tcnative.version>2.0.25.Final</netty.tcnative.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.26.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.10.0</protobuf.version>
-    <protoc.version>3.10.0</protoc.version>
+    <protobuf.version>3.11.0</protobuf.version>
+    <protoc.version>3.11.0</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -209,9 +209,9 @@ def com_google_code_findbugs_jsr305():
 def com_google_code_gson():
     jvm_maven_import_external(
         name = "com_google_code_gson_gson",
-        artifact = "com.google.code.gson:gson:jar:2.8.5",
+        artifact = "com.google.code.gson:gson:jar:2.8.6",
         server_urls = ["http://central.maven.org/maven2"],
-        artifact_sha256 = "233a0149fc365c9f6edbd683cfe266b19bdc773be98eabdaf6b3c924b48e7d81",
+        artifact_sha256 = "c8fb4839054d280b3033f800d1f5a97de2f028eb8ba2eb458ad287e536f3f25f",
         licenses = ["notice"],  # Apache 2.0
     )
 
@@ -258,9 +258,9 @@ def com_google_protobuf():
     # This statement defines the @com_google_protobuf repo.
     http_archive(
         name = "com_google_protobuf",
-        sha256 = "33cba8b89be6c81b1461f1c438424f7a1aa4e31998dbe9ed6f8319583daac8c7",
-        strip_prefix = "protobuf-3.10.0",
-        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.10.0.zip"],
+        sha256 = "60d2012e3922e429294d3a4ac31f336016514a91e5a63fd33f35743ccfe1bd7d",
+        strip_prefix = "protobuf-3.11.0",
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.11.0.zip"],
     )
 
 def com_google_protobuf_javalite():


### PR DESCRIPTION
Updating Protobuf to bring in improvements for Android.

Protobuf pulls in the newer version of gson and we are happy to update
to it.

CC @ericgribkoff; I'd like this to get into the release cut (but I can always backport it)