### PR TITLE
core: Decrease minimum allowed keepalive time interval (#7180)

### DIFF
--- a/core/src/main/java/io/grpc/internal/KeepAliveManager.java
+++ b/core/src/main/java/io/grpc/internal/KeepAliveManager.java
@@ -32,7 +32,7 @@ import javax.annotation.concurrent.GuardedBy;
  * Manages keepalive pings.
  */
 public class KeepAliveManager {
-  private static final long MIN_KEEPALIVE_TIME_NANOS = TimeUnit.SECONDS.toNanos(10);
+  private static final long MIN_KEEPALIVE_TIME_NANOS = TimeUnit.SECONDS.toNanos(1L);
   private static final long MIN_KEEPALIVE_TIMEOUT_NANOS = TimeUnit.MILLISECONDS.toNanos(10L);
 
   private final ScheduledExecutorService scheduler;
@@ -233,7 +233,7 @@ public class KeepAliveManager {
   }
 
   /**
-   * Bumps keepalive time to 10 seconds if the specified value was smaller than that.
+   * Bumps keepalive time to minimum value if the specified value was smaller than that.
    */
   public static long clampKeepAliveTimeInNanos(long keepAliveTimeInNanos) {
     return Math.max(keepAliveTimeInNanos, MIN_KEEPALIVE_TIME_NANOS);


### PR DESCRIPTION
This PR implements the enhancement requested in issue #7180 
The use-case is to detect a gone connection to the ETCD server on client-side quicker, to be able to connect to an other instance.

I have successfully tested the change with client-side keepalive of 3s and server-side minimum-keepalive of 1s.