### PR TITLE
interop-testing: fix bug for xds dependency not published yet

### DIFF
--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -113,13 +113,12 @@ task grpclb_long_lived_affinity_test_client(type: CreateStartScripts) {
 }
 
 task xds_test_client(type: CreateStartScripts) {
+    // Use task dependsOn instead of depending on project(':grpc-xds') in configurations because
+    // grpc-xds is not published yet and we don't want grpc-interop-testin to depend on it in maven.
     dependsOn ':grpc-xds:jar'
     mainClassName = "io.grpc.testing.integration.XdsTestClient"
     applicationName = "xds-test-client"
     outputDir = new File(project.buildDir, 'tmp')
-
-    // Using output files instead of depending on project(':grpc-xds') directly because grpc-xds is
-    // not published yet and we don't want it to be a dependency of grpc-interop-testing in maven.
     classpath = startScripts.classpath + fileTree("${project(':grpc-xds').buildDir}/libs")
     doLast {
         unixScript.text = unixScript.text.replace(

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -14,7 +14,6 @@ configurations {
 }
 
 evaluationDependsOn(project(':grpc-context').path)
-evaluationDependsOn(project(':grpc-xds').path)
 
 dependencies {
     compile project(':grpc-alts'),
@@ -36,10 +35,6 @@ dependencies {
     testCompile project(':grpc-context').sourceSets.test.output,
             libraries.mockito
     alpnagent libraries.jetty_alpn_agent
-
-    // Using source output instead of depending on project(':grpc-xds') directly because grpc-xds is
-    // not published yet and we don't want it to be a dependency of grpc-interop-testing in maven.
-    runtime project(':grpc-xds').sourceSets.main.output
 }
 
 configureProtoCompilation()
@@ -118,9 +113,13 @@ task grpclb_long_lived_affinity_test_client(type: CreateStartScripts) {
 }
 
 task xds_test_client(type: CreateStartScripts) {
+    dependsOn ':grpc-xds:jar'
     mainClassName = "io.grpc.testing.integration.XdsTestClient"
     applicationName = "xds-test-client"
     outputDir = new File(project.buildDir, 'tmp')
+
+    // Using output files instead of depending on project(':grpc-xds') directly because grpc-xds is
+    // not published yet and we don't want it to be a dependency of grpc-interop-testing in maven.
     classpath = startScripts.classpath + fileTree("${project(':grpc-xds').buildDir}/libs")
     doLast {
         unixScript.text = unixScript.text.replace(

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -14,6 +14,7 @@ configurations {
 }
 
 evaluationDependsOn(project(':grpc-context').path)
+evaluationDependsOn(project(':grpc-xds').path)
 
 dependencies {
     compile project(':grpc-alts'),
@@ -25,7 +26,6 @@ dependencies {
             project(':grpc-protobuf'),
             project(':grpc-stub'),
             project(':grpc-testing'),
-            project(':grpc-xds'),
             libraries.google_auth_oauth2_http,
             libraries.junit,
             libraries.truth
@@ -36,6 +36,10 @@ dependencies {
     testCompile project(':grpc-context').sourceSets.test.output,
             libraries.mockito
     alpnagent libraries.jetty_alpn_agent
+
+    // Using source output instead of depending on project(':grpc-xds') directly because grpc-xds is
+    // not published yet and we don't want it to be a dependency of grpc-interop-testing in maven.
+    runtime project(':grpc-xds').sourceSets.main.output
 }
 
 configureProtoCompilation()
@@ -117,7 +121,13 @@ task xds_test_client(type: CreateStartScripts) {
     mainClassName = "io.grpc.testing.integration.XdsTestClient"
     applicationName = "xds-test-client"
     outputDir = new File(project.buildDir, 'tmp')
-    classpath = jar.outputs.files + configurations.runtime
+    classpath = startScripts.classpath + fileTree("${project(':grpc-xds').buildDir}/libs")
+    doLast {
+        unixScript.text = unixScript.text.replace(
+                '\$APP_HOME/lib/grpc-xds', "${project(':grpc-xds').buildDir}/libs/grpc-xds")
+        windowsScript.text = windowsScript.text.replace(
+                '%APP_HOME%\\lib\\grpc-xds', "${project(':grpc-xds').buildDir}\\libs\\grpc-xds")
+    }
 }
 
 task xds_test_server(type: CreateStartScripts) {


### PR DESCRIPTION
In v1.27.0 release the grpc-interop-testing artifact in maven includes grpc-xds, but grpc-xds is not yet published. It should be removed from the dependency list in maven artifact.