### PR TITLE
xds: clean up xDS fallback balancer filtering out grpclb balancer addresses

### DIFF
--- a/xds/src/main/java/io/grpc/xds/FallbackLb.java
+++ b/xds/src/main/java/io/grpc/xds/FallbackLb.java
@@ -18,17 +18,14 @@ package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
-import static io.grpc.xds.XdsLoadBalancerProvider.XDS_POLICY_NAME;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import io.grpc.Attributes;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.Status;
-import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.ServiceConfigUtil.LbConfig;
 import io.grpc.util.ForwardingLoadBalancer;
 import io.grpc.util.GracefulSwitchLoadBalancer;
@@ -112,20 +109,6 @@ final class FallbackLb extends ForwardingLoadBalancer {
     fallbackPolicyLb.switchTo(lbRegistry.getProvider(newFallbackPolicyName));
 
     List<EquivalentAddressGroup> servers = resolvedAddresses.getAddresses();
-    // Some addresses in the list may be grpclb-v1 balancer addresses, so if the fallback policy
-    // does not support grpclb-v1 balancer addresses, then we need to exclude them from the list.
-    // TODO(chengyuanzhang): delete the following logic after changing internal resolver
-    //  to not include grpclb server addresses.
-    if (!newFallbackPolicyName.equals("grpclb") && !newFallbackPolicyName.equals(XDS_POLICY_NAME)) {
-      ImmutableList.Builder<EquivalentAddressGroup> backends = ImmutableList.builder();
-      for (EquivalentAddressGroup eag : resolvedAddresses.getAddresses()) {
-        if (eag.getAttributes().get(GrpcAttributes.ATTR_LB_ADDR_AUTHORITY) == null) {
-          backends.add(eag);
-        }
-      }
-      servers = backends.build();
-    }
-
     // TODO(zhangkun83): FIXME(#5496): this is a temporary hack.
     if (servers.isEmpty()
         && !fallbackPolicyLb.canHandleEmptyAddressListFromNameResolution()) {


### PR DESCRIPTION
#6637 changed to put grpclb balancer addresses in `ResolutionResult.attributes` instead of in `addresses`. We have also migrated the internal resolver to do the same. So LB policies will never receive grpclb balancer addresses in `ResolutionResult.getAddresses()`.