### PR TITLE
alts: _Actually_ use Conscrypt when available

### DIFF
--- a/alts/src/main/java/io/grpc/alts/internal/AesGcmAeadCrypter.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AesGcmAeadCrypter.java
@@ -18,6 +18,7 @@ package io.grpc.alts.internal;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.grpc.internal.ConscryptLoader;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
@@ -110,7 +111,8 @@ final class AesGcmAeadCrypter implements AeadCrypter {
     return KEY_LENGTH;
   }
 
-  private static Provider getConscrypt() {
+  @VisibleForTesting
+  static Provider getConscrypt() {
     if (!ConscryptLoader.isPresent()) {
       return null;
     }
@@ -129,7 +131,7 @@ final class AesGcmAeadCrypter implements AeadCrypter {
       return null;
     }
     try {
-      Cipher.getInstance(AES_GCM, CONSCRYPT);
+      Cipher.getInstance(AES_GCM, provider);
     } catch (SecurityException t) {
       // Pre-Java 7u121/Java 8u111 fails with SecurityException:
       //   JCE cannot authenticate the provider Conscrypt

--- a/alts/src/test/java/io/grpc/alts/internal/AesGcmAeadCrypterTest.java
+++ b/alts/src/test/java/io/grpc/alts/internal/AesGcmAeadCrypterTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.alts.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.TruthJUnit.assume;
+
+import org.conscrypt.Conscrypt;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class AesGcmAeadCrypterTest {
+  @Test
+  public void getConscrypt_worksWhenConscryptIsAvailable() {
+    assume().that(Conscrypt.isAvailable()).isTrue();
+    assertThat(AesGcmAeadCrypter.getConscrypt()).isNotNull();
+  }
+}


### PR DESCRIPTION
Previously the check for Conscrypt would always fail because CONSCRYPT
was guaranteed to be null.