### PR TITLE
examples: Allow passing target and simplify lifecycle

### DIFF
--- a/examples/src/test/java/io/grpc/examples/routeguide/RouteGuideClientTest.java
+++ b/examples/src/test/java/io/grpc/examples/routeguide/RouteGuideClientTest.java
@@ -40,7 +40,6 @@ import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -96,14 +95,9 @@ public class RouteGuideClientTest {
     // Use a mutable service registry for later registering the service impl for each test case.
     grpcCleanup.register(InProcessServerBuilder.forName(serverName)
         .fallbackHandlerRegistry(serviceRegistry).directExecutor().build().start());
-    client =
-        new RouteGuideClient(InProcessChannelBuilder.forName(serverName).directExecutor());
+    client = new RouteGuideClient(grpcCleanup.register(
+        InProcessChannelBuilder.forName(serverName).directExecutor().build()));
     client.setTestHelper(testHelper);
-  }
-
-  @After
-  public void tearDown() throws Exception {
-    client.shutdown();
   }
 
   /**


### PR DESCRIPTION
The target can be provided on the command line to avoid needing to recompile
the example just to change where the server is located. We use a target instead
of addresses as that is the approach we have wanted to encourage for a while
since it allows choosing alternative name resolvers.

We typically encourage injecting Channels, not ManagedChannels, which has the
added benefit of simplifying the example. Less indirection makes for a better
example.

Swapping to target string could be done to examples-tls and examples-gauth as
well, but it would be much more invasive to the tls example and the gauth
example would need proper testing after the change.

------

These are things that I've wanted for a while, but now the target change is
necessary for the xds example and the rest sort of falls out of that.