### PR TITLE
buildscripts: Combine android builds together

### DIFF
--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -27,25 +27,11 @@ echo y | ${ANDROID_HOME}/tools/bin/sdkmanager "build-tools;28.0.3"
 # Proto deps
 buildscripts/make_dependencies.sh
 
-# Build grpc-cronet
-
-pushd cronet
-../gradlew build
-popd
-
-# Build grpc-android
-
-pushd android
-../gradlew build
-popd
-
-# Build android-interop-testing
-pushd android-interop-testing
-../gradlew build
-popd
-
-# Examples pull dependencies from maven local
-./gradlew publishToMavenLocal
+./gradlew \
+    :grpc-android-interop-testing:build \
+    :grpc-android:build \
+    :grpc-cronet:build \
+    publishToMavenLocal
 
 if [[ ! -z $(git status --porcelain) ]]; then
   git status


### PR DESCRIPTION
Previously the android projects were separate from the main build and
each other. For quite a while now they have been integrated in the main
project. There's no longer any need to build each separately.

-------

That's assuming the gradle process doesn't OOM :smile:. But we'll learn
that quickly enough.