### PR TITLE
stub: Stop linking to Guava Javadoc

### DIFF
--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -17,6 +17,5 @@ dependencies {
 }
 
 javadoc {
-    options.links "https://google.github.io/guava/releases/${guavaVersion}/api/docs/"
     exclude 'io/grpc/stub/Internal*'
 }


### PR DESCRIPTION
This resolves the following warning when building with JDK 8 introduced
in 9c5427fd4:
javadoc: warning - Error fetching URL: https://google.github.io/guava/releases/30.0-android/api/docs/

Guava is now building their Javadoc with JDK 11. JDK 11 swapped from
producing package-list to element-list, and stopped creating
package-list entirely. This file is what Javadoc uses to cross-link
documentation, and so it no longer works on the JDK 8 build, even though
the files have virtually the same contents.

ListenableFuture was the only reason we were including the Guava
Javadoc; let's just drop the link instead of worrying about this
silliness.