### PR TITLE
xds: change route data validation logic

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -864,29 +864,9 @@ final class XdsClientImpl extends XdsClient {
           "Virtual host [" + virtualHost.getName()
               + "] contains non-default route as the last route");
     }
-    // We only validate the default route unless path matching is enabled.
     if (!enableExperimentalRouting) {
       EnvoyProtoData.Route defaultRoute = Iterables.getLast(routes);
-      if (defaultRoute.getRouteAction().getCluster() == null) {
-        throw new InvalidProtoDataException(
-            "Virtual host [" + virtualHost.getName()
-                + "] default route contains no cluster name");
-      }
       return Collections.singletonList(defaultRoute);
-    }
-
-    // We do more validation if path matching is enabled, but whether every single route is
-    // required to be valid for grpc is TBD.
-    // For now we consider the whole list invalid if anything invalid for grpc is found.
-    // TODO(zdapeng): Fix it if the decision is different from current implementation.
-    // TODO(zdapeng): Add test for validation.
-    for (EnvoyProtoData.Route route : routes) {
-      if (route.getRouteAction().getCluster() == null
-          && route.getRouteAction().getWeightedCluster() == null) {
-        throw new InvalidProtoDataException(
-            "Virtual host [" + virtualHost.getName()
-                + "] contains route without cluster or weighted cluster");
-      }
     }
     return Collections.unmodifiableList(routes);
   }


### PR DESCRIPTION
- `Route`s with action of specifying `cluster_header` should be skipped.
- Eliminate unnecessary logic for validating converted data in XdsClientImpl.