### PR TITLE
Replace javax.annotation-api with Tomcat's annotations-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,7 @@ subprojects {
             gson: "com.google.code.gson:gson:2.8.6",
             guava: "com.google.guava:guava:${guavaVersion}",
             hpack: 'com.twitter:hpack:0.10.1',
-            javax_annotation: 'javax.annotation:javax.annotation-api:1.2',
+            javax_annotation: 'org.apache.tomcat:annotations-api:6.0.53',
             jsr305: 'com.google.code.findbugs:jsr305:3.0.2',
             google_api_protos: 'com.google.api.grpc:proto-google-common-protos:1.17.0',
             google_auth_credentials: "com.google.auth:google-auth-library-credentials:${googleauthVersion}",

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation 'io.grpc:grpc-okhttp:1.30.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'io.grpc:grpc-protobuf-lite:1.30.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'io.grpc:grpc-stub:1.30.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'javax.annotation:javax.annotation-api:1.2'
+    implementation 'org.apache.tomcat:annotations-api:6.0.53'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.google.truth:truth:1.0.1'

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -52,5 +52,5 @@ dependencies {
     implementation 'io.grpc:grpc-okhttp:1.30.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'io.grpc:grpc-protobuf-lite:1.30.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'io.grpc:grpc-stub:1.30.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'javax.annotation:javax.annotation-api:1.2'
+    implementation 'org.apache.tomcat:annotations-api:6.0.53'
 }

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -51,5 +51,5 @@ dependencies {
     implementation 'io.grpc:grpc-okhttp:1.30.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'io.grpc:grpc-protobuf-lite:1.30.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'io.grpc:grpc-stub:1.30.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'javax.annotation:javax.annotation-api:1.2'
+    implementation 'org.apache.tomcat:annotations-api:6.0.53'
 }

--- a/examples/android/strictmode/app/build.gradle
+++ b/examples/android/strictmode/app/build.gradle
@@ -52,5 +52,5 @@ dependencies {
     implementation 'io.grpc:grpc-okhttp:1.30.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'io.grpc:grpc-protobuf-lite:1.30.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'io.grpc:grpc-stub:1.30.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'javax.annotation:javax.annotation-api:1.2'
+    implementation 'org.apache.tomcat:annotations-api:6.0.53'
 }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -29,7 +29,7 @@ def protocVersion = protobufVersion
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
-    compileOnly "javax.annotation:javax.annotation-api:1.2"
+    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
 
     // examples/advanced need this for JsonFormat
     implementation "com.google.protobuf:protobuf-java-util:${protobufVersion}"

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -29,7 +29,7 @@ def protocVersion = '3.11.0'
 dependencies {
     // grpc-alts transitively depends on grpc-netty-shaded, grpc-protobuf, and grpc-stub
     implementation "io.grpc:grpc-alts:${grpcVersion}"
-    compileOnly "javax.annotation:javax.annotation-api:1.2"
+    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
 }
 
 protobuf {

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-auth:${grpcVersion}"
-    compileOnly "javax.annotation:javax.annotation-api:1.2"
+    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
     implementation "com.google.auth:google-auth-library-oauth2-http:0.9.0"
     implementation "com.google.api.grpc:grpc-google-cloud-pubsub-v1:0.1.24"
     runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -50,9 +50,9 @@
       <artifactId>grpc-auth</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>1.2</version>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>annotations-api</artifactId>
+      <version>6.0.53</version>
       <scope>provided</scope> <!-- not needed at runtime -->
     </dependency>
     <dependency>

--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-services:${grpcVersion}"
-    compileOnly "javax.annotation:javax.annotation-api:1.2"
+    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
     runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
     testImplementation 'junit:junit:4.12'

--- a/examples/example-hostname/pom.xml
+++ b/examples/example-hostname/pom.xml
@@ -45,9 +45,9 @@
       <artifactId>grpc-services</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>1.2</version>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>annotations-api</artifactId>
+      <version>6.0.53</version>
       <scope>provided</scope> <!-- not needed at runtime -->
     </dependency>
     <dependency>

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation "io.jsonwebtoken:jjwt:0.9.1"
     implementation "javax.xml.bind:jaxb-api:2.3.1"
 
-    compileOnly "javax.annotation:javax.annotation-api:1.2"
+    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
 
     runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
 

--- a/examples/example-jwt-auth/pom.xml
+++ b/examples/example-jwt-auth/pom.xml
@@ -58,9 +58,9 @@
       <version>2.3.1</version>
     </dependency>
     <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>1.2</version>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>annotations-api</artifactId>
+      <version>6.0.53</version>
       <scope>provided</scope> <!-- not needed at runtime -->
     </dependency>
     <dependency>

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation "io.grpc:grpc-netty:${grpcVersion}"
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
-    compileOnly "javax.annotation:javax.annotation-api:1.2"
+    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
     runtimeOnly "io.netty:netty-tcnative-boringssl-static:${nettyTcNativeVersion}"
 }
 

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -42,9 +42,9 @@
       <artifactId>grpc-stub</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>1.2</version>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>annotations-api</artifactId>
