### PR TITLE
Bump versions for lots of dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,11 +55,11 @@ subprojects {
         javaPluginPath = "$rootDir/compiler/build/exe/java_plugin/$protocPluginBaseName$exeSuffix"
 
         nettyVersion = '4.1.51.Final'
-        guavaVersion = '29.0-android'
-        googleauthVersion = '0.22.0'
+        guavaVersion = '30.0-android'
+        googleauthVersion = '0.22.2'
         protobufVersion = '3.12.0'
         protocVersion = protobufVersion
-        opencensusVersion = '0.24.0'
+        opencensusVersion = '0.28.0'
 
         configureProtoCompilation = {
             String generatedSourcePath = "${projectDir}/src/generated"
@@ -138,31 +138,30 @@ subprojects {
 
         libraries = [
             android_annotations: "com.google.android:annotations:4.1.1.4",
-            animalsniffer_annotations: "org.codehaus.mojo:animal-sniffer-annotations:1.18",
-            errorprone: "com.google.errorprone:error_prone_annotations:2.3.4",
+            animalsniffer_annotations: "org.codehaus.mojo:animal-sniffer-annotations:1.19",
+            errorprone: "com.google.errorprone:error_prone_annotations:2.4.0",
             cronet_api: 'org.chromium.net:cronet-api:76.3809.111',
             cronet_embedded: 'org.chromium.net:cronet-embedded:66.3359.158',
             gson: "com.google.code.gson:gson:2.8.6",
             guava: "com.google.guava:guava:${guavaVersion}",
-            hpack: 'com.twitter:hpack:0.10.1',
             javax_annotation: 'org.apache.tomcat:annotations-api:6.0.53',
             jsr305: 'com.google.code.findbugs:jsr305:3.0.2',
-            google_api_protos: 'com.google.api.grpc:proto-google-common-protos:1.17.0',
+            google_api_protos: 'com.google.api.grpc:proto-google-common-protos:2.0.1',
             google_auth_credentials: "com.google.auth:google-auth-library-credentials:${googleauthVersion}",
             google_auth_oauth2_http: "com.google.auth:google-auth-library-oauth2-http:${googleauthVersion}",
             okhttp: 'com.squareup.okhttp:okhttp:2.7.4',
-            okio: 'com.squareup.okio:okio:1.13.0',
+            okio: 'com.squareup.okio:okio:1.17.5',
             opencensus_api: "io.opencensus:opencensus-api:${opencensusVersion}",
             opencensus_contrib_grpc_metrics: "io.opencensus:opencensus-contrib-grpc-metrics:${opencensusVersion}",
             opencensus_impl: "io.opencensus:opencensus-impl:${opencensusVersion}",
             opencensus_impl_lite: "io.opencensus:opencensus-impl-lite:${opencensusVersion}",
             opencensus_proto: "io.opencensus:opencensus-proto:0.2.0",
             instrumentation_api: 'com.google.instrumentation:instrumentation-api:0.4.3',
-            perfmark: 'io.perfmark:perfmark-api:0.19.0',
+            perfmark: 'io.perfmark:perfmark-api:0.23.0',
             protobuf: "com.google.protobuf:protobuf-java:${protobufVersion}",
             protobuf_lite: "com.google.protobuf:protobuf-javalite:${protobufVersion}",
             protobuf_util: "com.google.protobuf:protobuf-java-util:${protobufVersion}",
-            lang: "org.apache.commons:commons-lang3:3.5",
+            lang: "org.apache.commons:commons-lang3:3.11",
 
             netty: "io.netty:netty-codec-http2:[${nettyVersion}]",
             netty_epoll: "io.netty:netty-transport-native-epoll:${nettyVersion}:linux-x86_64",
@@ -175,21 +174,21 @@ subprojects {
             netty_tcnative: 'io.netty:netty-tcnative-boringssl-static:2.0.31.Final',
 
             conscrypt: 'org.conscrypt:conscrypt-openjdk-uber:2.5.1',
-            re2j: 'com.google.re2j:re2j:1.2',
+            re2j: 'com.google.re2j:re2j:1.5',
 
-            bouncycastle: 'org.bouncycastle:bcpkix-jdk15on:1.61',
+            bouncycastle: 'org.bouncycastle:bcpkix-jdk15on:1.67',
 
             // Test dependencies.
             junit: 'junit:junit:4.12',
             mockito: 'org.mockito:mockito-core:3.3.3',
             truth: 'com.google.truth:truth:1.0.1',
             guava_testlib: "com.google.guava:guava-testlib:${guavaVersion}",
-            androidx_test: "androidx.test:core:1.2.0",
+            androidx_test: "androidx.test:core:1.3.0",
             robolectric: "org.robolectric:robolectric:4.3.1",
 
             // Benchmark dependencies
-            hdrhistogram: 'org.hdrhistogram:HdrHistogram:2.1.10',
-            math: 'org.apache.commons:commons-math3:3.6',
+            hdrhistogram: 'org.hdrhistogram:HdrHistogram:2.1.12',
+            math: 'org.apache.commons:commons-math3:3.6.1',
 
             // Jetty ALPN dependencies
             jetty_alpn_agent: 'org.mortbay.jetty.alpn:jetty-alpn-agent:2.0.10'

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 
     testImplementation "io.grpc:grpc-testing:${grpcVersion}"
     testImplementation "junit:junit:4.12"
-    testImplementation "org.mockito:mockito-core:2.28.2"
+    testImplementation "org.mockito:mockito-core:3.4.0"
 }
 
 protobuf {

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.28.2</version>
+      <version>3.4.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -33,11 +33,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java-util</artifactId>
-      <version>${protobuf.version}</version>
-    </dependency>
-    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
       <scope>runtime</scope>
@@ -53,6 +48,11 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-auth</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.tomcat</groupId>

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 
     testImplementation "io.grpc:grpc-testing:${grpcVersion}"
     testImplementation "junit:junit:4.12"
-    testImplementation "org.mockito:mockito-core:2.28.2"
+    testImplementation "org.mockito:mockito-core:3.4.0"
 }
 
 protobuf {

--- a/examples/example-jwt-auth/pom.xml
+++ b/examples/example-jwt-auth/pom.xml
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.28.2</version>
+      <version>3.4.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -34,11 +34,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java-util</artifactId>
-      <version>${protobuf.version}</version>
-    </dependency>
-    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
       <scope>runtime</scope>
@@ -52,6 +47,11 @@
       <artifactId>grpc-stub</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+      <version>${protobuf.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.tomcat</groupId>
       <artifactId>annotations-api</artifactId>
       <version>6.0.53</version>
@@ -61,11 +61,6 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-testing</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.errorprone</groupId>
-      <artifactId>error_prone_annotations</artifactId>
-      <version>2.3.4</version> <!-- prefer to use 2.3.3 or later -->
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.28.2</version>
+      <version>3.4.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -1133,7 +1133,7 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
     public void data(boolean inFinished, int streamId, BufferedSource in, int length)
         throws IOException {
       logger.logData(OkHttpFrameLogger.Direction.INBOUND,
-          streamId, in.buffer(), length, inFinished);
+          streamId, in.getBuffer(), length, inFinished);
       OkHttpClientStream stream = getStream(streamId);
       if (stream == null) {
         if (mayHaveCreatedStream(streamId)) {
@@ -1150,7 +1150,7 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
         in.require(length);
 
         Buffer buf = new Buffer();
-        buf.write(in.buffer(), length);
+        buf.write(in.getBuffer(), length);
         PerfMark.event("OkHttpClientTransport$ClientFrameHandler.data",
             stream.transportState().tag());
         synchronized (lock) {

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -11,18 +11,18 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # )
 IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "com.google.android:annotations:4.1.1.4",
-    "com.google.api.grpc:proto-google-common-protos:1.17.0",
+    "com.google.api.grpc:proto-google-common-protos:2.0.1",
     "com.google.auth:google-auth-library-credentials:0.22.0",
     "com.google.auth:google-auth-library-oauth2-http:0.22.0",
     "com.google.code.findbugs:jsr305:3.0.2",
     "com.google.code.gson:gson:jar:2.8.6",
-    "com.google.errorprone:error_prone_annotations:2.3.4",
+    "com.google.errorprone:error_prone_annotations:2.4.0",
     "com.google.guava:failureaccess:1.0.1",
     "com.google.guava:guava:29.0-android",
     "com.google.j2objc:j2objc-annotations:1.3",
     "com.google.truth:truth:1.0.1",
     "com.squareup.okhttp:okhttp:2.7.4",
-    "com.squareup.okio:okio:1.13.0",
+    "com.squareup.okio:okio:1.17.5",
     "io.netty:netty-buffer:4.1.51.Final",
     "io.netty:netty-codec-http2:4.1.51.Final",
     "io.netty:netty-codec-http:4.1.51.Final",
@@ -37,11 +37,11 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "io.netty:netty-transport:4.1.51.Final",
     "io.opencensus:opencensus-api:0.24.0",
     "io.opencensus:opencensus-contrib-grpc-metrics:0.24.0",
-    "io.perfmark:perfmark-api:0.19.0",
+    "io.perfmark:perfmark-api:0.23.0",
     "junit:junit:4.12",
-    "org.apache.commons:commons-lang3:3.5",
+    "org.apache.commons:commons-lang3:3.11",
     "org.apache.tomcat:annotations-api:6.0.53",
-    "org.codehaus.mojo:animal-sniffer-annotations:1.18",
+    "org.codehaus.mojo:animal-sniffer-annotations:1.19",
 ]
 
 # For use with maven_install's override_targets.


### PR DESCRIPTION
I didn't touch Protobuf and Netty; we upgrade those individually. Below
are issues I encountered that caused me to not upgrade (further).

Guava 30.1-android fails to build with Android without enabling
desugaring. https://github.com/google/guava/issues/5358

Robolectric 4.4 breaks AndroidChannelBuilderTest.
https://github.com/grpc/grpc-java/issues/7731

Opencensus 0.28.1+ is incompatible with gRPC.
https://github.com/census-instrumentation/opencensus-java/issues/2069
https://github.com/grpc/grpc-java/issues/7732

Truth now defines the asm dependency as "compile" although it is still
optional. But asm appears to have accidentally included incorrect gradle
module metadata in their release (I see they've disabled the metadata on
master) which make gradle think it requires Java 8. We could asm
everywhere, but that's is annoying. It seems likely this will resolve
itself.

Mockito can be upgraded to 3.4.0, but it deprecates initMocks, which
causes more code churn than I wanted in this commit. I still
synchronized the example versions on 3.4.0, though, as it was already
being used in some examples and the examples don't use initMocks.