### PR TITLE
netty: enable io.grpc.netty.useCustomAllocator by default (take 2)

### DIFF
--- a/netty/src/main/java/io/grpc/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/netty/Utils.java
@@ -92,7 +92,7 @@ class Utils {
 
     static {
       if (Boolean.parseBoolean(
-              System.getProperty("io.grpc.netty.useCustomAllocator", "false"))) {
+              System.getProperty("io.grpc.netty.useCustomAllocator", "true"))) {
         int maxOrder;
         if (System.getProperty("io.netty.allocator.maxOrder") == null) {
           // See the implementation of PooledByteBufAllocator.  DEFAULT_MAX_ORDER in there is


### PR DESCRIPTION
Since #6526 has resolved the memory leak, let's turn it back on.