### PR TITLE
core: fix pending call not drained when shutdown

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -783,6 +783,10 @@ final class ManagedChannelImpl extends ManagedChannel implements
       public void run() {
         channelLogger.log(ChannelLogLevel.INFO, "Entering SHUTDOWN state");
         channelStateManager.gotoState(SHUTDOWN);
+        if (configSelector.get() == INITIAL_PENDING_SELECTOR) {
+          configSelector.set(null);
+          drainPendingCalls();
+        }
       }
     }
 
@@ -1919,10 +1923,6 @@ final class ManagedChannelImpl extends ManagedChannel implements
     @Override
     public void transportShutdown(Status s) {
       checkState(shutdown.get(), "Channel must have been shut down");
-      if (configSelector.get() == INITIAL_PENDING_SELECTOR) {
-        configSelector.set(null);
-        drainPendingCalls();
-      }
     }
 
     @Override

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1000,13 +1000,12 @@ final class ManagedChannelImpl extends ManagedChannel implements
           if (configSelector.get() == INITIAL_PENDING_SELECTOR) {
             configSelector.set(null);
           }
-          if (pendingCalls == null) {
-            uncommittedRetriableStreamsRegistry.onShutdownNow(SHUTDOWN_NOW_STATUS);
-          } else {
+          if (pendingCalls != null) {
             for (RealChannel.PendingCall<?, ?> pendingCall : pendingCalls) {
               pendingCall.cancel("Channel is forcefully shutdown", null);
             }
           }
+          uncommittedRetriableStreamsRegistry.onShutdownNow(SHUTDOWN_NOW_STATUS);
           maybeShutdownNowSubchannels();
         }
       }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1066,9 +1066,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
             if (pendingCalls.isEmpty()) {
               inUseStateAggregator.updateObjectInUse(pendingCallsInUseObject, false);
               pendingCalls = null;
-              if (shutdownNowed) {
-                uncommittedRetriableStreamsRegistry.onShutdownNow(SHUTDOWN_NOW_STATUS);
-              } else if (shutdown.get()) {
+              if (shutdown.get()) {
                 uncommittedRetriableStreamsRegistry.onShutdown(SHUTDOWN_STATUS);
               }
             }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -553,10 +553,11 @@ public class ManagedChannelImplTest {
     createChannel();
     ClientCall<String, Integer> call = channel.newCall(method, CallOptions.DEFAULT);
     call.start(mockCallListener, new Metadata());
+    verify(mockCallListener, never()).onClose(any(Status.class), any(Metadata.class));
     channel.shutdown();
-    assertTrue(channel.isShutdown());
     executor.runDueTasks();
-    verify(mockCallListener).onClose(any(Status.class), any(Metadata.class));
+    verify(mockCallListener).onClose(statusCaptor.capture(), any(Metadata.class));
+    assertThat(statusCaptor.getValue().getCode()).isEqualTo(Code.UNAVAILABLE);
   }
 
   @Test
@@ -571,7 +572,8 @@ public class ManagedChannelImplTest {
     ClientCall<String, Integer> call = channel.newCall(method, CallOptions.DEFAULT);
     call.start(mockCallListener, new Metadata());
     executor.runDueTasks();
-    verify(mockCallListener).onClose(any(Status.class), any(Metadata.class));
+    verify(mockCallListener).onClose(statusCaptor.capture(), any(Metadata.class));
+    assertThat(statusCaptor.getValue().getCode()).isEqualTo(Code.UNAVAILABLE);
   }
 
   @Test


### PR DESCRIPTION
There was bug that new pending calls were not drained after channel is shutdown. The bug was worked around by #7354 .

Fixing by making sure new calls fail immediately if the channel is already shutdown.

The tests added will be breaking if #7354 is simply reverted without fix.