### PR TITLE
xds: rollback PGV dependency from using maven artifact to importing proto source

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -44,8 +44,10 @@ which can be obtained at:
 
   * LICENSE:
     * xds/third_party/protoc-gen-validate/LICENSE (Apache License 2.0)
+  * NOTICE:
+      * xds/third_party/protoc-gen-validate/NOTICE
   * HOMEPAGE:
-    * https://github.com/lyft/protoc-gen-validate
+    * https://github.com/envoyproxy/protoc-gen-validate
   * LOCATION_IN_GRPC:
     * xds/third_party/protoc-gen-validate
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -38,6 +38,17 @@ obtained at:
   * LOCATION_IN_GRPC:
     * xds/third_party/envoy
 
+This product contains a modified portion of 'protoc-gen-validate (PGV)',
+an open source protoc plugin to generate polyglot message validators,
+which can be obtained at:
+
+  * LICENSE:
+    * xds/third_party/protoc-gen-validate/LICENSE (Apache License 2.0)
+  * HOMEPAGE:
+    * https://github.com/lyft/protoc-gen-validate
+  * LOCATION_IN_GRPC:
+    * xds/third_party/protoc-gen-validate
+
 This product contains a modified portion of 'udpa',
 an open source universal data plane API, which can be obtained at:
 

