### PR TITLE
core: Delay transport shutdown during updateAddresses()

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -114,7 +114,6 @@ final class ManagedChannelImpl extends ManagedChannel implements
 
   static final long IDLE_TIMEOUT_MILLIS_DISABLE = -1;
 
-  @VisibleForTesting
   static final long SUBCHANNEL_SHUTDOWN_DELAY_SECONDS = 5;
 
   @VisibleForTesting

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -367,6 +367,9 @@ public class ManagedChannelImplIdlenessTest {
     requestConnectionSafely(helper, subchannel);
     MockClientTransportInfo t1 = newTransports.poll();
     t1.listener.transportReady();
+
+    // Drain InternalSubchannel's delayed shutdown on updateAddresses
+    timer.forwardTime(ManagedChannelImpl.SUBCHANNEL_SHUTDOWN_DELAY_SECONDS, TimeUnit.SECONDS);
   }
 
   @Test
@@ -459,6 +462,9 @@ public class ManagedChannelImplIdlenessTest {
     oobChannel.newCall(method, CallOptions.DEFAULT).start(mockCallListener, new Metadata());
     MockClientTransportInfo t1 = newTransports.poll();
     t1.listener.transportReady();
+
+    // Drain InternalSubchannel's delayed shutdown on updateAddresses
+    timer.forwardTime(ManagedChannelImpl.SUBCHANNEL_SHUTDOWN_DELAY_SECONDS, TimeUnit.SECONDS);
   }
 
   @Test


### PR DESCRIPTION
A user has been seeing "InternalSubchannel closed transport due to address
change" errors (b/153064566). It is unclear if they are predomenent, but they
are at least adding noise. Since #2562 is still far from being generally
solved, we delay the shutdown a while to side-step the race.