### PR TITLE
Animal-sniffer-annotation 1.18

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -20,7 +20,7 @@ dependencies {
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
         // prefer 3.0.2 from libraries instead of 3.0.1
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
-        // prefer 1.17 from libraries instead of 1.14
+        // prefer our own version from libraries instead of Guava's dependency
         exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
     }
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -16,11 +16,9 @@ dependencies {
             libraries.jsr305,
             libraries.animalsniffer_annotations
     compile (libraries.guava) {
-        // prefer 2.3.3 from libraries instead of 2.1.3
+        // prefer our own versions from libraries instead of Guava's dependency
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
-        // prefer 3.0.2 from libraries instead of 3.0.1
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
-        // prefer our own version from libraries instead of Guava's dependency
         exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ subprojects {
 
         libraries = [
             android_annotations: "com.google.android:annotations:4.1.1.4",
-            animalsniffer_annotations: "org.codehaus.mojo:animal-sniffer-annotations:1.17",
+            animalsniffer_annotations: "org.codehaus.mojo:animal-sniffer-annotations:1.18",
             errorprone: "com.google.errorprone:error_prone_annotations:2.3.3",
             gson: "com.google.code.gson:gson:2.8.5",
             guava: "com.google.guava:guava:${guavaVersion}",

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -13,11 +13,9 @@ dependencies {
     compile project(':grpc-api'),
             libraries.protobuf_lite
     compile (libraries.guava) {
-        // prefer 2.3.3 from libraries instead of 2.1.3
+        // prefer our own versions from libraries instead of Guava's dependency
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
-        // prefer 3.0.2 from libraries instead of 3.0.1
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
-        // prefer 1.17 from libraries instead of 1.14
         exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
     }
 

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -13,11 +13,9 @@ dependencies {
     compile project(':grpc-api'),
             libraries.protobuf
     compile (libraries.guava) {
-        // prefer 2.3.2 from libraries instead of 2.1.3
+        // prefer our own versions from libraries instead of Guava's dependency
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
-        // prefer 3.0.2 from libraries instead of 3.0.1
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
-        // prefer 1.17 from libraries instead of 1.14
         exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
     }
 

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -473,8 +473,8 @@ def org_apache_commons_lang3():
 def org_codehaus_mojo_animal_sniffer_annotations():
     jvm_maven_import_external(
         name = "org_codehaus_mojo_animal_sniffer_annotations",
-        artifact = "org.codehaus.mojo:animal-sniffer-annotations:1.17",
+        artifact = "org.codehaus.mojo:animal-sniffer-annotations:1.18",
         server_urls = ["http://central.maven.org/maven2"],
-        artifact_sha256 = "92654f493ecfec52082e76354f0ebf87648dc3d5cec2e3c3cdb947c016747a53",
+        artifact_sha256 = "47f05852b48ee9baefef80fa3d8cea60efa4753c0013121dd7fe5eef2e5c729d",
         licenses = ["notice"],  # MIT
     )


### PR DESCRIPTION
Upgrading animal-sniffer-annotation to the latest [1.18](https://search.maven.org/artifact/org.codehaus.mojo/animal-sniffer-annotations/1.18/jar).

There was a problem in upperBoundCheck in google-cloud-firestore:  https://github.com/googleapis/java-firestore/pull/34.