### PR TITLE
Revert "SECURITY.md: add instruction for disabling Conscrypt's defaul…

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -232,13 +232,8 @@ import java.security.Security;
 ...
 
 // Somewhere in main()
-Security.insertProviderAt(
-    Conscrypt.newProviderBuilder().provideTrustManager(false).build(), 1);
+Security.insertProviderAt(Conscrypt.newProvider(), 1);
 ```
-
-Note: according to [Conscrypt Implementation Notes](https://github.com/google/conscrypt/blob/2.4.0/IMPLEMENTATION_NOTES.md#hostname-verification),
-its default `HostnameVerifier` on OpenJDK always fails. This can be worked 
-around by disabling its default `TrustManager` implementation as shown above.
 
 ### TLS with Jetty ALPN
 


### PR DESCRIPTION
…t TrustManager (#6962)"

This reverts commit e089ceaadca78029c7c984eeb0ff199b2fbd78b4.

-----------------

Reverting this note as https://github.com/google/conscrypt/pull/867 was merged and the latest Conscrypt has a usable default HostnameVerifier.

