### PR TITLE
interop-testing: use server hostname instead of id for xds test

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
@@ -130,7 +130,8 @@ public final class XdsTestServer {
       try {
         host = InetAddress.getLocalHost().getHostName();
       } catch (UnknownHostException e) {
-        logger.log(Level.WARNING, "Failed to get host", e);
+        logger.log(Level.SEVERE, "Failed to get host", e);
+        throw new RuntimeException(e);
       }
     }
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
@@ -124,7 +124,7 @@ public final class XdsTestServer {
   }
 
   private class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
-    private String host = "";
+    private final String host;
 
     private TestServiceImpl() {
       try {


### PR DESCRIPTION
Hostname is more informative for tests running on GCP, and unlike server ID, doesn't require the client to have knowledge about the server's command-line arguments 