### PR TITLE
Fix builders ABI backward compatibility broken in v1.33.0

### DIFF
--- a/api/src/main/java/io/grpc/ForwardingServerBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingServerBuilder.java
@@ -30,8 +30,7 @@ import javax.annotation.Nullable;
  * @since 1.33.0
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/7393")
-public abstract class ForwardingServerBuilder<T extends ForwardingServerBuilder<T>>
-    extends ServerBuilder<T> {
+public abstract class ForwardingServerBuilder<T extends ServerBuilder<T>> extends ServerBuilder<T> {
 
   /** The default constructor. */
   protected ForwardingServerBuilder() {}

--- a/api/src/main/java/io/grpc/ForwardingServerBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingServerBuilder.java
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
  * @since 1.33.0
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/7393")
-public abstract class ForwardingServerBuilder<T extends ServerBuilder<T>> extends ServerBuilder<T> {
+abstract class ForwardingServerBuilder<T extends ServerBuilder<T>> extends ServerBuilder<T> {
 
   /** The default constructor. */
   protected ForwardingServerBuilder() {}

--- a/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -21,9 +21,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.grpc.ChannelLogger;
 import io.grpc.ExperimentalApi;
-import io.grpc.ForwardingChannelBuilder;
 import io.grpc.Internal;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.internal.AbstractManagedChannelImplBuilder;
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.GrpcUtil;
@@ -45,7 +45,7 @@ import javax.annotation.Nullable;
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1783")
 public final class InProcessChannelBuilder extends
-    ForwardingChannelBuilder<InProcessChannelBuilder> {
+    AbstractManagedChannelImplBuilder<InProcessChannelBuilder> {
   /**
    * Create a channel builder that will connect to the server with the given name.
    *

--- a/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
@@ -21,10 +21,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.base.Preconditions;
 import io.grpc.Deadline;
 import io.grpc.ExperimentalApi;
-import io.grpc.ForwardingServerBuilder;
 import io.grpc.Internal;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerStreamTracer;
+import io.grpc.internal.AbstractServerImplBuilder;
 import io.grpc.internal.FixedObjectPool;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.InternalServer;
@@ -72,7 +72,8 @@ import java.util.concurrent.TimeUnit;
  * </pre>
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1783")
-public final class InProcessServerBuilder extends ForwardingServerBuilder<InProcessServerBuilder> {
+public final class InProcessServerBuilder extends
+    AbstractServerImplBuilder<InProcessServerBuilder> {
   /**
    * Create a server builder that will bind with the given name.
    *

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2020 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import com.google.common.base.MoreObjects;
+import io.grpc.BinaryLog;
+import io.grpc.ClientInterceptor;
+import io.grpc.CompressorRegistry;
+import io.grpc.DecompressorRegistry;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.NameResolver;
+import io.grpc.ProxyDetector;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * Temporarily duplicates of {@link io.grpc.ForwardingChannelBuilder} to fix ABI backward
+ * compatibility.
+ *
+ * @param <T> The concrete type of this builder.
+ * @see <a href="https://github.com/grpc/grpc-java/issues/7211">grpc/grpc-java#7211</a>
+ */
+public abstract class AbstractManagedChannelImplBuilder
+    <T extends AbstractManagedChannelImplBuilder<T>> extends ManagedChannelBuilder<T> {
+
+  /**
+   * The default constructor.
+   */
+  protected AbstractManagedChannelImplBuilder() {}
+
+  /**
+   * This method serves to force sub classes to "hide" this static factory.
+   */
+  public static ManagedChannelBuilder<?> forAddress(String name, int port) {
+    throw new UnsupportedOperationException("Subclass failed to hide static factory");
+  }
+
+  /**
+   * This method serves to force sub classes to "hide" this static factory.
+   */
+  public static ManagedChannelBuilder<?> forTarget(String target) {
+    throw new UnsupportedOperationException("Subclass failed to hide static factory");
+  }
+
+  /**
+   * Returns the delegated {@code ManagedChannelBuilder}.
+   */
+  protected abstract ManagedChannelBuilder<?> delegate();
+
+  @Override
+  public T directExecutor() {
+    delegate().directExecutor();
+    return thisT();
+  }
+
+  @Override
+  public T executor(Executor executor) {
+    delegate().executor(executor);
+    return thisT();
+  }
+
+  @Override
+  public T offloadExecutor(Executor executor) {
+    delegate().offloadExecutor(executor);
+    return thisT();
+  }
+
+  @Override
+  public T intercept(List<ClientInterceptor> interceptors) {
+    delegate().intercept(interceptors);
+    return thisT();
+  }
+
+  @Override
+  public T intercept(ClientInterceptor... interceptors) {
+    delegate().intercept(interceptors);
+    return thisT();
+  }
+
+  @Override
+  public T userAgent(String userAgent) {
+    delegate().userAgent(userAgent);
+    return thisT();
+  }
+
+  @Override
+  public T overrideAuthority(String authority) {
+    delegate().overrideAuthority(authority);
+    return thisT();
+  }
+
+  @Override
+  public T usePlaintext() {
+    delegate().usePlaintext();
+    return thisT();
+  }
+
+  @Override
+  public T useTransportSecurity() {
+    delegate().useTransportSecurity();
+    return thisT();
+  }
+
+  @Deprecated
+  @Override
+  public T nameResolverFactory(NameResolver.Factory resolverFactory) {
+    delegate().nameResolverFactory(resolverFactory);
+    return thisT();
+  }
+
+  @Override
+  public T defaultLoadBalancingPolicy(String policy) {
+    delegate().defaultLoadBalancingPolicy(policy);
+    return thisT();
+  }
+
+  @Override
+  public T enableFullStreamDecompression() {
+    delegate().enableFullStreamDecompression();
+    return thisT();
+  }
+
+  @Override
+  public T decompressorRegistry(DecompressorRegistry registry) {
+    delegate().decompressorRegistry(registry);
+    return thisT();
+  }
+
+  @Override
+  public T compressorRegistry(CompressorRegistry registry) {
+    delegate().compressorRegistry(registry);
+    return thisT();
+  }
+
+  @Override
+  public T idleTimeout(long value, TimeUnit unit) {
+    delegate().idleTimeout(value, unit);
+    return thisT();
+  }
+
+  @Override
+  public T maxInboundMessageSize(int max) {
+    delegate().maxInboundMessageSize(max);
+    return thisT();
+  }
+
+  @Override
+  public T maxInboundMetadataSize(int max) {
+    delegate().maxInboundMetadataSize(max);
+    return thisT();
+  }
+
+  @Override
+  public T keepAliveTime(long keepAliveTime, TimeUnit timeUnit) {
+    delegate().keepAliveTime(keepAliveTime, timeUnit);
+    return thisT();
+  }
+
+  @Override
+  public T keepAliveTimeout(long keepAliveTimeout, TimeUnit timeUnit) {
+    delegate().keepAliveTimeout(keepAliveTimeout, timeUnit);
+    return thisT();
+  }
+
+  @Override
+  public T keepAliveWithoutCalls(boolean enable) {
+    delegate().keepAliveWithoutCalls(enable);
+    return thisT();
+  }
+
+  @Override
+  public T maxRetryAttempts(int maxRetryAttempts) {
+    delegate().maxRetryAttempts(maxRetryAttempts);
+    return thisT();
+  }
+
+  @Override
+  public T maxHedgedAttempts(int maxHedgedAttempts) {
+    delegate().maxHedgedAttempts(maxHedgedAttempts);
+    return thisT();
+  }
+
+  @Override
+  public T retryBufferSize(long bytes) {
+    delegate().retryBufferSize(bytes);
+    return thisT();
+  }
+
+  @Override
+  public T perRpcBufferLimit(long bytes) {
+    delegate().perRpcBufferLimit(bytes);
+    return thisT();
+  }
+
+  @Override
+  public T disableRetry() {
+    delegate().disableRetry();
+    return thisT();
+  }
+
+  @Override
+  public T enableRetry() {
+    delegate().enableRetry();
+    return thisT();
+  }
+
+  @Override
+  public T setBinaryLog(BinaryLog binaryLog) {
+    delegate().setBinaryLog(binaryLog);
+    return thisT();
+  }
+
+  @Override
+  public T maxTraceEvents(int maxTraceEvents) {
+    delegate().maxTraceEvents(maxTraceEvents);
+    return thisT();
+  }
+
+  @Override
+  public T proxyDetector(ProxyDetector proxyDetector) {
+    delegate().proxyDetector(proxyDetector);
+    return thisT();
+  }
+
+  @Override
+  public T defaultServiceConfig(@Nullable Map<String, ?> serviceConfig) {
+    delegate().defaultServiceConfig(serviceConfig);
+    return thisT();
+  }
+
+  @Override
+  public T disableServiceConfigLookUp() {
+    delegate().disableServiceConfigLookUp();
+    return thisT();
+  }
+
+  /**
+   * Returns the {@link ManagedChannel} built by the delegate by default. Overriding method can
+   * return different value.
+   */
+  @Override
+  public ManagedChannel build() {
+    return delegate().build();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("delegate", delegate()).toString();
+  }
+
+  /**
+   * Returns the correctly typed version of the builder.
+   */
+  protected final T thisT() {
+    @SuppressWarnings("unchecked")
+    T thisT = (T) this;
+    return thisT;
+  }
+}

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
- * Temporarily duplicates of {@link io.grpc.ForwardingChannelBuilder} to fix ABI backward
+ * Temporarily duplicates {@link io.grpc.ForwardingChannelBuilder} to fix ABI backward
  * compatibility.
  *
  * @param <T> The concrete type of this builder.

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import io.grpc.ForwardingServerBuilder;
+import io.grpc.ServerBuilder;
+
+/**
+ * Temporary shim for {@link io.grpc.ForwardingServerBuilder} to fix ABI backward compatibility.
+ *
+ * @param <T> The concrete type of this builder.
+ * @see <a href="https://github.com/grpc/grpc-java/issues/7211">grpc/grpc-java#7211</a>
+ */
+public abstract class AbstractServerImplBuilder
+    <T extends AbstractServerImplBuilder<T>> extends ForwardingServerBuilder<T> {
+  /**
+   * This method serves to force sub classes to "hide" this static factory.
+   */
+  public static ServerBuilder<?> forPort(int port) {
+    throw new UnsupportedOperationException("Subclass failed to hide static factory");
+  }
+}

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -16,21 +16,167 @@
 
 package io.grpc.internal;
 
-import io.grpc.ForwardingServerBuilder;
+import com.google.common.base.MoreObjects;
+import io.grpc.BinaryLog;
+import io.grpc.BindableService;
+import io.grpc.CompressorRegistry;
+import io.grpc.DecompressorRegistry;
+import io.grpc.HandlerRegistry;
+import io.grpc.Server;
 import io.grpc.ServerBuilder;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.ServerStreamTracer;
+import io.grpc.ServerTransportFilter;
+import java.io.File;
+import java.io.InputStream;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 
 /**
- * Temporary shim for {@link io.grpc.ForwardingServerBuilder} to fix ABI backward compatibility.
+ * A {@link ServerBuilder} that delegates all its builder method to another builder by default.
  *
+ * <p>Temporarily duplicates io.grpc.ForwardingServerBuilder (temporarily package-private)
+ * to fix ABI backward compatibility.
+
  * @param <T> The concrete type of this builder.
  * @see <a href="https://github.com/grpc/grpc-java/issues/7211">grpc/grpc-java#7211</a>
  */
 public abstract class AbstractServerImplBuilder
-    <T extends AbstractServerImplBuilder<T>> extends ForwardingServerBuilder<T> {
+    <T extends AbstractServerImplBuilder<T>> extends ServerBuilder<T> {
+
+  /** The default constructor. */
+  protected AbstractServerImplBuilder() {}
+
   /**
    * This method serves to force sub classes to "hide" this static factory.
    */
   public static ServerBuilder<?> forPort(int port) {
     throw new UnsupportedOperationException("Subclass failed to hide static factory");
+  }
+
+  /**
+   * Returns the delegated {@code ServerBuilder}.
+   */
+  protected abstract ServerBuilder<?> delegate();
+
+  @Override
+  public T directExecutor() {
+    delegate().directExecutor();
+    return thisT();
+  }
+
+  @Override
+  public T executor(@Nullable Executor executor) {
+    delegate().executor(executor);
+    return thisT();
+  }
+
+  @Override
+  public T addService(ServerServiceDefinition service) {
+    delegate().addService(service);
+    return thisT();
+  }
+
+  @Override
+  public T addService(BindableService bindableService) {
+    delegate().addService(bindableService);
+    return thisT();
+  }
+
+  @Override
+  public T intercept(ServerInterceptor interceptor) {
+    delegate().intercept(interceptor);
+    return thisT();
+  }
+
+  @Override
+  public T addTransportFilter(ServerTransportFilter filter) {
+    delegate().addTransportFilter(filter);
+    return thisT();
+  }
+
+  @Override
+  public T addStreamTracerFactory(ServerStreamTracer.Factory factory) {
+    delegate().addStreamTracerFactory(factory);
+    return thisT();
+  }
+
+  @Override
+  public T fallbackHandlerRegistry(@Nullable HandlerRegistry fallbackRegistry) {
+    delegate().fallbackHandlerRegistry(fallbackRegistry);
+    return thisT();
+  }
+
+  @Override
+  public T useTransportSecurity(File certChain, File privateKey) {
+    delegate().useTransportSecurity(certChain, privateKey);
+    return thisT();
+  }
+
+  @Override
+  public T useTransportSecurity(InputStream certChain, InputStream privateKey) {
+    delegate().useTransportSecurity(certChain, privateKey);
+    return thisT();
+  }
+
+  @Override
+  public T decompressorRegistry(@Nullable DecompressorRegistry registry) {
+    delegate().decompressorRegistry(registry);
+    return thisT();
+  }
+
+  @Override
+  public T compressorRegistry(@Nullable CompressorRegistry registry) {
+    delegate().compressorRegistry(registry);
+    return thisT();
+  }
+
+  @Override
+  public T handshakeTimeout(long timeout, TimeUnit unit) {
+    delegate().handshakeTimeout(timeout, unit);
+    return thisT();
+  }
+
+  @Override
+  public T maxInboundMessageSize(int bytes) {
+    delegate().maxInboundMessageSize(bytes);
+    return thisT();
+  }
+
+  @Override
+  public T maxInboundMetadataSize(int bytes) {
+    delegate().maxInboundMetadataSize(bytes);
+    return thisT();
+  }
+
+  @Override
+  public T setBinaryLog(BinaryLog binaryLog) {
+    delegate().setBinaryLog(binaryLog);
+    return thisT();
+  }
+
+  /**
+   * Returns the {@link Server} built by the delegate by default. Overriding method can return
+   * different value.
+   */
+  @Override
+  public Server build() {
+    return delegate().build();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("delegate", delegate()).toString();
+  }
+
+  /**
+   * Returns the correctly typed version of the builder.
+   */
+  protected final T thisT() {
+    @SuppressWarnings("unchecked")
+    T thisT = (T) this;
+    return thisT;
   }
 }

--- a/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.base.Defaults;
+import io.grpc.ForwardingTestUtil;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Collections;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link AbstractManagedChannelImplBuilder}.
+ */
+@RunWith(JUnit4.class)
+public class AbstractManagedChannelImplBuilderTest {
+  private final ManagedChannelBuilder<?> mockDelegate = mock(ManagedChannelBuilder.class);
+
+  private final AbstractManagedChannelImplBuilder<?> testChannelBuilder = new TestBuilder();
+
+  private final class TestBuilder extends AbstractManagedChannelImplBuilder<TestBuilder> {
+    @Override
+    protected ManagedChannelBuilder<?> delegate() {
+      return mockDelegate;
+    }
+  }
+
+  @Test
+  public void allMethodsForwarded() throws Exception {
+    ForwardingTestUtil.testMethodsForwarded(
+        ManagedChannelBuilder.class,
+        mockDelegate,
+        testChannelBuilder,
+        Collections.<Method>emptyList(),
+        new ForwardingTestUtil.ArgumentProvider() {
+          @Override
+          public Object get(Method method, int argPos, Class<?> clazz) {
+            if (method.getName().equals("maxInboundMetadataSize")) {
+              assertThat(argPos).isEqualTo(0);
+              return 1; // an arbitrary positive number
+            }
+            return null;
+          }
+        });
+  }
+
+  @Test
+  public void allBuilderMethodsReturnThis() throws Exception {
+    for (Method method : ManagedChannelBuilder.class.getDeclaredMethods()) {
+      if (Modifier.isStatic(method.getModifiers()) || Modifier.isPrivate(method.getModifiers())) {
+        continue;
+      }
+      if (method.getName().equals("build")) {
+        continue;
+      }
+      Class<?>[] argTypes = method.getParameterTypes();
+      Object[] args = new Object[argTypes.length];
+      for (int i = 0; i < argTypes.length; i++) {
+        args[i] = Defaults.defaultValue(argTypes[i]);
+      }
+      if (method.getName().equals("maxInboundMetadataSize")) {
+        args[0] = 1; // an arbitrary positive number
+      }
+
+      Object returnedValue = method.invoke(testChannelBuilder, args);
+
+      assertThat(returnedValue).isSameInstanceAs(testChannelBuilder);
+    }
+  }
+
+  @Test
+  public void buildReturnsDelegateBuildByDefault() {
+    ManagedChannel mockChannel = mock(ManagedChannel.class);
+    doReturn(mockChannel).when(mockDelegate).build();
+
+    assertThat(testChannelBuilder.build()).isSameInstanceAs(mockChannel);
+  }
+}

--- a/core/src/test/java/io/grpc/internal/AbstractServerImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerImplBuilderTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.base.Defaults;
+import io.grpc.ForwardingTestUtil;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Collections;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link AbstractServerImplBuilderTest}.
+ */
+@RunWith(JUnit4.class)
+public class AbstractServerImplBuilderTest {
+  private final ServerBuilder<?> mockDelegate = mock(ServerBuilder.class);
+
+  private final AbstractServerImplBuilder<?> testServerBuilder = new TestBuilder();
+
+  private final class TestBuilder extends AbstractServerImplBuilder<TestBuilder> {
+    @Override
+    protected ServerBuilder<?> delegate() {
+      return mockDelegate;
+    }
+  }
+
+  @Test
+  public void allMethodsForwarded() throws Exception {
+    ForwardingTestUtil.testMethodsForwarded(
+        ServerBuilder.class,
+        mockDelegate,
+        testServerBuilder,
+        Collections.<Method>emptyList());
+  }
+
+  @Test
+  public void allBuilderMethodsReturnThis() throws Exception {
+    for (Method method : ServerBuilder.class.getDeclaredMethods()) {
+      if (Modifier.isStatic(method.getModifiers()) || Modifier.isPrivate(method.getModifiers())) {
+        continue;
+      }
+      if (method.getName().equals("build")) {
+        continue;
+      }
+      Class<?>[] argTypes = method.getParameterTypes();
+      Object[] args = new Object[argTypes.length];
+      for (int i = 0; i < argTypes.length; i++) {
+        args[i] = Defaults.defaultValue(argTypes[i]);
+      }
+
+      Object returnedValue = method.invoke(testServerBuilder, args);
+
+      assertThat(returnedValue).isSameInstanceAs(testServerBuilder);
+    }
+  }
+
+  @Test
+  public void buildReturnsDelegateBuildByDefault() {
+    Server server = mock(Server.class);
+    doReturn(server).when(mockDelegate).build();
+
+    assertThat(testServerBuilder.build()).isSameInstanceAs(server);
+  }
+}

--- a/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
@@ -26,9 +26,9 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.ChannelLogger;
 import io.grpc.ExperimentalApi;
-import io.grpc.ForwardingChannelBuilder;
 import io.grpc.Internal;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.internal.AbstractManagedChannelImplBuilder;
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.GrpcUtil;
@@ -50,7 +50,8 @@ import org.chromium.net.ExperimentalCronetEngine;
 
 /** Convenience class for building channels with the cronet transport. */
 @ExperimentalApi("There is no plan to make this API stable, given transport API instability")
-public final class CronetChannelBuilder extends ForwardingChannelBuilder<CronetChannelBuilder> {
+public final class CronetChannelBuilder
+    extends AbstractManagedChannelImplBuilder<CronetChannelBuilder> {
 
   private static final String LOG_TAG = "CronetChannelBuilder";
 

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -30,10 +30,10 @@ import io.grpc.ChannelCredentials;
 import io.grpc.ChannelLogger;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.ExperimentalApi;
-import io.grpc.ForwardingChannelBuilder;
 import io.grpc.HttpConnectProxiedSocketAddress;
 import io.grpc.Internal;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.internal.AbstractManagedChannelImplBuilder;
 import io.grpc.internal.AtomicBackoff;
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.ConnectionClientTransport;
@@ -69,7 +69,8 @@ import javax.net.ssl.SSLException;
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1784")
 @CanIgnoreReturnValue
-public final class NettyChannelBuilder extends ForwardingChannelBuilder<NettyChannelBuilder> {
+public final class NettyChannelBuilder extends
+    AbstractManagedChannelImplBuilder<NettyChannelBuilder> {
 
   // 1MiB.
   public static final int DEFAULT_FLOW_CONTROL_WINDOW = 1024 * 1024;

--- a/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
@@ -27,10 +27,10 @@ import static io.grpc.internal.GrpcUtil.SERVER_KEEPALIVE_TIME_NANOS_DISABLED;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.grpc.ExperimentalApi;
-import io.grpc.ForwardingServerBuilder;
 import io.grpc.Internal;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerStreamTracer;
+import io.grpc.internal.AbstractServerImplBuilder;
 import io.grpc.internal.FixedObjectPool;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.InternalServer;
@@ -66,7 +66,7 @@ import javax.net.ssl.SSLException;
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1784")
 @CanIgnoreReturnValue
-public final class NettyServerBuilder extends ForwardingServerBuilder<NettyServerBuilder> {
+public final class NettyServerBuilder extends AbstractServerImplBuilder<NettyServerBuilder> {
 
   // 1MiB
   public static final int DEFAULT_FLOW_CONTROL_WINDOW = 1024 * 1024;

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -29,11 +29,11 @@ import io.grpc.ChoiceChannelCredentials;
 import io.grpc.CompositeCallCredentials;
 import io.grpc.CompositeChannelCredentials;
 import io.grpc.ExperimentalApi;
-import io.grpc.ForwardingChannelBuilder;
 import io.grpc.InsecureChannelCredentials;
 import io.grpc.Internal;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.TlsChannelCredentials;
+import io.grpc.internal.AbstractManagedChannelImplBuilder;
 import io.grpc.internal.AtomicBackoff;
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.ConnectionClientTransport;
@@ -67,7 +67,8 @@ import javax.net.ssl.SSLSocketFactory;
 
 /** Convenience class for building channels with the OkHttp transport. */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1785")
-public final class OkHttpChannelBuilder extends ForwardingChannelBuilder<OkHttpChannelBuilder> {
+public final class OkHttpChannelBuilder extends
+    AbstractManagedChannelImplBuilder<OkHttpChannelBuilder> {
 
   public static final int DEFAULT_FLOW_CONTROL_WINDOW = 65535;
   private final ManagedChannelImplBuilder managedChannelImplBuilder;


### PR DESCRIPTION
### What's this PR do?
Brings back `io.grpc.internal.AbstractManagedChannelImplBuilder` and `io.grpc.internal.AbstractServerImplBuilder` to the class hierarchy to fix broken ABI backward compatibility.

### Any background context you want to provide?
#### AbstractManagedChannelImplBuilder
`AbstractManagedChannelImplBuilder` brought back as a copy of `ForwardingChannelBuilder` support pre-v1.33 binary interface, e.g. `io.grpc.netty.NettyChannelBuilder.maxInboundMessageSize(I)Lio/grpc/internal/AbstractManagedChannelImplBuilder;`

#### AbstractServerImplBuilder
- Brings back `io.grpc.internal.AbstractManagedChannelImplBuilder` and `io.grpc.internal.AbstractServerImplBuilder` to the class hierarchy to fix broken ABI backward compatibility.
- Since `ForwardingServerBuilder` was introduced in v1.33.0, I changed it to `ForwardingServerBuilder<T extends ServerBuilder<T>>`. and made it package-private.

### What are the relevant tickets?
- Fixes #7552
- Partially undoes #7211 


