### PR TITLE
android-interop-testing: remove SDK version configurations from manifest to avoid Android Studio warnings

### DIFF
--- a/android-interop-testing/src/androidTest/AndroidManifest.xml
+++ b/android-interop-testing/src/androidTest/AndroidManifest.xml
@@ -2,11 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="io.grpc.android.integrationtest.test" >
 
-    <!-- API level 14+ is required for TLS since Google Play Services v10.2 -->
-    <uses-sdk
-        android:minSdkVersion="14"
-        android:targetSdkVersion="22"/>
-
     <instrumentation
         android:name="androidx.test.runner.AndroidJUnitRunner"
         android:targetPackage="io.grpc.android.integrationtest" />

--- a/android-interop-testing/src/main/AndroidManifest.xml
+++ b/android-interop-testing/src/main/AndroidManifest.xml
@@ -2,11 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="io.grpc.android.integrationtest" >
 
-    <!-- API level 14+ is required for TLS since Google Play Services v10.2 -->
-    <uses-sdk
-      android:minSdkVersion="14"
-      android:targetSdkVersion="22"/>
-
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application


### PR DESCRIPTION
Android Studio gives warning: "The minSdk version should not be declared in the android manifest file". Typically `minSdkVersion` should be configured in `build.gradle`, it was set in manifest since internally we use Blaze. cl/316513856 is created to update the internal BUILD file that configures `minSdkVersion`. After that CL is merged, this changed can be imported (or patch that CL to the import CL).