### PR TITLE
Add disableAutoRequest method that disables all automatic inbound flow-control requests

### DIFF
--- a/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlClient.java
+++ b/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlClient.java
@@ -44,76 +44,79 @@ public class ManualFlowControlClient {
 
     // When using manual flow-control and back-pressure on the client, the ClientResponseObserver handles both
     // request and response streams.
-    ClientResponseObserver<HelloRequest, HelloReply> clientResponseObserver =
-        new ClientResponseObserver<HelloRequest, HelloReply>() {
+    class FlowControlResponseObserver implements ClientResponseObserver<HelloRequest, HelloReply> {
 
-          ClientCallStreamObserver<HelloRequest> requestStream;
+      ClientCallStreamObserver<HelloRequest> requestStream;
+
+      @Override
+      public void beforeStart(final ClientCallStreamObserver<HelloRequest> requestStream) {
+        this.requestStream = requestStream;
+        // Set up manual flow control for the response stream. It feels backwards to configure the response
+        // stream's flow control using the request stream's observer, but this is the way it is.
+        requestStream.disableAutoRequest();
+
+        // Set up a back-pressure-aware producer for the request stream. The onReadyHandler will be invoked
+        // when the consuming side has enough buffer space to receive more messages.
+        //
+        // Messages are serialized into a transport-specific transmit buffer. Depending on the size of this buffer,
+        // MANY messages may be buffered, however, they haven't yet been sent to the server. The server must call
+        // request() to pull a buffered message from the client.
+        //
+        // Note: the onReadyHandler's invocation is serialized on the same thread pool as the incoming
+        // StreamObserver's onNext(), onError(), and onComplete() handlers. Blocking the onReadyHandler will prevent
+        // additional messages from being processed by the incoming StreamObserver. The onReadyHandler must return
+        // in a timely manner or else message processing throughput will suffer.
+        requestStream.setOnReadyHandler(new Runnable() {
+          // An iterator is used so we can pause and resume iteration of the request data.
+          Iterator<String> iterator = names().iterator();
 
           @Override
-          public void beforeStart(final ClientCallStreamObserver<HelloRequest> requestStream) {
-            this.requestStream = requestStream;
-            // Set up manual flow control for the response stream. It feels backwards to configure the response
-            // stream's flow control using the request stream's observer, but this is the way it is.
-            requestStream.disableAutoRequest();
-
-            // Set up a back-pressure-aware producer for the request stream. The onReadyHandler will be invoked
-            // when the consuming side has enough buffer space to receive more messages.
-            //
-            // Messages are serialized into a transport-specific transmit buffer. Depending on the size of this buffer,
-            // MANY messages may be buffered, however, they haven't yet been sent to the server. The server must call
-            // request() to pull a buffered message from the client.
-            //
-            // Note: the onReadyHandler's invocation is serialized on the same thread pool as the incoming
-            // StreamObserver's onNext(), onError(), and onComplete() handlers. Blocking the onReadyHandler will prevent
-            // additional messages from being processed by the incoming StreamObserver. The onReadyHandler must return
-            // in a timely manner or else message processing throughput will suffer.
-            requestStream.setOnReadyHandler(new Runnable() {
-              // An iterator is used so we can pause and resume iteration of the request data.
-              Iterator<String> iterator = names().iterator();
-
-              @Override
-              public void run() {
-                // Start generating values from where we left off on a non-gRPC thread.
-                while (requestStream.isReady()) {
-                  if (iterator.hasNext()) {
-                      // Send more messages if there are more messages to send.
-                      String name = iterator.next();
-                      logger.info("--> " + name);
-                      HelloRequest request = HelloRequest.newBuilder().setName(name).build();
-                      requestStream.onNext(request);
-                  } else {
-                      // Signal completion if there is nothing left to send.
-                      requestStream.onCompleted();
-                  }
-                }
+          public void run() {
+            // Start generating values from where we left off on a non-gRPC thread.
+            while (requestStream.isReady()) {
+              if (iterator.hasNext()) {
+                // Send more messages if there are more messages to send.
+                String name = iterator.next();
+                logger.info("--> " + name);
+                HelloRequest request = HelloRequest.newBuilder().setName(name).build();
+                requestStream.onNext(request);
+              } else {
+                // Signal completion if there is nothing left to send.
+                requestStream.onCompleted();
               }
-            });
+            }
           }
+        });
+      }
 
-          @Override
-          public void onNext(HelloReply value) {
-            logger.info("<-- " + value.getMessage());
-            // Signal the sender to send one message.
-            requestStream.request(1);
-          }
+      @Override
+      public void onNext(HelloReply value) {
+        logger.info("<-- " + value.getMessage());
+        // Signal the sender to send one message.
+        requestStream.request(1);
+      }
 
-          @Override
-          public void onError(Throwable t) {
-            t.printStackTrace();
-            done.countDown();
-          }
+      @Override
+      public void onError(Throwable t) {
+        t.printStackTrace();
+        done.countDown();
+      }
 
-          @Override
-          public void onCompleted() {
-            logger.info("All Done");
-            done.countDown();
-          }
-        };
+      @Override
+      public void onCompleted() {
+        logger.info("All Done");
+        done.countDown();
+      }
+
+      void request(int numMessages) {
+        requestStream.request(numMessages);
+      }
+    }
+    FlowControlResponseObserver responseObserver = new FlowControlResponseObserver();
 
     // Note: clientResponseObserver is handling both request and response stream processing.
-    ClientCallStreamObserver<HelloRequest> requestObserver =
-        (ClientCallStreamObserver<HelloRequest>) stub.sayHelloStreaming(clientResponseObserver);
-    requestObserver.request(1);
+    stub.sayHelloStreaming(responseObserver);
+    responseObserver.request(1);
 
     done.await();
 

--- a/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlClient.java
+++ b/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlClient.java
@@ -44,79 +44,74 @@ public class ManualFlowControlClient {
 
     // When using manual flow-control and back-pressure on the client, the ClientResponseObserver handles both
     // request and response streams.
-    class FlowControlResponseObserver implements ClientResponseObserver<HelloRequest, HelloReply> {
+    ClientResponseObserver<HelloRequest, HelloReply> clientResponseObserver =
+        new ClientResponseObserver<HelloRequest, HelloReply>() {
 
-      ClientCallStreamObserver<HelloRequest> requestStream;
-
-      @Override
-      public void beforeStart(final ClientCallStreamObserver<HelloRequest> requestStream) {
-        this.requestStream = requestStream;
-        // Set up manual flow control for the response stream. It feels backwards to configure the response
-        // stream's flow control using the request stream's observer, but this is the way it is.
-        requestStream.disableAutoRequest();
-
-        // Set up a back-pressure-aware producer for the request stream. The onReadyHandler will be invoked
-        // when the consuming side has enough buffer space to receive more messages.
-        //
-        // Messages are serialized into a transport-specific transmit buffer. Depending on the size of this buffer,
-        // MANY messages may be buffered, however, they haven't yet been sent to the server. The server must call
-        // request() to pull a buffered message from the client.
-        //
-        // Note: the onReadyHandler's invocation is serialized on the same thread pool as the incoming
-        // StreamObserver's onNext(), onError(), and onComplete() handlers. Blocking the onReadyHandler will prevent
-        // additional messages from being processed by the incoming StreamObserver. The onReadyHandler must return
-        // in a timely manner or else message processing throughput will suffer.
-        requestStream.setOnReadyHandler(new Runnable() {
-          // An iterator is used so we can pause and resume iteration of the request data.
-          Iterator<String> iterator = names().iterator();
+          ClientCallStreamObserver<HelloRequest> requestStream;
 
           @Override
-          public void run() {
-            // Start generating values from where we left off on a non-gRPC thread.
-            while (requestStream.isReady()) {
-              if (iterator.hasNext()) {
-                // Send more messages if there are more messages to send.
-                String name = iterator.next();
-                logger.info("--> " + name);
-                HelloRequest request = HelloRequest.newBuilder().setName(name).build();
-                requestStream.onNext(request);
-              } else {
-                // Signal completion if there is nothing left to send.
-                requestStream.onCompleted();
+          public void beforeStart(final ClientCallStreamObserver<HelloRequest> requestStream) {
+            this.requestStream = requestStream;
+            // Set up manual flow control for the response stream. It feels backwards to configure the response
+            // stream's flow control using the request stream's observer, but this is the way it is.
+            requestStream.disableAutoRequestWithInitial(1);
+
+            // Set up a back-pressure-aware producer for the request stream. The onReadyHandler will be invoked
+            // when the consuming side has enough buffer space to receive more messages.
+            //
+            // Messages are serialized into a transport-specific transmit buffer. Depending on the size of this buffer,
+            // MANY messages may be buffered, however, they haven't yet been sent to the server. The server must call
+            // request() to pull a buffered message from the client.
+            //
+            // Note: the onReadyHandler's invocation is serialized on the same thread pool as the incoming
+            // StreamObserver's onNext(), onError(), and onComplete() handlers. Blocking the onReadyHandler will prevent
+            // additional messages from being processed by the incoming StreamObserver. The onReadyHandler must return
+            // in a timely manner or else message processing throughput will suffer.
+            requestStream.setOnReadyHandler(new Runnable() {
+              // An iterator is used so we can pause and resume iteration of the request data.
+              Iterator<String> iterator = names().iterator();
+
+              @Override
+              public void run() {
+                // Start generating values from where we left off on a non-gRPC thread.
+                while (requestStream.isReady()) {
+                  if (iterator.hasNext()) {
+                      // Send more messages if there are more messages to send.
+                      String name = iterator.next();
+                      logger.info("--> " + name);
+                      HelloRequest request = HelloRequest.newBuilder().setName(name).build();
+                      requestStream.onNext(request);
+                  } else {
+                      // Signal completion if there is nothing left to send.
+                      requestStream.onCompleted();
+                  }
+                }
               }
-            }
+            });
           }
-        });
-      }
 
-      @Override
-      public void onNext(HelloReply value) {
-        logger.info("<-- " + value.getMessage());
-        // Signal the sender to send one message.
-        requestStream.request(1);
-      }
+          @Override
+          public void onNext(HelloReply value) {
+            logger.info("<-- " + value.getMessage());
+            // Signal the sender to send one message.
+            requestStream.request(1);
+          }
 
-      @Override
-      public void onError(Throwable t) {
-        t.printStackTrace();
-        done.countDown();
-      }
+          @Override
+          public void onError(Throwable t) {
+            t.printStackTrace();
+            done.countDown();
+          }
 
-      @Override
-      public void onCompleted() {
-        logger.info("All Done");
-        done.countDown();
-      }
-
-      void request(int numMessages) {
-        requestStream.request(numMessages);
-      }
-    }
-    FlowControlResponseObserver responseObserver = new FlowControlResponseObserver();
+          @Override
+          public void onCompleted() {
+            logger.info("All Done");
+            done.countDown();
+          }
+        };
 
     // Note: clientResponseObserver is handling both request and response stream processing.
-    stub.sayHelloStreaming(responseObserver);
-    responseObserver.request(1);
+    stub.sayHelloStreaming(clientResponseObserver);
 
     done.await();
 

--- a/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlClient.java
+++ b/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlClient.java
@@ -54,7 +54,7 @@ public class ManualFlowControlClient {
             this.requestStream = requestStream;
             // Set up manual flow control for the response stream. It feels backwards to configure the response
             // stream's flow control using the request stream's observer, but this is the way it is.
-            requestStream.disableAutoInboundFlowControl();
+            requestStream.disableAutoRequest();
 
             // Set up a back-pressure-aware producer for the request stream. The onReadyHandler will be invoked
             // when the consuming side has enough buffer space to receive more messages.
@@ -111,7 +111,9 @@ public class ManualFlowControlClient {
         };
 
     // Note: clientResponseObserver is handling both request and response stream processing.
-    stub.sayHelloStreaming(clientResponseObserver);
+    ClientCallStreamObserver<HelloRequest> requestObserver =
+        (ClientCallStreamObserver<HelloRequest>) stub.sayHelloStreaming(clientResponseObserver);
+    requestObserver.request(1);
 
     done.await();
 

--- a/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlServer.java
+++ b/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlServer.java
@@ -39,7 +39,7 @@ public class ManualFlowControlServer {
         // stream's flow control using the response stream's observer, but this is the way it is.
         final ServerCallStreamObserver<HelloReply> serverCallStreamObserver =
             (ServerCallStreamObserver<HelloReply>) responseObserver;
-        serverCallStreamObserver.disableAutoRequest();
+        serverCallStreamObserver.disableAutoRequestWithInitial(0);
 
         // Set up a back-pressure-aware consumer for the request stream. The onReadyHandler will be invoked
         // when the consuming side has enough buffer space to receive more messages.

--- a/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlServer.java
+++ b/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlServer.java
@@ -39,7 +39,7 @@ public class ManualFlowControlServer {
         // stream's flow control using the response stream's observer, but this is the way it is.
         final ServerCallStreamObserver<HelloReply> serverCallStreamObserver =
             (ServerCallStreamObserver<HelloReply>) responseObserver;
-        serverCallStreamObserver.disableAutoInboundFlowControl();
+        serverCallStreamObserver.disableAutoRequest();
 
         // Set up a back-pressure-aware consumer for the request stream. The onReadyHandler will be invoked
         // when the consuming side has enough buffer space to receive more messages.

--- a/services/src/main/java/io/grpc/protobuf/services/ProtoReflectionService.java
+++ b/services/src/main/java/io/grpc/protobuf/services/ProtoReflectionService.java
@@ -135,8 +135,7 @@ public final class ProtoReflectionService extends ServerReflectionGrpc.ServerRef
     ProtoReflectionStreamObserver requestObserver =
         new ProtoReflectionStreamObserver(updateIndexIfNecessary(), serverCallStreamObserver);
     serverCallStreamObserver.setOnReadyHandler(requestObserver);
-    serverCallStreamObserver.disableAutoRequest();
-    serverCallStreamObserver.request(1);
+    serverCallStreamObserver.disableAutoRequestWithInitial(1);
     return requestObserver;
   }
 

--- a/services/src/main/java/io/grpc/protobuf/services/ProtoReflectionService.java
+++ b/services/src/main/java/io/grpc/protobuf/services/ProtoReflectionService.java
@@ -135,7 +135,7 @@ public final class ProtoReflectionService extends ServerReflectionGrpc.ServerRef
     ProtoReflectionStreamObserver requestObserver =
         new ProtoReflectionStreamObserver(updateIndexIfNecessary(), serverCallStreamObserver);
     serverCallStreamObserver.setOnReadyHandler(requestObserver);
-    serverCallStreamObserver.disableAutoInboundFlowControl();
+    serverCallStreamObserver.disableAutoRequest();
     serverCallStreamObserver.request(1);
     return requestObserver;
   }

--- a/services/src/test/java/io/grpc/protobuf/services/ProtoReflectionServiceTest.java
+++ b/services/src/test/java/io/grpc/protobuf/services/ProtoReflectionServiceTest.java
@@ -532,8 +532,11 @@ public class ProtoReflectionServiceTest {
         (ClientCallStreamObserver<ServerReflectionRequest>)
             stub.serverReflectionInfo(clientResponseObserver);
 
-    // ClientCalls.startCall() calls request(1) initially, so we should get an immediate response.
+    // Verify we don't receive a response until we request it.    requestObserver.onNext(flowControlRequest);
     requestObserver.onNext(flowControlRequest);
+    assertEquals(0, clientResponseObserver.getResponses().size());
+
+    requestObserver.request(1);
     assertEquals(1, clientResponseObserver.getResponses().size());
     assertEquals(flowControlGoldenResponse, clientResponseObserver.getResponses().get(0));
 
@@ -594,7 +597,7 @@ public class ProtoReflectionServiceTest {
 
     @Override
     public void beforeStart(final ClientCallStreamObserver<ServerReflectionRequest> requestStream) {
-      requestStream.disableAutoInboundFlowControl();
+      requestStream.disableAutoRequest();
     }
 
     @Override

--- a/services/src/test/java/io/grpc/protobuf/services/ProtoReflectionServiceTest.java
+++ b/services/src/test/java/io/grpc/protobuf/services/ProtoReflectionServiceTest.java
@@ -560,17 +560,15 @@ public class ProtoReflectionServiceTest {
         (ClientCallStreamObserver<ServerReflectionRequest>)
             stub.serverReflectionInfo(clientResponseObserver);
 
-    // ClientCalls.startCall() calls request(1) initially, so make additional request.
-    requestObserver.onNext(flowControlRequest);
     requestObserver.onNext(flowControlRequest);
     requestObserver.onCompleted();
-    assertEquals(1, clientResponseObserver.getResponses().size());
+    assertEquals(0, clientResponseObserver.getResponses().size());
     assertFalse(clientResponseObserver.onCompleteCalled());
 
     requestObserver.request(1);
     assertTrue(clientResponseObserver.onCompleteCalled());
-    assertEquals(2, clientResponseObserver.getResponses().size());
-    assertEquals(flowControlGoldenResponse, clientResponseObserver.getResponses().get(1));
+    assertEquals(1, clientResponseObserver.getResponses().size());
+    assertEquals(flowControlGoldenResponse, clientResponseObserver.getResponses().get(0));
   }
 
   private final ServerReflectionRequest flowControlRequest =

--- a/services/src/test/java/io/grpc/protobuf/services/ProtoReflectionServiceTest.java
+++ b/services/src/test/java/io/grpc/protobuf/services/ProtoReflectionServiceTest.java
@@ -595,7 +595,7 @@ public class ProtoReflectionServiceTest {
 
     @Override
     public void beforeStart(final ClientCallStreamObserver<ServerReflectionRequest> requestStream) {
-      requestStream.disableAutoRequest();
+      requestStream.disableAutoRequestWithInitial(0);
     }
 
     @Override

--- a/services/src/test/java/io/grpc/protobuf/services/ProtoReflectionServiceTest.java
+++ b/services/src/test/java/io/grpc/protobuf/services/ProtoReflectionServiceTest.java
@@ -532,7 +532,7 @@ public class ProtoReflectionServiceTest {
         (ClientCallStreamObserver<ServerReflectionRequest>)
             stub.serverReflectionInfo(clientResponseObserver);
 
-    // Verify we don't receive a response until we request it.    requestObserver.onNext(flowControlRequest);
+    // Verify we don't receive a response until we request it.
     requestObserver.onNext(flowControlRequest);
     assertEquals(0, clientResponseObserver.getResponses().size());
 

--- a/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
@@ -113,8 +113,8 @@ public abstract class CallStreamObserver<V> implements StreamObserver<V> {
   public abstract void disableAutoInboundFlowControl();
 
   /**
-   * Disables automatic flow control where initial tokens are requested when the call is started,
-   * and a token is returned to the peer after a call to the 'inbound' {@link
+   * Disables automatic flow control where initial messages are requested when the call is started,
+   * and an additional message is requested to be read after a call to the 'inbound' {@link
    * io.grpc.stub.StreamObserver#onNext(Object)} has completed. If disabled an application must
    * make explicit calls to {@link #request} to receive any messages.
    *
@@ -122,7 +122,7 @@ public abstract class CallStreamObserver<V> implements StreamObserver<V> {
    * ClientResponseObserver#beforeStart}. On server-side it may only be called during the initial
    * call to the application, before the service returns its {@code StreamObserver}.
    *
-   * <p>Note that for server-side cases where the message is recieved before the handler is invoked,
+   * <p>Note that for server-side cases where the message is received before the handler is invoked,
    * this method will have no effect. This is true for:
    *
    * <ul>

--- a/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
@@ -133,7 +133,7 @@ public abstract class CallStreamObserver<V> implements StreamObserver<V> {
    * }</pre>
    * 
    * @deprecated Use {@link #disableAutoRequest} instead (see note above about migrating). This
-   * method will be removed.
+   *     method will be removed.
    */
   @Deprecated
   public abstract void disableAutoInboundFlowControl();

--- a/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
@@ -112,11 +112,7 @@ public abstract class CallStreamObserver<V> implements StreamObserver<V> {
    * already disables all inbound requests.  On the client side, {@code
    * disableAutoRequestWithInitial(1)} should be called to maintain existing behavior as
    * {@code disableAutoInboundFlowControl} does not disable the initial request.
-   * 
-   * @deprecated Use {@link #disableAutoRequest} instead (see note above about migrating). This
-   *     method will be removed.
    */
-  @Deprecated
   public abstract void disableAutoInboundFlowControl();
 
   /**
@@ -136,6 +132,8 @@ public abstract class CallStreamObserver<V> implements StreamObserver<V> {
    *   <li>{@link io.grpc.MethodDescriptor.MethodType#SERVER_STREAMING} operations.</li>
    * </ul>
    * </p>
+
+   <p>This API is still a work in-progress and will likely change in the future.
    */
   public abstract void disableAutoRequestWithInitial(int request);
 

--- a/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
@@ -132,8 +132,8 @@ public abstract class CallStreamObserver<V> implements StreamObserver<V> {
    *   <li>{@link io.grpc.MethodDescriptor.MethodType#SERVER_STREAMING} operations.</li>
    * </ul>
    * </p>
-
-   <p>This API is still a work in-progress and will likely change in the future.
+   *
+   * <p>This API is still a work in-progress and will likely change in the future.
    */
   public abstract void disableAutoRequestWithInitial(int request);
 

--- a/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
@@ -107,8 +107,9 @@ public abstract class CallStreamObserver<V> implements StreamObserver<V> {
    * </ul>
    * </p>
    * 
-   * <p>Migrating to {@link #disableAutoRequest} requires making adding an initial {@link #request}
-   * after the call has started. For example:
+   * <p>On the server side, migrating to {@link #disableAutoRequest} requires no changes; they have
+   * identical behavior.  On the client-side, migrating to {@code disableAutoRequest} requires
+   * making adding an initial {@link #request} after the call has started. For example:
    * 
    * <pre>{@code
    * Rectangle request = ...;

--- a/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
@@ -106,8 +106,32 @@ public abstract class CallStreamObserver<V> implements StreamObserver<V> {
    *   </li>
    * </ul>
    * </p>
+   *
+   * @deprecated Use {@link #disableAutoRequest} instead. This method will be removed.
    */
+  @Deprecated
   public abstract void disableAutoInboundFlowControl();
+
+  /**
+   * Disables automatic flow control where initial tokens are requested when the call is started,
+   * and a token is returned to the peer after a call to the 'inbound' {@link
+   * io.grpc.stub.StreamObserver#onNext(Object)} has completed. If disabled an application must
+   * make explicit calls to {@link #request} to receive any messages.
+   *
+   * <p>On client-side this method may only be called during {@link
+   * ClientResponseObserver#beforeStart}. On server-side it may only be called during the initial
+   * call to the application, before the service returns its {@code StreamObserver}.
+   *
+   * <p>Note that for server-side cases where the message is recieved before the handler is invoked,
+   * this method will have no effect. This is true for:
+   *
+   * <ul>
+   *   <li>{@link io.grpc.MethodDescriptor.MethodType#UNARY} operations.</li>
+   *   <li>{@link io.grpc.MethodDescriptor.MethodType#SERVER_STREAMING} operations.</li>
+   * </ul>
+   * </p>
+   */
+  public abstract void disableAutoRequest();
 
   /**
    * Requests the peer to produce {@code count} more messages to be delivered to the 'inbound'

--- a/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
@@ -106,8 +106,33 @@ public abstract class CallStreamObserver<V> implements StreamObserver<V> {
    *   </li>
    * </ul>
    * </p>
-   *
-   * @deprecated Use {@link #disableAutoRequest} instead. This method will be removed.
+   * 
+   * <p>Migrating to {@link #disableAutoRequest} requires making adding an initial {@link #request}
+   * after the call has started. For example:
+   * 
+   * <pre>{@code
+   * Rectangle request = ...;
+   * class ResponseObserver implements ClientResponseObserver<Rectangle, Feature> {
+   *   private ClientCallStreamObserver<Rectangle> requestObserver;
+   *   ...
+   *   @Override public void beforeStart(ClientCallStreamObserver<Rectangle> requestObserver) {
+   *     this.requestObserver = requestObserver;
+   *     requestObserver.disableAutoRequest();
+   *     // Note that requestObserver.request can not be called before the call is started
+   *     ...
+   *   }
+   *   // Need to expose the request method outside the Observer
+   *   void request(int numMessages) {
+   *     requestObserver.request(numMessages);
+   *   }
+   * }
+   * ResponseObserver responseObserver = new ResponseObserver();
+   * asyncStub.listFeatures(request, responseObserver);
+   * responseObserver.request(1);
+   * }</pre>
+   * 
+   * @deprecated Use {@link #disableAutoRequest} instead (see note above about migrating). This
+   * method will be removed.
    */
   @Deprecated
   public abstract void disableAutoInboundFlowControl();

--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -274,7 +274,7 @@ public final class ClientCalls {
         req,
         new StreamObserverToCallListenerAdapter<>(
             responseObserver,
-            new CallToStreamObserverAdapter<>(call, streamingResponse));
+            new CallToStreamObserverAdapter<>(call, streamingResponse)));
   }
 
   private static <ReqT, RespT> void asyncUnaryRequestCall(

--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -466,7 +466,7 @@ public final class ClientCalls {
   /**
    * Completes a {@link GrpcFuture} using {@link StreamObserver} events.
    */
-  private static final class UnaryStreamToFuture<ReqT, RespT> extends StartableListener<RespT> {
+  private static final class UnaryStreamToFuture<RespT> extends StartableListener<RespT> {
     private final GrpcFuture<RespT> responseFuture;
     private RespT value;
 

--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -320,7 +320,7 @@ public final class ClientCalls {
     private final ClientCall<T, ?> call;
     private final boolean streamingResponse;
     private Runnable onReadyHandler;
-    private int initalRequest = 1;
+    private int initialRequest = 1;
     private boolean autoRequestEnabled = true;
     private boolean aborted = false;
     private boolean completed = false;
@@ -380,7 +380,7 @@ public final class ClientCalls {
         throw new IllegalStateException(
             "Cannot disable auto flow control after call started. Use ClientResponseObserver");
       }
-      Preconditions.checkArugment(request >= 0, "Initial requests must be non-negative");
+      Preconditions.checkArgument(request >= 0, "Initial requests must be non-negative");
       initialRequest = request;
       autoRequestEnabled = false;
     }

--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -384,7 +384,10 @@ public final class ClientCalls {
 
     @Override
     public void disableAutoRequest() {
-      checkState(!frozen, "Cannot disable auto flow control after call started. Use ClientResponseObserver");
+      if (frozen) {
+        throw new IllegalStateException(
+            "Cannot disable auto flow control after call started. Use ClientResponseObserver");
+      }
       autoRequestMode = AutoRequestMode.DISABLED;
     }
 

--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -372,6 +372,7 @@ public final class ClientCalls {
       this.onReadyHandler = onReadyHandler;
     }
 
+    @Deprecated
     @Override
     public void disableAutoInboundFlowControl() {
       if (frozen) {

--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -326,7 +326,7 @@ public final class ClientCalls {
     private boolean completed = false;
 
     // Non private to avoid synthetic class
-    CallToStreamObserverAdapter(ClientCall<T, ?> call) {
+    CallToStreamObserverAdapter(ClientCall<T, ?> call, boolean streamingResponse) {
       this.call = call;
       this.streamingResponse = streamingResponse;
     }

--- a/stub/src/main/java/io/grpc/stub/ClientResponseObserver.java
+++ b/stub/src/main/java/io/grpc/stub/ClientResponseObserver.java
@@ -30,8 +30,7 @@ public interface ClientResponseObserver<ReqT, RespT> extends StreamObserver<Resp
    * onReady events, disable auto inbound flow and perform other advanced functions.
    *
    * <p>Only the methods {@link ClientCallStreamObserver#setOnReadyHandler(Runnable)} and
-   * {@link ClientCallStreamObserver#disableAutoInboundFlowControl()} may be called within this
-   * callback
+   * {@link ClientCallStreamObserver#disableAutoRequest()} may be called within this callback
    *
    * <pre>
    *   // Copy an iterator to the request stream under flow-control

--- a/stub/src/main/java/io/grpc/stub/ClientResponseObserver.java
+++ b/stub/src/main/java/io/grpc/stub/ClientResponseObserver.java
@@ -30,7 +30,8 @@ public interface ClientResponseObserver<ReqT, RespT> extends StreamObserver<Resp
    * onReady events, disable auto inbound flow and perform other advanced functions.
    *
    * <p>Only the methods {@link ClientCallStreamObserver#setOnReadyHandler(Runnable)} and
-   * {@link ClientCallStreamObserver#disableAutoRequest()} may be called within this callback
+   * {@link ClientCallStreamObserver#disableAutoRequestWithInitial(int)} may be called within
+   * this callback
    *
    * <pre>
    *   // Copy an iterator to the request stream under flow-control

--- a/stub/src/main/java/io/grpc/stub/ServerCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCalls.java
@@ -223,7 +223,7 @@ public final class ServerCalls {
           new ServerCallStreamObserverImpl<>(call);
       StreamObserver<ReqT> requestObserver = method.invoke(responseObserver);
       responseObserver.freeze();
-      if (responseObserver.autoFlowControlEnabled) {
+      if (responseObserver.autoRequestEnabled) {
         call.request(1);
       }
       return new StreamingServerCallListener(requestObserver, responseObserver, call);
@@ -251,7 +251,7 @@ public final class ServerCalls {
         requestObserver.onNext(request);
 
         // Request delivery of the next inbound message.
-        if (responseObserver.autoFlowControlEnabled) {
+        if (responseObserver.autoRequestEnabled) {
           call.request(1);
         }
       }
@@ -308,7 +308,7 @@ public final class ServerCalls {
     final ServerCall<ReqT, RespT> call;
     volatile boolean cancelled;
     private boolean frozen;
-    private boolean autoFlowControlEnabled = true;
+    private boolean autoRequestEnabled = true;
     private boolean sentHeaders;
     private Runnable onReadyHandler;
     private Runnable onCancelHandler;
@@ -401,8 +401,13 @@ public final class ServerCalls {
 
     @Override
     public void disableAutoInboundFlowControl() {
+      disableAutoRequest();
+    }
+
+    @Override
+    public void disableAutoRequest() {
       checkState(!frozen, "Cannot disable auto flow control after initialization");
-      autoFlowControlEnabled = false;
+      autoRequestEnabled = false;
     }
 
     @Override

--- a/stub/src/main/java/io/grpc/stub/ServerCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCalls.java
@@ -223,8 +223,8 @@ public final class ServerCalls {
           new ServerCallStreamObserverImpl<>(call);
       StreamObserver<ReqT> requestObserver = method.invoke(responseObserver);
       responseObserver.freeze();
-      if (responseObserver.autoRequestEnabled) {
-        call.request(1);
+      if (responseObserver.initialRequest > 0) {
+        call.request(responseObserver.initialRequest);
       }
       return new StreamingServerCallListener(requestObserver, responseObserver, call);
     }
@@ -308,6 +308,7 @@ public final class ServerCalls {
     final ServerCall<ReqT, RespT> call;
     volatile boolean cancelled;
     private boolean frozen;
+    private int initialRequest;
     private boolean autoRequestEnabled = true;
     private boolean sentHeaders;
     private Runnable onReadyHandler;
@@ -402,12 +403,14 @@ public final class ServerCalls {
     @Deprecated
     @Override
     public void disableAutoInboundFlowControl() {
-      disableAutoRequest();
+      disableAutoRequestWithInitial(0);
     }
 
     @Override
-    public void disableAutoRequest() {
+    public void disableAutoRequestWithInitial(int request) {
       checkState(!frozen, "Cannot disable auto flow control after initialization");
+      checkArugment(request >= 0, "Initial requests must be non-negative");
+      initialRequest = request;
       autoRequestEnabled = false;
     }
 

--- a/stub/src/main/java/io/grpc/stub/ServerCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCalls.java
@@ -409,7 +409,7 @@ public final class ServerCalls {
     @Override
     public void disableAutoRequestWithInitial(int request) {
       checkState(!frozen, "Cannot disable auto flow control after initialization");
-      checkArugment(request >= 0, "Initial requests must be non-negative");
+      checkArgument(request >= 0, "Initial requests must be non-negative");
       initialRequest = request;
       autoRequestEnabled = false;
     }

--- a/stub/src/main/java/io/grpc/stub/ServerCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCalls.java
@@ -409,7 +409,7 @@ public final class ServerCalls {
     @Override
     public void disableAutoRequestWithInitial(int request) {
       checkState(!frozen, "Cannot disable auto flow control after initialization");
-      checkArgument(request >= 0, "Initial requests must be non-negative");
+      Preconditions.checkArgument(request >= 0, "Initial requests must be non-negative");
       initialRequest = request;
       autoRequestEnabled = false;
     }

--- a/stub/src/main/java/io/grpc/stub/ServerCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCalls.java
@@ -308,7 +308,7 @@ public final class ServerCalls {
     final ServerCall<ReqT, RespT> call;
     volatile boolean cancelled;
     private boolean frozen;
-    private int initialRequest;
+    private int initialRequest = 1;
     private boolean autoRequestEnabled = true;
     private boolean sentHeaders;
     private Runnable onReadyHandler;

--- a/stub/src/main/java/io/grpc/stub/ServerCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCalls.java
@@ -399,6 +399,7 @@ public final class ServerCalls {
       this.onCancelHandler = onCancelHandler;
     }
 
+    @Deprecated
     @Override
     public void disableAutoInboundFlowControl() {
       disableAutoRequest();

--- a/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
+++ b/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
@@ -375,7 +375,7 @@ public class ClientCallsTest {
     ClientCalls.asyncBidiStreamingCall(call, new ClientResponseObserver<Integer, String>() {
       @Override
       public void beforeStart(ClientCallStreamObserver<Integer> requestStream) {
-        requestStream.disableAutoRequest();
+        requestStream.disableAutoRequestWithInitial(0);
       }
 
       @Override
@@ -404,7 +404,7 @@ public class ClientCallsTest {
         new ClientResponseObserver<Integer, String>() {
           @Override
           public void beforeStart(ClientCallStreamObserver<Integer> requestStream) {
-            requestStream.disableAutoRequest();
+            requestStream.disableAutoRequestWithInitial(0);
           }
 
           @Override
@@ -452,7 +452,7 @@ public class ClientCallsTest {
       @Override
       public void beforeStart(ClientCallStreamObserver<Integer> requestStream) {
         this.requestStream = requestStream;
-        requestStream.disableAutoRequest();
+        requestStream.disableAutoRequestWithInitial(0);
       }
 
       @Override
@@ -538,7 +538,7 @@ public class ClientCallsTest {
         new ClientResponseObserver<Integer, Integer>() {
           @Override
           public void beforeStart(final ClientCallStreamObserver<Integer> requestStream) {
-            requestStream.disableAutoRequest();
+            requestStream.disableAutoRequestWithInitial(0);
           }
 
           @Override
@@ -586,7 +586,7 @@ public class ClientCallsTest {
               public StreamObserver<Integer> invoke(StreamObserver<Integer> responseObserver) {
                 final ServerCallStreamObserver<Integer> serverCallObserver =
                     (ServerCallStreamObserver<Integer>) responseObserver;
-                serverCallObserver.disableAutoRequest();
+                serverCallObserver.disableAutoRequestWithInitial(0);
                 observerFuture.set(serverCallObserver);
                 return new StreamObserver<Integer>() {
                   @Override

--- a/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
+++ b/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
@@ -331,7 +331,6 @@ public class ClientCallsTest {
     };
     ClientCalls.asyncBidiStreamingCall(call, new ClientResponseObserver<Integer, String>() {
       @Override
-      @SuppressWarnings("deprecation")
       public void beforeStart(ClientCallStreamObserver<Integer> requestStream) {
         requestStream.disableAutoInboundFlowControl();
       }

--- a/stub/src/test/java/io/grpc/stub/ServerCallsTest.java
+++ b/stub/src/test/java/io/grpc/stub/ServerCallsTest.java
@@ -276,7 +276,7 @@ public class ServerCallsTest {
         callHandler.startCall(serverCall, new Metadata());
     callListener.onMessage(1);
     try {
-      callObserver.get().disableAutoRequest();
+      callObserver.get().disableAutoRequestWithInitial(0);
       fail("Cannot set onCancel handler after service invocation");
     } catch (IllegalStateException expected) {
       // Expected
@@ -316,7 +316,7 @@ public class ServerCallsTest {
               public StreamObserver<Integer> invoke(StreamObserver<Integer> responseObserver) {
                 ServerCallStreamObserver<Integer> serverCallObserver =
                     (ServerCallStreamObserver<Integer>) responseObserver;
-                serverCallObserver.disableAutoRequest();
+                serverCallObserver.disableAutoRequestWithInitial(0);
                 return new ServerCalls.NoopStreamObserver<>();
               }
             });
@@ -339,7 +339,7 @@ public class ServerCallsTest {
               public void invoke(Integer req, StreamObserver<Integer> responseObserver) {
                 ServerCallStreamObserver<Integer> serverCallObserver =
                     (ServerCallStreamObserver<Integer>) responseObserver;
-                serverCallObserver.disableAutoRequest();
+                serverCallObserver.disableAutoRequestWithInitial(0);
               }
             });
     callHandler.startCall(serverCall, new Metadata());

--- a/stub/src/test/java/io/grpc/stub/ServerCallsTest.java
+++ b/stub/src/test/java/io/grpc/stub/ServerCallsTest.java
@@ -289,7 +289,6 @@ public class ServerCallsTest {
         ServerCalls.asyncBidiStreamingCall(
             new ServerCalls.BidiStreamingMethod<Integer, Integer>() {
               @Override
-              @SuppressWarnings("deprecation")
               public StreamObserver<Integer> invoke(StreamObserver<Integer> responseObserver) {
                 ServerCallStreamObserver<Integer> serverCallObserver =
                     (ServerCallStreamObserver<Integer>) responseObserver;

--- a/stub/src/test/java/io/grpc/stub/ServerCallsTest.java
+++ b/stub/src/test/java/io/grpc/stub/ServerCallsTest.java
@@ -260,7 +260,7 @@ public class ServerCallsTest {
   }
 
   @Test
-  public void cannotDisableAutoFlowControlAfterServiceInvocation() throws Exception {
+  public void cannotDisableAutoRequestAfterServiceInvocation() throws Exception {
     final AtomicReference<ServerCallStreamObserver<Integer>> callObserver =
         new AtomicReference<>();
     ServerCallHandler<Integer, Integer> callHandler =
@@ -276,7 +276,7 @@ public class ServerCallsTest {
         callHandler.startCall(serverCall, new Metadata());
     callListener.onMessage(1);
     try {
-      callObserver.get().disableAutoInboundFlowControl();
+      callObserver.get().disableAutoRequest();
       fail("Cannot set onCancel handler after service invocation");
     } catch (IllegalStateException expected) {
       // Expected
@@ -289,6 +289,7 @@ public class ServerCallsTest {
         ServerCalls.asyncBidiStreamingCall(
             new ServerCalls.BidiStreamingMethod<Integer, Integer>() {
               @Override
+              @SuppressWarnings("deprecation")
               public StreamObserver<Integer> invoke(StreamObserver<Integer> responseObserver) {
                 ServerCallStreamObserver<Integer> serverCallObserver =
                     (ServerCallStreamObserver<Integer>) responseObserver;
@@ -307,7 +308,30 @@ public class ServerCallsTest {
   }
 
   @Test
-  public void disablingInboundAutoFlowControlForUnaryHasNoEffect() throws Exception {
+  public void disablingInboundAutoRequestSuppressesRequestsForMoreMessages() throws Exception {
+    ServerCallHandler<Integer, Integer> callHandler =
+        ServerCalls.asyncBidiStreamingCall(
+            new ServerCalls.BidiStreamingMethod<Integer, Integer>() {
+              @Override
+              public StreamObserver<Integer> invoke(StreamObserver<Integer> responseObserver) {
+                ServerCallStreamObserver<Integer> serverCallObserver =
+                    (ServerCallStreamObserver<Integer>) responseObserver;
+                serverCallObserver.disableAutoRequest();
+                return new ServerCalls.NoopStreamObserver<>();
+              }
+            });
+    ServerCall.Listener<Integer> callListener =
+        callHandler.startCall(serverCall, new Metadata());
+    callListener.onReady();
+    // Transport should not call this if nothing has been requested but forcing it here
+    // to verify that message delivery does not trigger a call to request(1).
+    callListener.onMessage(1);
+    // Should never be called
+    assertThat(serverCall.requestCalls).isEmpty();
+  }
+
+  @Test
+  public void disablingInboundAutoRequestForUnaryHasNoEffect() throws Exception {
     ServerCallHandler<Integer, Integer> callHandler =
         ServerCalls.asyncUnaryCall(
             new ServerCalls.UnaryMethod<Integer, Integer>() {
@@ -315,7 +339,7 @@ public class ServerCallsTest {
               public void invoke(Integer req, StreamObserver<Integer> responseObserver) {
                 ServerCallStreamObserver<Integer> serverCallObserver =
                     (ServerCallStreamObserver<Integer>) responseObserver;
-                serverCallObserver.disableAutoInboundFlowControl();
+                serverCallObserver.disableAutoRequest();
               }
             });
     callHandler.startCall(serverCall, new Metadata());


### PR DESCRIPTION
The default behavior of requesting initial messages is applied even if disableAutoInboundFlowControl is called. ServerCalls disables all automatic flow control which is much more useful in case the user can't handle incoming messages until some time after the call has started.  This change creates a new StartableListener that has an onStart method that is invoked when the call is started which makes initial requests if necessary.

See #6806 