### PR TITLE
SECURITY.md: add instruction for disabling Conscrypt's default TrustManager

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -232,8 +232,13 @@ import java.security.Security;
 ...
 
 // Somewhere in main()
-Security.insertProviderAt(Conscrypt.newProvider(), 1);
+Security.insertProviderAt(
+    Conscrypt.newProviderBuilder().provideTrustManager(false).build(), 1);
 ```
+
+Note: according to [Conscrypt Implementation Notes](https://github.com/google/conscrypt/blob/2.4.0/IMPLEMENTATION_NOTES.md#hostname-verification),
+its default `HostnameVerifier` on OpenJDK always fails. This can be worked 
+around by disabling its default `TrustManager` implementation as shown above.
 
 ### TLS with Jetty ALPN
 


### PR DESCRIPTION
See details in https://github.com/google/conscrypt/issues/834.