### PR TITLE
api: delete LoadBalancer.Helper APIs that had been deprecated for a long time

### DIFF
--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -905,45 +905,6 @@ public abstract class LoadBalancer {
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
   public abstract static class Helper {
     /**
-     * Equivalent to {@link #createSubchannel(List, Attributes)} with the given single {@code
-     * EquivalentAddressGroup}.
-     *
-     * @since 1.2.0
-     * @deprecated Use {@link #createSubchannel(io.grpc.LoadBalancer.CreateSubchannelArgs)}
-     *             instead. Note the new API must be called from {@link #getSynchronizationContext
-     *             the Synchronization Context}.
-     */
-    @Deprecated
-    public final Subchannel createSubchannel(EquivalentAddressGroup addrs, Attributes attrs) {
-      checkNotNull(addrs, "addrs");
-      return createSubchannel(Collections.singletonList(addrs), attrs);
-    }
-
-    /**
-     * Creates a Subchannel, which is a logical connection to the given group of addresses which are
-     * considered equivalent.  The {@code attrs} are custom attributes associated with this
-     * Subchannel, and can be accessed later through {@link Subchannel#getAttributes
-     * Subchannel.getAttributes()}.
-     *
-     * <p>It is recommended you call this method from the Synchronization Context, otherwise your
-     * logic around the creation may race with {@link #handleSubchannelState}.  See
-     * <a href="https://github.com/grpc/grpc-java/issues/5015">#5015</a> for more discussions.
-     *
-     * <p>The LoadBalancer is responsible for closing unused Subchannels, and closing all
-     * Subchannels within {@link #shutdown}.
-     *
-     * @throws IllegalArgumentException if {@code addrs} is empty
-     * @since 1.14.0
-     * @deprecated Use {@link #createSubchannel(io.grpc.LoadBalancer.CreateSubchannelArgs)}
-     *             instead. Note the new API must be called from {@link #getSynchronizationContext
-     *             the Synchronization Context}.
-     */
-    @Deprecated
-    public Subchannel createSubchannel(List<EquivalentAddressGroup> addrs, Attributes attrs) {
-      throw new UnsupportedOperationException();
-    }
-
-    /**
      * Creates a Subchannel, which is a logical connection to the given group of addresses which are
      * considered equivalent.  The {@code attrs} are custom attributes associated with this
      * Subchannel, and can be accessed later through {@link Subchannel#getAttributes
@@ -957,44 +918,6 @@ public abstract class LoadBalancer {
      * @since 1.22.0
      */
     public Subchannel createSubchannel(CreateSubchannelArgs args) {
-      throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Equivalent to {@link #updateSubchannelAddresses(io.grpc.LoadBalancer.Subchannel, List)} with
-     * the given single {@code EquivalentAddressGroup}.
-     *
-     * <p>It should be called from the Synchronization Context.  Currently will log a warning if
-     * violated.  It will become an exception eventually.  See <a
-     * href="https://github.com/grpc/grpc-java/issues/5015">#5015</a> for the background.
-     *
-     * @since 1.4.0
-     * @deprecated use {@link Subchannel#updateAddresses} instead
-     */
-    @Deprecated
-    public final void updateSubchannelAddresses(
-        Subchannel subchannel, EquivalentAddressGroup addrs) {
-      checkNotNull(addrs, "addrs");
-      updateSubchannelAddresses(subchannel, Collections.singletonList(addrs));
-    }
-
-    /**
-     * Replaces the existing addresses used with {@code subchannel}. This method is superior to
-     * {@link #createSubchannel} when the new and old addresses overlap, since the subchannel can
-     * continue using an existing connection.
-     *
-     * <p>It should be called from the Synchronization Context.  Currently will log a warning if
-     * violated.  It will become an exception eventually.  See <a
-     * href="https://github.com/grpc/grpc-java/issues/5015">#5015</a> for the background.
-     *
-     * @throws IllegalArgumentException if {@code subchannel} was not returned from {@link
-     *     #createSubchannel} or {@code addrs} is empty
-     * @since 1.14.0
-     * @deprecated use {@link Subchannel#updateAddresses} instead
-     */
-    @Deprecated
-    public void updateSubchannelAddresses(
-        Subchannel subchannel, List<EquivalentAddressGroup> addrs) {
       throw new UnsupportedOperationException();
     }
 
@@ -1116,18 +1039,6 @@ public abstract class LoadBalancer {
     }
 
     /**
-     * Schedule a task to be run in the Synchronization Context, which serializes the task with the
-     * callback methods on the {@link LoadBalancer} interface.
-     *
-     * @since 1.2.0
-     * @deprecated use/implement {@code getSynchronizationContext()} instead
-     */
-    @Deprecated
-    public void runSerialized(Runnable task) {
-      getSynchronizationContext().execute(task);
-    }
-
-    /**
      * Returns a {@link SynchronizationContext} that runs tasks in the same Synchronization Context
      * as that the callback methods on the {@link LoadBalancer} interface are run in.
      *
@@ -1156,17 +1067,6 @@ public abstract class LoadBalancer {
     public ScheduledExecutorService getScheduledExecutorService() {
       throw new UnsupportedOperationException();
     }
-
-    /**
-     * Returns the NameResolver of the channel.
-     *
-     * @since 1.2.0
-     *
-     * @deprecated this method will be deleted in a future release.  If you think it shouldn't be
-     *     deleted, please file an issue on <a href="https://github.com/grpc/grpc-java">github</a>.
-     */
-    @Deprecated
-    public abstract NameResolver.Factory getNameResolverFactory();
 
     /**
      * Returns the authority string of the channel, which is derived from the DNS-style target name.

--- a/api/src/test/java/io/grpc/LoadBalancerTest.java
+++ b/api/src/test/java/io/grpc/LoadBalancerTest.java
@@ -45,7 +45,6 @@ public class LoadBalancerTest {
   private final Attributes attrs = Attributes.newBuilder()
       .set(Attributes.Key.create("trash"), new Object())
       .build();
-  private final Subchannel emptySubchannel = new EmptySubchannel();
 
   @Test
   public void pickResult_withSubchannel() {
@@ -123,38 +122,6 @@ public class LoadBalancerTest {
     assertThat(error1).isNotEqualTo(drop1);
   }
 
-  @Deprecated
-  @Test
-  public void helper_createSubchannel_old_delegates() {
-    class OverrideCreateSubchannel extends NoopHelper {
-      boolean ran;
-
-      @Override
-      public Subchannel createSubchannel(List<EquivalentAddressGroup> addrsIn, Attributes attrsIn) {
-        assertThat(addrsIn).hasSize(1);
-        assertThat(addrsIn.get(0)).isSameInstanceAs(eag);
-        assertThat(attrsIn).isSameInstanceAs(attrs);
-        ran = true;
-        return subchannel;
-      }
-    }
-
-    OverrideCreateSubchannel helper = new OverrideCreateSubchannel();
-    assertThat(helper.createSubchannel(eag, attrs)).isSameInstanceAs(subchannel);
-    assertThat(helper.ran).isTrue();
-  }
-
-  @Test
-  @SuppressWarnings("deprecation")
-  public void helper_createSubchannelList_oldApi_throws() {
-    try {
-      new NoopHelper().createSubchannel(Arrays.asList(eag), attrs);
-      fail("Should throw");
-    } catch (UnsupportedOperationException e) {
-      // expected
-    }
-  }
-
   @Test
   public void helper_createSubchannelList_throws() {
     try {
@@ -166,33 +133,6 @@ public class LoadBalancerTest {
     } catch (UnsupportedOperationException e) {
       // expected
     }
-  }
-
-  @Deprecated
-  @Test
-  public void helper_updateSubchannelAddresses_delegates() {
-    class OverrideUpdateSubchannel extends NoopHelper {
-      boolean ran;
-
-      @Override
-      public void updateSubchannelAddresses(
-          Subchannel subchannelIn, List<EquivalentAddressGroup> addrsIn) {
-        assertThat(subchannelIn).isSameInstanceAs(emptySubchannel);
-        assertThat(addrsIn).hasSize(1);
-        assertThat(addrsIn.get(0)).isSameInstanceAs(eag);
-        ran = true;
-      }
-    }
-
-    OverrideUpdateSubchannel helper = new OverrideUpdateSubchannel();
-    helper.updateSubchannelAddresses(emptySubchannel, eag);
-    assertThat(helper.ran).isTrue();
-  }
-
-  @Deprecated
-  @Test(expected = UnsupportedOperationException.class)
-  public void helper_updateSubchannelAddressesList_throws() {
-    new NoopHelper().updateSubchannelAddresses(null, Arrays.asList(eag));
   }
 
   @Test
@@ -407,12 +347,6 @@ public class LoadBalancerTest {
         ConnectivityState newState, LoadBalancer.SubchannelPicker newPicker) {}
 
     @Override public SynchronizationContext getSynchronizationContext() {
-      return null;
-    }
-
-    @Deprecated
-    @Override
-    public NameResolver.Factory getNameResolverFactory() {
       return null;
     }
 

--- a/core/src/main/java/io/grpc/util/ForwardingLoadBalancerHelper.java
+++ b/core/src/main/java/io/grpc/util/ForwardingLoadBalancerHelper.java
@@ -17,7 +17,6 @@
 package io.grpc.util;
 
 import com.google.common.base.MoreObjects;
-import io.grpc.Attributes;
 import io.grpc.ChannelCredentials;
 import io.grpc.ChannelLogger;
 import io.grpc.ConnectivityState;
@@ -32,7 +31,6 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.NameResolver;
 import io.grpc.NameResolverRegistry;
 import io.grpc.SynchronizationContext;
-import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
@@ -42,22 +40,9 @@ public abstract class ForwardingLoadBalancerHelper extends LoadBalancer.Helper {
    */
   protected abstract LoadBalancer.Helper delegate();
 
-  @Deprecated
-  @Override
-  public Subchannel createSubchannel(List<EquivalentAddressGroup> addrs, Attributes attrs) {
-    return delegate().createSubchannel(addrs, attrs);
-  }
-
   @Override
   public Subchannel createSubchannel(CreateSubchannelArgs args) {
     return delegate().createSubchannel(args);
-  }
-
-  @Deprecated
-  @Override
-  public void updateSubchannelAddresses(
-      Subchannel subchannel, List<EquivalentAddressGroup> addrs) {
-    delegate().updateSubchannelAddresses(subchannel, addrs);
   }
 
   @Override
@@ -95,18 +80,6 @@ public abstract class ForwardingLoadBalancerHelper extends LoadBalancer.Helper {
   @Override
   public void refreshNameResolution() {
     delegate().refreshNameResolution();
-  }
-
-  @Override
-  @Deprecated
-  public void runSerialized(Runnable task) {
-    delegate().runSerialized(task);
-  }
-
-  @Deprecated
-  @Override
-  public NameResolver.Factory getNameResolverFactory() {
-    return delegate().getNameResolverFactory();
   }
 
   @Override

--- a/core/src/test/java/io/grpc/internal/PickFirstLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/internal/PickFirstLoadBalancerTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
@@ -114,11 +113,8 @@ public class PickFirstLoadBalancerTest {
   }
 
   @After
-  @SuppressWarnings("deprecation")
   public void tearDown() throws Exception {
     verifyNoMoreInteractions(mockArgs);
-    verify(mockHelper, never()).createSubchannel(
-        ArgumentMatchers.<EquivalentAddressGroup>anyList(), any(Attributes.class));
   }
 
   @Test

--- a/core/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
@@ -71,7 +71,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
@@ -141,11 +140,8 @@ public class RoundRobinLoadBalancerTest {
   }
 
   @After
-  @SuppressWarnings("deprecation")
   public void tearDown() throws Exception {
     verifyNoMoreInteractions(mockArgs);
-    verify(mockHelper, never()).createSubchannel(
-        ArgumentMatchers.<List<EquivalentAddressGroup>>any(), any(Attributes.class));
   }
 
   @Test

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -65,7 +65,6 @@ import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.LoadBalancer.SubchannelStateListener;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
-import io.grpc.NameResolver;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.SynchronizationContext;
@@ -2648,12 +2647,6 @@ public class GrpclbLoadBalancerTest {
     public void updateBalancingState(
         @Nonnull ConnectivityState newState, @Nonnull SubchannelPicker newPicker) {
       currentPicker = newPicker;
-    }
-
-    @Override
-    @SuppressWarnings("deprecation")
-    public NameResolver.Factory getNameResolverFactory() {
-      return mock(NameResolver.Factory.class);
     }
 
     @Override

--- a/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
+++ b/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
@@ -46,7 +46,6 @@ import io.grpc.LoadBalancerProvider;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
-import io.grpc.NameResolver;
 import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.Status;
 import io.grpc.Status.Code;
@@ -576,12 +575,6 @@ public class CachingRlsLbClientTest {
     public void updateBalancingState(
         @Nonnull ConnectivityState newState, @Nonnull SubchannelPicker newPicker) {
       // no-op
-    }
-
-    @Override
-    @Deprecated
-    public NameResolver.Factory getNameResolverFactory() {
-      throw new UnsupportedOperationException();
     }
 
     @Override

--- a/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
@@ -50,7 +50,6 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.Marshaller;
 import io.grpc.MethodDescriptor.MethodType;
-import io.grpc.NameResolver;
 import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.Status;
 import io.grpc.SynchronizationContext;
@@ -469,12 +468,6 @@ public class RlsLoadBalancerTest {
     public void updateBalancingState(
         @Nonnull ConnectivityState newState, @Nonnull SubchannelPicker newPicker) {
       // no-op
-    }
-
-    @Override
-    @Deprecated
-    public NameResolver.Factory getNameResolverFactory() {
-      throw new UnsupportedOperationException();
     }
 
     @Override

--- a/services/src/test/java/io/grpc/services/HealthCheckingLoadBalancerFactoryTest.java
+++ b/services/src/test/java/io/grpc/services/HealthCheckingLoadBalancerFactoryTest.java
@@ -55,7 +55,6 @@ import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.LoadBalancer.SubchannelStateListener;
 import io.grpc.ManagedChannel;
-import io.grpc.NameResolver;
 import io.grpc.Server;
 import io.grpc.Status;
 import io.grpc.Status.Code;
@@ -1261,12 +1260,6 @@ public class HealthCheckingLoadBalancerFactoryTest {
     @Override
     public ScheduledExecutorService getScheduledExecutorService() {
       return clock.getScheduledExecutorService();
-    }
-
-    @Deprecated
-    @Override
-    public NameResolver.Factory getNameResolverFactory() {
-      throw new AssertionError("Should not be called");
     }
 
     @Override

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancerTest.java
@@ -34,7 +34,6 @@ import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.ManagedChannel;
-import io.grpc.NameResolver;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.SynchronizationContext;
@@ -430,12 +429,6 @@ public class CdsLoadBalancerTest {
     @Override
     public SynchronizationContext getSynchronizationContext() {
       return syncContext;
-    }
-
-    @Deprecated
-    @Override
-    public NameResolver.Factory getNameResolverFactory() {
-      throw new UnsupportedOperationException("should not be called");
     }
 
     @Override

--- a/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
@@ -38,7 +38,6 @@ import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
-import io.grpc.NameResolver;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.SynchronizationContext;
@@ -611,12 +610,6 @@ public class ClusterImplLoadBalancerTest {
 
     @Override
     public ManagedChannel createOobChannel(EquivalentAddressGroup eag, String authority) {
-      throw new UnsupportedOperationException("should not be called");
-    }
-
-    @Deprecated
-    @Override
-    public NameResolver.Factory getNameResolverFactory() {
       throw new UnsupportedOperationException("should not be called");
     }
 

--- a/xds/src/test/java/io/grpc/xds/EdsLoadBalancer2Test.java
+++ b/xds/src/test/java/io/grpc/xds/EdsLoadBalancer2Test.java
@@ -39,7 +39,6 @@ import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.ManagedChannel;
-import io.grpc.NameResolver;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.SynchronizationContext;
@@ -853,12 +852,6 @@ public class EdsLoadBalancer2Test {
 
     @Override
     public ManagedChannel createOobChannel(EquivalentAddressGroup eag, String authority) {
-      throw new UnsupportedOperationException("should not be called");
-    }
-
-    @Deprecated
-    @Override
-    public NameResolver.Factory getNameResolverFactory() {
       throw new UnsupportedOperationException("should not be called");
     }
 

--- a/xds/src/test/java/io/grpc/xds/OrcaOobUtilTest.java
+++ b/xds/src/test/java/io/grpc/xds/OrcaOobUtilTest.java
@@ -53,7 +53,6 @@ import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.LoadBalancer.SubchannelStateListener;
 import io.grpc.ManagedChannel;
-import io.grpc.NameResolver;
 import io.grpc.Status;
 import io.grpc.SynchronizationContext;
 import io.grpc.inprocess.InProcessChannelBuilder;
@@ -871,12 +870,6 @@ public class OrcaOobUtilTest {
     @Override
     public ScheduledExecutorService getScheduledExecutorService() {
       return fakeClock.getScheduledExecutorService();
-    }
-
-    @Deprecated
-    @Override
-    public NameResolver.Factory getNameResolverFactory() {
-      throw new AssertionError("Should not be called");
     }
 
     @Override


### PR DESCRIPTION
Delete a bunch of old LoadBalancer.Helper APIs that had been deprecated for a long time.

- `createSubchannel(EquivalentAddressGroup addrs, Attributes attrs)`
`createSubchannel(List<EquivalentAddressGroup> addrs, Attributes attrs)`

    Deprecated in #5722 (v1.22)

- `updateSubchannelAddresses(Subchannel subchannel, EquivalentAddressGroup addrs)`
`updateSubchannelAddresses(Subchannel subchannel, List<EquivalentAddressGroup> addrs)`
    
    Deprecated in #5802 (v1.22)


These deprecated APIs has stronger implementation requirement for synchronization as they originally did not require invocations to be from the SynchronizationContext (although a logged warning was added later if detected the call is not from the SynchronizationContext). Their replacements relaxed the burden for implementations to be thread-safe and would throw if calls are not from the SynchronizationContext.


Other old deprecated APIs are:
- `runSerialized(Runnable task)`: deprecated in #4971 (v1.17)

- `getNameResolverFactory()`: deprecated in #5418 (1.20.0)


--------------------
TODO: will need to migrate internal usages.