### PR TITLE
core: On unexpected EOS, mention whether the frame was empty

### DIFF
--- a/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java
+++ b/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java
@@ -144,10 +144,11 @@ public abstract class Http2ClientStreamTransportState extends AbstractClientStre
             new Metadata());
         return;
       }
+      int frameSize = frame.readableBytes();
       inboundDataReceived(frame);
       if (endOfStream) {
         // This is a protocol violation as we expect to receive trailers.
-        if (frame.readableBytes() > 0) {
+        if (frameSize > 0) {
           transportError = Status.INTERNAL
               .withDescription("Received unexpected EOS on non-empty DATA frame from server");
         } else {

--- a/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java
+++ b/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java
@@ -147,8 +147,13 @@ public abstract class Http2ClientStreamTransportState extends AbstractClientStre
       inboundDataReceived(frame);
       if (endOfStream) {
         // This is a protocol violation as we expect to receive trailers.
-        transportError =
-            Status.INTERNAL.withDescription("Received unexpected EOS on DATA frame from server.");
+        if (frame.readableBytes() > 0) {
+          transportError = Status.INTERNAL
+              .withDescription("Received unexpected EOS on non-empty DATA frame from server");
+        } else {
+          transportError = Status.INTERNAL
+              .withDescription("Received unexpected EOS on empty DATA frame from server");
+        }
         transportErrorMetadata = new Metadata();
         transportReportStatus(transportError, false, transportErrorMetadata);
       }


### PR DESCRIPTION
Empty DATA frames with EOS tell a stronger tale as to where the server
may have its bug.

----

This is an alternative to #7277

CC @kmjung, @birenroy