### PR TITLE
LoadWorker: clarify the semantics of --server_port flag

### DIFF
--- a/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadWorker.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadWorker.java
@@ -104,7 +104,7 @@ public class LoadWorker {
               + "\n  --driver_port=<port>"
               + "\n    Port to expose grpc.testing.WorkerService, used by driver to initiate work."
               + "\n  --server_port=<port>"
-              + "\n    Port to start load servers on. Defaults to any available port");
+              + "\n    Port to start load servers on, if not specified by the server config message. Defaults to any available port.");
       System.exit(1);
     }
     LoadWorker loadWorker = new LoadWorker(driverPort, serverPort);

--- a/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadWorker.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadWorker.java
@@ -104,7 +104,8 @@ public class LoadWorker {
               + "\n  --driver_port=<port>"
               + "\n    Port to expose grpc.testing.WorkerService, used by driver to initiate work."
               + "\n  --server_port=<port>"
-              + "\n    Port to start load servers on, if not specified by the server config message. Defaults to any available port.");
+              + "\n    Port to start load servers on, if not specified by the server config message."
+              + "\n    Defaults to any available port.");
       System.exit(1);
     }
     LoadWorker loadWorker = new LoadWorker(driverPort, serverPort);

--- a/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadWorker.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadWorker.java
@@ -104,8 +104,8 @@ public class LoadWorker {
               + "\n  --driver_port=<port>"
               + "\n    Port to expose grpc.testing.WorkerService, used by driver to initiate work."
               + "\n  --server_port=<port>"
-              + "\n    Port to start load servers on, if not specified by the server config message."
-              + "\n    Defaults to any available port.");
+              + "\n    Port to start load servers on, if not specified by the server config"
+              + "\n    message. Defaults to any available port.");
       System.exit(1);
     }
     LoadWorker loadWorker = new LoadWorker(driverPort, serverPort);


### PR DESCRIPTION
The behavior is as follows:
https://github.com/grpc/grpc-java/blob/59528d8efec465326b071ffc6f3f2220bcf641c9/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadWorker.java#L136
(ServerConfig.port takes precedence if set).

grpc-go's documentation is clearer:
https://github.com/grpc/grpc-go/blob/02cd07d9bb5609fe76f8bb8d948037e79a8b29c7/benchmark/worker/main.go#L44