### PR TITLE
bom: publish grpc-xds to bom (backport v1.28.x)

### DIFF
--- a/bom/build.gradle
+++ b/bom/build.gradle
@@ -12,7 +12,7 @@ publishing {
 
       pom.withXml {
         // Generate bom using subprojects
-        def internalProjects = [project.name, 'grpc-xds', 'grpc-gae-interop-testing-jdk8', 'grpc-compiler']
+        def internalProjects = [project.name, 'grpc-gae-interop-testing-jdk8', 'grpc-compiler']
 
         def dependencyManagement = asNode().appendNode('dependencyManagement')
         def dependencies = dependencyManagement.appendNode('dependencies')


### PR DESCRIPTION
Backport of #6783 
cherry-pick of 9cb277d7af229546f68c4d2af0c322557d0cf2a0