### PR TITLE
core: refactor to delete RetryPolicy.DEFAULT

### DIFF
--- a/core/src/main/java/io/grpc/internal/HedgingPolicy.java
+++ b/core/src/main/java/io/grpc/internal/HedgingPolicy.java
@@ -20,8 +20,8 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import io.grpc.Status.Code;
-import java.util.Collections;
 import java.util.Set;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -32,10 +32,6 @@ final class HedgingPolicy {
   final int maxAttempts;
   final long hedgingDelayNanos;
   final Set<Code> nonFatalStatusCodes;
-
-  /** No hedging. */
-  static final HedgingPolicy DEFAULT =
-      new HedgingPolicy(1, 0, Collections.<Code>emptySet());
 
   /**
    * The caller is supposed to have validated the arguments and handled throwing exception or
@@ -75,6 +71,8 @@ final class HedgingPolicy {
         .toString();
   }
 
+  // TODO(zdapeng): delete this because HedgingPolicy will be always available prior to starting
+  //  RetriableStream.
   /**
    * Provides the most suitable hedging policy for a call.
    */
@@ -83,6 +81,7 @@ final class HedgingPolicy {
     /**
      * This method is used no more than once for each call. Never returns null.
      */
+    @Nullable
     HedgingPolicy get();
   }
 }

