### PR TITLE
interop-testing: add --fail_on_failed_rpc flag support

### DIFF
--- a/buildscripts/kokoro/xds.sh
+++ b/buildscripts/kokoro/xds.sh
@@ -31,4 +31,5 @@ JAVA_OPTS=-Djava.util.logging.config.file=grpc-java/buildscripts/xds_logging.pro
     --client_cmd="grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-client \
       --server=xds:///{server_uri} \
       --stats_port={stats_port} \
-      --qps={qps}"
+      --qps={qps} \
+      {fail_on_failed_rpc}"


### PR DESCRIPTION
Some of the xDS test cases should not have any failed RPCs. This adds a flag that will cause the client to fail with an error if any expected RPCs fail. Support for setting the flag when appropriate is being added in https://github.com/grpc/grpc/pull/22763.