--- a/build.gradle
+++ b/build.gradle
@@ -151,7 +151,6 @@ subprojects {
             opencensus_impl_lite: "io.opencensus:opencensus-impl-lite:${opencensusVersion}",
             instrumentation_api: 'com.google.instrumentation:instrumentation-api:0.4.3',
             perfmark: 'io.perfmark:perfmark-api:0.19.0',
-            pgv: 'io.envoyproxy.protoc-gen-validate:pgv-java-stub:0.2.0',
             protobuf: "com.google.protobuf:protobuf-java:${protobufVersion}",
             protobuf_lite: "com.google.protobuf:protobuf-javalite:${protobufVersion}",
             protobuf_util: "com.google.protobuf:protobuf-java-util:${protobufVersion}",

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -25,11 +25,7 @@ dependencies {
             project(':grpc-services'),
             project(path: ':grpc-alts', configuration: 'shadow')
     def nettyDependency = compile project(':grpc-netty')
-    def pgvDependency = compile (libraries.pgv) {
-        // PGV depends on com.google.protobuf:protobuf-java 3.6.1 conflicting with :grpc-protobuf
-        exclude group: 'com.google.protobuf'
-    }
-
+    
     compile (libraries.protobuf_util) {
         // prefer our own versions instead of protobuf-util's dependency
         exclude group: 'com.google.guava', module: 'guava'
@@ -47,7 +43,7 @@ dependencies {
             libraries.guava_testlib,
             libraries.netty_epoll
 
-    shadow configurations.compile.getDependencies().minus([nettyDependency, pgvDependency])
+    shadow configurations.compile.getDependencies().minus([nettyDependency])
     shadow project(path: ':grpc-netty-shaded', configuration: 'shadow')
 
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
@@ -77,7 +73,6 @@ shadowJar {
     classifier = null
     dependencies {
         include(project(':grpc-xds'))
-        include(dependency('io.envoyproxy.protoc-gen-validate:'))
     }
     relocate 'com.github.udpa', 'io.grpc.xds.shaded.com.github.udpa'
     relocate 'io.envoyproxy', 'io.grpc.xds.shaded.io.envoyproxy'

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -54,6 +54,7 @@ sourceSets {
     main {
         proto {
             srcDir 'third_party/envoy/src/main/proto'
+            srcDir 'third_party/protoc-gen-validate/src/main/proto'
             srcDir 'third_party/udpa/src/main/proto'
         }
     }

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -25,7 +25,7 @@ dependencies {
             project(':grpc-services'),
             project(path: ':grpc-alts', configuration: 'shadow')
     def nettyDependency = compile project(':grpc-netty')
-    
+
     compile (libraries.protobuf_util) {
         // prefer our own versions instead of protobuf-util's dependency
         exclude group: 'com.google.guava', module: 'guava'

--- a/xds/third_party/protoc-gen-validate/LICENSE
+++ b/xds/third_party/protoc-gen-validate/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/xds/third_party/protoc-gen-validate/NOTICE
+++ b/xds/third_party/protoc-gen-validate/NOTICE
@@ -1,0 +1,4 @@
+protoc-gen-validate
+Copyright 2019 Envoy Project Authors
+
+Licensed under Apache License 2.0. See LICENSE for terms.

--- a/xds/third_party/protoc-gen-validate/import.sh
+++ b/xds/third_party/protoc-gen-validate/import.sh
@@ -18,8 +18,8 @@
 set -e
 BRANCH=master
 # import GIT_ORIGIN_REV_ID from one of the google internal CLs
-GIT_ORIGIN_REV_ID=8e6aaf55f4954f1ef9d3ee2e8f5a50e79cc04f8f
-GIT_REPO="https://github.com/lyft/protoc-gen-validate.git"
+GIT_ORIGIN_REV_ID=ab56c3dd1cf9b516b62c5087e1ec1471bd63631e
+GIT_REPO="https://github.com/envoyproxy/protoc-gen-validate.git"
 GIT_BASE_DIR=protoc-gen-validate
 SOURCE_PROTO_BASE_DIR=protoc-gen-validate
 TARGET_PROTO_BASE_DIR=src/main/proto
@@ -37,6 +37,7 @@ git checkout $GIT_ORIGIN_REV_ID
 popd
 
 cp -p "${tmpdir}/${GIT_BASE_DIR}/LICENSE" LICENSE
+cp -p "${tmpdir}/${GIT_BASE_DIR}/NOTICE" NOTICE
 
 mkdir -p "${TARGET_PROTO_BASE_DIR}"
 pushd "${TARGET_PROTO_BASE_DIR}"

--- a/xds/third_party/protoc-gen-validate/import.sh
+++ b/xds/third_party/protoc-gen-validate/import.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Copyright 2018 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Update GIT_ORIGIN_REV_ID then in this directory run ./import.sh
+
+set -e
+BRANCH=master
+# import GIT_ORIGIN_REV_ID from one of the google internal CLs
+GIT_ORIGIN_REV_ID=8e6aaf55f4954f1ef9d3ee2e8f5a50e79cc04f8f
+GIT_REPO="https://github.com/lyft/protoc-gen-validate.git"
+GIT_BASE_DIR=protoc-gen-validate
+SOURCE_PROTO_BASE_DIR=protoc-gen-validate
+TARGET_PROTO_BASE_DIR=src/main/proto
+FILES=(
+validate/validate.proto
+)
+
+# clone the protoc-gen-validate github repo in a tmp directory
+tmpdir="$(mktemp -d)"
+pushd "${tmpdir}"
+rm -rf "$GIT_BASE_DIR"
+git clone -b $BRANCH $GIT_REPO
+cd "$GIT_BASE_DIR"
+git checkout $GIT_ORIGIN_REV_ID
+popd
+
+cp -p "${tmpdir}/${GIT_BASE_DIR}/LICENSE" LICENSE
+
+mkdir -p "${TARGET_PROTO_BASE_DIR}"
+pushd "${TARGET_PROTO_BASE_DIR}"
+
+# copy proto files to project directory
+for file in "${FILES[@]}"
+do
+  mkdir -p "$(dirname "${file}")"
+  cp -p "${tmpdir}/${SOURCE_PROTO_BASE_DIR}/${file}" "${file}"
+done
+popd
+
+rm -rf "$tmpdir"

--- a/xds/third_party/protoc-gen-validate/src/main/proto/validate/validate.proto
+++ b/xds/third_party/protoc-gen-validate/src/main/proto/validate/validate.proto
@@ -1,0 +1,750 @@
+syntax = "proto2";
+package validate;
+
+option go_package = "github.com/lyft/protoc-gen-validate/validate";
+
+import "google/protobuf/descriptor.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+
+// Validation rules applied at the message level
+extend google.protobuf.MessageOptions {
+    // Disabled nullifies any validation rules for this message, including any
+    // message fields associated with it that do support validation.
+    optional bool disabled = 919191;
+}
+
+// Validation rules applied at the oneof level
+extend google.protobuf.OneofOptions {
+    // Required ensures that exactly one the field options in a oneof is set;
+    // validation fails if no fields in the oneof are set.
+    optional bool required = 919191;
+}
+
+// Validation rules applied at the field level
+extend google.protobuf.FieldOptions {
+    // Rules specify the validations to be performed on this field. By default,
+    // no validation is performed against a field.
+    optional FieldRules rules = 919191;
+}
+
+// FieldRules encapsulates the rules for each type of field. Depending on the
+// field, the correct set should be used to ensure proper validations.
+message FieldRules {
+    oneof type {
+        // Scalar Field Types
+        FloatRules    float    = 1;
+        DoubleRules   double   = 2;
+        Int32Rules    int32    = 3;
+        Int64Rules    int64    = 4;
+        UInt32Rules   uint32   = 5;
+        UInt64Rules   uint64   = 6;
+        SInt32Rules   sint32   = 7;
+        SInt64Rules   sint64   = 8;
+        Fixed32Rules  fixed32  = 9;
+        Fixed64Rules  fixed64  = 10;
+        SFixed32Rules sfixed32 = 11;
+        SFixed64Rules sfixed64 = 12;
+        BoolRules     bool     = 13;
+        StringRules   string   = 14;
+        BytesRules    bytes    = 15;
+
+        // Complex Field Types
+        EnumRules     enum     = 16;
+        MessageRules  message  = 17;
+        RepeatedRules repeated = 18;
+        MapRules      map      = 19;
+
+        // Well-Known Field Types
+        AnyRules       any       = 20;
+        DurationRules  duration  = 21;
+        TimestampRules timestamp = 22;
+    }
+}
+
+// FloatRules describes the constraints applied to `float` values
+message FloatRules {
+    // Const specifies that this field must be exactly the specified value
+    optional float const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional float lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional float lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional float gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional float gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated float in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated float not_in = 7;
+}
+
+// DoubleRules describes the constraints applied to `double` values
+message DoubleRules {
+    // Const specifies that this field must be exactly the specified value
+    optional double const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional double lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional double lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional double gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional double gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated double in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated double not_in = 7;
+}
+
+// Int32Rules describes the constraints applied to `int32` values
+message Int32Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional int32 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional int32 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional int32 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional int32 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional int32 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated int32 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated int32 not_in = 7;
+}
+
+// Int64Rules describes the constraints applied to `int64` values
+message Int64Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional int64 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional int64 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional int64 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional int64 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional int64 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated int64 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated int64 not_in = 7;
+}
+
+// UInt32Rules describes the constraints applied to `uint32` values
+message UInt32Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional uint32 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional uint32 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional uint32 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional uint32 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional uint32 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated uint32 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated uint32 not_in = 7;
+}
+
+// UInt64Rules describes the constraints applied to `uint64` values
+message UInt64Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional uint64 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional uint64 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional uint64 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional uint64 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional uint64 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated uint64 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated uint64 not_in = 7;
+}
+
+// SInt32Rules describes the constraints applied to `sint32` values
+message SInt32Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional sint32 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional sint32 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional sint32 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional sint32 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional sint32 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated sint32 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated sint32 not_in = 7;
+}
+
+// SInt64Rules describes the constraints applied to `sint64` values
+message SInt64Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional sint64 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional sint64 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional sint64 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional sint64 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional sint64 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated sint64 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated sint64 not_in = 7;
+}
+
+// Fixed32Rules describes the constraints applied to `fixed32` values
+message Fixed32Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional fixed32 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional fixed32 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional fixed32 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional fixed32 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional fixed32 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated fixed32 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated fixed32 not_in = 7;
+}
+
+// Fixed64Rules describes the constraints applied to `fixed64` values
+message Fixed64Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional fixed64 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional fixed64 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional fixed64 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional fixed64 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional fixed64 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated fixed64 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated fixed64 not_in = 7;
+}
+
+// SFixed32Rules describes the constraints applied to `sfixed32` values
+message SFixed32Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional sfixed32 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional sfixed32 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional sfixed32 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional sfixed32 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional sfixed32 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated sfixed32 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated sfixed32 not_in = 7;
+}
+
+// SFixed64Rules describes the constraints applied to `sfixed64` values
+message SFixed64Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional sfixed64 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional sfixed64 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional sfixed64 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional sfixed64 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional sfixed64 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated sfixed64 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated sfixed64 not_in = 7;
+}
+
+// BoolRules describes the constraints applied to `bool` values
+message BoolRules {
+    // Const specifies that this field must be exactly the specified value
+    optional bool const = 1;
+}
+
+// StringRules describe the constraints applied to `string` values
+message StringRules {
+    // Const specifies that this field must be exactly the specified value
+    optional string const = 1;
+
+    // MinLen specifies that this field must be the specified number of
+    // characters (Unicode code points) at a minimum. Note that the number of
+    // characters may differ from the number of bytes in the string.
+    optional uint64 min_len = 2;
+
+    // MaxLen specifies that this field must be the specified number of
+    // characters (Unicode code points) at a maximum. Note that the number of
+    // characters may differ from the number of bytes in the string.
+    optional uint64 max_len = 3;
+
+    // MinBytes specifies that this field must be the specified number of bytes
+    // at a minimum
+    optional uint64 min_bytes = 4;
+
+    // MaxBytes specifies that this field must be the specified number of bytes
+    // at a maximum
+    optional uint64 max_bytes = 5;
+
+    // Pattern specifes that this field must match against the specified
+    // regular expression (RE2 syntax). The included expression should elide
+    // any delimiters.
+    optional string pattern  = 6;
+
+    // Prefix specifies that this field must have the specified substring at
+    // the beginning of the string.
+    optional string prefix   = 7;
+
+    // Suffix specifies that this field must have the specified substring at
+    // the end of the string.
+    optional string suffix   = 8;
+
+    // Contains specifies that this field must have the specified substring
+    // anywhere in the string.
+    optional string contains = 9;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated string in     = 10;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated string not_in = 11;
+
+    // WellKnown rules provide advanced constraints against common string
+    // patterns
+    oneof well_known {
+        // Email specifies that the field must be a valid email address as
+        // defined by RFC 5322
+        bool email    = 12;
+
+        // Hostname specifies that the field must be a valid hostname as
+        // defined by RFC 1034. This constraint does not support
+        // internationalized domain names (IDNs).
+        bool hostname = 13;
+
+        // Ip specifies that the field must be a valid IP (v4 or v6) address.
+        // Valid IPv6 addresses should not include surrounding square brackets.
+        bool ip       = 14;
+
+        // Ipv4 specifies that the field must be a valid IPv4 address.
+        bool ipv4     = 15;
+
+        // Ipv6 specifies that the field must be a valid IPv6 address. Valid
+        // IPv6 addresses should not include surrounding square brackets.
+        bool ipv6     = 16;
+
+        // Uri specifies that the field must be a valid, absolute URI as defined
+        // by RFC 3986
+        bool uri      = 17;
+
+        // UriRef specifies that the field must be a valid URI as defined by RFC
+        // 3986 and may be relative or absolute.
+        bool uri_ref  = 18;
+    }
+}
+
+// BytesRules describe the constraints applied to `bytes` values
+message BytesRules {
+    // Const specifies that this field must be exactly the specified value
+    optional bytes const = 1;
+
+    // MinLen specifies that this field must be the specified number of bytes
+    // at a minimum
+    optional uint64 min_len = 2;
+
+    // MaxLen specifies that this field must be the specified number of bytes
+    // at a maximum
+    optional uint64 max_len = 3;
+
+    // Pattern specifes that this field must match against the specified
+    // regular expression (RE2 syntax). The included expression should elide
+    // any delimiters.
+    optional string pattern  = 4;
+
+    // Prefix specifies that this field must have the specified bytes at the
+    // beginning of the string.
+    optional bytes  prefix   = 5;
+
+    // Suffix specifies that this field must have the specified bytes at the
+    // end of the string.
+    optional bytes  suffix   = 6;
+
+    // Contains specifies that this field must have the specified bytes
+    // anywhere in the string.
+    optional bytes  contains = 7;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated bytes in     = 8;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated bytes not_in = 9;
+
+    // WellKnown rules provide advanced constraints against common byte
+    // patterns
+    oneof well_known {
+        // Ip specifies that the field must be a valid IP (v4 or v6) address in
+        // byte format
+        bool ip   = 10;
+
+        // Ipv4 specifies that the field must be a valid IPv4 address in byte
+        // format
+        bool ipv4 = 11;
+
+        // Ipv6 specifies that the field must be a valid IPv6 address in byte
+        // format
+        bool ipv6 = 12;
+    }
+}
+
+// EnumRules describe the constraints applied to enum values
+message EnumRules {
+    // Const specifies that this field must be exactly the specified value
+    optional int32 const        = 1;
+
+    // DefinedOnly specifies that this field must be only one of the defined
+    // values for this enum, failing on any undefined value.
+    optional bool  defined_only = 2;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated int32 in           = 3;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated int32 not_in       = 4;
+}
+
+// MessageRules describe the constraints applied to embedded message values.
+// For message-type fields, validation is performed recursively.
+message MessageRules {
+    // Skip specifies that the validation rules of this field should not be
+    // evaluated
+    optional bool skip     = 1;
+
+    // Required specifies that this field must be set
+    optional bool required = 2;
+}
+
+// RepeatedRules describe the constraints applied to `repeated` values
+message RepeatedRules {
+    // MinItems specifies that this field must have the specified number of
+    // items at a minimum
+    optional uint64 min_items = 1;
+
+    // MaxItems specifies that this field must have the specified number of
+    // items at a maximum
+    optional uint64 max_items = 2;
+
+    // Unique specifies that all elements in this field must be unique. This
+    // contraint is only applicable to scalar and enum types (messages are not
+    // supported).
+    optional bool   unique    = 3;
+
+    // Items specifies the contraints to be applied to each item in the field.
+    // Repeated message fields will still execute validation against each item
+    // unless skip is specified here.
+    optional FieldRules items = 4;
+}
+
+// MapRules describe the constraints applied to `map` values
+message MapRules {
+    // MinPairs specifies that this field must have the specified number of
+    // KVs at a minimum
+    optional uint64 min_pairs = 1;
+
+    // MaxPairs specifies that this field must have the specified number of
+    // KVs at a maximum
+    optional uint64 max_pairs = 2;
+
+    // NoSparse specifies values in this field cannot be unset. This only
+    // applies to map's with message value types.
+    optional bool no_sparse = 3;
+
+    // Keys specifies the constraints to be applied to each key in the field.
+    optional FieldRules keys   = 4;
+
+    // Values specifies the constraints to be applied to the value of each key
+    // in the field. Message values will still have their validations evaluated
+    // unless skip is specified here.
+    optional FieldRules values = 5;
+}
+
+// AnyRules describe constraints applied exclusively to the
+// `google.protobuf.Any` well-known type
+message AnyRules {
+    // Required specifies that this field must be set
+    optional bool required = 1;
+
+    // In specifies that this field's `type_url` must be equal to one of the
+    // specified values.
+    repeated string in     = 2;
+
+    // NotIn specifies that this field's `type_url` must not be equal to any of
+    // the specified values.
+    repeated string not_in = 3;
+}
+
+// DurationRules describe the constraints applied exclusively to the
+// `google.protobuf.Duration` well-known type
+message DurationRules {
+    // Required specifies that this field must be set
+    optional bool required = 1;
+
+    // Const specifies that this field must be exactly the specified value
+    optional google.protobuf.Duration const = 2;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional google.protobuf.Duration lt = 3;
+
+    // Lt specifies that this field must be less than the specified value,
+    // inclusive
+    optional google.protobuf.Duration lte = 4;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive
+    optional google.protobuf.Duration gt = 5;
+
+    // Gte specifies that this field must be greater than the specified value,
+    // inclusive
+    optional google.protobuf.Duration gte = 6;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated google.protobuf.Duration in = 7;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated google.protobuf.Duration not_in = 8;
+}
+
+// TimestampRules describe the constraints applied exclusively to the
+// `google.protobuf.Timestamp` well-known type
+message TimestampRules {
+    // Required specifies that this field must be set
+    optional bool required = 1;
+
+    // Const specifies that this field must be exactly the specified value
+    optional google.protobuf.Timestamp const = 2;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional google.protobuf.Timestamp lt = 3;
+
+    // Lte specifies that this field must be less than the specified value,
+    // inclusive
+    optional google.protobuf.Timestamp lte = 4;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive
+    optional google.protobuf.Timestamp gt = 5;
+
+    // Gte specifies that this field must be greater than the specified value,
+    // inclusive
+    optional google.protobuf.Timestamp gte = 6;
+
+    // LtNow specifies that this must be less than the current time. LtNow
+    // can only be used with the Within rule.
+    optional bool lt_now  = 7;
+
+    // GtNow specifies that this must be greater than the current time. GtNow
+    // can only be used with the Within rule.
+    optional bool gt_now  = 8;
+
+    // Within specifies that this field must be within this duration of the
+    // current time. This constraint can be used alone or with the LtNow and
+    // GtNow rules.
+    optional google.protobuf.Duration within = 9;
+}

