### PR TITLE
example-xds: Mirror helloworld and hostname example (1.34.x backport)

### DIFF
--- a/examples/example-xds/README.md
+++ b/examples/example-xds/README.md
@@ -2,8 +2,9 @@ gRPC XDS Example
 ================
 
 The XDS example consists of a Hello World client and a Hello World server capable of
-being configured with the XDS management protocol. Out-of-the-box they behave the same
-as their hello-world version.
+being configured with the XDS management protocol. Out-of-the-box the client
+behaves the same the hello-world version and the server behaves similar to the
+example-hostname but with a required dependency on xDS.
 
 __XDS support is incomplete and experimental, with limited compatibility. It
 will be very hard to produce a working environment just by this example. Please
@@ -30,23 +31,21 @@ the `io.grpc.xds.bootstrap` java system property to point to the gRPC XDS bootst
 bootstrap format). This is needed by both `build/install/example-xds/bin/xds-hello-world-client`
 and `build/install/example-xds/bin/xds-hello-world-server`.
 
-1. To start the XDS-enabled example server, run:
+1. To start the XDS-enabled example server on its default port of 50051, run:
 ```
 $ export GRPC_XDS_BOOTSTRAP=/path/to/bootstrap.json
-$ ./build/install/example-xds/bin/xds-hello-world-server 8000 my-test-xds-server
+$ ./build/install/example-xds/bin/xds-hello-world-server
 ```
-
-The first command line argument is the port to listen on (`8000`) and the second argument is a string
-id (`my-test-xds-server`) to be included in the greeting response to the client.
 
 2. In a different terminal window, run the XDS-enabled example client:
 ```
 $ export GRPC_XDS_BOOTSTRAP=/path/to/bootstrap.json
-$ ./build/install/example-xds/bin/xds-hello-world-client my-test-xds-client xds:///yourServersName:8000
+$ ./build/install/example-xds/bin/xds-hello-world-client "xds world" xds:///yourServersName
 ```
-The first command line argument (`my-test-xds-client`) is the name you wish to include in the greeting request
-to the server and the second argument (`xds:///yourServersName:8000`) is the target to connect to using the
-`xds:` target scheme.
+The first command line argument (`xds world`) is the name you wish to include in
+the greeting request to the server and the second argument
+(`xds:///yourServersName`) is the target to connect to using the `xds:` target
+scheme.
 
 ### Run the example with xDS Credentials
 
@@ -58,13 +57,13 @@ This code is enabled by providing an additional command line argument.
 1. On the server side, add `--secure` on the command line to authorize use of xDS security:
 ```
 $ export GRPC_XDS_BOOTSTRAP=/path/to/bootstrap.json
-$ ./build/install/example-xds/bin/xds-hello-world-server 8000 my-test-xds-server --secure
+$ ./build/install/example-xds/bin/xds-hello-world-server --secure
 ```
 
 2. Similarly, add `--secure` on the command line when you run the xDS client:
 ```
 $ export GRPC_XDS_BOOTSTRAP=/path/to/bootstrap.json
-$ ./build/install/example-xds/bin/xds-hello-world-client my-test-xds-client xds:///yourServersName:8000 --secure
+$ ./build/install/example-xds/bin/xds-hello-world-client --secure "xds world" xds:///yourServersName
 ```
 
 In this case, if the xDS management server is configured to provide mTLS credentials (for example) to the client and

