### PR TITLE
example-tls: Update grpc version, current is invalid

### DIFF
--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -23,7 +23,7 @@ targetCompatibility = 1.7
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.31.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.29.0' // CURRENT_GRPC_VERSION
 def nettyTcNativeVersion = '2.0.30.Final'
 def protocVersion = '3.12.0'
 


### PR DESCRIPTION
changing grpc version, apparently `1.31.0-SNAPSHOT` isn't available on `https://maven-central.storage-download.googleapis.com/maven2/`