### PR TITLE
Gracefully shutdown example servers

### DIFF
--- a/api/src/main/java/io/grpc/Server.java
+++ b/api/src/main/java/io/grpc/Server.java
@@ -107,7 +107,7 @@ public abstract class Server {
    * After this call returns, this server has released the listening socket(s) and may be reused by
    * another server.
    *
-   * Note that this method will not wait for preexisting calls to finish before returning.
+   * <p>Note that this method will not wait for preexisting calls to finish before returning.
    * {@link #awaitTermination()} or {@link #awaitTermination(long, TimeUnit)} needs to be called to
    * wait for existing calls to finish.
    *

--- a/api/src/main/java/io/grpc/Server.java
+++ b/api/src/main/java/io/grpc/Server.java
@@ -104,8 +104,12 @@ public abstract class Server {
 
   /**
    * Initiates an orderly shutdown in which preexisting calls continue but new calls are rejected.
-   * This call will not wait for preexisting calls finish before returning. After this call returns,
-   * this server has released the listening socket(s) and may be reused by another server.
+   * After this call returns, this server has released the listening socket(s) and may be reused by
+   * another server.
+   *
+   * Note that this method will not wait for preexisting calls to finish before returning.
+   * {@link #awaitTermination()} or {@link #awaitTermination(long, TimeUnit)} needs to be called to
+   * wait for existing calls to finish.
    *
    * @return {@code this} object
    * @since 1.0.0

--- a/api/src/main/java/io/grpc/Server.java
+++ b/api/src/main/java/io/grpc/Server.java
@@ -104,8 +104,8 @@ public abstract class Server {
 
   /**
    * Initiates an orderly shutdown in which preexisting calls continue but new calls are rejected.
-   * After this call returns, this server has released the listening socket(s) and may be reused by
-   * another server.
+   * This call will not wait for preexisting calls finish before returning. After this call returns,
+   * this server has released the listening socket(s) and may be reused by another server.
    *
    * @return {@code this} object
    * @since 1.0.0

--- a/examples/src/main/java/io/grpc/examples/advanced/HelloJsonServer.java
+++ b/examples/src/main/java/io/grpc/examples/advanced/HelloJsonServer.java
@@ -60,19 +60,19 @@ public class HelloJsonServer {
       public void run() {
         // Use stderr here since the logger may have been reset by its JVM shutdown hook.
         System.err.println("*** shutting down gRPC server since JVM is shutting down");
-        HelloJsonServer.this.stop();
+        try {
+          HelloJsonServer.this.stop();
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
         System.err.println("*** server shut down");
       }
     });
   }
 
-  private void stop() {
+  private void stop() throws InterruptedException {
     if (server != null) {
-      try {
-        server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
-      } catch (InterruptedException e) {
-        logger.warning(e.getMessage());
-      }
+      server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
     }
   }
 

--- a/examples/src/main/java/io/grpc/examples/advanced/HelloJsonServer.java
+++ b/examples/src/main/java/io/grpc/examples/advanced/HelloJsonServer.java
@@ -28,6 +28,7 @@ import io.grpc.examples.helloworld.HelloRequest;
 import io.grpc.stub.ServerCalls.UnaryMethod;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 /**
@@ -67,7 +68,11 @@ public class HelloJsonServer {
 
   private void stop() {
     if (server != null) {
-      server.shutdown();
+      try {
+        server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        logger.warning(e.getMessage());
+      }
     }
   }
 

--- a/examples/src/main/java/io/grpc/examples/advanced/HelloJsonServer.java
+++ b/examples/src/main/java/io/grpc/examples/advanced/HelloJsonServer.java
@@ -63,7 +63,7 @@ public class HelloJsonServer {
         try {
           HelloJsonServer.this.stop();
         } catch (InterruptedException e) {
-          e.printStackTrace();
+          e.printStackTrace(System.err);
         }
         System.err.println("*** server shut down");
       }

--- a/examples/src/main/java/io/grpc/examples/experimental/CompressingHelloWorldServerAllMethods.java
+++ b/examples/src/main/java/io/grpc/examples/experimental/CompressingHelloWorldServerAllMethods.java
@@ -17,6 +17,7 @@
 package io.grpc.examples.experimental;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 import io.grpc.Metadata;
@@ -70,7 +71,11 @@ public class CompressingHelloWorldServerAllMethods {
 
   private void stop() {
     if (server != null) {
-      server.shutdown();
+      try {
+        server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        logger.warning(e.getMessage());
+      }
     }
   }
 

--- a/examples/src/main/java/io/grpc/examples/experimental/CompressingHelloWorldServerAllMethods.java
+++ b/examples/src/main/java/io/grpc/examples/experimental/CompressingHelloWorldServerAllMethods.java
@@ -34,7 +34,7 @@ import io.grpc.stub.StreamObserver;
 
 /**
  * Server that manages startup/shutdown of a {@code Greeter} server
- * with an interceptor to enable compression for all responses. 
+ * with an interceptor to enable compression for all responses.
  */
 public class CompressingHelloWorldServerAllMethods {
   private static final Logger logger = Logger.getLogger(CompressingHelloWorldServerAllMethods.class.getName());
@@ -63,19 +63,19 @@ public class CompressingHelloWorldServerAllMethods {
       public void run() {
         // Use stderr here since the logger may have been reset by its JVM shutdown hook.
         System.err.println("*** shutting down gRPC server since JVM is shutting down");
-        CompressingHelloWorldServerAllMethods.this.stop();
+        try {
+          CompressingHelloWorldServerAllMethods.this.stop();
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
         System.err.println("*** server shut down");
       }
     });
   }
 
-  private void stop() {
+  private void stop() throws InterruptedException {
     if (server != null) {
-      try {
-        server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
-      } catch (InterruptedException e) {
-        logger.warning(e.getMessage());
-      }
+      server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
     }
   }
 

--- a/examples/src/main/java/io/grpc/examples/experimental/CompressingHelloWorldServerAllMethods.java
+++ b/examples/src/main/java/io/grpc/examples/experimental/CompressingHelloWorldServerAllMethods.java
@@ -66,7 +66,7 @@ public class CompressingHelloWorldServerAllMethods {
         try {
           CompressingHelloWorldServerAllMethods.this.stop();
         } catch (InterruptedException e) {
-          e.printStackTrace();
+          e.printStackTrace(System.err);
         }
         System.err.println("*** server shut down");
       }

--- a/examples/src/main/java/io/grpc/examples/experimental/CompressingHelloWorldServerPerMethod.java
+++ b/examples/src/main/java/io/grpc/examples/experimental/CompressingHelloWorldServerPerMethod.java
@@ -53,7 +53,7 @@ public class CompressingHelloWorldServerPerMethod {
         try {
           CompressingHelloWorldServerPerMethod.this.stop();
         } catch (InterruptedException e) {
-          e.printStackTrace();
+          e.printStackTrace(System.err);
         }
         System.err.println("*** server shut down");
       }

--- a/examples/src/main/java/io/grpc/examples/experimental/CompressingHelloWorldServerPerMethod.java
+++ b/examples/src/main/java/io/grpc/examples/experimental/CompressingHelloWorldServerPerMethod.java
@@ -50,19 +50,19 @@ public class CompressingHelloWorldServerPerMethod {
       public void run() {
         // Use stderr here since the logger may have been reset by its JVM shutdown hook.
         System.err.println("*** shutting down gRPC server since JVM is shutting down");
-        CompressingHelloWorldServerPerMethod.this.stop();
+        try {
+          CompressingHelloWorldServerPerMethod.this.stop();
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
         System.err.println("*** server shut down");
       }
     });
   }
 
-  private void stop() {
+  private void stop() throws InterruptedException {
     if (server != null) {
-      try {
-        server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
-      } catch (InterruptedException e) {
-        logger.warning(e.getMessage());
-      }
+      server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
     }
   }
 

--- a/examples/src/main/java/io/grpc/examples/experimental/CompressingHelloWorldServerPerMethod.java
+++ b/examples/src/main/java/io/grpc/examples/experimental/CompressingHelloWorldServerPerMethod.java
@@ -17,6 +17,7 @@
 package io.grpc.examples.experimental;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 import io.grpc.Server;
@@ -57,7 +58,11 @@ public class CompressingHelloWorldServerPerMethod {
 
   private void stop() {
     if (server != null) {
-      server.shutdown();
+      try {
+        server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        logger.warning(e.getMessage());
+      }
     }
   }
 

--- a/examples/src/main/java/io/grpc/examples/header/CustomHeaderServer.java
+++ b/examples/src/main/java/io/grpc/examples/header/CustomHeaderServer.java
@@ -24,6 +24,7 @@ import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 /**
@@ -56,7 +57,11 @@ public class CustomHeaderServer {
 
   private void stop() {
     if (server != null) {
-      server.shutdown();
+      try {
+        server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        logger.warning(e.getMessage());
+      }
     }
   }
 

--- a/examples/src/main/java/io/grpc/examples/header/CustomHeaderServer.java
+++ b/examples/src/main/java/io/grpc/examples/header/CustomHeaderServer.java
@@ -52,7 +52,7 @@ public class CustomHeaderServer {
         try {
           CustomHeaderServer.this.stop();
         } catch (InterruptedException e) {
-          e.printStackTrace();
+          e.printStackTrace(System.err);
         }
         System.err.println("*** server shut down");
       }

--- a/examples/src/main/java/io/grpc/examples/header/CustomHeaderServer.java
+++ b/examples/src/main/java/io/grpc/examples/header/CustomHeaderServer.java
@@ -49,19 +49,19 @@ public class CustomHeaderServer {
       public void run() {
         // Use stderr here since the logger may have been reset by its JVM shutdown hook.
         System.err.println("*** shutting down gRPC server since JVM is shutting down");
-        CustomHeaderServer.this.stop();
+        try {
+          CustomHeaderServer.this.stop();
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
         System.err.println("*** server shut down");
       }
     });
   }
 
-  private void stop() {
+  private void stop() throws InterruptedException {
     if (server != null) {
-      try {
-        server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
-      } catch (InterruptedException e) {
-        logger.warning(e.getMessage());
-      }
+      server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
     }
   }
 

--- a/examples/src/main/java/io/grpc/examples/hedging/HedgingHelloWorldServer.java
+++ b/examples/src/main/java/io/grpc/examples/hedging/HedgingHelloWorldServer.java
@@ -29,6 +29,7 @@ import io.grpc.examples.helloworld.HelloRequest;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 /**
@@ -61,7 +62,11 @@ public class HedgingHelloWorldServer {
 
   private void stop() {
     if (server != null) {
-      server.shutdown();
+      try {
+        server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        logger.warning(e.getMessage());
+      }
     }
   }
 

--- a/examples/src/main/java/io/grpc/examples/hedging/HedgingHelloWorldServer.java
+++ b/examples/src/main/java/io/grpc/examples/hedging/HedgingHelloWorldServer.java
@@ -54,19 +54,19 @@ public class HedgingHelloWorldServer {
       public void run() {
         // Use stderr here since the logger may have been reset by its JVM shutdown hook.
         System.err.println("*** shutting down gRPC server since JVM is shutting down");
-        HedgingHelloWorldServer.this.stop();
+        try {
+          HedgingHelloWorldServer.this.stop();
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
         System.err.println("*** server shut down");
       }
     });
   }
 
-  private void stop() {
+  private void stop() throws InterruptedException {
     if (server != null) {
-      try {
-        server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
-      } catch (InterruptedException e) {
-        logger.warning(e.getMessage());
-      }
+      server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
     }
   }
 

--- a/examples/src/main/java/io/grpc/examples/hedging/HedgingHelloWorldServer.java
+++ b/examples/src/main/java/io/grpc/examples/hedging/HedgingHelloWorldServer.java
@@ -57,7 +57,7 @@ public class HedgingHelloWorldServer {
         try {
           HedgingHelloWorldServer.this.stop();
         } catch (InterruptedException e) {
-          e.printStackTrace();
+          e.printStackTrace(System.err);
         }
         System.err.println("*** server shut down");
       }

--- a/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldServer.java
+++ b/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldServer.java
@@ -47,7 +47,7 @@ public class HelloWorldServer {
         try {
           HelloWorldServer.this.stop();
         } catch (InterruptedException e) {
-          e.printStackTrace();
+          e.printStackTrace(System.err);
         }
         System.err.println("*** server shut down");
       }

--- a/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldServer.java
+++ b/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldServer.java
@@ -20,6 +20,7 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 /**
@@ -51,7 +52,11 @@ public class HelloWorldServer {
 
   private void stop() {
     if (server != null) {
-      server.shutdown();
+      try {
+        server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        logger.warning(e.getMessage());
+      }
     }
   }
 

--- a/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldServer.java
+++ b/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldServer.java
@@ -44,19 +44,19 @@ public class HelloWorldServer {
       public void run() {
         // Use stderr here since the logger may have been reset by its JVM shutdown hook.
         System.err.println("*** shutting down gRPC server since JVM is shutting down");
-        HelloWorldServer.this.stop();
+        try {
+          HelloWorldServer.this.stop();
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
         System.err.println("*** server shut down");
       }
     });
   }
 
-  private void stop() {
+  private void stop() throws InterruptedException {
     if (server != null) {
-      try {
-        server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
-      } catch (InterruptedException e) {
-        logger.warning(e.getMessage());
-      }
+      server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
     }
   }
 

--- a/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlServer.java
+++ b/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlServer.java
@@ -140,7 +140,7 @@ public class ManualFlowControlServer {
         try {
           server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
-          e.printStackTrace();
+          e.printStackTrace(System.err);
         }
       }
     });

--- a/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlServer.java
+++ b/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlServer.java
@@ -23,6 +23,7 @@ import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
 
@@ -136,7 +137,11 @@ public class ManualFlowControlServer {
       @Override
       public void run() {
         logger.info("Shutting down");
-        server.shutdown();
+        try {
+          server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+          logger.warning(e.getMessage());
+        }
       }
     });
     server.awaitTermination();

--- a/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlServer.java
+++ b/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlServer.java
@@ -140,7 +140,7 @@ public class ManualFlowControlServer {
         try {
           server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
-          logger.warning(e.getMessage());
+          e.printStackTrace();
         }
       }
     });

--- a/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlServer.java
+++ b/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlServer.java
@@ -136,7 +136,8 @@ public class ManualFlowControlServer {
     Runtime.getRuntime().addShutdownHook(new Thread() {
       @Override
       public void run() {
-        logger.info("Shutting down");
+        // Use stderr here since the logger may have been reset by its JVM shutdown hook.
+        System.err.println("Shutting down");
         try {
           server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
         } catch (InterruptedException e) {

--- a/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
+++ b/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -82,7 +83,11 @@ public class RouteGuideServer {
   /** Stop serving requests and shutdown resources. */
   public void stop() {
     if (server != null) {
-      server.shutdown();
+      try {
+        server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        logger.warning(e.getMessage());
+      }
     }
   }
 

--- a/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
+++ b/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
@@ -74,20 +74,20 @@ public class RouteGuideServer {
       public void run() {
         // Use stderr here since the logger may have been reset by its JVM shutdown hook.
         System.err.println("*** shutting down gRPC server since JVM is shutting down");
-        RouteGuideServer.this.stop();
+        try {
+          RouteGuideServer.this.stop();
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
         System.err.println("*** server shut down");
       }
     });
   }
 
   /** Stop serving requests and shutdown resources. */
-  public void stop() {
+  public void stop() throws InterruptedException {
     if (server != null) {
-      try {
-        server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
-      } catch (InterruptedException e) {
-        logger.warning(e.getMessage());
-      }
+      server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
     }
   }
 

--- a/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
+++ b/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
@@ -77,7 +77,7 @@ public class RouteGuideServer {
         try {
           RouteGuideServer.this.stop();
         } catch (InterruptedException e) {
-          e.printStackTrace();
+          e.printStackTrace(System.err);
         }
         System.err.println("*** server shut down");
       }

--- a/examples/src/test/java/io/grpc/examples/routeguide/RouteGuideServerTest.java
+++ b/examples/src/test/java/io/grpc/examples/routeguide/RouteGuideServerTest.java
@@ -87,7 +87,7 @@ public class RouteGuideServerTest {
   @After
   public void tearDown() {
     try {
-		  server.stop();
+      server.stop();
     } catch (InterruptedException e) {
       e.printStackTrace();
     }

--- a/examples/src/test/java/io/grpc/examples/routeguide/RouteGuideServerTest.java
+++ b/examples/src/test/java/io/grpc/examples/routeguide/RouteGuideServerTest.java
@@ -86,7 +86,11 @@ public class RouteGuideServerTest {
 
   @After
   public void tearDown() {
-    server.stop();
+    try {
+		  server.stop();
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
   }
 
   @Test


### PR DESCRIPTION
The example servers do not properly wait until preexisting calls complete before shutting down (https://github.com/grpc/grpc-java/issues/6511).

This PR
- Adds a call to `awaitTermination` to wait for preexisting calls to complete (with a 30s timeout)
- Updates the API documentation for `Server.shutdown` to clarify that the call does not wait for preexisting calls to complete before returning.