### PR TITLE
xds: drop support for balancer_name in XdsConfig

### DIFF
--- a/core/src/main/java/io/grpc/internal/ServiceConfigUtil.java
+++ b/core/src/main/java/io/grpc/internal/ServiceConfigUtil.java
@@ -48,8 +48,6 @@ public final class ServiceConfigUtil {
   private static final String SERVICE_CONFIG_METHOD_CONFIG_KEY = "methodConfig";
   private static final String SERVICE_CONFIG_LOAD_BALANCING_POLICY_KEY = "loadBalancingPolicy";
   private static final String SERVICE_CONFIG_LOAD_BALANCING_CONFIG_KEY = "loadBalancingConfig";
-  // TODO(chengyuanzhang): delete this key after shifting to use bootstrap.
-  private static final String XDS_CONFIG_BALANCER_NAME_KEY = "balancerName";
   private static final String XDS_CONFIG_CHILD_POLICY_KEY = "childPolicy";
   private static final String XDS_CONFIG_FALLBACK_POLICY_KEY = "fallbackPolicy";
   private static final String XDS_CONFIG_EDS_SERVICE_NAME = "edsServiceName";
@@ -418,14 +416,6 @@ public final class ServiceConfigUtil {
       result.add(unwrapLoadBalancingConfig(rawChildPolicy));
     }
     return Collections.unmodifiableList(result);
-  }
-
-  /**
-   * Extracts the loadbalancer name from xds loadbalancer config.
-   */
-  // TODO(chengyuanzhang): delete after shifting to use bootstrap.
-  public static String getBalancerNameFromXdsConfig(Map<String, ?> rawXdsConfig) {
-    return JsonUtil.getString(rawXdsConfig, XDS_CONFIG_BALANCER_NAME_KEY);
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/ServiceConfigUtil.java
+++ b/core/src/main/java/io/grpc/internal/ServiceConfigUtil.java
@@ -361,7 +361,6 @@ public final class ServiceConfigUtil {
       "loadBalancingConfig": [
         {"xds" :
           {
-            "balancerName": "balancer1",
             "childPolicy": [...],
             "fallbackPolicy": [...],
           }

--- a/core/src/test/java/io/grpc/internal/ServiceConfigUtilTest.java
+++ b/core/src/test/java/io/grpc/internal/ServiceConfigUtilTest.java
@@ -17,7 +17,6 @@
 package io.grpc.internal;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import io.grpc.internal.ServiceConfigUtil.LbConfig;
@@ -33,21 +32,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ServiceConfigUtilTest {
   @Test
-  public void getBalancerNameFromXdsConfig() throws Exception {
-    String rawLbConfig = "{"
-        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
-        + "\"childPolicy\" : [{\"round_robin\" : {}}, {\"lbPolicy2\" : {\"key\" : \"val\"}}],"
-        + "\"fallbackPolicy\" : [{\"lbPolicy3\" : {\"key\" : \"val\"}}, {\"lbPolicy4\" : {}}]"
-        + "}";
-    assertEquals(
-        "dns:///balancer.example.com:8080",
-        ServiceConfigUtil.getBalancerNameFromXdsConfig(checkObject(JsonParser.parse(rawLbConfig))));
-  }
-
-  @Test
   public void getChildPolicyFromXdsConfig() throws Exception {
     String rawLbConfig = "{"
-        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
         + "\"childPolicy\" : [{\"round_robin\" : {}}, {\"lbPolicy2\" : {\"key\" : \"val\"}}],"
         + "\"fallbackPolicy\" : [{\"lbPolicy3\" : {\"key\" : \"val\"}}, {\"lbPolicy4\" : {}}]"
         + "}";
@@ -65,7 +51,6 @@ public class ServiceConfigUtilTest {
   @Test
   public void getChildPolicyFromXdsConfig_null() throws Exception {
     String rawLbConfig = "{"
-        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
         + "\"fallbackPolicy\" : [{\"lbPolicy3\" : {\"key\" : \"val\"}}, {\"lbPolicy4\" : {}}]"
         + "}";
 
@@ -78,7 +63,6 @@ public class ServiceConfigUtilTest {
   @Test
   public void getFallbackPolicyFromXdsConfig() throws Exception {
     String rawLbConfig = "{"
-        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
         + "\"childPolicy\" : [{\"round_robin\" : {}}, {\"lbPolicy2\" : {\"key\" : \"val\"}}],"
         + "\"fallbackPolicy\" : [{\"lbPolicy3\" : {\"key\" : \"val\"}}, {\"lbPolicy4\" : {}}]"
         + "}";
@@ -96,7 +80,6 @@ public class ServiceConfigUtilTest {
   @Test
   public void getFallbackPolicyFromXdsConfig_null() throws Exception {
     String rawLbConfig = "{"
-        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
         + "\"childPolicy\" : [{\"round_robin\" : {}}, {\"lbPolicy2\" : {\"key\" : \"val\"}}]"
         + "}";
 
@@ -109,7 +92,6 @@ public class ServiceConfigUtilTest {
   @Test
   public void getEdsServiceNameFromXdsConfig() throws Exception {
     String rawLbConfig = "{"
-        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
         + "\"childPolicy\" : [{\"round_robin\" : {}}, {\"lbPolicy2\" : {\"key\" : \"val\"}}],"
         + "\"fallbackPolicy\" : [{\"lbPolicy3\" : {\"key\" : \"val\"}}, {\"lbPolicy4\" : {}}],"
         + "\"edsServiceName\" : \"dns:///eds.service.com:8080\""
@@ -123,7 +105,6 @@ public class ServiceConfigUtilTest {
   @Test
   public void getEdsServiceNameFromXdsConfig_null() throws Exception {
     String rawLbConfig = "{"
-        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
         + "\"childPolicy\" : [{\"round_robin\" : {}}, {\"lbPolicy2\" : {\"key\" : \"val\"}}],"
         + "\"fallbackPolicy\" : [{\"lbPolicy3\" : {\"key\" : \"val\"}}, {\"lbPolicy4\" : {}}]"
         + "}";
@@ -136,7 +117,6 @@ public class ServiceConfigUtilTest {
   @Test
   public void getLrsServerNameFromXdsConfig() throws Exception {
     String rawLbConfig = "{"
-        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
         + "\"childPolicy\" : [{\"round_robin\" : {}}, {\"lbPolicy2\" : {\"key\" : \"val\"}}],"
         + "\"fallbackPolicy\" : [{\"lbPolicy3\" : {\"key\" : \"val\"}}, {\"lbPolicy4\" : {}}],"
         + "\"lrsLoadReportingServerName\" : \"dns:///lrs.service.com:8080\""
@@ -150,7 +130,6 @@ public class ServiceConfigUtilTest {
   @Test
   public void getLrsServerNameFromXdsConfig_null() throws Exception {
     String rawLbConfig = "{"
-        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
         + "\"childPolicy\" : [{\"round_robin\" : {}}, {\"lbPolicy2\" : {\"key\" : \"val\"}}],"
         + "\"fallbackPolicy\" : [{\"lbPolicy3\" : {\"key\" : \"val\"}}, {\"lbPolicy4\" : {}}]"
         + "}";
@@ -163,7 +142,6 @@ public class ServiceConfigUtilTest {
   @Test
   public void unwrapLoadBalancingConfig() throws Exception {
     String lbConfig = "{\"xds_experimental\" : { "
-        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
         + "\"childPolicy\" : [{\"round_robin\" : {}}, {\"lbPolicy2\" : {\"key\" : \"val\"}}]"
         + "}}";
 
@@ -171,8 +149,7 @@ public class ServiceConfigUtilTest {
         ServiceConfigUtil.unwrapLoadBalancingConfig(checkObject(JsonParser.parse(lbConfig)));
     assertThat(config.getPolicyName()).isEqualTo("xds_experimental");
     assertThat(config.getRawConfigValue()).isEqualTo(JsonParser.parse(
-            "{\"balancerName\" : \"dns:///balancer.example.com:8080\","
-            + "\"childPolicy\" : [{\"round_robin\" : {}}, {\"lbPolicy2\" : {\"key\" : \"val\"}}]"
+            "{\"childPolicy\" : [{\"round_robin\" : {}}, {\"lbPolicy2\" : {\"key\" : \"val\"}}]"
             + "}"));
   }
 
@@ -180,7 +157,6 @@ public class ServiceConfigUtilTest {
   public void unwrapLoadBalancingConfig_failOnTooManyFields() throws Exception {
     // A LoadBalancingConfig should not have more than one field.
     String lbConfig = "{\"xds_experimental\" : { "
-        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
         + "\"childPolicy\" : [{\"round_robin\" : {}}, {\"lbPolicy2\" : {\"key\" : \"val\"}}]"
         + "},"
         + "\"grpclb\" : {} }";
@@ -219,7 +195,7 @@ public class ServiceConfigUtilTest {
   @Test
   public void unwrapLoadBalancingConfigList() throws Exception {
     String lbConfig = "[ "
-        + "{\"xds_experimental\" : {\"balancerName\" : \"dns:///balancer.example.com:8080\"} },"
+        + "{\"xds_experimental\" : {\"unknown_field\" : \"dns:///balancer.example.com:8080\"} },"
         + "{\"grpclb\" : {} } ]";
     List<LbConfig> configs =
         ServiceConfigUtil.unwrapLoadBalancingConfigList(
@@ -227,7 +203,7 @@ public class ServiceConfigUtilTest {
     assertThat(configs).containsExactly(
         ServiceConfigUtil.unwrapLoadBalancingConfig(checkObject(JsonParser.parse(
                 "{\"xds_experimental\" : "
-                + "{\"balancerName\" : \"dns:///balancer.example.com:8080\"} }"))),
+                + "{\"unknown_field\" : \"dns:///balancer.example.com:8080\"} }"))),
         ServiceConfigUtil.unwrapLoadBalancingConfig(checkObject(JsonParser.parse(
                 "{\"grpclb\" : {} }")))).inOrder();
   }

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
@@ -253,7 +253,6 @@ public final class CdsLoadBalancer extends LoadBalancer {
           "The load balancing policy in ClusterUpdate '%s' is not supported", newUpdate);
 
       final XdsConfig edsConfig = new XdsConfig(
-          /* balancerName = */ null,
           new LbConfig(newUpdate.getLbPolicy(), ImmutableMap.<String, Object>of()),
           /* fallbackPolicy = */ null,
           /* edsServiceName = */ newUpdate.getEdsServiceName(),

--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -23,7 +23,6 @@ import static java.util.logging.Level.FINEST;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.envoyproxy.envoy.api.v2.core.Node;
 import io.grpc.Attributes;
 import io.grpc.ChannelLogger;
 import io.grpc.ChannelLogger.ChannelLogLevel;
@@ -53,7 +52,6 @@ import io.grpc.xds.XdsClient.RefCountedXdsClientObjectPool;
 import io.grpc.xds.XdsClient.XdsClientFactory;
 import io.grpc.xds.XdsLoadBalancerProvider.XdsConfig;
 import io.grpc.xds.XdsSubchannelPickers.ErrorPicker;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -165,36 +163,21 @@ final class LookasideLb extends LoadBalancer {
 
     // Init XdsClient.
     if (xdsClient == null) {
-      // There are three usecases:
-      // 1. The EDS-only legacy usecase that requires balancerName from xds config.
-      //    Note: we don't support balancerName change.
-      //    TODO(zdapeng): Remove the legacy case.
-      // 2. The EDS-only with bootstrap usecase:
-      //    The name resolver resolves a ResolvedAddresses with an XdsConfig without balancerName
-      //    field. Use the bootstrap information to create a channel.
-      // 3. Non EDS-only usecase:
+      // There are two usecases:
+      // 1. The EDS-only:
+      //    The name resolver resolves a ResolvedAddresses with an XdsConfig. Use the bootstrap
+      //    information to create a channel.
+      // 2. Non EDS-only usecase:
       //    XDS_CLIENT_REF attribute is available from ResolvedAddresses either from
       //    XdsNameResolver or CDS policy.
       //
       // We assume XdsConfig switching happens only within one usecase, and there is no switching
       // between different usecases.
-      if (newXdsConfig.balancerName != null) {
-        // This is the EDS-only legacy usecase that requires balancerName from xds config.
-        channel = initLbChannel(
-            lookasideLbHelper, newXdsConfig.balancerName, Collections.<ChannelCreds>emptyList());
-        xdsClientRef = new RefCountedXdsClientObjectPool(new XdsClientFactory() {
-          @Override
-          XdsClient createXdsClient() {
-            return new XdsComms2(
-                channel, lookasideLbHelper, new ExponentialBackoffPolicy.Provider(),
-                GrpcUtil.STOPWATCH_SUPPLIER, Node.getDefaultInstance());
-          }
-        });
-      } else if (xdsClientRefFromResolver != null) {
+      if (xdsClientRefFromResolver != null) {
         // This is the Non EDS-only usecase.
         xdsClientRef = xdsClientRefFromResolver;
       } else {
-        // This is the EDS-only with bootstrap usecase.
+        // This is the EDS-only usecase.
         final BootstrapInfo bootstrapInfo;
         try {
           bootstrapInfo = bootstrapper.readBootstrap();
@@ -230,15 +213,12 @@ final class LookasideLb extends LoadBalancer {
         });
       }
 
-      // At this point the xdsClientRef is assigned in all usecases, cache them for later use.
+      // At this point the xdsClientRef is assigned in both usecases, cache them for later use.
       this.xdsClientRef = xdsClientRef;
       xdsClient = xdsClientRef.getObject();
     }
 
-    // Note: balancerName change is unsupported and ignored.
-    // TODO(zdapeng): Remove support for balancerName.
     // Note: childPolicy change will be handled in LocalityStore, to be implemented.
-
     // If edsServiceName in XdsConfig is changed, do a graceful switch.
     if (xdsConfig == null
         || !Objects.equals(newXdsConfig.edsServiceName, xdsConfig.edsServiceName)) {
@@ -295,11 +275,11 @@ final class LookasideLb extends LoadBalancer {
 
   private static ManagedChannel initLbChannel(
       Helper helper,
-      String balancerName,
+      String serverUri,
       List<ChannelCreds> channelCredsList) {
     ManagedChannel channel = null;
     try {
-      channel = helper.createResolvingOobChannel(balancerName);
+      channel = helper.createResolvingOobChannel(serverUri);
     } catch (UnsupportedOperationException uoe) {
       // Temporary solution until createResolvingOobChannel is implemented.
       // FIXME (https://github.com/grpc/grpc-java/issues/5495)
@@ -309,19 +289,19 @@ final class LookasideLb extends LoadBalancer {
             FINEST,
             "createResolvingOobChannel() not supported by the helper: " + helper,
             uoe);
-        logger.log(FINEST, "creating oob channel for target {0}", balancerName);
+        logger.log(FINEST, "creating oob channel for target {0}", serverUri);
       }
 
       // Use the first supported channel credentials configuration.
       // Currently, only "google_default" is supported.
       for (ChannelCreds creds : channelCredsList) {
         if (creds.getType().equals("google_default")) {
-          channel = GoogleDefaultChannelBuilder.forTarget(balancerName).build();
+          channel = GoogleDefaultChannelBuilder.forTarget(serverUri).build();
           break;
         }
       }
       if (channel == null) {
-        channel = ManagedChannelBuilder.forTarget(balancerName).build();
+        channel = ManagedChannelBuilder.forTarget(serverUri).build();
       }
     }
     return channel;
@@ -401,8 +381,6 @@ final class LookasideLb extends LoadBalancer {
 
       @Override
       public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-        XdsConfig xdsConfig = (XdsConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
-
         if (endpointWatcher != null) {
           // TODO(zddapeng): Handle child policy changed if any.
           return;
@@ -420,7 +398,7 @@ final class LookasideLb extends LoadBalancer {
 
         // TODO(zdapeng): Use XdsClient to do Lrs directly.
         // For now create an LRS Client.
-        if (xdsConfig.balancerName != null) {
+        if (channel != null) {
           lrsClient = loadReportClientFactory.createLoadReportClient(
               channel, helper, new ExponentialBackoffPolicy.Provider(), loadStatsStore);
         } else {

--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancerProvider.java
@@ -76,8 +76,6 @@ public final class XdsLoadBalancerProvider extends LoadBalancerProvider {
   static ConfigOrError parseLoadBalancingConfigPolicy(
       Map<String, ?> rawLoadBalancingPolicyConfig, LoadBalancerRegistry registry) {
     try {
-      String newBalancerName =
-          ServiceConfigUtil.getBalancerNameFromXdsConfig(rawLoadBalancingPolicyConfig);
       LbConfig childPolicy = selectChildPolicy(rawLoadBalancingPolicyConfig, registry);
       LbConfig fallbackPolicy = selectFallbackPolicy(rawLoadBalancingPolicyConfig, registry);
       String edsServiceName =
@@ -85,8 +83,7 @@ public final class XdsLoadBalancerProvider extends LoadBalancerProvider {
       String lrsServerName =
           ServiceConfigUtil.getLrsServerNameFromXdsConfig(rawLoadBalancingPolicyConfig);
       return ConfigOrError.fromConfig(
-          new XdsConfig(
-              newBalancerName, childPolicy, fallbackPolicy, edsServiceName, lrsServerName));
+          new XdsConfig(childPolicy, fallbackPolicy, edsServiceName, lrsServerName));
     } catch (RuntimeException e) {
       return ConfigOrError.fromError(
           Status.UNKNOWN.withDescription("Failed to parse config " + e.getMessage()).withCause(e));
@@ -130,9 +127,6 @@ public final class XdsLoadBalancerProvider extends LoadBalancerProvider {
    * Represents a successfully parsed and validated LoadBalancingConfig for XDS.
    */
   static final class XdsConfig {
-    // TODO(chengyuanzhang): delete after shifting to use bootstrap.
-    @Nullable
-    final String balancerName;
     // TODO(carl-mastrangelo): make these Object's containing the fully parsed child configs.
     @Nullable
     final LbConfig childPolicy;
@@ -149,10 +143,10 @@ public final class XdsLoadBalancerProvider extends LoadBalancerProvider {
     final String lrsServerName;
 
     XdsConfig(
-        @Nullable String balancerName, @Nullable LbConfig childPolicy,
-        @Nullable LbConfig fallbackPolicy, @Nullable String edsServiceName,
+        @Nullable LbConfig childPolicy,
+        @Nullable LbConfig fallbackPolicy,
+        @Nullable String edsServiceName,
         @Nullable String lrsServerName) {
-      this.balancerName = balancerName;
       this.childPolicy = childPolicy;
       this.fallbackPolicy = fallbackPolicy;
       this.edsServiceName = edsServiceName;
@@ -162,7 +156,6 @@ public final class XdsLoadBalancerProvider extends LoadBalancerProvider {
     @Override
     public String toString() {
       return MoreObjects.toStringHelper(this)
-          .add("balancerName", balancerName)
           .add("childPolicy", childPolicy)
           .add("fallbackPolicy", fallbackPolicy)
           .add("edsServiceName", edsServiceName)
@@ -176,8 +169,7 @@ public final class XdsLoadBalancerProvider extends LoadBalancerProvider {
         return false;
       }
       XdsConfig that = (XdsConfig) obj;
-      return Objects.equal(this.balancerName, that.balancerName)
-          && Objects.equal(this.childPolicy, that.childPolicy)
+      return Objects.equal(this.childPolicy, that.childPolicy)
           && Objects.equal(this.fallbackPolicy, that.fallbackPolicy)
           && Objects.equal(this.edsServiceName, that.edsServiceName)
           && Objects.equal(this.lrsServerName, that.lrsServerName);
@@ -185,8 +177,7 @@ public final class XdsLoadBalancerProvider extends LoadBalancerProvider {
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(
-          balancerName, childPolicy, fallbackPolicy, edsServiceName, lrsServerName);
+      return Objects.hashCode(childPolicy, fallbackPolicy, edsServiceName, lrsServerName);
     }
   }
 }

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancerTest.java
@@ -235,7 +235,6 @@ public class CdsLoadBalancerTest {
     ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor1 = ArgumentCaptor.forClass(null);
     verify(edsLoadBalancer1).handleResolvedAddresses(resolvedAddressesCaptor1.capture());
     XdsConfig expectedXdsConfig = new XdsConfig(
-        null,
         new LbConfig("round_robin", ImmutableMap.<String, Object>of()),
         null,
         "edsServiceFoo.googleapis.com",
@@ -282,7 +281,6 @@ public class CdsLoadBalancerTest {
     ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor2 = ArgumentCaptor.forClass(null);
     verify(edsLoadBalancer2).handleResolvedAddresses(resolvedAddressesCaptor2.capture());
     expectedXdsConfig = new XdsConfig(
-        null,
         new LbConfig("round_robin", ImmutableMap.<String, Object>of()),
         null,
         "edsServiceBar.googleapis.com",
@@ -311,7 +309,6 @@ public class CdsLoadBalancerTest {
             .build());
     verify(edsLoadBalancer2, times(2)).handleResolvedAddresses(resolvedAddressesCaptor2.capture());
     expectedXdsConfig = new XdsConfig(
-        null,
         new LbConfig("round_robin", ImmutableMap.<String, Object>of()),
         null,
         "edsServiceBar2.googleapis.com",

--- a/xds/src/test/java/io/grpc/xds/FallbackLbTest.java
+++ b/xds/src/test/java/io/grpc/xds/FallbackLbTest.java
@@ -133,7 +133,6 @@ public class FallbackLbTest {
     EquivalentAddressGroup eag112 = new EquivalentAddressGroup(mock(SocketAddress.class));
     List<EquivalentAddressGroup> eags11 = ImmutableList.of(eag111, eag112);
     String lbConfigRaw11 = "{"
-        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
         + "\"fallbackPolicy\" : [{\"fallback_1\" : { \"fallback_1_option\" : \"yes\"}}]"
         + "}";
     @SuppressWarnings("unchecked")
@@ -160,7 +159,6 @@ public class FallbackLbTest {
     EquivalentAddressGroup eag121 = new EquivalentAddressGroup(mock(SocketAddress.class));
     List<EquivalentAddressGroup> eags12 = ImmutableList.of(eag121);
     String lbConfigRaw12 = "{"
-        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
         + "\"fallbackPolicy\" : [{\"fallback_1\" : { \"fallback_1_option\" : \"no\"}}]"
         + "}";
     @SuppressWarnings("unchecked")
@@ -185,7 +183,6 @@ public class FallbackLbTest {
     EquivalentAddressGroup eag212 = new EquivalentAddressGroup(mock(SocketAddress.class));
     List<EquivalentAddressGroup> eags21 = ImmutableList.of(eag211, eag212);
     String lbConfigRaw21 = "{"
-        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
         + "\"fallbackPolicy\" : [{\"fallback_2\" : { \"fallback_2_option\" : \"yes\"}}]"
         + "}";
     @SuppressWarnings("unchecked")
@@ -221,7 +218,6 @@ public class FallbackLbTest {
     EquivalentAddressGroup eag221 = new EquivalentAddressGroup(mock(SocketAddress.class));
     List<EquivalentAddressGroup> eags22 = ImmutableList.of(eag221);
     String lbConfigRaw22 = "{"
-        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
         + "\"fallbackPolicy\" : [{\"fallback_2\" : { \"fallback_2_option\" : \"no\"}}]"
         + "}";
     @SuppressWarnings("unchecked")
@@ -263,7 +259,6 @@ public class FallbackLbTest {
     List<EquivalentAddressGroup> eags = ImmutableList.of(eag0, eag1, eag2);
 
     String lbConfigRaw = "{"
-        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
         + "\"fallbackPolicy\" : [{\"fallback_1\" : { \"fallback_1_option\" : \"yes\"}}]"
         + "}";
     @SuppressWarnings("unchecked")
@@ -296,7 +291,6 @@ public class FallbackLbTest {
         ImmutableList.<SocketAddress>of(new InetSocketAddress(8082)), attributes);
     List<EquivalentAddressGroup> eags = ImmutableList.of(eag1, eag2);
     String lbConfigRaw = "{"
-        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
         + "\"fallbackPolicy\" : [{\"fallback_1\" : { \"fallback_1_option\" : \"yes\"}}]"
         + "}";
     @SuppressWarnings("unchecked")
@@ -354,7 +348,6 @@ public class FallbackLbTest {
     List<EquivalentAddressGroup> eags = ImmutableList.of(eag0, eag1, eag2);
 
     String lbConfigRaw = "{"
-        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
         + "\"fallbackPolicy\" : [{\"grpclb\" : { \"grpclb_option\" : \"yes\"}}]"
         + "}";
     @SuppressWarnings("unchecked")

--- a/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
+++ b/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
@@ -249,11 +249,17 @@ public class LookasideLbTest {
       }
     });
 
+    List<ServerInfo> serverList =
+        ImmutableList.of(
+            new ServerInfo("trafficdirector.googleapis.com", ImmutableList.<ChannelCreds>of()));
+    BootstrapInfo bootstrapInfo = new BootstrapInfo(serverList, Node.getDefaultInstance());
+    doReturn(bootstrapInfo).when(bootstrapper).readBootstrap();
+
     lookasideLb = new LookasideLb(
         helper, edsUpdateCallback, lbRegistry, localityStoreFactory, loadReportClientFactory,
         bootstrapper);
 
-    String lbConfigRaw11 = "{\"balancerName\" : \"dns:///balancer1.example.com:8080\"}";
+    String lbConfigRaw11 = "{}";
     @SuppressWarnings("unchecked")
     Map<String, ?> lbConfig11 = (Map<String, ?>) JsonParser.parse(lbConfigRaw11);
     defaultResolvedAddress = ResolvedAddresses.newBuilder()
@@ -464,28 +470,6 @@ public class LookasideLbTest {
     verify(localityStore5).reset();
 
     xdsClientRef.returnObject(xdsClientFromResolver);
-  }
-
-  @Deprecated // balancerName will be unsupported.
-  @Test
-  public void handleResolvedAddress_createLbChannel()
-      throws Exception {
-    // Test balancer created with the default real LookasideChannelLbFactory
-    lookasideLb = new LookasideLb(helper, mock(EndpointUpdateCallback.class));
-    String lbConfigRaw = "{'balancerName' : 'dns:///balancer1.example.com:8080'}"
-        .replace("'", "\"");
-    @SuppressWarnings("unchecked")
-    Map<String, ?> lbConfig = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
-    ResolvedAddresses resolvedAddresses = ResolvedAddresses.newBuilder()
-        .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
-        .setAttributes(Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig).build())
-        .build();
-
-    verify(helper, never()).createResolvingOobChannel(anyString());
-    lookasideLb.handleResolvedAddresses(resolvedAddresses);
-    verify(helper).createResolvingOobChannel("dns:///balancer1.example.com:8080");
-
-    lookasideLb.shutdown();
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/XdsLoadBalancerProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadBalancerProviderTest.java
@@ -107,7 +107,6 @@ public class XdsLoadBalancerProviderTest {
   @Test
   public void selectChildPolicy() throws Exception {
     String rawLbConfig = "{"
-        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
         + "\"childPolicy\" : [{\"unsupported_1\" : {}}, {\"supported_1\" : {\"key\" : \"val\"}},"
         + "{\"supported_2\" : {\"key\" : \"val\"}}],"
         + "\"fallbackPolicy\" : [{\"lbPolicy3\" : {\"key\" : \"val\"}}, {\"lbPolicy4\" : {}}]"
@@ -126,7 +125,6 @@ public class XdsLoadBalancerProviderTest {
   @Test
   public void selectFallBackPolicy() throws Exception {
     String rawLbConfig = "{"
-        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
         + "\"childPolicy\" : [{\"lbPolicy3\" : {\"key\" : \"val\"}}, {\"lbPolicy4\" : {}}],"
         + "\"fallbackPolicy\" : [{\"unsupported\" : {}}, {\"supported_1\" : {\"key\" : \"val\"}},"
         + "{\"supported_2\" : {\"key\" : \"val\"}}]"
@@ -143,7 +141,6 @@ public class XdsLoadBalancerProviderTest {
   @Test
   public void selectFallBackPolicy_roundRobinIsDefault() throws Exception {
     String rawLbConfig = "{"
-        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
         + "\"childPolicy\" : [{\"lbPolicy3\" : {\"key\" : \"val\"}}, {\"lbPolicy4\" : {}}]"
         + "}";
     LbConfig expectedFallbackPolicy = ServiceConfigUtil.unwrapLoadBalancingConfig(
@@ -158,7 +155,6 @@ public class XdsLoadBalancerProviderTest {
   @Test
   public void parseLoadBalancingConfigPolicy() throws Exception {
     String rawLbConfig = "{"
-        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
         + "\"childPolicy\" : [{\"lbPolicy3\" : {\"key\" : \"val\"}}, {\"supported_1\" : {}}],"
         + "\"fallbackPolicy\" : [{\"unsupported\" : {}}, {\"round_robin\" : {\"key\" : \"val\"}},"
         + "{\"supported_2\" : {\"key\" : \"val\"}}],"

--- a/xds/src/test/java/io/grpc/xds/XdsLoadBalancerProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadBalancerProviderTest.java
@@ -173,7 +173,6 @@ public class XdsLoadBalancerProviderTest {
     assertThat(configOrError.getConfig()).isInstanceOf(XdsConfig.class);
     assertThat(configOrError.getConfig()).isEqualTo(
         new XdsConfig(
-            "dns:///balancer.example.com:8080",
             ServiceConfigUtil.unwrapLoadBalancingConfig(
                 checkObject(JsonParser.parse("{\"supported_1\" : {}}"))),
             ServiceConfigUtil.unwrapLoadBalancingConfig(


### PR DESCRIPTION
Verified in internal interop tests, we can drop balancer_name in XdsConfig now.