### PR TITLE
Channel builders extend public API

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
@@ -20,6 +20,7 @@ import static io.grpc.benchmarks.Utils.pickUnusedPort;
 
 import com.google.protobuf.ByteString;
 import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
 import io.grpc.Server;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -30,7 +31,6 @@ import io.grpc.benchmarks.proto.Messages.SimpleResponse;
 import io.grpc.benchmarks.qps.AsyncServer;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
-import io.grpc.internal.AbstractManagedChannelImplBuilder;
 import io.grpc.internal.AbstractServerImplBuilder;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
@@ -81,7 +81,7 @@ public class TransportBenchmark {
   @Setup
   public void setUp() throws Exception {
     AbstractServerImplBuilder<?> serverBuilder;
-    AbstractManagedChannelImplBuilder<?> channelBuilder;
+    ManagedChannelBuilder<?> channelBuilder;
     switch (transport) {
       case INPROCESS:
       {

--- a/core/src/main/java/io/grpc/inprocess/InternalInProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InternalInProcessChannelBuilder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.inprocess;
+
+import io.grpc.Internal;
+
+/**
+ * Internal {@link InProcessChannelBuilder} accessor.  This is intended for usage internal to the
+ * gRPC team.  If you *really* think you need to use this, contact the gRPC team first.
+ */
+@Internal
+public final class InternalInProcessChannelBuilder {
+
+  public static void setStatsEnabled(InProcessChannelBuilder builder, boolean value) {
+    builder.setStatsEnabled(value);
+  }
+
+  private InternalInProcessChannelBuilder() {}
+}

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -51,7 +51,7 @@ import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
- * The base class for channel builders.
+ * Abstract base class for channel builders.
  *
  * @param <T> The concrete type of this builder.
  */

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2020 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import com.google.common.base.Preconditions;
+import io.grpc.ManagedChannelBuilder;
+import java.net.SocketAddress;
+import java.util.concurrent.Executor;
+import javax.annotation.Nullable;
+
+/**
+ * Default managed channel builder, for usage in Transport implementations.
+ */
+public final class ManagedChannelImplBuilder
+    extends AbstractManagedChannelImplBuilder<ManagedChannelImplBuilder> {
+
+  private boolean authorityCheckerDisabled;
+  @Deprecated
+  @Nullable
+  private OverrideAuthorityChecker authorityChecker;
+
+  /**
+   * An interface for Transport implementors to provide the {@link ClientTransportFactory}
+   * appropriate for the channel.
+   */
+  public interface ClientTransportFactoryBuilder {
+    ClientTransportFactory buildClientTransportFactory();
+  }
+
+  /**
+   * An interface for Transport implementors to provide a default port to {@link
+   * io.grpc.NameResolver} for use in cases where the target string doesn't include a port. The
+   * default implementation returns {@link GrpcUtil#DEFAULT_PORT_SSL}.
+   */
+  public interface ChannelBuilderDefaultPortProvider {
+    int getDefaultPort();
+  }
+
+  /**
+   * Default implementation of {@link ChannelBuilderDefaultPortProvider} that returns a fixed port.
+   */
+  public static final class FixedPortProvider implements ChannelBuilderDefaultPortProvider {
+    private final int port;
+
+    public FixedPortProvider(int port) {
+      this.port = port;
+    }
+
+    @Override
+    public int getDefaultPort() {
+      return port;
+    }
+  }
+
+  private final class ManagedChannelDefaultPortProvider implements
+      ChannelBuilderDefaultPortProvider {
+    @Override
+    public int getDefaultPort() {
+      return ManagedChannelImplBuilder.super.getDefaultPort();
+    }
+  }
+
+  private final ClientTransportFactoryBuilder clientTransportFactoryBuilder;
+  private final ChannelBuilderDefaultPortProvider channelBuilderDefaultPortProvider;
+
+  /**
+   * Creates a new managed channel builder with a target string, which can be either a valid {@link
+   * io.grpc.NameResolver}-compliant URI, or an authority string. Transport implementors must
+   * provide client transport factory builder, and may set custom channel default port provider.
+   */
+  public ManagedChannelImplBuilder(String target,
+      ClientTransportFactoryBuilder clientTransportFactoryBuilder,
+      @Nullable ChannelBuilderDefaultPortProvider channelBuilderDefaultPortProvider) {
+    super(target);
+    this.clientTransportFactoryBuilder = Preconditions
+        .checkNotNull(clientTransportFactoryBuilder, "clientTransportFactoryBuilder");
+
+    if (channelBuilderDefaultPortProvider != null) {
+      this.channelBuilderDefaultPortProvider = channelBuilderDefaultPortProvider;
+    } else {
+      this.channelBuilderDefaultPortProvider = new ManagedChannelDefaultPortProvider();
+    }
+  }
+
+  /**
+   * Creates a new managed channel builder with the given server address, authority string of the
+   * channel. Transport implementors must provide client transport factory builder, and may set
+   * custom channel default port provider.
+   */
+  public ManagedChannelImplBuilder(SocketAddress directServerAddress, String authority,
+      ClientTransportFactoryBuilder clientTransportFactoryBuilder,
+      @Nullable ChannelBuilderDefaultPortProvider channelBuilderDefaultPortProvider) {
+    super(directServerAddress, authority);
+    this.clientTransportFactoryBuilder = Preconditions
+        .checkNotNull(clientTransportFactoryBuilder, "clientTransportFactoryBuilder");
+
+    if (channelBuilderDefaultPortProvider != null) {
+      this.channelBuilderDefaultPortProvider = channelBuilderDefaultPortProvider;
+    } else {
+      this.channelBuilderDefaultPortProvider = new ManagedChannelDefaultPortProvider();
+    }
+  }
+
+  @Override
+  protected ClientTransportFactory buildTransportFactory() {
+    return clientTransportFactoryBuilder.buildClientTransportFactory();
+  }
+
+  @Override
+  protected int getDefaultPort() {
+    return channelBuilderDefaultPortProvider.getDefaultPort();
+  }
+
+  /** Disable the check whether the authority is valid. */
+  public ManagedChannelImplBuilder disableCheckAuthority() {
+    authorityCheckerDisabled = true;
+    return this;
+  }
+
+  /** Enable previously disabled authority check. */
+  public ManagedChannelImplBuilder enableCheckAuthority() {
+    authorityCheckerDisabled = false;
+    return this;
+  }
+
+  @Deprecated
+  public interface OverrideAuthorityChecker {
+    String checkAuthority(String authority);
+  }
+
+  @Deprecated
+  public void overrideAuthorityChecker(@Nullable OverrideAuthorityChecker authorityChecker) {
+    this.authorityChecker = authorityChecker;
+  }
+
+  @Override
+  protected String checkAuthority(String authority) {
+    if (authorityCheckerDisabled) {
+      return authority;
+    }
+    if (authorityChecker != null) {
+      return authorityChecker.checkAuthority(authority);
+    }
+    return super.checkAuthority(authority);
+  }
+
+  @Override
+  public void setStatsEnabled(boolean value) {
+    super.setStatsEnabled(value);
+  }
+
+  @Override
+  public void setStatsRecordStartedRpcs(boolean value) {
+    super.setStatsRecordStartedRpcs(value);
+  }
+
+  @Override
+  public void setStatsRecordFinishedRpcs(boolean value) {
+    super.setStatsRecordFinishedRpcs(value);
+  }
+
+  @Override
+  public void setStatsRecordRealTimeMetrics(boolean value) {
+    super.setStatsRecordRealTimeMetrics(value);
+  }
+
+  @Override
+  public void setTracingEnabled(boolean value) {
+    super.setTracingEnabled(value);
+  }
+
+  @Override
+  public ObjectPool<? extends Executor> getOffloadExecutorPool() {
+    return super.getOffloadExecutorPool();
+  }
+
+  public static ManagedChannelBuilder<?> forAddress(String name, int port) {
+    throw new UnsupportedOperationException("ClientTransportFactoryBuilder is required");
+  }
+
+  public static ManagedChannelBuilder<?> forTarget(String target) {
+    throw new UnsupportedOperationException("ClientTransportFactoryBuilder is required");
+  }
+}

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2020 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.grpc.internal.ManagedChannelImplBuilder.ChannelBuilderDefaultPortProvider;
+import io.grpc.internal.ManagedChannelImplBuilder.ClientTransportFactoryBuilder;
+import io.grpc.internal.ManagedChannelImplBuilder.FixedPortProvider;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+/** Unit tests for {@link ManagedChannelImplBuilder}. */
+@RunWith(JUnit4.class)
+public class ManagedChannelImplBuilderTest {
+  private static final int DUMMY_PORT = 42;
+  private static final String DUMMY_TARGET = "fake-target";
+  private static final String DUMMY_AUTHORITY_VALID = "valid:1234";
+  private static final String DUMMY_AUTHORITY_INVALID = "[ : : 1]";
+
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Mock private ClientTransportFactoryBuilder mockClientTransportFactoryBuilder;
+  @Mock private ChannelBuilderDefaultPortProvider mockChannelBuilderDefaultPortProvider;
+  private ManagedChannelImplBuilder builder;
+
+  @Before
+  public void setUp() throws Exception {
+    builder = new ManagedChannelImplBuilder(
+        DUMMY_TARGET,
+        mockClientTransportFactoryBuilder,
+        mockChannelBuilderDefaultPortProvider);
+  }
+
+  /** Ensure buildTransportFactory() delegates to the custom implementation. */
+  @Test
+  public void buildTransportFactory() {
+    final ClientTransportFactory clientTransportFactory = mock(ClientTransportFactory.class);
+    when(mockClientTransportFactoryBuilder.buildClientTransportFactory())
+        .thenReturn(clientTransportFactory);
+    assertEquals(clientTransportFactory, builder.buildTransportFactory());
+    verify(mockClientTransportFactoryBuilder).buildClientTransportFactory();
+  }
+
+  /** Ensure getDefaultPort() returns default port when no custom implementation provided. */
+  @Test
+  public void getDefaultPort_default() {
+    final ManagedChannelImplBuilder builderNoPortProvider = new ManagedChannelImplBuilder(
+        DUMMY_TARGET, mockClientTransportFactoryBuilder, null);
+    assertEquals(GrpcUtil.DEFAULT_PORT_SSL, builderNoPortProvider.getDefaultPort());
+  }
+
+  /** Ensure getDefaultPort() delegates to the custom implementation. */
+  @Test
+  public void getDefaultPort_custom() {
+    when(mockChannelBuilderDefaultPortProvider.getDefaultPort()).thenReturn(DUMMY_PORT);
+    assertEquals(DUMMY_PORT, builder.getDefaultPort());
+    verify(mockChannelBuilderDefaultPortProvider).getDefaultPort();
+  }
+
+  /** Test FixedPortProvider(int port). */
+  @Test
+  public void getDefaultPort_fixedPortProvider() {
+    final ManagedChannelImplBuilder builderFixedPortProvider = new ManagedChannelImplBuilder(
+        DUMMY_TARGET,
+        mockClientTransportFactoryBuilder,
+        new FixedPortProvider(DUMMY_PORT));
+    assertEquals(DUMMY_PORT, builderFixedPortProvider.getDefaultPort());
+  }
+
+  @Test
+  public void checkAuthority_validAuthorityAllowed() {
+    assertEquals(DUMMY_AUTHORITY_VALID, builder.checkAuthority(DUMMY_AUTHORITY_VALID));
+  }
+
+  @Test
+  public void checkAuthority_invalidAuthorityFailed() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Invalid authority");
+
+    builder.checkAuthority(DUMMY_AUTHORITY_INVALID);
+  }
+
+  @Test
+  public void disableCheckAuthority_validAuthorityAllowed() {
+    builder.disableCheckAuthority();
+    assertEquals(DUMMY_AUTHORITY_VALID, builder.checkAuthority(DUMMY_AUTHORITY_VALID));
+  }
+
+  @Test
+  public void disableCheckAuthority_invalidAuthorityAllowed() {
+    builder.disableCheckAuthority();
+    assertEquals(DUMMY_AUTHORITY_INVALID, builder.checkAuthority(DUMMY_AUTHORITY_INVALID));
+  }
+
+  @Test
+  public void enableCheckAuthority_validAuthorityAllowed() {
+    builder.disableCheckAuthority().enableCheckAuthority();
+    assertEquals(DUMMY_AUTHORITY_VALID, builder.checkAuthority(DUMMY_AUTHORITY_VALID));
+  }
+
+  @Test
+  public void disableCheckAuthority_invalidAuthorityFailed() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Invalid authority");
+
+    builder.disableCheckAuthority().enableCheckAuthority();
+    builder.checkAuthority(DUMMY_AUTHORITY_INVALID);
+  }
+
+  /** Ensure authority check can disabled with custom authority check implementation. */
+  @Test
+  @SuppressWarnings("deprecation")
+  public void overrideAuthorityChecker_default() {
+    builder.overrideAuthorityChecker(
+        new io.grpc.internal.ManagedChannelImplBuilder.OverrideAuthorityChecker() {
+          @Override public String checkAuthority(String authority) {
+            return authority;
+          }
+        });
+    assertEquals(DUMMY_AUTHORITY_INVALID, builder.checkAuthority(DUMMY_AUTHORITY_INVALID));
+  }
+
+  /** Ensure custom authority is ignored after disableCheckAuthority(). */
+  @Test
+  @SuppressWarnings("deprecation")
+  public void overrideAuthorityChecker_ignored() {
+    builder.overrideAuthorityChecker(
+        new io.grpc.internal.ManagedChannelImplBuilder.OverrideAuthorityChecker() {
+          @Override public String checkAuthority(String authority) {
+            throw new IllegalArgumentException();
+          }
+        });
+    builder.disableCheckAuthority();
+    assertEquals(DUMMY_AUTHORITY_INVALID, builder.checkAuthority(DUMMY_AUTHORITY_INVALID));
+  }
+}

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -62,6 +62,7 @@ import io.grpc.NameResolver.ResolutionResult;
 import io.grpc.Status;
 import io.grpc.StringMarshaller;
 import io.grpc.internal.FakeClock.ScheduledTask;
+import io.grpc.internal.ManagedChannelImplBuilder.ClientTransportFactoryBuilder;
 import io.grpc.internal.TestUtils.MockClientTransportInfo;
 import java.net.SocketAddress;
 import java.net.URI;
@@ -159,21 +160,15 @@ public class ManagedChannelImplIdlenessTest {
     when(mockTransportFactory.getScheduledExecutorService())
         .thenReturn(timer.getScheduledExecutorService());
 
-    class Builder extends AbstractManagedChannelImplBuilder<Builder> {
-      Builder(String target) {
-        super(target);
-      }
+    ManagedChannelImplBuilder builder = new ManagedChannelImplBuilder("fake://target",
+        new ClientTransportFactoryBuilder() {
+          @Override public ClientTransportFactory buildClientTransportFactory() {
+            throw new UnsupportedOperationException();
+          }
+        },
+        null);
 
-      @Override protected ClientTransportFactory buildTransportFactory() {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override public Builder usePlaintext() {
-        throw new UnsupportedOperationException();
-      }
-    }
-
-    Builder builder = new Builder("fake://target")
+    builder
         .nameResolverFactory(mockNameResolverFactory)
         .defaultLoadBalancingPolicy(MOCK_POLICY_NAME)
         .idleTimeout(IDLE_TIMEOUT_SECONDS, TimeUnit.SECONDS)

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -107,6 +107,8 @@ import io.grpc.StringMarshaller;
 import io.grpc.internal.ClientTransportFactory.ClientTransportOptions;
 import io.grpc.internal.InternalSubchannel.TransportLogger;
 import io.grpc.internal.ManagedChannelImpl.ScParser;
+import io.grpc.internal.ManagedChannelImplBuilder.ClientTransportFactoryBuilder;
+import io.grpc.internal.ManagedChannelImplBuilder.FixedPortProvider;
 import io.grpc.internal.ServiceConfigUtil.PolicySelection;
 import io.grpc.internal.TestUtils.MockClientTransportInfo;
 import io.grpc.stub.ClientCalls;
@@ -269,7 +271,7 @@ public class ManagedChannelImplTest {
   private CallCredentials creds;
   @Mock
   private Executor offloadExecutor;
-  private ChannelBuilder channelBuilder;
+  private ManagedChannelImplBuilder channelBuilder;
   private boolean requestConnection = true;
   private BlockingQueue<MockClientTransportInfo> transports;
   private boolean panicExpected;
@@ -325,14 +327,20 @@ public class ManagedChannelImplTest {
     when(balancerRpcExecutorPool.getObject())
         .thenReturn(balancerRpcExecutor.getScheduledExecutorService());
 
-    channelBuilder =
-        new ChannelBuilder()
-            .nameResolverFactory(new FakeNameResolverFactory.Builder(expectedUri).build())
-            .defaultLoadBalancingPolicy(MOCK_POLICY_NAME)
-            .userAgent(USER_AGENT)
-            .idleTimeout(
-                AbstractManagedChannelImplBuilder.IDLE_MODE_MAX_TIMEOUT_DAYS, TimeUnit.DAYS)
-            .offloadExecutor(offloadExecutor);
+    channelBuilder = new ManagedChannelImplBuilder(TARGET,
+        new ClientTransportFactoryBuilder() {
+          @Override
+          public ClientTransportFactory buildClientTransportFactory() {
+            throw new UnsupportedOperationException();
+          }
+        },
+        new FixedPortProvider(DEFAULT_PORT));
+    channelBuilder
+        .nameResolverFactory(new FakeNameResolverFactory.Builder(expectedUri).build())
+        .defaultLoadBalancingPolicy(MOCK_POLICY_NAME)
+        .userAgent(USER_AGENT)
+        .idleTimeout(ManagedChannelImplBuilder.IDLE_MODE_MAX_TIMEOUT_DAYS, TimeUnit.DAYS)
+        .offloadExecutor(offloadExecutor);
     channelBuilder.executorPool = executorPool;
     channelBuilder.binlog = null;
     channelBuilder.channelz = channelz;
@@ -3466,21 +3474,18 @@ public class ManagedChannelImplTest {
     }
 
     FakeNameResolverFactory2 factory = new FakeNameResolverFactory2();
-    final class CustomBuilder extends AbstractManagedChannelImplBuilder<CustomBuilder> {
 
-      CustomBuilder() {
-        super(TARGET);
-        this.executorPool = ManagedChannelImplTest.this.executorPool;
-        this.channelz = ManagedChannelImplTest.this.channelz;
-      }
-
-      @Override
-      protected ClientTransportFactory buildTransportFactory() {
-        return mockTransportFactory;
-      }
-    }
-
-    ManagedChannel mychannel = new CustomBuilder().nameResolverFactory(factory).build();
+    ManagedChannelImplBuilder customBuilder = new ManagedChannelImplBuilder(TARGET,
+        new ClientTransportFactoryBuilder() {
+          @Override
+          public ClientTransportFactory buildClientTransportFactory() {
+            return mockTransportFactory;
+          }
+        },
+        null);
+    customBuilder.executorPool = executorPool;
+    customBuilder.channelz = channelz;
+    ManagedChannel mychannel = customBuilder.nameResolverFactory(factory).build();
 
     ClientCall<Void, Void> call1 =
         mychannel.newCall(TestMethodDescriptors.voidMethod(), CallOptions.DEFAULT);
@@ -4022,22 +4027,6 @@ public class ManagedChannelImplTest {
       if (resolvedOobChannel != null) {
         resolvedOobChannel.shutdownNow();
       }
-    }
-  }
-
-  private static final class ChannelBuilder
-      extends AbstractManagedChannelImplBuilder<ChannelBuilder> {
-
-    ChannelBuilder() {
-      super(TARGET);
-    }
-
-    @Override protected ClientTransportFactory buildTransportFactory() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override protected int getDefaultPort() {
-      return DEFAULT_PORT;
     }
   }
 

--- a/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
+++ b/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
@@ -46,6 +46,8 @@ import io.grpc.LoadBalancerRegistry;
 import io.grpc.NameResolver;
 import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.Status;
+import io.grpc.internal.ManagedChannelImplBuilder.ClientTransportFactoryBuilder;
+import io.grpc.internal.ManagedChannelImplBuilder.FixedPortProvider;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.util.ArrayList;
@@ -151,7 +153,7 @@ public class ServiceConfigErrorHandlingTest {
   private ObjectPool<Executor> balancerRpcExecutorPool;
   @Mock
   private Executor blockingExecutor;
-  private ChannelBuilder channelBuilder;
+  private ManagedChannelImplBuilder channelBuilder;
 
   private void createChannel(ClientInterceptor... interceptors) {
     checkState(channel == null);
@@ -197,14 +199,21 @@ public class ServiceConfigErrorHandlingTest {
         .thenReturn(timer.getScheduledExecutorService());
     when(executorPool.getObject()).thenReturn(executor.getScheduledExecutorService());
 
-    channelBuilder =
-        new ChannelBuilder()
-            .nameResolverFactory(new FakeNameResolverFactory.Builder(expectedUri).build())
-            .defaultLoadBalancingPolicy(MOCK_POLICY_NAME)
-            .userAgent(USER_AGENT)
-            .idleTimeout(
-                AbstractManagedChannelImplBuilder.IDLE_MODE_MAX_TIMEOUT_DAYS, TimeUnit.DAYS)
-            .offloadExecutor(blockingExecutor);
+    channelBuilder = new ManagedChannelImplBuilder(TARGET,
+        new ClientTransportFactoryBuilder() {
+          @Override
+          public ClientTransportFactory buildClientTransportFactory() {
+            throw new UnsupportedOperationException();
+          }
+        },
+        new FixedPortProvider(DEFAULT_PORT));
+
+    channelBuilder
+        .nameResolverFactory(new FakeNameResolverFactory.Builder(expectedUri).build())
+        .defaultLoadBalancingPolicy(MOCK_POLICY_NAME)
+        .userAgent(USER_AGENT)
+        .idleTimeout(ManagedChannelImplBuilder.IDLE_MODE_MAX_TIMEOUT_DAYS, TimeUnit.DAYS)
+        .offloadExecutor(blockingExecutor);
     channelBuilder.executorPool = executorPool;
     channelBuilder.binlog = null;
     channelBuilder.channelz = channelz;
@@ -525,22 +534,6 @@ public class ServiceConfigErrorHandlingTest {
     assertThat(newResolvedAddress.getAttributes().get(InternalConfigSelector.KEY))
         .isNull();
     verify(mockLoadBalancer, never()).handleNameResolutionError(any(Status.class));
-  }
-
-  private static final class ChannelBuilder
-      extends AbstractManagedChannelImplBuilder<ChannelBuilder> {
-
-    ChannelBuilder() {
-      super(TARGET);
-    }
-
-    @Override protected ClientTransportFactory buildTransportFactory() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override protected int getDefaultPort() {
-      return DEFAULT_PORT;
-    }
   }
 
   private static final class FakeBackoffPolicyProvider implements BackoffPolicy.Provider {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -27,6 +27,7 @@ import io.grpc.internal.AbstractManagedChannelImplBuilder;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.testing.TestUtils;
 import io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.InternalNettyChannelBuilder;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.okhttp.OkHttpChannelBuilder;
@@ -425,7 +426,9 @@ public class TestServiceClient {
         if (fullStreamDecompression) {
           nettyBuilder.enableFullStreamDecompression();
         }
-        builder = nettyBuilder;
+        // Disable the default census stats interceptor, use testing interceptor instead.
+        InternalNettyChannelBuilder.setStatsEnabled(nettyBuilder, false);
+        return nettyBuilder.intercept(createCensusStatsClientInterceptor());
       } else {
         OkHttpChannelBuilder okBuilder = OkHttpChannelBuilder.forAddress(serverHost, serverPort);
         if (serverHostOverride != null) {

--- a/interop-testing/src/test/java/io/grpc/testing/integration/AutoWindowSizingOnTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/AutoWindowSizingOnTest.java
@@ -17,6 +17,7 @@
 package io.grpc.testing.integration;
 
 import io.grpc.internal.AbstractServerImplBuilder;
+import io.grpc.netty.InternalNettyChannelBuilder;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.NettyServerBuilder;
@@ -39,7 +40,7 @@ public class AutoWindowSizingOnTest extends AbstractInteropTest {
         .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
         .initialFlowControlWindow(NettyChannelBuilder.DEFAULT_FLOW_CONTROL_WINDOW);
     // Disable the default census stats interceptor, use testing interceptor instead.
-    io.grpc.internal.TestingAccessor.setStatsEnabled(builder, false);
+    InternalNettyChannelBuilder.setStatsEnabled(builder, false);
     return builder.intercept(createCensusStatsClientInterceptor());
   }
 }

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
@@ -17,6 +17,7 @@
 package io.grpc.testing.integration;
 
 import io.grpc.internal.AbstractServerImplBuilder;
+import io.grpc.netty.InternalNettyChannelBuilder;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.NettyServerBuilder;
@@ -57,7 +58,7 @@ public class Http2NettyLocalChannelTest extends AbstractInteropTest {
         .flowControlWindow(65 * 1024)
         .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE);
     // Disable the default census stats interceptor, use testing interceptor instead.
-    io.grpc.internal.TestingAccessor.setStatsEnabled(builder, false);
+    InternalNettyChannelBuilder.setStatsEnabled(builder, false);
     return builder.intercept(createCensusStatsClientInterceptor());
   }
 

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNotEquals;
 import io.grpc.internal.AbstractServerImplBuilder;
 import io.grpc.internal.testing.TestUtils;
 import io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.InternalNettyChannelBuilder;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.NettyServerBuilder;
 import io.netty.handler.ssl.ClientAuth;
@@ -71,7 +72,7 @@ public class Http2NettyTest extends AbstractInteropTest {
               .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE)
               .build());
       // Disable the default census stats interceptor, use testing interceptor instead.
-      io.grpc.internal.TestingAccessor.setStatsEnabled(builder, false);
+      InternalNettyChannelBuilder.setStatsEnabled(builder, false);
       return builder.intercept(createCensusStatsClientInterceptor());
     } catch (Exception ex) {
       throw new RuntimeException(ex);

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
@@ -29,6 +29,7 @@ import io.grpc.internal.testing.StreamRecorder;
 import io.grpc.internal.testing.TestUtils;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyServerBuilder;
+import io.grpc.okhttp.InternalOkHttpChannelBuilder;
 import io.grpc.okhttp.OkHttpChannelBuilder;
 import io.grpc.okhttp.internal.Platform;
 import io.grpc.stub.StreamObserver;
@@ -102,7 +103,7 @@ public class Http2OkHttpTest extends AbstractInteropTest {
       throw new RuntimeException(e);
     }
     // Disable the default census stats interceptor, use testing interceptor instead.
-    io.grpc.internal.TestingAccessor.setStatsEnabled(builder, false);
+    InternalOkHttpChannelBuilder.setStatsEnabled(builder, false);
     return builder.intercept(createCensusStatsClientInterceptor());
   }
 

--- a/interop-testing/src/test/java/io/grpc/testing/integration/InProcessTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/InProcessTest.java
@@ -18,6 +18,7 @@ package io.grpc.testing.integration;
 
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.inprocess.InternalInProcessChannelBuilder;
 import io.grpc.internal.AbstractServerImplBuilder;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -38,7 +39,7 @@ public class InProcessTest extends AbstractInteropTest {
   protected InProcessChannelBuilder createChannelBuilder() {
     InProcessChannelBuilder builder = InProcessChannelBuilder.forName(SERVER_NAME);
     // Disable the default census stats interceptor, use testing interceptor instead.
-    io.grpc.internal.TestingAccessor.setStatsEnabled(builder, false);
+    InternalInProcessChannelBuilder.setStatsEnabled(builder, false);
     return builder.intercept(createCensusStatsClientInterceptor());
   }
 

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
@@ -37,6 +37,7 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.internal.AbstractServerImplBuilder;
 import io.grpc.internal.GrpcUtil;
+import io.grpc.netty.InternalNettyChannelBuilder;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.testing.integration.Messages.BoolValue;
@@ -165,7 +166,7 @@ public class TransportCompressionTest extends AbstractInteropTest {
         })
         .usePlaintext();
     // Disable the default census stats interceptor, use testing interceptor instead.
-    io.grpc.internal.TestingAccessor.setStatsEnabled(builder, false);
+    InternalNettyChannelBuilder.setStatsEnabled(builder, false);
     return builder.intercept(createCensusStatsClientInterceptor());
   }
 

--- a/netty/src/main/java/io/grpc/netty/InternalNettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/InternalNettyChannelBuilder.java
@@ -31,12 +31,29 @@ public final class InternalNettyChannelBuilder {
   /**
    * Checks authority upon channel construction.  The purpose of this interface is to raise the
    * visibility of {@link NettyChannelBuilder.OverrideAuthorityChecker}.
+   * @deprecated To be removed, use {@link #disableCheckAuthority(NettyChannelBuilder builder)} to
+   *     disable authority check.
    */
+  @Deprecated
   public interface OverrideAuthorityChecker extends NettyChannelBuilder.OverrideAuthorityChecker {}
 
+  /**
+   * Overrides authority checker.
+   * @deprecated To be removed, use {@link #disableCheckAuthority(NettyChannelBuilder builder)} to
+   *     disable authority check.
+   */
+  @Deprecated
   public static void overrideAuthorityChecker(
       NettyChannelBuilder channelBuilder, OverrideAuthorityChecker authorityChecker) {
     channelBuilder.overrideAuthorityChecker(authorityChecker);
+  }
+
+  public static void disableCheckAuthority(NettyChannelBuilder builder) {
+    builder.disableCheckAuthority();
+  }
+
+  public static void enableCheckAuthority(NettyChannelBuilder builder) {
+    builder.enableCheckAuthority();
   }
 
   /** A class that provides a Netty handler to control protocol negotiation. */
@@ -66,6 +83,10 @@ public final class InternalNettyChannelBuilder {
 
   public static void setStatsRecordStartedRpcs(NettyChannelBuilder builder, boolean value) {
     builder.setStatsRecordStartedRpcs(value);
+  }
+
+  public static void setStatsRecordFinishedRpcs(NettyChannelBuilder builder, boolean value) {
+    builder.setStatsRecordFinishedRpcs(value);
   }
 
   public static void setStatsRecordRealTimeMetrics(NettyChannelBuilder builder, boolean value) {

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -28,15 +28,19 @@ import io.grpc.Attributes;
 import io.grpc.ChannelLogger;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.ExperimentalApi;
+import io.grpc.ForwardingChannelBuilder;
 import io.grpc.HttpConnectProxiedSocketAddress;
 import io.grpc.Internal;
-import io.grpc.internal.AbstractManagedChannelImplBuilder;
+import io.grpc.ManagedChannelBuilder;
 import io.grpc.internal.AtomicBackoff;
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.FixedObjectPool;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.KeepAliveManager;
+import io.grpc.internal.ManagedChannelImplBuilder;
+import io.grpc.internal.ManagedChannelImplBuilder.ChannelBuilderDefaultPortProvider;
+import io.grpc.internal.ManagedChannelImplBuilder.ClientTransportFactoryBuilder;
 import io.grpc.internal.ObjectPool;
 import io.grpc.internal.SharedResourcePool;
 import io.grpc.internal.TransportTracer;
@@ -63,8 +67,7 @@ import javax.net.ssl.SSLException;
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1784")
 @CanIgnoreReturnValue
-public final class NettyChannelBuilder
-    extends AbstractManagedChannelImplBuilder<NettyChannelBuilder> {
+public final class NettyChannelBuilder extends ForwardingChannelBuilder<NettyChannelBuilder> {
 
   // 1MiB.
   public static final int DEFAULT_FLOW_CONTROL_WINDOW = 1024 * 1024;
@@ -85,16 +88,16 @@ public final class NettyChannelBuilder
     DEFAULT_AUTO_FLOW_CONTROL = Boolean.parseBoolean(autoFlowControl);
   }
 
-  private final Map<ChannelOption<?>, Object> channelOptions =
-      new HashMap<>();
-
+  private final ManagedChannelImplBuilder managedChannelImplBuilder;
+  private TransportTracer.Factory transportTracerFactory = TransportTracer.getDefaultFactory();
+  private final Map<ChannelOption<?>, Object> channelOptions = new HashMap<>();
   private NegotiationType negotiationType = NegotiationType.TLS;
-  private OverrideAuthorityChecker authorityChecker;
   private ChannelFactory<? extends Channel> channelFactory = DEFAULT_CHANNEL_FACTORY;
   private ObjectPool<? extends EventLoopGroup> eventLoopGroupPool = DEFAULT_EVENT_LOOP_GROUP_POOL;
   private SslContext sslContext;
   private boolean autoFlowControl = DEFAULT_AUTO_FLOW_CONTROL;
   private int flowControlWindow = DEFAULT_FLOW_CONTROL_WINDOW;
+  private int maxInboundMessageSize = GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
   private int maxHeaderListSize = GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE;
   private long keepAliveTimeNanos = KEEPALIVE_TIME_NANOS_DISABLED;
   private long keepAliveTimeoutNanos = DEFAULT_KEEPALIVE_TIMEOUT_NANOS;
@@ -142,14 +145,39 @@ public final class NettyChannelBuilder
     this(GrpcUtil.authorityFromHostAndPort(host, port));
   }
 
+  private final class NettyChannelTransportFactoryBuilder implements ClientTransportFactoryBuilder {
+    @Override
+    public ClientTransportFactory buildClientTransportFactory() {
+      return buildTransportFactory();
+    }
+  }
+
+  private final class NettyChannelDefaultPortProvider implements ChannelBuilderDefaultPortProvider {
+    @Override
+    public int getDefaultPort() {
+      return NettyChannelBuilder.this.getDefaultPort();
+    }
+  }
+
   @CheckReturnValue
   NettyChannelBuilder(String target) {
-    super(target);
+    managedChannelImplBuilder = new ManagedChannelImplBuilder(target,
+        new NettyChannelTransportFactoryBuilder(),
+        new NettyChannelDefaultPortProvider());
   }
 
   @CheckReturnValue
   NettyChannelBuilder(SocketAddress address) {
-    super(address, getAuthorityFromAddress(address));
+    managedChannelImplBuilder = new ManagedChannelImplBuilder(address,
+        getAuthorityFromAddress(address),
+        new NettyChannelTransportFactoryBuilder(),
+        new NettyChannelDefaultPortProvider());
+  }
+
+  @Internal
+  @Override
+  protected ManagedChannelBuilder<?> delegate() {
+    return managedChannelImplBuilder;
   }
 
   @CheckReturnValue
@@ -408,10 +436,20 @@ public final class NettyChannelBuilder
     }
   }
 
+  /**
+   * Sets the maximum message size allowed for a single gRPC frame. If an inbound messages larger
+   * than this limit is received it will not be processed and the RPC will fail with
+   * RESOURCE_EXHAUSTED.
+   */
   @Override
+  public NettyChannelBuilder maxInboundMessageSize(int max) {
+    checkArgument(max >= 0, "negative max");
+    maxInboundMessageSize = max;
+    return this;
+  }
+
   @CheckReturnValue
-  @Internal
-  protected ClientTransportFactory buildTransportFactory() {
+  ClientTransportFactory buildTransportFactory() {
     assertEventLoopAndChannelType();
 
     ProtocolNegotiator negotiator;
@@ -427,12 +465,12 @@ public final class NettyChannelBuilder
         }
       }
       negotiator = createProtocolNegotiatorByType(negotiationType, localSslContext,
-          this.getOffloadExecutorPool());
+          this.managedChannelImplBuilder.getOffloadExecutorPool());
     }
 
     return new NettyTransportFactory(
         negotiator, channelFactory, channelOptions,
-        eventLoopGroupPool, autoFlowControl, flowControlWindow, maxInboundMessageSize(),
+        eventLoopGroupPool, autoFlowControl, flowControlWindow, maxInboundMessageSize,
         maxHeaderListSize, keepAliveTimeNanos, keepAliveTimeoutNanos, keepAliveWithoutCalls,
         transportTracerFactory, localSocketPicker, useGetForSafeMethods);
   }
@@ -448,9 +486,8 @@ public final class NettyChannelBuilder
         "Both EventLoopGroup and ChannelType should be provided or neither should be");
   }
 
-  @Override
   @CheckReturnValue
-  protected int getDefaultPort() {
+  int getDefaultPort() {
     switch (negotiationType) {
       case PLAINTEXT:
       case PLAINTEXT_UPGRADE:
@@ -460,10 +497,6 @@ public final class NettyChannelBuilder
       default:
         throw new AssertionError(negotiationType + " not handled");
     }
-  }
-
-  void overrideAuthorityChecker(@Nullable OverrideAuthorityChecker authorityChecker) {
-    this.authorityChecker = authorityChecker;
   }
 
   @VisibleForTesting
@@ -484,19 +517,22 @@ public final class NettyChannelBuilder
     }
   }
 
-  @CheckReturnValue
-  interface OverrideAuthorityChecker {
-    String checkAuthority(String authority);
+  @Deprecated
+  interface OverrideAuthorityChecker extends ManagedChannelImplBuilder.OverrideAuthorityChecker {}
+
+  @Deprecated
+  void overrideAuthorityChecker(@Nullable OverrideAuthorityChecker authorityChecker) {
+    this.managedChannelImplBuilder.overrideAuthorityChecker(authorityChecker);
   }
 
-  @Override
-  @CheckReturnValue
-  @Internal
-  protected String checkAuthority(String authority) {
-    if (authorityChecker != null) {
-      return authorityChecker.checkAuthority(authority);
-    }
-    return super.checkAuthority(authority);
+  NettyChannelBuilder disableCheckAuthority() {
+    this.managedChannelImplBuilder.disableCheckAuthority();
+    return this;
+  }
+
+  NettyChannelBuilder enableCheckAuthority() {
+    this.managedChannelImplBuilder.enableCheckAuthority();
+    return this;
   }
 
   void protocolNegotiatorFactory(ProtocolNegotiatorFactory protocolNegotiatorFactory) {
@@ -504,24 +540,24 @@ public final class NettyChannelBuilder
         = checkNotNull(protocolNegotiatorFactory, "protocolNegotiatorFactory");
   }
 
-  @Override
-  protected void setTracingEnabled(boolean value) {
-    super.setTracingEnabled(value);
+  void setTracingEnabled(boolean value) {
+    this.managedChannelImplBuilder.setTracingEnabled(value);
   }
 
-  @Override
-  protected void setStatsEnabled(boolean value) {
-    super.setStatsEnabled(value);
+  void setStatsEnabled(boolean value) {
+    this.managedChannelImplBuilder.setStatsEnabled(value);
   }
 
-  @Override
-  protected void setStatsRecordStartedRpcs(boolean value) {
-    super.setStatsRecordStartedRpcs(value);
+  void setStatsRecordStartedRpcs(boolean value) {
+    this.managedChannelImplBuilder.setStatsRecordStartedRpcs(value);
   }
 
-  @Override
-  protected void setStatsRecordRealTimeMetrics(boolean value) {
-    super.setStatsRecordRealTimeMetrics(value);
+  void setStatsRecordFinishedRpcs(boolean value) {
+    this.managedChannelImplBuilder.setStatsRecordFinishedRpcs(value);
+  }
+
+  void setStatsRecordRealTimeMetrics(boolean value) {
+    this.managedChannelImplBuilder.setStatsRecordRealTimeMetrics(value);
   }
 
   @VisibleForTesting

--- a/okhttp/src/main/java/io/grpc/okhttp/InternalOkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/InternalOkHttpChannelBuilder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.okhttp;
+
+import io.grpc.Internal;
+
+/**
+ * Internal {@link OkHttpChannelBuilder} accessor.  This is intended for usage internal to the gRPC
+ * team.  If you *really* think you need to use this, contact the gRPC team first.
+ */
+@Internal
+public final class InternalOkHttpChannelBuilder {
+
+  public static void setStatsEnabled(OkHttpChannelBuilder builder, boolean value) {
+    builder.setStatsEnabled(value);
+  }
+
+  private InternalOkHttpChannelBuilder() {}
+}

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
@@ -72,20 +72,26 @@ public class OkHttpChannelBuilderTest {
   }
 
   @Test
-  public void overrideAllowsInvalidAuthority() {
-    OkHttpChannelBuilder builder = new OkHttpChannelBuilder("good", 1234) {
-      @Override
-      protected String checkAuthority(String authority) {
-        return authority;
-      }
-    };
+  public void failOverrideInvalidAuthority() {
+    OkHttpChannelBuilder builder = new OkHttpChannelBuilder("good", 1234);
 
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Invalid authority:");
+    builder.overrideAuthority("[invalidauthority");
+  }
+
+  @Test
+  public void disableCheckAuthorityAllowsInvalidAuthority() {
+    OkHttpChannelBuilder builder = new OkHttpChannelBuilder("good", 1234)
+        .disableCheckAuthority();
     builder.overrideAuthority("[invalidauthority").usePlaintext().buildTransportFactory();
   }
 
   @Test
-  public void failOverrideInvalidAuthority() {
-    OkHttpChannelBuilder builder = new OkHttpChannelBuilder("good", 1234);
+  public void enableCheckAuthorityFailOverrideInvalidAuthority() {
+    OkHttpChannelBuilder builder = new OkHttpChannelBuilder("good", 1234)
+        .disableCheckAuthority()
+        .enableCheckAuthority();
 
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Invalid authority:");

--- a/testing/src/main/java/io/grpc/internal/TestingAccessor.java
+++ b/testing/src/main/java/io/grpc/internal/TestingAccessor.java
@@ -20,13 +20,6 @@ package io.grpc.internal;
  * Test helper that allows accessing package-private stuff.
  */
 public final class TestingAccessor {
-  /**
-   * Disable or enable client side census stats features.
-   */
-  public static void setStatsEnabled(
-      AbstractManagedChannelImplBuilder<?> builder, boolean statsEnabled) {
-    builder.setStatsEnabled(statsEnabled);
-  }
 
   /**
    * Disable or enable server side census stats features.


### PR DESCRIPTION
The first part of #7211: Hide `AbstractManagedChannelImplBuilder` from public API.

### Note to reviewers
I broke down changes into more-or-less logically encapsulated commits. It might be more convenient to review them one by one. An exception is `Internal*ChannelBuilder` classes, their purpose becomes clear only in commit `interop-testing, testing: setup channels with internal channel builders`. 