### PR TITLE
netty: return status code unavailable when netty channel has unresolved InetSocketAddress

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -103,7 +103,8 @@ public final class NettyChannelBuilder
    * Creates a new builder with the given server address. This factory method is primarily intended
    * for using Netty Channel types other than SocketChannel. {@link #forAddress(String, int)} should
    * generally be preferred over this method, since that API permits delaying DNS lookups and
-   * noticing changes to DNS.
+   * noticing changes to DNS. If an unresolved InetSocketAddress is passed in, then it will remain
+   * unresolved.
    */
   @CheckReturnValue
   public static NettyChannelBuilder forAddress(SocketAddress serverAddress) {

--- a/netty/src/main/java/io/grpc/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/netty/Utils.java
@@ -54,6 +54,7 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.nio.channels.ClosedChannelException;
+import java.nio.channels.UnresolvedAddressException;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ThreadFactory;
@@ -269,6 +270,9 @@ class Utils {
     }
     if (t instanceof IOException) {
       return Status.UNAVAILABLE.withDescription("io exception").withCause(t);
+    }
+    if (t instanceof UnresolvedAddressException) {
+      return Status.UNAVAILABLE.withDescription("unresolved address").withCause(t);
     }
     if (t instanceof Http2Exception) {
       return Status.INTERNAL.withDescription("http2 exception").withCause(t);

--- a/netty/src/test/java/io/grpc/netty/UtilsTest.java
+++ b/netty/src/test/java/io/grpc/netty/UtilsTest.java
@@ -42,6 +42,7 @@ import io.netty.handler.codec.http2.Http2Error;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.util.AsciiString;
+import java.nio.channels.UnresolvedAddressException;
 import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -60,6 +61,8 @@ public class UtilsTest {
     assertSame(s, Utils.statusFromThrowable(new Exception(s.asException())));
     Throwable t;
     t = new ConnectTimeoutException("msg");
+    assertStatusEquals(Status.UNAVAILABLE.withCause(t), Utils.statusFromThrowable(t));
+    t = new UnresolvedAddressException();
     assertStatusEquals(Status.UNAVAILABLE.withCause(t), Utils.statusFromThrowable(t));
     t = new Http2Exception(Http2Error.INTERNAL_ERROR, "msg");
     assertStatusEquals(Status.INTERNAL.withCause(t), Utils.statusFromThrowable(t));


### PR DESCRIPTION
Closes #6954 

Bug fix to return status code `UNAVAILABLE` when a netty channel has an unresolved InetSocketAddress

- [x] Adds check in netty utils
- [x] Updates unit test for netty utils 
- [x] Adds test case to ensure status code `UNAVAILABLE` is returned