### PR TITLE
android-interop-testing: resolve build warnings

### DIFF
--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -87,4 +87,14 @@ task checkStyleTest(type: Checkstyle) {
 
 project.tasks['check'].dependsOn checkStyleMain, checkStyleTest
 
+import net.ltgt.gradle.errorprone.CheckSeverity
+
+tasks.withType(JavaCompile) {
+    options.compilerArgs += [
+            "-Xlint:-cast"
+    ]
+    // Reuses source code from grpc-interop-testing, which targets Java 7 (no method references)
+    options.errorprone.check("UnnecessaryAnonymousClass", CheckSeverity.OFF)
+}
+
 configureProtoCompilation()

--- a/android-interop-testing/src/main/java/io/grpc/android/integrationtest/InteropTask.java
+++ b/android-interop-testing/src/main/java/io/grpc/android/integrationtest/InteropTask.java
@@ -53,6 +53,7 @@ final class InteropTask extends AsyncTask<Void, Void, String> {
     tester.setUp();
   }
 
+  @SuppressWarnings("Finally")
   @Override
   protected String doInBackground(Void... ignored) {
     try {


### PR DESCRIPTION
Resolves #6866. 

- Suppressed protobuf-javalite's redundant cast warning by adding `"-Xlint:-cast"` compiler argument.
- Suppressed errorprone `UnnecessaryAnonymousClass` warning for reused source code in `grpc-interop-testing`.
- Suppressed "throw in finally" warning. (I am confused by the output of that method, so suppressed the warning instead of trying to rewrite the logic).