### PR TITLE
Revert "core: Fix migrating deframer compatibility with RetriableStream"

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractStream.java
@@ -157,7 +157,8 @@ public abstract class AbstractStream implements Stream {
           maxMessageSize,
           statsTraceCtx,
           transportTracer);
-      deframer = new MigratingThreadDeframer(this, this, rawDeframer);
+      // TODO(#7168): use MigratingThreadDeframer when enabling retry doesn't break.
+      deframer = rawDeframer;
     }
 
     final void optimizeForDirectExecutor() {


### PR DESCRIPTION
This reverts commit bcb287bb1573a864a45fa1903465277bf3c80772 in #7195, which caused weighted_round_robin_test_cpp_java (cl/320536176) failing consistently.