### PR TITLE
COMPILING.md: update protoc version requirement

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -43,7 +43,7 @@ This section is only necessary if you are making changes to the code
 generation. Most users only need to use `skipCodegen=true` as discussed above.
 
 ### Build Protobuf
-The codegen plugin is C++ code and requires protobuf 3.0.0 or later.
+The codegen plugin is C++ code and requires protobuf 3.12.0 or later.
 
 For Linux, Mac and MinGW:
 ```

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -18,7 +18,7 @@ you may want to build your own codegen.
 
 * Linux, Mac OS X with Clang, or Windows with MSYS2
 * Java 7 or up
-* [Protobuf](https://github.com/google/protobuf) 3.0.0-beta-3 or up
+* [Protobuf](https://github.com/google/protobuf) 3.12.0 or up
 
 ## Compiling and testing the codegen
 Change to the `compiler` directory:


### PR DESCRIPTION
older version can't compile new proto3 field presence changes (#7058)

```
> Task :grpc-compiler:compileJava_pluginExecutableJava_pluginCpp FAILED

Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.6.2/userguide/command_line_interface.html#sec:command_line_warnings
67 actionable tasks: 21 executed, 46 up-to-date
<-------------> 0% WAITING
> Resolve files of :grpc-android-interop-testing:debugCompileClasspath > Transf
> Transforming artifact annotations.jar (com.google.android:annotations:4.1.1.4
> Resolve files of :grpc-android-interop-testing:debugCompileClasspath > Transf
> :grpc-android:verifyReleaseResources
/home/jihuncho/git/grpc-java/compiler/src/java_plugin/cpp/java_plugin.cpp:46:12: error: ‘uint64_t JavaGrpcGenerator::GetSupportedFeatures() const’ marked ‘override’, but does not override
   46 |   uint64_t GetSupportedFeatures() const override {
      |            ^~~~~~~~~~~~~~~~~~~~
/home/jihuncho/git/grpc-java/compiler/src/java_plugin/cpp/java_plugin.cpp: In member function ‘uint64_t JavaGrpcGenerator::GetSupportedFeatures() const’:
/home/jihuncho/git/grpc-java/compiler/src/java_plugin/cpp/java_plugin.cpp:47:12: error: ‘FEATURE_PROTO3_OPTIONAL’ was not declared in this scope
   47 |     return FEATURE_PROTO3_OPTIONAL;
      |            ^~~~~~~~~~~~~~~~~~~~~~~
```