### PR TITLE
Add xds client flags

### DIFF
--- a/buildscripts/kokoro/xds.sh
+++ b/buildscripts/kokoro/xds.sh
@@ -20,9 +20,15 @@ popd
 git clone -b "${branch}" --single-branch --depth=1 https://github.com/grpc/grpc.git
 
 grpc/tools/run_tests/helper_scripts/prep_xds.sh
+
+# Test cases "path_matching" and "header_matching" are not included in "all",
+# because not all interop clients in all languages support these new tests.
+#
+# TODO(ericgribkoff): remove "path_matching" and "header_matching" from
+# --test_case after they are added into "all".
 JAVA_OPTS=-Djava.util.logging.config.file=grpc-java/buildscripts/xds_logging.properties \
   python3 grpc/tools/run_tests/run_xds_tests.py \
-    --test_case=all \
+    --test_case="all,path_matching,header_matching" \
     --project_id=grpc-testing \
     --source_image=projects/grpc-testing/global/images/xds-test-server \
     --path_to_server_binary=/java_server/grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-server \

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
@@ -16,6 +16,9 @@
 
 package io.grpc.testing.integration;
 
+import com.google.common.base.CaseFormat;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -24,12 +27,16 @@ import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.CallOptions;
+import io.grpc.Channel;
 import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
 import io.grpc.Grpc;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
 import io.grpc.Server;
