### PR TITLE
xds: fix NPE in fallback mode in CDS flow

### DIFF
--- a/xds/src/main/java/io/grpc/xds/FallbackLb.java
+++ b/xds/src/main/java/io/grpc/xds/FallbackLb.java
@@ -100,6 +100,13 @@ final class FallbackLb extends ForwardingLoadBalancer {
     }
 
     LbConfig fallbackPolicy = xdsConfig.fallbackPolicy;
+    if (fallbackPolicy == null) {
+      // In the latest xDS design, fallback is not supported.
+      fallbackLbHelper.updateBalancingState(
+          TRANSIENT_FAILURE,
+          new ErrorPicker(Status.UNAVAILABLE.withDescription("Fallback is not supported")));
+      return;
+    }
     String newFallbackPolicyName = fallbackPolicy.getPolicyName();
     fallbackPolicyLb.switchTo(lbRegistry.getProvider(newFallbackPolicyName));
 


### PR DESCRIPTION
In CDS flow, fallback is not supported. The fallback_policy in XdsConfig is null, causing NPE. This PR fixes that bug.