### PR TITLE
xds: accept all forms of gkeClusterUrl and fix the 'x-goog-request-params' value

### DIFF
--- a/xds/src/main/java/io/grpc/xds/internal/certprovider/MeshCaCertificateProvider.java
+++ b/xds/src/main/java/io/grpc/xds/internal/certprovider/MeshCaCertificateProvider.java
@@ -457,7 +457,7 @@ final class MeshCaCertificateProvider extends CertificateProvider {
 
         @Override
         public void start(Listener<RespT> responseListener, Metadata headers) {
-          headers.put(KEY_FOR_ZONE_INFO, zone);
+          headers.put(KEY_FOR_ZONE_INFO, "location=locations/" + zone);
           super.start(responseListener, headers);
         }
       };

--- a/xds/src/main/java/io/grpc/xds/internal/certprovider/MeshCaCertificateProviderProvider.java
+++ b/xds/src/main/java/io/grpc/xds/internal/certprovider/MeshCaCertificateProviderProvider.java
@@ -69,7 +69,7 @@ final class MeshCaCertificateProviderProvider implements CertificateProviderProv
   static final long RPC_TIMEOUT_SECONDS = 10L;
 
   private static final Pattern CLUSTER_URL_PATTERN = Pattern
-      .compile(".*/projects/(.*)/locations/(.*)/clusters/.*");
+      .compile(".*/projects/(.*)/(?:locations|zones)/(.*)/clusters/.*");
 
   private static final String TRUST_DOMAIN_SUFFIX = ".svc.id.goog";
   private static final String AUDIENCE_PREFIX = "identitynamespace:";

--- a/xds/src/test/java/io/grpc/xds/internal/certprovider/CommonCertProviderTestUtils.java
+++ b/xds/src/test/java/io/grpc/xds/internal/certprovider/CommonCertProviderTestUtils.java
@@ -163,6 +163,34 @@ public class CommonCertProviderTestUtils {
     return Bootstrapper.parseConfig(rawData);
   }
 
