### PR TITLE
xds: retain locality stats counter when the child balancer for that locality is deactivated

### DIFF
--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -26,7 +26,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.grpc.ConnectivityState;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.InternalLogId;
@@ -114,8 +113,6 @@ interface LocalityStore {
     private final OrcaOobUtil orcaOobUtil;
     private final PriorityManager priorityManager = new PriorityManager();
     private final Map<Locality, LocalityLbState> localityMap = new HashMap<>();
-    // Most current set of localities instructed by traffic director
-    private Set<Locality> localities = ImmutableSet.of();
     private List<DropOverload> dropOverloads = ImmutableList.of();
     private long metricsReportIntervalNano = -1;
 
@@ -201,7 +198,6 @@ interface LocalityStore {
         localityMap.get(locality).shutdown();
       }
       localityMap.clear();
-      localities = ImmutableSet.of();
       priorityManager.reset();
     }
 
@@ -215,7 +211,6 @@ interface LocalityStore {
           localityLbState.refreshEndpoints(localityInfoMap.get(locality));
         }
       }
-      localities = newLocalities;
       priorityManager.updateLocalities(localityInfoMap);
       for (Locality oldLocality : localityMap.keySet()) {
         if (!newLocalities.contains(oldLocality)) {
@@ -572,7 +567,6 @@ interface LocalityStore {
         logger.log(XdsLogLevel.INFO, "Create child balancer for locality {0}", locality);
         LocalityLbState localityLbState = new LocalityLbState(locality);
         localityMap.put(locality, localityLbState);
-        LocalityLbEndpoints localityLbEndpoints = localityInfoMap.get(locality);
         localityLbState.refreshEndpoints(localityInfoMap.get(locality));
       }
     }

--- a/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
@@ -236,39 +236,6 @@ public class LocalityStoreTest {
   }
 
   @Test
-  @SuppressWarnings("unchecked")
-  public void updateLocalityStore_updateStatsStoreLocalityTracking() {
-    Map<Locality, LocalityLbEndpoints> localityInfoMap = new HashMap<>();
-    localityInfoMap
-        .put(locality1,
-            new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0));
-    localityInfoMap
-        .put(locality2,
-            new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0));
-    localityStore.updateLocalityStore(ImmutableMap.copyOf(localityInfoMap));
-    verify(loadStatsStore).addLocality(locality1);
-    verify(loadStatsStore).addLocality(locality2);
-
-    localityInfoMap
-        .put(locality3,
-            new LocalityLbEndpoints(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0));
-    localityStore.updateLocalityStore(ImmutableMap.copyOf(localityInfoMap));
-    verify(loadStatsStore).addLocality(locality3);
-
-    localityInfoMap = ImmutableMap
-        .of(locality4,
-            new LocalityLbEndpoints(ImmutableList.of(lbEndpoint41, lbEndpoint42), 4, 0));
-    localityStore.updateLocalityStore(ImmutableMap.copyOf(localityInfoMap));
-    verify(loadStatsStore).removeLocality(locality1);
-    verify(loadStatsStore).removeLocality(locality2);
-    verify(loadStatsStore).removeLocality(locality3);
-    verify(loadStatsStore).addLocality(locality4);
-
-    localityStore.updateLocalityStore(ImmutableMap.copyOf(Collections.EMPTY_MAP));
-    verify(loadStatsStore).removeLocality(locality4);
-  }
-
-  @Test
   public void updateLocalityStore_pickResultInterceptedForLoadRecordingWhenSubchannelReady() {
     // Simulate receiving two localities.
     LocalityLbEndpoints localityInfo1 =


### PR DESCRIPTION
Bug description: 
- When receiving an EDS update that removes a locality, the child balancer for that locality is not deleted immediately (delayed deletion for 15 minutes). However, the load stats counter for that locality is always deleted from the LoadStatsStore immediately! After a while (< 15 minutes) when this locality is added back, a new counter is created for it. However, the undeleted leaf balancer for this locality is still using the old counter. All loads are still recorded into the counter. This results in load reporting always reports 0 RPCs for that locality.

Fix:
- Create the counter for recording per locality stats upon creating the child balancer for that locality. When the locality is deactivated (due to EDS response update removes it), the counter is not deleted from the LoadStatsStore. Delete it when the child balancer for that locality is shut down. In this way, the lifecycle of the load stats counter for a certain locality stays same with the child balancer for that locality. This is exactly what will happen after we refactor LocalityStore to PriorityLoadBalancer and LrsLoadBalancer (i.e., when some priority is deactivated, its subtree is not deleted immediately, so the LrsLoadBalancer instances for localities still hold the load stats counters).

This change also refactored class organizations (which I consider to be extremely messy) in LocalityStore