### PR TITLE
Set `SETTINGS_MAX_FRAME_SIZE` appropriately during initial handshake

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -136,11 +136,13 @@ class NettyClientHandler extends AbstractNettyHandler {
       boolean autoFlowControl,
       int flowControlWindow,
       int maxHeaderListSize,
+      int maxFrameSize,
       Supplier<Stopwatch> stopwatchFactory,
       Runnable tooManyPingsRunnable,
       TransportTracer transportTracer,
       Attributes eagAttributes,
-      String authority) {
+      String authority
+  ) {
     Preconditions.checkArgument(maxHeaderListSize > 0, "maxHeaderListSize must be positive");
     Http2HeadersDecoder headersDecoder = new GrpcHttp2ClientHeadersDecoder(maxHeaderListSize);
     Http2FrameReader frameReader = new DefaultHttp2FrameReader(headersDecoder);
@@ -161,28 +163,32 @@ class NettyClientHandler extends AbstractNettyHandler {
         autoFlowControl,
         flowControlWindow,
         maxHeaderListSize,
+        maxFrameSize,
         stopwatchFactory,
         tooManyPingsRunnable,
         transportTracer,
         eagAttributes,
-        authority);
+        authority
+    );
   }
 
   @VisibleForTesting
   static NettyClientHandler newHandler(
-      final Http2Connection connection,
-      Http2FrameReader frameReader,
-      Http2FrameWriter frameWriter,
-      ClientTransportLifecycleManager lifecycleManager,
-      KeepAliveManager keepAliveManager,
-      boolean autoFlowControl,
-      int flowControlWindow,
-      int maxHeaderListSize,
-      Supplier<Stopwatch> stopwatchFactory,
-      Runnable tooManyPingsRunnable,
-      TransportTracer transportTracer,
-      Attributes eagAttributes,
-      String authority) {
+          final Http2Connection connection,
+          Http2FrameReader frameReader,
+          Http2FrameWriter frameWriter,
+          ClientTransportLifecycleManager lifecycleManager,
+          KeepAliveManager keepAliveManager,
+          boolean autoFlowControl,
+          int flowControlWindow,
+          int maxHeaderListSize,
+          int maxFrameSeize,
+          Supplier<Stopwatch> stopwatchFactory,
+          Runnable tooManyPingsRunnable,
+          TransportTracer transportTracer,
+          Attributes eagAttributes,
+          String authority
+  ) {
     Preconditions.checkNotNull(connection, "connection");
     Preconditions.checkNotNull(frameReader, "frameReader");
     Preconditions.checkNotNull(lifecycleManager, "lifecycleManager");
@@ -225,6 +231,7 @@ class NettyClientHandler extends AbstractNettyHandler {
     settings.initialWindowSize(flowControlWindow);
     settings.maxConcurrentStreams(0);
     settings.maxHeaderListSize(maxHeaderListSize);
+    settings.maxFrameSize(maxFrameSeize);
 
     return new NettyClientHandler(
         decoder,

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -220,6 +220,7 @@ class NettyClientTransport implements ConnectionClientTransport {
         autoFlowControl,
         flowControlWindow,
         maxHeaderListSize,
+        maxMessageSize,
         GrpcUtil.STOPWATCH_SUPPLIER,
         tooManyPingsRunnable,
         transportTracer,

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -793,11 +793,13 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
         false,
         flowControlWindow,
         maxHeaderListSize,
+        maxFrameSize,
         stopwatchSupplier,
         tooManyPingsRunnable,
         transportTracer,
         Attributes.EMPTY,
-        "someauthority");
+        "someauthority"
+    );
   }
 
   @Override

--- a/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
+++ b/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
@@ -18,6 +18,7 @@ package io.grpc.netty;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_WINDOW_SIZE;
+import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_FRAME_SIZE_LOWER_BOUND;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
@@ -101,6 +102,7 @@ public abstract class NettyHandlerTestBase<T extends Http2ConnectionHandler> {
 
   protected final TransportTracer transportTracer = new TransportTracer();
   protected int flowControlWindow = DEFAULT_WINDOW_SIZE;
+  protected int maxFrameSize = MAX_FRAME_SIZE_LOWER_BOUND;
   protected boolean autoFlowControl = false;
 
   private final FakeClock fakeClock = new FakeClock();


### PR DESCRIPTION
Currently `NettyClientTransport.maxMessageSize` isn't set as [`SETTINGS_MAX_FRAME_SIZE`](https://http2.github.io/http2-spec/#SETTINGS_MAX_FRAME_SIZE) within `SETTINGS` handshake therefore capping all the incoming and outgoing data-frames to be of size no more than default cap (16384);

 This change sets it properly, making sure it's advertised appropriately during the handshake.