### PR TITLE
xds: fix regression for deleting EDS resources referenced by unchanged CDS resources

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -441,6 +441,8 @@ final class ClientXdsClient extends AbstractXdsClient {
       if (!edsClusterConfig.getServiceName().isEmpty()) {
         edsServiceName = edsClusterConfig.getServiceName();
         edsResources.add(edsServiceName);
+      } else {
+        edsResources.add(clusterName);
       }
       EdsClusterConfig config = new EdsClusterConfig(lbPolicy, edsServiceName,
           lrsServerName, maxConcurrentRequests, upstreamTlsContext);


### PR DESCRIPTION
A bug was introduced in #7696 for processing CDS responses.

Upon receiving a CDS response (state of the world), EDS resources no longer referenced by CDS resources in the latest response should be removed. Every EDS resource is referenced by some CDS resource either by appearing as its `edsServiceName` field or has the same name as the CDS resource if `edsServiceName == null`. #7696 did not retain EDS resources that has the same name as CDS resources.