### PR TITLE
all: remove deprecated internal OverrideAuthorityChecker

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -29,9 +29,6 @@ public final class ManagedChannelImplBuilder
     extends AbstractManagedChannelImplBuilder<ManagedChannelImplBuilder> {
 
   private boolean authorityCheckerDisabled;
-  @Deprecated
-  @Nullable
-  private OverrideAuthorityChecker authorityChecker;
 
   /**
    * An interface for Transport implementors to provide the {@link ClientTransportFactory}
@@ -137,23 +134,10 @@ public final class ManagedChannelImplBuilder
     return this;
   }
 
-  @Deprecated
-  public interface OverrideAuthorityChecker {
-    String checkAuthority(String authority);
-  }
-
-  @Deprecated
-  public void overrideAuthorityChecker(@Nullable OverrideAuthorityChecker authorityChecker) {
-    this.authorityChecker = authorityChecker;
-  }
-
   @Override
   protected String checkAuthority(String authority) {
     if (authorityCheckerDisabled) {
       return authority;
-    }
-    if (authorityChecker != null) {
-      return authorityChecker.checkAuthority(authority);
     }
     return super.checkAuthority(authority);
   }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
@@ -132,31 +132,4 @@ public class ManagedChannelImplBuilderTest {
     builder.disableCheckAuthority().enableCheckAuthority();
     builder.checkAuthority(DUMMY_AUTHORITY_INVALID);
   }
-
-  /** Ensure authority check can disabled with custom authority check implementation. */
-  @Test
-  @SuppressWarnings("deprecation")
-  public void overrideAuthorityChecker_default() {
-    builder.overrideAuthorityChecker(
-        new io.grpc.internal.ManagedChannelImplBuilder.OverrideAuthorityChecker() {
-          @Override public String checkAuthority(String authority) {
-            return authority;
-          }
-        });
-    assertEquals(DUMMY_AUTHORITY_INVALID, builder.checkAuthority(DUMMY_AUTHORITY_INVALID));
-  }
-
-  /** Ensure custom authority is ignored after disableCheckAuthority(). */
-  @Test
-  @SuppressWarnings("deprecation")
-  public void overrideAuthorityChecker_ignored() {
-    builder.overrideAuthorityChecker(
-        new io.grpc.internal.ManagedChannelImplBuilder.OverrideAuthorityChecker() {
-          @Override public String checkAuthority(String authority) {
-            throw new IllegalArgumentException();
-          }
-        });
-    builder.disableCheckAuthority();
-    assertEquals(DUMMY_AUTHORITY_INVALID, builder.checkAuthority(DUMMY_AUTHORITY_INVALID));
-  }
 }

--- a/netty/src/main/java/io/grpc/netty/InternalNettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/InternalNettyChannelBuilder.java
@@ -28,26 +28,6 @@ import io.netty.channel.socket.nio.NioSocketChannel;
 @Internal
 public final class InternalNettyChannelBuilder {
 
-  /**
-   * Checks authority upon channel construction.  The purpose of this interface is to raise the
-   * visibility of {@link NettyChannelBuilder.OverrideAuthorityChecker}.
-   * @deprecated To be removed, use {@link #disableCheckAuthority(NettyChannelBuilder builder)} to
-   *     disable authority check.
-   */
-  @Deprecated
-  public interface OverrideAuthorityChecker extends NettyChannelBuilder.OverrideAuthorityChecker {}
-
-  /**
-   * Overrides authority checker.
-   * @deprecated To be removed, use {@link #disableCheckAuthority(NettyChannelBuilder builder)} to
-   *     disable authority check.
-   */
-  @Deprecated
-  public static void overrideAuthorityChecker(
-      NettyChannelBuilder channelBuilder, OverrideAuthorityChecker authorityChecker) {
-    channelBuilder.overrideAuthorityChecker(authorityChecker);
-  }
-
   public static void disableCheckAuthority(NettyChannelBuilder builder) {
     builder.disableCheckAuthority();
   }

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -517,14 +517,6 @@ public final class NettyChannelBuilder extends ForwardingChannelBuilder<NettyCha
     }
   }
 
