### PR TITLE
rls: cleanup and minor enhancement for rls logging

### DIFF
--- a/rls/src/main/java/io/grpc/rls/LbPolicyConfiguration.java
+++ b/rls/src/main/java/io/grpc/rls/LbPolicyConfiguration.java
@@ -270,7 +270,6 @@ final class LbPolicyConfiguration {
     public String toString() {
       return MoreObjects.toStringHelper(this)
           .add("target", target)
-          .add("helper", helper)
           .add("picker", picker)
           .add("state", state)
           .toString();


### PR DESCRIPTION
Cleanup toString() for cache entries, and print more debug information about cache entry when `pickSubchannel()`. This will be more helpful to debug.