### PR TITLE
Sync grpc-proto to 1ff78907

### DIFF
--- a/alts/src/main/proto/grpc/gcp/handshaker.proto
+++ b/alts/src/main/proto/grpc/gcp/handshaker.proto
@@ -105,6 +105,9 @@ message StartClientHandshakeReq {
 
   // (Optional) RPC protocol versions supported by the client.
   RpcProtocolVersions rpc_versions = 9;
+
+  // (Optional) Maximum frame size supported by the client.
+  uint32 max_frame_size = 10;
 }
 
 message ServerHandshakeParameters {
@@ -143,6 +146,9 @@ message StartServerHandshakeReq {
 
   // (Optional) RPC protocol versions supported by the server.
   RpcProtocolVersions rpc_versions = 6;
+
+  // (Optional) Maximum frame size supported by the server.
+  uint32 max_frame_size = 7;
 }
 
 message NextHandshakeMessageReq {
@@ -190,6 +196,9 @@ message HandshakerResult {
 
   // The RPC protocol versions supported by the peer.
   RpcProtocolVersions peer_rpc_versions = 7;
+
+  // The maximum frame size of the peer.
+  uint32 max_frame_size = 8;
 }
 
 message HandshakerStatus {

--- a/grpclb/BUILD.bazel
+++ b/grpclb/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
 load("//:java_grpc_library.bzl", "java_grpc_library")
 
 java_library(
@@ -9,7 +8,6 @@ java_library(
     visibility = ["//visibility:public"],
     deps = [
         ":load_balancer_java_grpc",
-        ":load_balancer_java_proto",
         "//api",
         "//core:internal",
         "//core:util",
@@ -18,25 +16,12 @@ java_library(
         "@com_google_guava_guava//jar",
         "@com_google_j2objc_j2objc_annotations//jar",
         "@com_google_protobuf//:protobuf_java_util",
+        "@io_grpc_grpc_proto//:grpclb_load_balancer_java_proto",
     ],
-)
-
-proto_library(
-    name = "load_balancer_proto",
-    srcs = ["src/main/proto/grpc/lb/v1/load_balancer.proto"],
-    deps = [
-        "@com_google_protobuf//:duration_proto",
-        "@com_google_protobuf//:timestamp_proto",
-    ],
-)
-
-java_proto_library(
-    name = "load_balancer_java_proto",
-    deps = [":load_balancer_proto"],
 )
 
 java_grpc_library(
     name = "load_balancer_java_grpc",
-    srcs = [":load_balancer_proto"],
-    deps = [":load_balancer_java_proto"],
+    srcs = ["@io_grpc_grpc_proto//:grpclb_load_balancer_proto"],
+    deps = ["@io_grpc_grpc_proto//:grpclb_load_balancer_java_proto"],
 )

--- a/grpclb/src/main/proto/grpc/lb/v1/load_balancer.proto
+++ b/grpclb/src/main/proto/grpc/lb/v1/load_balancer.proto
@@ -97,10 +97,11 @@ message LoadBalanceResponse {
 
     // If this field is set, then the client should eagerly enter fallback
     // mode (even if there are existing, healthy connections to backends).
-    // See go/grpclb-explicit-fallback for more details.
     FallbackResponse fallback_response = 3;
   }
 }
+
+message FallbackResponse {}
 
 message InitialLoadBalanceResponse {
   // This is an application layer redirect that indicates the client should use
@@ -115,8 +116,6 @@ message InitialLoadBalanceResponse {
   // positive.
   google.protobuf.Duration client_stats_report_interval = 2;
 }
-
-message FallbackResponse {}
 
 message ServerList {
   // Contains a list of servers selected by the load balancer. The list will

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -311,9 +311,9 @@ def com_squareup_okio_okio():
 def io_grpc_grpc_proto():
     http_archive(
         name = "io_grpc_grpc_proto",
-        sha256 = "9d96f861f01ed9e3d805024e72a6b218b626da2114c69c1cad5d0e967c8e23be",
-        strip_prefix = "grpc-proto-435d723289d348e1bc420d420b364369d565182a",
-        urls = ["https://github.com/grpc/grpc-proto/archive/435d723289d348e1bc420d420b364369d565182a.zip"],
+        sha256 = "e3f2bf5caa217b8a703acb52cc5a503f06545b6be7889e44ea428f29e7320e9d",
+        strip_prefix = "grpc-proto-1ff7890719cea62825beeff16d6c2c66cf51ea90",
+        urls = ["https://github.com/grpc/grpc-proto/archive/1ff7890719cea62825beeff16d6c2c66cf51ea90.zip"],
     )
 
 def io_netty_netty_buffer():


### PR DESCRIPTION
This noticed that load_balancer.proto had local changes introduced
in #6549. This was not noticed by Bazel because grpclb was not using
the io_grpc_grpc_proto repository. These issues have been fixed.