### PR TITLE
examples: Add hostname example (v1.27.x backport)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ install:
   - pushd examples && ./gradlew build && popd
   - pushd examples && mvn verify && popd
   - pushd examples/example-alts && ../gradlew build && popd
+  - pushd examples/example-hostname && ../gradlew build && popd
+  - pushd examples/example-hostname && mvn verify && popd
   - pushd examples/example-tls && ../gradlew clean build && popd
   - pushd examples/example-kotlin && ../gradlew build && popd
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -45,6 +45,8 @@ $ VERSION_FILES=(
   examples/example-alts/build.gradle
   examples/example-gauth/build.gradle
   examples/example-gauth/pom.xml
+  examples/example-hostname/build.gradle
+  examples/example-hostname/pom.xml
   examples/example-kotlin/build.gradle
   examples/example-kotlin/android/helloworld/app/build.gradle
   examples/example-tls/build.gradle

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -64,6 +64,10 @@ if [[ -z "${SKIP_TESTS:-}" ]]; then
   # --batch-mode reduces log spam
   mvn clean verify --batch-mode
   popd
+  pushd examples/example-hostname
+  ../gradlew build $GRADLE_FLAGS
+  mvn verify --batch-mode
+  popd
   pushd examples/example-tls
   mvn clean verify --batch-mode
   popd

--- a/examples/example-hostname/BUILD.bazel
+++ b/examples/example-hostname/BUILD.bazel
@@ -1,0 +1,50 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
+
+proto_library(
+    name = "helloworld_proto",
+    srcs = ["src/main/proto/helloworld/helloworld.proto"],
+)
+
+java_proto_library(
+    name = "helloworld_java_proto",
+    deps = [":helloworld_proto"],
+)
+
+java_grpc_library(
+    name = "helloworld_java_grpc",
+    srcs = [":helloworld_proto"],
+    deps = [":helloworld_java_proto"],
+)
+
+java_library(
+    name = "hostname_greeter",
+    testonly = 1,
+    srcs = [
+        "src/main/java/io/grpc/examples/hostname/HostnameGreeter.java",
+    ],
+    deps = [
+        ":helloworld_java_grpc",
+        ":helloworld_java_proto",
+        "@io_grpc_grpc_java//stub",
+    ],
+)
+
+java_binary(
+    name = "hostname-server",
+    testonly = 1,
+    srcs = [
+        "src/main/java/io/grpc/examples/hostname/HostnameServer.java",
+    ],
+    main_class = "io.grpc.examples.hostname.HostnameServer",
+    runtime_deps = [
+        "@io_grpc_grpc_java//netty",
+    ],
+    deps = [
+        ":hostname_greeter",
+        "@io_grpc_grpc_java//api",
+        "@io_grpc_grpc_java//services:health",
+        "@io_grpc_grpc_java//services:reflection",
+        "@io_grpc_grpc_proto//:health_java_proto",
+    ],
+)

--- a/examples/example-hostname/README.md
+++ b/examples/example-hostname/README.md
@@ -1,0 +1,60 @@
+gRPC Hostname Example
+=====================
+
+The hostname example is a Hello World server whose response includes its
+hostname. It also supports health and reflection services. This makes it a good
+server to test infrastructure, like load balancing.
+
+The example requires grpc-java to already be built. You are strongly encouraged
+to check out a git release tag, since there will already be a build of grpc
+available. Otherwise you must follow [COMPILING](../../COMPILING.md).
+
+### Build the example
+
+1. Build the hello-world example client. See [the examples README](../README.md)
+
+2. Build this server. From the `grpc-java/examples/examples-hostname` directory:
+```
+$ ../gradlew installDist
+```
+
+This creates the script `build/install/hostname-server/bin/hostname-server` that
+runs the example.
+
+To run the hostname example, run:
+
+```
+$ ./build/install/hostname/bin/hostname-server
+```
+
+And in a different terminal window run the hello-world client:
+
+```
+$ ../build/install/examples/bin/hello-world-client
+```
+
+### Maven
+
+If you prefer to use Maven:
+1. Build the hello-world example client. See [the examples README](../README.md)
+
+2. Run in this directory:
+```
+$ mvn verify
+$ # Run the server (from the examples-hostname directory)
+$ mvn exec:java -Dexec.mainClass=io.grpc.examples.hostname.HostnameServer
+$ # In another terminal run the client (from the examples directory)
+$ cd ..
+$ mvn exec:java -Dexec.mainClass=io.grpc.examples.helloworld.HelloWorldClient
+```
+
+### Bazel
+
+If you prefer to use Bazel, run from the `grpc-java/examples` directory:
+```
+$ bazel build :hello-world-client example-hostname:hostname-server
+$ # Run the server
+$ ./bazel-bin/example-hostname/hostname-server
+$ # In another terminal run the client
+$ ./bazel-bin/hello-world-client
+```

--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -1,0 +1,54 @@
+plugins {
+    id 'application' // Provide convenience executables for trying out the examples.
+    id 'java'
+
+    id "com.google.protobuf" version "0.8.10"
+}
+
+repositories {
+    maven { // The google mirror is less flaky than mavenCentral()
+        url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
+    mavenCentral()
+    mavenLocal()
+}
+
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
+// IMPORTANT: You probably want the non-SNAPSHOT version of gRPC. Make sure you
+// are looking at a tagged version of the example and not "master"!
+
+// Feel free to delete the comment at the next line. It is just for safely
+// updating the version in our release process.
+def grpcVersion = '1.27.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+def protobufVersion = '3.11.0'
+
+dependencies {
+    implementation "io.grpc:grpc-protobuf:${grpcVersion}"
+    implementation "io.grpc:grpc-stub:${grpcVersion}"
+    implementation "io.grpc:grpc-services:${grpcVersion}"
+    compileOnly "javax.annotation:javax.annotation-api:1.2"
+    runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
+
+    testImplementation 'junit:junit:4.12'
+    testImplementation "io.grpc:grpc-testing:${grpcVersion}"
+}
+
+protobuf {
+  protoc {
+    artifact = "com.google.protobuf:protoc:${protobufVersion}"
+  }
+  plugins {
+    grpc {
+      artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}"
+    }
+  }
+  generateProtoTasks {
+    all()*.plugins {
+      grpc {}
+    }
+  }
+}
+
+applicationName = 'hostname-server'
+mainClassName = 'io.grpc.examples.hostname.HostnameServer'

--- a/examples/example-hostname/pom.xml
+++ b/examples/example-hostname/pom.xml
@@ -1,0 +1,118 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.grpc</groupId>
+  <artifactId>example-hostname</artifactId>
+  <packaging>jar</packaging>
+  <!-- Feel free to delete the comment at the end of these lines. It is just
+       for safely updating the version in our release process. -->
+  <version>1.27.0-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <name>example-hostname</name>
+  <url>https://github.com/grpc/grpc-java</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <grpc.version>1.27.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <protoc.version>3.11.0</protoc.version>
+    <!-- required for jdk9 -->
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-bom</artifactId>
+        <version>${grpc.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-protobuf</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-services</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.2</version>
+      <scope>provided</scope> <!-- not needed at runtime -->
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty-shaded</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-testing</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.6.2</version>
+      </extension>
+    </extensions>
+    <plugins>
+      <plugin>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>0.6.1</version>
+        <configuration>
+          <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
+          <pluginId>grpc-java</pluginId>
+          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+              <goal>compile-custom</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.4.1</version>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireUpperBoundDeps/>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/examples/example-hostname/settings.gradle
+++ b/examples/example-hostname/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'hostname'

--- a/examples/example-hostname/src/main/java/io/grpc/examples/hostname/HostnameGreeter.java
+++ b/examples/example-hostname/src/main/java/io/grpc/examples/hostname/HostnameGreeter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.examples.hostname;
+
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Random;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/** Greeter implementation which replies identifying itself with its hostname. */
+public final class HostnameGreeter extends GreeterGrpc.GreeterImplBase {
+  private static final Logger logger = Logger.getLogger(HostnameGreeter.class.getName());
+
+  private final String serverName;
+
+  public HostnameGreeter(String serverName) {
+    if (serverName == null) {
+      serverName = determineHostname();
+    }
+    this.serverName = serverName;
+  }
+
+  @Override
+  public void sayHello(HelloRequest req, StreamObserver<HelloReply> responseObserver) {
+    HelloReply reply = HelloReply.newBuilder()
+        .setMessage("Hello " + req.getName() + ", from " + serverName)
+        .build();
+    responseObserver.onNext(reply);
+    responseObserver.onCompleted();
+  }
+
+  private static String determineHostname() {
+    try {
+      return InetAddress.getLocalHost().getHostName();
+    } catch (IOException ex) {
+      logger.log(Level.INFO, "Failed to determine hostname. Will generate one", ex);
+    }
+    // Strange. Well, let's make an identifier for ourselves.
+    return "generated-" + new Random().nextInt();
+  }
+}

--- a/examples/example-hostname/src/main/java/io/grpc/examples/hostname/HostnameServer.java
+++ b/examples/example-hostname/src/main/java/io/grpc/examples/hostname/HostnameServer.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.examples.hostname;
+
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
+import io.grpc.protobuf.services.ProtoReflectionService;
+import io.grpc.services.HealthStatusManager;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A server that hosts HostnameGreeter, plus infrastructure services like health and reflection.
+ *
+ * <p>This server is intended to be a general purpose "dummy" server.
+ */
+public final class HostnameServer {
+  public static void main(String[] args) throws IOException, InterruptedException {
+    int port = 50051;
+    String hostname = null;
+    if (args.length >= 1) {
+      try {
+        port = Integer.parseInt(args[0]);
+      } catch (NumberFormatException ex) {
+        System.err.println("Usage: [port [hostname]]");
+        System.err.println("");
+        System.err.println("  port      The listen port. Defaults to " + port);
+        System.err.println("  hostname  The name clients will see in greet responses. ");
+        System.err.println("            Defaults to the machine's hostname");
+        System.exit(1);
+      }
+    }
+    if (args.length >= 2) {
+      hostname = args[1];
+    }
+    HealthStatusManager health = new HealthStatusManager();
+    final Server server = ServerBuilder.forPort(port)
+        .addService(new HostnameGreeter(hostname))
+        .addService(ProtoReflectionService.newInstance())
+        .addService(health.getHealthService())
+        .build()
+        .start();
+    System.out.println("Listening on port " + port);
+    Runtime.getRuntime().addShutdownHook(new Thread() {
+      @Override
+      public void run() {
+        // Start graceful shutdown
+        server.shutdown();
+        try {
+          // Wait for RPCs to complete processing
+          if (!server.awaitTermination(30, TimeUnit.SECONDS)) {
+            // That was plenty of time. Let's cancel the remaining RPCs
+            server.shutdownNow();
+            // shutdownNow isn't instantaneous, so give a bit of time to clean resources up
+            // gracefully. Normally this will be well under a second.
+            server.awaitTermination(5, TimeUnit.SECONDS);
+          }
+        } catch (InterruptedException ex) {
+          server.shutdownNow();
+        }
+      }
+    });
+    // This would normally be tied to the service's dependencies. For example, if HostnameGreeter
+    // used a Channel to contact a required service, then when 'channel.getState() ==
+    // TRANSIENT_FAILURE' we'd want to set NOT_SERVING. But HostnameGreeter has no dependencies, so
+    // hard-coding SERVING is appropriate.
+    health.setStatus("", ServingStatus.SERVING);
+    server.awaitTermination();
+  }
+}

--- a/examples/example-hostname/src/main/proto/helloworld/helloworld.proto
+++ b/examples/example-hostname/src/main/proto/helloworld/helloworld.proto
@@ -1,0 +1,37 @@
+// Copyright 2015 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.helloworld";
+option java_outer_classname = "HelloWorldProto";
+option objc_class_prefix = "HLW";
+
+package helloworld;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+  string message = 1;
+}

--- a/examples/example-hostname/src/test/java/io/grpc/examples/hostname/HostnameGreeterTest.java
+++ b/examples/example-hostname/src/test/java/io/grpc/examples/hostname/HostnameGreeterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.examples.hostname;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.hostname.HostnameGreeter;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.testing.GrpcCleanupRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link HostnameGreeter}.
+ *
+ * <p>This is very similar to HelloWorldServerTest, so see it for more descriptions.
+ */
+@RunWith(JUnit4.class)
+public class HostnameGreeterTest {
+  @Rule
+  public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  private GreeterGrpc.GreeterBlockingStub blockingStub =
+        GreeterGrpc.newBlockingStub(grpcCleanup.register(
+            InProcessChannelBuilder.forName("hostname").directExecutor().build()));
+
+  @Test
+  public void sayHello_fixedHostname() throws Exception {
+    grpcCleanup.register(
+        InProcessServerBuilder.forName("hostname")
+          .directExecutor().addService(new HostnameGreeter("me")).build().start());
+
+    HelloReply reply =
+        blockingStub.sayHello(HelloRequest.newBuilder().setName("you").build());
+    assertEquals("Hello you, from me", reply.getMessage());
+  }
+
+  @Test
+  public void sayHello_dynamicHostname() throws Exception {
+    grpcCleanup.register(
+        InProcessServerBuilder.forName("hostname")
+          .directExecutor().addService(new HostnameGreeter(null)).build().start());
+
+    // Just verifing the service doesn't crash
+    HelloReply reply =
+        blockingStub.sayHello(HelloRequest.newBuilder().setName("anonymous").build());
+    assertTrue(reply.getMessage(), reply.getMessage().startsWith("Hello anonymous, from "));
+  }
+}

