### PR TITLE
core: fix floating-point number formatting Locale

### DIFF
--- a/context/src/main/java/io/grpc/Deadline.java
+++ b/context/src/main/java/io/grpc/Deadline.java
@@ -207,7 +207,7 @@ public final class Deadline implements Comparable<Deadline> {
     }
     buf.append(seconds);
     if (nanos > 0) {
-      buf.append(String.format(Locale.ROOT, ".%09d", nanos));
+      buf.append(String.format(Locale.US, ".%09d", nanos));
     }
     buf.append("s from now");
     if (ticker != SYSTEM_TICKER) {

--- a/context/src/main/java/io/grpc/Deadline.java
+++ b/context/src/main/java/io/grpc/Deadline.java
@@ -17,6 +17,7 @@
 package io.grpc;
 
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -206,7 +207,7 @@ public final class Deadline implements Comparable<Deadline> {
     }
     buf.append(seconds);
     if (nanos > 0) {
-      buf.append(String.format(".%09d", nanos));
+      buf.append(String.format(Locale.ROOT, ".%09d", nanos));
     }
     buf.append("s from now");
     if (ticker != SYSTEM_TICKER) {

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -54,6 +54,7 @@ import io.perfmark.PerfMark;
 import io.perfmark.Tag;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.Locale;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -441,7 +442,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
         buf.append('-');
       }
       buf.append(seconds);
-      buf.append(String.format(".%09d", nanos));
+      buf.append(String.format(Locale.ROOT, ".%09d", nanos));
       buf.append("s. ");
       buf.append(insight);
       stream.cancel(DEADLINE_EXCEEDED.augmentDescription(buf.toString()));

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -442,7 +442,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
         buf.append('-');
       }
       buf.append(seconds);
-      buf.append(String.format(Locale.ROOT, ".%09d", nanos));
+      buf.append(String.format(Locale.US, ".%09d", nanos));
       buf.append("s. ");
       buf.append(insight);
       stream.cancel(DEADLINE_EXCEEDED.augmentDescription(buf.toString()));

--- a/core/src/main/java/io/grpc/internal/DelayedClientCall.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientCall.java
@@ -30,6 +30,7 @@ import io.grpc.Metadata;
 import io.grpc.Status;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -117,7 +118,7 @@ class DelayedClientCall<ReqT, RespT> extends ClientCall<ReqT, RespT> {
       buf.append("Deadline exceeded after ");
     }
     buf.append(seconds);
-    buf.append(String.format(".%09d", nanos));
+    buf.append(String.format(Locale.ROOT, ".%09d", nanos));
     buf.append("s. ");
     /** Cancels the call if deadline exceeded prior to the real call being set. */
     class DeadlineExceededRunnable implements Runnable {

--- a/core/src/main/java/io/grpc/internal/DelayedClientCall.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientCall.java
@@ -118,7 +118,7 @@ class DelayedClientCall<ReqT, RespT> extends ClientCall<ReqT, RespT> {
       buf.append("Deadline exceeded after ");
     }
     buf.append(seconds);
-    buf.append(String.format(Locale.ROOT, ".%09d", nanos));
+    buf.append(String.format(Locale.US, ".%09d", nanos));
     buf.append("s. ");
     /** Cancels the call if deadline exceeded prior to the real call being set. */
     class DeadlineExceededRunnable implements Runnable {


### PR DESCRIPTION
In some Locale, floating-point number like `1,234.56` is formatted as `1.234,56`; and in some Locale, integers are formatted with non-ASCII decimal digits.

https://developer.android.com/reference/java/util/Locale.html#default_locale