### PR TITLE
xds: rename experimental_cds policy name to cds_experimental

### DIFF
--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
@@ -48,7 +48,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 
 /**
- * Load balancer for experimental_cds LB policy.
+ * Load balancer for cds_experimental LB policy.
  */
 public final class CdsLoadBalancer extends LoadBalancer {
   private final ChannelLogger channelLogger;

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancerProvider.java
@@ -31,12 +31,12 @@ import java.util.Objects;
 /**
  * The provider for the "cds" balancing policy.  This class should not be directly referenced in
  * code.  The policy should be accessed through {@link io.grpc.LoadBalancerRegistry#getProvider}
- * with the name "cds" (currently "experimental_cds").
+ * with the name "cds" (currently "cds_experimental").
  */
 @Internal
 public class CdsLoadBalancerProvider extends LoadBalancerProvider {
 
-  static final String CDS_POLICY_NAME = "experimental_cds";
+  static final String CDS_POLICY_NAME = "cds_experimental";
   private static final String CLUSTER_KEY = "cluster";
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -139,7 +139,7 @@ final class XdsNameResolver extends NameResolver {
         String serviceConfig = "{\n"
             + "  \"loadBalancingConfig\": [\n"
             + "    {\n"
-            + "      \"experimental_cds\": {\n"
+            + "      \"cds_experimental\": {\n"
             + "        \"cluster\": \"" + update.getClusterName() + "\"\n"
             + "      }\n"
             + "    }\n"

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -263,9 +263,9 @@ public class XdsNameResolverTest {
     List<Map<String, ?>> rawLbConfigs =
         (List<Map<String, ?>>) serviceConfig.get("loadBalancingConfig");
     Map<String, ?> lbConfig = Iterables.getOnlyElement(rawLbConfigs);
-    assertThat(lbConfig.keySet()).containsExactly("experimental_cds");
+    assertThat(lbConfig.keySet()).containsExactly("cds_experimental");
     @SuppressWarnings("unchecked")
-    Map<String, ?> rawConfigValues = (Map<String, ?>) lbConfig.get("experimental_cds");
+    Map<String, ?> rawConfigValues = (Map<String, ?>) lbConfig.get("cds_experimental");
     assertThat(rawConfigValues).containsExactly("cluster", clusterName);
   }
 
@@ -308,8 +308,8 @@ public class XdsNameResolverTest {
     List<Map<String, ?>> rawLbConfigs =
         (List<Map<String, ?>>) serviceConfig.get("loadBalancingConfig");
     Map<String, ?> lbConfig = Iterables.getOnlyElement(rawLbConfigs);
-    assertThat(lbConfig.keySet()).containsExactly("experimental_cds");
-    Map<String, ?> rawConfigValues = (Map<String, ?>) lbConfig.get("experimental_cds");
+    assertThat(lbConfig.keySet()).containsExactly("cds_experimental");
+    Map<String, ?> rawConfigValues = (Map<String, ?>) lbConfig.get("cds_experimental");
     assertThat(rawConfigValues).containsExactly("cluster", "cluster-foo.googleapis.com");
 
     // Simulate receiving another LDS response that tells client to do RDS.
@@ -331,8 +331,8 @@ public class XdsNameResolverTest {
     serviceConfig = result.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
     rawLbConfigs = (List<Map<String, ?>>) serviceConfig.get("loadBalancingConfig");
     lbConfig = Iterables.getOnlyElement(rawLbConfigs);
-    assertThat(lbConfig.keySet()).containsExactly("experimental_cds");
-    rawConfigValues = (Map<String, ?>) lbConfig.get("experimental_cds");
+    assertThat(lbConfig.keySet()).containsExactly("cds_experimental");
+    rawConfigValues = (Map<String, ?>) lbConfig.get("cds_experimental");
     assertThat(rawConfigValues).containsExactly("cluster", "cluster-blade.googleapis.com");
   }
 
@@ -367,9 +367,9 @@ public class XdsNameResolverTest {
     List<Map<String, ?>> rawLbConfigs =
         (List<Map<String, ?>>) serviceConfig.get("loadBalancingConfig");
     Map<String, ?> lbConfig = Iterables.getOnlyElement(rawLbConfigs);
-    assertThat(lbConfig.keySet()).containsExactly("experimental_cds");
+    assertThat(lbConfig.keySet()).containsExactly("cds_experimental");
     @SuppressWarnings("unchecked")
-    Map<String, ?> rawConfigValues = (Map<String, ?>) lbConfig.get("experimental_cds");
+    Map<String, ?> rawConfigValues = (Map<String, ?>) lbConfig.get("cds_experimental");
     assertThat(rawConfigValues).containsExactly("cluster", "cluster-foo.googleapis.com");
   }
 


### PR DESCRIPTION
Incorporating comment https://github.com/grpc/grpc-java/pull/6504#discussion_r363463413. Currently there is no cross-language resolver sending CDS config so there is no impact of the change.