### PR TITLE
interop: add channelz to xds interop test server running in non-secure mode

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
@@ -78,6 +78,7 @@ public final class XdsTestClient {
   private final Map<String, Integer> rpcsStartedByMethod = new HashMap<>();
   private final Map<String, Integer> rpcsFailedByMethod = new HashMap<>();
   private final Map<String, Integer> rpcsSucceededByMethod = new HashMap<>();
+  private static final int CHANNELZ_MAX_PAGE_SIZE = 100;
 
   private int numChannels = 1;
   private boolean printResponse = false;
@@ -236,7 +237,7 @@ public final class XdsTestClient {
             .addService(new XdsStatsImpl())
             .addService(new ConfigureUpdateServiceImpl())
             .addService(ProtoReflectionService.newInstance())
-            .addService(ChannelzService.newInstance(100))
+            .addService(ChannelzService.newInstance(CHANNELZ_MAX_PAGE_SIZE))
             .build();
     try {
       statsServer.start();

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
@@ -51,6 +51,7 @@ public final class XdsTestServer {
   private static final Context.Key<String> CALL_BEHAVIOR_KEY =
       Context.key("rpc-behavior");
   private static final String CALL_BEHAVIOR_KEEP_OPEN_VALUE = "keep-open";
+  private static final int CHANNELZ_MAX_PAGE_SIZE = 100;
 
   private static Logger logger = Logger.getLogger(XdsTestServer.class.getName());
 
@@ -176,7 +177,7 @@ public final class XdsTestServer {
               .addService(new XdsUpdateHealthServiceImpl(health))
               .addService(health.getHealthService())
               .addService(ProtoReflectionService.newInstance())
-              .addService(ChannelzService.newInstance(100))
+              .addService(ChannelzService.newInstance(CHANNELZ_MAX_PAGE_SIZE))
               .build()
               .start();
     } else {
@@ -188,7 +189,7 @@ public final class XdsTestServer {
               .addService(new XdsUpdateHealthServiceImpl(health))
               .addService(health.getHealthService())
               .addService(ProtoReflectionService.newInstance())
-              .addService(ChannelzService.newInstance(100))
+              .addService(ChannelzService.newInstance(CHANNELZ_MAX_PAGE_SIZE))
               .build()
               .start();
       maintenanceServer = null;

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
@@ -188,6 +188,7 @@ public final class XdsTestServer {
               .addService(new XdsUpdateHealthServiceImpl(health))
               .addService(health.getHealthService())
               .addService(ProtoReflectionService.newInstance())
+              .addService(ChannelzService.newInstance(100))
               .build()
               .start();
       maintenanceServer = null;


### PR DESCRIPTION
Server-side channelz checks will be used in non-secure (baseline) interop tests as well.