### PR TITLE
buildscripts: Add xDS Kubernetes Interop tests buildscript placeholder

### DIFF
--- a/buildscripts/kokoro/xds-k8s.cfg
+++ b/buildscripts/kokoro/xds-k8s.cfg
@@ -1,0 +1,11 @@
+# Config file for internal CI
+
+# Location of the continuous shell script in repository.
+build_file: "grpc-java/buildscripts/kokoro/xds-k8s.sh"
+timeout_mins: 90
+action {
+  define_artifacts {
+    regex: "artifacts/*sponge_log.xml"
+    regex: "artifacts/*sponge_log.log"
+  }
+}

--- a/buildscripts/kokoro/xds-k8s.sh
+++ b/buildscripts/kokoro/xds-k8s.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# A placeholder for xDS interop tests executed on GKE
+echo "Coming soon"


### PR DESCRIPTION
To be used for testing new `xds-k8s` test job.