### PR TITLE
all: bump protobuf to 3.12.0

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -47,7 +47,7 @@ The codegen plugin is C++ code and requires protobuf 3.0.0 or later.
 
 For Linux, Mac and MinGW:
 ```
-$ PROTOBUF_VERSION=3.11.0
+$ PROTOBUF_VERSION=3.12.0
 $ curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protobuf-all-$PROTOBUF_VERSION.tar.gz
 $ tar xzf protobuf-all-$PROTOBUF_VERSION.tar.gz
 $ cd protobuf-$PROTOBUF_VERSION
@@ -80,16 +80,16 @@ When building on Windows and VC++, you need to specify project properties for
 Gradle to find protobuf:
 ```
 .\gradlew publishToMavenLocal ^
-    -PvcProtobufInclude=C:\path\to\protobuf-3.11.0\src ^
-    -PvcProtobufLibs=C:\path\to\protobuf-3.11.0\vsprojects\Release ^
+    -PvcProtobufInclude=C:\path\to\protobuf-3.12.0\src ^
+    -PvcProtobufLibs=C:\path\to\protobuf-3.12.0\vsprojects\Release ^
     -PtargetArch=x86_32
 ```
 
 Since specifying those properties every build is bothersome, you can instead
 create ``<project-root>\gradle.properties`` with contents like:
 ```
