### PR TITLE
Replaced outdated exclusion comments

### DIFF
--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -22,9 +22,8 @@ dependencies {
             libraries.protobuf,
             libraries.conscrypt
     compile (libraries.google_auth_oauth2_http) {
-        // prefer 26.0-android from libraries instead of 25.1-android
+        // prefer our own versions instead of google-auth-oauth2-http's dependency
         exclude group: 'com.google.guava', module: 'guava'
-        // prefer 0.19.2 from libraries instead of 0.18.0
         exclude group: 'io.opencensus', module: 'opencensus-api'
     }
     compileOnly libraries.javax_annotation

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -18,19 +18,15 @@ dependencies {
             libraries.android_annotations,
             libraries.perfmark
     compile (libraries.opencensus_api) {
-        // prefer 3.0.2 from libraries instead of 3.0.1
+        // prefer our own versions instead of opencensus-api's dependency
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
-        // prefer 20.0 from libraries instead of 19.0
         exclude group: 'com.google.guava', module: 'guava'
-        // we'll always be more up-to-date
         exclude group: 'io.grpc', module: 'grpc-context'
     }
     compile (libraries.opencensus_contrib_grpc_metrics) {
-        // prefer 3.0.2 from libraries instead of 3.0.1
+        // prefer our own versions instead of opencensus-contrib's dependency
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
-        // we'll always be more up-to-date
         exclude group: 'io.grpc', module: 'grpc-context'
-        // prefer 20.0 from libraries instead of 19.0
         exclude group: 'com.google.guava', module: 'guava'
     }
 

--- a/grpclb/build.gradle
+++ b/grpclb/build.gradle
@@ -16,9 +16,8 @@ dependencies {
             project(':grpc-stub'),
             libraries.protobuf
     compile (libraries.protobuf_util) {
-        // prefer 26.0-android from libraries instead of 20.0
+        // prefer our own versions instead of protobuf-util's dependency
         exclude group: 'com.google.guava', module: 'guava'
-        // prefer 2.3.3 from libraries instead of 2.3.2
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }
     compileOnly libraries.javax_annotation

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -15,7 +15,7 @@ dependencies {
             libraries.okio
 
     compile (libraries.okhttp) {
-        // prefer 1.13.0 from libraries instead of 1.6.0
+        // prefer our own versions instead of okhttp's dependency
         exclude group: 'com.squareup.okio', module: 'okio'
     }
 

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -23,9 +23,8 @@ dependencies {
             project(':grpc-stub'),
             project(':grpc-core')
     compile (libraries.protobuf_util) {
-        // prefer 26.0-android from libraries instead of 20.0
+        // prefer our own versions instead of protobuf-util's dependency
         exclude group: 'com.google.guava', module: 'guava'
-        // prefer 2.3.3 from libraries instead of 2.3.2
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }
 

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -15,7 +15,7 @@ dependencies {
             libraries.junit
 
     testCompile (libraries.mockito) {
-        // prefer 1.3 from JUnit instead of 1.1
+        // prefer our own versions instead of mockito's dependency
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
 

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -32,9 +32,8 @@ dependencies {
         exclude group: 'com.google.protobuf'
     }
     compile (libraries.protobuf_util) {
-        // prefer 26.0-android from libraries instead of 20.0
+        // prefer our own versions instead of protobuf-util's dependency
         exclude group: 'com.google.guava', module: 'guava'
-        // prefer 2.3.3 from libraries instead of 2.3.2
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }
 


### PR DESCRIPTION
Followup of https://github.com/grpc/grpc-java/pull/6488#discussion_r354459784. These comments on exclusions with specific versions are hard to maintain.