### PR TITLE
stub: fix javadoc to indicate correct version1.25.0 -> 1.26.0 (backport of #6522 to 1.26.x)

### DIFF
--- a/stub/src/main/java/io/grpc/stub/AbstractAsyncStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractAsyncStub.java
@@ -28,7 +28,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * <p>DO NOT MOCK: Customizing options doesn't work properly in mocks. Use InProcessChannelBuilder
  * to create a real channel suitable for testing. It is also possible to mock Channel instead.
  *
- * @since 1.25.0
+ * @since 1.26.0
  */
 @ThreadSafe
 @CheckReturnValue
@@ -41,7 +41,7 @@ public abstract class AbstractAsyncStub<S extends AbstractAsyncStub<S>> extends 
   /**
    * Returns a new async stub with the given channel for the provided method configurations.
    *
-   * @since 1.25.0
+   * @since 1.26.0
    * @param factory the factory to create an async stub
    * @param channel the channel that this stub will use to do communications
    */
@@ -53,7 +53,7 @@ public abstract class AbstractAsyncStub<S extends AbstractAsyncStub<S>> extends 
   /**
    * Returns a new async stub with the given channel for the provided method configurations.
    *
-   * @since 1.25.0
+   * @since 1.26.0
    * @param factory the factory to create an async stub
    * @param channel the channel that this stub will use to do communications
    * @param callOptions the runtime call options to be applied to every call on this stub

--- a/stub/src/main/java/io/grpc/stub/AbstractBlockingStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractBlockingStub.java
@@ -28,7 +28,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * <p>DO NOT MOCK: Customizing options doesn't work properly in mocks. Use InProcessChannelBuilder
  * to create a real channel suitable for testing. It is also possible to mock Channel instead.
  *
- * @since 1.25.0
+ * @since 1.26.0
  */
 @ThreadSafe
 @CheckReturnValue
@@ -42,7 +42,7 @@ public abstract class AbstractBlockingStub<S extends AbstractBlockingStub<S>>
   /**
    * Returns a new blocking stub with the given channel for the provided method configurations.
    *
-   * @since 1.25.0
+   * @since 1.26.0
    * @param factory the factory to create a blocking stub
    * @param channel the channel that this stub will use to do communications
    */
@@ -54,7 +54,7 @@ public abstract class AbstractBlockingStub<S extends AbstractBlockingStub<S>>
   /**
    * Returns a new blocking stub with the given channel for the provided method configurations.
    *
-   * @since 1.25.0
+   * @since 1.26.0
    * @param factory the factory to create a blocking stub
    * @param channel the channel that this stub will use to do communications
    * @param callOptions the runtime call options to be applied to every call on this stub

--- a/stub/src/main/java/io/grpc/stub/AbstractFutureStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractFutureStub.java
@@ -28,7 +28,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * <p>DO NOT MOCK: Customizing options doesn't work properly in mocks. Use InProcessChannelBuilder
  * to create a real channel suitable for testing. It is also possible to mock Channel instead.
  *
- * @since 1.25.0
+ * @since 1.26.0
  */
 @ThreadSafe
 @CheckReturnValue
@@ -41,7 +41,7 @@ public abstract class AbstractFutureStub<S extends AbstractFutureStub<S>> extend
   /**
    * Returns a new future stub with the given channel for the provided method configurations.
    *
-   * @since 1.25.0
+   * @since 1.26.0
    * @param factory the factory to create a future stub
    * @param channel the channel that this stub will use to do communications
    */
@@ -53,7 +53,7 @@ public abstract class AbstractFutureStub<S extends AbstractFutureStub<S>> extend
   /**
    * Returns a new future stub with the given channel for the provided method configurations.
    *
-   * @since 1.25.0
+   * @since 1.26.0
    * @param factory the factory to create a future stub
    * @param channel the channel that this stub will use to do communications
    * @param callOptions the runtime call options to be applied to every call on this stub

--- a/stub/src/main/java/io/grpc/stub/AbstractStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractStub.java
@@ -104,7 +104,7 @@ public abstract class AbstractStub<S extends AbstractStub<S>> {
   /**
    * Returns a new stub with the given channel for the provided method configurations.
    *
-   * @since 1.25.0
+   * @since 1.26.0
    * @param factory the factory to create a stub
    * @param channel the channel that this stub will use to do communications
    */
@@ -116,7 +116,7 @@ public abstract class AbstractStub<S extends AbstractStub<S>> {
   /**
    * Returns a new stub with the given channel for the provided method configurations.
    *
-   * @since 1.25.0
+   * @since 1.26.0
    * @param factory the factory to create a stub
    * @param channel the channel that this stub will use to do communications
    * @param callOptions the runtime call options to be applied to every call on this stub
@@ -253,7 +253,7 @@ public abstract class AbstractStub<S extends AbstractStub<S>> {
   /**
    * A factory class for stub.
    *
-   * @since 1.25.0
+   * @since 1.26.0
    */
   public interface StubFactory<T extends AbstractStub<T>> {
     T newStub(Channel channel, CallOptions callOptions);


### PR DESCRIPTION
backport of #6522 to 1.26.x