### PR TITLE
interop-testing: adds assertions to empty_stream test case.

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -790,6 +790,8 @@ public abstract class AbstractInteropTest {
         = asyncStub.fullDuplexCall(responseObserver);
     requestObserver.onCompleted();
     responseObserver.awaitCompletion(operationTimeoutMillis(), TimeUnit.MILLISECONDS);
+    assertSuccess(responseObserver);
+    assertTrue("Expected an empty stream", responseObserver.getValues().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
If the server fails (e.g.: with an unimplemented status), the test still succeeds.
This change adds assertions to check the status code as well as the expected number of responses.