### PR TITLE
xds: handle EDS update with no localities

### DIFF
--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -473,7 +473,12 @@ interface LocalityStore {
                 "Priority {0} contains localities: {1}", i, priorityTable.get(i));
           }
         }
-
+        if (priorityTable.isEmpty()) {
+          helper.updateBalancingState(
+              TRANSIENT_FAILURE,
+              new ErrorPicker(Status.UNAVAILABLE.withDescription("Received 0 locality")));
+          return;
+        }
         currentPriority = -1;
         failOver();
       }

--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -1189,10 +1189,6 @@ final class XdsClientImpl extends XdsClient {
       }
       EndpointUpdate.Builder updateBuilder = EndpointUpdate.newBuilder();
       updateBuilder.setClusterName(clusterName);
-      if (assignment.getEndpointsCount() == 0) {
-        errorMessage = "ClusterLoadAssignment " + clusterName + " : no locality endpoints.";
-        break;
-      }
       Set<Integer> priorities = new HashSet<>();
       int maxPriority = -1;
       for (io.envoyproxy.envoy.api.v2.endpoint.LocalityLbEndpoints localityLbEndpoints

--- a/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
@@ -58,6 +58,7 @@ import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.Status;
+import io.grpc.Status.Code;
 import io.grpc.SynchronizationContext;
 import io.grpc.internal.FakeClock;
 import io.grpc.internal.FakeClock.ScheduledTask;
@@ -922,6 +923,16 @@ public class LocalityStoreTest {
           .isEqualTo(
               localityInfoMap.get(localitiesBySubchannel.get(subchannel)).getLocalityWeight());
     }
+  }
+
+  @Test
+  public void updateLocalityStore_emptyEndpoints() {
+    localityStore.updateLocalityStore(Collections.<Locality, LocalityLbEndpoints>emptyMap());
+    assertThat(loadBalancers).hasSize(0);
+    ArgumentCaptor<SubchannelPicker> pickerCaptor = ArgumentCaptor.forClass(null);
+    verify(helper).updateBalancingState(eq(TRANSIENT_FAILURE), pickerCaptor.capture());
+    PickResult result = pickerCaptor.getValue().pickSubchannel(mock(PickSubchannelArgs.class));
+    assertThat(result.getStatus().getCode()).isEqualTo(Code.UNAVAILABLE);
   }
 
   @Test


### PR DESCRIPTION
Previously XdsClient sends an NACK after receiving an EDS response with 0 localities. [Updated gRFC](https://github.com/grpc/proposal/pull/174) considers such a response valid and should not be NACK. It's the LB policy's job to react (i.e., goes into TRANSIENT_FAILURE) regarding 0 localities.

The update, although contains 0 localities, should be propagated to downstream LB policies as much as possible (to the one that indeed requires endpoints/localities). Handling it too early leaves downstream policies in a half-baked state.

Mirrors https://github.com/grpc/grpc/pull/22612.

