### PR TITLE
xds: clean up verbose getters and builders on XdsClient interface

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
@@ -349,12 +349,12 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
             logger.log(XdsLogLevel.DEBUG, "Received endpoint update {0}", update);
             if (logger.isLoggable(XdsLogLevel.INFO)) {
               logger.log(XdsLogLevel.INFO, "Cluster {0}: {1} localities, {2} drop categories",
-                  update.getClusterName(), update.getLocalityLbEndpointsMap().size(),
-                  update.getDropPolicies().size());
+                  update.clusterName, update.localityLbEndpointsMap.size(),
+                  update.dropPolicies.size());
             }
             Map<Locality, LocalityLbEndpoints> localityLbEndpoints =
-                update.getLocalityLbEndpointsMap();
-            List<DropOverload> dropOverloads = update.getDropPolicies();
+                update.localityLbEndpointsMap;
+            List<DropOverload> dropOverloads = update.dropPolicies;
             List<EquivalentAddressGroup> addresses = new ArrayList<>();
             Map<String, Map<Locality, Integer>> prioritizedLocalityWeights = new HashMap<>();
             for (Locality locality : localityLbEndpoints.keySet()) {
@@ -386,7 +386,7 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
             if (prioritizedLocalityWeights.isEmpty()) {
               // Will still update the result, as if the cluster resource is revoked.
               logger.log(XdsLogLevel.INFO,
-                  "Cluster {0} has no usable priority/locality/endpoint", update.getClusterName());
+                  "Cluster {0} has no usable priority/locality/endpoint", update.clusterName);
             }
             List<String> priorities = new ArrayList<>(prioritizedLocalityWeights.keySet());
             Collections.sort(priorities);

--- a/xds/src/main/java/io/grpc/xds/EdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/EdsLoadBalancer2.java
@@ -213,12 +213,12 @@ final class EdsLoadBalancer2 extends LoadBalancer {
                 "Received endpoint update from xDS client {0}: {1}", xdsClient, update);
             if (logger.isLoggable(XdsLogLevel.INFO)) {
               logger.log(XdsLogLevel.INFO, "Received endpoint update: cluster_name={0}, "
-                      + "{1} localities, {2} drop categories", update.getClusterName(),
-                  update.getLocalityLbEndpointsMap().size(), update.getDropPolicies().size());
+                      + "{1} localities, {2} drop categories", update.clusterName,
+                  update.localityLbEndpointsMap.size(), update.dropPolicies.size());
             }
-            dropOverloads = update.getDropPolicies();
+            dropOverloads = update.dropPolicies;
             Map<Locality, LocalityLbEndpoints> localityLbEndpoints =
