### PR TITLE
interop-testing: support rpc keep-open for xDS test server

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
@@ -41,7 +41,7 @@ import java.util.logging.Logger;
 public final class XdsTestServer {
   static final Metadata.Key<String> HOSTNAME_KEY =
       Metadata.Key.of("hostname", Metadata.ASCII_STRING_MARSHALLER);
-  static final Metadata.Key<String> CALL_BEHAVIOR_KEY =
+  private static final Metadata.Key<String> CALL_BEHAVIOR_KEY =
       Metadata.Key.of("rpc-behavior", Metadata.ASCII_STRING_MARSHALLER);
 
   private static Logger logger = Logger.getLogger(XdsTestServer.class.getName());


### PR DESCRIPTION
Sending out server changes separately to unblock other languages' test client.

/cc @donnadionne @menghanl 