### PR TITLE
core: change catch blocks for Android <19

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -576,8 +576,14 @@ public abstract class AbstractManagedChannelImplBuilder
                     recordStartedRpcs,
                     recordFinishedRpcs,
                     recordRealTimeMetrics);
-      } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
-          | InvocationTargetException e) {
+      } catch (ClassNotFoundException e) {
+        // Replace these separate catch statements with multicatch when Android min-API >= 19
+        log.log(Level.FINE, "Unable to apply census stats", e);
+      } catch (NoSuchMethodException e) {
+        log.log(Level.FINE, "Unable to apply census stats", e);
+      } catch (IllegalAccessException e) {
+        log.log(Level.FINE, "Unable to apply census stats", e);
+      } catch (InvocationTargetException e) {
         log.log(Level.FINE, "Unable to apply census stats", e);
       }
       if (statsInterceptor != null) {
@@ -595,9 +601,15 @@ public abstract class AbstractManagedChannelImplBuilder
         Method getClientInterceptroMethod =
             censusTracingAccessor.getDeclaredMethod("getClientInterceptor");
         tracingInterceptor = (ClientInterceptor) getClientInterceptroMethod.invoke(null);
-      } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
-          | InvocationTargetException e) {
-        log.log(Level.FINE, "Unable to apply census tracing", e);
+      } catch (ClassNotFoundException e) {
+        // Replace these separate catch statements with multicatch when Android min-API >= 19
+        log.log(Level.FINE, "Unable to apply census stats", e);
+      } catch (NoSuchMethodException e) {
+        log.log(Level.FINE, "Unable to apply census stats", e);
+      } catch (IllegalAccessException e) {
+        log.log(Level.FINE, "Unable to apply census stats", e);
+      } catch (InvocationTargetException e) {
+        log.log(Level.FINE, "Unable to apply census stats", e);
       }
       if (tracingInterceptor != null) {
         effectiveInterceptors.add(0, tracingInterceptor);

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -253,8 +253,14 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
                     recordStartedRpcs,
                     recordFinishedRpcs,
                     recordRealTimeMetrics);
-      } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
-          | InvocationTargetException e) {
+      } catch (ClassNotFoundException e) {
+        // Replace these separate catch statements with multicatch when Android min-API >= 19
+        log.log(Level.FINE, "Unable to apply census stats", e);
+      } catch (NoSuchMethodException e) {
+        log.log(Level.FINE, "Unable to apply census stats", e);
+      } catch (IllegalAccessException e) {
+        log.log(Level.FINE, "Unable to apply census stats", e);
+      } catch (InvocationTargetException e) {
         log.log(Level.FINE, "Unable to apply census stats", e);
       }
       if (censusStatsTracerFactory != null) {
@@ -270,9 +276,15 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
             censusTracingAccessor.getDeclaredMethod("getServerStreamTracerFactory");
         tracingStreamTracerFactory =
             (ServerStreamTracer.Factory) getServerStreamTracerFactoryMethod.invoke(null);
-      } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
-          | InvocationTargetException e) {
-        log.log(Level.FINE, "Unable to apply census tracing", e);
+      } catch (ClassNotFoundException e) {
+        // Replace these separate catch statements with multicatch when Android min-API >= 19
+        log.log(Level.FINE, "Unable to apply census stats", e);
+      } catch (NoSuchMethodException e) {
+        log.log(Level.FINE, "Unable to apply census stats", e);
+      } catch (IllegalAccessException e) {
+        log.log(Level.FINE, "Unable to apply census stats", e);
+      } catch (InvocationTargetException e) {
+        log.log(Level.FINE, "Unable to apply census stats", e);
       }
       if (tracingStreamTracerFactory != null) {
         tracerFactories.add(tracingStreamTracerFactory);


### PR DESCRIPTION
Caught by lint warning during import. Compiler optimizations may cause issues with older Android versions.