### PR TITLE
interop-testing: fix bug of xds test missing transitive dependency

### DIFF
--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -115,7 +115,9 @@ task grpclb_long_lived_affinity_test_client(type: CreateStartScripts) {
 task xds_test_client(type: CreateStartScripts) {
     // Use task dependsOn instead of depending on project(':grpc-xds') in configurations because
     // grpc-xds is not published yet and we don't want grpc-interop-testin to depend on it in maven.
-    dependsOn ':grpc-xds:jar'
+    dependsOn ':grpc-xds:shadowJar'
+    // Add all other dependencies that grpc-xds needs.
+    dependencies { compile project(':grpc-services'), libraries.netty_epoll }
     mainClassName = "io.grpc.testing.integration.XdsTestClient"
     applicationName = "xds-test-client"
     outputDir = new File(project.buildDir, 'tmp')


### PR DESCRIPTION
This fixes a bug introduced in #6675 .

grpc-interop-testing should have added all dependency e.g. enovy that grpc-xds needs.  