### PR TITLE
stub: default impl for disableAutoRequestWithInitial(int)

### DIFF
--- a/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
@@ -135,7 +135,9 @@ public abstract class CallStreamObserver<V> implements StreamObserver<V> {
    *
    * <p>This API is still a work in-progress and will likely change in the future.
    */
-  public abstract void disableAutoRequestWithInitial(int request);
+  public void disableAutoRequestWithInitial(int request) {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Requests the peer to produce {@code count} more messages to be delivered to the 'inbound'


### PR DESCRIPTION
this prevents compile error for users extending Client/ServerCallStreamObserver. 