### PR TITLE
removed deprecated method blockingExecutor

### DIFF
--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -77,13 +77,6 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
     return thisT();
   }
 
-  @Deprecated
-  @Override
-  public T blockingExecutor(Executor executor) {
-    delegate().blockingExecutor(executor);
-    return thisT();
-  }
-
   @Override
   public T intercept(List<ClientInterceptor> interceptors) {
     delegate().intercept(interceptors);

--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -124,12 +124,6 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
     throw new UnsupportedOperationException();
   }
 
-  @Deprecated
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/6279")
-  public T blockingExecutor(Executor executor) {
-    return offloadExecutor(executor);
-  }
-
   /**
    * Adds interceptors that will be called before the channel performs its real work. This is
    * functionally equivalent to using {@link ClientInterceptors#intercept(Channel, List)}, but while


### PR DESCRIPTION
All blockingExecutor usages have been cleaned up, so removing the method.