### PR TITLE
netty-shaded: Fix publish regression for javadoc and sources (v1.32.x backport)

### DIFF
--- a/netty/shaded/build.gradle
+++ b/netty/shaded/build.gradle
@@ -47,6 +47,9 @@ publishing {
         maven(MavenPublication) {
             // Ideally swap to project.shadow.component(it) when it isn't broken for project deps
             artifact shadowJar
+            // Empty jars are not published via withJavadocJar() and withSourcesJar()
+            artifact javadocJar
+            artifact sourcesJar
 
             pom.withXml {
                 def dependencies = asNode().appendNode('dependencies')


### PR DESCRIPTION
96ad6338 accidentally caused the javadoc and sources jars to no longer
be published for grpc-netty-shaded. It would appear to be due to the
jars being empty. This commit causes them to be published again.

-------

This is a backport of #7405