### PR TITLE
xds: fix bug of not ignoring responses received after shutdown

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -832,6 +832,9 @@ final class XdsClientImpl extends XdsClient {
       syncContext.execute(new Runnable() {
         @Override
         public void run() {
+          if (closed) {
+            return;
+          }
           responseReceived = true;
           String typeUrl = response.getTypeUrl();
           // Nonce in each response is echoed back in the following ACK/NACK request. It is


### PR DESCRIPTION
This is an implementation bug, I think we would not need to add a test case covering it (regardless for regression purposes).