### PR TITLE
xds: integrate usage of XdsClient in XdsNameResolver

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -148,7 +148,9 @@ final class XdsNameResolver extends NameResolver {
         try {
           config = (Map<String, ?>) JsonParser.parse(serviceConfig);
         } catch (IOException e) {
-          throw new AssertionError("Should never happen: invalid service config format");
+          listener.onError(
+              Status.UNKNOWN.withDescription("Invalid service config").withCause(e));
+          return;
         }
         Attributes attrs =
             Attributes.newBuilder()

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -145,7 +145,8 @@ final class XdsNameResolver extends NameResolver {
         ResolutionResult result =
             ResolutionResult.newBuilder()
                 .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
-                .setAttributes(attrs).build();
+                .setAttributes(attrs)
+                .build();
         listener.onResult(result);
       }
 

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -138,7 +138,7 @@ final class XdsNameResolver extends NameResolver {
         String serviceConfig = "{\n"
             + "  \"loadBalancingConfig\": [\n"
             + "    {\n"
-            + "      \"cds_experimental\": {\n"
+            + "      \"experimental_cds\": {\n"
             + "        \"cluster\": \"" + update.getClusterName() + "\"\n"
             + "      }\n"
             + "    }\n"

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -183,7 +183,7 @@ final class XdsNameResolver extends NameResolver {
   @Override
   public void shutdown() {
     if (xdsClient != null) {
-      xdsClientPool.returnObject(xdsClient);
+      xdsClient = xdsClientPool.returnObject(xdsClient);
     }
   }
 }

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
@@ -19,6 +19,9 @@ package io.grpc.xds;
 import com.google.common.base.Preconditions;
 import io.grpc.NameResolver.Args;
 import io.grpc.NameResolverProvider;
+import io.grpc.internal.ExponentialBackoffPolicy;
+import io.grpc.internal.GrpcUtil;
+import io.grpc.xds.XdsClient.XdsChannelFactory;
 import java.net.URI;
 
 /**
@@ -46,7 +49,14 @@ public final class XdsNameResolverProvider extends NameResolverProvider {
           targetPath,
           targetUri);
       String name = targetPath.substring(1);
-      return new XdsNameResolver(name);
+      return
+          new XdsNameResolver(
+              name,
+              args,
+              new ExponentialBackoffPolicy.Provider(),
+              GrpcUtil.STOPWATCH_SUPPLIER.get(),
+              XdsChannelFactory.getInstance(),
+              Bootstrapper.getInstance());
     }
     return null;
   }

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
@@ -54,7 +54,7 @@ public final class XdsNameResolverProvider extends NameResolverProvider {
               name,
               args,
               new ExponentialBackoffPolicy.Provider(),
-              GrpcUtil.STOPWATCH_SUPPLIER.get(),
+              GrpcUtil.STOPWATCH_SUPPLIER,
               XdsChannelFactory.getInstance(),
               Bootstrapper.getInstance());
     }

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverProviderTest.java
@@ -82,4 +82,31 @@ public class XdsNameResolverProviderTest {
             args))
         .isNull();
   }
+
+  @Test
+  public void validName_withAuthority() {
+    XdsNameResolver resolver =
+        provider.newNameResolver(
+            URI.create("xds-experimental://trafficdirector.google.com/foo.googleapis.com"), args);
+    assertThat(resolver).isNotNull();
+    assertThat(resolver.getServiceAuthority()).isEqualTo("foo.googleapis.com");
+  }
+
+  @Test
+  public void validName_noAuthority() {
+    XdsNameResolver resolver =
+        provider.newNameResolver(URI.create("xds-experimental:///foo.googleapis.com"), args);
+    assertThat(resolver).isNotNull();
+    assertThat(resolver.getServiceAuthority()).isEqualTo("foo.googleapis.com");
+  }
+
+  @Test
+  public void invalidName_hostnameContainsUnderscore() {
+    try {
+      provider.newNameResolver(URI.create("xds-experimental:///foo_bar.googleapis.com"), args);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
+  }
 }

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverProviderTest.java
@@ -26,6 +26,7 @@ import io.grpc.NameResolver;
 import io.grpc.NameResolver.ServiceConfigParser;
 import io.grpc.NameResolverProvider;
 import io.grpc.SynchronizationContext;
+import io.grpc.internal.FakeClock;
 import io.grpc.internal.GrpcUtil;
 import java.net.URI;
 import org.junit.Test;
@@ -42,11 +43,14 @@ public class XdsNameResolverProviderTest {
           throw new AssertionError(e);
         }
       });
+
+  private final FakeClock fakeClock = new FakeClock();
   private final NameResolver.Args args = NameResolver.Args.newBuilder()
       .setDefaultPort(8080)
       .setProxyDetector(GrpcUtil.NOOP_PROXY_DETECTOR)
       .setSynchronizationContext(syncContext)
       .setServiceConfigParser(mock(ServiceConfigParser.class))
+      .setScheduledExecutorService(fakeClock.getScheduledExecutorService())
       .setChannelLogger(mock(ChannelLogger.class))
       .build();
 

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverProviderTest.java
@@ -106,8 +106,9 @@ public class XdsNameResolverProviderTest {
 
   @Test
   public void invalidName_hostnameContainsUnderscore() {
+    URI uri = URI.create("xds-experimental:///foo_bar.googleapis.com");
     try {
-      provider.newNameResolver(URI.create("xds-experimental:///foo_bar.googleapis.com"), args);
+      provider.newNameResolver(uri, args);
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) {
       // Expected

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -159,7 +159,7 @@ public class XdsNameResolverTest {
             HOST_NAME + ":" + PORT,
             args,
             backoffPolicyProvider,
-            fakeClock.getStopwatchSupplier().get(),
+            fakeClock.getStopwatchSupplier(),
             channelFactory,
             bootstrapper);
     assertThat(responseObservers).isEmpty();
@@ -184,7 +184,7 @@ public class XdsNameResolverTest {
             HOST_NAME + ":" + PORT,
             args,
             backoffPolicyProvider,
-            fakeClock.getStopwatchSupplier().get(),
+            fakeClock.getStopwatchSupplier(),
             channelFactory,
             bootstrapper);
     resolver.start(mockListener);
@@ -209,7 +209,7 @@ public class XdsNameResolverTest {
             HOST_NAME + ":" + PORT,
             args,
             backoffPolicyProvider,
-            fakeClock.getStopwatchSupplier().get(),
+            fakeClock.getStopwatchSupplier(),
             channelFactory,
             bootstrapper);
     resolver.start(mockListener);

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -17,28 +17,51 @@
 package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.fail;
+import static io.grpc.xds.XdsClientTestHelper.buildDiscoveryResponse;
+import static io.grpc.xds.XdsClientTestHelper.buildListener;
+import static io.grpc.xds.XdsClientTestHelper.buildRouteConfiguration;
+import static io.grpc.xds.XdsClientTestHelper.buildVirtualHost;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.protobuf.Any;
+import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
+import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
+import io.envoyproxy.envoy.api.v2.core.AggregatedConfigSource;
+import io.envoyproxy.envoy.api.v2.core.ConfigSource;
 import io.envoyproxy.envoy.api.v2.core.Node;
+import io.envoyproxy.envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager;
+import io.envoyproxy.envoy.config.filter.network.http_connection_manager.v2.Rds;
+import io.envoyproxy.envoy.service.discovery.v2.AggregatedDiscoveryServiceGrpc.AggregatedDiscoveryServiceImplBase;
 import io.grpc.ChannelLogger;
+import io.grpc.ManagedChannel;
 import io.grpc.NameResolver;
 import io.grpc.NameResolver.ResolutionResult;
 import io.grpc.NameResolver.ServiceConfigParser;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.SynchronizationContext;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.internal.BackoffPolicy;
+import io.grpc.internal.FakeClock;
 import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.GrpcUtil;
-import io.grpc.xds.Bootstrapper.ChannelCreds;
+import io.grpc.internal.ObjectPool;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+import io.grpc.xds.Bootstrapper.ServerInfo;
+import io.grpc.xds.XdsClient.XdsChannelFactory;
 import java.io.IOException;
-import java.net.URI;
-import java.util.Collections;
+import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,10 +74,15 @@ import org.mockito.junit.MockitoRule;
 /** Unit tests for {@link XdsNameResolver}. */
 @RunWith(JUnit4.class)
 public class XdsNameResolverTest {
+  private static final String HOST_NAME = "foo.googleapis.com";
+  private static final int PORT = 443;
   private static final Node FAKE_BOOTSTRAP_NODE =
-      Node.newBuilder().setBuildVersion("fakeVer").build();
+      Node.newBuilder().setId("XdsNameResolverTest").build();
 
-  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+  @Rule
+  public final MockitoRule mocks = MockitoJUnit.rule();
+  @Rule
+  public final GrpcCleanupRule cleanupRule = new GrpcCleanupRule();
   
   private final SynchronizationContext syncContext = new SynchronizationContext(
       new Thread.UncaughtExceptionHandler() {
@@ -64,84 +92,82 @@ public class XdsNameResolverTest {
         }
       });
 
+  private final FakeClock fakeClock = new FakeClock();
   private final NameResolver.Args args =
       NameResolver.Args.newBuilder()
           .setDefaultPort(8080)
           .setProxyDetector(GrpcUtil.NOOP_PROXY_DETECTOR)
           .setSynchronizationContext(syncContext)
           .setServiceConfigParser(mock(ServiceConfigParser.class))
+          .setScheduledExecutorService(fakeClock.getScheduledExecutorService())
           .setChannelLogger(mock(ChannelLogger.class))
           .build();
 
-  private final XdsNameResolverProvider provider = new XdsNameResolverProvider();
 
-  @Mock private NameResolver.Listener2 mockListener;
+  private final Queue<StreamObserver<DiscoveryResponse>> responseObservers = new ArrayDeque<>();
 
-  @Test
-  public void validName_withAuthority() {
-    XdsNameResolver resolver =
-        provider.newNameResolver(
-            URI.create("xds-experimental://trafficdirector.google.com/foo.googleapis.com"), args);
-    assertThat(resolver).isNotNull();
-    assertThat(resolver.getServiceAuthority()).isEqualTo("foo.googleapis.com");
-  }
+  @Mock
+  private BackoffPolicy.Provider backoffPolicyProvider;
+  @Mock
+  private NameResolver.Listener2 mockListener;
 
-  @Test
-  public void validName_noAuthority() {
-    XdsNameResolver resolver =
-        provider.newNameResolver(URI.create("xds-experimental:///foo.googleapis.com"), args);
-    assertThat(resolver).isNotNull();
-    assertThat(resolver.getServiceAuthority()).isEqualTo("foo.googleapis.com");
-  }
+  private XdsChannelFactory channelFactory;
+  private XdsNameResolver xdsNameResolver;
 
-  @Test
-  public void invalidName_hostnameContainsUnderscore() {
-    try {
-      provider.newNameResolver(URI.create("xds-experimental:///foo_bar.googleapis.com"), args);
-      fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) {
-      // Expected
-    }
-  }
+  @Before
+  public void setUp() throws IOException {
+    final String serverName = InProcessServerBuilder.generateName();
+    AggregatedDiscoveryServiceImplBase serviceImpl = new AggregatedDiscoveryServiceImplBase() {
+      @Override
+      public StreamObserver<DiscoveryRequest> streamAggregatedResources(
+          final StreamObserver<DiscoveryResponse> responseObserver) {
+        responseObservers.offer(responseObserver);
+        @SuppressWarnings("unchecked")
+        StreamObserver<DiscoveryRequest> requestObserver = mock(StreamObserver.class);
+        return requestObserver;
+      }
+    };
 
-  @Test
-  public void resolve_bootstrapResult() {
-    final ChannelCreds loasCreds = new ChannelCreds("loas2", null);
-    final ChannelCreds googleDefaultCreds = new ChannelCreds("google_default", null);
+    cleanupRule.register(
+        InProcessServerBuilder
+            .forName(serverName)
+            .addService(serviceImpl)
+            .directExecutor()
+            .build()
+            .start());
+    final ManagedChannel channel =
+        cleanupRule.register(InProcessChannelBuilder.forName(serverName).directExecutor().build());
+
+    channelFactory = new XdsChannelFactory() {
+      @Override
+      ManagedChannel createChannel(List<ServerInfo> servers) {
+        return channel;
+      }
+    };
     Bootstrapper bootstrapper = new Bootstrapper() {
       @Override
       public BootstrapInfo readBootstrap() {
         List<ServerInfo> serverList =
             ImmutableList.of(
-                new ServerInfo("trafficdirector.googleapis.com",
-                    ImmutableList.of(loasCreds, googleDefaultCreds)));
+                new ServerInfo(serverName,
+                    ImmutableList.<ChannelCreds>of()));
         return new BootstrapInfo(serverList, FAKE_BOOTSTRAP_NODE);
       }
     };
-    XdsNameResolver resolver = new XdsNameResolver("foo.googleapis.com", bootstrapper);
-    resolver.start(mockListener);
-    ArgumentCaptor<ResolutionResult> resultCaptor = ArgumentCaptor.forClass(null);
-    verify(mockListener).onResult(resultCaptor.capture());
-    ResolutionResult result = resultCaptor.getValue();
-    assertThat(result.getAddresses()).isEmpty();
+    xdsNameResolver =
+        new XdsNameResolver(
+            HOST_NAME + ":" + PORT,
+            args,
+            backoffPolicyProvider,
+            fakeClock.getStopwatchSupplier().get(),
+            channelFactory,
+            bootstrapper);
+    assertThat(responseObservers).isEmpty();
+  }
 
-    Map<String, ?> serviceConfig =
-        result.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
-    @SuppressWarnings("unchecked")
-    List<Map<String, ?>> rawLbConfigs =
-        (List<Map<String, ?>>) serviceConfig.get("loadBalancingConfig");
-    Map<String, ?> xdsLbConfig = Iterables.getOnlyElement(rawLbConfigs);
-    assertThat(xdsLbConfig.keySet()).containsExactly("xds_experimental");
-    @SuppressWarnings("unchecked")
-    Map<String, ?> rawConfigValues = (Map<String, ?>) xdsLbConfig.get("xds_experimental");
-    assertThat(rawConfigValues)
-        .containsExactly(
-            "childPolicy",
-            Collections.singletonList(
-                Collections.singletonMap("round_robin", Collections.EMPTY_MAP)));
-    assertThat(result.getAttributes().get(XdsNameResolver.XDS_NODE)).isEqualTo(FAKE_BOOTSTRAP_NODE);
-    assertThat(result.getAttributes().get(XdsNameResolver.XDS_CHANNEL_CREDS_LIST))
-        .containsExactly(loasCreds, googleDefaultCreds);
+  @After
+  public void tearDown() {
+    xdsNameResolver.shutdown();
   }
 
   @Test
@@ -153,7 +179,14 @@ public class XdsNameResolverTest {
       }
     };
 
-    XdsNameResolver resolver = new XdsNameResolver("foo.googleapis.com", bootstrapper);
+    XdsNameResolver resolver =
+        new XdsNameResolver(
+            HOST_NAME + ":" + PORT,
+            args,
+            backoffPolicyProvider,
+            fakeClock.getStopwatchSupplier().get(),
+            channelFactory,
+            bootstrapper);
     resolver.start(mockListener);
     ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(null);
     verify(mockListener).onError(statusCaptor.capture());
@@ -171,7 +204,14 @@ public class XdsNameResolverTest {
       }
     };
 
-    XdsNameResolver resolver = new XdsNameResolver("foo.googleapis.com", bootstrapper);
+    XdsNameResolver resolver =
+        new XdsNameResolver(
+            HOST_NAME + ":" + PORT,
+            args,
+            backoffPolicyProvider,
+            fakeClock.getStopwatchSupplier().get(),
+            channelFactory,
+            bootstrapper);
     resolver.start(mockListener);
     ArgumentCaptor<Status> errorCaptor = ArgumentCaptor.forClass(null);
     verify(mockListener).onError(errorCaptor.capture());
@@ -179,5 +219,213 @@ public class XdsNameResolverTest {
     assertThat(error.getCode()).isEqualTo(Code.UNAVAILABLE);
     assertThat(error.getDescription()).isEqualTo("Failed to bootstrap");
     assertThat(error.getCause()).hasMessageThat().isEqualTo("Fail to read bootstrap file");
+  }
+
+  @Test
+  public void resolve_passXdsClientRefInResult() {
+    xdsNameResolver.start(mockListener);
+    assertThat(responseObservers).hasSize(1);
+    StreamObserver<DiscoveryResponse> responseObserver = responseObservers.poll();
+
+    // Simulate receiving an LDS response that contains cluster resolution directly in-line.
+    String clusterName = "cluster-foo.googleapis.com";
+    responseObserver.onNext(
+        buildLdsResponseForCluster("0", HOST_NAME, PORT, clusterName, "0000"));
+
+    ArgumentCaptor<ResolutionResult> resolutionResultCaptor = ArgumentCaptor.forClass(null);
+    verify(mockListener).onResult(resolutionResultCaptor.capture());
+    ResolutionResult result = resolutionResultCaptor.getValue();
+    ObjectPool<XdsClient> xdsClientPool = result.getAttributes().get(XdsAttributes.XDS_CLIENT_REF);
+    assertThat(xdsClientPool).isNotNull();
+  }
+
+  @Test
+  public void resolve_foundResource() {
+    xdsNameResolver.start(mockListener);
+    assertThat(responseObservers).hasSize(1);
+    StreamObserver<DiscoveryResponse> responseObserver = responseObservers.poll();
+
+    // Simulate receiving an LDS response that contains cluster resolution directly in-line.
+    String clusterName = "cluster-foo.googleapis.com";
+    responseObserver.onNext(
+        buildLdsResponseForCluster("0", HOST_NAME, PORT, clusterName, "0000"));
+
+    ArgumentCaptor<ResolutionResult> resolutionResultCaptor = ArgumentCaptor.forClass(null);
+    verify(mockListener).onResult(resolutionResultCaptor.capture());
+    ResolutionResult result = resolutionResultCaptor.getValue();
+    assertThat(result.getAddresses()).isEmpty();
+    Map<String, ?> serviceConfig =
+        result.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
+    @SuppressWarnings("unchecked")
+    List<Map<String, ?>> rawLbConfigs =
+        (List<Map<String, ?>>) serviceConfig.get("loadBalancingConfig");
+    Map<String, ?> lbConfig = Iterables.getOnlyElement(rawLbConfigs);
+    assertThat(lbConfig.keySet()).containsExactly("cds_experimental");
+    @SuppressWarnings("unchecked")
+    Map<String, ?> rawConfigValues = (Map<String, ?>) lbConfig.get("cds_experimental");
+    assertThat(rawConfigValues).containsExactly("cluster", clusterName);
+  }
+
+  @Test
+  public void resolve_ResourceNotFound() {
+    xdsNameResolver.start(mockListener);
+    assertThat(responseObservers).hasSize(1);
+    StreamObserver<DiscoveryResponse> responseObserver = responseObservers.poll();
+
+    // Simulate receiving an LDS response that does not contain requested resource.
+    String clusterName = "cluster-bar.googleapis.com";
+    responseObserver.onNext(
+        buildLdsResponseForCluster("0", "bar.googleapis.com", 80, clusterName, "0000"));
+
+    ArgumentCaptor<ResolutionResult> resolutionResultCaptor = ArgumentCaptor.forClass(null);
+    verify(mockListener).onResult(resolutionResultCaptor.capture());
+    ResolutionResult result = resolutionResultCaptor.getValue();
+    assertThat(result.getAddresses()).isEmpty();
+    assertThat(result.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG)).isNull();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void resolve_resourceUpdated() {
+    xdsNameResolver.start(mockListener);
+    assertThat(responseObservers).hasSize(1);
+    StreamObserver<DiscoveryResponse> responseObserver = responseObservers.poll();
+
+    // Simulate receiving an LDS response that contains cluster resolution directly in-line.
+    responseObserver.onNext(
+        buildLdsResponseForCluster("0", HOST_NAME, PORT, "cluster-foo.googleapis.com", "0000"));
+
+    ArgumentCaptor<ResolutionResult> resolutionResultCaptor = ArgumentCaptor.forClass(null);
+    verify(mockListener).onResult(resolutionResultCaptor.capture());
+    ResolutionResult result = resolutionResultCaptor.getValue();
+    assertThat(result.getAddresses()).isEmpty();
+    Map<String, ?> serviceConfig =
+        result.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
+
+    List<Map<String, ?>> rawLbConfigs =
+        (List<Map<String, ?>>) serviceConfig.get("loadBalancingConfig");
+    Map<String, ?> lbConfig = Iterables.getOnlyElement(rawLbConfigs);
+    assertThat(lbConfig.keySet()).containsExactly("cds_experimental");
+    Map<String, ?> rawConfigValues = (Map<String, ?>) lbConfig.get("cds_experimental");
+    assertThat(rawConfigValues).containsExactly("cluster", "cluster-foo.googleapis.com");
+
+    // Simulate receiving another LDS response that tells client to do RDS.
+    String routeConfigName = "route-foo.googleapis.com";
+    responseObserver.onNext(
+        buildLdsResponseForRdsResource("1", HOST_NAME, PORT, routeConfigName, "0001"));
+
+    // Client sent an RDS request for resource "route-foo.googleapis.com" (Omitted in this test).
+
+    // Simulate receiving an RDS response that contains the resource "route-foo.googleapis.com"
+    // with cluster resolution for "foo.googleapis.com".
+    responseObserver.onNext(
+        buildRdsResponseForCluster("0", routeConfigName, "foo.googleapis.com",
+            "cluster-blade.googleapis.com", "0000"));
+
+    verify(mockListener, times(2)).onResult(resolutionResultCaptor.capture());
+    result = resolutionResultCaptor.getValue();
+    assertThat(result.getAddresses()).isEmpty();
+    serviceConfig = result.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
+    rawLbConfigs = (List<Map<String, ?>>) serviceConfig.get("loadBalancingConfig");
+    lbConfig = Iterables.getOnlyElement(rawLbConfigs);
+    assertThat(lbConfig.keySet()).containsExactly("cds_experimental");
+    rawConfigValues = (Map<String, ?>) lbConfig.get("cds_experimental");
+    assertThat(rawConfigValues).containsExactly("cluster", "cluster-blade.googleapis.com");
+  }
+
+  @Test
+  public void resolve_resourceNewlyAdded() {
+    xdsNameResolver.start(mockListener);
+    assertThat(responseObservers).hasSize(1);
+    StreamObserver<DiscoveryResponse> responseObserver = responseObservers.poll();
+
+    // Simulate receiving an LDS response that does not contain requested resource.
+    responseObserver.onNext(
+        buildLdsResponseForCluster("0", "bar.googleapis.com", 80,
+            "cluster-bar.googleapis.com", "0000"));
+
+    ArgumentCaptor<ResolutionResult> resolutionResultCaptor = ArgumentCaptor.forClass(null);
+    verify(mockListener).onResult(resolutionResultCaptor.capture());
+    ResolutionResult result = resolutionResultCaptor.getValue();
+    assertThat(result.getAddresses()).isEmpty();
+    assertThat(result.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG)).isNull();
+
+    // Simulate receiving another LDS response that contains cluster resolution directly in-line.
+    responseObserver.onNext(
+        buildLdsResponseForCluster("1", HOST_NAME, PORT, "cluster-foo.googleapis.com",
+            "0001"));
+
+    verify(mockListener, times(2)).onResult(resolutionResultCaptor.capture());
+    result = resolutionResultCaptor.getValue();
+    assertThat(result.getAddresses()).isEmpty();
+    Map<String, ?> serviceConfig =
+        result.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
+    @SuppressWarnings("unchecked")
+    List<Map<String, ?>> rawLbConfigs =
+        (List<Map<String, ?>>) serviceConfig.get("loadBalancingConfig");
+    Map<String, ?> lbConfig = Iterables.getOnlyElement(rawLbConfigs);
+    assertThat(lbConfig.keySet()).containsExactly("cds_experimental");
+    @SuppressWarnings("unchecked")
+    Map<String, ?> rawConfigValues = (Map<String, ?>) lbConfig.get("cds_experimental");
+    assertThat(rawConfigValues).containsExactly("cluster", "cluster-foo.googleapis.com");
+  }
+
+  /**
+   * Builds an LDS DiscoveryResponse containing the mapping of given host name (with port if any)
+   * to the given cluster name directly in-line. Clients receiving this response is able to
+   * resolve cluster name for the given hostname:port immediately.
+   */
+  private DiscoveryResponse buildLdsResponseForCluster(String versionInfo,
+      String hostName, int port, String clusterName, String nonce) {
+    String ldsResourceName = port == -1 ? hostName : hostName + ":" + port;
+    List<Any> listeners = ImmutableList.of(
+        Any.pack(buildListener(ldsResourceName,
+            Any.pack(
+                HttpConnectionManager.newBuilder()
+                    .setRouteConfig(
+                        buildRouteConfiguration("route-foo.googleapis.com",
+                            ImmutableList.of(
+                                buildVirtualHost(
+                                    ImmutableList.of("foo.googleapis.com"),
+                                    clusterName))))
+                    .build()))));
+    return buildDiscoveryResponse(versionInfo, listeners, XdsClientImpl.ADS_TYPE_URL_LDS, nonce);
+  }
+
+  /**
+   * Builds an LDS DiscoveryResponse containing the mapping of given host name (with port if any)
+   * to the given RDS resource name. Clients receiving this response is able to send an RDS
+   * request for resolving the cluster name for the given hostname:port.
+   */
+  private DiscoveryResponse buildLdsResponseForRdsResource(String versionInfo,
+      String hostName, int port, String routeConfigName, String nonce) {
+    String ldsResourceName = port == -1 ? hostName : hostName + ":" + port;
+    Rds rdsConfig =
+        Rds.newBuilder()
+            // Must set to use ADS.
+            .setConfigSource(
+                ConfigSource.newBuilder().setAds(AggregatedConfigSource.getDefaultInstance()))
+            .setRouteConfigName(routeConfigName)
+            .build();
+
+    List<Any> listeners = ImmutableList.of(
+        Any.pack(buildListener(ldsResourceName,
+            Any.pack(HttpConnectionManager.newBuilder().setRds(rdsConfig).build()))));
+    return buildDiscoveryResponse(versionInfo, listeners, XdsClientImpl.ADS_TYPE_URL_LDS, nonce);
+  }
+
+  /**
+   * Builds an RDS DiscoveryResponse containing the mapping of given route config name to the
+   * given cluster name under.
+   */
+  private DiscoveryResponse buildRdsResponseForCluster(String versionInfo,
+      String routeConfigName, String hostName, String clusterName, String nonce) {
+    List<Any> routeConfigs = ImmutableList.of(
+        Any.pack(
+            buildRouteConfiguration(
+                routeConfigName,
+                ImmutableList.of(
+                    buildVirtualHost(ImmutableList.of(hostName), clusterName)))));
+    return buildDiscoveryResponse(versionInfo, routeConfigs, XdsClientImpl.ADS_TYPE_URL_RDS, nonce);
   }
 }

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -260,9 +260,9 @@ public class XdsNameResolverTest {
     List<Map<String, ?>> rawLbConfigs =
         (List<Map<String, ?>>) serviceConfig.get("loadBalancingConfig");
     Map<String, ?> lbConfig = Iterables.getOnlyElement(rawLbConfigs);
-    assertThat(lbConfig.keySet()).containsExactly("cds_experimental");
+    assertThat(lbConfig.keySet()).containsExactly("experimental_cds");
     @SuppressWarnings("unchecked")
-    Map<String, ?> rawConfigValues = (Map<String, ?>) lbConfig.get("cds_experimental");
+    Map<String, ?> rawConfigValues = (Map<String, ?>) lbConfig.get("experimental_cds");
     assertThat(rawConfigValues).containsExactly("cluster", clusterName);
   }
 
