### PR TITLE
core: fix bugs in service config error handling

### DIFF
--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory2.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory2.java
@@ -167,7 +167,7 @@ public final class AutoConfiguredLoadBalancerFactory2 {
             ResolvedAddresses.newBuilder()
                 .setAddresses(resolvedSelection.serverList)
                 .setAttributes(attributes)
-                .setLoadBalancingPolicyConfig(lbConfig)
+                .setLoadBalancingPolicyConfig(lbConfig != null ? lbConfig.getConfig() : null)
                 .build());
         return Status.OK;
       }

--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory2.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory2.java
@@ -149,7 +149,7 @@ public final class AutoConfiguredLoadBalancerFactory2 {
             ChannelLogLevel.INFO, "Load balancer changed from {0} to {1}",
             old.getClass().getSimpleName(), delegate.getClass().getSimpleName());
       }
-      ConfigOrError lbConfig = selection.config;
+      Object lbConfig = selection.config;
       if (lbConfig != null) {
         helper.getChannelLogger().log(
             ChannelLogLevel.DEBUG, "Load-balancing config: {0}", selection.config);
@@ -167,7 +167,7 @@ public final class AutoConfiguredLoadBalancerFactory2 {
             ResolvedAddresses.newBuilder()
                 .setAddresses(resolvedSelection.serverList)
                 .setAttributes(attributes)
-                .setLoadBalancingPolicyConfig(lbConfig != null ? lbConfig.getConfig() : null)
+                .setLoadBalancingPolicyConfig(lbConfig)
                 .build());
         return Status.OK;
       }
