### PR TITLE
buildscripts: xDS Kubernetes Interop tests buildscript

### DIFF
--- a/buildscripts/kokoro/xds-k8s-install-test-driver.sh
+++ b/buildscripts/kokoro/xds-k8s-install-test-driver.sh
@@ -231,7 +231,7 @@ kokoro_write_sponge_properties() {
   # testgrid reports.
   cat >"${KOKORO_ARTIFACTS_DIR}/custom_sponge_config.csv" <<EOF
 TESTS_FORMAT_VERSION,2
-TESTGRID_EXCLUDE,0
+TESTGRID_EXCLUDE,${TESTGRID_EXCLUDE:-1}
 GIT_ORIGIN_URL,${GIT_ORIGIN_URL:?GIT_ORIGIN_URL must be set}
 GIT_COMMIT_SHORT,${GIT_COMMIT_SHORT:?GIT_COMMIT_SHORT must be set}
 EOF

--- a/buildscripts/kokoro/xds-k8s-install-test-driver.sh
+++ b/buildscripts/kokoro/xds-k8s-install-test-driver.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# TODO(sergiitk): move to grpc/grpc when implementing support of other languages
+set -eo pipefail
+
+# Constants
+readonly PYTHON_BIN="python3.6"
+# Test driver
+readonly TEST_DRIVER_REPO_NAME="grpc"
+readonly TEST_DRIVER_REPO_URL="https://github.com/grpc/grpc.git"
+readonly TEST_DRIVER_BRANCH="${TEST_DRIVER_BRANCH:-master}"
+readonly TEST_DRIVER_PATH="tools/run_tests/xds_k8s_test_driver"
+readonly TEST_DRIVER_PROTOS_PATH="src/proto/grpc/testing"
+
+run_safe() {
+  # Run command end report its exit code.
+  # Don't terminate the script if the code is negative.
+  local exit_code=-1
+  "$@" || exit_code=$?
+  echo "Exit code: ${exit_code}"
+}
+
+parse_src_repo_git_info() {
+  local src_dir="${SRC_DIR:?SRC_DIR must be set}"
+  readonly GIT_ORIGIN_URL=$(git -C "${src_dir}" remote get-url origin)
+  readonly GIT_COMMIT_SHORT=$(git -C "${src_dir}" rev-parse --short HEAD)
+}
+
+gcloud_gcr_list_matching_tags() {
+  gcloud container images list-tags --format="table[box](tags,digest,timestamp.date())" --filter="tags:$2" "$1"
+}
+
+gcloud_update() {
+  echo "Update gcloud components:"
+  gcloud -q components update
+}
+
+gcloud_get_cluster_credentials() {
+  gcloud container clusters get-credentials "${GKE_CLUSTER_NAME}" --zone "${GKE_CLUSTER_ZONE}"
+  readonly KUBE_CONTEXT="$(kubectl config current-context)"
+}
+
+test_driver_get_source() {
+  if [[ -d "${TEST_DRIVER_REPO_DIR}" ]]; then
+    echo "Found driver directory: ${TEST_DRIVER_REPO_DIR}"
+  else
+    echo "Cloning driver to ${TEST_DRIVER_REPO_URL} branch ${TEST_DRIVER_BRANCH} to ${TEST_DRIVER_REPO_DIR}"
+    git clone -b "${TEST_DRIVER_BRANCH}" --depth=1 "${TEST_DRIVER_REPO_URL}" "${TEST_DRIVER_REPO_DIR}"
+  fi
+}
+
+test_driver_pip_install() {
+  echo "Install python dependencies"
+  cd "${TEST_DRIVER_FULL_DIR}"
+
+  # Create and activate virtual environment already using one
+  if [[ -z "${VIRTUAL_ENV}" ]]; then
+    local venv_dir="${TEST_DRIVER_FULL_DIR}/venv"
+    if [[ -d "${venv_dir}" ]]; then
+      echo "Found python virtual environment directory: ${venv_dir}"
+    else
+      echo "Creating python virtual environment: ${venv_dir}"
+      "${PYTHON_BIN} -m venv ${venv_dir}"
+    fi
+    source "${venv_dir}/bin/activate"
+  fi
+
+  pip install -r requirements.txt
+  echo "Installed Python packages:"
+  pip list
+}
+
+test_driver_compile_protos() {
+  declare -a protos
+  protos=(
+    "${TEST_DRIVER_PROTOS_PATH}/test.proto"
+    "${TEST_DRIVER_PROTOS_PATH}/messages.proto"
+    "${TEST_DRIVER_PROTOS_PATH}/empty.proto"
+  )
+  echo "Generate python code from grpc.testing protos: ${protos[*]}"
+  cd "${TEST_DRIVER_REPO_DIR}"
+  python3 -m grpc_tools.protoc \
+    --proto_path=. \
+    --python_out="${TEST_DRIVER_FULL_DIR}" \
+    --grpc_python_out="${TEST_DRIVER_FULL_DIR}" \
+    "${protos[@]}"
+  local protos_out_dir="${TEST_DRIVER_FULL_DIR}/${TEST_DRIVER_PROTOS_PATH}"
+  echo "Generated files ${protos_out_dir}:"
+  ls -Fl "${protos_out_dir}"
+}
+
+test_driver_install() {
+  readonly TEST_DRIVER_REPO_DIR="${1:?Usage kokoro_init TEST_DRIVER_REPO_DIR}"
+  readonly TEST_DRIVER_FULL_DIR="${TEST_DRIVER_REPO_DIR}/${TEST_DRIVER_PATH}"
+  # Test driver installation:
+  # https://github.com/grpc/grpc/tree/master/tools/run_tests/xds_k8s_test_driver#installation
+  test_driver_get_source
+  test_driver_pip_install
+  test_driver_compile_protos
+}
+
+kokoro_print_version() {
+  echo "Kokoro VM version:"
+  if [[ -f /VERSION ]]; then
+    cat /VERSION
+  fi
+  run_safe lsb_release -a
+}
+
+kokoro_write_sponge_properties() {
+  # CSV format: "property_name","property_value"
+  # Bump TESTS_FORMAT_VERSION when reported test name changed enough to when it
+  # makes more sense to discard previous test results from a testgrid board.
+  # Use GIT_ORIGIN_URL to exclude test runs executed against repo forks from
+  # testgrid reports.
+  cat >"${KOKORO_ARTIFACTS_DIR}/custom_sponge_config.csv" <<EOF
+TESTS_FORMAT_VERSION,2
+TESTGRID_EXCLUDE,0
+GIT_ORIGIN_URL,${GIT_ORIGIN_URL:?GIT_ORIGIN_URL must be set}
+GIT_COMMIT_SHORT,${GIT_COMMIT_SHORT:?GIT_COMMIT_SHORT must be set}
+EOF
+  echo "Sponge properties:"
+  cat "${KOKORO_ARTIFACTS_DIR}/custom_sponge_config.csv"
+}
+
+kokoro_export_secrets() {
+  readonly PRIVATE_API_KEY=$(cat "${KOKORO_KEYSTORE_DIR}/73836_grpc_xds_interop_tests_gcp_alpha_apis_key")
+  export PRIVATE_API_KEY
+}
+
+kokoro_setup_python_virtual_environment() {
+  # Kokoro provides pyenv, so use it instead `python -m venv`
+  echo "Setup pyenv environment"
+  eval "$(pyenv init -)"
+  eval "$(pyenv virtualenv-init -)"
+  echo "Activating python virtual environment"
+  pyenv virtualenv 3.6.1 k8s_xds_test_runner
+  pyenv local k8s_xds_test_runner
+  pyenv activate k8s_xds_test_runner
+}
+
+kokoro_init() {
+  local src_repository_name="${1:?Usage kokoro_init GITHUB_REPOSITORY_NAME}"
+  # Capture Kokoro VM version info in the log.
+  kokoro_print_version
+
+  # Kokoro clones repo to ${KOKORO_ARTIFACTS_DIR}/github/${GITHUB_REPOSITORY}
+  local github_root="${KOKORO_ARTIFACTS_DIR}/github"
+  readonly SRC_DIR="${github_root}/${src_repository_name}"
+  local test_driver_repo_dir="${github_root}/${TEST_DRIVER_REPO_NAME}"
+  parse_src_repo_git_info SRC_DIR
+  # Report extra information about the job via sponge properties
+  kokoro_write_sponge_properties
+
+  # Turn off command trace print before exporting secrets.
+  local debug_on=0
+  if [[ $- =~ x ]]; then
+    debug_on=1
+    set +x
+  fi
+  kokoro_export_secrets
+  kokoro_setup_python_virtual_environment
+  # Re-enable debug output after secrets exported and noisy pyenv activated
+  ((debug_on == 0)) || set -x
+
+  # gcloud requires python, so this should be executed after pyenv setup
+  gcloud_update
+  gcloud_get_cluster_credentials
+  test_driver_install "${test_driver_repo_dir}"
+  readonly TEST_DRIVER_CONFIG="config/grpc-testing.cfg"
+  # Test artifacts dir: xml reports, logs, etc.
+  local artifacts_dir="${KOKORO_ARTIFACTS_DIR}/artifacts"
+  # Folders after $ARTIFACTS_DIR reported as target name
+  readonly TEST_XML_OUTPUT_DIR="${artifacts_dir}/${KOKORO_JOB_NAME}"
+  mkdir -p "${artifacts_dir}" "${TEST_XML_OUTPUT_DIR}"
+}
+
+local_init() {
+  local script_dir="${1:?Usage: local_init SCRIPT_DIR}"
+  readonly SRC_DIR="$(git -C "${script_dir}" rev-parse --show-toplevel)"
+  parse_src_repo_git_info SRC_DIR
+  readonly KUBE_CONTEXT="${KUBE_CONTEXT:-$(kubectl config current-context)}"
+  local test_driver_repo_dir
+  test_driver_repo_dir="${TEST_DRIVER_REPO_DIR:-$(mktemp -d)/${TEST_DRIVER_REPO_NAME}}"
+  test_driver_install "${test_driver_repo_dir}"
+  readonly TEST_DRIVER_CONFIG="config/local-dev.cfg"
+  # Test out
+  readonly TEST_XML_OUTPUT_DIR="${TEST_DRIVER_FULL_DIR}/out"
+  mkdir -p "${TEST_XML_OUTPUT_DIR}"
+}

--- a/buildscripts/kokoro/xds-k8s-install-test-driver.sh
+++ b/buildscripts/kokoro/xds-k8s-install-test-driver.sh
@@ -288,16 +288,7 @@ kokoro_setup_test_driver() {
   local test_driver_repo_dir="${github_root}/${TEST_DRIVER_REPO_NAME}"
   parse_src_repo_git_info SRC_DIR
   kokoro_write_sponge_properties
-
-  # Turn off command trace print before exporting secrets.
-  local debug_on=0
-  if [[ $- =~ x ]]; then
-    debug_on=1
-    set +x
-  fi
   kokoro_setup_python_virtual_environment
-  # Re-enable debug output after secrets exported and noisy pyenv activated
-  ((debug_on == 0)) || set -x
 
   # gcloud requires python, so this should be executed after pyenv setup
   gcloud_update

--- a/buildscripts/kokoro/xds-k8s-install-test-driver.sh
+++ b/buildscripts/kokoro/xds-k8s-install-test-driver.sh
@@ -240,20 +240,6 @@ EOF
 }
 
 #######################################
-# Export Keystore secrets assigned to the Kokoro build.
-# Globals:
-#   KOKORO_KEYSTORE_DIR
-#   PRIVATE_API_KEY: Exported. Populated with name GCP project secret key.
-#                    Used by the test driver to access private APIs
-# Arguments:
-#   None
-#######################################
-kokoro_export_secrets() {
-  readonly PRIVATE_API_KEY=$(cat "${KOKORO_KEYSTORE_DIR}/73836_grpc_xds_interop_tests_gcp_alpha_apis_key")
-  export PRIVATE_API_KEY
-}
-
-#######################################
 # Configure Python virtual environment on Kokoro VM.
 # Arguments:
 #   None
@@ -284,8 +270,6 @@ kokoro_setup_python_virtual_environment() {
 #   TEST_DRIVER_FLAGFILE: Populated with relative path to test driver flagfile
 #   TEST_XML_OUTPUT_DIR: Populated with the path to test xUnit XML report
 #   KUBE_CONTEXT: Populated with name of kubectl context with GKE cluster access
-#   PRIVATE_API_KEY: Populated with name GCP project secret key. Used by the
-#                    test driver to access private APIs
 #   GIT_ORIGIN_URL: Populated with the origin URL of git repo used for the build
 #   GIT_COMMIT_SHORT: Populated with the short SHA-1 of git commit being built
 # Arguments:
@@ -311,7 +295,6 @@ kokoro_setup_test_driver() {
     debug_on=1
     set +x
   fi
-  kokoro_export_secrets
   kokoro_setup_python_virtual_environment
   # Re-enable debug output after secrets exported and noisy pyenv activated
   ((debug_on == 0)) || set -x
@@ -342,8 +325,6 @@ kokoro_setup_test_driver() {
 #   GIT_ORIGIN_URL: Populated with the origin URL of git repo used for the build
 #   GIT_COMMIT_SHORT: Populated with the short SHA-1 of git commit being built
 #   KUBE_CONTEXT: Populated with name of kubectl context with GKE cluster access
-#   PRIVATE_API_KEY: Exported. Populated with name GCP project secret key.
-#                    Used by the test driver to access private APIs
 # Arguments:
 #   The path to the folder containing the build script
 # Outputs:

--- a/buildscripts/kokoro/xds-k8s-install-test-driver.sh
+++ b/buildscripts/kokoro/xds-k8s-install-test-driver.sh
@@ -219,6 +219,7 @@ kokoro_print_version() {
 #   KOKORO_ARTIFACTS_DIR
 #   GIT_ORIGIN_URL
 #   GIT_COMMIT_SHORT
+#   TESTGRID_EXCLUDE
 # Arguments:
 #   None
 # Outputs:

--- a/buildscripts/kokoro/xds-k8s-install-test-driver.sh
+++ b/buildscripts/kokoro/xds-k8s-install-test-driver.sh
@@ -98,7 +98,9 @@ gcloud_get_cluster_credentials() {
 #######################################
 test_driver_get_source() {
   if [[ -d "${TEST_DRIVER_REPO_DIR}" ]]; then
-    echo "Found driver directory: ${TEST_DRIVER_REPO_DIR}"
+    echo "Found driver directory: ${TEST_DRIVER_REPO_DIR}. Updating to latest ${TEST_DRIVER_BRANCH}"
+    git -C "${TEST_DRIVER_REPO_DIR}" checkout "${TEST_DRIVER_BRANCH}"
+    git -C "${TEST_DRIVER_REPO_DIR}" pull origin "${TEST_DRIVER_BRANCH}"
   else
     echo "Cloning driver to ${TEST_DRIVER_REPO_URL} branch ${TEST_DRIVER_BRANCH} to ${TEST_DRIVER_REPO_DIR}"
     git clone -b "${TEST_DRIVER_BRANCH}" --depth=1 "${TEST_DRIVER_REPO_URL}" "${TEST_DRIVER_REPO_DIR}"
@@ -121,7 +123,7 @@ test_driver_pip_install() {
   echo "Install python dependencies"
   cd "${TEST_DRIVER_FULL_DIR}"
 
-  # Create and activate virtual environment already using one
+  # Create and activate virtual environment unless already using one
   if [[ -z "${VIRTUAL_ENV}" ]]; then
     local venv_dir="${TEST_DRIVER_FULL_DIR}/venv"
     if [[ -d "${venv_dir}" ]]; then
@@ -258,7 +260,7 @@ kokoro_export_secrets() {
 #   Writes the output of `pyenv` commands to stdout
 #######################################
 kokoro_setup_python_virtual_environment() {
-  # Kokoro provides pyenv, so use it instead `python -m venv`
+  # Kokoro provides pyenv, so use it instead of `python -m venv`
   echo "Setup pyenv environment"
   eval "$(pyenv init -)"
   eval "$(pyenv virtualenv-init -)"

--- a/buildscripts/kokoro/xds-k8s-install-test-driver.sh
+++ b/buildscripts/kokoro/xds-k8s-install-test-driver.sh
@@ -234,7 +234,7 @@ kokoro_write_sponge_properties() {
   # testgrid reports.
   cat >"${KOKORO_ARTIFACTS_DIR}/custom_sponge_config.csv" <<EOF
 TESTS_FORMAT_VERSION,2
-TESTGRID_EXCLUDE,${TESTGRID_EXCLUDE:-1}
+TESTGRID_EXCLUDE,${TESTGRID_EXCLUDE:-0}
 GIT_ORIGIN_URL,${GIT_ORIGIN_URL:?GIT_ORIGIN_URL must be set}
 GIT_COMMIT_SHORT,${GIT_COMMIT_SHORT:?GIT_COMMIT_SHORT must be set}
 EOF

--- a/buildscripts/kokoro/xds-k8s-install-test-driver.sh
+++ b/buildscripts/kokoro/xds-k8s-install-test-driver.sh
@@ -87,9 +87,12 @@ gcloud_get_cluster_credentials() {
 # Clone the source code of the test driver to $TEST_DRIVER_REPO_DIR, unless
 # given folder exists.
 # Globals:
-#   TEST_DRIVER_REPO_DIR
 #   TEST_DRIVER_REPO_URL
 #   TEST_DRIVER_BRANCH
+#   TEST_DRIVER_REPO_DIR: path to the repo containing the test driver
+#   TEST_DRIVER_REPO_DIR_USE_EXISTING: set non-empty value to use exiting
+#      clone of the driver repo located at $TEST_DRIVER_REPO_DIR.
+#      Useful for debugging the build script locally.
 # Arguments:
 #   None
 # Outputs:
@@ -97,10 +100,8 @@ gcloud_get_cluster_credentials() {
 #   Writes driver source code to $TEST_DRIVER_REPO_DIR
 #######################################
 test_driver_get_source() {
-  if [[ -d "${TEST_DRIVER_REPO_DIR}" ]]; then
-    echo "Found driver directory: ${TEST_DRIVER_REPO_DIR}. Updating to latest ${TEST_DRIVER_BRANCH}"
-    git -C "${TEST_DRIVER_REPO_DIR}" checkout "${TEST_DRIVER_BRANCH}"
-    git -C "${TEST_DRIVER_REPO_DIR}" pull origin "${TEST_DRIVER_BRANCH}"
+  if [[ -n "${TEST_DRIVER_REPO_DIR_USE_EXISTING}" && -d "${TEST_DRIVER_REPO_DIR}" ]]; then
+    echo "Using exiting driver directory: ${TEST_DRIVER_REPO_DIR}."
   else
     echo "Cloning driver to ${TEST_DRIVER_REPO_URL} branch ${TEST_DRIVER_BRANCH} to ${TEST_DRIVER_REPO_DIR}"
     git clone -b "${TEST_DRIVER_BRANCH}" --depth=1 "${TEST_DRIVER_REPO_URL}" "${TEST_DRIVER_REPO_DIR}"

--- a/buildscripts/kokoro/xds-k8s-install-test-driver.sh
+++ b/buildscripts/kokoro/xds-k8s-install-test-driver.sh
@@ -30,6 +30,7 @@ run_ignore_exit_code() {
 # Parses information about git repository at given path to global variables.
 # Globals:
 #   GIT_ORIGIN_URL: Populated with the origin URL of git repo used for the build
+#   GIT_COMMIT: Populated with the SHA-1 of git commit being built
 #   GIT_COMMIT_SHORT: Populated with the short SHA-1 of git commit being built
 # Arguments:
 #   Git source dir
@@ -37,6 +38,7 @@ run_ignore_exit_code() {
 parse_src_repo_git_info() {
   local src_dir="${SRC_DIR:?SRC_DIR must be set}"
   readonly GIT_ORIGIN_URL=$(git -C "${src_dir}" remote get-url origin)
+  readonly GIT_COMMIT=$(git -C "${src_dir}" rev-parse HEAD)
   readonly GIT_COMMIT_SHORT=$(git -C "${src_dir}" rev-parse --short HEAD)
 }
 
@@ -271,6 +273,7 @@ kokoro_setup_python_virtual_environment() {
 #   TEST_XML_OUTPUT_DIR: Populated with the path to test xUnit XML report
 #   KUBE_CONTEXT: Populated with name of kubectl context with GKE cluster access
 #   GIT_ORIGIN_URL: Populated with the origin URL of git repo used for the build
+#   GIT_COMMIT: Populated with the SHA-1 of git commit being built
 #   GIT_COMMIT_SHORT: Populated with the short SHA-1 of git commit being built
 # Arguments:
 #   The name of github repository being built
@@ -314,6 +317,7 @@ kokoro_setup_test_driver() {
 #   TEST_DRIVER_FLAGFILE: Populated with relative path to test driver flagfile
 #   TEST_XML_OUTPUT_DIR: Populated with the path to test xUnit XML report
 #   GIT_ORIGIN_URL: Populated with the origin URL of git repo used for the build
+#   GIT_COMMIT: Populated with the SHA-1 of git commit being built
 #   GIT_COMMIT_SHORT: Populated with the short SHA-1 of git commit being built
 #   KUBE_CONTEXT: Populated with name of kubectl context with GKE cluster access
 # Arguments:

--- a/buildscripts/kokoro/xds-k8s.cfg
+++ b/buildscripts/kokoro/xds-k8s.cfg
@@ -4,15 +4,6 @@
 build_file: "grpc-java/buildscripts/kokoro/xds-k8s.sh"
 timeout_mins: 90
 
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 73836
-      keyname: "grpc_xds_interop_tests_gcp_alpha_apis_key"
-    }
-  }
-}
-
 action {
   define_artifacts {
     regex: "artifacts/**/*sponge_log.xml"

--- a/buildscripts/kokoro/xds-k8s.cfg
+++ b/buildscripts/kokoro/xds-k8s.cfg
@@ -3,9 +3,20 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc-java/buildscripts/kokoro/xds-k8s.sh"
 timeout_mins: 90
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73836
+      keyname: "grpc_xds_interop_tests_gcp_alpha_apis_key"
+    }
+  }
+}
+
 action {
   define_artifacts {
-    regex: "artifacts/*sponge_log.xml"
-    regex: "artifacts/*sponge_log.log"
+    regex: "artifacts/**/*sponge_log.xml"
+    regex: "artifacts/**/*sponge_log.log"
+    strip_prefix: "artifacts"
   }
 }

--- a/buildscripts/kokoro/xds-k8s.sh
+++ b/buildscripts/kokoro/xds-k8s.sh
@@ -136,8 +136,6 @@ run_test() {
 #   GIT_ORIGIN_URL: Populated with the origin URL of git repo used for the build
 #   GIT_COMMIT_SHORT: Populated with the short SHA-1 of git commit being built
 #   KUBE_CONTEXT: Populated with name of kubectl context with GKE cluster access
-#   PRIVATE_API_KEY: Exported. Populated with name GCP project secret key.
-#                    Used by the test driver to access private APIs
 # Arguments:
 #   None
 # Outputs:

--- a/buildscripts/kokoro/xds-k8s.sh
+++ b/buildscripts/kokoro/xds-k8s.sh
@@ -3,47 +3,86 @@ set -eo pipefail
 
 # Constants
 readonly GITHUB_REPOSITORY_NAME="grpc-java"
-readonly SCRIPT_DIR=$(dirname "$0")
 # GKE Cluster
 readonly GKE_CLUSTER_NAME="interop-test-psm-sec1-us-central1"
 readonly GKE_CLUSTER_ZONE="us-central1-a"
 ## xDS test server/client Docker images
 readonly IMAGE_NAME="gcr.io/grpc-testing/xds-k8s-test-java"
 readonly IMAGE_BUILD_SKIP="${IMAGE_BUILD_SKIP:-1}"
+# Build paths
+readonly BUILD_INSTALL_PATH="interop-testing/build/install"
+readonly BUILD_APP_PATH="${BUILD_INSTALL_PATH}/grpc-interop-testing"
 
+#######################################
+# Builds the test app using gradle and smoke-checks its binaries
+# Globals:
+#   SRC_DIR
+#   BUILD_APP_PATH
+# Arguments:
+#   None
+# Outputs:
+#   Writes the output of xds-test-client and xds-test-server --help to stderr
+#######################################
 build_java_test_app() {
   echo "Building Java test app"
   cd "${SRC_DIR}"
-  ./gradlew --no-daemon grpc-interop-testing:installDist -x test -PskipCodegen=true -PskipAndroid=true --console=plain
+  ./gradlew --no-daemon grpc-interop-testing:installDist -x test \
+    -PskipCodegen=true -PskipAndroid=true --console=plain
+
   # Test-run binaries
-  run_safe "${TEST_APP_BUILD_APP_DIR}/bin/xds-test-client" --help
-  run_safe "${TEST_APP_BUILD_APP_DIR}/bin/xds-test-server" --help
+  run_ignore_exit_code "${SRC_DIR}/${BUILD_APP_PATH}/bin/xds-test-client" --help
+  run_ignore_exit_code "${SRC_DIR}/${BUILD_APP_PATH}/bin/xds-test-server" --help
 }
 
+#######################################
+# Builds test app Docker images and pushes them to GCR
+# Globals:
+#   BUILD_INSTALL_PATH
+#   IMAGE_NAME
+#   SERVER_IMAGE_TAG
+#   CLIENT_IMAGE_TAG
+# Arguments:
+#   None
+# Outputs:
+#   Writes the output of `gcloud builds submit` to stdout, stderr
+#######################################
 build_test_app_docker_images() {
   local docker_dir="${SRC_DIR}/buildscripts/xds-k8s"
   echo "Building Java test app Docker Images"
   # Copy Docker files and log properties to the build dir
-  cp -rv "${docker_dir}/"*.Dockerfile "${TEST_APP_BUILD_INSTALL_DIR}"
-  cp -rv "${docker_dir}/"*.properties "${TEST_APP_BUILD_INSTALL_DIR}"
+  cp -rv "${docker_dir}/"*.Dockerfile "${SRC_DIR}/${BUILD_INSTALL_PATH}"
+  cp -rv "${docker_dir}/"*.properties "${SRC_DIR}/${BUILD_INSTALL_PATH}"
+  # TODO(sergiitk): extra "cosmetic" tags for versioned branches
   # Run Google Cloud Build
-  gcloud builds submit "${TEST_APP_BUILD_INSTALL_DIR}" \
+  gcloud builds submit "${SRC_DIR}/${BUILD_INSTALL_PATH}" \
     --config "${docker_dir}/cloudbuild.yaml" \
     --substitutions "_IMAGE_NAME=${IMAGE_NAME},_SERVER_IMAGE_TAG=${SERVER_IMAGE_TAG},_CLIENT_IMAGE_TAG=${CLIENT_IMAGE_TAG}"
-  # TODO(sergiitk): extra "cosmetic" tags for versioned branches
 }
 
+#######################################
+# Builds test app and its docker images unless they already exist
+# Globals:
+#   IMAGE_NAME
+#   SERVER_IMAGE_TAG
+#   CLIENT_IMAGE_TAG
+#   IMAGE_BUILD_SKIP
+# Arguments:
+#   None
+# Outputs:
+#   Writes the output to stdout, stderr
+#######################################
 build_docker_images_if_needed() {
   # Check if images already exist
-  server_tags=$(gcloud_gcr_list_matching_tags "${IMAGE_NAME}" "${SERVER_IMAGE_TAG}")
-  printf "Server image: %s:%s\n%s\n" "${IMAGE_NAME}" "${SERVER_IMAGE_TAG}" "${server_tags:-Server image not found}"
-  client_tags=$(gcloud_gcr_list_matching_tags "${IMAGE_NAME}" "${CLIENT_IMAGE_TAG}")
-  printf "Client image: %s:%s\n%s\n" "${IMAGE_NAME}" "${CLIENT_IMAGE_TAG}" "${client_tags:-Client image not found}"
+  server_tags="$(gcloud_gcr_list_image_tags "${IMAGE_NAME}" "${SERVER_IMAGE_TAG}")"
+  printf "Server image: %s:%s\n" "${IMAGE_NAME}" "${SERVER_IMAGE_TAG}"
+  echo "${server_tags:-Server image not found}"
+
+  client_tags="$(gcloud_gcr_list_image_tags "${IMAGE_NAME}" "${CLIENT_IMAGE_TAG}")"
+  printf "Client image: %s:%s\n" "${IMAGE_NAME}" "${CLIENT_IMAGE_TAG}"
+  echo "${client_tags:-Client image not found}"
 
   # Build if one of images is missing or IMAGE_BUILD_SKIP=0
   if [[ "${IMAGE_BUILD_SKIP}" == "0" || -z "${server_tags}" && -z "${client_tags}" ]]; then
-    readonly TEST_APP_BUILD_INSTALL_DIR="${SRC_DIR}/interop-testing/build/install"
-    readonly TEST_APP_BUILD_APP_DIR="${TEST_APP_BUILD_OUT_DIR}/grpc-interop-testing"
     build_java_test_app
     build_test_app_docker_images
   else
@@ -51,14 +90,28 @@ build_docker_images_if_needed() {
   fi
 }
 
+#######################################
+# Executes the test case
+# Globals:
+#   TEST_DRIVER_FLAGFILE: Relative path to test driver flagfile
+#   KUBE_CONTEXT: The name of kubectl context with GKE cluster access
+#   TEST_XML_OUTPUT_DIR: Output directory for the test xUnit XML report
+#   IMAGE_NAME: The name of GCR image with the test app
+#   SERVER_IMAGE_TAG: Test server image tag used in this build
+#   CLIENT_IMAGE_TAG: Test client image tag used in this build
+# Arguments:
+#   Test case name
+# Outputs:
+#   Writes the output of test execution to stdout, stderr
+#   Test xUnit report to ${TEST_XML_OUTPUT_DIR}/${test_name}/sponge_log.xml
+#######################################
 run_test() {
   # Test driver usage:
   # https://github.com/grpc/grpc/tree/master/tools/run_tests/xds_k8s_test_driver#basic-usage
   local test_name="${1:?Usage: run_test test_name}"
-  cd "${TEST_DRIVER_FULL_DIR}"
   set -x
   python -m "tests.${test_name}" \
-    --flagfile="${TEST_DRIVER_CONFIG}" \
+    --flagfile="${TEST_DRIVER_FLAGFILE}" \
     --kube_context="${KUBE_CONTEXT}" \
     --server_image="${IMAGE_NAME}:${SERVER_IMAGE_TAG}" \
     --client_image="${IMAGE_NAME}:${CLIENT_IMAGE_TAG}" \
@@ -67,22 +120,47 @@ run_test() {
   set +x
 }
 
+#######################################
+# Main function: provision software necessary to execute tests, and run them
+# Globals:
+#   KOKORO_ARTIFACTS_DIR
+#   GITHUB_REPOSITORY_NAME
+#   SERVER_IMAGE_TAG: Populated with test server image tag used in this build
+#   CLIENT_IMAGE_TAG: Populated with test client image tag used in this build
+#   SRC_DIR: Populated with absolute path to the source repo
+#   TEST_DRIVER_REPO_DIR: Populated with the path to the repo containing
+#                         the test driver
+#   TEST_DRIVER_FULL_DIR: Populated with the path to the test driver source code
+#   TEST_DRIVER_FLAGFILE: Populated with relative path to test driver flagfile
+#   TEST_XML_OUTPUT_DIR: Populated with the path to test xUnit XML report
+#   GIT_ORIGIN_URL: Populated with the origin URL of git repo used for the build
+#   GIT_COMMIT_SHORT: Populated with the short SHA-1 of git commit being built
+#   KUBE_CONTEXT: Populated with name of kubectl context with GKE cluster access
+#   PRIVATE_API_KEY: Exported. Populated with name GCP project secret key.
+#                    Used by the test driver to access private APIs
+# Arguments:
+#   None
+# Outputs:
+#   Writes the output of test execution to stdout, stderr
+#######################################
 main() {
-  # Intentional: source from the same dir as xds-k8s.sh
-  # shellcheck disable=SC1090
-  source "${SCRIPT_DIR}/xds-k8s-install-test-driver.sh"
+  local script_dir
+  script_dir="$(dirname "$0")"
+  # shellcheck source=buildscripts/kokoro/xds-k8s-install-test-driver.sh
+  source "${script_dir}/xds-k8s-install-test-driver.sh"
   set -x
   if [[ -n "${KOKORO_ARTIFACTS_DIR}" ]]; then
-    kokoro_init "${GITHUB_REPOSITORY_NAME}"
+    kokoro_setup_test_driver "${GITHUB_REPOSITORY_NAME}"
   else
-    local_init "${SCRIPT_DIR}"
+    local_setup_test_driver "${script_dir}"
   fi
   readonly SERVER_IMAGE_TAG="server-${GIT_COMMIT_SHORT}"
   readonly CLIENT_IMAGE_TAG="client-${GIT_COMMIT_SHORT}"
   build_docker_images_if_needed
   # Run tests
+  cd "${TEST_DRIVER_FULL_DIR}"
   run_test baseline_test
-  run_test security_test
+#  run_test security_test
 }
 
 main "$@"

--- a/buildscripts/kokoro/xds-k8s.sh
+++ b/buildscripts/kokoro/xds-k8s.sh
@@ -1,4 +1,88 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -eo pipefail
 
-# A placeholder for xDS interop tests executed on GKE
-echo "Coming soon"
+# Constants
+readonly GITHUB_REPOSITORY_NAME="grpc-java"
+readonly SCRIPT_DIR=$(dirname "$0")
+# GKE Cluster
+readonly GKE_CLUSTER_NAME="interop-test-psm-sec1-us-central1"
+readonly GKE_CLUSTER_ZONE="us-central1-a"
+## xDS test server/client Docker images
+readonly IMAGE_NAME="gcr.io/grpc-testing/xds-k8s-test-java"
+readonly IMAGE_BUILD_SKIP="${IMAGE_BUILD_SKIP:-1}"
+
+build_java_test_app() {
+  echo "Building Java test app"
+  cd "${SRC_DIR}"
+  ./gradlew --no-daemon grpc-interop-testing:installDist -x test -PskipCodegen=true -PskipAndroid=true --console=plain
+  # Test-run binaries
+  run_safe "${TEST_APP_BUILD_APP_DIR}/bin/xds-test-client" --help
+  run_safe "${TEST_APP_BUILD_APP_DIR}/bin/xds-test-server" --help
+}
+
+build_test_app_docker_images() {
+  local docker_dir="${SRC_DIR}/buildscripts/xds-k8s"
+  echo "Building Java test app Docker Images"
+  # Copy Docker files and log properties to the build dir
+  cp -rv "${docker_dir}/"*.Dockerfile "${TEST_APP_BUILD_INSTALL_DIR}"
+  cp -rv "${docker_dir}/"*.properties "${TEST_APP_BUILD_INSTALL_DIR}"
+  # Run Google Cloud Build
+  gcloud builds submit "${TEST_APP_BUILD_INSTALL_DIR}" \
+    --config "${docker_dir}/cloudbuild.yaml" \
+    --substitutions "_IMAGE_NAME=${IMAGE_NAME},_SERVER_IMAGE_TAG=${SERVER_IMAGE_TAG},_CLIENT_IMAGE_TAG=${CLIENT_IMAGE_TAG}"
+  # TODO(sergiitk): extra "cosmetic" tags for versioned branches
+}
+
+build_docker_images_if_needed() {
+  # Check if images already exist
+  server_tags=$(gcloud_gcr_list_matching_tags "${IMAGE_NAME}" "${SERVER_IMAGE_TAG}")
+  printf "Server image: %s:%s\n%s\n" "${IMAGE_NAME}" "${SERVER_IMAGE_TAG}" "${server_tags:-Server image not found}"
+  client_tags=$(gcloud_gcr_list_matching_tags "${IMAGE_NAME}" "${CLIENT_IMAGE_TAG}")
+  printf "Client image: %s:%s\n%s\n" "${IMAGE_NAME}" "${CLIENT_IMAGE_TAG}" "${client_tags:-Client image not found}"
+
+  # Build if one of images is missing or IMAGE_BUILD_SKIP=0
+  if [[ "${IMAGE_BUILD_SKIP}" == "0" || -z "${server_tags}" && -z "${client_tags}" ]]; then
+    readonly TEST_APP_BUILD_INSTALL_DIR="${SRC_DIR}/interop-testing/build/install"
+    readonly TEST_APP_BUILD_APP_DIR="${TEST_APP_BUILD_OUT_DIR}/grpc-interop-testing"
+    build_java_test_app
+    build_test_app_docker_images
+  else
+    echo "Skipping Java test app build"
+  fi
+}
+
+run_test() {
+  # Test driver usage:
+  # https://github.com/grpc/grpc/tree/master/tools/run_tests/xds_k8s_test_driver#basic-usage
+  local test_name="${1:?Usage: run_test test_name}"
+  cd "${TEST_DRIVER_FULL_DIR}"
+  set -x
+  python -m "tests.${test_name}" \
+    --flagfile="${TEST_DRIVER_CONFIG}" \
+    --kube_context="${KUBE_CONTEXT}" \
+    --server_image="${IMAGE_NAME}:${SERVER_IMAGE_TAG}" \
+    --client_image="${IMAGE_NAME}:${CLIENT_IMAGE_TAG}" \
+    --xml_output_file="${TEST_XML_OUTPUT_DIR}/${test_name}/sponge_log.xml" \
+    --force_cleanup
+  set +x
+}
+
+main() {
+  # Intentional: source from the same dir as xds-k8s.sh
+  # shellcheck disable=SC1090
+  source "${SCRIPT_DIR}/xds-k8s-install-test-driver.sh"
+  set -x
+  if [[ -n "${KOKORO_ARTIFACTS_DIR}" ]]; then
+    kokoro_init "${GITHUB_REPOSITORY_NAME}"
+  else
+    local_init "${SCRIPT_DIR}"
+  fi
+  readonly SERVER_IMAGE_TAG="server-${GIT_COMMIT_SHORT}"
+  readonly CLIENT_IMAGE_TAG="client-${GIT_COMMIT_SHORT}"
+  build_docker_images_if_needed
+  # Run tests
+  run_test baseline_test
+  run_test security_test
+}
+
+main "$@"

--- a/buildscripts/kokoro/xds-k8s.sh
+++ b/buildscripts/kokoro/xds-k8s.sh
@@ -9,7 +9,7 @@ readonly GKE_CLUSTER_ZONE="us-central1-a"
 ## xDS test server/client Docker images
 readonly SERVER_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/java-server"
 readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/java-client"
-readonly IMAGE_BUILD_SKIP="${IMAGE_BUILD_SKIP:-1}"
+readonly FORCE_IMAGE_BUILD="${FORCE_IMAGE_BUILD:-0}"
 readonly BUILD_APP_PATH="interop-testing/build/install/grpc-interop-testing"
 
 #######################################
@@ -67,7 +67,7 @@ build_test_app_docker_images() {
 #   SERVER_IMAGE_NAME: Test server Docker image name
 #   CLIENT_IMAGE_NAME: Test client Docker image name
 #   GIT_COMMIT: SHA-1 of git commit being built
-#   IMAGE_BUILD_SKIP
+#   FORCE_IMAGE_BUILD
 # Arguments:
 #   None
 # Outputs:
@@ -83,8 +83,8 @@ build_docker_images_if_needed() {
   printf "Client image: %s:%s\n" "${CLIENT_IMAGE_NAME}" "${GIT_COMMIT}"
   echo "${client_tags:-Client image not found}"
 
-  # Build if one of images is missing or IMAGE_BUILD_SKIP=0
-  if [[ "${IMAGE_BUILD_SKIP}" == "0" || -z "${server_tags}" && -z "${client_tags}" ]]; then
+  # Build if any of the images are missing, or FORCE_IMAGE_BUILD=1
+  if [[ "${FORCE_IMAGE_BUILD}" == "1" || -z "${server_tags}" || -z "${client_tags}" ]]; then
     build_java_test_app
     build_test_app_docker_images
   else

--- a/buildscripts/kokoro/xds-k8s.sh
+++ b/buildscripts/kokoro/xds-k8s.sh
@@ -160,7 +160,7 @@ main() {
   # Run tests
   cd "${TEST_DRIVER_FULL_DIR}"
   run_test baseline_test
-#  run_test security_test
+  run_test security_test
 }
 
 main "$@"

--- a/buildscripts/kokoro/xds-k8s.sh
+++ b/buildscripts/kokoro/xds-k8s.sh
@@ -58,7 +58,8 @@ build_test_app_docker_images() {
   gcloud builds submit "${build_dir}" \
     --config "${docker_dir}/cloudbuild.yaml" \
     --substitutions "_SERVER_IMAGE_NAME=${SERVER_IMAGE_NAME},_CLIENT_IMAGE_NAME=${CLIENT_IMAGE_NAME},COMMIT_SHA=${GIT_COMMIT}"
-  # TODO(sergiitk): extra "cosmetic" tags for versioned branches
+  # TODO(sergiitk): extra "cosmetic" tags for versioned branches, e.g. v1.34.x
+  # TODO(sergiitk): do this when adding support for custom configs per version
 }
 
 #######################################

--- a/buildscripts/xds-k8s/cloudbuild.yaml
+++ b/buildscripts/xds-k8s/cloudbuild.yaml
@@ -2,22 +2,21 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
     - 'build'
-    - '--tag=${_IMAGE_NAME}:${_SERVER_IMAGE_TAG}'
+    - '--tag=${_SERVER_IMAGE_NAME}:${COMMIT_SHA}'
     - '--file=test-server.Dockerfile'
     - '.'
 
 - name: 'gcr.io/cloud-builders/docker'
   args:
     - 'build'
-    - '--tag=${_IMAGE_NAME}:${_CLIENT_IMAGE_TAG}'
+    - '--tag=${_CLIENT_IMAGE_NAME}:${COMMIT_SHA}'
     - '--file=test-client.Dockerfile'
     - '.'
 
 substitutions:
-  _IMAGE_NAME: gcr.io/grpc-testing/xds-k8s-test-java
-  _SERVER_IMAGE_TAG: server-dev
-  _CLIENT_IMAGE_TAG: client-dev
+  _SERVER_IMAGE_NAME: gcr.io/grpc-testing/xds-interop/java-server
+  _CLIENT_IMAGE_NAME: gcr.io/grpc-testing/xds-interop/java-client
 
 images:
-  - '${_IMAGE_NAME}:${_SERVER_IMAGE_TAG}'
-  - '${_IMAGE_NAME}:${_CLIENT_IMAGE_TAG}'
+  - '${_SERVER_IMAGE_NAME}:${COMMIT_SHA}'
+  - '${_CLIENT_IMAGE_NAME}:${COMMIT_SHA}'

--- a/buildscripts/xds-k8s/cloudbuild.yaml
+++ b/buildscripts/xds-k8s/cloudbuild.yaml
@@ -1,0 +1,23 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+    - 'build'
+    - '--tag=${_IMAGE_NAME}:${_SERVER_IMAGE_TAG}'
+    - '--file=test-server.Dockerfile'
+    - '.'
+
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+    - 'build'
+    - '--tag=${_IMAGE_NAME}:${_CLIENT_IMAGE_TAG}'
+    - '--file=test-client.Dockerfile'
+    - '.'
+
+substitutions:
+  _IMAGE_NAME: gcr.io/grpc-testing/xds-k8s-test-java
+  _SERVER_IMAGE_TAG: server-dev
+  _CLIENT_IMAGE_TAG: client-dev
+
+images:
+  - '${_IMAGE_NAME}:${_SERVER_IMAGE_TAG}'
+  - '${_IMAGE_NAME}:${_CLIENT_IMAGE_TAG}'

--- a/buildscripts/xds-k8s/logging-debug.properties
+++ b/buildscripts/xds-k8s/logging-debug.properties
@@ -1,0 +1,7 @@
+handlers=java.util.logging.ConsoleHandler
+io.grpc.ChannelLogger.level=FINEST
+io.grpc.level=FINEST
+io.netty.level=FINEST
+java.util.logging.ConsoleHandler.level=ALL
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format=[%1$tF %1$tT.%1$tL %1tZ] [%4$-7s] [%3$s] %5$s %6$s %n

--- a/buildscripts/xds-k8s/logging-json.properties
+++ b/buildscripts/xds-k8s/logging-json.properties
@@ -1,0 +1,8 @@
+handlers=java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level=FINEST
+java.util.logging.ConsoleHandler.formatter=io.github.devatherock.json.formatter.JSONFormatter
+io.github.devatherock.json.formatter.JSONFormatter.key_timestamp=time
+io.github.devatherock.json.formatter.JSONFormatter.key_log_level=severity
+io.github.devatherock.json.formatter.JSONFormatter.use_slf4j_level_names=true
+io.grpc.ChannelLogger.level=FINEST
+io.grpc.xds.level=FINEST

--- a/buildscripts/xds-k8s/logging.properties
+++ b/buildscripts/xds-k8s/logging.properties
@@ -1,0 +1,6 @@
+handlers=java.util.logging.ConsoleHandler
+io.grpc.ChannelLogger.level=FINEST
+io.grpc.xds.level=FINEST
+java.util.logging.ConsoleHandler.level=FINEST
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format=[%1$tF %1$tT.%1$tL %1tZ] [%4$-7s] [%3$s] %5$s %6$s %n

--- a/buildscripts/xds-k8s/test-client.Dockerfile
+++ b/buildscripts/xds-k8s/test-client.Dockerfile
@@ -1,0 +1,15 @@
+# Build runtime image.
+FROM openjdk:11.0.9.1-jdk
+
+ENV APP_DIR=/usr/src/app
+WORKDIR $APP_DIR
+
+# Install the app
+COPY grpc-interop-testing/ $APP_DIR/
+
+# Copy all logging profiles, use json logging by default
+COPY logging*.properties $APP_DIR/
+ENV JAVA_OPTS="-Djava.util.logging.config.file=$APP_DIR/logging-json.properties"
+
+# Client
+ENTRYPOINT ["bin/xds-test-client"]

--- a/buildscripts/xds-k8s/test-server.Dockerfile
+++ b/buildscripts/xds-k8s/test-server.Dockerfile
@@ -1,0 +1,15 @@
+# Build runtime image.
+FROM openjdk:11.0.9.1-jdk
+
+ENV APP_DIR=/usr/src/app
+WORKDIR $APP_DIR
+
+# Install the app
+COPY grpc-interop-testing/ $APP_DIR/
+
+# Copy all logging profiles, use json logging by default
+COPY logging*.properties $APP_DIR/
+ENV JAVA_OPTS="-Djava.util.logging.config.file=$APP_DIR/logging-json.properties"
+
+# Server
+ENTRYPOINT ["bin/xds-test-server"]

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -32,6 +32,13 @@ dependencies {
     censusGrpcMetricDependency 'implementation'
     googleOauth2Dependency 'implementation'
     compileOnly libraries.javax_annotation
+    // TODO(sergiitk): replace with com.google.cloud:google-cloud-logging
+    // Used instead of google-cloud-logging because it's failing
+    // due to a circular dependency on grpc.
+    // https://cloud.google.com/logging/docs/setup/java#the_javautillogging_handler
+    // Error example: "java.util.logging.ErrorManager: 1"
+    // Latest failing version com.google.cloud:google-cloud-logging:2.1.2
+    runtimeOnly group: 'io.github.devatherock', name: 'jul-jsonformatter', version: '1.1.0'
     runtimeOnly libraries.opencensus_impl,
             libraries.netty_tcnative,
             project(':grpc-grpclb')


### PR DESCRIPTION
Buildscript for xDS Kubernetes Interop security tests.

- Test Driver: https://github.com/grpc/grpc/tree/master/tools/run_tests/xds_k8s_test_driver#basic-usage
- Invocation examples (commit sha): [`225ab7b`](https://source.cloud.google.com/results/invocations/f68ccd84-b763-4363-86da-82ae98a0dd12/targets),  [`016af9e07`](https://source.cloud.google.com/results/invocations/7f31b781-3dd3-4c0a-9f77-b685d4bd8dd8/targets), [`9d60157`](https://source.cloud.google.com/results/invocations/0d65ffca-a946-48a6-991e-50260ba3f234/targets)
- Ref [Shell Style Guide](https://google.github.io/styleguide/shellguide.html)
