### PR TITLE
Suggested changes for supporting OSGi Remote Services

### DIFF
--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -1116,8 +1116,8 @@ static void PrintGrcpServiceInterfaceMethods(const ServiceDescriptor* service,
             continue;
         }
 
-        (*vars)["input_type"] = method->input_type()->name();
-        (*vars)["output_type"] = method->output_type()->name();
+        (*vars)["input_type"] = MessageFullJavaName(method->input_type());
+        (*vars)["output_type"] = MessageFullJavaName(method->output_type());
         (*vars)["method_name"] = method->name();
 
         p->Print(

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -1120,7 +1120,6 @@ static void PrintGrcpServiceInterfaceMethods(const ServiceDescriptor* service,
         (*vars)["output_type"] = method->output_type()->name();
         (*vars)["method_name"] = method->name();
 
-        p->Print("@Override\n");
         p->Print(
             *vars,
             "public void $method_name$($input_type$ request, StreamObserver<$output_type$> responseObserver) {\n");

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -1435,7 +1435,7 @@ std::string ServiceClassName(const google::protobuf::ServiceDescriptor* service)
 }
 
 std::string OSGiServiceClassName(const google::protobuf::ServiceDescriptor* service) {
-    return service->name();
+    return service->name() + "Intf";
 }
 
 std::string OSGiAbstractImplServiceClassName(const google::protobuf::ServiceDescriptor* service) {

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -1100,6 +1100,7 @@ static void PrintOSGiAbstractServiceInterfaceMethods(const ServiceDescriptor* se
             continue;
         }
 
+        p->Print("@Override\n");
         p->Print(
             *vars,
             "public abstract $output_type$ $method_name$($input_type$ request);\n\n");
@@ -1119,6 +1120,7 @@ static void PrintGrcpServiceInterfaceMethods(const ServiceDescriptor* service,
         (*vars)["output_type"] = method->output_type()->name();
         (*vars)["method_name"] = method->name();
 
+        p->Print("@Override\n");
         p->Print(
             *vars,
             "public void $method_name$($input_type$ request, StreamObserver<$output_type$> responseObserver) {\n");

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -1069,8 +1069,8 @@ static void PrintOSGiServiceInterfaceMethods(const ServiceDescriptor* service,
     Printer* p) {
     for (int i = 0; i < service->method_count(); i++) {
         const google::protobuf::MethodDescriptor* method = service->method(i);
-        (*vars)["input_type"] = method->input_type()->name();
-        (*vars)["output_type"] = method->output_type()->name();
+        (*vars)["input_type"] = MessageFullJavaName(method->input_type());
+        (*vars)["output_type"] = MessageFullJavaName(method->output_type());
         (*vars)["method_name"] = method->name();
         bool client_streaming = method->client_streaming();
         bool server_streaming = method->server_streaming();
@@ -1090,8 +1090,8 @@ static void PrintOSGiAbstractServiceInterfaceMethods(const ServiceDescriptor* se
     Printer* p) {
     for (int i = 0; i < service->method_count(); i++) {
         const google::protobuf::MethodDescriptor* method = service->method(i);
-        (*vars)["input_type"] = method->input_type()->name();
-        (*vars)["output_type"] = method->output_type()->name();
+        (*vars)["input_type"] = MessageFullJavaName(method->input_type());
+        (*vars)["output_type"] = MessageFullJavaName(method->output_type());
         (*vars)["method_name"] = method->name();
         bool client_streaming = method->client_streaming();
         bool server_streaming = method->server_streaming();

--- a/compiler/src/java_plugin/cpp/java_generator.h
+++ b/compiler/src/java_plugin/cpp/java_generator.h
@@ -62,11 +62,29 @@ std::string ServiceJavaPackage(const google::protobuf::FileDescriptor* file);
 // the given service.
 std::string ServiceClassName(const google::protobuf::ServiceDescriptor* service);
 
+// Returns the name of the outer class that wraps in all the generated code for
+// the given service.
+std::string OSGiServiceClassName(const google::protobuf::ServiceDescriptor* service);
+
+std::string OSGiAbstractImplServiceClassName(const google::protobuf::ServiceDescriptor* service);
+
 // Writes the generated service interface into the given ZeroCopyOutputStream
 void GenerateService(const google::protobuf::ServiceDescriptor* service,
                      google::protobuf::io::ZeroCopyOutputStream* out,
                      ProtoFlavor flavor,
                      bool disable_version);
+
+// Writes the generated service interface into the given ZeroCopyOutputStream
+void GenerateOSGiService(const google::protobuf::ServiceDescriptor* service,
+    google::protobuf::io::ZeroCopyOutputStream* out,
+    ProtoFlavor flavor,
+    bool disable_version);
+
+// Writes the generated abstract class into the given ZeroCopyOutputStream
+void GenerateOSGiAbstractImplService(const google::protobuf::ServiceDescriptor* service,
+    google::protobuf::io::ZeroCopyOutputStream* out,
+    ProtoFlavor flavor,
+    bool disable_version);
 
 }  // namespace java_grpc_generator
 

--- a/compiler/src/java_plugin/cpp/java_plugin.cpp
+++ b/compiler/src/java_plugin/cpp/java_plugin.cpp
@@ -73,6 +73,27 @@ class JavaGrpcGenerator : public google::protobuf::compiler::CodeGenerator {
       java_grpc_generator::GenerateService(
           service, output.get(), flavor, disable_version);
     }
+
+    // generate service interface (OSGi)
+    for (int i = 0; i < file->service_count(); ++i) {
+        const google::protobuf::ServiceDescriptor* service = file->service(i);
+        std:string filename = package_filename + java_grpc_generator::OSGiServiceClassName(service) + ".java";
+        std::unique_ptr<google::protobuf::io::ZeroCopyOutputStream> output(
+            context->Open(filename));
+        java_grpc_generator::GenerateOSGiService(
+            service, output.get(), flavor, disable_version);
+    }
+
+    // generate abstract impl class 
+    for (int i = 0; i < file->service_count(); ++i) {
+        const google::protobuf::ServiceDescriptor* service = file->service(i);
+    std::string filename = package_filename + java_grpc_generator::OSGiAbstractImplServiceClassName(service) + ".java";
+        std::unique_ptr<google::protobuf::io::ZeroCopyOutputStream> output(
+            context->Open(filename));
+        java_grpc_generator::GenerateOSGiAbstractImplService(
+            service, output.get(), flavor, disable_version);
+    }
+
     return true;
   }
 };


### PR DESCRIPTION
Added methods in java_generator.h/.cpp for generating two new types:

GenerateOSGiService - Generates interface class(s) (in java_package
directory) that has the same name as the rpc declaration in the
protofile.  For example:

```
service HealthCheck {
  rpc check(HealthCheckRequest) returns (HealthCheckResponse);
}
```

along with all the other classes normally generated by grcp plugin it would generate a HealthCheck service interface class:

```
package io.grpc.health.v1;

public interface HealthCheck {

    public HealthCheckResponse check(HealthCheckRequest request);

}
```

Note that only blocking method calls (not streaming) are included in the
interface.

GenerateOSGiAbstractImplService generates an abstract impl class that
implements the (e.g.) HealthCheck interface, with naming convention
Abstract<service name>Impl:

```
package io.grpc.health.v1;

import io.grpc.stub.StreamObserver;

public abstract class AbstractHealthCheckImpl extends
HealthCheckGrpc.HealthCheckImplBase implements HealthCheck {

    public abstract HealthCheckResponse check(HealthCheckRequest
request);

    public void check(HealthCheckRequest request,
StreamObserver<HealthCheckResponse> responseObserver) {
        responseObserver.onNext(check(request));
        responseObserver.onCompleted();
    }
}
```

Note that the impl of the grcp check/2 method calls the service
interface method check/1.

With the service interface method and the abstract service impl class,
it is easy for a remote service to be created as all that is needed is
to provide implementation for check/1 method in subclass.  Consumers of
the remote service use the interface only.