### PR TITLE
xds: reorder the shutdown of delegate and xds-client for better semantics of ServerWrapperForXds

### DIFF
--- a/xds/src/main/java/io/grpc/xds/internal/sds/ServerWrapperForXds.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/ServerWrapperForXds.java
@@ -113,15 +113,15 @@ public final class ServerWrapperForXds extends Server {
 
   @Override
   public Server shutdown() {
-    xdsClientWrapperForServerSds.shutdown();
     delegate.shutdown();
+    xdsClientWrapperForServerSds.shutdown();
     return this;
   }
 
   @Override
   public Server shutdownNow() {
-    xdsClientWrapperForServerSds.shutdown();
     delegate.shutdownNow();
+    xdsClientWrapperForServerSds.shutdown();
     return this;
   }
 


### PR DESCRIPTION
@ejona86 one of the items in the TODOs we discussed.