### PR TITLE
api,core: Add ServerInterceptor2 interface

### DIFF
--- a/api/src/main/java/io/grpc/ForwardingServerBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingServerBuilder.java
@@ -78,6 +78,12 @@ abstract class ForwardingServerBuilder<T extends ServerBuilder<T>> extends Serve
   }
 
   @Override
+  public T intercept(ServerInterceptor2 interceptor) {
+    delegate().intercept(interceptor);
+    return thisT();
+  }
+
+  @Override
   public T addTransportFilter(ServerTransportFilter filter) {
     delegate().addTransportFilter(filter);
     return thisT();

--- a/api/src/main/java/io/grpc/ServerBuilder.java
+++ b/api/src/main/java/io/grpc/ServerBuilder.java
@@ -105,6 +105,22 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
   }
 
   /**
+   * Adds a {@link ServerInterceptor2} that is run for all services on the server.  Interceptors
+   * added through this method always run before per-service interceptors added through {@link
+   * ServerInterceptors} and any interceptors added through {@link #intercept(ServerInterceptor)}.
+   * Interceptors run in the reverse order in which they are added, just as with consecutive calls
+   * to {@code ServerInterceptors.intercept()}.
+   *
+   * @param interceptor the all-service interceptor
+   * @return this
+   * @since 1.35.0
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/????")
+  public T intercept(ServerInterceptor2 interceptor) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Adds a {@link ServerTransportFilter}. The order of filters being added is the order they will
    * be executed.
    *

--- a/api/src/main/java/io/grpc/ServerInterceptor2.java
+++ b/api/src/main/java/io/grpc/ServerInterceptor2.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Interface for intercepting server calls by modifying the {@link ServerMethodDefinition} after
+ * method lookup and before call dispatch. This provides a superset of the functionality offered by
+ * {@link ServerInterceptor}.
+ */
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/????")
+@ThreadSafe
+public interface ServerInterceptor2 {
+  /**
+   * Intercept and modify the {@link ServerMethodDefinition}.
+   *
+   * <p>The returned ServerMethodDefinition cannot be null and implementations must not throw.
+   */
+  <ReqT, RespT> ServerMethodDefinition<ReqT, RespT> interceptMethodDefinition(
+      ServerMethodDefinition<ReqT, RespT> method);
+}

--- a/api/src/main/java/io/grpc/ServerMethodDefinition.java
+++ b/api/src/main/java/io/grpc/ServerMethodDefinition.java
@@ -16,6 +16,9 @@
 
 package io.grpc;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Definition of a method exposed by a {@link Server}.
  *
