### PR TITLE
Attach exemplars to stats in census instrumentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,8 +155,8 @@ subprojects {
             opencensus_api: "io.opencensus:opencensus-api:${opencensusVersion}",
             opencensus_contrib_grpc_metrics: "io.opencensus:opencensus-contrib-grpc-metrics:${opencensusVersion}",
             opencensus_impl: "io.opencensus:opencensus-impl:${opencensusVersion}",
-            opencensus_impl_lite: "io.opencensus:opencensus-impl-lite:${opencensusVersion}",
             opencensus_proto: "io.opencensus:opencensus-proto:0.2.0",
+            opencensus_exemplar_util: "io.opencensus:opencensus-contrib-exemplar-util:${opencensusVersion}",
             instrumentation_api: 'com.google.instrumentation:instrumentation-api:0.4.3',
             perfmark: 'io.perfmark:perfmark-api:0.19.0',
             protobuf: "com.google.protobuf:protobuf-java:${protobufVersion}",
@@ -230,6 +230,9 @@ subprojects {
                 exclude group: 'com.google.code.findbugs', module: 'jsr305'
                 exclude group: 'com.google.guava', module: 'guava'
                 // we'll always be more up-to-date
+                exclude group: 'io.grpc', module: 'grpc-context'
+            }
+            dependencies."$configurationName"(libraries.opencensus_exemplar_util) {
                 exclude group: 'io.grpc', module: 'grpc-context'
             }
             dependencies.runtimeOnly project(':grpc-context')

--- a/census/src/main/java/io/grpc/census/InternalCensusStatsAccessor.java
+++ b/census/src/main/java/io/grpc/census/InternalCensusStatsAccessor.java
@@ -24,6 +24,7 @@ import io.grpc.ServerStreamTracer;
 import io.opencensus.stats.StatsRecorder;
 import io.opencensus.tags.Tagger;
 import io.opencensus.tags.propagation.TagContextBinarySerializer;
+import io.opencensus.trace.Tracer;
 
 /**
  * Accessor for getting {@link ClientInterceptor} or {@link ServerStreamTracer.Factory} with
@@ -68,13 +69,14 @@ public final class InternalCensusStatsAccessor {
       TagContextBinarySerializer tagCtxSerializer,
       StatsRecorder statsRecorder,
       Supplier<Stopwatch> stopwatchSupplier,
+      Tracer censusTracer,
       boolean propagateTags,
       boolean recordStartedRpcs,
       boolean recordFinishedRpcs,
       boolean recordRealTimeMetrics) {
     CensusStatsModule censusStats =
         new CensusStatsModule(
-            tagger, tagCtxSerializer, statsRecorder, stopwatchSupplier,
+            tagger, tagCtxSerializer, statsRecorder, stopwatchSupplier, censusTracer,
             propagateTags, recordStartedRpcs, recordFinishedRpcs, recordRealTimeMetrics);
     return censusStats.getClientInterceptor();
   }
@@ -104,13 +106,14 @@ public final class InternalCensusStatsAccessor {
       TagContextBinarySerializer tagCtxSerializer,
       StatsRecorder statsRecorder,
       Supplier<Stopwatch> stopwatchSupplier,
+      Tracer censusTracer,
       boolean propagateTags,
       boolean recordStartedRpcs,
       boolean recordFinishedRpcs,
       boolean recordRealTimeMetrics) {
     CensusStatsModule censusStats =
         new CensusStatsModule(
-            tagger, tagCtxSerializer, statsRecorder, stopwatchSupplier,
+            tagger, tagCtxSerializer, statsRecorder, stopwatchSupplier, censusTracer,
             propagateTags, recordStartedRpcs, recordFinishedRpcs, recordRealTimeMetrics);
     return censusStats.getServerTracerFactory();
   }

--- a/census/src/test/java/io/grpc/census/CensusModulesTest.java
+++ b/census/src/test/java/io/grpc/census/CensusModulesTest.java
@@ -213,7 +213,7 @@ public class CensusModulesTest {
     censusStats =
         new CensusStatsModule(
             tagger, tagCtxSerializer, statsRecorder, fakeClock.getStopwatchSupplier(),
-            true, true, true, false /* real-time */);
+            tracer, true, true, true, false /* real-time */);
     censusTracing = new CensusTracingModule(tracer, mockTracingPropagationHandler);
   }
 
@@ -387,7 +387,7 @@ public class CensusModulesTest {
     CensusStatsModule localCensusStats =
         new CensusStatsModule(
             tagger, tagCtxSerializer, statsRecorder, fakeClock.getStopwatchSupplier(),
-            true, recordStarts, recordFinishes, recordRealTime);
+            tracer, true, recordStarts, recordFinishes, recordRealTime);
     CensusStatsModule.ClientCallTracer callTracer =
         localCensusStats.newClientCallTracer(
             tagger.empty(), method.getFullMethodName());
