### PR TITLE
xds: add support for setting bootstrap file with java system property

### DIFF
--- a/examples/example-xds/README.md
+++ b/examples/example-xds/README.md
@@ -6,7 +6,7 @@ being configured with the XDS management protocol. Out-of-the-box they behave th
 as their hello-world version.
 
 __XDS support is incomplete and experimental, with limited compatibility. It
-will be very hard to produce a working enviornment just by this example. Please
+will be very hard to produce a working environment just by this example. Please
 refer to documentation specific for your XDS management server and
 environment.__
 
@@ -24,8 +24,8 @@ This creates the scripts `build/install/example-xds/bin/hello-world-client-xds` 
 ### Run the example without using XDS Credentials
 
 To use XDS, you should first deploy the XDS management server in your deployment environment
-and know its name. You need to set the `GRPC_XDS_BOOTSTRAP` environment variable to point to the
-gRPC XDS bootstrap file (see
+and know its name. You need to set the `GRPC_XDS_BOOTSTRAP` environment variable (preferred) or if that is not set then
+the `io.grpc.xds.bootstrap` java system property to point to the gRPC XDS bootstrap file (see
 [gRFC A27](https://github.com/grpc/proposal/blob/master/A27-xds-global-load-balancing.md#xdsclient-and-bootstrap-file) for the
 bootstrap format). This is needed by both `build/install/example-xds/bin/hello-world-client-xds`
 and `build/install/example-xds/bin/hello-world-server-xds`.
@@ -61,7 +61,7 @@ $ export GRPC_XDS_BOOTSTRAP=/path/to/bootstrap.json
 $ ./build/install/example-xds/bin/hello-world-server-xds 8000 my-test-xds-server --secure
 ```
 
-2. Similarly, add `--secure` on the comamnd line when you run the xDS client:
+2. Similarly, add `--secure` on the command line when you run the xDS client:
 ```
 $ export GRPC_XDS_BOOTSTRAP=/path/to/bootstrap.json
 $ ./build/install/example-xds/bin/hello-world-client-xds xds:///yourServersName:8000 my-test-xds-client --secure

--- a/xds/src/test/java/io/grpc/xds/XdsClientWrapperForServerSdsTestMisc.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientWrapperForServerSdsTestMisc.java
@@ -201,7 +201,9 @@ public class XdsClientWrapperForServerSdsTestMisc {
     } catch (IOException expected) {
       assertThat(expected)
               .hasMessageThat()
-              .contains("Environment variable GRPC_XDS_BOOTSTRAP not defined");
+              .contains(
+                      "Environment variable GRPC_XDS_BOOTSTRAP"
+                      + " or Java System Property io.grpc.xds.bootstrap not defined.");
     }
     ArgumentCaptor<Status> argCaptor = ArgumentCaptor.forClass(null);
     verify(mockServerWatcher).onError(argCaptor.capture());
@@ -210,7 +212,9 @@ public class XdsClientWrapperForServerSdsTestMisc {
     assertThat(captured.getCause()).isInstanceOf(XdsInitializationException.class);
     assertThat(captured.getCause())
         .hasMessageThat()
-        .contains("Environment variable GRPC_XDS_BOOTSTRAP not defined");
+        .contains(
+                "Environment variable GRPC_XDS_BOOTSTRAP"
+                + " or Java System Property io.grpc.xds.bootstrap not defined.");
   }
 
   private DownstreamTlsContext sendListenerUpdate(

--- a/xds/src/test/java/io/grpc/xds/XdsServerBuilderTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerBuilderTest.java
@@ -236,7 +236,9 @@ public class XdsServerBuilderTest {
     } catch (IOException expected) {
       assertThat(expected)
               .hasMessageThat()
-              .contains("Environment variable GRPC_XDS_BOOTSTRAP not defined");
+              .contains(
+                      "Environment variable GRPC_XDS_BOOTSTRAP"
+                      + " or Java System Property io.grpc.xds.bootstrap not defined.");
     }
     ArgumentCaptor<Status> argCaptor = ArgumentCaptor.forClass(null);
     verify(mockErrorNotifier).onError(argCaptor.capture());
@@ -245,7 +247,9 @@ public class XdsServerBuilderTest {
     assertThat(captured.getCause()).isInstanceOf(XdsInitializationException.class);
     assertThat(captured.getCause())
             .hasMessageThat()
-            .contains("Environment variable GRPC_XDS_BOOTSTRAP not defined");
+            .contains(
+                    "Environment variable GRPC_XDS_BOOTSTRAP"
+                    + " or Java System Property io.grpc.xds.bootstrap not defined.");
   }
 
   @Test


### PR DESCRIPTION
While most languages support setting environment variables during runtime,
Java does not. In Java, the preferred approach is to use Java System Properties
in order so specify configuration options. By checking for the existence
of the io.grpc.xds.bootstrap property if GRPC_XDS_BOOTSTRAP is not found,
it is possible to either supply the bootstrap location during runtime or as
a Java argument. The environment variable still takes precedence in order
to not break any existing documentation.

For discussion see #7605 .