### PR TITLE
xds: make XdsChannelFactory default instance a constant.

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -480,7 +480,7 @@ abstract class XdsClient {
    * Factory for creating channels to xDS severs.
    */
   abstract static class XdsChannelFactory {
-    private static XdsChannelFactory DEFAULT_INSTANCE = new XdsChannelFactory() {
+    private static final XdsChannelFactory DEFAULT_INSTANCE = new XdsChannelFactory() {
 
       /**
        * Creates a channel to the first server in the given list.


### PR DESCRIPTION
The naming of the `DEFAULT_INSTANCE` indicates it is a constant, but a `final` is missing.