### PR TITLE
xds: allow duplicated route matcher and prefix='/' (backport to v1.29.x)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
@@ -421,6 +421,16 @@ final class EnvoyProtoData {
       return hasRegex;
     }
 
+    boolean isDefaultMatcher() {
+      if (hasRegex) {
+        return false;
+      }
+      if (!path.isEmpty()) {
+        return false;
+      }
+      return prefix.isEmpty() || prefix.equals("/");
+    }
+
     @Override
     public boolean equals(Object o) {
       if (this == o) {

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -227,14 +227,16 @@ final class XdsNameResolver extends NameResolver {
     for (Route route : routesUpdate) {
       String service = "";
       String method = "";
-      String prefix = route.getRouteMatch().getPrefix();
-      String path = route.getRouteMatch().getPath();
-      if (!prefix.isEmpty()) {
-        service = prefix.substring(1, prefix.length() - 1);
-      } else if (!path.isEmpty()) {
-        int splitIndex = path.lastIndexOf('/');
-        service = path.substring(1, splitIndex);
-        method = path.substring(splitIndex + 1);
+      if (!route.getRouteMatch().isDefaultMatcher()) {
+        String prefix = route.getRouteMatch().getPrefix();
+        String path = route.getRouteMatch().getPath();
+        if (!prefix.isEmpty()) {
+          service = prefix.substring(1, prefix.length() - 1);
+        } else if (!path.isEmpty()) {
+          int splitIndex = path.lastIndexOf('/');
+          service = path.substring(1, splitIndex);
+          method = path.substring(splitIndex + 1);
+        }
       }
       Map<String, String> methodName = ImmutableMap.of("service", service, "method", method);
       String actionName;


### PR DESCRIPTION
Backport of #6932
cherry-pick of 3bd141bf184a82a2cc92c98c906141d5b32ee88e