### PR TITLE
xds: add more route matching types in converted Route data structure

### DIFF
--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -24,7 +24,8 @@ dependencies {
             project(':grpc-core'),
             project(':grpc-services'),
             project(path: ':grpc-alts', configuration: 'shadow'),
-            libraries.gson
+            libraries.gson,
+            libraries.re2j
     def nettyDependency = implementation project(':grpc-netty')
 
     implementation (libraries.opencensus_proto) {

--- a/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
@@ -866,7 +866,7 @@ final class EnvoyProtoData {
     public String toString() {
       ToStringHelper toStringHelper =
           MoreObjects.toStringHelper(this).add("name", name);
-      if (exactMatch !=null) {
+      if (exactMatch != null) {
         toStringHelper.add("exactMatch", exactMatch);
       }
       if (safeRegExMatch != null) {

--- a/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
@@ -479,7 +479,7 @@ final class EnvoyProtoData {
       }
       if (routeMatch.getErrorDetail() != null) {
         return StructOrError.fromError(
-            "Invalid route [" + proto.getName() + "] : " + routeMatch.getErrorDetail());
+            "Invalid route [" + proto.getName() + "]: " + routeMatch.getErrorDetail());
       }
 
       StructOrError<RouteAction> routeAction;
@@ -494,13 +494,12 @@ final class EnvoyProtoData {
         case FILTER_ACTION:
           return StructOrError.fromError("Unsupported action type: filter_action");
         case ACTION_NOT_SET:
-          // fall through
         default:
           return StructOrError.fromError("Unknown action type: " + proto.getActionCase());
       }
       if (routeAction.getErrorDetail() != null) {
         return StructOrError.fromError(
-            "Invalid route [" + proto.getName() + "] : " + routeAction.getErrorDetail());
+            "Invalid route [" + proto.getName() + "]: " + routeAction.getErrorDetail());
       }
       return StructOrError.fromStruct(new Route(routeMatch.getStruct(), routeAction.getStruct()));
     }
@@ -561,7 +560,6 @@ final class EnvoyProtoData {
       if (pathPrefixMatch != null) {
         return pathPrefixMatch.isEmpty() || pathPrefixMatch.equals("/");
       }
-      // TODO (chengyuanzhang): can path match with regex be a default route?
       return false;
     }
 
@@ -626,7 +624,6 @@ final class EnvoyProtoData {
             denominator = 1_000_000;
             break;
           case UNRECOGNIZED:
-            // fall through
           default:
             return StructOrError.fromError(
                 "Unrecognized fractional percent denominator: " + percent.getDenominator());
@@ -671,7 +668,6 @@ final class EnvoyProtoData {
           safeRegExPathMatch = proto.getSafeRegex().getRegex();
           break;
         case PATHSPECIFIER_NOT_SET:
-          // fall through
         default:
           return StructOrError.fromError("Unknown path match type");
       }
@@ -805,7 +801,6 @@ final class EnvoyProtoData {
           suffixMatch = proto.getSuffixMatch();
           break;
         case HEADERMATCHSPECIFIER_NOT_SET:
-          // fall through
         default:
           return StructOrError.fromError("Unknown header matcher type");
       }
@@ -978,7 +973,6 @@ final class EnvoyProtoData {
           }
           break;
         case CLUSTERSPECIFIER_NOT_SET:
-          // fall through
         default:
           return StructOrError.fromError(
               "Unknown cluster specifier: " + proto.getClusterSpecifierCase());

--- a/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import io.envoyproxy.envoy.type.FractionalPercent;
 import io.envoyproxy.envoy.type.FractionalPercent.DenominatorType;
@@ -29,6 +28,7 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
@@ -101,12 +101,12 @@ final class EnvoyProtoData {
         return false;
       }
       StructOrError<?> that = (StructOrError<?>) o;
-      return Objects.equal(errorDetail, that.errorDetail) && Objects.equal(struct, that.struct);
+      return Objects.equals(errorDetail, that.errorDetail) && Objects.equals(struct, that.struct);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(errorDetail, struct);
+      return Objects.hash(errorDetail, struct);
     }
 
     @Override
@@ -174,14 +174,14 @@ final class EnvoyProtoData {
         return false;
       }
       Locality locality = (Locality) o;
-      return Objects.equal(region, locality.region)
-          && Objects.equal(zone, locality.zone)
-          && Objects.equal(subZone, locality.subZone);
+      return Objects.equals(region, locality.region)
+          && Objects.equals(zone, locality.zone)
+          && Objects.equals(subZone, locality.subZone);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(region, zone, subZone);
+      return Objects.hash(region, zone, subZone);
     }
 
     @Override
@@ -247,12 +247,12 @@ final class EnvoyProtoData {
       LocalityLbEndpoints that = (LocalityLbEndpoints) o;
       return localityWeight == that.localityWeight
           && priority == that.priority
-          && Objects.equal(endpoints, that.endpoints);
+          && Objects.equals(endpoints, that.endpoints);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(endpoints, localityWeight, priority);
+      return Objects.hash(endpoints, localityWeight, priority);
     }
 
     @Override
@@ -325,13 +325,13 @@ final class EnvoyProtoData {
       }
       LbEndpoint that = (LbEndpoint) o;
       return loadBalancingWeight == that.loadBalancingWeight
-          && Objects.equal(eag, that.eag)
+          && Objects.equals(eag, that.eag)
           && isHealthy == that.isHealthy;
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(eag, loadBalancingWeight, isHealthy);
+      return Objects.hash(eag, loadBalancingWeight, isHealthy);
     }
 
     @Override
@@ -401,12 +401,12 @@ final class EnvoyProtoData {
         return false;
       }
       DropOverload that = (DropOverload) o;
-      return dropsPerMillion == that.dropsPerMillion && Objects.equal(category, that.category);
+      return dropsPerMillion == that.dropsPerMillion && Objects.equals(category, that.category);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(category, dropsPerMillion);
+      return Objects.hash(category, dropsPerMillion);
     }
 
     @Override
@@ -450,13 +450,13 @@ final class EnvoyProtoData {
         return false;
       }
       Route route = (Route) o;
-      return Objects.equal(routeMatch, route.routeMatch)
-          && Objects.equal(routeAction, route.routeAction);
+      return Objects.equals(routeMatch, route.routeMatch)
+          && Objects.equals(routeAction, route.routeAction);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(routeMatch, routeAction);
+      return Objects.hash(routeMatch, routeAction);
     }
 
     @Override
@@ -570,16 +570,16 @@ final class EnvoyProtoData {
         return false;
       }
       RouteMatch that = (RouteMatch) o;
-      return Objects.equal(pathPrefixMatch, that.pathPrefixMatch)
-          && Objects.equal(pathExactMatch, that.pathExactMatch)
-          && Objects.equal(pathSafeRegExMatch, that.pathSafeRegExMatch)
-          && Objects.equal(fractionMatch, that.fractionMatch)
-          && Objects.equal(headerMatchers, that.headerMatchers);
+      return Objects.equals(pathPrefixMatch, that.pathPrefixMatch)
+          && Objects.equals(pathExactMatch, that.pathExactMatch)
+          && Objects.equals(pathSafeRegExMatch, that.pathSafeRegExMatch)
+          && Objects.equals(fractionMatch, that.fractionMatch)
+          && Objects.equals(headerMatchers, that.headerMatchers);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(pathPrefixMatch, pathExactMatch, headerMatchers, fractionMatch);
+      return Objects.hash(pathPrefixMatch, pathExactMatch, headerMatchers, fractionMatch);
     }
 
     @Override
@@ -699,7 +699,7 @@ final class EnvoyProtoData {
 
       @Override
       public int hashCode() {
-        return Objects.hashCode(numerator, denominator);
+        return Objects.hash(numerator, denominator);
       }
 
       @Override
@@ -711,8 +711,8 @@ final class EnvoyProtoData {
           return false;
         }
         Fraction that = (Fraction) o;
-        return Objects.equal(numerator, that.numerator)
-            && Objects.equal(denominator, that.denominator);
+        return Objects.equals(numerator, that.numerator)
+            && Objects.equals(denominator, that.denominator);
       }
 
       @Override
@@ -819,19 +819,19 @@ final class EnvoyProtoData {
         return false;
       }
       HeaderMatcher that = (HeaderMatcher) o;
-      return Objects.equal(name, that.name)
-          && Objects.equal(exactMatch, that.exactMatch)
-          && Objects.equal(safeRegExMatch, that.safeRegExMatch)
-          && Objects.equal(rangeMatch, that.rangeMatch)
-          && Objects.equal(presentMatch, that.presentMatch)
-          && Objects.equal(prefixMatch, that.prefixMatch)
-          && Objects.equal(suffixMatch, that.suffixMatch)
-          && Objects.equal(isInvertedMatch, that.isInvertedMatch);
+      return Objects.equals(name, that.name)
+          && Objects.equals(exactMatch, that.exactMatch)
+          && Objects.equals(safeRegExMatch, that.safeRegExMatch)
+          && Objects.equals(rangeMatch, that.rangeMatch)
+          && Objects.equals(presentMatch, that.presentMatch)
+          && Objects.equals(prefixMatch, that.prefixMatch)
+          && Objects.equals(suffixMatch, that.suffixMatch)
+          && Objects.equals(isInvertedMatch, that.isInvertedMatch);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(
+      return Objects.hash(
           name, exactMatch, safeRegExMatch, rangeMatch, presentMatch, prefixMatch,
           suffixMatch, isInvertedMatch);
     }
