### PR TITLE
interop-testing: allow multiple port in test server

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
@@ -98,8 +98,8 @@ public class TestServiceServer {
       String value = parts[1];
       if ("port".equals(key)) {
         port.clear();
-        for (String v : Splitter.onPattern("\\s+|,").split(value)) {
-          port.add(Integer.parseInt(v));
+        for (String v : Splitter.on(',').split(value)) {
+          port.add(Integer.parseInt(v.trim()));
         }
         if (port.isEmpty()) {
           System.err.println("Unknown server port");

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
@@ -17,8 +17,8 @@
 package io.grpc.testing.integration;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
 import com.google.common.util.concurrent.MoreExecutors;
-import io.grpc.Grpc;
 import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
 import io.grpc.ServerCredentials;
@@ -26,6 +26,10 @@ import io.grpc.ServerInterceptors;
 import io.grpc.TlsServerCredentials;
 import io.grpc.alts.AltsServerCredentials;
 import io.grpc.internal.testing.TestUtils;
+import io.grpc.netty.NettyServerBuilder;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -64,7 +68,7 @@ public class TestServiceServer {
     server.blockUntilShutdown();
   }
 
-  private int port = 8080;
+  private final ArrayList<Integer> port = new ArrayList<>(Collections.singletonList(8080));
   private boolean useTls = true;
   private boolean useAlts = false;
 
@@ -93,7 +97,15 @@ public class TestServiceServer {
       }
       String value = parts[1];
       if ("port".equals(key)) {
-        port = Integer.parseInt(value);
+        port.clear();
+        for (String v : Splitter.onPattern("\\s+|,").split(value)) {
+          port.add(Integer.parseInt(v));
+        }
+        if (port.isEmpty()) {
+          System.err.println("Unknown server port");
+          usage = true;
+          break;
+        }
       } else if ("use_tls".equals(key)) {
         useTls = Boolean.parseBoolean(value);
       } else if ("use_alts".equals(key)) {
@@ -118,7 +130,7 @@ public class TestServiceServer {
       System.out.println(
           "Usage: [ARGS...]"
               + "\n"
-              + "\n  --port=PORT           Port to connect to. Default " + s.port
+              + "\n  --port=<port_1>,<port_2>...<port_N>  Port to connect to. Default " + s.port
               + "\n  --use_tls=true|false  Whether to use TLS. Default " + s.useTls
               + "\n  --use_alts=true|false Whether to use ALTS. Enable ALTS will disable TLS."
               + "\n                        Default " + s.useAlts
@@ -139,8 +151,11 @@ public class TestServiceServer {
     } else {
       serverCreds = InsecureServerCredentials.create();
     }
-    server = Grpc.newServerBuilderForPort(port, serverCreds)
-        .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
+    NettyServerBuilder serverBuilder = NettyServerBuilder.forPort(port.get(0), serverCreds);
+    for (int i = 1; i < port.size(); i++) {
+      serverBuilder.addListenAddress(new InetSocketAddress(port.get(i)));
+    }
+    server = serverBuilder.maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
         .addService(
             ServerInterceptors.intercept(
                 new TestServiceImpl(executor), TestServiceImpl.interceptors()))


### PR DESCRIPTION
### Test
`$ ./run-test-server.sh --use_tls=false --port=2,3`

`$ ./run-test-server.sh --use_tls=false --port=8080`

```
$ ./run-test-server.sh --use_tls=false --port=2,2
Exception in thread "main" java.io.IOException: Failed to bind to address 0.0.0.0/0.0.0.0:2
	at io.grpc.netty.NettyServer.start(NettyServer.java:328)
	at io.grpc.internal.ServerImpl.start(ServerImpl.java:179)
	at io.grpc.internal.ServerImpl.start(ServerImpl.java:90)
	at io.grpc.testing.integration.TestServiceServer.start(TestServiceServer.java:165)
	at io.grpc.testing.integration.TestServiceServer.main(TestServiceServer.java:68)
Caused by: java.net.BindException: Address already in use
	at sun.nio.ch.Net.bind0(Native Method)
	at sun.nio.ch.Net.bind(Net.java:433)
	at sun.nio.ch.Net.bind(Net.java:425)
	at sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:220)
	at io.netty.channel.socket.nio.NioServerSocketChannel.doBind(NioServerSocketChannel.java:134)
	at io.netty.channel.AbstractChannel$AbstractUnsafe.bind(AbstractChannel.java:550)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.bind(DefaultChannelPipeline.java:1334)
	at io.netty.channel.AbstractChannelHandlerContext.invokeBind(AbstractChannelHandlerContext.java:506)
	at io.netty.channel.AbstractChannelHandlerContext.bind(AbstractChannelHandlerContext.java:491)
	at io.netty.channel.DefaultChannelPipeline.bind(DefaultChannelPipeline.java:973)
	at io.netty.channel.AbstractChannel.bind(AbstractChannel.java:248)
	at io.netty.bootstrap.AbstractBootstrap$2.run(AbstractBootstrap.java:356)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:500)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:748)
```