### PR TITLE
buildscripts: update xds test server arg (v1.28.x backport)

### DIFF
--- a/buildscripts/kokoro/xds.cfg
+++ b/buildscripts/kokoro/xds.cfg
@@ -2,4 +2,4 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-java/buildscripts/kokoro/xds.sh"
-timeout_mins: 60
+timeout_mins: 90

--- a/buildscripts/kokoro/xds.sh
+++ b/buildscripts/kokoro/xds.sh
@@ -5,9 +5,6 @@ if [[ -f /VERSION ]]; then
   cat /VERSION
 fi
 
-sudo apt-get install -y python3-pip
-sudo python3 -m pip install grpcio grpcio-tools google-api-python-client google-auth-httplib2
-
 cd github
 
 pushd grpc-java/interop-testing
@@ -22,4 +19,7 @@ python3 grpc/tools/run_tests/run_xds_tests.py \
     --project_id=grpc-testing \
     --gcp_suffix=$(date '+%s') \
     --verbose \
-    --client_cmd='grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-client --server=xds-experimental:///{service_host}:{service_port} --stats_port={stats_port} --qps={qps}'
+    --client_cmd="grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-client \
+      --server=xds-experimental:///{server_uri} \
+      --stats_port={stats_port} \
+      --qps={qps}"


### PR DESCRIPTION
Cherry-pick of https://github.com/grpc/grpc-java/pull/6816