### PR TITLE
examples: Throw exception in test instead of printStackTrace

### DIFF
--- a/examples/src/test/java/io/grpc/examples/routeguide/RouteGuideServerTest.java
+++ b/examples/src/test/java/io/grpc/examples/routeguide/RouteGuideServerTest.java
@@ -85,12 +85,8 @@ public class RouteGuideServerTest {
   }
 
   @After
-  public void tearDown() {
-    try {
-      server.stop();
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    }
+  public void tearDown() throws Exception {
+    server.stop();
   }
 
   @Test


### PR DESCRIPTION
Throwing makes cleaner code and also is more helpful if the exception is ever
thrown, as the error will be more clear.

-----

I noticed this after #6512 was already merged. Minor, but good to fix in an example.

CC @dounan