### PR TITLE
xds: rename experimental routing flag to GRPC_XDS_EXPERIMENTAL_ROUTING

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -96,10 +96,9 @@ final class XdsClientImpl extends XdsClient {
   static final String ADS_TYPE_URL_EDS =
       "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment";
 
-  // For now we do not support path matching unless enabled manually.
   // Mutable for testing.
-  static boolean enablePathMatching = Boolean.parseBoolean(
-      System.getenv("ENABLE_EXPERIMENTAL_PATH_MATCHING"));
+  static boolean enableExperimentalRouting = Boolean.parseBoolean(
+      System.getenv("GRPC_XDS_EXPERIMENTAL_ROUTING"));
 
   private final MessagePrinter respPrinter = new MessagePrinter();
 
@@ -645,7 +644,7 @@ final class XdsClientImpl extends XdsClient {
     if (routes != null) {
       // Found  routes in the in-lined RouteConfiguration.
       ConfigUpdate configUpdate;
-      if (!enablePathMatching) {
+      if (!enableExperimentalRouting) {
         EnvoyProtoData.Route defaultRoute = Iterables.getLast(routes);
         configUpdate =
             ConfigUpdate.newBuilder()
@@ -828,7 +827,7 @@ final class XdsClientImpl extends XdsClient {
 
       // Found routes in the in-lined RouteConfiguration.
       ConfigUpdate configUpdate;
-      if (!enablePathMatching) {
+      if (!enableExperimentalRouting) {
         EnvoyProtoData.Route defaultRoute = Iterables.getLast(routes);
         configUpdate =
             ConfigUpdate.newBuilder()
@@ -916,7 +915,7 @@ final class XdsClientImpl extends XdsClient {
     }
 
     // We only validate the default route unless path matching is enabled.
-    if (!enablePathMatching) {
+    if (!enableExperimentalRouting) {
       EnvoyProtoData.Route route = routes.get(routes.size() - 1);
       RouteMatch routeMatch = route.getRouteMatch();
       if (!routeMatch.isDefaultMatcher()) {

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTest.java
@@ -303,7 +303,7 @@ public class XdsClientImplTest {
 
   @After
   public void tearDown() {
-    XdsClientImpl.enablePathMatching = false;
+    XdsClientImpl.enableExperimentalRouting = false;
     xdsClient.shutdown();
     assertThat(adsEnded.get()).isTrue();
     assertThat(lrsEnded.get()).isTrue();
@@ -643,7 +643,7 @@ public class XdsClientImplTest {
    */
   @Test
   public void resolveVirtualHostWithPathMatchingInRdsResponse() {
-    XdsClientImpl.enablePathMatching = true;
+    XdsClientImpl.enableExperimentalRouting = true;
     xdsClient.watchConfigData(TARGET_AUTHORITY, configWatcher);
     StreamObserver<DiscoveryResponse> responseObserver = responseObservers.poll();
     StreamObserver<DiscoveryRequest> requestObserver = requestObservers.poll();

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -185,7 +185,7 @@ public class XdsNameResolverTest {
   @After
   public void tearDown() {
     xdsNameResolver.shutdown();
-    XdsClientImpl.enablePathMatching = false;
+    XdsClientImpl.enableExperimentalRouting = false;
   }
 
   @Test
@@ -345,7 +345,7 @@ public class XdsNameResolverTest {
   @Test
   @SuppressWarnings("unchecked")
   public void resolve_resourceUpdated_multipleRoutes() {
-    XdsClientImpl.enablePathMatching = true;
+    XdsClientImpl.enableExperimentalRouting = true;
     xdsNameResolver.start(mockListener);
     assertThat(responseObservers).hasSize(1);
     StreamObserver<DiscoveryResponse> responseObserver = responseObservers.poll();
@@ -482,7 +482,7 @@ public class XdsNameResolverTest {
   @Test
   @SuppressWarnings("unchecked")
   public void resolve_resourceUpdated_allowDuplicateMatchers() {
-    XdsClientImpl.enablePathMatching = true;
+    XdsClientImpl.enableExperimentalRouting = true;
     xdsNameResolver.start(mockListener);
     assertThat(responseObservers).hasSize(1);
     StreamObserver<DiscoveryResponse> responseObserver = responseObservers.poll();


### PR DESCRIPTION
Rename according to the design doc.