### PR TITLE
xds: make EndpointWatcher.onError() trigger TRANSIENT_FAILURE only if no endpoint update received earlier

### DIFF
--- a/xds/src/main/java/io/grpc/xds/LookasideLb.java
+++ b/xds/src/main/java/io/grpc/xds/LookasideLb.java
@@ -437,7 +437,13 @@ final class LookasideLb extends LoadBalancer {
     @Override
     public void onError(Status error) {
       channelLogger.log(ChannelLogLevel.ERROR, "EDS load balancer received an error: {0}",  error);
-      lookasideLbHelper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(error));
+
+      // If we get an error before getting any valid result, we should put the channel in
+      // TRANSIENT_FAILURE; if they get an error after getting a valid result, we keep using the
+      // previous channel state.
+      if (!firstEndpointUpdateReceived) {
+        lookasideLbHelper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(error));
+      }
       endpointUpdateCallback.onError();
     }
   }

--- a/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
+++ b/xds/src/test/java/io/grpc/xds/LookasideLbTest.java
@@ -663,7 +663,7 @@ public class LookasideLbTest {
   }
 
   @Test
-  public void verifyErrorPropagation() {
+  public void verifyErrorPropagation_noPreviousEndpointUpdateReceived() {
     deliverResolvedAddresses(new XdsConfig(null, null, "edsServiceName1", null));
 
     verify(helper, never()).updateBalancingState(
@@ -672,6 +672,31 @@ public class LookasideLbTest {
     // Forwarding 20 seconds so that the xds client will deem EDS resource not available.
     fakeClock.forwardTime(20, TimeUnit.SECONDS);
     verify(helper).updateBalancingState(eq(TRANSIENT_FAILURE), any(SubchannelPicker.class));
+    verify(edsUpdateCallback).onError();
+  }
+
+  @Test
+  public void verifyErrorPropagation_withPreviousEndpointUpdateReceived() {
+    deliverResolvedAddresses(new XdsConfig(null, null, "edsServiceName1", null));
+    // Endpoint update received.
+    ClusterLoadAssignment clusterLoadAssignment =
+        buildClusterLoadAssignment("edsServiceName1",
+            ImmutableList.of(
+                buildLocalityLbEndpoints("region1", "zone1", "subzone1",
+                    ImmutableList.of(
+                        buildLbEndpoint("192.168.0.1", 8080, HEALTHY, 2)),
+                    1, 0)),
+            ImmutableList.of(buildDropOverload("throttle", 1000)));
+    receiveEndpointUpdate(clusterLoadAssignment);
+
+    verify(helper, never()).updateBalancingState(
+        eq(TRANSIENT_FAILURE), any(SubchannelPicker.class));
+    verify(edsUpdateCallback, never()).onError();
+
+    // XdsClient stream receives an error.
+    responseObserver.onError(new RuntimeException("fake error"));
+    verify(helper, never()).updateBalancingState(
+        eq(TRANSIENT_FAILURE), any(SubchannelPicker.class));
     verify(edsUpdateCallback).onError();
   }
 


### PR DESCRIPTION
For `EndpointWatcher.onError()`, if we get the error before getting any valid result, we should put the channel in TRANSIENT_FAILURE; if they get the error after getting a valid result, we keep using the previous channel state.

This will be roughly in line with c-core https://github.com/grpc/grpc/blob/v1.26.0/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc#L646 except requesting re-resolution.