### PR TITLE
xds: exclude 3 transitive deps from opencensus_proto to use our own

### DIFF
--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -23,10 +23,15 @@ dependencies {
             project(':grpc-stub'),
             project(':grpc-core'),
             project(':grpc-services'),
-            project(path: ':grpc-alts', configuration: 'shadow'),
-            libraries.opencensus_proto
+            project(path: ':grpc-alts', configuration: 'shadow')
     def nettyDependency = compile project(':grpc-netty')
 
+    compile (libraries.opencensus_proto) {
+        // prefer our own versions instead of opencensus_proto's
+        exclude group: 'com.google.protobuf', module: 'protobuf-java'
+        exclude group: 'io.grpc', module: 'grpc-protobuf'
+        exclude group: 'io.grpc', module: 'grpc-stub'
+    }
     compile (libraries.protobuf_util) {
         // prefer our own versions instead of protobuf-util's dependency
         exclude group: 'com.google.guava', module: 'guava'


### PR DESCRIPTION
This resolves the problem described in https://github.com/grpc/grpc-java/pull/6876 