### PR TITLE
all: introduce gradle util functions to manage guava dependency

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -15,12 +15,7 @@ dependencies {
             libraries.errorprone,
             libraries.jsr305,
             libraries.animalsniffer_annotations
-    compile (libraries.guava) {
-        // prefer our own versions from libraries instead of Guava's dependency
-        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
-        exclude group: 'com.google.code.findbugs', module: 'jsr305'
-        exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
-    }
+    guavaDependency 'compile'
 
     testCompile project(':grpc-context').sourceSets.test.output,
             project(':grpc-testing'),

--- a/build.gradle
+++ b/build.gradle
@@ -185,6 +185,57 @@ subprojects {
             // Jetty ALPN dependencies
             jetty_alpn_agent: 'org.mortbay.jetty.alpn:jetty-alpn-agent:2.0.9'
         ]
+
+        // A util function to config guava dependency with transitive dependencies
+        // properly resolved for the failOnVersionConflict strategy.
+        guavaDependency = { configurationName ->
+            dependencies."$configurationName"(libraries.guava) {
+                exclude group: 'com.google.code.findbugs', module: 'jsr305'
+                exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+                exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
+            }
+            dependencies."$configurationName" libraries.errorprone
+            dependencies.runtimeOnly libraries.animalsniffer_annotations
+            dependencies.runtimeOnly libraries.jsr305
+        }
+
+        // A util function to config opencensus_api dependency with transitive
+        // dependencies properly resolved for the failOnVersionConflict strategy.
+        censusApiDependency = { configurationName ->
+            dependencies."$configurationName"(libraries.opencensus_api) {
+                exclude group: 'com.google.code.findbugs', module: 'jsr305'
+                exclude group: 'com.google.guava', module: 'guava'
+                // we'll always be more up-to-date
+                exclude group: 'io.grpc', module: 'grpc-context'
+            }
+            dependencies.runtimeOnly project(':grpc-context')
+            dependencies.runtimeOnly libraries.jsr305
+            guavaDependency 'runtimeOnly'
+        }
+
+        // A util function to config opencensus_contrib_grpc_metrics dependency
+        // with transitive dependencies properly resolved for the failOnVersionConflict
+        // strategy.
+        censusGrpcMetricDependency = { configurationName ->
+            dependencies."$configurationName"(libraries.opencensus_contrib_grpc_metrics) {
+                exclude group: 'com.google.code.findbugs', module: 'jsr305'
+                exclude group: 'com.google.guava', module: 'guava'
+                // we'll always be more up-to-date
+                exclude group: 'io.grpc', module: 'grpc-context'
+            }
+            dependencies.runtimeOnly project(':grpc-context')
+            dependencies.runtimeOnly libraries.jsr305
+            guavaDependency 'runtimeOnly'
+        }
+
+        // A util function to config perfmark dependency with transitive
+        // dependencies properly resolved for the failOnVersionConflict strategy.
+        perfmarkDependency = { configurationName ->
+            dependencies."$configurationName"(libraries.perfmark) {
+                exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+            }
+            dependencies.runtimeOnly libraries.errorprone
+        }
     }
 
     // Define a separate configuration for managing the dependency on Jetty ALPN agent.

--- a/census/build.gradle
+++ b/census/build.gradle
@@ -9,24 +9,9 @@ evaluationDependsOn(project(':grpc-api').path)
 
 dependencies {
     compile project(':grpc-api')
-            
-    compile (libraries.opencensus_api) {
-        // prefer 3.0.2 from libraries instead of 3.0.1
-        exclude group: 'com.google.code.findbugs', module: 'jsr305'
-        // prefer 20.0 from libraries instead of 19.0
-        exclude group: 'com.google.guava', module: 'guava'
-        // we'll always be more up-to-date
-        exclude group: 'io.grpc', module: 'grpc-context'
-    }
-    
-    compile (libraries.opencensus_contrib_grpc_metrics) {
-        // prefer 3.0.2 from libraries instead of 3.0.1
-        exclude group: 'com.google.code.findbugs', module: 'jsr305'
-        // we'll always be more up-to-date
-        exclude group: 'io.grpc', module: 'grpc-context'
-        // prefer 20.0 from libraries instead of 19.0
-        exclude group: 'com.google.guava', module: 'guava'
-    }
+
+    censusApiDependency 'compile'
+    censusGrpcMetricDependency 'compile'
 
     testCompile project(':grpc-api').sourceSets.test.output,
             project(':grpc-context').sourceSets.test.output,

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -17,10 +17,7 @@ dependencies {
             libraries.gson,
             libraries.android_annotations,
             libraries.errorprone // prefer our version to perfmark's 2.3.3
-    compile (libraries.perfmark) {
-        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
-    }
-
+    perfmarkDependency 'compile'
     testCompile project(':grpc-context').sourceSets.test.output,
             project(':grpc-api').sourceSets.test.output,
             project(':grpc-testing'),

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -12,12 +12,7 @@ description = 'gRPC: Protobuf Lite'
 dependencies {
     compile project(':grpc-api'),
             libraries.protobuf_lite
-    compile (libraries.guava) {
-        // prefer our own versions from libraries instead of Guava's dependency
-        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
-        exclude group: 'com.google.code.findbugs', module: 'jsr305'
-        exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
-    }
+    guavaDependency 'compile'
 
     testCompile project(':grpc-core')
 

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -12,12 +12,7 @@ description = 'gRPC: Protobuf'
 dependencies {
     compile project(':grpc-api'),
             libraries.protobuf
-    compile (libraries.guava) {
-        // prefer our own versions from libraries instead of Guava's dependency
-        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
-        exclude group: 'com.google.code.findbugs', module: 'jsr305'
-        exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
-    }
+    guavaDependency 'compile'
 
     compile (libraries.google_api_protos) {
         // 'com.google.api:api-common' transitively depends on auto-value, which breaks our

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -14,14 +14,7 @@ dependencies {
             project(':grpc-stub'),
             libraries.junit
 
-    compile (libraries.opencensus_api) {
-        // prefer 3.0.2 from libraries instead of 3.0.1
-        exclude group: 'com.google.code.findbugs', module: 'jsr305'
-        // prefer 20.0 from libraries instead of 19.0
-        exclude group: 'com.google.guava', module: 'guava'
-        // we'll always be more up-to-date
-        exclude group: 'io.grpc', module: 'grpc-context'
-    }
+    censusApiDependency 'compile'
 
     testCompile (libraries.mockito) {
         // prefer our own versions instead of mockito's dependency


### PR DESCRIPTION
Define util function to exclude guava's transitive dependencies jsr305 and animal-sniffer-annotations, and always manually add them as runtimeOnly dependency. error_prone_annotations is an exception: It is also excluded but manually added not as runtimeOnly. It must always compile with guava, otherwise users will see warning spams if guava is in the compile classpath but error_prone_annotations is not.