### PR TITLE
Add implementation note regarding server interceptors and thread locals

### DIFF
--- a/api/src/main/java/io/grpc/ServerInterceptor.java
+++ b/api/src/main/java/io/grpc/ServerInterceptor.java
@@ -29,6 +29,12 @@ import javax.annotation.concurrent.ThreadSafe;
  * <li>Logging and monitoring call behavior</li>
  * <li>Delegating calls to other servers</li>
  * </ul>
+ *
+ * <p><b>Implementation note:</b> Implementations that provide thread local variables must remove
+ * them before they return from {@link #interceptCall(ServerCall, Metadata, ServerCallHandler)}
+ * because each message that is processed as part of the call might be handled by a different
+ * thread (including the first message). If you wish to provide the thread local for the duration
+ * of the entire call you have to reassign and clear them in each method of the returned listener.
  */
 @ThreadSafe
 public interface ServerInterceptor {


### PR DESCRIPTION
There seems to be some confusion regarding the correct usage of thread locals inside `ServerInterceptor`s.

- [LogNet/grpc-spring-boot-starter](https://github.com/LogNet/grpc-spring-boot-starter/pull/155/files#diff-07d6148150d4e7f10aaec9088ea218e9R32) (included in the latest release)
- [revinate/grpc-spring-security-demo](https://github.com/revinate/grpc-spring-security-demo/blob/master/src/main/java/com/revinate/grpcspringsecurity/grpc/interceptor/SecurityContextPersistenceInterceptor.java#L13)
- [pagrus7/grpc-spring-boot-starter](https://github.com/pagrus7/grpc-spring-boot-starter/commit/15ab3c0114f821bf850039fef479b67c2d88db86#diff-db6175e8e9e96445fddc3aaade684689R7)

In all these examples the thread local is assigned during `interceptCall`/`startCall` and only removed on completion/error/close.
I try to warn about these broken implementations, but they are still out there after all and even new ones are created. IMO we should add a hint to the `ServerInterceptor` that strongly warns about the wrong usage of thread locals inside `ServerInterceptor`s.

I also considered adding such a hint to `ServerCall.Listener` and the the corresponding client classes, but I would like to ask for opinion first.