### PR TITLE
android-interop-testing: set minSdkVersion to 14 in manifest

### DIFF
--- a/android-interop-testing/src/main/AndroidManifest.xml
+++ b/android-interop-testing/src/main/AndroidManifest.xml
@@ -3,7 +3,9 @@
     package="io.grpc.android.integrationtest" >
 
     <!-- API level 14+ is required for TLS since Google Play Services v10.2 -->
-    <uses-sdk android:targetSdkVersion="22"/>
+    <uses-sdk
+      android:minSdkVersion="14"
+      android:targetSdkVersion="22"/>
 
     <uses-permission android:name="android.permission.INTERNET" />
 


### PR DESCRIPTION
Mistakenly deleted in #6829 due to warning when the refactoring was WIP. This should not be changed as this is how minSdkVersion specified for non-gradle builds.