@@ -337,7 +337,7 @@ public final class AutoConfiguredLoadBalancerFactory2 {
               return parsedLbPolicyConfig;
             }
             return ConfigOrError.fromConfig(
-                new PolicySelection(provider, serviceConfig, parsedLbPolicyConfig));
+                new PolicySelection(provider, serviceConfig, parsedLbPolicyConfig.getConfig()));
           }
         }
         return ConfigOrError.fromError(
@@ -364,12 +364,12 @@ public final class AutoConfiguredLoadBalancerFactory2 {
   static final class PolicySelection {
     final LoadBalancerProvider provider;
     @Nullable final Map<String, ?> rawConfig;
-    @Nullable final ConfigOrError config;
+    @Nullable final Object config;
 
     PolicySelection(
         LoadBalancerProvider provider,
         @Nullable Map<String, ?> rawConfig,
-        @Nullable ConfigOrError config) {
+        @Nullable Object config) {
       this.provider = checkNotNull(provider, "provider");
       this.rawConfig = rawConfig;
       this.config = config;

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl2.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl2.java
@@ -249,7 +249,6 @@ final class ManagedChannelImpl2 extends ManagedChannel implements
   private final ChannelLogger channelLogger;
   private final InternalChannelz channelz;
 
-  private final ScParser serviceConfigParser;
   // Must be mutated and read from syncContext
   // a flag for doing channel tracing when flipped
   private ResolutionState lastResolutionState = ResolutionState.NO_RESOLUTION;
@@ -583,7 +582,7 @@ final class ManagedChannelImpl2 extends ManagedChannel implements
         new ExecutorHolder(
             checkNotNull(builder.offloadExecutorPool, "offloadExecutorPool"));
     this.nameResolverRegistry = builder.nameResolverRegistry;
-    this.serviceConfigParser =
+    ScParser serviceConfigParser =
         new ScParser(
             retryEnabled,
             builder.maxRetryAttempts,
@@ -1333,13 +1332,9 @@ final class ManagedChannelImpl2 extends ManagedChannel implements
           ConfigOrError configOrError = resolutionResult.getServiceConfig();
           ServiceConfigHolder validServiceConfig = null;
           Status serviceConfigError = null;
-          Map<String, ?> rawServiceConfig =
-              resolutionResult.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
-          if (configOrError == null && rawServiceConfig != null) {
-            // use service config json in deprecated attributes
-            configOrError = serviceConfigParser.parseServiceConfig(rawServiceConfig);
-          }
           if (configOrError != null) {
+            Map<String, ?> rawServiceConfig =
+                resolutionResult.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
             validServiceConfig = configOrError.getConfig() == null
                 ? null
                 : new ServiceConfigHolder(

--- a/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest2.java
+++ b/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest2.java
@@ -687,7 +687,7 @@ public class AutoConfiguredLoadBalancerFactoryTest2 {
     verify(channelLogger).log(
         eq(ChannelLogLevel.DEBUG),
         eq("Load-balancing config: {0}"),
-        eq(testLbParsedConfig));
+        eq(testLbParsedConfig.getConfig()));
     verifyNoMoreInteractions(channelLogger);
 
     testLbParsedConfig = ConfigOrError.fromConfig("bar");
@@ -703,7 +703,7 @@ public class AutoConfiguredLoadBalancerFactoryTest2 {
     verify(channelLogger).log(
         eq(ChannelLogLevel.DEBUG),
         eq("Load-balancing config: {0}"),
-        eq(testLbParsedConfig));
+        eq(testLbParsedConfig.getConfig()));
     verifyNoMoreInteractions(channelLogger);
 
     servers = Collections.singletonList(new EquivalentAddressGroup(
@@ -815,7 +815,7 @@ public class AutoConfiguredLoadBalancerFactoryTest2 {
     ConfigOrError parsed = lbf.parseLoadBalancerPolicy(serviceConfig, channelLogger);
     assertThat(parsed).isNotNull();
     assertThat(parsed.getConfig()).isNotNull();
-    assertThat(((PolicySelection) parsed.getConfig()).config.getConfig()).isNotNull();
+    assertThat(((PolicySelection) parsed.getConfig()).config).isNotNull();
   }
 
   @Test
@@ -827,7 +827,7 @@ public class AutoConfiguredLoadBalancerFactoryTest2 {
     ConfigOrError parsed = lbf.parseLoadBalancerPolicy(serviceConfig, channelLogger);
     assertThat(parsed).isNotNull();
     assertThat(parsed.getConfig()).isNotNull();
-    assertThat(((PolicySelection) parsed.getConfig()).config.getConfig()).isNotNull();
+    assertThat(((PolicySelection) parsed.getConfig()).config).isNotNull();
     verify(channelLogger).log(
         eq(ChannelLogLevel.DEBUG),
         eq("{0} specified by Service Config are not available"),

--- a/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest2.java
+++ b/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest2.java
@@ -386,7 +386,7 @@ public class AutoConfiguredLoadBalancerFactoryTest2 {
     verify(testLbBalancer2).handleResolvedAddresses(resultCaptor.capture());
     assertThat(resultCaptor.getValue().getAddresses()).isEmpty();
     assertThat(resultCaptor.getValue().getLoadBalancingPolicyConfig())
-        .isEqualTo(nextParsedConfigOrError2.get());
+        .isEqualTo(nextParsedConfigOrError2.get().getConfig());
     assertThat(resultCaptor.getValue().getAttributes().get(ATTR_LOAD_BALANCING_CONFIG))
         .isEqualTo(rawServiceConfig);
   }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest2.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest2.java
@@ -1006,7 +1006,7 @@ public class ManagedChannelImplTest2 {
             new PolicySelection(
                 mockLoadBalancerProvider,
                 parseConfig(rawLbConfig),
-                ConfigOrError.fromConfig(new Object())));
+                new Object()));
     nameResolverFactory.nextConfigOrError.set(ConfigOrError.fromConfig(parsedServiceConfig));
     nameResolverFactory.nextRawServiceConfig.set(rawServiceConfig);
     channelBuilder.nameResolverFactory(nameResolverFactory);
@@ -3486,7 +3486,7 @@ public class ManagedChannelImplTest2 {
     Object fakeLbConfig = new Object();
     PolicySelection lbConfigs =
         new PolicySelection(
-            mockLoadBalancerProvider, rawServiceConfig, ConfigOrError.fromConfig(fakeLbConfig));
+            mockLoadBalancerProvider, rawServiceConfig, fakeLbConfig);
     mockLoadBalancerProvider.parseLoadBalancingPolicyConfig(rawServiceConfig);
     ManagedChannelServiceConfig2 managedChannelServiceConfig =
         createManagedChannelServiceConfig(rawServiceConfig, lbConfigs);

--- a/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
+++ b/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
@@ -43,7 +43,6 @@ import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.NameResolver;
 import io.grpc.NameResolver.ConfigOrError;
-import io.grpc.NameResolver.ServiceConfigParser;
 import io.grpc.Status;
 import java.net.SocketAddress;
 import java.net.URI;
@@ -488,34 +487,6 @@ public class ServiceConfigErrorHandlingTest {
     assertThat(channel.getState(false)).isEqualTo(ConnectivityState.IDLE);
   }
 
-  @Test
-  public void serviceConfigUsingAttributes() throws Exception {
-    FakeNameResolverFactory nameResolverFactory =
-        new FakeNameResolverFactory.Builder(expectedUri)
-            .setServers(ImmutableList.of(addressGroup))
-            .setEnableServiceConfigParsing(false)
-            .build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
-
-    Map<String, Object> rawServiceConfig =
-        parseJson("{\"loadBalancingConfig\": [{\"mock_lb\": {\"check\": \"1st raw config\"}}]}");
-    nameResolverFactory.nextRawServiceConfig.set(rawServiceConfig);
-
-    createChannel();
-
-    ArgumentCaptor<ResolvedAddresses> resultCaptor =
-        ArgumentCaptor.forClass(ResolvedAddresses.class);
-    verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
-    ResolvedAddresses resolvedAddresses = resultCaptor.getValue();
-    assertThat(resolvedAddresses.getAddresses()).containsExactly(addressGroup);
-    assertThat(resolvedAddresses.getLoadBalancingPolicyConfig()).isEqualTo("1st raw config");
-    assertThat(resolvedAddresses.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG))
-        .isEqualTo(rawServiceConfig);
-    verify(mockLoadBalancer, never()).handleNameResolutionError(any(Status.class));
-
-    assertThat(channel.getState(false)).isNotEqualTo(ConnectivityState.TRANSIENT_FAILURE);
-  }
-
   private static final class ChannelBuilder
       extends AbstractManagedChannelImplBuilder<ChannelBuilder> {
 
@@ -552,17 +523,14 @@ public class ServiceConfigErrorHandlingTest {
     final boolean resolvedAtStart;
     final ArrayList<FakeNameResolver> resolvers = new ArrayList<>();
     final AtomicReference<Map<String, ?>> nextRawServiceConfig = new AtomicReference<>();
-    final boolean enableServiceConfigParsing;
 
     FakeNameResolverFactory(
         URI expectedUri,
         List<EquivalentAddressGroup> servers,
-        boolean resolvedAtStart,
-        boolean enableServiceConfigParsing) {
+        boolean resolvedAtStart) {
       this.expectedUri = expectedUri;
       this.servers = servers;
       this.resolvedAtStart = resolvedAtStart;
-      this.enableServiceConfigParsing = enableServiceConfigParsing;
     }
 
     @Override
@@ -571,17 +539,7 @@ public class ServiceConfigErrorHandlingTest {
         return null;
       }
       assertEquals(DEFAULT_PORT, args.getDefaultPort());
-      FakeNameResolver resolver;
-      if (enableServiceConfigParsing) {
-        resolver = new FakeNameResolver(args.getServiceConfigParser());
-      } else {
-        resolver = new FakeNameResolver(new ServiceConfigParser() {
-          @Override
-          public ConfigOrError parseServiceConfig(Map<String, ?> rawServiceConfig) {
-            return null;
-          }
-        });
-      }
+      FakeNameResolver resolver = new FakeNameResolver(args.getServiceConfigParser());
       resolvers.add(resolver);
       return resolver;
     }
@@ -653,7 +611,6 @@ public class ServiceConfigErrorHandlingTest {
       final URI expectedUri;
       List<EquivalentAddressGroup> servers = ImmutableList.of();
       boolean resolvedAtStart = true;
-      boolean enableServiceConfigParsing = true;
 
       Builder(URI expectedUri) {
         this.expectedUri = expectedUri;
@@ -664,14 +621,8 @@ public class ServiceConfigErrorHandlingTest {
         return this;
       }
 
-      Builder setEnableServiceConfigParsing(boolean enableServiceConfigParsing) {
-        this.enableServiceConfigParsing = enableServiceConfigParsing;
-        return this;
-      }
-
       FakeNameResolverFactory build() {
-        return new FakeNameResolverFactory(
-            expectedUri, servers, resolvedAtStart, enableServiceConfigParsing);
+        return new FakeNameResolverFactory(expectedUri, servers, resolvedAtStart);
       }
     }
   }

--- a/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
+++ b/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
@@ -270,7 +270,7 @@ public class ServiceConfigErrorHandlingTest {
     verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
     ResolvedAddresses resolvedAddresses = resultCaptor.getValue();
     assertThat(resolvedAddresses.getAddresses()).containsExactly(addressGroup);
-    assertThat(getLbPolicyConfig(resolvedAddresses)).isEqualTo("12");
+    assertThat(resolvedAddresses.getLoadBalancingPolicyConfig()).isEqualTo("12");
     assertThat(resolvedAddresses.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG))
         .isEqualTo(rawServiceConfig);
     verify(mockLoadBalancer, never()).handleNameResolutionError(any(Status.class));
@@ -315,7 +315,7 @@ public class ServiceConfigErrorHandlingTest {
 
     ResolvedAddresses resolvedAddresses = resultCaptor.getValue();
     assertThat(resolvedAddresses.getAddresses()).isEmpty();
-    assertThat(getLbPolicyConfig(resolvedAddresses)).isEqualTo("val");;
+    assertThat(resolvedAddresses.getLoadBalancingPolicyConfig()).isEqualTo("val");;
 
     verify(mockLoadBalancer, never()).handleNameResolutionError(any(Status.class));
     assertThat(channel.getState(false)).isNotEqualTo(ConnectivityState.TRANSIENT_FAILURE);
@@ -340,7 +340,7 @@ public class ServiceConfigErrorHandlingTest {
     verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
     ResolvedAddresses resolvedAddresses = resultCaptor.getValue();
     assertThat(resolvedAddresses.getAddresses()).containsExactly(addressGroup);
-    assertThat(getLbPolicyConfig(resolvedAddresses)).isEqualTo("foo");
+    assertThat(resolvedAddresses.getLoadBalancingPolicyConfig()).isEqualTo("foo");
     verify(mockLoadBalancer, never()).handleNameResolutionError(any(Status.class));
 
     assertThat(channel.getState(false)).isNotEqualTo(ConnectivityState.TRANSIENT_FAILURE);
@@ -362,7 +362,7 @@ public class ServiceConfigErrorHandlingTest {
     verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
     ResolvedAddresses resolvedAddresses = resultCaptor.getValue();
     assertThat(resolvedAddresses.getAddresses()).containsExactly(addressGroup);
-    assertThat(getLbPolicyConfig(resolvedAddresses)).isNull();
+    assertThat(resolvedAddresses.getLoadBalancingPolicyConfig()).isNull();
     assertThat(resolvedAddresses.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG))
         .isEmpty();
     verify(mockLoadBalancer, never()).handleNameResolutionError(any(Status.class));
@@ -390,7 +390,7 @@ public class ServiceConfigErrorHandlingTest {
     verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
     ResolvedAddresses resolvedAddresses = resultCaptor.getValue();
     assertThat(resolvedAddresses.getAddresses()).containsExactly(addressGroup);
-    assertThat(getLbPolicyConfig(resolvedAddresses)).isEqualTo("foo");
+    assertThat(resolvedAddresses.getLoadBalancingPolicyConfig()).isEqualTo("foo");
     assertThat(resolvedAddresses.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG))
         .isEqualTo(defaultServiceConfig);
     verify(mockLoadBalancer, never()).handleNameResolutionError(any(Status.class));
@@ -438,7 +438,7 @@ public class ServiceConfigErrorHandlingTest {
 
     ResolvedAddresses resolvedAddresses = resultCaptor.getValue();
     assertThat(resolvedAddresses.getAddresses()).containsExactly(addressGroup);
-    assertThat(getLbPolicyConfig(resolvedAddresses)).isEqualTo("mate");
+    assertThat(resolvedAddresses.getLoadBalancingPolicyConfig()).isEqualTo("mate");
     assertThat(resolvedAddresses.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG))
         .isEqualTo(defaultServiceConfig);
     verify(mockLoadBalancer, never()).handleNameResolutionError(any(Status.class));
@@ -465,7 +465,7 @@ public class ServiceConfigErrorHandlingTest {
     verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
     ResolvedAddresses resolvedAddresses = resultCaptor.getValue();
     assertThat(resolvedAddresses.getAddresses()).containsExactly(addressGroup);
-    assertThat(getLbPolicyConfig(resolvedAddresses)).isEqualTo("1st raw config");
+    assertThat(resolvedAddresses.getLoadBalancingPolicyConfig()).isEqualTo("1st raw config");
     assertThat(resolvedAddresses.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG))
         .isEqualTo(rawServiceConfig);
     verify(mockLoadBalancer, never()).handleNameResolutionError(any(Status.class));
@@ -481,7 +481,7 @@ public class ServiceConfigErrorHandlingTest {
     verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
     ResolvedAddresses newResolvedAddress = resultCaptor.getValue();
     // should use previous service config because new service config is invalid.
-    assertThat(getLbPolicyConfig(resolvedAddresses)).isEqualTo("1st raw config");
+    assertThat(resolvedAddresses.getLoadBalancingPolicyConfig()).isEqualTo("1st raw config");
     assertThat(newResolvedAddress.getAttributes()).isNotEqualTo(Attributes.EMPTY);
     assertThat(newResolvedAddress.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG))
         .isEqualTo(rawServiceConfig);
@@ -660,13 +660,5 @@ public class ServiceConfigErrorHandlingTest {
   @SuppressWarnings("unchecked")
   private static Map<String, Object> parseJson(String json) throws Exception {
     return (Map<String, Object>) JsonParser.parse(json);
-  }
-
-  @Nullable
-  private static Object getLbPolicyConfig(ResolvedAddresses resolvedAddresses) {
-    ConfigOrError loadBalancingPolicyConfig =
-        (ConfigOrError) resolvedAddresses.getLoadBalancingPolicyConfig();
-    return
-        loadBalancingPolicyConfig == null ? null : loadBalancingPolicyConfig.getConfig();
   }
 }


### PR DESCRIPTION
~1. Allow legacy way to pass service config via attributes~
2. fix AutoConfiguredLBFactory may populate ConfigOrError instead of
actual config.