### PR TITLE
grpc-context: add a option to create Context.Key with default name

### DIFF
--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -153,19 +153,21 @@ public class Context {
   }
 
   /**
-   * Create a {@link Key} with the given debug name. Multiple different keys may have the same name;
-   * the name is intended for debugging purposes and does not impact behavior.
+   * Create a {@link Key} with the given debug name.
+   * @param debugString a name is intended for debugging purposes and does not impact behavior;
+   *                    Multiple different keys may have the same debugString.
    */
-  public static <T> Key<T> key(String name) {
-    return new Key<>(name);
+  public static <T> Key<T> key(String debugString) {
+    return new Key<>(debugString);
   }
 
   /**
-   * Create a {@link Key} with the given debug name and default value. Multiple different keys may
-   * have the same name; the name is intended for debugging purposes and does not impact behavior.
+   * Create a {@link Key} with the given debug name and default value.
+   * @param debugString a name is intended for debugging purposes and does not impact behavior;
+   *                    Multiple different keys may have the same debugString.
    */
-  public static <T> Key<T> keyWithDefault(String name, T defaultValue) {
-    return new Key<>(name, defaultValue);
+  public static <T> Key<T> keyWithDefault(String debugString, T defaultValue) {
+    return new Key<>(debugString, defaultValue);
   }
 
   /**

--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -18,8 +18,6 @@ package io.grpc;
 
 import io.grpc.Context.CheckReturnValue;
 import io.grpc.PersistentHashArrayMappedTrie.Node;
-
-import javax.annotation.Nonnull;
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.concurrent.Callable;
@@ -159,8 +157,9 @@ public class Context {
    *
    * @param debugString a name intended for debugging purposes and does not impact behavior.
    *                    multiple different keys may have the same debugString.
+   *                    a value should be not null.
    */
-  public static <T> Key<T> key(@Nonnull String debugString) {
+  public static <T> Key<T> key(String debugString) {
     return new Key<>(debugString);
   }
 
@@ -169,8 +168,9 @@ public class Context {
    *
    * @param debugString a name intended for debugging purposes and does not impact behavior.
    *                    multiple different keys may have the same debugString.
+   *                    a value should be not null.
    */
-  public static <T> Key<T> keyWithDefault(@Nonnull String debugString, T defaultValue) {
+  public static <T> Key<T> keyWithDefault(String debugString, T defaultValue) {
     return new Key<>(debugString, defaultValue);
   }
 

--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -153,6 +153,14 @@ public class Context {
   }
 
   /**
+   * Create a {@link Key} with {@value io.grpc.Context.Key#DEFAULT_NAME} value as a debug name. Multiple different keys may have the same name;
+   * the name is intended for debugging purposes and does not impact behavior.
+   */
+  public static <T> Key<T> key() {
+    return new Key<>();
+  }
+
+  /**
    * Create a {@link Key} with the given debug name. Multiple different keys may have the same name;
    * the name is intended for debugging purposes and does not impact behavior.
    */
@@ -946,8 +954,13 @@ public class Context {
    * Key for indexing values stored in a context.
    */
   public static final class Key<T> {
+    public final static String DEFAULT_NAME = "default";
     private final String name;
     private final T defaultValue;
+
+    Key() {
+      this(DEFAULT_NAME, null);
+    }
 
     Key(String name) {
       this(name, null);

--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -156,8 +156,8 @@ public class Context {
    * Create a {@link Key} with the given debug name.
    *
    * @param debugString a name intended for debugging purposes and does not impact behavior.
-   *                    multiple different keys may have the same debugString.
-   *                    a value should be not null.
+   *                    Multiple different keys may have the same debugString.
+   *                    The value should be not null.
    */
   public static <T> Key<T> key(String debugString) {
     return new Key<>(debugString);
@@ -167,8 +167,8 @@ public class Context {
    * Create a {@link Key} with the given debug name and default value.
    *
    * @param debugString a name intended for debugging purposes and does not impact behavior.
-   *                    multiple different keys may have the same debugString.
-   *                    a value should be not null.
+   *                    Multiple different keys may have the same debugString.
+   *                    The value should be not null.
    */
   public static <T> Key<T> keyWithDefault(String debugString, T defaultValue) {
     return new Key<>(debugString, defaultValue);

--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -153,14 +153,6 @@ public class Context {
   }
 
   /**
-   * Create a {@link Key} with {@value io.grpc.Context.Key#DEFAULT_NAME} value as a debug name. Multiple different keys may have the same name;
-   * the name is intended for debugging purposes and does not impact behavior.
-   */
-  public static <T> Key<T> key() {
-    return new Key<>();
-  }
-
-  /**
    * Create a {@link Key} with the given debug name. Multiple different keys may have the same name;
    * the name is intended for debugging purposes and does not impact behavior.
    */
@@ -954,13 +946,8 @@ public class Context {
    * Key for indexing values stored in a context.
    */
   public static final class Key<T> {
-    public final static String DEFAULT_NAME = "default";
     private final String name;
     private final T defaultValue;
-
-    Key() {
-      this(DEFAULT_NAME, null);
-    }
 
     Key(String name) {
       this(name, null);

--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -156,8 +156,9 @@ public class Context {
 
   /**
    * Create a {@link Key} with the given debug name.
-   * @param debugString a name is intended for debugging purposes and does not impact behavior;
-   *                    Multiple different keys may have the same debugString.
+   *
+   * @param debugString a name intended for debugging purposes and does not impact behavior.
+   *                    multiple different keys may have the same debugString.
    */
   public static <T> Key<T> key(@Nonnull String debugString) {
     return new Key<>(debugString);
@@ -165,8 +166,9 @@ public class Context {
 
   /**
    * Create a {@link Key} with the given debug name and default value.
-   * @param debugString a name is intended for debugging purposes and does not impact behavior;
-   *                    Multiple different keys may have the same debugString.
+   *
+   * @param debugString a name intended for debugging purposes and does not impact behavior.
+   *                    multiple different keys may have the same debugString.
    */
   public static <T> Key<T> keyWithDefault(@Nonnull String debugString, T defaultValue) {
     return new Key<>(debugString, defaultValue);

--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -18,6 +18,8 @@ package io.grpc;
 
 import io.grpc.Context.CheckReturnValue;
 import io.grpc.PersistentHashArrayMappedTrie.Node;
+
+import javax.annotation.Nonnull;
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.concurrent.Callable;
@@ -157,7 +159,7 @@ public class Context {
    * @param debugString a name is intended for debugging purposes and does not impact behavior;
    *                    Multiple different keys may have the same debugString.
    */
-  public static <T> Key<T> key(String debugString) {
+  public static <T> Key<T> key(@Nonnull String debugString) {
     return new Key<>(debugString);
   }
 
@@ -166,7 +168,7 @@ public class Context {
    * @param debugString a name is intended for debugging purposes and does not impact behavior;
    *                    Multiple different keys may have the same debugString.
    */
-  public static <T> Key<T> keyWithDefault(String debugString, T defaultValue) {
+  public static <T> Key<T> keyWithDefault(@Nonnull String debugString, T defaultValue) {
     return new Key<>(debugString, defaultValue);
   }
 


### PR DESCRIPTION
## Motivation
- Motivated Issue : #7024 
### Background
  - Context.key(name) is the function to create Context.Key object instance.
  - the name parameter of Context.key(name) is used as debug name and does not impact behavior.
### The Main Point
  - But, Users cannot create Context.Key without specifying debug name
  - It means user must specify the debug name of Context.Key although the user don't want to use it.
  - It is better that a parameter for debug (like the name parameter) is being optional
  - It will make users recognize `multiple different keys may have a same name` from the code before they see the document of the function