-                update.getLocalityLbEndpointsMap();
+                update.localityLbEndpointsMap;
             endpointAddresses = new ArrayList<>();
             prioritizedLocalityWeights = new HashMap<>();
             for (Locality locality : localityLbEndpoints.keySet()) {

--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -107,19 +107,11 @@ abstract class XdsClient {
 
   static final class RdsUpdate implements ResourceUpdate {
     // The list virtual hosts that make up the route table.
-    private final List<VirtualHost> virtualHosts;
+    final List<VirtualHost> virtualHosts;
 
-    private RdsUpdate(List<VirtualHost> virtualHosts) {
+    RdsUpdate(List<VirtualHost> virtualHosts) {
       this.virtualHosts = Collections.unmodifiableList(
           new ArrayList<>(checkNotNull(virtualHosts, "virtualHosts")));
-    }
-
-    static RdsUpdate fromVirtualHosts(List<VirtualHost> virtualHosts) {
-      return new RdsUpdate(virtualHosts);
-    }
-
-    List<VirtualHost> getVirtualHosts() {
-      return virtualHosts;
     }
 
     @Override

--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -49,13 +49,21 @@ abstract class XdsClient {
 
   static final class LdsUpdate implements ResourceUpdate {
     // Total number of nanoseconds to keep alive an HTTP request/response stream.
-    private final long httpMaxStreamDurationNano;
+    final long httpMaxStreamDurationNano;
     // The name of the route configuration to be used for RDS resource discovery.
     @Nullable
-    private final String rdsName;
+    final String rdsName;
     // The list virtual hosts that make up the route table.
     @Nullable
-    private final List<VirtualHost> virtualHosts;
+    final List<VirtualHost> virtualHosts;
+
+    LdsUpdate(long httpMaxStreamDurationNano, String rdsName) {
+      this(httpMaxStreamDurationNano, rdsName, null);
+    }
+
+    LdsUpdate(long httpMaxStreamDurationNano, List<VirtualHost> virtualHosts) {
+      this(httpMaxStreamDurationNano, null, virtualHosts);
+    }
 
     private LdsUpdate(long httpMaxStreamDurationNano, @Nullable String rdsName,
         @Nullable List<VirtualHost> virtualHosts) {
@@ -63,20 +71,6 @@ abstract class XdsClient {
       this.rdsName = rdsName;
       this.virtualHosts = virtualHosts == null
           ? null : Collections.unmodifiableList(new ArrayList<>(virtualHosts));
-    }
-
-    long getHttpMaxStreamDurationNano() {
-      return httpMaxStreamDurationNano;
-    }
-
-    @Nullable
-    String getRdsName() {
-      return rdsName;
-    }
-
-    @Nullable
-    List<VirtualHost> getVirtualHosts() {
-      return virtualHosts;
     }
 
     @Override
@@ -108,44 +102,6 @@ abstract class XdsClient {
         toStringHelper.add("virtualHosts", virtualHosts);
       }
       return toStringHelper.toString();
-    }
-
-    static Builder newBuilder() {
-      return new Builder();
-    }
-
-    static class Builder {
-      private long httpMaxStreamDurationNano;
-      @Nullable
-      private String rdsName;
-      @Nullable
-      private List<VirtualHost> virtualHosts;
-
-      private Builder() {
-      }
-
-      Builder setHttpMaxStreamDurationNano(long httpMaxStreamDurationNano) {
-        this.httpMaxStreamDurationNano = httpMaxStreamDurationNano;
-        return this;
-      }
-
-      Builder setRdsName(String rdsName) {
-        this.rdsName = rdsName;
-        return this;
-      }
-
-      Builder addVirtualHost(VirtualHost virtualHost) {
-        if (virtualHosts == null) {
-          virtualHosts = new ArrayList<>();
-        }
-        virtualHosts.add(virtualHost);
-        return this;
-      }
-
-      LdsUpdate build() {
-        checkState((rdsName == null) != (virtualHosts == null), "one of rdsName and virtualHosts");
-        return new LdsUpdate(httpMaxStreamDurationNano, rdsName, virtualHosts);
-      }
     }
   }
 

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -467,9 +467,9 @@ final class XdsNameResolver extends NameResolver {
             return;
           }
           logger.log(XdsLogLevel.INFO, "Receive LDS resource update: {0}", update);
-          httpMaxStreamDurationNano = update.getHttpMaxStreamDurationNano();
-          List<VirtualHost> virtualHosts = update.getVirtualHosts();
-          String rdsName = update.getRdsName();
+          httpMaxStreamDurationNano = update.httpMaxStreamDurationNano;
+          List<VirtualHost> virtualHosts = update.virtualHosts;
+          String rdsName = update.rdsName;
           if (rdsName != null && rdsName.equals(rdsResource)) {
             return;
           }

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -603,7 +603,7 @@ final class XdsNameResolver extends NameResolver {
             if (RdsResourceWatcherImpl.this != rdsWatcher) {
               return;
             }
-            updateRoutes(update.getVirtualHosts());
+            updateRoutes(update.virtualHosts);
           }
         });
       }

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
@@ -879,12 +879,12 @@ public abstract class ClientXdsClientTestBase {
         "0000");
     verify(edsResourceWatcher).onChanged(edsUpdateCaptor.capture());
     EdsUpdate edsUpdate = edsUpdateCaptor.getValue();
-    assertThat(edsUpdate.getClusterName()).isEqualTo(EDS_RESOURCE);
-    assertThat(edsUpdate.getDropPolicies())
+    assertThat(edsUpdate.clusterName).isEqualTo(EDS_RESOURCE);
+    assertThat(edsUpdate.dropPolicies)
         .containsExactly(
             new DropOverload("lb", 200),
             new DropOverload("throttle", 1000));
-    assertThat(edsUpdate.getLocalityLbEndpointsMap())
+    assertThat(edsUpdate.localityLbEndpointsMap)
         .containsExactly(
             new Locality("region1", "zone1", "subzone1"),
             new LocalityLbEndpoints(
@@ -928,12 +928,12 @@ public abstract class ClientXdsClientTestBase {
     xdsClient.watchEdsResource(EDS_RESOURCE, watcher);
     verify(watcher).onChanged(edsUpdateCaptor.capture());
     EdsUpdate edsUpdate = edsUpdateCaptor.getValue();
-    assertThat(edsUpdate.getClusterName()).isEqualTo(EDS_RESOURCE);
-    assertThat(edsUpdate.getDropPolicies())
+    assertThat(edsUpdate.clusterName).isEqualTo(EDS_RESOURCE);
+    assertThat(edsUpdate.dropPolicies)
         .containsExactly(
             new DropOverload("lb", 200),
             new DropOverload("throttle", 1000));
-    assertThat(edsUpdate.getLocalityLbEndpointsMap())
+    assertThat(edsUpdate.localityLbEndpointsMap)
         .containsExactly(
             new Locality("region1", "zone1", "subzone1"),
             new LocalityLbEndpoints(
@@ -987,12 +987,12 @@ public abstract class ClientXdsClientTestBase {
         "0000");
     verify(edsResourceWatcher).onChanged(edsUpdateCaptor.capture());
     EdsUpdate edsUpdate = edsUpdateCaptor.getValue();
-    assertThat(edsUpdate.getClusterName()).isEqualTo(EDS_RESOURCE);
-    assertThat(edsUpdate.getDropPolicies())
+    assertThat(edsUpdate.clusterName).isEqualTo(EDS_RESOURCE);
+    assertThat(edsUpdate.dropPolicies)
         .containsExactly(
             new DropOverload("lb", 200),
             new DropOverload("throttle", 1000));
-    assertThat(edsUpdate.getLocalityLbEndpointsMap())
+    assertThat(edsUpdate.localityLbEndpointsMap)
         .containsExactly(
             new Locality("region1", "zone1", "subzone1"),
             new LocalityLbEndpoints(
@@ -1015,9 +1015,9 @@ public abstract class ClientXdsClientTestBase {
 
     verify(edsResourceWatcher, times(2)).onChanged(edsUpdateCaptor.capture());
     edsUpdate = edsUpdateCaptor.getValue();
-    assertThat(edsUpdate.getClusterName()).isEqualTo(EDS_RESOURCE);
-    assertThat(edsUpdate.getDropPolicies()).isEmpty();
-    assertThat(edsUpdate.getLocalityLbEndpointsMap())
+    assertThat(edsUpdate.clusterName).isEqualTo(EDS_RESOURCE);
+    assertThat(edsUpdate.dropPolicies).isEmpty();
+    assertThat(edsUpdate.localityLbEndpointsMap)
         .containsExactly(
             new Locality("region2", "zone2", "subzone2"),
             new LocalityLbEndpoints(
@@ -1071,9 +1071,9 @@ public abstract class ClientXdsClientTestBase {
                         mf.buildDropOverload("lb", 100)))));
     call.sendResponse("0", clusterLoadAssignments, ResourceType.EDS, "0000");
     verify(edsWatcher).onChanged(edsUpdateCaptor.capture());
-    assertThat(edsUpdateCaptor.getValue().getClusterName()).isEqualTo(resource);
+    assertThat(edsUpdateCaptor.getValue().clusterName).isEqualTo(resource);
     verify(edsResourceWatcher).onChanged(edsUpdateCaptor.capture());
-    assertThat(edsUpdateCaptor.getValue().getClusterName()).isEqualTo(EDS_RESOURCE);
+    assertThat(edsUpdateCaptor.getValue().clusterName).isEqualTo(EDS_RESOURCE);
 
     clusters = ImmutableList.of(
         Any.pack(mf.buildEdsCluster(resource, null, true, null, null)),  // no change
@@ -1124,12 +1124,12 @@ public abstract class ClientXdsClientTestBase {
     call.sendResponse("0", clusterLoadAssignments, ResourceType.EDS, "0000");
     verify(edsResourceWatcher).onChanged(edsUpdateCaptor.capture());
     EdsUpdate edsUpdate = edsUpdateCaptor.getValue();
-    assertThat(edsUpdate.getClusterName()).isEqualTo(EDS_RESOURCE);
-    assertThat(edsUpdate.getDropPolicies())
+    assertThat(edsUpdate.clusterName).isEqualTo(EDS_RESOURCE);
+    assertThat(edsUpdate.dropPolicies)
         .containsExactly(
             new DropOverload("lb", 200),
             new DropOverload("throttle", 1000));
-    assertThat(edsUpdate.getLocalityLbEndpointsMap())
+    assertThat(edsUpdate.localityLbEndpointsMap)
         .containsExactly(
             new Locality("region1", "zone1", "subzone1"),
             new LocalityLbEndpoints(
@@ -1153,9 +1153,9 @@ public abstract class ClientXdsClientTestBase {
 
     verify(watcher1).onChanged(edsUpdateCaptor.capture());
     edsUpdate = edsUpdateCaptor.getValue();
-    assertThat(edsUpdate.getClusterName()).isEqualTo(edsResource);
-    assertThat(edsUpdate.getDropPolicies()).isEmpty();
-    assertThat(edsUpdate.getLocalityLbEndpointsMap())
+    assertThat(edsUpdate.clusterName).isEqualTo(edsResource);
+    assertThat(edsUpdate.dropPolicies).isEmpty();
+    assertThat(edsUpdate.localityLbEndpointsMap)
         .containsExactly(
             new Locality("region2", "zone2", "subzone2"),
             new LocalityLbEndpoints(
@@ -1163,9 +1163,9 @@ public abstract class ClientXdsClientTestBase {
                     new LbEndpoint("172.44.2.2", 8000, 3, true)), 2, 0));
     verify(watcher2).onChanged(edsUpdateCaptor.capture());
     edsUpdate = edsUpdateCaptor.getValue();
-    assertThat(edsUpdate.getClusterName()).isEqualTo(edsResource);
-    assertThat(edsUpdate.getDropPolicies()).isEmpty();
-    assertThat(edsUpdate.getLocalityLbEndpointsMap())
+    assertThat(edsUpdate.clusterName).isEqualTo(edsResource);
+    assertThat(edsUpdate.dropPolicies).isEmpty();
+    assertThat(edsUpdate.localityLbEndpointsMap)
         .containsExactly(
             new Locality("region2", "zone2", "subzone2"),
             new LocalityLbEndpoints(

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
@@ -252,7 +252,7 @@ public abstract class ClientXdsClientTestBase {
     call.verifyRequest(NODE, "0", Collections.singletonList(LDS_RESOURCE), ResourceType.LDS,
         "0000");
     verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
-    assertThat(ldsUpdateCaptor.getValue().getVirtualHosts()).hasSize(2);
+    assertThat(ldsUpdateCaptor.getValue().virtualHosts).hasSize(2);
     assertThat(fakeClock.getPendingTasks(LDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
   }
 
@@ -268,7 +268,7 @@ public abstract class ClientXdsClientTestBase {
     call.verifyRequest(NODE, "0", Collections.singletonList(LDS_RESOURCE), ResourceType.LDS,
         "0000");
     verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
-    assertThat(ldsUpdateCaptor.getValue().getRdsName()).isEqualTo(RDS_RESOURCE);
+    assertThat(ldsUpdateCaptor.getValue().rdsName).isEqualTo(RDS_RESOURCE);
     assertThat(fakeClock.getPendingTasks(LDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
   }
 
@@ -286,7 +286,7 @@ public abstract class ClientXdsClientTestBase {
     LdsResourceWatcher watcher = mock(LdsResourceWatcher.class);
     xdsClient.watchLdsResource(LDS_RESOURCE, watcher);
     verify(watcher).onChanged(ldsUpdateCaptor.capture());
-    assertThat(ldsUpdateCaptor.getValue().getRdsName()).isEqualTo(RDS_RESOURCE);
+    assertThat(ldsUpdateCaptor.getValue().rdsName).isEqualTo(RDS_RESOURCE);
     call.verifyNoMoreRequest();
   }
 
@@ -315,7 +315,7 @@ public abstract class ClientXdsClientTestBase {
     call.verifyRequest(NODE, "0", Collections.singletonList(LDS_RESOURCE), ResourceType.LDS,
         "0000");
     verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
-    assertThat(ldsUpdateCaptor.getValue().getVirtualHosts()).hasSize(2);
+    assertThat(ldsUpdateCaptor.getValue().virtualHosts).hasSize(2);
 
     listeners = ImmutableList.of(
         Any.pack(mf.buildListenerForRds(LDS_RESOURCE, RDS_RESOURCE)));
@@ -325,7 +325,7 @@ public abstract class ClientXdsClientTestBase {
     call.verifyRequest(NODE, "1", Collections.singletonList(LDS_RESOURCE), ResourceType.LDS,
         "0001");
     verify(ldsResourceWatcher, times(2)).onChanged(ldsUpdateCaptor.capture());
-    assertThat(ldsUpdateCaptor.getValue().getRdsName()).isEqualTo(RDS_RESOURCE);
+    assertThat(ldsUpdateCaptor.getValue().rdsName).isEqualTo(RDS_RESOURCE);
   }
 
   @Test
@@ -341,7 +341,7 @@ public abstract class ClientXdsClientTestBase {
     call.verifyRequest(NODE, "0", Collections.singletonList(LDS_RESOURCE), ResourceType.LDS,
         "0000");
     verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
-    assertThat(ldsUpdateCaptor.getValue().getVirtualHosts()).hasSize(2);
+    assertThat(ldsUpdateCaptor.getValue().virtualHosts).hasSize(2);
 
     call.sendResponse("1", Collections.<Any>emptyList(), ResourceType.LDS, "0001");
 
@@ -374,11 +374,11 @@ public abstract class ClientXdsClientTestBase {
             mf.buildRouteConfiguration("do not care", mf.buildOpaqueVirtualHosts(4)))));
     call.sendResponse("0", listeners, ResourceType.LDS, "0000");
     verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
-    assertThat(ldsUpdateCaptor.getValue().getVirtualHosts()).hasSize(2);
+    assertThat(ldsUpdateCaptor.getValue().virtualHosts).hasSize(2);
     verify(watcher1).onChanged(ldsUpdateCaptor.capture());
-    assertThat(ldsUpdateCaptor.getValue().getVirtualHosts()).hasSize(4);
+    assertThat(ldsUpdateCaptor.getValue().virtualHosts).hasSize(4);
     verify(watcher2).onChanged(ldsUpdateCaptor.capture());
-    assertThat(ldsUpdateCaptor.getValue().getVirtualHosts()).hasSize(4);
+    assertThat(ldsUpdateCaptor.getValue().virtualHosts).hasSize(4);
   }
 
   @Test
@@ -481,7 +481,7 @@ public abstract class ClientXdsClientTestBase {
         Any.pack(mf.buildListenerForRds(LDS_RESOURCE, RDS_RESOURCE)));
     call.sendResponse("0", listeners, ResourceType.LDS, "0000");
     verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
-    assertThat(ldsUpdateCaptor.getValue().getRdsName()).isEqualTo(RDS_RESOURCE);
+    assertThat(ldsUpdateCaptor.getValue().rdsName).isEqualTo(RDS_RESOURCE);
 
     List<Any> routeConfigs = ImmutableList.of(
         Any.pack(mf.buildRouteConfiguration(RDS_RESOURCE, mf.buildOpaqueVirtualHosts(2))));
@@ -494,7 +494,7 @@ public abstract class ClientXdsClientTestBase {
             mf.buildRouteConfiguration("do not care", mf.buildOpaqueVirtualHosts(5)))));
     call.sendResponse("1", listeners, ResourceType.LDS, "0001");
     verify(ldsResourceWatcher, times(2)).onChanged(ldsUpdateCaptor.capture());
-    assertThat(ldsUpdateCaptor.getValue().getVirtualHosts()).hasSize(5);
+    assertThat(ldsUpdateCaptor.getValue().virtualHosts).hasSize(5);
     verify(rdsResourceWatcher).onResourceDoesNotExist(RDS_RESOURCE);
   }
 

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
@@ -412,7 +412,7 @@ public abstract class ClientXdsClientTestBase {
     call.verifyRequest(NODE, "0", Collections.singletonList(RDS_RESOURCE), ResourceType.RDS,
         "0000");
     verify(rdsResourceWatcher).onChanged(rdsUpdateCaptor.capture());
-    assertThat(rdsUpdateCaptor.getValue().getVirtualHosts()).hasSize(2);
+    assertThat(rdsUpdateCaptor.getValue().virtualHosts).hasSize(2);
     assertThat(fakeClock.getPendingTasks(RDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
   }
 
@@ -431,7 +431,7 @@ public abstract class ClientXdsClientTestBase {
     RdsResourceWatcher watcher = mock(RdsResourceWatcher.class);
     xdsClient.watchRdsResource(RDS_RESOURCE, watcher);
     verify(watcher).onChanged(rdsUpdateCaptor.capture());
-    assertThat(rdsUpdateCaptor.getValue().getVirtualHosts()).hasSize(2);
+    assertThat(rdsUpdateCaptor.getValue().virtualHosts).hasSize(2);
     call.verifyNoMoreRequest();
   }
 
@@ -459,7 +459,7 @@ public abstract class ClientXdsClientTestBase {
     call.verifyRequest(NODE, "0", Collections.singletonList(RDS_RESOURCE), ResourceType.RDS,
         "0000");
     verify(rdsResourceWatcher).onChanged(rdsUpdateCaptor.capture());
-    assertThat(rdsUpdateCaptor.getValue().getVirtualHosts()).hasSize(2);
+    assertThat(rdsUpdateCaptor.getValue().virtualHosts).hasSize(2);
 
     routeConfigs = ImmutableList.of(
         Any.pack(mf.buildRouteConfiguration(RDS_RESOURCE, mf.buildOpaqueVirtualHosts(4))));
@@ -469,7 +469,7 @@ public abstract class ClientXdsClientTestBase {
     call.verifyRequest(NODE, "1", Collections.singletonList(RDS_RESOURCE), ResourceType.RDS,
         "0001");
     verify(rdsResourceWatcher, times(2)).onChanged(rdsUpdateCaptor.capture());
-    assertThat(rdsUpdateCaptor.getValue().getVirtualHosts()).hasSize(4);
+    assertThat(rdsUpdateCaptor.getValue().virtualHosts).hasSize(4);
   }
 
   @Test
@@ -487,7 +487,7 @@ public abstract class ClientXdsClientTestBase {
         Any.pack(mf.buildRouteConfiguration(RDS_RESOURCE, mf.buildOpaqueVirtualHosts(2))));
     call.sendResponse("0", routeConfigs, ResourceType.RDS, "0000");
     verify(rdsResourceWatcher).onChanged(rdsUpdateCaptor.capture());
-    assertThat(rdsUpdateCaptor.getValue().getVirtualHosts()).hasSize(2);
+    assertThat(rdsUpdateCaptor.getValue().virtualHosts).hasSize(2);
 
     listeners = ImmutableList.of(
         Any.pack(mf.buildListener(LDS_RESOURCE,
@@ -519,7 +519,7 @@ public abstract class ClientXdsClientTestBase {
     call.sendResponse("0", routeConfigs, ResourceType.RDS, "0000");
 
     verify(rdsResourceWatcher).onChanged(rdsUpdateCaptor.capture());
-    assertThat(rdsUpdateCaptor.getValue().getVirtualHosts()).hasSize(2);
+    assertThat(rdsUpdateCaptor.getValue().virtualHosts).hasSize(2);
     verifyNoMoreInteractions(watcher1, watcher2);
 
     routeConfigs = ImmutableList.of(Any.pack(
@@ -527,9 +527,9 @@ public abstract class ClientXdsClientTestBase {
     call.sendResponse("2", routeConfigs, ResourceType.RDS, "0002");
 
     verify(watcher1).onChanged(rdsUpdateCaptor.capture());
-    assertThat(rdsUpdateCaptor.getValue().getVirtualHosts()).hasSize(4);
+    assertThat(rdsUpdateCaptor.getValue().virtualHosts).hasSize(4);
     verify(watcher2).onChanged(rdsUpdateCaptor.capture());
-    assertThat(rdsUpdateCaptor.getValue().getVirtualHosts()).hasSize(4);
+    assertThat(rdsUpdateCaptor.getValue().virtualHosts).hasSize(4);
     verifyNoMoreInteractions(rdsResourceWatcher);
   }
 

--- a/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
@@ -788,14 +788,8 @@ public class ClusterResolverLoadBalancerTest {
     void deliverClusterLoadAssignment(String resource, List<DropOverload> dropOverloads,
         Map<Locality, LocalityLbEndpoints> localityLbEndpointsMap) {
       if (watchers.containsKey(resource)) {
-        EdsUpdate.Builder builder  = EdsUpdate.newBuilder().setClusterName(resource);
-        for (DropOverload dropOverload : dropOverloads) {
-          builder.addDropPolicy(dropOverload);
-        }
-        for (Locality locality : localityLbEndpointsMap.keySet()) {
-          builder.addLocalityLbEndpoints(locality, localityLbEndpointsMap.get(locality));
-        }
-        watchers.get(resource).onChanged(builder.build());
+        watchers.get(resource).onChanged(
+            new EdsUpdate(resource, localityLbEndpointsMap, dropOverloads));
       }
     }
 

--- a/xds/src/test/java/io/grpc/xds/EdsLoadBalancer2Test.java
+++ b/xds/src/test/java/io/grpc/xds/EdsLoadBalancer2Test.java
@@ -713,14 +713,8 @@ public class EdsLoadBalancer2Test {
         @Override
         public void run() {
           if (watchers.containsKey(resource)) {
-            EdsUpdate.Builder builder  = EdsUpdate.newBuilder().setClusterName(resource);
-            for (DropOverload dropOverload : dropOverloads) {
-              builder.addDropPolicy(dropOverload);
-            }
-            for (Locality locality : localityLbEndpointsMap.keySet()) {
-              builder.addLocalityLbEndpoints(locality, localityLbEndpointsMap.get(locality));
-            }
-            watchers.get(resource).onChanged(builder.build());
+            watchers.get(resource).onChanged(
+                new EdsUpdate(resource, localityLbEndpointsMap, dropOverloads));
           }
         }
       });

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -745,12 +745,7 @@ public class XdsNameResolverTest {
           if (!resourceName.equals(ldsResource)) {
             return;
           }
-          LdsUpdate.Builder updateBuilder = LdsUpdate.newBuilder();
-          updateBuilder.setHttpMaxStreamDurationNano(httpMaxStreamDurationNano);
-          for (VirtualHost virtualHost : virtualHosts) {
-            updateBuilder.addVirtualHost(virtualHost);
-          }
-          ldsWatcher.onChanged(updateBuilder.build());
+          ldsWatcher.onChanged(new LdsUpdate(httpMaxStreamDurationNano, virtualHosts));
         }
       });
     }
@@ -764,7 +759,7 @@ public class XdsNameResolverTest {
           }
           VirtualHost virtualHost =
               new VirtualHost("virtual-host", Collections.singletonList(AUTHORITY), routes);
-          ldsWatcher.onChanged(LdsUpdate.newBuilder().addVirtualHost(virtualHost).build());
+          ldsWatcher.onChanged(new LdsUpdate(0, Collections.singletonList(virtualHost)));
         }
       });
     }
@@ -776,7 +771,7 @@ public class XdsNameResolverTest {
           if (!resourceName.equals(ldsResource)) {
             return;
           }
-          ldsWatcher.onChanged(LdsUpdate.newBuilder().setRdsName(rdsName).build());
+          ldsWatcher.onChanged(new LdsUpdate(0, rdsName));
         }
       });
     }

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -795,7 +795,7 @@ public class XdsNameResolverTest {
           if (!resourceName.equals(rdsResource)) {
             return;
           }
-          rdsWatcher.onChanged(RdsUpdate.fromVirtualHosts(virtualHosts));
+          rdsWatcher.onChanged(new RdsUpdate(virtualHosts));
         }
       });
     }


### PR DESCRIPTION
It's common in xDS for passing around configurations, which are (effectively) immutable. In most cases, those configuration instances are created by internal implementations and used internally as well. As configurations become complicated, getters and builders are verbose. They contribute to a significant amount of trivial code (e.g., adding one field requires adding one getter and one setter on builder). In #7696, CdsUpdate is extended to represent a complex combination of cluster types and usages of the data structure are non-homogenous. It would be extremely cumbersome to use getters and builder(s) for such cases. So to make data types consistent (on XdsClient interface) and reduce the verbosity of usage, this change eliminates getters and builders for xDS updates on XdsClient interface (server side's `ListenerUpdate` is unchanged, it may fall into a different story).

This change should be a pure refactor for code health, no behavior/code logic should be affected.