### PR TITLE
all: disable compileClasspath transitivity for gradle build

### DIFF
--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -13,15 +13,24 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-    api project(':grpc-core')
+    api project(':grpc-api'),
+            project(':grpc-core'),
+            libraries.jsr305
     implementation project(':grpc-auth'),
             project(':grpc-grpclb'),
             project(':grpc-protobuf'),
             project(':grpc-stub'),
+            libraries.google_auth_credentials,
             libraries.lang,
             libraries.protobuf,
             libraries.conscrypt
-    def nettyDependency = implementation project(':grpc-netty')
+    def nettyDependency = implementation project(':grpc-netty'),
+            libraries.netty,
+            libraries.netty_buffer,
+            libraries.netty_codec,
+            libraries.netty_common,
+            libraries.netty_handler,
+            libraries.netty_transport
     implementation (libraries.google_auth_oauth2_http) {
         // prefer our own versions instead of google-auth-oauth2-http's dependency
         exclude group: 'com.google.guava', module: 'guava'

--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     implementation 'com.android.support:support-fragment:26.1.0'
     implementation 'com.google.android.gms:play-services-base:15.0.1'
     implementation 'com.google.android.gms:play-services-basement:15.0.1'
+    implementation 'org.hamcrest:hamcrest-core:1.3'
 
     implementation project(':grpc-api'),
             project(':grpc-auth'),
@@ -69,6 +70,8 @@ dependencies {
             project(':grpc-stub'),
             project(':grpc-testing'),
             libraries.google_auth_credentials,
+            libraries.guava_failureaccess,
+            libraries.j2objc_annotations,
             libraries.jsr305,
             libraries.junit,
             libraries.protobuf_lite,
@@ -81,10 +84,7 @@ dependencies {
     censusGrpcMetricDependency 'implementation'
     guavaDependency 'implementation'
 
-    compileOnly 'org.hamcrest:hamcrest-core:1.3',
-            libraries.guava_failureaccess,
-            libraries.j2objc_annotations,
-            libraries.javax_annotation
+    compileOnly libraries.javax_annotation
 
     androidTestImplementation 'androidx.test:rules:1.1.0-alpha1'
     androidTestImplementation 'androidx.test:runner:1.1.0-alpha1'

--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -81,7 +81,8 @@ dependencies {
     censusGrpcMetricDependency 'implementation'
     guavaDependency 'implementation'
 
-    compileOnly libraries.guava_failureaccess,
+    compileOnly 'org.hamcrest:hamcrest-core:1.3',
+            libraries.guava_failureaccess,
             libraries.j2objc_annotations,
             libraries.javax_annotation
 

--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -48,26 +48,42 @@ android {
 }
 
 dependencies {
+    implementation 'android.arch.lifecycle:common:1.0.0'
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support:multidex:1.0.3'
     implementation 'com.android.support:support-annotations:27.1.1'
+    implementation 'com.android.support:support-compat:26.1.0'
+    implementation 'com.android.support:support-core-ui:26.1.0'
+    implementation 'com.android.support:support-core-utils:26.1.0'
+    implementation 'com.android.support:support-fragment:26.1.0'
     implementation 'com.google.android.gms:play-services-base:15.0.1'
+    implementation 'com.google.android.gms:play-services-basement:15.0.1'
 
-    implementation project(':grpc-auth'),
+    implementation project(':grpc-api'),
+            project(':grpc-auth'),
             project(':grpc-census'),
+            project(':grpc-context'),
+            project(':grpc-core'),
             project(':grpc-okhttp'),
             project(':grpc-protobuf-lite'),
             project(':grpc-stub'),
             project(':grpc-testing'),
+            libraries.google_auth_credentials,
+            libraries.jsr305,
             libraries.junit,
+            libraries.protobuf_lite,
             libraries.truth
 
     implementation (libraries.google_auth_oauth2_http) {
         exclude group: 'org.apache.httpcomponents'
     }
+    censusApiDependency 'implementation'
     censusGrpcMetricDependency 'implementation'
+    guavaDependency 'implementation'
 
-    compileOnly libraries.javax_annotation
+    compileOnly libraries.guava_failureaccess,
+            libraries.j2objc_annotations,
+            libraries.javax_annotation
 
     androidTestImplementation 'androidx.test:rules:1.1.0-alpha1'
     androidTestImplementation 'androidx.test:runner:1.1.0-alpha1'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,9 @@ repositories {
 }
 
 dependencies {
-    api project(':grpc-core')
+    api project(':grpc-api'),
+            project(':grpc-core'),
+            libraries.jsr305
     guavaDependency 'implementation'
     testImplementation project('::grpc-okhttp')
     testImplementation libraries.androidx_test

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -9,7 +9,8 @@ plugins {
 description = "gRPC: Auth"
 dependencies {
     api project(':grpc-api'),
-            libraries.google_auth_credentials
+            libraries.google_auth_credentials,
+            libraries.jsr305
     guavaDependency 'implementation'
     testImplementation project(':grpc-testing'),
             libraries.google_auth_oauth2_http

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -21,16 +21,25 @@ configurations {
 }
 
 dependencies {
-    implementation project(':grpc-core'),
+    implementation project(':grpc-api'),
+            project(':grpc-core'),
             project(':grpc-netty'),
             project(':grpc-okhttp'),
             project(':grpc-stub'),
             project(':grpc-protobuf'),
             project(':grpc-testing'),
             libraries.hdrhistogram,
+            libraries.jsr305,
             libraries.netty_tcnative,
+            libraries.netty_buffer,
+            libraries.netty_common,
             libraries.netty_epoll,
-            libraries.math
+            libraries.netty_handler,
+            libraries.netty_transport,
+            libraries.netty_transport_uds,
+            libraries.math,
+            libraries.protobuf
+    guavaDependency 'implementation'
     compileOnly libraries.javax_annotation
     alpnagent libraries.jetty_alpn_agent
 

--- a/build.gradle
+++ b/build.gradle
@@ -139,7 +139,9 @@ subprojects {
             cronet_embedded: 'org.chromium.net:cronet-embedded:66.3359.158',
             gson: "com.google.code.gson:gson:2.8.6",
             guava: "com.google.guava:guava:${guavaVersion}",
+            guava_failureaccess: 'com.google.guava:failureaccess:1.0.1',
             hpack: 'com.twitter:hpack:0.10.1',
+            j2objc_annotations: 'com.google.j2objc:j2objc-annotations:1.3',
             javax_annotation: 'org.apache.tomcat:annotations-api:6.0.53',
             jsr305: 'com.google.code.findbugs:jsr305:3.0.2',
             google_api_protos: 'com.google.api.grpc:proto-google-common-protos:1.17.0',
@@ -160,8 +162,15 @@ subprojects {
             lang: "org.apache.commons:commons-lang3:3.5",
 
             netty: "io.netty:netty-codec-http2:[${nettyVersion}]",
+            netty_buffer: "io.netty:netty-buffer:${nettyVersion}",
+            netty_codec: "io.netty:netty-codec:${nettyVersion}",
+            netty_codec_http: "io.netty:netty-codec-http:${nettyVersion}",
+            netty_common: "io.netty:netty-common:${nettyVersion}",
             netty_epoll: "io.netty:netty-transport-native-epoll:${nettyVersion}:linux-x86_64",
+            netty_handler: "io.netty:netty-handler:${nettyVersion}",
             netty_proxy_handler: "io.netty:netty-handler-proxy:${nettyVersion}",
+            netty_transport: "io.netty:netty-transport:${nettyVersion}",
+            netty_transport_uds: "io.netty:netty-transport-native-unix-common:${nettyVersion}",
 
             // Keep the following references of tcnative version in sync whenever it's updated
             // SECURITY.md (multiple occurrences)
@@ -230,6 +239,19 @@ subprojects {
             guavaDependency 'runtimeOnly'
         }
 
+        // A util function to config google_api_protos dependency with some
+        // harmful transitive dependencies properly cleaned up.
+        googleApiProtosDependency = { configurationName ->
+            dependencies."$configurationName"(libraries.google_api_protos) {
+                // 'com.google.api:api-common' transitively depends on auto-value, which breaks our
+                // annotations.
+                exclude group: 'com.google.api', module: 'api-common'
+                // Prefer our more up-to-date protobuf over that from google_api_protos
+                exclude group: 'com.google.protobuf', module: 'protobuf-java'
+            }
+            dependencies.runtimeOnly libraries.protobuf
+        }
+
         // A util function to config perfmark dependency with transitive
         // dependencies properly resolved for the failOnVersionConflict strategy.
         perfmarkDependency = { configurationName ->
@@ -241,6 +263,12 @@ subprojects {
     }
 
     configurations {
+        if (isAndroid) {
+            debugCompileClasspath.transitive = false
+            releaseCompileClasspath.transitive = false
+        } else {
+            compileClasspath.transitive = false
+        }
         // Detect Maven Enforcer's dependencyConvergence failures. We only
         // care for artifacts used as libraries by others.
         if (isAndroid && !(project.name in ['grpc-android-interop-testing'])) {

--- a/census/build.gradle
+++ b/census/build.gradle
@@ -8,7 +8,9 @@ description = 'gRPC: Census'
 evaluationDependsOn(project(':grpc-api').path)
 
 dependencies {
-    api project(':grpc-api')
+    api project(':grpc-api'),
+            project(':grpc-context'),
+            libraries.jsr305
     guavaDependency 'implementation'
     censusApiDependency 'implementation'
     censusGrpcMetricDependency 'implementation'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -13,13 +13,17 @@ evaluationDependsOn(project(':grpc-context').path)
 evaluationDependsOn(project(':grpc-api').path)
 
 dependencies {
-    api project(':grpc-api')
+    api project(':grpc-api'),
+            project(':grpc-context'),
+            libraries.jsr305
     implementation libraries.gson,
             libraries.android_annotations,
             libraries.animalsniffer_annotations,
             libraries.errorprone
     guavaDependency 'implementation'
     perfmarkDependency 'implementation'
+    compileOnly libraries.guava_failureaccess,
+            libraries.j2objc_annotations
     testImplementation project(':grpc-context').sourceSets.test.output,
             project(':grpc-api').sourceSets.test.output,
             project(':grpc-testing'),

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -19,11 +19,11 @@ dependencies {
     implementation libraries.gson,
             libraries.android_annotations,
             libraries.animalsniffer_annotations,
-            libraries.errorprone
+            libraries.errorprone,
+            libraries.guava_failureaccess,
+            libraries.j2objc_annotations
     guavaDependency 'implementation'
     perfmarkDependency 'implementation'
-    compileOnly libraries.guava_failureaccess,
-            libraries.j2objc_annotations
     testImplementation project(':grpc-context').sourceSets.test.output,
             project(':grpc-api').sourceSets.test.output,
             project(':grpc-testing'),

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -36,10 +36,10 @@ dependencies {
     api project(':grpc-api'),
             project(':grpc-core'),
             libraries.cronet_api
-    implementation libraries.jsr305
+    implementation libraries.guava_failureaccess,
+            libraries.j2objc_annotations,
+            libraries.jsr305
     guavaDependency 'implementation'
-    compileOnly libraries.guava_failureaccess,
-            libraries.j2objc_annotations
     testImplementation project(':grpc-testing')
 
     testImplementation libraries.cronet_embedded

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -33,9 +33,13 @@ android {
 }
 
 dependencies {
-    api project(':grpc-core'),
+    api project(':grpc-api'),
+            project(':grpc-core'),
             libraries.cronet_api
+    implementation libraries.jsr305
     guavaDependency 'implementation'
+    compileOnly libraries.guava_failureaccess,
+            libraries.j2objc_annotations
     testImplementation project(':grpc-testing')
 
     testImplementation libraries.cronet_embedded

--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -45,6 +45,8 @@ apply plugin: 'com.google.cloud.tools.appengine'  // App Engine tasks
 dependencies {
     providedCompile group: 'javax.servlet', name: 'servlet-api', version:'2.5'
     runtimeOnly 'com.google.appengine:appengine-api-1.0-sdk:1.9.59'
+    implementation project(':grpc-api')
+    implementation project(':grpc-core')
     implementation project(':grpc-netty')
     implementation project(":grpc-stub")
     implementation (project(':grpc-interop-testing')) {

--- a/grpclb/build.gradle
+++ b/grpclb/build.gradle
@@ -11,9 +11,11 @@ description = "gRPC: GRPCLB LoadBalancer plugin"
 evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
-    implementation project(':grpc-core'),
+    implementation project(':grpc-api'),
+            project(':grpc-core'),
             project(':grpc-protobuf'),
             project(':grpc-stub'),
+            libraries.jsr305,
             libraries.protobuf
     implementation (libraries.protobuf_util) {
         // prefer our own versions instead of protobuf-util's dependency

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -31,6 +31,8 @@ dependencies {
             project(':grpc-testing'),
             libraries.google_auth_credentials,
             libraries.google_auth_oauth2_http,
+            libraries.guava_failureaccess,
+            libraries.j2objc_annotations,
             libraries.jsr305,
             libraries.junit,
             libraries.netty_handler,
@@ -42,9 +44,7 @@ dependencies {
     censusApiDependency 'implementation'
     censusGrpcMetricDependency 'implementation'
     guavaDependency 'implementation'
-    compileOnly libraries.guava_failureaccess,
-            libraries.j2objc_annotations,
-            libraries.javax_annotation
+    compileOnly libraries.javax_annotation
     runtimeOnly libraries.opencensus_impl,
             libraries.netty_tcnative,
             project(':grpc-grpclb')

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -18,20 +18,33 @@ evaluationDependsOn(project(':grpc-context').path)
 
 dependencies {
     implementation project(path: ':grpc-alts', configuration: 'shadow'),
+            project(':grpc-api'),
             project(':grpc-auth'),
             project(':grpc-census'),
             project(':grpc-core'),
+            project(':grpc-context'),
             project(':grpc-netty'),
             project(':grpc-okhttp'),
             project(':grpc-protobuf'),
             project(':grpc-services'),
             project(':grpc-stub'),
             project(':grpc-testing'),
+            libraries.google_auth_credentials,
             libraries.google_auth_oauth2_http,
+            libraries.jsr305,
             libraries.junit,
+            libraries.netty_handler,
+            libraries.protobuf,
             libraries.truth
+    implementation (project(':grpc-protobuf-lite')) {
+        exclude group: 'com.google.protobuf', module: 'protobuf-javalite'
+    }
+    censusApiDependency 'implementation'
     censusGrpcMetricDependency 'implementation'
-    compileOnly libraries.javax_annotation
+    guavaDependency 'implementation'
+    compileOnly libraries.guava_failureaccess,
+            libraries.j2objc_annotations,
+            libraries.javax_annotation
     runtimeOnly libraries.opencensus_impl,
             libraries.netty_tcnative,
             project(':grpc-grpclb')

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -16,12 +16,21 @@ configurations {
 evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
-    api project(':grpc-core'),
-            libraries.netty
-    implementation libraries.netty_proxy_handler
+    api project(':grpc-api'),
+            project(':grpc-core'),
+            libraries.jsr305,
+            libraries.netty,
+            libraries.netty_handler
+    implementation libraries.netty_buffer,
+            libraries.netty_codec,
+            libraries.netty_codec_http,
+            libraries.netty_common,
+            libraries.netty_transport,
+            libraries.netty_proxy_handler
     guavaDependency 'implementation'
     perfmarkDependency 'implementation'
-
+    compileOnly libraries.guava_failureaccess,
+            libraries.j2objc_annotations
     // Tests depend on base class defined by core module.
     testImplementation project(':grpc-core').sourceSets.test.output,
             project(':grpc-testing'),

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -18,6 +18,8 @@ evaluationDependsOn(project(':grpc-core').path)
 dependencies {
     api project(':grpc-api'),
             project(':grpc-core'),
+            libraries.guava_failureaccess,
+            libraries.j2objc_annotations,
             libraries.jsr305,
             libraries.netty,
             libraries.netty_handler
@@ -29,8 +31,6 @@ dependencies {
             libraries.netty_proxy_handler
     guavaDependency 'implementation'
     perfmarkDependency 'implementation'
-    compileOnly libraries.guava_failureaccess,
-            libraries.j2objc_annotations
     // Tests depend on base class defined by core module.
     testImplementation project(':grpc-core').sourceSets.test.output,
             project(':grpc-testing'),

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -18,11 +18,11 @@ dependencies {
         // prefer our own versions instead of okhttp's dependency
         exclude group: 'com.squareup.okio', module: 'okio'
     }
-    implementation libraries.okio
+    implementation libraries.guava_failureaccess,
+            libraries.j2objc_annotations,
+            libraries.okio
     guavaDependency 'implementation'
     perfmarkDependency 'implementation'
-    compileOnly libraries.guava_failureaccess,
-            libraries.j2objc_annotations
     // Tests depend on base class defined by core module.
     testImplementation project(':grpc-core').sourceSets.test.output,
             project(':grpc-testing'),

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -11,7 +11,9 @@ description = "gRPC: OkHttp"
 evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
-    api project(':grpc-core')
+    api project(':grpc-api'),
+            project(':grpc-core'),
+            libraries.jsr305
     api (libraries.okhttp) {
         // prefer our own versions instead of okhttp's dependency
         exclude group: 'com.squareup.okio', module: 'okio'
@@ -19,6 +21,8 @@ dependencies {
     implementation libraries.okio
     guavaDependency 'implementation'
     perfmarkDependency 'implementation'
+    compileOnly libraries.guava_failureaccess,
+            libraries.j2objc_annotations
     // Tests depend on base class defined by core module.
     testImplementation project(':grpc-core').sourceSets.test.output,
             project(':grpc-testing'),

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -15,13 +15,7 @@ dependencies {
             libraries.protobuf
     guavaDependency 'implementation'
 
-    api (libraries.google_api_protos) {
-        // 'com.google.api:api-common' transitively depends on auto-value, which breaks our
-        // annotations.
-        exclude group: 'com.google.api', module: 'api-common'
-        // Prefer our more up-to-date protobuf over 3.2.0
-        exclude group: 'com.google.protobuf', module: 'protobuf-java'
-    }
+    googleApiProtosDependency 'api'
 
     api (project(':grpc-protobuf-lite')) {
         exclude group: 'com.google.protobuf', module: 'protobuf-javalite'

--- a/rls/build.gradle
+++ b/rls/build.gradle
@@ -14,12 +14,12 @@ dependencies {
             project(':grpc-core'),
             project(':grpc-protobuf'),
             project(':grpc-stub'),
+            libraries.guava_failureaccess,
+            libraries.j2objc_annotations,
             libraries.jsr305,
             libraries.protobuf
     guavaDependency 'implementation'
-    compileOnly libraries.guava_failureaccess,
-            libraries.j2objc_annotations,
-            libraries.javax_annotation
+    compileOnly libraries.javax_annotation
     testImplementation libraries.truth,
             project(':grpc-testing'),
             project(':grpc-testing-proto'),

--- a/rls/build.gradle
+++ b/rls/build.gradle
@@ -10,11 +10,16 @@ description = "gRPC: RouteLookupService Loadbalancing plugin"
 evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
-    implementation project(':grpc-core'),
+    implementation project(':grpc-api'),
+            project(':grpc-core'),
             project(':grpc-protobuf'),
-            project(':grpc-stub')
+            project(':grpc-stub'),
+            libraries.jsr305,
+            libraries.protobuf
     guavaDependency 'implementation'
-    compileOnly libraries.javax_annotation
+    compileOnly libraries.guava_failureaccess,
+            libraries.j2objc_annotations,
+            libraries.javax_annotation
     testImplementation libraries.truth,
             project(':grpc-testing'),
             project(':grpc-testing-proto'),

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -19,9 +19,13 @@ description = "gRPC: Services"
 evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
-    api project(':grpc-protobuf'),
+    api project(':grpc-api'),
+            project(':grpc-context'),
+            project(':grpc-protobuf'),
             project(':grpc-stub'),
-            project(':grpc-core')
+            project(':grpc-core'),
+            libraries.jsr305,
+            libraries.protobuf
     implementation (libraries.protobuf_util) {
         // prefer our own versions instead of protobuf-util's dependency
         exclude group: 'com.google.guava', module: 'guava'

--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -11,9 +11,9 @@ dependencies {
     api project(':grpc-api'),
             project(':grpc-context'),
             libraries.jsr305
-    compileOnly libraries.guava_failureaccess,
-            libraries.j2objc_annotations
     guavaDependency 'api'
+    implementation libraries.guava_failureaccess,
+            libraries.j2objc_annotations
     testImplementation libraries.truth,
             project(':grpc-testing')
     signature "org.codehaus.mojo.signature:java17:1.0@signature"

--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -8,7 +8,11 @@ plugins {
 
 description = "gRPC: Stub"
 dependencies {
-    api project(':grpc-api')
+    api project(':grpc-api'),
+            project(':grpc-context'),
+            libraries.jsr305
+    compileOnly libraries.guava_failureaccess,
+            libraries.j2objc_annotations
     guavaDependency 'api'
     testImplementation libraries.truth,
             project(':grpc-testing')

--- a/testing-proto/build.gradle
+++ b/testing-proto/build.gradle
@@ -8,9 +8,12 @@ plugins {
 description = "gRPC: Testing Protos"
 
 dependencies {
-    api project(':grpc-protobuf'),
+    api project(':grpc-api'),
+            project(':grpc-protobuf'),
             project(':grpc-stub')
+    guavaDependency 'api'
     compileOnly libraries.javax_annotation
+    implementation libraries.protobuf
     testImplementation libraries.truth
     testRuntime libraries.javax_annotation
 }

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -10,10 +10,15 @@ description = "gRPC: Testing"
 evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
-    api project(':grpc-core'),
+    api project(':grpc-api'),
+            project(':grpc-core'),
+            project(':grpc-context'),
             project(':grpc-stub'),
+            libraries.jsr305,
             libraries.junit
-
+    compileOnly libraries.guava_failureaccess,
+            libraries.j2objc_annotations
+    guavaDependency 'implementation'
     censusApiDependency 'implementation'
 
     testImplementation (libraries.mockito) {

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -14,10 +14,10 @@ dependencies {
             project(':grpc-core'),
             project(':grpc-context'),
             project(':grpc-stub'),
+            libraries.guava_failureaccess,
+            libraries.j2objc_annotations,
             libraries.jsr305,
             libraries.junit
-    compileOnly libraries.guava_failureaccess,
-            libraries.j2objc_annotations
     guavaDependency 'implementation'
     censusApiDependency 'implementation'
 

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -19,13 +19,23 @@ description = "gRPC: XDS plugin"
 evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
-    implementation project(':grpc-protobuf'),
+    implementation project(':grpc-api'),
+            project(':grpc-context'),
+            project(':grpc-protobuf'),
             project(':grpc-stub'),
             project(':grpc-core'),
             project(':grpc-services'),
             project(path: ':grpc-alts', configuration: 'shadow'),
-            libraries.gson
-    def nettyDependency = implementation project(':grpc-netty')
+            libraries.jsr305,
+            libraries.gson,
+            libraries.protobuf
+    def nettyDependency = implementation project(':grpc-netty'),
+            libraries.netty,
+            libraries.netty_codec,
+            libraries.netty_common,
+            libraries.netty_handler,
+            libraries.netty_transport,
+            libraries.netty_transport_uds
 
     implementation (libraries.opencensus_proto) {
         // prefer our own versions instead of opencensus_proto's
@@ -38,6 +48,8 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }
+    googleApiProtosDependency 'implementation'
+    guavaDependency 'implementation'
 
     testImplementation project(':grpc-core').sourceSets.test.output
 


### PR DESCRIPTION
Set `compileClasspath.transitive = false` and then add all dependencies that have to be added to each subproject.

- Benefit of setting `compileClasspath.transitive = false`:
  + Boost incremental compilation time because the subproject will no longer load the whole transitive dependency tree to compile, instead it only loads dependencies that are explicitly added for the subproject.
  + The compile time dependency structure of a subproject will be flat and more clear, no longer be a tree structure. If our code depends on X and Y with X transitively depends on Y, we have to explicitly add both X and Y in order to compile. More like Bazel. Previously the build can still pass even if Y is not explicitly added.
- Downside:
  + A number of individual io.netty artifacts have to be added for netty.
  + Whenever we use `SettableFuture.create()`, we have to add `libraries.guava_failureaccess` and `libraries.j2objc_annotations` in order to compile.