### PR TITLE
xds: replace verifyNoMoreInteractions with verifyNoInteractions

### DIFF
--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -1865,8 +1866,7 @@ public class XdsClientImplTest {
     assertThat(fakeClock.getPendingTasks(CDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
     assertThat(timeoutTask.isCancelled()).isTrue();
 
-    // TODO(chengyuanzhang): migrate to verifyNoInteractions.
-    verifyNoMoreInteractions(watcher3, watcher4);
+    verifyNoInteractions(watcher3, watcher4);
   }
 
   @Test
@@ -2133,8 +2133,7 @@ public class XdsClientImplTest {
                     new LbEndpoint("192.168.0.1", 8080,
                         2, true)), 1, 0));
 
-    // TODO(chengyuanzhang): migrate to verifyNoInteractions.
-    verifyNoMoreInteractions(watcher3);
+    verifyNoInteractions(watcher3);
 
     // Management server sends back another EDS response contains ClusterLoadAssignment for the
     // other requested cluster.
@@ -2518,8 +2517,7 @@ public class XdsClientImplTest {
     assertThat(fakeClock.getPendingTasks(EDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
     assertThat(timeoutTask.isCancelled()).isTrue();
 
-    // TODO(chengyuanzhang): migrate to verifyNoInteractions.
-    verifyNoMoreInteractions(watcher3, watcher4);
+    verifyNoInteractions(watcher3, watcher4);
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTestV2.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTestV2.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -1874,8 +1875,7 @@ public class XdsClientImplTestV2 {
     assertThat(fakeClock.getPendingTasks(CDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
     assertThat(timeoutTask.isCancelled()).isTrue();
 
-    // TODO(chengyuanzhang): migrate to verifyNoInteractions.
-    verifyNoMoreInteractions(watcher3, watcher4);
+    verifyNoInteractions(watcher3, watcher4);
   }
 
   @Test
@@ -2142,8 +2142,7 @@ public class XdsClientImplTestV2 {
                     new LbEndpoint("192.168.0.1", 8080,
                         2, true)), 1, 0));
 
-    // TODO(chengyuanzhang): migrate to verifyNoInteractions.
-    verifyNoMoreInteractions(watcher3);
+    verifyNoInteractions(watcher3);
 
     // Management server sends back another EDS response contains ClusterLoadAssignment for the
     // other requested cluster.
@@ -2527,8 +2526,7 @@ public class XdsClientImplTestV2 {
     assertThat(fakeClock.getPendingTasks(EDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
     assertThat(timeoutTask.isCancelled()).isTrue();
 
-    // TODO(chengyuanzhang): migrate to verifyNoInteractions.
-    verifyNoMoreInteractions(watcher3, watcher4);
+    verifyNoInteractions(watcher3, watcher4);
   }
 
   @Test


### PR DESCRIPTION
This reverts a mistaken and unnecessary change introduced by #7299.

There was a syncing mistake:

#7282 upgraded Mockito to 3.3.3 and replaced verifyZeroInteractions with verifyNotInteractions. But when I merged the master with #7299, the IDE did not pull and index the latest Mockito dependency, which marked verifyNoInteractions as unresolved. I thought it was the method being deprecated and didn't realize it was already the new method that #7282 migrated.