### PR TITLE
netty: log NativeIoException as FINE level (backport  v1.25.x)

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
@@ -19,6 +19,7 @@ package io.grpc.netty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.InternalChannelz.SocketStats;
@@ -49,6 +50,10 @@ class NettyServerTransport implements ServerTransport {
   // connectionLog is for connection related messages only
   private static final Logger connectionLog = Logger.getLogger(
       String.format("%s.connections", NettyServerTransport.class.getName()));
+
+  // Some exceptions are not very useful and add too much noise to the log
+  private static final ImmutableList<String> QUIET_EXCEPTIONS = ImmutableList.of(
+      "NativeIoException" /* Netty exceptions */);
 
   private final InternalLogId logId;
   private final Channel channel;
@@ -178,7 +183,8 @@ class NettyServerTransport implements ServerTransport {
    */
   @VisibleForTesting
   static Level getLogLevel(Throwable t) {
-    if (t.getClass().equals(IOException.class)) {
+    if (t.getClass().equals(IOException.class)
+        || QUIET_EXCEPTIONS.contains(t.getClass().getSimpleName())) {
       return Level.FINE;
     }
     return Level.INFO;

--- a/netty/src/test/java/io/grpc/netty/NettyServerTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerTransportTest.java
@@ -56,4 +56,13 @@ public class NettyServerTransportTest {
     assertThat(e.getMessage()).isNull();
     assertThat(getLogLevel(e)).isEqualTo(Level.INFO);
   }
+
+  @Test
+  public void fakeNettyNativeIoException() {
+    class NativeIoException extends IOException {}
+
+    NativeIoException fakeNativeIoException = new NativeIoException();
+
+    assertThat(getLogLevel(fakeNativeIoException)).isEqualTo(Level.FINE);
+  }
 }


### PR DESCRIPTION
backport of #6477 to 1.25.x