### PR TITLE
xds: disable processing of UpstreamTlsContext until we are ready to test the feature

### DIFF
--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer.java
@@ -290,7 +290,9 @@ public final class CdsLoadBalancer extends LoadBalancer {
               /* edsServiceName = */ newUpdate.getEdsServiceName(),
               /* lrsServerName = */ newUpdate.getLrsServerName(),
               new PolicySelection(lbProvider, ImmutableMap.<String, Object>of(), lbConfig));
-      updateSslContextProvider(newUpdate.getUpstreamTlsContext());
+      if (false) {
+        updateSslContextProvider(newUpdate.getUpstreamTlsContext());
+      }
       if (edsBalancer == null) {
         edsBalancer = lbRegistry.getProvider(EDS_POLICY_NAME).newLoadBalancer(helper);
       }

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancerTest.java
@@ -76,6 +76,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -338,6 +339,7 @@ public class CdsLoadBalancerTest {
     assertThat(xdsClientPool.xdsClient).isNull();
   }
 
+  @Ignore
   @Test
   public void handleCdsConfigUpdate_withUpstreamTlsContext()  {
     assertThat(xdsClient).isNull();


### PR DESCRIPTION
Will make the same fix in 1.30 once approved/merged