### PR TITLE
RouteGuideClient example: use E7 format for latitude & longitude

### DIFF
--- a/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideClient.java
+++ b/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideClient.java
@@ -218,8 +218,8 @@ public class RouteGuideClient {
 
     try {
       RouteNote[] requests =
-          {newNote("First message", 0, 0), newNote("Second message", 0, 1),
-              newNote("Third message", 1, 0), newNote("Fourth message", 1, 1)};
+          {newNote("First message", 0, 0), newNote("Second message", 0, 10000000),
+              newNote("Third message", 10000000, 0), newNote("Fourth message", 10000000, 10000000)};
 
       for (RouteNote request : requests) {
         info("Sending message \"{0}\" at {1}, {2}", request.getMessage(), request.getLocation()

--- a/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideClient.java
+++ b/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideClient.java
@@ -218,8 +218,8 @@ public class RouteGuideClient {
 
     try {
       RouteNote[] requests =
-          {newNote("First message", 0, 0), newNote("Second message", 0, 10000000),
-              newNote("Third message", 10000000, 0), newNote("Fourth message", 10000000, 10000000)};
+          {newNote("First message", 0, 0), newNote("Second message", 0, 10_000_000),
+              newNote("Third message", 10_000_000, 0), newNote("Fourth message", 10_000_000, 10_000_000)};
 
       for (RouteNote request : requests) {
         info("Sending message \"{0}\" at {1}, {2}", request.getMessage(), request.getLocation()

--- a/examples/src/test/java/io/grpc/examples/routeguide/RouteGuideClientTest.java
+++ b/examples/src/test/java/io/grpc/examples/routeguide/RouteGuideClientTest.java
@@ -400,9 +400,9 @@ public class RouteGuideClientTest {
     assertEquals(
         Arrays.asList(
             Point.newBuilder().setLatitude(0).setLongitude(0).build(),
-            Point.newBuilder().setLatitude(0).setLongitude(1).build(),
-            Point.newBuilder().setLatitude(1).setLongitude(0).build(),
-            Point.newBuilder().setLatitude(1).setLongitude(1).build()
+            Point.newBuilder().setLatitude(0).setLongitude(10_000_000).build(),
+            Point.newBuilder().setLatitude(10_000_000).setLongitude(0).build(),
+            Point.newBuilder().setLatitude(10_000_000).setLongitude(10_000_000).build()
         ),
         locationsDelivered);
 


### PR DESCRIPTION
As indicated in the proto file, "Points are represented as latitude-longitude pairs in the E7 representation".

@srini100