### PR TITLE
Revert "census: Set SpanKind on Client/Server traces (#6680)"

### DIFF
--- a/census/src/main/java/io/grpc/census/CensusTracingModule.java
+++ b/census/src/main/java/io/grpc/census/CensusTracingModule.java
@@ -238,7 +238,6 @@ final class CensusTracingModule {
                   generateTraceSpanName(false, method.getFullMethodName()),
                   parentSpan)
               .setRecordEvents(true)
-              .setSpanKind(Span.Kind.CLIENT)
               .startSpan();
     }
 
@@ -309,7 +308,6 @@ final class CensusTracingModule {
                   generateTraceSpanName(true, fullMethodName),
                   remoteSpan)
               .setRecordEvents(true)
-              .setSpanKind(Span.Kind.SERVER)
               .startSpan();
     }
 


### PR DESCRIPTION
This reverts commit 60bc74620fc88b321a46791241326939de70ed20.

This breaks internal tests. In the internal opencensus implementation, Span without kind needs to be in the format of "[Recv|Sent].Namespace.Service.Method" and Span with kind needs to be in the format of "Namespace.Service/Method".