### PR TITLE
Use system.getProperty() to replace system.getenv() in examples module.

### DIFF
--- a/examples/src/main/java/io/grpc/examples/hedging/HedgingHelloWorldClient.java
+++ b/examples/src/main/java/io/grpc/examples/hedging/HedgingHelloWorldClient.java
@@ -165,7 +165,7 @@ public class HedgingHelloWorldClient {
   }
 
   public static void main(String[] args) throws Exception {
-    boolean hedging = !Boolean.parseBoolean(System.getenv(ENV_DISABLE_HEDGING));
+    boolean hedging = !Boolean.parseBoolean(System.getProperty(ENV_DISABLE_HEDGING));
     final HedgingHelloWorldClient client = new HedgingHelloWorldClient("localhost", 50051, hedging);
     ForkJoinPool executor = new ForkJoinPool();
 

--- a/examples/src/main/java/io/grpc/examples/retrying/RetryingHelloWorldClient.java
+++ b/examples/src/main/java/io/grpc/examples/retrying/RetryingHelloWorldClient.java
@@ -126,7 +126,7 @@ public class RetryingHelloWorldClient {
   }
 
   public static void main(String[] args) throws Exception {
-    boolean enableRetries = !Boolean.parseBoolean(System.getenv(ENV_DISABLE_RETRYING));
+    boolean enableRetries = !Boolean.parseBoolean(System.getProperty(ENV_DISABLE_RETRYING));
     final RetryingHelloWorldClient client = new RetryingHelloWorldClient("localhost", 50051, enableRetries);
     ForkJoinPool executor = new ForkJoinPool();
 


### PR DESCRIPTION
For-#7697