### PR TITLE
api: Fix MethodType documentation overspecification

### DIFF
--- a/api/src/main/java/io/grpc/MethodDescriptor.java
+++ b/api/src/main/java/io/grpc/MethodDescriptor.java
@@ -85,7 +85,7 @@ public final class MethodDescriptor<ReqT, RespT> {
     UNARY,
 
     /**
-     * Zero or more request messages followed by one response message.
+     * Zero or more request messages with one response message.
      */
     CLIENT_STREAMING,
 
@@ -106,9 +106,8 @@ public final class MethodDescriptor<ReqT, RespT> {
     UNKNOWN;
 
     /**
-     * Returns {@code true} if the client will immediately send one request message to the server
-     * after calling {@link ClientCall#start(io.grpc.ClientCall.Listener, io.grpc.Metadata)}
-     * and then immediately half-close the stream by calling {@link io.grpc.ClientCall#halfClose()}.
+     * Returns {@code true} for {@code UNARY} and {@code SERVER_STREAMING}, which do not permit the
+     * client to stream.
      *
      * @since 1.0.0
      */
@@ -117,9 +116,8 @@ public final class MethodDescriptor<ReqT, RespT> {
     }
 
     /**
-     * Returns {@code true} if the server will immediately send one response message to the client
-     * upon receipt of {@link io.grpc.ServerCall.Listener#onHalfClose()} and then immediately
-     * close the stream by calling {@link ServerCall#close(Status, io.grpc.Metadata)}.
+     * Returns {@code true} for {@code UNARY} and {@code CLIENT_STREAMING}, which do not permit the
+     * server to stream.
      *
      * @since 1.0.0
      */


### PR DESCRIPTION
The server does not _have_ to wait until half close in CLIENT_STREAMING, and
commonly wouldn't in error cases. {client,server}SendsOneMessage were way
over-specifying the behavior and included unnecessary and incorrect words like
"immediately." Those methods shouldn't be the defining the behavior in that
much precision anyway; that would be the job of the individual enum values, if
anything.