### PR TITLE
core: Include wait-for-ready in deadline exceeded insights

### DIFF
--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -375,5 +375,13 @@ final class DelayedClientTransport implements ManagedClientTransport {
       }
       syncContext.drain();
     }
+
+    @Override
+    public void appendTimeoutInsight(InsightBuilder insight) {
+      if (args.getCallOptions().isWaitForReady()) {
+        insight.append("wait_for_ready");
+      }
+      super.appendTimeoutInsight(insight);
+    }
   }
 }

--- a/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
@@ -16,6 +16,7 @@
 
 package io.grpc.internal;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -598,6 +599,17 @@ public class DelayedClientTransportTest {
     stream.start(streamListener);
     assertTrue(delayedTransport.hasPendingStreams());
     verify(transportListener).transportInUse(true);
+  }
+
+  @Test
+  public void pendingStream_appendTimeoutInsight_waitForReady() {
+    ClientStream stream = delayedTransport.newStream(
+        method, headers, callOptions.withWaitForReady());
+    stream.start(streamListener);
+    InsightBuilder insight = new InsightBuilder();
+    stream.appendTimeoutInsight(insight);
+    assertThat(insight.toString())
+        .matches("\\[wait_for_ready, buffered_nanos=[0-9]+\\, waiting_for_connection]");
   }
 
   private static TransportProvider newTransportProvider(final ClientTransport transport) {


### PR DESCRIPTION
There was a report from a user in b/176088054 that experienced an RPC
waiting_for_connection that failed after 45 minutes due to deadline.
That would be quite normal for wait-for-ready, but because we didn't
include that detail in the status we have to do code inspection to
determine if wait-for-ready was enabled.

CC @zhangkun83 