### PR TITLE
xds: print xDS request messages with JsonFormat

### DIFF
--- a/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
@@ -77,7 +77,7 @@ abstract class AbstractXdsClient extends XdsClient {
           throw new AssertionError(e);
         }
       });
-  private final MessagePrinter respPrinter = new MessagePrinter();
+  private final MessagePrinter msgPrinter = new MessagePrinter();
   private final InternalLogId logId;
   private final XdsLogger logger;
   private final XdsChannel xdsChannel;
@@ -571,7 +571,7 @@ abstract class AbstractXdsClient extends XdsClient {
                   ResourceType type = ResourceType.fromTypeUrl(response.getTypeUrl());
                   if (logger.isLoggable(XdsLogLevel.DEBUG)) {
                     logger.log(XdsLogLevel.DEBUG, "Received {0} response:\n{1}",
-                        type, respPrinter.print(response));
+                        type, msgPrinter.print(response));
                   }
                   handleRpcResponse(type, response.getVersionInfo(), response.getResourcesList(),
                       response.getNonce());
@@ -623,7 +623,7 @@ abstract class AbstractXdsClient extends XdsClient {
       }
       io.envoyproxy.envoy.api.v2.DiscoveryRequest request = builder.build();
       requestWriter.onNext(request);
-      logger.log(XdsLogLevel.DEBUG, "Sent DiscoveryRequest\n{0}", request);
+      logger.log(XdsLogLevel.DEBUG, "Sent DiscoveryRequest\n{0}", msgPrinter.print(request));
     }
 
     @Override
@@ -648,7 +648,7 @@ abstract class AbstractXdsClient extends XdsClient {
               ResourceType type = ResourceType.fromTypeUrl(response.getTypeUrl());
               if (logger.isLoggable(XdsLogLevel.DEBUG)) {
                 logger.log(XdsLogLevel.DEBUG, "Received {0} response:\n{1}",
-                    type, respPrinter.print(response));
+                    type, msgPrinter.print(response));
               }
               handleRpcResponse(type, response.getVersionInfo(), response.getResourcesList(),
                   response.getNonce());
@@ -700,7 +700,7 @@ abstract class AbstractXdsClient extends XdsClient {
       }
       DiscoveryRequest request = builder.build();
       requestWriter.onNext(request);
-      logger.log(XdsLogLevel.DEBUG, "Sent DiscoveryRequest\n{0}", request);
+      logger.log(XdsLogLevel.DEBUG, "Sent DiscoveryRequest\n{0}", msgPrinter.print(request));
     }
 
     @Override


### PR DESCRIPTION
Currently xDS response messages are printed with protobuf JsonFormat as they may contain `Any`-type messages. JsonFormat internally uses Gson for generating human-readable message representations. The [default Gson instance](https://github.com/protocolbuffers/protobuf/blob/9ee163a5d77c99ba0ed64a9728d3963b4a240849/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java#L727) [escapes HTML characters](https://www.javadoc.io/doc/com.google.code.gson/gson/2.7/com/google/gson/GsonBuilder.html#disableHtmlEscaping--), which causes characters like '=' to be printed as '\u003d'. There is nothing can be done on our side to disable this as it is protobuf's internal implementation (https://github.com/protocolbuffers/protobuf/issues/7273).

To make the same content consistent in both request and response messages consistent, we use JsonFormat to print both.