### PR TITLE
benchmark: clean up jmh plugin configurations

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -14,9 +14,6 @@ run.enabled = false
 
 jmh {
     jvmArgs = "-server -Xms2g -Xmx2g"
-    // Workaround
-    // https://github.com/melix/jmh-gradle-plugin/issues/97#issuecomment-316664026
-    includeTests = true
 }
 
 configurations {
@@ -30,14 +27,15 @@ dependencies {
             project(':grpc-stub'),
             project(':grpc-protobuf'),
             project(':grpc-testing'),
-            libraries.junit,
-            libraries.mockito,
             libraries.hdrhistogram,
             libraries.netty_tcnative,
             libraries.netty_epoll,
             libraries.math
     compileOnly libraries.javax_annotation
     alpnagent libraries.jetty_alpn_agent
+
+    testCompile libraries.junit,
+            libraries.mockito
 }
 
 import net.ltgt.gradle.errorprone.CheckSeverity

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ pluginManagement {
         id "com.google.protobuf" version "0.8.8"
         id "digital.wup.android-maven-publish" version "3.6.2"
         id "me.champeau.gradle.japicmp" version "0.2.5"
-        id "me.champeau.gradle.jmh" version "0.4.5"
+        id "me.champeau.gradle.jmh" version "0.5.0"
         id "net.ltgt.errorprone" version "0.8.1"
         id "ru.vyarus.animalsniffer" version "1.5.0"
     }


### PR DESCRIPTION
- Bump jmh plugin version to 0.5.0, which is compatible with current Gradle version.
- Removed unnecessary workaround for jmh known issues in previous version.
- Fix dependencies to avoid getting duplicated class error when running jmhJar.


Fixes #6762.