### PR TITLE
xds: make channel creds required in bootstrap file

### DIFF
--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -101,19 +101,19 @@ public abstract class Bootstrapper {
       logger.log(XdsLogLevel.INFO, "xDS server URI: {0}", serverUri);
       List<ChannelCreds> channelCredsOptions = new ArrayList<>();
       List<?> rawChannelCredsList = JsonUtil.getList(serverConfig, "channel_creds");
-      // List of channel creds is optional.
-      if (rawChannelCredsList != null) {
-        List<Map<String, ?>> channelCredsList = JsonUtil.checkObjectList(rawChannelCredsList);
-        for (Map<String, ?> channelCreds : channelCredsList) {
-          String type = JsonUtil.getString(channelCreds, "type");
-          if (type == null) {
-            throw new IOException("Invalid bootstrap: 'xds_servers' contains server with "
-                + "unknown type 'channel_creds'.");
-          }
-          logger.log(XdsLogLevel.INFO, "Channel credentials option: {0}", type);
-          ChannelCreds creds = new ChannelCreds(type, JsonUtil.getObject(channelCreds, "config"));
-          channelCredsOptions.add(creds);
+      if (rawChannelCredsList == null) {
+        throw new IOException("Invalid bootstrap: 'channel_creds' required");
+      }
+      List<Map<String, ?>> channelCredsList = JsonUtil.checkObjectList(rawChannelCredsList);
+      for (Map<String, ?> channelCreds : channelCredsList) {
+        String type = JsonUtil.getString(channelCreds, "type");
+        if (type == null) {
+          throw new IOException("Invalid bootstrap: 'xds_servers' contains server with "
+              + "unknown type 'channel_creds'.");
         }
+        logger.log(XdsLogLevel.INFO, "Channel credentials option: {0}", type);
+        ChannelCreds creds = new ChannelCreds(type, JsonUtil.getObject(channelCreds, "config"));
+        channelCredsOptions.add(creds);
       }
       List<String> serverFeatures = JsonUtil.getListOfStrings(serverConfig, "server_features");
       if (serverFeatures != null) {

--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -102,14 +102,15 @@ public abstract class Bootstrapper {
       List<ChannelCreds> channelCredsOptions = new ArrayList<>();
       List<?> rawChannelCredsList = JsonUtil.getList(serverConfig, "channel_creds");
       if (rawChannelCredsList == null || rawChannelCredsList.isEmpty()) {
-        throw new IOException("Invalid bootstrap: 'channel_creds' required");
+        throw new IOException(
+            "Invalid bootstrap: server " + serverUri + " 'channel_creds' required");
       }
       List<Map<String, ?>> channelCredsList = JsonUtil.checkObjectList(rawChannelCredsList);
       for (Map<String, ?> channelCreds : channelCredsList) {
         String type = JsonUtil.getString(channelCreds, "type");
         if (type == null) {
-          throw new IOException("Invalid bootstrap: 'xds_servers' contains server with "
-              + "unknown type 'channel_creds'.");
+          throw new IOException(
+              "Invalid bootstrap: server " + serverUri + " with 'channel_creds' type unspecified");
         }
         logger.log(XdsLogLevel.INFO, "Channel credentials option: {0}", type);
         ChannelCreds creds = new ChannelCreds(type, JsonUtil.getObject(channelCreds, "config"));

--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -101,7 +101,7 @@ public abstract class Bootstrapper {
       logger.log(XdsLogLevel.INFO, "xDS server URI: {0}", serverUri);
       List<ChannelCreds> channelCredsOptions = new ArrayList<>();
       List<?> rawChannelCredsList = JsonUtil.getList(serverConfig, "channel_creds");
-      if (rawChannelCredsList == null) {
+      if (rawChannelCredsList == null || rawChannelCredsList.isEmpty()) {
         throw new IOException("Invalid bootstrap: 'channel_creds' required");
       }
       List<Map<String, ?>> channelCredsList = JsonUtil.checkObjectList(rawChannelCredsList);

--- a/xds/src/test/java/io/grpc/xds/BootstrapperTest.java
+++ b/xds/src/test/java/io/grpc/xds/BootstrapperTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Iterables;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.GrpcUtil.GrpcBuildVersion;
 import io.grpc.xds.Bootstrapper.BootstrapInfo;
+import io.grpc.xds.Bootstrapper.ChannelCreds;
 import io.grpc.xds.Bootstrapper.ServerInfo;
 import io.grpc.xds.EnvoyProtoData.Locality;
 import io.grpc.xds.EnvoyProtoData.Node;
@@ -234,7 +235,10 @@ public class BootstrapperTest {
     String rawData = "{\n"
         + "  \"xds_servers\": [\n"
         + "    {\n"
-        + "      \"server_uri\": \"trafficdirector.googleapis.com:443\"\n"
+        + "      \"server_uri\": \"trafficdirector.googleapis.com:443\",\n"
+        + "      \"channel_creds\": [\n"
+        + "        {\"type\": \"insecure\"}\n"
+        + "      ]\n"
         + "    }\n"
         + "  ]\n"
         + "}";
@@ -243,7 +247,10 @@ public class BootstrapperTest {
     assertThat(info.getServers()).hasSize(1);
     ServerInfo serverInfo = Iterables.getOnlyElement(info.getServers());
     assertThat(serverInfo.getServerUri()).isEqualTo("trafficdirector.googleapis.com:443");
-    assertThat(serverInfo.getChannelCredentials()).isEmpty();
+    assertThat(serverInfo.getChannelCredentials()).hasSize(1);
+    ChannelCreds creds = Iterables.getOnlyElement(serverInfo.getChannelCredentials());
+    assertThat(creds.getType()).isEqualTo("insecure");
+    assertThat(creds.getConfig()).isNull();
     assertThat(info.getNode()).isEqualTo(getNodeBuilder().build());
   }
 

--- a/xds/src/test/java/io/grpc/xds/BootstrapperTest.java
+++ b/xds/src/test/java/io/grpc/xds/BootstrapperTest.java
@@ -122,7 +122,9 @@ public class BootstrapperTest {
         + "    },\n"
         + "    {\n"
         + "      \"server_uri\": \"trafficdirector-bar.googleapis.com:443\",\n"
-        + "      \"channel_creds\": []\n"
+        + "      \"channel_creds\": [\n"
+        + "        {\"type\": \"insecure\"}"
+        + "      ]\n"
         + "    }\n"
         + "  ]\n"
         + "}";
@@ -143,7 +145,9 @@ public class BootstrapperTest {
     assertThat(serverInfoList.get(0).getServerFeatures()).contains("xds_v3");
     assertThat(serverInfoList.get(1).getServerUri())
         .isEqualTo("trafficdirector-bar.googleapis.com:443");
-    assertThat(serverInfoList.get(1).getChannelCredentials()).isEmpty();
+    assertThat(serverInfoList.get(1).getChannelCredentials().get(0).getType())
+        .isEqualTo("insecure");
+    assertThat(serverInfoList.get(0).getChannelCredentials().get(0).getConfig()).isNull();
     assertThat(info.getNode()).isEqualTo(
         getNodeBuilder()
             .setId("ENVOY_NODE_ID")


### PR DESCRIPTION
This PR only adds validation to the bootstrap file to require users specify at least one channel creds configuration.

In a following up PR, creating the xDS channel will select the first supported channel creds and fail (e.g., an exception thrown) to create the channel if none is supported (instead of failing back to use parent channel's channel creds). Need to clean up the interfaces for creating XdsClient/Channel.


Also, Ideally I am thinking about having a `BootstrapException`. Using `IOException` is not accurate here.