### PR TITLE
README.md: Include annotations api dep in code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Download [the JARs][]. Or for Maven with non-Android, add to your `pom.xml`:
   <artifactId>grpc-stub</artifactId>
   <version>1.29.0</version>
 </dependency>
+<dependency> <!-- necessary for Java 9+ -->
+  <groupId>org.apache.tomcat</groupId>
+  <artifactId>annotations-api</artifactId>
+  <version>6.0.53</version>
+  <scope>provided</scope>
+</dependency>
 ```
 
 Or for Gradle with non-Android, add to your dependencies:
@@ -61,6 +67,7 @@ Or for Gradle with non-Android, add to your dependencies:
 implementation 'io.grpc:grpc-netty-shaded:1.29.0'
 implementation 'io.grpc:grpc-protobuf:1.29.0'
 implementation 'io.grpc:grpc-stub:1.29.0'
+compileOnly 'org.apache.tomcat:annotations-api:6.0.53' // necessary for Java 9+
 ```
 
 For Android client, use `grpc-okhttp` instead of `grpc-netty-shaded` and
@@ -69,6 +76,7 @@ For Android client, use `grpc-okhttp` instead of `grpc-netty-shaded` and
 implementation 'io.grpc:grpc-okhttp:1.29.0'
 implementation 'io.grpc:grpc-protobuf-lite:1.29.0'
 implementation 'io.grpc:grpc-stub:1.29.0'
+compileOnly 'org.apache.tomcat:annotations-api:6.0.53' // necessary for Java 9+
 ```
 
 [the JARs]:


### PR DESCRIPTION
We include this dep in our examples, but never mentioned it in the README.
Instead of getting into details about what it's for, the brief comment should
avoid most confusion for existing Java 8 users about why it appears to be
unnecessary.

------

#5950 didn't get the necessary fixes to be merged, and instead of me making those fixes now it seems this approach will be easier for users.