### PR TITLE
xds: incorporate initial fetch timeout as resource not found for xDS protocol

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -772,6 +772,16 @@ final class XdsClientImpl extends XdsClient {
     for (String clusterName : clusterNamesToEndpointUpdates.keySet()) {
       if (!edsServices.contains(clusterName)) {
         absentEdsResources.add(clusterName);
+        // Notify EDS resource removal to watchers.
+        if (endpointWatchers.containsKey(clusterName)) {
+          Set<EndpointWatcher> watchers = endpointWatchers.get(clusterName);
+          for (EndpointWatcher watcher : watchers) {
+            watcher.onError(
+                Status.NOT_FOUND
+                    .withDescription(
+                        "Endpoint resource for cluster [" + clusterName + "] is deleted."));
+          }
+        }
       }
     }
     clusterNamesToEndpointUpdates.keySet().retainAll(edsServices);

--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -190,18 +190,6 @@ final class XdsClientImpl extends XdsClient {
     if (rpcRetryTimer != null) {
       rpcRetryTimer.cancel();
     }
-    if (rdsRespTimer != null) {
-      rdsRespTimer.cancel();
-      rdsRespTimer = null;
-    }
-    for (ScheduledHandle handle : cdsRespTimers.values()) {
-      handle.cancel();
-    }
-    cdsRespTimers.clear();
-    for (ScheduledHandle handle :edsRespTimers.values()) {
-      handle.cancel();
-    }
-    edsRespTimers.clear();
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -759,7 +759,6 @@ final class XdsClientImpl extends XdsClient {
     }
     clusterNamesToEndpointUpdates.keySet().retainAll(edsServices);
 
-    // Disarm initial fetch timers for received resources.
     for (String clusterName : clusterUpdates.keySet()) {
       if (cdsRespTimers.containsKey(clusterName)) {
         cdsRespTimers.get(clusterName).cancel();

--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -353,7 +353,8 @@ final class XdsClientImpl extends XdsClient {
       adsStream.sendXdsRequest(ADS_TYPE_URL_EDS, endpointWatchers.keySet());
       ScheduledHandle timeoutHandle =
           syncContext
-              .schedule(new EdsResourceFetchTimeoutTask(clusterName),
+              .schedule(
+                  new EdsResourceFetchTimeoutTask(clusterName),
                   INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS, timeService);
       edsRespTimers.put(clusterName, timeoutHandle);
     }

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -60,6 +60,7 @@ import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -278,6 +279,7 @@ public class XdsNameResolverTest {
     responseObserver.onNext(
         buildLdsResponseForCluster("0", "bar.googleapis.com", 80, clusterName, "0000"));
 
+    fakeClock.forwardTime(XdsClientImpl.INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
     ArgumentCaptor<ResolutionResult> resolutionResultCaptor = ArgumentCaptor.forClass(null);
     verify(mockListener).onResult(resolutionResultCaptor.capture());
     ResolutionResult result = resolutionResultCaptor.getValue();
@@ -345,6 +347,7 @@ public class XdsNameResolverTest {
         buildLdsResponseForCluster("0", "bar.googleapis.com", 80,
             "cluster-bar.googleapis.com", "0000"));
 
+    fakeClock.forwardTime(XdsClientImpl.INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
     ArgumentCaptor<ResolutionResult> resolutionResultCaptor = ArgumentCaptor.forClass(null);
     verify(mockListener).onResult(resolutionResultCaptor.capture());
     ResolutionResult result = resolutionResultCaptor.getValue();


### PR DESCRIPTION
We use timeout to conclude resource not exist in xDS protocol.

RDS and EDS protocols are quasi-incremental, each response may not include all the requested resources that present on server side. The way to conclude a requested resource not exist is to use a timeout. In Envoy, this timeout is defined as [initial fetch timeout](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/config_source.proto#envoy-api-field-core-configsource-initial-fetch-timeout), which is set up at the time client starts subscribing to some resource and disarmed at the time client receives update for that resource. In gRPC's implementation, we set this timeout to be constant 15 seconds, instead of getting its value from ConfigSource proto message.

Initial fetch timeout was initially considered to be not required for LDS and CDS. But gRPC is trying to avoid the temporary inconsistency in the case of racing request/response.  https://github.com/envoyproxy/envoy/pull/9322 clarifies that case and suggests to use a timeout for LDS/CDS as well.