### PR TITLE
grpclb: expose balancer address related attributes in internal accessor

### DIFF
--- a/grpclb/src/main/java/io/grpc/grpclb/InternalGrpclbConstantsAccessor.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/InternalGrpclbConstantsAccessor.java
@@ -20,6 +20,7 @@ import io.grpc.Attributes;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.Internal;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Internal {@link GrpclbConstants} accessor. This is intended for usage internal to the gRPC
@@ -41,9 +42,25 @@ public class InternalGrpclbConstantsAccessor {
   }
 
   /**
+   * Populates gRPC LB address authority from attributes.
+   */
+  @Nullable
+  public static String getLbAddrAuthorityAttr(@EquivalentAddressGroup.Attr Attributes attrs) {
+    return attrs.get(GrpclbConstants.ATTR_LB_ADDR_AUTHORITY);
+  }
+
+  /**
    * Sets attribute for gRPC LB addresses.
    */
   public static Attributes setLbAddrAttr(Attributes attrs, List<EquivalentAddressGroup> lbAddrs) {
     return attrs.toBuilder().set(GrpclbConstants.ATTR_LB_ADDRS, lbAddrs).build();
+  }
+
+  /**
+   * Populates gRPC LB addresses from attributes.
+   */
+  @Nullable
+  public static List<EquivalentAddressGroup> getLbAddrAttr(Attributes attrs) {
+    return attrs.get(GrpclbConstants.ATTR_LB_ADDRS);
   }
 }

--- a/grpclb/src/main/java/io/grpc/grpclb/InternalGrpclbConstantsAccessor.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/InternalGrpclbConstantsAccessor.java
@@ -20,7 +20,6 @@ import io.grpc.Attributes;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.Internal;
 import java.util.List;
-import javax.annotation.Nullable;
 
 /**
  * Internal {@link GrpclbConstants} accessor. This is intended for usage internal to the gRPC
@@ -33,34 +32,10 @@ public class InternalGrpclbConstantsAccessor {
   private InternalGrpclbConstantsAccessor() {
   }
 
-  /**
-   * Sets attribute for gRPC LB address authority.
-   */
-  public static Attributes setLbAddrAuthorityAttr(
-      @EquivalentAddressGroup.Attr Attributes attrs, String authority) {
-    return attrs.toBuilder().set(GrpclbConstants.ATTR_LB_ADDR_AUTHORITY, authority).build();
-  }
+  public static Attributes.Key<List<EquivalentAddressGroup>> ATTR_LB_ADDRS =
+      GrpclbConstants.ATTR_LB_ADDRS;
 
-  /**
-   * Populates gRPC LB address authority from attributes.
-   */
-  @Nullable
-  public static String getLbAddrAuthorityAttr(@EquivalentAddressGroup.Attr Attributes attrs) {
-    return attrs.get(GrpclbConstants.ATTR_LB_ADDR_AUTHORITY);
-  }
-
-  /**
-   * Sets attribute for gRPC LB addresses.
-   */
-  public static Attributes setLbAddrAttr(Attributes attrs, List<EquivalentAddressGroup> lbAddrs) {
-    return attrs.toBuilder().set(GrpclbConstants.ATTR_LB_ADDRS, lbAddrs).build();
-  }
-
-  /**
-   * Populates gRPC LB addresses from attributes.
-   */
-  @Nullable
-  public static List<EquivalentAddressGroup> getLbAddrAttr(Attributes attrs) {
-    return attrs.get(GrpclbConstants.ATTR_LB_ADDRS);
-  }
+  @EquivalentAddressGroup.Attr
+  public static Attributes.Key<String> ATTR_LB_ADDR_AUTHORITY =
+      GrpclbConstants.ATTR_LB_ADDR_AUTHORITY;
 }


### PR DESCRIPTION
Patches #6667. Add getters for tests that populate grpclb balancer address related attribute values.