### PR TITLE
xds: sync envoy proto to commit 1c27396b1f7e756ba79eed72b47f485d44da1d41

### DIFF
--- a/xds/third_party/envoy/import.sh
+++ b/xds/third_party/envoy/import.sh
@@ -18,7 +18,7 @@
 set -e
 BRANCH=master
 # import VERSION from one of the google internal CLs
-VERSION=fd28e42f31730f5ed6f13f52999692a4885dd312
+VERSION=1c27396b1f7e756ba79eed72b47f485d44da1d41
 GIT_REPO="https://github.com/envoyproxy/envoy.git"
 GIT_BASE_DIR=envoy
 SOURCE_PROTO_BASE_DIR=envoy/api

--- a/xds/third_party/envoy/src/main/proto/envoy/config/accesslog/v3/accesslog.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/accesslog/v3/accesslog.proto
@@ -254,6 +254,7 @@ message ResponseFlagFilter {
         in: "UMSDR"
         in: "RFCF"
         in: "NFCF"
+        in: "DT"
       }
     }
   }];

--- a/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/cluster.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/cluster.proto
@@ -612,7 +612,32 @@ message Cluster {
     //
     // This is limited somewhat arbitrarily to 3 because prefetching connections too aggressively can
     // harm latency more than the prefetching helps.
-    google.protobuf.DoubleValue prefetch_ratio = 1 [(validate.rules).double = {lte: 3.0 gte: 1.0}];
+    google.protobuf.DoubleValue per_upstream_prefetch_ratio = 1
+        [(validate.rules).double = {lte: 3.0 gte: 1.0}];
+
+    // Indicates how many many streams (rounded up) can be anticipated across a cluster for each
+    // stream, useful for low QPS services. This is currently supported for a subset of
+    // deterministic non-hash-based load-balancing algorithms (weighted round robin, random).
+    // Unlike per_upstream_prefetch_ratio this prefetches across the upstream instances in a
+    // cluster, doing best effort predictions of what upstream would be picked next and
+    // pre-establishing a connection.
+    //
+    // For example if prefetching is set to 2 for a round robin HTTP/2 cluster, on the first
+    // incoming stream, 2 connections will be prefetched - one to the first upstream for this
+    // cluster, one to the second on the assumption there will be a follow-up stream.
+    //
+    // Prefetching will be limited to one prefetch per configured upstream in the cluster.
+    //
+    // If this value is not set, or set explicitly to one, Envoy will fetch as many connections
+    // as needed to serve streams in flight, so during warm up and in steady state if a connection
+    // is closed (and per_upstream_prefetch_ratio is not set), there will be a latency hit for
+    // connection establishment.
+    //
+    // If both this and prefetch_ratio are set, Envoy will make sure both predicted needs are met,
+    // basically prefetching max(predictive-prefetch, per-upstream-prefetch), for each upstream.
+    // TODO(alyssawilk) per LB docs and LB overview docs when unhiding.
+    google.protobuf.DoubleValue predictive_prefetch_ratio = 2
+        [(validate.rules).double = {lte: 3.0 gte: 1.0}];
   }
 
   reserved 12, 15, 7, 11, 35;

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/substitution_format_string.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/substitution_format_string.proto
@@ -23,15 +23,18 @@ message SubstitutionFormatString {
     // Specify a format with command operators to form a text string.
     // Its details is described in :ref:`format string<config_access_log_format_strings>`.
     //
-    // .. code-block::
+    // For example, setting ``text_format`` like below,
     //
-    //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
+    // .. validated-code-block:: yaml
+    //   :type-name: envoy.config.core.v3.SubstitutionFormatString
     //
-    // The following plain text will be created:
+    //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\n"
     //
-    // .. code-block::
+    // generates plain text similar to:
     //
-    //   upstream connect error:204:path=/foo
+    // .. code-block:: text
+    //
+    //   upstream connect error:503:path=/foo
     //
     string text_format = 1 [(validate.rules).string = {min_bytes: 1}];
 
@@ -41,11 +44,12 @@ message SubstitutionFormatString {
     // Nested JSON objects may be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).
     // See the documentation for a specific command operator for details.
     //
-    // .. code-block::
+    // .. validated-code-block:: yaml
+    //   :type-name: envoy.config.core.v3.SubstitutionFormatString
     //
-    //  json_format:
-    //    status: %RESPONSE_CODE%
-    //    message: %LOCAL_REPLY_BODY%
+    //   json_format:
+    //     status: "%RESPONSE_CODE%"
+    //     message: "%LOCAL_REPLY_BODY%"
     //
     // The following JSON object would be created:
     //
@@ -65,4 +69,15 @@ message SubstitutionFormatString {
   //   empty string, so that empty values are omitted entirely.
   // * for ``json_format`` the keys with null values are omitted in the output structure.
   bool omit_empty_values = 3;
+
+  // Specify a *content_type* field.
+  // If this field is not set then ``text/plain`` is used for *text_format* and
+  // ``application/json`` is used for *json_format*.
+  //
+  // .. validated-code-block:: yaml
+  //   :type-name: envoy.config.core.v3.SubstitutionFormatString
+  //
+  //   content_type: "text/html; charset=UTF-8"
+  //
+  string content_type = 4;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/config/route/v3/route_components.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/route/v3/route_components.proto
@@ -778,7 +778,7 @@ message RouteAction {
     // <https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md>`_, use that value as the
     // *max_stream_duration*, but limit the applied timeout to the maximum value specified here.
     // If set to 0, the `grpc-timeout` header is used without modification.
-    google.protobuf.Duration grpc_max_timeout = 2;
+    google.protobuf.Duration grpc_timeout_header_max = 2;
 
     // If present, Envoy will adjust the timeout provided by the `grpc-timeout` header by
     // subtracting the provided duration from the header. This is useful for allowing Envoy to set
@@ -786,7 +786,7 @@ message RouteAction {
     // makes it more likely that Envoy will handle the timeout instead of having the call canceled
     // by the client. If, after applying the offset, the resulting timeout is zero or negative,
     // the stream will timeout immediately.
-    google.protobuf.Duration grpc_timeout_offset = 3;
+    google.protobuf.Duration grpc_timeout_header_offset = 3;
   }
 
   reserved 12, 18, 19, 16, 22, 21, 10;

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -571,27 +571,29 @@ message LocalReplyConfig {
   // The configuration to form response body from the :ref:`command operators <config_access_log_command_operators>`
   // and to specify response content type as one of: plain/text or application/json.
   //
-  // Example one: plain/text body_format.
+  // Example one: "plain/text" ``body_format``.
   //
-  // .. code-block::
+  // .. validated-code-block:: yaml
+  //   :type-name: envoy.config.core.v3.SubstitutionFormatString
   //
-  //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
+  //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\n"
   //
-  // The following response body in `plain/text` format will be generated for a request with
+  // The following response body in "plain/text" format will be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.
   //
-  // .. code-block::
+  // .. code-block:: text
   //
   //   upstream connect error:503:path=/foo
   //
-  //  Example two: application/json body_format.
+  // Example two: "application/json" ``body_format``.
   //
-  // .. code-block::
+  // .. validated-code-block:: yaml
+  //   :type-name: envoy.config.core.v3.SubstitutionFormatString
   //
-  //  json_format:
-  //    status: %RESPONSE_CODE%
-  //    message: %LOCAL_REPLY_BODY%
-  //    path: $REQ(:path)%
+  //   json_format:
+  //     status: "%RESPONSE_CODE%"
+  //     message: "%LOCAL_REPLY_BODY%"
+  //     path: "%REQ(:path)%"
   //
   // The following response body in "application/json" format would be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.
@@ -809,13 +811,13 @@ message HttpFilter {
   // sufficient. It also serves as a resource name in ExtensionConfigDS.
   string name = 1 [(validate.rules).string = {min_bytes: 1}];
 
-  // Filter specific configuration which depends on the filter being instantiated. See the supported
-  // filters for further documentation.
   oneof config_type {
+    // Filter specific configuration which depends on the filter being instantiated. See the supported
+    // filters for further documentation.
     google.protobuf.Any typed_config = 4;
 
     // Configuration source specifier for an extension configuration discovery service.
-    // In case of a failure and without the default configuration, the HTTP listener responds with 500.
+    // In case of a failure and without the default configuration, the HTTP listener responds with code 500.
     // Extension configs delivered through this mechanism are not expected to require warming (see https://github.com/envoyproxy/envoy/issues/12061).
     config.core.v3.ExtensionConfigSource config_discovery = 5;
   }

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -151,7 +151,9 @@ message TlsCertificate {
   // TLS private key is not password encrypted.
   config.core.v3.DataSource password = 3 [(udpa.annotations.sensitive) = true];
 
-  // [#not-implemented-hide:]
+  // The OCSP response to be stapled with this certificate during the handshake.
+  // The response must be DER-encoded and may only be  provided via ``filename`` or
+  // ``inline_bytes``. The response may pertain to only one certificate.
   config.core.v3.DataSource ocsp_staple = 4;
 
   // [#not-implemented-hide:]
@@ -205,7 +207,7 @@ message CertificateValidationContext {
     ACCEPT_UNTRUSTED = 1;
   }
 
-  reserved 4;
+  reserved 4, 5;
 
   reserved "verify_subject_alt_name";
 
@@ -314,9 +316,6 @@ message CertificateValidationContext {
   //   therefore this option must be used together with :ref:`trusted_ca
   //   <envoy_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
   repeated type.matcher.v3.StringMatcher match_subject_alt_names = 9;
-
-  // [#not-implemented-hide:] Must present a signed time-stamped OCSP response.
-  google.protobuf.BoolValue require_ocsp_staple = 5;
 
   // [#not-implemented-hide:] Must present signed certificate time-stamp.
   google.protobuf.BoolValue require_signed_certificate_timestamp = 6;

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -54,10 +54,32 @@ message UpstreamTlsContext {
   google.protobuf.UInt32Value max_session_keys = 4;
 }
 
-// [#next-free-field: 8]
+// [#next-free-field: 9]
 message DownstreamTlsContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.auth.DownstreamTlsContext";
+
+  enum OcspStaplePolicy {
+    // OCSP responses are optional. If an OCSP response is absent
+    // or expired, the associated certificate will be used for
+    // connections without an OCSP staple.
+    LENIENT_STAPLING = 0;
+
+    // OCSP responses are optional. If an OCSP response is absent,
+    // the associated certificate will be used without an
+    // OCSP staple. If a response is provided but is expired,
+    // the associated certificate will not be used for
+    // subsequent connections. If no suitable certificate is found,
+    // the connection is rejected.
+    STRICT_STAPLING = 1;
+
+    // OCSP responses are required. Configuration will fail if
+    // a certificate is provided without an OCSP response. If a
+    // response expires, the associated certificate will not be
+    // used connections. If no suitable certificate is found, the
+    // connection is rejected.
+    MUST_STAPLE = 2;
+  }
 
   // Common TLS context settings.
   CommonTlsContext common_tls_context = 1;
@@ -96,6 +118,11 @@ message DownstreamTlsContext {
     lt {seconds: 4294967296}
     gte {}
   }];
+
+  // Config for whether to use certificates if they do not have
+  // an accompanying OCSP response or if the response expires at runtime.
+  // Defaults to LENIENT_STAPLING
+  OcspStaplePolicy ocsp_staple_policy = 8 [(validate.rules).enum = {defined_only: true}];
 }
 
 // TLS context shared by both client and server TLS contexts.


### PR DESCRIPTION
The xDS timeout fields have been renamed by https://github.com/envoyproxy/envoy/pull/13247, so update the protos to pick up that change.


Internal Envoy import CL: cl/335029474