### PR TITLE
xds: log raw response messages in sync context

### DIFF
--- a/xds/src/main/java/io/grpc/xds/LoadReportClient.java
+++ b/xds/src/main/java/io/grpc/xds/LoadReportClient.java
@@ -315,7 +315,7 @@ final class LoadReportClient {
               syncContext.execute(new Runnable() {
                 @Override
                 public void run() {
-                  logger.log(XdsLogLevel.DEBUG, "Received LRS response:\n{0}", response);
+                  logger.log(XdsLogLevel.DEBUG, "Received LoadStatsResponse:\n{0}", response);
                   handleResponse(LoadStatsResponseData.fromEnvoyProtoV2(response));
                 }
               });

--- a/xds/src/main/java/io/grpc/xds/LoadReportClient.java
+++ b/xds/src/main/java/io/grpc/xds/LoadReportClient.java
@@ -213,7 +213,7 @@ final class LoadReportClient {
     }
 
     // Must run in syncContext.
-    final void handleRpcComplete() {
+    final void handleRpcCompleted() {
       handleStreamClosed(Status.UNAVAILABLE.withDescription("Closed by server"));
     }
 
@@ -336,7 +336,7 @@ final class LoadReportClient {
               syncContext.execute(new Runnable() {
                 @Override
                 public void run() {
-                  handleRpcComplete();
+                  handleRpcCompleted();
                 }
               });
             }
@@ -396,7 +396,7 @@ final class LoadReportClient {
               syncContext.execute(new Runnable() {
                 @Override
                 public void run() {
-                  handleRpcComplete();
+                  handleRpcCompleted();
                 }
               });
             }

--- a/xds/src/main/java/io/grpc/xds/LoadReportClient.java
+++ b/xds/src/main/java/io/grpc/xds/LoadReportClient.java
@@ -185,49 +185,36 @@ final class LoadReportClient {
 
     abstract void sendError(Exception error);
 
-    final void handleResponse(final LoadStatsResponseData response) {
-      syncContext.execute(new Runnable() {
-        @Override
-        public void run() {
-          if (closed) {
-            return;
-          }
-          if (!initialResponseReceived) {
-            logger.log(XdsLogLevel.DEBUG, "Initial LRS response received");
-            initialResponseReceived = true;
-          }
-          reportAllClusters = response.getSendAllClusters();
-          if (reportAllClusters) {
-            logger.log(XdsLogLevel.INFO, "Report loads for all clusters");
-          } else {
-            logger.log(XdsLogLevel.INFO, "Report loads for clusters: ", response.getClustersList());
-            clusterNames = response.getClustersList();
-          }
-          long interval = response.getLoadReportingIntervalNanos();
-          logger.log(XdsLogLevel.INFO, "Update load reporting interval to {0} ns", interval);
-          loadReportIntervalNano = interval;
-          scheduleNextLoadReport();
-        }
-      });
+    // Must run in syncContext.
+    final void handleResponse(LoadStatsResponseData response) {
+      if (closed) {
+        return;
+      }
+      if (!initialResponseReceived) {
+        logger.log(XdsLogLevel.DEBUG, "Initial LRS response received");
+        initialResponseReceived = true;
+      }
+      reportAllClusters = response.getSendAllClusters();
+      if (reportAllClusters) {
+        logger.log(XdsLogLevel.INFO, "Report loads for all clusters");
+      } else {
+        logger.log(XdsLogLevel.INFO, "Report loads for clusters: ", response.getClustersList());
+        clusterNames = response.getClustersList();
+      }
+      long interval = response.getLoadReportingIntervalNanos();
+      logger.log(XdsLogLevel.INFO, "Update load reporting interval to {0} ns", interval);
+      loadReportIntervalNano = interval;
+      scheduleNextLoadReport();
     }
 
-    final void handleRpcError(final Throwable t) {
-      syncContext.execute(new Runnable() {
-        @Override
-        public void run() {
-          handleStreamClosed(Status.fromThrowable(t));
-        }
-      });
+    // Must run in syncContext.
+    final void handleRpcError(Throwable t) {
+      handleStreamClosed(Status.fromThrowable(t));
     }
 
+    // Must run in syncContext.
     final void handleRpcComplete() {
-      syncContext.execute(new Runnable() {
-        @Override
-        public void run() {
-          handleStreamClosed(
-              Status.UNAVAILABLE.withDescription("Closed by server"));
-        }
-      });
+      handleStreamClosed(Status.UNAVAILABLE.withDescription("Closed by server"));
     }
 
     private void sendLoadReport() {
@@ -324,19 +311,34 @@ final class LoadReportClient {
           new StreamObserver<io.envoyproxy.envoy.service.load_stats.v2.LoadStatsResponse>() {
             @Override
             public void onNext(
-                io.envoyproxy.envoy.service.load_stats.v2.LoadStatsResponse response) {
-              logger.log(XdsLogLevel.DEBUG, "Received LRS response:\n{0}", response);
-              handleResponse(LoadStatsResponseData.fromEnvoyProtoV2(response));
+                final io.envoyproxy.envoy.service.load_stats.v2.LoadStatsResponse response) {
+              syncContext.execute(new Runnable() {
+                @Override
+                public void run() {
+                  logger.log(XdsLogLevel.DEBUG, "Received LRS response:\n{0}", response);
+                  handleResponse(LoadStatsResponseData.fromEnvoyProtoV2(response));
+                }
+              });
             }
 
             @Override
-            public void onError(Throwable t) {
-              handleRpcError(t);
+            public void onError(final Throwable t) {
+              syncContext.execute(new Runnable() {
+                @Override
+                public void run() {
+                  handleRpcError(t);
+                }
+              });
             }
 
             @Override
             public void onCompleted() {
-              handleRpcComplete();
+              syncContext.execute(new Runnable() {
+                @Override
+                public void run() {
+                  handleRpcComplete();
+                }
+              });
             }
           };
       io.envoyproxy.envoy.service.load_stats.v2.LoadReportingServiceGrpc.LoadReportingServiceStub
@@ -369,19 +371,34 @@ final class LoadReportClient {
       StreamObserver<LoadStatsResponse> lrsResponseReaderV3 =
           new StreamObserver<LoadStatsResponse>() {
             @Override
-            public void onNext(LoadStatsResponse response) {
-              logger.log(XdsLogLevel.DEBUG, "Received LRS response:\n{0}", response);
-              handleResponse(LoadStatsResponseData.fromEnvoyProtoV3(response));
+            public void onNext(final LoadStatsResponse response) {
+              syncContext.execute(new Runnable() {
+                @Override
+                public void run() {
+                  logger.log(XdsLogLevel.DEBUG, "Received LRS response:\n{0}", response);
+                  handleResponse(LoadStatsResponseData.fromEnvoyProtoV3(response));
+                }
+              });
             }
 
             @Override
-            public void onError(Throwable t) {
-              handleRpcError(t);
+            public void onError(final Throwable t) {
+              syncContext.execute(new Runnable() {
+                @Override
+                public void run() {
+                  handleRpcError(t);
+                }
+              });
             }
 
             @Override
             public void onCompleted() {
-              handleRpcComplete();
+              syncContext.execute(new Runnable() {
+                @Override
+                public void run() {
+                  handleRpcComplete();
+                }
+              });
             }
           };
       LoadReportingServiceStub stubV3 =

--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -1460,7 +1460,7 @@ final class XdsClientImpl extends XdsClient {
     abstract void sendError(Exception error);
 
     // Must run in syncContext.
-    final void onDiscoveryResponse(DiscoveryResponseData response) {
+    final void handleResponse(DiscoveryResponseData response) {
       if (closed) {
         return;
       }
@@ -1500,12 +1500,12 @@ final class XdsClientImpl extends XdsClient {
     }
 
     // Must run in syncContext.
-    final void onError(Throwable t) {
+    final void handleRpcError(Throwable t) {
       handleStreamClosed(Status.fromThrowable(t));
     }
 
     // Must run in syncContext.
-    final void onCompleted() {
+    final void handleRpcCompleted() {
       handleStreamClosed(Status.UNAVAILABLE.withDescription("Closed by server"));
     }
 
@@ -1734,7 +1734,7 @@ final class XdsClientImpl extends XdsClient {
                   }
                   DiscoveryResponseData responseData =
                       DiscoveryResponseData.fromEnvoyProtoV2(response);
-                  onDiscoveryResponse(responseData);
+                  handleResponse(responseData);
                 }
               });
             }
@@ -1744,7 +1744,7 @@ final class XdsClientImpl extends XdsClient {
               syncContext.execute(new Runnable() {
                 @Override
                 public void run() {
-                  AdsStreamV2.this.onError(t);
+                  handleRpcError(t);
                 }
               });
             }
@@ -1754,7 +1754,7 @@ final class XdsClientImpl extends XdsClient {
               syncContext.execute(new Runnable() {
                 @Override
                 public void run() {
-                  AdsStreamV2.this.onCompleted();
+                  handleRpcCompleted();
                 }
               });
             }
@@ -1800,7 +1800,7 @@ final class XdsClientImpl extends XdsClient {
                     "Received DiscoveryResponse:\n{0}", respPrinter.print(response));
               }
               DiscoveryResponseData responseData = DiscoveryResponseData.fromEnvoyProto(response);
-              onDiscoveryResponse(responseData);
+              handleResponse(responseData);
             }
           });
         }
@@ -1810,7 +1810,7 @@ final class XdsClientImpl extends XdsClient {
           syncContext.execute(new Runnable() {
             @Override
             public void run() {
-              AdsStream.this.onError(t);
+              handleRpcError(t);
             }
           });
         }
@@ -1820,7 +1820,7 @@ final class XdsClientImpl extends XdsClient {
           syncContext.execute(new Runnable() {
             @Override
             public void run() {
-              AdsStream.this.onCompleted();
+              handleRpcCompleted();
             }
           });
         }

--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -1459,68 +1459,54 @@ final class XdsClientImpl extends XdsClient {
 
     abstract void sendError(Exception error);
 
-    final void onDiscoveryResponse(final DiscoveryResponseData response) {
-      syncContext.execute(
-          new Runnable() {
-            @Override
-            public void run() {
-              if (closed) {
-                return;
-              }
-              responseReceived = true;
-              String respNonce = response.getNonce();
-              // Nonce in each response is echoed back in the following ACK/NACK request. It is
-              // used for management server to identify which response the client is ACKing/NACking.
-              // To avoid confusion, client-initiated requests will always use the nonce in
-              // most recently received responses of each resource type.
-              ResourceType resourceType = response.getResourceType();
-              switch (resourceType) {
-                case LDS:
-                  ldsRespNonce = respNonce;
-                  handleLdsResponse(response);
-                  break;
-                case RDS:
-                  rdsRespNonce = respNonce;
-                  handleRdsResponse(response);
-                  break;
-                case CDS:
-                  cdsRespNonce = respNonce;
-                  handleCdsResponse(response);
-                  break;
-                case EDS:
-                  edsRespNonce = respNonce;
-                  handleEdsResponse(response);
-                  break;
-                case UNKNOWN:
-                  logger.log(
-                      XdsLogLevel.WARNING,
-                      "Received an unknown type of DiscoveryResponse\n{0}",
-                      respNonce);
-                  break;
-                default:
-                  throw new AssertionError("Missing case in enum switch: " + resourceType);
-              }
-            }
-          });
+    // Must run in syncContext.
+    final void onDiscoveryResponse(DiscoveryResponseData response) {
+      if (closed) {
+        return;
+      }
+      responseReceived = true;
+      String respNonce = response.getNonce();
+      // Nonce in each response is echoed back in the following ACK/NACK request. It is
+      // used for management server to identify which response the client is ACKing/NACking.
+      // To avoid confusion, client-initiated requests will always use the nonce in
+      // most recently received responses of each resource type.
+      ResourceType resourceType = response.getResourceType();
+      switch (resourceType) {
+        case LDS:
+          ldsRespNonce = respNonce;
+          handleLdsResponse(response);
+          break;
+        case RDS:
+          rdsRespNonce = respNonce;
+          handleRdsResponse(response);
+          break;
+        case CDS:
+          cdsRespNonce = respNonce;
+          handleCdsResponse(response);
+          break;
+        case EDS:
+          edsRespNonce = respNonce;
+          handleEdsResponse(response);
+          break;
+        case UNKNOWN:
+          logger.log(
+              XdsLogLevel.WARNING,
+              "Received an unknown type of DiscoveryResponse\n{0}",
+              respNonce);
+          break;
+        default:
+          throw new AssertionError("Missing case in enum switch: " + resourceType);
+      }
     }
 
-    final void onError(final Throwable t) {
-      syncContext.execute(new Runnable() {
-        @Override
-        public void run() {
-          handleStreamClosed(Status.fromThrowable(t));
-        }
-      });
+    // Must run in syncContext.
+    final void onError(Throwable t) {
+      handleStreamClosed(Status.fromThrowable(t));
     }
 
+    // Must run in syncContext.
     final void onCompleted() {
-      syncContext.execute(new Runnable() {
-        @Override
-        public void run() {
-          handleStreamClosed(
-              Status.UNAVAILABLE.withDescription("Closed by server"));
-        }
-      });
+      handleStreamClosed(Status.UNAVAILABLE.withDescription("Closed by server"));
     }
 
     private void handleStreamClosed(Status error) {
@@ -1737,27 +1723,42 @@ final class XdsClientImpl extends XdsClient {
       StreamObserver<io.envoyproxy.envoy.api.v2.DiscoveryResponse> responseReaderV2 =
           new StreamObserver<io.envoyproxy.envoy.api.v2.DiscoveryResponse>() {
             @Override
-            public void onNext(io.envoyproxy.envoy.api.v2.DiscoveryResponse response) {
-              DiscoveryResponseData responseData =
-                  DiscoveryResponseData.fromEnvoyProtoV2(response);
-              if (logger.isLoggable(XdsLogLevel.DEBUG)) {
-                logger.log(
-                    XdsLogLevel.DEBUG,
-                    "Received {0} response:\n{1}",
-                    responseData.getResourceType(),
-                    respPrinter.print(response));
-              }
-              onDiscoveryResponse(responseData);
+            public void onNext(final io.envoyproxy.envoy.api.v2.DiscoveryResponse response) {
+              syncContext.execute(new Runnable() {
+                @Override
+                public void run() {
+                  DiscoveryResponseData responseData =
+                      DiscoveryResponseData.fromEnvoyProtoV2(response);
+                  if (logger.isLoggable(XdsLogLevel.DEBUG)) {
+                    logger.log(
+                        XdsLogLevel.DEBUG,
+                        "Received {0} response:\n{1}",
+                        responseData.getResourceType(),
+                        respPrinter.print(response));
+                  }
+                  onDiscoveryResponse(responseData);
+                }
+              });
             }
 
             @Override
-            public void onError(Throwable t) {
-              AdsStreamV2.this.onError(t);
+            public void onError(final Throwable t) {
+              syncContext.execute(new Runnable() {
+                @Override
+                public void run() {
+                  AdsStreamV2.this.onError(t);
+                }
+              });
             }
 
             @Override
             public void onCompleted() {
-              AdsStreamV2.this.onCompleted();
+              syncContext.execute(new Runnable() {
+                @Override
+                public void run() {
+                  AdsStreamV2.this.onCompleted();
+                }
+              });
             }
           };
       requestWriterV2 = stubV2.withWaitForReady().streamAggregatedResources(responseReaderV2);
@@ -1791,27 +1792,42 @@ final class XdsClientImpl extends XdsClient {
     void start() {
       StreamObserver<DiscoveryResponse> responseReader = new StreamObserver<DiscoveryResponse>() {
         @Override
-        public void onNext(DiscoveryResponse response) {
-          DiscoveryResponseData responseData =
-              DiscoveryResponseData.fromEnvoyProto(response);
-          if (logger.isLoggable(XdsLogLevel.DEBUG)) {
-            logger.log(
-                XdsLogLevel.DEBUG,
-                "Received {0} response:\n{1}",
-                responseData.getResourceType(),
-                respPrinter.print(response));
-          }
-          onDiscoveryResponse(responseData);
+        public void onNext(final DiscoveryResponse response) {
+          syncContext.execute(new Runnable() {
+            @Override
+            public void run() {
+              DiscoveryResponseData responseData =
+                  DiscoveryResponseData.fromEnvoyProto(response);
+              if (logger.isLoggable(XdsLogLevel.DEBUG)) {
+                logger.log(
+                    XdsLogLevel.DEBUG,
+                    "Received {0} response:\n{1}",
+                    responseData.getResourceType(),
+                    respPrinter.print(response));
+              }
+              onDiscoveryResponse(responseData);
+            }
+          });
         }
 
         @Override
-        public void onError(Throwable t) {
-          AdsStream.this.onError(t);
+        public void onError(final Throwable t) {
+          syncContext.execute(new Runnable() {
+            @Override
+            public void run() {
+              AdsStream.this.onError(t);
+            }
+          });
         }
 
         @Override
         public void onCompleted() {
-          AdsStream.this.onCompleted();
+          syncContext.execute(new Runnable() {
+            @Override
+            public void run() {
+              AdsStream.this.onCompleted();
+            }
+          });
         }
       };
       requestWriter = stub.withWaitForReady().streamAggregatedResources(responseReader);

--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -1728,9 +1728,9 @@ final class XdsClientImpl extends XdsClient {
                 @Override
                 public void run() {
                   if (logger.isLoggable(XdsLogLevel.DEBUG)) {
-                    logger.log(
-                        XdsLogLevel.DEBUG,
-                        "Received DiscoveryResponse:\n{0}", respPrinter.print(response));
+                    logger.log(XdsLogLevel.DEBUG, "Received {0} response:\n{1}",
+                        ResourceType.fromTypeUrl(response.getTypeUrl()),
+                        respPrinter.print(response));
                   }
                   DiscoveryResponseData responseData =
                       DiscoveryResponseData.fromEnvoyProtoV2(response);
@@ -1795,9 +1795,8 @@ final class XdsClientImpl extends XdsClient {
             @Override
             public void run() {
               if (logger.isLoggable(XdsLogLevel.DEBUG)) {
-                logger.log(
-                    XdsLogLevel.DEBUG,
-                    "Received DiscoveryResponse:\n{0}", respPrinter.print(response));
+                logger.log(XdsLogLevel.DEBUG, "Received {0} response:\n{1}",
+                    ResourceType.fromTypeUrl(response.getTypeUrl()), respPrinter.print(response));
               }
               DiscoveryResponseData responseData = DiscoveryResponseData.fromEnvoyProto(response);
               handleResponse(responseData);

--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -1727,15 +1727,13 @@ final class XdsClientImpl extends XdsClient {
               syncContext.execute(new Runnable() {
                 @Override
                 public void run() {
-                  DiscoveryResponseData responseData =
-                      DiscoveryResponseData.fromEnvoyProtoV2(response);
                   if (logger.isLoggable(XdsLogLevel.DEBUG)) {
                     logger.log(
                         XdsLogLevel.DEBUG,
-                        "Received {0} response:\n{1}",
-                        responseData.getResourceType(),
-                        respPrinter.print(response));
+                        "Received DiscoveryResponse:\n{0}", respPrinter.print(response));
                   }
+                  DiscoveryResponseData responseData =
+                      DiscoveryResponseData.fromEnvoyProtoV2(response);
                   onDiscoveryResponse(responseData);
                 }
               });
@@ -1796,15 +1794,12 @@ final class XdsClientImpl extends XdsClient {
           syncContext.execute(new Runnable() {
             @Override
             public void run() {
-              DiscoveryResponseData responseData =
-                  DiscoveryResponseData.fromEnvoyProto(response);
               if (logger.isLoggable(XdsLogLevel.DEBUG)) {
                 logger.log(
                     XdsLogLevel.DEBUG,
-                    "Received {0} response:\n{1}",
-                    responseData.getResourceType(),
-                    respPrinter.print(response));
+                    "Received DiscoveryResponse:\n{0}", respPrinter.print(response));
               }
+              DiscoveryResponseData responseData = DiscoveryResponseData.fromEnvoyProto(response);
               onDiscoveryResponse(responseData);
             }
           });


### PR DESCRIPTION
Logging raw response messages should be run in the same synchronization context as other response handling logics. Otherwise, logs for the same response message will be interleaved.

Including minor cosmetic improvements.