### PR TITLE
core: refactor GracefulSwitchLoadBalancer to switch based on LoadBalancer.Factory

### DIFF
--- a/api/src/main/java/io/grpc/LoadBalancerProvider.java
+++ b/api/src/main/java/io/grpc/LoadBalancerProvider.java
@@ -86,15 +86,16 @@ public abstract class LoadBalancerProvider extends LoadBalancer.Factory {
   }
 
   /**
-   * Uses identity equality.
+   * Equal provider instances must be of the same class, have the same policy name, priority and
+   * availability, and parse lb configs in the same way.
    */
   @Override
-  public final boolean equals(Object other) {
+  public boolean equals(Object other) {
     return this == other;
   }
 
   @Override
-  public final int hashCode() {
+  public int hashCode() {
     return super.hashCode();
   }
 

--- a/api/src/main/java/io/grpc/LoadBalancerProvider.java
+++ b/api/src/main/java/io/grpc/LoadBalancerProvider.java
@@ -86,16 +86,15 @@ public abstract class LoadBalancerProvider extends LoadBalancer.Factory {
   }
 
   /**
-   * Equal provider instances must be of the same class, have the same policy name, priority and
-   * availability, and parse lb configs in the same way.
+   * Uses identity equality.
    */
   @Override
-  public boolean equals(Object other) {
+  public final boolean equals(Object other) {
     return this == other;
   }
 
   @Override
-  public int hashCode() {
+  public final int hashCode() {
     return super.hashCode();
   }
 

--- a/core/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
@@ -76,7 +76,10 @@ public final class GracefulSwitchLoadBalancer extends ForwardingLoadBalancer {
     this.helper = checkNotNull(helper, "helper");
   }
 
-  /** Gracefully switch to a new policy defined by the given factory. */
+  /**
+   * Gracefully switch to a new policy defined by the given factory, if the given factory isn't
+   * equal to the current one.
+   */
   public void switchTo(LoadBalancer.Factory newBalancerFactory) {
     checkNotNull(newBalancerFactory, "newBalancerFactory");
 

--- a/core/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
@@ -76,10 +76,7 @@ public final class GracefulSwitchLoadBalancer extends ForwardingLoadBalancer {
     this.helper = checkNotNull(helper, "helper");
   }
 
-  /**
-   * Gracefully switch to a new policy defined by the given factory. Two factories are considered to
-   * define the same policy if and only if one {@code equals()} the other.
-   */
+  /** Gracefully switch to a new policy defined by the given factory. */
   public void switchTo(LoadBalancer.Factory newBalancerFactory) {
     checkNotNull(newBalancerFactory, "newBalancerFactory");
 

--- a/core/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
@@ -29,10 +29,9 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * A load balancer that gracefully swaps to a new policy. If the channel is
- * currently in a state other than READY, the new balancer type will be swapped into place
- * immediately. Otherwise, the channel will keep using the old balancer type until the balancer of
- * the new type reports READY or the old balancer exits READY.
+ * A load balancer that gracefully swaps to a new lb policy. If the channel is currently in a state
+ * other than READY, the new policy will be swapped into place immediately.  Otherwise, the channel
+ * will keep using the old policy until the new policy reports READY or the old policy exits READY.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/5999")
 @NotThreadSafe // Must be accessed in SynchronizationContext
@@ -79,7 +78,7 @@ public final class GracefulSwitchLoadBalancer extends ForwardingLoadBalancer {
 
   /**
    * Gracefully switch to a new policy defined by the given factory. Two factories are considered to
-   * define the same policy if and only if one {@code equals()} to the other.
+   * define the same policy if and only if one {@code equals()} the other.
    */
   public void switchTo(LoadBalancer.Factory newBalancerFactory) {
     checkNotNull(newBalancerFactory, "newBalancerFactory");

--- a/core/src/test/java/io/grpc/util/GracefulSwitchLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/util/GracefulSwitchLoadBalancerTest.java
@@ -40,8 +40,10 @@ import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.Status;
 import java.net.SocketAddress;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Rule;
@@ -416,6 +418,70 @@ public class GracefulSwitchLoadBalancerTest {
     gracefulSwitchLb.switchTo(lbProviders.get(lbPolicies[0]));
     verify(lb1).shutdown();
     assertThat(balancers.get(lbPolicies[0])).isSameInstanceAs(lb0);
+
+    verifyNoMoreInteractions(lb0, lb1);
+  }
+
+
+  @Test
+  public void newProviderEqualToOldOneShouldHaveNoEffect() {
+    final List<LoadBalancer> balancers = new ArrayList<>();
+
+    final class LoadBalancerProviderWithId extends LoadBalancerProvider {
+      final int id;
+
+      LoadBalancerProviderWithId(int id) {
+        this.id = id;
+      }
+
+      @Override
+      public boolean isAvailable() {
+        return true;
+      }
+
+      @Override
+      public int getPriority() {
+        return 5;
+      }
+
+      @Override
+      public String getPolicyName() {
+        return "fake_name";
+      }
+
+      @Override
+      public LoadBalancer newLoadBalancer(Helper helper) {
+        LoadBalancer balancer = mock(LoadBalancer.class);
+        balancers.add(balancer);
+        return balancer;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+        if (!(o instanceof LoadBalancerProviderWithId)) {
+          return false;
+        }
+        LoadBalancerProviderWithId that = (LoadBalancerProviderWithId) o;
+        return id == that.id;
+      }
+
+      @Override
+      public int hashCode() {
+        return id;
+      }
+    }
+
+    gracefulSwitchLb.switchTo(new LoadBalancerProviderWithId(0));
+    assertThat(balancers).hasSize(1);
+    LoadBalancer lb0 = balancers.get(0);
+
+    gracefulSwitchLb.switchTo(new LoadBalancerProviderWithId(0));
+    assertThat(balancers).hasSize(1);
+
+    gracefulSwitchLb.switchTo(new LoadBalancerProviderWithId(1));
+    assertThat(balancers).hasSize(2);
+    LoadBalancer lb1 = balancers.get(1);
+    verify(lb0).shutdown();
 
     verifyNoMoreInteractions(lb0, lb1);
   }

--- a/core/src/test/java/io/grpc/util/GracefulSwitchLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/util/GracefulSwitchLoadBalancerTest.java
@@ -424,29 +424,14 @@ public class GracefulSwitchLoadBalancerTest {
 
 
   @Test
-  public void newProviderEqualToOldOneShouldHaveNoEffect() {
+  public void newLbFactoryEqualToOldOneShouldHaveNoEffect() {
     final List<LoadBalancer> balancers = new ArrayList<>();
 
-    final class LoadBalancerProviderWithId extends LoadBalancerProvider {
+    final class LoadBalancerFactoryWithId extends LoadBalancer.Factory {
       final int id;
 
-      LoadBalancerProviderWithId(int id) {
+      LoadBalancerFactoryWithId(int id) {
         this.id = id;
-      }
-
-      @Override
-      public boolean isAvailable() {
-        return true;
-      }
-
-      @Override
-      public int getPriority() {
-        return 5;
-      }
-
-      @Override
-      public String getPolicyName() {
-        return "fake_name";
       }
 
       @Override
@@ -458,10 +443,10 @@ public class GracefulSwitchLoadBalancerTest {
 
       @Override
       public boolean equals(Object o) {
-        if (!(o instanceof LoadBalancerProviderWithId)) {
+        if (!(o instanceof LoadBalancerFactoryWithId)) {
           return false;
         }
-        LoadBalancerProviderWithId that = (LoadBalancerProviderWithId) o;
+        LoadBalancerFactoryWithId that = (LoadBalancerFactoryWithId) o;
         return id == that.id;
       }
 
@@ -471,14 +456,14 @@ public class GracefulSwitchLoadBalancerTest {
       }
     }
 
-    gracefulSwitchLb.switchTo(new LoadBalancerProviderWithId(0));
+    gracefulSwitchLb.switchTo(new LoadBalancerFactoryWithId(0));
     assertThat(balancers).hasSize(1);
     LoadBalancer lb0 = balancers.get(0);
 
-    gracefulSwitchLb.switchTo(new LoadBalancerProviderWithId(0));
+    gracefulSwitchLb.switchTo(new LoadBalancerFactoryWithId(0));
     assertThat(balancers).hasSize(1);
 
-    gracefulSwitchLb.switchTo(new LoadBalancerProviderWithId(1));
+    gracefulSwitchLb.switchTo(new LoadBalancerFactoryWithId(1));
     assertThat(balancers).hasSize(2);
     LoadBalancer lb1 = balancers.get(1);
     verify(lb0).shutdown();

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -329,15 +329,28 @@ final class LookasideLb extends LoadBalancer {
       return 5;
     }
 
-    // A synthetic policy name identified by edsServiceName in XdsConfig.
     @Override
     public String getPolicyName() {
-      return "xds_policy__edsServiceName_" + edsServiceName;
+      return "cluster_endpoints_balancer";
     }
 
     @Override
     public LoadBalancer newLoadBalancer(Helper helper) {
       return new ClusterEndpointsBalancer(helper);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof ClusterEndpointsBalancerProvider)) {
+        return false;
+      }
+      ClusterEndpointsBalancerProvider that = (ClusterEndpointsBalancerProvider) o;
+      return edsServiceName.equals(that.edsServiceName);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(super.hashCode(), edsServiceName);
     }
 
     /**


### PR DESCRIPTION
`GracefulSwitchLoadBalancer` was doing switch based on `LoadBalancerProvider.getPolicyName()`. This turned out to be very awkward when I have to synthesize a policy name for the provider, and what I actually care about is the identity of the lb provider not necessarily the policy name.

Now `GracefulSwitchLoadBalancer` is doing switch based on identity of `LoadBalancer.Factory`, which is simpler.