### PR TITLE
interop-testing: sync SimpleResponse definition with core and go

### DIFF
--- a/interop-testing/src/main/proto/grpc/testing/messages.proto
+++ b/interop-testing/src/main/proto/grpc/testing/messages.proto
@@ -41,6 +41,21 @@ message EchoStatus {
   string message = 2;
 }
 
+// The type of route that a client took to reach a server w.r.t. gRPCLB.
+// The server must fill in "fallback" if it detects that the RPC reached
+// the server via the "gRPCLB fallback" path, and "backend" if it detects
+// that the RPC reached the server via "gRPCLB backend" path (i.e. if it got
+// the address of this server from the gRPCLB server BalanceLoad RPC). Exactly
+// how this detection is done is context and server dependent.
+enum GrpclbRouteType {
+  // Server didn't detect the route that a client took to reach it.
+  GRPCLB_ROUTE_TYPE_UNKNOWN = 0;
+  // Indicates that a client reached a server via gRPCLB fallback.
+  GRPCLB_ROUTE_TYPE_FALLBACK = 1;
+  // Indicates that a client reached a server as a gRPCLB-given backend.
+  GRPCLB_ROUTE_TYPE_BACKEND = 2;
+}
+
 // Unary request.
 message SimpleRequest {
   reserved 1;
@@ -85,8 +100,10 @@ message SimpleResponse {
   // Server ID. This must be unique among different server instances,
   // but the same across all RPC's made to a particular server instance.
   string server_id = 4;
+  // gRPCLB Path.
+  GrpclbRouteType grpclb_route_type = 5;
   // Server hostname.
-  string hostname = 5;
+  string hostname = 6;
 }
 
 message SimpleContext {


### PR DESCRIPTION
The `grpclb_route_type` field already exists in the core and Go repos.