### PR TITLE
buildscripts,interop-testing: Increase logging for xDS tests (v1.28.x backport)

### DIFF
--- a/buildscripts/kokoro/xds.sh
+++ b/buildscripts/kokoro/xds.sh
@@ -17,7 +17,8 @@ popd
 git clone https://github.com/grpc/grpc.git
 
 grpc/tools/run_tests/helper_scripts/prep_xds.sh
-python3 grpc/tools/run_tests/run_xds_tests.py \
+JAVA_OPTS=-Djava.util.logging.config.file=grpc-java/buildscripts/xds_logging.properties \
+  python3 grpc/tools/run_tests/run_xds_tests.py \
     --test_case=all \
     --project_id=grpc-testing \
     --gcp_suffix=$(date '+%s') \

--- a/buildscripts/xds_logging.properties
+++ b/buildscripts/xds_logging.properties
@@ -1,0 +1,5 @@
+handlers=java.util.logging.ConsoleHandler
+io.grpc.ChannelLogger.level=FINEST
+io.grpc.xds.level=FINEST
+java.util.logging.ConsoleHandler.level=FINEST
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
@@ -223,7 +223,7 @@ public final class XdsTestClient {
 
               @Override
               public void onClose(Status status, Metadata trailers) {
-                if (!status.isOk()) {
+                if (printResponse && !status.isOk()) {
                   logger.log(Level.WARNING, "Greeting RPC failed with status {0}", status);
                 }
                 for (XdsStatsWatcher watcher : savedWatchers) {


### PR DESCRIPTION
Cherry-pick of https://github.com/grpc/grpc-java/pull/6818