### PR TITLE
core: fix typos in Forwarding* classes

### DIFF
--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
- * A {@link ManagedChannelBuilder} that delegates all its builder method to another builder by
+ * A {@link ManagedChannelBuilder} that delegates all its builder methods to another builder by
  * default.
  *
  * @param <T> The type of the subclass extending this abstract class.

--- a/api/src/main/java/io/grpc/ForwardingClientCall.java
+++ b/api/src/main/java/io/grpc/ForwardingClientCall.java
@@ -17,7 +17,7 @@
 package io.grpc;
 
 /**
- * A {@link ClientCall} which forwards all of it's methods to another {@link ClientCall}.
+ * A {@link ClientCall} which forwards all of its methods to another {@link ClientCall}.
  */
 public abstract class ForwardingClientCall<ReqT, RespT>
     extends PartialForwardingClientCall<ReqT, RespT> {

--- a/api/src/main/java/io/grpc/ForwardingServerBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingServerBuilder.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
- * A {@link ServerBuilder} that delegates all its builder method to another builder by default.
+ * A {@link ServerBuilder} that delegates all its builder methods to another builder by default.
  *
  * @param <T> The type of the subclass extending this abstract class.
  * @since 1.33.0

--- a/api/src/main/java/io/grpc/ForwardingServerCall.java
+++ b/api/src/main/java/io/grpc/ForwardingServerCall.java
@@ -17,7 +17,7 @@
 package io.grpc;
 
 /**
- * A {@link ServerCall} which forwards all of it's methods to another {@link ServerCall}.
+ * A {@link ServerCall} which forwards all of its methods to another {@link ServerCall}.
  */
 public abstract class ForwardingServerCall<ReqT, RespT>
     extends PartialForwardingServerCall<ReqT, RespT> {


### PR DESCRIPTION
all its methods belong to us
![](https://upload.wikimedia.org/wikipedia/en/0/03/Aybabtu.png)

Ref https://github.com/grpc/grpc-java/pull/7633/files#r525631830
Fixing sources - that was a typo from copy paste of a copy paste