### PR TITLE
core, grpclb: change policy selection strategy for Grpclb policy (take one: eliminate special logic for deciding grpclb policy in core)

### DIFF
--- a/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
@@ -223,6 +223,7 @@ public final class AltsProtocolNegotiator {
       return SCHEME;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public ChannelHandler newHandler(GrpcHttp2ConnectionHandler grpcHandler) {
       ChannelHandler gnh = InternalProtocolNegotiators.grpcNegotiationHandler(grpcHandler);

--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
@@ -44,15 +44,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 // TODO(creamsoup) fully deprecate LoadBalancer.ATTR_LOAD_BALANCING_CONFIG
 @SuppressWarnings("deprecation")
 public final class AutoConfiguredLoadBalancerFactory {
-  private static final Logger logger =
-      Logger.getLogger(AutoConfiguredLoadBalancerFactory.class.getName());
-  private static final String GRPCLB_POLICY_NAME = "grpclb";
 
   private final LoadBalancerRegistry registry;
   private final String defaultPolicy;
@@ -92,7 +88,6 @@ public final class AutoConfiguredLoadBalancerFactory {
     private final Helper helper;
     private LoadBalancer delegate;
     private LoadBalancerProvider delegateProvider;
-    private boolean roundRobinDueToGrpclbDepMissing;
 
     AutoConfiguredLoadBalancer(Helper helper) {
       this.helper = helper;
@@ -125,48 +120,53 @@ public final class AutoConfiguredLoadBalancerFactory {
       }
       PolicySelection policySelection =
           (PolicySelection) resolvedAddresses.getLoadBalancingPolicyConfig();
-      ResolvedPolicySelection resolvedSelection;
 
-      try {
-        resolvedSelection = resolveLoadBalancerProvider(servers, policySelection);
-      } catch (PolicyException e) {
-        Status s = Status.INTERNAL.withDescription(e.getMessage());
-        helper.updateBalancingState(ConnectivityState.TRANSIENT_FAILURE, new FailingPicker(s));
-        delegate.shutdown();
-        delegateProvider = null;
-        delegate = new NoopLoadBalancer();
-        return Status.OK;
+      if (policySelection == null) {
+        LoadBalancerProvider defaultProvider;
+        try {
+          defaultProvider = getProviderOrThrow(defaultPolicy, "using default policy");
+        } catch (PolicyException e) {
+          Status s = Status.INTERNAL.withDescription(e.getMessage());
+          helper.updateBalancingState(ConnectivityState.TRANSIENT_FAILURE, new FailingPicker(s));
+          delegate.shutdown();
+          delegateProvider = null;
+          delegate = new NoopLoadBalancer();
+          return Status.OK;
+        }
+        policySelection =
+            new PolicySelection(defaultProvider, /* rawConfig= */ null, /* config= */ null);
       }
-      PolicySelection selection = resolvedSelection.policySelection;
 
       if (delegateProvider == null
-          || !selection.provider.getPolicyName().equals(delegateProvider.getPolicyName())) {
+          || !policySelection.provider.getPolicyName().equals(delegateProvider.getPolicyName())) {
         helper.updateBalancingState(ConnectivityState.CONNECTING, new EmptyPicker());
         delegate.shutdown();
-        delegateProvider = selection.provider;
+        delegateProvider = policySelection.provider;
         LoadBalancer old = delegate;
         delegate = delegateProvider.newLoadBalancer(helper);
         helper.getChannelLogger().log(
             ChannelLogLevel.INFO, "Load balancer changed from {0} to {1}",
             old.getClass().getSimpleName(), delegate.getClass().getSimpleName());
       }
-      Object lbConfig = selection.config;
+      Object lbConfig = policySelection.config;
       if (lbConfig != null) {
         helper.getChannelLogger().log(
-            ChannelLogLevel.DEBUG, "Load-balancing config: {0}", selection.config);
+            ChannelLogLevel.DEBUG, "Load-balancing config: {0}", policySelection.config);
         attributes =
-            attributes.toBuilder().set(ATTR_LOAD_BALANCING_CONFIG, selection.rawConfig).build();
+            attributes.toBuilder()
+                .set(ATTR_LOAD_BALANCING_CONFIG, policySelection.rawConfig)
+                .build();
       }
 
       LoadBalancer delegate = getDelegate();
-      if (resolvedSelection.serverList.isEmpty()
+      if (resolvedAddresses.getAddresses().isEmpty()
           && !delegate.canHandleEmptyAddressListFromNameResolution()) {
         return Status.UNAVAILABLE.withDescription(
             "NameResolver returned no usable address. addrs=" + servers + ", attrs=" + attributes);
       } else {
         delegate.handleResolvedAddresses(
             ResolvedAddresses.newBuilder()
-                .setAddresses(resolvedSelection.serverList)
+                .setAddresses(resolvedAddresses.getAddresses())
                 .setAttributes(attributes)
                 .setLoadBalancingPolicyConfig(lbConfig)
                 .build());
@@ -205,78 +205,6 @@ public final class AutoConfiguredLoadBalancerFactory {
     @VisibleForTesting
     LoadBalancerProvider getDelegateProvider() {
       return delegateProvider;
-    }
-
-    /**
-     * Resolves a load balancer based on given criteria.  If policySelection is {@code null} and
-     * given servers contains any gRPC LB addresses, it will fall back to "grpclb". If no gRPC LB
-     * addresses are not present, it will fall back to {@link #defaultPolicy}.
-     *
-     * @param servers The list of servers reported
-     * @param policySelection the selected policy from raw service config
-     * @return the resolved policy selection
-     */
-    @VisibleForTesting
-    ResolvedPolicySelection resolveLoadBalancerProvider(
-        List<EquivalentAddressGroup> servers, @Nullable PolicySelection policySelection)
-        throws PolicyException {
-      // Check for balancer addresses
-      boolean haveBalancerAddress = false;
-      List<EquivalentAddressGroup> backendAddrs = new ArrayList<>();
-      for (EquivalentAddressGroup s : servers) {
-        if (s.getAttributes().get(GrpcAttributes.ATTR_LB_ADDR_AUTHORITY) != null) {
-          haveBalancerAddress = true;
-        } else {
-          backendAddrs.add(s);
-        }
-      }
-
-      if (policySelection != null) {
-        String policyName = policySelection.provider.getPolicyName();
-        return new ResolvedPolicySelection(
-            policySelection, policyName.equals(GRPCLB_POLICY_NAME) ? servers : backendAddrs);
-      }
-
-      if (haveBalancerAddress) {
-        // This is a special case where the existence of balancer address in the resolved address
-        // selects "grpclb" policy if the service config couldn't select a policy
-        LoadBalancerProvider grpclbProvider = registry.getProvider(GRPCLB_POLICY_NAME);
-        if (grpclbProvider == null) {
-          if (backendAddrs.isEmpty()) {
-            throw new PolicyException(
-                "Received ONLY balancer addresses but grpclb runtime is missing");
-          }
-          if (!roundRobinDueToGrpclbDepMissing) {
-            // We don't log the warning every time we have an update.
-            roundRobinDueToGrpclbDepMissing = true;
-            String errorMsg = "Found balancer addresses but grpclb runtime is missing."
-                + " Will use round_robin. Please include grpc-grpclb in your runtime dependencies.";
-            helper.getChannelLogger().log(ChannelLogLevel.ERROR, errorMsg);
-            logger.warning(errorMsg);
-          }
-          return new ResolvedPolicySelection(
-              new PolicySelection(
-                  getProviderOrThrow(
-                      "round_robin", "received balancer addresses but grpclb runtime is missing"),
-                  /* rawConfig = */ null,
-                  /* config= */ null),
-              backendAddrs);
-        }
-        return new ResolvedPolicySelection(
-            new PolicySelection(
-                grpclbProvider, /* rawConfig= */ null, /* config= */ null), servers);
-      }
-      // No balancer address this time.  If balancer address shows up later, we want to make sure
-      // the warning is logged one more time.
-      roundRobinDueToGrpclbDepMissing = false;
-
-      // No config nor balancer address. Use default.
-      return new ResolvedPolicySelection(
-          new PolicySelection(
-              getProviderOrThrow(defaultPolicy, "using default policy"),
-              /* rawConfig= */ null,
-              /* config= */ null),
-          servers);
     }
   }
 

--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
@@ -41,7 +41,6 @@ import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.Status;
 import io.grpc.internal.ServiceConfigUtil.LbConfig;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -329,26 +328,6 @@ public final class AutoConfiguredLoadBalancerFactory {
           .add("provider", provider)
           .add("rawConfig", rawConfig)
           .add("config", config)
-          .toString();
-    }
-  }
-
-  @VisibleForTesting
-  static final class ResolvedPolicySelection {
-    final PolicySelection policySelection;
-    final List<EquivalentAddressGroup> serverList;
-
-    ResolvedPolicySelection(
-        PolicySelection policySelection, List<EquivalentAddressGroup> serverList) {
-      this.policySelection = checkNotNull(policySelection, "policySelection");
-      this.serverList = Collections.unmodifiableList(checkNotNull(serverList, "serverList"));
-    }
-
-    @Override
-    public String toString() {
-      return MoreObjects.toStringHelper(this)
-          .add("policySelection", policySelection)
-          .add("serverList", serverList)
           .toString();
     }
   }

--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -300,11 +300,9 @@ final class DnsNameResolver extends NameResolver {
       }
 
       ResolutionResult.Builder resultBuilder = ResolutionResult.newBuilder().setAddresses(servers);
+      Attributes.Builder attributesBuilder = Attributes.newBuilder();
       if (!resolutionResults.balancerAddresses.isEmpty()) {
-        resultBuilder.setAttributes(
-            Attributes.newBuilder()
-                .set(GrpcAttributes.ATTR_LB_ADDRS, resolutionResults.balancerAddresses)
-                .build());
+        attributesBuilder.set(GrpcAttributes.ATTR_LB_ADDRS, resolutionResults.balancerAddresses);
       }
       if (!resolutionResults.txtRecords.isEmpty()) {
         ConfigOrError rawServiceConfig =
@@ -319,17 +317,14 @@ final class DnsNameResolver extends NameResolver {
           Map<String, ?> verifiedRawServiceConfig = (Map<String, ?>) rawServiceConfig.getConfig();
           ConfigOrError parsedServiceConfig =
               serviceConfigParser.parseServiceConfig(verifiedRawServiceConfig);
-          resultBuilder
-              .setAttributes(
-                  Attributes.newBuilder()
-                      .set(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG, verifiedRawServiceConfig)
-                      .build())
-              .setServiceConfig(parsedServiceConfig);
+          resultBuilder.setServiceConfig(parsedServiceConfig);
+          attributesBuilder
+              .set(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG, verifiedRawServiceConfig);
         }
       } else {
         logger.log(Level.FINE, "No TXT records found for {0}", new Object[]{host});
       }
-      savedListener.onResult(resultBuilder.build());
+      savedListener.onResult(resultBuilder.setAttributes(attributesBuilder.build()).build());
     }
   }
 

--- a/core/src/main/java/io/grpc/internal/GrpcAttributes.java
+++ b/core/src/main/java/io/grpc/internal/GrpcAttributes.java
@@ -38,6 +38,12 @@ public final class GrpcAttributes {
   public static final Attributes.Key<Map<String, ?>> NAME_RESOLVER_SERVICE_CONFIG =
       Attributes.Key.create("service-config");
 
+  /**
+   * Attribute key for gRPC LB server addresses.
+   *
+   * <p>Deprecated: this will be used for grpclb specific logic, which will be moved out of core.
+   */
+  @Deprecated
   @NameResolver.ResolutionResultAttr
   public static final Attributes.Key<List<EquivalentAddressGroup>> ATTR_LB_ADDRS =
       Attributes.Key.create("io.grpc.grpclb.lbAddrs");
@@ -45,7 +51,10 @@ public final class GrpcAttributes {
   /**
    * The naming authority of a gRPC LB server address.  It is an address-group-level attribute,
    * present when the address group is a LoadBalancer.
+   *
+   * <p>Deprecated: this will be used for grpclb specific logic, which will be moved out of core.
    */
+  @Deprecated
   @EquivalentAddressGroup.Attr
   public static final Attributes.Key<String> ATTR_LB_ADDR_AUTHORITY =
       Attributes.Key.create("io.grpc.grpclb.lbAddrAuthority");

--- a/core/src/main/java/io/grpc/internal/GrpcAttributes.java
+++ b/core/src/main/java/io/grpc/internal/GrpcAttributes.java
@@ -38,6 +38,7 @@ public final class GrpcAttributes {
   public static final Attributes.Key<Map<String, ?>> NAME_RESOLVER_SERVICE_CONFIG =
       Attributes.Key.create("service-config");
 
+  @NameResolver.ResolutionResultAttr
   public static final Attributes.Key<List<EquivalentAddressGroup>> ATTR_LB_ADDRS =
       Attributes.Key.create("io.grpc.grpclb.lbAddrs");
 

--- a/core/src/main/java/io/grpc/internal/GrpcAttributes.java
+++ b/core/src/main/java/io/grpc/internal/GrpcAttributes.java
@@ -21,6 +21,7 @@ import io.grpc.EquivalentAddressGroup;
 import io.grpc.Grpc;
 import io.grpc.NameResolver;
 import io.grpc.SecurityLevel;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -36,6 +37,9 @@ public final class GrpcAttributes {
   @NameResolver.ResolutionResultAttr
   public static final Attributes.Key<Map<String, ?>> NAME_RESOLVER_SERVICE_CONFIG =
       Attributes.Key.create("service-config");
+
+  public static final Attributes.Key<List<EquivalentAddressGroup>> ATTR_LB_ADDRS =
+      Attributes.Key.create("io.grpc.grpclb.lbAddrs");
 
   /**
    * The naming authority of a gRPC LB server address.  It is an address-group-level attribute,

--- a/core/src/main/java/io/grpc/internal/JndiResourceResolverFactory.java
+++ b/core/src/main/java/io/grpc/internal/JndiResourceResolverFactory.java
@@ -129,6 +129,7 @@ final class JndiResourceResolverFactory implements DnsNameResolver.ResourceResol
       return Collections.unmodifiableList(serviceConfigTxtRecords);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public List<EquivalentAddressGroup> resolveSrv(
         AddressResolver addressResolver, String grpclbHostname) throws Exception {

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -561,6 +561,7 @@ public class DnsNameResolverTest {
     assertThat(ac.getValue().getServiceConfig()).isNull();
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void resolve_balancerAddrsAsAttributes() throws Exception {
     InetAddress backendAddr = InetAddress.getByAddress(new byte[] {127, 0, 0, 0});

--- a/core/src/test/java/io/grpc/internal/JndiResourceResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/JndiResourceResolverTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.when;
 import io.grpc.Attributes;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.internal.DnsNameResolver.AddressResolver;
-import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.JndiResourceResolverFactory.JndiRecordFetcher;
 import io.grpc.internal.JndiResourceResolverFactory.JndiResourceResolver;
 import io.grpc.internal.JndiResourceResolverFactory.RecordFetcher;
@@ -81,6 +80,7 @@ public class JndiResourceResolverTest {
     assertThat(resolver.resolveTxt("service.example.com")).isEqualTo(golden);
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void srvRecordLookup() throws Exception {
     AddressResolver addressResolver = mock(AddressResolver.class);

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbConstants.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbConstants.java
@@ -42,10 +42,12 @@ public final class GrpclbConstants {
   static final Attributes.Key<String> TOKEN_ATTRIBUTE_KEY =
       Attributes.Key.create("lb-token");
 
+  @SuppressWarnings("deprecation")
   @EquivalentAddressGroup.Attr
   static final Attributes.Key<List<EquivalentAddressGroup>> ATTR_LB_ADDRS =
       io.grpc.internal.GrpcAttributes.ATTR_LB_ADDRS;
 
+  @SuppressWarnings("deprecation")
   @EquivalentAddressGroup.Attr
   static final Attributes.Key<String> ATTR_LB_ADDR_AUTHORITY =
       io.grpc.internal.GrpcAttributes.ATTR_LB_ADDR_AUTHORITY;

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbConstants.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbConstants.java
@@ -20,6 +20,7 @@ import io.grpc.Attributes;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.ExperimentalApi;
 import io.grpc.Metadata;
+import java.util.List;
 
 /**
  * Constants for the GRPCLB load-balancer.
@@ -40,6 +41,14 @@ public final class GrpclbConstants {
   @EquivalentAddressGroup.Attr
   static final Attributes.Key<String> TOKEN_ATTRIBUTE_KEY =
       Attributes.Key.create("lb-token");
+
+  @EquivalentAddressGroup.Attr
+  static final Attributes.Key<List<EquivalentAddressGroup>> ATTR_LB_ADDRS =
+      io.grpc.internal.GrpcAttributes.ATTR_LB_ADDRS;
+
+  @EquivalentAddressGroup.Attr
+  static final Attributes.Key<String> ATTR_LB_ADDR_AUTHORITY =
+      io.grpc.internal.GrpcAttributes.ATTR_LB_ADDR_AUTHORITY;
 
   private GrpclbConstants() { }
 }

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -103,7 +103,7 @@ class GrpclbLoadBalancer extends LoadBalancer {
 
     if (newLbAddresses != null) {
       for (EquivalentAddressGroup lbAddr : newLbAddresses) {
-        String lbAddrAuthority = lbAddr.getAttributes().get(GrpcAttributes.ATTR_LB_ADDR_AUTHORITY);
+        String lbAddrAuthority = lbAddr.getAttributes().get(GrpclbConstants.ATTR_LB_ADDR_AUTHORITY);
         if (lbAddrAuthority == null) {
           throw new AssertionError(
               "This is a bug: LB address " + lbAddr + " does not have an authority.");

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -92,8 +92,15 @@ class GrpclbLoadBalancer extends LoadBalancer {
   @SuppressWarnings("deprecation")  // TODO(creamsoup) migrate to use parsed service config
   public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     Attributes attributes = resolvedAddresses.getAttributes();
-    List<LbAddressGroup> newLbAddressGroups = new ArrayList<>();
     List<EquivalentAddressGroup> newLbAddresses = attributes.get(GrpcAttributes.ATTR_LB_ADDRS);
+    if ((newLbAddresses == null || newLbAddresses.isEmpty())
+        && resolvedAddresses.getAddresses().isEmpty()) {
+      handleNameResolutionError(
+          Status.UNAVAILABLE.withDescription("No backend or balancer addresses found"));
+      return;
+    }
+    List<LbAddressGroup> newLbAddressGroups = new ArrayList<>();
+
     if (newLbAddresses != null) {
       for (EquivalentAddressGroup lbAddr : newLbAddresses) {
         String lbAddrAuthority = lbAddr.getAttributes().get(GrpcAttributes.ATTR_LB_ADDR_AUTHORITY);

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -91,22 +91,23 @@ class GrpclbLoadBalancer extends LoadBalancer {
   @Override
   @SuppressWarnings("deprecation")  // TODO(creamsoup) migrate to use parsed service config
   public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-    List<EquivalentAddressGroup> updatedServers = resolvedAddresses.getAddresses();
     Attributes attributes = resolvedAddresses.getAttributes();
-    // LB addresses and backend addresses are treated separately
     List<LbAddressGroup> newLbAddressGroups = new ArrayList<>();
-    List<EquivalentAddressGroup> newBackendServers = new ArrayList<>();
-    for (EquivalentAddressGroup server : updatedServers) {
-      String lbAddrAuthority = server.getAttributes().get(GrpcAttributes.ATTR_LB_ADDR_AUTHORITY);
-      if (lbAddrAuthority != null) {
-        newLbAddressGroups.add(new LbAddressGroup(server, lbAddrAuthority));
-      } else {
-        newBackendServers.add(server);
+    List<EquivalentAddressGroup> newLbAddresses = attributes.get(GrpcAttributes.ATTR_LB_ADDRS);
+    if (newLbAddresses != null) {
+      for (EquivalentAddressGroup lbAddr : newLbAddresses) {
+        String lbAddrAuthority = lbAddr.getAttributes().get(GrpcAttributes.ATTR_LB_ADDR_AUTHORITY);
+        if (lbAddrAuthority == null) {
+          throw new AssertionError(
+              "This is a bug: LB address " + lbAddr + " does not have an authority.");
+        }
+        newLbAddressGroups.add(new LbAddressGroup(lbAddr, lbAddrAuthority));
       }
     }
 
     newLbAddressGroups = Collections.unmodifiableList(newLbAddressGroups);
-    newBackendServers = Collections.unmodifiableList(newBackendServers);
+    List<EquivalentAddressGroup> newBackendServers =
+        Collections.unmodifiableList(resolvedAddresses.getAddresses());
     Map<String, ?> rawLbConfigValue = attributes.get(ATTR_LOAD_BALANCING_CONFIG);
     Mode newMode = retrieveModeFromLbConfig(rawLbConfigValue, helper.getChannelLogger());
     if (!mode.equals(newMode)) {
@@ -182,6 +183,11 @@ class GrpclbLoadBalancer extends LoadBalancer {
     if (grpclbState != null) {
       grpclbState.propagateError(error);
     }
+  }
+
+  @Override
+  public boolean canHandleEmptyAddressListFromNameResolution() {
+    return true;
   }
 
   @VisibleForTesting

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -793,7 +793,7 @@ final class GrpclbState {
     // actually used in the normal case. https://github.com/grpc/grpc-java/issues/4618 should allow
     // this to be more obvious.
     Attributes attrs = Attributes.newBuilder()
-        .set(GrpcAttributes.ATTR_LB_ADDR_AUTHORITY, authority)
+        .set(GrpclbConstants.ATTR_LB_ADDR_AUTHORITY, authority)
         .build();
     return new LbAddressGroup(flattenEquivalentAddressGroup(eags, attrs), authority);
   }

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -2356,15 +2356,17 @@ public class GrpclbLoadBalancerTest {
       final List<EquivalentAddressGroup> backendAddrs,
       final List<EquivalentAddressGroup> balancerAddrs,
       Attributes attrs) {
-    final Attributes attributes =
-        attrs.toBuilder().set(GrpclbConstants.ATTR_LB_ADDRS, balancerAddrs).build();
+    if (!balancerAddrs.isEmpty()) {
+      attrs = attrs.toBuilder().set(GrpclbConstants.ATTR_LB_ADDRS, balancerAddrs).build();
+    }
+    final Attributes finalAttrs = attrs;
     syncContext.execute(new Runnable() {
       @Override
       public void run() {
         balancer.handleResolvedAddresses(
             ResolvedAddresses.newBuilder()
                 .setAddresses(backendAddrs)
-                .setAttributes(attributes)
+                .setAttributes(finalAttrs)
                 .build());
       }
     });

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -151,16 +151,16 @@ public class GrpclbLoadBalancerTest {
   private SubchannelPool subchannelPool;
   private final ArrayList<String> logs = new ArrayList<>();
   private final ChannelLogger channelLogger = new ChannelLogger() {
-      @Override
-      public void log(ChannelLogLevel level, String msg) {
-        logs.add(level + ": " + msg);
-      }
+    @Override
+    public void log(ChannelLogLevel level, String msg) {
+      logs.add(level + ": " + msg);
+    }
 
-      @Override
-      public void log(ChannelLogLevel level, String template, Object... args) {
-        log(level, MessageFormat.format(template, args));
-      }
-    };
+    @Override
+    public void log(ChannelLogLevel level, String template, Object... args) {
+      log(level, MessageFormat.format(template, args));
+    }
+  };
   private SubchannelPicker currentPicker;
   private LoadBalancerGrpc.LoadBalancerImplBase mockLbService;
   @Captor
@@ -207,12 +207,12 @@ public class GrpclbLoadBalancerTest {
             StreamObserver<LoadBalanceRequest> requestObserver =
                 mock(StreamObserver.class);
             Answer<Void> closeRpc = new Answer<Void>() {
-                @Override
-                public Void answer(InvocationOnMock invocation) {
-                  responseObserver.onCompleted();
-                  return null;
-                }
-              };
+              @Override
+              public Void answer(InvocationOnMock invocation) {
+                responseObserver.onCompleted();
+                return null;
+              }
+            };
             doAnswer(closeRpc).when(requestObserver).onCompleted();
             lbRequestObservers.add(requestObserver);
             return requestObserver;
@@ -221,63 +221,63 @@ public class GrpclbLoadBalancerTest {
     fakeLbServer = InProcessServerBuilder.forName("fakeLb")
         .directExecutor().addService(mockLbService).build().start();
     doAnswer(new Answer<ManagedChannel>() {
-        @Override
-        public ManagedChannel answer(InvocationOnMock invocation) throws Throwable {
-          String authority = (String) invocation.getArguments()[1];
-          ManagedChannel channel;
-          if (failingLbAuthorities.contains(authority)) {
-            channel = InProcessChannelBuilder.forName("nonExistFakeLb").directExecutor()
-                .overrideAuthority(authority).build();
-          } else {
-            channel = InProcessChannelBuilder.forName("fakeLb").directExecutor()
-                .overrideAuthority(authority).build();
-          }
-          fakeOobChannels.add(channel);
-          oobChannelTracker.add(channel);
-          return channel;
+      @Override
+      public ManagedChannel answer(InvocationOnMock invocation) throws Throwable {
+        String authority = (String) invocation.getArguments()[1];
+        ManagedChannel channel;
+        if (failingLbAuthorities.contains(authority)) {
+          channel = InProcessChannelBuilder.forName("nonExistFakeLb").directExecutor()
+              .overrideAuthority(authority).build();
+        } else {
+          channel = InProcessChannelBuilder.forName("fakeLb").directExecutor()
+              .overrideAuthority(authority).build();
         }
-      }).when(helper).createOobChannel(any(EquivalentAddressGroup.class), any(String.class));
+        fakeOobChannels.add(channel);
+        oobChannelTracker.add(channel);
+        return channel;
+      }
+    }).when(helper).createOobChannel(any(EquivalentAddressGroup.class), any(String.class));
     doAnswer(new Answer<Subchannel>() {
-        @Override
-        public Subchannel answer(InvocationOnMock invocation) throws Throwable {
-          Subchannel subchannel = mock(Subchannel.class);
-          EquivalentAddressGroup eag = (EquivalentAddressGroup) invocation.getArguments()[0];
-          Attributes attrs = (Attributes) invocation.getArguments()[1];
-          when(subchannel.getAllAddresses()).thenReturn(Arrays.asList(eag));
-          when(subchannel.getAttributes()).thenReturn(attrs);
-          mockSubchannels.add(subchannel);
-          pooledSubchannelTracker.add(subchannel);
-          return subchannel;
-        }
-      }).when(subchannelPool).takeOrCreateSubchannel(
-          any(EquivalentAddressGroup.class), any(Attributes.class));
+      @Override
+      public Subchannel answer(InvocationOnMock invocation) throws Throwable {
+        Subchannel subchannel = mock(Subchannel.class);
+        EquivalentAddressGroup eag = (EquivalentAddressGroup) invocation.getArguments()[0];
+        Attributes attrs = (Attributes) invocation.getArguments()[1];
+        when(subchannel.getAllAddresses()).thenReturn(Arrays.asList(eag));
+        when(subchannel.getAttributes()).thenReturn(attrs);
+        mockSubchannels.add(subchannel);
+        pooledSubchannelTracker.add(subchannel);
+        return subchannel;
+      }
+    }).when(subchannelPool).takeOrCreateSubchannel(
+        any(EquivalentAddressGroup.class), any(Attributes.class));
     doAnswer(new Answer<Subchannel>() {
-        @Override
-        public Subchannel answer(InvocationOnMock invocation) throws Throwable {
-          Subchannel subchannel = mock(Subchannel.class);
-          List<EquivalentAddressGroup> eagList =
-              (List<EquivalentAddressGroup>) invocation.getArguments()[0];
-          Attributes attrs = (Attributes) invocation.getArguments()[1];
-          when(subchannel.getAllAddresses()).thenReturn(eagList);
-          when(subchannel.getAttributes()).thenReturn(attrs);
-          mockSubchannels.add(subchannel);
-          unpooledSubchannelTracker.add(subchannel);
-          return subchannel;
-        }
-        // TODO(zhangkun83): remove the deprecation suppression on this method once migrated to
-        // the new createSubchannel().
-      }).when(helper).createSubchannel(any(List.class), any(Attributes.class));
+      @Override
+      public Subchannel answer(InvocationOnMock invocation) throws Throwable {
+        Subchannel subchannel = mock(Subchannel.class);
+        List<EquivalentAddressGroup> eagList =
+            (List<EquivalentAddressGroup>) invocation.getArguments()[0];
+        Attributes attrs = (Attributes) invocation.getArguments()[1];
+        when(subchannel.getAllAddresses()).thenReturn(eagList);
+        when(subchannel.getAttributes()).thenReturn(attrs);
+        mockSubchannels.add(subchannel);
+        unpooledSubchannelTracker.add(subchannel);
+        return subchannel;
+      }
+      // TODO(zhangkun83): remove the deprecation suppression on this method once migrated to
+      // the new createSubchannel().
+    }).when(helper).createSubchannel(any(List.class), any(Attributes.class));
     when(helper.getSynchronizationContext()).thenReturn(syncContext);
     when(helper.getScheduledExecutorService()).thenReturn(fakeClock.getScheduledExecutorService());
     when(helper.getChannelLogger()).thenReturn(channelLogger);
     doAnswer(new Answer<Void>() {
-        @Override
-        public Void answer(InvocationOnMock invocation) throws Throwable {
-          currentPicker = (SubchannelPicker) invocation.getArguments()[1];
-          return null;
-        }
-      }).when(helper).updateBalancingState(
-          any(ConnectivityState.class), any(SubchannelPicker.class));
+      @Override
+      public Void answer(InvocationOnMock invocation) throws Throwable {
+        currentPicker = (SubchannelPicker) invocation.getArguments()[1];
+        return null;
+      }
+    }).when(helper).updateBalancingState(
+        any(ConnectivityState.class), any(SubchannelPicker.class));
     when(helper.getAuthority()).thenReturn(SERVICE_AUTHORITY);
     when(backoffPolicy1.nextBackoffNanos()).thenReturn(10L, 100L);
     when(backoffPolicy2.nextBackoffNanos()).thenReturn(10L, 100L);
@@ -293,11 +293,11 @@ public class GrpclbLoadBalancerTest {
     try {
       if (balancer != null) {
         syncContext.execute(new Runnable() {
-            @Override
-            public void run() {
-              balancer.shutdown();
-            }
-          });
+          @Override
+          public void run() {
+            balancer.shutdown();
+          }
+        });
       }
       for (ManagedChannel channel : oobChannelTracker) {
         assertTrue(channel + " is shutdown", channel.isShutdown());
@@ -468,9 +468,11 @@ public class GrpclbLoadBalancerTest {
     when(args.getHeaders()).thenReturn(headers);
 
     long loadReportIntervalMillis = 1983;
-    List<EquivalentAddressGroup> grpclbResolutionList = createResolvedServerAddresses(true);
+    List<EquivalentAddressGroup> grpclbBalancerList = createResolvedBalancerAddresses(1);
     Attributes grpclbResolutionAttrs = Attributes.EMPTY;
-    deliverResolvedAddresses(grpclbResolutionList, grpclbResolutionAttrs);
+    deliverResolvedAddresses(
+        Collections.<EquivalentAddressGroup>emptyList(),
+        grpclbBalancerList, grpclbResolutionAttrs);
 
     // Fallback timer is started as soon as address is resolved.
     assertEquals(1, fakeClock.numPendingTasks(FALLBACK_MODE_TASK_FILTER));
@@ -485,7 +487,7 @@ public class GrpclbLoadBalancerTest {
 
     inOrder.verify(lbRequestObserver).onNext(
         eq(LoadBalanceRequest.newBuilder().setInitialRequest(
-                InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
+            InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
             .build()));
 
     // Simulate receiving LB response
@@ -593,7 +595,7 @@ public class GrpclbLoadBalancerTest {
                     .setLoadBalanceToken("token0003")
                     .setNumCalls(1)   // pick4
                     .build())
-        .build());
+            .build());
 
     PickResult pick5 = picker.pickSubchannel(args);
     assertSame(subchannel1, pick1.getSubchannel());
@@ -641,7 +643,7 @@ public class GrpclbLoadBalancerTest {
 
     inOrder.verify(lbRequestObserver).onNext(
         eq(LoadBalanceRequest.newBuilder().setInitialRequest(
-                InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
+            InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
             .build()));
 
     // Load reporting is also requested
@@ -693,9 +695,11 @@ public class GrpclbLoadBalancerTest {
     PickSubchannelArgs args = mock(PickSubchannelArgs.class);
     when(args.getHeaders()).thenReturn(headers);
 
-    List<EquivalentAddressGroup> grpclbResolutionList = createResolvedServerAddresses(true);
+    List<EquivalentAddressGroup> grpclbBalancerList = createResolvedBalancerAddresses(1);
     Attributes grpclbResolutionAttrs = Attributes.EMPTY;
-    deliverResolvedAddresses(grpclbResolutionList, grpclbResolutionAttrs);
+    deliverResolvedAddresses(
+        Collections.<EquivalentAddressGroup>emptyList(),
+        grpclbBalancerList, grpclbResolutionAttrs);
     assertEquals(1, fakeOobChannels.size());
     verify(mockLbService).balanceLoad(lbResponseObserverCaptor.capture());
     StreamObserver<LoadBalanceResponse> lbResponseObserver = lbResponseObserverCaptor.getValue();
@@ -731,9 +735,11 @@ public class GrpclbLoadBalancerTest {
     PickSubchannelArgs args = mock(PickSubchannelArgs.class);
     when(args.getHeaders()).thenReturn(headers);
 
-    List<EquivalentAddressGroup> grpclbResolutionList = createResolvedServerAddresses(true);
+    List<EquivalentAddressGroup> grpclbBalancerList = createResolvedBalancerAddresses(1);
     Attributes grpclbResolutionAttrs = Attributes.EMPTY;
-    deliverResolvedAddresses(grpclbResolutionList, grpclbResolutionAttrs);
+    deliverResolvedAddresses(
+        Collections.<EquivalentAddressGroup>emptyList(),
+        grpclbBalancerList, grpclbResolutionAttrs);
     assertEquals(1, fakeOobChannels.size());
     verify(mockLbService).balanceLoad(lbResponseObserverCaptor.capture());
     StreamObserver<LoadBalanceResponse> lbResponseObserver = lbResponseObserverCaptor.getValue();
@@ -743,7 +749,7 @@ public class GrpclbLoadBalancerTest {
 
     inOrder.verify(lbRequestObserver).onNext(
         eq(LoadBalanceRequest.newBuilder().setInitialRequest(
-                InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
+            InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
             .build()));
 
     // Simulate receiving LB response
@@ -780,8 +786,8 @@ public class GrpclbLoadBalancerTest {
         eq(LoadBalanceRequest.newBuilder()
             .setClientStats(
                 ClientStats.newBuilder(expectedReport)
-                .setTimestamp(Timestamps.fromNanos(fakeClock.getTicker().read()))
-                .build())
+                    .setTimestamp(Timestamps.fromNanos(fakeClock.getTicker().read()))
+                    .build())
             .build()));
   }
 
@@ -803,11 +809,12 @@ public class GrpclbLoadBalancerTest {
     assertThat(picker.pickList).containsExactly(new ErrorEntry(error));
 
     // Recover with a subsequent success
-    List<EquivalentAddressGroup> resolvedServers = createResolvedServerAddresses(true);
-    EquivalentAddressGroup eag = resolvedServers.get(0);
+    List<EquivalentAddressGroup> grpclbBalancerList = createResolvedBalancerAddresses(1);
+    EquivalentAddressGroup eag = grpclbBalancerList.get(0);
 
     Attributes resolutionAttrs = Attributes.EMPTY;
-    deliverResolvedAddresses(resolvedServers, resolutionAttrs);
+    deliverResolvedAddresses(
+        Collections.<EquivalentAddressGroup>emptyList(), grpclbBalancerList, resolutionAttrs);
 
     verify(helper).createOobChannel(eq(eag), eq(lbAuthority(0)));
     verify(mockLbService).balanceLoad(lbResponseObserverCaptor.capture());
@@ -817,11 +824,13 @@ public class GrpclbLoadBalancerTest {
   public void grpclbThenNameResolutionFails() {
     InOrder inOrder = inOrder(helper, subchannelPool);
     // Go to GRPCLB first
-    List<EquivalentAddressGroup> grpclbResolutionList = createResolvedServerAddresses(true);
+    List<EquivalentAddressGroup> grpclbBalancerList = createResolvedBalancerAddresses(1);
     Attributes grpclbResolutionAttrs = Attributes.EMPTY;
-    deliverResolvedAddresses(grpclbResolutionList, grpclbResolutionAttrs);
+    deliverResolvedAddresses(
+        Collections.<EquivalentAddressGroup>emptyList(),
+        grpclbBalancerList, grpclbResolutionAttrs);
 
-    verify(helper).createOobChannel(eq(grpclbResolutionList.get(0)), eq(lbAuthority(0)));
+    verify(helper).createOobChannel(eq(grpclbBalancerList.get(0)), eq(lbAuthority(0)));
     assertEquals(1, fakeOobChannels.size());
     ManagedChannel oobChannel = fakeOobChannels.poll();
     verify(mockLbService).balanceLoad(lbResponseObserverCaptor.capture());
@@ -854,59 +863,63 @@ public class GrpclbLoadBalancerTest {
 
   @Test
   public void grpclbUpdatedAddresses_avoidsReconnect() {
-    List<EquivalentAddressGroup> grpclbResolutionList =
-        createResolvedServerAddresses(true, false);
+    List<EquivalentAddressGroup> backendList = createResolvedBackendAddresses(1);
+    List<EquivalentAddressGroup> grpclbBalancerList = createResolvedBalancerAddresses(1);
     Attributes grpclbResolutionAttrs = Attributes.EMPTY;
-    deliverResolvedAddresses(grpclbResolutionList, grpclbResolutionAttrs);
+    deliverResolvedAddresses(backendList, grpclbBalancerList, grpclbResolutionAttrs);
 
-    verify(helper).createOobChannel(eq(grpclbResolutionList.get(0)), eq(lbAuthority(0)));
+    verify(helper).createOobChannel(eq(grpclbBalancerList.get(0)), eq(lbAuthority(0)));
     ManagedChannel oobChannel = fakeOobChannels.poll();
     assertEquals(1, lbRequestObservers.size());
 
-    List<EquivalentAddressGroup> grpclbResolutionList2 =
-        createResolvedServerAddresses(true, false, true);
+    List<EquivalentAddressGroup> backendList2 = createResolvedBackendAddresses(1);
+    List<EquivalentAddressGroup> grpclbBalancerList2 = createResolvedBalancerAddresses(2);
     EquivalentAddressGroup combinedEag = new EquivalentAddressGroup(Arrays.asList(
-        grpclbResolutionList2.get(0).getAddresses().get(0),
-        grpclbResolutionList2.get(2).getAddresses().get(0)),
+        grpclbBalancerList2.get(0).getAddresses().get(0),
+        grpclbBalancerList2.get(1).getAddresses().get(0)),
         lbAttributes(lbAuthority(0)));
-    deliverResolvedAddresses(grpclbResolutionList2, grpclbResolutionAttrs);
+    deliverResolvedAddresses(backendList2, grpclbBalancerList2, grpclbResolutionAttrs);
     verify(helper).updateOobChannelAddresses(eq(oobChannel), eq(combinedEag));
     assertEquals(1, lbRequestObservers.size()); // No additional RPC
   }
 
   @Test
   public void grpclbUpdatedAddresses_reconnectOnAuthorityChange() {
-    List<EquivalentAddressGroup> grpclbResolutionList =
-        createResolvedServerAddresses(true, false);
+    List<EquivalentAddressGroup> backendList = createResolvedBackendAddresses(1);
+    List<EquivalentAddressGroup> grpclbBalancerList = createResolvedBalancerAddresses(1);
     Attributes grpclbResolutionAttrs = Attributes.EMPTY;
-    deliverResolvedAddresses(grpclbResolutionList, grpclbResolutionAttrs);
+    deliverResolvedAddresses(backendList, grpclbBalancerList, grpclbResolutionAttrs);
 
-    verify(helper).createOobChannel(eq(grpclbResolutionList.get(0)), eq(lbAuthority(0)));
+    verify(helper).createOobChannel(eq(grpclbBalancerList.get(0)), eq(lbAuthority(0)));
     ManagedChannel oobChannel = fakeOobChannels.poll();
     assertEquals(1, lbRequestObservers.size());
 
     final String newAuthority = "some-new-authority";
-    List<EquivalentAddressGroup> grpclbResolutionList2 =
-        createResolvedServerAddresses(false);
-    grpclbResolutionList2.add(new EquivalentAddressGroup(
-        new FakeSocketAddress("somethingNew"), lbAttributes(newAuthority)));
-    deliverResolvedAddresses(grpclbResolutionList2, grpclbResolutionAttrs);
+    List<EquivalentAddressGroup> backendList2 = createResolvedBackendAddresses(1);
+    List<EquivalentAddressGroup> grpclbBalancerList2 =
+        Collections.singletonList(
+            new EquivalentAddressGroup(
+                new FakeSocketAddress("somethingNew"), lbAttributes(newAuthority)));
+    deliverResolvedAddresses(
+        backendList2, grpclbBalancerList2, grpclbResolutionAttrs);
     assertTrue(oobChannel.isTerminated());
-    verify(helper).createOobChannel(eq(grpclbResolutionList2.get(1)), eq(newAuthority));
+    verify(helper).createOobChannel(eq(grpclbBalancerList2.get(0)), eq(newAuthority));
     assertEquals(2, lbRequestObservers.size()); // An additional RPC
   }
 
   @Test
   public void grpclbWorking() {
     InOrder inOrder = inOrder(helper, subchannelPool);
-    List<EquivalentAddressGroup> grpclbResolutionList = createResolvedServerAddresses(true);
+    List<EquivalentAddressGroup> grpclbBalancerList = createResolvedBalancerAddresses(1);
     Attributes grpclbResolutionAttrs = Attributes.EMPTY;
-    deliverResolvedAddresses(grpclbResolutionList, grpclbResolutionAttrs);
+    deliverResolvedAddresses(
+        Collections.<EquivalentAddressGroup>emptyList(),
+        grpclbBalancerList, grpclbResolutionAttrs);
 
     // Fallback timer is started as soon as the addresses are resolved.
     assertEquals(1, fakeClock.numPendingTasks(FALLBACK_MODE_TASK_FILTER));
 
-    verify(helper).createOobChannel(eq(grpclbResolutionList.get(0)), eq(lbAuthority(0)));
+    verify(helper).createOobChannel(eq(grpclbBalancerList.get(0)), eq(lbAuthority(0)));
     assertEquals(1, fakeOobChannels.size());
     ManagedChannel oobChannel = fakeOobChannels.poll();
     verify(mockLbService).balanceLoad(lbResponseObserverCaptor.capture());
@@ -915,7 +928,7 @@ public class GrpclbLoadBalancerTest {
     StreamObserver<LoadBalanceRequest> lbRequestObserver = lbRequestObservers.poll();
     verify(lbRequestObserver).onNext(
         eq(LoadBalanceRequest.newBuilder().setInitialRequest(
-                InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
+            InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
             .build()));
 
     // Simulate receiving LB response
@@ -1174,13 +1187,14 @@ public class GrpclbLoadBalancerTest {
     long loadReportIntervalMillis = 1983;
     InOrder inOrder = inOrder(helper, subchannelPool);
 
-    // Create a resolution list with a mixture of balancer and backend addresses
-    List<EquivalentAddressGroup> resolutionList =
-        createResolvedServerAddresses(false, true, false);
+    // Create balancer and backend addresses
+    List<EquivalentAddressGroup> backendList = createResolvedBackendAddresses(2);
+    List<EquivalentAddressGroup> grpclbBalancerList = createResolvedBalancerAddresses(1);
     Attributes resolutionAttrs = Attributes.EMPTY;
-    deliverResolvedAddresses(resolutionList, resolutionAttrs);
+    deliverResolvedAddresses(backendList, grpclbBalancerList, resolutionAttrs);
 
-    inOrder.verify(helper).createOobChannel(eq(resolutionList.get(1)), eq(lbAuthority(0)));
+    inOrder.verify(helper)
+        .createOobChannel(eq(grpclbBalancerList.get(0)), eq(lbAuthority(0)));
 
     // Attempted to connect to balancer
     assertEquals(1, fakeOobChannels.size());
@@ -1192,7 +1206,7 @@ public class GrpclbLoadBalancerTest {
 
     verify(lbRequestObserver).onNext(
         eq(LoadBalanceRequest.newBuilder().setInitialRequest(
-                InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
+            InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
             .build()));
     lbResponseObserver.onNext(buildInitialResponse(loadReportIntervalMillis));
     // We don't care if these methods have been run.
@@ -1214,11 +1228,11 @@ public class GrpclbLoadBalancerTest {
 
       assertEquals(0, fakeClock.numPendingTasks(FALLBACK_MODE_TASK_FILTER));
       List<EquivalentAddressGroup> fallbackList =
-          Arrays.asList(resolutionList.get(0), resolutionList.get(2));
+          Arrays.asList(backendList.get(0), backendList.get(1));
       assertThat(logs).containsExactly(
           "INFO: Using fallback backends",
           "INFO: Using RR list=[[[FakeSocketAddress-fake-address-0]/{}], "
-              + "[[FakeSocketAddress-fake-address-2]/{}]], drop=[null, null]",
+              + "[[FakeSocketAddress-fake-address-1]/{}]], drop=[null, null]",
           "INFO: CONNECTING: picks=[BUFFER_ENTRY], drops=[null, null]").inOrder();
 
       // Fall back to the backends from resolver
@@ -1228,20 +1242,21 @@ public class GrpclbLoadBalancerTest {
       verify(lbRequestObserver, never()).onCompleted();
     }
 
-    ////////////////////////////////////////////////////////
-    // Name resolver sends new list without any backend addr
-    ////////////////////////////////////////////////////////
-    resolutionList = createResolvedServerAddresses(true, true);
-    deliverResolvedAddresses(resolutionList, resolutionAttrs);
+    //////////////////////////////////////////////////////////////////////
+    // Name resolver sends new resolution results without any backend addr
+    //////////////////////////////////////////////////////////////////////
+    grpclbBalancerList = createResolvedBalancerAddresses(2);
+    deliverResolvedAddresses(
+        Collections.<EquivalentAddressGroup>emptyList(),grpclbBalancerList, resolutionAttrs);
 
     // New addresses are updated to the OobChannel
     inOrder.verify(helper).updateOobChannelAddresses(
         same(oobChannel),
         eq(new EquivalentAddressGroup(
-                Arrays.asList(
-                    resolutionList.get(0).getAddresses().get(0),
-                    resolutionList.get(1).getAddresses().get(0)),
-                lbAttributes(lbAuthority(0)))));
+            Arrays.asList(
+                grpclbBalancerList.get(0).getAddresses().get(0),
+                grpclbBalancerList.get(1).getAddresses().get(0)),
+            lbAttributes(lbAuthority(0)))));
 
     if (timerExpires) {
       // Still in fallback logic, except that the backend list is empty
@@ -1249,21 +1264,22 @@ public class GrpclbLoadBalancerTest {
           inOrder, Collections.<EquivalentAddressGroup>emptyList());
     }
 
-    //////////////////////////////////////////////////
-    // Name resolver sends new list with backend addrs
-    //////////////////////////////////////////////////
-    resolutionList = createResolvedServerAddresses(true, false, false);
-    deliverResolvedAddresses(resolutionList, resolutionAttrs);
+    ////////////////////////////////////////////////////////////////
+    // Name resolver sends new resolution results with backend addrs
+    ////////////////////////////////////////////////////////////////
+    backendList = createResolvedBackendAddresses(2);
+    grpclbBalancerList = createResolvedBalancerAddresses(1);
+    deliverResolvedAddresses(backendList, grpclbBalancerList, resolutionAttrs);
 
     // New LB address is updated to the OobChannel
     inOrder.verify(helper).updateOobChannelAddresses(
         same(oobChannel),
-        eq(resolutionList.get(0)));
+        eq(grpclbBalancerList.get(0)));
 
     if (timerExpires) {
       // New backend addresses are used for fallback
       fallbackTestVerifyUseOfFallbackBackendLists(
-          inOrder, Arrays.asList(resolutionList.get(1), resolutionList.get(2)));
+          inOrder, Arrays.asList(backendList.get(0), backendList.get(1)));
     }
 
     ////////////////////////////////////////////////
@@ -1283,7 +1299,7 @@ public class GrpclbLoadBalancerTest {
       lbRequestObserver = lbRequestObservers.poll();
       verify(lbRequestObserver).onNext(
           eq(LoadBalanceRequest.newBuilder().setInitialRequest(
-                  InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
+              InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
               .build()));
     }
 
@@ -1302,8 +1318,9 @@ public class GrpclbLoadBalancerTest {
     ///////////////////////////////////////////////////////////////
     // New backend addresses from resolver outside of fallback mode
     ///////////////////////////////////////////////////////////////
-    resolutionList = createResolvedServerAddresses(true, false);
-    deliverResolvedAddresses(resolutionList, resolutionAttrs);
+    backendList = createResolvedBackendAddresses(1);
+    grpclbBalancerList = createResolvedBalancerAddresses(1);
+    deliverResolvedAddresses(backendList, grpclbBalancerList, resolutionAttrs);
     // Will not affect the round robin list at all
     inOrder.verify(helper, never())
         .updateBalancingState(any(ConnectivityState.class), any(SubchannelPicker.class));
@@ -1317,13 +1334,13 @@ public class GrpclbLoadBalancerTest {
     long loadReportIntervalMillis = 1983;
     InOrder inOrder = inOrder(helper, subchannelPool);
 
-    // Create a resolution list with a mixture of balancer and backend addresses
-    List<EquivalentAddressGroup> resolutionList =
-        createResolvedServerAddresses(false, true, false);
+    // Create balancer and backend addresses
+    List<EquivalentAddressGroup> backendList = createResolvedBackendAddresses(2);
+    List<EquivalentAddressGroup> grpclbBalancerList = createResolvedBalancerAddresses(1);
     Attributes resolutionAttrs = Attributes.EMPTY;
-    deliverResolvedAddresses(resolutionList, resolutionAttrs);
+    deliverResolvedAddresses(backendList, grpclbBalancerList, resolutionAttrs);
 
-    inOrder.verify(helper).createOobChannel(eq(resolutionList.get(1)), eq(lbAuthority(0)));
+    inOrder.verify(helper).createOobChannel(eq(grpclbBalancerList.get(0)), eq(lbAuthority(0)));
 
     // Attempted to connect to balancer
     assertThat(fakeOobChannels).hasSize(1);
@@ -1334,7 +1351,7 @@ public class GrpclbLoadBalancerTest {
 
     verify(lbRequestObserver).onNext(
         eq(LoadBalanceRequest.newBuilder().setInitialRequest(
-                InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
+            InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
             .build()));
     lbResponseObserver.onNext(buildInitialResponse(loadReportIntervalMillis));
     // We don't care if these methods have been run.
@@ -1353,7 +1370,7 @@ public class GrpclbLoadBalancerTest {
 
     // Fall back to the backends from resolver
     fallbackTestVerifyUseOfFallbackBackendLists(
-        inOrder, Arrays.asList(resolutionList.get(0), resolutionList.get(2)));
+        inOrder, Arrays.asList(backendList.get(0), backendList.get(1)));
 
     // A new stream is created
     verify(mockLbService, times(2)).balanceLoad(lbResponseObserverCaptor.capture());
@@ -1361,7 +1378,7 @@ public class GrpclbLoadBalancerTest {
     lbRequestObserver = lbRequestObservers.poll();
     verify(lbRequestObserver).onNext(
         eq(LoadBalanceRequest.newBuilder().setInitialRequest(
-                InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
+            InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
             .build()));
   }
 
@@ -1369,19 +1386,20 @@ public class GrpclbLoadBalancerTest {
   public void grpclbFallback_noBalancerAddress() {
     InOrder inOrder = inOrder(helper, subchannelPool);
 
-    // Create a resolution list with just backend addresses
-    List<EquivalentAddressGroup> resolutionList = createResolvedServerAddresses(false, false);
+    // Create just backend addresses
+    List<EquivalentAddressGroup> backendList = createResolvedBackendAddresses(2);
     Attributes resolutionAttrs = Attributes.EMPTY;
-    deliverResolvedAddresses(resolutionList, resolutionAttrs);
+    deliverResolvedAddresses(
+        backendList, Collections.<EquivalentAddressGroup>emptyList(), resolutionAttrs);
 
     assertThat(logs).containsExactly(
-          "INFO: Using fallback backends",
-          "INFO: Using RR list=[[[FakeSocketAddress-fake-address-0]/{}], "
-              + "[[FakeSocketAddress-fake-address-1]/{}]], drop=[null, null]",
-          "INFO: CONNECTING: picks=[BUFFER_ENTRY], drops=[null, null]").inOrder();
+        "INFO: Using fallback backends",
+        "INFO: Using RR list=[[[FakeSocketAddress-fake-address-0]/{}], "
+            + "[[FakeSocketAddress-fake-address-1]/{}]], drop=[null, null]",
+        "INFO: CONNECTING: picks=[BUFFER_ENTRY], drops=[null, null]").inOrder();
 
     // Fall back to the backends from resolver
-    fallbackTestVerifyUseOfFallbackBackendLists(inOrder, resolutionList);
+    fallbackTestVerifyUseOfFallbackBackendLists(inOrder, backendList);
 
     // No fallback timeout timer scheduled.
     assertEquals(0, fakeClock.numPendingTasks(FALLBACK_MODE_TASK_FILTER));
@@ -1410,13 +1428,13 @@ public class GrpclbLoadBalancerTest {
     long loadReportIntervalMillis = 1983;
     InOrder inOrder = inOrder(helper, mockLbService, subchannelPool);
 
-    // Create a resolution list with a mixture of balancer and backend addresses
-    List<EquivalentAddressGroup> resolutionList =
-        createResolvedServerAddresses(false, true, false);
+    // Create balancer and backend addresses
+    List<EquivalentAddressGroup> backendList = createResolvedBackendAddresses(2);
+    List<EquivalentAddressGroup> grpclbBalancerList = createResolvedBalancerAddresses(1);
     Attributes resolutionAttrs = Attributes.EMPTY;
-    deliverResolvedAddresses(resolutionList, resolutionAttrs);
+    deliverResolvedAddresses(backendList, grpclbBalancerList, resolutionAttrs);
 
-    inOrder.verify(helper).createOobChannel(eq(resolutionList.get(1)), eq(lbAuthority(0)));
+    inOrder.verify(helper).createOobChannel(eq(grpclbBalancerList.get(0)), eq(lbAuthority(0)));
 
     // Attempted to connect to balancer
     assertEquals(1, fakeOobChannels.size());
@@ -1428,7 +1446,7 @@ public class GrpclbLoadBalancerTest {
 
     verify(lbRequestObserver).onNext(
         eq(LoadBalanceRequest.newBuilder().setInitialRequest(
-                InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
+            InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
             .build()));
     lbResponseObserver.onNext(buildInitialResponse(loadReportIntervalMillis));
     // We don't care if these methods have been run.
@@ -1465,7 +1483,7 @@ public class GrpclbLoadBalancerTest {
     if (balancerBroken && allSubchannelsBroken) {
       // Going into fallback
       subchannels = fallbackTestVerifyUseOfFallbackBackendLists(
-          inOrder, Arrays.asList(resolutionList.get(0), resolutionList.get(2)));
+          inOrder, Arrays.asList(backendList.get(0), backendList.get(1)));
 
       // When in fallback mode, fallback timer should not be scheduled when all backend
       // connections are lost
@@ -1486,9 +1504,9 @@ public class GrpclbLoadBalancerTest {
 
     if (!(balancerBroken && allSubchannelsBroken)) {
       verify(subchannelPool, never()).takeOrCreateSubchannel(
-          eq(resolutionList.get(0)), any(Attributes.class));
+          eq(backendList.get(0)), any(Attributes.class));
       verify(subchannelPool, never()).takeOrCreateSubchannel(
-          eq(resolutionList.get(2)), any(Attributes.class));
+          eq(backendList.get(1)), any(Attributes.class));
     }
   }
 
@@ -1555,15 +1573,15 @@ public class GrpclbLoadBalancerTest {
 
   @Test
   public void grpclbMultipleAuthorities() throws Exception {
-    List<EquivalentAddressGroup> grpclbResolutionList = Arrays.asList(
+    List<EquivalentAddressGroup> backendList = Collections.singletonList(
+        new EquivalentAddressGroup(new FakeSocketAddress("not-a-lb-address")));
+    List<EquivalentAddressGroup> grpclbBalancerList = Arrays.asList(
         new EquivalentAddressGroup(
             new FakeSocketAddress("fake-address-1"),
             lbAttributes("fake-authority-1")),
         new EquivalentAddressGroup(
             new FakeSocketAddress("fake-address-2"),
             lbAttributes("fake-authority-2")),
-        new EquivalentAddressGroup(
-            new FakeSocketAddress("not-a-lb-address")),
         new EquivalentAddressGroup(
             new FakeSocketAddress("fake-address-3"),
             lbAttributes("fake-authority-1")));
@@ -1574,7 +1592,7 @@ public class GrpclbLoadBalancerTest {
         lbAttributes("fake-authority-1")); // Supporting multiple authorities would be good, one day
 
     Attributes grpclbResolutionAttrs = Attributes.EMPTY;
-    deliverResolvedAddresses(grpclbResolutionList, grpclbResolutionAttrs);
+    deliverResolvedAddresses(backendList, grpclbBalancerList, grpclbResolutionAttrs);
 
     verify(helper).createOobChannel(goldenOobChannelEag, "fake-authority-1");
   }
@@ -1588,9 +1606,11 @@ public class GrpclbLoadBalancerTest {
             .build();
     InOrder inOrder =
         inOrder(mockLbService, backoffPolicyProvider, backoffPolicy1, backoffPolicy2, helper);
-    List<EquivalentAddressGroup> grpclbResolutionList = createResolvedServerAddresses(true);
+    List<EquivalentAddressGroup> grpclbBalancerList = createResolvedBalancerAddresses(1);
     Attributes grpclbResolutionAttrs = Attributes.EMPTY;
-    deliverResolvedAddresses(grpclbResolutionList, grpclbResolutionAttrs);
+    deliverResolvedAddresses(
+        Collections.<EquivalentAddressGroup>emptyList(),
+        grpclbBalancerList, grpclbResolutionAttrs);
 
     assertEquals(1, fakeOobChannels.size());
     @SuppressWarnings("unused")
@@ -1693,11 +1713,13 @@ public class GrpclbLoadBalancerTest {
     InOrder inOrder = inOrder(helper);
 
     String lbConfig = "{\"childPolicy\" : [ {\"pick_first\" : {}} ]}";
-    List<EquivalentAddressGroup> grpclbResolutionList = createResolvedServerAddresses(true);
+    List<EquivalentAddressGroup> grpclbBalancerList = createResolvedBalancerAddresses(1);
     Attributes grpclbResolutionAttrs = Attributes.newBuilder().set(
         LoadBalancer.ATTR_LOAD_BALANCING_CONFIG, parseJsonObject(lbConfig)).build();
 
-    deliverResolvedAddresses(grpclbResolutionList, grpclbResolutionAttrs);
+    deliverResolvedAddresses(
+        Collections.<EquivalentAddressGroup>emptyList(),
+        grpclbBalancerList, grpclbResolutionAttrs);
 
     assertEquals(1, fakeOobChannels.size());
     verify(mockLbService).balanceLoad(lbResponseObserverCaptor.capture());
@@ -1706,7 +1728,7 @@ public class GrpclbLoadBalancerTest {
     StreamObserver<LoadBalanceRequest> lbRequestObserver = lbRequestObservers.poll();
     verify(lbRequestObserver).onNext(
         eq(LoadBalanceRequest.newBuilder().setInitialRequest(
-                InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
+            InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
             .build()));
 
     // Simulate receiving LB response
@@ -1722,8 +1744,8 @@ public class GrpclbLoadBalancerTest {
     // the new createSubchannel().
     inOrder.verify(helper).createSubchannel(
         eq(Arrays.asList(
-                new EquivalentAddressGroup(backends1.get(0).addr, eagAttrsWithToken("token0001")),
-                new EquivalentAddressGroup(backends1.get(1).addr, eagAttrsWithToken("token0002")))),
+            new EquivalentAddressGroup(backends1.get(0).addr, eagAttrsWithToken("token0001")),
+            new EquivalentAddressGroup(backends1.get(1).addr, eagAttrsWithToken("token0002")))),
         any(Attributes.class));
 
     // Initially IDLE
@@ -1779,9 +1801,9 @@ public class GrpclbLoadBalancerTest {
     assertThat(mockSubchannels).isEmpty();
     verify(subchannel).updateAddresses(
         eq(Arrays.asList(
-                new EquivalentAddressGroup(backends2.get(0).addr, eagAttrsWithToken("token0001")),
-                new EquivalentAddressGroup(backends2.get(2).addr,
-                    eagAttrsWithToken("token0004")))));
+            new EquivalentAddressGroup(backends2.get(0).addr, eagAttrsWithToken("token0001")),
+            new EquivalentAddressGroup(backends2.get(2).addr,
+                eagAttrsWithToken("token0004")))));
     inOrder.verify(helper).updateBalancingState(eq(READY), pickerCaptor.capture());
     RoundRobinPicker picker4 = (RoundRobinPicker) pickerCaptor.getValue();
     assertThat(picker4.dropList).containsExactly(
@@ -1825,10 +1847,12 @@ public class GrpclbLoadBalancerTest {
   @SuppressWarnings("deprecation")  // TODO(creamsoup) use parsed object
   private void subtestShutdownWithoutSubchannel(String childPolicy) throws Exception {
     String lbConfig = "{\"childPolicy\" : [ {\"" + childPolicy + "\" : {}} ]}";
-    List<EquivalentAddressGroup> grpclbResolutionList = createResolvedServerAddresses(true);
+    List<EquivalentAddressGroup> grpclbBalancerList = createResolvedBalancerAddresses(1);
     Attributes grpclbResolutionAttrs = Attributes.newBuilder().set(
         LoadBalancer.ATTR_LOAD_BALANCING_CONFIG, parseJsonObject(lbConfig)).build();
-    deliverResolvedAddresses(grpclbResolutionList, grpclbResolutionAttrs);
+    deliverResolvedAddresses(
+        Collections.<EquivalentAddressGroup>emptyList(),
+        grpclbBalancerList, grpclbResolutionAttrs);
     verify(mockLbService).balanceLoad(lbResponseObserverCaptor.capture());
     assertEquals(1, lbRequestObservers.size());
     StreamObserver<LoadBalanceRequest> requestObserver = lbRequestObservers.poll();
@@ -1848,12 +1872,12 @@ public class GrpclbLoadBalancerTest {
 
     String lbConfig = "{\"childPolicy\" : [ {\"pick_first\" : {}} ]}";
 
-    // Name resolver returns a mix of balancer and backend addresses
-    List<EquivalentAddressGroup> grpclbResolutionList =
-        createResolvedServerAddresses(false, true, false);
+    // Name resolver returns balancer and backend addresses
+    List<EquivalentAddressGroup> backendList = createResolvedBackendAddresses(2);
+    List<EquivalentAddressGroup> grpclbBalancerList = createResolvedBalancerAddresses(1);
     Attributes grpclbResolutionAttrs = Attributes.newBuilder().set(
         LoadBalancer.ATTR_LOAD_BALANCING_CONFIG, parseJsonObject(lbConfig)).build();
-    deliverResolvedAddresses(grpclbResolutionList, grpclbResolutionAttrs);
+    deliverResolvedAddresses(backendList, grpclbBalancerList, grpclbResolutionAttrs);
 
     // Attempted to connect to balancer
     assertEquals(1, fakeOobChannels.size());
@@ -1868,7 +1892,7 @@ public class GrpclbLoadBalancerTest {
     // TODO(zhangkun83): remove the deprecation suppression on this method once migrated to
     // the new createSubchannel().
     inOrder.verify(helper).createSubchannel(
-        eq(Arrays.asList(grpclbResolutionList.get(0), grpclbResolutionList.get(2))),
+        eq(Arrays.asList(backendList.get(0), backendList.get(1))),
         any(Attributes.class));
 
     assertThat(mockSubchannels).hasSize(1);
@@ -1905,9 +1929,9 @@ public class GrpclbLoadBalancerTest {
     assertThat(mockSubchannels).isEmpty();
     verify(subchannel).updateAddresses(
         eq(Arrays.asList(
-                new EquivalentAddressGroup(backends1.get(0).addr, eagAttrsWithToken("token0001")),
-                new EquivalentAddressGroup(backends1.get(1).addr,
-                    eagAttrsWithToken("token0002")))));
+            new EquivalentAddressGroup(backends1.get(0).addr, eagAttrsWithToken("token0001")),
+            new EquivalentAddressGroup(backends1.get(1).addr,
+                eagAttrsWithToken("token0002")))));
     inOrder.verify(helper).updateBalancingState(eq(READY), pickerCaptor.capture());
     RoundRobinPicker picker2 = (RoundRobinPicker) pickerCaptor.getValue();
     assertThat(picker2.dropList).containsExactly(null, null);
@@ -1927,11 +1951,13 @@ public class GrpclbLoadBalancerTest {
     InOrder inOrder = inOrder(helper);
 
     String lbConfig = "{\"childPolicy\" : [ {\"round_robin\" : {}} ]}";
-    List<EquivalentAddressGroup> grpclbResolutionList = createResolvedServerAddresses(true);
+    List<EquivalentAddressGroup> grpclbBalancerList = createResolvedBalancerAddresses(1);
     Attributes grpclbResolutionAttrs = Attributes.newBuilder().set(
         LoadBalancer.ATTR_LOAD_BALANCING_CONFIG, parseJsonObject(lbConfig)).build();
 
-    deliverResolvedAddresses(grpclbResolutionList, grpclbResolutionAttrs);
+    deliverResolvedAddresses(
+        Collections.<EquivalentAddressGroup>emptyList(),
+        grpclbBalancerList, grpclbResolutionAttrs);
 
     assertEquals(1, fakeOobChannels.size());
     ManagedChannel oobChannel = fakeOobChannels.poll();
@@ -1941,7 +1967,7 @@ public class GrpclbLoadBalancerTest {
     StreamObserver<LoadBalanceRequest> lbRequestObserver = lbRequestObservers.poll();
     verify(lbRequestObserver).onNext(
         eq(LoadBalanceRequest.newBuilder().setInitialRequest(
-                InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
+            InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
             .build()));
 
     // Simulate receiving LB response
@@ -1971,7 +1997,9 @@ public class GrpclbLoadBalancerTest {
     lbConfig = "{\"childPolicy\" : [ {\"pick_first\" : {}} ]}";
     grpclbResolutionAttrs = Attributes.newBuilder().set(
         LoadBalancer.ATTR_LOAD_BALANCING_CONFIG, parseJsonObject(lbConfig)).build();
-    deliverResolvedAddresses(grpclbResolutionList, grpclbResolutionAttrs);
+    deliverResolvedAddresses(
+        Collections.<EquivalentAddressGroup>emptyList(),
+        grpclbBalancerList, grpclbResolutionAttrs);
 
 
     // GrpclbState will be shutdown, and a new one will be created
@@ -1989,7 +2017,7 @@ public class GrpclbLoadBalancerTest {
     lbRequestObserver = lbRequestObservers.poll();
     verify(lbRequestObserver).onNext(
         eq(LoadBalanceRequest.newBuilder().setInitialRequest(
-                InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
+            InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
             .build()));
 
     // Simulate receiving LB response
@@ -2003,8 +2031,8 @@ public class GrpclbLoadBalancerTest {
     // the new createSubchannel().
     inOrder.verify(helper).createSubchannel(
         eq(Arrays.asList(
-                new EquivalentAddressGroup(backends1.get(0).addr, eagAttrsWithToken("token0001")),
-                new EquivalentAddressGroup(backends1.get(1).addr, eagAttrsWithToken("token0002")))),
+            new EquivalentAddressGroup(backends1.get(0).addr, eagAttrsWithToken("token0001")),
+            new EquivalentAddressGroup(backends1.get(1).addr, eagAttrsWithToken("token0002")))),
         any(Attributes.class));
 
     inOrder.verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
@@ -2088,19 +2116,18 @@ public class GrpclbLoadBalancerTest {
   @Test
   public void grpclbWorking_lbSendsFallbackMessage() {
     InOrder inOrder = inOrder(helper, subchannelPool);
-    List<EquivalentAddressGroup> grpclbResolutionList =
-        createResolvedServerAddresses(true, true, false, false);
-    List<EquivalentAddressGroup> fallbackEags = grpclbResolutionList.subList(2, 4);
+    List<EquivalentAddressGroup> backendList = createResolvedBackendAddresses(2);
+    List<EquivalentAddressGroup> grpclbBalancerList = createResolvedBalancerAddresses(2);
     Attributes grpclbResolutionAttrs = Attributes.EMPTY;
-    deliverResolvedAddresses(grpclbResolutionList, grpclbResolutionAttrs);
+    deliverResolvedAddresses(backendList, grpclbBalancerList, grpclbResolutionAttrs);
 
     // Fallback timer is started as soon as the addresses are resolved.
     assertEquals(1, fakeClock.numPendingTasks(FALLBACK_MODE_TASK_FILTER));
 
     List<SocketAddress> addrs = new ArrayList<>();
-    addrs.addAll(grpclbResolutionList.get(0).getAddresses());
-    addrs.addAll(grpclbResolutionList.get(1).getAddresses());
-    Attributes attr = grpclbResolutionList.get(0).getAttributes();
+    addrs.addAll(grpclbBalancerList.get(0).getAddresses());
+    addrs.addAll(grpclbBalancerList.get(1).getAddresses());
+    Attributes attr = grpclbBalancerList.get(0).getAttributes();
     EquivalentAddressGroup oobChannelEag = new EquivalentAddressGroup(addrs, attr);
     verify(helper).createOobChannel(eq(oobChannelEag), eq(lbAuthority(0)));
     assertEquals(1, fakeOobChannels.size());
@@ -2206,7 +2233,7 @@ public class GrpclbLoadBalancerTest {
         .returnSubchannel(eq(subchannel2), eq(ConnectivityStateInfo.forNonError(READY)));
 
     // verify fallback
-    fallbackTestVerifyUseOfFallbackBackendLists(inOrder, fallbackEags);
+    fallbackTestVerifyUseOfFallbackBackendLists(inOrder, backendList);
 
     assertFalse(oobChannel.isShutdown());
     verify(lbRequestObserver, never()).onCompleted();
@@ -2293,48 +2320,60 @@ public class GrpclbLoadBalancerTest {
   private void deliverSubchannelState(
       final Subchannel subchannel, final ConnectivityStateInfo newState) {
     syncContext.execute(new Runnable() {
-        @Override
-        public void run() {
-          // TODO(zhangkun83): remove the deprecation suppression on this method once migrated to
-          // the new API.
-          balancer.handleSubchannelState(subchannel, newState);
-        }
-      });
+      @Override
+      public void run() {
+        // TODO(zhangkun83): remove the deprecation suppression on this method once migrated to
+        // the new API.
+        balancer.handleSubchannelState(subchannel, newState);
+      }
+    });
   }
 
   private void deliverNameResolutionError(final Status error) {
     syncContext.execute(new Runnable() {
-        @Override
-        public void run() {
-          balancer.handleNameResolutionError(error);
-        }
-      });
+      @Override
+      public void run() {
+        balancer.handleNameResolutionError(error);
+      }
+    });
   }
 
   private void deliverResolvedAddresses(
-      final List<EquivalentAddressGroup> addrs, final Attributes attrs) {
+      final List<EquivalentAddressGroup> backendAddrs,
+      final List<EquivalentAddressGroup> balancerAddrs,
+      Attributes attrs) {
+    final Attributes attributes =
+        attrs.toBuilder().set(GrpclbConstants.ATTR_LB_ADDRS, balancerAddrs).build();
     syncContext.execute(new Runnable() {
-        @Override
-        public void run() {
-          balancer.handleResolvedAddresses(
-              ResolvedAddresses.newBuilder().setAddresses(addrs).setAttributes(attrs).build());
-        }
-      });
+      @Override
+      public void run() {
+        balancer.handleResolvedAddresses(
+            ResolvedAddresses.newBuilder()
+                .setAddresses(backendAddrs)
+                .setAttributes(attributes)
+                .build());
+      }
+    });
   }
 
   private GrpclbClientLoadRecorder getLoadRecorder() {
     return balancer.getGrpclbState().getLoadRecorder();
   }
 
-  private static List<EquivalentAddressGroup> createResolvedServerAddresses(boolean ... isLb) {
-    ArrayList<EquivalentAddressGroup> list = new ArrayList<>();
-    for (int i = 0; i < isLb.length; i++) {
+  private static List<EquivalentAddressGroup> createResolvedBackendAddresses(int n) {
+    List<EquivalentAddressGroup> list = new ArrayList<>();
+    for (int i = 0; i < n; i++) {
       SocketAddress addr = new FakeSocketAddress("fake-address-" + i);
-      EquivalentAddressGroup eag =
-          new EquivalentAddressGroup(
-              addr,
-              isLb[i] ? lbAttributes(lbAuthority(i)) : Attributes.EMPTY);
-      list.add(eag);
+      list.add(new EquivalentAddressGroup(addr));
+    }
+    return list;
+  }
+
+  private static List<EquivalentAddressGroup> createResolvedBalancerAddresses(int n) {
+    List<EquivalentAddressGroup> list = new ArrayList<>();
+    for (int i = 0; i < n; i++) {
+      SocketAddress addr = new FakeSocketAddress("fake-address-" + i);
+      list.add(new EquivalentAddressGroup(addr, lbAttributes(lbAuthority(i))));
     }
     return list;
   }

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -2401,7 +2401,7 @@ public class GrpclbLoadBalancerTest {
 
   private static Attributes lbAttributes(String authority) {
     return Attributes.newBuilder()
-        .set(GrpcAttributes.ATTR_LB_ADDR_AUTHORITY, authority)
+        .set(GrpclbConstants.ATTR_LB_ADDR_AUTHORITY, authority)
         .build();
   }
 

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -792,6 +792,20 @@ public class GrpclbLoadBalancerTest {
   }
 
   @Test
+  public void receiveNoBackendAndBalancerAddress() {
+    deliverResolvedAddresses(
+        Collections.<EquivalentAddressGroup>emptyList(),
+        Collections.<EquivalentAddressGroup>emptyList(),
+        Attributes.EMPTY);
+    verify(helper).updateBalancingState(eq(TRANSIENT_FAILURE), pickerCaptor.capture());
+    RoundRobinPicker picker = (RoundRobinPicker) pickerCaptor.getValue();
+    assertThat(picker.dropList).isEmpty();
+    Status error = Iterables.getOnlyElement(picker.pickList).picked(new Metadata()).getStatus();
+    assertThat(error.getCode()).isEqualTo(Code.UNAVAILABLE);
+    assertThat(error.getDescription()).isEqualTo("No backend or balancer addresses found");
+  }
+
+  @Test
   public void nameResolutionFailsThenRecover() {
     Status error = Status.NOT_FOUND.withDescription("www.google.com not found");
     deliverNameResolutionError(error);

--- a/xds/src/main/java/io/grpc/xds/FallbackLb.java
+++ b/xds/src/main/java/io/grpc/xds/FallbackLb.java
@@ -61,6 +61,7 @@ final class FallbackLb extends ForwardingLoadBalancer {
     return fallbackPolicyLb;
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     Attributes attributes = resolvedAddresses.getAttributes();
@@ -113,6 +114,8 @@ final class FallbackLb extends ForwardingLoadBalancer {
     List<EquivalentAddressGroup> servers = resolvedAddresses.getAddresses();
     // Some addresses in the list may be grpclb-v1 balancer addresses, so if the fallback policy
     // does not support grpclb-v1 balancer addresses, then we need to exclude them from the list.
+    // TODO(chengyuanzhang): delete the following logic after changing internal resolver
+    //  to not include grpclb server addresses.
     if (!newFallbackPolicyName.equals("grpclb") && !newFallbackPolicyName.equals(XDS_POLICY_NAME)) {
       ImmutableList.Builder<EquivalentAddressGroup> backends = ImmutableList.builder();
       for (EquivalentAddressGroup eag : resolvedAddresses.getAddresses()) {


### PR DESCRIPTION
In this take:
- `DnsNameResolver` returns balancer addresses as a `GrpcAttributes.ATTR_LB_ADDRS` attribute in `ResolutionResult`.
- `AutoConfiguredLoadBalancerFactory` decides LB policy solely based on parsed service config without looking at resolved addresses. Behavior changes:
   - If no LB policy is specified in service config, default to `pick_first`, even if there exist balancer addresses.
   - If `grpclb` specified but not available and no other specified policies available, it will fail without fallback to `round_robin`.
- `GrpclbLoadBalancer` populates balancer addresses from `ResolvedAddresses`'s attribute (`GrpclbConstants.ATTR_LB_ADDRS`) instead of sieving from addresses.


Next step after this change is to separate logic for querying SRV record in `DnsNameResolver` to a `grpclb` specific resolver.