### PR TITLE
xds: support multiple xDS servers in bootstrap file

### DIFF
--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -73,28 +73,34 @@ public abstract class Bootstrapper {
     @SuppressWarnings("unchecked")
     Map<String, ?> rawBootstrap = (Map<String, ?>) JsonParser.parse(rawData);
 
-    Map<String, ?> rawServerConfig = JsonUtil.getObject(rawBootstrap, "xds_server");
-    if (rawServerConfig == null) {
-      throw new IOException("Invalid bootstrap: 'xds_server' does not exist.");
+    List<ServerInfo> servers = new ArrayList<>();
+    List<?> rawServerConfigs = JsonUtil.getList(rawBootstrap, "xds_servers");
+    if (rawServerConfigs == null) {
+      throw new IOException("Invalid bootstrap: 'xds_servers' does not exist.");
     }
-    // Field "server_uri" is required.
-    String serverUri = JsonUtil.getString(rawServerConfig, "server_uri");
-    if (serverUri == null) {
-      throw new IOException("Invalid bootstrap: 'xds_server : server_uri' does not exist.");
-    }
-    List<ChannelCreds> channelCredsOptions = new ArrayList<>();
-    List<?> rawChannelCredsList = JsonUtil.getList(rawServerConfig, "channel_creds");
-    // List of channel creds is optional.
-    if (rawChannelCredsList != null) {
-      List<Map<String, ?>> channelCredsList = JsonUtil.checkObjectList(rawChannelCredsList);
-      for (Map<String, ?> channelCreds : channelCredsList) {
-        String type = JsonUtil.getString(channelCreds, "type");
-        if (type == null) {
-          throw new IOException("Invalid bootstrap: 'channel_creds' contains unknown type.");
-        }
-        ChannelCreds creds = new ChannelCreds(type, JsonUtil.getObject(channelCreds, "config"));
-        channelCredsOptions.add(creds);
+    List<Map<String, ?>> serverConfigList = JsonUtil.checkObjectList(rawServerConfigs);
+    for (Map<String, ?> serverConfig : serverConfigList) {
+      // Field "server_uri" is required.
+      String serverUri = JsonUtil.getString(serverConfig, "server_uri");
+      if (serverUri == null) {
+        throw new IOException("Invalid bootstrap: 'xds_servers' contains unknown server.");
       }
+      List<ChannelCreds> channelCredsOptions = new ArrayList<>();
+      List<?> rawChannelCredsList = JsonUtil.getList(serverConfig, "channel_creds");
+      // List of channel creds is optional.
+      if (rawChannelCredsList != null) {
+        List<Map<String, ?>> channelCredsList = JsonUtil.checkObjectList(rawChannelCredsList);
+        for (Map<String, ?> channelCreds : channelCredsList) {
+          String type = JsonUtil.getString(channelCreds, "type");
+          if (type == null) {
+            throw new IOException("Invalid bootstrap: 'xds_servers' contains server with "
+                + "unknown type 'channel_creds'.");
+          }
+          ChannelCreds creds = new ChannelCreds(type, JsonUtil.getObject(channelCreds, "config"));
+          channelCredsOptions.add(creds);
+        }
+      }
+      servers.add(new ServerInfo(serverUri, channelCredsOptions));
     }
 
     Node.Builder nodeBuilder = Node.newBuilder();
@@ -133,7 +139,7 @@ public abstract class Bootstrapper {
     }
     nodeBuilder.setBuildVersion(GrpcUtil.getGrpcBuildVersion());
 
-    return new BootstrapInfo(serverUri, channelCredsOptions, nodeBuilder.build());
+    return new BootstrapInfo(servers, nodeBuilder.build());
   }
 
   /**
@@ -203,26 +209,48 @@ public abstract class Bootstrapper {
   }
 
   /**
+   * Data class containing xDS server information, such as server URI and channel credential
+   * options to be used for communication.
+   */
+  @Immutable
+  static class ServerInfo {
+    private final String serverUri;
+    private final List<ChannelCreds> channelCredsList;
+
+    @VisibleForTesting
+    ServerInfo(String serverUri, List<ChannelCreds> channelCredsList) {
+      this.serverUri = serverUri;
+      this.channelCredsList = channelCredsList;
+    }
+
+    String getServerUri() {
+      return serverUri;
+    }
+
+    List<ChannelCreds> getChannelCredentials() {
+      return Collections.unmodifiableList(channelCredsList);
+    }
+  }
+
+  /**
    * Data class containing the results of reading bootstrap.
    */
   @Immutable
   public static class BootstrapInfo {
-    private final String serverUri;
-    private final List<ChannelCreds> channelCredsList;
+    private List<ServerInfo> servers;
     private final Node node;
 
     @VisibleForTesting
-    BootstrapInfo(String serverUri, List<ChannelCreds> channelCredsList, Node node) {
-      this.serverUri = serverUri;
-      this.channelCredsList = channelCredsList;
+    BootstrapInfo(List<ServerInfo> servers, Node node) {
+      this.servers = servers;
       this.node = node;
     }
 
     /**
-     * Returns the URI the traffic director to be connected to.
+     * Returns the list of connection configurations for traffic directors to be connected to.
      */
-    String getServerUri() {
-      return serverUri;
+    List<ServerInfo> getServers() {
+      return Collections.unmodifiableList(servers);
     }
 
     /**
@@ -232,11 +260,5 @@ public abstract class Bootstrapper {
       return node;
     }
 
-    /**
-     * Returns the credentials to use when communicating with the xDS server.
-     */
-    List<ChannelCreds> getChannelCredentials() {
-      return Collections.unmodifiableList(channelCredsList);
-    }
   }
 }

--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -80,7 +80,6 @@ public abstract class Bootstrapper {
     }
     List<Map<String, ?>> serverConfigList = JsonUtil.checkObjectList(rawServerConfigs);
     for (Map<String, ?> serverConfig : serverConfigList) {
-      // Field "server_uri" is required.
       String serverUri = JsonUtil.getString(serverConfig, "server_uri");
       if (serverUri == null) {
         throw new IOException("Invalid bootstrap: 'xds_servers' contains unknown server.");
@@ -247,7 +246,7 @@ public abstract class Bootstrapper {
     }
 
     /**
-     * Returns the list of connection configurations for traffic directors to be connected to.
+     * Returns the list of xDS servers to be connected to.
      */
     List<ServerInfo> getServers() {
       return Collections.unmodifiableList(servers);

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -41,6 +41,7 @@ import io.grpc.internal.ObjectPool;
 import io.grpc.util.GracefulSwitchLoadBalancer;
 import io.grpc.xds.Bootstrapper.BootstrapInfo;
 import io.grpc.xds.Bootstrapper.ChannelCreds;
+import io.grpc.xds.Bootstrapper.ServerInfo;
 import io.grpc.xds.EnvoyProtoData.DropOverload;
 import io.grpc.xds.EnvoyProtoData.Locality;
 import io.grpc.xds.EnvoyProtoData.LocalityLbEndpoints;
@@ -191,9 +192,21 @@ final class LookasideLb extends LoadBalancer {
               new ErrorPicker(Status.UNAVAILABLE.withCause(e)));
           return;
         }
+
+        List<ServerInfo> serverList = bootstrapInfo.getServers();
+        if (serverList.isEmpty()) {
+          lookasideLbHelper.updateBalancingState(
+              TRANSIENT_FAILURE,
+              new ErrorPicker(
+                  Status.UNAVAILABLE
+                      .withDescription("No traffic director provided by bootstrap")));
+          return;
+        }
+        // Currently we only support using the first server from bootstrap.
+        ServerInfo serverInfo = serverList.get(0);
         channel = initLbChannel(
-            lookasideLbHelper, bootstrapInfo.getServerUri(),
-            bootstrapInfo.getChannelCredentials());
+            lookasideLbHelper, serverInfo.getServerUri(),
+            serverInfo.getChannelCredentials());
         xdsClientRef = new RefCountedXdsClientObjectPool(new XdsClientFactory() {
           @Override
           XdsClient createXdsClient() {

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -100,13 +100,16 @@ final class XdsNameResolver extends NameResolver {
     // Currently we only support using the first server from bootstrap.
     ServerInfo serverInfo = serverList.get(0);
 
-    String serviceConfig = "{"
-        + "\"loadBalancingConfig\": ["
-        + "{\"xds_experimental\" : {"
-        + "\"balancerName\" : \"" + serverInfo.getServerUri() + "\","
-        + "\"childPolicy\" : [{\"round_robin\" : {}}]"
-        + "}}"
-        + "]}";
+    String serviceConfig = "{\n"
+        + "  \"loadBalancingConfig\": [\n"
+        + "    {\n"
+        + "      \"xds_experimental\": {\n"
+        + "        \"balancerName\": \"" + serverInfo.getServerUri() + "\",\n"
+        + "        \"childPolicy\": [ {\"round_robin\": {} } ]\n"
+        + "      }\n"
+        + "    }"
+        + "  ]\n"
+        + "}";
     Map<String, ?> config;
     try {
       config = (Map<String, ?>) JsonParser.parse(serviceConfig);

--- a/xds/src/test/java/io/grpc/xds/BootstrapperTest.java
+++ b/xds/src/test/java/io/grpc/xds/BootstrapperTest.java
@@ -41,23 +41,28 @@ public class BootstrapperTest {
 
   @Test
   public void parseBootstrap_validData() throws IOException {
-    String rawData = "{"
-        + "\"node\": {"
-        + "\"id\": \"ENVOY_NODE_ID\","
-        + "\"cluster\": \"ENVOY_CLUSTER\","
-        + "\"locality\": {"
-        + "\"region\": \"ENVOY_REGION\", \"zone\": \"ENVOY_ZONE\", \"sub_zone\": \"ENVOY_SUBZONE\""
-        + "},"
-        + "\"metadata\": {"
-        + "\"TRAFFICDIRECTOR_INTERCEPTION_PORT\": \"ENVOY_PORT\", "
-        + "\"TRAFFICDIRECTOR_NETWORK_NAME\": \"VPC_NETWORK_NAME\""
-        + "}"
-        + "},"
-        + "\"xds_servers\": [ {"
-        + "\"server_uri\": \"trafficdirector.googleapis.com:443\","
-        + "\"channel_creds\": "
-        + "[ {\"type\": \"tls\"}, {\"type\": \"loas\"}, {\"type\": \"google_default\"} ]"
-        + "} ]"
+    String rawData = "{\n"
+        + "  \"node\": {\n"
+        + "    \"id\": \"ENVOY_NODE_ID\",\n"
+        + "    \"cluster\": \"ENVOY_CLUSTER\",\n"
+        + "    \"locality\": {\n"
+        + "      \"region\": \"ENVOY_REGION\",\n"
+        + "      \"zone\": \"ENVOY_ZONE\",\n"
+        + "      \"sub_zone\": \"ENVOY_SUBZONE\"\n"
+        + "    },\n"
+        + "    \"metadata\": {\n"
+        + "      \"TRAFFICDIRECTOR_INTERCEPTION_PORT\": \"ENVOY_PORT\",\n"
+        + "      \"TRAFFICDIRECTOR_NETWORK_NAME\": \"VPC_NETWORK_NAME\"\n"
+        + "    }\n"
+        + "  },\n"
+        + "  \"xds_servers\": [\n"
+        + "    {\n"
+        + "      \"server_uri\": \"trafficdirector.googleapis.com:443\",\n"
+        + "      \"channel_creds\": [\n"
+        + "        {\"type\": \"tls\"}, {\"type\": \"loas\"}, {\"type\": \"google_default\"}\n"
+        + "      ]\n"
+        + "    }\n"
+        + "  ]\n"
         + "}";
 
     BootstrapInfo info = Bootstrapper.parseConfig(rawData);
@@ -99,10 +104,12 @@ public class BootstrapperTest {
 
   @Test
   public void parseBootstrap_minimumRequiredFields() throws IOException {
-    String rawData = "{"
-        + "\"xds_servers\": [ {"
-        + "\"server_uri\": \"trafficdirector.googleapis.com:443\""
-        + "} ]"
+    String rawData = "{\n"
+        + "  \"xds_servers\": [\n"
+        + "    {\n"
+        + "      \"server_uri\": \"trafficdirector.googleapis.com:443\"\n"
+        + "    }\n"
+        + "  ]\n"
         + "}";
 
     BootstrapInfo info = Bootstrapper.parseConfig(rawData);
@@ -120,18 +127,20 @@ public class BootstrapperTest {
 
   @Test
   public void parseBootstrap_noXdsServers() throws IOException {
-    String rawData = "{"
-        + "\"node\": {"
-        + "\"id\": \"ENVOY_NODE_ID\","
-        + "\"cluster\": \"ENVOY_CLUSTER\","
-        + "\"locality\": {"
-        + "\"region\": \"ENVOY_REGION\", \"zone\": \"ENVOY_ZONE\", \"sub_zone\": \"ENVOY_SUBZONE\""
-        + "},"
-        + "\"metadata\": {"
-        + "\"TRAFFICDIRECTOR_INTERCEPTION_PORT\": \"ENVOY_PORT\", "
-        + "\"TRAFFICDIRECTOR_NETWORK_NAME\": \"VPC_NETWORK_NAME\""
-        + "}"
-        + "}"
+    String rawData = "{\n"
+        + "  \"node\": {\n"
+        + "    \"id\": \"ENVOY_NODE_ID\",\n"
+        + "    \"cluster\": \"ENVOY_CLUSTER\",\n"
+        + "    \"locality\": {\n"
+        + "      \"region\": \"ENVOY_REGION\",\n"
+        + "      \"zone\": \"ENVOY_ZONE\",\n"
+        + "      \"sub_zone\": \"ENVOY_SUBZONE\"\n"
+        + "    },\n"
+        + "    \"metadata\": {\n"
+        + "      \"TRAFFICDIRECTOR_INTERCEPTION_PORT\": \"ENVOY_PORT\",\n"
+        + "      \"TRAFFICDIRECTOR_NETWORK_NAME\": \"VPC_NETWORK_NAME\"\n"
+        + "    }\n"
+        + "  }\n"
         + "}";
 
     thrown.expect(IOException.class);
@@ -142,21 +151,26 @@ public class BootstrapperTest {
   @Test
   public void parseBootstrap_serverWithoutServerUri() throws IOException {
     String rawData = "{"
-        + "\"node\": {"
-        + "\"id\": \"ENVOY_NODE_ID\","
-        + "\"cluster\": \"ENVOY_CLUSTER\","
-        + "\"locality\": {"
-        + "\"region\": \"ENVOY_REGION\", \"zone\": \"ENVOY_ZONE\", \"sub_zone\": \"ENVOY_SUBZONE\""
-        + "},"
-        + "\"metadata\": {"
-        + "\"TRAFFICDIRECTOR_INTERCEPTION_PORT\": \"ENVOY_PORT\", "
-        + "\"TRAFFICDIRECTOR_NETWORK_NAME\": \"VPC_NETWORK_NAME\""
-        + "}"
-        + "},"
-        + "\"xds_servers\": [ {"
-        + "\"channel_creds\": "
-        + "[ {\"type\": \"tls\"}, {\"type\": \"loas\"} ]"
-        + "} ] "
+        + "  \"node\": {\n"
+        + "    \"id\": \"ENVOY_NODE_ID\",\n"
+        + "    \"cluster\": \"ENVOY_CLUSTER\",\n"
+        + "    \"locality\": {\n"
+        + "      \"region\": \"ENVOY_REGION\",\n"
+        + "      \"zone\": \"ENVOY_ZONE\",\n"
+        + "      \"sub_zone\": \"ENVOY_SUBZONE\"\n"
+        + "    },\n"
+        + "    \"metadata\": {\n"
+        + "      \"TRAFFICDIRECTOR_INTERCEPTION_PORT\": \"ENVOY_PORT\",\n"
+        + "      \"TRAFFICDIRECTOR_NETWORK_NAME\": \"VPC_NETWORK_NAME\"\n"
+        + "    }\n"
+        + "  },\n"
+        + "  \"xds_servers\": [\n"
+        + "    {\n"
+        + "      \"channel_creds\": [\n"
+        + "        {\"type\": \"tls\"}, {\"type\": \"loas\"}\n"
+        + "      ]\n"
+        + "    }\n"
+        + "  ]\n "
         + "}";
 
     thrown.expect(IOException.class);

--- a/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
+++ b/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
@@ -74,6 +74,7 @@ import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
 import io.grpc.xds.Bootstrapper.BootstrapInfo;
 import io.grpc.xds.Bootstrapper.ChannelCreds;
+import io.grpc.xds.Bootstrapper.ServerInfo;
 import io.grpc.xds.EnvoyProtoData.DropOverload;
 import io.grpc.xds.EnvoyProtoData.Locality;
 import io.grpc.xds.EnvoyProtoData.LocalityLbEndpoints;
@@ -489,9 +490,10 @@ public class LookasideLbTest {
 
   @Test
   public void handleResolvedAddress_withBootstrap() throws Exception {
-    BootstrapInfo bootstrapInfo = new BootstrapInfo(
-        "trafficdirector.googleapis.com", ImmutableList.<ChannelCreds>of(),
-        Node.getDefaultInstance());
+    List<ServerInfo> serverList =
+        ImmutableList.of(
+            new ServerInfo("trafficdirector.googleapis.com", ImmutableList.<ChannelCreds>of()));
+    BootstrapInfo bootstrapInfo = new BootstrapInfo(serverList, Node.getDefaultInstance());
     doReturn(bootstrapInfo).when(bootstrapper).readBootstrap();
 
     String lbConfigRaw =

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -147,6 +147,24 @@ public class XdsNameResolverTest {
   }
 
   @Test
+  public void resolve_bootstrapProvidesNoTrafficDirectorInfo() {
+    Bootstrapper bootstrapper = new Bootstrapper() {
+      @Override
+      public BootstrapInfo readBootstrap() {
+        return new BootstrapInfo(ImmutableList.<ServerInfo>of(), FAKE_BOOTSTRAP_NODE);
+      }
+    };
+
+    XdsNameResolver resolver = new XdsNameResolver("foo.googleapis.com", bootstrapper);
+    resolver.start(mockListener);
+    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(null);
+    verify(mockListener).onError(statusCaptor.capture());
+    assertThat(statusCaptor.getValue().getCode()).isEqualTo(Code.UNAVAILABLE);
+    assertThat(statusCaptor.getValue().getDescription())
+        .isEqualTo("No traffic director provided by bootstrap");
+  }
+
+  @Test
   public void resolve_failToBootstrap() {
     Bootstrapper bootstrapper = new Bootstrapper() {
       @Override

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -111,8 +111,11 @@ public class XdsNameResolverTest {
     Bootstrapper bootstrapper = new Bootstrapper() {
       @Override
       public BootstrapInfo readBootstrap() {
-        return new BootstrapInfo("trafficdirector.googleapis.com",
-            ImmutableList.of(loasCreds, googleDefaultCreds), FAKE_BOOTSTRAP_NODE);
+        List<ServerInfo> serverList =
+            ImmutableList.of(
+                new ServerInfo("trafficdirector.googleapis.com",
+                    ImmutableList.of(loasCreds, googleDefaultCreds)));
+        return new BootstrapInfo(serverList, FAKE_BOOTSTRAP_NODE);
       }
     };
     XdsNameResolver resolver = new XdsNameResolver("foo.googleapis.com", bootstrapper);


### PR DESCRIPTION
In the future, the xDS bootstrap may provides multiple xDS server, with each has its own server URI and channel credential configurations. gRPC client will try to connect to them one by one until found the first reachable one. For now, we only support using the first one.

In this PR:
- Changed the logic of parsing bootstrap file, including the format of data returned to gRPC client.
- Reformated JSON strings in bootstrap related tests.
- Added a couple of test cases for parsing bootstrap file.
- Changed constructor for `XdsClientIImpl` to take in a list of management servers.