### PR TITLE
xds: remove log in data path

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -238,10 +238,6 @@ final class XdsNameResolver extends NameResolver {
       Map<String, ?> rawServiceConfig =
           generateServiceConfigWithMethodTimeoutConfig(
               selectedRoute.getRouteAction().getTimeoutNano());
-      if (logger.isLoggable(XdsLogLevel.INFO)) {
-        logger.log(XdsLogLevel.INFO,
-            "Generated service config (method config):\n{0}", new Gson().toJson(rawServiceConfig));
-      }
       ConfigOrError parsedServiceConfig = serviceConfigParser.parseServiceConfig(rawServiceConfig);
       Object config = parsedServiceConfig.getConfig();
       if (config == null) {


### PR DESCRIPTION
`ConfigSelector.selectConfig()` is called for every single RPC. Having a log there is too verbose. Developers generally just enables `FINEST` for debugging xDS, so lowering its log level doesn't help, would rather just not log it.