### PR TITLE
xds: stop setting PROXYLESS_CLIENT_HOSTNAME node metadata in LRS requests

### DIFF
--- a/xds/src/main/java/io/grpc/xds/LoadReportClient.java
+++ b/xds/src/main/java/io/grpc/xds/LoadReportClient.java
@@ -39,9 +39,7 @@ import io.grpc.xds.EnvoyProtoData.Node;
 import io.grpc.xds.XdsClient.XdsChannel;
 import io.grpc.xds.XdsLogger.XdsLogLevel;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
@@ -53,9 +51,6 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 final class LoadReportClient {
-  @VisibleForTesting
-  static final String TARGET_NAME_METADATA_KEY = "PROXYLESS_CLIENT_HOSTNAME";
-
   private final InternalLogId logId;
   private final XdsLogger logger;
   private final XdsChannel xdsChannel;
@@ -91,14 +86,7 @@ final class LoadReportClient {
     this.backoffPolicyProvider = checkNotNull(backoffPolicyProvider, "backoffPolicyProvider");
     checkNotNull(stopwatchSupplier, "stopwatchSupplier");
     this.retryStopwatch = stopwatchSupplier.get();
-    checkNotNull(targetName, "targetName");
-    checkNotNull(node, "node");
-    Map<String, Object> newMetadata = new HashMap<>();
-    if (node.getMetadata() != null) {
-      newMetadata.putAll(node.getMetadata());
-    }
-    newMetadata.put(TARGET_NAME_METADATA_KEY, targetName);
-    this.node = node.toBuilder().setMetadata(newMetadata).build();
+    this.node = checkNotNull(node, "node");
     logId = InternalLogId.allocate("lrs-client", targetName);
     logger = XdsLogger.withLogId(logId);
     logger.log(XdsLogLevel.INFO, "Created");

--- a/xds/src/test/java/io/grpc/xds/LoadReportClientTest.java
+++ b/xds/src/test/java/io/grpc/xds/LoadReportClientTest.java
@@ -469,10 +469,7 @@ public class LoadReportClientTest {
                         Struct.newBuilder()
                             .putFields(
                                 "TRAFFICDIRECTOR_NETWORK_HOSTNAME",
-                                Value.newBuilder().setStringValue("default").build())
-                            .putFields(
-                                LoadReportClient.TARGET_NAME_METADATA_KEY,
-                                Value.newBuilder().setStringValue(TARGET_NAME).build())))
+                                Value.newBuilder().setStringValue("default").build())))
             .build();
   }
 
@@ -490,11 +487,6 @@ public class LoadReportClientTest {
 
     @Override
     public boolean matches(LoadStatsRequest argument) {
-      if (!argument.getNode().getMetadata()
-          .getFieldsOrThrow(LoadReportClient.TARGET_NAME_METADATA_KEY)
-          .getStringValue().equals(TARGET_NAME)) {
-        return false;
-      }
       if (argument.getClusterStatsCount() != expectedStats.size()) {
         return false;
       }


### PR DESCRIPTION
Corresponding change in C-core: https://github.com/grpc/grpc/pull/24136