### PR TITLE
core: fix a race in ServerImpl for multi-transport-server

### DIFF
--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -420,7 +420,6 @@ public class ServerImplTest {
     } catch (IOException e) {
       assertSame(ex, e);
     }
-    verifyNoMoreInteractions(executorPool);
   }
 
   @Test


### PR DESCRIPTION
As discovered in #6601 and its partial fix #6610,  `ServerImpl` (https://github.com/grpc/grpc-java/blob/v1.26.0/core/src/main/java/io/grpc/internal/ServerImpl.java#L184) and  `NettyServer` (https://github.com/grpc/grpc-java/blob/v1.26.0/netty/src/main/java/io/grpc/netty/NettyServer.java#L251) have risk of deadlock.

Targeting the issue #6641.

There might be two things need be done to make the code healthy:
1. move `ts.start(listener)` out of synchronization block
2. move multiple port support from `ServerImpl` to `NettyServer`.

This PR is working on (1).