### PR TITLE
all: migrate gradle build to java-library plugin

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -31,7 +31,7 @@ for (subproject in rootProject.subprojects) {
 }
 
 dependencies {
-    compile subprojects.minus(project(':grpc-protobuf-lite'))
+    implementation subprojects.minus(project(':grpc-protobuf-lite'))
 }
 
 javadoc {

--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "com.github.johnrengelman.shadow"
@@ -13,35 +13,35 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-    compile project(':grpc-auth'),
-            project(':grpc-core'),
+    api project(':grpc-core')
+    compileOnly libraries.javax_annotation
+    implementation project(':grpc-auth'),
             project(':grpc-grpclb'),
             project(':grpc-protobuf'),
             project(':grpc-stub'),
             libraries.lang,
-            libraries.protobuf,
             libraries.conscrypt
-    def nettyDependency = compile project(':grpc-netty')
-    compile (libraries.google_auth_oauth2_http) {
+    def nettyDependency = implementation project(':grpc-netty')
+    implementation (libraries.google_auth_oauth2_http) {
         // prefer our own versions instead of google-auth-oauth2-http's dependency
         exclude group: 'com.google.guava', module: 'guava'
         // we'll always be more up-to-date
         exclude group: 'io.grpc', module: 'grpc-context'
     }
-    compileOnly libraries.javax_annotation
-
-    shadow configurations.compile.getDependencies().minus(nettyDependency)
-    shadow project(path: ':grpc-netty-shaded', configuration: 'shadow')
-
-    testCompile project(':grpc-testing'),
+    guavaDependency 'implementation'
+    testImplementation project(':grpc-testing'),
             project(':grpc-testing-proto'),
             libraries.guava,
             libraries.guava_testlib,
             libraries.junit,
             libraries.mockito,
             libraries.truth
-    testRuntime libraries.netty_tcnative,
-            libraries.netty_epoll
+    testRuntimeOnly libraries.netty_epoll,
+            libraries.netty_tcnative
+
+    shadow configurations.implementation.getDependencies().minus(nettyDependency),
+            project(path: ':grpc-netty-shaded', configuration: 'shadow')
+
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -61,10 +61,10 @@ dependencies {
             project(':grpc-testing'),
             libraries.junit,
             libraries.truth
-
     implementation (libraries.google_auth_oauth2_http) {
         exclude group: 'org.apache.httpcomponents'
     }
+    censusGrpcMetricDependency 'implementation'
 
     compileOnly libraries.javax_annotation
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,12 +27,12 @@ repositories {
 
 dependencies {
     implementation project(':grpc-core')
-
-    testImplementation project('::grpc-okhttp')
-    testImplementation libraries.androidx_test
-    testImplementation libraries.junit
-    testImplementation libraries.robolectric
-    testImplementation libraries.truth
+    guavaDependency 'implementation'
+    testImplementation project('::grpc-okhttp'),
+            libraries.androidx_test,
+            libraries.junit,
+            libraries.robolectric,
+            libraries.truth
 }
 
 task javadocs(type: Javadoc) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,7 @@ repositories {
 }
 
 dependencies {
-    implementation project(':grpc-core')
+    api project(':grpc-core')
     guavaDependency 'implementation'
     testImplementation project('::grpc-okhttp'),
             libraries.androidx_test,

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "me.champeau.gradle.jmh"
@@ -11,20 +11,12 @@ description = 'gRPC: API'
 evaluationDependsOn(project(':grpc-context').path)
 
 dependencies {
-    compile project(':grpc-context'),
-            libraries.errorprone,
-            libraries.jsr305,
-            libraries.animalsniffer_annotations
-    compile (libraries.guava) {
-        // prefer our own versions from libraries instead of Guava's dependency
-        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
-        exclude group: 'com.google.code.findbugs', module: 'jsr305'
-        exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
-    }
-
-    testCompile project(':grpc-context').sourceSets.test.output,
-            project(':grpc-testing'),
+    api project(':grpc-context'),
+            libraries.jsr305
+    guavaDependency 'implementation'
+    testImplementation project(':grpc-context').sourceSets.test.output,
             project(':grpc-grpclb'),
+            project(':grpc-testing'),
             libraries.guava_testlib
 
     jmh project(':grpc-core')

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"
@@ -8,11 +8,12 @@ plugins {
 
 description = "gRPC: Auth"
 dependencies {
-    compile project(':grpc-api'),
+    api project(':grpc-api'),
             libraries.google_auth_credentials
     guavaDependency 'implementation'
-    testCompile project(':grpc-testing'),
+    testImplementation project(':grpc-testing'),
             libraries.google_auth_oauth2_http
+
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -10,6 +10,7 @@ description = "gRPC: Auth"
 dependencies {
     compile project(':grpc-api'),
             libraries.google_auth_credentials
+    guavaDependency 'implementation'
     testCompile project(':grpc-testing'),
             libraries.google_auth_oauth2_http
     signature "org.codehaus.mojo.signature:java17:1.0@signature"

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -21,20 +21,20 @@ configurations {
 }
 
 dependencies {
-    compile project(':grpc-core'),
+    alpnagent libraries.jetty_alpn_agent
+
+    compileOnly libraries.javax_annotation
+    implementation project(':grpc-core'),
             project(':grpc-netty'),
             project(':grpc-okhttp'),
             project(':grpc-stub'),
             project(':grpc-protobuf'),
             project(':grpc-testing'),
             libraries.hdrhistogram,
-            libraries.netty_tcnative,
+            libraries.math,
             libraries.netty_epoll,
-            libraries.math
-    compileOnly libraries.javax_annotation
-    alpnagent libraries.jetty_alpn_agent
-
-    testCompile libraries.junit,
+            libraries.netty_tcnative
+    testImplementation libraries.junit,
             libraries.mockito
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ subprojects {
         }
     }
 
+    def isAndroid = project.name in [
+            'grpc-android', 'grpc-android-interop-testing', 'grpc-cronet']
+
     ext {
         def exeSuffix = osdetector.os == 'windows' ? ".exe" : ""
         protocPluginBaseName = 'protoc-gen-grpc-java'
@@ -54,7 +57,6 @@ subprojects {
         opencensusVersion = '0.24.0'
 
         configureProtoCompilation = {
-            boolean isAndroid = project.getName().contains('android')
             String generatedSourcePath = "${projectDir}/src/generated"
             project.protobuf {
                 protoc {
@@ -241,16 +243,20 @@ subprojects {
         }
     }
 
-    // Define a separate configuration for managing the dependency on Jetty ALPN agent.
     configurations {
-        compile {
-            // Detect Maven Enforcer's dependencyConvergence failures. We only
-            // care for artifacts used as libraries by others.
-            if (!(project.name in [
+        // Detect Maven Enforcer's dependencyConvergence failures. We only
+        // care for artifacts used as libraries by others.
+        if (isAndroid && !(project.name in ['grpc-android-interop-testing'])) {
+            releaseRuntimeClasspath {
+                resolutionStrategy.failOnVersionConflict()
+            }
+        }
+        if (!isAndroid && !(project.name in [
                 'grpc-benchmarks',
                 'grpc-interop-testing',
                 'grpc-gae-interop-testing-jdk8',
-            ])) {
+        ])) {
+            runtimeClasspath {
                 resolutionStrategy.failOnVersionConflict()
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -199,6 +199,15 @@ subprojects {
             dependencies.runtimeOnly libraries.animalsniffer_annotations
             dependencies.runtimeOnly libraries.jsr305
         }
+        // A util function to config perfmark dependency with the given configuration
+        // name. We exclude some of its transitive dependencies and manually
+        // add them with a specific version.
+        perfmarkDependency = { configurationName ->
+            dependencies."$configurationName"(libraries.perfmark) {
+                exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+            }
+            dependencies.runtimeOnly libraries.errorprone
+        }
     }
 
     // Define a separate configuration for managing the dependency on Jetty ALPN agent.

--- a/build.gradle
+++ b/build.gradle
@@ -185,6 +185,20 @@ subprojects {
             // Jetty ALPN dependencies
             jetty_alpn_agent: 'org.mortbay.jetty.alpn:jetty-alpn-agent:2.0.9'
         ]
+
+        // A util function to config guava dependency with the given configuration
+        // name. We exclude some of its transitive dependencies and manually
+        // add them with a specific version.
+        guavaDependency = { configurationName ->
+            dependencies."$configurationName"(libraries.guava) {
+                exclude group: 'com.google.code.findbugs', module: 'jsr305'
+                exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+                exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
+            }
+            dependencies."$configurationName" libraries.errorprone
+            dependencies.runtimeOnly libraries.animalsniffer_annotations
+            dependencies.runtimeOnly libraries.jsr305
+        }
     }
 
     // Define a separate configuration for managing the dependency on Jetty ALPN agent.

--- a/build.gradle
+++ b/build.gradle
@@ -199,6 +199,37 @@ subprojects {
             dependencies.runtimeOnly libraries.animalsniffer_annotations
             dependencies.runtimeOnly libraries.jsr305
         }
+
+        // A util function to config opencensus_api dependency with the given
+        // configuration name. We exclude some of its transitive dependencies
+        // and manually add them with a specific version.
+        censusApiDependency = { configurationName ->
+            dependencies."$configurationName"(libraries.opencensus_api) {
+                exclude group: 'com.google.code.findbugs', module: 'jsr305'
+                exclude group: 'com.google.guava', module: 'guava'
+                // we'll always be more up-to-date
+                exclude group: 'io.grpc', module: 'grpc-context'
+            }
+            dependencies.runtimeOnly project(':grpc-context')
+            dependencies.runtimeOnly libraries.jsr305
+            guavaDependency 'runtimeOnly'
+        }
+
+        // A util function to config opencensus_contrib_grpc_metrics dependency
+        // with the given configuration name. We exclude some of its transitive
+        // dependencies and manually add them with a specific version.
+        censusGrpcMetricDependency = { configurationName ->
+            dependencies."$configurationName"(libraries.opencensus_contrib_grpc_metrics) {
+                exclude group: 'com.google.code.findbugs', module: 'jsr305'
+                exclude group: 'com.google.guava', module: 'guava'
+                // we'll always be more up-to-date
+                exclude group: 'io.grpc', module: 'grpc-context'
+            }
+            dependencies.runtimeOnly project(':grpc-context')
+            dependencies.runtimeOnly libraries.jsr305
+            guavaDependency 'runtimeOnly'
+        }
+
         // A util function to config perfmark dependency with the given configuration
         // name. We exclude some of its transitive dependencies and manually
         // add them with a specific version.

--- a/census/build.gradle
+++ b/census/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 }
 
@@ -8,27 +8,11 @@ description = 'gRPC: Census'
 evaluationDependsOn(project(':grpc-api').path)
 
 dependencies {
-    compile project(':grpc-api')
-            
-    compile (libraries.opencensus_api) {
-        // prefer 3.0.2 from libraries instead of 3.0.1
-        exclude group: 'com.google.code.findbugs', module: 'jsr305'
-        // prefer 20.0 from libraries instead of 19.0
-        exclude group: 'com.google.guava', module: 'guava'
-        // we'll always be more up-to-date
-        exclude group: 'io.grpc', module: 'grpc-context'
-    }
-    
-    compile (libraries.opencensus_contrib_grpc_metrics) {
-        // prefer 3.0.2 from libraries instead of 3.0.1
-        exclude group: 'com.google.code.findbugs', module: 'jsr305'
-        // we'll always be more up-to-date
-        exclude group: 'io.grpc', module: 'grpc-context'
-        // prefer 20.0 from libraries instead of 19.0
-        exclude group: 'com.google.guava', module: 'guava'
-    }
+    api project(':grpc-api')
+    censusApiDependency 'implementation'
+    censusGrpcMetricDependency 'implementation'
     guavaDependency 'implementation'
-    testCompile project(':grpc-api').sourceSets.test.output,
+    testImplementation project(':grpc-api').sourceSets.test.output,
             project(':grpc-context').sourceSets.test.output,
             project(':grpc-core').sourceSets.test.output,
             project(':grpc-testing'),

--- a/census/build.gradle
+++ b/census/build.gradle
@@ -27,7 +27,7 @@ dependencies {
         // prefer 20.0 from libraries instead of 19.0
         exclude group: 'com.google.guava', module: 'guava'
     }
-
+    guavaDependency 'implementation'
     testCompile project(':grpc-api').sourceSets.test.output,
             project(':grpc-context').sourceSets.test.output,
             project(':grpc-core').sourceSets.test.output,

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -126,14 +126,14 @@ model {
 }
 
 configurations {
-    testLiteCompile
+    testLiteImplementation
 }
 
 dependencies {
-    testCompile project(':grpc-protobuf'),
+    testImplementation project(':grpc-protobuf'),
             project(':grpc-stub'),
             libraries.javax_annotation
-    testLiteCompile project(':grpc-protobuf-lite'),
+    testLiteImplementation project(':grpc-protobuf-lite'),
             project(':grpc-stub'),
             libraries.javax_annotation
 }

--- a/context/build.gradle
+++ b/context/build.gradle
@@ -10,7 +10,9 @@ plugins {
 description = 'gRPC: Context'
 
 dependencies {
-    testCompile libraries.jsr305, libraries.guava_testlib
+    testImplementation libraries.guava_testlib,
+            libraries.jsr305
+
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -16,11 +16,11 @@ dependencies {
     compile project(':grpc-api'),
             libraries.gson,
             libraries.android_annotations,
-            libraries.errorprone // prefer our version to perfmark's 2.3.3
     compile (libraries.perfmark) {
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }
-
+    implementation libraries.animalsniffer_annotations
+    guavaDependency 'implementation'
     testCompile project(':grpc-context').sourceSets.test.output,
             project(':grpc-api').sourceSets.test.output,
             project(':grpc-testing'),

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"
@@ -13,20 +13,17 @@ evaluationDependsOn(project(':grpc-context').path)
 evaluationDependsOn(project(':grpc-api').path)
 
 dependencies {
-    compile project(':grpc-api'),
-            libraries.gson,
-            libraries.android_annotations,
-    compile (libraries.perfmark) {
-        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
-    }
-    implementation libraries.animalsniffer_annotations
+    api project(':grpc-api')
+    implementation libraries.android_annotations,
+            libraries.animalsniffer_annotations,
+            libraries.gson
     guavaDependency 'implementation'
-    testCompile project(':grpc-context').sourceSets.test.output,
-            project(':grpc-api').sourceSets.test.output,
-            project(':grpc-testing'),
+    perfmarkDependency 'implementation'
+    testImplementation project(':grpc-api').sourceSets.test.output,
+            project(':grpc-context').sourceSets.test.output,
             project(':grpc-grpclb'),
+            project(':grpc-testing'),
             libraries.guava_testlib
-    
     testRuntimeOnly project(':grpc-census')
 
     jmh project(':grpc-testing')

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -33,7 +33,7 @@ android {
 }
 
 dependencies {
-    implementation project(':grpc-core'),
+    api project(':grpc-core'),
             libraries.cronet_api
     guavaDependency 'implementation'
     testImplementation project(':grpc-testing'),

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -33,15 +33,14 @@ android {
 }
 
 dependencies {
-    implementation project(':grpc-core')
-    testImplementation project(':grpc-testing')
-
-    implementation libraries.cronet_api
-    testImplementation libraries.cronet_embedded
-
-    testImplementation libraries.junit
-    testImplementation libraries.mockito
-    testImplementation libraries.robolectric
+    implementation project(':grpc-core'),
+            libraries.cronet_api
+    guavaDependency 'implementation'
+    testImplementation project(':grpc-testing'),
+            libraries.cronet_embedded,
+            libraries.junit,
+            libraries.mockito,
+            libraries.robolectric
 }
 
 task javadocs(type: Javadoc) {

--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -43,17 +43,15 @@ repositories {
 apply plugin: 'com.google.cloud.tools.appengine'  // App Engine tasks
 
 dependencies {
-    providedCompile group: 'javax.servlet', name: 'servlet-api', version:'2.5'
-    compile 'com.google.appengine:appengine-api-1.0-sdk:1.9.59'
-    // Deps needed by all gRPC apps in GAE
-    compile libraries.google_api_protos
-    compile project(":grpc-okhttp")
-    compile project(":grpc-protobuf")
-    compile project(":grpc-stub")
-    compile (project(":grpc-interop-testing")) {
-        exclude group: "io.grpc", module: "grpc-netty-shaded"
+    implementation project(':grpc-netty'),
+            project(":grpc-stub"),
+            libraries.protobuf,
+            libraries.truth
+    implementation (project(':grpc-interop-testing')) {
+        exclude group: 'io.grpc', module: 'grpc-alts'
     }
-    compile libraries.netty_tcnative
+    providedCompile group: 'javax.servlet', name: 'servlet-api', version:'2.5'
+    runtimeOnly 'com.google.appengine:appengine-api-1.0-sdk:1.9.59'
 }
 
 compileJava {

--- a/grpclb/build.gradle
+++ b/grpclb/build.gradle
@@ -11,17 +11,17 @@ description = "gRPC: GRPCLB LoadBalancer plugin"
 evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
-    compile project(':grpc-core'),
+    compileOnly libraries.javax_annotation
+    implementation project(':grpc-core'),
             project(':grpc-protobuf'),
             project(':grpc-stub'),
-            libraries.protobuf
-    compile (libraries.protobuf_util) {
-        // prefer our own versions instead of protobuf-util's dependency
-        exclude group: 'com.google.guava', module: 'guava'
+    implementation (libraries.protobuf_util) {
+        // prefer our own version from grpc-stub instead of protobuf-util's dependency
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+        // prefer our own version from grpc-stub instead of protobuf-util's dependency
+        exclude group: 'com.google.guava', module: 'guava'
     }
-    compileOnly libraries.javax_annotation
-    testCompile libraries.truth,
+    testImplementation libraries.truth,
             project(':grpc-core').sourceSets.test.output
 }
 

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -31,6 +31,7 @@ dependencies {
             libraries.junit,
             libraries.truth
     compileOnly libraries.javax_annotation
+    censusGrpcMetricDependency 'implementation'
     runtime libraries.opencensus_impl,
             libraries.netty_tcnative,
             project(':grpc-grpclb')

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -17,7 +17,9 @@ configurations {
 evaluationDependsOn(project(':grpc-context').path)
 
 dependencies {
-    compile project(path: ':grpc-alts', configuration: 'shadow'),
+    alpnagent libraries.jetty_alpn_agent
+    compileOnly libraries.javax_annotation
+    implementation project(path: ':grpc-alts', configuration: 'shadow'),
             project(':grpc-auth'),
             project(':grpc-census'),
             project(':grpc-core'),
@@ -30,15 +32,13 @@ dependencies {
             libraries.google_auth_oauth2_http,
             libraries.junit,
             libraries.truth
-    compileOnly libraries.javax_annotation
     censusGrpcMetricDependency 'implementation'
-    runtime libraries.opencensus_impl,
+    runtimeOnly project(':grpc-grpclb'),
             libraries.netty_tcnative,
-            project(':grpc-grpclb')
-    xdsRuntime project(path: ':grpc-xds', configuration: 'shadow')
-    testCompile project(':grpc-context').sourceSets.test.output,
+            libraries.opencensus_impl
+    testImplementation project(':grpc-context').sourceSets.test.output,
             libraries.mockito
-    alpnagent libraries.jetty_alpn_agent
+    xdsRuntime project(path: ':grpc-xds', configuration: 'shadow')
 }
 
 configureProtoCompilation()

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -20,6 +20,7 @@ dependencies {
             libraries.netty,
             libraries.netty_proxy_handler
     guavaDependency 'implementation'
+    perfmarkDependency 'implementation'
     // Tests depend on base class defined by core module.
     testCompile project(':grpc-core').sourceSets.test.output,
             project(':grpc-testing'),

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     compile project(':grpc-core'),
             libraries.netty,
             libraries.netty_proxy_handler
-
+    guavaDependency 'implementation'
     // Tests depend on base class defined by core module.
     testCompile project(':grpc-core').sourceSets.test.output,
             project(':grpc-testing'),

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"
@@ -16,20 +16,22 @@ configurations {
 evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
-    compile project(':grpc-core'),
-            libraries.netty,
-            libraries.netty_proxy_handler
+    alpnagent libraries.jetty_alpn_agent
+
+    api project(':grpc-core'),
+            libraries.netty
+    implementation libraries.netty_proxy_handler
     guavaDependency 'implementation'
     perfmarkDependency 'implementation'
     // Tests depend on base class defined by core module.
-    testCompile project(':grpc-core').sourceSets.test.output,
+    testImplementation project(':grpc-core').sourceSets.test.output,
             project(':grpc-testing'),
             project(':grpc-testing-proto')
-    testRuntime libraries.netty_tcnative,
-            libraries.conscrypt,
-            libraries.netty_epoll
+    testRuntimeOnly libraries.conscrypt,
+            libraries.netty_epoll,
+            libraries.netty_tcnative
+
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
-    alpnagent libraries.jetty_alpn_agent
 }
 
 import net.ltgt.gradle.errorprone.CheckSeverity

--- a/netty/shaded/build.gradle
+++ b/netty/shaded/build.gradle
@@ -10,10 +10,10 @@ description = "gRPC: Netty Shaded"
 sourceSets { testShadow {} }
 
 dependencies {
-    compile project(':grpc-netty')
-    runtime libraries.netty_tcnative,
-            libraries.netty_epoll
-    testShadowCompile files(shadowJar),
+    implementation project(':grpc-netty')
+    runtimeOnly libraries.netty_epoll,
+            libraries.netty_tcnative
+    testShadowImplementation files(shadowJar),
             configurations.shadow,
             project(':grpc-testing-proto'),
             project(':grpc-testing'),

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"
@@ -11,19 +11,19 @@ description = "gRPC: OkHttp"
 evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
-    compile project(':grpc-core'),
-            libraries.okio
-
-    compile (libraries.okhttp) {
+    api project(':grpc-core')
+    api (libraries.okhttp) {
         // prefer our own versions instead of okhttp's dependency
         exclude group: 'com.squareup.okio', module: 'okio'
     }
+    implementation libraries.okio
     guavaDependency 'implementation'
     perfmarkDependency 'implementation'
     // Tests depend on base class defined by core module.
-    testCompile project(':grpc-core').sourceSets.test.output,
-            project(':grpc-testing'),
-            project(':grpc-netty')
+    testImplementation project(':grpc-core').sourceSets.test.output,
+            project(':grpc-netty'),
+            project(':grpc-testing')
+
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -19,6 +19,7 @@ dependencies {
         exclude group: 'com.squareup.okio', module: 'okio'
     }
     guavaDependency 'implementation'
+    perfmarkDependency 'implementation'
     // Tests depend on base class defined by core module.
     testCompile project(':grpc-core').sourceSets.test.output,
             project(':grpc-testing'),

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -18,7 +18,7 @@ dependencies {
         // prefer our own versions instead of okhttp's dependency
         exclude group: 'com.squareup.okio', module: 'okio'
     }
-
+    guavaDependency 'implementation'
     // Tests depend on base class defined by core module.
     testCompile project(':grpc-core').sourceSets.test.output,
             project(':grpc-testing'),

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -12,13 +12,7 @@ description = 'gRPC: Protobuf Lite'
 dependencies {
     compile project(':grpc-api'),
             libraries.protobuf_lite
-    compile (libraries.guava) {
-        // prefer our own versions from libraries instead of Guava's dependency
-        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
-        exclude group: 'com.google.code.findbugs', module: 'jsr305'
-        exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
-    }
-
+    guavaDependency 'implementation'
     testCompile project(':grpc-core')
 
     signature "org.codehaus.mojo.signature:java17:1.0@signature"

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "com.google.protobuf"
@@ -10,10 +10,10 @@ plugins {
 description = 'gRPC: Protobuf Lite'
 
 dependencies {
-    compile project(':grpc-api'),
+    api project(':grpc-api'),
             libraries.protobuf_lite
     guavaDependency 'implementation'
-    testCompile project(':grpc-core')
+    testImplementation project(':grpc-core')
 
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -12,13 +12,6 @@ description = 'gRPC: Protobuf'
 dependencies {
     compile project(':grpc-api'),
             libraries.protobuf
-    compile (libraries.guava) {
-        // prefer our own versions from libraries instead of Guava's dependency
-        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
-        exclude group: 'com.google.code.findbugs', module: 'jsr305'
-        exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
-    }
-
     compile (libraries.google_api_protos) {
         // 'com.google.api:api-common' transitively depends on auto-value, which breaks our
         // annotations.
@@ -30,6 +23,7 @@ dependencies {
     compile (project(':grpc-protobuf-lite')) {
         exclude group: 'com.google.protobuf', module: 'protobuf-javalite'
     }
+    guavaDependency 'implementation'
 
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
 }

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "com.google.protobuf"
@@ -10,18 +10,17 @@ plugins {
 description = 'gRPC: Protobuf'
 
 dependencies {
-    compile project(':grpc-api'),
+    api project(':grpc-api'),
             libraries.protobuf
-    compile (libraries.google_api_protos) {
+    api (project(':grpc-protobuf-lite')) {
+        exclude group: 'com.google.protobuf', module: 'protobuf-javalite'
+    }
+    api (libraries.google_api_protos) {
         // 'com.google.api:api-common' transitively depends on auto-value, which breaks our
         // annotations.
         exclude group: 'com.google.api', module: 'api-common'
-        // Prefer our more up-to-date protobuf over 3.2.0
+        // prefer our own version from libraries
         exclude group: 'com.google.protobuf', module: 'protobuf-java'
-    }
-
-    compile (project(':grpc-protobuf-lite')) {
-        exclude group: 'com.google.protobuf', module: 'protobuf-javalite'
     }
     guavaDependency 'implementation'
 

--- a/rls/build.gradle
+++ b/rls/build.gradle
@@ -9,12 +9,12 @@ description = "gRPC: RouteLookupService Loadbalancing plugin"
 evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
+    compileOnly libraries.javax_annotation
     implementation project(':grpc-core'),
             project(':grpc-protobuf'),
             project(':grpc-stub')
-    compileOnly libraries.javax_annotation
-    testCompile libraries.truth,
-            project(':grpc-core').sourceSets.test.output  // for FakeClock
+    testImplementation project(':grpc-core').sourceSets.test.output,  // for FakeClock
+            libraries.truth
 }
 
 configureProtoCompilation()

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "com.google.protobuf"
@@ -19,20 +19,21 @@ description = "gRPC: Services"
 evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
-    compile project(':grpc-protobuf'),
-            project(':grpc-stub'),
-            project(':grpc-core')
-    compile (libraries.protobuf_util) {
-        // prefer our own versions instead of protobuf-util's dependency
-        exclude group: 'com.google.guava', module: 'guava'
-        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
-    }
-
+    api project(':grpc-core'),
+            project(':grpc-protobuf'),
+            project(':grpc-stub')
     compileOnly libraries.javax_annotation
-    testCompile project(':grpc-testing'),
+    implementation (libraries.protobuf_util) {
+        // prefer our own version from grpc-stub instead of protobuf-util's dependency
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+        // prefer our own version from grpc-stub instead of protobuf-util's dependency
+        exclude group: 'com.google.guava', module: 'guava'
+    }
+    testCompileOnly libraries.javax_annotation
+    testImplementation project(':grpc-testing'),
             libraries.netty_epoll, // for DomainSocketAddress
             project(':grpc-core').sourceSets.test.output  // for FakeClock
-    testCompileOnly libraries.javax_annotation
+
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
 }
 

--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -8,7 +8,9 @@ plugins {
 
 description = "gRPC: Stub"
 dependencies {
-    compile project(':grpc-api')
+    compile project(':grpc-api'),
+            libraries.errorprone
+    guavaDependency 'compile'
     testCompile libraries.truth,
             project(':grpc-testing')
     signature "org.codehaus.mojo.signature:java17:1.0@signature"

--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"
@@ -8,11 +8,11 @@ plugins {
 
 description = "gRPC: Stub"
 dependencies {
-    compile project(':grpc-api'),
-            libraries.errorprone
-    guavaDependency 'compile'
-    testCompile libraries.truth,
-            project(':grpc-testing')
+    api project(':grpc-api')
+    guavaDependency 'api'
+    testImplementation project(':grpc-testing'),
+            libraries.truth
+            
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/testing-proto/build.gradle
+++ b/testing-proto/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "com.google.protobuf"
@@ -8,10 +8,10 @@ plugins {
 description = "gRPC: Testing Protos"
 
 dependencies {
-    compile project(':grpc-protobuf'),
+    api project(':grpc-protobuf'),
             project(':grpc-stub')
     compileOnly libraries.javax_annotation
-    testCompile libraries.truth
+    testImplementation libraries.truth
     testRuntime libraries.javax_annotation
 }
 

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"
@@ -10,19 +10,16 @@ description = "gRPC: Testing"
 evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
-    compile project(':grpc-core'),
+    api project(':grpc-core'),
             project(':grpc-stub'),
             libraries.junit
-
     censusApiDependency 'implementation'
-
-    testCompile (libraries.mockito) {
+    testImplementation project(':grpc-core').sourceSets.test.output,
+            project(':grpc-testing-proto')
+    testImplementation (libraries.mockito) {
         // prefer our own versions instead of mockito's dependency
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
-
-    testCompile project(':grpc-testing-proto'),
-            project(':grpc-core').sourceSets.test.output
 }
 
 javadoc { exclude 'io/grpc/internal/**' }

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -14,14 +14,7 @@ dependencies {
             project(':grpc-stub'),
             libraries.junit
 
-    compile (libraries.opencensus_api) {
-        // prefer 3.0.2 from libraries instead of 3.0.1
-        exclude group: 'com.google.code.findbugs', module: 'jsr305'
-        // prefer 20.0 from libraries instead of 19.0
-        exclude group: 'com.google.guava', module: 'guava'
-        // we'll always be more up-to-date
-        exclude group: 'io.grpc', module: 'grpc-context'
-    }
+    censusApiDependency 'implementation'
 
     testCompile (libraries.mockito) {
         // prefer our own versions instead of mockito's dependency

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -19,42 +19,40 @@ description = "gRPC: XDS plugin"
 evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
-    compile project(':grpc-protobuf'),
+    compileOnly libraries.javax_annotation,
+            // At runtime use the epoll included in grpc-netty-shaded
+            libraries.netty_epoll
+    implementation project(':grpc-protobuf'),
             project(':grpc-stub'),
             project(':grpc-core'),
             project(':grpc-services'),
             project(path: ':grpc-alts', configuration: 'shadow'),
             libraries.gson
-    def nettyDependency = compile project(':grpc-netty')
-
-    compile (libraries.opencensus_proto) {
-        // prefer our own versions instead of opencensus_proto's
+    def nettyDependency = implementation project(':grpc-netty')
+    implementation (libraries.opencensus_proto) {
+        // prefer our own version from grpc-protobuf instead of opencensus_proto's dependency
         exclude group: 'com.google.protobuf', module: 'protobuf-java'
+        // we'll always be more up-to-date
         exclude group: 'io.grpc', module: 'grpc-protobuf'
         exclude group: 'io.grpc', module: 'grpc-stub'
     }
-    compile (libraries.protobuf_util) {
-        // prefer our own versions instead of protobuf-util's dependency
-        exclude group: 'com.google.guava', module: 'guava'
+    implementation (libraries.protobuf_util) {
+        // prefer our own version from grpc-stub instead of protobuf-util's dependency
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+        // prefer our own version from grpc-stub instead of protobuf-util's dependency
+        exclude group: 'com.google.guava', module: 'guava'
     }
-
-    testCompile project(':grpc-core').sourceSets.test.output
-
-    compileOnly libraries.javax_annotation,
-            // At runtime use the epoll included in grpc-netty-shaded
-            libraries.netty_epoll
-    
-    testCompile project(':grpc-testing'), 
+    testImplementation project(':grpc-core').sourceSets.test.output,
+            project(':grpc-testing'), 
             project(':grpc-testing-proto'),
             libraries.guava_testlib,
             libraries.netty_epoll
+    testRuntimeOnly libraries.netty_tcnative
 
-    shadow configurations.compile.getDependencies().minus([nettyDependency])
+    shadow configurations.implementation.getDependencies().minus([nettyDependency])
     shadow project(path: ':grpc-netty-shaded', configuration: 'shadow')
 
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
-    testRuntime libraries.netty_tcnative
 }
 
 sourceSets {


### PR DESCRIPTION
- Use gradle configuration `api` for dependencies that are part of grpc public api signatures.
- Replace deprecated gradle configurations `compile`, `testCompile`, `runtime` and `testRuntime`.
- Exclude guava's transitive dependencies jsr305 and animal-sniffer-annotations, and always manually add them as runtimeOnly dependency. `error_prone_annotations` is an exception: It is also excluded but manually added not as runtimeOnly. It must always compile with guava, otherwise users will see warning spams if guava is in the compile classpath but error_prone_annotations is not (See https://github.com/google/guava/issues/2721).