### PR TITLE
Bump Jetty ALPN to 2.0.10 for Java 8u252

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -185,7 +185,7 @@ subprojects {
             math: 'org.apache.commons:commons-math3:3.6',
 
             // Jetty ALPN dependencies
-            jetty_alpn_agent: 'org.mortbay.jetty.alpn:jetty-alpn-agent:2.0.9'
+            jetty_alpn_agent: 'org.mortbay.jetty.alpn:jetty-alpn-agent:2.0.10'
         ]
 
         // A util function to config guava dependency with transitive dependencies

--- a/netty/src/test/java/io/grpc/netty/TlsTest.java
+++ b/netty/src/test/java/io/grpc/netty/TlsTest.java
@@ -114,6 +114,10 @@ public class TlsTest {
           // Java 9+
         } catch (ClassNotFoundException ignored) {
           // Before Java 9
+          // TODO(ejona): remove this assume once we upgrade to Netty 4.1.50.Final. GrpcSslContexts
+          // detects the Java 9 ALPN API in Java 8 u252, but Netty does not support it in our
+          // current version
+          Assume.assumeTrue("Jetty ALPN not found", JettyTlsUtil.isJettyAlpnConfigured());
           try {
             GrpcSslContexts.configure(SslContextBuilder.forClient(), jdkProvider);
           } catch (IllegalArgumentException ex) {


### PR DESCRIPTION
Since Travis in on Java 8u252, we won't actually be testing Jetty ALPN at this
point. We're also not testing the Java 9 ALPN API on Java 8, since our current
version of Netty doesn't support it (but an upgrade is available that does).
