### PR TITLE
xds: fail to create xDS channel if no server with supported channel creds found

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsChannelFactory.java
+++ b/xds/src/main/java/io/grpc/xds/XdsChannelFactory.java
@@ -16,8 +16,6 @@
 
 package io.grpc.xds;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -44,7 +42,9 @@ abstract class XdsChannelFactory {
      */
     @Override
     XdsChannel createChannel(List<ServerInfo> servers) throws XdsInitializationException {
-      checkArgument(!servers.isEmpty(), "No management server provided.");
+      if (servers.isEmpty()) {
+        throw new XdsInitializationException("No server provided");
+      }
       XdsLogger logger = XdsLogger.withPrefix("xds-client-channel-factory");
       ServerInfo serverInfo = servers.get(0);
       String serverUri = serverInfo.getServerUri();

--- a/xds/src/main/java/io/grpc/xds/XdsChannelFactory.java
+++ b/xds/src/main/java/io/grpc/xds/XdsChannelFactory.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.alts.GoogleDefaultChannelBuilder;
+import io.grpc.xds.Bootstrapper.ChannelCreds;
+import io.grpc.xds.Bootstrapper.ServerInfo;
+import io.grpc.xds.XdsClient.XdsChannel;
+import io.grpc.xds.XdsLogger.XdsLogLevel;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Factory for creating channels to xDS severs.
+ */
+abstract class XdsChannelFactory {
+  @VisibleForTesting
+  static boolean experimentalV3SupportEnvVar = Boolean.parseBoolean(
+      System.getenv("GRPC_XDS_EXPERIMENTAL_V3_SUPPORT"));
+
+  private static final String XDS_V3_SERVER_FEATURE = "xds_v3";
+  private static final XdsChannelFactory DEFAULT_INSTANCE = new XdsChannelFactory() {
+    /**
+     * Creates a channel to the first server in the given list.
+     */
+    @Override
+    XdsChannel createChannel(List<ServerInfo> servers) throws XdsInitializationException {
+      checkArgument(!servers.isEmpty(), "No management server provided.");
+      XdsLogger logger = XdsLogger.withPrefix("xds-client-channel-factory");
+      ServerInfo serverInfo = servers.get(0);
+      String serverUri = serverInfo.getServerUri();
+      logger.log(XdsLogLevel.INFO, "Creating channel to {0}", serverUri);
+      List<ChannelCreds> channelCredsList = serverInfo.getChannelCredentials();
+      ManagedChannelBuilder<?> channelBuilder = null;
+      // Use the first supported channel credentials configuration.
+      for (ChannelCreds creds : channelCredsList) {
+        switch (creds.getType()) {
+          case "google_default":
+            logger.log(XdsLogLevel.INFO, "Using channel credentials: google_default");
+            channelBuilder = GoogleDefaultChannelBuilder.forTarget(serverUri);
+            break;
+          case "insecure":
+            logger.log(XdsLogLevel.INFO, "Using channel credentials: insecure");
+            channelBuilder = ManagedChannelBuilder.forTarget(serverUri).usePlaintext();
+            break;
+          case "tls":
+            logger.log(XdsLogLevel.INFO, "Using channel credentials: tls");
+            channelBuilder = ManagedChannelBuilder.forTarget(serverUri);
+            break;
+          default:
+        }
+        if (channelBuilder != null) {
+          break;
+        }
+      }
+      if (channelBuilder == null) {
+        throw new XdsInitializationException("No server with supported channel creds found");
+      }
+
+      ManagedChannel channel = channelBuilder
+          .keepAliveTime(5, TimeUnit.MINUTES)
+          .build();
+      boolean useProtocolV3 = experimentalV3SupportEnvVar
+          && serverInfo.getServerFeatures().contains(XDS_V3_SERVER_FEATURE);
+
+      return new XdsChannel(channel, useProtocolV3);
+    }
+  };
+
+  static XdsChannelFactory getInstance() {
+    return DEFAULT_INSTANCE;
+  }
+
+  /**
+   * Creates a channel to one of the provided management servers.
+   *
+   * @throws XdsInitializationException if failed to create a channel with the given list of
+   *         servers.
+   */
+  abstract XdsChannel createChannel(List<ServerInfo> servers) throws XdsInitializationException;
+}

--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -53,7 +53,6 @@ import io.grpc.SynchronizationContext;
 import io.grpc.SynchronizationContext.ScheduledHandle;
 import io.grpc.internal.BackoffPolicy;
 import io.grpc.stub.StreamObserver;
-import io.grpc.xds.Bootstrapper.ServerInfo;
 import io.grpc.xds.EnvoyProtoData.DropOverload;
 import io.grpc.xds.EnvoyProtoData.Locality;
 import io.grpc.xds.EnvoyProtoData.LocalityLbEndpoints;
@@ -196,18 +195,14 @@ final class XdsClientImpl extends XdsClient {
 
   XdsClientImpl(
       String targetName,
-      List<ServerInfo> servers,  // list of management servers
-      XdsChannelFactory channelFactory,
+      XdsChannel channel,
       Node node,
       SynchronizationContext syncContext,
       ScheduledExecutorService timeService,
       BackoffPolicy.Provider backoffPolicyProvider,
       Supplier<Stopwatch> stopwatchSupplier) {
     this.targetName = checkNotNull(targetName, "targetName");
-    XdsChannel xdsChannel =
-        checkNotNull(channelFactory, "channelFactory")
-            .createChannel(checkNotNull(servers, "servers"));
-    this.xdsChannel = xdsChannel;
+    this.xdsChannel = checkNotNull(channel, "channel");
     this.node = checkNotNull(node, "node");
     this.syncContext = checkNotNull(syncContext, "syncContext");
     this.timeService = checkNotNull(timeService, "timeService");

--- a/xds/src/test/java/io/grpc/xds/EdsLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/EdsLoadBalancerTest.java
@@ -80,7 +80,6 @@ import io.grpc.xds.LoadStatsManager.LoadStatsStore;
 import io.grpc.xds.LocalityStore.LocalityStoreFactory;
 import io.grpc.xds.XdsClient.EndpointUpdate;
 import io.grpc.xds.XdsClient.XdsChannel;
-import io.grpc.xds.XdsClient.XdsChannelFactory;
 import java.net.InetSocketAddress;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -240,8 +239,7 @@ public class EdsLoadBalancerTest {
       xdsClientPoolFromResolveAddresses = new FakeXdsClientPool(
           new XdsClientImpl(
               SERVICE_AUTHORITY,
-              serverList,
-              channelFactory,
+              new XdsChannel(channel, /* useProtocolV3= */ false),
               node,
               syncContext,
               fakeClock.getScheduledExecutorService(),

--- a/xds/src/test/java/io/grpc/xds/XdsChannelFactoryTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsChannelFactoryTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import io.grpc.xds.Bootstrapper.ChannelCreds;
+import io.grpc.xds.Bootstrapper.ServerInfo;
+import io.grpc.xds.XdsClient.XdsChannel;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link XdsChannelFactory}.
+ */
+@RunWith(JUnit4.class)
+public class XdsChannelFactoryTest {
+
+  private final XdsChannelFactory channelFactory = XdsChannelFactory.getInstance();
+  private final List<XdsChannel> channels = new ArrayList<>();
+  private ServerInfo server1;  // google_default
+  private ServerInfo server2;  // plaintext, v3
+  private ServerInfo server3;  // unsupported
+
+  @Before
+  public void setUp() {
+    ChannelCreds googleDefault = new ChannelCreds("google_default", null);
+    ChannelCreds insecure = new ChannelCreds("insecure", null);
+    ChannelCreds unsupported = new ChannelCreds("unsupported", null);
+    server1 = new ServerInfo("server1.com", Collections.singletonList(googleDefault),
+        Collections.<String>emptyList());
+    server2 = new ServerInfo("server2.com", Collections.singletonList(insecure),
+        Collections.singletonList("xds_v3"));
+    server3 = new ServerInfo("server4.com", Collections.singletonList(unsupported),
+        Collections.<String>emptyList());
+  }
+
+  @After
+  public void tearDown() {
+    for (XdsChannel channel : channels) {
+      channel.getManagedChannel().shutdown();
+    }
+  }
+
+  @Test
+  public void failToCreateChannel_unsupportedChannelCreds() {
+    try {
+      createChannel(server3);
+      fail("Should have thrown");
+    } catch (XdsInitializationException expected) {
+    }
+  }
+
+  @Test
+  public void defaultUseV2ProtocolL() throws XdsInitializationException {
+    XdsChannel channel = createChannel(server1);
+    assertThat(channel.isUseProtocolV3()).isFalse();
+  }
+
+  @Test
+  public void supportServerFeature_v3Protocol() throws XdsInitializationException {
+    boolean originalV3SupportEnvVar = XdsChannelFactory.experimentalV3SupportEnvVar;
+    XdsChannelFactory.experimentalV3SupportEnvVar = true;
+    try {
+      XdsChannel channel = createChannel(server2);
+      assertThat(channel.isUseProtocolV3()).isTrue();
+    } finally {
+      XdsChannelFactory.experimentalV3SupportEnvVar = originalV3SupportEnvVar;
+    }
+  }
+
+  private XdsChannel createChannel(ServerInfo... servers) throws XdsInitializationException {
+    XdsChannel channel = channelFactory.createChannel(Arrays.asList(servers));
+    channels.add(channel);
+    return channel;
+  }
+}

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTestV2.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTestV2.java
@@ -86,8 +86,6 @@ import io.grpc.internal.FakeClock.ScheduledTask;
 import io.grpc.internal.FakeClock.TaskFilter;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
-import io.grpc.xds.Bootstrapper.ChannelCreds;
-import io.grpc.xds.Bootstrapper.ServerInfo;
 import io.grpc.xds.EnvoyProtoData.DropOverload;
 import io.grpc.xds.EnvoyProtoData.LbEndpoint;
 import io.grpc.xds.EnvoyProtoData.Locality;
@@ -100,7 +98,6 @@ import io.grpc.xds.XdsClient.ConfigWatcher;
 import io.grpc.xds.XdsClient.EndpointUpdate;
 import io.grpc.xds.XdsClient.EndpointWatcher;
 import io.grpc.xds.XdsClient.XdsChannel;
-import io.grpc.xds.XdsClient.XdsChannelFactory;
 import io.grpc.xds.XdsClientImpl.MessagePrinter;
 import java.io.IOException;
 import java.util.ArrayDeque;
@@ -278,23 +275,10 @@ public class XdsClientImplTestV2 {
     channel =
         cleanupRule.register(InProcessChannelBuilder.forName(serverName).directExecutor().build());
 
-    List<ServerInfo> servers =
-        ImmutableList.of(new ServerInfo(serverName, ImmutableList.<ChannelCreds>of(), null));
-    XdsChannelFactory channelFactory = new XdsChannelFactory() {
-      @Override
-      XdsChannel createChannel(List<ServerInfo> servers) {
-        ServerInfo serverInfo = Iterables.getOnlyElement(servers);
-        assertThat(serverInfo.getServerUri()).isEqualTo(serverName);
-        assertThat(serverInfo.getChannelCredentials()).isEmpty();
-        return new XdsChannel(channel, false);
-      }
-    };
-
     xdsClient =
         new XdsClientImpl(
             TARGET_AUTHORITY,
-            servers,
-            channelFactory,
+            new XdsChannel(channel, /* useProtocolV3= */ false),
             Node.newBuilder().build(),
             syncContext,
             fakeClock.getScheduledExecutorService(),

--- a/xds/src/test/java/io/grpc/xds/XdsClientTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientTest.java
@@ -21,12 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import com.google.common.collect.ImmutableList;
-import io.grpc.xds.Bootstrapper.ChannelCreds;
-import io.grpc.xds.Bootstrapper.ServerInfo;
 import io.grpc.xds.XdsClient.RefCountedXdsClientObjectPool;
-import io.grpc.xds.XdsClient.XdsChannel;
-import io.grpc.xds.XdsClient.XdsChannelFactory;
 import io.grpc.xds.XdsClient.XdsClientFactory;
 import org.junit.Rule;
 import org.junit.Test;
@@ -106,59 +101,5 @@ public class XdsClientTest {
 
     XdsClient xdsClient2 = xdsClientPool.getObject();
     assertThat(xdsClient2).isNotSameInstanceAs(xdsClient1);
-  }
-
-  @Test
-  public void channelFactorySupportsV3() {
-    boolean originalV3SupportEnvVar = XdsChannelFactory.experimentalV3SupportEnvVar;
-    try {
-      XdsChannelFactory xdsChannelFactory = XdsChannelFactory.getInstance();
-      XdsChannelFactory.experimentalV3SupportEnvVar = true;
-      XdsChannel xdsChannel =
-          xdsChannelFactory.createChannel(
-              ImmutableList.of(
-                  new ServerInfo(
-                      "xdsserver.com",
-                      ImmutableList.<ChannelCreds>of(),
-                      ImmutableList.<String>of()),
-                  new ServerInfo(
-                      "xdsserver2.com",
-                      ImmutableList.<ChannelCreds>of(),
-                      ImmutableList.of("xds_v3"))));
-      xdsChannel.getManagedChannel().shutdown();
-      assertThat(xdsChannel.isUseProtocolV3()).isFalse();
-
-      XdsChannelFactory.experimentalV3SupportEnvVar = false;
-      xdsChannel =
-          xdsChannelFactory.createChannel(
-              ImmutableList.of(
-                  new ServerInfo(
-                      "xdsserver.com",
-                      ImmutableList.<ChannelCreds>of(),
-                      ImmutableList.of("xds_v3")),
-                  new ServerInfo(
-                      "xdsserver2.com",
-                      ImmutableList.<ChannelCreds>of(),
-                      ImmutableList.of("baz"))));
-      xdsChannel.getManagedChannel().shutdown();
-      assertThat(xdsChannel.isUseProtocolV3()).isFalse();
-
-      XdsChannelFactory.experimentalV3SupportEnvVar = true;
-      xdsChannel =
-          xdsChannelFactory.createChannel(
-              ImmutableList.of(
-                  new ServerInfo(
-                      "xdsserver.com",
-                      ImmutableList.<ChannelCreds>of(),
-                      ImmutableList.of("xds_v3")),
-                  new ServerInfo(
-                      "xdsserver2.com",
-                      ImmutableList.<ChannelCreds>of(),
-                      ImmutableList.of("baz"))));
-      xdsChannel.getManagedChannel().shutdown();
-      assertThat(xdsChannel.isUseProtocolV3()).isTrue();
-    } finally {
-      XdsChannelFactory.experimentalV3SupportEnvVar = originalV3SupportEnvVar;
-    }
   }
 }

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -18,6 +18,7 @@ package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -30,6 +31,7 @@ import com.google.common.collect.Iterables;
 import io.grpc.CallOptions;
 import io.grpc.InternalConfigSelector;
 import io.grpc.InternalConfigSelector.Result;
+import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.MethodType;
@@ -46,11 +48,13 @@ import io.grpc.internal.ObjectPool;
 import io.grpc.internal.PickSubchannelArgsImpl;
 import io.grpc.testing.TestMethodDescriptors;
 import io.grpc.xds.Bootstrapper.BootstrapInfo;
+import io.grpc.xds.Bootstrapper.ServerInfo;
 import io.grpc.xds.EnvoyProtoData.ClusterWeight;
 import io.grpc.xds.EnvoyProtoData.Node;
 import io.grpc.xds.EnvoyProtoData.Route;
 import io.grpc.xds.EnvoyProtoData.RouteAction;
-import io.grpc.xds.XdsClient.XdsClientPoolFactory;
+import io.grpc.xds.XdsClient.XdsChannel;
+import io.grpc.xds.XdsNameResolverProvider.XdsClientPoolFactory;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -88,6 +92,12 @@ public class XdsNameResolverTest {
       return ConfigOrError.fromConfig(rawServiceConfig);
     }
   };
+  private final XdsChannelFactory channelFactory = new XdsChannelFactory() {
+    @Override
+    XdsChannel createChannel(List<ServerInfo> servers) throws XdsInitializationException {
+      return new XdsChannel(mock(ManagedChannel.class), false);
+    }
+  };
   private final FakeXdsClientPoolFactory xdsClientPoolFactory = new FakeXdsClientPoolFactory();
   private final String cluster1 = "cluster-foo.googleapis.com";
   private final String cluster2 = "cluster-bar.googleapis.com";
@@ -119,7 +129,7 @@ public class XdsNameResolverTest {
       }
     };
     resolver = new XdsNameResolver(AUTHORITY, serviceConfigParser, syncContext, bootstrapper,
-        xdsClientPoolFactory, mockRandom);
+        channelFactory, xdsClientPoolFactory, mockRandom);
   }
 
   @Test
@@ -131,13 +141,44 @@ public class XdsNameResolverTest {
       }
     };
     resolver = new XdsNameResolver(AUTHORITY, serviceConfigParser, syncContext, bootstrapper,
-        xdsClientPoolFactory, mockRandom);
+        channelFactory, xdsClientPoolFactory, mockRandom);
     resolver.start(mockListener);
     verify(mockListener).onError(errorCaptor.capture());
     Status error = errorCaptor.getValue();
     assertThat(error.getCode()).isEqualTo(Code.UNAVAILABLE);
-    assertThat(error.getDescription()).isEqualTo("Failed to load xDS bootstrap");
+    assertThat(error.getDescription()).isEqualTo("Failed to initialize xDS");
     assertThat(error.getCause()).hasMessageThat().isEqualTo("Fail to read bootstrap file");
+  }
+
+  @Test
+  public void resolve_failToCreateXdsChannel() {
+    Bootstrapper bootstrapper = new Bootstrapper() {
+      @Override
+      public BootstrapInfo readBootstrap() {
+        return new BootstrapInfo(
+            ImmutableList.of(
+                new ServerInfo(
+                    "trafficdirector.googleapis.com",
+                    ImmutableList.<ChannelCreds>of(), ImmutableList.<String>of())),
+            Node.newBuilder().build(),
+            null);
+      }
+    };
+    XdsChannelFactory channelFactory = new XdsChannelFactory() {
+      @Override
+      XdsChannel createChannel(List<ServerInfo> servers) throws XdsInitializationException {
+        throw new XdsInitializationException("No server with supported channel creds found");
+      }
+    };
+    resolver = new XdsNameResolver(AUTHORITY, serviceConfigParser, syncContext, bootstrapper,
+        channelFactory, xdsClientPoolFactory, mockRandom);
+    resolver.start(mockListener);
+    verify(mockListener).onError(errorCaptor.capture());
+    Status error = errorCaptor.getValue();
+    assertThat(error.getCode()).isEqualTo(Code.UNAVAILABLE);
+    assertThat(error.getDescription()).isEqualTo("Failed to initialize xDS");
+    assertThat(error.getCause()).hasMessageThat()
+        .isEqualTo("No server with supported channel creds found");
   }
 
   @SuppressWarnings("unchecked")
@@ -472,7 +513,8 @@ public class XdsNameResolverTest {
 
   private final class FakeXdsClientPoolFactory implements XdsClientPoolFactory {
     @Override
-    public ObjectPool<XdsClient> newXdsClientObjectPool(BootstrapInfo bootstrapInfo) {
+    public ObjectPool<XdsClient> newXdsClientObjectPool(
+        BootstrapInfo bootstrapInfo, XdsChannel channel) {
       return new ObjectPool<XdsClient>() {
         @Override
         public XdsClient getObject() {


### PR DESCRIPTION
Follow up for #7396.

The main change is to create the xDS channel outside XdsClient and creating the xDS channel can fail.