### PR TITLE
core,netty: let ServerListener.serverShutdown() only be called when InternalServer.start() returns

### DIFF
--- a/core/src/main/java/io/grpc/internal/ServerListener.java
+++ b/core/src/main/java/io/grpc/internal/ServerListener.java
@@ -32,8 +32,9 @@ public interface ServerListener {
 
   /**
    * The server is shutting down. No new transports will be processed, but existing transports may
-   * continue. Shutdown is only caused by a call to {@link InternalServer#shutdown()}. All
-   * resources have been released.
+   * continue. Shutdown is only caused by a call to {@link InternalServer#shutdown()} after
+   * {@link InternalServer#start(ServerListener)} returns successfully. All resources have been
+   * released.
    */
   void serverShutdown();
 }

--- a/netty/src/main/java/io/grpc/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServer.java
@@ -249,6 +249,10 @@ class NettyServer implements InternalServer, InternalWithLogId {
       throw new IOException("Failed to bind", future.cause());
     }
     channel = future.channel();
+
+    // We should never throw any Exception after this point to abide by the contract of
+    // ServerListener.serverShutdown()
+
     try {
       channel.eventLoop().execute(new Runnable() {
         @Override

--- a/netty/src/main/java/io/grpc/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServer.java
@@ -249,13 +249,17 @@ class NettyServer implements InternalServer, InternalWithLogId {
       throw new IOException("Failed to bind", future.cause());
     }
     channel = future.channel();
-    channel.eventLoop().execute(new Runnable() {
-      @Override
-      public void run() {
-        listenSocketStats = new ListenSocket(channel);
-        channelz.addListenSocket(listenSocketStats);
-      }
-    });
+    try {
+      channel.eventLoop().execute(new Runnable() {
+        @Override
+        public void run() {
+          listenSocketStats = new ListenSocket(channel);
+          channelz.addListenSocket(listenSocketStats);
+        }
+      });
+    } catch (RuntimeException e) {
+      log.log(Level.WARNING, "Error while starting server", e);
+    }
   }
 
   @Override


### PR DESCRIPTION
`ServerImpl.activeTransportServers` is broken, because `listener.serverShutdown()` may or may not be called when `start()` throws. Now change the API spec of `ServerListener.serverShutdown()` so that it won't be called if `start()` throws. 

This spec change is reasonable because `server.shutdown()` is never called if `Server.start()` throws in a lot of users' code, e.g.:

```
Server server = null;
try {
  server = ServerBuilder.forPort(8080).build().start();
} catch (IOException e) {
  // server is null, so shutdown() is never called for the half-baked server.
}

if (server != null) {
  server.shutdown();
} 
```