### PR TITLE
census: Set SpanKind on Client/Server traces

### DIFF
--- a/census/src/main/java/io/grpc/census/CensusTracingModule.java
+++ b/census/src/main/java/io/grpc/census/CensusTracingModule.java
@@ -238,6 +238,7 @@ final class CensusTracingModule {
                   generateTraceSpanName(false, method.getFullMethodName()),
                   parentSpan)
               .setRecordEvents(true)
+              .setSpanKind(Span.Kind.CLIENT)
               .startSpan();
     }
 
@@ -308,6 +309,7 @@ final class CensusTracingModule {
                   generateTraceSpanName(true, fullMethodName),
                   remoteSpan)
               .setRecordEvents(true)
+              .setSpanKind(Span.Kind.SERVER)
               .startSpan();
     }
 


### PR DESCRIPTION
This PR sets the SpanKinds of Client/Server traces, in order to distinguish them more easily after export.