@@ -24,11 +27,13 @@ package io.grpc;
 public final class ServerMethodDefinition<ReqT, RespT> {
   private final MethodDescriptor<ReqT, RespT> method;
   private final ServerCallHandler<ReqT, RespT> handler;
+  private final List<ServerStreamTracer.Factory> streamTracerFactories;
 
   private ServerMethodDefinition(MethodDescriptor<ReqT, RespT> method,
       ServerCallHandler<ReqT, RespT> handler) {
     this.method = method;
     this.handler = handler;
+    this.streamTracerFactories = new ArrayList<>();
   }
 
   /**
@@ -63,5 +68,17 @@ public final class ServerMethodDefinition<ReqT, RespT> {
   public ServerMethodDefinition<ReqT, RespT> withServerCallHandler(
       ServerCallHandler<ReqT, RespT> handler) {
     return new ServerMethodDefinition<>(method, handler);
+  }
+
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/????")
+  public ServerMethodDefinition<ReqT, RespT>
+      addStreamTracerFactory(ServerStreamTracer.Factory factory) {
+    streamTracerFactories.add(factory);
+    return this;
+  }
+
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/????")
+  public List<? extends ServerStreamTracer.Factory> getStreamTracerFactories() {
+    return streamTracerFactories;
   }
 }

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -25,6 +25,7 @@ import io.grpc.HandlerRegistry;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptor;
+import io.grpc.ServerInterceptor2;
 import io.grpc.ServerServiceDefinition;
 import io.grpc.ServerStreamTracer;
 import io.grpc.ServerTransportFilter;
@@ -87,6 +88,12 @@ public abstract class AbstractServerImplBuilder
 
   @Override
   public T intercept(ServerInterceptor interceptor) {
+    delegate().intercept(interceptor);
+    return thisT();
+  }
+
+  @Override
+  public T intercept(ServerInterceptor2 interceptor) {
     delegate().intercept(interceptor);
     return thisT();
   }

--- a/core/src/main/java/io/grpc/internal/ServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ServerImplBuilder.java
@@ -32,6 +32,7 @@ import io.grpc.InternalChannelz;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptor;
+import io.grpc.ServerInterceptor2;
 import io.grpc.ServerMethodDefinition;
 import io.grpc.ServerServiceDefinition;
 import io.grpc.ServerStreamTracer;
@@ -75,6 +76,7 @@ public final class ServerImplBuilder extends ServerBuilder<ServerImplBuilder> {
       new InternalHandlerRegistry.Builder();
   final List<ServerTransportFilter> transportFilters = new ArrayList<>();
   final List<ServerInterceptor> interceptors = new ArrayList<>();
+  final List<ServerInterceptor2> interceptors2 = new ArrayList<>();
   private final List<ServerStreamTracer.Factory> streamTracerFactories = new ArrayList<>();
   private final ClientTransportServersBuilder clientTransportServersBuilder;
   HandlerRegistry fallbackRegistry = DEFAULT_FALLBACK_REGISTRY;
@@ -140,6 +142,12 @@ public final class ServerImplBuilder extends ServerBuilder<ServerImplBuilder> {
   @Override
   public ServerImplBuilder intercept(ServerInterceptor interceptor) {
     interceptors.add(checkNotNull(interceptor, "interceptor"));
+    return this;
+  }
+
+  @Override
+  public ServerImplBuilder intercept(ServerInterceptor2 interceptor) {
+    interceptors2.add(checkNotNull(interceptor, "interceptor"));
     return this;
   }
 

--- a/core/src/test/java/io/grpc/internal/AbstractTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractTransportTest.java
@@ -872,6 +872,7 @@ public abstract class AbstractTransportTest {
       assertThat(clientStreamTracer1.getOutboundWireSize()).isEqualTo(0L);
       assertThat(clientStreamTracer1.getOutboundUncompressedSize()).isEqualTo(0L);
     }
+    serverStream.statsTraceContext().serverCallStarted(serverStreamTracer1.getServerCallInfo());
     assertThat(serverStreamTracer1.nextInboundEvent()).isEqualTo("inboundMessage(0)");
     assertNull("no additional message expected", serverStreamListener.messageQueue.poll());
 

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -68,6 +68,7 @@ import io.grpc.ServerCall;
 import io.grpc.ServerCall.Listener;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
+import io.grpc.ServerInterceptor2;
 import io.grpc.ServerMethodDefinition;
 import io.grpc.ServerServiceDefinition;
 import io.grpc.ServerStreamTracer;
@@ -698,6 +699,48 @@ public class ServerImplTest {
     final Context.Key<String> key1 = Context.key("key1");
     final Context.Key<String> key2 = Context.key("key2");
     final Context.Key<String> key3 = Context.key("key3");
+    final Context.Key<String> serverInterceptor2_handlerKey =
+            Context.key("serverInterceptor2_handlerKey");
+    final Context.Key<String> serverInterceptor2_tracerKey =
+        Context.key("serverInterceptor2_tracerKey");
+
+    final TestServerStreamTracer streamTracer = new TestServerStreamTracer() {
+      @Override
+      public Context filterContext(Context context) {
+        Context newCtx = super.filterContext(context);
+        return newCtx
+            .withValue(serverInterceptor2_tracerKey, "serverInterceptor2_tracerKey");
+      }
+    };
+    final ServerStreamTracer.Factory streamTracerFactory = new ServerStreamTracer.Factory() {
+      @Override
+      public ServerStreamTracer newServerStreamTracer(String fullMethodName, Metadata headers) {
+        return streamTracer;
+      }
+    };
+    ServerInterceptor2 serverInterceptor2 = new ServerInterceptor2() {
+      @Override
+      public <ReqT, RespT> ServerMethodDefinition<ReqT, RespT>
+          interceptMethodDefinition(final ServerMethodDefinition<ReqT, RespT> method) {
+        final ServerCallHandler<ReqT, RespT> handler = method.getServerCallHandler();
+        return method.withServerCallHandler(new ServerCallHandler<ReqT, RespT>() {
+          @Override
+          public ServerCall.Listener<ReqT>
+              startCall(ServerCall<ReqT, RespT> call, Metadata headers) {
+            Context ctx =
+                Context.current().withValue(serverInterceptor2_handlerKey,
+                "serverInterceptor2_handlerKey");
+            Context origCtx = ctx.attach();
+            try {
+              capturedContexts.add(ctx);
+              return handler.startCall(call, headers);
+            } finally {
+              ctx.detach(origCtx);
+            }
+          }
+        }).addStreamTracerFactory(streamTracerFactory);
+      }
+    };
     ServerInterceptor interceptor1 = new ServerInterceptor() {
         @Override
         public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
@@ -743,6 +786,7 @@ public class ServerImplTest {
     mutableFallbackRegistry.addService(
         ServerServiceDefinition.builder(new ServiceDescriptor("Waiter", METHOD))
             .addMethod(METHOD, callHandler).build());
+    builder.intercept(serverInterceptor2);
     builder.intercept(interceptor2);
     builder.intercept(interceptor1);
     createServer();
@@ -761,19 +805,29 @@ public class ServerImplTest {
     assertEquals(1, executor.runDueTasks());
 
     Context ctx1 = capturedContexts.poll();
-    assertEquals("value1", key1.get(ctx1));
+    assertEquals("serverInterceptor2_tracerKey", serverInterceptor2_tracerKey.get(ctx1));
+    assertEquals("serverInterceptor2_handlerKey", serverInterceptor2_handlerKey.get(ctx1));
+    assertNull(key1.get(ctx1));
     assertNull(key2.get(ctx1));
     assertNull(key3.get(ctx1));
 
     Context ctx2 = capturedContexts.poll();
+    assertEquals("serverInterceptor2_handlerKey", serverInterceptor2_handlerKey.get(ctx2));
     assertEquals("value1", key1.get(ctx2));
-    assertEquals("value2", key2.get(ctx2));
+    assertNull(key2.get(ctx2));
     assertNull(key3.get(ctx2));
 
     Context ctx3 = capturedContexts.poll();
+    assertEquals("serverInterceptor2_handlerKey", serverInterceptor2_handlerKey.get(ctx3));
     assertEquals("value1", key1.get(ctx3));
     assertEquals("value2", key2.get(ctx3));
-    assertEquals("value3", key3.get(ctx3));
+    assertNull(key3.get(ctx3));
+
+    Context ctx4 = capturedContexts.poll();
+    assertEquals("serverInterceptor2_handlerKey", serverInterceptor2_handlerKey.get(ctx4));
+    assertEquals("value1", key1.get(ctx4));
+    assertEquals("value2", key2.get(ctx4));
+    assertEquals("value3", key3.get(ctx4));
 
     assertTrue(capturedContexts.isEmpty());
   }
@@ -1204,7 +1258,7 @@ public class ServerImplTest {
             Context.ROOT.withCancellation(),
             PerfMark.createTag());
     ServerStreamListener mockListener = mock(ServerStreamListener.class);
-    listener.setListener(mockListener);
+    listener.setListener(mockListener, Context.ROOT.withCancellation());
 
     TestError expectedT = new TestError();
     doThrow(expectedT).when(mockListener)
@@ -1230,7 +1284,7 @@ public class ServerImplTest {
             Context.ROOT.withCancellation(),
             PerfMark.createTag());
     ServerStreamListener mockListener = mock(ServerStreamListener.class);
-    listener.setListener(mockListener);
+    listener.setListener(mockListener, Context.ROOT.withCancellation());
 
     RuntimeException expectedT = new RuntimeException();
     doThrow(expectedT).when(mockListener)
@@ -1256,7 +1310,7 @@ public class ServerImplTest {
             Context.ROOT.withCancellation(),
             PerfMark.createTag());
     ServerStreamListener mockListener = mock(ServerStreamListener.class);
-    listener.setListener(mockListener);
+    listener.setListener(mockListener, Context.ROOT.withCancellation());
 
     TestError expectedT = new TestError();
     doThrow(expectedT).when(mockListener).halfClosed();
@@ -1280,7 +1334,7 @@ public class ServerImplTest {
             Context.ROOT.withCancellation(),
             PerfMark.createTag());
     ServerStreamListener mockListener = mock(ServerStreamListener.class);
-    listener.setListener(mockListener);
+    listener.setListener(mockListener, Context.ROOT.withCancellation());
 
     RuntimeException expectedT = new RuntimeException();
     doThrow(expectedT).when(mockListener).halfClosed();
@@ -1304,7 +1358,7 @@ public class ServerImplTest {
             Context.ROOT.withCancellation(),
             PerfMark.createTag());
     ServerStreamListener mockListener = mock(ServerStreamListener.class);
-    listener.setListener(mockListener);
+    listener.setListener(mockListener, Context.ROOT.withCancellation());
 
     TestError expectedT = new TestError();
     doThrow(expectedT).when(mockListener).onReady();
@@ -1328,7 +1382,7 @@ public class ServerImplTest {
             Context.ROOT.withCancellation(),
             PerfMark.createTag());
     ServerStreamListener mockListener = mock(ServerStreamListener.class);
-    listener.setListener(mockListener);
+    listener.setListener(mockListener, Context.ROOT.withCancellation());
 
     RuntimeException expectedT = new RuntimeException();
     doThrow(expectedT).when(mockListener).onReady();


### PR DESCRIPTION
`ServerInterceptor2` allows rewriting the `ServerMethodDefinition`. This accommodates, among other things, setting stream tracers on the `ServerMethodDefinition` as part of an interceptor, rather than requiring stream tracer factories to be added directly to the server builder prior to construction.

Since some aspects of the stats trace context are currently created when the stream begins and before method handler lookup has occurred, which means any stream tracers attached via a `ServerInterceptor2` must be invoked later, after method lookup. And one of the abilities of a server stream tracer is filtering the context in which the call will take place. This PR rewires things in `ServerImpl` to accomodate a (partially) delayed creation of the stats trace context itself and the context in which the call operates.

Notes for review:

1) The `StatsTraceContext` class already had several client-specific and server-specific methods. This PR adds more. It is probably worthwhile splitting the class into a ClientStatsTraceContext and ServerStatsTraceContext.
1) Looking at it now, the Javadoc for `ServerBuilder#intercept(io.grpc.ServerInterceptor2)`is confusing when discussing "order" in relation to the existing `ServerInterceptor`, as the `ServerInterceptor2` API is actually invoked prior to the call starting, so outside of the `ServerInteceptor#startCall` ordering entirely - but `ServerInterceptor2` can still rewrite the `ServerCallHandler` to mimic the operation of a `ServerInterceptor`.