### PR TITLE
Log expected STREAM_CLOSED exceptions for already closed streams at FINE level

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -532,13 +532,13 @@ class NettyServerHandler extends AbstractNettyHandler {
   @Override
   protected void onStreamError(ChannelHandlerContext ctx, boolean outbound, Throwable cause,
       StreamException http2Ex) {
+    NettyServerStream.TransportState serverStream = serverStream(
+        connection().stream(Http2Exception.streamId(http2Ex)));
     Level level = Level.WARNING;
     if (serverStream == null && http2Ex.error() == Http2Error.STREAM_CLOSED) {
       level = Level.FINE;
     }
     logger.log(level, "Stream Error", cause);
-    NettyServerStream.TransportState serverStream = serverStream(
-        connection().stream(Http2Exception.streamId(http2Ex)));
     Tag tag = serverStream != null ? serverStream.tag() : PerfMark.createTag();
     PerfMark.startTask("NettyServerHandler.onStreamError", tag);
     try {

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -532,7 +532,8 @@ class NettyServerHandler extends AbstractNettyHandler {
   @Override
   protected void onStreamError(ChannelHandlerContext ctx, boolean outbound, Throwable cause,
       StreamException http2Ex) {
-    logger.log(Level.WARNING, "Stream Error", cause);
+    Level level = http2Ex.error() == Http2Error.STREAM_CLOSED ? Level.FINE : Level.WARNING;
+    logger.log(level, "Stream Error", cause);
     NettyServerStream.TransportState serverStream = serverStream(
         connection().stream(Http2Exception.streamId(http2Ex)));
     Tag tag = serverStream != null ? serverStream.tag() : PerfMark.createTag();

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -532,7 +532,10 @@ class NettyServerHandler extends AbstractNettyHandler {
   @Override
   protected void onStreamError(ChannelHandlerContext ctx, boolean outbound, Throwable cause,
       StreamException http2Ex) {
-    Level level = http2Ex.error() == Http2Error.STREAM_CLOSED ? Level.FINE : Level.WARNING;
+    Level level = Level.WARNING;
+    if (serverStream == null && http2Ex.error() == Http2Error.STREAM_CLOSED) {
+      level = Level.FINE;
+    }
     logger.log(level, "Stream Error", cause);
     NettyServerStream.TransportState serverStream = serverStream(
         connection().stream(Http2Exception.streamId(http2Ex)));


### PR DESCRIPTION
See this PR in netty: https://github.com/netty/netty/pull/9798 . It's possible that one peer has closed the stream, yet another frame from peers arrives after it. This is largely harmless, as explained in the PR from netty repository. If we don't do this, the log will be polluted with these harmless logs. 