### PR TITLE
bazel: Fix renamed javalite target (v1.26.x backport)

### DIFF
--- a/protobuf-lite/BUILD.bazel
+++ b/protobuf-lite/BUILD.bazel
@@ -10,7 +10,7 @@ java_library(
         "@com_google_guava_guava//jar",
         "@com_google_j2objc_j2objc_annotations//jar",
     ] + select({
-        ":android": ["@com_google_protobuf_javalite//:protobuf_java_lite"],
+        ":android": ["@com_google_protobuf_javalite//:protobuf_javalite"],
         "//conditions:default": ["@com_google_protobuf//:protobuf_java"],
     }),
 )


### PR DESCRIPTION
This was missed from 2d592642a, because the select hid the failure.

-----

This is a backport of #6544