### PR TITLE
Remove deprecated javadoc options

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -275,15 +275,6 @@ subprojects {
         }
     }
 
-    // For jdk10 we must explicitly choose between html4 and html5, otherwise we get a warning
-    if (JavaVersion.current().isJava10Compatible()) {
-        allprojects {
-            tasks.withType(Javadoc) {
-                options.addBooleanOption('html4', true)
-            }
-        }
-    }
-
     jacoco { toolVersion = "0.8.2" }
 
     checkstyle {


### PR DESCRIPTION
This PR fixes the problems during build due to deprecated html4 and html5 options in JDK 11 as mentioned in #7637.