### PR TITLE
compiler: support proto3 field presence for codegen

### DIFF
--- a/compiler/src/java_plugin/cpp/java_plugin.cpp
+++ b/compiler/src/java_plugin/cpp/java_plugin.cpp
@@ -43,10 +43,14 @@ class JavaGrpcGenerator : public google::protobuf::compiler::CodeGenerator {
   JavaGrpcGenerator() {}
   virtual ~JavaGrpcGenerator() {}
 
+  uint64_t GetSupportedFeatures() const override {
+    return FEATURE_PROTO3_OPTIONAL;
+  }
+
   virtual bool Generate(const google::protobuf::FileDescriptor* file,
                         const std::string& parameter,
                         google::protobuf::compiler::GeneratorContext* context,
-                        std::string* error) const {
+                        std::string* error) const override {
     std::vector<std::pair<std::string, std::string> > options;
     google::protobuf::compiler::ParseGeneratorParameter(parameter, &options);
 


### PR DESCRIPTION
Support proto3 field presence #7051.

This is the same change as https://github.com/grpc/grpc/pull/22998/files#diff-6c29ff8771ae54ddf2c14e2ef3eb554fR37-R44