### PR TITLE
xds: treat target server authority opaquely for resolving cluster name (v1.28.x backport) (#6767) 

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -391,19 +391,17 @@ abstract class XdsClient {
   abstract void shutdown();
 
   /**
-   * Registers a watcher to receive {@link ConfigUpdate} for service with the given hostname and
-   * port.
+   * Registers a watcher to receive {@link ConfigUpdate} for service with the given target
+   * authority.
    *
    * <p>Unlike watchers for cluster data and endpoint data, at most one ConfigWatcher can be
    * registered. Once it is registered, it cannot be unregistered.
    *
-   * @param hostName the host name part of the "xds:" URI for the server name that the gRPC client
-   *     targets for. Must NOT contain port.
-   * @param port the port part of the "xds:" URI for the server name that the gRPC client targets
-   *     for. -1 if not specified.
+   * @param targetAuthority authority of the "xds:" URI for the server name that the gRPC client
+   *     targets for.
    * @param watcher the {@link ConfigWatcher} to receive {@link ConfigUpdate}.
    */
-  void watchConfigData(String hostName, int port, ConfigWatcher watcher) {
+  void watchConfigData(String targetAuthority, ConfigWatcher watcher) {
   }
 
   /**

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -16,7 +16,6 @@
 
 package io.grpc.xds;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Stopwatch;
@@ -32,6 +31,7 @@ import io.grpc.Status.Code;
 import io.grpc.SynchronizationContext;
 import io.grpc.internal.BackoffPolicy;
 import io.grpc.internal.GrpcAttributes;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.JsonParser;
 import io.grpc.internal.ObjectPool;
 import io.grpc.xds.Bootstrapper.BootstrapInfo;
@@ -43,7 +43,6 @@ import io.grpc.xds.XdsClient.XdsChannelFactory;
 import io.grpc.xds.XdsClient.XdsClientFactory;
 import io.grpc.xds.XdsLogger.XdsLogLevel;
 import java.io.IOException;
-import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
@@ -61,8 +60,6 @@ final class XdsNameResolver extends NameResolver {
 
   private final XdsLogger logger;
   private final String authority;
-  private final String hostName;
-  private final int port;
   private final XdsChannelFactory channelFactory;
   private final SynchronizationContext syncContext;
   private final ScheduledExecutorService timeService;
@@ -83,12 +80,7 @@ final class XdsNameResolver extends NameResolver {
       Supplier<Stopwatch> stopwatchSupplier,
       XdsChannelFactory channelFactory,
       Bootstrapper bootstrapper) {
-    URI nameUri = URI.create("//" + checkNotNull(name, "name"));
-    checkArgument(nameUri.getHost() != null, "Invalid hostname: %s", name);
-    authority =
-        checkNotNull(nameUri.getAuthority(), "nameUri (%s) doesn't have an authority", nameUri);
-    hostName = nameUri.getHost();
-    port = nameUri.getPort();  // -1 if not specified
+    authority = GrpcUtil.checkAuthority(checkNotNull(name, "name"));
     this.channelFactory = checkNotNull(channelFactory, "channelFactory");
     this.syncContext = checkNotNull(args.getSynchronizationContext(), "syncContext");
     this.timeService = checkNotNull(args.getScheduledExecutorService(), "timeService");
@@ -140,7 +132,7 @@ final class XdsNameResolver extends NameResolver {
     };
     xdsClientPool = new RefCountedXdsClientObjectPool(xdsClientFactory);
     xdsClient = xdsClientPool.getObject();
-    xdsClient.watchConfigData(hostName, port, new ConfigWatcher() {
+    xdsClient.watchConfigData(authority, new ConfigWatcher() {
       @Override
       public void onConfigChanged(ConfigUpdate update) {
         logger.log(

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTest.java
@@ -123,9 +123,7 @@ import org.mockito.MockitoAnnotations;
 @RunWith(JUnit4.class)
 public class XdsClientImplTest {
 
-  private static final String TARGET_NAME = "foo.googleapis.com:8080";
-  private static final String HOSTNAME = "foo.googleapis.com";
-  private static final int PORT = 8080;
+  private static final String TARGET_AUTHORITY = "foo.googleapis.com:8080";
 
   private static final Node NODE = Node.getDefaultInstance();
   private static final FakeClock.TaskFilter RPC_RETRY_TASK_FILTER =
@@ -284,7 +282,7 @@ public class XdsClientImplTest {
 
     xdsClient =
         new XdsClientImpl(
-            TARGET_NAME,
+            TARGET_AUTHORITY,
             servers,
             channelFactory,
             NODE,
@@ -321,13 +319,13 @@ public class XdsClientImplTest {
    */
   @Test
   public void ldsResponseWithoutMatchingResource() {
-    xdsClient.watchConfigData(HOSTNAME, PORT, configWatcher);
+    xdsClient.watchConfigData(TARGET_AUTHORITY, configWatcher);
     StreamObserver<DiscoveryResponse> responseObserver = responseObservers.poll();
     StreamObserver<DiscoveryRequest> requestObserver = requestObservers.poll();
 
     // Client sends an LDS request for the host name (with port) to management server.
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
 
     assertThat(fakeClock.getPendingTasks(LDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).hasSize(1);
@@ -357,7 +355,7 @@ public class XdsClientImplTest {
 
     // Client sends an ACK LDS request.
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "0", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "0", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "0000")));
 
     verify(configWatcher, never()).onConfigChanged(any(ConfigUpdate.class));
@@ -379,13 +377,13 @@ public class XdsClientImplTest {
    */
   @Test
   public void failToFindVirtualHostInLdsResponseInLineRouteConfig() {
-    xdsClient.watchConfigData(HOSTNAME, PORT, configWatcher);
+    xdsClient.watchConfigData(TARGET_AUTHORITY, configWatcher);
     StreamObserver<DiscoveryResponse> responseObserver = responseObservers.poll();
     StreamObserver<DiscoveryRequest> requestObserver = requestObservers.poll();
 
     // Client sends an LDS request for the host name (with port) to management server.
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
     assertThat(fakeClock.getPendingTasks(LDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).hasSize(1);
 
@@ -399,7 +397,7 @@ public class XdsClientImplTest {
                     "some other cluster")));
 
     List<Any> listeners = ImmutableList.of(
-        Any.pack(buildListener("foo.googleapis.com:8080", /* matching resource */
+        Any.pack(buildListener(TARGET_AUTHORITY, /* matching resource */
             Any.pack(HttpConnectionManager.newBuilder().setRouteConfig(routeConfig).build()))));
     DiscoveryResponse response =
         buildDiscoveryResponse("0", listeners, XdsClientImpl.ADS_TYPE_URL_LDS, "0000");
@@ -408,7 +406,7 @@ public class XdsClientImplTest {
     // Client sends an NACK LDS request.
     verify(requestObserver)
         .onNext(
-            argThat(new DiscoveryRequestMatcher("", "foo.googleapis.com:8080",
+            argThat(new DiscoveryRequestMatcher("", TARGET_AUTHORITY,
                 XdsClientImpl.ADS_TYPE_URL_LDS, "0000")));
 
     verify(configWatcher, never()).onConfigChanged(any(ConfigUpdate.class));
@@ -430,13 +428,13 @@ public class XdsClientImplTest {
    */
   @Test
   public void resolveVirtualHostInLdsResponse() {
-    xdsClient.watchConfigData(HOSTNAME, PORT, configWatcher);
+    xdsClient.watchConfigData(TARGET_AUTHORITY, configWatcher);
     StreamObserver<DiscoveryResponse> responseObserver = responseObservers.poll();
     StreamObserver<DiscoveryRequest> requestObserver = requestObservers.poll();
 
     // Client sends an LDS request for the host name (with port) to management server.
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
     ScheduledTask ldsRespTimer =
         Iterables.getOnlyElement(
@@ -462,14 +460,14 @@ public class XdsClientImplTest {
                                 ImmutableList.of("baz.googleapis.com"),
                                 "cluster-baz.googleapis.com"))))
                 .build()))),
-        Any.pack(buildListener("foo.googleapis.com:8080", /* matching resource */
+        Any.pack(buildListener(TARGET_AUTHORITY, /* matching resource */
             Any.pack(
                 HttpConnectionManager.newBuilder()
-                    .setRouteConfig(
+                    .setRouteConfig( // target route configuration
                         buildRouteConfiguration("route-foo.googleapis.com",
                             ImmutableList.of(
-                                buildVirtualHost(
-                                    ImmutableList.of("foo.googleapis.com", "bar.googleapis.com"),
+                                buildVirtualHost( // matching virtual host
+                                    ImmutableList.of(TARGET_AUTHORITY, "bar.googleapis.com"),
                                     "cluster.googleapis.com"),
                                 buildVirtualHost(
                                     ImmutableList.of("something does not match"),
@@ -483,7 +481,7 @@ public class XdsClientImplTest {
 
     // Client sends an ACK request.
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "0", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "0", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "0000")));
 
     ArgumentCaptor<ConfigUpdate> configUpdateCaptor = ArgumentCaptor.forClass(null);
@@ -502,13 +500,13 @@ public class XdsClientImplTest {
    */
   @Test
   public void rdsResponseWithoutMatchingResource() {
-    xdsClient.watchConfigData(HOSTNAME, PORT, configWatcher);
+    xdsClient.watchConfigData(TARGET_AUTHORITY, configWatcher);
     StreamObserver<DiscoveryResponse> responseObserver = responseObservers.poll();
     StreamObserver<DiscoveryRequest> requestObserver = requestObservers.poll();
 
     // Client sends an LDS request for the host name (with port) to management server.
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
 
     Rds rdsConfig =
@@ -519,7 +517,7 @@ public class XdsClientImplTest {
             .setRouteConfigName("route-foo.googleapis.com")
             .build();
     List<Any> listeners = ImmutableList.of(
-        Any.pack(buildListener("foo.googleapis.com:8080", /* matching resource */
+        Any.pack(buildListener(TARGET_AUTHORITY, /* matching resource */
             Any.pack(HttpConnectionManager.newBuilder().setRds(rdsConfig).build())))
     );
     DiscoveryResponse response =
@@ -528,7 +526,7 @@ public class XdsClientImplTest {
 
     // Client sends an ACK LDS request.
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "0", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "0", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "0000")));
 
     // Client sends an (first) RDS request.
@@ -545,13 +543,15 @@ public class XdsClientImplTest {
             buildRouteConfiguration(
                 "some resource name does not match route-foo.googleapis.com",
                 ImmutableList.of(
-                    buildVirtualHost(ImmutableList.of("foo.googleapis.com"),
+                    buildVirtualHost(
+                        ImmutableList.of(TARGET_AUTHORITY),
                         "whatever cluster")))),
         Any.pack(
             buildRouteConfiguration(
                 "some other resource name does not match route-foo.googleapis.com",
                 ImmutableList.of(
-                    buildVirtualHost(ImmutableList.of("foo.googleapis.com"),
+                    buildVirtualHost(
+                        ImmutableList.of(TARGET_AUTHORITY),
                         "some more whatever cluster")))));
     response = buildDiscoveryResponse("0", routeConfigs, XdsClientImpl.ADS_TYPE_URL_RDS, "0000");
     responseObserver.onNext(response);
@@ -577,7 +577,7 @@ public class XdsClientImplTest {
    */
   @Test
   public void resolveVirtualHostInRdsResponse() {
-    xdsClient.watchConfigData(HOSTNAME, PORT, configWatcher);
+    xdsClient.watchConfigData(TARGET_AUTHORITY, configWatcher);
     StreamObserver<DiscoveryResponse> responseObserver = responseObservers.poll();
     StreamObserver<DiscoveryRequest> requestObserver = requestObservers.poll();
 
@@ -590,7 +590,7 @@ public class XdsClientImplTest {
             .build();
 
     List<Any> listeners = ImmutableList.of(
-        Any.pack(buildListener("foo.googleapis.com:8080", /* matching resource */
+        Any.pack(buildListener(TARGET_AUTHORITY, /* matching resource */
             Any.pack(HttpConnectionManager.newBuilder().setRds(rdsConfig).build())))
     );
     DiscoveryResponse response =
@@ -606,11 +606,11 @@ public class XdsClientImplTest {
     List<Any> routeConfigs = ImmutableList.of(
         Any.pack(
             buildRouteConfiguration(
-                "route-foo.googleapis.com",
+                "route-foo.googleapis.com", // target route configuration
                 ImmutableList.of(
                     buildVirtualHost(ImmutableList.of("something does not match"),
                         "some cluster"),
-                    buildVirtualHost(ImmutableList.of("foo.googleapis.com", "bar.googleapis.com"),
+                    buildVirtualHost(ImmutableList.of(TARGET_AUTHORITY, "bar.googleapis.com:443"),
                         "cluster.googleapis.com")))),  // matching virtual host
         Any.pack(
             buildRouteConfiguration(
@@ -643,7 +643,7 @@ public class XdsClientImplTest {
    */
   @Test
   public void failToFindVirtualHostInRdsResponse() {
-    xdsClient.watchConfigData(HOSTNAME, PORT, configWatcher);
+    xdsClient.watchConfigData(TARGET_AUTHORITY, configWatcher);
     StreamObserver<DiscoveryResponse> responseObserver = responseObservers.poll();
     StreamObserver<DiscoveryRequest> requestObserver = requestObservers.poll();
 
@@ -656,7 +656,7 @@ public class XdsClientImplTest {
             .build();
 
     List<Any> listeners = ImmutableList.of(
-        Any.pack(buildListener("foo.googleapis.com:8080", /* matching resource */
+        Any.pack(buildListener(TARGET_AUTHORITY, /* matching resource */
             Any.pack(HttpConnectionManager.newBuilder().setRds(rdsConfig).build())))
     );
     DiscoveryResponse response =
@@ -711,7 +711,7 @@ public class XdsClientImplTest {
    */
   @Test
   public void matchingVirtualHostDoesNotContainRouteAction() {
-    xdsClient.watchConfigData(HOSTNAME, PORT, configWatcher);
+    xdsClient.watchConfigData(TARGET_AUTHORITY, configWatcher);
     StreamObserver<DiscoveryResponse> responseObserver = responseObservers.poll();
     StreamObserver<DiscoveryRequest> requestObserver = requestObservers.poll();
 
@@ -724,7 +724,7 @@ public class XdsClientImplTest {
             .build();
 
     List<Any> listeners = ImmutableList.of(
-        Any.pack(buildListener("foo.googleapis.com:8080", /* matching resource */
+        Any.pack(buildListener(TARGET_AUTHORITY, /* matching resource */
             Any.pack(HttpConnectionManager.newBuilder().setRds(rdsConfig).build())))
     );
     DiscoveryResponse response =
@@ -777,28 +777,29 @@ public class XdsClientImplTest {
    */
   @Test
   public void notifyUpdatedResources() {
-    xdsClient.watchConfigData(HOSTNAME, PORT, configWatcher);
+    xdsClient.watchConfigData(TARGET_AUTHORITY, configWatcher);
     StreamObserver<DiscoveryResponse> responseObserver = responseObservers.poll();
     StreamObserver<DiscoveryRequest> requestObserver = requestObservers.poll();
 
     // Client sends an LDS request for the host name (with port) to management server.
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
 
     // Management server sends back an LDS response containing a RouteConfiguration for the
     // requested Listener directly in-line.
     RouteConfiguration routeConfig =
         buildRouteConfiguration(
-            "route-foo.googleapis.com",
+            "route-foo.googleapis.com", // target route configuration
             ImmutableList.of(
-                buildVirtualHost(ImmutableList.of("foo.googleapis.com", "bar.googleapis.com"),
+                buildVirtualHost( // matching virtual host
+                    ImmutableList.of(TARGET_AUTHORITY, "bar.googleapis.com:443"),
                     "cluster.googleapis.com"),
                 buildVirtualHost(ImmutableList.of("something does not match"),
                     "some cluster")));
 
     List<Any> listeners = ImmutableList.of(
-        Any.pack(buildListener("foo.googleapis.com:8080", /* matching resource */
+        Any.pack(buildListener(TARGET_AUTHORITY, /* matching resource */
             Any.pack(HttpConnectionManager.newBuilder().setRouteConfig(routeConfig).build())))
     );
     DiscoveryResponse response =
@@ -807,7 +808,7 @@ public class XdsClientImplTest {
 
     // Client sends an ACK LDS request.
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "0", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "0", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "0000")));
 
     // Cluster name is resolved and notified to config watcher.
@@ -820,13 +821,13 @@ public class XdsClientImplTest {
         buildRouteConfiguration(
             "another-route-foo.googleapis.com",
             ImmutableList.of(
-                buildVirtualHost(ImmutableList.of("foo.googleapis.com", "bar.googleapis.com"),
+                buildVirtualHost(ImmutableList.of(TARGET_AUTHORITY, "bar.googleapis.com:443"),
                     "another-cluster.googleapis.com"),
                 buildVirtualHost(ImmutableList.of("something does not match"),
                     "some cluster")));
 
     listeners = ImmutableList.of(
-        Any.pack(buildListener("foo.googleapis.com:8080", /* matching resource */
+        Any.pack(buildListener(TARGET_AUTHORITY, /* matching resource */
             Any.pack(HttpConnectionManager.newBuilder().setRouteConfig(routeConfig).build())))
     );
     response =
@@ -835,7 +836,7 @@ public class XdsClientImplTest {
 
     // Client sends an ACK LDS request.
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "1", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "1", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "0001")));
 
     // Updated cluster name is notified to config watcher.
@@ -855,7 +856,7 @@ public class XdsClientImplTest {
             .build();
 
     listeners = ImmutableList.of(
-        Any.pack(buildListener("foo.googleapis.com:8080", /* matching resource */
+        Any.pack(buildListener(TARGET_AUTHORITY, /* matching resource */
             Any.pack(HttpConnectionManager.newBuilder().setRds(rdsConfig).build())))
     );
     response =
@@ -864,7 +865,7 @@ public class XdsClientImplTest {
 
     // Client sends an ACK LDS request.
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "2", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "2", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "0002")));
 
     // Client sends an (first) RDS request.
@@ -881,7 +882,7 @@ public class XdsClientImplTest {
                 ImmutableList.of(
                     buildVirtualHost(ImmutableList.of("something does not match"),
                         "some cluster"),
-                    buildVirtualHost(ImmutableList.of("foo.googleapis.com", "bar.googleapis.com"),
+                    buildVirtualHost(ImmutableList.of(TARGET_AUTHORITY, "bar.googleapis.com:443"),
                         "some-other-cluster.googleapis.com")))));
     response = buildDiscoveryResponse("0", routeConfigs, XdsClientImpl.ADS_TYPE_URL_RDS, "0000");
     responseObserver.onNext(response);
@@ -904,7 +905,7 @@ public class XdsClientImplTest {
             buildRouteConfiguration(
                 "some-route-to-foo.googleapis.com",
                 ImmutableList.of(
-                    buildVirtualHost(ImmutableList.of("foo.googleapis.com", "bar.googleapis.com"),
+                    buildVirtualHost(ImmutableList.of(TARGET_AUTHORITY, "bar.googleapis.com:443"),
                         "an-updated-cluster.googleapis.com")))));
     response = buildDiscoveryResponse("1", routeConfigs, XdsClientImpl.ADS_TYPE_URL_RDS, "0001");
     responseObserver.onNext(response);
@@ -943,13 +944,13 @@ public class XdsClientImplTest {
    */
   @Test
   public void waitRdsResponsesForRequestedResource() {
-    xdsClient.watchConfigData(HOSTNAME, PORT, configWatcher);
+    xdsClient.watchConfigData(TARGET_AUTHORITY, configWatcher);
     StreamObserver<DiscoveryResponse> responseObserver = responseObservers.poll();
     StreamObserver<DiscoveryRequest> requestObserver = requestObservers.poll();
 
     // Client sends an LDS request for the host name (with port) to management server.
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
 
     // Management sends back an LDS response telling client to do RDS.
@@ -962,7 +963,7 @@ public class XdsClientImplTest {
             .build();
 
     List<Any> listeners = ImmutableList.of(
-        Any.pack(buildListener("foo.googleapis.com:8080", /* matching resource */
+        Any.pack(buildListener(TARGET_AUTHORITY, /* matching resource */
             Any.pack(HttpConnectionManager.newBuilder().setRds(rdsConfig).build())))
     );
     DiscoveryResponse response =
@@ -971,7 +972,7 @@ public class XdsClientImplTest {
 
     // Client sends an ACK LDS request.
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "0", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "0", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "0000")));
 
     // Client sends an (first) RDS request.
@@ -993,7 +994,8 @@ public class XdsClientImplTest {
             buildRouteConfiguration(
                 "some resource name does not match route-foo.googleapis.com",
                 ImmutableList.of(
-                    buildVirtualHost(ImmutableList.of("foo.googleapis.com"),
+                    buildVirtualHost(
+                        ImmutableList.of(TARGET_AUTHORITY),
                         "some more cluster")))));
     response = buildDiscoveryResponse("0", routeConfigs, XdsClientImpl.ADS_TYPE_URL_RDS, "0000");
     responseObserver.onNext(response);
@@ -1014,11 +1016,13 @@ public class XdsClientImplTest {
     routeConfigs = ImmutableList.of(
         Any.pack(
             buildRouteConfiguration(
-                "route-foo.googleapis.com",
+                "route-foo.googleapis.com", // target route configuration
                 ImmutableList.of(
-                    buildVirtualHost(ImmutableList.of("something does not match"),
+                    buildVirtualHost(
+                        ImmutableList.of("something does not match"),
                         "some cluster"),
-                    buildVirtualHost(ImmutableList.of("foo.googleapis.com", "bar.googleapis.com"),
+                    buildVirtualHost( // matching virtual host
+                        ImmutableList.of(TARGET_AUTHORITY, "bar.googleapis.com:443"),
                         "another-cluster.googleapis.com")))));
     response = buildDiscoveryResponse("1", routeConfigs, XdsClientImpl.ADS_TYPE_URL_RDS, "0001");
     responseObserver.onNext(response);
@@ -1042,13 +1046,13 @@ public class XdsClientImplTest {
    */
   @Test
   public void routeConfigurationRemovedNotifiedToWatcher() {
-    xdsClient.watchConfigData(HOSTNAME, PORT, configWatcher);
+    xdsClient.watchConfigData(TARGET_AUTHORITY, configWatcher);
     StreamObserver<DiscoveryResponse> responseObserver = responseObservers.poll();
     StreamObserver<DiscoveryRequest> requestObserver = requestObservers.poll();
 
     // Client sends an LDS request for the host name (with port) to management server.
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
 
     // Management sends back an LDS response telling client to do RDS.
@@ -1061,7 +1065,7 @@ public class XdsClientImplTest {
             .build();
 
     List<Any> listeners = ImmutableList.of(
-        Any.pack(buildListener("foo.googleapis.com:8080", /* matching resource */
+        Any.pack(buildListener(TARGET_AUTHORITY, /* matching resource */
             Any.pack(HttpConnectionManager.newBuilder().setRds(rdsConfig).build())))
     );
     DiscoveryResponse response =
@@ -1070,7 +1074,7 @@ public class XdsClientImplTest {
 
     // Client sends an ACK LDS request.
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "0", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "0", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "0000")));
 
     // Client sends an (first) RDS request.
@@ -1082,9 +1086,10 @@ public class XdsClientImplTest {
     List<Any> routeConfigs = ImmutableList.of(
         Any.pack(
             buildRouteConfiguration(
-                "route-foo.googleapis.com",
+                "route-foo.googleapis.com", // target route configuration
                 ImmutableList.of(
-                    buildVirtualHost(ImmutableList.of("foo.googleapis.com"),
+                    buildVirtualHost(
+                        ImmutableList.of(TARGET_AUTHORITY), // matching virtual host
                         "cluster.googleapis.com")))));
     response = buildDiscoveryResponse("0", routeConfigs, XdsClientImpl.ADS_TYPE_URL_RDS, "0000");
     responseObserver.onNext(response);
@@ -1108,7 +1113,7 @@ public class XdsClientImplTest {
 
     // Client sent an ACK LDS request.
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "1", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "1", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "0001")));
 
     // Notify config watcher with an error.
@@ -1124,7 +1129,7 @@ public class XdsClientImplTest {
    */
   @Test
   public void updateRdsRequestResourceWhileInitialResourceFetchInProgress() {
-    xdsClient.watchConfigData(HOSTNAME, PORT, configWatcher);
+    xdsClient.watchConfigData(TARGET_AUTHORITY, configWatcher);
     StreamObserver<DiscoveryResponse> responseObserver = responseObservers.poll();
     StreamObserver<DiscoveryRequest> requestObserver = requestObservers.poll();
 
@@ -1138,7 +1143,7 @@ public class XdsClientImplTest {
             .build();
 
     List<Any> listeners = ImmutableList.of(
-        Any.pack(buildListener("foo.googleapis.com:8080", /* matching resource */
+        Any.pack(buildListener(TARGET_AUTHORITY, /* matching resource */
             Any.pack(HttpConnectionManager.newBuilder().setRds(rdsConfig).build())))
     );
     DiscoveryResponse response =
@@ -1166,8 +1171,10 @@ public class XdsClientImplTest {
             .build();
 
     listeners = ImmutableList.of(
-        Any.pack(buildListener("foo.googleapis.com:8080", /* matching resource */
-            Any.pack(HttpConnectionManager.newBuilder().setRds(rdsConfig).build())))
+        Any.pack(
+            buildListener(
+                TARGET_AUTHORITY, /* matching resource */
+                Any.pack(HttpConnectionManager.newBuilder().setRds(rdsConfig).build())))
     );
     response = buildDiscoveryResponse("1", listeners, XdsClientImpl.ADS_TYPE_URL_LDS, "0001");
     responseObserver.onNext(response);
@@ -1187,9 +1194,10 @@ public class XdsClientImplTest {
     List<Any> routeConfigs = ImmutableList.of(
         Any.pack(
             buildRouteConfiguration(
-                "route-bar.googleapis.com",
+                "route-bar.googleapis.com", // target route configuration
                 ImmutableList.of(
-                    buildVirtualHost(ImmutableList.of("foo.googleapis.com"),
+                    buildVirtualHost(
+                        ImmutableList.of(TARGET_AUTHORITY), // matching virtual host
                         "cluster.googleapis.com")))));
     response = buildDiscoveryResponse("0", routeConfigs, XdsClientImpl.ADS_TYPE_URL_RDS, "0000");
     responseObserver.onNext(response);
@@ -2439,7 +2447,7 @@ public class XdsClientImplTest {
     InOrder inOrder =
         Mockito.inOrder(mockedDiscoveryService, backoffPolicyProvider, backoffPolicy1,
             backoffPolicy2);
-    xdsClient.watchConfigData(HOSTNAME, PORT, configWatcher);
+    xdsClient.watchConfigData(TARGET_AUTHORITY, configWatcher);
 
     ArgumentCaptor<StreamObserver<DiscoveryResponse>> responseObserverCaptor =
         ArgumentCaptor.forClass(null);
@@ -2451,7 +2459,7 @@ public class XdsClientImplTest {
 
     // Client sends an LDS request for the host name (with port) to management server.
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
 
     // Management server closes the RPC stream immediately.
@@ -2471,7 +2479,7 @@ public class XdsClientImplTest {
 
     // Client retried by sending an LDS request.
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
 
     // Management server closes the RPC stream with an error.
@@ -2491,7 +2499,7 @@ public class XdsClientImplTest {
 
     // Client retried again by sending an LDS.
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
 
     // Management server responses with a listener for the requested resource.
@@ -2503,7 +2511,7 @@ public class XdsClientImplTest {
             .build();
 
     List<Any> listeners = ImmutableList.of(
-        Any.pack(buildListener("foo.googleapis.com:8080", /* matching resource */
+        Any.pack(buildListener(TARGET_AUTHORITY, /* matching resource */
             Any.pack(HttpConnectionManager.newBuilder().setRds(rdsConfig).build())))
     );
     DiscoveryResponse ldsResponse =
@@ -2512,7 +2520,7 @@ public class XdsClientImplTest {
 
     // Client sent back an ACK LDS request.
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "0", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "0", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "0000")));
 
     // Client sent an RDS request based on the received listener.
@@ -2531,7 +2539,7 @@ public class XdsClientImplTest {
     responseObserver = responseObserverCaptor.getValue();
     requestObserver = requestObservers.poll();
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
 
     // RPC stream closed immediately
@@ -2548,7 +2556,7 @@ public class XdsClientImplTest {
     responseObserver = responseObserverCaptor.getValue();
     requestObserver = requestObservers.poll();
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
 
     // Management server sends an LDS response.
@@ -2559,9 +2567,10 @@ public class XdsClientImplTest {
     List<Any> routeConfigs = ImmutableList.of(
         Any.pack(
             buildRouteConfiguration(
-                "route-foo.googleapis.com",
+                "route-foo.googleapis.com", // target route configuration
                 ImmutableList.of(
-                    buildVirtualHost(ImmutableList.of("foo.googleapis.com"),
+                    buildVirtualHost(
+                        ImmutableList.of(TARGET_AUTHORITY), // matching virtual host
                         "cluster.googleapis.com")))));
     DiscoveryResponse rdsResponse =
         buildDiscoveryResponse("0", routeConfigs, XdsClientImpl.ADS_TYPE_URL_RDS, "0000");
@@ -2581,7 +2590,7 @@ public class XdsClientImplTest {
     fakeClock.runDueTasks();
     requestObserver = requestObservers.poll();
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
 
     verifyNoMoreInteractions(backoffPolicyProvider, backoffPolicy1, backoffPolicy2);
@@ -2595,7 +2604,7 @@ public class XdsClientImplTest {
     InOrder inOrder =
         Mockito.inOrder(mockedDiscoveryService, backoffPolicyProvider, backoffPolicy1,
             backoffPolicy2);
-    xdsClient.watchConfigData(HOSTNAME, PORT, configWatcher);
+    xdsClient.watchConfigData(TARGET_AUTHORITY, configWatcher);
 
     ArgumentCaptor<StreamObserver<DiscoveryResponse>> responseObserverCaptor =
         ArgumentCaptor.forClass(null);
@@ -2643,7 +2652,7 @@ public class XdsClientImplTest {
 
     // Retry resumes requests for all wanted resources.
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
     verify(requestObserver)
         .onNext(eq(buildDiscoveryRequest(NODE, "", "cluster.googleapis.com",
@@ -2672,7 +2681,7 @@ public class XdsClientImplTest {
     responseObserver = responseObserverCaptor.getValue();
     requestObserver = requestObservers.poll();
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
     verify(requestObserver)
         .onNext(eq(buildDiscoveryRequest(NODE, "", "cluster.googleapis.com",
@@ -2701,7 +2710,7 @@ public class XdsClientImplTest {
     responseObserver = responseObserverCaptor.getValue();
     requestObserver = requestObservers.poll();
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
     verify(requestObserver)
         .onNext(eq(buildDiscoveryRequest(NODE, "", "cluster.googleapis.com",
@@ -2734,7 +2743,7 @@ public class XdsClientImplTest {
     requestObserver = requestObservers.poll();
 
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
     verify(requestObserver)
         .onNext(eq(buildDiscoveryRequest(NODE, "", "cluster.googleapis.com",
@@ -2762,7 +2771,7 @@ public class XdsClientImplTest {
         .streamAggregatedResources(responseObserverCaptor.capture());
     requestObserver = requestObservers.poll();
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
     verify(requestObserver)
         .onNext(eq(buildDiscoveryRequest(NODE, "", "cluster.googleapis.com",
@@ -2783,7 +2792,7 @@ public class XdsClientImplTest {
     InOrder inOrder =
         Mockito.inOrder(mockedDiscoveryService, backoffPolicyProvider, backoffPolicy1,
             backoffPolicy2);
-    xdsClient.watchConfigData(HOSTNAME, PORT, configWatcher);
+    xdsClient.watchConfigData(TARGET_AUTHORITY, configWatcher);
 
     ArgumentCaptor<StreamObserver<DiscoveryResponse>> responseObserverCaptor =
         ArgumentCaptor.forClass(null);
@@ -2807,7 +2816,7 @@ public class XdsClientImplTest {
     StreamObserver<DiscoveryRequest> requestObserver = requestObservers.poll();
 
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
 
     // Management server becomes unreachable.
@@ -2828,7 +2837,7 @@ public class XdsClientImplTest {
     requestObserver = requestObservers.poll();
 
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
     verify(requestObserver)
         .onNext(eq(buildDiscoveryRequest(NODE, "", "cluster.googleapis.com",
@@ -2852,7 +2861,7 @@ public class XdsClientImplTest {
     requestObserver = requestObservers.poll();
 
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
     verify(requestObserver)
         .onNext(eq(buildDiscoveryRequest(NODE, "", "cluster.googleapis.com",
@@ -2895,7 +2904,7 @@ public class XdsClientImplTest {
     responseObserver = responseObserverCaptor.getValue();
     requestObserver = requestObservers.poll();
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
     verify(requestObserver)
         .onNext(eq(buildDiscoveryRequest(NODE, "", "cluster.googleapis.com",
@@ -2922,7 +2931,7 @@ public class XdsClientImplTest {
     requestObserver = requestObservers.poll();
 
     verify(requestObserver)
-        .onNext(eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        .onNext(eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
     verify(requestObserver, never())
         .onNext(eq(buildDiscoveryRequest(NODE, "", "cluster.googleapis.com",
@@ -2940,7 +2949,7 @@ public class XdsClientImplTest {
     InOrder inOrder =
         Mockito.inOrder(mockedDiscoveryService, backoffPolicyProvider, backoffPolicy1,
             backoffPolicy2);
-    xdsClient.watchConfigData(HOSTNAME, PORT, configWatcher);
+    xdsClient.watchConfigData(TARGET_AUTHORITY, configWatcher);
 
     ArgumentCaptor<StreamObserver<DiscoveryResponse>> responseObserverCaptor =
         ArgumentCaptor.forClass(null);
@@ -2959,7 +2968,7 @@ public class XdsClientImplTest {
             .build();
 
     List<Any> listeners = ImmutableList.of(
-        Any.pack(buildListener("foo.googleapis.com:8080", /* matching resource */
+        Any.pack(buildListener(TARGET_AUTHORITY, /* matching resource */
             Any.pack(HttpConnectionManager.newBuilder().setRds(rdsConfig).build())))
     );
     DiscoveryResponse response =
@@ -2994,7 +3003,7 @@ public class XdsClientImplTest {
 
     // Client resumed requests and management server sends back LDS resources again.
     verify(requestObserver).onNext(
-        eq(buildDiscoveryRequest(NODE, "", "foo.googleapis.com:8080",
+        eq(buildDiscoveryRequest(NODE, "", TARGET_AUTHORITY,
             XdsClientImpl.ADS_TYPE_URL_LDS, "")));
     responseObserver.onNext(response);
 
@@ -3012,9 +3021,10 @@ public class XdsClientImplTest {
     List<Any> routeConfigs = ImmutableList.of(
         Any.pack(
             buildRouteConfiguration(
-                "route-foo.googleapis.com",
+                "route-foo.googleapis.com", // target route configuration
                 ImmutableList.of(
-                    buildVirtualHost(ImmutableList.of("foo.googleapis.com"),
+                    buildVirtualHost(
+                        ImmutableList.of(TARGET_AUTHORITY), // matching virtual host
                         "cluster-foo.googleapis.com")))));
     response = buildDiscoveryResponse("0", routeConfigs, XdsClientImpl.ADS_TYPE_URL_RDS, "0000");
     responseObserver.onNext(response);
@@ -3119,7 +3129,7 @@ public class XdsClientImplTest {
   // Simulates the use case of watching clusters/endpoints based on service config resolved by
   // LDS/RDS.
   private void waitUntilConfigResolved(StreamObserver<DiscoveryResponse> responseObserver) {
-    // Client sent an LDS request for resource "foo.googleapis.com:8080" (Omitted).
+    // Client sent an LDS request for resource TARGET_AUTHORITY (Omitted).
 
     // Management server responses with a listener telling client to do RDS.
     Rds rdsConfig =
@@ -3130,7 +3140,7 @@ public class XdsClientImplTest {
             .build();
 
     List<Any> listeners = ImmutableList.of(
-        Any.pack(buildListener("foo.googleapis.com:8080", /* matching resource */
+        Any.pack(buildListener(TARGET_AUTHORITY, /* matching resource */
             Any.pack(HttpConnectionManager.newBuilder().setRds(rdsConfig).build())))
     );
     DiscoveryResponse ldsResponse =
@@ -3144,9 +3154,10 @@ public class XdsClientImplTest {
     List<Any> routeConfigs = ImmutableList.of(
         Any.pack(
             buildRouteConfiguration(
-                "route-foo.googleapis.com",
+                "route-foo.googleapis.com", // target route configuration
                 ImmutableList.of(
-                    buildVirtualHost(ImmutableList.of("foo.googleapis.com"),
+                    buildVirtualHost(
+                        ImmutableList.of(TARGET_AUTHORITY), // matching virtual host
                         "cluster.googleapis.com")))));
     DiscoveryResponse rdsResponse =
         buildDiscoveryResponse("0", routeConfigs, XdsClientImpl.ADS_TYPE_URL_RDS, "0000");

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -78,8 +78,7 @@ import org.mockito.junit.MockitoRule;
 // TODO(creamsoup) use parsed service config
 @SuppressWarnings("deprecation")
 public class XdsNameResolverTest {
-  private static final String HOST_NAME = "foo.googleapis.com";
-  private static final int PORT = 443;
+  private static final String AUTHORITY = "foo.googleapis.com:80";
   private static final Node FAKE_BOOTSTRAP_NODE =
       Node.newBuilder().setId("XdsNameResolverTest").build();
 
@@ -166,7 +165,7 @@ public class XdsNameResolverTest {
     };
     xdsNameResolver =
         new XdsNameResolver(
-            HOST_NAME + ":" + PORT,
+            AUTHORITY,
             args,
             backoffPolicyProvider,
             fakeClock.getStopwatchSupplier(),
@@ -191,7 +190,7 @@ public class XdsNameResolverTest {
 
     XdsNameResolver resolver =
         new XdsNameResolver(
-            HOST_NAME + ":" + PORT,
+            AUTHORITY,
             args,
             backoffPolicyProvider,
             fakeClock.getStopwatchSupplier(),
@@ -216,7 +215,7 @@ public class XdsNameResolverTest {
 
     XdsNameResolver resolver =
         new XdsNameResolver(
-            HOST_NAME + ":" + PORT,
+            AUTHORITY,
             args,
             backoffPolicyProvider,
             fakeClock.getStopwatchSupplier(),
@@ -240,7 +239,7 @@ public class XdsNameResolverTest {
     // Simulate receiving an LDS response that contains cluster resolution directly in-line.
     String clusterName = "cluster-foo.googleapis.com";
     responseObserver.onNext(
-        buildLdsResponseForCluster("0", HOST_NAME, PORT, clusterName, "0000"));
+        buildLdsResponseForCluster("0", AUTHORITY, clusterName, "0000"));
 
     ArgumentCaptor<ResolutionResult> resolutionResultCaptor = ArgumentCaptor.forClass(null);
     verify(mockListener).onResult(resolutionResultCaptor.capture());
@@ -258,7 +257,7 @@ public class XdsNameResolverTest {
     // Simulate receiving an LDS response that contains cluster resolution directly in-line.
     String clusterName = "cluster-foo.googleapis.com";
     responseObserver.onNext(
-        buildLdsResponseForCluster("0", HOST_NAME, PORT, clusterName, "0000"));
+        buildLdsResponseForCluster("0", AUTHORITY, clusterName, "0000"));
 
     ArgumentCaptor<ResolutionResult> resolutionResultCaptor = ArgumentCaptor.forClass(null);
     verify(mockListener).onResult(resolutionResultCaptor.capture());
@@ -286,7 +285,7 @@ public class XdsNameResolverTest {
     // Simulate receiving an LDS response that does not contain requested resource.
     String clusterName = "cluster-bar.googleapis.com";
     responseObserver.onNext(
-        buildLdsResponseForCluster("0", "bar.googleapis.com", 80, clusterName, "0000"));
+        buildLdsResponseForCluster("0", "bar.googleapis.com", clusterName, "0000"));
 
     fakeClock.forwardTime(XdsClientImpl.INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
     ArgumentCaptor<ResolutionResult> resolutionResultCaptor = ArgumentCaptor.forClass(null);
@@ -305,7 +304,7 @@ public class XdsNameResolverTest {
 
     // Simulate receiving an LDS response that contains cluster resolution directly in-line.
     responseObserver.onNext(
-        buildLdsResponseForCluster("0", HOST_NAME, PORT, "cluster-foo.googleapis.com", "0000"));
+        buildLdsResponseForCluster("0", AUTHORITY, "cluster-foo.googleapis.com", "0000"));
 
     ArgumentCaptor<ResolutionResult> resolutionResultCaptor = ArgumentCaptor.forClass(null);
     verify(mockListener).onResult(resolutionResultCaptor.capture());
@@ -325,14 +324,14 @@ public class XdsNameResolverTest {
     // Simulate receiving another LDS response that tells client to do RDS.
     String routeConfigName = "route-foo.googleapis.com";
     responseObserver.onNext(
-        buildLdsResponseForRdsResource("1", HOST_NAME, PORT, routeConfigName, "0001"));
+        buildLdsResponseForRdsResource("1", AUTHORITY, routeConfigName, "0001"));
 
     // Client sent an RDS request for resource "route-foo.googleapis.com" (Omitted in this test).
 
     // Simulate receiving an RDS response that contains the resource "route-foo.googleapis.com"
     // with cluster resolution for "foo.googleapis.com".
     responseObserver.onNext(
-        buildRdsResponseForCluster("0", routeConfigName, "foo.googleapis.com",
+        buildRdsResponseForCluster("0", routeConfigName, AUTHORITY,
             "cluster-blade.googleapis.com", "0000"));
 
     verify(mockListener, times(2)).onResult(resolutionResultCaptor.capture());
@@ -355,7 +354,7 @@ public class XdsNameResolverTest {
 
     // Simulate receiving an LDS response that does not contain requested resource.
     responseObserver.onNext(
-        buildLdsResponseForCluster("0", "bar.googleapis.com", 80,
+        buildLdsResponseForCluster("0", "bar.googleapis.com",
             "cluster-bar.googleapis.com", "0000"));
 
     fakeClock.forwardTime(XdsClientImpl.INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
@@ -367,7 +366,7 @@ public class XdsNameResolverTest {
 
     // Simulate receiving another LDS response that contains cluster resolution directly in-line.
     responseObserver.onNext(
-        buildLdsResponseForCluster("1", HOST_NAME, PORT, "cluster-foo.googleapis.com",
+        buildLdsResponseForCluster("1", AUTHORITY, "cluster-foo.googleapis.com",
             "0001"));
 
     verify(mockListener, times(2)).onResult(resolutionResultCaptor.capture());
@@ -387,35 +386,33 @@ public class XdsNameResolverTest {
   }
 
   /**
-   * Builds an LDS DiscoveryResponse containing the mapping of given host name (with port if any) to
-   * the given cluster name directly in-line. Clients receiving this response is able to resolve
-   * cluster name for the given hostname:port immediately.
+   * Builds an LDS DiscoveryResponse containing the mapping of given host to
+   * the given cluster name directly in-line. Clients receiving this response is
+   * able to resolve cluster name for the given host immediately.
    */
   private static DiscoveryResponse buildLdsResponseForCluster(
-      String versionInfo, String hostName, int port, String clusterName, String nonce) {
-    String ldsResourceName = port == -1 ? hostName : hostName + ":" + port;
+      String versionInfo, String host, String clusterName, String nonce) {
     List<Any> listeners = ImmutableList.of(
-        Any.pack(buildListener(ldsResourceName,
+        Any.pack(buildListener(host, // target Listener resource
             Any.pack(
                 HttpConnectionManager.newBuilder()
                     .setRouteConfig(
-                        buildRouteConfiguration("route-foo.googleapis.com",
+                        buildRouteConfiguration("route-foo.googleapis.com", // doesn't matter
                             ImmutableList.of(
                                 buildVirtualHost(
-                                    ImmutableList.of("foo.googleapis.com"),
+                                    ImmutableList.of(host), // exact match
                                     clusterName))))
                     .build()))));
     return buildDiscoveryResponse(versionInfo, listeners, XdsClientImpl.ADS_TYPE_URL_LDS, nonce);
   }
 
   /**
-   * Builds an LDS DiscoveryResponse containing the mapping of given host name (with port if any) to
-   * the given RDS resource name. Clients receiving this response is able to send an RDS request for
-   * resolving the cluster name for the given hostname:port.
+   * Builds an LDS DiscoveryResponse containing the mapping of given host to
+   * the given RDS resource name. Clients receiving this response is able to
+   * send an RDS request for resolving the cluster name for the given host.
    */
   private static DiscoveryResponse buildLdsResponseForRdsResource(
-      String versionInfo, String hostName, int port, String routeConfigName, String nonce) {
-    String ldsResourceName = port == -1 ? hostName : hostName + ":" + port;
+      String versionInfo, String host, String routeConfigName, String nonce) {
     Rds rdsConfig =
         Rds.newBuilder()
             // Must set to use ADS.
@@ -425,19 +422,20 @@ public class XdsNameResolverTest {
             .build();
 
     List<Any> listeners = ImmutableList.of(
-        Any.pack(buildListener(ldsResourceName,
-            Any.pack(HttpConnectionManager.newBuilder().setRds(rdsConfig).build()))));
+        Any.pack(
+            buildListener(
+                host, Any.pack(HttpConnectionManager.newBuilder().setRds(rdsConfig).build()))));
     return buildDiscoveryResponse(versionInfo, listeners, XdsClientImpl.ADS_TYPE_URL_LDS, nonce);
   }
 
   /**
-   * Builds an RDS DiscoveryResponse containing the mapping of given route config name to the given
-   * cluster name under.
+   * Builds an RDS DiscoveryResponse containing route configuration with the given name and a
+   * virtual host that matches the given host to the given cluster name.
    */
   private static DiscoveryResponse buildRdsResponseForCluster(
       String versionInfo,
       String routeConfigName,
-      String hostName,
+      String host,
       String clusterName,
       String nonce) {
     List<Any> routeConfigs = ImmutableList.of(
@@ -445,7 +443,7 @@ public class XdsNameResolverTest {
             buildRouteConfiguration(
                 routeConfigName,
                 ImmutableList.of(
-                    buildVirtualHost(ImmutableList.of(hostName), clusterName)))));
+                    buildVirtualHost(ImmutableList.of(host), clusterName)))));
     return buildDiscoveryResponse(versionInfo, routeConfigs, XdsClientImpl.ADS_TYPE_URL_RDS, nonce);
   }
 }


### PR DESCRIPTION
Fixes usage of target hostname:port in xDS plugin.

The target hostname:port used to construct gRPC channel should be treated opaquely. XdsNameResolver should not try to split it and should use it opaquely for sending LDS requests. In received RouteConfiguration messages, do not stripe off port (if any) for finding the virtual host with domain name matching the requested LDS resource name.
 
-------------------------------
Backport of #6767.


_Manual change:_

- Since the original change [ef44795594a46c7c2ab58ca84fda02386a95f7a2](https://github.com/grpc/grpc-java/commit/ef44795594a46c7c2ab58ca84fda02386a95f7a2) was committed after #6705, which cleaned up usages of internal attribute NAME_RESOLVER_SERVICE_CONFIG in `XdsNameResolver`. This backport commit needs to revert the change of removing `SuppressWarnings("deprecation")` in `XdsNameResolverTest`.