### PR TITLE
buildscripts: Check for out-of-date codegen after android builds

### DIFF
--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -47,6 +47,12 @@ popd
 # Examples pull dependencies from maven local
 ./gradlew publishToMavenLocal
 
+if [[ ! -z $(git status --porcelain) ]]; then
+  git status
+  echo "Error Working directory is not clean. Forget to commit generated files?"
+  exit 1
+fi
+
 # Build examples
 
 cd ./examples/android/clientcache


### PR DESCRIPTION
Issues like that fixed in 05048cf3 should have failed the CI, like it
does for the rest of the build (on both Travis and linux_artifacts).