### PR TITLE
Add suppressions for GuardedBy violations

### DIFF
--- a/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
@@ -149,9 +149,12 @@ class CronetClientTransport implements ConnectionClientTransport {
     return new StartCallback().clientStream;
   }
 
+  @SuppressWarnings("GuardedBy")
   @GuardedBy("lock")
   private void startStream(CronetClientStream stream) {
     streams.add(stream);
+    // TODO(b/145386688): This access should be guarded by 'stream.transportState().lock'; instead
+    // found: 'this.lock'
     stream.transportState().start(streamFactory);
   }
 

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -260,7 +260,8 @@ class OkHttpClientStream extends AbstractClientStream {
     public void start(int streamId) {
       checkState(id == ABSENT_ID, "the stream has been started with id %s", streamId);
       id = streamId;
-      state.onStreamAllocated();
+      /* This access should be guarded by 'OkHttpClientStream.this.state.lock'; instead found: 'this.lock' */ state
+          .onStreamAllocated();
 
       if (canStart) {
         // Only happens when the stream has neither been started nor cancelled.
@@ -373,7 +374,8 @@ class OkHttpClientStream extends AbstractClientStream {
       cancelSent = true;
       if (canStart) {
         // stream is pending.
-        transport.removePendingStream(OkHttpClientStream.this);
+        /* This access should be guarded by 'this.transport.lock'; instead found: 'this.lock' */ transport
+            .removePendingStream(OkHttpClientStream.this);
         // release holding data, so they can be GCed or returned to pool earlier.
         requestHeaders = null;
         pendingData.clear();
@@ -416,7 +418,8 @@ class OkHttpClientStream extends AbstractClientStream {
               userAgent,
               useGet,
               transport.isUsingPlaintext());
-      transport.streamReadyToStart(OkHttpClientStream.this);
+      /* This access should be guarded by 'this.transport.lock'; instead found: 'this.lock' */ transport
+          .streamReadyToStart(OkHttpClientStream.this);
     }
 
     Tag tag() {

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -256,12 +256,14 @@ class OkHttpClientStream extends AbstractClientStream {
       tag = PerfMark.createTag(methodName);
     }
 
+    @SuppressWarnings("GuardedBy")
     @GuardedBy("lock")
     public void start(int streamId) {
       checkState(id == ABSENT_ID, "the stream has been started with id %s", streamId);
       id = streamId;
-      /* This access should be guarded by 'OkHttpClientStream.this.state.lock'; instead found: 'this.lock' */ state
-          .onStreamAllocated();
+      // TODO(b/145386688): This access should be guarded by 'OkHttpClientStream.this.state.lock';
+      // instead found: 'this.lock'
+      state.onStreamAllocated();
 
       if (canStart) {
         // Only happens when the stream has neither been started nor cancelled.
@@ -366,6 +368,7 @@ class OkHttpClientStream extends AbstractClientStream {
       }
     }
 
+    @SuppressWarnings("GuardedBy")
     @GuardedBy("lock")
     private void cancel(Status reason, boolean stopDelivery, Metadata trailers) {
       if (cancelSent) {
@@ -374,8 +377,9 @@ class OkHttpClientStream extends AbstractClientStream {
       cancelSent = true;
       if (canStart) {
         // stream is pending.
-        /* This access should be guarded by 'this.transport.lock'; instead found: 'this.lock' */ transport
-            .removePendingStream(OkHttpClientStream.this);
+        // TODO(b/145386688): This access should be guarded by 'this.transport.lock'; instead found:
+        // 'this.lock'
+        transport.removePendingStream(OkHttpClientStream.this);
         // release holding data, so they can be GCed or returned to pool earlier.
         requestHeaders = null;
         pendingData.clear();
@@ -408,6 +412,7 @@ class OkHttpClientStream extends AbstractClientStream {
       }
     }
 
+    @SuppressWarnings("GuardedBy")
     @GuardedBy("lock")
     private void streamReady(Metadata metadata, String path) {
       requestHeaders =
@@ -418,8 +423,9 @@ class OkHttpClientStream extends AbstractClientStream {
               userAgent,
               useGet,
               transport.isUsingPlaintext());
-      /* This access should be guarded by 'this.transport.lock'; instead found: 'this.lock' */ transport
-          .streamReadyToStart(OkHttpClientStream.this);
+      // TODO(b/145386688): This access should be guarded by 'this.transport.lock'; instead found:
+      // 'this.lock'
+      transport.streamReadyToStart(OkHttpClientStream.this);
     }
 
     Tag tag() {

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -1111,7 +1111,9 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
       }
     }
 
-    /** Handle an HTTP2 DATA frame. */
+    /**
+     * Handle an HTTP2 DATA frame.
+     */
     @SuppressWarnings("GuardedBy")
     @Override
     public void data(boolean inFinished, int streamId, BufferedSource in, int length)
@@ -1154,11 +1156,12 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
       }
     }
 
-    /** Handle HTTP2 HEADER and CONTINUATION frames. */
+    /**
+     * Handle HTTP2 HEADER and CONTINUATION frames.
+     */
     @SuppressWarnings("GuardedBy")
     @Override
-    public void headers(
-        boolean outFinished,
+    public void headers(boolean outFinished,
         boolean inFinished,
         int streamId,
         int associatedStreamId,

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -430,7 +430,9 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
         stream.id() == OkHttpClientStream.ABSENT_ID, "StreamId already assigned");
     streams.put(nextStreamId, stream);
     setInUse(stream);
-    stream.transportState().start(nextStreamId);
+    /* This access should be guarded by 'stream.transportState().lock'; instead found: 'this.lock' */ stream
+        .transportState()
+        .start(nextStreamId);
     // For unary and server streaming, there will be a data frame soon, no need to flush the header.
     if ((stream.getType() != MethodType.UNARY && stream.getType() != MethodType.SERVER_STREAMING)
         || stream.useGet()) {
@@ -1136,7 +1138,9 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
         PerfMark.event("OkHttpClientTransport$ClientFrameHandler.data",
             stream.transportState().tag());
         synchronized (lock) {
-          stream.transportState().transportDataReceived(buf, inFinished);
+          /* This access should be guarded by 'stream.transportState().lock'; instead found: 'OkHttpClientTransport.this.lock' */ stream
+              .transportState()
+              .transportDataReceived(buf, inFinished);
         }
       }
 
@@ -1186,7 +1190,9 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
           if (failedStatus == null) {
             PerfMark.event("OkHttpClientTransport$ClientFrameHandler.headers",
                 stream.transportState().tag());
-            stream.transportState().transportHeadersReceived(headerBlock, inFinished);
+            /* This access should be guarded by 'stream.transportState().lock'; instead found: 'OkHttpClientTransport.this.lock' */ stream
+                .transportState()
+                .transportHeadersReceived(headerBlock, inFinished);
           } else {
             if (!inFinished) {
               frameWriter.rstStream(streamId, ErrorCode.CANCEL);

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -424,15 +424,16 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
     }
   }
 
+  @SuppressWarnings("GuardedBy")
   @GuardedBy("lock")
   private void startStream(OkHttpClientStream stream) {
     Preconditions.checkState(
         stream.id() == OkHttpClientStream.ABSENT_ID, "StreamId already assigned");
     streams.put(nextStreamId, stream);
     setInUse(stream);
-    /* This access should be guarded by 'stream.transportState().lock'; instead found: 'this.lock' */ stream
-        .transportState()
-        .start(nextStreamId);
+    // TODO(b/145386688): This access should be guarded by 'stream.transportState().lock'; instead
+    // found: 'this.lock'
+    stream.transportState().start(nextStreamId);
     // For unary and server streaming, there will be a data frame soon, no need to flush the header.
     if ((stream.getType() != MethodType.UNARY && stream.getType() != MethodType.SERVER_STREAMING)
         || stream.useGet()) {
@@ -1110,9 +1111,8 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
       }
     }
 
-    /**
-     * Handle an HTTP2 DATA frame.
-     */
+    /** Handle an HTTP2 DATA frame. */
+    @SuppressWarnings("GuardedBy")
     @Override
     public void data(boolean inFinished, int streamId, BufferedSource in, int length)
         throws IOException {
@@ -1138,9 +1138,9 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
         PerfMark.event("OkHttpClientTransport$ClientFrameHandler.data",
             stream.transportState().tag());
         synchronized (lock) {
-          /* This access should be guarded by 'stream.transportState().lock'; instead found: 'OkHttpClientTransport.this.lock' */ stream
-              .transportState()
-              .transportDataReceived(buf, inFinished);
+          // TODO(b/145386688): This access should be guarded by 'stream.transportState().lock';
+          // instead found: 'OkHttpClientTransport.this.lock'
+          stream.transportState().transportDataReceived(buf, inFinished);
         }
       }
 
@@ -1154,11 +1154,11 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
       }
     }
 
-    /**
-     * Handle HTTP2 HEADER and CONTINUATION frames.
-     */
+    /** Handle HTTP2 HEADER and CONTINUATION frames. */
+    @SuppressWarnings("GuardedBy")
     @Override
-    public void headers(boolean outFinished,
+    public void headers(
+        boolean outFinished,
         boolean inFinished,
         int streamId,
         int associatedStreamId,
@@ -1190,9 +1190,9 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
           if (failedStatus == null) {
             PerfMark.event("OkHttpClientTransport$ClientFrameHandler.headers",
                 stream.transportState().tag());
-            /* This access should be guarded by 'stream.transportState().lock'; instead found: 'OkHttpClientTransport.this.lock' */ stream
-                .transportState()
-                .transportHeadersReceived(headerBlock, inFinished);
+            // TODO(b/145386688): This access should be guarded by 'stream.transportState().lock';
+            // instead found: 'OkHttpClientTransport.this.lock'
+            stream.transportState().transportHeadersReceived(headerBlock, inFinished);
           } else {
             if (!inFinished) {
               frameWriter.rstStream(streamId, ErrorCode.CANCEL);


### PR DESCRIPTION
This supports releasing a new version of GuardedBy which finds more mistakes than it used to.