### PR TITLE
Upgrade to Mockito 3.3.3

### DIFF
--- a/api/src/test/java/io/grpc/ServerInterceptorsTest.java
+++ b/api/src/test/java/io/grpc/ServerInterceptorsTest.java
@@ -25,8 +25,8 @@ import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 import io.grpc.MethodDescriptor.Marshaller;
 import io.grpc.MethodDescriptor.MethodType;
@@ -102,9 +102,9 @@ public class ServerInterceptorsTest {
   /** Final checks for all tests. */
   @After
   public void makeSureExpectedMocksUnused() {
-    verifyZeroInteractions(requestMarshaller);
-    verifyZeroInteractions(responseMarshaller);
-    verifyZeroInteractions(listener);
+    verifyNoInteractions(requestMarshaller);
+    verifyNoInteractions(responseMarshaller);
+    verifyNoInteractions(listener);
   }
 
   @Test

--- a/build.gradle
+++ b/build.gradle
@@ -179,7 +179,7 @@ subprojects {
 
             // Test dependencies.
             junit: 'junit:junit:4.12',
-            mockito: 'org.mockito:mockito-core:2.28.2',
+            mockito: 'org.mockito:mockito-core:3.3.3',
             truth: 'com.google.truth:truth:1.0.1',
             guava_testlib: "com.google.guava:guava-testlib:${guavaVersion}",
             androidx_test: "androidx.test:core:1.2.0",

--- a/census/src/test/java/io/grpc/census/CensusModulesTest.java
+++ b/census/src/test/java/io/grpc/census/CensusModulesTest.java
@@ -37,8 +37,8 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
@@ -1039,7 +1039,7 @@ public class CensusModulesTest {
     ServerStreamTracer.Factory tracerFactory = censusTracing.getServerTracerFactory();
     ServerStreamTracer serverStreamTracer =
         tracerFactory.newServerStreamTracer(method.getFullMethodName(), new Metadata());
-    verifyZeroInteractions(mockTracingPropagationHandler);
+    verifyNoInteractions(mockTracingPropagationHandler);
     verify(tracer).spanBuilderWithRemoteParent(
         eq("Recv.package1.service2.method3"), ArgumentMatchers.<SpanContext>isNull());
     verify(spyServerSpanBuilder).setRecordEvents(eq(true));

--- a/core/src/test/java/io/grpc/internal/ApplicationThreadDeframerTest.java
+++ b/core/src/test/java/io/grpc/internal/ApplicationThreadDeframerTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 import com.google.common.io.ByteStreams;
 import com.google.common.primitives.Bytes;
@@ -57,7 +56,7 @@ public class ApplicationThreadDeframerTest {
   @Test
   public void requestInvokesMessagesAvailableOnListener() {
     applicationThreadDeframer.request(1);
-    verifyZeroInteractions(mockDeframer);
+    verifyNoMoreInteractions(mockDeframer);
     listener.runStoredProducer();
     verify(mockDeframer).request(1);
   }
@@ -66,7 +65,7 @@ public class ApplicationThreadDeframerTest {
   public void deframeInvokesMessagesAvailableOnListener() {
     ReadableBuffer frame = ReadableBuffers.wrap(new byte[1]);
     applicationThreadDeframer.deframe(frame);
-    verifyZeroInteractions(mockDeframer);
+    verifyNoMoreInteractions(mockDeframer);
     listener.runStoredProducer();
     verify(mockDeframer).deframe(frame);
   }
@@ -74,7 +73,7 @@ public class ApplicationThreadDeframerTest {
   @Test
   public void closeWhenCompleteInvokesMessagesAvailableOnListener() {
     applicationThreadDeframer.closeWhenComplete();
-    verifyZeroInteractions(mockDeframer);
+    verifyNoMoreInteractions(mockDeframer);
     listener.runStoredProducer();
     verify(mockDeframer).closeWhenComplete();
   }

--- a/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
+++ b/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
@@ -27,8 +27,8 @@ import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.base.Preconditions;
@@ -634,7 +634,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
     PolicySelection policySelection = (PolicySelection) parsed.getConfig();
     assertThat(policySelection.config).isNotNull();
     assertThat(policySelection.provider).isInstanceOf(GrpclbLoadBalancerProvider.class);
-    verifyZeroInteractions(channelLogger);
+    verifyNoInteractions(channelLogger);
   }
 
   public static class ForwardingLoadBalancer extends LoadBalancer {

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
@@ -154,7 +154,7 @@ public class ClientCallImplTest {
 
   @After
   public void tearDown() {
-    verifyZeroInteractions(streamTracerFactory);
+    verifyNoInteractions(streamTracerFactory);
   }
 
   @Test
@@ -696,7 +696,7 @@ public class ClientCallImplTest {
     call.halfClose();
 
     // Stream should never be created.
-    verifyZeroInteractions(clientStreamProvider);
+    verifyNoInteractions(clientStreamProvider);
 
     try {
       call.sendMessage(null);
@@ -729,7 +729,7 @@ public class ClientCallImplTest {
     assertEquals(Status.Code.DEADLINE_EXCEEDED, statusCaptor.getValue().getCode());
     assertThat(statusCaptor.getValue().getDescription())
         .startsWith("ClientCall started after deadline exceeded");
-    verifyZeroInteractions(clientStreamProvider);
+    verifyNoInteractions(clientStreamProvider);
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -46,8 +46,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.base.Throwables;
@@ -1192,7 +1192,7 @@ public class ManagedChannelImplTest {
     if (shouldFail) {
       verify(mockCallListener).onClose(same(status), any(Metadata.class));
     } else {
-      verifyZeroInteractions(mockCallListener);
+      verifyNoInteractions(mockCallListener);
     }
 
     // This call doesn't involve delayed transport
@@ -1203,7 +1203,7 @@ public class ManagedChannelImplTest {
     if (shouldFail) {
       verify(mockCallListener2).onClose(same(status), any(Metadata.class));
     } else {
-      verifyZeroInteractions(mockCallListener2);
+      verifyNoInteractions(mockCallListener2);
     }
   }
 
@@ -1691,7 +1691,7 @@ public class ManagedChannelImplTest {
     verify(mockTransport, never()).newStream(
         any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class));
 
-    verifyZeroInteractions(mockCallListener);
+    verifyNoInteractions(mockCallListener);
     assertEquals(1, balancerRpcExecutor.runDueTasks());
     verify(mockCallListener).onClose(
         same(SubchannelChannel.NOT_READY_ERROR), any(Metadata.class));
@@ -1723,7 +1723,7 @@ public class ManagedChannelImplTest {
     verify(mockTransport, never()).newStream(
         any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class));
 
-    verifyZeroInteractions(mockCallListener);
+    verifyNoInteractions(mockCallListener);
     assertEquals(1, balancerRpcExecutor.runDueTasks());
     verify(mockCallListener).onClose(
         same(SubchannelChannel.WAIT_FOR_READY_ERROR), any(Metadata.class));
@@ -1994,8 +1994,8 @@ public class ManagedChannelImplTest {
         Arrays.asList(factory1, factory2),
         callOptionsCaptor.getValue().getStreamTracerFactories());
     // The factories are safely not stubbed because we do not expect any usage of them.
-    verifyZeroInteractions(factory1);
-    verifyZeroInteractions(factory2);
+    verifyNoInteractions(factory1);
+    verifyNoInteractions(factory2);
   }
 
   @Test
@@ -2030,8 +2030,8 @@ public class ManagedChannelImplTest {
         Arrays.asList(factory1, factory2),
         callOptionsCaptor.getValue().getStreamTracerFactories());
     // The factories are safely not stubbed because we do not expect any usage of them.
-    verifyZeroInteractions(factory1);
-    verifyZeroInteractions(factory2);
+    verifyNoInteractions(factory1);
+    verifyNoInteractions(factory2);
   }
 
   @Test
@@ -2261,7 +2261,7 @@ public class ManagedChannelImplTest {
     assertEquals(SHUTDOWN, channel.getState(false));
 
     // We didn't stub mockPicker, because it should have never been called in this test.
-    verifyZeroInteractions(mockPicker);
+    verifyNoInteractions(mockPicker);
   }
 
   @Test
@@ -2282,7 +2282,7 @@ public class ManagedChannelImplTest {
     call2.start(mockCallListener2, new Metadata());
 
     executor.runDueTasks();
-    verifyZeroInteractions(mockCallListener, mockCallListener2);
+    verifyNoInteractions(mockCallListener, mockCallListener2);
 
     // Enter panic
     final Throwable panicReason = new Exception("Simulated uncaught exception");

--- a/core/src/test/java/io/grpc/internal/MessageFramerTest.java
+++ b/core/src/test/java/io/grpc/internal/MessageFramerTest.java
@@ -23,8 +23,8 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 import io.grpc.Codec;
 import io.grpc.StreamTracer;
@@ -177,7 +177,7 @@ public class MessageFramerTest {
   @Test
   public void emptyUnknownLengthPayloadYieldsFrame() {
     writeUnknownLength(framer, new byte[0]);
-    verifyZeroInteractions(sink);
+    verifyNoInteractions(sink);
     framer.flush();
     verify(sink).deliverFrame(toWriteBuffer(new byte[] {0, 0, 0, 0, 0}), false, true, 1);
     // One alloc for the header

--- a/core/src/test/java/io/grpc/util/MutableHandlerRegistryTest.java
+++ b/core/src/test/java/io/grpc/util/MutableHandlerRegistryTest.java
@@ -99,8 +99,8 @@ public class MutableHandlerRegistryTest {
   /** Final checks for all tests. */
   @After
   public void makeSureMocksUnused() {
-    Mockito.verifyZeroInteractions(requestMarshaller);
-    Mockito.verifyZeroInteractions(responseMarshaller);
+    Mockito.verifyNoInteractions(requestMarshaller);
+    Mockito.verifyNoInteractions(responseMarshaller);
     Mockito.verifyNoMoreInteractions(flowHandler);
     Mockito.verifyNoMoreInteractions(coupleHandler);
     Mockito.verifyNoMoreInteractions(fewHandler);

--- a/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
@@ -28,8 +28,8 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableListMultimap;
@@ -160,7 +160,7 @@ public class NettyServerStreamTest extends NettyStreamTestBase<NettyServerStream
     assertThat(ImmutableListMultimap.copyOf(sendHeaders.headers()))
         .containsExactlyEntriesIn(expectedHeaders);
     assertThat(sendHeaders.endOfStream()).isTrue();
-    verifyZeroInteractions(serverListener);
+    verifyNoInteractions(serverListener);
 
     // Sending complete. Listener gets closed()
     stream().transportState().complete();
@@ -188,7 +188,7 @@ public class NettyServerStreamTest extends NettyStreamTestBase<NettyServerStream
     assertThat(ImmutableListMultimap.copyOf(sendHeaders.headers()))
         .containsExactlyEntriesIn(expectedHeaders);
     assertThat(sendHeaders.endOfStream()).isTrue();
-    verifyZeroInteractions(serverListener);
+    verifyNoInteractions(serverListener);
 
     // Sending complete. Listener gets closed()
     stream().transportState().complete();

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -44,8 +44,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
@@ -1586,7 +1586,7 @@ public class OkHttpClientTransportTest {
   @Test
   public void transportReady() throws Exception {
     initTransport();
-    verifyZeroInteractions(transportListener);
+    verifyNoInteractions(transportListener);
     frameHandler().settings(false, new Settings());
     verify(transportListener).transportReady();
     shutdownAndVerify();

--- a/services/src/test/java/io/grpc/services/HealthCheckingLoadBalancerFactoryTest.java
+++ b/services/src/test/java/io/grpc/services/HealthCheckingLoadBalancerFactoryTest.java
@@ -34,8 +34,8 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.util.concurrent.MoreExecutors;
@@ -364,7 +364,7 @@ public class HealthCheckingLoadBalancerFactoryTest {
       assertThat(healthImpls[i].calls).hasSize(1);
     }
 
-    verifyZeroInteractions(backoffPolicyProvider);
+    verifyNoInteractions(backoffPolicyProvider);
   }
 
   @Test
@@ -433,7 +433,7 @@ public class HealthCheckingLoadBalancerFactoryTest {
         unavailableStateWithMsg("Health-check service responded SERVICE_UNKNOWN for 'BarService'"));
 
     verifyNoMoreInteractions(origLb, mockStateListeners[0], mockStateListeners[1]);
-    verifyZeroInteractions(backoffPolicyProvider);
+    verifyNoInteractions(backoffPolicyProvider);
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/OrcaOobUtilTest.java
+++ b/xds/src/test/java/io/grpc/xds/OrcaOobUtilTest.java
@@ -30,8 +30,8 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import com.github.udpa.udpa.data.orca.v1.OrcaLoadReport;
@@ -302,7 +302,7 @@ public class OrcaOobUtilTest {
       assertThat(orcaServiceImps[i].calls).hasSize(1);
     }
 
-    verifyZeroInteractions(backoffPolicyProvider);
+    verifyNoInteractions(backoffPolicyProvider);
   }
 
   @Test
@@ -388,7 +388,7 @@ public class OrcaOobUtilTest {
       assertThat(orcaServiceImps[i].calls).hasSize(1);
     }
 
-    verifyZeroInteractions(backoffPolicyProvider);
+    verifyNoInteractions(backoffPolicyProvider);
   }
 
   @Test
@@ -424,7 +424,7 @@ public class OrcaOobUtilTest {
     assertLog(subchannel.logs, "DEBUG: Received an ORCA report: " + report);
     verify(mockOrcaListener0).onLoadReport(eq(report));
 
-    verifyZeroInteractions(backoffPolicyProvider);
+    verifyNoInteractions(backoffPolicyProvider);
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/OrcaPerRequestUtilTest.java
+++ b/xds/src/test/java/io/grpc/xds/OrcaPerRequestUtilTest.java
@@ -23,8 +23,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import com.github.udpa.udpa.data.orca.v1.OrcaLoadReport;
@@ -164,7 +164,7 @@ public class OrcaPerRequestUtilTest {
         OrcaLoadReport.getDefaultInstance());
     parentTracer.inboundTrailers(trailer);
     verify(orcaListener1).onLoadReport(eq(OrcaLoadReport.getDefaultInstance()));
-    verifyZeroInteractions(childFactory);
-    verifyZeroInteractions(orcaListener2);
+    verifyNoInteractions(childFactory);
+    verifyNoInteractions(orcaListener2);
   }
 }

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTest.java
@@ -38,8 +38,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
@@ -1866,7 +1866,7 @@ public class XdsClientImplTest {
     assertThat(fakeClock.getPendingTasks(CDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
     assertThat(timeoutTask.isCancelled()).isTrue();
 
-    verifyZeroInteractions(watcher3, watcher4);
+    verifyNoInteractions(watcher3, watcher4);
   }
 
   @Test
@@ -2133,7 +2133,7 @@ public class XdsClientImplTest {
                     new LbEndpoint("192.168.0.1", 8080,
                         2, true)), 1, 0));
 
-    verifyZeroInteractions(watcher3);
+    verifyNoInteractions(watcher3);
 
     // Management server sends back another EDS response contains ClusterLoadAssignment for the
     // other requested cluster.
@@ -2517,7 +2517,7 @@ public class XdsClientImplTest {
     assertThat(fakeClock.getPendingTasks(EDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
     assertThat(timeoutTask.isCancelled()).isTrue();
 
-    verifyZeroInteractions(watcher3, watcher4);
+    verifyNoInteractions(watcher3, watcher4);
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTestV2.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTestV2.java
@@ -38,8 +38,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
@@ -1875,7 +1875,7 @@ public class XdsClientImplTestV2 {
     assertThat(fakeClock.getPendingTasks(CDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
     assertThat(timeoutTask.isCancelled()).isTrue();
 
-    verifyZeroInteractions(watcher3, watcher4);
+    verifyNoInteractions(watcher3, watcher4);
   }
 
   @Test
@@ -2142,7 +2142,7 @@ public class XdsClientImplTestV2 {
                     new LbEndpoint("192.168.0.1", 8080,
                         2, true)), 1, 0));
 
-    verifyZeroInteractions(watcher3);
+    verifyNoInteractions(watcher3);
 
     // Management server sends back another EDS response contains ClusterLoadAssignment for the
     // other requested cluster.
@@ -2526,7 +2526,7 @@ public class XdsClientImplTestV2 {
     assertThat(fakeClock.getPendingTasks(EDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
     assertThat(timeoutTask.isCancelled()).isTrue();
 
-    verifyZeroInteractions(watcher3, watcher4);
+    verifyNoInteractions(watcher3, watcher4);
   }
 
   @Test


### PR DESCRIPTION
verifyZeroInteractions has the same behavior as verifyNoMoreInteractions. It
was deprecated in Mockito 3.0.1 and replaced with verifyNoInteractions, which
does not change behavior depending on previous verify() calls. All instances
were replaced with verifyNoInteractions, except those in
ApplicationThreadDeframerTest which were replaced with verifyNoMoreInteractions
since there is a verify() call in `@Before`.

-----

3.3.3 was chosen as that is the last version that matches the internal mockito version. The internal linter was complaining about verifyZeroInteractions being deprecated.