### PR TITLE
core: fix javadoc warnings

### DIFF
--- a/core/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
@@ -34,7 +34,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  * other than READY, the new policy will be swapped into place immediately.  Otherwise, the channel
  * will keep using the old policy until the new policy reports READY or the old policy exits READY.
  *
- * <p>The balancer must {@link #switchTo(Factory) switch to} a policy prior to {@link
+ * <p>The balancer must {@link #switchTo(LoadBalancer.Factory) switch to} a policy prior to {@link
  * LoadBalancer#handleResolvedAddresses(ResolvedAddresses) handling resolved addresses} for the
  * first time.
  */


### PR DESCRIPTION
Fixes #6755

```
> Task :grpc-core:javadoc
core/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java:43: warning - Tag @link: can't find switchTo(Factory) in io.grpc.util.GracefulSwitchLoadBalancer
1 warning
```