### PR TITLE
core: turn Channel into TF if resolver gives empty addresses with policy selection cannot handle it (backport v1.30x)

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1369,7 +1369,6 @@ final class ManagedChannelImpl extends ManagedChannel implements
               "Resolved address: {0}, config={1}",
               servers,
               resolutionResult.getAttributes());
-          ResolutionState lastResolutionStateCopy = lastResolutionState;
 
           if (lastResolutionState != ResolutionState.SUCCESS) {
             channelLogger.log(ChannelLogLevel.INFO, "Address resolved: {0}", servers);
@@ -1457,14 +1456,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
                     .build());
 
             if (!handleResult.isOk()) {
-              if (servers.isEmpty() && lastResolutionStateCopy == ResolutionState.SUCCESS) {
-                // lb doesn't expose that it needs address or not, because for some LB it is not
-                // deterministic. Assuming lb needs address if LB returns error when the address is
-                // empty and it is not the first resolution.
-                scheduleExponentialBackOffInSyncContext();
-              } else {
-                handleErrorInSyncContext(handleResult.augmentDescription(resolver + " was used"));
-              }
+              handleErrorInSyncContext(handleResult.augmentDescription(resolver + " was used"));
             }
           }
         }


### PR DESCRIPTION
The original service config error handling design was unclear about the case when an updated resolution result with valid service config and empty address is returned to Channel, and the selected LB policy does not accept empty addresses. Existing implementation silently triggers resolver backoff after LB policy is changed, while leaving Channel being CONNECTING state, if there was an old service config resolved. This change converge the behaviors of whether the received service config is the first one or an update to a previous config, in both cases, Channel goes into TRANSIENT_FAILURE if the selected LB policy cannot handle empty addresses.

------------
Backport of #7073. 