### PR TITLE
Prepare for JUnit 4.13

### DIFF
--- a/api/src/test/java/io/grpc/ContextsTest.java
+++ b/api/src/test/java/io/grpc/ContextsTest.java
@@ -16,15 +16,14 @@
 
 package io.grpc;
 
+import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.Contexts.interceptCall;
 import static io.grpc.Contexts.statusFromCancelled;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -240,7 +239,7 @@ public class ContextsTest {
     executorService.command.run();
 
     assertTrue(cancellableContext.isCancelled());
-    assertThat(cancellableContext.cancellationCause(), instanceOf(TimeoutException.class));
+    assertThat(cancellableContext.cancellationCause()).isInstanceOf(TimeoutException.class);
 
     Status status = statusFromCancelled(cancellableContext);
     assertNotNull(status);

--- a/api/src/test/java/io/grpc/MetadataTest.java
+++ b/api/src/test/java/io/grpc/MetadataTest.java
@@ -49,6 +49,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class MetadataTest {
 
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   private static final Metadata.BinaryMarshaller<Fish> FISH_MARSHALLER =

--- a/api/src/test/java/io/grpc/MethodDescriptorTest.java
+++ b/api/src/test/java/io/grpc/MethodDescriptorTest.java
@@ -37,6 +37,7 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class MethodDescriptorTest {
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule
   public final ExpectedException thrown = ExpectedException.none();
 

--- a/api/src/test/java/io/grpc/ServerInterceptorsTest.java
+++ b/api/src/test/java/io/grpc/ServerInterceptorsTest.java
@@ -56,6 +56,7 @@ public class ServerInterceptorsTest {
   @Rule
   public final MockitoRule mocks = MockitoJUnit.rule();
 
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule
   public final ExpectedException thrown = ExpectedException.none();
 

--- a/api/src/test/java/io/grpc/ServerServiceDefinitionTest.java
+++ b/api/src/test/java/io/grpc/ServerServiceDefinitionTest.java
@@ -52,6 +52,7 @@ public class ServerServiceDefinitionTest {
         = ServerMethodDefinition.create(method1, methodHandler1);
   private ServerMethodDefinition<String, Integer> methodDef2
         = ServerMethodDefinition.create(method2, methodHandler2);
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 

--- a/api/src/test/java/io/grpc/ServiceDescriptorTest.java
+++ b/api/src/test/java/io/grpc/ServiceDescriptorTest.java
@@ -36,6 +36,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ServiceDescriptorTest {
 
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule
   public final ExpectedException thrown = ExpectedException.none();
 

--- a/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
@@ -75,6 +75,7 @@ import org.mockito.stubbing.Answer;
 public class AbstractClientStreamTest {
 
   @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   private final StatsTraceContext statsTraceCtx = StatsTraceContext.NOOP;

--- a/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
@@ -57,6 +57,7 @@ public class AbstractServerStreamTest {
   private static final int TIMEOUT_MS = 1000;
   private static final int MAX_MESSAGE_SIZE = 100;
 
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   private final WritableBufferAllocator allocator = new WritableBufferAllocator() {

--- a/core/src/test/java/io/grpc/internal/AbstractTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractTransportTest.java
@@ -224,6 +224,7 @@ public abstract class AbstractTransportTest {
           }
         }));
 
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 

--- a/core/src/test/java/io/grpc/internal/ConnectivityStateManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/ConnectivityStateManagerTest.java
@@ -38,6 +38,7 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class ConnectivityStateManagerTest {
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule
   public final ExpectedException thrown = ExpectedException.none();
 

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -98,6 +98,7 @@ public class DnsNameResolverTest {
 
   @Rule public final TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(10));
   @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   private final Map<String, ?> serviceConfig = new LinkedHashMap<>();

--- a/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
+++ b/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
@@ -44,6 +44,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class GrpcUtilTest {
 
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   @Test

--- a/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
+++ b/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
@@ -77,6 +77,7 @@ import org.mockito.junit.MockitoRule;
 public class InternalSubchannelTest {
   @Rule
   public final MockitoRule mocks = MockitoJUnit.rule();
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule
   public final ExpectedException thrown = ExpectedException.none();
 

--- a/core/src/test/java/io/grpc/internal/JsonParserTest.java
+++ b/core/src/test/java/io/grpc/internal/JsonParserTest.java
@@ -35,6 +35,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class JsonParserTest {
 
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule
   public final ExpectedException thrown = ExpectedException.none();
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
@@ -80,6 +80,7 @@ public class ManagedChannelImplBuilderTest {
       };
 
   @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Rule public final GrpcCleanupRule grpcCleanupRule = new GrpcCleanupRule();
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelServiceConfigTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelServiceConfigTest.java
@@ -41,6 +41,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ManagedChannelServiceConfigTest {
 
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule
   public final ExpectedException thrown = ExpectedException.none();
 

--- a/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
+++ b/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
@@ -337,6 +337,7 @@ public class MessageDeframerTest {
 
   @RunWith(JUnit4.class)
   public static class SizeEnforcingInputStreamTests {
+    @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
 

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -59,6 +59,7 @@ import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public class ServerCallImplTest {
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Mock private ServerStream stream;
   @Mock private ServerCall.Listener<Long> callListener;

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -139,6 +139,7 @@ public class ServerImplTest {
       };
   private static final String AUTHORITY = "some_authority";
 
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   @BeforeClass

--- a/core/src/test/java/io/grpc/util/GracefulSwitchLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/util/GracefulSwitchLoadBalancerTest.java
@@ -62,6 +62,7 @@ import org.mockito.InOrder;
  */
 @RunWith(JUnit4.class)
 public class GracefulSwitchLoadBalancerTest {
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule
   public final ExpectedException thrown = ExpectedException.none();
 

--- a/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
@@ -41,6 +41,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class NettyChannelBuilderTest {
 
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule public final ExpectedException thrown = ExpectedException.none();
   private final SslContext noSslContext = null;
 

--- a/netty/src/test/java/io/grpc/netty/NettyServerBuilderTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerBuilderTest.java
@@ -40,6 +40,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class NettyServerBuilderTest {
 
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   private NettyServerBuilder builder = NettyServerBuilder.forPort(8080);

--- a/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
+++ b/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
@@ -122,6 +122,7 @@ public class ProtocolNegotiatorsTest {
 
   private static final int TIMEOUT_SECONDS = 60;
   @Rule public final TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(TIMEOUT_SECONDS));
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   private final EventLoopGroup group = new DefaultEventLoop();

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
@@ -47,6 +47,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class OkHttpChannelBuilderTest {
 
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Rule public final GrpcCleanupRule grpcCleanupRule = new GrpcCleanupRule();
 

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpProtocolNegotiatorTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpProtocolNegotiatorTest.java
@@ -49,6 +49,7 @@ import org.mockito.ArgumentMatchers;
  */
 @RunWith(JUnit4.class)
 public class OkHttpProtocolNegotiatorTest {
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   private final SSLSocket sock = mock(SSLSocket.class);

--- a/okhttp/src/test/java/io/grpc/okhttp/UtilsTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/UtilsTest.java
@@ -37,6 +37,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class UtilsTest {
 
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule
   public final ExpectedException thrown = ExpectedException.none();
 

--- a/protobuf-lite/src/test/java/io/grpc/protobuf/lite/ProtoLiteUtilsTest.java
+++ b/protobuf-lite/src/test/java/io/grpc/protobuf/lite/ProtoLiteUtilsTest.java
@@ -51,6 +51,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ProtoLiteUtilsTest {
 
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   private Marshaller<Type> marshaller = ProtoLiteUtils.marshaller(Type.getDefaultInstance());

--- a/testing/src/test/java/io/grpc/testing/GrpcCleanupRuleTest.java
+++ b/testing/src/test/java/io/grpc/testing/GrpcCleanupRuleTest.java
@@ -51,6 +51,7 @@ import org.mockito.InOrder;
 public class GrpcCleanupRuleTest {
   public static final FakeClock fakeClock = new FakeClock();
 
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 

--- a/xds/src/test/java/io/grpc/xds/BootstrapperTest.java
+++ b/xds/src/test/java/io/grpc/xds/BootstrapperTest.java
@@ -40,6 +40,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class BootstrapperTest {
 
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/PriorityLoadBalancerProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/PriorityLoadBalancerProviderTest.java
@@ -34,6 +34,7 @@ import org.junit.runners.JUnit4;
 /** Tests for {@link PriorityLoadBalancerProvider}. */
 @RunWith(JUnit4.class)
 public class PriorityLoadBalancerProviderTest {
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   @SuppressWarnings("ExpectedExceptionChecker")

--- a/xds/src/test/java/io/grpc/xds/WeightedRandomPickerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedRandomPickerTest.java
@@ -42,6 +42,7 @@ import org.mockito.junit.MockitoRule;
  */
 @RunWith(JUnit4.class)
 public class WeightedRandomPickerTest {
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule
   public final ExpectedException thrown = ExpectedException.none();
 

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTest.java
@@ -176,6 +176,7 @@ public class XdsClientImplTest {
 
   @Rule
   public final GrpcCleanupRule cleanupRule = new GrpcCleanupRule();
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 

--- a/xds/src/test/java/io/grpc/xds/XdsClientTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientTest.java
@@ -34,6 +34,7 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class XdsClientTest {
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule
   public final ExpectedException thrown = ExpectedException.none();
 

--- a/xds/src/test/java/io/grpc/xds/internal/rbac/engine/AuthzEngineTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/rbac/engine/AuthzEngineTest.java
@@ -44,6 +44,7 @@ import org.mockito.junit.MockitoRule;
 /** Unit tests for constructor of CEL-based Authorization Engine. */
 @RunWith(JUnit4.class)
 public class AuthzEngineTest {
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule
   public final ExpectedException thrown = ExpectedException.none();
 


### PR DESCRIPTION
It deprecates ExpectedException and Assert.assertThat(T, org.hamcrest.Matcher).
Without Java 8 we don't want to migrate away from ExpectedException at
this time. We tend to prefer Truth over Hamcrest, so I swapped the one
instance of Assert.assertThat() to use Truth. With this change we get a
warning-less build with JUnit 4.13. We don't yet upgrade because we
still need to support JUnit 4.12 for some use-cases, but will be able to
upgrade to 4.13 soon when they upgrade.

CC @elharo 