### PR TITLE
DelayedTransport shutdown race

### DIFF
--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -294,12 +294,10 @@ final class DelayedClientTransport implements ManagedClientTransport {
         if (callOptions.getExecutor() != null) {
           executor = callOptions.getExecutor();
         }
-        executor.execute(new Runnable() {
-            @Override
-            public void run() {
-              stream.createRealStream(transport);
-            }
-          });
+        Runnable runnable = stream.createRealStream(transport);
+        if (runnable != null) {
+          executor.execute(runnable);
+        }
         toRemove.add(stream);
       }  // else: stay pending
     }
@@ -346,7 +344,8 @@ final class DelayedClientTransport implements ManagedClientTransport {
       this.args = args;
     }
 
-    private void createRealStream(ClientTransport transport) {
+    /** Runnable may be null. */
+    private Runnable createRealStream(ClientTransport transport) {
       ClientStream realStream;
       Context origContext = context.attach();
       try {
@@ -355,7 +354,7 @@ final class DelayedClientTransport implements ManagedClientTransport {
       } finally {
         context.detach(origContext);
       }
-      setStream(realStream);
+      return setStream(realStream);
     }
 
     @Override

--- a/core/src/main/java/io/grpc/internal/MetadataApplierImpl.java
+++ b/core/src/main/java/io/grpc/internal/MetadataApplierImpl.java
@@ -95,7 +95,11 @@ final class MetadataApplierImpl extends MetadataApplier {
     // returnStream() has been called before me, thus delayedStream must have been
     // created.
     checkState(delayedStream != null, "delayedStream is null");
-    delayedStream.setStream(stream);
+    Runnable slow = delayedStream.setStream(stream);
+    if (slow != null) {
+      // TODO(ejona): run this on a separate thread
+      slow.run();
+    }
   }
 
   /**

--- a/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
@@ -315,6 +315,8 @@ public class DelayedClientTransportTest {
     // Fail-fast streams
     DelayedStream ff1 = (DelayedStream) delayedTransport.newStream(
         method, headers, failFastCallOptions);
+    ff1.start(mock(ClientStreamListener.class));
+    ff1.halfClose();
     PickSubchannelArgsImpl ff1args = new PickSubchannelArgsImpl(method, headers,
         failFastCallOptions);
     verify(transportListener).transportInUse(true);
@@ -345,6 +347,7 @@ public class DelayedClientTransportTest {
         wfr3Executor.getScheduledExecutorService());
     DelayedStream wfr3 = (DelayedStream) delayedTransport.newStream(
         method, headers, wfr3callOptions);
+    wfr3.halfClose();
     PickSubchannelArgsImpl wfr3args = new PickSubchannelArgsImpl(method, headers,
         wfr3callOptions);
     DelayedStream wfr4 = (DelayedStream) delayedTransport.newStream(
@@ -380,18 +383,22 @@ public class DelayedClientTransportTest {
     inOrder.verify(picker).pickSubchannel(wfr4args);
 
     inOrder.verifyNoMoreInteractions();
-    // Make sure that real transport creates streams in the executor
-    verify(mockRealTransport, never()).newStream(
-        any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class));
-    verify(mockRealTransport2, never()).newStream(
-        any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class));
-    fakeExecutor.runDueTasks();
-    assertEquals(0, fakeExecutor.numPendingTasks());
+    // Make sure that streams are created and started immediately, not in any executor. This is
+    // necessary during shut down to guarantee that when DelayedClientTransport terminates, all
+    // streams are now owned by a real transport (which should prevent the Channel from
+    // terminating).
     // ff1 and wfr1 went through
     verify(mockRealTransport).newStream(method, headers, failFastCallOptions);
     verify(mockRealTransport2).newStream(method, headers, waitForReadyCallOptions);
     assertSame(mockRealStream, ff1.getRealStream());
     assertSame(mockRealStream2, wfr1.getRealStream());
+    verify(mockRealStream).start(any(ClientStreamListener.class));
+    // But also verify that non-start()-related calls are run within the Executor, since they may be
+    // slow.
+    verify(mockRealStream, never()).halfClose();
+    fakeExecutor.runDueTasks();
+    assertEquals(0, fakeExecutor.numPendingTasks());
+    verify(mockRealStream).halfClose();
     // The ff2 has failed due to picker returning an error
     assertSame(Status.UNAVAILABLE, ((FailingClientStream) ff2.getRealStream()).getError());
     // Other streams are still buffered
@@ -430,10 +437,11 @@ public class DelayedClientTransportTest {
     assertSame(mockRealStream2, wfr2.getRealStream());
     assertSame(mockRealStream2, wfr4.getRealStream());
 
-    // If there is an executor in the CallOptions, it will be used to create the real stream.
-    assertNull(wfr3.getRealStream());
-    wfr3Executor.runDueTasks();
     assertSame(mockRealStream, wfr3.getRealStream());
+    // If there is an executor in the CallOptions, it will be used to create the real stream.
+    verify(mockRealStream, times(1)).halfClose(); // 1 for ff1
+    wfr3Executor.runDueTasks();
+    verify(mockRealStream, times(2)).halfClose();
 
     // New streams will use the last picker
     DelayedStream wfr5 = (DelayedStream) delayedTransport.newStream(

--- a/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
@@ -220,13 +220,6 @@ public class DelayedStreamTest {
   }
 
   @Test
-  public void setStreamThenCancelled() {
-    callMeMaybe(stream.setStream(realStream));
-    stream.cancel(Status.CANCELLED);
-    verify(realStream).cancel(same(Status.CANCELLED));
-  }
-
-  @Test
   public void setStreamTwice() {
     stream.start(listener);
     callMeMaybe(stream.setStream(realStream));
@@ -238,26 +231,17 @@ public class DelayedStreamTest {
 
   @Test
   public void cancelThenSetStream() {
+    stream.start(listener);
     stream.cancel(Status.CANCELLED);
     callMeMaybe(stream.setStream(realStream));
-    stream.start(listener);
     stream.isReady();
     verifyNoMoreInteractions(realStream);
   }
 
-  @Test
+  @Test(expected = IllegalStateException.class)
   public void cancel_beforeStart() {
     Status status = Status.CANCELLED.withDescription("that was quick");
     stream.cancel(status);
-    stream.start(listener);
-    verify(listener).closed(same(status), any(Metadata.class));
-  }
-
-  @Test
-  public void cancelledThenStart() {
-    stream.cancel(Status.CANCELLED);
-    stream.start(listener);
-    verify(listener).closed(eq(Status.CANCELLED), any(Metadata.class));
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
@@ -72,7 +72,7 @@ public class DelayedStreamTest {
     final String authority = "becauseIsaidSo";
     stream.setAuthority(authority);
     stream.start(listener);
-    stream.setStream(realStream);
+    callMeMaybe(stream.setStream(realStream));
     InOrder inOrder = inOrder(realStream);
     inOrder.verify(realStream).setAuthority(authority);
     inOrder.verify(realStream).start(any(ClientStreamListener.class));
@@ -92,9 +92,9 @@ public class DelayedStreamTest {
 
   @Test
   public void setStream_sendsAllMessages() {
-    stream.start(listener);
     stream.setCompressor(Codec.Identity.NONE);
     stream.setDecompressorRegistry(DecompressorRegistry.getDefaultInstance());
+    stream.start(listener);
 
     stream.setMessageCompression(true);
     InputStream message = new ByteArrayInputStream(new byte[]{'a'});
@@ -102,7 +102,7 @@ public class DelayedStreamTest {
     stream.setMessageCompression(false);
     stream.writeMessage(message);
 
-    stream.setStream(realStream);
+    callMeMaybe(stream.setStream(realStream));
 
     verify(realStream).setCompressor(Codec.Identity.NONE);
     verify(realStream).setDecompressorRegistry(DecompressorRegistry.getDefaultInstance());
@@ -125,7 +125,7 @@ public class DelayedStreamTest {
   public void setStream_halfClose() {
     stream.start(listener);
     stream.halfClose();
-    stream.setStream(realStream);
+    callMeMaybe(stream.setStream(realStream));
 
     verify(realStream).halfClose();
   }
@@ -134,7 +134,7 @@ public class DelayedStreamTest {
   public void setStream_flush() {
     stream.start(listener);
     stream.flush();
-    stream.setStream(realStream);
+    callMeMaybe(stream.setStream(realStream));
     verify(realStream).flush();
 
     stream.flush();
@@ -146,7 +146,7 @@ public class DelayedStreamTest {
     stream.start(listener);
     stream.request(1);
     stream.request(2);
-    stream.setStream(realStream);
+    callMeMaybe(stream.setStream(realStream));
     verify(realStream).request(1);
     verify(realStream).request(2);
 
@@ -158,7 +158,7 @@ public class DelayedStreamTest {
   public void setStream_setMessageCompression() {
     stream.start(listener);
     stream.setMessageCompression(false);
-    stream.setStream(realStream);
+    callMeMaybe(stream.setStream(realStream));
     verify(realStream).setMessageCompression(false);
 
     stream.setMessageCompression(true);
@@ -169,7 +169,7 @@ public class DelayedStreamTest {
   public void setStream_isReady() {
     stream.start(listener);
     assertFalse(stream.isReady());
-    stream.setStream(realStream);
+    callMeMaybe(stream.setStream(realStream));
     verify(realStream, never()).isReady();
 
     assertFalse(stream.isReady());
@@ -190,7 +190,7 @@ public class DelayedStreamTest {
 
     assertEquals(Attributes.EMPTY, stream.getAttributes());
 
-    stream.setStream(realStream);
+    callMeMaybe(stream.setStream(realStream));
     assertEquals(attributes, stream.getAttributes());
   }
 
@@ -204,7 +204,7 @@ public class DelayedStreamTest {
   @Test
   public void startThenSetStreamThenCancelled() {
     stream.start(listener);
-    stream.setStream(realStream);
+    callMeMaybe(stream.setStream(realStream));
     stream.cancel(Status.CANCELLED);
     verify(realStream).start(any(ClientStreamListener.class));
     verify(realStream).cancel(same(Status.CANCELLED));
@@ -212,7 +212,7 @@ public class DelayedStreamTest {
 
   @Test
   public void setStreamThenStartThenCancelled() {
-    stream.setStream(realStream);
+    callMeMaybe(stream.setStream(realStream));
     stream.start(listener);
     stream.cancel(Status.CANCELLED);
     verify(realStream).start(same(listener));
@@ -221,7 +221,7 @@ public class DelayedStreamTest {
 
   @Test
   public void setStreamThenCancelled() {
-    stream.setStream(realStream);
+    callMeMaybe(stream.setStream(realStream));
     stream.cancel(Status.CANCELLED);
     verify(realStream).cancel(same(Status.CANCELLED));
   }
@@ -229,9 +229,9 @@ public class DelayedStreamTest {
   @Test
   public void setStreamTwice() {
     stream.start(listener);
-    stream.setStream(realStream);
+    callMeMaybe(stream.setStream(realStream));
     verify(realStream).start(any(ClientStreamListener.class));
-    stream.setStream(mock(ClientStream.class));
+    callMeMaybe(stream.setStream(mock(ClientStream.class)));
     stream.flush();
     verify(realStream).flush();
   }
@@ -239,7 +239,7 @@ public class DelayedStreamTest {
   @Test
   public void cancelThenSetStream() {
     stream.cancel(Status.CANCELLED);
-    stream.setStream(realStream);
+    callMeMaybe(stream.setStream(realStream));
     stream.start(listener);
     stream.isReady();
     verifyNoMoreInteractions(realStream);
@@ -275,7 +275,7 @@ public class DelayedStreamTest {
 
     IsReadyListener isReadyListener = new IsReadyListener();
     stream.start(isReadyListener);
-    stream.setStream(new NoopClientStream() {
+    callMeMaybe(stream.setStream(new NoopClientStream() {
       @Override
       public void start(ClientStreamListener listener) {
         // This call to the listener should end up being delayed.
@@ -286,7 +286,7 @@ public class DelayedStreamTest {
       public boolean isReady() {
         return true;
       }
-    });
+    }));
     assertTrue(isReadyListener.onReadyCalled);
   }
 
@@ -302,7 +302,7 @@ public class DelayedStreamTest {
 
     final InOrder inOrder = inOrder(listener);
     stream.start(listener);
-    stream.setStream(new NoopClientStream() {
+    callMeMaybe(stream.setStream(new NoopClientStream() {
       @Override
       public void start(ClientStreamListener passedListener) {
         passedListener.onReady();
@@ -314,7 +314,7 @@ public class DelayedStreamTest {
 
         verifyNoMoreInteractions(listener);
       }
-    });
+    }));
     inOrder.verify(listener).onReady();
     inOrder.verify(listener).headersRead(headers);
     inOrder.verify(listener).messagesAvailable(producer1);
@@ -332,7 +332,7 @@ public class DelayedStreamTest {
     final Status status = Status.UNKNOWN.withDescription("unique status");
 
     stream.start(listener);
-    stream.setStream(realStream);
+    callMeMaybe(stream.setStream(realStream));
     verify(realStream).start(listenerCaptor.capture());
     ClientStreamListener delayedListener = listenerCaptor.getValue();
     delayedListener.onReady();
@@ -371,11 +371,17 @@ public class DelayedStreamTest {
         }
       }).when(realStream).appendTimeoutInsight(any(InsightBuilder.class));
     stream.start(listener);
-    stream.setStream(realStream);
+    callMeMaybe(stream.setStream(realStream));
 
     InsightBuilder insight = new InsightBuilder();
     stream.appendTimeoutInsight(insight);
     assertThat(insight.toString())
         .matches("\\[buffered_nanos=[0-9]+, remote_addr=127\\.0\\.0\\.1:443\\]");
+  }
+
+  private void callMeMaybe(Runnable r) {
+    if (r != null) {
+      r.run();
+    }
   }
 }


### PR DESCRIPTION
To fix #6283.
Change to be more explicit and fail fast on ClientStream calls order before and after start(), corresponding to configuration and RPC calls, respectively. This fixes the issue because it guarantees that removing from pendingStream in delayedClientTransport means it is safe to shutdown. If by the time pendingStream is processed, start() has not been called yet, nothing will drain because of the explicit strict call check, and the subsequent calls will directly execute on the realStream. This is guarded in the locking block.