### PR TITLE
interop-testing: Avoid alts incompatibility with netty

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -396,9 +396,10 @@ public class TestServiceClient {
   private class Tester extends AbstractInteropTest {
     @Override
     protected ManagedChannelBuilder<?> createChannelBuilder() {
+      boolean useGeneric = false;
       ChannelCredentials channelCredentials;
       if (customCredentialsType != null) {
-        useOkHttp = false; // Retain old behavior; avoids erroring if incompatible
+        useGeneric = true; // Retain old behavior; avoids erroring if incompatible
         if (customCredentialsType.equals("google_default_credentials")) {
           channelCredentials = GoogleDefaultChannelCredentials.create();
         } else if (customCredentialsType.equals("compute_engine_channel_creds")) {
@@ -409,7 +410,7 @@ public class TestServiceClient {
         }
 
       } else if (useAlts) {
-        useOkHttp = false; // Retain old behavior; avoids erroring if incompatible
+        useGeneric = true; // Retain old behavior; avoids erroring if incompatible
         channelCredentials = AltsChannelCredentials.create();
 
       } else if (useTls) {
@@ -441,6 +442,14 @@ public class TestServiceClient {
         } else {
           channelCredentials = InsecureChannelCredentials.create();
         }
+      }
+      if (useGeneric) {
+        ManagedChannelBuilder<?> channelBuilder =
+            Grpc.newChannelBuilderForAddress(serverHost, serverPort, channelCredentials);
+        if (serverHostOverride != null) {
+          channelBuilder.overrideAuthority(serverHostOverride);
+        }
+        return channelBuilder;
       }
       if (!useOkHttp) {
         NettyChannelBuilder nettyBuilder =


### PR DESCRIPTION
alts requires netty-shaded, not netty.

----

This fixes the interop tests that are failing on grpc/grpc: https://source.cloud.google.com/results/invocations/df375b99-abd8-47e7-a044-2677adae9f42/targets/grpc%2Fcore%2Fpull_request%2Flinux%2Fgrpc_interop_alts/log