--- a/core/src/main/java/io/grpc/internal/HedgingPolicy.java
+++ b/core/src/main/java/io/grpc/internal/HedgingPolicy.java
@@ -79,7 +79,7 @@ final class HedgingPolicy {
   interface Provider {
 
     /**
-     * This method is used no more than once for each call. Never returns null.
+     * This method is used no more than once for each call.
      */
     @Nullable
     HedgingPolicy get();

--- a/core/src/main/java/io/grpc/internal/ManagedChannelServiceConfig.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelServiceConfig.java
@@ -267,12 +267,12 @@ final class ManagedChannelServiceConfig {
       Map<String, ?> retryPolicyMap =
           retryEnabled ? ServiceConfigUtil.getRetryPolicyFromMethodConfig(methodConfig) : null;
       retryPolicy = retryPolicyMap == null
-          ? RetryPolicy.DEFAULT : retryPolicy(retryPolicyMap, maxRetryAttemptsLimit);
+          ? null : retryPolicy(retryPolicyMap, maxRetryAttemptsLimit);
 
       Map<String, ?> hedgingPolicyMap =
           retryEnabled ? ServiceConfigUtil.getHedgingPolicyFromMethodConfig(methodConfig) : null;
       hedgingPolicy = hedgingPolicyMap == null
-          ? HedgingPolicy.DEFAULT : hedgingPolicy(hedgingPolicyMap, maxHedgedAttemptsLimit);
+          ? null : hedgingPolicy(hedgingPolicyMap, maxHedgedAttemptsLimit);
     }
 
     @Override

--- a/core/src/main/java/io/grpc/internal/RetryPolicy.java
+++ b/core/src/main/java/io/grpc/internal/RetryPolicy.java
@@ -95,7 +95,7 @@ final class RetryPolicy {
   interface Provider {
 
     /**
-     * This method is used no more than once for each call. Never returns null.
+     * This method is used no more than once for each call.
      */
     @Nullable
     RetryPolicy get();

--- a/core/src/main/java/io/grpc/internal/RetryPolicy.java
+++ b/core/src/main/java/io/grpc/internal/RetryPolicy.java
@@ -19,11 +19,10 @@ package io.grpc.internal;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
-import io.grpc.Status;
 import io.grpc.Status.Code;
-import java.util.Collections;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -36,10 +35,6 @@ final class RetryPolicy {
   final long maxBackoffNanos;
   final double backoffMultiplier;
   final Set<Code> retryableStatusCodes;
-
-  /** No retry. */
-  static final RetryPolicy DEFAULT =
-      new RetryPolicy(1, 0, 0, 1, Collections.<Status.Code>emptySet());
 
   /**
    * The caller is supposed to have validated the arguments and handled throwing exception or
@@ -92,6 +87,8 @@ final class RetryPolicy {
         .toString();
   }
 
+  // TODO(zdapeng): delete this because RetryPolicy will be always available prior to starting
+  //  RetriableStream.
   /**
    * Provides the most suitable retry policy for a call.
    */
@@ -100,6 +97,7 @@ final class RetryPolicy {
     /**
      * This method is used no more than once for each call. Never returns null.
      */
+    @Nullable
     RetryPolicy get();
   }
 }

--- a/core/src/main/java/io/grpc/internal/ServiceConfigInterceptor.java
+++ b/core/src/main/java/io/grpc/internal/ServiceConfigInterceptor.java
@@ -82,7 +82,7 @@ final class ServiceConfigInterceptor implements ClientInterceptor {
         }
 
         verify(
-            retryPolicy.equals(RetryPolicy.DEFAULT) || hedgingPolicy.equals(HedgingPolicy.DEFAULT),
+            retryPolicy == null || hedgingPolicy == null,
             "Can not apply both retry and hedging policy for the method '%s'", method);
 
         callOptions = callOptions
@@ -97,9 +97,10 @@ final class ServiceConfigInterceptor implements ClientInterceptor {
            * <p>Note that this method is used no more than once for each call.
            */
           @Override
+          @Nullable
           public RetryPolicy get() {
             if (!initComplete) {
-              return RetryPolicy.DEFAULT;
+              return null;
             }
             return getRetryPolicyFromConfig(method);
           }
@@ -113,14 +114,14 @@ final class ServiceConfigInterceptor implements ClientInterceptor {
            * <p>Note that this method is used no more than once for each call.
            */
           @Override
+          @Nullable
           public HedgingPolicy get() {
             if (!initComplete) {
-              return HedgingPolicy.DEFAULT;
+              return null;
             }
             HedgingPolicy hedgingPolicy = getHedgingPolicyFromConfig(method);
             verify(
-                hedgingPolicy.equals(HedgingPolicy.DEFAULT)
-                    || getRetryPolicyFromConfig(method).equals(RetryPolicy.DEFAULT),
+                hedgingPolicy == null || getRetryPolicyFromConfig(method) == null,
                 "Can not apply both retry and hedging policy for the method '%s'", method);
             return hedgingPolicy;
           }
@@ -190,14 +191,16 @@ final class ServiceConfigInterceptor implements ClientInterceptor {
   }
 
   @VisibleForTesting
+  @Nullable
   RetryPolicy getRetryPolicyFromConfig(MethodDescriptor<?, ?> method) {
     MethodInfo info = getMethodInfo(method);
-    return info == null ? RetryPolicy.DEFAULT : info.retryPolicy;
+    return info == null ? null : info.retryPolicy;
   }
 
   @VisibleForTesting
+  @Nullable
   HedgingPolicy getHedgingPolicyFromConfig(MethodDescriptor<?, ?> method) {
     MethodInfo info = getMethodInfo(method);
-    return info == null ? HedgingPolicy.DEFAULT : info.hedgingPolicy;
+    return info == null ? null : info.hedgingPolicy;
   }
 }

--- a/core/src/test/java/io/grpc/internal/HedgingPolicyTest.java
+++ b/core/src/test/java/io/grpc/internal/HedgingPolicyTest.java
@@ -74,14 +74,10 @@ public class HedgingPolicyTest {
       MethodDescriptor.Builder<Void, Void> builder = TestMethodDescriptors.voidMethod().toBuilder();
 
       MethodDescriptor<Void, Void> method = builder.setFullMethodName("not/exist").build();
-      assertEquals(
-          HedgingPolicy.DEFAULT,
-          serviceConfigInterceptor.getHedgingPolicyFromConfig(method));
+      assertThat(serviceConfigInterceptor.getHedgingPolicyFromConfig(method)).isNull();
 
       method = builder.setFullMethodName("not_exist/Foo1").build();
-      assertEquals(
-          HedgingPolicy.DEFAULT,
-          serviceConfigInterceptor.getHedgingPolicyFromConfig(method));
+      assertThat(serviceConfigInterceptor.getHedgingPolicyFromConfig(method)).isNull();
 
       method = builder.setFullMethodName("SimpleService1/not_exist").build();
 
@@ -101,9 +97,7 @@ public class HedgingPolicyTest {
           serviceConfigInterceptor.getHedgingPolicyFromConfig(method));
 
       method = builder.setFullMethodName("SimpleService2/not_exist").build();
-      assertEquals(
-          HedgingPolicy.DEFAULT,
-          serviceConfigInterceptor.getHedgingPolicyFromConfig(method));
+      assertThat(serviceConfigInterceptor.getHedgingPolicyFromConfig(method)).isNull();
 
       method = builder.setFullMethodName("SimpleService2/Foo2").build();
       assertEquals(

--- a/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
@@ -144,8 +144,8 @@ public class RetriableStreamTest {
         ChannelBufferMeter channelBufferUsed, long perRpcBufferLimit, long channelBufferLimit,
         Executor callExecutor,
         ScheduledExecutorService scheduledExecutorService,
-        final RetryPolicy retryPolicy,
-        final HedgingPolicy hedgingPolicy,
+        @Nullable final RetryPolicy retryPolicy,
+        @Nullable final HedgingPolicy hedgingPolicy,
         @Nullable Throttle throttle) {
       super(
           method, headers, channelBufferUsed, perRpcBufferLimit, channelBufferLimit, callExecutor,
@@ -196,14 +196,14 @@ public class RetriableStreamTest {
     return new RecordedRetriableStream(
         method, new Metadata(), channelBufferUsed, PER_RPC_BUFFER_LIMIT, CHANNEL_BUFFER_LIMIT,
         MoreExecutors.directExecutor(), fakeClock.getScheduledExecutorService(), RETRY_POLICY,
-        HedgingPolicy.DEFAULT, throttle);
+        null, throttle);
   }
 
   private RetriableStream<String> newThrottledHedgingStream(Throttle throttle) {
     return new RecordedRetriableStream(
         method, new Metadata(), channelBufferUsed, PER_RPC_BUFFER_LIMIT, CHANNEL_BUFFER_LIMIT,
         MoreExecutors.directExecutor(), fakeClock.getScheduledExecutorService(),
-        RetryPolicy.DEFAULT, HEDGING_POLICY, throttle);
+        null, HEDGING_POLICY, throttle);
   }
 
   @After
@@ -1576,7 +1576,7 @@ public class RetriableStreamTest {
     RetriableStream<String> unretriableStream = new RecordedRetriableStream(
         method, new Metadata(), channelBufferUsed, PER_RPC_BUFFER_LIMIT, CHANNEL_BUFFER_LIMIT,
         MoreExecutors.directExecutor(), fakeClock.getScheduledExecutorService(),
-        RetryPolicy.DEFAULT, HedgingPolicy.DEFAULT, null);
+        null, null, null);
 
     // start
     doReturn(mockStream1).when(retriableStreamRecorder).newSubstream(0);

--- a/core/src/test/java/io/grpc/internal/RetryPolicyTest.java
+++ b/core/src/test/java/io/grpc/internal/RetryPolicyTest.java
@@ -77,14 +77,10 @@ public class RetryPolicyTest {
       MethodDescriptor.Builder<Void, Void> builder = TestMethodDescriptors.voidMethod().toBuilder();
 
       MethodDescriptor<Void, Void> method = builder.setFullMethodName("not/exist").build();
-      assertEquals(
-          RetryPolicy.DEFAULT,
-          serviceConfigInterceptor.getRetryPolicyFromConfig(method));
+      assertThat(serviceConfigInterceptor.getRetryPolicyFromConfig(method)).isNull();
 
       method = builder.setFullMethodName("not_exist/Foo1").build();
-      assertEquals(
-          RetryPolicy.DEFAULT,
-          serviceConfigInterceptor.getRetryPolicyFromConfig(method));
+      assertThat(serviceConfigInterceptor.getRetryPolicyFromConfig(method)).isNull();
 
       method = builder.setFullMethodName("SimpleService1/not_exist").build();
 
@@ -108,9 +104,7 @@ public class RetryPolicyTest {
           serviceConfigInterceptor.getRetryPolicyFromConfig(method));
 
       method = builder.setFullMethodName("SimpleService2/not_exist").build();
-      assertEquals(
-          RetryPolicy.DEFAULT,
-          serviceConfigInterceptor.getRetryPolicyFromConfig(method));
+      assertThat(serviceConfigInterceptor.getRetryPolicyFromConfig(method)).isNull();
 
       method = builder.setFullMethodName("SimpleService2/Foo2").build();
       assertEquals(

--- a/core/src/test/java/io/grpc/internal/ServiceConfigInterceptorTest.java
+++ b/core/src/test/java/io/grpc/internal/ServiceConfigInterceptorTest.java
@@ -123,9 +123,9 @@ public class ServiceConfigInterceptorTest {
     verify(channel).newCall(eq(methodDescriptor), callOptionsCap.capture());
     assertThat(callOptionsCap.getValue().isWaitForReady()).isFalse();
     assertThat(callOptionsCap.getValue().getOption(RETRY_POLICY_KEY).get())
-        .isEqualTo(RetryPolicy.DEFAULT);
+        .isNull();
     assertThat(callOptionsCap.getValue().getOption(HEDGING_POLICY_KEY).get())
-        .isEqualTo(HedgingPolicy.DEFAULT);
+        .isNull();
   }
 
   @Test


### PR DESCRIPTION
We used `null` and `RetryPolicy.DEFAULT` for the value of `retryPolicy` in `RetriableStream` to distinguish the state between name resolution not being completed and name resolution being completed but no retry policy. After the change #7259 , name resolution is always completed when creating a `RetriableStream`, so the distinction will be gone. It will be cleaner to get rid of `RetryPolicy.DEFAULT` and simply use `null` for absence of RetryPolicy. `RetryPolicy.Provider` will be deleted in upcoming PR.