### PR TITLE
xds: add toString() and delete unnecessary equals()/hashCode() for LB configs

### DIFF
--- a/xds/src/main/java/io/grpc/xds/AddressFilter.java
+++ b/xds/src/main/java/io/grpc/xds/AddressFilter.java
@@ -82,5 +82,10 @@ final class AddressFilter {
     PathChain(String name) {
       this.name = checkNotNull(name, "name");
     }
+
+    @Override
+    public String toString() {
+      return name + (next == null ? "" : ", " + next);
+    }
   }
 }

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancerProvider.java
@@ -18,6 +18,7 @@ package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.base.MoreObjects;
 import io.grpc.Internal;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
@@ -26,7 +27,6 @@ import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.Status;
 import io.grpc.internal.JsonUtil;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * The provider for the "cds" balancing policy.  This class should not be directly referenced in
@@ -96,20 +96,8 @@ public class CdsLoadBalancerProvider extends LoadBalancerProvider {
     }
 
     @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      CdsConfig cdsConfig = (CdsConfig) o;
-      return Objects.equals(name, cdsConfig.name);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(name);
+    public String toString() {
+      return MoreObjects.toStringHelper(this).add("name", name).toString();
     }
   }
 }

--- a/xds/src/main/java/io/grpc/xds/EdsLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/EdsLoadBalancerProvider.java
@@ -19,7 +19,6 @@ package io.grpc.xds;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import io.grpc.Internal;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
@@ -94,30 +93,6 @@ public class EdsLoadBalancerProvider extends LoadBalancerProvider {
           .add("localityPickingPolicy", localityPickingPolicy)
           .add("endpointPickingPolicy", endpointPickingPolicy)
           .toString();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-      if (!(obj instanceof EdsConfig)) {
-        return false;
-      }
-      EdsConfig that = (EdsConfig) obj;
-      return Objects.equal(this.clusterName, that.clusterName)
-          && Objects.equal(this.edsServiceName, that.edsServiceName)
-          && Objects.equal(this.lrsServerName, that.lrsServerName)
-          && Objects.equal(this.localityPickingPolicy, that.localityPickingPolicy)
-          && Objects.equal(this.endpointPickingPolicy, that.endpointPickingPolicy);
-    }
-
-    @Override
-    public int hashCode() {
-      return
-          Objects.hashCode(
-              clusterName,
-              edsServiceName,
-              lrsServerName,
-              localityPickingPolicy,
-              endpointPickingPolicy);
     }
   }
 }

--- a/xds/src/main/java/io/grpc/xds/LrsLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/LrsLoadBalancerProvider.java
@@ -18,6 +18,7 @@ package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.MoreObjects;
 import io.grpc.Internal;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancerProvider;
@@ -79,6 +80,17 @@ public final class LrsLoadBalancerProvider extends LoadBalancerProvider {
       this.lrsServerName = checkNotNull(lrsServerName, "lrsServerName");
       this.locality = checkNotNull(locality, "locality");
       this.childPolicy = checkNotNull(childPolicy, "childPolicy");
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("clusterName", clusterName)
+          .add("edsServiceName", edsServiceName)
+          .add("lrsServerName", lrsServerName)
+          .add("locality", locality)
+          .add("childPolicy", childPolicy)
+          .toString();
     }
   }
 }


### PR DESCRIPTION
Do not implement equals()/hashCode() unless there is a reason to.

There is probably more equals()/hashCode() to be deleted. e.g., `WeightedTargetConfig`. But its test is relying on its equals()/hashCode() implementation.