@@ -861,7 +861,7 @@ final class EnvoyProtoData {
 
       @Override
       public int hashCode() {
-        return Objects.hashCode(start, end);
+        return Objects.hash(start, end);
       }
 
       @Override
@@ -873,8 +873,8 @@ final class EnvoyProtoData {
           return false;
         }
         Range that = (Range) o;
-        return Objects.equal(start, that.start)
-            && Objects.equal(end, that.end);
+        return Objects.equals(start, that.start)
+            && Objects.equals(end, that.end);
       }
 
       @Override
@@ -930,14 +930,14 @@ final class EnvoyProtoData {
         return false;
       }
       RouteAction that = (RouteAction) o;
-      return Objects.equal(cluster, that.cluster)
-              && Objects.equal(clusterHeader, that.clusterHeader)
-              && Objects.equal(weightedClusters, that.weightedClusters);
+      return Objects.equals(cluster, that.cluster)
+              && Objects.equals(clusterHeader, that.clusterHeader)
+              && Objects.equals(weightedClusters, that.weightedClusters);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(cluster, clusterHeader, weightedClusters);
+      return Objects.hash(cluster, clusterHeader, weightedClusters);
     }
 
     @Override
@@ -1012,12 +1012,12 @@ final class EnvoyProtoData {
         return false;
       }
       ClusterWeight that = (ClusterWeight) o;
-      return weight == that.weight && Objects.equal(name, that.name);
+      return weight == that.weight && Objects.equals(name, that.name);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(name, weight);
+      return Objects.hash(name, weight);
     }
 
     @Override

--- a/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
@@ -40,6 +40,10 @@ import javax.annotation.Nullable;
  *
  * <p>For data types that need to be sent as protobuf messages, a {@code toEnvoyProtoXXX} instance
  * method is defined to convert an instance to Envoy proto message.