+      <version>6.0.53</version>
       <scope>provided</scope> <!-- not needed at runtime -->
     </dependency>
     <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -47,9 +47,9 @@
       <artifactId>grpc-stub</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>1.2</version>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>annotations-api</artifactId>
+      <version>6.0.53</version>
       <scope>provided</scope> <!-- not needed at runtime -->
     </dependency>
     <dependency>

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -39,9 +39,9 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "io.opencensus:opencensus-api:0.24.0",
     "io.opencensus:opencensus-contrib-grpc-metrics:0.24.0",
     "io.perfmark:perfmark-api:0.19.0",
-    "javax.annotation:javax.annotation-api:1.2",
     "junit:junit:4.12",
     "org.apache.commons:commons-lang3:3.5",
+    "org.apache.tomcat:annotations-api:6.0.53",
     "org.codehaus.mojo:animal-sniffer-annotations:1.18",
 ]
 
@@ -148,12 +148,12 @@ def grpc_java_repositories():
         io_opencensus_opencensus_contrib_grpc_metrics()
     if not native.existing_rule("io_perfmark_perfmark_api"):
         io_perfmark_perfmark_api()
-    if not native.existing_rule("javax_annotation_javax_annotation_api"):
-        javax_annotation_javax_annotation_api()
     if not native.existing_rule("junit_junit"):
         junit_junit()
     if not native.existing_rule("org_apache_commons_commons_lang3"):
         org_apache_commons_commons_lang3()
+    if not native.existing_rule("org_apache_tomcat_annotations_api"):
+        org_apache_tomcat_annotations_api()
     if not native.existing_rule("org_codehaus_mojo_animal_sniffer_annotations"):
         org_codehaus_mojo_animal_sniffer_annotations()
 
@@ -451,16 +451,6 @@ def io_perfmark_perfmark_api():
         licenses = ["notice"],  # Apache 2.0
     )
 
-def javax_annotation_javax_annotation_api():
-    # Use //stub:javax_annotation for neverlink=1 support.
-    jvm_maven_import_external(
-        name = "javax_annotation_javax_annotation_api",
-        artifact = "javax.annotation:javax.annotation-api:1.2",
-        server_urls = ["https://repo.maven.apache.org/maven2/"],
-        artifact_sha256 = "5909b396ca3a2be10d0eea32c74ef78d816e1b4ead21de1d78de1f890d033e04",
-        licenses = ["reciprocal"],  # CDDL License
-    )
-
 def junit_junit():
     jvm_maven_import_external(
         name = "junit_junit",
@@ -476,6 +466,16 @@ def org_apache_commons_commons_lang3():
         artifact = "org.apache.commons:commons-lang3:3.5",
         server_urls = ["https://repo.maven.apache.org/maven2/"],
         artifact_sha256 = "8ac96fc686512d777fca85e144f196cd7cfe0c0aec23127229497d1a38ff651c",
+        licenses = ["notice"],  # Apache 2.0
+    )
+
+def org_apache_tomcat_annotations_api():
+    # Use //stub:javax_annotation for neverlink=1 support.
+    jvm_maven_import_external(
+        name = "org_apache_tomcat_annotations_api",
+        artifact = "org.apache.tomcat:annotations-api:6.0.53",
+        server_urls = ["https://repo.maven.apache.org/maven2/"],
+        artifact_sha256 = "253829d3c12b7381d1044fc22c6436cff025fe0d459e4a329413e560a7d0dd13",
         licenses = ["notice"],  # Apache 2.0
     )
 

--- a/services/BUILD.bazel
+++ b/services/BUILD.bazel
@@ -60,7 +60,6 @@ java_library(
         "@com_google_protobuf//:protobuf_java",
         "@com_google_protobuf//:protobuf_java_util",
         "@io_grpc_grpc_proto//:reflection_java_proto_deprecated",
-        "@javax_annotation_javax_annotation_api//jar",
     ],
 )
 

--- a/stub/BUILD.bazel
+++ b/stub/BUILD.bazel
@@ -19,5 +19,5 @@ java_library(
     name = "javax_annotation",
     neverlink = 1,  # @Generated is source-retention
     visibility = ["//visibility:public"],
-    exports = ["@javax_annotation_javax_annotation_api//jar"],
+    exports = ["@org_apache_tomcat_annotations_api//jar"],
 )


### PR DESCRIPTION
javax.annotation-api is licensed CDDL, which was not noticed when it was
introduced. Tomcat provides an Apache 2 version of the same annotation. Note
that this annotation is only used when compiling with Java 9+.

Unfortunately this may cause classpath collisions since there are _many_ copies
of this annotation on Maven Central; we wanted one canonical source and
javax.annotation-api seemed like that source. We hope this won't impact many
users since we have always suggested using it only for compilation. But it will
probably impact some users. However, we didn't create this mess, this seems to
be "standard practice" for J2EE, which this annotation is now part of, so we're
just impacted by it.

Fixes #6833

----

CC @ulfjack