### PR TITLE
core: always propagate RetriableStream.Sublistener.onReady() (backport v1.30.x)

### DIFF
--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -947,10 +947,10 @@ abstract class RetriableStream<ReqT> implements ClientStream {
 
     @Override
     public void onReady() {
-      // TODO(zdapeng): the more correct way to handle onReady
-      if (state.drainedSubstreams.contains(substream)) {
-        masterListener.onReady();
-      }
+      // FIXME(#7089): hedging case is broken.
+      // TODO(zdapeng): optimization: if the substream is not drained yet, delay onReady() once
+      // drained and if is still ready.
+      masterListener.onReady();
     }
   }
 


### PR DESCRIPTION
Backport of #7090 , cherry-pick of 959769aad890b27d713e50d229a54d5bb821fe78

This fixes #6817 for the normal retry case, although it makes the hedging issue #7089 more broken, and there is still space of optimization for normal retry.