### PR TITLE
interop-testing: Remove comparison of proto field to null

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/GrpclbLongLivedAffinityTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/GrpclbLongLivedAffinityTestClient.java
@@ -16,8 +16,6 @@
 
 package io.grpc.testing.integration;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.protobuf.ByteString;
 import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
@@ -175,7 +173,6 @@ public final class GrpclbLongLivedAffinityTestClient {
             blockingStub.withDeadlineAfter(1, TimeUnit.MINUTES).unaryCall(request);
         logger.info("Received response");
         String serverId = response.getServerId();
-        checkNotNull(serverId, "serverId is null");
         if (lastServerId != null && !lastServerId.equals(serverId)) {
           String msg = "Expected serverId " + lastServerId + ", but got " + serverId;
           logger.warning(msg + ". affinityBreakageBudget=" + affinityBreakageBudget);


### PR DESCRIPTION
Proto fields aren't null. The getter will return an empty string instead
of null.

cl/326415191