### PR TITLE
buildscripts: fix url of grpc core repo

### DIFF
--- a/buildscripts/kokoro/xds.sh
+++ b/buildscripts/kokoro/xds.sh
@@ -14,7 +14,7 @@ pushd grpc-java/interop-testing
 ../gradlew installDist -x test -PskipCodegen=true -PskipAndroid=true
 popd
 
-git clone https://github.com/ericgribkoff/grpc.git
+git clone https://github.com/grpc/grpc.git
 
 grpc/tools/run_tests/helper_scripts/prep_xds.sh
 python3 grpc/tools/run_tests/run_xds_tests.py \


### PR DESCRIPTION
Mistakenly left this pointing to my fork in https://github.com/grpc/grpc-java/pull/6662