### PR TITLE
Build Linux artifacts using CentOS 7

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,7 @@ How to Create a Release of GRPC Java (for Maintainers Only)
 Build Environments
 ------------------
 We deploy GRPC to Maven Central under the following systems:
-- Ubuntu 14.04 with Docker 13.03.0 that runs CentOS 6.9
+- Ubuntu 14.04 with Docker 13.03.0 that runs CentOS 7
 - Windows 7 64-bit with Visual Studio
 - Mac OS X 10.14.6
 

--- a/buildscripts/build_docker.sh
+++ b/buildscripts/build_docker.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 set -eu -o pipefail
 
-readonly proto_dir="$(mktemp -d --tmpdir protobuf.XXXXXX)"
-wget -O - https://github.com/google/protobuf/archive/v3.12.0.tar.gz | tar xz -C "$proto_dir"
-
-docker build -t protoc-artifacts "$proto_dir"/protobuf-3.12.0/protoc-artifacts
-rm -r "$proto_dir"
+readonly buildscripts_dir="$(dirname "$(readlink -f "$0")")"
+docker build -t grpc-java-artifacts "$buildscripts_dir"/grpc-java-artifacts

--- a/buildscripts/grpc-java-artifacts/Dockerfile
+++ b/buildscripts/grpc-java-artifacts/Dockerfile
@@ -1,0 +1,25 @@
+FROM centos:7.9.2009
+
+RUN yum install -y \
+	    glibc-devel \
+	    glibc-devel.i686 \
+	    libstdc++-static \
+	    libstdc++-static.i686 \
+            autoconf \
+            automake \
+            gcc-c++ \
+            gcc-c++.i686 \
+            java-1.8.0-openjdk-devel \
+            libstdc++-devel \
+            libstdc++-devel.i686 \
+            libtool \
+            make \
+            tar \
+            which \
+            && \
+    yum clean all
+
+# Install Maven
+RUN curl -Ls http://apache.cs.utah.edu/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz | \
+    tar xz -C /var/local
+ENV PATH /var/local/apache-maven-3.3.9/bin:$PATH

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -27,7 +27,7 @@ if [ -f ${INSTALL_DIR}/bin/protoc ]; then
 # TODO(ejona): swap to `brew install --devel protobuf` once it is up-to-date
 else
   if [[ ! -d "$DOWNLOAD_DIR"/protobuf-"${PROTOBUF_VERSION}" ]]; then
-    wget -O - https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protobuf-all-${PROTOBUF_VERSION}.tar.gz | tar xz -C $DOWNLOAD_DIR
+    curl -Ls https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protobuf-all-${PROTOBUF_VERSION}.tar.gz | tar xz -C $DOWNLOAD_DIR
   fi
   pushd $DOWNLOAD_DIR/protobuf-${PROTOBUF_VERSION}
   # install here so we don't need sudo

--- a/buildscripts/run_in_docker.sh
+++ b/buildscripts/run_in_docker.sh
@@ -21,5 +21,5 @@ fi
 # the original exit code. $DOCKER_ARGS can not be quoted, otherwise it becomes a '' which confuses
 # docker.
 exec docker run $DOCKER_ARGS --rm=true -v "${grpc_java_dir}":/grpc-java -w /grpc-java \
-  protoc-artifacts \
+  grpc-java-artifacts \
   bash -c "function fixFiles() { chown -R $(id -u):$(id -g) /grpc-java; }; trap fixFiles EXIT; $(quote "$@")"


### PR DESCRIPTION
CentOS 6 is dead and no longer has update servers. CentOS 7 is older
than Debian 9 (oldstable), so binaries hopefully work on both. More
testing is necessary, but everything's broken now, so this is better
than nothing.

We stop using protoc-artifacts because now the container is
straight-forward enough that we can just use our own. Previously the
"devtoolset" stuff made us want to share the container.

-----

Even if we don't want to do this in the future, I imagine this is "good enough"
for the moment just to fix the build.

CC @dapengzhang0 