### PR TITLE
buildscripts: fail when curl upload fails

### DIFF
--- a/buildscripts/sonatype-upload.sh
+++ b/buildscripts/sonatype-upload.sh
@@ -85,7 +85,7 @@ REPOID="$(
       <description>Release upload</description>
     </data>
   </promoteRequest>"
-  curl -s -X POST -d "$XML" -u "$USERPASS" -H "Content-Type: application/xml" \
+  curl -f -s -X POST -d "$XML" -u "$USERPASS" -H "Content-Type: application/xml" \
     "$STAGING_URL/profiles/$PROFILE_ID/start" |
   grep stagedRepositoryId |
   sed 's/.*<stagedRepositoryId>\(.*\)<\/stagedRepositoryId>.*/\1/'
@@ -94,8 +94,12 @@ echo "Repository id: $REPOID"
 
 for X in $(cd "$DIR" && find -type f | cut -b 3-); do
   echo "Uploading $X"
-  curl -T "$DIR/$X" -u "$USERPASS" -H "Content-Type: application/octet-stream" \
-    "$STAGING_URL/deployByRepositoryId/$REPOID/$X"
+  HTTP_CODE=$(curl -w "HTTP Status:\n%{http_code}" -T "$DIR/$X" -u "$USERPASS" -H "Content-Type: application/octet-stream" \
+    "$STAGING_URL/deployByRepositoryId/$REPOID/$X" | tee /dev/tty | tail -n 1)
+  if [ "$HTTP_CODE" -ne 200 ]; then
+    echo "Upload failed"
+    exit 1
+  fi;
 done
 
 echo "Closing staging repo"
@@ -106,5 +110,5 @@ XML="
     <description>Auto-close via upload script</description>
   </data>
 </promoteRequest>"
-curl -X POST -d "$XML" -u "$USERPASS" -H "Content-Type: application/xml" \
+curl -f -X POST -d "$XML" -u "$USERPASS" -H "Content-Type: application/xml" \
   "$STAGING_URL/profiles/$PROFILE_ID/finish"


### PR DESCRIPTION
Avoid "successfully" running the artifacts job when the curl commands do not actually succeed. In recent memory (two weeks ago?), I accidentally tried to release a -SNAPSHOT version which is properly rejected by sonatype but the kokoro jobs themselves were reporting success.

Just adding `-f` to the curl command will achieve the desired effect in that the jobs will fail, but this flag unfortunately also stops showing the content retrieved from the server: in the above scenario, the 400 response in the logs very helpfully told us that:

```
<h1>400 - Bad Request</h1>
    <p>Storing of item iogrpc-1231:/io/grpc/grpc-testing/1.31.1-SNAPSHOT/maven-metadata.xml.sha1 is forbidden by Maven Repository policy. Because iogrpc-1231 is a RELEASE repository</p>
```

So seeing this message is useful, which results in adding the http code to the output via `-w` and the manual fail if not 200 logic below. I didn't add this to the other curl commands (yet), because my bash is not great and I wasn't sure if this is worth writing a function for (the curl command on line 88 is more complicated and greps the output). Also only sort of tested (e.g., locally against a dummy server, not run against sonatype), so leaving as a draft for now.