### PR TITLE
Revert "all: let interop test use shaded dependency correctly (#6780)"

### DIFF
--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -38,7 +38,6 @@ dependencies {
             libraries.truth
     testRuntime libraries.netty_tcnative,
             libraries.netty_epoll
-    shadow project(path: ':grpc-netty-shaded', configuration: 'shadow')
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -50,9 +50,7 @@ dependencies {
     compile project(":grpc-okhttp")
     compile project(":grpc-protobuf")
     compile project(":grpc-stub")
-    compile (project(":grpc-interop-testing")) {
-        exclude group: "io.grpc", module: "grpc-netty-shaded"
-    }
+    compile project(":grpc-interop-testing")
     compile libraries.netty_tcnative
 }
 

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -16,7 +16,7 @@ configurations {
 evaluationDependsOn(project(':grpc-context').path)
 
 dependencies {
-    compile project(path: ':grpc-alts', configuration: 'shadow'),
+    compile project(':grpc-alts'),
             project(':grpc-auth'),
             project(':grpc-census'),
             project(':grpc-core'),
@@ -113,13 +113,21 @@ task grpclb_long_lived_affinity_test_client(type: CreateStartScripts) {
 }
 
 task xds_test_client(type: CreateStartScripts) {
+    // Use task dependsOn instead of depending on project(':grpc-xds') in configurations because
+    // grpc-xds is not published yet and we don't want grpc-interop-testin to depend on it in maven.
+    dependsOn ':grpc-xds:shadowJar'
+    // Add all other dependencies that grpc-xds needs.
+    dependencies { compile project(':grpc-services'), libraries.netty_epoll }
     mainClassName = "io.grpc.testing.integration.XdsTestClient"
     applicationName = "xds-test-client"
-    dependencies {
-        runtime project(path: ':grpc-xds', configuration: 'shadow')
-    }
     outputDir = new File(project.buildDir, 'tmp')
-    classpath = startScripts.classpath
+    classpath = startScripts.classpath + fileTree("${project(':grpc-xds').buildDir}/libs")
+    doLast {
+        unixScript.text = unixScript.text.replace(
+                '\$APP_HOME/lib/grpc-xds', "${project(':grpc-xds').buildDir}/libs/grpc-xds")
+        windowsScript.text = windowsScript.text.replace(
+                '%APP_HOME%\\lib\\grpc-xds', "${project(':grpc-xds').buildDir}\\libs\\grpc-xds")
+    }
 }
 
 task xds_test_server(type: CreateStartScripts) {

--- a/interop-testing/src/test/java/io/grpc/ChannelAndServerBuilderTest.java
+++ b/interop-testing/src/test/java/io/grpc/ChannelAndServerBuilderTest.java
@@ -59,11 +59,7 @@ public class ChannelAndServerBuilderTest {
     }
     List<Object[]> classes = new ArrayList<>();
     for (ClassInfo classInfo : classInfos) {
-      String className = classInfo.getName();
-      if (className.contains("io.grpc.netty.shaded.io.netty")) {
-        continue;
-      }
-      Class<?> clazz = Class.forName(className, false /*initialize*/, loader);
+      Class<?> clazz = Class.forName(classInfo.getName(), false /*initialize*/, loader);
       if (ServerBuilder.class.isAssignableFrom(clazz) && clazz != ServerBuilder.class) {
         classes.add(new Object[]{clazz});
       } else if (ManagedChannelBuilder.class.isAssignableFrom(clazz)

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -24,7 +24,8 @@ dependencies {
             project(':grpc-core'),
             project(':grpc-netty'),
             project(':grpc-services'),
-            project(path: ':grpc-alts', configuration: 'shadow')
+            project(':grpc-alts'),
+            libraries.netty_epoll
     
     compile (libraries.pgv) {
         // PGV depends on com.google.protobuf:protobuf-java 3.6.1 conflicting with :grpc-protobuf
@@ -38,16 +39,11 @@ dependencies {
 
     testCompile project(':grpc-core').sourceSets.test.output
 
-    compileOnly libraries.javax_annotation,
-            // At runtime use the epoll included in grpc-netty-shaded
-            libraries.netty_epoll
+    compileOnly libraries.javax_annotation
     
     testCompile project(':grpc-testing'), 
             project(':grpc-testing-proto'),
-            libraries.guava_testlib,
-            libraries.netty_epoll
-
-    shadow project(path: ':grpc-netty-shaded', configuration: 'shadow')
+            libraries.guava_testlib
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     testRuntime libraries.netty_tcnative
 }


### PR DESCRIPTION
This reverts commit c5f48b8e384ca1ad91b67886f8cbff27c9bcfd8d.

Revert because caused a regression in the ALTS tests. https://source.cloud.google.com/results/invocations/691d9965-fea1-487d-b606-352a5234039e/targets/grpc%2Fcore%2Fpull_request%2Flinux%2Fgrpc_interop_toprod/log

2020-03-01 20:02:12,491 Exception in thread "main" java.lang.NoClassDefFoundError: org/apache/commons/lang3/SystemUtils
	at io.grpc.alts.CheckGcpEnvironment.isRunningOnGcp(CheckGcpEnvironment.java:69)
	at io.grpc.alts.CheckGcpEnvironment.isOnGcp(CheckGcpEnvironment.java:44)
	at io.grpc.alts.ComputeEngineChannelBuilder.<init>(ComputeEngineChannelBuilder.java:62)
	at io.grpc.alts.ComputeEngineChannelBuilder.forTarget(ComputeEngineChannelBuilder.java:72)
	at io.grpc.alts.ComputeEngineChannelBuilder.forAddress(ComputeEngineChannelBuilder.java:77)
	at io.grpc.testing.integration.TestServiceClient$Tester.createChannel(TestServiceClient.java:399)
	at io.grpc.testing.integration.AbstractInteropTest.setUp(AbstractInteropTest.java:309)
	at io.grpc.testing.integration.TestServiceClient.setUp(TestServiceClient.java:198)
	at io.grpc.testing.integration.TestServiceClient.main(TestServiceClient.java:56)
Caused by: java.lang.ClassNotFoundException: org.apache.commons.lang3.SystemUtils
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 9 more