### PR TITLE
core: refactor ClientTransportProvider to ClientStreamProvider

### DIFF
--- a/core/src/main/java/io/grpc/internal/SubchannelChannel.java
+++ b/core/src/main/java/io/grpc/internal/SubchannelChannel.java
@@ -23,13 +23,11 @@ import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.Context;
-import io.grpc.LoadBalancer.PickSubchannelArgs;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
-import io.grpc.internal.ClientCallImpl.ClientTransportProvider;
+import io.grpc.internal.ClientCallImpl.ClientStreamProvider;
 import io.grpc.internal.ClientStreamListener.RpcProgress;
-import io.grpc.internal.GrpcUtil;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -48,21 +46,20 @@ final class SubchannelChannel extends Channel {
   private final ScheduledExecutorService deadlineCancellationExecutor;
   private final CallTracer callsTracer;
 
-  private final ClientTransportProvider transportProvider = new ClientTransportProvider() {
+  private final ClientStreamProvider transportProvider = new ClientStreamProvider() {
       @Override
-      public ClientTransport get(PickSubchannelArgs args) {
+      public ClientStream newStream(MethodDescriptor<?, ?> method,
+          CallOptions callOptions, Metadata headers, Context context) {
         ClientTransport transport = subchannel.getTransport();
         if (transport == null) {
-          return notReadyTransport;
-        } else {
-          return transport;
+          transport = notReadyTransport;
         }
-      }
-
-      @Override
-      public <ReqT> ClientStream newRetriableStream(MethodDescriptor<ReqT, ?> method,
-          CallOptions callOptions, Metadata headers, Context context) {
-        throw new UnsupportedOperationException("OobChannel should not create retriable streams");
+        Context origContext = context.attach();
+        try {
+          return transport.newStream(method, headers, callOptions);
+        } finally {
+          context.detach(origContext);
+        }
       }
     };
 
@@ -109,7 +106,7 @@ final class SubchannelChannel extends Channel {
     return new ClientCallImpl<>(methodDescriptor,
         effectiveExecutor,
         callOptions.withOption(GrpcUtil.CALL_OPTIONS_RPC_OWNED_BY_BALANCER, Boolean.TRUE),
-        transportProvider, deadlineCancellationExecutor, callsTracer, false /* retryEnabled */);
+        transportProvider, deadlineCancellationExecutor, callsTracer);
   }
 
   @Override


### PR DESCRIPTION
Replace the two APIs of `ClientCallImpl.ClientTransportProvider` with a single API: newStream()

~This might make `ManagedChanelImpl` more flexible to apply `ConfigSelector`.~