### PR TITLE
Condense redundant catch block

### DIFF
--- a/android-interop-testing/app/src/androidTest/java/io/grpc/android/integrationtest/InteropInstrumentationTest.java
+++ b/android-interop-testing/app/src/androidTest/java/io/grpc/android/integrationtest/InteropInstrumentationTest.java
@@ -68,11 +68,7 @@ public class InteropInstrumentationTest {
     if (useTls) {
       try {
         ProviderInstaller.installIfNeeded(InstrumentationRegistry.getTargetContext());
-      } catch (GooglePlayServicesRepairableException e) {
-        // The provider is helpful, but it is possible to succeed without it.
-        // Hope that the system-provided libraries are new enough.
-        Log.i(LOG_TAG, "Failed installing security provider", e);
-      } catch (GooglePlayServicesNotAvailableException e) {
+      } catch (GooglePlayServicesRepairableException | GooglePlayServicesNotAvailableException e) {
         // The provider is helpful, but it is possible to succeed without it.
         // Hope that the system-provided libraries are new enough.
         Log.i(LOG_TAG, "Failed installing security provider", e);


### PR DESCRIPTION
It was annoying to see 2 exceptions being caught in 2 different blocks handling the exception the exact same way. It does not change the execution of the code at all.