### PR TITLE
xds: make stats objects thread-safe

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
+++ b/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
@@ -42,7 +42,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * pairs.
  *
  * <p>This class is thread-safe for recording client call stats and backend metrics.
- * 
+ *
  * <p>Calls of {@link #snapshot()} must be serialized externally.
  */
 final class ClientLoadCounter {

--- a/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
+++ b/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
@@ -35,16 +35,14 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Client side load stats recorder that provides RPC counting and metrics recording as name-value
  * pairs.
- *
- * <p>This class is thread-safe for recording client call stats and backend metrics.
- *
- * <p>Calls of {@link #snapshot()} must be serialized externally.
  */
+@ThreadSafe
 final class ClientLoadCounter {
 
   private static final int THREAD_BALANCING_FACTOR = 64;
@@ -83,10 +81,8 @@ final class ClientLoadCounter {
   /**
    * Generates a snapshot for load stats recorded in this counter for the interval between calls
    * of this method.
-   *
-   * <p>Calls to this method must be serialized externally.
    */
-  ClientLoadSnapshot snapshot() {
+  synchronized ClientLoadSnapshot snapshot() {
     Map<String, MetricValue> aggregatedValues = new HashMap<>();
     for (MetricRecorder recorder : metricRecorders) {
       Map<String, MetricValue> map = recorder.takeAll();
@@ -132,6 +128,7 @@ final class ClientLoadCounter {
    * A {@link ClientLoadSnapshot} represents a snapshot of {@link ClientLoadCounter}, which is a
    * read-only copy of load stats recorded for some period of time.
    */
+  @Immutable
   static final class ClientLoadSnapshot {
     private final long callsSucceeded;
     private final long callsInProgress;
@@ -190,8 +187,8 @@ final class ClientLoadCounter {
   /**
    * Atomic unit of recording for metric data.
    */
+  @Immutable
   static final class MetricValue {
-
     private int numReports;
     private double totalValue;
 
@@ -228,8 +225,8 @@ final class ClientLoadCounter {
   /**
    * Single contention-balanced bucket for recording metric data.
    */
+  @ThreadSafe
   private static class MetricRecorder {
-
     private Map<String, MetricValue> metricValues = new HashMap<>();
 
     synchronized void addValue(String metricName, double value) {

--- a/xds/src/main/java/io/grpc/xds/LoadStatsManager.java
+++ b/xds/src/main/java/io/grpc/xds/LoadStatsManager.java
@@ -119,16 +119,16 @@ final class LoadStatsManager {
     return res;
   }
 
+  // Introduced for testing.
   @VisibleForTesting
   interface LoadStatsStoreFactory {
     LoadStatsStore newLoadStatsStore(String cluster, String clusterService);
   }
 
   /**
-   * Interface for client side load stats store. An {@code LoadStatsStore} maintains load stats per
-   * cluster:cluster_service exposed by traffic director from a gRPC client's perspective,
-   * including dropped calls. Load stats for endpoints are aggregated in locality granularity
-   * while the numbers of dropped calls are aggregated in cluster:cluster_service granularity.
+   * Interface for client side load stats store. A {@link LoadStatsStore} instance holds the load
+   * stats for a cluster from an gRPC client's perspective by maintaining a set of locality
+   * counters for each locality it is tracking loads for.
    */
   interface LoadStatsStore {
 
@@ -136,26 +136,24 @@ final class LoadStatsManager {
      * Generates a report based on recorded load stats (including RPC counts, backend metrics and
      * dropped calls) for the interval since the previous call of this method.
      */
-    // TODO(chengyuanzhang): do not use proto type directly.
     ClusterStats generateLoadReport();
 
     /**
-     * Track load stats for endpoints in the provided locality. Only load stats for endpoints
-     * in tracked localities will be included in generated load reports.
+     * Adds tracking for load stats sent to the given {@code locality}. Returns the counter
+     * object responsible for tracking the client load stats to the given {@code locality}.
+     * Only load stats for tracked localities will be included in generated load reports.
      */
     ClientLoadCounter addLocality(Locality locality);
 
     /**
-     * Drop tracking load stats for endpoints in the provided locality. Load stats for endpoints
-     * in removed localities will no longer be included in future generated load reports after
+     * Drops tracking for load stats sent to the given {@code locality}. Load stats for removed
+     * localities will no longer be included in future generated load reports after
      * their currently recording stats have been fully reported.
      */
     void removeLocality(Locality locality);
 
     /**
      * Records a drop decision.
-     *
-     * <p>This method is thread-safe.
      */
     void recordDroppedRequest(String category);
   }

--- a/xds/src/main/java/io/grpc/xds/LoadStatsManager.java
+++ b/xds/src/main/java/io/grpc/xds/LoadStatsManager.java
@@ -154,6 +154,8 @@ final class LoadStatsManager {
 
     /**
      * Records a drop decision.
+     *
+     * <p>This method must be thread-safe.
      */
     void recordDroppedRequest(String category);
   }


### PR DESCRIPTION
A `LoadStatsStore` instance will be used for tracking stats for a global cluster, and multiple client channel may retrieve the same instance for recording loads sent to the same global cluster.

`ClientLoadCounter` is already thread-safe for recording loads, mostly are just document improvements.