### PR TITLE
example-xds: Change arg from --secure to --xds-creds (1.34.x backport)

### DIFF
--- a/examples/example-xds/src/main/java/io/grpc/examples/helloworldxds/XdsHelloWorldClient.java
+++ b/examples/example-xds/src/main/java/io/grpc/examples/helloworldxds/XdsHelloWorldClient.java
@@ -71,12 +71,14 @@ public class XdsHelloWorldClient {
     ChannelCredentials credentials = InsecureChannelCredentials.create();
     if (args.length > 0) {
       if ("--help".equals(args[0])) {
-        System.out.println("Usage: [--secure] [NAME [TARGET]]\n");
-        System.err.println("  --secure  Use credentials provided by xDS. Defaults to insecure");
-        System.err.println("  NAME      The name you wish to be greeted by. Defaults to " + user);
-        System.err.println("  TARGET    The server to connect to. Defaults to " + target);
+        System.out.println("Usage: [--xds-creds] [NAME [TARGET]]");
+        System.out.println("");
+        System.err.println("  --xds-creds  Use credentials provided by xDS. Defaults to insecure");
+        System.out.println("");
+        System.err.println("  NAME    The name you wish to be greeted by. Defaults to " + user);
+        System.err.println("  TARGET  The server to connect to. Defaults to " + target);
         System.exit(1);
-      } else if ("--secure".equals(args[0])) {
+      } else if ("--xds-creds".equals(args[0])) {
         // The xDS credentials use the security configured by the xDS server when available. When
         // xDS is not used or when xDS does not provide security configuration, the xDS credentials
         // fall back to other credentials (in this case, InsecureChannelCredentials).

--- a/examples/example-xds/src/main/java/io/grpc/examples/helloworldxds/XdsHelloWorldServer.java
+++ b/examples/example-xds/src/main/java/io/grpc/examples/helloworldxds/XdsHelloWorldServer.java
@@ -36,7 +36,7 @@ public class XdsHelloWorldServer {
     int port = 50051;
     String hostname = null;
     ServerCredentials credentials = InsecureServerCredentials.create();
-    if (args.length >= 1 && "--secure".equals(args[0])) {
+    if (args.length >= 1 && "--xds-creds".equals(args[0])) {
       // The xDS credentials use the security configured by the xDS server when available. When xDS
       // is not used or when xDS does not provide security configuration, the xDS credentials fall
       // back to other credentials (in this case, InsecureServerCredentials).
@@ -47,9 +47,10 @@ public class XdsHelloWorldServer {
       try {
         port = Integer.parseInt(args[0]);
       } catch (NumberFormatException ex) {
-        System.err.println("Usage: [--secure] [PORT [HOSTNAME]]");
+        System.err.println("Usage: [--xds-creds] [PORT [HOSTNAME]]");
         System.err.println("");
-        System.err.println("  --secure  Use credentials provided by xDS. Defaults to insecure");
+        System.err.println("  --xds-creds  Use credentials provided by xDS. Defaults to insecure");
+        System.err.println("");
         System.err.println("  PORT      The listen port. Defaults to " + port);
         System.err.println("  HOSTNAME  The name clients will see in greet responses. ");
         System.err.println("            Defaults to the machine's hostname");


### PR DESCRIPTION
The xds creds don't actually guarantee anything is secure. We don't want
to give new users a false impression.

-----

I inserted a new blank line to avoid needing to align the position argument descriptions with the flag description.

Backport of #7668