### PR TITLE
compiler: Use namespace aliases to reduce internal diff

### DIFF
--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -43,12 +43,14 @@
 
 namespace java_grpc_generator {
 
-using google::protobuf::FileDescriptor;
-using google::protobuf::ServiceDescriptor;
-using google::protobuf::MethodDescriptor;
-using google::protobuf::Descriptor;
-using google::protobuf::io::Printer;
-using google::protobuf::SourceLocation;
+namespace protobuf = google::protobuf;
+
+using protobuf::Descriptor;
+using protobuf::FileDescriptor;
+using protobuf::MethodDescriptor;
+using protobuf::ServiceDescriptor;
+using protobuf::SourceLocation;
+using protobuf::io::Printer;
 using std::to_string;
 
 // java keywords from: https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.9
@@ -162,7 +164,7 @@ static inline std::string MethodIdFieldName(const MethodDescriptor* method) {
 }
 
 static inline std::string MessageFullJavaName(const Descriptor* desc) {
-  return google::protobuf::compiler::java::ClassName(desc);
+  return protobuf::compiler::java::ClassName(desc);
 }
 
 // TODO(nmittler): Remove once protobuf includes javadoc methods in distribution.
@@ -425,12 +427,12 @@ static void PrintMethodFields(
         "            .setFullMethodName(generateFullMethodName(SERVICE_NAME, \"$method_name$\"))\n");
         
     bool safe = method->options().idempotency_level()
-        == google::protobuf::MethodOptions_IdempotencyLevel_NO_SIDE_EFFECTS;
+        == protobuf::MethodOptions_IdempotencyLevel_NO_SIDE_EFFECTS;
     if (safe) {
       p->Print(*vars, "            .setSafe(true)\n");
     } else {
       bool idempotent = method->options().idempotency_level()
-          == google::protobuf::MethodOptions_IdempotencyLevel_IDEMPOTENT;
+          == protobuf::MethodOptions_IdempotencyLevel_IDEMPOTENT;
       if (idempotent) {
         p->Print(*vars, "            .setIdempotent(true)\n");
       }
@@ -916,7 +918,7 @@ static void PrintGetServiceDescriptorMethod(const ServiceDescriptor* service,
     (*vars)["proto_base_descriptor_supplier"] = service->name() + "BaseDescriptorSupplier";
     (*vars)["proto_file_descriptor_supplier"] = service->name() + "FileDescriptorSupplier";
     (*vars)["proto_method_descriptor_supplier"] = service->name() + "MethodDescriptorSupplier";
-    (*vars)["proto_class_name"] = google::protobuf::compiler::java::ClassName(service->file());
+    (*vars)["proto_class_name"] = protobuf::compiler::java::ClassName(service->file());
     p->Print(
         *vars,
         "private static abstract class $proto_base_descriptor_supplier$\n"
@@ -1186,7 +1188,7 @@ void PrintImports(Printer* p) {
 }
 
 void GenerateService(const ServiceDescriptor* service,
-                     google::protobuf::io::ZeroCopyOutputStream* out,
+                     protobuf::io::ZeroCopyOutputStream* out,
                      ProtoFlavor flavor,
                      bool disable_version) {
   // All non-generated classes must be referred by fully qualified names to
@@ -1242,7 +1244,7 @@ void GenerateService(const ServiceDescriptor* service,
 }
 
 std::string ServiceJavaPackage(const FileDescriptor* file) {
-  std::string result = google::protobuf::compiler::java::ClassName(file);
+  std::string result = protobuf::compiler::java::ClassName(file);
   size_t last_dot_pos = result.find_last_of('.');
   if (last_dot_pos != std::string::npos) {
     result.resize(last_dot_pos);
@@ -1252,7 +1254,7 @@ std::string ServiceJavaPackage(const FileDescriptor* file) {
   return result;
 }
 
-std::string ServiceClassName(const google::protobuf::ServiceDescriptor* service) {
+std::string ServiceClassName(const ServiceDescriptor* service) {
   return service->name() + "Grpc";
 }
 

--- a/compiler/src/java_plugin/cpp/java_generator.h
+++ b/compiler/src/java_plugin/cpp/java_generator.h
@@ -47,24 +47,26 @@ class LogHelper {
 // Abort the program after logging the mesage.
 #define GRPC_CODEGEN_FAIL GRPC_CODEGEN_CHECK(false)
 
-using namespace std;
-
 namespace java_grpc_generator {
+
+namespace impl {
+namespace protobuf = google::protobuf;
+} // namespace impl
 
 enum ProtoFlavor {
   NORMAL, LITE
 };
 
 // Returns the package name of the gRPC services defined in the given file.
-std::string ServiceJavaPackage(const google::protobuf::FileDescriptor* file);
+std::string ServiceJavaPackage(const impl::protobuf::FileDescriptor* file);
 
 // Returns the name of the outer class that wraps in all the generated code for
 // the given service.
-std::string ServiceClassName(const google::protobuf::ServiceDescriptor* service);
+std::string ServiceClassName(const impl::protobuf::ServiceDescriptor* service);
 
 // Writes the generated service interface into the given ZeroCopyOutputStream
-void GenerateService(const google::protobuf::ServiceDescriptor* service,
-                     google::protobuf::io::ZeroCopyOutputStream* out,
+void GenerateService(const impl::protobuf::ServiceDescriptor* service,
+                     impl::protobuf::io::ZeroCopyOutputStream* out,
                      ProtoFlavor flavor,
                      bool disable_version);
 

--- a/compiler/src/java_plugin/cpp/java_plugin.cpp
+++ b/compiler/src/java_plugin/cpp/java_plugin.cpp
@@ -27,6 +27,8 @@
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/io/zero_copy_stream.h>
 
+namespace protobuf = google::protobuf;
+
 static std::string JavaPackageToDir(const std::string& package_name) {
   std::string package_dir = package_name;
   for (size_t i = 0; i < package_dir.size(); ++i) {
@@ -38,7 +40,7 @@ static std::string JavaPackageToDir(const std::string& package_name) {
   return package_dir;
 }
 
-class JavaGrpcGenerator : public google::protobuf::compiler::CodeGenerator {
+class JavaGrpcGenerator : public protobuf::compiler::CodeGenerator {
  public:
   JavaGrpcGenerator() {}
   virtual ~JavaGrpcGenerator() {}
@@ -47,12 +49,12 @@ class JavaGrpcGenerator : public google::protobuf::compiler::CodeGenerator {
     return FEATURE_PROTO3_OPTIONAL;
   }
 
-  virtual bool Generate(const google::protobuf::FileDescriptor* file,
+  virtual bool Generate(const protobuf::FileDescriptor* file,
                         const std::string& parameter,
-                        google::protobuf::compiler::GeneratorContext* context,
+                        protobuf::compiler::GeneratorContext* context,
                         std::string* error) const override {
     std::vector<std::pair<std::string, std::string> > options;
-    google::protobuf::compiler::ParseGeneratorParameter(parameter, &options);
+    protobuf::compiler::ParseGeneratorParameter(parameter, &options);
 
     java_grpc_generator::ProtoFlavor flavor =
         java_grpc_generator::ProtoFlavor::NORMAL;
@@ -69,10 +71,10 @@ class JavaGrpcGenerator : public google::protobuf::compiler::CodeGenerator {
     std::string package_name = java_grpc_generator::ServiceJavaPackage(file);
     std::string package_filename = JavaPackageToDir(package_name);
     for (int i = 0; i < file->service_count(); ++i) {
-      const google::protobuf::ServiceDescriptor* service = file->service(i);
+      const protobuf::ServiceDescriptor* service = file->service(i);
       std::string filename = package_filename
           + java_grpc_generator::ServiceClassName(service) + ".java";
-      std::unique_ptr<google::protobuf::io::ZeroCopyOutputStream> output(
+      std::unique_ptr<protobuf::io::ZeroCopyOutputStream> output(
           context->Open(filename));
       java_grpc_generator::GenerateService(
           service, output.get(), flavor, disable_version);
@@ -83,5 +85,5 @@ class JavaGrpcGenerator : public google::protobuf::compiler::CodeGenerator {
 
 int main(int argc, char* argv[]) {
   JavaGrpcGenerator generator;
-  return google::protobuf::compiler::PluginMain(argc, argv, &generator);
+  return protobuf::compiler::PluginMain(argc, argv, &generator);
 }


### PR DESCRIPTION
Due to historical reasons, protobuf is in the proto2:: namespace
internally instead of google::protobuf. We have been maintaining diffs
that replace each occurence of one with the other. Instead we can simply
create a namespace alias and use that alias instead of the canonical
name. That greatly reduces the size of the diff and its likelihood to
break.

If the names ever align in the future, we can swap back to the canonical
names.