### PR TITLE
buildscripts: add missing CI coverage for examples

### DIFF
--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -55,6 +55,8 @@ cd ../routeguide
 ../../gradlew build
 cd ../helloworld
 ../../gradlew build
+cd ../strictmode
+../../gradlew build
 
 # Skip APK size and dex count comparisons for non-PR builds
 

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -66,7 +66,7 @@ if [[ -z "${SKIP_TESTS:-}" ]]; then
   popd
   pushd examples/example-hostname
   ../gradlew build $GRADLE_FLAGS
-  mvn verify --batch-mode
+  mvn clean verify --batch-mode
   popd
   pushd examples/example-tls
   ../gradlew build $GRADLE_FLAGS

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -62,19 +62,19 @@ if [[ -z "${SKIP_TESTS:-}" ]]; then
   ./gradlew clean $GRADLE_FLAGS
   ./gradlew build $GRADLE_FLAGS
   # --batch-mode reduces log spam
-  mvn clean verify --batch-mode
+  mvn verify --batch-mode
   popd
   pushd examples/example-hostname
   ../gradlew build $GRADLE_FLAGS
-  mvn clean verify --batch-mode
+  mvn verify --batch-mode
   popd
   pushd examples/example-tls
   ../gradlew build $GRADLE_FLAGS
-  mvn clean verify --batch-mode
+  mvn verify --batch-mode
   popd
   pushd examples/example-jwt-auth
   ../gradlew build $GRADLE_FLAGS
-  mvn clean verify --batch-mode
+  mvn verify --batch-mode
   popd
   pushd examples/example-xds
   ../gradlew build $GRADLE_FLAGS

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -69,6 +69,11 @@ if [[ -z "${SKIP_TESTS:-}" ]]; then
   mvn verify --batch-mode
   popd
   pushd examples/example-tls
+  ../gradlew build $GRADLE_FLAGS
+  mvn clean verify --batch-mode
+  popd
+  pushd examples/example-jwt-auth
+  ../gradlew build $GRADLE_FLAGS
   mvn clean verify --batch-mode
   popd
   pushd examples/example-xds


### PR DESCRIPTION
It would be best if we can have our CIs cover as much as possible.

- Added coverage for `example/android/strictmode`, although it is most identical to helloworld.
- Added coverage for `examples/example-jwt-auth`.
- Added missing gradle build coverage for `examples/example-tls`.