### PR TITLE
rls: allow defaultTarget in RouteLookupConfig unset

### DIFF
--- a/rls/src/main/java/io/grpc/rls/RlsProtoData.java
+++ b/rls/src/main/java/io/grpc/rls/RlsProtoData.java
@@ -195,6 +195,7 @@ final class RlsProtoData {
 
     private final ImmutableList<String> validTargets;
 
+    @Nullable
     private final String defaultTarget;
 
     RouteLookupConfig(
@@ -205,6 +206,7 @@ final class RlsProtoData {
         @Nullable Long staleAgeInMillis,
         long cacheSizeBytes,
         List<String> validTargets,
+        @Nullable
         String defaultTarget) {
       checkState(
           !checkNotNull(grpcKeyBuilders, "grpcKeyBuilders").isEmpty(),
@@ -233,7 +235,7 @@ final class RlsProtoData {
       checkArgument(cacheSizeBytes > 0, "cacheSize must be positive");
       this.cacheSizeBytes = cacheSizeBytes;
       this.validTargets = ImmutableList.copyOf(checkNotNull(validTargets, "validTargets"));
-      this.defaultTarget = checkNotNull(defaultTarget, "defaultTarget");
+      this.defaultTarget = defaultTarget;
     }
 
     /**


### PR DESCRIPTION
The `default_target` field can be unset per the [spec](http://go/grpc-rls-lb-policy-design)

Also fixed a synchronization bug (related to #7460 cc @ejona86 ) that `createOrGet()` should be guarded by lock.