### PR TITLE
core, grpclb: clean up grpclb specific attributes in core

### DIFF
--- a/alts/BUILD.bazel
+++ b/alts/BUILD.bazel
@@ -11,6 +11,7 @@ java_library(
         ":handshaker_java_proto",
         "//api",
         "//core:internal",
+        "//grpclb",
         "//netty",
         "//stub",
         "@com_google_code_findbugs_jsr305//jar",
@@ -32,7 +33,6 @@ java_library(
         "src/main/java/io/grpc/alts/*.java",
     ]),
     visibility = ["//visibility:public"],
-    runtime_deps = ["//grpclb"],
     deps = [
         ":alts_internal",
         ":handshaker_java_grpc",

--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -15,6 +15,7 @@ targetCompatibility = 1.7
 dependencies {
     compile project(':grpc-auth'),
             project(':grpc-core'),
+            project(':grpc-grpclb'),
             project(':grpc-netty'),
             project(':grpc-protobuf'),
             project(':grpc-stub'),
@@ -28,7 +29,6 @@ dependencies {
         exclude group: 'io.grpc', module: 'grpc-context'
     }
     compileOnly libraries.javax_annotation
-    runtime project(':grpc-grpclb')
     testCompile project(':grpc-testing'),
             project(':grpc-testing-proto'),
             libraries.guava,

--- a/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
@@ -30,7 +30,6 @@ import io.grpc.SecurityLevel;
 import io.grpc.Status;
 import io.grpc.alts.internal.RpcProtocolVersionsUtil.RpcVersionsCheckResult;
 import io.grpc.grpclb.GrpclbConstants;
-import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.ObjectPool;
 import io.grpc.netty.GrpcHttp2ConnectionHandler;
 import io.grpc.netty.InternalNettyChannelBuilder;
@@ -229,7 +228,8 @@ public final class AltsProtocolNegotiator {
       ChannelHandler gnh = InternalProtocolNegotiators.grpcNegotiationHandler(grpcHandler);
       ChannelHandler securityHandler;
       if (grpcHandler.getEagAttributes().get(GrpclbConstants.ATTR_LB_ADDR_AUTHORITY) != null
-          || grpcHandler.getEagAttributes().get(GrpcAttributes.ATTR_LB_PROVIDED_BACKEND) != null) {
+          || grpcHandler.getEagAttributes().get(
+              GrpclbConstants.ATTR_LB_PROVIDED_BACKEND) != null) {
         TsiHandshaker handshaker = handshakerFactory.newHandshaker(grpcHandler.getAuthority());
         NettyTsiHandshaker nettyHandshaker = new NettyTsiHandshaker(handshaker);
         securityHandler =

--- a/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
@@ -29,6 +29,7 @@ import io.grpc.InternalChannelz.Security;
 import io.grpc.SecurityLevel;
 import io.grpc.Status;
 import io.grpc.alts.internal.RpcProtocolVersionsUtil.RpcVersionsCheckResult;
+import io.grpc.grpclb.GrpclbConstants;
 import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.ObjectPool;
 import io.grpc.netty.GrpcHttp2ConnectionHandler;
@@ -223,12 +224,11 @@ public final class AltsProtocolNegotiator {
       return SCHEME;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public ChannelHandler newHandler(GrpcHttp2ConnectionHandler grpcHandler) {
       ChannelHandler gnh = InternalProtocolNegotiators.grpcNegotiationHandler(grpcHandler);
       ChannelHandler securityHandler;
-      if (grpcHandler.getEagAttributes().get(GrpcAttributes.ATTR_LB_ADDR_AUTHORITY) != null
+      if (grpcHandler.getEagAttributes().get(GrpclbConstants.ATTR_LB_ADDR_AUTHORITY) != null
           || grpcHandler.getEagAttributes().get(GrpcAttributes.ATTR_LB_PROVIDED_BACKEND) != null) {
         TsiHandshaker handshaker = handshakerFactory.newHandshaker(grpcHandler.getAuthority());
         NettyTsiHandshaker nettyHandshaker = new NettyTsiHandshaker(handshaker);

--- a/alts/src/test/java/io/grpc/alts/internal/GoogleDefaultProtocolNegotiatorTest.java
+++ b/alts/src/test/java/io/grpc/alts/internal/GoogleDefaultProtocolNegotiatorTest.java
@@ -24,8 +24,8 @@ import com.google.common.collect.ImmutableList;
 import io.grpc.Attributes;
 import io.grpc.Channel;
 import io.grpc.ManagedChannel;
+import io.grpc.grpclb.GrpclbConstants;
 import io.grpc.inprocess.InProcessChannelBuilder;
-import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.ObjectPool;
 import io.grpc.netty.GrpcHttp2ConnectionHandler;
 import io.grpc.netty.GrpcSslContexts;
@@ -80,7 +80,7 @@ public final class GoogleDefaultProtocolNegotiatorTest {
   @Test
   public void altsHandler() {
     Attributes eagAttributes =
-        Attributes.newBuilder().set(GrpcAttributes.ATTR_LB_PROVIDED_BACKEND, true).build();
+        Attributes.newBuilder().set(GrpclbConstants.ATTR_LB_PROVIDED_BACKEND, true).build();
     GrpcHttp2ConnectionHandler mockHandler = mock(GrpcHttp2ConnectionHandler.class);
     when(mockHandler.getEagAttributes()).thenReturn(eagAttributes);
 

--- a/core/src/main/java/io/grpc/internal/GrpcAttributes.java
+++ b/core/src/main/java/io/grpc/internal/GrpcAttributes.java
@@ -26,17 +26,6 @@ import io.grpc.SecurityLevel;
  */
 public final class GrpcAttributes {
   /**
-   * The naming authority of a gRPC LB server address.  It is an address-group-level attribute,
-   * present when the address group is a LoadBalancer.
-   *
-   * <p>Deprecated: this will be used for grpclb specific logic, which will be moved out of core.
-   */
-  @Deprecated
-  @EquivalentAddressGroup.Attr
-  public static final Attributes.Key<String> ATTR_LB_ADDR_AUTHORITY =
-      Attributes.Key.create("io.grpc.grpclb.lbAddrAuthority");
-
-  /**
    * Whether this EquivalentAddressGroup was provided by a GRPCLB server. It would be rare for this
    * value to be {@code false}; generally it would be better to not have the key present at all.
    */

--- a/core/src/main/java/io/grpc/internal/GrpcAttributes.java
+++ b/core/src/main/java/io/grpc/internal/GrpcAttributes.java
@@ -26,14 +26,6 @@ import io.grpc.SecurityLevel;
  */
 public final class GrpcAttributes {
   /**
-   * Whether this EquivalentAddressGroup was provided by a GRPCLB server. It would be rare for this
-   * value to be {@code false}; generally it would be better to not have the key present at all.
-   */
-  @EquivalentAddressGroup.Attr
-  public static final Attributes.Key<Boolean> ATTR_LB_PROVIDED_BACKEND =
-      Attributes.Key.create("io.grpc.grpclb.lbProvidedBackend");
-
-  /**
    * The security level of the transport.  If it's not present, {@link SecurityLevel#NONE} should be
    * assumed.
    */

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbConstants.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbConstants.java
@@ -48,10 +48,13 @@ public final class GrpclbConstants {
   static final Attributes.Key<List<EquivalentAddressGroup>> ATTR_LB_ADDRS =
       Attributes.Key.create("io.grpc.grpclb.lbAddrs");
 
-  @SuppressWarnings("deprecation")
+  /**
+   * The naming authority of a gRPC LB server address.  It is an address-group-level attribute,
+   * present when the address group is a LoadBalancer.
+   */
   @EquivalentAddressGroup.Attr
-  static final Attributes.Key<String> ATTR_LB_ADDR_AUTHORITY =
-      io.grpc.internal.GrpcAttributes.ATTR_LB_ADDR_AUTHORITY;
+  public static final Attributes.Key<String> ATTR_LB_ADDR_AUTHORITY =
+      Attributes.Key.create("io.grpc.grpclb.lbAddrAuthority");
 
   private GrpclbConstants() { }
 }

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbConstants.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbConstants.java
@@ -56,5 +56,13 @@ public final class GrpclbConstants {
   public static final Attributes.Key<String> ATTR_LB_ADDR_AUTHORITY =
       Attributes.Key.create("io.grpc.grpclb.lbAddrAuthority");
 
+  /**
+   * Whether this EquivalentAddressGroup was provided by a GRPCLB server. It would be rare for this
+   * value to be {@code false}; generally it would be better to not have the key present at all.
+   */
+  @EquivalentAddressGroup.Attr
+  public static final Attributes.Key<Boolean> ATTR_LB_PROVIDED_BACKEND =
+      Attributes.Key.create("io.grpc.grpclb.lbProvidedBackend");
+
   private GrpclbConstants() { }
 }

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -47,7 +47,6 @@ import io.grpc.Status;
 import io.grpc.SynchronizationContext;
 import io.grpc.SynchronizationContext.ScheduledHandle;
 import io.grpc.internal.BackoffPolicy;
-import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.TimeProvider;
 import io.grpc.lb.v1.ClientStats;
 import io.grpc.lb.v1.InitialLoadBalanceRequest;
@@ -86,7 +85,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 final class GrpclbState {
   static final long FALLBACK_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(10);
   private static final Attributes LB_PROVIDED_BACKEND_ATTRS =
-      Attributes.newBuilder().set(GrpcAttributes.ATTR_LB_PROVIDED_BACKEND, true).build();
+      Attributes.newBuilder().set(GrpclbConstants.ATTR_LB_PROVIDED_BACKEND, true).build();
 
   @VisibleForTesting
   static final PickResult DROP_PICK_RESULT =

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -76,7 +76,6 @@ import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.internal.BackoffPolicy;
 import io.grpc.internal.FakeClock;
-import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.JsonParser;
 import io.grpc.lb.v1.ClientStats;
 import io.grpc.lb.v1.ClientStatsPerToken;
@@ -142,7 +141,7 @@ public class GrpclbLoadBalancerTest {
         }
       };
   private static final Attributes LB_BACKEND_ATTRS =
-      Attributes.newBuilder().set(GrpcAttributes.ATTR_LB_PROVIDED_BACKEND, true).build();
+      Attributes.newBuilder().set(GrpclbConstants.ATTR_LB_PROVIDED_BACKEND, true).build();
 
   @Mock
   private Helper helper;


### PR DESCRIPTION
Final cleanup following #6637 and #6723 to move all Grpclb related attributes out of grpc-core and into grpc-grpclb. Now grpc-alts will have a compile dependency on grpc-grpclb instead of runtimeOnly.