### PR TITLE
xds: generate EDS config with hardcoded locality picking policy

### DIFF
--- a/xds/src/main/java/io/grpc/xds/EdsLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/EdsLoadBalancerProvider.java
@@ -17,7 +17,6 @@
 package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.grpc.xds.XdsLbPolicies.WEIGHTED_TARGET_POLICY_NAME;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
@@ -25,7 +24,6 @@ import io.grpc.Internal;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancerProvider;
-import io.grpc.LoadBalancerRegistry;
 import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.internal.ServiceConfigUtil.PolicySelection;
 import java.util.Map;
@@ -73,21 +71,6 @@ public class EdsLoadBalancerProvider extends LoadBalancerProvider {
     final String lrsServerName;
     final PolicySelection localityPickingPolicy;
     final PolicySelection endpointPickingPolicy;
-
-    // TODO(chengyuanzhang): delete me.
-    EdsConfig(
-        String clusterName,
-        @Nullable String edsServiceName,
-        @Nullable String lrsServerName,
-        PolicySelection endpointPickingPolicy) {
-      this.clusterName = checkNotNull(clusterName, "clusterName");
-      this.edsServiceName = edsServiceName;
-      this.lrsServerName = lrsServerName;
-      this.endpointPickingPolicy = checkNotNull(endpointPickingPolicy, "endpointPickingPolicy");
-      LoadBalancerProvider provider =
-          LoadBalancerRegistry.getDefaultRegistry().getProvider(WEIGHTED_TARGET_POLICY_NAME);
-      localityPickingPolicy = new PolicySelection(provider, null, null);
-    }
 
     EdsConfig(
         String clusterName,

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancerTest.java
@@ -89,6 +89,7 @@ public class CdsLoadBalancerTest {
     MockitoAnnotations.initMocks(this);
 
     LoadBalancerRegistry registry = new LoadBalancerRegistry();
+    registry.register(new FakeLoadBalancerProvider(XdsLbPolicies.WEIGHTED_TARGET_POLICY_NAME));
     registry.register(new FakeLoadBalancerProvider(XdsLbPolicies.EDS_POLICY_NAME));
     registry.register(new FakeLoadBalancerProvider("round_robin"));
     ObjectPool<XdsClient> xdsClientPool = new ObjectPool<XdsClient>() {
@@ -135,6 +136,8 @@ public class CdsLoadBalancerTest {
     assertThat(edsConfig.clusterName).isEqualTo(CLUSTER);
     assertThat(edsConfig.edsServiceName).isNull();
     assertThat(edsConfig.lrsServerName).isNull();
+    assertThat(edsConfig.localityPickingPolicy.getProvider().getPolicyName())
+        .isEqualTo(XdsLbPolicies.WEIGHTED_TARGET_POLICY_NAME);  // hardcoded to weighted-target
     assertThat(edsConfig.endpointPickingPolicy.getProvider().getPolicyName())
         .isEqualTo("round_robin");
   }
@@ -174,6 +177,8 @@ public class CdsLoadBalancerTest {
     assertThat(edsConfig.clusterName).isEqualTo(CLUSTER);
     assertThat(edsConfig.edsServiceName).isNull();
     assertThat(edsConfig.lrsServerName).isNull();
+    assertThat(edsConfig.localityPickingPolicy.getProvider().getPolicyName())
+        .isEqualTo(XdsLbPolicies.WEIGHTED_TARGET_POLICY_NAME);  // hardcoded to weighted-target
     assertThat(edsConfig.endpointPickingPolicy.getProvider().getPolicyName())
         .isEqualTo("round_robin");
 
@@ -185,6 +190,8 @@ public class CdsLoadBalancerTest {
     assertThat(edsConfig.clusterName).isEqualTo(CLUSTER);
     assertThat(edsConfig.edsServiceName).isEqualTo(edsService);
     assertThat(edsConfig.lrsServerName).isEqualTo(loadReportServer);
+    assertThat(edsConfig.localityPickingPolicy.getProvider().getPolicyName())
+        .isEqualTo(XdsLbPolicies.WEIGHTED_TARGET_POLICY_NAME);  // hardcoded to weighted-target
     assertThat(edsConfig.endpointPickingPolicy.getProvider().getPolicyName())
         .isEqualTo("round_robin");
   }


### PR DESCRIPTION
This cleans up the temporary workaround code that implicitly includes the locality picking policy internally inside the EDS LB config creation.