### PR TITLE
Change logging level from INFO to FINE.

### DIFF
--- a/alts/src/main/java/io/grpc/alts/internal/AltsTsiHandshaker.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsTsiHandshaker.java
@@ -189,7 +189,7 @@ public final class AltsTsiHandshaker implements TsiHandshaker {
       maxFrameSize = Math.min(peerMaxFrameSize, AltsTsiFrameProtector.getMaxFrameSize());
       maxFrameSize = Math.max(AltsTsiFrameProtector.getMinFrameSize(), maxFrameSize);
     }
-    logger.log(Level.INFO, "Maximum frame size value is " + maxFrameSize);
+    logger.log(Level.FINE, "Maximum frame size value is {0}.", maxFrameSize);
     return new AltsTsiFrameProtector(maxFrameSize, new AltsChannelCrypter(key, isClient), alloc);
   }
 


### PR DESCRIPTION
In AltsTsiHandshaker.java, we log maximum frame size value. Changing the log level from INFO to FINE.