-  @Deprecated
-  interface OverrideAuthorityChecker extends ManagedChannelImplBuilder.OverrideAuthorityChecker {}
-
-  @Deprecated
-  void overrideAuthorityChecker(@Nullable OverrideAuthorityChecker authorityChecker) {
-    this.managedChannelImplBuilder.overrideAuthorityChecker(authorityChecker);
-  }
-
   NettyChannelBuilder disableCheckAuthority() {
     this.managedChannelImplBuilder.disableCheckAuthority();
     return this;

--- a/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import io.grpc.ManagedChannel;
-import io.grpc.internal.GrpcUtil;
 import io.grpc.netty.NettyTestUtil.TrackingObjectPoolForTest;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFactory;
@@ -89,41 +88,6 @@ public class NettyChannelBuilderTest {
     } finally {
       shutdown(channel);
     }
-  }
-
-  @Test
-  @Deprecated
-  public void overrideAllowsInvalidAuthority() {
-    NettyChannelBuilder builder = new NettyChannelBuilder(new SocketAddress(){});
-    InternalNettyChannelBuilder.overrideAuthorityChecker(builder,
-        new io.grpc.netty.InternalNettyChannelBuilder.OverrideAuthorityChecker() {
-          @Override
-          public String checkAuthority(String authority) {
-            return authority;
-          }
-        });
-    Object unused = builder.overrideAuthority("[invalidauthority")
-        .negotiationType(NegotiationType.PLAINTEXT)
-        .buildTransportFactory();
-  }
-
-  @Test
-  @Deprecated
-  public void overrideFailsInvalidAuthority() {
-    NettyChannelBuilder builder = new NettyChannelBuilder(new SocketAddress(){});
-    InternalNettyChannelBuilder.overrideAuthorityChecker(builder,
-        new io.grpc.netty.InternalNettyChannelBuilder.OverrideAuthorityChecker() {
-          @Override
-          public String checkAuthority(String authority) {
-            return GrpcUtil.checkAuthority(authority);
-          }
-        });
-
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Invalid authority:");
-    Object unused = builder.overrideAuthority("[invalidauthority")
-        .negotiationType(NegotiationType.PLAINTEXT)
-        .buildTransportFactory();
   }
 
   @Test

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -146,7 +146,6 @@ public class OkHttpChannelBuilder extends ForwardingChannelBuilder<OkHttpChannel
     this(GrpcUtil.authorityFromHostAndPort(host, port));
   }
 
-  @SuppressWarnings("deprecation")
   private OkHttpChannelBuilder(String target) {
     final class OkHttpChannelTransportFactoryBuilder implements ClientTransportFactoryBuilder {
       @Override

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -165,14 +165,6 @@ public class OkHttpChannelBuilder extends ForwardingChannelBuilder<OkHttpChannel
     managedChannelImplBuilder = new ManagedChannelImplBuilder(target,
         new OkHttpChannelTransportFactoryBuilder(),
         new OkHttpChannelDefaultPortProvider());
-
-    managedChannelImplBuilder.overrideAuthorityChecker(
-        new io.grpc.internal.ManagedChannelImplBuilder.OverrideAuthorityChecker() {
-          @Override
-          public String checkAuthority(String authority) {
-            return OkHttpChannelBuilder.this.checkAuthority(authority);
-          }
-        });
   }
 
   @Internal
@@ -431,10 +423,6 @@ public class OkHttpChannelBuilder extends ForwardingChannelBuilder<OkHttpChannel
         maxInboundMetadataSize,
         transportTracerFactory,
         useGetForSafeMethods);
-  }
-
-  protected String checkAuthority(String authority) {
-    return GrpcUtil.checkAuthority(authority);
   }
 
   final OkHttpChannelBuilder disableCheckAuthority() {

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
@@ -81,17 +81,6 @@ public class OkHttpChannelBuilderTest {
   }
 
   @Test
-  public void checkAuthorityOverrideAllowsInvalidAuthority() {
-    OkHttpChannelBuilder builder = new OkHttpChannelBuilder("good", 1234) {
-      @Override
-      protected String checkAuthority(String authority) {
-        return authority;
-      }
-    };
-    builder.overrideAuthority("[invalidauthority").usePlaintext().buildTransportFactory();
-  }
-
-  @Test
   public void disableCheckAuthorityAllowsInvalidAuthority() {
     OkHttpChannelBuilder builder = new OkHttpChannelBuilder("good", 1234)
         .disableCheckAuthority();


### PR DESCRIPTION
A part of #7211.
OverrideAuthorityChecker was replaced with `disableCheckAuthority()` / `enableCheckAuthority()` in #7359 and #7399 for internal backward compatibility.

cc @ejona86.