### PR TITLE
xds: promote EdsLoadBalancer2

### DIFF
--- a/xds/src/main/java/io/grpc/xds/EdsLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/EdsLoadBalancerProvider.java
@@ -56,7 +56,7 @@ public class EdsLoadBalancerProvider extends LoadBalancerProvider {
 
   @Override
   public LoadBalancer newLoadBalancer(Helper helper) {
-    return new EdsLoadBalancer(helper);
+    return new EdsLoadBalancer2(helper);
   }
 
   @Override


### PR DESCRIPTION
Looks the header matching interop test is passing now. Rerunning all the tests.

This PR only promotes `EdsLoadBalancer2`. Cleanup will be done later in a separate PR.