### PR TITLE
xds: fix bug of verifying xDS requests with ordered resource names.

### DIFF
--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTest.java
@@ -1474,9 +1474,10 @@ public class XdsClientImplTest {
     // Client sent a new CDS request for all interested resources.
     verify(requestObserver)
         .onNext(
-            eq(buildDiscoveryRequest(NODE, "0",
-                ImmutableList.of("cluster-foo.googleapis.com", "cluster-bar.googleapis.com"),
-                XdsClientImpl.ADS_TYPE_URL_CDS, "0000")));
+            argThat(
+                new DiscoveryRequestMatcher("0",
+                    ImmutableList.of("cluster-foo.googleapis.com", "cluster-bar.googleapis.com"),
+                    XdsClientImpl.ADS_TYPE_URL_CDS, "0000")));
 
     // Management server sends back a CDS response with Cluster for all requested cluster.
     clusters = ImmutableList.of(


### PR DESCRIPTION
When verifying xDS requests, the order of resource names should not matter. `DiscoveryRequestMatcher` can take care of that. 

The best practice is to use `DiscoveryRequestMatcher` for verifying all requests (even those without error message or single resource). You may see in `XdsClientImplTest.java` that a mixed usage of `DiscoveryRequestMatcher` and literal comparison of `DiscoveryRequest` messages. This is because  `DiscoveryRequestMatcher` was introduced later while there were a lot of usages of literal comparison that worked (i.e., for requests having only a single resource and no error_message) and I did not bother change them. 😢 