### PR TITLE
java_grpc_library: Inline find_java_toolchain and find_java_runtime_toolchain

### DIFF
--- a/java_grpc_library.bzl
+++ b/java_grpc_library.bzl
@@ -1,7 +1,5 @@
 """Build rule for java_grpc_library."""
 
-load("@bazel_tools//tools/jdk:toolchain_utils.bzl", "find_java_runtime_toolchain", "find_java_toolchain")
-
 _JavaRpcToolchainInfo = provider(
     fields = [
         "host_javabase",
@@ -107,8 +105,8 @@ def _java_rpc_library_impl(ctx):
 
     java_info = java_common.compile(
         ctx,
-        java_toolchain = find_java_toolchain(ctx, toolchain.java_toolchain),
-        host_javabase = find_java_runtime_toolchain(ctx, toolchain.host_javabase),
+        java_toolchain = toolchain.java_toolchain[java_common.JavaToolchainInfo],
+        host_javabase = toolchain.host_javabase[java_common.JavaRuntimeInfo],
         source_jars = [srcjar],
         output = ctx.outputs.jar,
         output_source_jar = ctx.outputs.srcjar,


### PR DESCRIPTION
These methods were used to migrate the Java toolchains to use toolchain
resolution. Now that the migration is complete, the toolchain providers
can be used directly.

------

Export of cl/292224245

~@cushon, you'll get to make a comment to make the CLA bot happy.~ Apparently not. CC @cushon