### PR TITLE
core: add accessor for bare method name in MethodDescriptor

### DIFF
--- a/api/src/main/java/io/grpc/MethodDescriptor.java
+++ b/api/src/main/java/io/grpc/MethodDescriptor.java
@@ -42,7 +42,6 @@ public final class MethodDescriptor<ReqT, RespT> {
   private final MethodType type;
   private final String fullMethodName;
   @Nullable private final String serviceName;
-  @Nullable private final String methodName;
   private final Marshaller<ReqT> requestMarshaller;
   private final Marshaller<RespT> responseMarshaller;
   private final @Nullable Object schemaDescriptor;
@@ -226,7 +225,6 @@ public final class MethodDescriptor<ReqT, RespT> {
     this.type = Preconditions.checkNotNull(type, "type");
     this.fullMethodName = Preconditions.checkNotNull(fullMethodName, "fullMethodName");
     this.serviceName = extractFullServiceName(fullMethodName);
-    this.methodName = extractMethodName(fullMethodName);
     this.requestMarshaller = Preconditions.checkNotNull(requestMarshaller, "requestMarshaller");
     this.responseMarshaller = Preconditions.checkNotNull(responseMarshaller, "responseMarshaller");
     this.schemaDescriptor = schemaDescriptor;
@@ -271,8 +269,8 @@ public final class MethodDescriptor<ReqT, RespT> {
    */
   @Nullable
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/5635")
-  public String getMethodName() {
-    return methodName;
+  public String getBareMethodName() {
+    return extractBareMethodName(fullMethodName);
   }
 
   /**
@@ -418,7 +416,8 @@ public final class MethodDescriptor<ReqT, RespT> {
    * @since 1.32.0
    */
   @Nullable
-  public static String extractMethodName(String fullMethodName) {
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/5635")
+  public static String extractBareMethodName(String fullMethodName) {
     int index = checkNotNull(fullMethodName, "fullMethodName").lastIndexOf('/');
     if (index == -1) {
       return null;

--- a/api/src/main/java/io/grpc/MethodDescriptor.java
+++ b/api/src/main/java/io/grpc/MethodDescriptor.java
@@ -42,6 +42,7 @@ public final class MethodDescriptor<ReqT, RespT> {
   private final MethodType type;
   private final String fullMethodName;
   @Nullable private final String serviceName;
+  @Nullable private final String methodName;
   private final Marshaller<ReqT> requestMarshaller;
   private final Marshaller<RespT> responseMarshaller;
   private final @Nullable Object schemaDescriptor;
@@ -225,6 +226,7 @@ public final class MethodDescriptor<ReqT, RespT> {
     this.type = Preconditions.checkNotNull(type, "type");
     this.fullMethodName = Preconditions.checkNotNull(fullMethodName, "fullMethodName");
     this.serviceName = extractFullServiceName(fullMethodName);
+    this.methodName = extractMethodName(fullMethodName);
     this.requestMarshaller = Preconditions.checkNotNull(requestMarshaller, "requestMarshaller");
     this.responseMarshaller = Preconditions.checkNotNull(responseMarshaller, "responseMarshaller");
     this.schemaDescriptor = schemaDescriptor;
@@ -260,6 +262,17 @@ public final class MethodDescriptor<ReqT, RespT> {
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/5635")
   public String getServiceName() {
     return serviceName;
+  }
+
+  /**
+   * A convenience method for {@code extractMethodName(getFullMethodName())}.
+   *
+   * @since 1.32.0
+   */
+  @Nullable
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/5635")
+  public String getMethodName() {
+    return methodName;
   }
 
   /**
@@ -396,6 +409,21 @@ public final class MethodDescriptor<ReqT, RespT> {
       return null;
     }
     return fullMethodName.substring(0, index);
+  }
+
+  /**
+   * Extract the method name out of a fully qualified method name. May return {@code null}
+   * if the input is malformed, but you cannot rely on it for the validity of the input.
+   *
+   * @since 1.32.0
+   */
+  @Nullable
+  public static String extractMethodName(String fullMethodName) {
+    int index = checkNotNull(fullMethodName, "fullMethodName").lastIndexOf('/');
+    if (index == -1) {
+      return null;
+    }
+    return fullMethodName.substring(index + 1);
   }
 
   /**

--- a/api/src/main/java/io/grpc/MethodDescriptor.java
+++ b/api/src/main/java/io/grpc/MethodDescriptor.java
@@ -263,7 +263,7 @@ public final class MethodDescriptor<ReqT, RespT> {
   }
 
   /**
-   * A convenience method for {@code extractMethodName(getFullMethodName())}.
+   * A convenience method for {@code extractBareMethodName(getFullMethodName())}.
    *
    * @since 1.32.0
    */

--- a/api/src/test/java/io/grpc/MethodDescriptorTest.java
+++ b/api/src/test/java/io/grpc/MethodDescriptorTest.java
@@ -178,6 +178,39 @@ public class MethodDescriptorTest {
   }
 
   @Test
+  public void getMethodName_extractsMethod() {
+    Marshaller<Void> marshaller = TestMethodDescriptors.voidMarshaller();
+    MethodDescriptor<?, ?> md = MethodDescriptor.newBuilder(marshaller, marshaller)
+        .setType(MethodType.UNARY)
+        .setFullMethodName("foo/bar")
+        .build();
+
+    assertEquals("bar", md.getMethodName());
+  }
+
+  @Test
+  public void getMethodName_returnsNull() {
+    Marshaller<Void> marshaller = TestMethodDescriptors.voidMarshaller();
+    MethodDescriptor<?, ?> md = MethodDescriptor.newBuilder(marshaller, marshaller)
+        .setType(MethodType.UNARY)
+        .setFullMethodName("foo-bar")
+        .build();
+
+    assertNull(md.getMethodName());
+  }
+
+  @Test
+  public void getMethodName_returnsEmptyStringWithMethodMissing() {
+    Marshaller<Void> marshaller = TestMethodDescriptors.voidMarshaller();
+    MethodDescriptor<?, ?> md = MethodDescriptor.newBuilder(marshaller, marshaller)
+        .setType(MethodType.UNARY)
+        .setFullMethodName("foo/")
+        .build();
+
+    assertTrue(md.getMethodName().isEmpty());
+  }
+
+  @Test
   public void toBuilderTest() {
     MethodDescriptor<String, String> md1 = MethodDescriptor.<String, String>newBuilder()
         .setType(MethodType.UNARY)

--- a/api/src/test/java/io/grpc/MethodDescriptorTest.java
+++ b/api/src/test/java/io/grpc/MethodDescriptorTest.java
@@ -178,36 +178,36 @@ public class MethodDescriptorTest {
   }
 
   @Test
-  public void getMethodName_extractsMethod() {
+  public void getBareMethodName_extractsMethod() {
     Marshaller<Void> marshaller = TestMethodDescriptors.voidMarshaller();
     MethodDescriptor<?, ?> md = MethodDescriptor.newBuilder(marshaller, marshaller)
         .setType(MethodType.UNARY)
         .setFullMethodName("foo/bar")
         .build();
 
-    assertEquals("bar", md.getMethodName());
+    assertEquals("bar", md.getBareMethodName());
   }
 
   @Test
-  public void getMethodName_returnsNull() {
+  public void getBareMethodName_returnsNull() {
     Marshaller<Void> marshaller = TestMethodDescriptors.voidMarshaller();
     MethodDescriptor<?, ?> md = MethodDescriptor.newBuilder(marshaller, marshaller)
         .setType(MethodType.UNARY)
         .setFullMethodName("foo-bar")
         .build();
 
-    assertNull(md.getMethodName());
+    assertNull(md.getBareMethodName());
   }
 
   @Test
-  public void getMethodName_returnsEmptyStringWithMethodMissing() {
+  public void getBareMethodName_returnsEmptyStringWithMethodMissing() {
     Marshaller<Void> marshaller = TestMethodDescriptors.voidMarshaller();
     MethodDescriptor<?, ?> md = MethodDescriptor.newBuilder(marshaller, marshaller)
         .setType(MethodType.UNARY)
         .setFullMethodName("foo/")
         .build();
 
-    assertTrue(md.getMethodName().isEmpty());
+    assertTrue(md.getBareMethodName().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
To implement credential restrictions based on not only service names but also (non-qualified) method names, we need to expose this property just like the service name got exposed through the API.

This reuses the same experimental tracking issue as getServiceName, but I can to file a new one if necessary.