-vcProtobufInclude=C:\\path\\to\\protobuf-3.11.0\\src
-vcProtobufLibs=C:\\path\\to\\protobuf-3.11.0\\vsprojects\\Release
+vcProtobufInclude=C:\\path\\to\\protobuf-3.12.0\\src
+vcProtobufLibs=C:\\path\\to\\protobuf-3.12.0\\vsprojects\\Release
 targetArch=x86_32
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ subprojects {
         nettyVersion = '4.1.48.Final'
         guavaVersion = '28.2-android'
         googleauthVersion = '0.20.0'
-        protobufVersion = '3.11.0'
+        protobufVersion = '3.12.0'
         protocVersion = protobufVersion
         opencensusVersion = '0.24.0'
 

--- a/buildscripts/build_docker.sh
+++ b/buildscripts/build_docker.sh
@@ -2,7 +2,7 @@
 set -eu -o pipefail
 
 readonly proto_dir="$(mktemp -d --tmpdir protobuf.XXXXXX)"
-wget -O - https://github.com/google/protobuf/archive/v3.11.0.tar.gz | tar xz -C "$proto_dir"
+wget -O - https://github.com/google/protobuf/archive/v3.12.0.tar.gz | tar xz -C "$proto_dir"
 
-docker build -t protoc-artifacts "$proto_dir"/protobuf-3.11.0/protoc-artifacts
+docker build -t protoc-artifacts "$proto_dir"/protobuf-3.12.0/protoc-artifacts
 rm -r "$proto_dir"

--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -1,4 +1,4 @@
-set PROTOBUF_VER=3.11.0
+set PROTOBUF_VER=3.12.0
 set CMAKE_NAME=cmake-3.3.2-win32-x86
 
 if not exist "protobuf-%PROTOBUF_VER%\cmake\build\Release\" (

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -3,7 +3,7 @@
 # Build protoc
 set -evux -o pipefail
 
-PROTOBUF_VERSION=3.11.0
+PROTOBUF_VERSION=3.12.0
 
 # ARCH is x86_64 bit unless otherwise specified.
 ARCH="${ARCH:-x86_64}"

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -28,7 +28,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.11.0' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.12.0' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.31.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -27,7 +27,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.11.0' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.12.0' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.31.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -26,7 +26,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.11.0' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.12.0' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.31.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/android/strictmode/app/build.gradle
+++ b/examples/android/strictmode/app/build.gradle
@@ -27,7 +27,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.11.0' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.12.0' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.31.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -23,7 +23,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.31.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.11.0'
+def protobufVersion = '3.12.0'
 def protocVersion = protobufVersion
 
 dependencies {

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.31.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.11.0'
+def protocVersion = '3.12.0'
 
 dependencies {
     // grpc-alts transitively depends on grpc-netty-shaded, grpc-protobuf, and grpc-stub

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.31.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.11.0'
+def protobufVersion = '3.12.0'
 def protocVersion = protobufVersion
 
 

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -33,6 +33,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+      <version>${protobuf.version}</version>
+    </dependency>
+    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
       <scope>runtime</scope>
@@ -59,11 +64,6 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-testing</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java-util</artifactId>
-      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.31.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.11.0</protobuf.version>
+    <protobuf.version>3.12.0</protobuf.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.31.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.11.0'
+def protobufVersion = '3.12.0'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-hostname/pom.xml
+++ b/examples/example-hostname/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.31.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protoc.version>3.11.0</protoc.version>
+    <protoc.version>3.12.0</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -23,7 +23,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.31.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.11.0'
+def protobufVersion = '3.12.0'
 def protocVersion = protobufVersion
 
 dependencies {

--- a/examples/example-jwt-auth/pom.xml
+++ b/examples/example-jwt-auth/pom.xml
@@ -14,8 +14,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.31.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.11.0</protobuf.version>
-    <protoc.version>3.11.0</protoc.version>
+    <protobuf.version>3.12.0</protobuf.version>
+    <protoc.version>3.12.0</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -25,7 +25,7 @@ targetCompatibility = 1.7
 // updating the version in our release process.
 def grpcVersion = '1.31.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 def nettyTcNativeVersion = '2.0.30.Final'
-def protocVersion = '3.11.0'
+def protocVersion = '3.12.0'
 
 dependencies {
     implementation "io.grpc:grpc-netty:${grpcVersion}"

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.31.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protoc.version>3.11.0</protoc.version>
+    <protoc.version>3.12.0</protoc.version>
     <netty.tcnative.version>2.0.30.Final</netty.tcnative.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -34,6 +34,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+      <version>${protobuf.version}</version>
+    </dependency>
+    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
       <scope>runtime</scope>
@@ -56,11 +61,6 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-testing</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java-util</artifactId>
-      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.31.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.11.0</protobuf.version>
-    <protoc.version>3.11.0</protoc.version>
+    <protobuf.version>3.12.0</protobuf.version>
+    <protoc.version>3.12.0</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -267,18 +267,18 @@ def com_google_protobuf():
     # This statement defines the @com_google_protobuf repo.
     http_archive(
         name = "com_google_protobuf",
-        sha256 = "60d2012e3922e429294d3a4ac31f336016514a91e5a63fd33f35743ccfe1bd7d",
-        strip_prefix = "protobuf-3.11.0",
-        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.11.0.zip"],
+        sha256 = "b37e96e81842af659605908a421960a5dc809acbc888f6b947bc320f8628e5b1",
+        strip_prefix = "protobuf-3.12.0",
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.12.0.zip"],
     )
 
 def com_google_protobuf_javalite():
     # java_lite_proto_library rules implicitly depend on @com_google_protobuf_javalite
     http_archive(
-        name = "com_google_protobuf_javalite",
-        sha256 = "e60211a40473f6be95b53f64559f82a3b2971672b11710db2fc9081708e25699",
-        strip_prefix = "protobuf-0425fa932ce95a32bb9f88b2c09b995e9ff8207b",
-        urls = ["https://github.com/google/protobuf/archive/0425fa932ce95a32bb9f88b2c09b995e9ff8207b.zip"],  # Commit with fixed javalite on 3.11.x branch
+        name = "b37e96e81842af659605908a421960a5dc809acbc888f6b947bc320f8628e5b1",
+        sha256 = "b37e96e81842af659605908a421960a5dc809acbc888f6b947bc320f8628e5b1",
+        strip_prefix = "protobuf-3.12.0",
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.12.0.zip"],
     )
 
 def com_google_truth_truth():

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -275,7 +275,7 @@ def com_google_protobuf():
 def com_google_protobuf_javalite():
     # java_lite_proto_library rules implicitly depend on @com_google_protobuf_javalite
     http_archive(
-        name = "b37e96e81842af659605908a421960a5dc809acbc888f6b947bc320f8628e5b1",
+        name = "com_google_protobuf_javalite",
         sha256 = "b37e96e81842af659605908a421960a5dc809acbc888f6b947bc320f8628e5b1",
         strip_prefix = "protobuf-3.12.0",
         urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.12.0.zip"],


### PR DESCRIPTION
Version 3.12.0 is needed for the feature of support for proto3 field presence #7051