### PR TITLE
Add exporting SSL/TLS master key log feature

### DIFF
--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -64,6 +64,7 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
+import io.netty.handler.ssl.SslMasterKeyHandler;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.util.AsciiString;
 import io.netty.util.Attribute;
@@ -396,6 +397,14 @@ final class ProtocolNegotiators {
       ctx.pipeline().addBefore(ctx.name(), /* name= */ null, this.executor != null
           ? new SslHandler(sslEngine, false, this.executor)
           : new SslHandler(sslEngine, false));
+
+      // Support exporting the key and session identifier to the log named
+      // "io.netty.wireshark" when the system property named "io.netty.ssl.masterKeyHandler"
+      // is "true". This feature is used to analyze gRPC traffic with Wireshark.
+      if (Boolean.getBoolean(SslMasterKeyHandler.SYSTEM_PROP_KEY)) {
+        ctx.pipeline().addBefore(ctx.name(), null,
+            SslMasterKeyHandler.newWireSharkSslMasterKeyHandler());
+      }
     }
 
     @Override
@@ -572,6 +581,14 @@ final class ProtocolNegotiators {
       ctx.pipeline().addBefore(ctx.name(), /* name= */ null, this.executor != null
           ? new SslHandler(sslEngine, false, this.executor)
           : new SslHandler(sslEngine, false));
+
+      // Support exporting the key and session identifier to the log named
+      // "io.netty.wireshark" when the system property named "io.netty.ssl.masterKeyHandler"
+      // is "true". This feature is used to analyze gRPC traffic with Wireshark.
+      if (Boolean.getBoolean(SslMasterKeyHandler.SYSTEM_PROP_KEY)) {
+        ctx.pipeline().addBefore(ctx.name(), null,
+            SslMasterKeyHandler.newWireSharkSslMasterKeyHandler());
+      }
     }
 
     @Override

--- a/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
+++ b/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
@@ -94,17 +94,20 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
+import io.netty.handler.ssl.SslMasterKeyHandler;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import java.io.File;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Filter;
+import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -1188,6 +1191,55 @@ public class ProtocolNegotiatorsTest {
     public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
       ctx.pipeline().replace(ctx.name(), null, next);
       ctx.pipeline().fireUserEventTriggered(ProtocolNegotiationEvent.DEFAULT);
+    }
+  }
+
+  @Test
+  public void clientTlsHandler_serverTlsHandler_sslMasterKeyLog() throws Exception {
+    final List<LogRecord> logs = new ArrayList<>();
+    Handler handler = new Handler() {
+      @Override public void publish(LogRecord record) {
+        logs.add(record);
+      }
+
+      @Override public void flush() {}
+
+      @Override public void close() {}
+    };
+
+    Logger logger = Logger.getLogger("io.netty.wireshark");
+    logger.addHandler(handler);
+
+    String oldPropValue = System.getProperty(SslMasterKeyHandler.SYSTEM_PROP_KEY);
+    try {
+      // The master key log feature should be disabled
+      // when the "io.netty.ssl.masterKeyHandler" property is missing.
+      System.clearProperty(SslMasterKeyHandler.SYSTEM_PROP_KEY);
+      clientTlsHandler_firesNegotiation();
+      assertThat(logs).isEmpty();
+
+      // The master key log feature should be disabled
+      // when the value of "io.netty.ssl.masterKeyHandler" property is not "true".
+      System.setProperty(SslMasterKeyHandler.SYSTEM_PROP_KEY, "false");
+      clientTlsHandler_firesNegotiation();
+      assertThat(logs).isEmpty();
+
+      // The master key log feature should be enabled
+      // when the value of "io.netty.ssl.masterKeyHandler" property is "true".
+      System.setProperty(SslMasterKeyHandler.SYSTEM_PROP_KEY, "true");
+      clientTlsHandler_firesNegotiation();
+
+      // writing key twice because both client and server will enable key log feature
+      assertThat(logs.size()).isEqualTo(2);
+      assertThat(logs.get(0).getMessage()).containsMatch("^RSA Session-ID:.+ Master-Key:");
+      assertThat(logs.get(1).getMessage()).containsMatch("^RSA Session-ID:.+ Master-Key:");
+    } finally {
+      logger.removeHandler(handler);
+      if (oldPropValue != null) {
+        System.setProperty(SslMasterKeyHandler.SYSTEM_PROP_KEY, oldPropValue);
+      } else {
+        System.clearProperty(SslMasterKeyHandler.SYSTEM_PROP_KEY);
+      }
     }
   }
 }


### PR DESCRIPTION
@ejona86 Could you help to review this PR?

Enable this feature by setting the system property in command argument
```
   -Dio.netty.ssl.masterKeyHandler=true
```
or in java code
```java
   System.setProperty(SslMasterKeyHandler.SYSTEM_PROP_KEY, "true");
```

The keys will be written to the log named "io.netty.wireshark" in the warnning level. To export the keys to a file, you can configure log factory like: (log4j.xml for example)
```xml
...
<appender name="key-file" class="org.apache.log4j.RollingFileAppender">
	<param name="file" value="d:/keyfile.txt"/>
	<layout class="org.apache.log4j.PatternLayout">
		<param name="ConversionPattern" value="%m%n"/>
	</layout>
</appender>
<category name="io.netty.wireshark">
	<priority value="DEBUG" />
	<appender-ref ref="key-file" />
</category>
...
```

Wireshark can analyze the messages gRPC over [TLS with this key log file](https://gitlab.com/wireshark/wireshark/-/wikis/tls).

There is a sample capture and key log file generated by using this commit:
- [grpc_person_search_protobuf_and_json_tls.pcapng][] -- Person search gRPC sample capture (port 60051 for protobuf payload and 60052 for json payload).
- [keylog.txt][] --- grpc_person_search_protobuf_and_json_tls.keylog.txt -- Key log file for above capture.

You can refer to [Wireshark gRPC wiki page][] for getting the 
`person_search_service.proto` and `addressbook.proto` files, and how to set the Wireshark for parsing gRPC network traffic.

And put the path of [keylog.txt][] in the key log preference in *Preferences->Protocols->TLS->(Pre)-Master-Secret log filename*.

Finally decode traffic on tcp port 60051 and 60052 as TLS.

[grpc_person_search_protobuf_and_json_tls.pcapng]: https://gitlab.com/wireshark/wireshark/-/wikis/uploads/bf889abf927b7d041b34a136dce7e176/grpc_person_search_protobuf_and_json_tls.pcapng
[keylog.txt]: https://gitlab.com/wireshark/wireshark/-/wikis/uploads/bdb819da1d262ac9226a9d9079eedb8d/grpc_person_search_protobuf_and_json_tls.keylog.txt
[Wireshark gRPC wiki page]: https://gitlab.com/wireshark/wireshark/-/wikis/grpc

close #7199