### PR TITLE
buildscripts: allow per-xds test case artifacts

### DIFF
--- a/buildscripts/kokoro/xds.cfg
+++ b/buildscripts/kokoro/xds.cfg
@@ -3,3 +3,9 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc-java/buildscripts/kokoro/xds.sh"
 timeout_mins: 90
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+  }
+}

--- a/buildscripts/kokoro/xds.sh
+++ b/buildscripts/kokoro/xds.sh
@@ -17,7 +17,7 @@ shopt -u extglob
 ../gradlew installDist -x test -PskipCodegen=true -PskipAndroid=true
 popd
 
-git clone -b "${branch}" https://github.com/grpc/grpc.git
+git clone -b "${branch}" --single-branch --depth=1 https://github.com/grpc/grpc.git
 
 grpc/tools/run_tests/helper_scripts/prep_xds.sh
 JAVA_OPTS=-Djava.util.logging.config.file=grpc-java/buildscripts/xds_logging.properties \


### PR DESCRIPTION
Set up in the test runner script by https://github.com/grpc/grpc/pull/22444