### PR TITLE
buildscripts: checkout matching grpc/grpc branch for xds test (v1.28.x backport)

### DIFF
--- a/buildscripts/kokoro/xds.sh
+++ b/buildscripts/kokoro/xds.sh
@@ -8,10 +8,16 @@ fi
 cd github
 
 pushd grpc-java/interop-testing
+branch=$(git branch --all --no-color --contains "${KOKORO_GITHUB_COMMIT}" \
+      | grep -v HEAD | head -1)
+shopt -s extglob
+branch="${branch//[[:space:]]}"
+branch="${branch##remotes/origin/}"
+shopt -u extglob
 ../gradlew installDist -x test -PskipCodegen=true -PskipAndroid=true
 popd
 
-git clone https://github.com/grpc/grpc.git
+git clone -b "${branch}" https://github.com/grpc/grpc.git
 
 grpc/tools/run_tests/helper_scripts/prep_xds.sh
 JAVA_OPTS=-Djava.util.logging.config.file=grpc-java/buildscripts/xds_logging.properties \


### PR DESCRIPTION
Cherry-pick of https://github.com/grpc/grpc-java/pull/6828