### PR TITLE
xds: add onResourceDoesNotExist API for resource watchers

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -390,36 +390,48 @@ abstract class XdsClient {
   }
 
   /**
+   * Watcher interface for a single requested xDS resource.
+   */
+  private interface ResourceWatcher {
+
+    /**
+     * Called when the resource discovery RPC encounters some transient error.
+     */
+    void onError(Status error);
+
+    /**
+     * Called when the requested resource is not available.
+     *
+     * @param resourceName name of the resource requested in discovery request.
+     */
+    void onResourceDoesNotExist(String resourceName);
+  }
+
+  /**
    * Config watcher interface. To be implemented by the xDS resolver.
    */
-  interface ConfigWatcher {
+  interface ConfigWatcher extends ResourceWatcher {
 
     /**
      * Called when receiving an update on virtual host configurations.
      */
     void onConfigChanged(ConfigUpdate update);
-
-    void onError(Status error);
   }
 
   /**
    * Cluster watcher interface.
    */
-  interface ClusterWatcher {
+  interface ClusterWatcher extends ResourceWatcher {
 
     void onClusterChanged(ClusterUpdate update);
-
-    void onError(Status error);
   }
 
   /**
    * Endpoint watcher interface.
    */
-  interface EndpointWatcher {
+  interface EndpointWatcher extends ResourceWatcher {
 
     void onEndpointChanged(EndpointUpdate update);
-
-    void onError(Status error);
   }
 
   /**

--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -437,14 +437,12 @@ abstract class XdsClient {
   /**
    * Listener watcher interface. To be used by {@link io.grpc.xds.internal.sds.XdsServerBuilder}.
    */
-  interface ListenerWatcher {
+  interface ListenerWatcher extends ResourceWatcher {
 
     /**
      * Called when receiving an update on Listener configuration.
      */
     void onListenerChanged(ListenerUpdate update);
-
-    void onError(Status error);
   }
 
   /**

--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -721,8 +721,7 @@ final class XdsClientImpl extends XdsClient {
       listenerWatcher.onListenerChanged(listenerUpdate);
     } else {
       if (ldsRespTimer == null) {
-        listenerWatcher.onError(Status.NOT_FOUND.withDescription("did not find listener for "
-            + listenerPort));
+        listenerWatcher.onResourceDoesNotExist(":" + listenerPort);
       }
     }
   }
@@ -1618,9 +1617,7 @@ final class XdsClientImpl extends XdsClient {
     public void run() {
       super.run();
       ldsRespTimer = null;
-      listenerWatcher.onError(
-          Status.NOT_FOUND
-              .withDescription("Listener resource for port " + resourceName + " not found."));
+      listenerWatcher.onResourceDoesNotExist(resourceName);
     }
   }
 

--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -286,10 +286,7 @@ final class XdsClientImpl extends XdsClient {
     // If local cache contains cluster information to be watched, notify the watcher immediately.
     if (absentCdsResources.contains(clusterName)) {
       logger.log(XdsLogLevel.DEBUG, "Cluster resource {0} is known to be absent", clusterName);
-      watcher.onError(
-          Status.NOT_FOUND
-              .withDescription(
-                  "Cluster resource [" + clusterName + "] not found."));
+      watcher.onResourceDoesNotExist(clusterName);
       return;
     }
     if (clusterNamesToClusterUpdates.containsKey(clusterName)) {
@@ -365,10 +362,7 @@ final class XdsClientImpl extends XdsClient {
       logger.log(
           XdsLogLevel.DEBUG,
           "Endpoint resource for cluster {0} is known to be absent.", clusterName);
-      watcher.onError(
-          Status.NOT_FOUND
-              .withDescription(
-                  "Endpoint resource for cluster " + clusterName + " not found."));
+      watcher.onResourceDoesNotExist(clusterName);
       return;
     }
     if (clusterNamesToEndpointUpdates.containsKey(clusterName)) {
@@ -686,11 +680,8 @@ final class XdsClientImpl extends XdsClient {
     } else {
       // The requested Listener is removed by management server.
       if (ldsRespTimer == null) {
-        configWatcher.onError(
-            Status.NOT_FOUND.withDescription(
-                "Listener resource for listener " + ldsResourceName + " does not exist"));
+        configWatcher.onResourceDoesNotExist(ldsResourceName);
       }
-
     }
   }
 
@@ -1093,10 +1084,7 @@ final class XdsClientImpl extends XdsClient {
         if (endpointWatchers.containsKey(clusterName)) {
           Set<EndpointWatcher> watchers = endpointWatchers.get(clusterName);
           for (EndpointWatcher watcher : watchers) {
-            watcher.onError(
-                Status.NOT_FOUND
-                    .withDescription(
-                        "Endpoint resource for cluster " + clusterName + " is deleted."));
+            watcher.onResourceDoesNotExist(clusterName);
           }
         }
       }
@@ -1121,9 +1109,7 @@ final class XdsClientImpl extends XdsClient {
       } else if (!cdsRespTimers.containsKey(clusterName)) {
         // Update for previously present resource being removed.
         for (ClusterWatcher watcher : entry.getValue()) {
-          watcher.onError(
-              Status.NOT_FOUND
-                  .withDescription("Cluster resource " + clusterName + " not found."));
+          watcher.onResourceDoesNotExist(entry.getKey());
         }
       }
     }
@@ -1617,9 +1603,7 @@ final class XdsClientImpl extends XdsClient {
     public void run() {
       super.run();
       ldsRespTimer = null;
-      configWatcher.onError(
-          Status.NOT_FOUND
-              .withDescription("Listener resource for listener " + resourceName + " not found."));
+      configWatcher.onResourceDoesNotExist(resourceName);
     }
   }
 
@@ -1651,9 +1635,7 @@ final class XdsClientImpl extends XdsClient {
     public void run() {
       super.run();
       rdsRespTimer = null;
-      configWatcher.onError(Status.NOT_FOUND
-          .withDescription(
-              "RouteConfiguration resource for route " + resourceName + " not found."));
+      configWatcher.onResourceDoesNotExist(resourceName);
     }
   }
 
@@ -1670,9 +1652,7 @@ final class XdsClientImpl extends XdsClient {
       cdsRespTimers.remove(resourceName);
       absentCdsResources.add(resourceName);
       for (ClusterWatcher wat : clusterWatchers.get(resourceName)) {
-        wat.onError(
-            Status.NOT_FOUND
-                .withDescription("Cluster resource " + resourceName + " not found."));
+        wat.onResourceDoesNotExist(resourceName);
       }
     }
   }
@@ -1690,10 +1670,7 @@ final class XdsClientImpl extends XdsClient {
       edsRespTimers.remove(resourceName);
       absentEdsResources.add(resourceName);
       for (EndpointWatcher wat : endpointWatchers.get(resourceName)) {
-        wat.onError(
-            Status.NOT_FOUND
-                .withDescription(
-                    "Endpoint resource for cluster " + resourceName + " not found."));
+        wat.onResourceDoesNotExist(resourceName);
       }
     }
   }

--- a/xds/src/main/java/io/grpc/xds/XdsClientWrapperForServerSds.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientWrapperForServerSds.java
@@ -131,12 +131,13 @@ public final class XdsClientWrapperForServerSds {
           }
 
           @Override
+          public void onResourceDoesNotExist(String resourceName) {
+            logger.log(Level.INFO, "Resource {0} is unavailable", resourceName);
+            curListener = null;
+          }
+
+          @Override
           public void onError(Status error) {
-            // In order to distinguish between IO error and resource not found, set curListener
-            // to null in case of NOT_FOUND
-            if (error.getCode().equals(Status.Code.NOT_FOUND)) {
-              curListener = null;
-            }
             // TODO(sanjaypujare): Implement logic for other cases based on final design.
             logger.log(Level.SEVERE, "ListenerWatcher in XdsClientWrapperForServerSds: {0}", error);
           }

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTestForListener.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTestForListener.java
@@ -338,12 +338,10 @@ public class XdsClientImplTestForListener {
             XdsClientImpl.ADS_TYPE_URL_LDS, "0000")));
 
     verify(listenerWatcher, never()).onListenerChanged(any(ListenerUpdate.class));
+    verify(listenerWatcher, never()).onResourceDoesNotExist(":" + PORT);
     verify(listenerWatcher, never()).onError(any(Status.class));
     fakeClock.forwardTime(XdsClientImpl.INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
-    ArgumentCaptor<Status> errorStatusCaptor = ArgumentCaptor.forClass(null);
-    verify(listenerWatcher).onError(errorStatusCaptor.capture());
-    Status error = errorStatusCaptor.getValue();
-    assertThat(error.getCode()).isEqualTo(Code.NOT_FOUND);
+    verify(listenerWatcher).onResourceDoesNotExist(":" + PORT);
     assertThat(fakeClock.getPendingTasks(LISTENER_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
   }
 
@@ -391,12 +389,10 @@ public class XdsClientImplTestForListener {
             XdsClientImpl.ADS_TYPE_URL_LDS, "0000")));
 
     verify(listenerWatcher, never()).onListenerChanged(any(ListenerUpdate.class));
+    verify(listenerWatcher, never()).onResourceDoesNotExist(":" + PORT);
     verify(listenerWatcher, never()).onError(any(Status.class));
     fakeClock.forwardTime(XdsClientImpl.INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
-    ArgumentCaptor<Status> errorStatusCaptor = ArgumentCaptor.forClass(null);
-    verify(listenerWatcher).onError(errorStatusCaptor.capture());
-    Status error = errorStatusCaptor.getValue();
-    assertThat(error.getCode()).isEqualTo(Code.NOT_FOUND);
+    verify(listenerWatcher).onResourceDoesNotExist(":" + PORT);
     assertThat(fakeClock.getPendingTasks(LISTENER_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
   }
 
@@ -443,7 +439,6 @@ public class XdsClientImplTestForListener {
         .onNext(eq(buildDiscoveryRequest(getNodeToVerify(), "0",
             XdsClientImpl.ADS_TYPE_URL_LDS, "0000")));
 
-    verify(listenerWatcher, never()).onError(any(Status.class));
     ArgumentCaptor<ListenerUpdate> listenerUpdateCaptor = ArgumentCaptor.forClass(null);
     verify(listenerWatcher, times(1)).onListenerChanged(listenerUpdateCaptor.capture());
     ListenerUpdate configUpdate = listenerUpdateCaptor.getValue();
@@ -501,7 +496,6 @@ public class XdsClientImplTestForListener {
         .onNext(eq(buildDiscoveryRequest(getNodeToVerify(), "0",
             XdsClientImpl.ADS_TYPE_URL_LDS, "0000")));
 
-    verify(listenerWatcher, never()).onError(any(Status.class));
     ArgumentCaptor<ListenerUpdate> listenerUpdateCaptor = ArgumentCaptor.forClass(null);
     verify(listenerWatcher, times(1)).onListenerChanged(listenerUpdateCaptor.capture());
 
@@ -632,8 +626,12 @@ public class XdsClientImplTestForListener {
         .onNext(eq(buildDiscoveryRequest(getNodeToVerify(), "0",
             XdsClientImpl.ADS_TYPE_URL_LDS, "0000")));
 
-    verify(listenerWatcher, never()).onError(any(Status.class));
     verify(listenerWatcher, never()).onListenerChanged(any(ListenerUpdate.class));
+    verify(listenerWatcher, never()).onResourceDoesNotExist(":" + PORT);
+    verify(listenerWatcher, never()).onError(any(Status.class));
+    fakeClock.forwardTime(XdsClientImpl.INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
+    verify(listenerWatcher).onResourceDoesNotExist(":" + PORT);
+    assertThat(fakeClock.getPendingTasks(LISTENER_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
   }
 
   /**

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -290,7 +290,8 @@ public class XdsNameResolverTest {
     verify(mockListener).onResult(resolutionResultCaptor.capture());
     ResolutionResult result = resolutionResultCaptor.getValue();
     assertThat(result.getAddresses()).isEmpty();
-    assertThat(result.getServiceConfig()).isNull();
+    assertThat(result.getServiceConfig().getConfig()).isNull();
+    assertThat(result.getServiceConfig().getError().getCode()).isEqualTo(Code.UNAVAILABLE);
   }
 
   @Test


### PR DESCRIPTION
Use `onResourceDoesNotExist()` API for notifying resource not found. Previously, it uses `onError()`, which mixes with errors for failures.

LB policies should go into TRANSIENT_FAILURE immediately after being notified with `onResourceDoesNotExist()`, even if its existing resource is working well. However, this is blocked by a TD's bug during resource transition. So currently, we still keep using the existing resource when even if it is removed.