### PR TITLE
build.gradle: do not add generated code into project SourceSets

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,10 +123,8 @@ subprojects {
                         release { java { srcDir "${generatedSourcePath}/release/grpc" } }
                     }
                 } else {
-                    project.sourceSets {
-                        main { java { srcDir "${generatedSourcePath}/main/grpc" } }
-                        test { java { srcDir "${generatedSourcePath}/test/grpc" } }
-                    }
+                    project.compileJava.source "${generatedSourcePath}/main/grpc"
+                    project.compileTestJava.source "${generatedSourcePath}/test/grpc"
                 }
             }
 


### PR DESCRIPTION
Adding generated code directly into the project source sets pollutes the source sets, which causes build tasks (e.g., Javadoc) depending on the source sets include the generated code as well. Instead, if we only feed them to the compilation tasks, they are used as internal implementations.

- [ ] FIXME: `gae-interop-testing-jdk8` may have some dependency problem that causes Javadoc fail.


`grpc-android` and `grpc-cronet` are not using protos, `grpc-android-interop-testing` (an application) uses protos but it is not published. So are may probably be fine not configure it for Android. If we do need, it might be a bit trickier. 

