### PR TITLE
Upgrade robolectric version to 4.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,7 @@ subprojects {
             mockito: 'org.mockito:mockito-core:2.28.2',
             truth: 'com.google.truth:truth:1.0',
             guava_testlib: "com.google.guava:guava-testlib:${guavaVersion}",
-            robolectric: "org.robolectric:robolectric:3.5.1",
+            robolectric: "org.robolectric:robolectric:4.3.1",
 
             // Benchmark dependencies
             hdrhistogram: 'org.hdrhistogram:HdrHistogram:2.1.10',


### PR DESCRIPTION
If compiling `grpc-cronet` with Java 9+, unit tests fail with `java.lang.NoClassDefFoundError: android/content/pm/PackageManager$NameNotFoundException`. Upgrading to Robolectric 4 seems to fix this.


/cc @sanjaypujare 