### PR TITLE
api: Fix javadoc reference to deprecated method

### DIFF
--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -209,8 +209,8 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
 
   /**
    * Provides a custom {@link NameResolver.Factory} for the channel. If this method is not called,
-   * the builder will try the providers listed by {@link NameResolverProvider#providers()} for the
-   * given target.
+   * the builder will try the providers registered in the default {@link NameResolverRegistry} for
+   * the given target.
    *
    * <p>This method should rarely be used, as name resolvers should provide a {@code
    * NameResolverProvider} and users rely on service loading to find implementations in the class


### PR DESCRIPTION
Updates the `ManagedChannelBuilder#nameResolverFactory()`'s javadocs to refer to the new `NameResolverRegistry` instead of the deprecated `NameResolverProvider#providers()` method.

This is also closer to the truth for the default implementations:

https://github.com/grpc/grpc-java/blob/84dd812db86cbfa77b0dda7839ae0ea876135057/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java#L251-L255