### PR TITLE
xds: use internal SynchronizationContext for XdsClient's synchronization

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -815,7 +815,6 @@ final class ClientXdsClient extends AbstractXdsClient {
         respTimer = null;
       }
       for (ResourceWatcher watcher : watchers) {
-        // TODO(chengyuanzhang): should invoke callback with watcher's own executor.
         watcher.onError(error);
       }
     }

--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -39,6 +39,7 @@ import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.Rds;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext;
 import io.grpc.Status;
+import io.grpc.SynchronizationContext.ScheduledHandle;
 import io.grpc.internal.BackoffPolicy;
 import io.grpc.xds.EnvoyProtoData.DropOverload;
 import io.grpc.xds.EnvoyProtoData.Locality;
@@ -56,7 +57,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -75,7 +75,6 @@ final class ClientXdsClient extends AbstractXdsClient {
       "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3"
           + ".HttpConnectionManager";
 
-  private final Object lock = new Object();
   private final Map<String, ResourceSubscriber> ldsResourceSubscribers = new HashMap<>();
   private final Map<String, ResourceSubscriber> rdsResourceSubscribers = new HashMap<>();
   private final Map<String, ResourceSubscriber> cdsResourceSubscribers = new HashMap<>();
@@ -538,133 +537,162 @@ final class ClientXdsClient extends AbstractXdsClient {
   }
 
   @Override
-  void watchLdsResource(String resourceName, LdsResourceWatcher watcher) {
-    synchronized (lock) {
-      ResourceSubscriber subscriber = ldsResourceSubscribers.get(resourceName);
-      if (subscriber == null) {
-        getLogger().log(XdsLogLevel.INFO, "Subscribe CDS resource {0}", resourceName);
-        subscriber = new ResourceSubscriber(ResourceType.LDS, resourceName);
-        ldsResourceSubscribers.put(resourceName, subscriber);
-        adjustResourceSubscription(ResourceType.LDS);
+  void watchLdsResource(final String resourceName, final LdsResourceWatcher watcher) {
+    getSyncContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        ResourceSubscriber subscriber = ldsResourceSubscribers.get(resourceName);
+        if (subscriber == null) {
+          getLogger().log(XdsLogLevel.INFO, "Subscribe CDS resource {0}", resourceName);
+          subscriber = new ResourceSubscriber(ResourceType.LDS, resourceName);
+          ldsResourceSubscribers.put(resourceName, subscriber);
+          adjustResourceSubscription(ResourceType.LDS);
+        }
+        subscriber.addWatcher(watcher);
       }
-      subscriber.addWatcher(watcher);
-    }
+    });
   }
 
   @Override
-  void cancelLdsResourceWatch(String resourceName, LdsResourceWatcher watcher) {
-    synchronized (lock) {
-      ResourceSubscriber subscriber = ldsResourceSubscribers.get(resourceName);
-      subscriber.removeWatcher(watcher);
-      if (!subscriber.isWatched()) {
-        subscriber.stopTimer();
-        getLogger().log(XdsLogLevel.INFO, "Unsubscribe LDS resource {0}", resourceName);
-        ldsResourceSubscribers.remove(resourceName);
-        adjustResourceSubscription(ResourceType.LDS);
+  void cancelLdsResourceWatch(final String resourceName, final LdsResourceWatcher watcher) {
+    getSyncContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        ResourceSubscriber subscriber = ldsResourceSubscribers.get(resourceName);
+        subscriber.removeWatcher(watcher);
+        if (!subscriber.isWatched()) {
+          subscriber.stopTimer();
+          getLogger().log(XdsLogLevel.INFO, "Unsubscribe LDS resource {0}", resourceName);
+          ldsResourceSubscribers.remove(resourceName);
+          adjustResourceSubscription(ResourceType.LDS);
+        }
       }
-    }
+    });
   }
 
   @Override