--- a/xds/third_party/protoc-gen-validate/src/main/proto/validate/validate.proto
+++ b/xds/third_party/protoc-gen-validate/src/main/proto/validate/validate.proto
@@ -1,7 +1,8 @@
 syntax = "proto2";
 package validate;
 
-option go_package = "github.com/lyft/protoc-gen-validate/validate";
+option go_package = "github.com/envoyproxy/protoc-gen-validate/validate";
+option java_package = "io.envoyproxy.pgv.validate";
 
 import "google/protobuf/descriptor.proto";
 import "google/protobuf/duration.proto";
@@ -11,26 +12,27 @@ import "google/protobuf/timestamp.proto";
 extend google.protobuf.MessageOptions {
     // Disabled nullifies any validation rules for this message, including any
     // message fields associated with it that do support validation.
-    optional bool disabled = 919191;
+    optional bool disabled = 1071;
 }
 
 // Validation rules applied at the oneof level
 extend google.protobuf.OneofOptions {
     // Required ensures that exactly one the field options in a oneof is set;
     // validation fails if no fields in the oneof are set.
-    optional bool required = 919191;
+    optional bool required = 1071;
 }
 
 // Validation rules applied at the field level
 extend google.protobuf.FieldOptions {
     // Rules specify the validations to be performed on this field. By default,
     // no validation is performed against a field.
-    optional FieldRules rules = 919191;
+    optional FieldRules rules = 1071;
 }
 
 // FieldRules encapsulates the rules for each type of field. Depending on the
 // field, the correct set should be used to ensure proper validations.
 message FieldRules {
+    optional MessageRules message = 17;
     oneof type {
         // Scalar Field Types
         FloatRules    float    = 1;
@@ -51,7 +53,6 @@ message FieldRules {
 
         // Complex Field Types
         EnumRules     enum     = 16;
-        MessageRules  message  = 17;
         RepeatedRules repeated = 18;
         MapRules      map      = 19;
 
@@ -457,6 +458,11 @@ message StringRules {
     // Const specifies that this field must be exactly the specified value
     optional string const = 1;
 
+    // Len specifies that this field must be the specified number of
+    // characters (Unicode code points). Note that the number of
+    // characters may differ from the number of bytes in the string.
+    optional uint64 len = 19;
+
     // MinLen specifies that this field must be the specified number of
     // characters (Unicode code points) at a minimum. Note that the number of
     // characters may differ from the number of bytes in the string.
@@ -466,6 +472,10 @@ message StringRules {
     // characters (Unicode code points) at a maximum. Note that the number of
     // characters may differ from the number of bytes in the string.
     optional uint64 max_len = 3;
+
+    // LenBytes specifies that this field must be the specified number of bytes
+    // at a minimum
+    optional uint64 len_bytes = 20;
 
     // MinBytes specifies that this field must be the specified number of bytes
     // at a minimum
@@ -491,6 +501,10 @@ message StringRules {
     // Contains specifies that this field must have the specified substring
     // anywhere in the string.
     optional string contains = 9;
+
+    // NotContains specifies that this field cannot have the specified substring
+    // anywhere in the string.
+    optional string not_contains = 23;
 
     // In specifies that this field must be equal to one of the specified
     // values
@@ -530,13 +544,46 @@ message StringRules {
         // UriRef specifies that the field must be a valid URI as defined by RFC
         // 3986 and may be relative or absolute.
         bool uri_ref  = 18;
+
+        // Address specifies that the field must be either a valid hostname as
+        // defined by RFC 1034 (which does not support internationalized domain
+        // names or IDNs), or it can be a valid IP (v4 or v6).
+        bool address  = 21;
+
+        // Uuid specifies that the field must be a valid UUID as defined by
+        // RFC 4122
+        bool uuid     = 22;
+
+        // WellKnownRegex specifies a common well known pattern defined as a regex.
+        KnownRegex well_known_regex = 24;
     }
+
+  // This applies to regexes HTTP_HEADER_NAME and HTTP_HEADER_VALUE to enable
+  // strict header validation.
+  // By default, this is true, and HTTP header validations are RFC-compliant.
+  // Setting to false will enable a looser validations that only disallows
+  // \r\n\0 characters, which can be used to bypass header matching rules.
+  optional bool strict = 25 [default = true];
+}
+
+// WellKnownRegex contain some well-known patterns.
+enum KnownRegex {
+  UNKNOWN = 0;
+
+  // HTTP header name as defined by RFC 7230.
+  HTTP_HEADER_NAME = 1;
+
+  // HTTP header value as defined by RFC 7230.
+  HTTP_HEADER_VALUE = 2;
 }
 
 // BytesRules describe the constraints applied to `bytes` values
 message BytesRules {
     // Const specifies that this field must be exactly the specified value
     optional bytes const = 1;
+
+    // Len specifies that this field must be the specified number of bytes
+    optional uint64 len = 13;
 
     // MinLen specifies that this field must be the specified number of bytes
     // at a minimum


### PR DESCRIPTION
PGV is adding new fields (`well_known_regex` and `strict`) to proto and some of our new features require the most current envoy API which in turn requires the new fields in latest PGV proto (https://github.com/envoyproxy/envoy/blob/master/api/envoy/api/v2/core/base.proto#L251), but they are not available in the latest PGV maven release.