### PR TITLE
okhttp: allow disable check authority via internal channel builder

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/InternalOkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/InternalOkHttpChannelBuilder.java
@@ -29,5 +29,13 @@ public final class InternalOkHttpChannelBuilder {
     builder.setStatsEnabled(value);
   }
 
+  public static void disableCheckAuthority(OkHttpChannelBuilder builder) {
+    builder.disableCheckAuthority();
+  }
+
+  public static void enableCheckAuthority(OkHttpChannelBuilder builder) {
+    builder.enableCheckAuthority();
+  }
+
   private InternalOkHttpChannelBuilder() {}
 }


### PR DESCRIPTION
Allow tests to control OKHttp authority check via `InternalOkHttpChannelBuilder`.