-  void watchRdsResource(String resourceName, RdsResourceWatcher watcher) {
-    synchronized (lock) {
-      ResourceSubscriber subscriber = rdsResourceSubscribers.get(resourceName);
-      if (subscriber == null) {
-        getLogger().log(XdsLogLevel.INFO, "Subscribe RDS resource {0}", resourceName);
-        subscriber = new ResourceSubscriber(ResourceType.RDS, resourceName);
-        rdsResourceSubscribers.put(resourceName, subscriber);
-        adjustResourceSubscription(ResourceType.RDS);
+  void watchRdsResource(final String resourceName, final RdsResourceWatcher watcher) {
+    getSyncContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        ResourceSubscriber subscriber = rdsResourceSubscribers.get(resourceName);
+        if (subscriber == null) {
+          getLogger().log(XdsLogLevel.INFO, "Subscribe RDS resource {0}", resourceName);
+          subscriber = new ResourceSubscriber(ResourceType.RDS, resourceName);
+          rdsResourceSubscribers.put(resourceName, subscriber);
+          adjustResourceSubscription(ResourceType.RDS);
+        }
+        subscriber.addWatcher(watcher);
       }
-      subscriber.addWatcher(watcher);
-    }
+    });
   }
 
   @Override
-  void cancelRdsResourceWatch(String resourceName, RdsResourceWatcher watcher) {
-    synchronized (lock) {
-      ResourceSubscriber subscriber = rdsResourceSubscribers.get(resourceName);
-      subscriber.removeWatcher(watcher);
-      if (!subscriber.isWatched()) {
-        subscriber.stopTimer();
-        getLogger().log(XdsLogLevel.INFO, "Unsubscribe RDS resource {0}", resourceName);
-        rdsResourceSubscribers.remove(resourceName);
-        adjustResourceSubscription(ResourceType.RDS);
+  void cancelRdsResourceWatch(final String resourceName, final RdsResourceWatcher watcher) {
+    getSyncContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        ResourceSubscriber subscriber = rdsResourceSubscribers.get(resourceName);
+        subscriber.removeWatcher(watcher);
+        if (!subscriber.isWatched()) {
+          subscriber.stopTimer();
+          getLogger().log(XdsLogLevel.INFO, "Unsubscribe RDS resource {0}", resourceName);
+          rdsResourceSubscribers.remove(resourceName);
+          adjustResourceSubscription(ResourceType.RDS);
+        }
       }
-    }
+    });
   }
 
   @Override
-  void watchCdsResource(String resourceName, CdsResourceWatcher watcher) {
-    synchronized (lock) {
-      ResourceSubscriber subscriber = cdsResourceSubscribers.get(resourceName);
-      if (subscriber == null) {
-        getLogger().log(XdsLogLevel.INFO, "Subscribe CDS resource {0}", resourceName);
-        subscriber = new ResourceSubscriber(ResourceType.CDS, resourceName);
-        cdsResourceSubscribers.put(resourceName, subscriber);
-        adjustResourceSubscription(ResourceType.CDS);
+  void watchCdsResource(final String resourceName, final CdsResourceWatcher watcher) {
+    getSyncContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        ResourceSubscriber subscriber = cdsResourceSubscribers.get(resourceName);
+        if (subscriber == null) {
+          getLogger().log(XdsLogLevel.INFO, "Subscribe CDS resource {0}", resourceName);
+          subscriber = new ResourceSubscriber(ResourceType.CDS, resourceName);
+          cdsResourceSubscribers.put(resourceName, subscriber);
+          adjustResourceSubscription(ResourceType.CDS);
+        }
+        subscriber.addWatcher(watcher);
       }
-      subscriber.addWatcher(watcher);
-    }
+    });
   }
 
   @Override
-  void cancelCdsResourceWatch(String resourceName, CdsResourceWatcher watcher) {
-    synchronized (lock) {
-      ResourceSubscriber subscriber = cdsResourceSubscribers.get(resourceName);
-      subscriber.removeWatcher(watcher);
-      if (!subscriber.isWatched()) {
-        subscriber.stopTimer();
-        getLogger().log(XdsLogLevel.INFO, "Unsubscribe CDS resource {0}", resourceName);
-        cdsResourceSubscribers.remove(resourceName);
-        adjustResourceSubscription(ResourceType.CDS);
+  void cancelCdsResourceWatch(final String resourceName, final CdsResourceWatcher watcher) {
+    getSyncContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        ResourceSubscriber subscriber = cdsResourceSubscribers.get(resourceName);
+        subscriber.removeWatcher(watcher);
+        if (!subscriber.isWatched()) {
+          subscriber.stopTimer();
+          getLogger().log(XdsLogLevel.INFO, "Unsubscribe CDS resource {0}", resourceName);
+          cdsResourceSubscribers.remove(resourceName);
+          adjustResourceSubscription(ResourceType.CDS);
+        }
       }
-    }
+    });
   }
 
   @Override
