### PR TITLE
interop-testing: Remove redundant tearDown() in hook

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -61,19 +61,6 @@ public class TestServiceClient {
     client.parseArgs(args);
     client.setUp();
 
-    Runtime.getRuntime().addShutdownHook(new Thread() {
-      @Override
-      @SuppressWarnings("CatchAndPrintStackTrace")
-      public void run() {
-        System.out.println("Shutting down");
-        try {
-          client.tearDown();
-        } catch (Exception e) {
-          e.printStackTrace();
-        }
-      }
-    });
-
     try {
       client.run();
     } finally {


### PR DESCRIPTION
The main() Thread will call tearDown() itself. It appears this
redundancy has existed since e813eaae2f, where the normal error handling
was enhanced at the same time as cleaning up resource management. The
cleanup should have made it obvious the hook was no longer needed, but
alas. Technically, it did originally provide a purpose if setup()
failed, but it would have been better to just move setup() into the
try-catch instead. Today it doesn't even provide that purpose.