### PR TITLE
Include native-image.properties in Netty shaded

### DIFF
--- a/api/src/main/java/io/grpc/ServiceProviders.java
+++ b/api/src/main/java/io/grpc/ServiceProviders.java
@@ -25,9 +25,6 @@ import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 
 final class ServiceProviders {
-  private ServiceProviders() {
-    // do not instantiate
-  }
 
   /**
    * If this is not Android, returns the highest priority implementation of the class via

--- a/build.gradle
+++ b/build.gradle
@@ -275,15 +275,6 @@ subprojects {
         }
     }
 
-    // For jdk10 we must explicitly choose between html4 and html5, otherwise we get a warning
-    if (JavaVersion.current().isJava10Compatible()) {
-        allprojects {
-            tasks.withType(Javadoc) {
-                options.addBooleanOption('html4', true)
-            }
-        }
-    }
-
     jacoco { toolVersion = "0.8.2" }
 
     checkstyle {

--- a/netty/shaded/build.gradle
+++ b/netty/shaded/build.gradle
@@ -26,6 +26,18 @@ jar {
     classifier = 'original'
 }
 
+task readFile(){
+    doLast{
+        File file = file('native-image.properties')
+        println file.text
+        println ""
+        file.readLines().each{
+            println it
+        }
+
+    }
+}
+
 shadowJar {
     classifier = null
     dependencies {

--- a/netty/shaded/native-image.properties
+++ b/netty/shaded/native-image.properties
@@ -1,0 +1,16 @@
+# Copyright 2019 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+Args = --initialize-at-build-time=io.grpc.netty.shaded.io.netty \
+       --initialize-at-run-time=io.grpc.netty.shaded.io.netty.handler.codec.http.HttpObjectEncoder,io.grpc.netty.shaded.io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder,io.grpc.netty.shaded.io.netty.handler.codec.http.websocketx.extensions.compression.DeflateDecoder


### PR DESCRIPTION
This is a temporary fix to #7540. This PR does not have a custom Transformer instead reads the configuration from a file and rewrites `native-image.properties` inside `META-INF`