### PR TITLE
Clarify CallStreamObserver's Javadoc

### DIFF
--- a/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
@@ -19,20 +19,25 @@ package io.grpc.stub;
 import io.grpc.ExperimentalApi;
 
 /**
- * A refinement of StreamObserver provided by the GRPC runtime to the application that allows for
- * more complex interactions with call behavior.
+ * A refinement of StreamObserver provided by the GRPC runtime to the application (the client or
+ * the server) that allows for more complex interactions with call behavior.
  *
- * <p>In any call there are logically two {@link StreamObserver} implementations:
+ * <p>In any call there are logically three {@link StreamObserver} implementations:
  * <ul>
- *   <li>'inbound' - which the GRPC runtime calls when it receives messages from the
- *   remote peer. This is implemented by the application.
+ *   <li>'inbound' - which the GRPC runtime calls when it receives messages from the server. This
+ *   is implemented by the client application.
  *   </li>
- *   <li>'outbound' - which the GRPC runtime provides to the application which it uses to
- *   send messages to the remote peer.
+ *   <li>'outbound', client-side - which the GRPC runtime provides to the client application and the
+ *   client uses this {@code StreamObserver} to send messages to the server.
+ *   </li>
+ *   <li>'outbound', server-side - which the GRPC runtime provides to the server application and
+ *   the server uses this {@code StreamObserver} to send messages (responses) to the client.
  *   </li>
  * </ul>
  *
- * <p>Implementations of this class represent the 'outbound' message stream.
+ * <p>Implementations of this class represent the 'outbound' message streams. The client-side
+ * one is {@link ClientCallStreamObserver} and the service-side one is
+ * {@link ServerCallStreamObserver}.
  *
  * <p>Like {@code StreamObserver}, implementations are not required to be thread-safe; if multiple
  * threads will be writing to an instance concurrently, the application must synchronize its calls.

--- a/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
@@ -22,13 +22,18 @@ import io.grpc.ExperimentalApi;
  * A refinement of StreamObserver provided by the GRPC runtime to the application (the client or
  * the server) that allows for more complex interactions with call behavior.
  *
- * <p>In any call there are logically three {@link StreamObserver} implementations:
+ * <p>In any call there are logically four {@link StreamObserver} implementations:
  * <ul>
- *   <li>'inbound' - which the GRPC runtime calls when it receives messages from the server. This
- *   is implemented by the client application.
+ *   <li>'inbound', client-side - which the GRPC runtime calls when it receives messages from
+ *   the server. This is implemented by the client application and passed into a service method
+ *   on a stub object.
  *   </li>
  *   <li>'outbound', client-side - which the GRPC runtime provides to the client application and the
  *   client uses this {@code StreamObserver} to send messages to the server.
+ *   </li>
+ *   <li>'inbound', server-side - which the GRPC runtime calls when it receives messages from
+ *   the client. This is implemented by the server application and returned from service
+ *   implementations of client-side streaming and bidirectional streaming methods.
  *   </li>
  *   <li>'outbound', server-side - which the GRPC runtime provides to the server application and
  *   the server uses this {@code StreamObserver} to send messages (responses) to the client.


### PR DESCRIPTION
Fixes #6552.

Apart the class-level comment, there are a few unclear places in the documentation to the methods which I don't know how to improve--please make your suggestions.

1. `... without requiring excessive buffering internally ...` in `isReady()` suggests that there may be some internal buffer, in-process, which may have spare space, and then `isReady()` can return true. However, the documentation `setOnReadyHandler()` has phrase `when peer is ready to receive more messages` which doesn't consider the above option.

2. Phrase `On server-side it may only be called during the initial call to the application, before the service returns its {@code StreamObserver}.` -- cannot make sense of this phrase, because service implementations don't normally return `StreamObserver` instances. Does it have something to do with `ClientStreamingMethod` and `BidiStreamingMethod`, the `StreamObserver`s returned by them?

3. In the documentation for `disableAutoInboundFlowControl()`, in the first phrase `Disables automatic flow control where a token is returned to the peer after a call to the 'inbound' {@link io.grpc.stub.StreamObserver#onNext(Object)} has completed.` it's unclear what does the phrase `a token is returned to the peer` mean, what is the "token" there.