### PR TITLE
xds: remove temporary APIs and update xds example to use new ServerCreds (#7644) (v1.34.x backport)

### DIFF
--- a/examples/example-xds/src/main/java/io/grpc/examples/helloworldxds/HelloWorldServerXds.java
+++ b/examples/example-xds/src/main/java/io/grpc/examples/helloworldxds/HelloWorldServerXds.java
@@ -16,12 +16,15 @@
 
 package io.grpc.examples.helloworldxds;
 
+import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
+import io.grpc.ServerCredentials;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.grpc.stub.StreamObserver;
 import io.grpc.xds.XdsServerBuilder;
+import io.grpc.xds.XdsServerCredentials;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -44,10 +47,11 @@ public class HelloWorldServerXds {
   }
 
   private void start() throws IOException {
-    XdsServerBuilder builder = XdsServerBuilder.forPort(port).addService(new HostnameGreeter(hostName));
-    if (useXdsCreds) {
-      builder = builder.useXdsSecurityWithPlaintextFallback();
-    }
+    ServerCredentials insecure = InsecureServerCredentials.create();
+    XdsServerBuilder builder =
+        XdsServerBuilder.forPort(
+                port, useXdsCreds ? XdsServerCredentials.create(insecure) : insecure)
+            .addService(new HostnameGreeter(hostName));
     server = builder.build().start();
     logger.info("Server started, listening on " + port);
     Runtime.getRuntime()

--- a/xds/src/main/java/io/grpc/xds/XdsServerBuilder.java
+++ b/xds/src/main/java/io/grpc/xds/XdsServerBuilder.java
@@ -17,9 +17,7 @@
 package io.grpc.xds;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import io.grpc.Attributes;
-import io.grpc.ExperimentalApi;
 import io.grpc.ForwardingServerBuilder;
 import io.grpc.Internal;
 import io.grpc.Server;
@@ -27,18 +25,9 @@ import io.grpc.ServerBuilder;
 import io.grpc.ServerCredentials;
 import io.grpc.Status;
 import io.grpc.netty.InternalNettyServerBuilder;
-import io.grpc.netty.InternalProtocolNegotiator.ProtocolNegotiator;
-import io.grpc.netty.InternalProtocolNegotiators;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.xds.internal.sds.SdsProtocolNegotiators;
-import io.grpc.xds.internal.sds.SdsProtocolNegotiators.ServerSdsProtocolNegotiator;
 import io.grpc.xds.internal.sds.ServerWrapperForXds;
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
-import java.io.File;
-import java.io.InputStream;
-import java.net.InetSocketAddress;
-import javax.net.ssl.SSLException;
 
 /**
  * A version of {@link ServerBuilder} to create xDS managed servers that will use SDS to set up SSL
@@ -48,14 +37,11 @@ public final class XdsServerBuilder extends ForwardingServerBuilder<XdsServerBui
 
   private final NettyServerBuilder delegate;
   private final int port;
-  private final boolean freezeNegotiator;
-  private ProtocolNegotiator fallbackProtocolNegotiator;
   private ErrorNotifier errorNotifier;
 
-  private XdsServerBuilder(NettyServerBuilder nettyDelegate, int port, boolean freezeNegotiator) {
+  private XdsServerBuilder(NettyServerBuilder nettyDelegate, int port) {
     this.delegate = nettyDelegate;
     this.port = port;
-    this.freezeNegotiator = freezeNegotiator;
   }
 
   @Override
@@ -64,99 +50,40 @@ public final class XdsServerBuilder extends ForwardingServerBuilder<XdsServerBui
     return delegate;
   }
 
-  /**
-   * Use xDS provided security with plaintext as fallback. Note, this experimental functionality
-   * is not ready for wide usage.
-   */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/7514")
-  public XdsServerBuilder useXdsSecurityWithPlaintextFallback() {
-    Preconditions.checkState(!freezeNegotiator, "Method unavailable when using ServerCredentials");
-    this.fallbackProtocolNegotiator = InternalProtocolNegotiators.serverPlaintext();
-    return this;
-  }
-
-  /**
-   * Use xDS provided security with TLS as fallback. Note, this experimental functionality
-   * is not ready for wide usage.
-   *
-   * @param certChain file containing the full certificate chain
-   * @param privateKey file containing the private key
-   */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/7514")
-  public XdsServerBuilder useXdsSecurityWithTransportSecurityFallback(
-      File certChain, File privateKey) throws SSLException {
-    Preconditions.checkState(!freezeNegotiator, "Method unavailable when using ServerCredentials");
-    SslContext sslContext = SslContextBuilder.forServer(certChain, privateKey).build();
-    this.fallbackProtocolNegotiator = InternalProtocolNegotiators.serverTls(sslContext);
-    return this;
-  }
-
-  /**
-   * Use xDS provided security with TLS as fallback. Note, this experimental functionality
-   * is not ready for wide usage.
-   *
-   * @param certChain InputStream containing the full certificate chain
-   * @param privateKey InputStream containing the private key
-   */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/7514")
-  public XdsServerBuilder useXdsSecurityWithTransportSecurityFallback(
-      InputStream certChain, InputStream privateKey) throws SSLException {
-    Preconditions.checkState(!freezeNegotiator, "Method unavailable when using ServerCredentials");
-    SslContext sslContext = SslContextBuilder.forServer(certChain, privateKey).build();
-    this.fallbackProtocolNegotiator = InternalProtocolNegotiators.serverTls(sslContext);
-    return this;
-  }
-
-  /** Set the fallback protocolNegotiator. Pass null to unset a previously set value. */
-  public XdsServerBuilder fallbackProtocolNegotiator(
-      ProtocolNegotiator fallbackProtocolNegotiator) {
-    Preconditions.checkState(!freezeNegotiator, "Method unavailable when using ServerCredentials");
-    this.fallbackProtocolNegotiator = fallbackProtocolNegotiator;
-    return this;
-  }
-
   /** Set the {@link ErrorNotifier}. Pass null to unset a previously set value. */
   public XdsServerBuilder errorNotifier(ErrorNotifier errorNotifier) {
     this.errorNotifier = errorNotifier;
     return this;
   }
 
-  /** Creates a gRPC server builder for the given port. */
-  public static XdsServerBuilder forPort(int port) {
-    NettyServerBuilder nettyDelegate = NettyServerBuilder.forAddress(new InetSocketAddress(port));
-    return new XdsServerBuilder(nettyDelegate, port, /* freezeNegotiator= */ false);
+  /**
+   * Unsupported call. Users should only use {@link #forPort(int, ServerCredentials)}.
+   */
+  public static ServerBuilder<?> forPort(int port) {
+    throw new UnsupportedOperationException(
+        "Unsupported call - use forPort(int, ServerCredentials)");
   }
 
   /** Creates a gRPC server builder for the given port. */
   public static XdsServerBuilder forPort(int port, ServerCredentials serverCredentials) {
     NettyServerBuilder nettyDelegate = NettyServerBuilder.forPort(port, serverCredentials);
-    return new XdsServerBuilder(nettyDelegate, port, /* freezeNegotiator= */ true);
+    return new XdsServerBuilder(nettyDelegate, port);
   }
 
   @Override
   public Server build() {
-    XdsClientWrapperForServerSds xdsClient = new XdsClientWrapperForServerSds(port);
-    ServerSdsProtocolNegotiator serverProtocolNegotiator = null;
-    if (fallbackProtocolNegotiator != null) {
-      serverProtocolNegotiator =
-          SdsProtocolNegotiators.serverProtocolNegotiator(fallbackProtocolNegotiator);
-    }
-    return buildServer(xdsClient, serverProtocolNegotiator);
+    return buildServer(new XdsClientWrapperForServerSds(port));
   }
 
   /**
-   * Creates a Server using the given xdsClient and serverSdsProtocolNegotiator.
+   * Creates a Server using the given xdsClient.
    */
   @VisibleForTesting
   ServerWrapperForXds buildServer(
-      XdsClientWrapperForServerSds xdsClient,
-      ServerSdsProtocolNegotiator serverProtocolNegotiator) {
+      XdsClientWrapperForServerSds xdsClient) {
     InternalNettyServerBuilder.eagAttributes(delegate, Attributes.newBuilder()
         .set(SdsProtocolNegotiators.SERVER_XDS_CLIENT, xdsClient)
         .build());
-    if (serverProtocolNegotiator != null) {
-      delegate.protocolNegotiator(serverProtocolNegotiator);
-    }
     return new ServerWrapperForXds(delegate.build(), xdsClient, errorNotifier);
   }
 

--- a/xds/src/test/java/io/grpc/xds/XdsSdsClientServerTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsSdsClientServerTest.java
@@ -353,7 +353,7 @@ public class XdsSdsClientServerTest {
         port,
         downstreamTlsContext,
         /* tlsContext2= */null);
-    cleanupRule.register(builder.buildServer(xdsClientWrapperForServerSds, null)).start();
+    cleanupRule.register(builder.buildServer(xdsClientWrapperForServerSds)).start();
   }
 
   static EnvoyServerProtoData.Listener buildListener(

--- a/xds/src/test/java/io/grpc/xds/XdsServerBuilderTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerBuilderTest.java
@@ -26,11 +26,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.google.common.util.concurrent.SettableFuture;
+import io.grpc.InsecureServerCredentials;
 import io.grpc.Status;
-import io.grpc.netty.InternalProtocolNegotiators;
 import io.grpc.testing.GrpcCleanupRule;
 import io.grpc.xds.internal.sds.CommonTlsContextTestsUtil;
-import io.grpc.xds.internal.sds.SdsProtocolNegotiators.ServerSdsProtocolNegotiator;
 import io.grpc.xds.internal.sds.ServerWrapperForXds;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -66,7 +65,9 @@ public class XdsServerBuilderTest {
       XdsServerBuilder.ErrorNotifier errorNotifier, boolean injectMockXdsClient)
       throws IOException {
     port = XdsServerTestHelper.findFreePort();
-    XdsServerBuilder builder = XdsServerBuilder.forPort(port);
+    XdsServerBuilder builder =
+        XdsServerBuilder.forPort(
+            port, XdsServerCredentials.create(InsecureServerCredentials.create()));
     if (errorNotifier != null) {
       builder = builder.errorNotifier(errorNotifier);
     }
@@ -76,10 +77,7 @@ public class XdsServerBuilderTest {
       listenerWatcher =
           XdsServerTestHelper.startAndGetWatcher(xdsClientWrapperForServerSds, mockXdsClient, port);
     }
-    ServerSdsProtocolNegotiator serverSdsProtocolNegotiator =
-        new ServerSdsProtocolNegotiator(InternalProtocolNegotiators.serverPlaintext());
-    xdsServer = cleanupRule.register(
-        builder.buildServer(xdsClientWrapperForServerSds, serverSdsProtocolNegotiator));
+    xdsServer = cleanupRule.register(builder.buildServer(xdsClientWrapperForServerSds));
   }
 
   private void verifyServer(


### PR DESCRIPTION
Backport of #7644