### PR TITLE
gradle: Verify gradle-wrapper.jar "manually"

### DIFF
--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -30,6 +30,16 @@ ARCH="${ARCH:-x86_64}"
 
 ARCH="$ARCH" buildscripts/make_dependencies.sh
 
+# It isn't important for the Gradle wrapper to be the same version as Gradle. It
+# rarely changes.
+GRADLE_WRAPPER_VERSION=4.10.1
+(
+  curl -Ls "https://services.gradle.org/distributions/gradle-$GRADLE_WRAPPER_VERSION-wrapper.jar.sha256"
+  echo "  gradle/wrapper/gradle-wrapper.jar"
+) | sha256sum --check
+diff gradle/wrapper/gradle-wrapper.jar \
+  examples/gradle/wrapper/gradle-wrapper.jar
+
 # Set properties via flags, do not pollute gradle.properties
 GRADLE_FLAGS="${GRADLE_FLAGS:-}"
 GRADLE_FLAGS+=" -PtargetArch=$ARCH"


### PR DESCRIPTION
This is based on [Gradle's manual verification steps][1], but clearly
modified. This approach avoids creating the checksum file on disk, which
would need to be removed if we ever check that generated code is
up-to-date (like we currently do on Travis-CI).

[1]: https://docs.gradle.org/current/userguide/gradle_wrapper.html#wrapper_checksum_verification

---

This is an alternative to #7380. It's easier for us to just have it part of the rest of our CI. If/When we have some GitHub Action CI, we can swap to using the action.

CC @sullis 