### PR TITLE
core: disable usage of PendingCall due to a bug

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -918,6 +918,9 @@ final class ManagedChannelImpl extends ManagedChannel implements
     @Override
     public <ReqT, RespT> ClientCall<ReqT, RespT> newCall(
         MethodDescriptor<ReqT, RespT> method, CallOptions callOptions) {
+      if (true) { // FIXME(zdapeng): there is a bug for using PendingCall. Temporarily disable it.
+        return newClientCall(method, callOptions);
+      }
       if (configSelector.get() != INITIAL_PENDING_SELECTOR) {
         return newClientCall(method, callOptions);
       }


### PR DESCRIPTION
#7259 failed internally and there seems to be a bug. Temporarily disable PendingCall.