-  void watchEdsResource(String resourceName, EdsResourceWatcher watcher) {
-    synchronized (lock) {
-      ResourceSubscriber subscriber = edsResourceSubscribers.get(resourceName);
-      if (subscriber == null) {
-        getLogger().log(XdsLogLevel.INFO, "Subscribe EDS resource {0}", resourceName);
-        subscriber = new ResourceSubscriber(ResourceType.EDS, resourceName);
-        edsResourceSubscribers.put(resourceName, subscriber);
-        adjustResourceSubscription(ResourceType.EDS);
+  void watchEdsResource(final String resourceName, final EdsResourceWatcher watcher) {
+    getSyncContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        ResourceSubscriber subscriber = edsResourceSubscribers.get(resourceName);
+        if (subscriber == null) {
+          getLogger().log(XdsLogLevel.INFO, "Subscribe EDS resource {0}", resourceName);
+          subscriber = new ResourceSubscriber(ResourceType.EDS, resourceName);
+          edsResourceSubscribers.put(resourceName, subscriber);
+          adjustResourceSubscription(ResourceType.EDS);
+        }
+        subscriber.addWatcher(watcher);
       }
-      subscriber.addWatcher(watcher);
-    }
+    });
   }
 
   @Override
-  void cancelEdsResourceWatch(String resourceName, EdsResourceWatcher watcher) {
-    synchronized (lock) {
-      ResourceSubscriber subscriber = edsResourceSubscribers.get(resourceName);
-      subscriber.removeWatcher(watcher);
-      if (!subscriber.isWatched()) {
-        subscriber.stopTimer();
-        getLogger().log(XdsLogLevel.INFO, "Unsubscribe EDS resource {0}", resourceName);
-        edsResourceSubscribers.remove(resourceName);
-        adjustResourceSubscription(ResourceType.EDS);
+  void cancelEdsResourceWatch(final String resourceName, final EdsResourceWatcher watcher) {
+    getSyncContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        ResourceSubscriber subscriber = edsResourceSubscribers.get(resourceName);
+        subscriber.removeWatcher(watcher);
+        if (!subscriber.isWatched()) {
+          subscriber.stopTimer();
+          getLogger().log(XdsLogLevel.INFO, "Unsubscribe EDS resource {0}", resourceName);
+          edsResourceSubscribers.remove(resourceName);
+          adjustResourceSubscription(ResourceType.EDS);
+        }
       }
-    }
+    });
   }
 
   @Override
   LoadStatsStore addClientStats(String clusterName, @Nullable String clusterServiceName) {
-    synchronized (lock) {
-      LoadStatsStore loadStatsStore = loadStatsManager
-          .addLoadStats(clusterName, clusterServiceName);
-      if (!reportingLoad) {
-        lrsClient.startLoadReporting();
-        reportingLoad = true;
-      }
-      return loadStatsStore;
+    LoadStatsStore loadStatsStore;
+    synchronized (this) {
+      loadStatsStore = loadStatsManager.addLoadStats(clusterName, clusterServiceName);
     }
+    getSyncContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        if (!reportingLoad) {
+          lrsClient.startLoadReporting();
+          reportingLoad = true;
+        }
+      }
+    });
+    return loadStatsStore;
   }
 
   @Override
   void removeClientStats(String clusterName, @Nullable String clusterServiceName) {
-    synchronized (lock) {
+    synchronized (this) {
       loadStatsManager.removeLoadStats(clusterName, clusterServiceName);
     }
   }
@@ -684,13 +712,6 @@ final class ClientXdsClient extends AbstractXdsClient {
     }
   }
 
