### PR TITLE
rls: use system property to use direct path for oob channel

### DIFF
--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -19,8 +19,11 @@ package io.grpc.rls;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Converter;
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.ConnectivityState;
@@ -32,6 +35,7 @@ import io.grpc.LoadBalancer.ResolvedAddresses;
 import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
 import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.Status;
@@ -77,6 +81,11 @@ final class CachingRlsLbClient {
       REQUEST_CONVERTER = new RlsProtoConverters.RouteLookupRequestConverter().reverse();
   private static final Converter<RouteLookupResponse, io.grpc.lookup.v1.RouteLookupResponse>
       RESPONSE_CONVERTER = new RouteLookupResponseConverter().reverse();
+
+  // System property to use direct path enabled OobChannel, by default direct path is enabled.
+  @VisibleForTesting
+  static final String RLS_ENABLE_OOB_CHANNEL_DIRECTPATH_PROPERTY =
+      "io.grpc.rls.CachingRlsLbClient.enable_oobchannel_directpath";
 
   // All cache status changes (pending, backoff, success) must be under this lock
   private final Object lock = new Object();
@@ -124,7 +133,13 @@ final class CachingRlsLbClient {
             timeProvider);
     RlsRequestFactory requestFactory = new RlsRequestFactory(lbPolicyConfig.getRouteLookupConfig());
     rlsPicker = new RlsPicker(requestFactory);
-    rlsChannel = helper.createResolvingOobChannel(rlsConfig.getLookupService());
+    ManagedChannelBuilder<?> rlsChannelBuilder =
+        helper.createResolvingOobChannelBuilder(rlsConfig.getLookupService());
+    if (isOobChannelDirectpathEnabled()) {
+      rlsChannelBuilder.defaultServiceConfig(getDirectpathServiceConfig());
+      rlsChannelBuilder.disableServiceConfigLookUp();
+    }
+    rlsChannel = rlsChannelBuilder.build();
     helper.updateBalancingState(ConnectivityState.CONNECTING, rlsPicker);
     rlsStub = RouteLookupServiceGrpc.newStub(rlsChannel);
     childLbResolvedAddressFactory =
@@ -135,6 +150,23 @@ final class CachingRlsLbClient {
     refCountedChildPolicyWrapperFactory =
         new RefCountedChildPolicyWrapperFactory(
             childLbHelperProvider, new BackoffRefreshListener());
+  }
+
+  private static boolean isOobChannelDirectpathEnabled() {
+    return System.getProperty(RLS_ENABLE_OOB_CHANNEL_DIRECTPATH_PROPERTY, "true").equals("true");
+  }
+
+  private static ImmutableMap<String, Object> getDirectpathServiceConfig() {
+    ImmutableMap<String, Object> pickFirstStrategy =
+        ImmutableMap.<String, Object>of("pick_first", ImmutableMap.of());
+
+    ImmutableMap<String, Object> childPolicy =
+        ImmutableMap.<String, Object>of("childPolicy", ImmutableList.of(pickFirstStrategy));
+
+    ImmutableMap<String, Object> grpcLbPolicy =
+        ImmutableMap.<String, Object>of("grpclb", childPolicy);
+
+    return ImmutableMap.<String, Object>of("loadBalancingConfig", ImmutableList.of(grpcLbPolicy));
   }
 
   @CheckReturnValue

--- a/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
+++ b/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
@@ -134,13 +134,13 @@ public class CachingRlsLbClientTest {
       new LbPolicyConfiguration(ROUTE_LOOKUP_CONFIG, childLbPolicy);
 
   private CachingRlsLbClient rlsLbClient;
-  private String existingEnableOobChannelDirectPath;
+  private boolean existingEnableOobChannelDirectPath;
 
   @Before
   public void setUp() throws Exception {
-    existingEnableOobChannelDirectPath =
-        System.getProperty(CachingRlsLbClient.RLS_ENABLE_OOB_CHANNEL_DIRECTPATH_PROPERTY);
-    System.setProperty(CachingRlsLbClient.RLS_ENABLE_OOB_CHANNEL_DIRECTPATH_PROPERTY, "false");
+    existingEnableOobChannelDirectPath = CachingRlsLbClient.enableOobChannelDirectPath;
+    CachingRlsLbClient.enableOobChannelDirectPath = false;
+
     rlsLbClient =
         CachingRlsLbClient.newBuilder()
             .setBackoffProvider(fakeBackoffProvider)
@@ -156,13 +156,7 @@ public class CachingRlsLbClientTest {
   @After
   public void tearDown() throws Exception {
     rlsLbClient.close();
-    if (existingEnableOobChannelDirectPath == null) {
-      System.clearProperty(CachingRlsLbClient.RLS_ENABLE_OOB_CHANNEL_DIRECTPATH_PROPERTY);
-    } else {
-      System.setProperty(
-          CachingRlsLbClient.RLS_ENABLE_OOB_CHANNEL_DIRECTPATH_PROPERTY,
-          existingEnableOobChannelDirectPath);
-    }
+    CachingRlsLbClient.enableOobChannelDirectPath = existingEnableOobChannelDirectPath;
   }
 
   private CachedRouteLookupResponse getInSyncContext(

--- a/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
@@ -120,11 +120,15 @@ public class RlsLoadBalancerTest {
   private MethodDescriptor<Object, Object> fakeSearchMethod;
   private MethodDescriptor<Object, Object> fakeRescueMethod;
   private RlsLoadBalancer rlsLb;
-  private String existingEnableOobChannelDirectPath;
+  private boolean existingEnableOobChannelDirectPath;
 
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
+
+    existingEnableOobChannelDirectPath = CachingRlsLbClient.enableOobChannelDirectPath;
+    CachingRlsLbClient.enableOobChannelDirectPath = false;
+
     fakeSearchMethod =
         MethodDescriptor.newBuilder()
             .setFullMethodName("com.google/Search")
@@ -171,24 +175,7 @@ public class RlsLoadBalancerTest {
   @After
   public void tearDown() throws Exception {
     rlsLb.shutdown();
-  }
-
-  @Before
-  public void setUpProperties() throws Exception {
-    existingEnableOobChannelDirectPath =
-        System.getProperty(CachingRlsLbClient.RLS_ENABLE_OOB_CHANNEL_DIRECTPATH_PROPERTY);
-    System.setProperty(CachingRlsLbClient.RLS_ENABLE_OOB_CHANNEL_DIRECTPATH_PROPERTY, "false");
-  }
-
-  @After
-  public void restoreProperties() throws Exception {
-    if (existingEnableOobChannelDirectPath == null) {
-      System.clearProperty(CachingRlsLbClient.RLS_ENABLE_OOB_CHANNEL_DIRECTPATH_PROPERTY);
-    } else {
-      System.setProperty(
-          CachingRlsLbClient.RLS_ENABLE_OOB_CHANNEL_DIRECTPATH_PROPERTY,
-          existingEnableOobChannelDirectPath);
-    }
+    CachingRlsLbClient.enableOobChannelDirectPath = existingEnableOobChannelDirectPath;
   }
 
   @Test


### PR DESCRIPTION
this allows client libraries to use directpath enabled RLS target while open source users can disable it when directpath is not used.