### PR TITLE
netty: TCP close during TLS handshake should be UNAVAILABLE (v1.32.x backport)

### DIFF
--- a/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
+++ b/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
@@ -33,6 +33,8 @@ import io.grpc.Attributes;
 import io.grpc.Grpc;
 import io.grpc.InternalChannelz.Security;
 import io.grpc.SecurityLevel;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.testing.TestUtils;
 import io.grpc.netty.ProtocolNegotiators.ClientTlsHandler;
@@ -531,6 +533,20 @@ public class ProtocolNegotiatorsTest {
     assertThat(error.get()).hasMessageThat().contains("Unable to find compatible protocol");
     ChannelHandlerContext grpcHandlerCtx = pipeline.context(grpcHandler);
     assertNull(grpcHandlerCtx);
+  }
+
+  @Test
+  public void clientTlsHandler_closeDuringNegotiation() throws Exception {
+    ClientTlsHandler handler = new ClientTlsHandler(grpcHandler, sslContext, "authority", null);
+    pipeline.addLast(new WriteBufferingAndExceptionHandler(handler));
+    ChannelFuture pendingWrite = channel.writeAndFlush(NettyClientHandler.NOOP_MESSAGE);
+
+    // SslHandler fires userEventTriggered() before channelInactive()
+    pipeline.fireChannelInactive();
+
+    assertThat(pendingWrite.cause()).isInstanceOf(StatusRuntimeException.class);
+    assertThat(Status.fromThrowable(pendingWrite.cause()).getCode())
+        .isEqualTo(Status.Code.UNAVAILABLE);
   }
 
   @Test


### PR DESCRIPTION
Normally the first exception/event experienced is the cause and is
followed by a stampede of ClosedChannelExceptions. In this case,
SslHandler is manufacturing a ClosedChannelException of its own and
propagating it _before_ the trigger event. This might be considered a
bug, but changing SslHandler's behavior would be very risky and almost
certainly break someone's code.

Fixes #7376

----

This is a backport of #7476