### PR TITLE
examples: add mavenCentral for android example's dependency repository (v1.31.x backport) (#7293)

### DIFF
--- a/examples/android/clientcache/build.gradle
+++ b/examples/android/clientcache/build.gradle
@@ -18,6 +18,9 @@ allprojects {
     repositories {
         google()
         jcenter()
+        // Some grpc-java releases may be missing in JCenter.
+        // See https://github.com/grpc/grpc-java/issues/5782
+        mavenCentral()
         mavenLocal()
     }
 }

--- a/examples/android/helloworld/build.gradle
+++ b/examples/android/helloworld/build.gradle
@@ -18,6 +18,9 @@ allprojects {
     repositories {
         google()
         jcenter()
+        // Some grpc-java releases may be missing in JCenter.
+        // See https://github.com/grpc/grpc-java/issues/5782
+        mavenCentral()
         mavenLocal()
     }
 }

--- a/examples/android/routeguide/build.gradle
+++ b/examples/android/routeguide/build.gradle
@@ -18,6 +18,9 @@ allprojects {
     repositories {
         google()
         jcenter()
+        // Some grpc-java releases may be missing in JCenter.
+        // See https://github.com/grpc/grpc-java/issues/5782
+        mavenCentral()
         mavenLocal()
     }
 }

--- a/examples/android/strictmode/build.gradle
+++ b/examples/android/strictmode/build.gradle
@@ -18,6 +18,9 @@ allprojects {
     repositories {
         google()
         jcenter()
+        // Some grpc-java releases may be missing in JCenter.
+        // See https://github.com/grpc/grpc-java/issues/5782
+        mavenCentral()
         mavenLocal()
     }
 }


### PR DESCRIPTION
Backport of #7293 