### PR TITLE
interopt-testing: let AbstractInteropTest.createChannelBuilder throw UnsupportedOperationException

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -342,7 +342,9 @@ public abstract class AbstractInteropTest {
     return createChannelBuilder().build();
   }
 
-  protected abstract ManagedChannelBuilder<?> createChannelBuilder();
+  protected ManagedChannelBuilder<?> createChannelBuilder() {
+    throw new UnsupportedOperationException("not implemented");
+  }
 
   @Nullable
   protected ClientInterceptor[] getAdditionalInterceptors() {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -342,6 +342,9 @@ public abstract class AbstractInteropTest {
     return createChannelBuilder().build();
   }
 
+  /**
+   * Creates a channel builder for {@link #createChannel()} to use.
+   */
   protected ManagedChannelBuilder<?> createChannelBuilder() {
     throw new UnsupportedOperationException("not implemented");
   }


### PR DESCRIPTION
To avoid breaking exiting users/grpc implementors.
When updating to new version of `io.grpc:grpc-interop-testing`, existing users would only fail one more test: `emptyUnaryWithRetriableStream()`.