### PR TITLE
interop-testing: Use normal runtimeOnly dep for xds

### DIFF
--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -48,7 +48,9 @@ dependencies {
     implementation project(':grpc-netty')
     implementation project(":grpc-stub")
     implementation (project(':grpc-interop-testing')) {
+        // Avoid grpc-netty-shaded dependency
         exclude group: 'io.grpc', module: 'grpc-alts'
+        exclude group: 'io.grpc', module: 'grpc-xds'
     }
     implementation libraries.junit
     implementation libraries.protobuf

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -11,7 +11,6 @@ startScripts.enabled = false
 
 configurations {
     alpnagent
-    xdsRuntime
 }
 
 evaluationDependsOn(project(':grpc-context').path)
@@ -34,8 +33,8 @@ dependencies {
     compileOnly libraries.javax_annotation
     runtimeOnly libraries.opencensus_impl,
             libraries.netty_tcnative,
-            project(':grpc-grpclb')
-    xdsRuntime project(path: ':grpc-xds', configuration: 'shadow')
+            project(':grpc-grpclb'),
+            project(path: ':grpc-xds', configuration: 'shadow')
     testImplementation project(':grpc-context').sourceSets.test.output,
             libraries.mockito
     alpnagent libraries.jetty_alpn_agent
@@ -128,7 +127,7 @@ task xds_test_client(type: CreateStartScripts) {
     mainClassName = "io.grpc.testing.integration.XdsTestClient"
     applicationName = "xds-test-client"
     outputDir = new File(project.buildDir, 'tmp')
-    classpath = startScripts.classpath + configurations.xdsRuntime
+    classpath = startScripts.classpath
 }
 
 task xds_test_server(type: CreateStartScripts) {
@@ -153,7 +152,6 @@ applicationDistribution.into("bin") {
 
 applicationDistribution.into("lib") {
     from(configurations.alpnagent)
-    from(configurations.xdsRuntime)
 }
 
 publishing {


### PR DESCRIPTION
This prevents grpc-xds and its transitive dependencies from being included
twice in distTar and distZip, which reduces the size from 60 MB to 40 MB. It
does mean that interop-testing as a whole depends on xds, but that should not
be an issue any longer. It was an issue before we started providing grpc-xds on
Maven Central.