### PR TITLE
avoid split big data frame by WeightedFairQueueByteDistributor.allocationQuantum

### DIFF
--- a/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
+++ b/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
@@ -99,6 +99,21 @@ abstract class AbstractNettyHandler extends GrpcHttp2ConnectionHandler {
     return ctx;
   }
 
+  protected static int getDistributorAllocationQuantum() {
+    int quantum = 16 * 1024;
+    try {
+      quantum = Integer.parseInt(
+          System.getProperty("io.grpc.netty.distributorAllocationQuantum",
+              Integer.toString(quantum)));
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          "io.grpc.netty.distributorAllocationQuantum must be integer");
+    }
+    Preconditions
+        .checkArgument(quantum > 0, "io.grpc.netty.distributorAllocationQuantum must be positive");
+    return quantum;
+  }
+
   /**
    * Sends initial connection window to the remote endpoint if necessary.
    */

--- a/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
+++ b/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
@@ -100,15 +100,7 @@ abstract class AbstractNettyHandler extends GrpcHttp2ConnectionHandler {
   }
 
   protected static int getDistributorAllocationQuantum() {
-    int quantum = 16 * 1024;
-    try {
-      quantum = Integer.parseInt(
-          System.getProperty("io.grpc.netty.distributorAllocationQuantum",
-              Integer.toString(quantum)));
-    } catch (NumberFormatException e) {
-      throw new IllegalArgumentException(
-          "io.grpc.netty.distributorAllocationQuantum must be integer");
-    }
+    int quantum = Integer.getInteger("io.grpc.netty.distributorAllocationQuantum", 16 * 1024);
     Preconditions
         .checkArgument(quantum > 0, "io.grpc.netty.distributorAllocationQuantum must be positive");
     return quantum;

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -149,7 +149,7 @@ class NettyClientHandler extends AbstractNettyHandler {
     Http2FrameWriter frameWriter = new DefaultHttp2FrameWriter();
     Http2Connection connection = new DefaultHttp2Connection(false);
     WeightedFairQueueByteDistributor dist = new WeightedFairQueueByteDistributor(connection);
-    dist.allocationQuantum(16 * 1024); // Make benchmarks fast again.
+    dist.allocationQuantum(getDistributorAllocationQuantum()); // Make benchmarks fast again.
     DefaultHttp2RemoteFlowController controller =
         new DefaultHttp2RemoteFlowController(connection, dist);
     connection.remote().flowController(controller);

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -212,7 +212,7 @@ class NettyServerHandler extends AbstractNettyHandler {
 
     final Http2Connection connection = new DefaultHttp2Connection(true);
     WeightedFairQueueByteDistributor dist = new WeightedFairQueueByteDistributor(connection);
-    dist.allocationQuantum(16 * 1024); // Make benchmarks fast again.
+    dist.allocationQuantum(getDistributorAllocationQuantum()); // Make benchmarks fast again.
     DefaultHttp2RemoteFlowController controller =
         new DefaultHttp2RemoteFlowController(connection, dist);
     connection.remote().flowController(controller);


### PR DESCRIPTION
fix for #7760 , add system property "io.grpc.netty.distributorAllocationQuantum" for WeightedFairQueueByteDistributor.allocationQuantum function