### PR TITLE
android, cronet, android-interop-testing, example/drop support for android SDK versions older than 16

### DIFF
--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -29,8 +29,7 @@ android {
 
     defaultConfig {
         applicationId "io.grpc.android.integrationtest"
-        // API level 14+ is required for TLS since Google Play Services v10.2
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,7 +11,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         consumerProguardFiles "proguard-rules.txt"
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
@@ -31,7 +31,10 @@ dependencies {
     testImplementation project('::grpc-okhttp')
     testImplementation libraries.androidx_test
     testImplementation libraries.junit
-    testImplementation libraries.robolectric
+    testImplementation (libraries.robolectric) {
+        // Unreleased change: https://github.com/robolectric/robolectric/pull/5432
+        exclude group: 'com.google.auto.service', module: 'auto-service'
+    }
     testImplementation libraries.truth
 }
 

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -42,7 +42,10 @@ dependencies {
 
     testImplementation libraries.junit
     testImplementation libraries.mockito
-    testImplementation libraries.robolectric
+    testImplementation (libraries.robolectric) {
+        // Unreleased change: https://github.com/robolectric/robolectric/pull/5432
+        exclude group: 'com.google.auto.service', module: 'auto-service'
+    }
 }
 
 task javadocs(type: Javadoc) {

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -6,8 +6,7 @@ android {
 
     defaultConfig {
         applicationId "io.grpc.helloworldexample"
-        // API level 14+ is required for TLS since Google Play Services v10.2
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "io.grpc.routeguideexample"
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Resolves #7244. 

This also includes the change to avoid pulling google auto-service from Robolectric, which gives a warning of

```
Annotation processors must be explicitly declared now.  The following dependencies on the compile classpath are found to contain annotation processor.  Please add them to the testAnnotationProcessor configuration.
  - auto-service-1.0-rc4.jar (com.google.auto.service:auto-service:1.0-rc4)
```

cl/323410410 cleans up the internal interop tests.