### PR TITLE
bazel: Use https to download from Maven Central (1.23.x backport)

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -142,7 +142,7 @@ def com_google_android_annotations():
     jvm_maven_import_external(
         name = "com_google_android_annotations",
         artifact = "com.google.android:annotations:4.1.1.4",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -151,7 +151,7 @@ def com_google_api_grpc_google_common_protos():
     jvm_maven_import_external(
         name = "com_google_api_grpc_proto_google_common_protos",
         artifact = "com.google.api.grpc:proto-google-common-protos:1.12.0",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "bd60cd7a423b00fb824c27bdd0293aaf4781be1daba6ed256311103fb4b84108",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -160,7 +160,7 @@ def com_google_auth_google_auth_library_credentials():
     jvm_maven_import_external(
         name = "com_google_auth_google_auth_library_credentials",
         artifact = "com.google.auth:google-auth-library-credentials:0.9.0",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "ac9efdd6a930e4df906fa278576fa825d979f74315f2faf5c91fe7e6aabb2788",
         licenses = ["notice"],  # BSD 3-clause
     )
@@ -169,7 +169,7 @@ def com_google_auth_google_auth_library_oauth2_http():
     jvm_maven_import_external(
         name = "com_google_auth_google_auth_library_oauth2_http",
         artifact = "com.google.auth:google-auth-library-oauth2-http:0.9.0",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "e55d9722102cc1245c8c43d69acd49d3c9bbfcc1bcf722e971425506b970097e",
         licenses = ["notice"],  # BSD 3-clause
     )
@@ -178,7 +178,7 @@ def com_google_code_findbugs_jsr305():
     jvm_maven_import_external(
         name = "com_google_code_findbugs_jsr305",
         artifact = "com.google.code.findbugs:jsr305:3.0.2",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -187,7 +187,7 @@ def com_google_code_gson():
     jvm_maven_import_external(
         name = "com_google_code_gson_gson",
         artifact = "com.google.code.gson:gson:jar:2.7",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "2d43eb5ea9e133d2ee2405cc14f5ee08951b8361302fdd93494a3a997b508d32",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -196,7 +196,7 @@ def com_google_errorprone_error_prone_annotations():
     jvm_maven_import_external(
         name = "com_google_errorprone_error_prone_annotations",
         artifact = "com.google.errorprone:error_prone_annotations:2.3.3",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "ec59f1b702d9afc09e8c3929f5c42777dec623a6ea2731ac694332c7d7680f5a",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -205,7 +205,7 @@ def com_google_guava():
     jvm_maven_import_external(
         name = "com_google_guava_guava",
         artifact = "com.google.guava:guava:26.0-android",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "1d044ebb866ef08b7d04e998b4260c9b52fab6e6d6b68d207859486bb3686cd5",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -215,7 +215,7 @@ def com_google_guava_failureaccess():
     jvm_maven_import_external(
         name = "com_google_guava_failureaccess",
         artifact = "com.google.guava:failureaccess:1.0.1",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -224,7 +224,7 @@ def com_google_j2objc_j2objc_annotations():
     jvm_maven_import_external(
         name = "com_google_j2objc_j2objc_annotations",
         artifact = "com.google.j2objc:j2objc-annotations:1.1",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "2994a7eb78f2710bd3d3bfb639b2c94e219cedac0d4d084d516e78c16dddecf6",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -253,7 +253,7 @@ def com_google_truth_truth():
     jvm_maven_import_external(
         name = "com_google_truth_truth",
         artifact = "com.google.truth:truth:0.45",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "0f7dced2a16e55a77e44fc3ff9c5be98d4bf4bb30abc18d78ffd735df950a69f",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -262,7 +262,7 @@ def com_squareup_okhttp():
     jvm_maven_import_external(
         name = "com_squareup_okhttp_okhttp",
         artifact = "com.squareup.okhttp:okhttp:2.5.0",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "1cc716e29539adcda677949508162796daffedb4794cbf947a6f65e696f0381c",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -271,7 +271,7 @@ def com_squareup_okio():
     jvm_maven_import_external(
         name = "com_squareup_okio_okio",
         artifact = "com.squareup.okio:okio:1.13.0",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "734269c3ebc5090e3b23566db558f421f0b4027277c79ad5d176b8ec168bb850",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -288,7 +288,7 @@ def io_netty_buffer():
     jvm_maven_import_external(
         name = "io_netty_netty_buffer",
         artifact = "io.netty:netty-buffer:4.1.38.Final",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "a3dcb49108f83b195e66cdad70b2d4a127c17f1be7f5b228a88ce18908c30b3e",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -297,7 +297,7 @@ def io_netty_codec():
     jvm_maven_import_external(
         name = "io_netty_netty_codec",
         artifact = "io.netty:netty-codec:4.1.38.Final",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "8a4cb96e2131eeb8a824014f0ee338b11c6041405446acf73181199ed05744ac",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -306,7 +306,7 @@ def io_netty_codec_http():
     jvm_maven_import_external(
         name = "io_netty_netty_codec_http",
         artifact = "io.netty:netty-codec-http:4.1.38.Final",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "b35c4ac78ed3aaefeb782965ce9f22901e5302bf5e75b75fbed79434ce007e8c",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -315,7 +315,7 @@ def io_netty_codec_http2():
     jvm_maven_import_external(
         name = "io_netty_netty_codec_http2",
         artifact = "io.netty:netty-codec-http2:4.1.38.Final",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "7e2d792407d2da34d3338a3e8f8ed421570fdbf845941b8ee0aa952fe0e07026",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -324,7 +324,7 @@ def io_netty_codec_socks():
     jvm_maven_import_external(
         name = "io_netty_netty_codec_socks",
         artifact = "io.netty:netty-codec-socks:4.1.38.Final",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "16d932d76d06992923ce640609d297fe35d9f7b219ea5f0514a4259f1f1f2146",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -333,7 +333,7 @@ def io_netty_common():
     jvm_maven_import_external(
         name = "io_netty_netty_common",
         artifact = "io.netty:netty-common:4.1.38.Final",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "710df7c27fe5ba4b15689ae10668cd10ab3b618a1291f3a47b2cc292a0fa67da",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -342,7 +342,7 @@ def io_netty_handler():
     jvm_maven_import_external(
         name = "io_netty_netty_handler",
         artifact = "io.netty:netty-handler:4.1.38.Final",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "b49b57dbdc88a2c77e3ea9b9d00d3136f28771e059b74a7be7458d7a86bfccd1",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -351,7 +351,7 @@ def io_netty_handler_proxy():
     jvm_maven_import_external(
         name = "io_netty_netty_handler_proxy",
         artifact = "io.netty:netty-handler-proxy:4.1.38.Final",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "9dab309a0422dd9858f431d503b58b854b37d2545c50ad7b4771f34d2288e5c0",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -360,7 +360,7 @@ def io_netty_resolver():
     jvm_maven_import_external(
         name = "io_netty_netty_resolver",
         artifact = "io.netty:netty-resolver:4.1.38.Final",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "3692c12a0035e566d5cd1dc1529d4f61725304c5e88817ae78b5c2f7f6d86cad",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -369,7 +369,7 @@ def io_netty_tcnative_boringssl_static():
     jvm_maven_import_external(
         name = "io_netty_netty_tcnative_boringssl_static",
         artifact = "io.netty:netty-tcnative-boringssl-static:2.0.25.Final",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "96d9c14ab4c47cbad7fec9bdb083917db971d3754d6c7fa89f958bc719e230ed",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -378,7 +378,7 @@ def io_netty_transport():
     jvm_maven_import_external(
         name = "io_netty_netty_transport",
         artifact = "io.netty:netty-transport:4.1.38.Final",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "5f826976585a49aae9b495290125a60a59dc6887fbe4c70da3182a83fb8bfa88",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -387,7 +387,7 @@ def io_opencensus_api():
     jvm_maven_import_external(
         name = "io_opencensus_opencensus_api",
         artifact = "io.opencensus:opencensus-api:0.21.0",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "8e2cb0f6391d8eb0a1bcd01e7748883f0033b1941754f4ed3f19d2c3e4276fc8",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -396,7 +396,7 @@ def io_opencensus_grpc_metrics():
     jvm_maven_import_external(
         name = "io_opencensus_opencensus_contrib_grpc_metrics",
         artifact = "io.opencensus:opencensus-contrib-grpc-metrics:0.21.0",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "29fc79401082301542cab89d7054d2f0825f184492654c950020553ef4ff0ef8",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -405,7 +405,7 @@ def io_perfmark():
     jvm_maven_import_external(
         name = "io_perfmark_perfmark_api",
         artifact = "io.perfmark:perfmark-api:0.19.0",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "b734ba2149712409a44eabdb799f64768578fee0defe1418bb108fe32ea43e1a",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -415,7 +415,7 @@ def javax_annotation():
     jvm_maven_import_external(
         name = "javax_annotation_javax_annotation_api",
         artifact = "javax.annotation:javax.annotation-api:1.2",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "5909b396ca3a2be10d0eea32c74ef78d816e1b4ead21de1d78de1f890d033e04",
         licenses = ["reciprocal"],  # CDDL License
     )
@@ -424,7 +424,7 @@ def junit_junit():
     jvm_maven_import_external(
         name = "junit_junit",
         artifact = "junit:junit:4.12",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a",
         licenses = ["notice"],  # EPL 1.0
     )
@@ -442,7 +442,7 @@ def org_apache_commons_lang3():
     jvm_maven_import_external(
         name = "org_apache_commons_commons_lang3",
         artifact = "org.apache.commons:commons-lang3:3.5",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "8ac96fc686512d777fca85e144f196cd7cfe0c0aec23127229497d1a38ff651c",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -451,7 +451,7 @@ def org_codehaus_mojo_animal_sniffer_annotations():
     jvm_maven_import_external(
         name = "org_codehaus_mojo_animal_sniffer_annotations",
         artifact = "org.codehaus.mojo:animal-sniffer-annotations:1.17",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "92654f493ecfec52082e76354f0ebf87648dc3d5cec2e3c3cdb947c016747a53",
         licenses = ["notice"],  # MIT
     )


### PR DESCRIPTION
central.maven.org shouldn't have been used in the first place as it isn't one
of the canonical URLs to Maven Central, but even more importantly we want to
use https. The previous URL will probably stop working January 15, 2020[1][2].

Fixes #6536

1. https://central.sonatype.org/articles/2019/Apr/30/http-access-to-repo1mavenorg-and-repomavenapacheorg-is-being-deprecated/
2. https://central.sonatype.org/articles/2019/Nov/15/non-canonical-urls-will-be-redirected-today/

Backport of #6543