### PR TITLE
api: Deprecate ManagedChannelBuilder.nameResolverFactory

### DIFF
--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -120,6 +120,7 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
     return thisT();
   }
 
+  @Deprecated
   @Override
   public T nameResolverFactory(NameResolver.Factory resolverFactory) {
     delegate().nameResolverFactory(resolverFactory);

--- a/api/src/main/java/io/grpc/LoadBalancerProvider.java
+++ b/api/src/main/java/io/grpc/LoadBalancerProvider.java
@@ -23,6 +23,16 @@ import java.util.Map;
 /**
  * Provider of {@link LoadBalancer}s.  Each provider is bounded to a load-balancing policy name.
  *
+ * <p>Implementations can be automatically discovered by gRPC via Java's SPI mechanism. For
+ * automatic discovery, the implementation must have a zero-argument constructor and include
+ * a resource named {@code META-INF/services/io.grpc.LoadBalancerProvider} in their JAR. The
+ * file's contents should be the implementation's class name. Implementations that need arguments in
+ * their constructor can be manually registered by {@link LoadBalancerRegistry#register}.
+ *
+ * <p>Implementations <em>should not</em> throw. If they do, it may interrupt class loading. If
+ * exceptions may reasonably occur for implementation-specific reasons, implementations should
+ * generally handle the exception gracefully and return {@code false} from {@link #isAvailable()}.
+ *
  * @since 1.17.0
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")

--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -219,7 +219,12 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    *
    * @return this
    * @since 1.0.0
+   * @deprecated Most usages should use a globally-registered {@link NameResolverProvider} instead,
+   *     with either the SPI mechanism or {@link NameResolverRegistry#register}. Replacements for
+   *     all use-cases are not necessarily available yet. See
+   *     <a href="https://github.com/grpc/grpc-java/issues/7133">#7133</a>.
    */
+  @Deprecated
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1770")
   public abstract T nameResolverFactory(NameResolver.Factory resolverFactory);
 

--- a/api/src/main/java/io/grpc/ManagedChannelProvider.java
+++ b/api/src/main/java/io/grpc/ManagedChannelProvider.java
@@ -25,6 +25,11 @@ import java.util.List;
 /**
  * Provider of managed channels for transport agnostic consumption.
  *
+ * <p>Implementations can be automatically discovered by gRPC via Java's SPI mechanism. For
+ * automatic discovery, the implementation must have a zero-argument constructor and include
+ * a resource named {@code META-INF/services/io.grpc.ManagedChannelProvider} in their JAR. The
+ * file's contents should be the implementation's class name.
+ *
  * <p>Implementations <em>should not</em> throw. If they do, it may interrupt class loading. If
  * exceptions may reasonably occur for implementation-specific reasons, implementations should
  * generally handle the exception gracefully and return {@code false} from {@link #isAvailable()}.

--- a/api/src/main/java/io/grpc/NameResolverProvider.java
+++ b/api/src/main/java/io/grpc/NameResolverProvider.java
@@ -21,6 +21,12 @@ import java.util.List;
 /**
  * Provider of name resolvers for name agnostic consumption.
  *
+ * <p>Implementations can be automatically discovered by gRPC via Java's SPI mechanism. For
+ * automatic discovery, the implementation must have a zero-argument constructor and include
+ * a resource named {@code META-INF/services/io.grpc.NameResolverProvider} in their JAR. The
+ * file's contents should be the implementation's class name. Implementations that need arguments in
+ * their constructor can be manually registered by {@link NameResolverRegistry#register}.
+ *
  * <p>Implementations <em>should not</em> throw. If they do, it may interrupt class loading. If
  * exceptions may reasonably occur for implementation-specific reasons, implementations should
  * generally handle the exception gracefully and return {@code false} from {@link #isAvailable()}.

--- a/api/src/main/java/io/grpc/ServerProvider.java
+++ b/api/src/main/java/io/grpc/ServerProvider.java
@@ -23,6 +23,11 @@ import java.util.Collections;
 /**
  * Provider of servers for transport agnostic consumption.
  *
+ * <p>Implementations can be automatically discovered by gRPC via Java's SPI mechanism. For
+ * automatic discovery, the implementation must have a zero-argument constructor and include
+ * a resource named {@code META-INF/services/io.grpc.ServerProvider} in their JAR. The
+ * file's contents should be the implementation's class name.
+ *
  * <p>Implementations <em>should not</em> throw. If they do, it may interrupt class loading. If
  * exceptions may reasonably occur for implementation-specific reasons, implementations should
  * generally handle the exception gracefully and return {@code false} from {@link #isAvailable()}.

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -243,6 +243,7 @@ public abstract class AbstractManagedChannelImplBuilder
     return intercept(Arrays.asList(interceptors));
   }
 
+  @Deprecated
   @Override
   public final T nameResolverFactory(NameResolver.Factory resolverFactory) {
     Preconditions.checkState(directServerAddress == null,

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1285,7 +1285,8 @@ final class ManagedChannelImpl extends ManagedChannel implements
       ResolvingOobChannelBuilder builder = new ResolvingOobChannelBuilder(target);
       builder.offloadExecutorPool = offloadExecutorHolder.pool;
       builder.overrideAuthority(getAuthority());
-      builder.nameResolverFactory(nameResolverFactory);
+      @SuppressWarnings("deprecation")
+      ResolvingOobChannelBuilder unused = builder.nameResolverFactory(nameResolverFactory);
       builder.executorPool = executorPool;
       builder.maxTraceEvents = maxTraceEvents;
       builder.proxyDetector = nameResolverArgs.getProxyDetector();

--- a/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
@@ -117,6 +117,7 @@ public class AbstractManagedChannelImplBuilderTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void nameResolverFactory_normal() {
     NameResolver.Factory nameResolverFactory = mock(NameResolver.Factory.class);
     assertEquals(builder, builder.nameResolverFactory(nameResolverFactory));
@@ -124,6 +125,7 @@ public class AbstractManagedChannelImplBuilderTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void nameResolverFactory_null() {
     NameResolver.Factory defaultValue = builder.getNameResolverFactory();
     builder.nameResolverFactory(mock(NameResolver.Factory.class));
@@ -132,6 +134,7 @@ public class AbstractManagedChannelImplBuilderTest {
   }
 
   @Test(expected = IllegalStateException.class)
+  @SuppressWarnings("deprecation")
   public void nameResolverFactory_notAllowedWithDirectAddress() {
     directAddressBuilder.nameResolverFactory(mock(NameResolver.Factory.class));
   }

--- a/xds/src/test/java/io/grpc/xds/XdsSdsClientServerTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsSdsClientServerTest.java
@@ -35,6 +35,8 @@ import io.envoyproxy.envoy.api.v2.auth.UpstreamTlsContext;
 import io.grpc.Attributes;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.NameResolver;
+import io.grpc.NameResolverProvider;
+import io.grpc.NameResolverRegistry;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.netty.InternalProtocolNegotiator.ProtocolNegotiator;
@@ -59,6 +61,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import javax.net.ssl.SSLHandshakeException;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -74,10 +77,18 @@ public class XdsSdsClientServerTest {
 
   @Rule public final GrpcCleanupRule cleanupRule = new GrpcCleanupRule();
   private int port;
+  private FakeNameResolverFactory fakeNameResolverFactory;
 
   @Before
   public void setUp() throws IOException {
     port = findFreePort();
+  }
+
+  @After
+  public void tearDown() {
+    if (fakeNameResolverFactory != null) {
+      NameResolverRegistry.getDefaultRegistry().deregister(fakeNameResolverFactory);
+    }
   }
 
   @Test
@@ -322,11 +333,10 @@ public class XdsSdsClientServerTest {
       final UpstreamTlsContext upstreamTlsContext, String overrideAuthority)
       throws URISyntaxException {
     URI expectedUri = new URI("sdstest://localhost:" + port);
-    FakeNameResolverFactory fakeNameResolverFactory = new FakeNameResolverFactory.Builder(
-        expectedUri).build();
+    fakeNameResolverFactory = new FakeNameResolverFactory.Builder(expectedUri).build();
+    NameResolverRegistry.getDefaultRegistry().register(fakeNameResolverFactory);
     XdsChannelBuilder channelBuilder =
-        XdsChannelBuilder.forTarget("sdstest://localhost:" + port)
-            .nameResolverFactory(fakeNameResolverFactory);
+        XdsChannelBuilder.forTarget("sdstest://localhost:" + port);
     if (overrideAuthority != null) {
       channelBuilder = channelBuilder.overrideAuthority(overrideAuthority);
     }
@@ -364,7 +374,7 @@ public class XdsSdsClientServerTest {
     }
   }
 
-  private static final class FakeNameResolverFactory extends NameResolver.Factory {
+  private static final class FakeNameResolverFactory extends NameResolverProvider {
     final URI expectedUri;
     List<EquivalentAddressGroup> servers = ImmutableList.of();
     final ArrayList<FakeNameResolver> resolvers = new ArrayList<>();
@@ -390,6 +400,16 @@ public class XdsSdsClientServerTest {
     @Override
     public String getDefaultScheme() {
       return "sdstest";
+    }
+
+    @Override
+    protected boolean isAvailable() {
+      return true;
+    }
+
+    @Override
+    protected int priority() {
+      return 5;
     }
 
     final class FakeNameResolver extends NameResolver {


### PR DESCRIPTION
It has been our intention for years to remove nameResolverFactory. We should
make it clear to users to avoid new code depending on it and so they can tell
us why they need it so we can provide replacements.

Also added documentation for Provider SPI discovery

----

I plan to merge the two commits separately.