### PR TITLE
netty: use netty default SO_BACKLOG

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServer.java
@@ -19,7 +19,6 @@ package io.grpc.netty;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.grpc.netty.NettyServerBuilder.MAX_CONNECTION_AGE_NANOS_DISABLED;
 import static io.netty.channel.ChannelOption.ALLOCATOR;
-import static io.netty.channel.ChannelOption.SO_BACKLOG;
 import static io.netty.channel.ChannelOption.SO_KEEPALIVE;
 
 import com.google.common.base.MoreObjects;
@@ -167,7 +166,6 @@ class NettyServer implements InternalServer, InternalWithLogId {
     b.group(bossGroup, workerGroup);
     b.channelFactory(channelFactory);
     // For non-socket based channel, the option will be ignored.
-    b.option(SO_BACKLOG, 128);
     b.childOption(SO_KEEPALIVE, true);
 
     if (channelOptions != null) {


### PR DESCRIPTION
as @ejona86 pointed out, we don't need to set `SO_BACKLOG` in netty. see https://github.com/grpc/grpc-java/pull/6947#issuecomment-617301450