### PR TITLE
alts: Migrate java proto map getter from get<field> to get<field>Map

### DIFF
--- a/alts/src/main/java/io/grpc/alts/internal/AltsAuthContext.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsAuthContext.java
@@ -103,6 +103,6 @@ public final class AltsAuthContext {
    * @return the context's peer attributes.
    */
   public Map<String, String> getPeerAttributes() {
-    return context.getPeerAttributes();
+    return context.getPeerAttributesMap();
   }
 }


### PR DESCRIPTION
This is part of a proto-wide cleanup of its map APIs.

cl/344096880