### PR TITLE
core: make subchannel creation timing restriction stricter

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1391,11 +1391,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
     @Override
     public AbstractSubchannel createSubchannel(CreateSubchannelArgs args) {
       syncContext.throwIfNotInThisSynchronizationContext();
-      return createSubchannelInternal(args);
-    }
-
-    private SubchannelImpl createSubchannelInternal(CreateSubchannelArgs args) {
-      // No new subchannel should be created after delayedTransport has been shutdown.
+      // No new subchannel should be created after load balancer has been shutdown.
       checkState(!terminating, "Channel is being terminated");
       return new SubchannelImpl(args, this);
     }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1425,8 +1425,8 @@ final class ManagedChannelImpl extends ManagedChannel implements
     }
 
     private SubchannelImpl createSubchannelInternal(CreateSubchannelArgs args) {
-      // TODO(ejona): can we be even stricter? Like loadBalancer == null?
-      checkState(!terminated, "Channel is terminated");
+      // No new subchannel should be created after delayedTransport has been shutdown.
+      checkState(!terminating, "Channel is being terminated");
       return new SubchannelImpl(args, this);
     }
 

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1819,18 +1819,8 @@ final class ManagedChannelImpl extends ManagedChannel implements
     private void internalStart(final SubchannelStateListener listener) {
       checkState(!started, "already started");
       checkState(!shutdown, "already shutdown");
+      checkState(!terminating, "Channel is being terminated");
       started = true;
-      // TODO(zhangkun): possibly remove the volatile of terminating when this whole method is
-      // required to be called from syncContext
-      if (terminating) {
-        syncContext.execute(new Runnable() {
-            @Override
-            public void run() {
-              listener.onSubchannelState(ConnectivityStateInfo.forNonError(SHUTDOWN));
-            }
-          });
-        return;
-      }
       final class ManagedInternalSubchannelCallback extends InternalSubchannel.Callback {
         // All callbacks are run in syncContext
         @Override


### PR DESCRIPTION
Throw for subchannel creation if the channel is being shutting down and the delayed transport is terminated (aka, all retry calls has been finished). 

This enforces a tighter timing restriction on load balancer implementations to ensure no subchannel should be created after the balancer itself has been shut down. A load balancer implementation may not always check its state before creating new subchannels. They can be out of sync when the subchannel creation is queued and executed later. We had run into exceptions below in xDS where [PriorityLoadBalancer enqueues addresses propagation to its child policy](https://github.com/grpc/grpc-java/blob/1a3db6701385ecfd8122b7093bc7b73ae5393c42/xds/src/main/java/io/grpc/xds/PriorityLoadBalancer.java#L251-L270) (to avoid reentrancy by `updateBalancingState()` upcalls) while the Channel (and therefore the LB tree) is shut down before it gets executed. Although we've fix existing LB implementations to not delay addresses propagation (instead enqueue upcalls if necessary), checking the consistency at LoadBalancer.Helper and making it throw if the load balancer had been shut down can help such bugs in load balancer implementations surface earlier.

```
~/grpc-java-1.34.1/examples/example-xds$ ./build/install/example-xds/bin/xds-hello-world-client "world"    xds:///helloworld-gce
Dec 29, 2020 6:42:40 PM io.grpc.examples.helloworldxds.XdsHelloWorldClient greet
INFO: Will try to greet world ...
Dec 29, 2020 6:42:43 PM io.grpc.examples.helloworldxds.XdsHelloWorldClient greet
INFO: Greeting: Hello world, from grpc-td-mig-us-central1-682b
Dec 29, 2020 6:42:43 PM io.grpc.internal.ManagedChannelImpl$2 uncaughtException
SEVERE: [Channel<1>: (xds:///helloworld-gce)] Uncaught exception in the SynchronizationContext. Panic!
java.lang.NullPointerException
        at io.grpc.internal.ManagedChannelImpl$SubchannelImpl.requestConnection(ManagedChannelImpl.java:1914)
        at io.grpc.util.ForwardingSubchannel.requestConnection(ForwardingSubchannel.java:49)
        at io.grpc.util.RoundRobinLoadBalancer.handleResolvedAddresses(RoundRobinLoadBalancer.java:113)
        at io.grpc.util.ForwardingLoadBalancer.handleResolvedAddresses(ForwardingLoadBalancer.java:46)
        at io.grpc.services.HealthCheckingLoadBalancerFactory$HealthCheckingLoadBalancer.handleResolvedAddresses(HealthCheckingLoadBalancerFactory.java:189)
        at io.grpc.util.ForwardingLoadBalancer.handleResolvedAddresses(ForwardingLoadBalancer.java:46)
        at io.grpc.xds.LrsLoadBalancer.handleResolvedAddresses(LrsLoadBalancer.java:87)
        at io.grpc.util.ForwardingLoadBalancer.handleResolvedAddresses(ForwardingLoadBalancer.java:46)
        at io.grpc.xds.WeightedTargetLoadBalancer.handleResolvedAddresses(WeightedTargetLoadBalancer.java:88)
        at io.grpc.util.ForwardingLoadBalancer.handleResolvedAddresses(ForwardingLoadBalancer.java:46)
        at io.grpc.xds.PriorityLoadBalancer$ChildLbState$1.run(PriorityLoadBalancer.java:263)
        at io.grpc.SynchronizationContext.drain(SynchronizationContext.java:95)
        at io.grpc.SynchronizationContext.execute(SynchronizationContext.java:127)
        at io.grpc.xds.EdsLoadBalancer2$EdsLbState$ChildLbState.onChanged(EdsLoadBalancer2.java:265)
        at io.grpc.xds.ClientXdsClient$ResourceSubscriber.notifyWatcher(ClientXdsClient.java:856)
        at io.grpc.xds.ClientXdsClient$ResourceSubscriber.onData(ClientXdsClient.java:815)
        at io.grpc.xds.ClientXdsClient.handleEdsResponse(ClientXdsClient.java:495)
        at io.grpc.xds.AbstractXdsClient$AbstractAdsStream.handleRpcResponse(AbstractXdsClient.java:493)
        at io.grpc.xds.AbstractXdsClient$AdsStreamV2$1$1.run(AbstractXdsClient.java:576)
        at io.grpc.SynchronizationContext.drain(SynchronizationContext.java:95)
        at io.grpc.SynchronizationContext.execute(SynchronizationContext.java:127)
        at io.grpc.xds.AbstractXdsClient$AdsStreamV2$1.onNext(AbstractXdsClient.java:568)
        at io.grpc.xds.AbstractXdsClient$AdsStreamV2$1.onNext(AbstractXdsClient.java:565)
        at io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onMessage(ClientCalls.java:465)
        at io.grpc.internal.DelayedClientCall$DelayedListener.onMessage(DelayedClientCall.java:448)
        at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1MessagesAvailable.runInternal(ClientCallImpl.java:716)
        at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1MessagesAvailable.runInContext(ClientCallImpl.java:701)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:834)
Dec 29, 2020 6:42:43 PM io.grpc.internal.ManagedChannelImpl$2 uncaughtException
SEVERE: [Channel<1>: (xds:///helloworld-gce)] Uncaught exception in the SynchronizationContext. Panic!
java.lang.NullPointerException
        at io.grpc.internal.ManagedChannelImpl$SubchannelImpl.getAllAddresses(ManagedChannelImpl.java:1921)
        at io.grpc.util.ForwardingSubchannel.getAllAddresses(ForwardingSubchannel.java:54)
        at io.grpc.LoadBalancer$Subchannel.getAddresses(LoadBalancer.java:1263)
        at io.grpc.util.RoundRobinLoadBalancer.processSubchannelState(RoundRobinLoadBalancer.java:139)
        at io.grpc.util.RoundRobinLoadBalancer.access$000(RoundRobinLoadBalancer.java:53)
        at io.grpc.util.RoundRobinLoadBalancer$1.onSubchannelState(RoundRobinLoadBalancer.java:109)
        at io.grpc.services.HealthCheckingLoadBalancerFactory$HealthCheckState.gotoState(HealthCheckingLoadBalancerFactory.java:332)
        at io.grpc.services.HealthCheckingLoadBalancerFactory$HealthCheckState.adjustHealthCheck(HealthCheckingLoadBalancerFactory.java:295)
        at io.grpc.services.HealthCheckingLoadBalancerFactory$HealthCheckState.onSubchannelState(HealthCheckingLoadBalancerFactory.java:275)
        at io.grpc.internal.ManagedChannelImpl$SubchannelImpl$1.run(ManagedChannelImpl.java:1771)
        at io.grpc.SynchronizationContext.drain(SynchronizationContext.java:95)
        at io.grpc.SynchronizationContext.execute(SynchronizationContext.java:127)
        at io.grpc.xds.EdsLoadBalancer2$EdsLbState$ChildLbState.onChanged(EdsLoadBalancer2.java:265)
        at io.grpc.xds.ClientXdsClient$ResourceSubscriber.notifyWatcher(ClientXdsClient.java:856)
        at io.grpc.xds.ClientXdsClient$ResourceSubscriber.onData(ClientXdsClient.java:815)
        at io.grpc.xds.ClientXdsClient.handleEdsResponse(ClientXdsClient.java:495)
        at io.grpc.xds.AbstractXdsClient$AbstractAdsStream.handleRpcResponse(AbstractXdsClient.java:493)
        at io.grpc.xds.AbstractXdsClient$AdsStreamV2$1$1.run(AbstractXdsClient.java:576)
        at io.grpc.SynchronizationContext.drain(SynchronizationContext.java:95)
        at io.grpc.SynchronizationContext.execute(SynchronizationContext.java:127)
        at io.grpc.xds.AbstractXdsClient$AdsStreamV2$1.onNext(AbstractXdsClient.java:568)
        at io.grpc.xds.AbstractXdsClient$AdsStreamV2$1.onNext(AbstractXdsClient.java:565)
        at io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onMessage(ClientCalls.java:465)
        at io.grpc.internal.DelayedClientCall$DelayedListener.onMessage(DelayedClientCall.java:448)
        at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1MessagesAvailable.runInternal(ClientCallImpl.java:716)
        at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1MessagesAvailable.runInContext(ClientCallImpl.java:701)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:834)

```