### PR TITLE
buildscripts: enable xDS circuit breaking test

### DIFF
--- a/buildscripts/kokoro/xds.sh
+++ b/buildscripts/kokoro/xds.sh
@@ -28,9 +28,9 @@ grpc/tools/run_tests/helper_scripts/prep_xds.sh
 # --test_case after they are added into "all".
 JAVA_OPTS=-Djava.util.logging.config.file=grpc-java/buildscripts/xds_logging.properties \
   python3 grpc/tools/run_tests/run_xds_tests.py \
-    --test_case="all,path_matching,header_matching" \
+    --test_case="all,path_matching,header_matching,circuit_breaking" \
     --project_id=grpc-testing \
-    --source_image=projects/grpc-testing/global/images/xds-test-server-2 \
+    --source_image=projects/grpc-testing/global/images/xds-test-server-3 \
     --path_to_server_binary=/java_server/grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-server \
     --gcp_suffix=$(date '+%s') \
     --verbose \


### PR DESCRIPTION
Enables xDS circuit breaking interop test for Java.

BTW, we'd better change the test client argument `--stats_port` to `--service_port` (or just `--port` or something better) as it is not just used for stats service now. But that change requires coordination for all languages and test driver. And we need to do it with two steps (add the new argument and then remove the old one). It's a bit annoying, we can live with it now.