+  static Bootstrapper.BootstrapInfo getMinimalBootstrapInfo_v1beta1AndZone() throws IOException {
+    String rawData =
+        "{\n"
+            + "  \"xds_servers\": [],\n"
+            + "  \"certificate_providers\": {\n"
+            + "    \"gcp_id\": {\n"
+            + "      \"plugin_name\": \"testca\",\n"
+            + "      \"config\": {\n"
+            + "        \"server\": {\n"
+            + "          \"api_type\": \"GRPC\",\n"
+            + "          \"grpc_services\": [{\n"
+            + "            \"google_grpc\": {\n"
+            + "              \"call_credentials\": [{\n"
+            + "                \"sts_service\": {\n"
+            + "                  \"subject_token_path\": \"/tmp/path5\"\n"
+            + "                }\n"
+            + "              }]\n" // end call_credentials
+            + "            }\n" // end google_grpc
+            + "          }]\n" // end grpc_services
+            + "        },\n" // end server
+            + "        \"location\": \"https://container.googleapis.com/v1beta1/projects/test-project1/zones/test-zone2/clusters/test-cluster3\"\n"
+            + "      }\n" // end config
+            + "    }\n" // end gcp_id
+            + "  }\n"
+            + "}";
+    return Bootstrapper.parseConfig(rawData);
+  }
+
   static Bootstrapper.BootstrapInfo getMinimalAndBadClusterUrlBootstrapInfo() throws IOException {
     String rawData =
             "{\n"

--- a/xds/src/test/java/io/grpc/xds/internal/certprovider/MeshCaCertificateProviderProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/certprovider/MeshCaCertificateProviderProviderTest.java
@@ -53,8 +53,6 @@ public class MeshCaCertificateProviderProviderTest {
           "identitynamespace:test-project1.svc.id.goog:https://container.googleapis.com/v1beta1/projects/test-project1/zones/test-zone2/clusters/test-cluster3";
   public static final String TMP_PATH_4 = "/tmp/path4";
   public static final String NON_DEFAULT_MESH_CA_URL = "nonDefaultMeshCaUrl";
-  public static final String GKE_CLUSTER_URL =
-      "https://container.googleapis.com/v1/projects/test-project1/locations/test-zone2/clusters/test-cluster3";
 
   @Mock
   StsCredentials.Factory stsCredentialsFactory;

--- a/xds/src/test/java/io/grpc/xds/internal/certprovider/MeshCaCertificateProviderProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/certprovider/MeshCaCertificateProviderProviderTest.java
@@ -49,6 +49,8 @@ public class MeshCaCertificateProviderProviderTest {
 
   public static final String EXPECTED_AUDIENCE =
       "identitynamespace:test-project1.svc.id.goog:https://container.googleapis.com/v1/projects/test-project1/locations/test-zone2/clusters/test-cluster3";
+  public static final String EXPECTED_AUDIENCE_V1BETA1_ZONE =
+          "identitynamespace:test-project1.svc.id.goog:https://container.googleapis.com/v1beta1/projects/test-project1/zones/test-zone2/clusters/test-cluster3";
   public static final String TMP_PATH_4 = "/tmp/path4";
   public static final String NON_DEFAULT_MESH_CA_URL = "nonDefaultMeshCaUrl";
   public static final String GKE_CLUSTER_URL =
@@ -119,6 +121,41 @@ public class MeshCaCertificateProviderProviderTest {
         .create(
             eq(MeshCaCertificateProviderProvider.STS_URL_DEFAULT),
             eq(EXPECTED_AUDIENCE),
+            eq("/tmp/path5"));
+    verify(meshCaCertificateProviderFactory, times(1))
+        .create(
+            eq(distWatcher),
+            eq(true),
+            eq(MeshCaCertificateProviderProvider.MESHCA_URL_DEFAULT),
+            eq("test-zone2"),
+            eq(MeshCaCertificateProviderProvider.CERT_VALIDITY_SECONDS_DEFAULT),
+            eq(MeshCaCertificateProviderProvider.KEY_SIZE_DEFAULT),
+            eq(MeshCaCertificateProviderProvider.KEY_ALGO_DEFAULT),
+            eq(MeshCaCertificateProviderProvider.SIGNATURE_ALGO_DEFAULT),
+            eq(meshCaChannelFactory),
+            eq(backoffPolicyProvider),
+            eq(MeshCaCertificateProviderProvider.RENEWAL_GRACE_PERIOD_SECONDS_DEFAULT),
+            eq(MeshCaCertificateProviderProvider.MAX_RETRY_ATTEMPTS_DEFAULT),
+            (GoogleCredentials) isNull(),
+            eq(mockService),
+            eq(timeProvider),
+            eq(TimeUnit.SECONDS.toMillis(RPC_TIMEOUT_SECONDS)));
+  }
+
+  @Test
+  public void createProvider_minimalConfig_v1beta1AndZone() throws IOException {
+    CertificateProvider.DistributorWatcher distWatcher =
+        new CertificateProvider.DistributorWatcher();
+    Map<String, ?> map = buildMinimalConfig_v1beta1AndZone();
+    ScheduledExecutorService mockService = mock(ScheduledExecutorService.class);
+    when(scheduledExecutorServiceFactory.create(
+            eq(MeshCaCertificateProviderProvider.MESHCA_URL_DEFAULT)))
+        .thenReturn(mockService);
+    provider.createCertificateProvider(map, distWatcher, true);
+    verify(stsCredentialsFactory, times(1))
+        .create(
+            eq(MeshCaCertificateProviderProvider.STS_URL_DEFAULT),
+            eq(EXPECTED_AUDIENCE_V1BETA1_ZONE),
             eq("/tmp/path5"));
     verify(meshCaCertificateProviderFactory, times(1))
         .create(
@@ -232,6 +269,11 @@ public class MeshCaCertificateProviderProviderTest {
 
   private static Map<String, ?> buildMinimalConfig() throws IOException {
     return getCertProviderConfig(CommonCertProviderTestUtils.getMinimalBootstrapInfo());
+  }
+
+  private static Map<String, ?> buildMinimalConfig_v1beta1AndZone() throws IOException {
+    return getCertProviderConfig(
+        CommonCertProviderTestUtils.getMinimalBootstrapInfo_v1beta1AndZone());
   }
 
   private static Map<String, ?> buildBadClusterUrlConfig() throws IOException {

--- a/xds/src/test/java/io/grpc/xds/internal/certprovider/MeshCaCertificateProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/certprovider/MeshCaCertificateProviderTest.java
@@ -534,7 +534,7 @@ public class MeshCaCertificateProviderTest {
     assertThat(receivedZoneValues).hasSize(count);
     for (int i = 0; i < count; i++) {
       assertThat(receivedStsCreds.poll()).isEqualTo("Bearer " + TEST_STS_TOKEN + i);
-      assertThat(receivedZoneValues.poll()).isEqualTo("us-west2-a");
+      assertThat(receivedZoneValues.poll()).isEqualTo("location=locations/us-west2-a");
     }
   }
 


### PR DESCRIPTION
As described here https://cloud.google.com/kubernetes-engine/docs/reference/rest we should support both `/v1/` and `/v1beta1/` and `/locations/` and `/zones/` in the GKE Cluster URL we read from the bootstrap file.

Also the location metadata header value should be `location=locations/$ZONE`