### PR TITLE
xds: only reschedule time for unresolved resources upon ADS stream restarts

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -754,8 +754,10 @@ final class ClientXdsClient extends AbstractXdsClient {
       watchers.remove(watcher);
     }
 
-    // FIXME(chengyuanzhang): should only restart timer if the resource is still unresolved.
     void restartTimer() {
+      if (data != null || absent) {  // resource already resolved
+        return;
+      }
       class ResourceNotFound implements Runnable {
         @Override
         public void run() {


### PR DESCRIPTION
#7427 changed to have xDS resource version info persist across ADS stream recreation so that the management server can choose to not send client resources that have already been sent previously (in the previous stream). It means the client should not consider previously received (resolved) resources not exist if it does not receive them on the new ADS stream. This PR fixes that.