### PR TITLE
all: Fix opencensus-api dependency conflict

### DIFF
--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -22,12 +22,7 @@ dependencies {
             libraries.protobuf,
             libraries.conscrypt
     def nettyDependency = implementation project(':grpc-netty')
-    implementation (libraries.google_auth_oauth2_http) {
-        // prefer our own versions instead of google-auth-oauth2-http's dependency
-        exclude group: 'com.google.guava', module: 'guava'
-        // we'll always be more up-to-date
-        exclude group: 'io.grpc', module: 'grpc-context'
-    }
+    googleOauth2Dependency 'implementation'
     guavaDependency 'implementation'
     compileOnly libraries.javax_annotation
 

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -11,8 +11,8 @@ dependencies {
     api project(':grpc-api'),
             libraries.google_auth_credentials
     guavaDependency 'implementation'
-    testImplementation project(':grpc-testing'),
-            libraries.google_auth_oauth2_http
+    testImplementation project(':grpc-testing')
+    googleOauth2Dependency 'testImplementation'
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -239,6 +239,17 @@ subprojects {
             guavaDependency 'runtimeOnly'
         }
 
+        googleOauth2Dependency = { configurationName ->
+            dependencies."$configurationName"(libraries.google_auth_oauth2_http) {
+                exclude group: 'com.google.guava', module: 'guava'
+                exclude group: 'io.grpc', module: 'grpc-context'
+                exclude group: 'io.opencensus', module: 'opencensus-api'
+            }
+            dependencies.runtimeOnly project(':grpc-context')
+            censusApiDependency 'runtimeOnly'
+            guavaDependency 'runtimeOnly'
+        }
+
         // A util function to config perfmark dependency with transitive
         // dependencies properly resolved for the failOnVersionConflict strategy.
         perfmarkDependency = { configurationName ->

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -27,10 +27,10 @@ dependencies {
             project(':grpc-stub'),
             project(':grpc-testing'),
             project(path: ':grpc-xds', configuration: 'shadow'),
-            libraries.google_auth_oauth2_http,
             libraries.junit,
             libraries.truth
     censusGrpcMetricDependency 'implementation'
+    googleOauth2Dependency 'implementation'
     compileOnly libraries.javax_annotation
     runtimeOnly libraries.opencensus_impl,
             libraries.netty_tcnative,


### PR DESCRIPTION
After #7733, grpc-all has dependency conflicts for opencensus-api

```
> Task :grpc-all:dependencyInsight
Dependency resolution failed because of conflict(s) on the following module(s):
   - io.opencensus:opencensus-api between versions 0.28.0 and 0.24.0

io.opencensus:opencensus-api:0.28.0
   variant "runtime" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-runtime
      org.gradle.libraryelements     = jar
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.version         = 7
   ]
   Selection reasons:
      - By conflict resolution : between versions 0.28.0 and 0.24.0

io.opencensus:opencensus-api:0.28.0
\--- project :grpc-testing
     \--- runtimeClasspath

io.opencensus:opencensus-api:0.24.0 -> 0.28.0
+--- com.google.http-client:google-http-client:1.38.0
|    +--- com.google.auth:google-auth-library-oauth2-http:0.22.2
|    |    \--- project :grpc-alts
|    |         \--- project :grpc-xds
|    |              \--- runtimeClasspath
|    \--- com.google.http-client:google-http-client-jackson2:1.38.0
|         \--- com.google.auth:google-auth-library-oauth2-http:0.22.2 (*)
\--- io.opencensus:opencensus-contrib-http-util:0.24.0
     \--- com.google.http-client:google-http-client:1.38.0 (*)

(*) - dependencies omitted (listed previously)
```

We depend on 0.28.0 while oauth2 depends on 0.24.0. This change replaces oauth2' opencensus-api dependency with our own.