### PR TITLE
Implemented Frame Size Negotiation in ALTS for gRPC Java

### DIFF
--- a/alts/src/main/java/io/grpc/alts/internal/AltsHandshakerClient.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsHandshakerClient.java
@@ -82,6 +82,7 @@ class AltsHandshakerClient {
         startClientReq.addTargetIdentitiesBuilder().setServiceAccount(serviceAccount);
       }
     }
+    startClientReq.setMaxFrameSize(AltsTsiFrameProtector.getMaxFrameSize());
     req.setClientStart(startClientReq);
   }
 
@@ -97,6 +98,7 @@ class AltsHandshakerClient {
     if (handshakerOptions.getRpcProtocolVersions() != null) {
       startServerReq.setRpcVersions(handshakerOptions.getRpcProtocolVersions());
     }
+    startServerReq.setMaxFrameSize(AltsTsiFrameProtector.getMaxFrameSize());
     req.setServerStart(startServerReq);
   }
 

--- a/alts/src/test/java/io/grpc/alts/internal/AltsHandshakerClientTest.java
+++ b/alts/src/test/java/io/grpc/alts/internal/AltsHandshakerClientTest.java
@@ -106,6 +106,7 @@ public class AltsHandshakerClientTest {
                     .setTargetName(TEST_TARGET_NAME)
                     .addTargetIdentities(
                         Identity.newBuilder().setServiceAccount(TEST_TARGET_SERVICE_ACCOUNT))
+                    .setMaxFrameSize(AltsTsiFrameProtector.getMaxFrameSize())
                     .build())
             .build();
     verify(mockStub).send(req);
@@ -132,6 +133,22 @@ public class AltsHandshakerClientTest {
 
     ByteBuffer inBytes = ByteBuffer.allocate(IN_BYTES_SIZE);
     ByteBuffer outFrame = handshaker.startServerHandshake(inBytes);
+
+    HandshakerReq req =
+        HandshakerReq.newBuilder()
+            .setServerStart(
+                StartServerHandshakeReq.newBuilder()
+                    .addApplicationProtocols(AltsHandshakerClient.getApplicationProtocol())
+                    .putHandshakeParameters(
+                      HandshakeProtocol.ALTS.getNumber(),
+                      ServerHandshakeParameters.newBuilder()
+                          .addRecordProtocols(AltsHandshakerClient.getRecordProtocol())
+                          .build())
+                    .setInBytes(ByteString.copyFrom(ByteBuffer.allocate(IN_BYTES_SIZE)))
+                    .setMaxFrameSize(AltsTsiFrameProtector.getMaxFrameSize())
+                    .build())
+            .build();
+    verify(mockStub).send(req);
 
     assertEquals(ByteString.copyFrom(outFrame), MockAltsHandshakerResp.getOutFrame());
     assertFalse(handshaker.isFinished());

--- a/alts/src/test/java/io/grpc/alts/internal/AltsTsiFrameProtectorTest.java
+++ b/alts/src/test/java/io/grpc/alts/internal/AltsTsiFrameProtectorTest.java
@@ -125,7 +125,7 @@ public class AltsTsiFrameProtectorTest {
         getDirectBuffer(
             AltsTsiFrameProtector.getHeaderBytes() + FakeChannelCrypter.getTagBytes(), ref);
     in.writeIntLE(
-        AltsTsiFrameProtector.getLimitMaxAllowedFrameBytes()
+        AltsTsiFrameProtector.getLimitMaxAllowedFrameSize()
             - AltsTsiFrameProtector.getHeaderLenFieldBytes()
             + 1);
     in.writeIntLE(6);
@@ -206,7 +206,7 @@ public class AltsTsiFrameProtectorTest {
         getDirectBuffer(
             AltsTsiFrameProtector.getHeaderBytes() + FakeChannelCrypter.getTagBytes(), ref);
     in.writeIntLE(
-        AltsTsiFrameProtector.getLimitMaxAllowedFrameBytes()
+        AltsTsiFrameProtector.getLimitMaxAllowedFrameSize()
             - AltsTsiFrameProtector.getHeaderLenFieldBytes());
     in.writeIntLE(6);
 

--- a/alts/src/test/java/io/grpc/alts/internal/FakeTsiHandshaker.java
+++ b/alts/src/test/java/io/grpc/alts/internal/FakeTsiHandshaker.java
@@ -224,7 +224,7 @@ public class FakeTsiHandshaker implements TsiHandshaker {
 
   @Override
   public TsiFrameProtector createFrameProtector(ByteBufAllocator alloc) {
-    return createFrameProtector(AltsTsiFrameProtector.getMaxAllowedFrameBytes(), alloc);
+    return createFrameProtector(AltsTsiFrameProtector.getMinFrameSize(), alloc);
   }
 
   @Override


### PR DESCRIPTION
gRPC Java uses zero copy frame protectors, and hence are capable of handling larger frame size. Frame Size Negotiation support in ALTS, extends send frame size from 16KB to 128KB, and thereby improves performance.

Design Document: go/seal-frame-size-negotiation-alts