### PR TITLE
xds: Added IncompleteData interface in mock CEL library

### DIFF
--- a/xds/src/main/java/io/grpc/xds/internal/rbac/engine/cel/IncompleteData.java
+++ b/xds/src/main/java/io/grpc/xds/internal/rbac/engine/cel/IncompleteData.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds.internal.rbac.engine.cel;
+
+/**
+ * Add an interface for interpreter to check if an object is an instance
+ * of PartialMessage.
+ * 
+ * <p>This is a Java stub for evaluating Common Expression Language (CEL). 
+ * More information about CEL can be found in https://github.com/google/cel-spec. 
+ * Once Java CEL has been open-sourced, this stub will be removed.
+ */
+public interface IncompleteData {}

--- a/xds/src/main/java/io/grpc/xds/internal/rbac/engine/cel/IncompleteData.java
+++ b/xds/src/main/java/io/grpc/xds/internal/rbac/engine/cel/IncompleteData.java
@@ -17,8 +17,8 @@
 package io.grpc.xds.internal.rbac.engine.cel;
 
 /**
- * Add an interface for interpreter to check if an object is an instance
- * of PartialMessage.
+ * Interpreter returns an instance of {@code IncompleteData} if 
+ * an object is an instance of {@link PartialMessage}.
  * 
  * <p>This is a Java stub for evaluating Common Expression Language (CEL). 
  * More information about CEL can be found in https://github.com/google/cel-spec. 


### PR DESCRIPTION
This PR added `IncompleteData` interface into the mock CEL library in gRPC-Java.

CEL `eval` function will return an `IncompleteData` object if there are missing attributes.

@ZhenLian 