### PR TITLE
Remove unused function

### DIFF
--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -161,10 +161,6 @@ static inline std::string MethodIdFieldName(const MethodDescriptor* method) {
   return "METHODID_" + ToAllUpperCase(method->name());
 }
 
-static inline bool ShouldGenerateAsLite(const Descriptor* desc) {
-  return false;
-}
-
 static inline std::string MessageFullJavaName(const Descriptor* desc) {
   return google::protobuf::compiler::java::ClassName(desc);
 }


### PR DESCRIPTION
INFO: From Compiling external/io_grpc_grpc_java/compiler/src/java_plugin/cpp/java_generator.cpp [for host]:
external/io_grpc_grpc_java/compiler/src/java_plugin/cpp/java_generator.cpp:164:20: warning: unused function 'ShouldGenerateAsLite' [-Wunused-function]
static inline bool ShouldGenerateAsLite(const Descriptor* desc) {
                   ^
1 warning generated.