### PR TITLE
alts: migrate java proto map getter from get<field> to get<field>Map

### DIFF
--- a/alts/src/main/java/io/grpc/alts/internal/AltsAuthContext.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsAuthContext.java
@@ -34,7 +34,7 @@ public final class AltsAuthContext {
             .setPeerServiceAccount(result.getPeerIdentity().getServiceAccount())
             .setLocalServiceAccount(result.getLocalIdentity().getServiceAccount())
             .setPeerRpcVersions(result.getPeerRpcVersions())
-            .putAllPeerAttributes(result.getPeerIdentity().getAttributes())
+            .putAllPeerAttributes(result.getPeerIdentity().getAttributesMap())
             .build();
   }
 

--- a/xds/src/main/java/io/grpc/xds/internal/rbac/engine/AuthorizationEngine.java
+++ b/xds/src/main/java/io/grpc/xds/internal/rbac/engine/AuthorizationEngine.java
@@ -85,7 +85,7 @@ public class AuthorizationEngine {
    */
   public AuthorizationEngine(RBAC rbacPolicy) {
     Map<String, Expr> conditions = new LinkedHashMap<>();
-    for (Map.Entry<String, Policy> policy: rbacPolicy.getPolicies().entrySet()) {
+    for (Map.Entry<String, Policy> policy: rbacPolicy.getPoliciesMap().entrySet()) {
       conditions.put(policy.getKey(), policy.getValue().getCondition());
     }
     allowEngine = (rbacPolicy.getAction() == Action.ALLOW) 
@@ -108,12 +108,12 @@ public class AuthorizationEngine {
         "Invalid RBAC list, " 
         + "must provide a RBAC with DENY action followed by a RBAC with ALLOW action. ");
     Map<String, Expr> denyConditions = new LinkedHashMap<>();
-    for (Map.Entry<String, Policy> policy: denyPolicy.getPolicies().entrySet()) {
+    for (Map.Entry<String, Policy> policy: denyPolicy.getPoliciesMap().entrySet()) {
       denyConditions.put(policy.getKey(), policy.getValue().getCondition());
     }
     denyEngine = new RbacEngine(Action.DENY, ImmutableMap.copyOf(denyConditions));
     Map<String, Expr> allowConditions = new LinkedHashMap<>();
-    for (Map.Entry<String, Policy> policy: allowPolicy.getPolicies().entrySet()) {
+    for (Map.Entry<String, Policy> policy: allowPolicy.getPoliciesMap().entrySet()) {
       allowConditions.put(policy.getKey(), policy.getValue().getCondition());
     }
     allowEngine = new RbacEngine(Action.ALLOW, ImmutableMap.copyOf(allowConditions));   


### PR DESCRIPTION
Migrate java proto map getter from get<field> to get<field>Map. 

This is part of a set of changes to java proto map API described here: go/java-proto-maplike

More information: go/java-proto-maplike-getFooMap

-----------
See internal cl/336170181