### PR TITLE
xds: fix mistake of taking wrong argument in log message (v1.34.x backport) (#7653)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
@@ -709,7 +709,7 @@ abstract class AbstractXdsClient extends XdsClient {
       }
       DiscoveryRequest request = builder.build();
       requestWriter.onNext(request);
-      logger.log(XdsLogLevel.DEBUG, "Sent DiscoveryRequest\n{0}", respPrinter);
+      logger.log(XdsLogLevel.DEBUG, "Sent DiscoveryRequest\n{0}", request);
     }
 
     @Override


### PR DESCRIPTION
Backport of #7653 