### PR TITLE
api: Add ExperimentalApi to Metadata.BinaryStreamMarshaller

### DIFF
--- a/api/src/main/java/io/grpc/Metadata.java
+++ b/api/src/main/java/io/grpc/Metadata.java
@@ -614,6 +614,7 @@ public final class Metadata {
   }
 
   /** Marshaller for metadata values that are serialized to an InputStream. */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/6575")
   public interface BinaryStreamMarshaller<T> {
     /**
      * Serializes a metadata value to an {@link InputStream}.
@@ -685,6 +686,7 @@ public final class Metadata {
      * @param name Must contain only the valid key characters as defined in the class comment. Must
      *     end with {@link #BINARY_HEADER_SUFFIX}.
      */
+    @ExperimentalApi("https://github.com/grpc/grpc-java/issues/6575")
     public static <T> Key<T> of(String name, BinaryStreamMarshaller<T> marshaller) {
       return new LazyStreamBinaryKey<>(name, marshaller);
     }


### PR DESCRIPTION
This was missed in d1078591 and the API has not yet been released.

CC @markb74. This is our standard procedure for new APIs. Shouldn't impact you much. If we make any incompatible changes we will fix internal references. Only risk is for unsubmitted CLs, but we aren't planning on any changes soon.