-import io.grpc.Status;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.StreamObserver;
@@ -47,6 +54,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
@@ -62,12 +70,23 @@ public final class XdsTestClient {
   private int numChannels = 1;
   private boolean printResponse = false;
   private int qps = 1;
+  private List<RpcType> rpc = ImmutableList.of(RpcType.UNARY_CALL);
+  private Map<RpcType, Metadata> metadata = new HashMap<>();
   private int rpcTimeoutSec = 2;
   private String server = "localhost:8080";
   private int statsPort = 8081;
   private Server statsServer;
   private long currentRequestId;
   private ListeningScheduledExecutorService exec;
+
+  private enum RpcType {
+    EMPTY_CALL,
+    UNARY_CALL;
+
+    public String toCamelCase() {
+      return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, toString());
+    }
+  }
 
   /**
    * The main application allowing this client to be launched from the command line.
@@ -111,12 +130,16 @@ public final class XdsTestClient {
         break;
       }
       String value = parts[1];
-      if ("num_channels".equals(key)) {
+      if ("metadata".equals(key)) {
+        metadata = parseMetadata(value);
+      } else if ("num_channels".equals(key)) {
         numChannels = Integer.valueOf(value);
       } else if ("print_response".equals(key)) {
         printResponse = Boolean.valueOf(value);
       } else if ("qps".equals(key)) {
         qps = Integer.valueOf(value);
+      } else if ("rpc".equals(key)) {
+        rpc = parseRpcs(value);
       } else if ("rpc_timeout_sec".equals(key)) {
         rpcTimeoutSec = Integer.valueOf(value);
       } else if ("server".equals(key)) {
@@ -139,8 +162,12 @@ public final class XdsTestClient {
               + c.numChannels
               + "\n  --print_response=BOOL  Write RPC response to stdout. Default: "
               + c.printResponse
-              + "\n  --qps=INT              Qps per channel. Default: "
+              + "\n  --qps=INT              Qps per channel, for each type of RPC. Default: "
               + c.qps
+              + "\n  --rpc=STR              Types of RPCs to make, ',' separated string. RPCs can "
+              + "be EmptyCall or UnaryCall."
+              + "\n  --metadata=STR         The metadata to send with each RPC, in the format "
+              + "EmptyCall:key1:value1,UnaryCall:key2:value2."
               + "\n  --rpc_timeout_sec=INT  Per RPC timeout seconds. Default: "
               + c.rpcTimeoutSec
               + "\n  --server=host:port     Address of server. Default: "
@@ -149,6 +176,45 @@ public final class XdsTestClient {
               + "Default: "
               + c.statsPort);
       System.exit(1);
+    }
+  }
+
+  private static List<RpcType> parseRpcs(String rpcArg) {
+    List<RpcType> rpcs = new ArrayList<>();
+    for (String rpc : Splitter.on(',').split(rpcArg)) {
+      rpcs.add(parseRpc(rpc));
+    }
+    return rpcs;
+  }
+
+  private static Map<RpcType, Metadata> parseMetadata(String metadataArg) {
+    Map<RpcType, Metadata> rpcMetadata = new HashMap<>();
+    for (String metadata : Splitter.on(',').omitEmptyStrings().split(metadataArg)) {
+      List<String> parts = Splitter.on(':').splitToList(metadata);
+      if (parts.size() != 3) {
+        throw new IllegalArgumentException("Invalid metadata: '" + metadata + "'");
+      }
+      RpcType rpc = parseRpc(parts.get(0));
+      String key = parts.get(1);
+      String value = parts.get(2);
+      Metadata md = new Metadata();
+      md.put(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), value);
+      if (rpcMetadata.containsKey(rpc)) {
+        rpcMetadata.get(rpc).merge(md);
+      } else {
+        rpcMetadata.put(rpc, md);
+      }
+    }
+    return rpcMetadata;
+  }
+
+  private static RpcType parseRpc(String rpc) {
+    if ("EmptyCall".equals(rpc)) {
+      return RpcType.EMPTY_CALL;
+    } else if ("UnaryCall".equals(rpc)) {
+      return RpcType.UNARY_CALL;
+    } else {
+      throw new IllegalArgumentException("Unknown RPC: '" + rpc + "'");
     }
   }
 
@@ -186,6 +252,11 @@ public final class XdsTestClient {
   private void runQps() throws InterruptedException, ExecutionException {
     final SettableFuture<Void> failure = SettableFuture.create();
     final class PeriodicRpc implements Runnable {
+      private final RpcType rpcType;
+
+      private PeriodicRpc(RpcType rpcType) {
+        this.rpcType = rpcType;
+      }
 
       @Override
       public void run() {
@@ -197,65 +268,87 @@ public final class XdsTestClient {
           savedWatchers.addAll(watchers);
         }
 
-        SimpleRequest request = SimpleRequest.newBuilder().setFillServerId(true).build();
+        final Metadata headersToSend;
+        if (metadata.containsKey(rpcType)) {
+          headersToSend = metadata.get(rpcType);
+        } else {
+          headersToSend = new Metadata();
+        }
         ManagedChannel channel = channels.get((int) (requestId % channels.size()));
-        final ClientCall<SimpleRequest, SimpleResponse> call =
-            channel.newCall(
-                TestServiceGrpc.getUnaryCallMethod(),
-                CallOptions.DEFAULT.withDeadlineAfter(rpcTimeoutSec, TimeUnit.SECONDS));
-        call.start(
-            new ClientCall.Listener<SimpleResponse>() {
-              private String hostname;
+        TestServiceGrpc.TestServiceBlockingStub stub = TestServiceGrpc.newBlockingStub(channel);
+        final AtomicReference<ClientCall<?, ?>> clientCallRef = new AtomicReference<>();
+        final AtomicReference<String> hostnameRef = new AtomicReference<>();
+        stub =
+            stub.withDeadlineAfter(rpcTimeoutSec, TimeUnit.SECONDS)
+                .withInterceptors(
+                    new ClientInterceptor() {
+                      @Override
+                      public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+                          MethodDescriptor<ReqT, RespT> method,
+                          CallOptions callOptions,
+                          Channel next) {
+                        ClientCall<ReqT, RespT> call = next.newCall(method, callOptions);
+                        clientCallRef.set(call);
+                        return new SimpleForwardingClientCall<ReqT, RespT>(call) {
+                          @Override
+                          public void start(Listener<RespT> responseListener, Metadata headers) {
+                            headers.merge(headersToSend);
+                            super.start(
+                                new SimpleForwardingClientCallListener<RespT>(responseListener) {
+                                  @Override
+                                  public void onHeaders(Metadata headers) {
+                                    hostnameRef.set(headers.get(XdsTestServer.HOSTNAME_KEY));
+                                    super.onHeaders(headers);
+                                  }
+                                },
+                                headers);
+                          }
+                        };
+                      }
+                    });
 
-              @Override
-              public void onMessage(SimpleResponse response) {
-                hostname = response.getHostname();
-                // TODO(ericgribkoff) Currently some test environments cannot access the stats RPC
-                // service and rely on parsing stdout.
-                if (printResponse) {
-                  System.out.println(
-                      "Greeting: Hello world, this is "
-                          + hostname
-                          + ", from "
-                          + call.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR));
-                }
-              }
-
-              @Override
-              public void onClose(Status status, Metadata trailers) {
-                if (printResponse && !status.isOk()) {
-                  logger.log(Level.WARNING, "Greeting RPC failed with status {0}", status);
-                }
-                for (XdsStatsWatcher watcher : savedWatchers) {
-                  watcher.rpcCompleted(requestId, hostname);
-                }
-              }
-            },
-            new Metadata());
-
-        call.sendMessage(request);
-        call.request(1);
-        call.halfClose();
+        if (rpcType == RpcType.EMPTY_CALL) {
+          stub.emptyCall(EmptyProtos.Empty.getDefaultInstance());
+        } else if (rpcType == RpcType.UNARY_CALL) {
+          SimpleRequest request = SimpleRequest.newBuilder().setFillServerId(true).build();
+          SimpleResponse response = stub.unaryCall(request);
+          // TODO(ericgribkoff) Currently some test environments cannot access the stats RPC
+          // service and rely on parsing stdout.
+          if (printResponse) {
+            System.out.println(
+                "Greeting: Hello world, this is "
+                    + response.getHostname()
+                    + ", from "
+                    + clientCallRef.get().getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR));
+          }
+        }
+        for (XdsStatsWatcher watcher : savedWatchers) {
+          watcher.rpcCompleted(rpcType.toCamelCase(), requestId, hostnameRef.get());
+        }
       }
     }
 
     long nanosPerQuery = TimeUnit.SECONDS.toNanos(1) / qps;
-    ListenableScheduledFuture<?> future =
-        exec.scheduleAtFixedRate(new PeriodicRpc(), 0, nanosPerQuery, TimeUnit.NANOSECONDS);
 
-    Futures.addCallback(
-        future,
-        new FutureCallback<Object>() {
+    for (RpcType rpcType : rpc) {
+      ListenableScheduledFuture<?> future =
+          exec.scheduleAtFixedRate(
+              new PeriodicRpc(rpcType), 0, nanosPerQuery, TimeUnit.NANOSECONDS);
 
-          @Override
-          public void onFailure(Throwable t) {
-            failure.setException(t);
-          }
+      Futures.addCallback(
+          future,
+          new FutureCallback<Object>() {
 
-          @Override
-          public void onSuccess(Object o) {}
-        },
-        MoreExecutors.directExecutor());
+            @Override
+            public void onFailure(Throwable t) {
+              failure.setException(t);
+            }
+
+            @Override
+            public void onSuccess(Object o) {}
+          },
+          MoreExecutors.directExecutor());
+    }
 
     failure.get();
   }
@@ -286,6 +379,7 @@ public final class XdsTestClient {
     private final long startId;
     private final long endId;
     private final Map<String, Integer> rpcsByPeer = new HashMap<>();
+    private final Map<String, Map<String, Integer>> rpcsByTypeAndPeer = new HashMap<>();
     private final Object lock = new Object();
     private int noRemotePeer;
 
@@ -295,7 +389,7 @@ public final class XdsTestClient {
       this.endId = endId;
     }
 
-    void rpcCompleted(long requestId, @Nullable String hostname) {
+    void rpcCompleted(String rpcType, long requestId, @Nullable String hostname) {
       synchronized (lock) {
         if (startId <= requestId && requestId < endId) {
           if (hostname != null) {
@@ -303,6 +397,19 @@ public final class XdsTestClient {
               rpcsByPeer.put(hostname, rpcsByPeer.get(hostname) + 1);
             } else {
               rpcsByPeer.put(hostname, 1);
+            }
+            if (rpcsByTypeAndPeer.containsKey(rpcType)) {
+              if (rpcsByTypeAndPeer.get(rpcType).containsKey(hostname)) {
+                rpcsByTypeAndPeer
+                    .get(rpcType)
+                    .put(hostname, rpcsByTypeAndPeer.get(rpcType).get(hostname) + 1);
+              } else {
+                rpcsByTypeAndPeer.get(rpcType).put(hostname, 1);
+              }
+            } else {
+              Map<String, Integer> rpcMap = new HashMap<>();
+              rpcMap.put(hostname, 1);
+              rpcsByTypeAndPeer.put(rpcType, rpcMap);
             }
           } else {
             noRemotePeer += 1;
@@ -325,6 +432,12 @@ public final class XdsTestClient {
       LoadBalancerStatsResponse.Builder builder = LoadBalancerStatsResponse.newBuilder();
       synchronized (lock) {
         builder.putAllRpcsByPeer(rpcsByPeer);
+        for (Map.Entry<String, Map<String, Integer>> entry : rpcsByTypeAndPeer.entrySet()) {
+          LoadBalancerStatsResponse.RpcsByPeer.Builder rpcs =
+              LoadBalancerStatsResponse.RpcsByPeer.newBuilder();
+          rpcs.putAllRpcsByPeer(entry.getValue());
+          builder.putRpcsByType(entry.getKey(), rpcs.build());
+        }
         builder.setNumFailures(noRemotePeer + (int) latch.getCount());
       }
       return builder.build();

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
@@ -72,7 +72,7 @@ public final class XdsTestClient {
   private int qps = 1;
   private List<RpcType> rpc = ImmutableList.of(RpcType.UNARY_CALL);
   private Map<RpcType, Metadata> metadata = new HashMap<>();
-  private int rpcTimeoutSec = 2;
+  private int rpcTimeoutSec = 20;
   private String server = "localhost:8080";
   private int statsPort = 8081;
   private Server statsServer;

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
@@ -436,7 +436,7 @@ public final class XdsTestClient {
           LoadBalancerStatsResponse.RpcsByPeer.Builder rpcs =
               LoadBalancerStatsResponse.RpcsByPeer.newBuilder();
           rpcs.putAllRpcsByPeer(entry.getValue());
-          builder.putRpcsByType(entry.getKey(), rpcs.build());
+          builder.putRpcsByMethod(entry.getKey(), rpcs.build());
         }
         builder.setNumFailures(noRemotePeer + (int) latch.getCount());
       }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
@@ -72,7 +72,7 @@ public final class XdsTestClient {
   private boolean printResponse = false;
   private int qps = 1;
   private List<RpcType> rpcTypes = ImmutableList.of(RpcType.UNARY_CALL);
-  private Map<RpcType, Metadata> metadata = new HashMap<>();
+  private EnumMap<RpcType, Metadata> metadata = new EnumMap<>(RpcType.class);
   private int rpcTimeoutSec = 20;
   private String server = "localhost:8080";
   private int statsPort = 8081;
@@ -188,8 +188,8 @@ public final class XdsTestClient {
     return rpcs;
   }
 
-  private static Map<RpcType, Metadata> parseMetadata(String metadataArg) {
-    Map<RpcType, Metadata> rpcMetadata = new HashMap<>();
+  private static EnumMap<RpcType, Metadata> parseMetadata(String metadataArg) {
+    EnumMap<RpcType, Metadata> rpcMetadata = new EnumMap<>(RpcType.class);
     for (String metadata : Splitter.on(',').omitEmptyStrings().split(metadataArg)) {
       List<String> parts = Splitter.on(':').splitToList(metadata);
       if (parts.size() != 3) {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
@@ -321,6 +321,11 @@ public final class XdsTestClient {
                     + ", from "
                     + clientCallRef.get().getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR));
           }
+          // Use the hostname from the response if not present in the metadata.
+          // TODO(ericgribkoff) Delete when server is deployed that sets metadata value.
+          if (hostnameRef.get() == null) {
+            hostnameRef.set(response.getHostname());
+          }
         }
         for (XdsStatsWatcher watcher : savedWatchers) {
           watcher.rpcCompleted(rpcType.toCamelCase(), requestId, hostnameRef.get());

--- a/interop-testing/src/main/proto/grpc/testing/messages.proto
+++ b/interop-testing/src/main/proto/grpc/testing/messages.proto
@@ -195,4 +195,10 @@ message LoadBalancerStatsResponse {
   map<string, int32> rpcs_by_peer = 1;
   // The number of RPCs that failed to record a remote peer.
   int32 num_failures = 2;
+  message RpcsByPeer {
+    // The number of completed RPCs for each peer.
+    map<string, int32> rpcs_by_peer = 1;
+  }
+  // The number of completed RPCs for each type (UnaryCall or EmptyCall).
+  map<string, RpcsByPeer> rpcs_by_type = 3;
 }

--- a/interop-testing/src/main/proto/grpc/testing/messages.proto
+++ b/interop-testing/src/main/proto/grpc/testing/messages.proto
@@ -200,5 +200,5 @@ message LoadBalancerStatsResponse {
     map<string, int32> rpcs_by_peer = 1;
   }
   // The number of completed RPCs for each type (UnaryCall or EmptyCall).
-  map<string, RpcsByPeer> rpcs_by_type = 3;
+  map<string, RpcsByPeer> rpcs_by_method = 3;
 }


### PR DESCRIPTION
New test cases require the `--rpc` and `--metadata` flags. This PR is the Java analog/port of the Go change in https://github.com/grpc/grpc-go/pull/3737

cc @menghanl 