### PR TITLE
okhttp: Keep checkAuthority() for backward compatibility

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -169,7 +169,6 @@ public class OkHttpChannelBuilder extends ForwardingChannelBuilder<OkHttpChannel
     managedChannelImplBuilder.overrideAuthorityChecker(
         new io.grpc.internal.ManagedChannelImplBuilder.OverrideAuthorityChecker() {
           @Override
-          @SuppressWarnings("deprecation")
           public String checkAuthority(String authority) {
             return OkHttpChannelBuilder.this.checkAuthority(authority);
           }
@@ -434,7 +433,6 @@ public class OkHttpChannelBuilder extends ForwardingChannelBuilder<OkHttpChannel
         useGetForSafeMethods);
   }
 
-  @Deprecated
   protected String checkAuthority(String authority) {
     return GrpcUtil.checkAuthority(authority);
   }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -35,7 +35,6 @@ import io.grpc.internal.KeepAliveManager;
 import io.grpc.internal.ManagedChannelImplBuilder;
 import io.grpc.internal.ManagedChannelImplBuilder.ChannelBuilderDefaultPortProvider;
 import io.grpc.internal.ManagedChannelImplBuilder.ClientTransportFactoryBuilder;
-import io.grpc.internal.ManagedChannelImplBuilder.OverrideAuthorityChecker;
 import io.grpc.internal.SharedResourceHolder;
 import io.grpc.internal.SharedResourceHolder.Resource;
 import io.grpc.internal.TransportTracer;
@@ -147,6 +146,7 @@ public class OkHttpChannelBuilder extends ForwardingChannelBuilder<OkHttpChannel
     this(GrpcUtil.authorityFromHostAndPort(host, port));
   }
 
+  @SuppressWarnings("deprecation")
   private OkHttpChannelBuilder(String target) {
     final class OkHttpChannelTransportFactoryBuilder implements ClientTransportFactoryBuilder {
       @Override
@@ -166,12 +166,14 @@ public class OkHttpChannelBuilder extends ForwardingChannelBuilder<OkHttpChannel
         new OkHttpChannelTransportFactoryBuilder(),
         new OkHttpChannelDefaultPortProvider());
 
-    managedChannelImplBuilder.overrideAuthorityChecker(new OverrideAuthorityChecker() {
-      @Override
-      public String checkAuthority(String authority) {
-        return OkHttpChannelBuilder.this.checkAuthority(authority);
-      }
-    });
+    managedChannelImplBuilder.overrideAuthorityChecker(
+        new io.grpc.internal.ManagedChannelImplBuilder.OverrideAuthorityChecker() {
+          @Override
+          @SuppressWarnings("deprecation")
+          public String checkAuthority(String authority) {
+            return OkHttpChannelBuilder.this.checkAuthority(authority);
+          }
+        });
   }
 
   @Internal

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -35,6 +35,7 @@ import io.grpc.internal.KeepAliveManager;
 import io.grpc.internal.ManagedChannelImplBuilder;
 import io.grpc.internal.ManagedChannelImplBuilder.ChannelBuilderDefaultPortProvider;
 import io.grpc.internal.ManagedChannelImplBuilder.ClientTransportFactoryBuilder;
+import io.grpc.internal.ManagedChannelImplBuilder.OverrideAuthorityChecker;
 import io.grpc.internal.SharedResourceHolder;
 import io.grpc.internal.SharedResourceHolder.Resource;
 import io.grpc.internal.TransportTracer;
@@ -164,6 +165,13 @@ public class OkHttpChannelBuilder extends ForwardingChannelBuilder<OkHttpChannel
     managedChannelImplBuilder = new ManagedChannelImplBuilder(target,
         new OkHttpChannelTransportFactoryBuilder(),
         new OkHttpChannelDefaultPortProvider());
+
+    managedChannelImplBuilder.overrideAuthorityChecker(new OverrideAuthorityChecker() {
+      @Override
+      public String checkAuthority(String authority) {
+        return OkHttpChannelBuilder.this.checkAuthority(authority);
+      }
+    });
   }
 
   @Internal
@@ -422,6 +430,11 @@ public class OkHttpChannelBuilder extends ForwardingChannelBuilder<OkHttpChannel
         maxInboundMetadataSize,
         transportTracerFactory,
         useGetForSafeMethods);
+  }
+
+  @Deprecated
+  protected String checkAuthority(String authority) {
+    return GrpcUtil.checkAuthority(authority);
   }
 
   final OkHttpChannelBuilder disableCheckAuthority() {

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
@@ -81,6 +81,18 @@ public class OkHttpChannelBuilderTest {
   }
 
   @Test
+  @Deprecated
+  public void checkAuthorityOverrideAllowsInvalidAuthority() {
+    OkHttpChannelBuilder builder = new OkHttpChannelBuilder("good", 1234) {
+      @Override
+      protected String checkAuthority(String authority) {
+        return authority;
+      }
+    };
+    builder.overrideAuthority("[invalidauthority").usePlaintext().buildTransportFactory();
+  }
+
+  @Test
   public void disableCheckAuthorityAllowsInvalidAuthority() {
     OkHttpChannelBuilder builder = new OkHttpChannelBuilder("good", 1234)
         .disableCheckAuthority();

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
@@ -81,7 +81,6 @@ public class OkHttpChannelBuilderTest {
   }
 
   @Test
-  @Deprecated
   public void checkAuthorityOverrideAllowsInvalidAuthority() {
     OkHttpChannelBuilder builder = new OkHttpChannelBuilder("good", 1234) {
       @Override


### PR DESCRIPTION
Keep deprecated `OkHttpChannelBuilder.checkAuthority()` for backward compatibility.