### PR TITLE
xds: fix LB policy address and balancing state update propagations

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
@@ -242,19 +242,20 @@ class ClusterManagerLoadBalancer extends LoadBalancer {
     private final class ChildLbStateHelper extends ForwardingLoadBalancerHelper {
 
       @Override
-      public void updateBalancingState(ConnectivityState newState, SubchannelPicker newPicker) {
-        currentState = newState;
-        currentPicker = newPicker;
-        // Subchannel picker and state are saved, but will only be propagated to the channel
-        // when the child instance exits deactivated state.
-        if (!deactivated) {
-          syncContext.execute(new Runnable() {
-            @Override
-            public void run() {
+      public void updateBalancingState(final ConnectivityState newState,
+          final SubchannelPicker newPicker) {
+        syncContext.execute(new Runnable() {
+          @Override
+          public void run() {
+            currentState = newState;
+            currentPicker = newPicker;
+            // Subchannel picker and state are saved, but will only be propagated to the channel
+            // when the child instance exits deactivated state.
+            if (!deactivated) {
               updateOverallBalancingState();
             }
-          });
-        }
+          }
+        });
       }
 
       @Override

--- a/xds/src/main/java/io/grpc/xds/PriorityLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/PriorityLoadBalancer.java
@@ -269,20 +269,21 @@ final class PriorityLoadBalancer extends LoadBalancer {
 
     final class ChildHelper extends ForwardingLoadBalancerHelper {
       @Override
-      public void updateBalancingState(ConnectivityState newState, SubchannelPicker newPicker) {
-        connectivityState = newState;
-        picker = newPicker;
-        if (deletionTimer != null && deletionTimer.isPending()) {
-          return;
-        }
-        if (failOverTimer.isPending()) {
-          if (newState.equals(READY) || newState.equals(TRANSIENT_FAILURE)) {
-            failOverTimer.cancel();
-          }
-        }
+      public void updateBalancingState(final ConnectivityState newState,
+          final SubchannelPicker newPicker) {
         syncContext.execute(new Runnable() {
           @Override
           public void run() {
+            connectivityState = newState;
+            picker = newPicker;
+            if (deletionTimer != null && deletionTimer.isPending()) {
+              return;
+            }
+            if (failOverTimer.isPending()) {
+              if (newState.equals(READY) || newState.equals(TRANSIENT_FAILURE)) {
+                failOverTimer.cancel();
+              }
+            }
             tryNextPriority(true);
           }
         });

--- a/xds/src/main/java/io/grpc/xds/WeightedTargetLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedTargetLoadBalancer.java
@@ -28,6 +28,7 @@ import io.grpc.ConnectivityState;
 import io.grpc.InternalLogId;
 import io.grpc.LoadBalancer;
 import io.grpc.Status;
+import io.grpc.SynchronizationContext;
 import io.grpc.util.ForwardingLoadBalancerHelper;
 import io.grpc.util.GracefulSwitchLoadBalancer;
 import io.grpc.xds.WeightedRandomPicker.WeightedChildPicker;
@@ -48,11 +49,13 @@ final class WeightedTargetLoadBalancer extends LoadBalancer {
   private final Map<String, GracefulSwitchLoadBalancer> childBalancers = new HashMap<>();
   private final Map<String, ChildHelper> childHelpers = new HashMap<>();
   private final Helper helper;
+  private final SynchronizationContext syncContext;
 
   private Map<String, WeightedPolicySelection> targets = ImmutableMap.of();
 
   WeightedTargetLoadBalancer(Helper helper) {
-    this.helper = helper;
+    this.helper = checkNotNull(helper, "helper");
+    this.syncContext = checkNotNull(helper.getSynchronizationContext(), "syncContext");
     logger = XdsLogger.withLogId(
         InternalLogId.allocate("weighted-target-lb", helper.getAuthority()));
     logger.log(XdsLogLevel.INFO, "Created");
@@ -63,10 +66,8 @@ final class WeightedTargetLoadBalancer extends LoadBalancer {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     Object lbConfig = resolvedAddresses.getLoadBalancingPolicyConfig();
     checkNotNull(lbConfig, "missing weighted_target lb config");
-
     WeightedTargetConfig weightedTargetConfig = (WeightedTargetConfig) lbConfig;
     Map<String, WeightedPolicySelection> newTargets = weightedTargetConfig.targets;
-
     for (String targetName : newTargets.keySet()) {
       WeightedPolicySelection weightedChildLbConfig = newTargets.get(targetName);
       if (!targets.containsKey(targetName)) {
@@ -81,9 +82,7 @@ final class WeightedTargetLoadBalancer extends LoadBalancer {
             .switchTo(weightedChildLbConfig.policySelection.getProvider());
       }
     }
-
     targets = newTargets;
-
     for (String targetName : targets.keySet()) {
       childBalancers.get(targetName).handleResolvedAddresses(
           resolvedAddresses.toBuilder()
@@ -101,6 +100,7 @@ final class WeightedTargetLoadBalancer extends LoadBalancer {
     }
     childBalancers.keySet().retainAll(targets.keySet());
     childHelpers.keySet().retainAll(targets.keySet());
+    updateOverallBalancingState();
   }
 
   @Override
@@ -183,7 +183,12 @@ final class WeightedTargetLoadBalancer extends LoadBalancer {
     public void updateBalancingState(ConnectivityState newState, SubchannelPicker newPicker) {
       currentState = newState;
       currentPicker = newPicker;
-      updateOverallBalancingState();
+      syncContext.execute(new Runnable() {
+        @Override
+        public void run() {
+          updateOverallBalancingState();
+        }
+      });
     }
 
     @Override

--- a/xds/src/main/java/io/grpc/xds/WeightedTargetLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedTargetLoadBalancer.java
@@ -180,12 +180,13 @@ final class WeightedTargetLoadBalancer extends LoadBalancer {
     SubchannelPicker currentPicker = BUFFER_PICKER;
 
     @Override
-    public void updateBalancingState(ConnectivityState newState, SubchannelPicker newPicker) {
-      currentState = newState;
-      currentPicker = newPicker;
+    public void updateBalancingState(final ConnectivityState newState,
+        final SubchannelPicker newPicker) {
       syncContext.execute(new Runnable() {
         @Override
         public void run() {
+          currentState = newState;
+          currentPicker = newPicker;
           updateOverallBalancingState();
         }
       });

--- a/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
@@ -41,6 +41,7 @@ import io.grpc.Metadata;
 import io.grpc.NameResolver;
 import io.grpc.Status;
 import io.grpc.Status.Code;
+import io.grpc.SynchronizationContext;
 import io.grpc.internal.ObjectPool;
 import io.grpc.internal.ServiceConfigUtil.PolicySelection;
 import io.grpc.xds.ClusterImplLoadBalancerProvider.ClusterImplConfig;
@@ -86,6 +87,13 @@ public class ClusterImplLoadBalancerTest {
   private static final String CLUSTER = "cluster-foo.googleapis.com";
   private static final String EDS_SERVICE_NAME = "service.googleapis.com";
   private static final String LRS_SERVER_NAME = "";
+  private final SynchronizationContext syncContext = new SynchronizationContext(
+      new Thread.UncaughtExceptionHandler() {
+        @Override
+        public void uncaughtException(Thread t, Throwable e) {
+          throw new AssertionError(e);
+        }
+      });
   private final Locality locality =
       new Locality("test-region", "test-zone", "test-subzone");
   private final PolicySelection roundRobin =
@@ -583,6 +591,12 @@ public class ClusterImplLoadBalancerTest {
   }
 
   private final class FakeLbHelper extends LoadBalancer.Helper {
+
+    @Override
+    public SynchronizationContext getSynchronizationContext() {
+      return syncContext;
+    }
+
     @Override
     public void updateBalancingState(
         @Nonnull ConnectivityState newState, @Nonnull SubchannelPicker newPicker) {

--- a/xds/src/test/java/io/grpc/xds/ClusterManagerLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterManagerLoadBalancerTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import io.grpc.CallOptions;
 import io.grpc.ConnectivityState;
 import io.grpc.EquivalentAddressGroup;
@@ -147,6 +146,7 @@ public class ClusterManagerLoadBalancerTest {
     assertThat(childBalancer3.name).isEqualTo("policy_c");
     assertThat(childBalancer3.config).isEqualTo(lbConfigInventory.get("childC"));
 
+    // delayed policy_b deletion
     fakeClock.forwardTime(
         ClusterManagerLoadBalancer.DELAYED_CHILD_DELETION_TIME_MINUTES, TimeUnit.MINUTES);
     assertThat(childBalancer2.shutdown).isTrue();
@@ -176,36 +176,41 @@ public class ClusterManagerLoadBalancerTest {
   }
 
   @Test
-  public void updateBalancingStateFromDeactivatedChildBalancer() {
-    FakeLoadBalancer balancer = deliverAddressesAndUpdateToRemoveChildPolicy("childA", "policy_a");
+  public void ignoreBalancingStateUpdateForDeactivatedChildLbs() {
+    deliverResolvedAddresses(ImmutableMap.of("childA", "policy_a", "childB", "policy_b"));
+    deliverResolvedAddresses(ImmutableMap.of("childB", "policy_b"));
+    FakeLoadBalancer childBalancer1 = childBalancers.get(0);  // policy_a (deactivated)
     Subchannel subchannel = mock(Subchannel.class);
-    balancer.deliverSubchannelState(subchannel, ConnectivityState.READY);
+    childBalancer1.deliverSubchannelState(subchannel, ConnectivityState.READY);
     verify(helper, never()).updateBalancingState(
         eq(ConnectivityState.READY), any(SubchannelPicker.class));
 
-    deliverResolvedAddresses(ImmutableMap.of("childA", "policy_a"));
+    // reactivate policy_a
+    deliverResolvedAddresses(ImmutableMap.of("childA", "policy_a", "childB", "policy_b"));
     verify(helper).updateBalancingState(eq(ConnectivityState.READY), pickerCaptor.capture());
     assertThat(pickSubchannel(pickerCaptor.getValue(), "childA").getSubchannel())
         .isEqualTo(subchannel);
   }
 
   @Test
-  public void errorPropagation() {
-    Status error = Status.UNAVAILABLE.withDescription("resolver error");
-    clusterManagerLoadBalancer.handleNameResolutionError(error);
+  public void handleNameResolutionError_beforeChildLbsInstantiated_returnErrorPicker() {
+    clusterManagerLoadBalancer.handleNameResolutionError(
+        Status.UNAVAILABLE.withDescription("resolver error"));
     verify(helper).updateBalancingState(
         eq(ConnectivityState.TRANSIENT_FAILURE), pickerCaptor.capture());
     PickResult result = pickerCaptor.getValue().pickSubchannel(mock(PickSubchannelArgs.class));
     assertThat(result.getStatus().getCode()).isEqualTo(Code.UNAVAILABLE);
     assertThat(result.getStatus().getDescription()).isEqualTo("resolver error");
+  }
 
+  @Test
+  public void handleNameResolutionError_afterChildLbsInstantiated_propagateToChildLbs() {
     deliverResolvedAddresses(ImmutableMap.of("childA", "policy_a", "childB", "policy_b"));
-
     assertThat(childBalancers).hasSize(2);
     FakeLoadBalancer childBalancer1 = childBalancers.get(0);
     FakeLoadBalancer childBalancer2 = childBalancers.get(1);
-
-    clusterManagerLoadBalancer.handleNameResolutionError(error);
+    clusterManagerLoadBalancer.handleNameResolutionError(
+        Status.UNAVAILABLE.withDescription("resolver error"));
     assertThat(childBalancer1.upstreamError.getCode()).isEqualTo(Code.UNAVAILABLE);
     assertThat(childBalancer1.upstreamError.getDescription()).isEqualTo("resolver error");
     assertThat(childBalancer2.upstreamError.getCode()).isEqualTo(Code.UNAVAILABLE);
@@ -213,44 +218,24 @@ public class ClusterManagerLoadBalancerTest {
   }
 
   @Test
-  public void errorPropagationToDeactivatedChildBalancer() {
-    FakeLoadBalancer balancer = deliverAddressesAndUpdateToRemoveChildPolicy("childA", "policy_a");
+  public void handleNameResolutionError_notPropagateToDeactivatedChildLbs() {
+    deliverResolvedAddresses(ImmutableMap.of("childA", "policy_a", "childB", "policy_b"));
+    deliverResolvedAddresses(ImmutableMap.of("childB", "policy_b"));
+    FakeLoadBalancer childBalancer1 = childBalancers.get(0);  // policy_a (deactivated)
+    FakeLoadBalancer childBalancer2 = childBalancers.get(1);  // policy_b
     clusterManagerLoadBalancer.handleNameResolutionError(
         Status.UNKNOWN.withDescription("unknown error"));
-    assertThat(balancer.upstreamError).isNull();
-  }
-
-  private FakeLoadBalancer deliverAddressesAndUpdateToRemoveChildPolicy(
-      String childName, String childPolicyName) {
-    lbConfigInventory.put("childFoo", null);
-    deliverResolvedAddresses(
-        ImmutableMap.of(childName, childPolicyName, "childFoo", "policy_foo"));
-
-    verify(helper, atLeastOnce()).updateBalancingState(
-        eq(ConnectivityState.CONNECTING), any(SubchannelPicker.class));
-    assertThat(childBalancers).hasSize(2);
-    FakeLoadBalancer balancer = childBalancers.get(0);
-
-    deliverResolvedAddresses(ImmutableMap.of("childFoo", "policy_foo"));
-    verify(helper, atLeast(2)).updateBalancingState(
-        eq(ConnectivityState.CONNECTING), any(SubchannelPicker.class));
-    assertThat(Iterables.getOnlyElement(fakeClock.getPendingTasks()).getDelay(TimeUnit.MINUTES))
-        .isEqualTo(ClusterManagerLoadBalancer.DELAYED_CHILD_DELETION_TIME_MINUTES);
-    return balancer;
+    assertThat(childBalancer1.upstreamError).isNull();
+    assertThat(childBalancer2.upstreamError.getCode()).isEqualTo(Code.UNKNOWN);
+    assertThat(childBalancer2.upstreamError.getDescription()).isEqualTo("unknown error");
   }
 
   private void deliverResolvedAddresses(final Map<String, String> childPolicies) {
-    syncContext.execute(new Runnable() {
-      @Override
-      public void run() {
-        clusterManagerLoadBalancer
-            .handleResolvedAddresses(
-                ResolvedAddresses.newBuilder()
-                    .setAddresses(Collections.<EquivalentAddressGroup>emptyList())
-                    .setLoadBalancingPolicyConfig(buildConfig(childPolicies))
-                    .build());
-      }
-    });
+    clusterManagerLoadBalancer.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setAddresses(Collections.<EquivalentAddressGroup>emptyList())
+            .setLoadBalancingPolicyConfig(buildConfig(childPolicies))
+            .build());
   }
 
   private ClusterManagerConfig buildConfig(Map<String, String> childPolicies) {
@@ -265,7 +250,7 @@ public class ClusterManagerLoadBalancerTest {
     return new ClusterManagerConfig(childPolicySelections);
   }
 
-  private static PickResult pickSubchannel(SubchannelPicker picker, String name) {
+  private static PickResult pickSubchannel(SubchannelPicker picker, String clusterName) {
     PickSubchannelArgs args =
         new PickSubchannelArgsImpl(
             MethodDescriptor.<Void, Void>newBuilder()
@@ -276,7 +261,7 @@ public class ClusterManagerLoadBalancerTest {
                 .build(),
             new Metadata(),
             CallOptions.DEFAULT.withOption(
-                XdsNameResolver.CLUSTER_SELECTION_KEY, name));
+                XdsNameResolver.CLUSTER_SELECTION_KEY, clusterName));
     return picker.pickSubchannel(args);
   }
 


### PR DESCRIPTION
Delaying `handleResolvedAddresses()` for propagating configs to the child LB policy can be problematic. For example, if channel shutdown has been enqueued when calling child policy's `handleResolvedAddresses()` is being enqueued (e.g., receiving updates from XdsClient), it should not be executed. Otherwise, subchannels may be created by LBs that have already been shut down.

We should follow the convention that never delay update/error propagation to downstream LB policies. To avoid reentrancy of downstream LB policies calling `updateBalancingState()` in-place, LB policy implementations can wrap the helper to delay such upcalls.

In the existing implementation, such problem exists in LB policies that manages a group of child policies. Specifically they are `ClusterManagerLoadBalancer` (manages a group of `CdsLoadBalancer` as its child policies), `PriorityLoadBalancer` (manages a group of `WeightedTargetLoadBalancer` or `ClusterImplLoadBalancer` in the new hierarchy) and `WeightedTargetLoadBalancer` (manages a group of 'target' LBs). 