### PR TITLE
xds: return empty service config to Channel when the requested LDS/RDS resource does not exist (backport v1.30x)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -46,6 +46,7 @@ import io.grpc.xds.XdsClient.XdsChannelFactory;
 import io.grpc.xds.XdsClient.XdsClientFactory;
 import io.grpc.xds.XdsLogger.XdsLogLevel;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -209,12 +210,11 @@ final class XdsNameResolver extends NameResolver {
     @Override
     public void onResourceDoesNotExist(String resourceName) {
       logger.log(XdsLogLevel.INFO, "Resource {0} is unavailable", resourceName);
+      ConfigOrError parsedServiceConfig =
+          serviceConfigParser.parseServiceConfig(Collections.<String, Object>emptyMap());
       ResolutionResult result =
           ResolutionResult.newBuilder()
-              .setServiceConfig(
-                  ConfigOrError.fromError(
-                      Status.UNAVAILABLE.withDescription(
-                          "Resource " + resourceName + " is unavailable")))
+              .setServiceConfig(parsedServiceConfig)
               .build();
       listener.onResult(result);
     }

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -274,6 +274,7 @@ public class XdsNameResolverTest {
     assertThat(result.getAddresses()).isEmpty();
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void resolve_ResourceNotFound() {
     xdsNameResolver.start(mockListener);
@@ -290,8 +291,7 @@ public class XdsNameResolverTest {
     verify(mockListener).onResult(resolutionResultCaptor.capture());
     ResolutionResult result = resolutionResultCaptor.getValue();
     assertThat(result.getAddresses()).isEmpty();
-    assertThat(result.getServiceConfig().getConfig()).isNull();
-    assertThat(result.getServiceConfig().getError().getCode()).isEqualTo(Code.UNAVAILABLE);
+    assertThat((Map<String, ?>) result.getServiceConfig().getConfig()).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
Backport of #7077.