### PR TITLE
api,netty: fix MethodDescriptor and InternalKnownTransport for netty-shaded (backport v1.28.x)

### DIFF
--- a/api/src/main/java/io/grpc/InternalKnownTransport.java
+++ b/api/src/main/java/io/grpc/InternalKnownTransport.java
@@ -24,6 +24,7 @@ package io.grpc;
 @Internal
 public enum InternalKnownTransport {
   NETTY,
+  NETTY_SHADED,
   ;
 }
 

--- a/api/src/main/java/io/grpc/MethodDescriptor.java
+++ b/api/src/main/java/io/grpc/MethodDescriptor.java
@@ -51,8 +51,7 @@ public final class MethodDescriptor<ReqT, RespT> {
 
   // Must be set to InternalKnownTransport.values().length
   // Not referenced to break the dependency.
-  private final AtomicReferenceArray<Object> rawMethodNames = new AtomicReferenceArray<>(1);
-
+  private final AtomicReferenceArray<Object> rawMethodNames = new AtomicReferenceArray<>(2);
 
   /**
    * Gets the cached "raw" method name for this Method Descriptor.  The raw name is transport

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -54,7 +54,9 @@ import javax.annotation.Nullable;
  */
 class NettyClientStream extends AbstractClientStream {
   private static final InternalMethodDescriptor methodDescriptorAccessor =
-      new InternalMethodDescriptor(InternalKnownTransport.NETTY);
+      new InternalMethodDescriptor(
+          NettyClientTransport.class.getName().contains("grpc.netty.shaded")
+              ? InternalKnownTransport.NETTY_SHADED : InternalKnownTransport.NETTY);
 
   private final Sink sink = new Sink();
   private final TransportState state;


### PR DESCRIPTION
cherry-pick of 5677a0b7237ca9d28768ee84f04f3e2a03f23fbb #6774 
Resolves #6765