### PR TITLE
xds: multiple changes needed for PSM security GA as discussed

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ServerXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ServerXdsClient.java
@@ -76,7 +76,7 @@ final class ServerXdsClient extends AbstractXdsClient {
     super(channel, useProtocolV3, node, timeService, backoffPolicyProvider, stopwatchSupplier);
     this.useNewApiForListenerQuery = useProtocolV3 && useNewApiForListenerQuery;
     this.instanceIp = (instanceIp != null ? instanceIp : "0.0.0.0");
-    this.grpcServerResourceId = grpcServerResourceId != null ? grpcServerResourceId : "grpc/server";
+    this.grpcServerResourceId = grpcServerResourceId;
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/XdsClientWrapperForServerSds.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientWrapperForServerSds.java
@@ -114,6 +114,12 @@ public final class XdsClientWrapperForServerSds {
             .keepAliveTime(5, TimeUnit.MINUTES).build();
     timeService = SharedResourceHolder.get(timeServiceResource);
     newServerApi = serverInfo.isUseProtocolV3() && experimentalNewServerApiEnvVar;
+    String grpcServerResourceId = bootstrapInfo.getGrpcServerResourceId();
+    if (newServerApi && grpcServerResourceId == null) {
+      reportError(
+          Status.INVALID_ARGUMENT.withDescription("missing grpc_server_resource_name_id value"));
+      throw new IOException("missing grpc_server_resource_name_id value");
+    }
     XdsClient xdsClientImpl =
         new ServerXdsClient(
             channel,
@@ -124,7 +130,7 @@ public final class XdsClientWrapperForServerSds {
             GrpcUtil.STOPWATCH_SUPPLIER,
             experimentalNewServerApiEnvVar,
             "0.0.0.0",
-            bootstrapInfo.getGrpcServerResourceId());
+            grpcServerResourceId);
     start(xdsClientImpl);
   }
 

--- a/xds/src/main/java/io/grpc/xds/XdsServerBuilder.java
+++ b/xds/src/main/java/io/grpc/xds/XdsServerBuilder.java
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * A version of {@link ServerBuilder} to create xDS managed servers that will use SDS to set up SSL
  * with peers. Note, this is not ready to use yet.
  */
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/7514")
 public final class XdsServerBuilder extends ForwardingServerBuilder<XdsServerBuilder> {
 
   private final NettyServerBuilder delegate;
@@ -93,7 +94,6 @@ public final class XdsServerBuilder extends ForwardingServerBuilder<XdsServerBui
     return new ServerWrapperForXds(delegate.build(), xdsClient, errorNotifier);
   }
 
-  @ExperimentalApi("TODO")
   public ServerBuilder<?> transportBuilder() {
     return delegate;
   }

--- a/xds/src/main/java/io/grpc/xds/XdsServerBuilder.java
+++ b/xds/src/main/java/io/grpc/xds/XdsServerBuilder.java
@@ -16,8 +16,11 @@
 
 package io.grpc.xds;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.Attributes;
+import io.grpc.ExperimentalApi;
 import io.grpc.ForwardingServerBuilder;
 import io.grpc.Internal;
 import io.grpc.Server;
@@ -28,6 +31,7 @@ import io.grpc.netty.InternalNettyServerBuilder;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.xds.internal.sds.SdsProtocolNegotiators;
 import io.grpc.xds.internal.sds.ServerWrapperForXds;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * A version of {@link ServerBuilder} to create xDS managed servers that will use SDS to set up SSL
@@ -38,6 +42,7 @@ public final class XdsServerBuilder extends ForwardingServerBuilder<XdsServerBui
   private final NettyServerBuilder delegate;
   private final int port;
   private ErrorNotifier errorNotifier;
+  private AtomicBoolean isServerBuilt = new AtomicBoolean(false);
 
   private XdsServerBuilder(NettyServerBuilder nettyDelegate, int port) {
     this.delegate = nettyDelegate;
@@ -81,10 +86,16 @@ public final class XdsServerBuilder extends ForwardingServerBuilder<XdsServerBui
   @VisibleForTesting
   ServerWrapperForXds buildServer(
       XdsClientWrapperForServerSds xdsClient) {
+    checkState(isServerBuilt.compareAndSet(false, true), "Server already built!");
     InternalNettyServerBuilder.eagAttributes(delegate, Attributes.newBuilder()
         .set(SdsProtocolNegotiators.SERVER_XDS_CLIENT, xdsClient)
         .build());
     return new ServerWrapperForXds(delegate.build(), xdsClient, errorNotifier);
+  }
+
+  @ExperimentalApi("TODO")
+  public ServerBuilder<?> transportBuilder() {
+    return delegate;
   }
 
   /** Watcher to receive error notifications from xDS control plane during {@code start()}. */

--- a/xds/src/main/java/io/grpc/xds/internal/sds/ServerWrapperForXds.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/ServerWrapperForXds.java
@@ -113,15 +113,15 @@ public final class ServerWrapperForXds extends Server {
 
   @Override
   public Server shutdown() {
-    xdsClientWrapperForServerSds.shutdown();
     delegate.shutdown();
+    xdsClientWrapperForServerSds.shutdown();
     return this;
   }
 
   @Override
   public Server shutdownNow() {
-    xdsClientWrapperForServerSds.shutdown();
     delegate.shutdownNow();
+    xdsClientWrapperForServerSds.shutdown();
     return this;
   }
 

--- a/xds/src/test/java/io/grpc/xds/XdsServerBuilderTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerBuilderTest.java
@@ -61,7 +61,7 @@ public class XdsServerBuilderTest {
   private int port;
   private XdsClientWrapperForServerSds xdsClientWrapperForServerSds;
 
-  private void buildServer(
+  private XdsServerBuilder buildServer(
       XdsServerBuilder.ErrorNotifier errorNotifier, boolean injectMockXdsClient)
       throws IOException {
     port = XdsServerTestHelper.findFreePort();
@@ -78,6 +78,7 @@ public class XdsServerBuilderTest {
           XdsServerTestHelper.startAndGetWatcher(xdsClientWrapperForServerSds, mockXdsClient, port);
     }
     xdsServer = cleanupRule.register(builder.buildServer(xdsClientWrapperForServerSds));
+    return builder;
   }
 
   private void verifyServer(
@@ -273,4 +274,15 @@ public class XdsServerBuilderTest {
     verifyShutdown();
   }
 
+  @Test
+  public void xdsServer_2ndBuild_expectException() throws IOException {
+    XdsServerBuilder.ErrorNotifier mockErrorNotifier = mock(XdsServerBuilder.ErrorNotifier.class);
+    XdsServerBuilder builder = buildServer(mockErrorNotifier, true);
+    try {
+      builder.build();
+      fail("exception expected");
+    } catch (IllegalStateException expected) {
+      assertThat(expected).hasMessageThat().contains("Server already built!");
+    }
+  }
 }


### PR DESCRIPTION
- check to allow XdsServerBuilder.build() only once
- add transportBuilder() to XdsServerBuilder
- remove "grpc/server" hardcoding
- reorder the shutdown of delegate and xdsClient as per new design

CC @ejona86 