### PR TITLE
Fix parameters of java_common.compile.

### DIFF
--- a/java_grpc_library.bzl
+++ b/java_grpc_library.bzl
@@ -106,7 +106,6 @@ def _java_rpc_library_impl(ctx):
     java_info = java_common.compile(
         ctx,
         java_toolchain = toolchain.java_toolchain[java_common.JavaToolchainInfo],
-        host_javabase = toolchain.host_javabase[java_common.JavaRuntimeInfo],
         source_jars = [srcjar],
         output = ctx.outputs.jar,
         output_source_jar = ctx.outputs.srcjar,


### PR DESCRIPTION
Parameter host_javabase is removed 

This is preparation for flipping incompatible_java_common_parameters.
See https://github.com/bazelbuild/bazel/issues/12373