### PR TITLE
all: let interop test use shaded dependency correctly take 2

### DIFF
--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -38,6 +38,7 @@ dependencies {
             libraries.truth
     testRuntime libraries.netty_tcnative,
             libraries.netty_epoll
+    shadow project(path: ':grpc-netty-shaded', configuration: 'shadow')
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -21,6 +21,7 @@ dependencies {
             libraries.lang,
             libraries.protobuf,
             libraries.conscrypt
+    def nettyDependency = compile project(':grpc-netty')
     compile (libraries.google_auth_oauth2_http) {
         // prefer our own versions instead of google-auth-oauth2-http's dependency
         exclude group: 'com.google.guava', module: 'guava'
@@ -29,13 +30,10 @@ dependencies {
     }
     compileOnly libraries.javax_annotation
 
-    // Use grpc-netty-shaded for transitive dependency.
-    compileOnly project(':grpc-netty')
+    shadow configurations.compile.getDependencies().minus(nettyDependency)
     shadow project(path: ':grpc-netty-shaded', configuration: 'shadow')
-    shadow configurations.compile.getDependencies()
 
-    testCompile project(':grpc-netty'),
-            project(':grpc-testing'),
+    testCompile project(':grpc-testing'),
             project(':grpc-testing-proto'),
             libraries.guava,
             libraries.guava_testlib,

--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     compile project(':grpc-auth'),
             project(':grpc-core'),
             project(':grpc-grpclb'),
-            project(':grpc-netty'),
             project(':grpc-protobuf'),
             project(':grpc-stub'),
             libraries.lang,
@@ -29,7 +28,14 @@ dependencies {
         exclude group: 'io.grpc', module: 'grpc-context'
     }
     compileOnly libraries.javax_annotation
-    testCompile project(':grpc-testing'),
+
+    // Use grpc-netty-shaded for transitive dependency.
+    compileOnly project(':grpc-netty')
+    shadow project(path: ':grpc-netty-shaded', configuration: 'shadow')
+    shadow configurations.compile.getDependencies()
+
+    testCompile project(':grpc-netty'),
+            project(':grpc-testing'),
             project(':grpc-testing-proto'),
             libraries.guava,
             libraries.guava_testlib,
@@ -38,7 +44,6 @@ dependencies {
             libraries.truth
     testRuntime libraries.netty_tcnative,
             libraries.netty_epoll
-    shadow project(path: ':grpc-netty-shaded', configuration: 'shadow')
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 
@@ -82,14 +87,16 @@ publishing {
             artifacts.remove(originalJar)
 
             pom.withXml {
-                // Swap our dependency to grpc-netty-shaded. Projects depending on this via
-                // project(':grpc-alts') will still be using the non-shaded form.
-                asNode().dependencies.'*'.findAll() { dep ->
-                    dep.artifactId.text() == 'grpc-netty'
-                }.each() { netty ->
-                    netty.artifactId*.value = 'grpc-netty-shaded'
-                    netty.version*.value = "[" + netty.version.text() + "]"
+                def dependenciesNode = new Node(null, 'dependencies')
+                project.configurations.shadow.allDependencies.each { dep ->
+                    def dependencyNode = dependenciesNode.appendNode('dependency')
+                    dependencyNode.appendNode('groupId', dep.group)
+                    dependencyNode.appendNode('artifactId', dep.name)
+                    def version = (dep.name == 'grpc-netty-shaded') ? '[' + dep.version + ']' : dep.version
+                    dependencyNode.appendNode('version', version)
+                    dependencyNode.appendNode('scope', 'compile')
                 }
+                asNode().dependencies[0].replaceNode(dependenciesNode)
             }
         }
     }

--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -50,7 +50,9 @@ dependencies {
     compile project(":grpc-okhttp")
     compile project(":grpc-protobuf")
     compile project(":grpc-stub")
-    compile project(":grpc-interop-testing")
+    compile (project(":grpc-interop-testing")) {
+        exclude group: "io.grpc", module: "grpc-netty-shaded"
+    }
     compile libraries.netty_tcnative
 }
 

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -16,7 +16,7 @@ configurations {
 evaluationDependsOn(project(':grpc-context').path)
 
 dependencies {
-    compile project(':grpc-alts'),
+    compile project(path: ':grpc-alts', configuration: 'shadow'),
             project(':grpc-auth'),
             project(':grpc-census'),
             project(':grpc-core'),
@@ -113,21 +113,13 @@ task grpclb_long_lived_affinity_test_client(type: CreateStartScripts) {
 }
 
 task xds_test_client(type: CreateStartScripts) {
-    // Use task dependsOn instead of depending on project(':grpc-xds') in configurations because
-    // grpc-xds is not published yet and we don't want grpc-interop-testin to depend on it in maven.
-    dependsOn ':grpc-xds:shadowJar'
-    // Add all other dependencies that grpc-xds needs.
-    dependencies { compile project(':grpc-services'), libraries.netty_epoll }
     mainClassName = "io.grpc.testing.integration.XdsTestClient"
     applicationName = "xds-test-client"
-    outputDir = new File(project.buildDir, 'tmp')
-    classpath = startScripts.classpath + fileTree("${project(':grpc-xds').buildDir}/libs")
-    doLast {
-        unixScript.text = unixScript.text.replace(
-                '\$APP_HOME/lib/grpc-xds', "${project(':grpc-xds').buildDir}/libs/grpc-xds")
-        windowsScript.text = windowsScript.text.replace(
-                '%APP_HOME%\\lib\\grpc-xds', "${project(':grpc-xds').buildDir}\\libs\\grpc-xds")
+    dependencies {
+        runtime project(path: ':grpc-xds', configuration: 'shadow')
     }
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = startScripts.classpath
 }
 
 task xds_test_server(type: CreateStartScripts) {

--- a/interop-testing/src/test/java/io/grpc/ChannelAndServerBuilderTest.java
+++ b/interop-testing/src/test/java/io/grpc/ChannelAndServerBuilderTest.java
@@ -59,7 +59,11 @@ public class ChannelAndServerBuilderTest {
     }
     List<Object[]> classes = new ArrayList<>();
     for (ClassInfo classInfo : classInfos) {
-      Class<?> clazz = Class.forName(classInfo.getName(), false /*initialize*/, loader);
+      String className = classInfo.getName();
+      if (className.contains("io.grpc.netty.shaded.io.netty")) {
+        continue;
+      }
+      Class<?> clazz = Class.forName(className, false /*initialize*/, loader);
       if (ServerBuilder.class.isAssignableFrom(clazz) && clazz != ServerBuilder.class) {
         classes.add(new Object[]{clazz});
       } else if (ManagedChannelBuilder.class.isAssignableFrom(clazz)

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -24,8 +24,7 @@ dependencies {
             project(':grpc-core'),
             project(':grpc-netty'),
             project(':grpc-services'),
-            project(':grpc-alts'),
-            libraries.netty_epoll
+            project(path: ':grpc-alts', configuration: 'shadow')
     
     compile (libraries.pgv) {
         // PGV depends on com.google.protobuf:protobuf-java 3.6.1 conflicting with :grpc-protobuf
@@ -39,11 +38,16 @@ dependencies {
 
     testCompile project(':grpc-core').sourceSets.test.output
 
-    compileOnly libraries.javax_annotation
+    compileOnly libraries.javax_annotation,
+            // At runtime use the epoll included in grpc-netty-shaded
+            libraries.netty_epoll
     
     testCompile project(':grpc-testing'), 
             project(':grpc-testing-proto'),
-            libraries.guava_testlib
+            libraries.guava_testlib,
+            libraries.netty_epoll
+
+    shadow project(path: ':grpc-netty-shaded', configuration: 'shadow')
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     testRuntime libraries.netty_tcnative
 }

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -24,19 +24,19 @@ dependencies {
             project(':grpc-core'),
             project(':grpc-services'),
             project(path: ':grpc-alts', configuration: 'shadow')
-    
-    compile (libraries.pgv) {
+    def nettyDependency = compile project(':grpc-netty')
+    def pgvDependency = compile (libraries.pgv) {
         // PGV depends on com.google.protobuf:protobuf-java 3.6.1 conflicting with :grpc-protobuf
         exclude group: 'com.google.protobuf'
     }
+
     compile (libraries.protobuf_util) {
         // prefer our own versions instead of protobuf-util's dependency
         exclude group: 'com.google.guava', module: 'guava'
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }
 
-    testCompile project(':grpc-core').sourceSets.test.output,
-            project(':grpc-netty')
+    testCompile project(':grpc-core').sourceSets.test.output
 
     compileOnly libraries.javax_annotation,
             // At runtime use the epoll included in grpc-netty-shaded
@@ -47,11 +47,9 @@ dependencies {
             libraries.guava_testlib,
             libraries.netty_epoll
 
-    // Use grpc-netty-shaded for transitive dependency.
-    compileOnly project(':grpc-netty')
+    shadow configurations.compile.getDependencies().minus([nettyDependency, pgvDependency])
     shadow project(path: ':grpc-netty-shaded', configuration: 'shadow')
-    shadow configurations.compile.getDependencies()
-    
+
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     testRuntime libraries.netty_tcnative
 }

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -22,7 +22,6 @@ dependencies {
     compile project(':grpc-protobuf'),
             project(':grpc-stub'),
             project(':grpc-core'),
-            project(':grpc-netty'),
             project(':grpc-services'),
             project(path: ':grpc-alts', configuration: 'shadow')
     
@@ -36,7 +35,8 @@ dependencies {
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }
 
-    testCompile project(':grpc-core').sourceSets.test.output
+    testCompile project(':grpc-core').sourceSets.test.output,
+            project(':grpc-netty')
 
     compileOnly libraries.javax_annotation,
             // At runtime use the epoll included in grpc-netty-shaded
@@ -47,7 +47,11 @@ dependencies {
             libraries.guava_testlib,
             libraries.netty_epoll
 
+    // Use grpc-netty-shaded for transitive dependency.
+    compileOnly project(':grpc-netty')
     shadow project(path: ':grpc-netty-shaded', configuration: 'shadow')
+    shadow configurations.compile.getDependencies()
+    
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     testRuntime libraries.netty_tcnative
 }
@@ -91,14 +95,16 @@ publishing {
             artifacts.removeAll { it.classifier == 'original' }
 
             pom.withXml {
-                // Swap our dependency to grpc-netty-shaded. Projects depending on this via
-                // project(':grpc-xds') will still be using the non-shaded form.
-                asNode().dependencies.'*'.findAll() { dep ->
-                    dep.artifactId.text() == 'grpc-netty'
-                }.each() { netty ->
-                    netty.artifactId*.value = 'grpc-netty-shaded'
-                    netty.version*.value = "[" + netty.version.text() + "]"
+                def dependenciesNode = new Node(null, 'dependencies')
+                project.configurations.shadow.allDependencies.each { dep ->
+                    def dependencyNode = dependenciesNode.appendNode('dependency')
+                    dependencyNode.appendNode('groupId', dep.group)
+                    dependencyNode.appendNode('artifactId', dep.name)
+                    def version = (dep.name == 'grpc-netty-shaded') ? '[' + dep.version + ']' : dep.version
+                    dependencyNode.appendNode('version', version)
+                    dependencyNode.appendNode('scope', 'compile')
                 }
+                asNode().dependencies[0].replaceNode(dependenciesNode)
             }
         }
     }


### PR DESCRIPTION
This include two commits: 

- first rolls forward #6791 
- then fixes the issue of missing transitive dependency for the shadow configuration.