### PR TITLE
xds: enable keepalive for XDS channel

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -40,6 +40,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
@@ -491,19 +492,23 @@ abstract class XdsClient {
         ServerInfo serverInfo = servers.get(0);
         String serverUri = serverInfo.getServerUri();
         List<ChannelCreds> channelCredsList = serverInfo.getChannelCredentials();
-        ManagedChannel ch = null;
+        ManagedChannelBuilder<?> channelBuilder = null;
         // Use the first supported channel credentials configuration.
         // Currently, only "google_default" is supported.
         for (ChannelCreds creds : channelCredsList) {
           if (creds.getType().equals("google_default")) {
-            ch = GoogleDefaultChannelBuilder.forTarget(serverUri).build();
+            channelBuilder = GoogleDefaultChannelBuilder.forTarget(serverUri);
             break;
           }
         }
-        if (ch == null) {
-          ch = ManagedChannelBuilder.forTarget(serverUri).build();
+        if (channelBuilder == null) {
+          channelBuilder = ManagedChannelBuilder.forTarget(serverUri);
         }
-        return ch;
+
+        return channelBuilder
+            .keepAliveTime(5, TimeUnit.MINUTES)
+            .keepAliveTimeout(20, TimeUnit.SECONDS)
+            .build();
       }
     };
 

--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -507,7 +507,6 @@ abstract class XdsClient {
 
         return channelBuilder
             .keepAliveTime(5, TimeUnit.MINUTES)
-            .keepAliveTimeout(20, TimeUnit.SECONDS)
             .build();
       }
     };


### PR DESCRIPTION
XDS clients will use a keepalive time of 5 minutes ~~, and a keepalive timeout of 20 seconds~~.

Unfortunately it's not possible to be tested in unit test.