### PR TITLE
Revert "netty: enable io.grpc.netty.useCustomAllocator by default"

### DIFF
--- a/netty/src/main/java/io/grpc/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/netty/Utils.java
@@ -91,7 +91,7 @@ class Utils {
         @Override
         public ByteBufAllocator create() {
           if (Boolean.parseBoolean(
-                  System.getProperty("io.grpc.netty.useCustomAllocator", "true"))) {
+                  System.getProperty("io.grpc.netty.useCustomAllocator", "false"))) {
             int maxOrder;
             if (System.getProperty("io.netty.allocator.maxOrder") == null) {
               // See the implementation of PooledByteBufAllocator.  DEFAULT_MAX_ORDER in there is


### PR DESCRIPTION
This reverts commit b0e00fd4bad58350bafbb0411b94c70979f7d3e1.

It may cause leak of netty native buffers when creating and shutting
down Channels on a regular basis.