### PR TITLE
core: add readable frame data to transport error

### DIFF
--- a/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java
+++ b/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java
@@ -148,7 +148,9 @@ public abstract class Http2ClientStreamTransportState extends AbstractClientStre
       if (endOfStream) {
         // This is a protocol violation as we expect to receive trailers.
         transportError =
-            Status.INTERNAL.withDescription("Received unexpected EOS on DATA frame from server.");
+            Status.INTERNAL.withDescription("Received unexpected EOS on DATA frame from server.")
+                .augmentDescription("DATA----------------------------\n"
+                    + ReadableBuffers.readAsString(frame, errorCharset));
         transportErrorMetadata = new Metadata();
         transportReportStatus(transportError, false, transportErrorMetadata);
       }


### PR DESCRIPTION
This change modifies the transportDataReceived handler in the HTTP/2 client stream transport state to log the readable bytes from the frame to the error status in the event of an unexpected EOS on a data frame. This allows users to more easily track down the source of these unexpected stream closures.