@@ -678,6 +678,7 @@ public class CensusModulesTest {
             tagCtxSerializer,
             statsRecorder,
             fakeClock.getStopwatchSupplier(),
+            tracer,
             propagate, recordStats, recordStats, recordStats);
     Metadata headers = new Metadata();
     CensusStatsModule.ClientCallTracer callTracer =
@@ -923,7 +924,7 @@ public class CensusModulesTest {
     CensusStatsModule localCensusStats =
         new CensusStatsModule(
             tagger, tagCtxSerializer, statsRecorder, fakeClock.getStopwatchSupplier(),
-            true, recordStarts, recordFinishes, recordRealTime);
+            tracer, true, recordStarts, recordFinishes, recordRealTime);
     ServerStreamTracer.Factory tracerFactory = localCensusStats.getServerTracerFactory();
     ServerStreamTracer tracer =
         tracerFactory.newServerStreamTracer(method.getFullMethodName(), new Metadata());
@@ -1184,7 +1185,7 @@ public class CensusModulesTest {
 
     CensusStatsModule localCensusStats = new CensusStatsModule(
         tagger, tagCtxSerializer, localStats.getStatsRecorder(), fakeClock.getStopwatchSupplier(),
-        false, false, true, false /* real-time */);
+        tracer, false, false, true, false /* real-time */);
 
     CensusStatsModule.ClientCallTracer callTracer =
         localCensusStats.newClientCallTracer(

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -70,6 +70,7 @@ import io.grpc.internal.testing.StatsTestUtils.FakeStatsRecorder;
 import io.grpc.internal.testing.StatsTestUtils.FakeTagContext;
 import io.grpc.internal.testing.StatsTestUtils.FakeTagContextBinarySerializer;
 import io.grpc.internal.testing.StatsTestUtils.FakeTagger;
+import io.grpc.internal.testing.StatsTestUtils.FakeTracer;
 import io.grpc.internal.testing.StatsTestUtils.MetricsRecord;
 import io.grpc.internal.testing.StreamRecorder;
 import io.grpc.internal.testing.TestClientStreamTracer;
@@ -156,6 +157,7 @@ public abstract class AbstractInteropTest {
   private static final FakeTagger tagger = new FakeTagger();
   private static final FakeTagContextBinarySerializer tagContextBinarySerializer =
       new FakeTagContextBinarySerializer();
+  private final FakeTracer censusTracer = new FakeTracer();
 
   private final AtomicReference<ServerCall<?, ?>> serverCallCapture =
       new AtomicReference<>();
@@ -353,14 +355,14 @@ public abstract class AbstractInteropTest {
         InternalCensusStatsAccessor
             .getClientInterceptor(
                 tagger, tagContextBinarySerializer, clientStatsRecorder,
-                GrpcUtil.STOPWATCH_SUPPLIER,
+                GrpcUtil.STOPWATCH_SUPPLIER, censusTracer,
                 true, true, true, false /* real-time metrics */);
   }
 
   protected final ServerStreamTracer.Factory createCustomCensusTracerFactory() {
     return InternalCensusStatsAccessor.getServerStreamTracerFactory(
         tagger, tagContextBinarySerializer, serverStatsRecorder,
-        GrpcUtil.STOPWATCH_SUPPLIER,
+        GrpcUtil.STOPWATCH_SUPPLIER, censusTracer,
         true, true, true, false /* real-time metrics */);
   }
 

--- a/testing/src/main/java/io/grpc/internal/testing/StatsTestUtils.java
+++ b/testing/src/main/java/io/grpc/internal/testing/StatsTestUtils.java
@@ -51,6 +51,7 @@ import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.SpanId;
 import io.opencensus.trace.TraceId;
 import io.opencensus.trace.TraceOptions;
+import io.opencensus.trace.Tracer;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
@@ -192,6 +193,20 @@ public class StatsTestUtils {
     @Override
     public Scope withTagContext(TagContext tags) {
       throw new UnsupportedOperationException();
+    }
+  }
+
+  public static final class FakeTracer extends Tracer {
+
+    @Override
+    public SpanBuilder spanBuilderWithExplicitParent(String spanName, @Nullable Span parent) {
+      return null;
+    }
+
+    @Override
+    public SpanBuilder spanBuilderWithRemoteParent(String spanName,
+        @Nullable SpanContext remoteParentSpanContext) {
+      return null;
     }
   }
 


### PR DESCRIPTION
Fixes #7505 (WIP)

This PR is functional and I can see trace exemplars for the `grpc.io/server/server_latency` metric in Cloud Monitoring when running [an example app](https://github.com/aabmass/grpctest). I don't think the sampling logic is quite right.

<img width="1507" alt="Screen Shot 2020-10-29 at 7 26 53 PM" src="https://user-images.githubusercontent.com/1510004/97642904-b7345a00-1a1c-11eb-80f8-135582b9068d.png">