### PR TITLE
Update Bazel+Javalite to 3.11

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -267,9 +267,9 @@ def com_google_protobuf_javalite():
     # java_lite_proto_library rules implicitly depend on @com_google_protobuf_javalite
     http_archive(
         name = "com_google_protobuf_javalite",
-        sha256 = "79d102c61e2a479a0b7e5fc167bcfaa4832a0c6aad4a75fa7da0480564931bcc",
-        strip_prefix = "protobuf-384989534b2246d413dbcd750744faab2607b516",
-        urls = ["https://github.com/google/protobuf/archive/384989534b2246d413dbcd750744faab2607b516.zip"],
+        sha256 = "e60211a40473f6be95b53f64559f82a3b2971672b11710db2fc9081708e25699",
+        strip_prefix = "protobuf-0425fa932ce95a32bb9f88b2c09b995e9ff8207b",
+        urls = ["https://github.com/google/protobuf/archive/0425fa932ce95a32bb9f88b2c09b995e9ff8207b.zip"],  # Commit with fixed javalite on 3.11.x branch
     )
 
 def com_google_truth_truth():


### PR DESCRIPTION
Bazel was stuck on the javalite branch of protobuf because the master
branch was lacking the toolchain necessary for javalite. The fix was
backported to 3.11 in protocolbuffers/protobuf#6976

CC @ericgribkoff