### PR TITLE
xds: retain locality stats counter when the child balancer for that locality is deactivated (backport v1.30.x)

### DIFF
--- a/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
@@ -236,39 +236,6 @@ public class LocalityStoreTest {
   }
 
   @Test
-  @SuppressWarnings("unchecked")
-  public void updateLocalityStore_updateStatsStoreLocalityTracking() {
-    Map<Locality, LocalityLbEndpoints> localityInfoMap = new HashMap<>();
-    localityInfoMap
-        .put(locality1,
-            new LocalityLbEndpoints(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1, 0));
-    localityInfoMap
-        .put(locality2,
-            new LocalityLbEndpoints(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2, 0));
-    localityStore.updateLocalityStore(ImmutableMap.copyOf(localityInfoMap));
-    verify(loadStatsStore).addLocality(locality1);
-    verify(loadStatsStore).addLocality(locality2);
-
-    localityInfoMap
-        .put(locality3,
-            new LocalityLbEndpoints(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3, 0));
-    localityStore.updateLocalityStore(ImmutableMap.copyOf(localityInfoMap));
-    verify(loadStatsStore).addLocality(locality3);
-
-    localityInfoMap = ImmutableMap
-        .of(locality4,
-            new LocalityLbEndpoints(ImmutableList.of(lbEndpoint41, lbEndpoint42), 4, 0));
-    localityStore.updateLocalityStore(ImmutableMap.copyOf(localityInfoMap));
-    verify(loadStatsStore).removeLocality(locality1);
-    verify(loadStatsStore).removeLocality(locality2);
-    verify(loadStatsStore).removeLocality(locality3);
-    verify(loadStatsStore).addLocality(locality4);
-
-    localityStore.updateLocalityStore(ImmutableMap.copyOf(Collections.EMPTY_MAP));
-    verify(loadStatsStore).removeLocality(locality4);
-  }
-
-  @Test
   public void updateLocalityStore_pickResultInterceptedForLoadRecordingWhenSubchannelReady() {
     // Simulate receiving two localities.
     LocalityLbEndpoints localityInfo1 =


### PR DESCRIPTION
Create the counter for recording per locality stats upon creating the child balancer for that locality. When the locality is deactivated (due to EDS response update removes it), the counter is not deleted from the LoadStatsStore. Delete it when the child balancer for that locality is shut down. In this way, the lifecycle of the load stats counter for a certain locality stays same with the child balancer for that locality. This is exactly what will happen after we refactor LocalityStore to PriorityLoadBalancer and LrsLoadBalancer (i.e., when some priority is deactivated, its subtree is not deleted immediately, so the LrsLoadBalancer instances for localities still hold the load stats counters).

-----------------
Backport of #7096.