### PR TITLE
Fix for https://github.com/grpc/grpc-java/issues/7612, increasing the…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ subprojects {
 
         nettyVersion = '4.1.51.Final'
         guavaVersion = '29.0-android'
-        googleauthVersion = '0.20.0'
+        googleauthVersion = '0.22.0'
         protobufVersion = '3.12.0'
         protocVersion = protobufVersion
         opencensusVersion = '0.24.0'

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -12,8 +12,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "com.google.android:annotations:4.1.1.4",
     "com.google.api.grpc:proto-google-common-protos:1.17.0",
-    "com.google.auth:google-auth-library-credentials:0.20.0",
-    "com.google.auth:google-auth-library-oauth2-http:0.20.0",
+    "com.google.auth:google-auth-library-credentials:0.22.0",
+    "com.google.auth:google-auth-library-oauth2-http:0.22.0",
     "com.google.code.findbugs:jsr305:3.0.2",
     "com.google.code.gson:gson:jar:2.8.6",
     "com.google.errorprone:error_prone_annotations:2.3.4",


### PR DESCRIPTION
… google auth library version to 0.22.0 to use the latest non-vulnerable apache httpclient 4.5.13