### PR TITLE
xds: support reading bootstrap config directly from env var or system property values

### DIFF
--- a/xds/src/test/java/io/grpc/xds/XdsClientWrapperForServerSdsTestMisc.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientWrapperForServerSdsTestMisc.java
@@ -201,9 +201,7 @@ public class XdsClientWrapperForServerSdsTestMisc {
     } catch (IOException expected) {
       assertThat(expected)
               .hasMessageThat()
-              .contains(
-                      "Environment variable GRPC_XDS_BOOTSTRAP"
-                      + " or Java System Property io.grpc.xds.bootstrap not defined.");
+              .contains("Cannot find bootstrap configuration");
     }
     ArgumentCaptor<Status> argCaptor = ArgumentCaptor.forClass(null);
     verify(mockServerWatcher).onError(argCaptor.capture());
@@ -212,9 +210,7 @@ public class XdsClientWrapperForServerSdsTestMisc {
     assertThat(captured.getCause()).isInstanceOf(XdsInitializationException.class);
     assertThat(captured.getCause())
         .hasMessageThat()
-        .contains(
-                "Environment variable GRPC_XDS_BOOTSTRAP"
-                + " or Java System Property io.grpc.xds.bootstrap not defined.");
+        .contains("Cannot find bootstrap configuration");
   }
 
   private DownstreamTlsContext sendListenerUpdate(

--- a/xds/src/test/java/io/grpc/xds/XdsServerBuilderTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerBuilderTest.java
@@ -234,9 +234,7 @@ public class XdsServerBuilderTest {
     } catch (IOException expected) {
       assertThat(expected)
               .hasMessageThat()
-              .contains(
-                      "Environment variable GRPC_XDS_BOOTSTRAP"
-                      + " or Java System Property io.grpc.xds.bootstrap not defined.");
+              .contains("Cannot find bootstrap configuration");
     }
     ArgumentCaptor<Status> argCaptor = ArgumentCaptor.forClass(null);
     verify(mockErrorNotifier).onError(argCaptor.capture());
@@ -245,9 +243,7 @@ public class XdsServerBuilderTest {
     assertThat(captured.getCause()).isInstanceOf(XdsInitializationException.class);
     assertThat(captured.getCause())
             .hasMessageThat()
-            .contains(
-                    "Environment variable GRPC_XDS_BOOTSTRAP"
-                    + " or Java System Property io.grpc.xds.bootstrap not defined.");
+            .contains("Cannot find bootstrap configuration");
   }
 
   @Test


### PR DESCRIPTION
Currently, gRPC uses the `GRPC_XDS_BOOSTRAP` env variable to find the bootstrap file. There are use cases where file based bootstrap config is not optimal like when a file system is not mounted. We want to have an option to input bootstrap config directly via an env variable. This change supports reading the bootstrap config from the following places (in order):

- If `GRPC_XDS_BOOTSTRAP` exists then use its value as the name of the bootstrap file. If the file is missing or the contents of the file are malformed, return an error.
 
- Else if `io.grpc.xds.bootstrap` exists then use its value as the name of the bootstrap file. If the file is missing or the contents are malformed, return an error.
 
- Else, if `GRPC_XDS_BOOTSTRAP_CONFIG` exists then use its value as the bootstrap config. If the value is malformed, return an error.
 
- Else, if `io.grpc.xds.bootstrap_value` exists then use its value as the bootstrap config. If the value is malformed, return an error.

--------------------
Would be easy to add some tests after #7810 is merged.