### PR TITLE
core: fix a bug in health check config propgation.

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1399,14 +1399,12 @@ final class ManagedChannelImpl extends ManagedChannel implements
           Attributes effectiveAttrs = resolutionResult.getAttributes();
           // Call LB only if it's not shutdown.  If LB is shutdown, lbHelper won't match.
           if (NameResolverListener.this.helper == ManagedChannelImpl.this.lbHelper) {
-            if (effectiveServiceConfig != validServiceConfig) {
-              Map<String, ?> healthCheckingConfig =
-                  effectiveServiceConfig.getHealthCheckingConfig();
-              if (healthCheckingConfig != null) {
-                effectiveAttrs = effectiveAttrs.toBuilder()
-                    .set(LoadBalancer.ATTR_HEALTH_CHECKING_CONFIG, healthCheckingConfig)
-                    .build();
-              }
+            Map<String, ?> healthCheckingConfig =
+                effectiveServiceConfig.getHealthCheckingConfig();
+            if (healthCheckingConfig != null) {
+              effectiveAttrs = effectiveAttrs.toBuilder()
+                  .set(LoadBalancer.ATTR_HEALTH_CHECKING_CONFIG, healthCheckingConfig)
+                  .build();
             }
 
             Status handleResult = helper.lb.tryHandleResolvedAddresses(


### PR DESCRIPTION
The condition "effectiveServiceConfig != validServiceConfig" should
have been deleted in commit 2162ad043677e3cbaac969b96fd4faa05448874b.

The condition was there before that commit because
NAME_RESOLVER_SERVICE_CONFIG was already in "attrs", thus it needed to
be re-added only if "effectiveServiceConfig" differs from the original
"validServiceConfig".

In contrast, ATTR_HEALTH_CHECKING_CONFIG is not in the original
"attrs" and always needs to be added.