### PR TITLE
buildscripts: Fix grpc-java-artifacts indentation

### DIFF
--- a/buildscripts/grpc-java-artifacts/Dockerfile
+++ b/buildscripts/grpc-java-artifacts/Dockerfile
@@ -1,17 +1,17 @@
 FROM centos:7.9.2009
 
 RUN yum install -y \
-	    glibc-devel \
-	    glibc-devel.i686 \
-	    libstdc++-static \
-	    libstdc++-static.i686 \
             autoconf \
             automake \
             gcc-c++ \
             gcc-c++.i686 \
+            glibc-devel \
+            glibc-devel.i686 \
             java-1.8.0-openjdk-devel \
             libstdc++-devel \
             libstdc++-devel.i686 \
+            libstdc++-static \
+            libstdc++-static.i686 \
             libtool \
             make \
             tar \


### PR DESCRIPTION
Re-sort packages, now that the tabs aren't skewing the sorting.

I'm quite confident I had fixed this already, but I had multiple copies
of this file on multiple machines and must have fixed the wrong copy.

CC @ericgribkoff 