### PR TITLE
okhttp: fix incorrect connection-level flow control handling at beginning of connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ For a guided tour, take a look at the [quick start
 guide](https://grpc.io/docs/quickstart/java.html) or the more explanatory [gRPC
 basics](https://grpc.io/docs/tutorials/basic/java.html).
 
-The [examples](https://github.com/grpc/grpc-java/tree/v1.23.0/examples) and the
-[Android example](https://github.com/grpc/grpc-java/tree/v1.23.0/examples/android)
+The [examples](https://github.com/grpc/grpc-java/tree/v1.24.0/examples) and the
+[Android example](https://github.com/grpc/grpc-java/tree/v1.24.0/examples/android)
 are standalone projects that showcase the usage of gRPC.
 
 Download
@@ -42,37 +42,37 @@ Download [the JARs][]. Or for Maven with non-Android, add to your `pom.xml`:
 <dependency>
   <groupId>io.grpc</groupId>
   <artifactId>grpc-netty-shaded</artifactId>
-  <version>1.23.0</version>
+  <version>1.24.0</version>
 </dependency>
 <dependency>
   <groupId>io.grpc</groupId>
   <artifactId>grpc-protobuf</artifactId>
-  <version>1.23.0</version>
+  <version>1.24.0</version>
 </dependency>
 <dependency>
   <groupId>io.grpc</groupId>
   <artifactId>grpc-stub</artifactId>
-  <version>1.23.0</version>
+  <version>1.24.0</version>
 </dependency>
 ```
 
 Or for Gradle with non-Android, add to your dependencies:
 ```gradle
-implementation 'io.grpc:grpc-netty-shaded:1.23.0'
-implementation 'io.grpc:grpc-protobuf:1.23.0'
-implementation 'io.grpc:grpc-stub:1.23.0'
+implementation 'io.grpc:grpc-netty-shaded:1.24.0'
+implementation 'io.grpc:grpc-protobuf:1.24.0'
+implementation 'io.grpc:grpc-stub:1.24.0'
 ```
 
 For Android client, use `grpc-okhttp` instead of `grpc-netty-shaded` and
 `grpc-protobuf-lite` instead of `grpc-protobuf`:
 ```gradle
-implementation 'io.grpc:grpc-okhttp:1.23.0'
-implementation 'io.grpc:grpc-protobuf-lite:1.23.0'
-implementation 'io.grpc:grpc-stub:1.23.0'
+implementation 'io.grpc:grpc-okhttp:1.24.0'
+implementation 'io.grpc:grpc-protobuf-lite:1.24.0'
+implementation 'io.grpc:grpc-stub:1.24.0'
 ```
 
 [the JARs]:
-https://search.maven.org/search?q=g:io.grpc%20AND%20v:1.23.0
+https://search.maven.org/search?q=g:io.grpc%20AND%20v:1.24.0
 
 Development snapshots are available in [Sonatypes's snapshot
 repository](https://oss.sonatype.org/content/repositories/snapshots/).
@@ -104,7 +104,7 @@ For protobuf-based codegen integrated with the Maven build system, you can use
       <configuration>
         <protocArtifact>com.google.protobuf:protoc:3.9.0:exe:${os.detected.classifier}</protocArtifact>
         <pluginId>grpc-java</pluginId>
-        <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.23.0:exe:${os.detected.classifier}</pluginArtifact>
+        <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.24.0:exe:${os.detected.classifier}</pluginArtifact>
       </configuration>
       <executions>
         <execution>
@@ -134,7 +134,7 @@ protobuf {
   }
   plugins {
     grpc {
-      artifact = 'io.grpc:protoc-gen-grpc-java:1.23.0'
+      artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0'
     }
   }
   generateProtoTasks {

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ For a guided tour, take a look at the [quick start
 guide](https://grpc.io/docs/quickstart/java.html) or the more explanatory [gRPC
 basics](https://grpc.io/docs/tutorials/basic/java.html).
 
-The [examples](https://github.com/grpc/grpc-java/tree/v1.24.1/examples) and the
-[Android example](https://github.com/grpc/grpc-java/tree/v1.24.1/examples/android)
+The [examples](https://github.com/grpc/grpc-java/tree/v1.24.2/examples) and the
+[Android example](https://github.com/grpc/grpc-java/tree/v1.24.2/examples/android)
 are standalone projects that showcase the usage of gRPC.
 
 Download
@@ -42,37 +42,37 @@ Download [the JARs][]. Or for Maven with non-Android, add to your `pom.xml`:
 <dependency>
   <groupId>io.grpc</groupId>
   <artifactId>grpc-netty-shaded</artifactId>
-  <version>1.24.1</version>
+  <version>1.24.2</version>
 </dependency>
 <dependency>
   <groupId>io.grpc</groupId>
   <artifactId>grpc-protobuf</artifactId>
-  <version>1.24.1</version>
+  <version>1.24.2</version>
 </dependency>
 <dependency>
   <groupId>io.grpc</groupId>
   <artifactId>grpc-stub</artifactId>
-  <version>1.24.1</version>
+  <version>1.24.2</version>
 </dependency>
 ```
 
 Or for Gradle with non-Android, add to your dependencies:
 ```gradle
-implementation 'io.grpc:grpc-netty-shaded:1.24.1'
-implementation 'io.grpc:grpc-protobuf:1.24.1'
-implementation 'io.grpc:grpc-stub:1.24.1'
+implementation 'io.grpc:grpc-netty-shaded:1.24.2'
+implementation 'io.grpc:grpc-protobuf:1.24.2'
+implementation 'io.grpc:grpc-stub:1.24.2'
 ```
 
 For Android client, use `grpc-okhttp` instead of `grpc-netty-shaded` and
 `grpc-protobuf-lite` instead of `grpc-protobuf`:
 ```gradle
-implementation 'io.grpc:grpc-okhttp:1.24.1'
-implementation 'io.grpc:grpc-protobuf-lite:1.24.1'
-implementation 'io.grpc:grpc-stub:1.24.1'
+implementation 'io.grpc:grpc-okhttp:1.24.2'
+implementation 'io.grpc:grpc-protobuf-lite:1.24.2'
+implementation 'io.grpc:grpc-stub:1.24.2'
 ```
 
 [the JARs]:
-https://search.maven.org/search?q=g:io.grpc%20AND%20v:1.24.1
+https://search.maven.org/search?q=g:io.grpc%20AND%20v:1.24.2
 
 Development snapshots are available in [Sonatypes's snapshot
 repository](https://oss.sonatype.org/content/repositories/snapshots/).
@@ -104,7 +104,7 @@ For protobuf-based codegen integrated with the Maven build system, you can use
       <configuration>
         <protocArtifact>com.google.protobuf:protoc:3.9.0:exe:${os.detected.classifier}</protocArtifact>
         <pluginId>grpc-java</pluginId>
-        <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.24.1:exe:${os.detected.classifier}</pluginArtifact>
+        <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.24.2:exe:${os.detected.classifier}</pluginArtifact>
       </configuration>
       <executions>
         <execution>
@@ -134,7 +134,7 @@ protobuf {
   }
   plugins {
     grpc {
-      artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1'
+      artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2'
     }
   }
   generateProtoTasks {

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ For a guided tour, take a look at the [quick start
 guide](https://grpc.io/docs/quickstart/java.html) or the more explanatory [gRPC
 basics](https://grpc.io/docs/tutorials/basic/java.html).
 
-The [examples](https://github.com/grpc/grpc-java/tree/v1.24.0/examples) and the
-[Android example](https://github.com/grpc/grpc-java/tree/v1.24.0/examples/android)
+The [examples](https://github.com/grpc/grpc-java/tree/v1.24.1/examples) and the
+[Android example](https://github.com/grpc/grpc-java/tree/v1.24.1/examples/android)
 are standalone projects that showcase the usage of gRPC.
 
 Download
@@ -42,37 +42,37 @@ Download [the JARs][]. Or for Maven with non-Android, add to your `pom.xml`:
 <dependency>
   <groupId>io.grpc</groupId>
   <artifactId>grpc-netty-shaded</artifactId>
-  <version>1.24.0</version>
+  <version>1.24.1</version>
 </dependency>
 <dependency>
   <groupId>io.grpc</groupId>
   <artifactId>grpc-protobuf</artifactId>
-  <version>1.24.0</version>
+  <version>1.24.1</version>
 </dependency>
 <dependency>
   <groupId>io.grpc</groupId>
   <artifactId>grpc-stub</artifactId>
-  <version>1.24.0</version>
+  <version>1.24.1</version>
 </dependency>
 ```
 
 Or for Gradle with non-Android, add to your dependencies:
 ```gradle
-implementation 'io.grpc:grpc-netty-shaded:1.24.0'
-implementation 'io.grpc:grpc-protobuf:1.24.0'
-implementation 'io.grpc:grpc-stub:1.24.0'
+implementation 'io.grpc:grpc-netty-shaded:1.24.1'
+implementation 'io.grpc:grpc-protobuf:1.24.1'
+implementation 'io.grpc:grpc-stub:1.24.1'
 ```
 
 For Android client, use `grpc-okhttp` instead of `grpc-netty-shaded` and
 `grpc-protobuf-lite` instead of `grpc-protobuf`:
 ```gradle
-implementation 'io.grpc:grpc-okhttp:1.24.0'
-implementation 'io.grpc:grpc-protobuf-lite:1.24.0'
-implementation 'io.grpc:grpc-stub:1.24.0'
+implementation 'io.grpc:grpc-okhttp:1.24.1'
+implementation 'io.grpc:grpc-protobuf-lite:1.24.1'
+implementation 'io.grpc:grpc-stub:1.24.1'
 ```
 
 [the JARs]:
-https://search.maven.org/search?q=g:io.grpc%20AND%20v:1.24.0
+https://search.maven.org/search?q=g:io.grpc%20AND%20v:1.24.1
 
 Development snapshots are available in [Sonatypes's snapshot
 repository](https://oss.sonatype.org/content/repositories/snapshots/).
@@ -104,7 +104,7 @@ For protobuf-based codegen integrated with the Maven build system, you can use
       <configuration>
         <protocArtifact>com.google.protobuf:protoc:3.9.0:exe:${os.detected.classifier}</protocArtifact>
         <pluginId>grpc-java</pluginId>
-        <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.24.0:exe:${os.detected.classifier}</pluginArtifact>
+        <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.24.1:exe:${os.detected.classifier}</pluginArtifact>
       </configuration>
       <executions>
         <execution>
@@ -134,7 +134,7 @@ protobuf {
   }
   plugins {
     grpc {
-      artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0'
+      artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1'
     }
   }
   generateProtoTasks {

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -119,6 +119,7 @@ Tagging the Release
    # Bump documented versions. Don't forget protobuf version
    $ ${EDITOR:-nano -w} README.md
    $ ${EDITOR:-nano -w} documentation/android-channel-builder.md
+   $ ${EDITOR:-nano -w} cronet/README.md
    $ git commit -a -m "Update README etc to reference $MAJOR.$MINOR.$PATCH"
    ```
 3. Change root build files to remove "-SNAPSHOT" for the next release version

--- a/alts/src/main/java/io/grpc/alts/ComputeEngineChannelBuilder.java
+++ b/alts/src/main/java/io/grpc/alts/ComputeEngineChannelBuilder.java
@@ -39,7 +39,7 @@ import javax.net.ssl.SSLException;
  * using ALTS if applicable and using TLS as fallback.
  */
 public final class ComputeEngineChannelBuilder
-    extends ForwardingChannelBuilder<GoogleDefaultChannelBuilder> {
+    extends ForwardingChannelBuilder<ComputeEngineChannelBuilder> {
 
   private final NettyChannelBuilder delegate;
 

--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -42,7 +42,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -71,11 +71,11 @@ dependencies {
     implementation 'junit:junit:4.12'
 
     // You need to build grpc-java to obtain the grpc libraries below.
-    implementation 'io.grpc:grpc-auth:1.24.2' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-okhttp:1.24.2' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.2' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.2' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-testing:1.24.2' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-auth:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-testing:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
 
     // workaround for https://github.com/google/protobuf/issues/1889
     protobuf 'com.google.protobuf:protobuf-java:3.0.2'

--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -42,7 +42,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -71,11 +71,11 @@ dependencies {
     implementation 'junit:junit:4.12'
 
     // You need to build grpc-java to obtain the grpc libraries below.
-    implementation 'io.grpc:grpc-auth:1.24.1' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-okhttp:1.24.1' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.1' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.1' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-testing:1.24.1' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-auth:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-testing:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 
     // workaround for https://github.com/google/protobuf/issues/1889
     protobuf 'com.google.protobuf:protobuf-java:3.0.2'

--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -42,7 +42,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -71,11 +71,11 @@ dependencies {
     implementation 'junit:junit:4.12'
 
     // You need to build grpc-java to obtain the grpc libraries below.
-    implementation 'io.grpc:grpc-auth:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-okhttp:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-testing:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-auth:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-testing:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 
     // workaround for https://github.com/google/protobuf/issues/1889
     protobuf 'com.google.protobuf:protobuf-java:3.0.2'

--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -42,7 +42,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -71,11 +71,11 @@ dependencies {
     implementation 'junit:junit:4.12'
 
     // You need to build grpc-java to obtain the grpc libraries below.
-    implementation 'io.grpc:grpc-auth:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-okhttp:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-testing:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-auth:1.24.2' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.2' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.2' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.2' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-testing:1.24.2' // CURRENT_GRPC_VERSION
 
     // workaround for https://github.com/google/protobuf/issues/1889
     protobuf 'com.google.protobuf:protobuf-java:3.0.2'

--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -42,7 +42,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -71,11 +71,11 @@ dependencies {
     implementation 'junit:junit:4.12'
 
     // You need to build grpc-java to obtain the grpc libraries below.
-    implementation 'io.grpc:grpc-auth:1.24.0' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-okhttp:1.24.0' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.0' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.0' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-testing:1.24.0' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-auth:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-testing:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
 
     // workaround for https://github.com/google/protobuf/issues/1889
     protobuf 'com.google.protobuf:protobuf-java:3.0.2'

--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -42,7 +42,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -71,11 +71,11 @@ dependencies {
     implementation 'junit:junit:4.12'
 
     // You need to build grpc-java to obtain the grpc libraries below.
-    implementation 'io.grpc:grpc-auth:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-okhttp:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-testing:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-auth:1.24.1' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.1' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.1' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.1' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-testing:1.24.1' // CURRENT_GRPC_VERSION
 
     // workaround for https://github.com/google/protobuf/issues/1889
     protobuf 'com.google.protobuf:protobuf-java:3.0.2'

--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -42,7 +42,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -71,11 +71,11 @@ dependencies {
     implementation 'junit:junit:4.12'
 
     // You need to build grpc-java to obtain the grpc libraries below.
-    implementation 'io.grpc:grpc-auth:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-okhttp:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-testing:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-auth:1.24.0' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.0' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.0' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.0' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-testing:1.24.0' // CURRENT_GRPC_VERSION
 
     // workaround for https://github.com/google/protobuf/issues/1889
     protobuf 'com.google.protobuf:protobuf-java:3.0.2'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 group = "io.grpc"
-version = "1.24.2" // CURRENT_GRPC_VERSION
+version = "1.24.3-SNAPSHOT" // CURRENT_GRPC_VERSION
 description = 'gRPC: Android'
 
 buildscript {
@@ -47,9 +47,9 @@ dependencies {
     errorprone 'com.google.errorprone:error_prone_core:2.3.3'
     errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
 
-    implementation 'io.grpc:grpc-core:1.24.2' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-core:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
 
-    testImplementation 'io.grpc:grpc-okhttp:1.24.2' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-okhttp:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:3.7.1'
     testImplementation 'com.google.truth:truth:0.45'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 group = "io.grpc"
-version = "1.24.2-SNAPSHOT" // CURRENT_GRPC_VERSION
+version = "1.24.2" // CURRENT_GRPC_VERSION
 description = 'gRPC: Android'
 
 buildscript {
@@ -47,9 +47,9 @@ dependencies {
     errorprone 'com.google.errorprone:error_prone_core:2.3.3'
     errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
 
-    implementation 'io.grpc:grpc-core:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-core:1.24.2' // CURRENT_GRPC_VERSION
 
-    testImplementation 'io.grpc:grpc-okhttp:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-okhttp:1.24.2' // CURRENT_GRPC_VERSION
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:3.7.1'
     testImplementation 'com.google.truth:truth:0.45'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 group = "io.grpc"
-version = "1.24.0" // CURRENT_GRPC_VERSION
+version = "1.24.1-SNAPSHOT" // CURRENT_GRPC_VERSION
 description = 'gRPC: Android'
 
 buildscript {
@@ -47,9 +47,9 @@ dependencies {
     errorprone 'com.google.errorprone:error_prone_core:2.3.3'
     errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
 
-    implementation 'io.grpc:grpc-core:1.24.0' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-core:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
 
-    testImplementation 'io.grpc:grpc-okhttp:1.24.0' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-okhttp:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:3.7.1'
     testImplementation 'com.google.truth:truth:0.45'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 group = "io.grpc"
-version = "1.24.0-SNAPSHOT" // CURRENT_GRPC_VERSION
+version = "1.24.0" // CURRENT_GRPC_VERSION
 description = 'gRPC: Android'
 
 buildscript {
@@ -47,9 +47,9 @@ dependencies {
     errorprone 'com.google.errorprone:error_prone_core:2.3.3'
     errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
 
-    implementation 'io.grpc:grpc-core:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-core:1.24.0' // CURRENT_GRPC_VERSION
 
-    testImplementation 'io.grpc:grpc-okhttp:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-okhttp:1.24.0' // CURRENT_GRPC_VERSION
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:3.7.1'
     testImplementation 'com.google.truth:truth:0.45'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 group = "io.grpc"
-version = "1.24.1-SNAPSHOT" // CURRENT_GRPC_VERSION
+version = "1.24.1" // CURRENT_GRPC_VERSION
 description = 'gRPC: Android'
 
 buildscript {
@@ -47,9 +47,9 @@ dependencies {
     errorprone 'com.google.errorprone:error_prone_core:2.3.3'
     errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
 
-    implementation 'io.grpc:grpc-core:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-core:1.24.1' // CURRENT_GRPC_VERSION
 
-    testImplementation 'io.grpc:grpc-okhttp:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-okhttp:1.24.1' // CURRENT_GRPC_VERSION
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:3.7.1'
     testImplementation 'com.google.truth:truth:0.45'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 group = "io.grpc"
-version = "1.25.0-SNAPSHOT" // CURRENT_GRPC_VERSION
+version = "1.24.0-SNAPSHOT" // CURRENT_GRPC_VERSION
 description = 'gRPC: Android'
 
 buildscript {
@@ -47,9 +47,9 @@ dependencies {
     errorprone 'com.google.errorprone:error_prone_core:2.3.3'
     errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
 
-    implementation 'io.grpc:grpc-core:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-core:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 
-    testImplementation 'io.grpc:grpc-okhttp:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-okhttp:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:3.7.1'
     testImplementation 'com.google.truth:truth:0.45'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 group = "io.grpc"
-version = "1.24.1" // CURRENT_GRPC_VERSION
+version = "1.24.2-SNAPSHOT" // CURRENT_GRPC_VERSION
 description = 'gRPC: Android'
 
 buildscript {
@@ -47,9 +47,9 @@ dependencies {
     errorprone 'com.google.errorprone:error_prone_core:2.3.3'
     errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
 
-    implementation 'io.grpc:grpc-core:1.24.1' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-core:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 
-    testImplementation 'io.grpc:grpc-okhttp:1.24.1' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-okhttp:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:3.7.1'
     testImplementation 'com.google.truth:truth:0.45'

--- a/api/src/test/java/io/grpc/NameResolverRegistryTest.java
+++ b/api/src/test/java/io/grpc/NameResolverRegistryTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 import io.grpc.NameResolver.ServiceConfigParser;
+import io.grpc.internal.BaseDnsNameResolverProvider;
 import io.grpc.internal.DnsNameResolverProvider;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.net.URI;
@@ -152,8 +153,11 @@ public class NameResolverRegistryTest {
   @Test
   public void baseProviders() {
     List<NameResolverProvider> providers = NameResolverRegistry.getDefaultRegistry().providers();
-    assertThat(providers).hasSize(1);
-    assertThat(providers.get(0)).isInstanceOf(DnsNameResolverProvider.class);
+    assertThat(providers).hasSize(2);
+    // 2 name resolvers from grpclb and core
+    for (NameResolverProvider provider : providers) {
+      assertThat(provider).isInstanceOf(BaseDnsNameResolverProvider.class);
+    }
     assertThat(NameResolverRegistry.getDefaultRegistry().asFactory().getDefaultScheme())
         .isEqualTo("dns");
   }

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -3,8 +3,7 @@ dependencies {
     compile project(':grpc-api'),
             libraries.google_auth_credentials
     testCompile project(':grpc-testing'),
-            libraries.google_auth_oauth2_http,
-            libraries.jwt
+            libraries.google_auth_oauth2_http
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -96,3 +96,12 @@ applicationDistribution.into("bin") {
     from(benchmark_worker)
     fileMode = 0755
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifact distZip
+            artifact distTar
+        }
+    }
+}

--- a/bom/build.gradle
+++ b/bom/build.gradle
@@ -30,6 +30,7 @@ publishing {
         dependencyNode.appendNode('groupId', project.group)
         dependencyNode.appendNode('artifactId', 'protoc-gen-grpc-java')
         dependencyNode.appendNode('version', project.version)
+        dependencyNode.appendNode('type', 'pom')
       }
     }
   }

--- a/bom/build.gradle
+++ b/bom/build.gradle
@@ -1,32 +1,36 @@
+plugins {
+  id "maven-publish"
+}
+
 description = 'gRPC: BOM'
 
 publishing {
-    publications {
-        maven(MavenPublication) {
-            // remove all other artifacts since BOM doesn't generates any Jar
-            artifacts = []
+  publications {
+    maven(MavenPublication) {
+      // remove all other artifacts since BOM doesn't generates any Jar
+      artifacts = []
 
-            pom.withXml {
-                // Generate bom using subprojects
-                def internalProjects = [project.name, 'grpc-xds', 'grpc-gae-interop-testing-jdk8', 'grpc-compiler']
+      pom.withXml {
+        // Generate bom using subprojects
+        def internalProjects = [project.name, 'grpc-xds', 'grpc-gae-interop-testing-jdk8', 'grpc-compiler']
 
-                def dependencyManagement = asNode().appendNode('dependencyManagement')
-                def dependencies = dependencyManagement.appendNode('dependencies')
-                rootProject.subprojects.each { subproject ->
-                    if (internalProjects.contains(subproject.name)) {
-		        return
-		    }
-                    def dependencyNode = dependencies.appendNode('dependency')
-                    dependencyNode.appendNode('groupId', subproject.group)
-                    dependencyNode.appendNode('artifactId', subproject.name)
-                    dependencyNode.appendNode('version', subproject.version)
-                }
-		// add protoc gen (produced by grpc-compiler with different artifact name)
-		def dependencyNode = dependencies.appendNode('dependency')
-	        dependencyNode.appendNode('groupId', project.group)
-	        dependencyNode.appendNode('artifactId', 'protoc-gen-grpc-java')
-	        dependencyNode.appendNode('version', project.version)
-	    }
+        def dependencyManagement = asNode().appendNode('dependencyManagement')
+        def dependencies = dependencyManagement.appendNode('dependencies')
+        rootProject.subprojects.each { subproject ->
+          if (internalProjects.contains(subproject.name)) {
+            return
+          }
+          def dependencyNode = dependencies.appendNode('dependency')
+          dependencyNode.appendNode('groupId', subproject.group)
+          dependencyNode.appendNode('artifactId', subproject.name)
+          dependencyNode.appendNode('version', subproject.version)
         }
+        // add protoc gen (produced by grpc-compiler with different artifact name)
+        def dependencyNode = dependencies.appendNode('dependency')
+        dependencyNode.appendNode('groupId', project.group)
+        dependencyNode.appendNode('artifactId', 'protoc-gen-grpc-java')
+        dependencyNode.appendNode('version', project.version)
+      }
     }
+  }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -191,7 +191,6 @@ subprojects {
             hpack: 'com.twitter:hpack:0.10.1',
             javax_annotation: 'javax.annotation:javax.annotation-api:1.2',
             jsr305: 'com.google.code.findbugs:jsr305:3.0.2',
-            jwt: 'com.auth0:java-jwt:3.8.2',
             google_api_protos: 'com.google.api.grpc:proto-google-common-protos:1.12.0',
             google_auth_credentials: "com.google.auth:google-auth-library-credentials:${googleauthVersion}",
             google_auth_oauth2_http: "com.google.auth:google-auth-library-oauth2-http:${googleauthVersion}",

--- a/build.gradle
+++ b/build.gradle
@@ -185,7 +185,7 @@ subprojects {
         libraries = [
             android_annotations: "com.google.android:annotations:4.1.1.4",
             animalsniffer_annotations: "org.codehaus.mojo:animal-sniffer-annotations:1.17",
-            errorprone: "com.google.errorprone:error_prone_annotations:2.3.2",
+            errorprone: "com.google.errorprone:error_prone_annotations:2.3.3",
             gson: "com.google.code.gson:gson:2.7",
             guava: "com.google.guava:guava:${guavaVersion}",
             hpack: 'com.twitter:hpack:0.10.1',
@@ -201,7 +201,7 @@ subprojects {
             opencensus_impl: "io.opencensus:opencensus-impl:${opencensusVersion}",
             opencensus_impl_lite: "io.opencensus:opencensus-impl-lite:${opencensusVersion}",
             instrumentation_api: 'com.google.instrumentation:instrumentation-api:0.4.3',
-            perfmark: 'io.perfmark:perfmark-api:0.17.0',
+            perfmark: 'io.perfmark:perfmark-api:0.19.0',
             protobuf: "com.google.protobuf:protobuf-java:${protobufVersion}",
             protobuf_lite: "com.google.protobuf:protobuf-lite:3.0.1",
             protoc_lite: "com.google.protobuf:protoc-gen-javalite:3.0.0",

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ subprojects {
     }
 
     group = "io.grpc"
-    version = "1.24.1-SNAPSHOT" // CURRENT_GRPC_VERSION
+    version = "1.24.1" // CURRENT_GRPC_VERSION
 
     sourceCompatibility = 1.7
     targetCompatibility = 1.7

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ subprojects {
     }
 
     group = "io.grpc"
-    version = "1.24.2" // CURRENT_GRPC_VERSION
+    version = "1.24.3-SNAPSHOT" // CURRENT_GRPC_VERSION
 
     sourceCompatibility = 1.7
     targetCompatibility = 1.7

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ subprojects {
     }
 
     group = "io.grpc"
-    version = "1.24.1" // CURRENT_GRPC_VERSION
+    version = "1.24.2-SNAPSHOT" // CURRENT_GRPC_VERSION
 
     sourceCompatibility = 1.7
     targetCompatibility = 1.7

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ subprojects {
     }
 
     group = "io.grpc"
-    version = "1.24.0" // CURRENT_GRPC_VERSION
+    version = "1.24.1-SNAPSHOT" // CURRENT_GRPC_VERSION
 
     sourceCompatibility = 1.7
     targetCompatibility = 1.7

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ subprojects {
     }
 
     group = "io.grpc"
-    version = "1.24.2-SNAPSHOT" // CURRENT_GRPC_VERSION
+    version = "1.24.2" // CURRENT_GRPC_VERSION
 
     sourceCompatibility = 1.7
     targetCompatibility = 1.7

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ subprojects {
     }
 
     group = "io.grpc"
-    version = "1.24.0-SNAPSHOT" // CURRENT_GRPC_VERSION
+    version = "1.24.0" // CURRENT_GRPC_VERSION
 
     sourceCompatibility = 1.7
     targetCompatibility = 1.7

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ subprojects {
     }
 
     group = "io.grpc"
-    version = "1.25.0-SNAPSHOT" // CURRENT_GRPC_VERSION
+    version = "1.24.0-SNAPSHOT" // CURRENT_GRPC_VERSION
 
     sourceCompatibility = 1.7
     targetCompatibility = 1.7

--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -86,7 +86,6 @@ new_apk_size="$(stat --printf=%s $HELLO_WORLD_OUTPUT_DIR/apk/release/app-release
 
 cd $BASE_DIR/github/grpc-java
 git checkout HEAD^
-./gradlew clean
 ./gradlew publishToMavenLocal
 cd examples/android/helloworld/
 ../../gradlew build

--- a/compiler/src/test/golden/TestDeprecatedService.java.txt
+++ b/compiler/src/test/golden/TestDeprecatedService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.0)",
+    value = "by gRPC proto compiler (version 1.24.1-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
 @java.lang.Deprecated
 public final class TestDeprecatedServiceGrpc {

--- a/compiler/src/test/golden/TestDeprecatedService.java.txt
+++ b/compiler/src/test/golden/TestDeprecatedService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.2-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.24.2)",
     comments = "Source: grpc/testing/compiler/test.proto")
 @java.lang.Deprecated
 public final class TestDeprecatedServiceGrpc {

--- a/compiler/src/test/golden/TestDeprecatedService.java.txt
+++ b/compiler/src/test/golden/TestDeprecatedService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.0-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.24.0)",
     comments = "Source: grpc/testing/compiler/test.proto")
 @java.lang.Deprecated
 public final class TestDeprecatedServiceGrpc {

--- a/compiler/src/test/golden/TestDeprecatedService.java.txt
+++ b/compiler/src/test/golden/TestDeprecatedService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.25.0-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.24.0-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
 @java.lang.Deprecated
 public final class TestDeprecatedServiceGrpc {

--- a/compiler/src/test/golden/TestDeprecatedService.java.txt
+++ b/compiler/src/test/golden/TestDeprecatedService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.1-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.24.1)",
     comments = "Source: grpc/testing/compiler/test.proto")
 @java.lang.Deprecated
 public final class TestDeprecatedServiceGrpc {

--- a/compiler/src/test/golden/TestDeprecatedService.java.txt
+++ b/compiler/src/test/golden/TestDeprecatedService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.1)",
+    value = "by gRPC proto compiler (version 1.24.2-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
 @java.lang.Deprecated
 public final class TestDeprecatedServiceGrpc {

--- a/compiler/src/test/golden/TestDeprecatedService.java.txt
+++ b/compiler/src/test/golden/TestDeprecatedService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.2)",
+    value = "by gRPC proto compiler (version 1.24.3-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
 @java.lang.Deprecated
 public final class TestDeprecatedServiceGrpc {

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.1-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.24.1)",
     comments = "Source: grpc/testing/compiler/test.proto")
 public final class TestServiceGrpc {
 

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.2)",
+    value = "by gRPC proto compiler (version 1.24.3-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
 public final class TestServiceGrpc {
 

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.1)",
+    value = "by gRPC proto compiler (version 1.24.2-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
 public final class TestServiceGrpc {
 

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.0)",
+    value = "by gRPC proto compiler (version 1.24.1-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
 public final class TestServiceGrpc {
 

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.0-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.24.0)",
     comments = "Source: grpc/testing/compiler/test.proto")
 public final class TestServiceGrpc {
 

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.25.0-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.24.0-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
 public final class TestServiceGrpc {
 

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.2-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.24.2)",
     comments = "Source: grpc/testing/compiler/test.proto")
 public final class TestServiceGrpc {
 

--- a/compiler/src/testLite/golden/TestDeprecatedService.java.txt
+++ b/compiler/src/testLite/golden/TestDeprecatedService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.0)",
+    value = "by gRPC proto compiler (version 1.24.1-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
 @java.lang.Deprecated
 public final class TestDeprecatedServiceGrpc {

--- a/compiler/src/testLite/golden/TestDeprecatedService.java.txt
+++ b/compiler/src/testLite/golden/TestDeprecatedService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.2-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.24.2)",
     comments = "Source: grpc/testing/compiler/test.proto")
 @java.lang.Deprecated
 public final class TestDeprecatedServiceGrpc {

--- a/compiler/src/testLite/golden/TestDeprecatedService.java.txt
+++ b/compiler/src/testLite/golden/TestDeprecatedService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.0-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.24.0)",
     comments = "Source: grpc/testing/compiler/test.proto")
 @java.lang.Deprecated
 public final class TestDeprecatedServiceGrpc {

--- a/compiler/src/testLite/golden/TestDeprecatedService.java.txt
+++ b/compiler/src/testLite/golden/TestDeprecatedService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.25.0-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.24.0-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
 @java.lang.Deprecated
 public final class TestDeprecatedServiceGrpc {

--- a/compiler/src/testLite/golden/TestDeprecatedService.java.txt
+++ b/compiler/src/testLite/golden/TestDeprecatedService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.1-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.24.1)",
     comments = "Source: grpc/testing/compiler/test.proto")
 @java.lang.Deprecated
 public final class TestDeprecatedServiceGrpc {

--- a/compiler/src/testLite/golden/TestDeprecatedService.java.txt
+++ b/compiler/src/testLite/golden/TestDeprecatedService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.1)",
+    value = "by gRPC proto compiler (version 1.24.2-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
 @java.lang.Deprecated
 public final class TestDeprecatedServiceGrpc {

--- a/compiler/src/testLite/golden/TestDeprecatedService.java.txt
+++ b/compiler/src/testLite/golden/TestDeprecatedService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.2)",
+    value = "by gRPC proto compiler (version 1.24.3-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
 @java.lang.Deprecated
 public final class TestDeprecatedServiceGrpc {

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.1-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.24.1)",
     comments = "Source: grpc/testing/compiler/test.proto")
 public final class TestServiceGrpc {
 

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.2)",
+    value = "by gRPC proto compiler (version 1.24.3-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
 public final class TestServiceGrpc {
 

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.1)",
+    value = "by gRPC proto compiler (version 1.24.2-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
 public final class TestServiceGrpc {
 

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.0)",
+    value = "by gRPC proto compiler (version 1.24.1-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
 public final class TestServiceGrpc {
 

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.0-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.24.0)",
     comments = "Source: grpc/testing/compiler/test.proto")
 public final class TestServiceGrpc {
 

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.25.0-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.24.0-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
 public final class TestServiceGrpc {
 

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.24.2-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.24.2)",
     comments = "Source: grpc/testing/compiler/test.proto")
 public final class TestServiceGrpc {
 

--- a/core/src/main/java/io/grpc/internal/BaseDnsNameResolverProvider.java
+++ b/core/src/main/java/io/grpc/internal/BaseDnsNameResolverProvider.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
+import io.grpc.InternalServiceProviders;
+import io.grpc.NameResolver;
+import io.grpc.NameResolverProvider;
+import java.net.URI;
+
+/**
+ * Base provider of name resolvers for name agnostic consumption.
+ */
+public abstract class BaseDnsNameResolverProvider extends NameResolverProvider {
+
+  private static final String SCHEME = "dns";
+
+  @VisibleForTesting
+  public static final String ENABLE_GRPCLB_PROPERTY_NAME =
+      "io.grpc.internal.DnsNameResolverProvider.enable_grpclb";
+
+  /** Returns boolean value of system property {@link #ENABLE_GRPCLB_PROPERTY_NAME}. */
+  protected abstract boolean isSrvEnabled();
+
+  @Override
+  public DnsNameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
+    if (SCHEME.equals(targetUri.getScheme())) {
+      String targetPath = Preconditions.checkNotNull(targetUri.getPath(), "targetPath");
+      Preconditions.checkArgument(targetPath.startsWith("/"),
+          "the path component (%s) of the target (%s) must start with '/'", targetPath, targetUri);
+      String name = targetPath.substring(1);
+      return new DnsNameResolver(
+          targetUri.getAuthority(),
+          name,
+          args,
+          GrpcUtil.SHARED_CHANNEL_EXECUTOR,
+          Stopwatch.createUnstarted(),
+          InternalServiceProviders.isAndroid(getClass().getClassLoader()),
+          isSrvEnabled());
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public String getDefaultScheme() {
+    return SCHEME;
+  }
+
+  @Override
+  protected boolean isAvailable() {
+    return true;
+  }
+}

--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -92,8 +92,6 @@ final class DnsNameResolver extends NameResolver {
       System.getProperty("io.grpc.internal.DnsNameResolverProvider.enable_jndi", "true");
   private static final String JNDI_LOCALHOST_PROPERTY =
       System.getProperty("io.grpc.internal.DnsNameResolverProvider.enable_jndi_localhost", "false");
-  private static final String JNDI_SRV_PROPERTY =
-      System.getProperty("io.grpc.internal.DnsNameResolverProvider.enable_grpclb", "false");
   private static final String JNDI_TXT_PROPERTY =
       System.getProperty("io.grpc.internal.DnsNameResolverProvider.enable_service_config", "false");
 
@@ -116,8 +114,6 @@ final class DnsNameResolver extends NameResolver {
   static boolean enableJndi = Boolean.parseBoolean(JNDI_PROPERTY);
   @VisibleForTesting
   static boolean enableJndiLocalhost = Boolean.parseBoolean(JNDI_LOCALHOST_PROPERTY);
-  @VisibleForTesting
-  static boolean enableSrv = Boolean.parseBoolean(JNDI_SRV_PROPERTY);
   @VisibleForTesting
   static boolean enableTxt = Boolean.parseBoolean(JNDI_TXT_PROPERTY);
 
@@ -147,14 +143,22 @@ final class DnsNameResolver extends NameResolver {
   private ResolutionResults cachedResolutionResults;
   private boolean shutdown;
   private Executor executor;
+  private final boolean enableSrv;
+
   private boolean resolving;
 
   // The field must be accessed from syncContext, although the methods on an Listener2 can be called
   // from any thread.
   private NameResolver.Listener2 listener;
 
-  DnsNameResolver(@Nullable String nsAuthority, String name, Args args,
-      Resource<Executor> executorResource, Stopwatch stopwatch, boolean isAndroid) {
+  DnsNameResolver(
+      @Nullable String nsAuthority,
+      String name,
+      Args args,
+      Resource<Executor> executorResource,
+      Stopwatch stopwatch,
+      boolean isAndroid,
+      boolean enableSrv) {
     Preconditions.checkNotNull(args, "args");
     // TODO: if a DNS server is provided as nsAuthority, use it.
     // https://www.captechconsulting.com/blogs/accessing-the-dusty-corners-of-dns-with-java
@@ -176,6 +180,7 @@ final class DnsNameResolver extends NameResolver {
     this.stopwatch = Preconditions.checkNotNull(stopwatch, "stopwatch");
     this.syncContext =
         Preconditions.checkNotNull(args.getSynchronizationContext(), "syncContext");
+    this.enableSrv = enableSrv;
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -195,7 +195,7 @@ public final class GrpcUtil {
 
   public static final Splitter ACCEPT_ENCODING_SPLITTER = Splitter.on(',').trimResults();
 
-  private static final String IMPLEMENTATION_VERSION = "1.24.0-SNAPSHOT"; // CURRENT_GRPC_VERSION
+  private static final String IMPLEMENTATION_VERSION = "1.24.0"; // CURRENT_GRPC_VERSION
 
   /**
    * The default timeout in nanos for a keepalive ping request.

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -195,7 +195,7 @@ public final class GrpcUtil {
 
   public static final Splitter ACCEPT_ENCODING_SPLITTER = Splitter.on(',').trimResults();
 
-  private static final String IMPLEMENTATION_VERSION = "1.25.0-SNAPSHOT"; // CURRENT_GRPC_VERSION
+  private static final String IMPLEMENTATION_VERSION = "1.24.0-SNAPSHOT"; // CURRENT_GRPC_VERSION
 
   /**
    * The default timeout in nanos for a keepalive ping request.

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -195,7 +195,7 @@ public final class GrpcUtil {
 
   public static final Splitter ACCEPT_ENCODING_SPLITTER = Splitter.on(',').trimResults();
 
-  private static final String IMPLEMENTATION_VERSION = "1.24.0"; // CURRENT_GRPC_VERSION
+  private static final String IMPLEMENTATION_VERSION = "1.24.1-SNAPSHOT"; // CURRENT_GRPC_VERSION
 
   /**
    * The default timeout in nanos for a keepalive ping request.

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -195,7 +195,7 @@ public final class GrpcUtil {
 
   public static final Splitter ACCEPT_ENCODING_SPLITTER = Splitter.on(',').trimResults();
 
-  private static final String IMPLEMENTATION_VERSION = "1.24.1"; // CURRENT_GRPC_VERSION
+  private static final String IMPLEMENTATION_VERSION = "1.24.2-SNAPSHOT"; // CURRENT_GRPC_VERSION
 
   /**
    * The default timeout in nanos for a keepalive ping request.

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -195,7 +195,7 @@ public final class GrpcUtil {
 
   public static final Splitter ACCEPT_ENCODING_SPLITTER = Splitter.on(',').trimResults();
 
-  private static final String IMPLEMENTATION_VERSION = "1.24.2-SNAPSHOT"; // CURRENT_GRPC_VERSION
+  private static final String IMPLEMENTATION_VERSION = "1.24.2"; // CURRENT_GRPC_VERSION
 
   /**
    * The default timeout in nanos for a keepalive ping request.

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -195,7 +195,7 @@ public final class GrpcUtil {
 
   public static final Splitter ACCEPT_ENCODING_SPLITTER = Splitter.on(',').trimResults();
 
-  private static final String IMPLEMENTATION_VERSION = "1.24.1-SNAPSHOT"; // CURRENT_GRPC_VERSION
+  private static final String IMPLEMENTATION_VERSION = "1.24.1"; // CURRENT_GRPC_VERSION
 
   /**
    * The default timeout in nanos for a keepalive ping request.

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -195,7 +195,7 @@ public final class GrpcUtil {
 
   public static final Splitter ACCEPT_ENCODING_SPLITTER = Splitter.on(',').trimResults();
 
-  private static final String IMPLEMENTATION_VERSION = "1.24.2"; // CURRENT_GRPC_VERSION
+  private static final String IMPLEMENTATION_VERSION = "1.24.3-SNAPSHOT"; // CURRENT_GRPC_VERSION
 
   /**
    * The default timeout in nanos for a keepalive ping request.

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverProviderTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverProviderTest.java
@@ -16,9 +16,12 @@
 
 package io.grpc.internal;
 
+import static com.google.common.truth.Truth.assertThat;
+import static io.grpc.internal.BaseDnsNameResolverProvider.ENABLE_GRPCLB_PROPERTY_NAME;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.mock;
 
 import io.grpc.NameResolver;
@@ -59,5 +62,12 @@ public class DnsNameResolverProviderTest {
         provider.newNameResolver(URI.create("dns:///localhost:443"), args).getClass());
     assertNull(
         provider.newNameResolver(URI.create("notdns:///localhost:443"), args));
+  }
+
+  @Test
+  public void isSrvEnabled_falseByDefault() {
+    assumeTrue(System.getProperty(ENABLE_GRPCLB_PROPERTY_NAME) == null);
+
+    assertThat(provider.isSrvEnabled()).isFalse();
   }
 }

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -165,18 +165,21 @@ public class DnsNameResolverTest {
       final ProxyDetector proxyDetector,
       Stopwatch stopwatch,
       boolean isAndroid) {
-    DnsNameResolver dnsResolver = new DnsNameResolver(
-        null,
-        name,
+    NameResolver.Args args =
         NameResolver.Args.newBuilder()
             .setDefaultPort(defaultPort)
             .setProxyDetector(proxyDetector)
             .setSynchronizationContext(syncContext)
             .setServiceConfigParser(mock(ServiceConfigParser.class))
-            .build(),
-        fakeExecutorResource,
-        stopwatch,
-        isAndroid);
+            .build();
+    return newResolver(name, stopwatch, isAndroid, args);
+  }
+
+  private DnsNameResolver newResolver(
+      String name, Stopwatch stopwatch, boolean isAndroid, NameResolver.Args args) {
+    DnsNameResolver dnsResolver =
+        new DnsNameResolver(
+            null, name, args, fakeExecutorResource, stopwatch, isAndroid, /* enableSrv= */ false);
     // By default, using the mocked ResourceResolver to avoid I/O
     dnsResolver.setResourceResolver(new JndiResourceResolver(recordFetcher));
     return dnsResolver;

--- a/cronet/README.md
+++ b/cronet/README.md
@@ -1,9 +1,8 @@
 gRPC Cronet Transport
 ========================
 
-**EXPERIMENTAL:**  *gRPC's Cronet transport is an experimental API, and is not
-yet integrated with our build system. Using Cronet with gRPC requires manually
-integrating the gRPC code in this directory into your Android application.*
+**EXPERIMENTAL:**  *gRPC's Cronet transport is an experimental API, its stability
+depends on upstream Cronet's implementation, which involves some experimental features.*
 
 This code enables using the [Chromium networking stack
 (Cronet)](https://chromium.googlesource.com/chromium/src/+/master/components/cronet)
@@ -17,13 +16,26 @@ Some advantages of using Cronet with gRPC:
 * Robust to Android network connectivity changes
 * Support for [QUIC](https://www.chromium.org/quic)
 
-Cronet jars are available on Google's Maven repository. See the example app at
-https://github.com/GoogleChrome/cronet-sample/blob/master/README.md. To use
-Cronet with gRPC, you will need to copy the gRPC source files contained in this
-directory into your application's code, as we do not currently provide a
-`grpc-cronet` dependency.
+Since gRPC's 1.24 release, the `grpc-cronet` package provides access to the 
+`CronetChannelBuilder` class. Cronet jars are available on Google's Maven repository. 
+See the example app at https://github.com/GoogleChrome/cronet-sample/blob/master/README.md.
 
-To use Cronet, you must have the `ACCESS_NETWORK_STATE` permission set in
+## Example usage:
+
+In your app module's `build.gradle` file, include a dependency on both `grpc-cronet` and the 
+Google Play Services Client Library for Cronet
+
+```
+implementation 'io.grpc:grpc-cronet:1.24.0'
+implementation 'com.google.android.gms:play-services-cronet:16.0.0'
+```
+
+In cases where Cronet cannot be loaded from Google Play services, there is a less performant 
+implementation of Cronet's API that can be used. Depend on `org.chromium.net:cronet-fallback` 
+to use this fall-back implementation.
+
+
+You will also need permission to access the device's network state in your 
 `AndroidManifest.xml`:
 
 ```

--- a/cronet/README.md
+++ b/cronet/README.md
@@ -26,7 +26,7 @@ In your app module's `build.gradle` file, include a dependency on both `grpc-cro
 Google Play Services Client Library for Cronet
 
 ```
-implementation 'io.grpc:grpc-cronet:1.24.0'
+implementation 'io.grpc:grpc-cronet:1.24.1'
 implementation 'com.google.android.gms:play-services-cronet:16.0.0'
 ```
 

--- a/cronet/README.md
+++ b/cronet/README.md
@@ -26,7 +26,7 @@ In your app module's `build.gradle` file, include a dependency on both `grpc-cro
 Google Play Services Client Library for Cronet
 
 ```
-implementation 'io.grpc:grpc-cronet:1.24.1'
+implementation 'io.grpc:grpc-cronet:1.24.2'
 implementation 'com.google.android.gms:play-services-cronet:16.0.0'
 ```
 

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -42,8 +42,8 @@ android {
     buildTypes {
         debug { minifyEnabled false }
         release {
-            minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            minifyEnabled false
+            consumerProguardFiles 'proguard-rules.pro'
         }
     }
     testOptions { unitTests { includeAndroidResources = true } }

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 group = "io.grpc"
-version = "1.24.2-SNAPSHOT" // CURRENT_GRPC_VERSION
+version = "1.24.2" // CURRENT_GRPC_VERSION
 description = "gRPC: Cronet Android"
 
 buildscript {
@@ -54,8 +54,8 @@ dependencies {
     errorprone 'com.google.errorprone:error_prone_core:2.3.3'
     errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
 
-    implementation 'io.grpc:grpc-core:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
-    testImplementation 'io.grpc:grpc-testing:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-core:1.24.2' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-testing:1.24.2' // CURRENT_GRPC_VERSION
 
     implementation 'org.chromium.net:cronet-api:76.3809.111'
     testImplementation 'org.chromium.net:cronet-embedded:66.3359.158'

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 group = "io.grpc"
-version = "1.24.1" // CURRENT_GRPC_VERSION
+version = "1.24.2-SNAPSHOT" // CURRENT_GRPC_VERSION
 description = "gRPC: Cronet Android"
 
 buildscript {
@@ -54,8 +54,8 @@ dependencies {
     errorprone 'com.google.errorprone:error_prone_core:2.3.3'
     errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
 
-    implementation 'io.grpc:grpc-core:1.24.1' // CURRENT_GRPC_VERSION
-    testImplementation 'io.grpc:grpc-testing:1.24.1' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-core:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-testing:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 
     implementation 'org.chromium.net:cronet-api:76.3809.111'
     testImplementation 'org.chromium.net:cronet-embedded:66.3359.158'

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 group = "io.grpc"
-version = "1.24.0" // CURRENT_GRPC_VERSION
+version = "1.24.1-SNAPSHOT" // CURRENT_GRPC_VERSION
 description = "gRPC: Cronet Android"
 
 buildscript {
@@ -54,8 +54,8 @@ dependencies {
     errorprone 'com.google.errorprone:error_prone_core:2.3.3'
     errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
 
-    implementation 'io.grpc:grpc-core:1.24.0' // CURRENT_GRPC_VERSION
-    testImplementation 'io.grpc:grpc-testing:1.24.0' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-core:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-testing:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
 
     implementation 'org.chromium.net:cronet-api:76.3809.111'
     testImplementation 'org.chromium.net:cronet-embedded:66.3359.158'

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 group = "io.grpc"
-version = "1.25.0-SNAPSHOT" // CURRENT_GRPC_VERSION
+version = "1.24.0-SNAPSHOT" // CURRENT_GRPC_VERSION
 description = "gRPC: Cronet Android"
 
 buildscript {
@@ -54,8 +54,8 @@ dependencies {
     errorprone 'com.google.errorprone:error_prone_core:2.3.3'
     errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
 
-    implementation 'io.grpc:grpc-core:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    testImplementation 'io.grpc:grpc-testing:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-core:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-testing:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 
     implementation 'org.chromium.net:cronet-api:76.3809.111'
     testImplementation 'org.chromium.net:cronet-embedded:66.3359.158'

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 group = "io.grpc"
-version = "1.24.2" // CURRENT_GRPC_VERSION
+version = "1.24.3-SNAPSHOT" // CURRENT_GRPC_VERSION
 description = "gRPC: Cronet Android"
 
 buildscript {
@@ -54,8 +54,8 @@ dependencies {
     errorprone 'com.google.errorprone:error_prone_core:2.3.3'
     errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
 
-    implementation 'io.grpc:grpc-core:1.24.2' // CURRENT_GRPC_VERSION
-    testImplementation 'io.grpc:grpc-testing:1.24.2' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-core:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-testing:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
 
     implementation 'org.chromium.net:cronet-api:76.3809.111'
     testImplementation 'org.chromium.net:cronet-embedded:66.3359.158'

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 group = "io.grpc"
-version = "1.24.0-SNAPSHOT" // CURRENT_GRPC_VERSION
+version = "1.24.0" // CURRENT_GRPC_VERSION
 description = "gRPC: Cronet Android"
 
 buildscript {
@@ -54,8 +54,8 @@ dependencies {
     errorprone 'com.google.errorprone:error_prone_core:2.3.3'
     errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
 
-    implementation 'io.grpc:grpc-core:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    testImplementation 'io.grpc:grpc-testing:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-core:1.24.0' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-testing:1.24.0' // CURRENT_GRPC_VERSION
 
     implementation 'org.chromium.net:cronet-api:76.3809.111'
     testImplementation 'org.chromium.net:cronet-embedded:66.3359.158'

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 group = "io.grpc"
-version = "1.24.1-SNAPSHOT" // CURRENT_GRPC_VERSION
+version = "1.24.1" // CURRENT_GRPC_VERSION
 description = "gRPC: Cronet Android"
 
 buildscript {
@@ -54,8 +54,8 @@ dependencies {
     errorprone 'com.google.errorprone:error_prone_core:2.3.3'
     errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
 
-    implementation 'io.grpc:grpc-core:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
-    testImplementation 'io.grpc:grpc-testing:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-core:1.24.1' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-testing:1.24.1' // CURRENT_GRPC_VERSION
 
     implementation 'org.chromium.net:cronet-api:76.3809.111'
     testImplementation 'org.chromium.net:cronet-embedded:66.3359.158'

--- a/documentation/android-channel-builder.md
+++ b/documentation/android-channel-builder.md
@@ -36,8 +36,8 @@ In your `build.gradle` file, include a dependency on both `grpc-android` and
 `grpc-okhttp`:
 
 ```
-implementation 'io.grpc:grpc-android:1.23.0'
-implementation 'io.grpc:grpc-okhttp:1.23.0'
+implementation 'io.grpc:grpc-android:1.24.0'
+implementation 'io.grpc:grpc-okhttp:1.24.0'
 ```
 
 You will also need permission to access the device's network state in your

--- a/documentation/android-channel-builder.md
+++ b/documentation/android-channel-builder.md
@@ -36,8 +36,8 @@ In your `build.gradle` file, include a dependency on both `grpc-android` and
 `grpc-okhttp`:
 
 ```
-implementation 'io.grpc:grpc-android:1.24.1'
-implementation 'io.grpc:grpc-okhttp:1.24.1'
+implementation 'io.grpc:grpc-android:1.24.2'
+implementation 'io.grpc:grpc-okhttp:1.24.2'
 ```
 
 You will also need permission to access the device's network state in your

--- a/documentation/android-channel-builder.md
+++ b/documentation/android-channel-builder.md
@@ -36,8 +36,8 @@ In your `build.gradle` file, include a dependency on both `grpc-android` and
 `grpc-okhttp`:
 
 ```
-implementation 'io.grpc:grpc-android:1.24.0'
-implementation 'io.grpc:grpc-okhttp:1.24.0'
+implementation 'io.grpc:grpc-android:1.24.1'
+implementation 'io.grpc:grpc-okhttp:1.24.1'
 ```
 
 You will also need permission to access the device's network state in your

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -31,7 +31,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.4.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -49,12 +49,12 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.0.2'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.google.truth:truth:0.45'
-    testImplementation 'io.grpc:grpc-testing:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-testing:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 }

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -31,7 +31,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.4.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -49,12 +49,12 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.0.2'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.0' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.0' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.0' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.google.truth:truth:0.45'
-    testImplementation 'io.grpc:grpc-testing:1.24.0' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-testing:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
 }

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -31,7 +31,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.4.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -49,12 +49,12 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.0.2'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.1' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.1' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.1' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.google.truth:truth:0.45'
-    testImplementation 'io.grpc:grpc-testing:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-testing:1.24.1' // CURRENT_GRPC_VERSION
 }

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -31,7 +31,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.4.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -49,12 +49,12 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.0.2'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.0' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.0' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.0' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.google.truth:truth:0.45'
-    testImplementation 'io.grpc:grpc-testing:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-testing:1.24.0' // CURRENT_GRPC_VERSION
 }

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -31,7 +31,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.4.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -49,12 +49,12 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.0.2'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.1' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.1' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.1' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.google.truth:truth:0.45'
-    testImplementation 'io.grpc:grpc-testing:1.24.1' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-testing:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 }

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -31,7 +31,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.4.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -49,12 +49,12 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.0.2'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.2' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.2' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.2' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.google.truth:truth:0.45'
-    testImplementation 'io.grpc:grpc-testing:1.24.2' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-testing:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
 }

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -31,7 +31,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.4.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -49,12 +49,12 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.0.2'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.2' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.2' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.2' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.google.truth:truth:0.45'
-    testImplementation 'io.grpc:grpc-testing:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-testing:1.24.2' // CURRENT_GRPC_VERSION
 }

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -30,7 +30,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -48,8 +48,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.0.2'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -30,7 +30,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -48,8 +48,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.0.2'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.1' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.1' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.1' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -30,7 +30,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -48,8 +48,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.0.2'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.0' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.0' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.0' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -30,7 +30,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -48,8 +48,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.0.2'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.1' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.1' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.1' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -30,7 +30,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -48,8 +48,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.0.2'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.2' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.2' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.2' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -30,7 +30,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -48,8 +48,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.0.2'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.0' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.0' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.0' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -30,7 +30,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -48,8 +48,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.0.2'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.2' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.2' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.2' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -29,7 +29,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -47,8 +47,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.0.2'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.1' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.1' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.1' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -29,7 +29,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -47,8 +47,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.0.2'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.0' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.0' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.0' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -29,7 +29,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -47,8 +47,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.0.2'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.1' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.1' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.1' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -29,7 +29,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -47,8 +47,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.0.2'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.0' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.0' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.0' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -29,7 +29,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -47,8 +47,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.0.2'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.2' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.2' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.2' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -29,7 +29,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -47,8 +47,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.0.2'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -29,7 +29,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -47,8 +47,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.0.2'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.2' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.2' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.2' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/examples/android/strictmode/app/build.gradle
+++ b/examples/android/strictmode/app/build.gradle
@@ -30,7 +30,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -48,8 +48,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.0' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.0' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.0' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/examples/android/strictmode/app/build.gradle
+++ b/examples/android/strictmode/app/build.gradle
@@ -30,7 +30,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -48,8 +48,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/examples/android/strictmode/app/build.gradle
+++ b/examples/android/strictmode/app/build.gradle
@@ -30,7 +30,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -48,8 +48,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.1' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.1' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.1' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/examples/android/strictmode/app/build.gradle
+++ b/examples/android/strictmode/app/build.gradle
@@ -30,7 +30,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -48,8 +48,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.0' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.0' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.0' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/examples/android/strictmode/app/build.gradle
+++ b/examples/android/strictmode/app/build.gradle
@@ -30,7 +30,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -48,8 +48,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.2' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.2' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.2' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/examples/android/strictmode/app/build.gradle
+++ b/examples/android/strictmode/app/build.gradle
@@ -30,7 +30,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -48,8 +48,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.2' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.2' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.2' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/examples/android/strictmode/app/build.gradle
+++ b/examples/android/strictmode/app/build.gradle
@@ -30,7 +30,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -48,8 +48,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.1' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.1' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.1' // CURRENT_GRPC_VERSION
     implementation 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -21,7 +21,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.2' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.9.0'
 def protocVersion = protobufVersion
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -21,7 +21,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.9.0'
 def protocVersion = protobufVersion
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -21,7 +21,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.0' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.9.0'
 def protocVersion = protobufVersion
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -21,7 +21,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.2' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.9.0'
 def protocVersion = protobufVersion
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -21,7 +21,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.0' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.9.0'
 def protocVersion = protobufVersion
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -21,7 +21,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.1' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.9.0'
 def protocVersion = protobufVersion
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -21,7 +21,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.1' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.9.0'
 def protocVersion = protobufVersion
 

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.2' // CURRENT_GRPC_VERSION
 def protocVersion = '3.9.0'
 
 dependencies {

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.2' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.9.0'
 
 dependencies {

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.0' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.9.0'
 
 dependencies {

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.9.0'
 
 dependencies {

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.1' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.9.0'
 
 dependencies {

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.0' // CURRENT_GRPC_VERSION
 def protocVersion = '3.9.0'
 
 dependencies {

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.1' // CURRENT_GRPC_VERSION
 def protocVersion = '3.9.0'
 
 dependencies {

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.0' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.9.0'
 def protocVersion = protobufVersion
 

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.0' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.9.0'
 def protocVersion = protobufVersion
 

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.2' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.9.0'
 def protocVersion = protobufVersion
 

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.2' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.9.0'
 def protocVersion = protobufVersion
 

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.1' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.9.0'
 def protocVersion = protobufVersion
 

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.9.0'
 def protocVersion = protobufVersion
 

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.1' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.9.0'
 def protocVersion = protobufVersion
 

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.24.2</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.24.3-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-gauth</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.24.2</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.24.3-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.9.0</protobuf.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.25.0-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.24.0-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-gauth</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.25.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.24.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.9.0</protobuf.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.24.2-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.24.2</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-gauth</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.24.2-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.24.2</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.9.0</protobuf.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.24.0</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.24.1-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-gauth</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.24.0</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.24.1-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.9.0</protobuf.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.24.1</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.24.2-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-gauth</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.24.1</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.24.2-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.9.0</protobuf.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.24.0-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.24.0</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-gauth</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.24.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.24.0</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.9.0</protobuf.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.24.1-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.24.1</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-gauth</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.24.1-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.24.1</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.9.0</protobuf.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>

--- a/examples/example-kotlin/android/helloworld/app/build.gradle
+++ b/examples/example-kotlin/android/helloworld/app/build.gradle
@@ -52,7 +52,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -72,9 +72,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.1' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.1' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.1' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 }
 
 repositories { mavenCentral() }

--- a/examples/example-kotlin/android/helloworld/app/build.gradle
+++ b/examples/example-kotlin/android/helloworld/app/build.gradle
@@ -52,7 +52,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -72,9 +72,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.1' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.1' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.1' // CURRENT_GRPC_VERSION
 }
 
 repositories { mavenCentral() }

--- a/examples/example-kotlin/android/helloworld/app/build.gradle
+++ b/examples/example-kotlin/android/helloworld/app/build.gradle
@@ -52,7 +52,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -72,9 +72,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.0' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.0' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.0' // CURRENT_GRPC_VERSION
 }
 
 repositories { mavenCentral() }

--- a/examples/example-kotlin/android/helloworld/app/build.gradle
+++ b/examples/example-kotlin/android/helloworld/app/build.gradle
@@ -52,7 +52,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -72,9 +72,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.0' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.0' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.0' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
 }
 
 repositories { mavenCentral() }

--- a/examples/example-kotlin/android/helloworld/app/build.gradle
+++ b/examples/example-kotlin/android/helloworld/app/build.gradle
@@ -52,7 +52,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -72,9 +72,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.2' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.2' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.2' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
 }
 
 repositories { mavenCentral() }

--- a/examples/example-kotlin/android/helloworld/app/build.gradle
+++ b/examples/example-kotlin/android/helloworld/app/build.gradle
@@ -52,7 +52,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -72,9 +72,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 }
 
 repositories { mavenCentral() }

--- a/examples/example-kotlin/android/helloworld/app/build.gradle
+++ b/examples/example-kotlin/android/helloworld/app/build.gradle
@@ -52,7 +52,7 @@ protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.9.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.24.2' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -72,9 +72,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.24.2' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.24.2' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.24.2' // CURRENT_GRPC_VERSION
 }
 
 repositories { mavenCentral() }

--- a/examples/example-kotlin/build.gradle
+++ b/examples/example-kotlin/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.0' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
 
 dependencies {
     def kotlinVersion = plugins.findPlugin("org.jetbrains.kotlin.jvm").kotlinPluginVersion

--- a/examples/example-kotlin/build.gradle
+++ b/examples/example-kotlin/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 
 dependencies {
     def kotlinVersion = plugins.findPlugin("org.jetbrains.kotlin.jvm").kotlinPluginVersion

--- a/examples/example-kotlin/build.gradle
+++ b/examples/example-kotlin/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.2' // CURRENT_GRPC_VERSION
 
 dependencies {
     def kotlinVersion = plugins.findPlugin("org.jetbrains.kotlin.jvm").kotlinPluginVersion

--- a/examples/example-kotlin/build.gradle
+++ b/examples/example-kotlin/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.2' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
 
 dependencies {
     def kotlinVersion = plugins.findPlugin("org.jetbrains.kotlin.jvm").kotlinPluginVersion

--- a/examples/example-kotlin/build.gradle
+++ b/examples/example-kotlin/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.1' // CURRENT_GRPC_VERSION
 
 dependencies {
     def kotlinVersion = plugins.findPlugin("org.jetbrains.kotlin.jvm").kotlinPluginVersion

--- a/examples/example-kotlin/build.gradle
+++ b/examples/example-kotlin/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.0' // CURRENT_GRPC_VERSION
 
 dependencies {
     def kotlinVersion = plugins.findPlugin("org.jetbrains.kotlin.jvm").kotlinPluginVersion

--- a/examples/example-kotlin/build.gradle
+++ b/examples/example-kotlin/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.1' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 
 dependencies {
     def kotlinVersion = plugins.findPlugin("org.jetbrains.kotlin.jvm").kotlinPluginVersion

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.0' // CURRENT_GRPC_VERSION
 def nettyTcNativeVersion = '2.0.25.Final'
 def protocVersion = '3.9.0'
 

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.2' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.3-SNAPSHOT' // CURRENT_GRPC_VERSION
 def nettyTcNativeVersion = '2.0.25.Final'
 def protocVersion = '3.9.0'
 

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.0' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
 def nettyTcNativeVersion = '2.0.25.Final'
 def protocVersion = '3.9.0'
 

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.1' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 def nettyTcNativeVersion = '2.0.25.Final'
 def protocVersion = '3.9.0'
 

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.25.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 def nettyTcNativeVersion = '2.0.25.Final'
 def protocVersion = '3.9.0'
 

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.1-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.1' // CURRENT_GRPC_VERSION
 def nettyTcNativeVersion = '2.0.25.Final'
 def protocVersion = '3.9.0'
 

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.24.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.24.2' // CURRENT_GRPC_VERSION
 def nettyTcNativeVersion = '2.0.25.Final'
 def protocVersion = '3.9.0'
 

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.24.0</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.24.1-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-tls</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.24.0</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.24.1-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protoc.version>3.9.0</protoc.version>
     <netty.tcnative.version>2.0.25.Final</netty.tcnative.version>
     <!-- required for jdk9 -->

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.24.0-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.24.0</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-tls</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.24.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.24.0</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protoc.version>3.9.0</protoc.version>
     <netty.tcnative.version>2.0.25.Final</netty.tcnative.version>
     <!-- required for jdk9 -->

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.24.2</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.24.3-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-tls</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.24.2</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.24.3-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protoc.version>3.9.0</protoc.version>
     <netty.tcnative.version>2.0.25.Final</netty.tcnative.version>
     <!-- required for jdk9 -->

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.25.0-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.24.0-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-tls</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.25.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.24.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protoc.version>3.9.0</protoc.version>
     <netty.tcnative.version>2.0.25.Final</netty.tcnative.version>
     <!-- required for jdk9 -->

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.24.1-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.24.1</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-tls</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.24.1-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.24.1</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protoc.version>3.9.0</protoc.version>
     <netty.tcnative.version>2.0.25.Final</netty.tcnative.version>
     <!-- required for jdk9 -->

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.24.2-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.24.2</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-tls</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.24.2-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.24.2</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protoc.version>3.9.0</protoc.version>
     <netty.tcnative.version>2.0.25.Final</netty.tcnative.version>
     <!-- required for jdk9 -->

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.24.1</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.24.2-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-tls</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.24.1</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.24.2-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protoc.version>3.9.0</protoc.version>
     <netty.tcnative.version>2.0.25.Final</netty.tcnative.version>
     <!-- required for jdk9 -->

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -63,6 +63,11 @@
       <version>${protobuf.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+      <version>2.3.3</version> <!-- prefer to use 2.3.3 or later -->
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.24.1-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.24.1</version><!-- CURRENT_GRPC_VERSION -->
   <name>examples</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.24.1-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.24.1</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.9.0</protobuf.version>
     <protoc.version>3.9.0</protoc.version>
     <!-- required for jdk9 -->

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.24.1</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.24.2-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>examples</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.24.1</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.24.2-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.9.0</protobuf.version>
     <protoc.version>3.9.0</protoc.version>
     <!-- required for jdk9 -->

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.24.2-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.24.2</version><!-- CURRENT_GRPC_VERSION -->
   <name>examples</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.24.2-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.24.2</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.9.0</protobuf.version>
     <protoc.version>3.9.0</protoc.version>
     <!-- required for jdk9 -->

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.24.0</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.24.1-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>examples</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.24.0</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.24.1-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.9.0</protobuf.version>
     <protoc.version>3.9.0</protoc.version>
     <!-- required for jdk9 -->

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.24.2</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.24.3-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>examples</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.24.2</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.24.3-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.9.0</protobuf.version>
     <protoc.version>3.9.0</protoc.version>
     <!-- required for jdk9 -->

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.25.0-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.24.0-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>examples</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.25.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.24.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.9.0</protobuf.version>
     <protoc.version>3.9.0</protoc.version>
     <!-- required for jdk9 -->

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.24.0-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.24.0</version><!-- CURRENT_GRPC_VERSION -->
   <name>examples</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.24.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.24.0</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.9.0</protobuf.version>
     <protoc.version>3.9.0</protoc.version>
     <!-- required for jdk9 -->

--- a/grpclb/build.gradle
+++ b/grpclb/build.gradle
@@ -16,6 +16,8 @@ dependencies {
     compile (libraries.protobuf_util) {
         // prefer 26.0-android from libraries instead of 20.0
         exclude group: 'com.google.guava', module: 'guava'
+        // prefer 2.3.3 from libraries instead of 2.3.2
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }
     compileOnly libraries.javax_annotation
     testCompile libraries.truth,

--- a/grpclb/src/main/resources/META-INF/services/io.grpc.NameResolverProvider
+++ b/grpclb/src/main/resources/META-INF/services/io.grpc.NameResolverProvider
@@ -1,0 +1,1 @@
+io.grpc.grpclb.SecretGrpclbNameResolverProvider$Provider

--- a/grpclb/src/test/java/io/grpc/grpclb/SecretGrpclbNameResolverProviderTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/SecretGrpclbNameResolverProviderTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.grpclb;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.grpc.internal.BaseDnsNameResolverProvider.ENABLE_GRPCLB_PROPERTY_NAME;
+import static org.junit.Assume.assumeTrue;
+
+import io.grpc.internal.DnsNameResolverProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SecretGrpclbNameResolverProviderTest {
+
+  @Test
+  public void priority_shouldBeHigherThanDefaultDnsNameResolver() {
+    DnsNameResolverProvider defaultDnsNameResolver = new DnsNameResolverProvider();
+    SecretGrpclbNameResolverProvider.Provider grpclbDnsNameResolver =
+        new SecretGrpclbNameResolverProvider.Provider();
+
+    assertThat(defaultDnsNameResolver.priority())
+        .isLessThan(grpclbDnsNameResolver.priority());
+  }
+
+  @Test
+  public void isSrvEnabled_trueByDefault() {
+    assumeTrue(System.getProperty(ENABLE_GRPCLB_PROPERTY_NAME) == null);
+
+    SecretGrpclbNameResolverProvider.Provider grpclbDnsNameResolver =
+        new SecretGrpclbNameResolverProvider.Provider();
+
+    assertThat(grpclbDnsNameResolver.isSrvEnabled()).isTrue();
+  }
+}

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -116,3 +116,12 @@ applicationDistribution.into("bin") {
     from(grpclb_long_lived_affinity_test_client)
     fileMode = 0755
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifact distZip
+            artifact distTar
+        }
+    }
+}

--- a/netty/src/main/java/io/grpc/netty/InternalProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/InternalProtocolNegotiators.java
@@ -19,7 +19,6 @@ package io.grpc.netty;
 import io.grpc.ChannelLogger;
 import io.grpc.netty.ProtocolNegotiators.ClientTlsHandler;
 import io.grpc.netty.ProtocolNegotiators.GrpcNegotiationHandler;
-import io.grpc.netty.ProtocolNegotiators.ProtocolNegotiationHandler;
 import io.grpc.netty.ProtocolNegotiators.WaitUntilActiveHandler;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -38,20 +37,6 @@ public final class InternalProtocolNegotiators {
    */
   public static ChannelLogger negotiationLogger(ChannelHandlerContext ctx) {
     return ProtocolNegotiators.negotiationLogger(ctx);
-  }
-
-  /**
-   * Buffers all writes until either {@link #writeBufferedAndRemove(ChannelHandlerContext)} or
-   * {@link #fail(ChannelHandlerContext, Throwable)} is called. This handler allows us to
-   * write to a {@link io.netty.channel.Channel} before we are allowed to write to it officially
-   * i.e.  before it's active or the TLS Handshake is complete.
-   */
-  public abstract static class AbstractBufferingHandler
-      extends ProtocolNegotiators.AbstractBufferingHandler {
-
-    protected AbstractBufferingHandler(ChannelHandler... handlers) {
-      super(handlers);
-    }
   }
 
   /**

--- a/okhttp/src/main/java/io/grpc/okhttp/Headers.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/Headers.java
@@ -34,7 +34,8 @@ import okio.ByteString;
  */
 class Headers {
 
-  public static final Header SCHEME_HEADER = new Header(Header.TARGET_SCHEME, "https");
+  public static final Header HTTPS_SCHEME_HEADER = new Header(Header.TARGET_SCHEME, "https");
+  public static final Header HTTP_SCHEME_HEADER = new Header(Header.TARGET_SCHEME, "http");
   public static final Header METHOD_HEADER = new Header(Header.TARGET_METHOD, GrpcUtil.HTTP_METHOD);
   public static final Header METHOD_GET_HEADER = new Header(Header.TARGET_METHOD, "GET");
   public static final Header CONTENT_TYPE_HEADER =
@@ -47,7 +48,12 @@ class Headers {
    * application thread context.
    */
   public static List<Header> createRequestHeaders(
-      Metadata headers, String defaultPath, String authority, String userAgent, boolean useGet) {
+      Metadata headers,
+      String defaultPath,
+      String authority,
+      String userAgent,
+      boolean useGet,
+      boolean usePlaintext) {
     Preconditions.checkNotNull(headers, "headers");
     Preconditions.checkNotNull(defaultPath, "defaultPath");
     Preconditions.checkNotNull(authority, "authority");
@@ -61,7 +67,11 @@ class Headers {
     List<Header> okhttpHeaders = new ArrayList<>(7 + InternalMetadata.headerCount(headers));
 
     // Set GRPC-specific headers.
-    okhttpHeaders.add(SCHEME_HEADER);
+    if (usePlaintext) {
+      okhttpHeaders.add(HTTP_SCHEME_HEADER);
+    } else {
+      okhttpHeaders.add(HTTPS_SCHEME_HEADER);
+    }
     if (useGet) {
       okhttpHeaders.add(METHOD_GET_HEADER);
     } else {

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -407,7 +407,14 @@ class OkHttpClientStream extends AbstractClientStream {
 
     @GuardedBy("lock")
     private void streamReady(Metadata metadata, String path) {
-      requestHeaders = Headers.createRequestHeaders(metadata, path, authority, userAgent, useGet);
+      requestHeaders =
+          Headers.createRequestHeaders(
+              metadata,
+              path,
+              authority,
+              userAgent,
+              useGet,
+              transport.isUsingPlaintext());
       transport.streamReadyToStart(OkHttpClientStream.this);
     }
 

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -481,8 +481,8 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
       synchronized (lock) {
         frameWriter = new ExceptionHandlingFrameWriter(OkHttpClientTransport.this, testFrameWriter,
             testFrameLogger);
-        outboundFlow =
-            new OutboundFlowController(OkHttpClientTransport.this, frameWriter, initialWindowSize);
+        outboundFlow = new OutboundFlowController(
+            OkHttpClientTransport.this, frameWriter, DEFAULT_WINDOW_SIZE);
       }
       serializingExecutor.execute(new Runnable() {
         @Override
@@ -508,7 +508,7 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
 
     synchronized (lock) {
       frameWriter = new ExceptionHandlingFrameWriter(this, rawFrameWriter);
-      outboundFlow = new OutboundFlowController(this, frameWriter, initialWindowSize);
+      outboundFlow = new OutboundFlowController(this, frameWriter, DEFAULT_WINDOW_SIZE);
     }
     final CountDownLatch latch = new CountDownLatch(1);
     // Connecting in the serializingExecutor, so that some stream operations like synStream

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -18,6 +18,7 @@ package io.grpc.okhttp;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.grpc.internal.GrpcUtil.TIMER_SERVICE;
+import static io.grpc.okhttp.Utils.DEFAULT_WINDOW_SIZE;
 import static io.grpc.okhttp.Utils.DEFAULT_WINDOW_UPDATE_RATIO;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -600,7 +601,12 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
       synchronized (lock) {
         frameWriter.connectionPreface();
         Settings settings = new Settings();
+        OkHttpSettingsUtil.set(settings, OkHttpSettingsUtil.INITIAL_WINDOW_SIZE, initialWindowSize);
         frameWriter.settings(settings);
+        if (initialWindowSize > DEFAULT_WINDOW_SIZE) {
+          frameWriter.windowUpdate(
+              Utils.CONNECTION_STREAM_ID, initialWindowSize - DEFAULT_WINDOW_SIZE);
+        }
       }
     } finally {
       latch.countDown();

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -311,6 +311,11 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
     initTransportTracer();
   }
 
+  // sslSocketFactory is set to null when use plaintext.
+  boolean isUsingPlaintext() {
+    return sslSocketFactory == null;
+  }
+
   private void initTransportTracer() {
     synchronized (lock) { // to make @GuardedBy linter happy
       transportTracer.setFlowControlWindowReader(new TransportTracer.FlowControlReader() {

--- a/okhttp/src/main/java/io/grpc/okhttp/Utils.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/Utils.java
@@ -42,6 +42,7 @@ class Utils {
    * is sent to expand the window.
    */
   static final float DEFAULT_WINDOW_UPDATE_RATIO = 0.5f;
+  static final int DEFAULT_WINDOW_SIZE = 65535;
   static final int CONNECTION_STREAM_ID = 0;
 
   public static Metadata convertHeaders(List<Header> http2Headers) {

--- a/okhttp/src/test/java/io/grpc/okhttp/HeadersTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/HeadersTest.java
@@ -53,6 +53,7 @@ public class HeadersTest {
         path,
         authority,
         userAgent,
+        false,
         false);
 
     // 7 reserved headers, 1 user header

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import com.google.common.io.BaseEncoding;
 import io.grpc.CallOptions;
@@ -181,7 +182,7 @@ public class OkHttpClientStreamTest {
     verify(mockedFrameWriter)
         .synStream(eq(false), eq(false), eq(3), eq(0), headersCaptor.capture());
     assertThat(headersCaptor.getValue()).containsExactly(
-        Headers.SCHEME_HEADER,
+        Headers.HTTPS_SCHEME_HEADER,
         Headers.METHOD_HEADER,
         new Header(Header.TARGET_AUTHORITY, "localhost"),
         new Header(Header.TARGET_PATH, "/" + methodDescriptor.getFullMethodName()),
@@ -189,6 +190,30 @@ public class OkHttpClientStreamTest {
         Headers.CONTENT_TYPE_HEADER,
         Headers.TE_HEADER)
             .inOrder();
+  }
+
+  @Test
+  public void start_headerPlaintext() throws IOException {
+    Metadata metaData = new Metadata();
+    metaData.put(GrpcUtil.USER_AGENT_KEY, "misbehaving-application");
+    when(transport.isUsingPlaintext()).thenReturn(true);
+    stream = new OkHttpClientStream(methodDescriptor, metaData, frameWriter, transport,
+        flowController, lock, MAX_MESSAGE_SIZE, INITIAL_WINDOW_SIZE, "localhost",
+        "good-application", StatsTraceContext.NOOP, transportTracer, CallOptions.DEFAULT);
+    stream.start(new BaseClientStreamListener());
+    stream.transportState().start(3);
+
+    verify(mockedFrameWriter)
+        .synStream(eq(false), eq(false), eq(3), eq(0), headersCaptor.capture());
+    assertThat(headersCaptor.getValue()).containsExactly(
+        Headers.HTTP_SCHEME_HEADER,
+        Headers.METHOD_HEADER,
+        new Header(Header.TARGET_AUTHORITY, "localhost"),
+        new Header(Header.TARGET_PATH, "/" + methodDescriptor.getFullMethodName()),
+        new Header(GrpcUtil.USER_AGENT_KEY.name(), "good-application"),
+        Headers.CONTENT_TYPE_HEADER,
+        Headers.TE_HEADER)
+        .inOrder();
   }
 
   @Test

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -22,8 +22,8 @@ import static io.grpc.internal.ClientStreamListener.RpcProgress.PROCESSED;
 import static io.grpc.internal.ClientStreamListener.RpcProgress.REFUSED;
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 import static io.grpc.okhttp.Headers.CONTENT_TYPE_HEADER;
+import static io.grpc.okhttp.Headers.HTTP_SCHEME_HEADER;
 import static io.grpc.okhttp.Headers.METHOD_HEADER;
-import static io.grpc.okhttp.Headers.SCHEME_HEADER;
 import static io.grpc.okhttp.Headers.TE_HEADER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -649,7 +649,7 @@ public class OkHttpClientTransportTest {
     stream.start(listener);
     Header userAgentHeader = new Header(GrpcUtil.USER_AGENT_KEY.name(),
             GrpcUtil.getGrpcUserAgent("okhttp", null));
-    List<Header> expectedHeaders = Arrays.asList(SCHEME_HEADER, METHOD_HEADER,
+    List<Header> expectedHeaders = Arrays.asList(HTTP_SCHEME_HEADER, METHOD_HEADER,
             new Header(Header.TARGET_AUTHORITY, "notarealauthority:80"),
             new Header(Header.TARGET_PATH, "/" + method.getFullMethodName()),
             userAgentHeader, CONTENT_TYPE_HEADER, TE_HEADER);
@@ -666,7 +666,7 @@ public class OkHttpClientTransportTest {
     OkHttpClientStream stream =
         clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
     stream.start(listener);
-    List<Header> expectedHeaders = Arrays.asList(SCHEME_HEADER, METHOD_HEADER,
+    List<Header> expectedHeaders = Arrays.asList(HTTP_SCHEME_HEADER, METHOD_HEADER,
         new Header(Header.TARGET_AUTHORITY, "notarealauthority:80"),
         new Header(Header.TARGET_PATH, "/" + method.getFullMethodName()),
         new Header(GrpcUtil.USER_AGENT_KEY.name(),

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -26,7 +26,7 @@ IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS = {
     "io.grpc:grpc-api": "@io_grpc_grpc_java//api",
     "io.grpc:grpc-auth": "@io_grpc_grpc_java//auth",
     "io.grpc:grpc-context": "@io_grpc_grpc_java//context",
-    "io.grpc:grpc-core": "@io_grpc_grpc_java//core_maven",
+    "io.grpc:grpc-core": "@io_grpc_grpc_java//core:core_maven",
     "io.grpc:grpc-grpclb": "@io_grpc_grpc_java//grpclb",
     "io.grpc:grpc-netty": "@io_grpc_grpc_java//netty",
     "io.grpc:grpc-netty-shaded": "@io_grpc_grpc_java//netty:shaded_maven",

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -179,7 +179,7 @@ def com_google_android_annotations():
     jvm_maven_import_external(
         name = "com_google_android_annotations",
         artifact = "com.google.android:annotations:4.1.1.4",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -188,7 +188,7 @@ def com_google_api_grpc_google_common_protos():
     jvm_maven_import_external(
         name = "com_google_api_grpc_proto_google_common_protos",
         artifact = "com.google.api.grpc:proto-google-common-protos:1.12.0",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "bd60cd7a423b00fb824c27bdd0293aaf4781be1daba6ed256311103fb4b84108",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -197,7 +197,7 @@ def com_google_auth_google_auth_library_credentials():
     jvm_maven_import_external(
         name = "com_google_auth_google_auth_library_credentials",
         artifact = "com.google.auth:google-auth-library-credentials:0.9.0",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "ac9efdd6a930e4df906fa278576fa825d979f74315f2faf5c91fe7e6aabb2788",
         licenses = ["notice"],  # BSD 3-clause
     )
@@ -206,7 +206,7 @@ def com_google_auth_google_auth_library_oauth2_http():
     jvm_maven_import_external(
         name = "com_google_auth_google_auth_library_oauth2_http",
         artifact = "com.google.auth:google-auth-library-oauth2-http:0.9.0",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "e55d9722102cc1245c8c43d69acd49d3c9bbfcc1bcf722e971425506b970097e",
         licenses = ["notice"],  # BSD 3-clause
     )
@@ -215,7 +215,7 @@ def com_google_code_findbugs_jsr305():
     jvm_maven_import_external(
         name = "com_google_code_findbugs_jsr305",
         artifact = "com.google.code.findbugs:jsr305:3.0.2",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -224,7 +224,7 @@ def com_google_code_gson():
     jvm_maven_import_external(
         name = "com_google_code_gson_gson",
         artifact = "com.google.code.gson:gson:jar:2.7",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "2d43eb5ea9e133d2ee2405cc14f5ee08951b8361302fdd93494a3a997b508d32",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -233,7 +233,7 @@ def com_google_errorprone_error_prone_annotations():
     jvm_maven_import_external(
         name = "com_google_errorprone_error_prone_annotations",
         artifact = "com.google.errorprone:error_prone_annotations:2.3.3",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "ec59f1b702d9afc09e8c3929f5c42777dec623a6ea2731ac694332c7d7680f5a",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -242,7 +242,7 @@ def com_google_guava():
     jvm_maven_import_external(
         name = "com_google_guava_guava",
         artifact = "com.google.guava:guava:26.0-android",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "1d044ebb866ef08b7d04e998b4260c9b52fab6e6d6b68d207859486bb3686cd5",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -252,7 +252,7 @@ def com_google_guava_failureaccess():
     jvm_maven_import_external(
         name = "com_google_guava_failureaccess",
         artifact = "com.google.guava:failureaccess:1.0.1",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -261,7 +261,7 @@ def com_google_j2objc_j2objc_annotations():
     jvm_maven_import_external(
         name = "com_google_j2objc_j2objc_annotations",
         artifact = "com.google.j2objc:j2objc-annotations:1.1",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "2994a7eb78f2710bd3d3bfb639b2c94e219cedac0d4d084d516e78c16dddecf6",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -290,7 +290,7 @@ def com_google_truth_truth():
     jvm_maven_import_external(
         name = "com_google_truth_truth",
         artifact = "com.google.truth:truth:0.45",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "0f7dced2a16e55a77e44fc3ff9c5be98d4bf4bb30abc18d78ffd735df950a69f",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -299,7 +299,7 @@ def com_squareup_okhttp():
     jvm_maven_import_external(
         name = "com_squareup_okhttp_okhttp",
         artifact = "com.squareup.okhttp:okhttp:2.5.0",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "1cc716e29539adcda677949508162796daffedb4794cbf947a6f65e696f0381c",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -308,7 +308,7 @@ def com_squareup_okio():
     jvm_maven_import_external(
         name = "com_squareup_okio_okio",
         artifact = "com.squareup.okio:okio:1.13.0",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "734269c3ebc5090e3b23566db558f421f0b4027277c79ad5d176b8ec168bb850",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -325,7 +325,7 @@ def io_netty_buffer():
     jvm_maven_import_external(
         name = "io_netty_netty_buffer",
         artifact = "io.netty:netty-buffer:4.1.38.Final",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "a3dcb49108f83b195e66cdad70b2d4a127c17f1be7f5b228a88ce18908c30b3e",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -334,7 +334,7 @@ def io_netty_codec():
     jvm_maven_import_external(
         name = "io_netty_netty_codec",
         artifact = "io.netty:netty-codec:4.1.38.Final",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "8a4cb96e2131eeb8a824014f0ee338b11c6041405446acf73181199ed05744ac",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -343,7 +343,7 @@ def io_netty_codec_http():
     jvm_maven_import_external(
         name = "io_netty_netty_codec_http",
         artifact = "io.netty:netty-codec-http:4.1.38.Final",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "b35c4ac78ed3aaefeb782965ce9f22901e5302bf5e75b75fbed79434ce007e8c",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -352,7 +352,7 @@ def io_netty_codec_http2():
     jvm_maven_import_external(
         name = "io_netty_netty_codec_http2",
         artifact = "io.netty:netty-codec-http2:4.1.38.Final",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "7e2d792407d2da34d3338a3e8f8ed421570fdbf845941b8ee0aa952fe0e07026",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -361,7 +361,7 @@ def io_netty_codec_socks():
     jvm_maven_import_external(
         name = "io_netty_netty_codec_socks",
         artifact = "io.netty:netty-codec-socks:4.1.38.Final",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "16d932d76d06992923ce640609d297fe35d9f7b219ea5f0514a4259f1f1f2146",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -370,7 +370,7 @@ def io_netty_common():
     jvm_maven_import_external(
         name = "io_netty_netty_common",
         artifact = "io.netty:netty-common:4.1.38.Final",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "710df7c27fe5ba4b15689ae10668cd10ab3b618a1291f3a47b2cc292a0fa67da",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -379,7 +379,7 @@ def io_netty_handler():
     jvm_maven_import_external(
         name = "io_netty_netty_handler",
         artifact = "io.netty:netty-handler:4.1.38.Final",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "b49b57dbdc88a2c77e3ea9b9d00d3136f28771e059b74a7be7458d7a86bfccd1",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -388,7 +388,7 @@ def io_netty_handler_proxy():
     jvm_maven_import_external(
         name = "io_netty_netty_handler_proxy",
         artifact = "io.netty:netty-handler-proxy:4.1.38.Final",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "9dab309a0422dd9858f431d503b58b854b37d2545c50ad7b4771f34d2288e5c0",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -397,7 +397,7 @@ def io_netty_resolver():
     jvm_maven_import_external(
         name = "io_netty_netty_resolver",
         artifact = "io.netty:netty-resolver:4.1.38.Final",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "3692c12a0035e566d5cd1dc1529d4f61725304c5e88817ae78b5c2f7f6d86cad",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -406,7 +406,7 @@ def io_netty_tcnative_boringssl_static():
     jvm_maven_import_external(
         name = "io_netty_netty_tcnative_boringssl_static",
         artifact = "io.netty:netty-tcnative-boringssl-static:2.0.25.Final",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "96d9c14ab4c47cbad7fec9bdb083917db971d3754d6c7fa89f958bc719e230ed",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -415,7 +415,7 @@ def io_netty_transport():
     jvm_maven_import_external(
         name = "io_netty_netty_transport",
         artifact = "io.netty:netty-transport:4.1.38.Final",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "5f826976585a49aae9b495290125a60a59dc6887fbe4c70da3182a83fb8bfa88",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -424,7 +424,7 @@ def io_netty_transport_native_epoll():
     jvm_maven_import_external(
         name = "io_netty_netty_transport_native_epoll",
         artifact = "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.38.Final",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "7933467e1cfc37bc6fb3f22af471ed69cb66bebaceab73d2041772bb6a38218a",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -433,7 +433,7 @@ def io_opencensus_api():
     jvm_maven_import_external(
         name = "io_opencensus_opencensus_api",
         artifact = "io.opencensus:opencensus-api:0.21.0",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "8e2cb0f6391d8eb0a1bcd01e7748883f0033b1941754f4ed3f19d2c3e4276fc8",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -442,7 +442,7 @@ def io_opencensus_grpc_metrics():
     jvm_maven_import_external(
         name = "io_opencensus_opencensus_contrib_grpc_metrics",
         artifact = "io.opencensus:opencensus-contrib-grpc-metrics:0.21.0",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "29fc79401082301542cab89d7054d2f0825f184492654c950020553ef4ff0ef8",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -451,7 +451,7 @@ def io_perfmark():
     jvm_maven_import_external(
         name = "io_perfmark_perfmark_api",
         artifact = "io.perfmark:perfmark-api:0.19.0",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "b734ba2149712409a44eabdb799f64768578fee0defe1418bb108fe32ea43e1a",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -461,7 +461,7 @@ def javax_annotation():
     jvm_maven_import_external(
         name = "javax_annotation_javax_annotation_api",
         artifact = "javax.annotation:javax.annotation-api:1.2",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "5909b396ca3a2be10d0eea32c74ef78d816e1b4ead21de1d78de1f890d033e04",
         licenses = ["reciprocal"],  # CDDL License
     )
@@ -470,7 +470,7 @@ def junit_junit():
     jvm_maven_import_external(
         name = "junit_junit",
         artifact = "junit:junit:4.12",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a",
         licenses = ["notice"],  # EPL 1.0
     )
@@ -488,7 +488,7 @@ def org_apache_commons_lang3():
     jvm_maven_import_external(
         name = "org_apache_commons_commons_lang3",
         artifact = "org.apache.commons:commons-lang3:3.5",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "8ac96fc686512d777fca85e144f196cd7cfe0c0aec23127229497d1a38ff651c",
         licenses = ["notice"],  # Apache 2.0
     )
@@ -497,7 +497,7 @@ def org_codehaus_mojo_animal_sniffer_annotations():
     jvm_maven_import_external(
         name = "org_codehaus_mojo_animal_sniffer_annotations",
         artifact = "org.codehaus.mojo:animal-sniffer-annotations:1.17",
-        server_urls = ["http://central.maven.org/maven2"],
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "92654f493ecfec52082e76354f0ebf87648dc3d5cec2e3c3cdb947c016747a53",
         licenses = ["notice"],  # MIT
     )

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -450,9 +450,9 @@ def io_opencensus_grpc_metrics():
 def io_perfmark():
     jvm_maven_import_external(
         name = "io_perfmark_perfmark_api",
-        artifact = "io.perfmark:perfmark-api:0.17.0",
+        artifact = "io.perfmark:perfmark-api:0.19.0",
         server_urls = ["http://central.maven.org/maven2"],
-        artifact_sha256 = "816c11409b8a0c6c9ce1cda14bed526e7b4da0e772da67c5b7b88eefd41520f9",
+        artifact_sha256 = "b734ba2149712409a44eabdb799f64768578fee0defe1418bb108fe32ea43e1a",
         licenses = ["notice"],  # Apache 2.0
     )
 

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -24,6 +24,8 @@ dependencies {
     compile (libraries.protobuf_util) {
         // prefer 26.0-android from libraries instead of 20.0
         exclude group: 'com.google.guava', module: 'guava'
+        // prefer 2.3.3 from libraries instead of 2.3.2
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }
 
     compileOnly libraries.javax_annotation

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     compile (libraries.protobuf_util) {
         // prefer 26.0-android from libraries instead of 20.0
         exclude group: 'com.google.guava', module: 'guava'
+        // prefer 2.3.3 from libraries instead of 2.3.2
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }
 
     testCompile project(':grpc-core').sourceSets.test.output


### PR DESCRIPTION
Addressing #6685 

Two changes:
1. On starting a connection, ensure the value of `OkHttpChannelBuilder.flowControlWindow(int)` is sent via Settings.INITIAL_WINDOW_SIZE. Also send a WINDOW_UPDATE after Settings to update the connection-level window.
2. Always initialize the `OutboundFlowController` with an initialWindowSize of 65335 bytes per the [http2 spec](https://http2.github.io/http2-spec/#InitialWindowSize) instead of using the inbound window size.