### PR TITLE
xds: precise logic for selecting the virtual host in RDS responses

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -627,11 +627,10 @@ final class XdsClientImpl extends XdsClient {
    * Processes a RouteConfiguration message to find the name of upstream cluster that requests
    * for the given host will be routed to. Returns the clusterName if found.
    * Otherwise, returns {@code null}.
-   *
    */
   @VisibleForTesting
   @Nullable
-  static String findClusterNameInRouteConfig(RouteConfiguration config, String hostname) {
+  static String findClusterNameInRouteConfig(RouteConfiguration config, String hostName) {
     List<VirtualHost> virtualHosts = config.getVirtualHostsList();
     // Domain search order:
     //  1. Exact domain names: ``www.foo.com``.
@@ -647,7 +646,7 @@ final class XdsClientImpl extends XdsClient {
     for (VirtualHost vHost : virtualHosts) {
       for (String domain : vHost.getDomainsList()) {
         boolean selected = false;
-        if (matchHostName(hostname, domain)) { // matching
+        if (matchHostName(hostName, domain)) { // matching
           if (!domain.contains("*")) { // exact matching
             selected = true;
           } else if (domain.length() > matchingLen) { // longer matching pattern

--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -642,13 +642,16 @@ final class XdsClientImpl extends XdsClient {
     //  Assuming only a single virtual host in the entire route configuration can match
     //  on ``*`` and a domain must be unique across all virtual hosts.
     int matchingLen = -1; // longest length of wildcard pattern that matches host name
+    boolean exactMatchFound = false;  // true if a virtual host with exactly matched domain found
     VirtualHost targetVirtualHost = null;  // target VirtualHost with longest matched domain
     for (VirtualHost vHost : virtualHosts) {
       for (String domain : vHost.getDomainsList()) {
         boolean selected = false;
         if (matchHostName(hostName, domain)) { // matching
           if (!domain.contains("*")) { // exact matching
-            selected = true;
+            exactMatchFound = true;
+            targetVirtualHost = vHost;
+            break;
           } else if (domain.length() > matchingLen) { // longer matching pattern
             selected = true;
           } else if (domain.length() == matchingLen && domain.startsWith("*")) { // suffix matching
@@ -659,6 +662,9 @@ final class XdsClientImpl extends XdsClient {
           matchingLen = domain.length();
           targetVirtualHost = vHost;
         }
+      }
+      if (exactMatchFound) {
+        break;
       }
     }
 

--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -670,6 +670,9 @@ final class XdsClientImpl extends XdsClient {
 
     // Proceed with the virtual host that has longest wildcard matched domain name with the
     // hostname in original "xds:" URI.
+    // Note we would consider upstream cluster not found if the virtual host is not configured
+    // correctly for gRPC, even if there exist other virtual hosts with (lower priority)
+    // matching domains.
     if (targetVirtualHost != null) {
       // The client will look only at the last route in the list (the default route),
       // whose match field must contain a prefix field whose value is empty string

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTest.java
@@ -3200,12 +3200,12 @@ public class XdsClientImplTest {
 
   @Test
   public void findClusterNameInRouteConfig_exactMatchFirst() {
-    String hostname = "foo.googleapis.com";
+    String hostname = "a.googleapis.com";
     String targetClusterName = "cluster-hello.googleapis.com";
     VirtualHost vHost1 =
         VirtualHost.newBuilder()
             .setName("virtualhost01.googleapis.com")  // don't care
-            .addAllDomains(ImmutableList.of("foo.googleapis.com", "bar.googleapis.com"))
+            .addAllDomains(ImmutableList.of("a.googleapis.com", "b.googleapis.com"))
             .addRoutes(
                 Route.newBuilder()
                     .setRoute(RouteAction.newBuilder().setCluster(targetClusterName))
@@ -3238,12 +3238,12 @@ public class XdsClientImplTest {
 
   @Test
   public void findClusterNameInRouteConfig_preferSuffixDomainOverPrefixDomain() {
-    String hostname = "foo.googleapis.com";
+    String hostname = "a.googleapis.com";
     String targetClusterName = "cluster-hello.googleapis.com";
     VirtualHost vHost1 =
         VirtualHost.newBuilder()
             .setName("virtualhost01.googleapis.com")  // don't care
-            .addAllDomains(ImmutableList.of("*.googleapis.com", "bar.googleapis.com"))
+            .addAllDomains(ImmutableList.of("*.googleapis.com", "b.googleapis.com"))
             .addRoutes(
                 Route.newBuilder()
                     .setRoute(RouteAction.newBuilder().setCluster(targetClusterName))
@@ -3252,7 +3252,7 @@ public class XdsClientImplTest {
     VirtualHost vHost2 =
         VirtualHost.newBuilder()
             .setName("virtualhost02.googleapis.com")  // don't care
-            .addAllDomains(ImmutableList.of("foo.googleapis.*"))
+            .addAllDomains(ImmutableList.of("a.googleapis.*"))
             .addRoutes(
                 Route.newBuilder()
                     .setRoute(RouteAction.newBuilder().setCluster("cluster-hi.googleapis.com"))
@@ -3276,7 +3276,7 @@ public class XdsClientImplTest {
 
   @Test
   public void findClusterNameInRouteConfig_asteriskMatchAnyDomain() {
-    String hostname = "foo.googleapis.com";
+    String hostname = "a.googleapis.com";
     String targetClusterName = "cluster-hello.googleapis.com";
     VirtualHost vHost1 =
         VirtualHost.newBuilder()
@@ -3290,7 +3290,7 @@ public class XdsClientImplTest {
     VirtualHost vHost2 =
         VirtualHost.newBuilder()
             .setName("virtualhost02.googleapis.com")  // don't care
-            .addAllDomains(ImmutableList.of("bar.googleapis.com"))
+            .addAllDomains(ImmutableList.of("b.googleapis.com"))
             .addRoutes(
                 Route.newBuilder()
                     .setRoute(RouteAction.newBuilder().setCluster("cluster-hi.googleapis.com"))

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTest.java
@@ -58,6 +58,8 @@ import io.envoyproxy.envoy.api.v2.core.Node;
 import io.envoyproxy.envoy.api.v2.endpoint.ClusterStats;
 import io.envoyproxy.envoy.api.v2.route.RedirectAction;
 import io.envoyproxy.envoy.api.v2.route.Route;
+import io.envoyproxy.envoy.api.v2.route.RouteAction;
+import io.envoyproxy.envoy.api.v2.route.RouteMatch;
 import io.envoyproxy.envoy.api.v2.route.VirtualHost;
 import io.envoyproxy.envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager;
 import io.envoyproxy.envoy.config.filter.network.http_connection_manager.v2.Rds;
@@ -3197,6 +3199,111 @@ public class XdsClientImplTest {
   }
 
   @Test
+  public void findClusterNameInRouteConfig_exactMatchFirst() {
+    String hostname = "foo.googleapis.com";
+    String targetClusterName = "cluster-hello.googleapis.com";
+    VirtualHost vHost1 =
+        VirtualHost.newBuilder()
+            .setName("virtualhost01.googleapis.com")  // don't care
+            .addAllDomains(ImmutableList.of("foo.googleapis.com", "bar.googleapis.com"))
+            .addRoutes(
+                Route.newBuilder()
+                    .setRoute(RouteAction.newBuilder().setCluster(targetClusterName))
+                    .setMatch(RouteMatch.newBuilder().setPrefix("")))
+            .build();
+    VirtualHost vHost2 =
+        VirtualHost.newBuilder()
+            .setName("virtualhost02.googleapis.com")  // don't care
+            .addAllDomains(ImmutableList.of("*.googleapis.com"))
+            .addRoutes(
+                Route.newBuilder()
+                    .setRoute(RouteAction.newBuilder().setCluster("cluster-hi.googleapis.com"))
+                    .setMatch(RouteMatch.newBuilder().setPrefix("")))
+            .build();
+    VirtualHost vHost3 =
+        VirtualHost.newBuilder()
+            .setName("virtualhost03.googleapis.com")  // don't care
+            .addAllDomains(ImmutableList.of("*"))
+            .addRoutes(
+                Route.newBuilder()
+                    .setRoute(RouteAction.newBuilder().setCluster("cluster-hey.googleapis.com"))
+                    .setMatch(RouteMatch.newBuilder().setPrefix("")))
+            .build();
+    RouteConfiguration routeConfig =
+        buildRouteConfiguration(
+            "route-foo.googleapis.com", ImmutableList.of(vHost1, vHost2, vHost3));
+    String result = XdsClientImpl.findClusterNameInRouteConfig(routeConfig, hostname);
+    assertThat(result).isEqualTo(targetClusterName);
+  }
+
+  @Test
+  public void findClusterNameInRouteConfig_preferSuffixDomainOverPrefixDomain() {
+    String hostname = "foo.googleapis.com";
+    String targetClusterName = "cluster-hello.googleapis.com";
+    VirtualHost vHost1 =
+        VirtualHost.newBuilder()
+            .setName("virtualhost01.googleapis.com")  // don't care
+            .addAllDomains(ImmutableList.of("*.googleapis.com", "bar.googleapis.com"))
+            .addRoutes(
+                Route.newBuilder()
+                    .setRoute(RouteAction.newBuilder().setCluster(targetClusterName))
+                    .setMatch(RouteMatch.newBuilder().setPrefix("")))
+            .build();
+    VirtualHost vHost2 =
+        VirtualHost.newBuilder()
+            .setName("virtualhost02.googleapis.com")  // don't care
+            .addAllDomains(ImmutableList.of("foo.googleapis.*"))
+            .addRoutes(
+                Route.newBuilder()
+                    .setRoute(RouteAction.newBuilder().setCluster("cluster-hi.googleapis.com"))
+                    .setMatch(RouteMatch.newBuilder().setPrefix("")))
+            .build();
+    VirtualHost vHost3 =
+        VirtualHost.newBuilder()
+            .setName("virtualhost03.googleapis.com")  // don't care
+            .addAllDomains(ImmutableList.of("*"))
+            .addRoutes(
+                Route.newBuilder()
+                    .setRoute(RouteAction.newBuilder().setCluster("cluster-hey.googleapis.com"))
+                    .setMatch(RouteMatch.newBuilder().setPrefix("")))
+            .build();
+    RouteConfiguration routeConfig =
+        buildRouteConfiguration(
+            "route-foo.googleapis.com", ImmutableList.of(vHost1, vHost2, vHost3));
+    String result = XdsClientImpl.findClusterNameInRouteConfig(routeConfig, hostname);
+    assertThat(result).isEqualTo(targetClusterName);
+  }
+
+  @Test
+  public void findClusterNameInRouteConfig_asteriskMatchAnyDomain() {
+    String hostname = "foo.googleapis.com";
+    String targetClusterName = "cluster-hello.googleapis.com";
+    VirtualHost vHost1 =
+        VirtualHost.newBuilder()
+            .setName("virtualhost01.googleapis.com")  // don't care
+            .addAllDomains(ImmutableList.of("*"))
+            .addRoutes(
+                Route.newBuilder()
+                    .setRoute(RouteAction.newBuilder().setCluster(targetClusterName))
+                    .setMatch(RouteMatch.newBuilder().setPrefix("")))
+            .build();
+    VirtualHost vHost2 =
+        VirtualHost.newBuilder()
+            .setName("virtualhost02.googleapis.com")  // don't care
+            .addAllDomains(ImmutableList.of("bar.googleapis.com"))
+            .addRoutes(
+                Route.newBuilder()
+                    .setRoute(RouteAction.newBuilder().setCluster("cluster-hi.googleapis.com"))
+                    .setMatch(RouteMatch.newBuilder().setPrefix("")))
+            .build();
+    RouteConfiguration routeConfig =
+        buildRouteConfiguration(
+            "route-foo.googleapis.com", ImmutableList.of(vHost1, vHost2));
+    String result = XdsClientImpl.findClusterNameInRouteConfig(routeConfig, hostname);
+    assertThat(result).isEqualTo(targetClusterName);
+  }
+
+  @Test
   public void messagePrinter_printLdsResponse() {
     MessagePrinter printer = new MessagePrinter();
     List<Any> listeners = ImmutableList.of(
@@ -3232,10 +3339,16 @@ public class XdsClientImplTest {
         + "            \"name\": \"virtualhost00.googleapis.com\",\n"
         + "            \"domains\": [\"foo.googleapis.com\", \"bar.googleapis.com\"],\n"
         + "            \"routes\": [{\n"
+        + "              \"match\": {\n"
+        + "                \"prefix\": \"\"\n"
+        + "              },\n"
         + "              \"route\": {\n"
         + "                \"cluster\": \"whatever cluster\"\n"
         + "              }\n"
         + "            }, {\n"
+        + "              \"match\": {\n"
+        + "                \"prefix\": \"\"\n"
+        + "              },\n"
         + "              \"route\": {\n"
         + "                \"cluster\": \"cluster.googleapis.com\"\n"
         + "              }\n"
@@ -3276,10 +3389,16 @@ public class XdsClientImplTest {
         + "      \"name\": \"virtualhost00.googleapis.com\",\n"
         + "      \"domains\": [\"foo.googleapis.com\", \"bar.googleapis.com\"],\n"
         + "      \"routes\": [{\n"
+        + "        \"match\": {\n"
+        + "          \"prefix\": \"\"\n"
+        + "        },\n"
         + "        \"route\": {\n"
         + "          \"cluster\": \"whatever cluster\"\n"
         + "        }\n"
         + "      }, {\n"
+        + "        \"match\": {\n"
+        + "          \"prefix\": \"\"\n"
+        + "        },\n"
         + "        \"route\": {\n"
         + "          \"cluster\": \"cluster.googleapis.com\"\n"
         + "        }\n"

--- a/xds/src/test/java/io/grpc/xds/XdsClientTestHelper.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientTestHelper.java
@@ -45,6 +45,7 @@ import io.envoyproxy.envoy.api.v2.core.SocketAddress;
 import io.envoyproxy.envoy.api.v2.listener.FilterChain;
 import io.envoyproxy.envoy.api.v2.route.Route;
 import io.envoyproxy.envoy.api.v2.route.RouteAction;
+import io.envoyproxy.envoy.api.v2.route.RouteMatch;
 import io.envoyproxy.envoy.api.v2.route.VirtualHost;
 import io.envoyproxy.envoy.config.listener.v2.ApiListener;
 import io.envoyproxy.envoy.type.FractionalPercent;
@@ -104,17 +105,19 @@ class XdsClientTestHelper {
   }
 
   static VirtualHost buildVirtualHost(List<String> domains, String clusterName) {
-    return
-        VirtualHost.newBuilder()
-            .setName("virtualhost00.googleapis.com")  // don't care
-            .addAllDomains(domains)
-            .addRoutes(Route.newBuilder()
-                .setRoute(RouteAction.newBuilder().setCluster("whatever cluster")))
-            .addRoutes(
-                // Only the last (default) route matters.
-                Route.newBuilder()
-                    .setRoute(RouteAction.newBuilder().setCluster(clusterName)))
-            .build();
+    return VirtualHost.newBuilder()
+        .setName("virtualhost00.googleapis.com") // don't care
+        .addAllDomains(domains)
+        .addRoutes(
+            Route.newBuilder()
+                .setRoute(RouteAction.newBuilder().setCluster("whatever cluster"))
+                .setMatch(RouteMatch.newBuilder().setPrefix("")))
+        .addRoutes(
+            // Only the last (default) route matters.
+            Route.newBuilder()
+                .setRoute(RouteAction.newBuilder().setCluster(clusterName))
+                .setMatch(RouteMatch.newBuilder().setPrefix("")))
+        .build();
   }
 
   static Cluster buildCluster(String clusterName, @Nullable String edsServiceName,


### PR DESCRIPTION
Implements the precise logic for choosing the virtual host in `RouteConfiguration` of RDS responses. Specifically, fixes logic for domain search order. Minor fix for checking `match` field in `RouteConfiguration`. Please see _RouteConfiguration Proto_ section in gRPC Client xDS API Flow design doc for specification. 