+ *
+ * <p>Data conversion should follow the invariant: converted data is guaranteed to be valid for
+ * gRPC. If the protobuf message contains invalid data, the conversion should fail and no object
+ * should be instantiated.
  */
 final class EnvoyProtoData {
 

--- a/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
@@ -551,11 +551,11 @@ final class EnvoyProtoData {
       if (pathSafeRegExMatch != null || fractionMatch != null) {
         return false;
       }
-      if (headerMatchers != null && !headerMatchers.isEmpty()) {
+      if (!headerMatchers.isEmpty()) {
         return false;
       }
       if (pathExactMatch != null) {
-        return pathExactMatch.isEmpty();
+        return false;
       }
       if (pathPrefixMatch != null) {
         return pathPrefixMatch.isEmpty() || pathPrefixMatch.equals("/");
@@ -652,14 +652,11 @@ final class EnvoyProtoData {
           exactPathMatch = proto.getPath();
           int lastSlash = exactPathMatch.lastIndexOf('/');
           // Supported exact match format:
-          // "" (default)
           // "/service/method"
-          if (!exactPathMatch.isEmpty()) {
-            if (!exactPathMatch.startsWith("/") || lastSlash == 0
-                || lastSlash == exactPathMatch.length() - 1) {
-              return StructOrError.fromError(
-                  "Invalid format of exact path match: " + exactPathMatch);
-            }
+          if (!exactPathMatch.startsWith("/") || lastSlash == 0
+              || lastSlash == exactPathMatch.length() - 1) {
+            return StructOrError.fromError(
+                "Invalid format of exact path match: " + exactPathMatch);
           }
           break;
         case REGEX:

--- a/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
@@ -847,8 +847,8 @@ final class EnvoyProtoData {
     @Override
     public int hashCode() {
       return Objects.hash(
-          name, exactMatch, safeRegExMatch, rangeMatch, presentMatch, prefixMatch,
-          suffixMatch, isInvertedMatch);
+          name, exactMatch, safeRegExMatch == null ? null : safeRegExMatch.pattern(),
+          rangeMatch, presentMatch, prefixMatch, suffixMatch, isInvertedMatch);
     }
 
     @Override

--- a/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
+import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.collect.ImmutableList;
 import com.google.re2j.Pattern;
 import com.google.re2j.PatternSyntaxException;
@@ -585,18 +586,28 @@ final class EnvoyProtoData {
 
     @Override
     public int hashCode() {
-      return Objects.hash(pathPrefixMatch, pathExactMatch, headerMatchers, fractionMatch);
+      return Objects.hash(
+          pathPrefixMatch, pathExactMatch,
+          pathSafeRegExMatch == null ? null : pathSafeRegExMatch.pattern(), headerMatchers,
+          fractionMatch);
     }
 
     @Override
     public String toString() {
-      return MoreObjects.toStringHelper(this)
-          .add("pathPrefixMatch", pathPrefixMatch)
-          .add("pathExactMatch", pathExactMatch)
-          .add("pathSafeRegExMatch", pathSafeRegExMatch)
-          .add("headerMatchers", headerMatchers)
-          .add("fractionMatch", fractionMatch)
-          .toString();
+      ToStringHelper toStringHelper = MoreObjects.toStringHelper(this);
+      if (pathPrefixMatch != null) {
+        toStringHelper.add("pathPrefixMatch", pathPrefixMatch);
+      }
+      if (pathExactMatch != null) {
+        toStringHelper.add("pathExactMatch", pathExactMatch);
+      }
+      if (pathSafeRegExMatch != null) {
+        toStringHelper.add("pathSafeRegExMatch",pathSafeRegExMatch.pattern());
+      }
+      if (fractionMatch != null) {
+        toStringHelper.add("fractionMatch", fractionMatch);
+      }
+      return toStringHelper.add("headerMatchers", headerMatchers).toString();
     }
 
     @VisibleForTesting
@@ -853,16 +864,27 @@ final class EnvoyProtoData {
 
     @Override
     public String toString() {
-      return MoreObjects.toStringHelper(this)
-          .add("name", name)
-          .add("exactMatch", exactMatch)
-          .add("safeRegExMatch", safeRegExMatch)
-          .add("rangeMatch", rangeMatch)
-          .add("presentMatch", presentMatch)
-          .add("prefixMatch", prefixMatch)
-          .add("suffixMatch", suffixMatch)
-          .add("isInvertedMatch", isInvertedMatch)
-          .toString();
+      ToStringHelper toStringHelper =
+          MoreObjects.toStringHelper(this).add("name", name);
+      if (exactMatch !=null) {
+        toStringHelper.add("exactMatch", exactMatch);
+      }
+      if (safeRegExMatch != null) {
+        toStringHelper.add("safeRegExMatch", safeRegExMatch.pattern());
+      }
+      if (rangeMatch != null) {
+        toStringHelper.add("rangeMatch", rangeMatch);
+      }
+      if (presentMatch != null) {
+        toStringHelper.add("presentMatch", presentMatch);
+      }
+      if (prefixMatch != null) {
+        toStringHelper.add("prefixMatch", prefixMatch);
+      }
+      if (suffixMatch != null) {
+        toStringHelper.add("suffixMatch", suffixMatch);
+      }
+      return toStringHelper.add("isInvertedMatch", isInvertedMatch).toString();
     }
 
     static final class Range {
@@ -958,11 +980,17 @@ final class EnvoyProtoData {
 
     @Override
     public String toString() {
-      return MoreObjects.toStringHelper(this)
-              .add("cluster", cluster)
-              .add("clusterHeader", clusterHeader)
-              .add("weightedCluster", weightedClusters)
-              .toString();
+      ToStringHelper toStringHelper = MoreObjects.toStringHelper(this);
+      if (cluster != null) {
+        toStringHelper.add("cluster", cluster);
+      }
+      if (clusterHeader != null) {
+        toStringHelper.add("clusterHeader", clusterHeader);
+      }
+      if (weightedClusters != null) {
+        toStringHelper.add("weightedClusters", weightedClusters);
+      }
+      return toStringHelper.toString();
     }
 
     @VisibleForTesting

--- a/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
@@ -696,6 +696,7 @@ final class EnvoyProtoData {
       private final int numerator;
       private final int denominator;
 
+      @VisibleForTesting
       Fraction(int numerator, int denominator) {
         this.numerator = numerator;
         this.denominator = denominator;
@@ -858,6 +859,7 @@ final class EnvoyProtoData {
       private final long start;
       private final long end;
 
+      @VisibleForTesting
       Range(long start, long end) {
         this.start = start;
         this.end = end;

--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -63,12 +63,12 @@ import io.grpc.xds.Bootstrapper.ServerInfo;
 import io.grpc.xds.EnvoyProtoData.DropOverload;
 import io.grpc.xds.EnvoyProtoData.Locality;
 import io.grpc.xds.EnvoyProtoData.LocalityLbEndpoints;
-import io.grpc.xds.EnvoyProtoData.RouteAction;
-import io.grpc.xds.EnvoyProtoData.RouteMatch;
+import io.grpc.xds.EnvoyProtoData.StructOrError;
 import io.grpc.xds.LoadReportClient.LoadReportCallback;
 import io.grpc.xds.XdsLogger.XdsLogLevel;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -601,14 +601,13 @@ final class XdsClientImpl extends XdsClient {
       //  data or one supersedes the other. TBD.
       if (requestedHttpConnManager.hasRouteConfig()) {
         RouteConfiguration rc = requestedHttpConnManager.getRouteConfig();
-        routes = findRoutesInRouteConfig(rc, ldsResourceName);
-        String errorDetail = validateRoutes(routes);
-        if (errorDetail != null) {
+        try {
+          routes = findRoutesInRouteConfig(rc, ldsResourceName);
+        } catch (InvalidProtoDataException e) {
           errorMessage =
               "Listener " + ldsResourceName + " : cannot find a valid cluster name in any "
-                  + "virtual hosts inside RouteConfiguration with domains matching: "
-                  + ldsResourceName
-                  + " with the reason : " + errorDetail;
+                  + "virtual hosts domains matching: " + ldsResourceName
+                  + " with the reason : " + e.getMessage();
         }
       } else if (requestedHttpConnManager.hasRds()) {
         Rds rds = requestedHttpConnManager.getRds();
@@ -643,23 +642,10 @@ final class XdsClientImpl extends XdsClient {
     }
     if (routes != null) {
       // Found  routes in the in-lined RouteConfiguration.
-      ConfigUpdate configUpdate;
-      if (!enableExperimentalRouting) {
-        EnvoyProtoData.Route defaultRoute = Iterables.getLast(routes);
-        configUpdate =
-            ConfigUpdate.newBuilder()
-                .addRoutes(ImmutableList.of(defaultRoute))
-                .build();
-        logger.log(
-            XdsLogLevel.INFO,
-            "Found cluster name (inlined in route config): {0}",
-            defaultRoute.getRouteAction().getCluster());
-      } else {
-        configUpdate = ConfigUpdate.newBuilder().addRoutes(routes).build();
-        logger.log(
-            XdsLogLevel.INFO,
-            "Found routes (inlined in route config): {0}", routes);
-      }
+      logger.log(
+          XdsLogLevel.DEBUG,
+          "Found routes (inlined in route config): {0}", routes);
+      ConfigUpdate configUpdate = ConfigUpdate.newBuilder().addRoutes(routes).build();
       configWatcher.onConfigChanged(configUpdate);
     } else if (rdsRouteConfigName != null) {
       // Send an RDS request if the resource to request has changed.
@@ -800,9 +786,10 @@ final class XdsClientImpl extends XdsClient {
     // Resolved cluster name for the requested resource, if exists.
     List<EnvoyProtoData.Route> routes = null;
     if (requestedRouteConfig != null) {
-      routes = findRoutesInRouteConfig(requestedRouteConfig, ldsResourceName);
-      String errorDetail = validateRoutes(routes);
-      if (errorDetail != null) {
+      try {
+        routes = findRoutesInRouteConfig(requestedRouteConfig, ldsResourceName);
+      } catch (InvalidProtoDataException e) {
+        String errorDetail = e.getMessage();
         adsStream.sendNackRequest(
             ADS_TYPE_URL_RDS, ImmutableList.of(adsStream.rdsResourceName),
             rdsResponse.getVersionInfo(),
@@ -824,24 +811,9 @@ final class XdsClientImpl extends XdsClient {
         rdsRespTimer.cancel();
         rdsRespTimer = null;
       }
-
-      // Found routes in the in-lined RouteConfiguration.
-      ConfigUpdate configUpdate;
-      if (!enableExperimentalRouting) {
-        EnvoyProtoData.Route defaultRoute = Iterables.getLast(routes);
-        configUpdate =
-            ConfigUpdate.newBuilder()
-                .addRoutes(ImmutableList.of(defaultRoute))
-                .build();
-        logger.log(
-            XdsLogLevel.INFO,
-            "Found cluster name: {0}",
-            defaultRoute.getRouteAction().getCluster());
-      } else {
-        configUpdate = ConfigUpdate.newBuilder().addRoutes(routes).build();
-        logger.log(XdsLogLevel.INFO, "Found {0} routes", routes.size());
-        logger.log(XdsLogLevel.DEBUG, "Found routes: {0}", routes);
-      }
+      logger.log(XdsLogLevel.DEBUG, "Found routes: {0}", routes);
+      ConfigUpdate configUpdate  =
+          ConfigUpdate.newBuilder().addRoutes(routes).build();
       configWatcher.onConfigChanged(configUpdate);
     }
   }
@@ -849,9 +821,72 @@ final class XdsClientImpl extends XdsClient {
   /**
    * Processes a RouteConfiguration message to find the routes that requests for the given host will
    * be routed to.
+   *
+   * @throws InvalidProtoDataException if the message contains invalid data.
    */
   @VisibleForTesting
   static List<EnvoyProtoData.Route> findRoutesInRouteConfig(
+      RouteConfiguration config, String hostName) throws InvalidProtoDataException {
+    VirtualHost targetVirtualHost = findVirtualHostForHostName(config, hostName);
+    if (targetVirtualHost == null) {
+      throw new InvalidProtoDataException("Unable to find virtual host for " + hostName);
+    }
+
+    // Note we would consider upstream cluster not found if the virtual host is not configured
+    // correctly for gRPC, even if there exist other virtual hosts with (lower priority)
+    // matching domains.
+    List<EnvoyProtoData.Route> routes = new ArrayList<>();
+    List<Route> routesProto = targetVirtualHost.getRoutesList();
+    for (Route routeProto : routesProto) {
+      StructOrError<EnvoyProtoData.Route> route =
+          EnvoyProtoData.Route.fromEnvoyProtoRoute(routeProto);
+      if (route == null) {
+        continue;
+      } else if (route.getErrorDetail() != null) {
+        throw new InvalidProtoDataException(
+            "Virtual host [" + targetVirtualHost.getName() + "] contains invalid route : "
+                + route.getErrorDetail());
+      }
+      routes.add(route.getStruct());
+    }
+    if (routes.isEmpty()) {
+      throw new InvalidProtoDataException(
+          "Virtual host [" + targetVirtualHost.getName() + "] contains no usable route");
+    }
+    if (!Iterables.getLast(routes).isDefaultRoute()) {
+      throw new InvalidProtoDataException(
+          "Virtual host [" + targetVirtualHost.getName()
+              + "] contains non-default route as the last route");
+    }
+    // We only validate the default route unless path matching is enabled.
+    if (!enableExperimentalRouting) {
+      EnvoyProtoData.Route defaultRoute = Iterables.getLast(routes);
+      if (defaultRoute.getRouteAction().getCluster() == null) {
+        throw new InvalidProtoDataException(
+            "Virtual host [" + targetVirtualHost.getName()
+                + "] default route contains no cluster name");
+      }
+      return Collections.singletonList(defaultRoute);
+    }
+
+    // We do more validation if path matching is enabled, but whether every single route is
+    // required to be valid for grpc is TBD.
+    // For now we consider the whole list invalid if anything invalid for grpc is found.
+    // TODO(zdapeng): Fix it if the decision is different from current implementation.
+    // TODO(zdapeng): Add test for validation.
+    for (EnvoyProtoData.Route route : routes) {
+      if (route.getRouteAction().getCluster() == null
+          && route.getRouteAction().getWeightedCluster() == null) {
+        throw new InvalidProtoDataException(
+            "Virtual host [" + targetVirtualHost.getName()
+                + "] contains route without cluster or weighted cluster");
+      }
+    }
+    return Collections.unmodifiableList(routes);
+  }
+
+  @VisibleForTesting
+  static VirtualHost findVirtualHostForHostName(
       RouteConfiguration config, String hostName) {
     List<VirtualHost> virtualHosts = config.getVirtualHostsList();
     // Domain search order:
@@ -889,91 +924,7 @@ final class XdsClientImpl extends XdsClient {
         break;
       }
     }
-
-    List<EnvoyProtoData.Route> routes = new ArrayList<>();
-    // Proceed with the virtual host that has longest wildcard matched domain name with the
-    // hostname in original "xds:" URI.
-    // Note we would consider upstream cluster not found if the virtual host is not configured
-    // correctly for gRPC, even if there exist other virtual hosts with (lower priority)
-    // matching domains.
-    if (targetVirtualHost != null) {
-      List<Route> routesProto = targetVirtualHost.getRoutesList();
-      for (Route route : routesProto) {
-        routes.add(EnvoyProtoData.Route.fromEnvoyProtoRoute(route));
-      }
-    }
-    return routes;
-  }
-
-  /**
-   * Validates the given list of routes and returns error details if there's any error.
-   */
-  @Nullable
-  private static String validateRoutes(List<EnvoyProtoData.Route> routes) {
-    if (routes.isEmpty()) {
-      return "No routes found";
-    }
-
-    // We only validate the default route unless path matching is enabled.
-    if (!enableExperimentalRouting) {
-      EnvoyProtoData.Route route = routes.get(routes.size() - 1);
-      RouteMatch routeMatch = route.getRouteMatch();
-      if (!routeMatch.isDefaultMatcher()) {
-        return "The last route must be the default route";
-      }
-      if (!routeMatch.isCaseSensitive()) {
-        return "Case-insensitive route match not supported";
-      }
-      if (route.getRouteAction() == null) {
-        return "Route action is not specified for the default route";
-      }
-      if (route.getRouteAction().getCluster().isEmpty()) {
-        return "Cluster is not specified for the default route";
-      }
-      return null;
-    }
-
-    // We do more validation if path matching is enabled, but whether every single route is required
-    // to be valid for grpc is TBD.
-    // For now we consider the whole list invalid if anything invalid for grpc is found.
-    // TODO(zdapeng): Fix it if the decision is different from current implementation.
-    // TODO(zdapeng): Add test for validation.
-    for (int i = 0; i < routes.size(); i++) {
-      EnvoyProtoData.Route route = routes.get(i);
-      RouteAction routeAction = route.getRouteAction();
-      if (routeAction == null) {
-        return "Route action is not specified for one of the routes";
-      }
-      RouteMatch routeMatch = route.getRouteMatch();
-      if (!routeMatch.isCaseSensitive()) {
-        return "Case-insensitive route match not supported";
-      }
-      if (!routeMatch.isDefaultMatcher()) {
-        String prefix = routeMatch.getPrefix();
-        String path = routeMatch.getPath();
-        if (!prefix.isEmpty()) {
-          if (!prefix.startsWith("/") || !prefix.endsWith("/") || prefix.length() < 3) {
-            return "Prefix route match must be in the format of '/service/'";
-          }
-        } else if (!path.isEmpty()) {
-          int lastSlash = path.lastIndexOf('/');
-          if (!path.startsWith("/") || lastSlash == 0 || lastSlash == path.length() - 1) {
-            return "Path route match must be in the format of '/service/method'";
-          }
-        } else if (routeMatch.hasRegex()) {
-          return "Regex route match not supported";
-        }
-      }
-      if (i == routes.size() - 1) {
-        if (!routeMatch.isDefaultMatcher()) {
-          return "The last route must be the default route";
-        }
-      }
-      if (routeAction.getCluster().isEmpty() && routeAction.getWeightedCluster().isEmpty()) {
-        return "Either cluster or weighted cluster route action must be provided";
-      }
-    }
-    return null;
+    return targetVirtualHost;
   }
 
   /**
@@ -1790,6 +1741,14 @@ final class XdsClientImpl extends XdsClient {
         res = message + " (failed to pretty-print: " + e + ")";
       }
       return res;
+    }
+  }
+
+  private static final class InvalidProtoDataException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    private InvalidProtoDataException(String message) {
+      super(message);
     }
   }
 }

--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -824,7 +824,6 @@ final class XdsClientImpl extends XdsClient {
    *
    * @throws InvalidProtoDataException if the message contains invalid data.
    */
-  @VisibleForTesting
   private static List<EnvoyProtoData.Route> findRoutesInRouteConfig(
       RouteConfiguration config, String hostName) throws InvalidProtoDataException {
     VirtualHost targetVirtualHost = findVirtualHostForHostName(config, hostName);
@@ -893,6 +892,7 @@ final class XdsClientImpl extends XdsClient {
   }
 
   @VisibleForTesting
+  @Nullable
   static VirtualHost findVirtualHostForHostName(
       RouteConfiguration config, String hostName) {
     List<VirtualHost> virtualHosts = config.getVirtualHostsList();

--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -1756,7 +1756,7 @@ final class XdsClientImpl extends XdsClient {
     private static final long serialVersionUID = 1L;
 
     private InvalidProtoDataException(String message) {
-      super(message);
+      super(message, null, false, false);
     }
   }
 }

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -159,21 +159,27 @@ final class XdsNameResolver extends NameResolver {
         rawLbConfig = generateXdsRoutingRawConfig(update.getRoutes());
       } else {
         Route defaultRoute = Iterables.getOnlyElement(update.getRoutes());
+        RouteAction action = defaultRoute.getRouteAction();
         String clusterName = defaultRoute.getRouteAction().getCluster();
-        if (!clusterName.isEmpty()) {
+        if (action.getCluster() != null) {
           logger.log(
               XdsLogLevel.INFO,
               "Received config update from xDS client {0}: cluster_name={1}",
               xdsClient,
               clusterName);
           rawLbConfig = generateCdsRawConfig(clusterName);
-        } else {
+        } else if (action.getWeightedCluster() != null) {
           logger.log(
               XdsLogLevel.INFO,
               "Received config update with one weighted cluster route from xDS client {0}",
               xdsClient);
           List<ClusterWeight> clusterWeights = defaultRoute.getRouteAction().getWeightedCluster();
           rawLbConfig = generateWeightedTargetRawConfig(clusterWeights);
+        } else {
+          // TODO (chengyuanzhang): route with cluster_header
+          logger.log(
+              XdsLogLevel.WARNING, "Route action with cluster_header is not implemented");
+          return;
         }
       }
 
@@ -229,15 +235,18 @@ final class XdsNameResolver extends NameResolver {
     for (Route route : routesUpdate) {
       String service = "";
       String method = "";
-      if (!route.getRouteMatch().isDefaultMatcher()) {
-        String prefix = route.getRouteMatch().getPrefix();
-        String path = route.getRouteMatch().getPath();
-        if (!prefix.isEmpty()) {
+      if (!route.isDefaultRoute()) {
+        String prefix = route.getRouteMatch().getPrefixPathMatch();
+        String path = route.getRouteMatch().getExactPathMatch();
+        if (prefix != null) {
           service = prefix.substring(1, prefix.length() - 1);
-        } else if (!path.isEmpty()) {
+        } else if (path != null) {
           int splitIndex = path.lastIndexOf('/');
           service = path.substring(1, splitIndex);
           method = path.substring(splitIndex + 1);
+        } else {
+          // TODO (chengyuanzhang): match with regex.
+          continue;
         }
       }
       Map<String, String> methodName = ImmutableMap.of("service", service, "method", method);
@@ -247,10 +256,10 @@ final class XdsNameResolver extends NameResolver {
       if (exitingActions.containsKey(routeAction)) {
         actionName = exitingActions.get(routeAction);
       } else {
-        if (!routeAction.getCluster().isEmpty()) {
+        if (routeAction.getCluster() != null) {
           actionName = "cds:" + routeAction.getCluster();
           actionPolicy = generateCdsRawConfig(routeAction.getCluster());
-        } else {
+        } else if (routeAction.getWeightedCluster() != null) {
           StringBuilder sb = new StringBuilder("weighted:");
           List<ClusterWeight> clusterWeights = routeAction.getWeightedCluster();
           for (ClusterWeight clusterWeight : clusterWeights) {
@@ -266,6 +275,9 @@ final class XdsNameResolver extends NameResolver {
             actionName = actionName + "_" + exitingActions.size();
           }
           actionPolicy = generateWeightedTargetRawConfig(clusterWeights);
+        } else {
+          // TODO (chengyuanzhang): route with cluster_header.
+          continue;
         }
         exitingActions.put(routeAction, actionName);
         List<?> childPolicies = ImmutableList.of(actionPolicy);

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -236,8 +236,8 @@ final class XdsNameResolver extends NameResolver {
       String service = "";
       String method = "";
       if (!route.isDefaultRoute()) {
-        String prefix = route.getRouteMatch().getPrefixPathMatch();
-        String path = route.getRouteMatch().getExactPathMatch();
+        String prefix = route.getRouteMatch().getPathPrefixMatch();
+        String path = route.getRouteMatch().getPathExactMatch();
         if (prefix != null) {
           service = prefix.substring(1, prefix.length() - 1);
         } else if (path != null) {

--- a/xds/src/test/java/io/grpc/xds/EnvoyProtoDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/EnvoyProtoDataTest.java
@@ -19,8 +19,6 @@ package io.grpc.xds;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import com.google.protobuf.BoolValue;
-import io.envoyproxy.envoy.api.v2.route.RouteMatch;
 import io.grpc.xds.EnvoyProtoData.Locality;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -73,26 +71,4 @@ public class EnvoyProtoDataTest {
   }
 
   // TODO(chengyuanzhang): add test for other data types.
-
-  @Test
-  public void routeMatchCaseSensitive() {
-    assertThat(
-            EnvoyProtoData.RouteMatch.fromEnvoyProtoRouteMatch(RouteMatch.newBuilder().build())
-                .isCaseSensitive())
-        .isTrue();
-    assertThat(
-        EnvoyProtoData.RouteMatch.fromEnvoyProtoRouteMatch(
-            RouteMatch.newBuilder()
-                .setCaseSensitive(BoolValue.newBuilder().setValue(true))
-                .build())
-            .isCaseSensitive())
-        .isTrue();
-    assertThat(
-            EnvoyProtoData.RouteMatch.fromEnvoyProtoRouteMatch(
-                    RouteMatch.newBuilder()
-                        .setCaseSensitive(BoolValue.newBuilder().setValue(false))
-                        .build())
-                .isCaseSensitive())
-        .isFalse();
-  }
 }

--- a/xds/src/test/java/io/grpc/xds/EnvoyProtoDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/EnvoyProtoDataTest.java
@@ -121,17 +121,15 @@ public class EnvoyProtoDataTest {
   public void isDefaultRoute() {
     StructOrError<Route> struct1 = Route.fromEnvoyProtoRoute(buildSimpleRouteProto("", null));
     StructOrError<Route> struct2 = Route.fromEnvoyProtoRoute(buildSimpleRouteProto("/", null));
-    StructOrError<Route> struct3 = Route.fromEnvoyProtoRoute(buildSimpleRouteProto(null, ""));
-    StructOrError<Route> struct4 =
+    StructOrError<Route> struct3 =
         Route.fromEnvoyProtoRoute(buildSimpleRouteProto("/service/", null));
-    StructOrError<Route> struct5 =
+    StructOrError<Route> struct4 =
         Route.fromEnvoyProtoRoute(buildSimpleRouteProto(null, "/service/method"));
 
     assertThat(struct1.getStruct().isDefaultRoute()).isTrue();
     assertThat(struct2.getStruct().isDefaultRoute()).isTrue();
-    assertThat(struct3.getStruct().isDefaultRoute()).isTrue();
+    assertThat(struct3.getStruct().isDefaultRoute()).isFalse();
     assertThat(struct4.getStruct().isDefaultRoute()).isFalse();
-    assertThat(struct5.getStruct().isDefaultRoute()).isFalse();
   }
 
   private static io.envoyproxy.envoy.api.v2.route.Route buildSimpleRouteProto(
@@ -163,11 +161,12 @@ public class EnvoyProtoDataTest {
 
     // path_specifier = path
     io.envoyproxy.envoy.api.v2.route.RouteMatch proto2 =
-        io.envoyproxy.envoy.api.v2.route.RouteMatch.newBuilder().setPath("").build();
+        io.envoyproxy.envoy.api.v2.route.RouteMatch.newBuilder().setPath("/service/method").build();
     StructOrError<RouteMatch> struct2 = RouteMatch.fromEnvoyProtoRouteMatch(proto2);
     assertThat(struct2.getErrorDetail()).isNull();
     assertThat(struct2.getStruct()).isEqualTo(
-        new RouteMatch(null, "", null, null, Collections.<HeaderMatcher>emptyList()));
+        new RouteMatch(
+            null, "/service/method", null, null, Collections.<HeaderMatcher>emptyList()));
 
     // path_specifier = regex
     @SuppressWarnings("deprecation")
@@ -233,7 +232,7 @@ public class EnvoyProtoDataTest {
     assertThat(struct2.getStruct()).isNotNull();
     assertThat(struct3.getStruct()).isNull();
     assertThat(struct4.getStruct()).isNotNull();
-    assertThat(struct5.getStruct()).isNotNull();
+    assertThat(struct5.getStruct()).isNull();
     assertThat(struct6.getStruct()).isNotNull();
     assertThat(struct7.getStruct()).isNull();
   }

--- a/xds/src/test/java/io/grpc/xds/EnvoyProtoDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/EnvoyProtoDataTest.java
@@ -19,7 +19,19 @@ package io.grpc.xds;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.testing.EqualsTester;
+import com.google.protobuf.BoolValue;
+import com.google.protobuf.UInt32Value;
+import io.envoyproxy.envoy.api.v2.route.QueryParameterMatcher;
+import io.envoyproxy.envoy.api.v2.route.RedirectAction;
+import io.grpc.xds.EnvoyProtoData.ClusterWeight;
+import io.grpc.xds.EnvoyProtoData.HeaderMatcher;
 import io.grpc.xds.EnvoyProtoData.Locality;
+import io.grpc.xds.EnvoyProtoData.Route;
+import io.grpc.xds.EnvoyProtoData.RouteAction;
+import io.grpc.xds.EnvoyProtoData.RouteMatch;
+import io.grpc.xds.EnvoyProtoData.StructOrError;
+import java.util.Collections;
+import javax.annotation.Nullable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -71,4 +83,278 @@ public class EnvoyProtoDataTest {
   }
 
   // TODO(chengyuanzhang): add test for other data types.
+
+  @Test
+  public void convertRoute() {
+    io.envoyproxy.envoy.api.v2.route.Route proto1 =
+        io.envoyproxy.envoy.api.v2.route.Route.newBuilder()
+            .setName("route-blade")
+            .setMatch(
+                io.envoyproxy.envoy.api.v2.route.RouteMatch.newBuilder()
+                    .setPath("/service/method"))
+            .setRoute(
+                io.envoyproxy.envoy.api.v2.route.RouteAction.newBuilder()
+                    .setCluster("cluster-foo"))
+            .build();
+    StructOrError<Route> struct1 = Route.fromEnvoyProtoRoute(proto1);
+    assertThat(struct1.getErrorDetail()).isNull();
+    assertThat(struct1.getStruct())
+        .isEqualTo(
+            new Route(
+                new RouteMatch(
+                    null, "/service/method", null, null, Collections.<HeaderMatcher>emptyList()),
+                new RouteAction("cluster-foo", null, null)));
+
+    io.envoyproxy.envoy.api.v2.route.Route unsupportedProto =
+        io.envoyproxy.envoy.api.v2.route.Route.newBuilder()
+            .setName("route-blade")
+            .setMatch(io.envoyproxy.envoy.api.v2.route.RouteMatch.newBuilder().setPath(""))
+            .setRedirect(RedirectAction.getDefaultInstance())
+            .build();
+    StructOrError<Route> unsupportedStruct = Route.fromEnvoyProtoRoute(unsupportedProto);
+    assertThat(unsupportedStruct.getErrorDetail()).isNotNull();
+    assertThat(unsupportedStruct.getStruct()).isNull();
+  }
+
+  @Test
+  public void isDefaultRoute() {
+    StructOrError<Route> struct1 = Route.fromEnvoyProtoRoute(buildSimpleRouteProto("", null));
+    StructOrError<Route> struct2 = Route.fromEnvoyProtoRoute(buildSimpleRouteProto("/", null));
+    StructOrError<Route> struct3 = Route.fromEnvoyProtoRoute(buildSimpleRouteProto(null, ""));
+    StructOrError<Route> struct4 =
+        Route.fromEnvoyProtoRoute(buildSimpleRouteProto("/service/", null));
+    StructOrError<Route> struct5 =
+        Route.fromEnvoyProtoRoute(buildSimpleRouteProto(null, "/service/method"));
+
+    assertThat(struct1.getStruct().isDefaultRoute()).isTrue();
+    assertThat(struct2.getStruct().isDefaultRoute()).isTrue();
+    assertThat(struct3.getStruct().isDefaultRoute()).isTrue();
+    assertThat(struct4.getStruct().isDefaultRoute()).isFalse();
+    assertThat(struct5.getStruct().isDefaultRoute()).isFalse();
+  }
+
+  private static io.envoyproxy.envoy.api.v2.route.Route buildSimpleRouteProto(
+      @Nullable String pathPrefix, @Nullable String path) {
+    io.envoyproxy.envoy.api.v2.route.Route.Builder routeBuilder =
+        io.envoyproxy.envoy.api.v2.route.Route.newBuilder()
+            .setName("simple-route")
+            .setRoute(io.envoyproxy.envoy.api.v2.route.RouteAction.newBuilder()
+            .setCluster("simple-cluster"));
+    if (pathPrefix != null) {
+      routeBuilder.setMatch(io.envoyproxy.envoy.api.v2.route.RouteMatch.newBuilder()
+          .setPrefix(pathPrefix));
+    } else if (path != null) {
+      routeBuilder.setMatch(io.envoyproxy.envoy.api.v2.route.RouteMatch.newBuilder()
+          .setPath(path));
+    }
+    return routeBuilder.build();
+  }
+
+  @Test
+  public void convertRouteMatch() {
+    // path_specifier = prefix
+    io.envoyproxy.envoy.api.v2.route.RouteMatch proto1 =
+        io.envoyproxy.envoy.api.v2.route.RouteMatch.newBuilder().setPrefix("/").build();
+    StructOrError<RouteMatch> struct1 = RouteMatch.fromEnvoyProtoRouteMatch(proto1);
+    assertThat(struct1.getErrorDetail()).isNull();
+    assertThat(struct1.getStruct()).isEqualTo(
+        new RouteMatch("/", null, null, null, Collections.<HeaderMatcher>emptyList()));
+
+    // path_specifier = path
+    io.envoyproxy.envoy.api.v2.route.RouteMatch proto2 =
+        io.envoyproxy.envoy.api.v2.route.RouteMatch.newBuilder().setPath("").build();
+    StructOrError<RouteMatch> struct2 = RouteMatch.fromEnvoyProtoRouteMatch(proto2);
+    assertThat(struct2.getErrorDetail()).isNull();
+    assertThat(struct2.getStruct()).isEqualTo(
+        new RouteMatch(null, "", null, null, Collections.<HeaderMatcher>emptyList()));
+
+    // path_specifier = regex
+    @SuppressWarnings("deprecation")
+    io.envoyproxy.envoy.api.v2.route.RouteMatch proto3 =
+        io.envoyproxy.envoy.api.v2.route.RouteMatch.newBuilder().setRegex("*").build();
+    StructOrError<RouteMatch> struct3 = RouteMatch.fromEnvoyProtoRouteMatch(proto3);
+    assertThat(struct3.getErrorDetail()).isNotNull();
+    assertThat(struct3.getStruct()).isNull();
+
+    // path_specifier = safe_regex
+    io.envoyproxy.envoy.api.v2.route.RouteMatch proto4 =
+        io.envoyproxy.envoy.api.v2.route.RouteMatch.newBuilder()
+            .setSafeRegex(
+                io.envoyproxy.envoy.type.matcher.RegexMatcher.newBuilder().setRegex("*")).build();
+    StructOrError<RouteMatch> struct4 = RouteMatch.fromEnvoyProtoRouteMatch(proto4);
+    assertThat(struct4.getErrorDetail()).isNull();
+    assertThat(struct4.getStruct()).isEqualTo(
+        new RouteMatch(null, null, "*", null, Collections.<HeaderMatcher>emptyList()));
+
+    // case_sensitive = false
+    io.envoyproxy.envoy.api.v2.route.RouteMatch proto5 =
+        io.envoyproxy.envoy.api.v2.route.RouteMatch.newBuilder()
+            .setCaseSensitive(BoolValue.newBuilder().setValue(false))
+            .build();
+    StructOrError<RouteMatch> struct5 = RouteMatch.fromEnvoyProtoRouteMatch(proto5);
+    assertThat(struct5.getErrorDetail()).isNotNull();
+    assertThat(struct5.getStruct()).isNull();
+
+    // query_parameters is set
+    io.envoyproxy.envoy.api.v2.route.RouteMatch proto6 =
+        io.envoyproxy.envoy.api.v2.route.RouteMatch.newBuilder()
+            .addQueryParameters(QueryParameterMatcher.getDefaultInstance())
+            .build();
+    StructOrError<RouteMatch> struct6 = RouteMatch.fromEnvoyProtoRouteMatch(proto6);
+    assertThat(struct6).isNull();
+
+    // TODO (chengyuanzhang): cover other path matching types.
+
+    // path_specifier unset
+    io.envoyproxy.envoy.api.v2.route.RouteMatch unsetProto =
+        io.envoyproxy.envoy.api.v2.route.RouteMatch.getDefaultInstance();
+    StructOrError<RouteMatch> unsetStruct = RouteMatch.fromEnvoyProtoRouteMatch(unsetProto);
+    assertThat(unsetStruct.getErrorDetail()).isNotNull();
+    assertThat(unsetStruct.getStruct()).isNull();
+  }
+
+  @Test
+  public void convertRouteMatch_pathMatchFormat() {
+    StructOrError<RouteMatch> struct1 =
+        RouteMatch.fromEnvoyProtoRouteMatch(buildSimpleRouteMatchProto("", null));
+    StructOrError<RouteMatch> struct2 =
+        RouteMatch.fromEnvoyProtoRouteMatch(buildSimpleRouteMatchProto("/", null));
+    StructOrError<RouteMatch> struct3 =
+        RouteMatch.fromEnvoyProtoRouteMatch(buildSimpleRouteMatchProto("/service", null));
+    StructOrError<RouteMatch> struct4 =
+        RouteMatch.fromEnvoyProtoRouteMatch(buildSimpleRouteMatchProto("/service/", null));
+    StructOrError<RouteMatch> struct5 =
+        RouteMatch.fromEnvoyProtoRouteMatch(buildSimpleRouteMatchProto(null, ""));
+    StructOrError<RouteMatch> struct6 =
+        RouteMatch.fromEnvoyProtoRouteMatch(buildSimpleRouteMatchProto(null, "/service/method"));
+    StructOrError<RouteMatch> struct7 =
+        RouteMatch.fromEnvoyProtoRouteMatch(buildSimpleRouteMatchProto(null, "/service/method/"));
+
+    assertThat(struct1.getStruct()).isNotNull();
+    assertThat(struct2.getStruct()).isNotNull();
+    assertThat(struct3.getStruct()).isNull();
+    assertThat(struct4.getStruct()).isNotNull();
+    assertThat(struct5.getStruct()).isNotNull();
+    assertThat(struct6.getStruct()).isNotNull();
+    assertThat(struct7.getStruct()).isNull();
+  }
+
+  private static io.envoyproxy.envoy.api.v2.route.RouteMatch buildSimpleRouteMatchProto(
+      @Nullable String pathPrefix, @Nullable String path) {
+    io.envoyproxy.envoy.api.v2.route.RouteMatch.Builder builder =
+        io.envoyproxy.envoy.api.v2.route.RouteMatch.newBuilder();
+    if (pathPrefix != null) {
+      builder.setPrefix(pathPrefix);
+    } else if (path != null) {
+      builder.setPath(path);
+    }
+    return builder.build();
+  }
+
+  @Test
+  public void convertRouteAction() {
+    // cluster_specifier = cluster
+    io.envoyproxy.envoy.api.v2.route.RouteAction proto1 =
+        io.envoyproxy.envoy.api.v2.route.RouteAction.newBuilder()
+            .setCluster("cluster-foo")
+            .build();
+    StructOrError<RouteAction> struct1 = RouteAction.fromEnvoyProtoRouteAction(proto1);
+    assertThat(struct1.getErrorDetail()).isNull();
+    assertThat(struct1.getStruct().getCluster()).isEqualTo("cluster-foo");
+    assertThat(struct1.getStruct().getClusterHeader()).isNull();
+    assertThat(struct1.getStruct().getWeightedCluster()).isNull();
+
+    // cluster_specifier = cluster_header
+    io.envoyproxy.envoy.api.v2.route.RouteAction proto2 =
+        io.envoyproxy.envoy.api.v2.route.RouteAction.newBuilder()
+            .setClusterHeader("cluster-bar")
+            .build();
+    StructOrError<RouteAction> struct2 = RouteAction.fromEnvoyProtoRouteAction(proto2);
+    assertThat(struct2.getErrorDetail()).isNull();
+    assertThat(struct2.getStruct().getCluster()).isNull();
+    assertThat(struct2.getStruct().getClusterHeader()).isEqualTo("cluster-bar");
+    assertThat(struct2.getStruct().getWeightedCluster()).isNull();
+
+    // cluster_specifier = weighted_cluster
+    io.envoyproxy.envoy.api.v2.route.RouteAction proto3 =
+        io.envoyproxy.envoy.api.v2.route.RouteAction.newBuilder()
+            .setWeightedClusters(
+                io.envoyproxy.envoy.api.v2.route.WeightedCluster.newBuilder()
+                    .addClusters(
+                        io.envoyproxy.envoy.api.v2.route.WeightedCluster.ClusterWeight.newBuilder()
+                            .setName("cluster-baz")
+                            .setWeight(UInt32Value.newBuilder().setValue(100))))
+            .build();
+    StructOrError<RouteAction> struct3 = RouteAction.fromEnvoyProtoRouteAction(proto3);
+    assertThat(struct3.getErrorDetail()).isNull();
+    assertThat(struct3.getStruct().getCluster()).isNull();
+    assertThat(struct3.getStruct().getClusterHeader()).isNull();
+    assertThat(struct3.getStruct().getWeightedCluster())
+        .containsExactly(new ClusterWeight("cluster-baz", 100));
+
+    // cluster_specifier unset
+    io.envoyproxy.envoy.api.v2.route.RouteAction unsetProto =
+        io.envoyproxy.envoy.api.v2.route.RouteAction.getDefaultInstance();
+    StructOrError<RouteAction> unsetStruct = RouteAction.fromEnvoyProtoRouteAction(unsetProto);
+    assertThat(unsetStruct.getErrorDetail()).isNotNull();
+    assertThat(unsetStruct.getStruct()).isNull();
+  }
+
+  @Test
+  public void convertHeaderMatcher() {
+    // header_match_specifier = exact_match
+    io.envoyproxy.envoy.api.v2.route.HeaderMatcher proto1 =
+        io.envoyproxy.envoy.api.v2.route.HeaderMatcher.newBuilder()
+            .setName(":method")
+            .setExactMatch("PUT")
+            .build();
+    StructOrError<HeaderMatcher> struct1 = HeaderMatcher.fromEnvoyProtoHeaderMatcher(proto1);
+    assertThat(struct1.getErrorDetail()).isNull();
+    assertThat(struct1.getStruct()).isEqualTo(
+        new HeaderMatcher(":method", "PUT", null, null, null, null, null, false));
+
+    // header_match_specifier = regex_match
+    @SuppressWarnings("deprecation")
+    io.envoyproxy.envoy.api.v2.route.HeaderMatcher proto2 =
+        io.envoyproxy.envoy.api.v2.route.HeaderMatcher.newBuilder()
+            .setName(":method")
+            .setRegexMatch("*")
+            .build();
+    StructOrError<HeaderMatcher> struct2 = HeaderMatcher.fromEnvoyProtoHeaderMatcher(proto2);
+    assertThat(struct2.getErrorDetail()).isNotNull();
+    assertThat(struct2.getStruct()).isNull();
+
+    // header_match_specifier = safe_regex_match
+    io.envoyproxy.envoy.api.v2.route.HeaderMatcher proto3 =
+        io.envoyproxy.envoy.api.v2.route.HeaderMatcher.newBuilder()
+            .setName(":method")
+            .setSafeRegexMatch(
+                io.envoyproxy.envoy.type.matcher.RegexMatcher.newBuilder().setRegex("P*"))
+            .build();
+    StructOrError<HeaderMatcher> struct3 = HeaderMatcher.fromEnvoyProtoHeaderMatcher(proto3);
+    assertThat(struct3.getErrorDetail()).isNull();
+    assertThat(struct3.getStruct()).isEqualTo(
+        new HeaderMatcher(":method", null, "P*", null, null, null, null, false));
+
+    // TODO (chengyuanzhang): cover other header_match types.
+
+    // header_match_specifier unset
+    io.envoyproxy.envoy.api.v2.route.HeaderMatcher unsetProto =
+        io.envoyproxy.envoy.api.v2.route.HeaderMatcher.getDefaultInstance();
+    StructOrError<HeaderMatcher> unsetStruct =
+        HeaderMatcher.fromEnvoyProtoHeaderMatcher(unsetProto);
+    assertThat(unsetStruct.getErrorDetail()).isNotNull();
+    assertThat(unsetStruct.getStruct()).isNull();
+  }
+
+  @Test
+  public void convertClusterWeight() {
+    io.envoyproxy.envoy.api.v2.route.WeightedCluster.ClusterWeight proto =
+        io.envoyproxy.envoy.api.v2.route.WeightedCluster.ClusterWeight.newBuilder()
+            .setName("cluster-foo")
+            .setWeight(UInt32Value.newBuilder().setValue(30)).build();
+    ClusterWeight struct = ClusterWeight.fromEnvoyProtoClusterWeight(proto);
+    assertThat(struct.getName()).isEqualTo("cluster-foo");
+    assertThat(struct.getWeight()).isEqualTo(30);
+  }
 }

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTest.java
@@ -113,6 +113,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
@@ -177,6 +178,8 @@ public class XdsClientImplTest {
 
   @Rule
   public final GrpcCleanupRule cleanupRule = new GrpcCleanupRule();
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
 
   private final SynchronizationContext syncContext = new SynchronizationContext(
       new Thread.UncaughtExceptionHandler() {
@@ -894,97 +897,6 @@ public class XdsClientImplTest {
     fakeClock.forwardTime(XdsClientImpl.INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
     verify(configWatcher).onResourceDoesNotExist("route-foo.googleapis.com");
     assertThat(fakeClock.getPendingTasks(RDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
-  }
-
-  /**
-   * Client receives an RDS response (after a previous LDS request-response) containing a
-   * RouteConfiguration message for the requested resource. But the RouteConfiguration message
-   * is invalid as the VirtualHost with domains matching the requested hostname contains a route
-   * with a case-insensitive matcher.
-   * The RDS response is NACKed, as if the XdsClient has not received this response.
-   * The config watcher is NOT notified with an error.
-   */
-  @Test
-  public void matchingVirtualHostWithCaseInsensitiveAndSensitiveRouteMatch() {
-    xdsClient.watchConfigData(TARGET_AUTHORITY, configWatcher);
-    StreamObserver<DiscoveryResponse> responseObserver = responseObservers.poll();
-    StreamObserver<DiscoveryRequest> requestObserver = requestObservers.poll();
-
-    Rds rdsConfig =
-        Rds.newBuilder()
-            // Must set to use ADS.
-            .setConfigSource(
-                ConfigSource.newBuilder().setAds(AggregatedConfigSource.getDefaultInstance()))
-            .setRouteConfigName("route-foo.googleapis.com")
-            .build();
-
-    List<Any> listeners = ImmutableList.of(
-        Any.pack(buildListener(TARGET_AUTHORITY, /* matching resource */
-            Any.pack(HttpConnectionManager.newBuilder().setRds(rdsConfig).build())))
-    );
-    DiscoveryResponse response =
-        buildDiscoveryResponse("0", listeners, XdsClientImpl.ADS_TYPE_URL_LDS, "0000");
-    responseObserver.onNext(response);
-
-    // Client sends an ACK LDS request and an RDS request for "route-foo.googleapis.com". (Omitted)
-
-    assertThat(fakeClock.getPendingTasks(RDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).hasSize(1);
-
-    // A VirtualHost with a Route with a case-insensitive matcher.
-    VirtualHost virtualHost =
-        VirtualHost.newBuilder()
-            .setName("virtualhost00.googleapis.com")  // don't care
-            .addDomains(TARGET_AUTHORITY)
-            .addRoutes(
-                Route.newBuilder()
-                    .setRoute(RouteAction.newBuilder().setCluster("cluster.googleapis.com"))
-                    .setMatch(RouteMatch.newBuilder().setPrefix("").setCaseSensitive(
-                        BoolValue.newBuilder().setValue(false))))
-            .build();
-
-    List<Any> routeConfigs = ImmutableList.of(
-        Any.pack(
-            buildRouteConfiguration("route-foo.googleapis.com",
-                ImmutableList.of(virtualHost))));
-    response = buildDiscoveryResponse("0", routeConfigs, XdsClientImpl.ADS_TYPE_URL_RDS, "0000");
-    responseObserver.onNext(response);
-
-    // Client sent an NACK RDS request.
-    verify(requestObserver)
-        .onNext(
-            argThat(new DiscoveryRequestMatcher("", "route-foo.googleapis.com",
-                XdsClientImpl.ADS_TYPE_URL_RDS, "0000")));
-
-    // A VirtualHost with a Route with a case-sensitive matcher.
-    virtualHost =
-        VirtualHost.newBuilder()
-            .setName("virtualhost00.googleapis.com")  // don't care
-            .addDomains(TARGET_AUTHORITY)
-            .addRoutes(
-                Route.newBuilder()
-                    .setRoute(RouteAction.newBuilder().setCluster("cluster.googleapis.com"))
-                    .setMatch(RouteMatch.newBuilder().setPrefix("").setCaseSensitive(
-                        BoolValue.newBuilder().setValue(true))))
-            .build();
-
-    routeConfigs = ImmutableList.of(
-        Any.pack(
-            buildRouteConfiguration("route-foo.googleapis.com",
-                ImmutableList.of(virtualHost))));
-    response = buildDiscoveryResponse("0", routeConfigs, XdsClientImpl.ADS_TYPE_URL_RDS, "0000");
-    responseObserver.onNext(response);
-
-    // Client sent an ACK RDS request.
-    verify(requestObserver)
-        .onNext(
-            argThat(new DiscoveryRequestMatcher(
-                "0",
-                ImmutableList.of("route-foo.googleapis.com"),
-                XdsClientImpl.ADS_TYPE_URL_RDS,
-                "0000")));
-
-    verify(configWatcher).onConfigChanged(any(ConfigUpdate.class));
-    verifyNoMoreInteractions(configWatcher);
   }
 
   /**
@@ -3462,28 +3374,16 @@ public class XdsClientImplTest {
         VirtualHost.newBuilder()
             .setName("virtualhost01.googleapis.com")  // don't care
             .addAllDomains(ImmutableList.of("a.googleapis.com", "b.googleapis.com"))
-            .addRoutes(
-                Route.newBuilder()
-                    .setRoute(RouteAction.newBuilder().setCluster("cluster-wow.googleapis.com"))
-                    .setMatch(RouteMatch.newBuilder().setPrefix("")))
             .build();
     VirtualHost vHost2 =
         VirtualHost.newBuilder()
             .setName("virtualhost02.googleapis.com")  // don't care
             .addAllDomains(ImmutableList.of("*.googleapis.com"))
-            .addRoutes(
-                Route.newBuilder()
-                    .setRoute(RouteAction.newBuilder().setCluster("cluster-hi.googleapis.com"))
-                    .setMatch(RouteMatch.newBuilder().setPrefix("")))
             .build();
     VirtualHost vHost3 =
         VirtualHost.newBuilder()
             .setName("virtualhost03.googleapis.com")  // don't care
             .addAllDomains(ImmutableList.of("*"))
-            .addRoutes(
-                Route.newBuilder()
-                    .setRoute(RouteAction.newBuilder().setCluster("cluster-hey.googleapis.com"))
-                    .setMatch(RouteMatch.newBuilder().setPrefix("")))
             .build();
     RouteConfiguration routeConfig =
         buildRouteConfiguration(
@@ -3498,28 +3398,16 @@ public class XdsClientImplTest {
         VirtualHost.newBuilder()
             .setName("virtualhost01.googleapis.com")  // don't care
             .addAllDomains(ImmutableList.of("*.googleapis.com", "b.googleapis.com"))
-            .addRoutes(
-                Route.newBuilder()
-                    .setRoute(RouteAction.newBuilder().setCluster("cluster-hello.googleapis.com"))
-                    .setMatch(RouteMatch.newBuilder().setPrefix("")))
             .build();
     VirtualHost vHost2 =
         VirtualHost.newBuilder()
             .setName("virtualhost02.googleapis.com")  // don't care
             .addAllDomains(ImmutableList.of("a.googleapis.*"))
-            .addRoutes(
-                Route.newBuilder()
-                    .setRoute(RouteAction.newBuilder().setCluster("cluster-hi.googleapis.com"))
-                    .setMatch(RouteMatch.newBuilder().setPrefix("")))
             .build();
     VirtualHost vHost3 =
         VirtualHost.newBuilder()
             .setName("virtualhost03.googleapis.com")  // don't care
             .addAllDomains(ImmutableList.of("*"))
-            .addRoutes(
-                Route.newBuilder()
-                    .setRoute(RouteAction.newBuilder().setCluster("cluster-hey.googleapis.com"))
-                    .setMatch(RouteMatch.newBuilder().setPrefix("")))
             .build();
     RouteConfiguration routeConfig =
         buildRouteConfiguration(
@@ -3534,24 +3422,54 @@ public class XdsClientImplTest {
         VirtualHost.newBuilder()
             .setName("virtualhost01.googleapis.com")  // don't care
             .addAllDomains(ImmutableList.of("*"))
-            .addRoutes(
-                Route.newBuilder()
-                    .setRoute(RouteAction.newBuilder().setCluster("cluster-hello.googleapis.com"))
-                    .setMatch(RouteMatch.newBuilder().setPrefix("")))
             .build();
     VirtualHost vHost2 =
         VirtualHost.newBuilder()
             .setName("virtualhost02.googleapis.com")  // don't care
             .addAllDomains(ImmutableList.of("b.googleapis.com"))
-            .addRoutes(
-                Route.newBuilder()
-                    .setRoute(RouteAction.newBuilder().setCluster("cluster-hi.googleapis.com"))
-                    .setMatch(RouteMatch.newBuilder().setPrefix("")))
             .build();
     RouteConfiguration routeConfig =
         buildRouteConfiguration(
             "route-foo.googleapis.com", ImmutableList.of(vHost1, vHost2));
     assertThat(XdsClientImpl.findVirtualHostForHostName(routeConfig, hostname)).isEqualTo(vHost1);
+  }
+
+  @Test
+  public void populateRoutesInVirtualHost_routeWithCaseInsensitiveMatch() {
+    VirtualHost virtualHost =
+        VirtualHost.newBuilder()
+            .setName("virtualhost00.googleapis.com")  // don't care
+            .addDomains(TARGET_AUTHORITY)
+            .addRoutes(
+                Route.newBuilder()
+                    .setRoute(RouteAction.newBuilder().setCluster("cluster.googleapis.com"))
+                    .setMatch(
+                        RouteMatch.newBuilder()
+                            .setPrefix("")
+                            .setCaseSensitive(BoolValue.newBuilder().setValue(false))))
+            .build();
+
+    thrown.expect(XdsClientImpl.InvalidProtoDataException.class);
+    XdsClientImpl.populateRoutesInVirtualHost(virtualHost);
+  }
+
+  @Test
+  public void populateRoutesInVirtualHost_lastRouteIsNotDefaultRoute() {
+    VirtualHost virtualHost =
+        VirtualHost.newBuilder()
+            .setName("virtualhost00.googleapis.com")  // don't care
+            .addDomains(TARGET_AUTHORITY)
+            .addRoutes(
+                Route.newBuilder()
+                    .setRoute(RouteAction.newBuilder().setCluster("cluster.googleapis.com"))
+                    .setMatch(
+                        RouteMatch.newBuilder()
+                            .setPrefix("/service/method")
+                            .setCaseSensitive(BoolValue.newBuilder().setValue(true))))
+            .build();
+
+    thrown.expect(XdsClientImpl.InvalidProtoDataException.class);
+    XdsClientImpl.populateRoutesInVirtualHost(virtualHost);
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -451,7 +451,7 @@ public class XdsNameResolverTest {
     // with a route resolution for a single weighted cluster route.
     Route weightedClustersDefaultRoute =
         Route.newBuilder()
-            .setMatch(RouteMatch.newBuilder().setPath(""))
+            .setMatch(RouteMatch.newBuilder().setPrefix(""))
             .setRoute(buildWeightedClusterRoute(
                 ImmutableMap.of(
                     "cluster-foo.googleapis.com", 20, "cluster-bar.googleapis.com", 80)))
@@ -521,7 +521,7 @@ public class XdsNameResolverTest {
                 .build(),
             // default, routed to cluster
             Route.newBuilder()
-                .setMatch(RouteMatch.newBuilder().setPath(""))
+                .setMatch(RouteMatch.newBuilder().setPrefix(""))
                 .setRoute(buildClusterRoute("cluster-hello.googleapis.com"))
                 .build());
     List<Any> routeConfigs = ImmutableList.of(

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -355,23 +355,23 @@ public class XdsNameResolverTest {
         ImmutableList.of(
             // path match, routed to cluster
             Route.newBuilder()
-                .setMatch(buildPathMatch("fooSvc", "hello"))
+                .setMatch(buildPathExactMatch("fooSvc", "hello"))
                 .setRoute(buildClusterRoute("cluster-hello.googleapis.com"))
                 .build(),
             // prefix match, routed to cluster
             Route.newBuilder()
-                .setMatch(buildPrefixMatch("fooSvc"))
+                .setMatch(buildPathPrefixMatch("fooSvc"))
                 .setRoute(buildClusterRoute("cluster-foo.googleapis.com"))
                 .build(),
             // path match, routed to weighted clusters
             Route.newBuilder()
-                .setMatch(buildPathMatch("barSvc", "hello"))
+                .setMatch(buildPathExactMatch("barSvc", "hello"))
                 .setRoute(buildWeightedClusterRoute(ImmutableMap.of(
                     "cluster-hello.googleapis.com", 40,  "cluster-hello2.googleapis.com", 60)))
                 .build(),
             // prefix match, routed to weighted clusters
             Route.newBuilder()
-                .setMatch(buildPrefixMatch("barSvc"))
+                .setMatch(buildPathPrefixMatch("barSvc"))
                 .setRoute(
                     buildWeightedClusterRoute(
                         ImmutableMap.of(
@@ -451,6 +451,7 @@ public class XdsNameResolverTest {
     // with a route resolution for a single weighted cluster route.
     Route weightedClustersDefaultRoute =
         Route.newBuilder()
+            .setMatch(RouteMatch.newBuilder().setPath(""))
             .setRoute(buildWeightedClusterRoute(
                 ImmutableMap.of(
                     "cluster-foo.googleapis.com", 20, "cluster-bar.googleapis.com", 80)))
@@ -496,23 +497,23 @@ public class XdsNameResolverTest {
         ImmutableList.of(
             // path match, routed to cluster
             Route.newBuilder()
-                .setMatch(buildPathMatch("fooSvc", "hello"))
+                .setMatch(buildPathExactMatch("fooSvc", "hello"))
                 .setRoute(buildClusterRoute("cluster-hello.googleapis.com"))
                 .build(),
             // prefix match, routed to cluster
             Route.newBuilder()
-                .setMatch(buildPrefixMatch("fooSvc"))
+                .setMatch(buildPathPrefixMatch("fooSvc"))
                 .setRoute(buildClusterRoute("cluster-foo.googleapis.com"))
                 .build(),
             // duplicate path match, routed to weighted clusters
             Route.newBuilder()
-                .setMatch(buildPathMatch("fooSvc", "hello"))
+                .setMatch(buildPathExactMatch("fooSvc", "hello"))
                 .setRoute(buildWeightedClusterRoute(ImmutableMap.of(
                     "cluster-hello.googleapis.com", 40,  "cluster-hello2.googleapis.com", 60)))
                 .build(),
-            // duplicage prefix match, routed to weighted clusters
+            // duplicate prefix match, routed to weighted clusters
             Route.newBuilder()
-                .setMatch(buildPrefixMatch("fooSvc"))
+                .setMatch(buildPathPrefixMatch("fooSvc"))
                 .setRoute(
                     buildWeightedClusterRoute(
                         ImmutableMap.of(
@@ -520,6 +521,7 @@ public class XdsNameResolverTest {
                 .build(),
             // default, routed to cluster
             Route.newBuilder()
+                .setMatch(RouteMatch.newBuilder().setPath(""))
                 .setRoute(buildClusterRoute("cluster-hello.googleapis.com"))
                 .build());
     List<Any> routeConfigs = ImmutableList.of(
@@ -722,11 +724,11 @@ public class XdsNameResolverTest {
     return buildDiscoveryResponse(versionInfo, routeConfigs, XdsClientImpl.ADS_TYPE_URL_RDS, nonce);
   }
 
-  private static RouteMatch buildPrefixMatch(String service) {
+  private static RouteMatch buildPathPrefixMatch(String service) {
     return RouteMatch.newBuilder().setPrefix("/" + service + "/").build();
   }
 
-  private static RouteMatch buildPathMatch(String service, String method) {
+  private static RouteMatch buildPathExactMatch(String service, String method) {
     return RouteMatch.newBuilder().setPath("/" + service + "/" + method).build();
   }
 


### PR DESCRIPTION
- All objects of converted types should be valid to gRPC (if the original proto message contains invalid data, the conversion should fail and no object should be instantiated).
- Use `null` in converted objects for unset fields in proto messages. This puts a much stronger/clearer signal for proto's `oneof` type.

Most conversion logic and tests are trivial. But the way we represent data and perform checks matters.