### PR TITLE
xds: remove xds balancer_name from resolved service config

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -104,7 +104,6 @@ final class XdsNameResolver extends NameResolver {
         + "  \"loadBalancingConfig\": [\n"
         + "    {\n"
         + "      \"xds_experimental\": {\n"
-        + "        \"balancerName\": \"" + serverInfo.getServerUri() + "\",\n"
         + "        \"childPolicy\": [ {\"round_robin\": {} } ]\n"
         + "      }\n"
         + "    }"

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -136,8 +136,6 @@ public class XdsNameResolverTest {
     Map<String, ?> rawConfigValues = (Map<String, ?>) xdsLbConfig.get("xds_experimental");
     assertThat(rawConfigValues)
         .containsExactly(
-            "balancerName",
-            "trafficdirector.googleapis.com",
             "childPolicy",
             Collections.singletonList(
                 Collections.singletonMap("round_robin", Collections.EMPTY_MAP)));


### PR DESCRIPTION
`XdsNameResolver` will eventually send out a CDS config instead EDS config, but balancer_name should never be sent out from `XdsNameResolver` anyway.

This PR is mainly to unblock current staging test.