@@ -305,8 +305,8 @@ public class XdsNameResolverTest {
     List<Map<String, ?>> rawLbConfigs =
         (List<Map<String, ?>>) serviceConfig.get("loadBalancingConfig");
     Map<String, ?> lbConfig = Iterables.getOnlyElement(rawLbConfigs);
-    assertThat(lbConfig.keySet()).containsExactly("cds_experimental");
-    Map<String, ?> rawConfigValues = (Map<String, ?>) lbConfig.get("cds_experimental");
+    assertThat(lbConfig.keySet()).containsExactly("experimental_cds");
+    Map<String, ?> rawConfigValues = (Map<String, ?>) lbConfig.get("experimental_cds");
     assertThat(rawConfigValues).containsExactly("cluster", "cluster-foo.googleapis.com");
 
     // Simulate receiving another LDS response that tells client to do RDS.
@@ -328,8 +328,8 @@ public class XdsNameResolverTest {
     serviceConfig = result.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
     rawLbConfigs = (List<Map<String, ?>>) serviceConfig.get("loadBalancingConfig");
     lbConfig = Iterables.getOnlyElement(rawLbConfigs);
-    assertThat(lbConfig.keySet()).containsExactly("cds_experimental");
-    rawConfigValues = (Map<String, ?>) lbConfig.get("cds_experimental");
+    assertThat(lbConfig.keySet()).containsExactly("experimental_cds");
+    rawConfigValues = (Map<String, ?>) lbConfig.get("experimental_cds");
     assertThat(rawConfigValues).containsExactly("cluster", "cluster-blade.googleapis.com");
   }
 
@@ -364,9 +364,9 @@ public class XdsNameResolverTest {
     List<Map<String, ?>> rawLbConfigs =
         (List<Map<String, ?>>) serviceConfig.get("loadBalancingConfig");
     Map<String, ?> lbConfig = Iterables.getOnlyElement(rawLbConfigs);
-    assertThat(lbConfig.keySet()).containsExactly("cds_experimental");
+    assertThat(lbConfig.keySet()).containsExactly("experimental_cds");
     @SuppressWarnings("unchecked")
-    Map<String, ?> rawConfigValues = (Map<String, ?>) lbConfig.get("cds_experimental");
+    Map<String, ?> rawConfigValues = (Map<String, ?>) lbConfig.get("experimental_cds");
     assertThat(rawConfigValues).containsExactly("cluster", "cluster-foo.googleapis.com");
   }
 

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -141,6 +141,7 @@ public class XdsNameResolverTest {
     channelFactory = new XdsChannelFactory() {
       @Override
       ManagedChannel createChannel(List<ServerInfo> servers) {
+        assertThat(Iterables.getOnlyElement(servers).getServerUri()).isEqualTo(serverName);
         return channel;
       }
     };


### PR DESCRIPTION
When `XdsNameResolver` starts, it instantiate an `XdsClient` instance to send out an xDS discovery RPC resolving cluster name for gRPC target. When a result found, return a `ResolutionResult` with service config containing `cds_experimental` as the load balancing config to the channel. The instantiated `XdsClient` instance is also passed as an `ResolutionResult.Attributes` to channel.