### PR TITLE
xds: fix regression for deleting EDS resources referenced by unchanged CDS resources (v1.35 backport)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -441,6 +441,8 @@ final class ClientXdsClient extends AbstractXdsClient {
       if (!edsClusterConfig.getServiceName().isEmpty()) {
         edsServiceName = edsClusterConfig.getServiceName();
         edsResources.add(edsServiceName);
+      } else {
+        edsResources.add(clusterName);
       }
       EdsClusterConfig config = new EdsClusterConfig(lbPolicy, edsServiceName,
           lrsServerName, maxConcurrentRequests, upstreamTlsContext);


### PR DESCRIPTION
A bug was introduced in the previous change for processing CDS responses. It mistakenly deleted EDS resources valid still referenced by CDS resources. EDS resource names either appear as the edsServiceName for CDS resources or has the same name as the CDS resources whose edsServiceName is null.

In the previous change, EDS resources having the same name as CDS resources are not retained. This caused LB subtrees for those EDS resources are shut down mistakenly, leading to RPC fails.



---------------------------
Backport of #7778