### PR TITLE
interop-testing: only need to count total number of succeeded RPCs for accumulated stats in xDS tests

### DIFF
--- a/interop-testing/src/main/proto/grpc/testing/messages.proto
+++ b/interop-testing/src/main/proto/grpc/testing/messages.proto
@@ -210,8 +210,8 @@ message LoadBalancerAccumulatedStatsRequest {}
 message LoadBalancerAccumulatedStatsResponse {
   // The total number of RPCs have ever issued.
   int32 num_rpcs_started = 1;
-  // The total number of RPCs have ever completed successfully for each peer.
-  map<string, int32> num_rpcs_succeeded_by_peer = 2;
+  // The total number of RPCs have ever completed successfully.
+  int32 num_rpcs_succeeded = 2;
   // The total number of RPCs have ever failed.
   int32 num_rpcs_failed = 3;
 }


### PR DESCRIPTION
Mirror of https://github.com/grpc/grpc/pull/24569.