### PR TITLE
core: Don't leak CallCredentials into OOB channels

### DIFF
--- a/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
+++ b/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
@@ -312,22 +312,4 @@ public class CallCredentialsApplyingTest {
     assertEquals(creds2Value, origHeaders.get(creds2Key));
     assertEquals(ORIG_HEADER_VALUE, origHeaders.get(ORIG_HEADER_KEY));
   }
-
-  private abstract static class BaseCallCredentials extends CallCredentials {
-    @Override public void thisUsesUnstableApi() {}
-  }
-
-  private static class FakeCallCredentials extends BaseCallCredentials {
-    private final Metadata headers;
-
-    public <T> FakeCallCredentials(Metadata.Key<T> key, T value) {
-      headers = new Metadata();
-      headers.put(key, value);
-    }
-
-    @Override public void applyRequestMetadata(
-        RequestInfo requestInfo, Executor appExecutor, CallCredentials.MetadataApplier applier) {
-      applier.apply(headers);
-    }
-  }
 }

--- a/core/src/test/java/io/grpc/internal/FakeCallCredentials.java
+++ b/core/src/test/java/io/grpc/internal/FakeCallCredentials.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import io.grpc.CallCredentials;
+import io.grpc.Metadata;
+import java.util.concurrent.Executor;
+
+/**
+ * CallCredentials that provides a single, fixed header.
+ */
+final class FakeCallCredentials extends CallCredentials {
+  private final Metadata headers;
+
+  public <T> FakeCallCredentials(Metadata.Key<T> key, T value) {
+    headers = new Metadata();
+    headers.put(key, value);
+  }
+
+  @Override
+  public void applyRequestMetadata(
+      CallCredentials.RequestInfo requestInfo,
+      Executor appExecutor,
+      CallCredentials.MetadataApplier applier) {
+    applier.apply(headers);
+  }
+
+  @Override public void thisUsesUnstableApi() {}
+}

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -330,7 +330,10 @@ public class ManagedChannelImplTest {
 
     channelBuilder = new ManagedChannelImplBuilder(TARGET,
         new UnsupportedClientTransportFactoryBuilder(), new FixedPortProvider(DEFAULT_PORT));
+    configureBuilder(channelBuilder);
+  }
 