-  @Override
-  protected void runWithSynchronized(Runnable runnable) {
-    synchronized (lock) {
-      runnable.run();
-    }
-  }
-
   /**
    * Tracks a single subscribed resource.
    */
@@ -700,7 +721,7 @@ final class ClientXdsClient extends AbstractXdsClient {
     private final Set<ResourceWatcher> watchers = new HashSet<>();
     private ResourceUpdate data;
     private boolean absent;
-    private ScheduledFuture<?> respTimer;
+    private ScheduledHandle respTimer;
 
     ResourceSubscriber(ResourceType type, String resource) {
       this.type = type;
@@ -731,12 +752,10 @@ final class ClientXdsClient extends AbstractXdsClient {
       class ResourceNotFound implements Runnable {
         @Override
         public void run() {
-          synchronized (lock) {
-            getLogger().log(XdsLogLevel.INFO, "{0} resource {1} initial fetch timeout",
-                type, resource);
-            respTimer = null;
-            onAbsent();
-          }
+          getLogger().log(XdsLogLevel.INFO, "{0} resource {1} initial fetch timeout",
+              type, resource);
+          respTimer = null;
+          onAbsent();
         }
 
         @Override
@@ -745,13 +764,14 @@ final class ClientXdsClient extends AbstractXdsClient {
         }
       }
 
-      respTimer = getTimeService().schedule(
-          new ResourceNotFound(), INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
+      respTimer = getSyncContext().schedule(
+          new ResourceNotFound(), INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS,
+          getTimeService());
     }
 
     void stopTimer() {
-      if (respTimer != null && !respTimer.isDone()) {
-        respTimer.cancel(false);
+      if (respTimer != null && respTimer.isPending()) {
+        respTimer.cancel();
         respTimer = null;
       }
     }
@@ -761,8 +781,8 @@ final class ClientXdsClient extends AbstractXdsClient {
     }
 
     void onData(ResourceUpdate data) {
-      if (respTimer != null && !respTimer.isDone()) {
-        respTimer.cancel(false);
+      if (respTimer != null && respTimer.isPending()) {
+        respTimer.cancel();
         respTimer = null;
       }
       ResourceUpdate oldData = this.data;
@@ -776,7 +796,7 @@ final class ClientXdsClient extends AbstractXdsClient {
     }
 
     void onAbsent() {
-      if (respTimer != null && !respTimer.isDone()) {  // too early to conclude absence
+      if (respTimer != null && respTimer.isPending()) {  // too early to conclude absence
         return;
       }
       getLogger().log(XdsLogLevel.INFO, "Conclude {0} resource {1} not exist", type, resource);
@@ -784,15 +804,14 @@ final class ClientXdsClient extends AbstractXdsClient {
         data = null;
         absent = true;
         for (ResourceWatcher watcher : watchers) {
-          // TODO(chengyuanzhang): should invoke callback with watcher's own executor.
           watcher.onResourceDoesNotExist(resource);
         }
       }
     }
 
     void onError(Status error) {
-      if (respTimer != null && !respTimer.isDone()) {
-        respTimer.cancel(false);
+      if (respTimer != null && respTimer.isPending()) {
+        respTimer.cancel();
         respTimer = null;
       }
       for (ResourceWatcher watcher : watchers) {
@@ -802,7 +821,6 @@ final class ClientXdsClient extends AbstractXdsClient {
     }
 
     private void notifyWatcher(ResourceWatcher watcher, ResourceUpdate update) {
-      // TODO(chengyuanzhang): should invoke callbacks with watcher's own executor.
       switch (type) {
         case LDS:
           ((LdsResourceWatcher) watcher).onChanged((LdsUpdate) update);

--- a/xds/src/main/java/io/grpc/xds/ServerXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ServerXdsClient.java
@@ -32,7 +32,6 @@ import io.envoyproxy.envoy.config.listener.v3.FilterChain;
 import io.envoyproxy.envoy.config.listener.v3.FilterChainMatch;
 import io.envoyproxy.envoy.config.listener.v3.Listener;
 import io.grpc.Status;
-import io.grpc.SynchronizationContext;
 import io.grpc.SynchronizationContext.ScheduledHandle;
 import io.grpc.internal.BackoffPolicy;
 import io.grpc.xds.EnvoyProtoData.Node;
@@ -54,7 +53,6 @@ final class ServerXdsClient extends AbstractXdsClient {
   // Longest time to wait, since the subscription to some resource, for concluding its absence.
   @VisibleForTesting
   static final int INITIAL_RESOURCE_FETCH_TIMEOUT_SEC = 15;
-  private final SynchronizationContext syncContext;
   @Nullable
   private ListenerWatcher listenerWatcher;
   private int listenerPort = -1;
@@ -63,33 +61,37 @@ final class ServerXdsClient extends AbstractXdsClient {
   @Nullable
   private ScheduledHandle ldsRespTimer;
 
-  ServerXdsClient(XdsChannel channel, Node node, SynchronizationContext syncContext,
-      ScheduledExecutorService timeService, BackoffPolicy.Provider backoffPolicyProvider,
-      Supplier<Stopwatch> stopwatchSupplier, boolean newServerApi, String instanceIp) {
+  ServerXdsClient(XdsChannel channel, Node node, ScheduledExecutorService timeService,
+      BackoffPolicy.Provider backoffPolicyProvider, Supplier<Stopwatch> stopwatchSupplier,
+      boolean newServerApi, String instanceIp) {
     super(channel, node, timeService, backoffPolicyProvider, stopwatchSupplier);
-    this.syncContext = checkNotNull(syncContext, "syncContext");
     this.newServerApi = channel.isUseProtocolV3() && newServerApi;
     this.instanceIp = (instanceIp != null ? instanceIp : "0.0.0.0");
   }
 
   @Override
-  void watchListenerData(int port, ListenerWatcher watcher) {
-    checkState(listenerWatcher == null, "ListenerWatcher already registered");
-    listenerWatcher = checkNotNull(watcher, "watcher");
-    checkArgument(port > 0, "port needs to be > 0");
-    this.listenerPort = port;
-    getLogger().log(XdsLogLevel.INFO, "Started watching listener for port {0}", port);
-    if (!newServerApi) {
-      updateNodeMetadataForListenerRequest(port);
-    }
-    adjustResourceSubscription(ResourceType.LDS);
-    if (!isInBackoff()) {
-      ldsRespTimer =
-          syncContext
-              .schedule(
-                  new ListenerResourceFetchTimeoutTask(":" + port),
-                  INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS, getTimeService());
-    }
+  void watchListenerData(final int port, final ListenerWatcher watcher) {
+    getSyncContext().execute(new Runnable() {
+      @Override
+      public void run() {
+        checkState(listenerWatcher == null, "ListenerWatcher already registered");
+        listenerWatcher = checkNotNull(watcher, "watcher");
+        checkArgument(port > 0, "port needs to be > 0");
+        listenerPort = port;
+        getLogger().log(XdsLogLevel.INFO, "Started watching listener for port {0}", port);
+        if (!newServerApi) {
+          updateNodeMetadataForListenerRequest(port);
+        }
+        adjustResourceSubscription(ResourceType.LDS);
+        if (!isInBackoff()) {
+          ldsRespTimer =
+              getSyncContext()
+                  .schedule(
+                      new ListenerResourceFetchTimeoutTask(":" + port),
+                      INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS, getTimeService());
+        }
+      }
+    });
   }
 
   @Nullable
@@ -203,7 +205,7 @@ final class ServerXdsClient extends AbstractXdsClient {
   protected void handleStreamRestarted() {
     if (listenerWatcher != null) {
       ldsRespTimer =
-          syncContext
+          getSyncContext()
               .schedule(
                   new ListenerResourceFetchTimeoutTask(":" + listenerPort),
                   INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS, getTimeService());
@@ -213,11 +215,6 @@ final class ServerXdsClient extends AbstractXdsClient {
   @Override
   protected void handleShutdown() {
     cleanUpResourceTimer();
-  }
-
-  @Override
-  protected void runWithSynchronized(Runnable runnable) {
-    syncContext.execute(runnable);
   }
 
   private void cleanUpResourceTimer() {

--- a/xds/src/main/java/io/grpc/xds/ServerXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ServerXdsClient.java
@@ -71,13 +71,13 @@ final class ServerXdsClient extends AbstractXdsClient {
 
   @Override
   void watchListenerData(final int port, final ListenerWatcher watcher) {
+    checkState(listenerWatcher == null, "ListenerWatcher already registered");
+    listenerWatcher = checkNotNull(watcher, "watcher");
+    checkArgument(port > 0, "port needs to be > 0");
+    listenerPort = port;
     getSyncContext().execute(new Runnable() {
       @Override
       public void run() {
-        checkState(listenerWatcher == null, "ListenerWatcher already registered");
-        listenerWatcher = checkNotNull(watcher, "watcher");
-        checkArgument(port > 0, "port needs to be > 0");
-        listenerPort = port;
         getLogger().log(XdsLogLevel.INFO, "Started watching listener for port {0}", port);
         if (!newServerApi) {
           updateNodeMetadataForListenerRequest(port);

--- a/xds/src/test/java/io/grpc/xds/ServerXdsClientNewServerApiTest.java
+++ b/xds/src/test/java/io/grpc/xds/ServerXdsClientNewServerApiTest.java
@@ -57,7 +57,6 @@ import io.grpc.Context.CancellationListener;
 import io.grpc.ManagedChannel;
 import io.grpc.Status;
 import io.grpc.Status.Code;
-import io.grpc.SynchronizationContext;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.internal.BackoffPolicy;
@@ -124,13 +123,6 @@ public class ServerXdsClientNewServerApiTest {
   @Rule
   public final GrpcCleanupRule cleanupRule = new GrpcCleanupRule();
 
-  private final SynchronizationContext syncContext = new SynchronizationContext(
-      new Thread.UncaughtExceptionHandler() {
-        @Override
-        public void uncaughtException(Thread t, Throwable e) {
-          throw new AssertionError(e);
-        }
-      });
   private final FakeClock fakeClock = new FakeClock();
 
   private final Queue<StreamObserver<DiscoveryResponse>> responseObservers = new ArrayDeque<>();
@@ -194,7 +186,7 @@ public class ServerXdsClientNewServerApiTest {
 
     xdsClient =
         new ServerXdsClient(new XdsChannel(channel, /* useProtocolV3= */ true), NODE,
-            syncContext, fakeClock.getScheduledExecutorService(), backoffPolicyProvider,
+            fakeClock.getScheduledExecutorService(), backoffPolicyProvider,
             fakeClock.getStopwatchSupplier(), true, INSTANCE_IP);
     // Only the connection to management server is established, no RPC request is sent until at
     // least one watcher is registered.

--- a/xds/src/test/java/io/grpc/xds/ServerXdsClientTest.java
+++ b/xds/src/test/java/io/grpc/xds/ServerXdsClientTest.java
@@ -21,6 +21,7 @@ import static io.grpc.xds.XdsClientTestHelper.buildDiscoveryResponseV2;
 import static io.grpc.xds.XdsClientTestHelper.buildListenerV2;
 import static io.grpc.xds.XdsClientTestHelper.buildRouteConfigurationV2;
 import static io.grpc.xds.XdsClientTestHelper.buildVirtualHostV2;
+import static org.junit.Assert.fail;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -225,6 +226,19 @@ public class ServerXdsClientTest {
         .setTypeUrl(typeUrl)
         .setResponseNonce(nonce)
         .build();
+  }
+
+  @Test
+  public void ldsResponse_2listenerWatchers_expectError() {
+    xdsClient.watchListenerData(PORT, listenerWatcher);
+    try {
+      xdsClient.watchListenerData(80, listenerWatcher);
+      fail("expected exception");
+    } catch (IllegalStateException expected) {
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("ListenerWatcher already registered");
+    }
   }
 
   /**


### PR DESCRIPTION
The XdsClient will create its own SynchronizationContext internally. All of its work will be done inside that SynchronizationContext. Watcher callbacks need to be synchronized with the watching party (on client side this is done by scheduling the task back to client channel's SynchronizationContext).