### PR TITLE
android-interop-testing: ErrorProne should ignore generated R class

### DIFF
--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -93,6 +93,7 @@ tasks.withType(JavaCompile) {
     options.compilerArgs += [
             "-Xlint:-cast"
     ]
+    appendToProperty(it.options.errorprone.excludedPaths, ".*/R.java", "|")
     // Reuses source code from grpc-interop-testing, which targets Java 7 (no method references)
     options.errorprone.check("UnnecessaryAnonymousClass", CheckSeverity.OFF)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -131,8 +131,11 @@ subprojects {
             }
 
             tasks.withType(JavaCompile) {
-                it.options.errorprone.excludedPaths = ".*/src/generated/[^/]+/java/.*" +
-                        "|.*/build/generated/source/proto/[^/]+/java/.*"
+                appendToProperty(
+                    it.options.errorprone.excludedPaths,
+                    ".*/src/generated/[^/]+/java/.*" +
+                        "|.*/build/generated/source/proto/[^/]+/java/.*",
+                    "|")
             }
         }
 
@@ -244,6 +247,14 @@ subprojects {
                 exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
             }
             dependencies.runtimeOnly libraries.errorprone
+        }
+
+        appendToProperty = { Property<String> property, String value, String separator ->
+            if (property.present) {
+                property.set(property.get() + separator + value)
+            } else {
+                property.set(value)
+            }
         }
     }
 


### PR DESCRIPTION
This silences many MutablePublicArray warnings that we can't do anything
about.