### PR TITLE
xds: support load reporting all clusters option and fix actual report interval measurement

### DIFF
--- a/xds/src/main/java/io/grpc/xds/LoadReportClient.java
+++ b/xds/src/main/java/io/grpc/xds/LoadReportClient.java
@@ -159,8 +159,7 @@ final class LoadReportClient {
       loadStatsEntities.put(clusterName, new HashMap<String, LoadStatsEntity>());
     }
     Map<String, LoadStatsEntity> clusterLoadStatsEntities = loadStatsEntities.get(clusterName);
-    clusterLoadStatsEntities.put(
-        clusterServiceName, new LoadStatsEntity(loadStatsStore, stopwatchSupplier.get()));
+    clusterLoadStatsEntities.put(clusterServiceName, new LoadStatsEntity(loadStatsStore));
   }
 
   /**
@@ -387,14 +386,13 @@ final class LoadReportClient {
     }
   }
 
-  private static final class LoadStatsEntity {
+  private final class LoadStatsEntity {
     private final LoadStatsStore loadStatsStore;
     private final Stopwatch stopwatch;
 
-    private LoadStatsEntity(LoadStatsStore loadStatsStore, Stopwatch stopwatch) {
+    private LoadStatsEntity(LoadStatsStore loadStatsStore) {
       this.loadStatsStore = loadStatsStore;
-      this.stopwatch = stopwatch;
-      stopwatch.reset().start();
+      this.stopwatch = stopwatchSupplier.get().reset().start();
     }
 
     private ClusterStats getLoadStats() {

--- a/xds/src/main/java/io/grpc/xds/LoadReportClient.java
+++ b/xds/src/main/java/io/grpc/xds/LoadReportClient.java
@@ -67,7 +67,7 @@ final class LoadReportClient {
   private final BackoffPolicy.Provider backoffPolicyProvider;
 
   // Sources of load stats data for each cluster:cluster_service.
-  private final Map<String, Map<String, LoadStatsStore>> loadStatsStoreMap = new HashMap<>();
+  private final Map<String, Map<String, LoadStatsEntity>> loadStatsEntities = new HashMap<>();
   private boolean started;
 
   @Nullable
@@ -148,18 +148,19 @@ final class LoadReportClient {
   void addLoadStatsStore(
       String clusterName, @Nullable String clusterServiceName, LoadStatsStore loadStatsStore) {
     checkState(
-        !loadStatsStoreMap.containsKey(clusterName)
-            || !loadStatsStoreMap.get(clusterName).containsKey(clusterServiceName),
+        !loadStatsEntities.containsKey(clusterName)
+            || !loadStatsEntities.get(clusterName).containsKey(clusterServiceName),
         "load stats for cluster: %s, cluster service: %s already exists",
         clusterName, clusterServiceName);
     logger.log(
         XdsLogLevel.INFO,
         "Add load stats for cluster: {0}, cluster_service: {1}", clusterName, clusterServiceName);
-    if (!loadStatsStoreMap.containsKey(clusterName)) {
-      loadStatsStoreMap.put(clusterName, new HashMap<String, LoadStatsStore>());
+    if (!loadStatsEntities.containsKey(clusterName)) {
+      loadStatsEntities.put(clusterName, new HashMap<String, LoadStatsEntity>());
     }
-    Map<String, LoadStatsStore> clusterLoadStatsStores = loadStatsStoreMap.get(clusterName);
-    clusterLoadStatsStores.put(clusterServiceName, loadStatsStore);
+    Map<String, LoadStatsEntity> clusterLoadStatsEntities = loadStatsEntities.get(clusterName);
+    clusterLoadStatsEntities.put(
+        clusterServiceName, new LoadStatsEntity(loadStatsStore, stopwatchSupplier.get()));
   }
 
   /**
@@ -167,8 +168,8 @@ final class LoadReportClient {
    */
   void removeLoadStatsStore(String clusterName, @Nullable String clusterServiceName) {
     checkState(
-        loadStatsStoreMap.containsKey(clusterName)
-            && loadStatsStoreMap.get(clusterName).containsKey(clusterServiceName),
+        loadStatsEntities.containsKey(clusterName)
+            && loadStatsEntities.get(clusterName).containsKey(clusterServiceName),
         "load stats for cluster: %s, cluster service: %s does not exist",
         clusterName, clusterServiceName);
     logger.log(
@@ -176,10 +177,10 @@ final class LoadReportClient {
         "Remove load stats for cluster: {0}, cluster_service: {1}",
         clusterName,
         clusterServiceName);
-    Map<String, LoadStatsStore> clusterLoadStatsStores = loadStatsStoreMap.get(clusterName);
-    clusterLoadStatsStores.remove(clusterServiceName);
-    if (clusterLoadStatsStores.isEmpty()) {
-      loadStatsStoreMap.remove(clusterName);
+    Map<String, LoadStatsEntity> clusterLoadStatsEntities = loadStatsEntities.get(clusterName);
+    clusterLoadStatsEntities.remove(clusterServiceName);
+    if (clusterLoadStatsEntities.isEmpty()) {
+      loadStatsEntities.remove(clusterName);
     }
   }
 
@@ -217,10 +218,8 @@ final class LoadReportClient {
 
   private class LrsStream implements StreamObserver<LoadStatsResponse> {
 
-    // Cluster to report loads for asked by management server.
     final Set<String> clusterNames = new HashSet<>();
     final LoadReportingServiceGrpc.LoadReportingServiceStub stub;
-    final Stopwatch reportStopwatch;
     StreamObserver<LoadStatsRequest> lrsRequestWriter;
     boolean initialResponseReceived;
     boolean closed;
@@ -229,15 +228,10 @@ final class LoadReportClient {
 
     LrsStream(LoadReportingServiceGrpc.LoadReportingServiceStub stub, Stopwatch stopwatch) {
       this.stub = checkNotNull(stub, "stub");
-      reportStopwatch = checkNotNull(stopwatch, "stopwatch");
     }
 
     void start() {
       lrsRequestWriter = stub.withWaitForReady().streamLoadStats(this);
-      reportStopwatch.reset().start();
-
-      // Send an initial LRS request with empty cluster stats. Management server is able to
-      // infer clusters the gRPC client sending loads to.
       LoadStatsRequest initRequest =
           LoadStatsRequest.newBuilder()
               .setNode(node)
@@ -278,19 +272,12 @@ final class LoadReportClient {
     }
 
     private void sendLoadReport() {
-      long interval = reportStopwatch.elapsed(TimeUnit.NANOSECONDS);
-      reportStopwatch.reset().start();
       LoadStatsRequest.Builder requestBuilder = LoadStatsRequest.newBuilder().setNode(node);
       for (String name : clusterNames) {
-        if (loadStatsStoreMap.containsKey(name)) {
-          Map<String, LoadStatsStore> clusterLoadStatsStores = loadStatsStoreMap.get(name);
-          for (LoadStatsStore statsStore : clusterLoadStatsStores.values()) {
-            ClusterStats report =
-                statsStore.generateLoadReport()
-                    .toBuilder()
-                    .setLoadReportInterval(Durations.fromNanos(interval))
-                    .build();
-            requestBuilder.addClusterStats(report);
+        if (loadStatsEntities.containsKey(name)) {
+          Map<String, LoadStatsEntity> clusterLoadStatsEntities = loadStatsEntities.get(name);
+          for (LoadStatsEntity entity : clusterLoadStatsEntities.values()) {
+            requestBuilder.addClusterStats(entity.getLoadStats());
           }
         }
       }
@@ -317,28 +304,27 @@ final class LoadReportClient {
       if (closed) {
         return;
       }
-
       if (!initialResponseReceived) {
         logger.log(XdsLogLevel.DEBUG, "Received LRS initial response:\n{0}", response);
         initialResponseReceived = true;
       } else {
         logger.log(XdsLogLevel.DEBUG, "Received LRS response:\n{0}", response);
       }
-      long interval =  Durations.toNanos(response.getLoadReportingInterval());
-      if (interval != loadReportIntervalNano) {
-        logger.log(XdsLogLevel.INFO, "Update load reporting interval to {0} ns", interval);
-        loadReportIntervalNano = interval;
-        callback.onReportResponse(loadReportIntervalNano);
-      }
-      if (clusterNames.size() != response.getClustersCount()
-          || !clusterNames.containsAll(response.getClustersList())) {
+      clusterNames.clear();
+      if (response.getSendAllClusters()) {
+        clusterNames.addAll(loadStatsEntities.keySet());
+        logger.log(XdsLogLevel.INFO, "Update to report loads for all clusters");
+      } else {
         logger.log(
             XdsLogLevel.INFO,
             "Update load reporting clusters to {0}", response.getClustersList());
-        clusterNames.clear();
         clusterNames.addAll(response.getClustersList());
       }
+      long interval = Durations.toNanos(response.getLoadReportingInterval());
+      logger.log(XdsLogLevel.INFO, "Update load reporting interval to {0} ns", interval);
+      loadReportIntervalNano = interval;
       scheduleNextLoadReport();
+      callback.onReportResponse(loadReportIntervalNano);
     }
 
     private void handleStreamClosed(Status status) {
@@ -398,6 +384,28 @@ final class LoadReportClient {
       if (lrsStream == this) {
         lrsStream = null;
       }
+    }
+  }
+
+  private static final class LoadStatsEntity {
+    private final LoadStatsStore loadStatsStore;
+    private final Stopwatch stopwatch;
+
+    private LoadStatsEntity(LoadStatsStore loadStatsStore, Stopwatch stopwatch) {
+      this.loadStatsStore = loadStatsStore;
+      this.stopwatch = stopwatch;
+      stopwatch.reset().start();
+    }
+
+    private ClusterStats getLoadStats() {
+      ClusterStats stats =
+          loadStatsStore.generateLoadReport()
+              .toBuilder()
+              .setLoadReportInterval(
+                  Durations.fromNanos(stopwatch.elapsed(TimeUnit.NANOSECONDS)))
+              .build();
+      stopwatch.reset().start();
+      return stats;
     }
   }
 


### PR DESCRIPTION
Two changes for `LoadReportClient` in this PR:

- Add support for `send_all_clusters` field in LRS response.
   - When it is set to `true`, just send load reports for clusters that the client is currently tracking (aka, is sending load to).

- The [actual load report interval](https://github.com/grpc/grpc-java/blob/8ef09d74283c0a5fb768b39a3e84023c7cb5422c/xds/third_party/envoy/src/main/proto/envoy/api/v2/endpoint/load_report.proto#L154) (in each `ClusterStats` message, which contains the stats for each cluster:eds_service) is tracked individually.
   - Example:
   Initially, if the client has load stats recorded for `cluster-foo:eds_service-foo` and `cluster-bar:eds_service-bar` while the management server is only asking for load stats for `cluster-foo:eds_service-foo` to be reported every 10 seconds. The actual LRS requests sent to the management server should contain only one `ClusterStats` message (for `cluster-foo:eds_service-foo`) with load report interval being 10 seconds. After a while, the management server asks load stats for `cluster-bar:eds_service-bar`. Then the first LRS request after that should contain `ClusterStats` for `cluster-bar:eds_service-bar` should set its actual load report interval to the whole period from the beginning (Although the definition of "beginning" is unclear here. We use the time when the client _starts to know_ the cluster while Envoy uses epoch. I think it shouldn't matter much for the first report of the cluster:eds_service). The point of this change is the actual load report interval for each cluster should be tracked individually as loads for clusters are not necessarily reported together. 

   - For reference, see [Enovy's implementation](https://github.com/markdroth/envoy/blob/b229528161b872be147267cf2b41f145c388822c/source/common/upstream/load_stats_reporter.cc#L173).
