### PR TITLE
interop: create PSM security xDS interop tests - server & client (v1.34.x backport)

### DIFF
--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -26,6 +26,7 @@ dependencies {
             project(':grpc-services'),
             project(':grpc-stub'),
             project(':grpc-testing'),
+            project(path: ':grpc-xds', configuration: 'shadow'),
             libraries.google_auth_oauth2_http,
             libraries.junit,
             libraries.truth
@@ -40,8 +41,7 @@ dependencies {
     runtimeOnly group: 'io.github.devatherock', name: 'jul-jsonformatter', version: '1.1.0'
     runtimeOnly libraries.opencensus_impl,
             libraries.netty_tcnative,
-            project(':grpc-grpclb'),
-            project(path: ':grpc-xds', configuration: 'shadow')
+            project(':grpc-grpclb')
     testImplementation project(':grpc-context').sourceSets.test.output,
             libraries.mockito
     alpnagent libraries.jetty_alpn_agent

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
@@ -78,6 +78,7 @@ public final class XdsTestClient {
   private final Map<String, Integer> rpcsStartedByMethod = new HashMap<>();
   private final Map<String, Integer> rpcsFailedByMethod = new HashMap<>();
   private final Map<String, Integer> rpcsSucceededByMethod = new HashMap<>();
+  private static final int CHANNELZ_MAX_PAGE_SIZE = 100;
 
   private int numChannels = 1;
   private boolean printResponse = false;
@@ -236,7 +237,7 @@ public final class XdsTestClient {
             .addService(new XdsStatsImpl())
             .addService(new ConfigureUpdateServiceImpl())
             .addService(ProtoReflectionService.newInstance())
-            .addService(ChannelzService.newInstance(100))
+            .addService(ChannelzService.newInstance(CHANNELZ_MAX_PAGE_SIZE))
             .build();
     try {
       statsServer.start();

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
@@ -149,7 +149,7 @@ public final class XdsTestClient {
         server = value;
       } else if ("stats_port".equals(key)) {
         statsPort = Integer.valueOf(value);
-      } else if ("secureMode".equals(key)) {
+      } else if ("secure_mode".equals(key)) {
         secureMode = Boolean.valueOf(value);
       } else {
         System.err.println("Unknown argument: " + key);
@@ -180,7 +180,7 @@ public final class XdsTestClient {
               + c.rpcTimeoutSec
               + "\n  --server=host:port     Address of server. Default: "
               + c.server
-              + "\n  --secureMode=BOOLEAN   Use true to enable XdsCredentials. Default: "
+              + "\n  --secure_mode=BOOLEAN  Use true to enable XdsCredentials. Default: "
               + c.secureMode
               + "\n  --stats_port=INT       Port to expose peer distribution stats service. "
               + "Default: "

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
@@ -39,6 +39,8 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Server;
 import io.grpc.netty.NettyServerBuilder;
+import io.grpc.protobuf.services.ProtoReflectionService;
+import io.grpc.services.ChannelzService;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.integration.Messages.ClientConfigureRequest;
 import io.grpc.testing.integration.Messages.ClientConfigureRequest.RpcType;
@@ -233,6 +235,8 @@ public final class XdsTestClient {
         NettyServerBuilder.forPort(statsPort)
             .addService(new XdsStatsImpl())
             .addService(new ConfigureUpdateServiceImpl())
+            .addService(ProtoReflectionService.newInstance())
+            .addService(ChannelzService.newInstance(100))
             .build();
     try {
       statsServer.start();

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
@@ -19,6 +19,7 @@ package io.grpc.testing.integration;
 import io.grpc.Context;
 import io.grpc.Contexts;
 import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
+import io.grpc.InsecureServerCredentials;
 import io.grpc.Metadata;
 import io.grpc.Server;
 import io.grpc.ServerCall;
@@ -32,6 +33,8 @@ import io.grpc.services.HealthStatusManager;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.integration.Messages.SimpleRequest;
 import io.grpc.testing.integration.Messages.SimpleResponse;
+import io.grpc.xds.XdsServerBuilder;
+import io.grpc.xds.XdsServerCredentials;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
@@ -51,9 +54,12 @@ public final class XdsTestServer {
   private static Logger logger = Logger.getLogger(XdsTestServer.class.getName());
 
   private int port = 8080;
+  private int maintenancePort = 8080;
+  private boolean secureMode = false;
   private String serverId = "java_server";
   private HealthStatusManager health;
   private Server server;
+  private Server maintenanceServer;
   private String host;
 
   /**
@@ -103,6 +109,10 @@ public final class XdsTestServer {
       String value = parts[1];
       if ("port".equals(key)) {
         port = Integer.valueOf(value);
+      } else if ("maintenance_port".equals(key)) {
+        maintenancePort = Integer.valueOf(value);
+      } else if ("secure_mode".equals(key)) {
+        secureMode = Boolean.parseBoolean(value);
       } else if ("server_id".equals(key)) {
         serverId = value;
       } else {
@@ -112,14 +122,30 @@ public final class XdsTestServer {
       }
     }
 
+    if (secureMode && (port == maintenancePort)) {
+      System.err.println(
+          "port and maintenance_port should be different for secure mode: port="
+              + port
+              + ", maintenance_port="
+              + maintenancePort);
+      usage = true;
+    }
+
     if (usage) {
       XdsTestServer s = new XdsTestServer();
       System.err.println(
           "Usage: [ARGS...]"
               + "\n"
-              + "\n  --port=INT          listening port for server."
+              + "\n  --port=INT          listening port for test server."
               + "\n                      Default: "
               + s.port
+              + "\n  --maintenance_port=INT      listening port for other servers."
+              + "\n                      Default: "
+              + s.maintenancePort
+              + "\n  --secure_mode=BOOLEAN Use true to enable XdsCredentials."
+              + " port and maintenance_port should be different for secure mode."
+              + "\n                      Default: "
+              + s.secureMode
               + "\n  --server_id=STRING  server ID for response."
               + "\n                      Default: "
               + s.serverId);
@@ -135,29 +161,57 @@ public final class XdsTestServer {
       throw new RuntimeException(e);
     }
     health = new HealthStatusManager();
-    server =
-        NettyServerBuilder.forPort(port)
-            .addService(
-                ServerInterceptors.intercept(
-                    new TestServiceImpl(serverId, host), new TestInfoInterceptor(host)))
-            .addService(new XdsUpdateHealthServiceImpl(health))
-            .addService(health.getHealthService())
-            .addService(ProtoReflectionService.newInstance())
-            .build()
-            .start();
+    if (secureMode) {
+      server =
+          XdsServerBuilder.forPort(
+                  port, XdsServerCredentials.create(InsecureServerCredentials.create()))
+              .addService(
+                  ServerInterceptors.intercept(
+                      new TestServiceImpl(serverId, host), new TestInfoInterceptor(host)))
+              .build()
+              .start();
+      maintenanceServer =
+          NettyServerBuilder.forPort(maintenancePort)
+              .addService(new XdsUpdateHealthServiceImpl(health))
+              .addService(health.getHealthService())
+              .addService(ProtoReflectionService.newInstance())
+              .build()
+              .start();
+    } else {
+      server =
+          NettyServerBuilder.forPort(port)
+              .addService(
+                  ServerInterceptors.intercept(
+                      new TestServiceImpl(serverId, host), new TestInfoInterceptor(host)))
+              .addService(new XdsUpdateHealthServiceImpl(health))
+              .addService(health.getHealthService())
+              .addService(ProtoReflectionService.newInstance())
+              .build()
+              .start();
+      maintenanceServer = null;
+    }
     health.setStatus("", ServingStatus.SERVING);
   }
 
   private void stop() throws Exception {
     server.shutdownNow();
+    if (maintenanceServer != null) {
+      maintenanceServer.shutdownNow();
+    }
     if (!server.awaitTermination(5, TimeUnit.SECONDS)) {
       System.err.println("Timed out waiting for server shutdown");
+    }
+    if (maintenanceServer != null && !maintenanceServer.awaitTermination(5, TimeUnit.SECONDS)) {
+      System.err.println("Timed out waiting for maintenanceServer shutdown");
     }
   }
 
   private void blockUntilShutdown() throws InterruptedException {
     if (server != null) {
       server.awaitTermination();
+    }
+    if (maintenanceServer != null) {
+      maintenanceServer.awaitTermination();
     }
   }
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
@@ -51,6 +51,7 @@ public final class XdsTestServer {
   private static final Context.Key<String> CALL_BEHAVIOR_KEY =
       Context.key("rpc-behavior");
   private static final String CALL_BEHAVIOR_KEEP_OPEN_VALUE = "keep-open";
+  private static final int CHANNELZ_MAX_PAGE_SIZE = 100;
 
   private static Logger logger = Logger.getLogger(XdsTestServer.class.getName());
 
@@ -176,7 +177,7 @@ public final class XdsTestServer {
               .addService(new XdsUpdateHealthServiceImpl(health))
               .addService(health.getHealthService())
               .addService(ProtoReflectionService.newInstance())
-              .addService(ChannelzService.newInstance(100))
+              .addService(ChannelzService.newInstance(CHANNELZ_MAX_PAGE_SIZE))
               .build()
               .start();
     } else {
@@ -188,6 +189,7 @@ public final class XdsTestServer {
               .addService(new XdsUpdateHealthServiceImpl(health))
               .addService(health.getHealthService())
               .addService(ProtoReflectionService.newInstance())
+              .addService(ChannelzService.newInstance(CHANNELZ_MAX_PAGE_SIZE))
               .build()
               .start();
       maintenanceServer = null;

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
@@ -29,6 +29,7 @@ import io.grpc.ServerInterceptors;
 import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.protobuf.services.ProtoReflectionService;
+import io.grpc.services.ChannelzService;
 import io.grpc.services.HealthStatusManager;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.integration.Messages.SimpleRequest;
@@ -175,6 +176,7 @@ public final class XdsTestServer {
               .addService(new XdsUpdateHealthServiceImpl(health))
               .addService(health.getHealthService())
               .addService(ProtoReflectionService.newInstance())
+              .addService(ChannelzService.newInstance(100))
               .build()
               .start();
     } else {


### PR DESCRIPTION
Backport of xDS Security support for XdsTestServer and XdsTestClient. 

#### Commit  / PR
- b5330f8 / interop: create PSM security xDS interop tests - server & client #7609
- f6a7880 / interop-testing: rename XdsTestClient secure_mode argument #7665
- badf703 / interop: add channelz and reflection support to xds interop test client and server #7701
- 385f36c / interop: add channelz to xds interop test server running in non-secure mode #7710
