### PR TITLE
netty: Allow handshakes to be interrupted by channel shutdown

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -767,7 +767,7 @@ class NettyClientHandler extends AbstractNettyHandler {
 
   private void forcefulClose(final ChannelHandlerContext ctx, final ForcefulCloseCommand msg,
       ChannelPromise promise) throws Exception {
-    // close() already called by NettyClientTransport, so just need to clean up streams
+    ctx.close();
     connection().forEachActiveStream(new Http2StreamVisitor() {
       @Override
       public boolean visit(Http2Stream stream) throws Http2Exception {

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -767,7 +767,6 @@ class NettyClientHandler extends AbstractNettyHandler {
 
   private void forcefulClose(final ChannelHandlerContext ctx, final ForcefulCloseCommand msg,
       ChannelPromise promise) throws Exception {
-    ctx.close();
     connection().forEachActiveStream(new Http2StreamVisitor() {
       @Override
       public boolean visit(Http2Stream stream) throws Http2Exception {
@@ -787,7 +786,7 @@ class NettyClientHandler extends AbstractNettyHandler {
         }
       }
     });
-    promise.setSuccess();
+    close(ctx, promise);
   }
 
   /**

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -346,9 +346,6 @@ class NettyClientTransport implements ConnectionClientTransport {
         @Override
         public void run() {
           lifecycleManager.notifyShutdown(reason);
-          // Call close() directly since negotiation may not have completed, such that a write would
-          // be queued.
-          channel.close();
           channel.write(new ForcefulCloseCommand(reason));
         }
       }, true);

--- a/netty/src/main/java/io/grpc/netty/WriteBufferingAndExceptionHandler.java
+++ b/netty/src/main/java/io/grpc/netty/WriteBufferingAndExceptionHandler.java
@@ -124,6 +124,11 @@ final class WriteBufferingAndExceptionHandler extends ChannelDuplexHandler {
       promise.setFailure(failCause);
       ReferenceCountUtil.release(msg);
     } else {
+      if (msg instanceof GracefulCloseCommand || msg instanceof ForcefulCloseCommand) {
+        // No point in continuing negotiation
+        ctx.close();
+        // Still enqueue the command in case the HTTP/2 handler is already on the pipeline
+      }
       bufferedWrites.add(new ChannelWrite(msg, promise));
     }
   }


### PR DESCRIPTION
If a handshake is ongoing during shutdown, this would substantially
reduce the time it takes to shut down. Previously, you would need to use
channel.shutdownNow() to have fast shutdown behavior, which is an
unnecessary use of the variant.

When the current approach was written WriteBufferingAndExceptionHandler
didn't exist and so it was hard to predict how the pipeline would react
to events (particularly because of HTTP/2 handler's re-definition of
close()). Now that WBAEH exists, this is more straight-forward.

-----

@susinmotion, this dramatically speeds the exit of your toy client after the RPCs complete.