### PR TITLE
POC: outbound protobuf zero-copy

### DIFF
--- a/api/src/main/java/io/grpc/ByteBufferBacked.java
+++ b/api/src/main/java/io/grpc/ByteBufferBacked.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Extension to an {@link java.io.OutputStream} or alike by adding methods that
+ * allow writing directly to an underlying {@link ByteBuffer}
+ */
+public interface ByteBufferBacked {
+
+  /**
+   * If available, returns a {@link ByteBuffer} backing this writable
+   * object whose position corresponds to this object's current
+   * writing position and with at least {@code size} remaining bytes.
+   *
+   * @param size minimum required size
+   * @return null if not supported or writable buffer of insufficient size
+   */
+  ByteBuffer getWritableBuffer(int size);
+
+  /**
+   * This must be called to notify that data has been written to the
+   * buffer previously returned from {@link #getWritableBuffer(int)},
+   * prior to calling any other methods.
+   *
+   * @param written number of bytes written
+   */
+  void bufferBytesWritten(int written);
+}

--- a/core/src/main/java/io/grpc/internal/MessageFramer.java
+++ b/core/src/main/java/io/grpc/internal/MessageFramer.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.lang.Math.min;
 
 import com.google.common.io.ByteStreams;
+import io.grpc.ByteBufferBacked;
 import io.grpc.Codec;
 import io.grpc.Compressor;
 import io.grpc.Drainable;
@@ -277,17 +278,12 @@ public class MessageFramer implements Framer {
     }
   }
 
-  private void writeRaw(byte[] b, int off, int len) {
+  // package-private to avoid synthetic access from OutputStreamAdapter
+  void writeRaw(byte[] b, int off, int len) {
     while (len > 0) {
-      if (buffer != null && buffer.writableBytes() == 0) {
-        commitToSink(false, false);
-      }
-      if (buffer == null) {
-        // Request a buffer allocation using the message length as a hint.
-        buffer = bufferAllocator.allocate(len);
-      }
-      int toWrite = min(len, buffer.writableBytes());
-      buffer.write(b, off, toWrite);
+      WritableBuffer buf = getWritableBuffer(len);
+      int toWrite = min(len, buf.writableBytes());
+      buf.write(b, off, toWrite);
       off += toWrite;
       len -= toWrite;
     }
@@ -301,6 +297,17 @@ public class MessageFramer implements Framer {
     if (buffer != null && buffer.readableBytes() > 0) {
       commitToSink(false, true);
     }
+  }
+
+  WritableBuffer getWritableBuffer(int len) {
+    if (buffer != null && buffer.writableBytes() == 0) {
+      commitToSink(false, false);
+    }
+    if (buffer == null) {
+      // Request a buffer allocation using the message length as a hint.
+      buffer = bufferAllocator.allocate(len);
+    }
+    return buffer;
   }
 
   /**
@@ -360,7 +367,7 @@ public class MessageFramer implements Framer {
   }
 
   /** OutputStream whose write()s are passed to the framer. */
-  private class OutputStreamAdapter extends OutputStream {
+  private class OutputStreamAdapter extends OutputStream implements ByteBufferBacked {
     /**
      * This is slow, don't call it.  If you care about write overhead, use a BufferedOutputStream.
      * Better yet, you can use your own single byte buffer and call
@@ -376,13 +383,29 @@ public class MessageFramer implements Framer {
     public void write(byte[] b, int off, int len) {
       writeRaw(b, off, len);
     }
+
+    @Override
+    public ByteBuffer getWritableBuffer(int size) {
+      if (size > 0) {
+        WritableBuffer buf = MessageFramer.this.getWritableBuffer(size);
+        if (buf instanceof ByteBufferBacked) {
+          return ((ByteBufferBacked) buf).getWritableBuffer(size);
+        }
+      }
+      return null;
+    }
+
+    @Override
+    public void bufferBytesWritten(int size) {
+      MessageFramer.bufferBytesWritten(buffer, size);
+    }
   }
 
   /**
    * Produce a collection of {@link WritableBuffer} instances from the data written to an
    * {@link OutputStream}.
    */
-  private final class BufferChainOutputStream extends OutputStream {
+  private final class BufferChainOutputStream extends OutputStream implements ByteBufferBacked {
     private final List<WritableBuffer> bufferList = new ArrayList<>();
     private WritableBuffer current;
 
@@ -403,7 +426,7 @@ public class MessageFramer implements Framer {
 
     @Override
     public void write(byte[] b, int off, int len) {
-      if (current == null) {
+      if (current == null && len > 0) {
         // Request len bytes initially from the allocator, it may give us more.
         current = bufferAllocator.allocate(len);
         bufferList.add(current);
@@ -431,5 +454,35 @@ public class MessageFramer implements Framer {
       }
       return readable;
     }
+
+    @Override
+    public ByteBuffer getWritableBuffer(int size) {
+      if (size > 0) {
+        if (current == null || current.writableBytes() == 0) {
+          bufferList.add(current = bufferAllocator.allocate(size));
+        }
+        if (current instanceof ByteBufferBacked) {
+          return ((ByteBufferBacked) current).getWritableBuffer(size);
+        }
+      }
+      return null;
+    }
+
+    @Override
+    public void bufferBytesWritten(int size) {
+      MessageFramer.bufferBytesWritten(current, size);
+    }
+  }
+
+  static void bufferBytesWritten(WritableBuffer buffer, int size) {
+    try {
+      ((ByteBufferBacked) buffer).bufferBytesWritten(size);
+      return;
+    } catch (ClassCastException cce) {
+      // fall-through
+    } catch (NullPointerException npe) {
+      // fall-through
+    }
+    throw new IllegalStateException();
   }
 }

--- a/protobuf-lite/src/main/java/io/grpc/protobuf/lite/ProtoLiteUtils.java
+++ b/protobuf-lite/src/main/java/io/grpc/protobuf/lite/ProtoLiteUtils.java
@@ -160,7 +160,7 @@ public final class ProtoLiteUtils {
         if (protoStream.parser() == parser) {
           try {
             @SuppressWarnings("unchecked")
-            T message = (T) ((ProtoInputStream) stream).message();
+            T message = (T) protoStream.message();
             return message;
           } catch (IllegalStateException ignored) {
             // Stream must have been read from, which is a strange state. Since the point of this


### PR DESCRIPTION
Outbound equivalent of #7330.

Protobuf doesn't support multiple `ByteBuffer`s in this direction but I don't think that matters much since the outbound buffers are typically allocated/sized to fit the messages.