### PR TITLE
github: Remove bug label from newly filed bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,6 @@
 ---
 name: Report a bug
 about: Create a bug report to help us improve
-labels: bug
 ---
 
 <!-- Please answer these questions before submitting a bug report. -->


### PR DESCRIPTION
We've been using the bug label for "confirmed" bugs. Many issues filed as bugs
turn out not to be bugs, but we've not generally remembered to remove the bug
label. This has been causing trouble for tracking bug closure rate, as the data
is now mostly garbage. This change is to put us back into our old flow where
confirmed bugs have the label.

CC @srini100 