### PR TITLE
api: Fix javadoc for ManagedChannelBuilder#forTarget(String)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -424,7 +424,7 @@ The following code snippet shows how you can call the Google Cloud PubSub API us
 
 ```java
 // Create a channel to the test service.
-ManagedChannel channel = ManagedChannelBuilder.forTarget("pubsub.googleapis.com")
+ManagedChannel channel = ManagedChannelBuilder.forTarget("dns:///pubsub.googleapis.com")
     .build();
 // Get the default credentials from the environment
 GoogleCredentials creds = GoogleCredentials.getApplicationDefault();

--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -55,8 +55,11 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * </ul>
    *
    * <p>An authority string will be converted to a {@code NameResolver}-compliant URI, which has
-   * {@code "dns"} as the scheme, no authority, and the original authority string as its path after
-   * properly escaped. Example authority strings:
+   * the scheme from the name resolver with the highest priority (e.g. {@code "dns"}),
+   * no authority, and the original authority string as its path after properly escaped.
+   * We recommend specifying the schema explicitly if it is known, to avoid problems with other
+   * libraries that might contain additional NameResolvers.
+   * Example authority strings:
    * <ul>
    *   <li>{@code "localhost"}</li>
    *   <li>{@code "127.0.0.1"}</li>

--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -57,8 +57,8 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * <p>An authority string will be converted to a {@code NameResolver}-compliant URI, which has
    * the scheme from the name resolver with the highest priority (e.g. {@code "dns"}),
    * no authority, and the original authority string as its path after properly escaped.
-   * We recommend specifying the schema explicitly if it is known, to avoid problems with other
-   * libraries that might contain additional NameResolvers.
+   * We recommend libraries to specify the schema explicitly if it is known, since libraries cannot
+   * know which NameResolver will be default during runtime.
    * Example authority strings:
    * <ul>
    *   <li>{@code "localhost"}</li>


### PR DESCRIPTION
The dns scheme is only the default scheme with grpc-java. Other
libraries could add more NameResolvers and thus change the default. For
compatibility reasons, the schema should therefore be specified
explicitly.

The current javadocs conflict with those of `NameResolverProdiver#priority()`, which allow setting a priority higher than DNS.

Users of grpc-spring-boot-starter who want to use a service discovery have the problem that many libraries don't provide a schema for DNS addresses and therefore don't work anymore without additional configuration.

https://github.com/yidongnan/grpc-spring-boot-starter/issues/268
https://github.com/yidongnan/grpc-spring-boot-starter/issues/304
https://github.com/yidongnan/grpc-spring-boot-starter/issues/300