### PR TITLE
core: copy the SchemaDescriptor when rebuilding descriptor

### DIFF
--- a/api/src/main/java/io/grpc/ServerInterceptors.java
+++ b/api/src/main/java/io/grpc/ServerInterceptors.java
@@ -187,13 +187,15 @@ public final class ServerInterceptors {
       wrappedMethods.add(wrapMethod(definition, wrappedMethodDescriptor));
     }
     // Build the new service descriptor
-    final ServerServiceDefinition.Builder serviceBuilder = ServerServiceDefinition
-        .builder(new ServiceDescriptor(serviceDef.getServiceDescriptor().getName(),
-            wrappedDescriptors));
-    // Create the new service definiton.
-    for (ServerMethodDefinition<?, ?> definition : wrappedMethods) {
-      serviceBuilder.addMethod(definition);
+    final ServiceDescriptor.Builder serviceDescriptorBuilder =
+        ServiceDescriptor.newBuilder(serviceDef.getServiceDescriptor().getName())
+            .setSchemaDescriptor(serviceDef.getServiceDescriptor().getSchemaDescriptor());
+    for (MethodDescriptor<?, ?> wrappedDescriptor : wrappedDescriptors) {
+      serviceDescriptorBuilder.addMethod(wrappedDescriptor);
     }
+    // Create the new service definition.
+    final ServerServiceDefinition.Builder serviceBuilder =
+        ServerServiceDefinition.builder(serviceDescriptorBuilder.build());
     return serviceBuilder.build();
   }
 

--- a/api/src/main/java/io/grpc/ServerInterceptors.java
+++ b/api/src/main/java/io/grpc/ServerInterceptors.java
@@ -196,6 +196,9 @@ public final class ServerInterceptors {
     // Create the new service definition.
     final ServerServiceDefinition.Builder serviceBuilder =
         ServerServiceDefinition.builder(serviceDescriptorBuilder.build());
+    for (ServerMethodDefinition<?, ?> definition : wrappedMethods) {
+      serviceBuilder.addMethod(definition);
+    }
     return serviceBuilder.build();
   }
 


### PR DESCRIPTION
useMarshalledMessages works by duplicating a ServerServiceDefinition while replacing just the marshallers. It currently does not copy over the SchemaDescriptors, which breaks at least the ProtoReflectionService.