### PR TITLE
android: add grpc-android into main build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,27 +1,11 @@
-apply plugin: 'com.android.library'
+plugins {
+    id "maven-publish"
 
-group = "io.grpc"
-version = "1.29.0-SNAPSHOT" // CURRENT_GRPC_VERSION
-description = 'gRPC: Android'
-
-buildscript {
-    repositories {
-        google()
-        jcenter()
-        mavenCentral()
-        maven { url "https://plugins.gradle.org/m2/" }
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
-        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.8.1"
-        classpath "digital.wup:android-maven-publish:3.6.2"
-    }
+    id "com.android.library"
+    id "digital.wup.android-maven-publish"
 }
 
-apply plugin: "maven-publish"
-apply plugin: "net.ltgt.errorprone"
-apply plugin: "digital.wup.android-maven-publish"
-apply plugin: "signing"
+description = 'gRPC: Android'
 
 android {
     compileSdkVersion 28
@@ -39,20 +23,15 @@ android {
 repositories {
     google()
     jcenter()
-    mavenCentral()
-    mavenLocal()
 }
 
 dependencies {
-    errorprone 'com.google.errorprone:error_prone_core:2.3.4'
-    errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
+    implementation project(':grpc-core')
 
-    implementation 'io.grpc:grpc-core:1.29.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-
-    testImplementation 'io.grpc:grpc-okhttp:1.29.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.robolectric:robolectric:4.3.1'
-    testImplementation 'com.google.truth:truth:1.0.1'
+    testImplementation project('::grpc-okhttp')
+    testImplementation libraries.junit
+    testImplementation libraries.robolectric
+    testImplementation libraries.truth
 }
 
 task javadocs(type: Javadoc) {
@@ -83,81 +62,11 @@ task sourcesJar(type: Jar) {
 
 publishing {
     publications {
-        maven(MavenPublication) {
+        maven {
             from components.android
 
             artifact javadocJar
             artifact sourcesJar
-
-            pom {
-                name = project.group + ":" + project.name
-                url = 'https://github.com/grpc/grpc-java'
-                afterEvaluate {
-                    // description is not available until evaluated.
-                    description = project.description
-                }
-
-                scm {
-                    connection = 'scm:git:https://github.com/grpc/grpc-java.git'
-                    developerConnection = 'scm:git:git@github.com:grpc/grpc-java.git'
-                    url = 'https://github.com/grpc/grpc-java'
-                }
-
-                licenses {
-                    license {
-                        name = 'Apache 2.0'
-                        url = 'https://opensource.org/licenses/Apache-2.0'
-                    }
-                }
-
-                developers {
-                    developer {
-                        id = "grpc.io"
-                        name = "gRPC Contributors"
-                        email = "grpc-io@googlegroups.com"
-                        url = "https://grpc.io/"
-                        organization = "gRPC Authors"
-                        organizationUrl = "https://www.google.com"
-                    }
-                }
-
-                withXml {
-                    asNode().dependencies.'*'.findAll() { dep ->
-                        dep.artifactId.text() in ['grpc-api', 'grpc-core']
-                    }.each() { core ->
-                        core.version*.value = "[" + core.version.text() + "]"
-                    }
-                }
-            }
         }
     }
-    repositories {
-        maven {
-            if (rootProject.hasProperty('repositoryDir')) {
-                url = new File(rootProject.repositoryDir).toURI()
-            } else {
-                String stagingUrl
-                if (rootProject.hasProperty('repositoryId')) {
-                    stagingUrl = 'https://oss.sonatype.org/service/local/staging/deployByRepositoryId/' +
-                            rootProject.repositoryId
-                } else {
-                    stagingUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-                }
-                credentials {
-                    if (rootProject.hasProperty('ossrhUsername') && rootProject.hasProperty('ossrhPassword')) {
-                        username = rootProject.ossrhUsername
-                        password = rootProject.ossrhPassword
-                    }
-                }
-                def releaseUrl = stagingUrl
-                def snapshotUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
-                url = version.endsWith('SNAPSHOT') ? snapshotUrl : releaseUrl
-            }
-        }
-    }
-}
-
-signing {
-    required false
-    sign publishing.publications.maven
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation project(':grpc-core')
 
     testImplementation project('::grpc-okhttp')
+    testImplementation libraries.androidx_test
     testImplementation libraries.junit
     testImplementation libraries.robolectric
     testImplementation libraries.truth

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'grpc-android'

--- a/build.gradle
+++ b/build.gradle
@@ -157,6 +157,7 @@ subprojects {
             mockito: 'org.mockito:mockito-core:2.28.2',
             truth: 'com.google.truth:truth:1.0.1',
             guava_testlib: "com.google.guava:guava-testlib:${guavaVersion}",
+            androidx_test: "androidx.test:core:1.2.0",
             robolectric: "org.robolectric:robolectric:4.3.1",
 
             // Benchmark dependencies

--- a/buildscripts/kokoro/linux_artifacts.sh
+++ b/buildscripts/kokoro/linux_artifacts.sh
@@ -16,7 +16,6 @@ echo y | ${ANDROID_HOME}/tools/bin/sdkmanager "build-tools;28.0.3"
 LOCAL_MVN_TEMP=$(mktemp -d)
 pushd "$GRPC_JAVA_DIR/android"
 ../gradlew publish \
-  --include-build "$GRPC_JAVA_DIR" \
   -Dorg.gradle.parallel=false \
   -PskipCodegen=true \
   -PrepositoryDir="$LOCAL_MVN_TEMP"

--- a/settings.gradle
+++ b/settings.gradle
@@ -86,4 +86,6 @@ if (settings.hasProperty('skipAndroid') && skipAndroid.toBoolean()) {
     println '*** Android SDK is required. To avoid building Android projects, set -PskipAndroid=true'
     include ":grpc-cronet"
     project(':grpc-cronet').projectDir = "$rootDir/cronet" as File
+    include ":grpc-android"
+    project(':grpc-android').projectDir = "$rootDir/android" as File
 }


### PR DESCRIPTION
For #6775. Basically a mirror of #6132, which was for grpc-cronet. After this change, dependencies in grpc-android is kept in sync with main build.

This change also migrated deprecated Robolectric methods to androidx.test methods. See [Robolectric migration guide](http://robolectric.org/migrating/#migrating-to-40).

> Robolectric 4.0 includes initial support for androidx.test APIs. We strongly recommend adding androidx.test:core:1.0.0 as a test dependency and using those APIs whenever possible rather than using Robolectric-specific APIs.