### PR TITLE
xds: fix the transport-socket-name to match what control plane sends

### DIFF
--- a/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
@@ -61,6 +61,7 @@ import javax.annotation.Nullable;
  */
 // TODO(chengyuanzhang): put data types into smaller categories.
 final class EnvoyProtoData {
+  static final String TRANSPORT_SOCKET_NAME_TLS = "envoy.transport_sockets.tls";
 
   // Prevent instantiation.
   private EnvoyProtoData() {
@@ -1806,6 +1807,4 @@ final class EnvoyProtoData {
       }
     }
   }
-
-  static final String TRANSPORT_SOCKET_NAME_TLS = "envoy.transport_sockets.tls";
 }

--- a/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
@@ -1806,4 +1806,6 @@ final class EnvoyProtoData {
       }
     }
   }
+
+  static final String TRANSPORT_SOCKET_NAME_TLS = "envoy.transport_sockets.tls";
 }

--- a/xds/src/main/java/io/grpc/xds/EnvoyServerProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyServerProtoData.java
@@ -16,6 +16,8 @@
 
 package io.grpc.xds;
 
+import static io.grpc.xds.EnvoyProtoData.TRANSPORT_SOCKET_NAME_TLS;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -295,7 +297,7 @@ public final class EnvoyServerProtoData {
         io.envoyproxy.envoy.config.listener.v3.FilterChain filterChain)
         throws InvalidProtocolBufferException {
       if (filterChain.hasTransportSocket()
-          && "tls".equals(filterChain.getTransportSocket().getName())) {
+          && TRANSPORT_SOCKET_NAME_TLS.equals(filterChain.getTransportSocket().getName())) {
         Any any = filterChain.getTransportSocket().getTypedConfig();
         return DownstreamTlsContext.fromEnvoyProtoDownstreamTlsContext(
             io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext.parseFrom(

--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl2.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl2.java
@@ -19,6 +19,7 @@ package io.grpc.xds;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static io.grpc.xds.EnvoyProtoData.TRANSPORT_SOCKET_NAME_TLS;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
@@ -783,7 +784,8 @@ final class XdsClientImpl2 extends XdsClient {
   @Nullable
   private static EnvoyServerProtoData.UpstreamTlsContext getTlsContextFromCluster(Cluster cluster)
       throws InvalidProtocolBufferException {
-    if (cluster.hasTransportSocket() && "tls".equals(cluster.getTransportSocket().getName())) {
+    if (cluster.hasTransportSocket()
+        && TRANSPORT_SOCKET_NAME_TLS.equals(cluster.getTransportSocket().getName())) {
       Any any = cluster.getTransportSocket().getTypedConfig();
       return EnvoyServerProtoData.UpstreamTlsContext.fromEnvoyProtoUpstreamTlsContext(
           any.unpack(UpstreamTlsContext.class));

--- a/xds/src/test/java/io/grpc/xds/EnvoyServerProtoDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/EnvoyServerProtoDataTest.java
@@ -118,7 +118,7 @@ public class EnvoyServerProtoDataTest {
                         .build())
                     .addApplicationProtocols("managed-mtls")
                     .build())
-            .setTransportSocket(TransportSocket.newBuilder().setName("tls")
+            .setTransportSocket(TransportSocket.newBuilder().setName("envoy.transport_sockets.tls")
                 .setTypedConfig(
                     Any.pack(CommonTlsContextTestsUtil.buildTestDownstreamTlsContext(
                         "google-sds-config-default", "ROOTCA")))

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTestForListener.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTestForListener.java
@@ -786,15 +786,17 @@ public class XdsClientImplTestForListener {
   @SuppressWarnings("deprecation")
   static FilterChain buildFilterChain(FilterChainMatch filterChainMatch,
                                       DownstreamTlsContext tlsContext, Filter...filters) {
-    return
-        FilterChain.newBuilder()
-            .setFilterChainMatch(filterChainMatch)
-            .setTransportSocket(tlsContext == null
+    return FilterChain.newBuilder()
+        .setFilterChainMatch(filterChainMatch)
+        .setTransportSocket(
+            tlsContext == null
                 ? TransportSocket.getDefaultInstance()
-                : TransportSocket.newBuilder().setName("tls").setTypedConfig(Any.pack(tlsContext))
+                : TransportSocket.newBuilder()
+                    .setName("envoy.transport_sockets.tls")
+                    .setTypedConfig(Any.pack(tlsContext))
                     .build())
-            .addAllFilters(Arrays.asList(filters))
-            .build();
+        .addAllFilters(Arrays.asList(filters))
+        .build();
   }
 
   static FilterChainMatch buildFilterChainMatch(int destPort, CidrRange...prefixRanges) {

--- a/xds/src/test/java/io/grpc/xds/XdsClientTestHelper.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientTestHelper.java
@@ -235,7 +235,9 @@ class XdsClientTestHelper {
     }
     if (upstreamTlsContext != null) {
       clusterBuilder.setTransportSocket(
-          TransportSocket.newBuilder().setName("tls").setTypedConfig(Any.pack(upstreamTlsContext)));
+          TransportSocket.newBuilder()
+              .setName("envoy.transport_sockets.tls")
+              .setTypedConfig(Any.pack(upstreamTlsContext)));
     }
     return clusterBuilder.build();
   }


### PR DESCRIPTION
The comment in envoy/src/api/envoy/config/cluster/v3/cluster.proto line 896 mentions using "tls" as the name but the actual string is "envoy.transport_sockets.tls" as per the example on line 654 in the same file.