### PR TITLE
xds: import envoy proto envoy/config/cluster/aggregate/v2alpha/cluster.proto

### DIFF
--- a/xds/third_party/envoy/import.sh
+++ b/xds/third_party/envoy/import.sh
@@ -80,6 +80,7 @@ envoy/config/core/v3/protocol.proto
 envoy/config/core/v3/proxy_protocol.proto
 envoy/config/core/v3/socket_option.proto
 envoy/config/core/v3/substitution_format_string.proto
+envoy/config/cluster/aggregate/v2alpha/cluster.proto
 envoy/config/endpoint/v3/endpoint.proto
 envoy/config/endpoint/v3/endpoint_components.proto
 envoy/config/endpoint/v3/load_report.proto

--- a/xds/third_party/envoy/src/main/proto/envoy/config/cluster/aggregate/v2alpha/cluster.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/cluster/aggregate/v2alpha/cluster.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package envoy.config.cluster.aggregate.v2alpha;
+
+import "udpa/annotations/migrate.proto";
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.config.cluster.aggregate.v2alpha";
+option java_outer_classname = "ClusterProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.clusters.aggregate.v3";
+option (udpa.annotations.file_status).package_version_status = FROZEN;
+
+// [#protodoc-title: Aggregate cluster configuration]
+
+// Configuration for the aggregate cluster. See the :ref:`architecture overview
+// <arch_overview_aggregate_cluster>` for more information.
+// [#extension: envoy.clusters.aggregate]
+message ClusterConfig {
+  // Load balancing clusters in aggregate cluster. Clusters are prioritized based on the order they
+  // appear in this list.
+  repeated string clusters = 1 [(validate.rules).repeated = {min_items: 1}];
+}


### PR DESCRIPTION
`ClusterConfig` specifies the list of cluster names within an aggregate cluster. Needed for aggregate cluster support.