### PR TITLE
all: migrate gradle build to java-library plugin

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -31,7 +31,7 @@ for (subproject in rootProject.subprojects) {
 }
 
 dependencies {
-    compile subprojects.minus(project(':grpc-protobuf-lite'))
+    implementation subprojects.minus(project(':grpc-protobuf-lite'))
 }
 
 javadoc {

--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "com.github.johnrengelman.shadow"
@@ -13,34 +13,35 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-    compile project(':grpc-auth'),
-            project(':grpc-core'),
+    api project(':grpc-core')
+    implementation project(':grpc-auth'),
             project(':grpc-grpclb'),
             project(':grpc-protobuf'),
             project(':grpc-stub'),
             libraries.lang,
             libraries.protobuf,
             libraries.conscrypt
-    def nettyDependency = compile project(':grpc-netty')
-    compile (libraries.google_auth_oauth2_http) {
+    def nettyDependency = implementation project(':grpc-netty')
+    implementation (libraries.google_auth_oauth2_http) {
         // prefer our own versions instead of google-auth-oauth2-http's dependency
         exclude group: 'com.google.guava', module: 'guava'
         // we'll always be more up-to-date
         exclude group: 'io.grpc', module: 'grpc-context'
     }
+    guavaDependency 'implementation'
     compileOnly libraries.javax_annotation
 
-    shadow configurations.compile.getDependencies().minus(nettyDependency)
+    shadow configurations.implementation.getDependencies().minus(nettyDependency)
     shadow project(path: ':grpc-netty-shaded', configuration: 'shadow')
 
-    testCompile project(':grpc-testing'),
+    testImplementation project(':grpc-testing'),
             project(':grpc-testing-proto'),
             libraries.guava,
             libraries.guava_testlib,
             libraries.junit,
             libraries.mockito,
             libraries.truth
-    testRuntime libraries.netty_tcnative,
+    testRuntimeOnly libraries.netty_tcnative,
             libraries.netty_epoll
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }

--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     implementation (libraries.google_auth_oauth2_http) {
         exclude group: 'org.apache.httpcomponents'
     }
+    censusGrpcMetricDependency 'implementation'
 
     compileOnly libraries.javax_annotation
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ repositories {
 
 dependencies {
     implementation project(':grpc-core')
-
+    guavaDependency 'implementation'
     testImplementation project('::grpc-okhttp')
     testImplementation libraries.androidx_test
     testImplementation libraries.junit

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,7 @@ repositories {
 }
 
 dependencies {
-    implementation project(':grpc-core')
+    api project(':grpc-core')
     guavaDependency 'implementation'
     testImplementation project('::grpc-okhttp')
     testImplementation libraries.androidx_test

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "me.champeau.gradle.jmh"
@@ -11,13 +11,11 @@ description = 'gRPC: API'
 evaluationDependsOn(project(':grpc-context').path)
 
 dependencies {
-    compile project(':grpc-context'),
-            libraries.errorprone,
-            libraries.jsr305,
-            libraries.animalsniffer_annotations
-    guavaDependency 'compile'
+    api project(':grpc-context'),
+            libraries.jsr305
+    guavaDependency 'implementation'
 
-    testCompile project(':grpc-context').sourceSets.test.output,
+    testImplementation project(':grpc-context').sourceSets.test.output,
             project(':grpc-testing'),
             project(':grpc-grpclb'),
             libraries.guava_testlib

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"
@@ -8,10 +8,10 @@ plugins {
 
 description = "gRPC: Auth"
 dependencies {
-    compile project(':grpc-api'),
+    api project(':grpc-api'),
             libraries.google_auth_credentials
     guavaDependency 'implementation'
-    testCompile project(':grpc-testing'),
+    testImplementation project(':grpc-testing'),
             libraries.google_auth_oauth2_http
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -10,6 +10,7 @@ description = "gRPC: Auth"
 dependencies {
     compile project(':grpc-api'),
             libraries.google_auth_credentials
+    guavaDependency 'implementation'
     testCompile project(':grpc-testing'),
             libraries.google_auth_oauth2_http
     signature "org.codehaus.mojo.signature:java17:1.0@signature"

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -21,7 +21,7 @@ configurations {
 }
 
 dependencies {
-    compile project(':grpc-core'),
+    implementation project(':grpc-core'),
             project(':grpc-netty'),
             project(':grpc-okhttp'),
             project(':grpc-stub'),
@@ -34,7 +34,7 @@ dependencies {
     compileOnly libraries.javax_annotation
     alpnagent libraries.jetty_alpn_agent
 
-    testCompile libraries.junit,
+    testImplementation libraries.junit,
             libraries.mockito
 }
 

--- a/census/build.gradle
+++ b/census/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 }
 
@@ -8,12 +8,12 @@ description = 'gRPC: Census'
 evaluationDependsOn(project(':grpc-api').path)
 
 dependencies {
-    compile project(':grpc-api')
+    api project(':grpc-api')
     guavaDependency 'implementation'
-    censusApiDependency 'compile'
-    censusGrpcMetricDependency 'compile'
+    censusApiDependency 'implementation'
+    censusGrpcMetricDependency 'implementation'
 
-    testCompile project(':grpc-api').sourceSets.test.output,
+    testImplementation project(':grpc-api').sourceSets.test.output,
             project(':grpc-context').sourceSets.test.output,
             project(':grpc-core').sourceSets.test.output,
             project(':grpc-testing'),

--- a/census/build.gradle
+++ b/census/build.gradle
@@ -9,7 +9,7 @@ evaluationDependsOn(project(':grpc-api').path)
 
 dependencies {
     compile project(':grpc-api')
-
+    guavaDependency 'implementation'
     censusApiDependency 'compile'
     censusGrpcMetricDependency 'compile'
 

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -126,14 +126,14 @@ model {
 }
 
 configurations {
-    testLiteCompile
+    testLiteImplementation
 }
 
 dependencies {
-    testCompile project(':grpc-protobuf'),
+    testImplementation project(':grpc-protobuf'),
             project(':grpc-stub'),
             libraries.javax_annotation
-    testLiteCompile project(':grpc-protobuf-lite'),
+    testLiteImplementation project(':grpc-protobuf-lite'),
             project(':grpc-stub'),
             libraries.javax_annotation
 }

--- a/context/build.gradle
+++ b/context/build.gradle
@@ -10,7 +10,7 @@ plugins {
 description = 'gRPC: Context'
 
 dependencies {
-    testCompile libraries.jsr305, libraries.guava_testlib
+    testImplementation libraries.jsr305, libraries.guava_testlib
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"
@@ -13,14 +13,14 @@ evaluationDependsOn(project(':grpc-context').path)
 evaluationDependsOn(project(':grpc-api').path)
 
 dependencies {
-    compile project(':grpc-api'),
-            libraries.gson,
+    api project(':grpc-api')
+    implementation libraries.gson,
             libraries.android_annotations,
             libraries.animalsniffer_annotations,
             libraries.errorprone
     guavaDependency 'implementation'
-    perfmarkDependency 'compile'
-    testCompile project(':grpc-context').sourceSets.test.output,
+    perfmarkDependency 'implementation'
+    testImplementation project(':grpc-context').sourceSets.test.output,
             project(':grpc-api').sourceSets.test.output,
             project(':grpc-testing'),
             project(':grpc-grpclb'),

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -16,7 +16,9 @@ dependencies {
     compile project(':grpc-api'),
             libraries.gson,
             libraries.android_annotations,
-            libraries.errorprone // prefer our version to perfmark's 2.3.3
+            libraries.animalsniffer_annotations,
+            libraries.errorprone
+    guavaDependency 'implementation'
     perfmarkDependency 'compile'
     testCompile project(':grpc-context').sourceSets.test.output,
             project(':grpc-api').sourceSets.test.output,

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -38,7 +38,6 @@ dependencies {
     guavaDependency 'implementation'
     testImplementation project(':grpc-testing')
 
-    implementation libraries.cronet_api
     testImplementation libraries.cronet_embedded
 
     testImplementation libraries.junit

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -33,7 +33,8 @@ android {
 }
 
 dependencies {
-    implementation project(':grpc-core')
+    api project(':grpc-core'),
+            libraries.cronet_api
     guavaDependency 'implementation'
     testImplementation project(':grpc-testing')
 

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -34,6 +34,7 @@ android {
 
 dependencies {
     implementation project(':grpc-core')
+    guavaDependency 'implementation'
     testImplementation project(':grpc-testing')
 
     implementation libraries.cronet_api

--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -44,16 +44,15 @@ apply plugin: 'com.google.cloud.tools.appengine'  // App Engine tasks
 
 dependencies {
     providedCompile group: 'javax.servlet', name: 'servlet-api', version:'2.5'
-    compile 'com.google.appengine:appengine-api-1.0-sdk:1.9.59'
-    // Deps needed by all gRPC apps in GAE
-    compile libraries.google_api_protos
-    compile project(":grpc-okhttp")
-    compile project(":grpc-protobuf")
-    compile project(":grpc-stub")
-    compile (project(":grpc-interop-testing")) {
-        exclude group: "io.grpc", module: "grpc-netty-shaded"
+    runtimeOnly 'com.google.appengine:appengine-api-1.0-sdk:1.9.59'
+    implementation project(':grpc-netty')
+    implementation project(":grpc-stub")
+    implementation (project(':grpc-interop-testing')) {
+        exclude group: 'io.grpc', module: 'grpc-alts'
     }
-    compile libraries.netty_tcnative
+    implementation libraries.protobuf
+    implementation libraries.truth
+    runtimeOnly libraries.netty_tcnative
 }
 
 compileJava {

--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -50,8 +50,8 @@ dependencies {
     implementation (project(':grpc-interop-testing')) {
         exclude group: 'io.grpc', module: 'grpc-alts'
     }
+    implementation libraries.junit
     implementation libraries.protobuf
-    implementation libraries.truth
     runtimeOnly libraries.netty_tcnative
 }
 

--- a/grpclb/build.gradle
+++ b/grpclb/build.gradle
@@ -11,17 +11,19 @@ description = "gRPC: GRPCLB LoadBalancer plugin"
 evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
-    compile project(':grpc-core'),
+    implementation project(':grpc-core'),
             project(':grpc-protobuf'),
             project(':grpc-stub'),
             libraries.protobuf
-    compile (libraries.protobuf_util) {
+    implementation (libraries.protobuf_util) {
         // prefer our own versions instead of protobuf-util's dependency
         exclude group: 'com.google.guava', module: 'guava'
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }
+    guavaDependency 'implementation'
+    runtimeOnly libraries.errorprone
     compileOnly libraries.javax_annotation
-    testCompile libraries.truth,
+    testImplementation libraries.truth,
             project(':grpc-core').sourceSets.test.output
 }
 

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -31,6 +31,7 @@ dependencies {
             libraries.junit,
             libraries.truth
     compileOnly libraries.javax_annotation
+    censusGrpcMetricDependency 'implementation'
     runtime libraries.opencensus_impl,
             libraries.netty_tcnative,
             project(':grpc-grpclb')

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -17,7 +17,7 @@ configurations {
 evaluationDependsOn(project(':grpc-context').path)
 
 dependencies {
-    compile project(path: ':grpc-alts', configuration: 'shadow'),
+    implementation project(path: ':grpc-alts', configuration: 'shadow'),
             project(':grpc-auth'),
             project(':grpc-census'),
             project(':grpc-core'),
@@ -30,13 +30,13 @@ dependencies {
             libraries.google_auth_oauth2_http,
             libraries.junit,
             libraries.truth
-    compileOnly libraries.javax_annotation
     censusGrpcMetricDependency 'implementation'
-    runtime libraries.opencensus_impl,
+    compileOnly libraries.javax_annotation
+    runtimeOnly libraries.opencensus_impl,
             libraries.netty_tcnative,
             project(':grpc-grpclb')
     xdsRuntime project(path: ':grpc-xds', configuration: 'shadow')
-    testCompile project(':grpc-context').sourceSets.test.output,
+    testImplementation project(':grpc-context').sourceSets.test.output,
             libraries.mockito
     alpnagent libraries.jetty_alpn_agent
 }

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     compile project(':grpc-core'),
             libraries.netty,
             libraries.netty_proxy_handler
+    guavaDependency 'implementation'
 
     // Tests depend on base class defined by core module.
     testCompile project(':grpc-core').sourceSets.test.output,

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"
@@ -16,17 +16,17 @@ configurations {
 evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
-    compile project(':grpc-core'),
-            libraries.netty,
-            libraries.netty_proxy_handler
+    api project(':grpc-core'),
+            libraries.netty
+    implementation libraries.netty_proxy_handler
     guavaDependency 'implementation'
     perfmarkDependency 'implementation'
 
     // Tests depend on base class defined by core module.
-    testCompile project(':grpc-core').sourceSets.test.output,
+    testImplementation project(':grpc-core').sourceSets.test.output,
             project(':grpc-testing'),
             project(':grpc-testing-proto')
-    testRuntime libraries.netty_tcnative,
+    testRuntimeOnly libraries.netty_tcnative,
             libraries.conscrypt,
             libraries.netty_epoll
     signature "org.codehaus.mojo.signature:java17:1.0@signature"

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -20,6 +20,7 @@ dependencies {
             libraries.netty,
             libraries.netty_proxy_handler
     guavaDependency 'implementation'
+    perfmarkDependency 'implementation'
 
     // Tests depend on base class defined by core module.
     testCompile project(':grpc-core').sourceSets.test.output,

--- a/netty/shaded/build.gradle
+++ b/netty/shaded/build.gradle
@@ -10,10 +10,10 @@ description = "gRPC: Netty Shaded"
 sourceSets { testShadow {} }
 
 dependencies {
-    compile project(':grpc-netty')
-    runtime libraries.netty_tcnative,
+    implementation project(':grpc-netty')
+    runtimeOnly libraries.netty_tcnative,
             libraries.netty_epoll
-    testShadowCompile files(shadowJar),
+    testShadowImplementation files(shadowJar),
             configurations.shadow,
             project(':grpc-testing-proto'),
             project(':grpc-testing'),

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -19,6 +19,7 @@ dependencies {
         exclude group: 'com.squareup.okio', module: 'okio'
     }
     guavaDependency 'implementation'
+    perfmarkDependency 'implementation'
     // Tests depend on base class defined by core module.
     testCompile project(':grpc-core').sourceSets.test.output,
             project(':grpc-testing'),

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"
@@ -11,17 +11,16 @@ description = "gRPC: OkHttp"
 evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
-    compile project(':grpc-core'),
-            libraries.okio
-
-    compile (libraries.okhttp) {
+    api project(':grpc-core')
+    api (libraries.okhttp) {
         // prefer our own versions instead of okhttp's dependency
         exclude group: 'com.squareup.okio', module: 'okio'
     }
+    implementation libraries.okio
     guavaDependency 'implementation'
     perfmarkDependency 'implementation'
     // Tests depend on base class defined by core module.
-    testCompile project(':grpc-core').sourceSets.test.output,
+    testImplementation project(':grpc-core').sourceSets.test.output,
             project(':grpc-testing'),
             project(':grpc-netty')
     signature "org.codehaus.mojo.signature:java17:1.0@signature"

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -18,7 +18,7 @@ dependencies {
         // prefer our own versions instead of okhttp's dependency
         exclude group: 'com.squareup.okio', module: 'okio'
     }
-
+    guavaDependency 'implementation'
     // Tests depend on base class defined by core module.
     testCompile project(':grpc-core').sourceSets.test.output,
             project(':grpc-testing'),

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "com.google.protobuf"
@@ -10,11 +10,12 @@ plugins {
 description = 'gRPC: Protobuf Lite'
 
 dependencies {
-    compile project(':grpc-api'),
+    api project(':grpc-api'),
             libraries.protobuf_lite
-    guavaDependency 'compile'
+    implementation libraries.jsr305
+    guavaDependency 'implementation'
 
-    testCompile project(':grpc-core')
+    testImplementation project(':grpc-core')
 
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "com.google.protobuf"
@@ -10,19 +10,20 @@ plugins {
 description = 'gRPC: Protobuf'
 
 dependencies {
-    compile project(':grpc-api'),
+    api project(':grpc-api'),
+            libraries.jsr305,
             libraries.protobuf
-    guavaDependency 'compile'
+    guavaDependency 'implementation'
 
-    compile (libraries.google_api_protos) {
+    api (libraries.google_api_protos) {
         // 'com.google.api:api-common' transitively depends on auto-value, which breaks our
         // annotations.
         exclude group: 'com.google.api', module: 'api-common'
-        // Prefer our more up-to-date protobuf over 3.2.0
+        // prefer our own version from libraries.protobuf
         exclude group: 'com.google.protobuf', module: 'protobuf-java'
     }
 
-    compile (project(':grpc-protobuf-lite')) {
+    api (project(':grpc-protobuf-lite')) {
         exclude group: 'com.google.protobuf', module: 'protobuf-javalite'
     }
 

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -19,7 +19,7 @@ dependencies {
         // 'com.google.api:api-common' transitively depends on auto-value, which breaks our
         // annotations.
         exclude group: 'com.google.api', module: 'api-common'
-        // prefer our own version from libraries.protobuf
+        // Prefer our more up-to-date protobuf over 3.2.0
         exclude group: 'com.google.protobuf', module: 'protobuf-java'
     }
 

--- a/rls/build.gradle
+++ b/rls/build.gradle
@@ -13,7 +13,7 @@ dependencies {
             project(':grpc-protobuf'),
             project(':grpc-stub')
     compileOnly libraries.javax_annotation
-    testCompile libraries.truth,
+    testImplementation libraries.truth,
             project(':grpc-testing'),
             project(':grpc-testing-proto'),
             project(':grpc-core').sourceSets.test.output  // for FakeClock

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "com.google.protobuf"
@@ -19,17 +19,19 @@ description = "gRPC: Services"
 evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
-    compile project(':grpc-protobuf'),
+    api project(':grpc-protobuf'),
             project(':grpc-stub'),
             project(':grpc-core')
-    compile (libraries.protobuf_util) {
+    implementation (libraries.protobuf_util) {
         // prefer our own versions instead of protobuf-util's dependency
         exclude group: 'com.google.guava', module: 'guava'
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }
+    guavaDependency 'implementation'
+    runtimeOnly libraries.errorprone
 
     compileOnly libraries.javax_annotation
-    testCompile project(':grpc-testing'),
+    testImplementation project(':grpc-testing'),
             libraries.netty_epoll, // for DomainSocketAddress
             project(':grpc-core').sourceSets.test.output  // for FakeClock
     testCompileOnly libraries.javax_annotation

--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"
@@ -8,9 +8,9 @@ plugins {
 
 description = "gRPC: Stub"
 dependencies {
-    compile project(':grpc-api')
-    guavaDependency 'compile'
-    testCompile libraries.truth,
+    api project(':grpc-api')
+    guavaDependency 'api'
+    testImplementation libraries.truth,
             project(':grpc-testing')
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"

--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -9,6 +9,7 @@ plugins {
 description = "gRPC: Stub"
 dependencies {
     compile project(':grpc-api')
+    guavaDependency 'compile'
     testCompile libraries.truth,
             project(':grpc-testing')
     signature "org.codehaus.mojo.signature:java17:1.0@signature"

--- a/testing-proto/build.gradle
+++ b/testing-proto/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "com.google.protobuf"
@@ -8,10 +8,10 @@ plugins {
 description = "gRPC: Testing Protos"
 
 dependencies {
-    compile project(':grpc-protobuf'),
+    api project(':grpc-protobuf'),
             project(':grpc-stub')
     compileOnly libraries.javax_annotation
-    testCompile libraries.truth
+    testImplementation libraries.truth
     testRuntime libraries.javax_annotation
 }
 

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"
@@ -10,18 +10,18 @@ description = "gRPC: Testing"
 evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
-    compile project(':grpc-core'),
+    api project(':grpc-core'),
             project(':grpc-stub'),
             libraries.junit
 
     censusApiDependency 'implementation'
 
-    testCompile (libraries.mockito) {
+    testImplementation (libraries.mockito) {
         // prefer our own versions instead of mockito's dependency
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
 
-    testCompile project(':grpc-testing-proto'),
+    testImplementation project(':grpc-testing-proto'),
             project(':grpc-core').sourceSets.test.output
 }
 

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -14,7 +14,7 @@ dependencies {
             project(':grpc-stub'),
             libraries.junit
 
-    censusApiDependency 'compile'
+    censusApiDependency 'implementation'
 
     testCompile (libraries.mockito) {
         // prefer our own versions instead of mockito's dependency

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -19,42 +19,42 @@ description = "gRPC: XDS plugin"
 evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
-    compile project(':grpc-protobuf'),
+    implementation project(':grpc-protobuf'),
             project(':grpc-stub'),
             project(':grpc-core'),
             project(':grpc-services'),
             project(path: ':grpc-alts', configuration: 'shadow'),
             libraries.gson
-    def nettyDependency = compile project(':grpc-netty')
+    def nettyDependency = implementation project(':grpc-netty')
 
-    compile (libraries.opencensus_proto) {
+    implementation (libraries.opencensus_proto) {
         // prefer our own versions instead of opencensus_proto's
         exclude group: 'com.google.protobuf', module: 'protobuf-java'
         exclude group: 'io.grpc', module: 'grpc-protobuf'
         exclude group: 'io.grpc', module: 'grpc-stub'
     }
-    compile (libraries.protobuf_util) {
+    implementation (libraries.protobuf_util) {
         // prefer our own versions instead of protobuf-util's dependency
         exclude group: 'com.google.guava', module: 'guava'
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }
 
-    testCompile project(':grpc-core').sourceSets.test.output
+    testImplementation project(':grpc-core').sourceSets.test.output
 
     compileOnly libraries.javax_annotation,
             // At runtime use the epoll included in grpc-netty-shaded
             libraries.netty_epoll
-    
-    testCompile project(':grpc-testing'), 
+
+    testImplementation project(':grpc-testing'),
             project(':grpc-testing-proto'),
             libraries.guava_testlib,
             libraries.netty_epoll
 
-    shadow configurations.compile.getDependencies().minus([nettyDependency])
+    shadow configurations.implementation.getDependencies().minus([nettyDependency])
     shadow project(path: ':grpc-netty-shaded', configuration: 'shadow')
 
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
-    testRuntime libraries.netty_tcnative
+    testRuntimeOnly libraries.netty_tcnative
 }
 
 sourceSets {


### PR DESCRIPTION
- Use gradle configuration `api` for dependencies that are part of grpc public api signatures.
- Replace deprecated gradle configurations `compile`, `testCompile`, `runtime` and `testRuntime`.
- With minimal change in dependencies: If we need dep X and Y to compile our code, and if X transitively depends on Y, then our build would still pass even if we only include X as `compile`/`implementation` dependency for our project. Ideally we should include both X and Y explicitly as `implementation` dependency for our project, but in this PR we don't add the missing Y if it is previously missing. A followup PR will try to add all such missing dependencies by setting 
  ```gradle
  configurations {
      compileClasspath.transitive = false
  }
  ```