### PR TITLE
benchmarks: Use correct classpath for scripts

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -61,7 +61,7 @@ task qps_client(type: CreateStartScripts) {
         "-javaagent:" + configurations.alpnagent.asPath
     ].plus(vmArgs)
     outputDir = new File(project.buildDir, 'tmp')
-    classpath = jar.outputs.files + project.configurations.runtime
+    classpath = startScripts.classpath
 }
 
 task openloop_client(type: CreateStartScripts) {
@@ -71,14 +71,14 @@ task openloop_client(type: CreateStartScripts) {
         "-javaagent:" + configurations.alpnagent.asPath
     ].plus(vmArgs)
     outputDir = new File(project.buildDir, 'tmp')
-    classpath = jar.outputs.files + project.configurations.runtime
+    classpath = startScripts.classpath
 }
 
 task qps_server(type: CreateStartScripts) {
     mainClassName = "io.grpc.benchmarks.qps.AsyncServer"
     applicationName = "qps_server"
     outputDir = new File(project.buildDir, 'tmp')
-    classpath = jar.outputs.files + project.configurations.runtime
+    classpath = startScripts.classpath
 }
 
 task benchmark_worker(type: CreateStartScripts) {
@@ -88,7 +88,7 @@ task benchmark_worker(type: CreateStartScripts) {
         "-javaagent:" + configurations.alpnagent.asPath
     ].plus(vmArgs)
     outputDir = new File(project.buildDir, 'tmp')
-    classpath = jar.outputs.files + project.configurations.runtime
+    classpath = startScripts.classpath
 }
 
 applicationDistribution.into("bin") {


### PR DESCRIPTION
'runtime' is the old classpath, pre-java-library plugin. We could swap to
'runtimeClasspath', but it is cleaner to just use startScript's defaults. We
already use that approach in interop-testing.

Fixes #7218

CC @raboof 