### PR TITLE
buildscripts: clean up android related scripts

### DIFF
--- a/buildscripts/kokoro/android-interop.sh
+++ b/buildscripts/kokoro/android-interop.sh
@@ -21,9 +21,6 @@ echo y | ${ANDROID_HOME}/tools/bin/sdkmanager "build-tools;28.0.3"
 # Proto deps
 buildscripts/make_dependencies.sh
 
-./gradlew publishToMavenLocal
-
-
 # Build and run interop instrumentation tests on Firebase Test Lab
 cd android-interop-testing
 ../gradlew assembleDebug

--- a/buildscripts/kokoro/android-interop.sh
+++ b/buildscripts/kokoro/android-interop.sh
@@ -30,8 +30,8 @@ cd android-interop-testing
 ../gradlew assembleDebugAndroidTest
 gcloud firebase test android run \
   --type instrumentation \
-  --app app/build/outputs/apk/debug/app-debug.apk \
-  --test app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk \
+  --app build/outputs/apk/debug/grpc-android-interop-testing-debug.apk \
+  --test build/outputs/apk/androidTest/debug/grpc-android-interop-testing-debug-androidTest.apk \
   --environment-variables \
       server_host=grpc-test.sandbox.googleapis.com,server_port=443,test_case=all \
   --device model=Nexus6P,version=27,locale=en,orientation=portrait \

--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -27,8 +27,6 @@ echo y | ${ANDROID_HOME}/tools/bin/sdkmanager "build-tools;28.0.3"
 # Proto deps
 buildscripts/make_dependencies.sh
 
-./gradlew publishToMavenLocal
-
 # Build grpc-cronet
 
 pushd cronet
@@ -45,6 +43,9 @@ popd
 pushd android-interop-testing
 ../gradlew build
 popd
+
+# Examples pulls dependencies from maven local
+./gradlew publishToMavenLocal
 
 # Build examples
 

--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -44,7 +44,7 @@ pushd android-interop-testing
 ../gradlew build
 popd
 
-# Examples pulls dependencies from maven local
+# Examples pull dependencies from maven local
 ./gradlew publishToMavenLocal
 
 # Build examples


### PR DESCRIPTION
1. Fix the [breakage](https://source.cloud.google.com/results/invocations/3376bdb6-7bde-4d88-88fe-d3cb6f58a0a6/targets/grpc%2Fjava%2Fmaster%2Fbranch%2Fandroid-interop/log) in `android-interop-testing` for apk path change.
2. Building `android-interop-testing` does not require gRPC in maven local.
3. Slightly modified `android.sh` to reflect building `grpc-cronet`, `grpc-android` and `grpc-android-interop-testing` does not require gRPC in maven local.