### PR TITLE
buildscripts: use xds-test-server image (v1.28.x backport)

### DIFF
--- a/buildscripts/kokoro/xds.sh
+++ b/buildscripts/kokoro/xds.sh
@@ -24,6 +24,8 @@ JAVA_OPTS=-Djava.util.logging.config.file=grpc-java/buildscripts/xds_logging.pro
   python3 grpc/tools/run_tests/run_xds_tests.py \
     --test_case=all \
     --project_id=grpc-testing \
+    --source_image=projects/grpc-testing/global/images/xds-test-server \
+    --path_to_server_binary=/java_server/grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-server \
     --gcp_suffix=$(date '+%s') \
     --verbose \
     --client_cmd="grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-client \


### PR DESCRIPTION
Cherry pick of https://github.com/grpc/grpc-java/pull/6889. Speeds up runs by ~30%, saving 20 minutes of test time.