### PR TITLE
Explain test value for flow control window

### DIFF
--- a/core/src/test/java/io/grpc/internal/AbstractTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractTransportTest.java
@@ -89,6 +89,12 @@ import org.mockito.InOrder;
 /** Standard unit tests for {@link ClientTransport}s and {@link ServerTransport}s. */
 @RunWith(JUnit4.class)
 public abstract class AbstractTransportTest {
+  /**
+   * Use a small flow control to help detect flow control bugs. Don't use 64KiB to test
+   * SETTINGS/WINDOW_UPDATE exchange.
+   */
+  public static final int TEST_FLOW_CONTROL_WINDOW = 65 * 1024;
+
   private static final int TIMEOUT_MS = 5000;
 
   private static final Attributes.Key<String> ADDITIONAL_TRANSPORT_ATTR_KEY =

--- a/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/NettyClientInteropServlet.java
+++ b/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/NettyClientInteropServlet.java
@@ -134,7 +134,8 @@ public final class NettyClientInteropServlet extends HttpServlet {
           ManagedChannelBuilder.forTarget(INTEROP_TEST_ADDRESS)
               .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE);
       assertTrue(builder instanceof NettyChannelBuilder);
-      ((NettyChannelBuilder) builder).flowControlWindow(65 * 1024);
+      ((NettyChannelBuilder) builder)
+          .flowControlWindow(AbstractInteropTest.TEST_FLOW_CONTROL_WINDOW);
       return builder;
     }
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -148,6 +148,12 @@ public abstract class AbstractInteropTest {
   /** Must be at least {@link #unaryPayloadLength()}, plus some to account for encoding overhead. */
   public static final int MAX_MESSAGE_SIZE = 16 * 1024 * 1024;
 
+  /**
+   * Use a small flow control to help detect flow control bugs. Don't use 64KiB to test
+   * SETTINGS/WINDOW_UPDATE exchange.
+   */
+  public static final int TEST_FLOW_CONTROL_WINDOW = 65 * 1024;
+
   private static final FakeTagger tagger = new FakeTagger();
   private static final FakeTagContextBinarySerializer tagContextBinarySerializer =
       new FakeTagContextBinarySerializer();

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -416,7 +416,7 @@ public class TestServiceClient {
         }
         NettyChannelBuilder nettyBuilder =
             NettyChannelBuilder.forAddress(serverHost, serverPort)
-                .flowControlWindow(65 * 1024)
+                .flowControlWindow(AbstractInteropTest.TEST_FLOW_CONTROL_WINDOW)
                 .negotiationType(useTls ? NegotiationType.TLS :
                   (useH2cUpgrade ? NegotiationType.PLAINTEXT_UPGRADE : NegotiationType.PLAINTEXT))
                 .sslContext(sslContext);

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
@@ -41,7 +41,7 @@ public class Http2NettyLocalChannelTest extends AbstractInteropTest {
   protected AbstractServerImplBuilder<?> getServerBuilder() {
     return NettyServerBuilder
         .forAddress(new LocalAddress("in-process-1"))
-        .flowControlWindow(65 * 1024)
+        .flowControlWindow(AbstractInteropTest.TEST_FLOW_CONTROL_WINDOW)
         .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
         .channelType(LocalServerChannel.class)
         .workerEventLoopGroup(eventLoopGroup)
@@ -55,7 +55,7 @@ public class Http2NettyLocalChannelTest extends AbstractInteropTest {
         .negotiationType(NegotiationType.PLAINTEXT)
         .channelType(LocalChannel.class)
         .eventLoopGroup(eventLoopGroup)
-        .flowControlWindow(65 * 1024)
+        .flowControlWindow(AbstractInteropTest.TEST_FLOW_CONTROL_WINDOW)
         .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE);
     // Disable the default census stats interceptor, use testing interceptor instead.
     InternalNettyChannelBuilder.setStatsEnabled(builder, false);

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
@@ -45,7 +45,7 @@ public class Http2NettyTest extends AbstractInteropTest {
     // Starts the server with HTTPS.
     try {
       return NettyServerBuilder.forPort(0)
-          .flowControlWindow(65 * 1024)
+          .flowControlWindow(AbstractInteropTest.TEST_FLOW_CONTROL_WINDOW)
           .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
           .sslContext(GrpcSslContexts
               .forServer(TestUtils.loadCert("server1.pem"), TestUtils.loadCert("server1.key"))
@@ -63,7 +63,7 @@ public class Http2NettyTest extends AbstractInteropTest {
     try {
       NettyChannelBuilder builder = NettyChannelBuilder
           .forAddress(TestUtils.testServerAddress((InetSocketAddress) getListenAddress()))
-          .flowControlWindow(65 * 1024)
+          .flowControlWindow(AbstractInteropTest.TEST_FLOW_CONTROL_WINDOW)
           .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
           .sslContext(GrpcSslContexts
               .forClient()

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
@@ -78,7 +78,7 @@ public class Http2OkHttpTest extends AbstractInteropTest {
       GrpcSslContexts.configure(contextBuilder, sslProvider);
       contextBuilder.ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE);
       return NettyServerBuilder.forPort(0)
-          .flowControlWindow(65 * 1024)
+          .flowControlWindow(AbstractInteropTest.TEST_FLOW_CONTROL_WINDOW)
           .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
           .sslContext(contextBuilder.build());
     } catch (IOException ex) {

--- a/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
@@ -47,7 +47,7 @@ public class NettyTransportTest extends AbstractTransportTest {
   private final ClientTransportFactory clientFactory = NettyChannelBuilder
       // Although specified here, address is ignored because we never call build.
       .forAddress("localhost", 0)
-      .flowControlWindow(65 * 1024)
+      .flowControlWindow(AbstractTransportTest.TEST_FLOW_CONTROL_WINDOW)
       .negotiationType(NegotiationType.PLAINTEXT)
       .setTransportTracerFactory(fakeClockTransportTracer)
       .buildTransportFactory();
@@ -67,7 +67,7 @@ public class NettyTransportTest extends AbstractTransportTest {
       List<ServerStreamTracer.Factory> streamTracerFactories) {
     return NettyServerBuilder
         .forAddress(new InetSocketAddress("localhost", 0))
-        .flowControlWindow(65 * 1024)
+        .flowControlWindow(AbstractTransportTest.TEST_FLOW_CONTROL_WINDOW)
         .setTransportTracerFactory(fakeClockTransportTracer)
         .buildTransportServers(streamTracerFactories);
   }
@@ -77,7 +77,7 @@ public class NettyTransportTest extends AbstractTransportTest {
       int port, List<ServerStreamTracer.Factory> streamTracerFactories) {
     return NettyServerBuilder
         .forAddress(new InetSocketAddress("localhost", port))
-        .flowControlWindow(65 * 1024)
+        .flowControlWindow(AbstractTransportTest.TEST_FLOW_CONTROL_WINDOW)
         .setTransportTracerFactory(fakeClockTransportTracer)
         .buildTransportServers(streamTracerFactories);
   }

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
@@ -56,7 +56,7 @@ public class OkHttpTransportTest extends AbstractTransportTest {
     return AccessProtectedHack.serverBuilderBuildTransportServer(
         NettyServerBuilder
             .forPort(0)
-            .flowControlWindow(65 * 1024),
+            .flowControlWindow(AbstractTransportTest.TEST_FLOW_CONTROL_WINDOW),
         streamTracerFactories,
         fakeClockTransportTracer);
   }
@@ -67,7 +67,7 @@ public class OkHttpTransportTest extends AbstractTransportTest {
     return AccessProtectedHack.serverBuilderBuildTransportServer(
         NettyServerBuilder
             .forAddress(new InetSocketAddress(port))
-            .flowControlWindow(65 * 1024),
+            .flowControlWindow(AbstractTransportTest.TEST_FLOW_CONTROL_WINDOW),
         streamTracerFactories,
         fakeClockTransportTracer);
   }


### PR DESCRIPTION
Move `65 * 1024` used in tests to a constant, and explain the reasoning behind this specific choice.