### PR TITLE
all: Move jacocoTestReport exclusions to individual projects

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -60,15 +60,11 @@ jacocoTestReport {
         html.enabled = true
     }
 
-    additionalSourceDirs.from(files(subprojects.sourceSets.main.allSource.srcDirs))
-    sourceDirectories.from(files(subprojects.sourceSets.main.allSource.srcDirs))
-    classDirectories.from(files(subprojects.sourceSets.main.output).collect {
-        fileTree(dir: it,
-        exclude: [
-                '**/io/grpc/internal/testing/**',
-                '**/io/grpc/okhttp/internal/**',
-        ])
-    })
+    subprojects.each { subproject ->
+        additionalSourceDirs.from(subproject.jacocoTestReport.additionalSourceDirs)
+        sourceDirectories.from(subproject.jacocoTestReport.sourceDirectories)
+        classDirectories.from(subproject.jacocoTestReport.classDirectories)
+    }
 }
 
 coveralls {

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -36,3 +36,12 @@ checkstyleMain.exclude '**/io/grpc/okhttp/internal/**'
 
 javadoc.exclude 'io/grpc/okhttp/internal/**'
 javadoc.options.links 'http://square.github.io/okhttp/2.x/okhttp/'
+
+jacocoTestReport {
+    classDirectories.from = sourceSets.main.output.collect {
+        fileTree(dir: it,
+        exclude: [
+                '**/io/grpc/okhttp/internal/**',
+        ])
+    }
+}

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -33,3 +33,12 @@ dependencies {
 }
 
 javadoc { exclude 'io/grpc/internal/**' }
+
+jacocoTestReport {
+    classDirectories.from = sourceSets.main.output.collect {
+        fileTree(dir: it,
+        exclude: [
+                '**/io/grpc/internal/testing/**',
+        ])
+    }
+}


### PR DESCRIPTION
The sourceSets.main.output.collect should probably be improved at some point to
improve loading performance, but this is technically better than what we had
before so let's call it a win and move on.

-----

This is in preparation for xds which has a lot of exclusions.