### PR TITLE
benchmarks: fix missing configuration for netty server

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
@@ -40,6 +40,8 @@ import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalServerChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -206,7 +208,8 @@ public abstract class AbstractBenchmark {
       sock.bind(new InetSocketAddress(BENCHMARK_ADDR, 0));
       SocketAddress address = sock.getLocalSocketAddress();
       sock.close();
-      serverBuilder = NettyServerBuilder.forAddress(address);
+      serverBuilder =
+          NettyServerBuilder.forAddress(address).channelType(NioServerSocketChannel.class);
       channelBuilder = NettyChannelBuilder.forAddress(address);
     }
 
@@ -220,6 +223,7 @@ public abstract class AbstractBenchmark {
     // Always use a different worker group from the client.
     ThreadFactory serverThreadFactory = new DefaultThreadFactory("STF pool", true /* daemon */);
     serverBuilder.workerEventLoopGroup(new NioEventLoopGroup(0, serverThreadFactory));
+    serverBuilder.bossEventLoopGroup(new NioEventLoopGroup(1, serverThreadFactory));
 
     // Always set connection and stream window size to same value
     serverBuilder.flowControlWindow(windowSize.bytes());
@@ -379,6 +383,7 @@ public abstract class AbstractBenchmark {
       // Use a dedicated event-loop for each channel
       channels[i] = channelBuilder
           .eventLoopGroup(new NioEventLoopGroup(1, clientThreadFactory))
+          .channelType(NioSocketChannel.class)
           .build();
     }
   }

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
@@ -210,7 +210,7 @@ public abstract class AbstractBenchmark {
       sock.close();
       serverBuilder =
           NettyServerBuilder.forAddress(address).channelType(NioServerSocketChannel.class);
-      channelBuilder = NettyChannelBuilder.forAddress(address);
+      channelBuilder = NettyChannelBuilder.forAddress(address).channelType(NioSocketChannel.class);
     }
 
     if (serverExecutor == ExecutorType.DIRECT) {
@@ -383,7 +383,6 @@ public abstract class AbstractBenchmark {
       // Use a dedicated event-loop for each channel
       channels[i] = channelBuilder
           .eventLoopGroup(new NioEventLoopGroup(1, clientThreadFactory))
-          .channelType(NioSocketChannel.class)
           .build();
     }
   }


### PR DESCRIPTION
note: for netty server, it requires to have all or nothing for channelType, boss/worker eventloop group settings.