--- a/examples/example-xds/build.gradle
+++ b/examples/example-xds/build.gradle
@@ -27,11 +27,13 @@ def nettyTcNativeVersion = '2.0.31.Final'
 def protocVersion = '3.12.0'
 
 dependencies {
-    implementation "io.grpc:grpc-netty-shaded:${grpcVersion}"
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"
+    implementation "io.grpc:grpc-services:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-xds:${grpcVersion}"
     compileOnly "org.apache.tomcat:annotations-api:6.0.53"
+
+    runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
 }
 
 protobuf {

--- a/examples/example-xds/build.gradle
+++ b/examples/example-xds/build.gradle
@@ -48,22 +48,22 @@ protobuf {
 
 startScripts.enabled = false
 
-task helloWorldClientXds(type: CreateStartScripts) {
-    mainClassName = 'io.grpc.examples.helloworldxds.HelloWorldClientXds'
+task xdsHelloWorldClient(type: CreateStartScripts) {
+    mainClassName = 'io.grpc.examples.helloworldxds.XdsHelloWorldClient'
     applicationName = 'xds-hello-world-client'
     outputDir = new File(project.buildDir, 'tmp')
     classpath = startScripts.classpath
 }
 
-task helloWorldServerXds(type: CreateStartScripts) {
-    mainClassName = 'io.grpc.examples.helloworldxds.HelloWorldServerXds'
+task xdsHelloWorldServer(type: CreateStartScripts) {
+    mainClassName = 'io.grpc.examples.helloworldxds.XdsHelloWorldServer'
     applicationName = 'xds-hello-world-server'
     outputDir = new File(project.buildDir, 'tmp')
     classpath = startScripts.classpath
 }
 
 applicationDistribution.into('bin') {
-    from(helloWorldClientXds)
-    from(helloWorldServerXds)
+    from(xdsHelloWorldClient)
+    from(xdsHelloWorldServer)
     fileMode = 0755
 }

--- a/examples/example-xds/src/main/java/io/grpc/examples/helloworldxds/HostnameGreeter.java
+++ b/examples/example-xds/src/main/java/io/grpc/examples/helloworldxds/HostnameGreeter.java
@@ -33,7 +33,7 @@ public final class HostnameGreeter extends GreeterGrpc.GreeterImplBase {
   private final String serverName;
 
   public HostnameGreeter(String serverName) {
-    if (serverName == null || serverName.isEmpty()) {
+    if (serverName == null) {
       serverName = determineHostname();
     }
     this.serverName = serverName;

--- a/examples/example-xds/src/main/java/io/grpc/examples/helloworldxds/XdsHelloWorldClient.java
+++ b/examples/example-xds/src/main/java/io/grpc/examples/helloworldxds/XdsHelloWorldClient.java
@@ -33,15 +33,15 @@ import java.util.logging.Logger;
 
 /**
  * A simple xDS client that requests a greeting from {@code HelloWorldServer} or {@link
- * HelloWorldServerXds}.
+ * XdsHelloWorldServer}.
  */
-public class HelloWorldClientXds {
-  private static final Logger logger = Logger.getLogger(HelloWorldClientXds.class.getName());
+public class XdsHelloWorldClient {
+  private static final Logger logger = Logger.getLogger(XdsHelloWorldClient.class.getName());
 
   private final GreeterGrpc.GreeterBlockingStub blockingStub;
 
   /** Construct client for accessing HelloWorld server using the existing channel. */
-  public HelloWorldClientXds(Channel channel) {
+  public XdsHelloWorldClient(Channel channel) {
     blockingStub = GreeterGrpc.newBlockingStub(channel);
   }
 
@@ -98,7 +98,7 @@ public class HelloWorldClientXds {
     ManagedChannel channel = Grpc.newChannelBuilder(target, credentials)
         .build();
     try {
-      HelloWorldClientXds client = new HelloWorldClientXds(channel);
+      XdsHelloWorldClient client = new XdsHelloWorldClient(channel);
       client.greet(user);
     } finally {
       channel.shutdownNow().awaitTermination(5, TimeUnit.SECONDS);

--- a/examples/example-xds/src/main/java/io/grpc/examples/helloworldxds/XdsHelloWorldServer.java
+++ b/examples/example-xds/src/main/java/io/grpc/examples/helloworldxds/XdsHelloWorldServer.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * An xDS-managed Server for the {@code Greeter} service.
  */
-public class HelloWorldServerXds {
+public class XdsHelloWorldServer {
   public static void main(String[] args) throws IOException, InterruptedException {
     int port = 50051;
     String hostname = null;


### PR DESCRIPTION
--secure was moved to front since many languages need flags to precede
positional parameters, and we'd like other languages to use the same
flags when feasible.

:8000 was removed from xds: target in the README, as it isn't all that
useful and is confusing as xDS itself provides the backend port numbers.

Backport of #7664

CC @voidzcy 