### PR TITLE
api,netty: Suppress violations of TruthIncompatibleType.

### DIFF
--- a/api/src/test/java/io/grpc/ClientInterceptorsTest.java
+++ b/api/src/test/java/io/grpc/ClientInterceptorsTest.java
@@ -307,6 +307,7 @@ public class ClientInterceptorsTest {
     assertThat(examinedHeaders).contains(inboundHeaders);
   }
 
+  @SuppressWarnings("TruthIncompatibleType")
   @Test
   public void normalCall() {
     ClientInterceptor interceptor = new ClientInterceptor() {
@@ -329,7 +330,8 @@ public class ClientInterceptorsTest {
     assertSame(listener, call.listener);
     assertSame(headers, call.headers);
     interceptedCall.sendMessage(null /*request*/);
-    assertThat(call.messages).containsExactly((Void) null /*request*/);
+    assertThat(call.messages)
+        .containsExactly(/* expected: String, actual: Void */ (Void) null /*request*/);
     interceptedCall.halfClose();
     assertTrue(call.halfClosed);
     interceptedCall.request(1);

--- a/netty/src/test/java/io/grpc/netty/WriteBufferingAndExceptionHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/WriteBufferingAndExceptionHandlerTest.java
@@ -283,6 +283,7 @@ public class WriteBufferingAndExceptionHandlerTest {
     }
   }
 
+  @SuppressWarnings("TruthIncompatibleType")
   @Test
   public void writesBuffered() throws Exception {
     final AtomicBoolean handlerAdded = new AtomicBoolean();
@@ -345,7 +346,10 @@ public class WriteBufferingAndExceptionHandlerTest {
     assertThat(chan.pipeline().context(handler)).isNull();
     assertThat(write.get().getClass()).isSameInstanceAs(Object.class);
     assertTrue(flush.get());
-    assertThat(chan.pipeline()).doesNotContain(handler);
+    assertThat(chan.pipeline())
+        .doesNotContain(
+            /* expected: Entry<String, ChannelHandler>, actual: WriteBufferingAndExceptionHandler */
+            handler);
   }
 
   @Test


### PR DESCRIPTION
Exporting an internal CL from @graememorgan

LSC: Suppress violations of TruthIncompatibleType.

Existing violations are being suppressed to allow making the check a compile-time error.

More details: go/lsc-truthincompatibletype