### PR TITLE
xds: use fallback PN if you get exception while retrieving SslContextProvider

### DIFF
--- a/xds/src/main/java/io/grpc/xds/internal/sds/SdsProtocolNegotiators.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/SdsProtocolNegotiators.java
@@ -305,7 +305,11 @@ public final class SdsProtocolNegotiators {
           return;
         } else {
           ctx.pipeline()
-              .replace(this, null, new ServerSdsHandler(grpcHandler, downstreamTlsContext));
+              .replace(
+                  this,
+                  null,
+                  new ServerSdsHandler(
+                      grpcHandler, downstreamTlsContext, fallbackProtocolNegotiator));
           ProtocolNegotiationEvent pne = InternalProtocolNegotiationEvent.getDefault();
           ctx.fireUserEventTriggered(pne);
           return;
@@ -321,10 +325,12 @@ public final class SdsProtocolNegotiators {
           extends InternalProtocolNegotiators.ProtocolNegotiationHandler {
     private final GrpcHttp2ConnectionHandler grpcHandler;
     private final DownstreamTlsContext downstreamTlsContext;
+    @Nullable private final ProtocolNegotiator fallbackProtocolNegotiator;
 
     ServerSdsHandler(
             GrpcHttp2ConnectionHandler grpcHandler,
-            DownstreamTlsContext downstreamTlsContext) {
+            DownstreamTlsContext downstreamTlsContext,
+            ProtocolNegotiator fallbackProtocolNegotiator) {
       super(
           // superclass (InternalProtocolNegotiators.ProtocolNegotiationHandler) expects 'next'
           // handler but we don't have a next handler _yet_. So we "disable" superclass's behavior
@@ -338,6 +344,7 @@ public final class SdsProtocolNegotiators {
       checkNotNull(grpcHandler, "grpcHandler");
       this.grpcHandler = grpcHandler;
       this.downstreamTlsContext = downstreamTlsContext;
+      this.fallbackProtocolNegotiator = fallbackProtocolNegotiator;
     }
 
     @Override
@@ -345,22 +352,41 @@ public final class SdsProtocolNegotiators {
       final BufferReadsHandler bufferReads = new BufferReadsHandler();
       ctx.pipeline().addBefore(ctx.name(), null, bufferReads);
 
-      final SslContextProvider sslContextProvider =
-              TlsContextManagerImpl.getInstance()
-                      .findOrCreateServerSslContextProvider(downstreamTlsContext);
-
+      SslContextProvider sslContextProviderTemp = null;
+      try {
+        sslContextProviderTemp =
+            TlsContextManagerImpl.getInstance()
+                .findOrCreateServerSslContextProvider(downstreamTlsContext);
+      } catch (Exception e) {
+        if (fallbackProtocolNegotiator == null) {
+          ctx.fireExceptionCaught(new CertStoreException("No certificate source found!", e));
+          return;
+        }
+        logger.log(Level.INFO, "Using fallback for {0}", ctx.channel().localAddress());
+        // Delegate rest of handshake to fallback handler
+        ctx.executor()
+            .execute(
+                new Runnable() {
+                  @Override
+                  public void run() {
+                    replaceHandler(
+                        fallbackProtocolNegotiator.newHandler(grpcHandler), ctx, bufferReads);
+                  }
+                });
+        return;
+      }
+      final SslContextProvider sslContextProvider = sslContextProviderTemp;
       sslContextProvider.addCallback(
           new SslContextProvider.Callback() {
 
             @Override
             public void updateSecret(SslContext sslContext) {
-              ChannelHandler handler =
-                  InternalProtocolNegotiators.serverTls(sslContext).newHandler(grpcHandler);
 
               // Delegate rest of handshake to TLS handler
-              ctx.pipeline().addAfter(ctx.name(), null, handler);
-              fireProtocolNegotiationEvent(ctx);
-              ctx.pipeline().remove(bufferReads);
+              replaceHandler(
+                  InternalProtocolNegotiators.serverTls(sslContext).newHandler(grpcHandler),
+                  ctx,
+                  bufferReads);
               TlsContextManagerImpl.getInstance()
                   .releaseServerSslContextProvider(sslContextProvider);
             }
@@ -371,6 +397,13 @@ public final class SdsProtocolNegotiators {
             }
           },
           ctx.executor());
+    }
+
+    private void replaceHandler(
+        ChannelHandler handler, ChannelHandlerContext ctx, BufferReadsHandler bufferReads) {
+      ctx.pipeline().addAfter(ctx.name(), null, handler);
+      fireProtocolNegotiationEvent(ctx);
+      ctx.pipeline().remove(bufferReads);
     }
   }
 }

--- a/xds/src/test/java/io/grpc/xds/XdsSdsClientServerTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsSdsClientServerTest.java
@@ -92,8 +92,8 @@ public class XdsSdsClientServerTest {
   @Test
   public void plaintextClientServer_withDefaultTlsContext() throws IOException, URISyntaxException {
     DownstreamTlsContext defaultTlsContext =
-            EnvoyServerProtoData.DownstreamTlsContext.fromEnvoyProtoDownstreamTlsContext(
-                    io.envoyproxy.envoy.api.v2.auth.DownstreamTlsContext.getDefaultInstance());
+        EnvoyServerProtoData.DownstreamTlsContext.fromEnvoyProtoDownstreamTlsContext(
+            io.envoyproxy.envoy.api.v2.auth.DownstreamTlsContext.getDefaultInstance());
     buildServerWithTlsContext(/* downstreamTlsContext= */ defaultTlsContext);
 
     SimpleServiceGrpc.SimpleServiceBlockingStub blockingStub =

--- a/xds/src/test/java/io/grpc/xds/XdsSdsClientServerTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsSdsClientServerTest.java
@@ -90,6 +90,18 @@ public class XdsSdsClientServerTest {
   }
 
   @Test
+  public void plaintextClientServer_withDefaultTlsContext() throws IOException, URISyntaxException {
+    DownstreamTlsContext defaultTlsContext =
+            EnvoyServerProtoData.DownstreamTlsContext.fromEnvoyProtoDownstreamTlsContext(
+                    io.envoyproxy.envoy.api.v2.auth.DownstreamTlsContext.getDefaultInstance());
+    buildServerWithTlsContext(/* downstreamTlsContext= */ defaultTlsContext);
+
+    SimpleServiceGrpc.SimpleServiceBlockingStub blockingStub =
+            getBlockingStub(/* upstreamTlsContext= */ null, /* overrideAuthority= */ null);
+    assertThat(unaryRpc("buddy", blockingStub)).isEqualTo("Hello buddy");
+  }
+
+  @Test
   public void nullFallbackProtocolNegotiator_expectException()
       throws IOException, URISyntaxException {
     buildServerWithTlsContext(/* downstreamTlsContext= */ null,


### PR DESCRIPTION
As promised in PR [#7131](https://github.com/grpc/grpc-java/pull/7131#discussion_r441212806) this takes care of default values in tlsContext