### PR TITLE
Revert " check pending stream completion at delayed transport lifecycle"

### DIFF
--- a/core/src/main/java/io/grpc/internal/DelayedStream.java
+++ b/core/src/main/java/io/grpc/internal/DelayedStream.java
@@ -39,7 +39,7 @@ import javax.annotation.concurrent.GuardedBy;
  * DelayedStream} may be internally altered by different threads, thus internal synchronization is
  * necessary.
  */
-abstract class DelayedStream implements ClientStream {
+class DelayedStream implements ClientStream {
   /** {@code true} once realStream is valid and all pending calls have been drained. */
   private volatile boolean passThrough;
   /**
@@ -221,14 +221,12 @@ abstract class DelayedStream implements ClientStream {
 
     if (savedPassThrough) {
       realStream.start(listener);
-      onTransferComplete();
     } else {
       final ClientStreamListener finalListener = listener;
       delayOrExecute(new Runnable() {
         @Override
         public void run() {
           realStream.start(finalListener);
-          onTransferComplete();
         }
       });
     }
@@ -304,7 +302,6 @@ abstract class DelayedStream implements ClientStream {
         listenerToClose.closed(reason, new Metadata());
       }
       drainPendingCalls();
-      onTransferComplete();
     }
   }
 
@@ -409,12 +406,6 @@ abstract class DelayedStream implements ClientStream {
   ClientStream getRealStream() {
     return realStream;
   }
-
-  /**
-   * Provides the place to define actions at the point when transfer is done.
-   * Call this method to trigger those transfer completion activities.
-   */
-  abstract void onTransferComplete();
 
   private static class DelayedStreamListener implements ClientStreamListener {
     private final ClientStreamListener realListener;

--- a/core/src/main/java/io/grpc/internal/MetadataApplierImpl.java
+++ b/core/src/main/java/io/grpc/internal/MetadataApplierImpl.java
@@ -47,7 +47,7 @@ final class MetadataApplierImpl extends MetadataApplier {
   boolean finalized;
 
   // not null if returnStream() was called before apply()
-  ApplierDelayedStream delayedStream;
+  DelayedStream delayedStream;
 
   MetadataApplierImpl(
       ClientTransport transport, MethodDescriptor<?, ?> method, Metadata origHeaders,
@@ -105,16 +105,11 @@ final class MetadataApplierImpl extends MetadataApplier {
     synchronized (lock) {
       if (returnedStream == null) {
         // apply() has not been called, needs to buffer the requests.
-        delayedStream = new ApplierDelayedStream();
+        delayedStream = new DelayedStream();
         return returnedStream = delayedStream;
       } else {
         return returnedStream;
       }
     }
-  }
-
-  private static class ApplierDelayedStream extends DelayedStream {
-    @Override
-    void onTransferComplete() {}
   }
 }

--- a/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
@@ -65,7 +65,7 @@ public class DelayedStreamTest {
   @Mock private ClientStreamListener listener;
   @Mock private ClientStream realStream;
   @Captor private ArgumentCaptor<ClientStreamListener> listenerCaptor;
-  private DelayedStream stream = new SimpleDelayedStream();
+  private DelayedStream stream = new DelayedStream();
 
   @Test
   public void setStream_setAuthority() {
@@ -377,11 +377,5 @@ public class DelayedStreamTest {
     stream.appendTimeoutInsight(insight);
     assertThat(insight.toString())
         .matches("\\[buffered_nanos=[0-9]+, remote_addr=127\\.0\\.0\\.1:443\\]");
-  }
-
-  private static class SimpleDelayedStream extends DelayedStream {
-    @Override
-    void onTransferComplete() {
-    }
   }
 }


### PR DESCRIPTION
Reverts grpc/grpc-java#7720 
in favor of alternative https://github.com/grpc/grpc-java/pull/7743 to fix the same problem.