### PR TITLE
core: fix a bug for hedging with throttling

### DIFF
--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -783,7 +783,6 @@ abstract class RetriableStream<ReqT> implements ClientStream {
       }
 
       if (state.winningSubstream == null) {
-        boolean isFatal = false;
         if (rpcProgress == RpcProgress.REFUSED
             && noMoreTransparentRetry.compareAndSet(false, true)) {
           // transparent retry
@@ -837,51 +836,54 @@ abstract class RetriableStream<ReqT> implements ClientStream {
             nextBackoffIntervalNanos = retryPolicy.initialBackoffNanos;
           }
 
-          RetryPlan retryPlan = makeRetryDecision(status, trailers);
-          if (retryPlan.shouldRetry) {
-            // The check state.winningSubstream == null, checking if is not already committed, is
-            // racy, but is still safe b/c the retry will also handle committed/cancellation
-            FutureCanceller scheduledRetryCopy;
-            synchronized (lock) {
-              scheduledRetry = scheduledRetryCopy = new FutureCanceller(lock);
-            }
-            scheduledRetryCopy.setFuture(scheduledExecutorService.schedule(
-                new Runnable() {
-                  @Override
-                  public void run() {
-                    callExecutor.execute(new Runnable() {
-                      @Override
-                      public void run() {
-                        // retry
-                        Substream newSubstream
-                            = createSubstream(substream.previousAttemptCount + 1);
-                        drain(newSubstream);
-                      }
-                    });
-                  }
-                },
-                retryPlan.backoffNanos,
-                TimeUnit.NANOSECONDS));
-            return;
-          }
-          isFatal = retryPlan.isFatal;
-          pushbackHedging(retryPlan.hedgingPushbackMillis);
-        }
-
-        if (isHedging) {
-          synchronized (lock) {
-            state = state.removeActiveHedge(substream);
-
-            // The invariant is whether or not #(Potential Hedge + active hedges) > 0.
-            // Once hasPotentialHedging(state) is false, it will always be false, and then
-            // #(state.activeHedges) will be decreasing. This guarantees that even there may be
-            // multiple concurrent hedges, one of the hedges will end up committed.
-            if (!isFatal) {
-              if (hasPotentialHedging(state) || !state.activeHedges.isEmpty()) {
-                return;
+          if (!isHedging) {
+            RetryPlan retryPlan = makeRetryDecision(status, trailers);
+            if (retryPlan.shouldRetry) {
+              // The check state.winningSubstream == null, checking if is not already committed, is
+              // racy, but is still safe b/c the retry will also handle committed/cancellation
+              FutureCanceller scheduledRetryCopy;
+              synchronized (lock) {
+                scheduledRetry = scheduledRetryCopy = new FutureCanceller(lock);
               }
-              // else, no activeHedges, no new hedges possible, try to commit
-            } // else, fatal, try to commit
+              scheduledRetryCopy.setFuture(
+                  scheduledExecutorService.schedule(
+                      new Runnable() {
+                        @Override
+                        public void run() {
+                          callExecutor.execute(
+                              new Runnable() {
+                                @Override
+                                public void run() {
+                                  // retry
+                                  Substream newSubstream =
+                                      createSubstream(substream.previousAttemptCount + 1);
+                                  drain(newSubstream);
+                                }
+                              });
+                        }
+                      },
+                      retryPlan.backoffNanos,
+                      TimeUnit.NANOSECONDS));
+              return;
+            }
+          } else {
+            HedgingPlan hedgingPlan = makeHedgingDecision(status, trailers);
+            if (hedgingPlan.isHedgeable) {
+              pushbackHedging(hedgingPlan.hedgingPushbackMillis);
+            }
+            synchronized (lock) {
+              state = state.removeActiveHedge(substream);
+              // The invariant is whether or not #(Potential Hedge + active hedges) > 0.
+              // Once hasPotentialHedging(state) is false, it will always be false, and then
+              // #(state.activeHedges) will be decreasing. This guarantees that even there may be
+              // multiple concurrent hedges, one of the hedges will end up committed.
+              if (hedgingPlan.isHedgeable) {
+                if (hasPotentialHedging(state) || !state.activeHedges.isEmpty()) {
+                  return;
+                }
+                // else, no activeHedges, no new hedges possible, try to commit
+              } // else, fatal, try to commit
+            }
           }
         }
       }
@@ -901,12 +903,6 @@ abstract class RetriableStream<ReqT> implements ClientStream {
       boolean shouldRetry = false;
       long backoffNanos = 0L;
       boolean isRetryableStatusCode = retryPolicy.retryableStatusCodes.contains(status.getCode());
-      boolean isNonFatalStatusCode = hedgingPolicy.nonFatalStatusCodes.contains(status.getCode());
-      if (isHedging && !isNonFatalStatusCode) {
-        // isFatal is true, no pushback
-        return new RetryPlan(/* shouldRetry = */ false, /* isFatal = */ true, 0, null);
-      }
-
       String pushbackStr = trailer.get(GRPC_RETRY_PUSHBACK_MS);
       Integer pushbackMillis = null;
       if (pushbackStr != null) {
@@ -916,11 +912,9 @@ abstract class RetriableStream<ReqT> implements ClientStream {
           pushbackMillis = -1;
         }
       }
-
       boolean isThrottled = false;
       if (throttle != null) {
-        if (isRetryableStatusCode || isNonFatalStatusCode
-            || (pushbackMillis != null && pushbackMillis < 0)) {
+        if (isRetryableStatusCode || (pushbackMillis != null && pushbackMillis < 0)) {
           isThrottled = !throttle.onQualifiedFailureThenCheckIsAboveThreshold();
         }
       }
@@ -933,7 +927,6 @@ abstract class RetriableStream<ReqT> implements ClientStream {
             nextBackoffIntervalNanos = Math.min(
                 (long) (nextBackoffIntervalNanos * retryPolicy.backoffMultiplier),
                 retryPolicy.maxBackoffNanos);
-
           } // else no retry
         } else if (pushbackMillis >= 0) {
           shouldRetry = true;
@@ -942,8 +935,27 @@ abstract class RetriableStream<ReqT> implements ClientStream {
         } // else no retry
       } // else no retry
 
-      return new RetryPlan(
-          shouldRetry, /* isFatal = */ false, backoffNanos, isHedging ? pushbackMillis : null);
+      return new RetryPlan(shouldRetry, backoffNanos);
+    }
+
+    private HedgingPlan makeHedgingDecision(Status status, Metadata trailer) {
+      String pushbackStr = trailer.get(GRPC_RETRY_PUSHBACK_MS);
+      Integer pushbackMillis = null;
+      if (pushbackStr != null) {
+        try {
+          pushbackMillis = Integer.valueOf(pushbackStr);
+        } catch (NumberFormatException e) {
+          pushbackMillis = -1;
+        }
+      }
+      boolean isFatal = !hedgingPolicy.nonFatalStatusCodes.contains(status.getCode());
+      boolean isThrottled = false;
+      if (throttle != null) {
+        if (!isFatal || (pushbackMillis != null && pushbackMillis < 0)) {
+          isThrottled = !throttle.onQualifiedFailureThenCheckIsAboveThreshold();
+        }
+      }
+      return new HedgingPlan(!isFatal && !isThrottled, pushbackMillis);
     }
 
     @Override
@@ -1361,17 +1373,22 @@ abstract class RetriableStream<ReqT> implements ClientStream {
 
   private static final class RetryPlan {
     final boolean shouldRetry;
-    final boolean isFatal; // receiving a status not among the nonFatalStatusCodes
     final long backoffNanos;
+
+    RetryPlan(boolean shouldRetry, long backoffNanos) {
+      this.shouldRetry = shouldRetry;
+      this.backoffNanos = backoffNanos;
+    }
+  }
+
+  private static final class HedgingPlan {
+    final boolean isHedgeable;
     @Nullable
     final Integer hedgingPushbackMillis;
 
-    RetryPlan(
-        boolean shouldRetry, boolean isFatal, long backoffNanos,
-        @Nullable Integer hedgingPushbackMillis) {
-      this.shouldRetry = shouldRetry;
-      this.isFatal = isFatal;
-      this.backoffNanos = backoffNanos;
+    public HedgingPlan(
+        boolean isHedgeable, @Nullable Integer hedgingPushbackMillis) {
+      this.isHedgeable = isHedgeable;
       this.hedgingPushbackMillis = hedgingPushbackMillis;
     }
   }

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -882,7 +882,7 @@ abstract class RetriableStream<ReqT> implements ClientStream {
                   return;
                 }
                 // else, no activeHedges, no new hedges possible, try to commit
-              } // else, fatal, try to commit
+              } // else, isHedgeable is false, try to commit
             }
           }
         }


### PR DESCRIPTION
Resolves #7222: If a hedging substream fails triggering throttling threshold, the call should be committed.

Refactored `RetryPlan` to two separate classes `RetryPlan` and `HedgingPlan`.