### PR TITLE
interop-testing: fix bug of not completing client configure RPC in xDS test client

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
@@ -430,6 +430,8 @@ public final class XdsTestClient {
         newMetadata.put(metadata.getType(), md);
       }
       rpcConfig = new RpcConfig(request.getTypesList(), newMetadata);
+      responseObserver.onNext(ClientConfigureResponse.getDefaultInstance());
+      responseObserver.onCompleted();
     }
   }
 


### PR DESCRIPTION
My bad, forgot to complete the call.