### PR TITLE
xds: add header matching special cases for hiding/exposing some gRPC headers

### DIFF
--- a/xds/src/main/java/io/grpc/xds/RouteMatch.java
+++ b/xds/src/main/java/io/grpc/xds/RouteMatch.java
@@ -65,7 +65,20 @@ final class RouteMatch {
       return false;
     }
     for (HeaderMatcher headerMatcher : headerMatchers) {
-      if (!headerMatcher.matchesValue(headers.get(headerMatcher.getName()))) {
+      Iterable<String> headerValues = headers.get(headerMatcher.getName());
+      // Special cases for hiding headers: "grpc-tags-bin", "grpc-trace-bin" and
+      // "grpc-previous-rpc-attempts".
+      if (headerMatcher.getName().equals("grpc-tags-bin")
+          || headerMatcher.getName().equals("grpc-trace-bin")
+          || headerMatcher.getName().equals("grpc-previous-rpc-attempts")) {
+        headerValues = null;
+      }
+      // Special case for exposing headers: "content-type".
+      // TODO(chengyuanzhang): expose "user-agent" and "grpc-timeout".
+      if (headerMatcher.getName().equals("content-type")) {
+        headerValues = Collections.singletonList("application/grpc");
+      }
+      if (!headerMatcher.matchesValue(headerValues)) {
         return false;
       }
     }

--- a/xds/src/main/java/io/grpc/xds/RouteMatch.java
+++ b/xds/src/main/java/io/grpc/xds/RouteMatch.java
@@ -66,15 +66,11 @@ final class RouteMatch {
     }
     for (HeaderMatcher headerMatcher : headerMatchers) {
       Iterable<String> headerValues = headers.get(headerMatcher.getName());
-      // Special cases for hiding headers: "grpc-tags-bin", "grpc-trace-bin" and
-      // "grpc-previous-rpc-attempts".
-      if (headerMatcher.getName().equals("grpc-tags-bin")
-          || headerMatcher.getName().equals("grpc-trace-bin")
-          || headerMatcher.getName().equals("grpc-previous-rpc-attempts")) {
+      // Special cases for hiding headers: "grpc-previous-rpc-attempts".
+      if (headerMatcher.getName().equals("grpc-previous-rpc-attempts")) {
         headerValues = null;
       }
       // Special case for exposing headers: "content-type".
-      // TODO(chengyuanzhang): expose "user-agent" and "grpc-timeout".
       if (headerMatcher.getName().equals("content-type")) {
         headerValues = Collections.singletonList("application/grpc");
       }

--- a/xds/src/main/java/io/grpc/xds/XdsRoutingLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/XdsRoutingLoadBalancer.java
@@ -266,9 +266,6 @@ final class XdsRoutingLoadBalancer extends LoadBalancer {
       Map<String, Iterable<String>> asciiHeaders = new HashMap<>();
       Metadata headers = args.getHeaders();
       for (String headerName : headers.keys()) {
-        if (headerName.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
-          continue;
-        }
         Metadata.Key<String> key = Metadata.Key.of(headerName, Metadata.ASCII_STRING_MARSHALLER);
         asciiHeaders.put(headerName, headers.getAll(key));
       }

--- a/xds/src/main/java/io/grpc/xds/XdsRoutingLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/XdsRoutingLoadBalancer.java
@@ -266,6 +266,9 @@ final class XdsRoutingLoadBalancer extends LoadBalancer {
       Map<String, Iterable<String>> asciiHeaders = new HashMap<>();
       Metadata headers = args.getHeaders();
       for (String headerName : headers.keys()) {
+        if (headerName.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
+          continue;
+        }
         Metadata.Key<String> key = Metadata.Key.of(headerName, Metadata.ASCII_STRING_MARSHALLER);
         asciiHeaders.put(headerName, headers.getAll(key));
       }

--- a/xds/src/test/java/io/grpc/xds/RouteMatchTest.java
+++ b/xds/src/test/java/io/grpc/xds/RouteMatchTest.java
@@ -164,15 +164,14 @@ public class RouteMatchTest {
   @Test
   public void headerMatching_specialCaseGrpcHeaders() {
     Map<String, Iterable<String>> headers = new HashMap<>();
-    headers.put("grpc-tags-bin", Collections.singletonList("fake-binary-tag"));
-    headers.put("grpc-trace-bin", Collections.singletonList("fake-binary-trace"));
     headers.put("grpc-previous-rpc-attempts", Collections.singletonList("0"));
+
     RouteMatch routeMatch1 =
         new RouteMatch(new PathMatcher("/FooService/barMethod", null, null),
             Arrays.asList(
                 new HeaderMatcher(
-                    "grpc-tags-bin", "fake-binary-tag", null, null, null, null,
-                null, false)),
+                    "grpc-previous-rpc-attempts", "0", null, null, null, null,
+                    null, false)),
             null);
     assertThat(routeMatch1.matches("/FooService/barMethod", headers)).isFalse();
 
@@ -180,28 +179,10 @@ public class RouteMatchTest {
         new RouteMatch(new PathMatcher("/FooService/barMethod", null, null),
             Arrays.asList(
                 new HeaderMatcher(
-                    "grpc-trace-bin", "fake-binary-trace", null, null, null, null,
-                    null, false)),
-            null);
-    assertThat(routeMatch2.matches("/FooService/barMethod", headers)).isFalse();
-
-    RouteMatch routeMatch3 =
-        new RouteMatch(new PathMatcher("/FooService/barMethod", null, null),
-            Arrays.asList(
-                new HeaderMatcher(
-                    "grpc-previous-rpc-attempts", "0", null, null, null, null,
-                    null, false)),
-            null);
-    assertThat(routeMatch3.matches("/FooService/barMethod", headers)).isFalse();
-
-    RouteMatch routeMatch4 =
-        new RouteMatch(new PathMatcher("/FooService/barMethod", null, null),
-            Arrays.asList(
-                new HeaderMatcher(
                     "content-type", "application/grpc", null, null, null, null,
                     null, false)),
             null);
-    assertThat(routeMatch4.matches("/FooService/barMethod", headers)).isTrue();
+    assertThat(routeMatch2.matches("/FooService/barMethod", headers)).isTrue();
   }
 
   private static final class FakeRandom implements ThreadSafeRandom {

--- a/xds/src/test/java/io/grpc/xds/RouteMatchTest.java
+++ b/xds/src/test/java/io/grpc/xds/RouteMatchTest.java
@@ -40,7 +40,7 @@ public class RouteMatchTest {
 
   @Before
   public void setUp() {
-    headers.put("content-type", Collections.singletonList("application/grpc"));
+    headers.put("authority", Collections.singletonList("foo.googleapis.com"));
     headers.put("grpc-encoding", Collections.singletonList("gzip"));
     headers.put("user-agent", Collections.singletonList("gRPC-Java"));
     headers.put("content-length", Collections.singletonList("1000"));
@@ -79,7 +79,7 @@ public class RouteMatchTest {
             new HeaderMatcher(
                 "grpc-encoding", "gzip", null, null, null, null, null, false),
             new HeaderMatcher(
-                "content-type", null, Pattern.compile(".*grpc.*"), null, null, null,
+                "authority", null, Pattern.compile(".*googleapis.*"), null, null, null,
                 null, false),
             new HeaderMatcher(
                 "content-length", null, null, new Range(100, 10000), null, null, null, false),
@@ -93,7 +93,7 @@ public class RouteMatchTest {
         new PathMatcher("/FooService/barMethod", null, null),
         Collections.singletonList(
             new HeaderMatcher(
-                "content-type", null, Pattern.compile(".*grpc.*"), null, null, null,
+                "authority", null, Pattern.compile(".*googleapis.*"), null, null, null,
                 null, true)),
         null);
     assertThat(routeMatch2.matches("/FooService/barMethod", headers)).isFalse();
@@ -159,6 +159,49 @@ public class RouteMatchTest {
             Collections.<HeaderMatcher>emptyList(),
             new FractionMatcher(100, 1000, new FakeRandom(100)));
     assertThat(routeMatch2.matches("/FooService/barMethod", headers)).isFalse();
+  }
+
+  @Test
+  public void headerMatching_specialCaseGrpcHeaders() {
+    Map<String, Iterable<String>> headers = new HashMap<>();
+    headers.put("grpc-tags-bin", Collections.singletonList("fake-binary-tag"));
+    headers.put("grpc-trace-bin", Collections.singletonList("fake-binary-trace"));
+    headers.put("grpc-previous-rpc-attempts", Collections.singletonList("0"));
+    RouteMatch routeMatch1 =
+        new RouteMatch(new PathMatcher("/FooService/barMethod", null, null),
+            Arrays.asList(
+                new HeaderMatcher(
+                    "grpc-tags-bin", "fake-binary-tag", null, null, null, null,
+                null, false)),
+            null);
+    assertThat(routeMatch1.matches("/FooService/barMethod", headers)).isFalse();
+
+    RouteMatch routeMatch2 =
+        new RouteMatch(new PathMatcher("/FooService/barMethod", null, null),
+            Arrays.asList(
+                new HeaderMatcher(
+                    "grpc-trace-bin", "fake-binary-trace", null, null, null, null,
+                    null, false)),
+            null);
+    assertThat(routeMatch2.matches("/FooService/barMethod", headers)).isFalse();
+
+    RouteMatch routeMatch3 =
+        new RouteMatch(new PathMatcher("/FooService/barMethod", null, null),
+            Arrays.asList(
+                new HeaderMatcher(
+                    "grpc-previous-rpc-attempts", "0", null, null, null, null,
+                    null, false)),
+            null);
+    assertThat(routeMatch3.matches("/FooService/barMethod", headers)).isFalse();
+
+    RouteMatch routeMatch4 =
+        new RouteMatch(new PathMatcher("/FooService/barMethod", null, null),
+            Arrays.asList(
+                new HeaderMatcher(
+                    "content-type", "application/grpc", null, null, null, null,
+                    null, false)),
+            null);
+    assertThat(routeMatch4.matches("/FooService/barMethod", headers)).isTrue();
   }
 
   private static final class FakeRandom implements ThreadSafeRandom {


### PR DESCRIPTION
- Expose "content-type" header (hard-coded) at header matching, pretend it's already there.
- ~Hide "grpc-tags-bin", "grpc-trace-bin" and "grpc-previous-rpc-attempts", pretend they are not there.~
- ~Do not exclude binary headers from header matching, they can still be useful for present matchers (which checks if a given header present regardless its value).~

Details in b/159631362
