### PR TITLE
android: suppress warnings for deprecated constants in ConnectivityManager

### DIFF
--- a/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
+++ b/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
@@ -205,6 +205,7 @@ public final class AndroidChannelBuilder extends ForwardingChannelBuilder<Androi
             };
       } else {
         final NetworkReceiver networkReceiver = new NetworkReceiver();
+        @SuppressWarnings("deprecation")
         IntentFilter networkIntentFilter =
             new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION);
         context.registerReceiver(networkReceiver, networkIntentFilter);

--- a/android/src/test/java/io/grpc/android/AndroidChannelBuilderTest.java
+++ b/android/src/test/java/io/grpc/android/AndroidChannelBuilderTest.java
@@ -51,6 +51,7 @@ import org.robolectric.shadows.ShadowNetworkInfo;
 @LooperMode(LEGACY)
 @RunWith(RobolectricTestRunner.class)
 @Config(shadows = {AndroidChannelBuilderTest.ShadowDefaultNetworkListenerConnectivityManager.class})
+@SuppressWarnings("deprecation")
 public final class AndroidChannelBuilderTest {
   private final NetworkInfo WIFI_CONNECTED =
       ShadowNetworkInfo.newInstance(


### PR DESCRIPTION
#6773 bumped Android SDK version to 28, in which some constants in `ConnectivityManager` have been deprecated such as [`ConnectivityManager. CONNECTIVITY_ACTION`](https://developer.android.com/reference/android/net/ConnectivityManager#CONNECTIVITY_ACTION), [`ConnectivityManager. TYPE_WIFI`](https://developer.android.com/reference/android/net/ConnectivityManager#TYPE_WIFI), [`ConnectivityManager. TYPE_MOBILE`](https://developer.android.com/reference/android/net/ConnectivityManager#TYPE_MOBILE), etc. In grpc-android, they are used for supporting legacy SDK connectivity state monitoring (and its unit tests). They work as intended for legacy SDK versions. So we suppress those warnings for the target SDK version 28.