--- a/services/BUILD.bazel
+++ b/services/BUILD.bazel
@@ -64,6 +64,23 @@ java_library(
     ],
 )
 
+java_library(
+    name = "health",
+    srcs = [
+        "src/main/java/io/grpc/services/HealthServiceImpl.java",
+        "src/main/java/io/grpc/services/HealthStatusManager.java",
+    ],
+    deps = [
+        ":_health_java_grpc",
+        "//api",
+        "//context",
+        "//stub",
+        "@com_google_code_findbugs_jsr305//jar",
+        "@com_google_guava_guava//jar",
+        "@io_grpc_grpc_proto//:health_java_proto",
+    ],
+)
+
 # These shouldn't be here, but this is better than having
 # a circular dependency on grpc-proto and grpc-java.
 
@@ -79,4 +96,11 @@ java_grpc_library(
     srcs = ["@io_grpc_grpc_proto//:channelz_proto"],
     visibility = ["//visibility:private"],
     deps = ["@io_grpc_grpc_proto//:channelz_java_proto"],
+)
+
+java_grpc_library(
+    name = "_health_java_grpc",
+    srcs = ["@io_grpc_grpc_proto//:health_proto"],
+    visibility = ["//visibility:private"],
+    deps = ["@io_grpc_grpc_proto//:health_java_proto"],
 )


### PR DESCRIPTION
This is placed in its own directory since it depends on grpc-services.

This is a backport of #6604

I remembered to fix the version numbers to reference 1.27.0-SNAPSHOT