### PR TITLE
Swap to new Google Maven Central mirror URL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ subprojects {
 
     repositories {
         maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
+            url "https://maven-central.storage-download.googleapis.com/maven2/" }
         mavenCentral()
         mavenLocal()
     }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 repositories {
     maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
+        url "https://maven-central.storage-download.googleapis.com/maven2/" }
     mavenCentral()
     mavenLocal()
 }

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 repositories {
     maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
+        url "https://maven-central.storage-download.googleapis.com/maven2/"
     }
     mavenCentral()
     mavenLocal()

--- a/examples/example-alts/settings.gradle
+++ b/examples/example-alts/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
     repositories {
         maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
+            url "https://maven-central.storage-download.googleapis.com/maven2/"
         }
         gradlePluginPortal()
     }

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 repositories {
     maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
+        url "https://maven-central.storage-download.googleapis.com/maven2/"
     }
     mavenCentral()
     mavenLocal()

--- a/examples/example-gauth/settings.gradle
+++ b/examples/example-gauth/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
     repositories {
         maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
+            url "https://maven-central.storage-download.googleapis.com/maven2/"
         }
         gradlePluginPortal()
     }

--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 repositories {
     maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
+        url "https://maven-central.storage-download.googleapis.com/maven2/" }
     mavenCentral()
     mavenLocal()
 }

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 repositories {
     maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
+        url "https://maven-central.storage-download.googleapis.com/maven2/"
     }
     mavenLocal()
 }

--- a/examples/example-jwt-auth/settings.gradle
+++ b/examples/example-jwt-auth/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
     repositories {
         maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
+            url "https://maven-central.storage-download.googleapis.com/maven2/"
         }
         gradlePluginPortal()
     }

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 repositories {
     maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
+        url "https://maven-central.storage-download.googleapis.com/maven2/"
     }
     mavenCentral()
     mavenLocal()

--- a/examples/example-tls/settings.gradle
+++ b/examples/example-tls/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
     repositories {
         maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
+            url "https://maven-central.storage-download.googleapis.com/maven2/"
         }
         gradlePluginPortal()
     }

--- a/examples/example-xds/build.gradle
+++ b/examples/example-xds/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 repositories {
     maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
+        url "https://maven-central.storage-download.googleapis.com/maven2/" }
     mavenCentral()
     mavenLocal()
 }

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
     repositories {
         maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
+            url "https://maven-central.storage-download.googleapis.com/maven2/"
         }
         gradlePluginPortal()
     }

--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     repositories {
         jcenter()    // Bintray's repository - a fast Maven Central mirror & more
         maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
+            url "https://maven-central.storage-download.googleapis.com/maven2/" }
     }
     dependencies {
         classpath 'com.google.cloud.tools:appengine-gradle-plugin:1.3.5'
@@ -36,7 +36,7 @@ repositories {
     // repositories for Jar's you access in your code
     mavenLocal()
     maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
+        url "https://maven-central.storage-download.googleapis.com/maven2/" }
     jcenter()
 }
 


### PR DESCRIPTION
As seen at https://maven-central.storage.googleapis.com/index.html . The old
URL still has content, but apparently is no longer being updated. For example,
jetty-alpn-agent-2.0.10.pom is not present.