+  private void configureBuilder(ManagedChannelImplBuilder channelBuilder) {
     channelBuilder
         .nameResolverFactory(new FakeNameResolverFactory.Builder(expectedUri).build())
         .defaultLoadBalancingPolicy(MOCK_POLICY_NAME)
@@ -1739,6 +1742,87 @@ public class ManagedChannelImplTest {
     assertTrue(channel.isTerminated());
     verify(balancerRpcExecutorPool, times(2))
         .returnObject(balancerRpcExecutor.getScheduledExecutorService());
+  }
+
+  @Test
+  public void oobchannelsHaveNoChannelCallCredentials() {
+    Metadata.Key<String> metadataKey =
+        Metadata.Key.of("token", Metadata.ASCII_STRING_MARSHALLER);
+    String channelCredValue = "channel-provided call cred";
+    channelBuilder = new ManagedChannelImplBuilder(TARGET,
+        new FakeCallCredentials(metadataKey, channelCredValue),
+        new UnsupportedClientTransportFactoryBuilder(), new FixedPortProvider(DEFAULT_PORT));
+    configureBuilder(channelBuilder);
+    createChannel();
+
+    // Verify that the normal channel has call creds, to validate configuration
+    Subchannel subchannel =
+        createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+    requestConnectionSafely(helper, subchannel);
+    MockClientTransportInfo transportInfo = transports.poll();
+    assertNotNull(transportInfo);
+    transportInfo.listener.transportReady();
+    when(mockPicker.pickSubchannel(any(PickSubchannelArgs.class))).thenReturn(
+        PickResult.withSubchannel(subchannel));
+    updateBalancingStateSafely(helper, READY, mockPicker);
+
+    String callCredValue = "per-RPC call cred";
+    CallOptions callOptions = CallOptions.DEFAULT
+        .withCallCredentials(new FakeCallCredentials(metadataKey, callCredValue));
+    Metadata headers = new Metadata();
+    ClientCall<String, Integer> call = channel.newCall(method, callOptions);
+    call.start(mockCallListener, headers);
+
+    verify(transportInfo.transport).newStream(same(method), same(headers), same(callOptions));
+    assertThat(headers.getAll(metadataKey))
+        .containsExactly(channelCredValue, callCredValue).inOrder();
+
+    // Verify that the oob channel does not
+    ManagedChannel oob = helper.createOobChannel(addressGroup, "oobauthority");
+
+    headers = new Metadata();
+    call = oob.newCall(method, callOptions);
+    call.start(mockCallListener2, headers);
+
+    transportInfo = transports.poll();
+    assertNotNull(transportInfo);
+    transportInfo.listener.transportReady();
+    balancerRpcExecutor.runDueTasks();
+
+    verify(transportInfo.transport).newStream(same(method), same(headers), same(callOptions));
+    assertThat(headers.getAll(metadataKey)).containsExactly(callCredValue);
+    oob.shutdownNow();
+
+    // Verify that resolving oob channel does not
+    oob = helper.createResolvingOobChannelBuilder("oobauthority")
+        .nameResolverFactory(
+            new FakeNameResolverFactory.Builder(URI.create("oobauthority")).build())
+        .defaultLoadBalancingPolicy(MOCK_POLICY_NAME)
+        .idleTimeout(ManagedChannelImplBuilder.IDLE_MODE_MAX_TIMEOUT_DAYS, TimeUnit.DAYS)
+        .build();
+    oob.getState(true);
+    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
+    verify(mockLoadBalancerProvider, times(2)).newLoadBalancer(helperCaptor.capture());
+    Helper oobHelper = helperCaptor.getValue();
+
+    subchannel =
+        createSubchannelSafely(oobHelper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+    requestConnectionSafely(oobHelper, subchannel);
+    transportInfo = transports.poll();
+    assertNotNull(transportInfo);
+    transportInfo.listener.transportReady();
+    SubchannelPicker mockPicker2 = mock(SubchannelPicker.class);
+    when(mockPicker2.pickSubchannel(any(PickSubchannelArgs.class))).thenReturn(
+        PickResult.withSubchannel(subchannel));
+    updateBalancingStateSafely(oobHelper, READY, mockPicker2);
+
+    headers = new Metadata();
+    call = oob.newCall(method, callOptions);
+    call.start(mockCallListener2, headers);
+
+    verify(transportInfo.transport).newStream(same(method), same(headers), same(callOptions));
+    assertThat(headers.getAll(metadataKey)).containsExactly(callCredValue);
+    oob.shutdownNow();
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -1745,7 +1745,7 @@ public class ManagedChannelImplTest {
   }
 
   @Test
-  public void oobchannelsHaveNoChannelCallCredentials() {
+  public void oobChannelHasNoChannelCallCredentials() {
     Metadata.Key<String> metadataKey =
         Metadata.Key.of("token", Metadata.ASCII_STRING_MARSHALLER);
     String channelCredValue = "channel-provided call cred";


### PR DESCRIPTION
The addition of CompositeChannelCredentials allowed CallCredentials to
be passed to the ManagedChannel itself. But the implementation was buggy
and used the call creds for out-of-band channels as well, which is
inappropriate since they have a different authority.

This also fixes a bug where resolving OOB channels would have CallCreds
duplicated; that wasn't noticed or important because we don't use
CallCreds in OOB channels.

Fixes #7643

-----

Note that the originalTransportFactory usage vs oobTransportFactory usage is
subtle. If you use the wrong one then CallCreds are duplicated. That's not great,
but also not the worst thing that could happen.