### PR TITLE
xds: fix LB policy address and balancing state update propagations (v1.35 backport)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
@@ -84,21 +84,18 @@ class ClusterManagerLoadBalancer extends LoadBalancer {
       } else {
         childLbStates.get(name).reactivate(childPolicyProvider);
       }
-      final LoadBalancer childLb = childLbStates.get(name).lb;
-      final ResolvedAddresses childAddresses =
+      LoadBalancer childLb = childLbStates.get(name).lb;
+      ResolvedAddresses childAddresses =
           resolvedAddresses.toBuilder().setLoadBalancingPolicyConfig(childConfig).build();
-      syncContext.execute(new Runnable() {
-        @Override
-        public void run() {
-          childLb.handleResolvedAddresses(childAddresses);
-        }
-      });
+      childLb.handleResolvedAddresses(childAddresses);
     }
     for (String name : childLbStates.keySet()) {
       if (!newChildPolicies.containsKey(name)) {
         childLbStates.get(name).deactivate();
       }
     }
+    // Must update channel picker before return so that new RPCs will not be routed to deleted
+    // clusters and resolver can remove them in service config.
     updateOverallBalancingState();
   }
 
@@ -245,12 +242,20 @@ class ClusterManagerLoadBalancer extends LoadBalancer {
     private final class ChildLbStateHelper extends ForwardingLoadBalancerHelper {
 
       @Override
-      public void updateBalancingState(ConnectivityState newState, SubchannelPicker newPicker) {
-        currentState = newState;
-        currentPicker = newPicker;
-        if (!deactivated) {
-          updateOverallBalancingState();
-        }
+      public void updateBalancingState(final ConnectivityState newState,
+          final SubchannelPicker newPicker) {
+        syncContext.execute(new Runnable() {
+          @Override
+          public void run() {
+            currentState = newState;
+            currentPicker = newPicker;
+            // Subchannel picker and state are saved, but will only be propagated to the channel
+            // when the child instance exits deactivated state.
+            if (!deactivated) {
+              updateOverallBalancingState();
+            }
+          }
+        });
       }
 
       @Override

--- a/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
@@ -41,6 +41,7 @@ import io.grpc.Metadata;
 import io.grpc.NameResolver;
 import io.grpc.Status;
 import io.grpc.Status.Code;
+import io.grpc.SynchronizationContext;
 import io.grpc.internal.ObjectPool;
 import io.grpc.internal.ServiceConfigUtil.PolicySelection;
 import io.grpc.xds.ClusterImplLoadBalancerProvider.ClusterImplConfig;
@@ -86,6 +87,13 @@ public class ClusterImplLoadBalancerTest {
   private static final String CLUSTER = "cluster-foo.googleapis.com";
   private static final String EDS_SERVICE_NAME = "service.googleapis.com";
   private static final String LRS_SERVER_NAME = "";
+  private final SynchronizationContext syncContext = new SynchronizationContext(
+      new Thread.UncaughtExceptionHandler() {
+        @Override
+        public void uncaughtException(Thread t, Throwable e) {
+          throw new AssertionError(e);
+        }
+      });
   private final Locality locality =
       new Locality("test-region", "test-zone", "test-subzone");
   private final PolicySelection roundRobin =
@@ -583,6 +591,12 @@ public class ClusterImplLoadBalancerTest {
   }
 
   private final class FakeLbHelper extends LoadBalancer.Helper {
+
+    @Override
+    public SynchronizationContext getSynchronizationContext() {
+      return syncContext;
+    }
+
     @Override
     public void updateBalancingState(
         @Nonnull ConnectivityState newState, @Nonnull SubchannelPicker newPicker) {


### PR DESCRIPTION
Delaying handleResolvedAddresses() for propagating configs to the child LB policy can be problematic. For example, if channel shutdown has been enqueued when calling child policy's handleResolvedAddresses() is being enqueued (e.g., receiving updates from XdsClient), it should not be executed. Otherwise, subchannels may be created by LBs that have already been shut down.

This change fixes LB config propagations in LB policies that manage a group of child LBs and delay the propagation for avoiding reentrancy. LB policies will always directly propagate child LB config/addresses updates directly. On the other hand, upcalls from child LB policies for balancing state updates will be queued and executed later.


------------------
Backport of #7772