### PR TITLE
Add a simple way to run grpc-java test inside emulated ARM64 docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ bin
 # Emacs
 *~
 \#*\#
+
+# ARM tests
+qemu-arm-static

--- a/buildscripts/grpc-java-linux-arm64-tests/Dockerfile
+++ b/buildscripts/grpc-java-linux-arm64-tests/Dockerfile
@@ -8,6 +8,3 @@ FROM arm64v8/debian:buster
 COPY qemu-arm-static /usr/bin
 
 RUN apt-get update && apt-get install -y --no-install-recommends openjdk-11-jdk-headless && apt-get clean
-
-COPY build_and_run_tests.sh /
-

--- a/buildscripts/grpc-java-linux-arm64-tests/Dockerfile
+++ b/buildscripts/grpc-java-linux-arm64-tests/Dockerfile
@@ -1,0 +1,13 @@
+# This docker image uses magic to seamlessly run its contents using qemu ARM emulator on x86 host.
+# See https://ownyourbits.com/2018/06/27/running-and-building-arm-docker-containers-in-x86/
+
+# We want to test on arm64v8
+FROM arm64v8/debian:buster
+
+# Make the host's qemu-arm-static emulator available from inside the docker container.
+COPY qemu-arm-static /usr/bin
+
+RUN apt-get update && apt-get install -y --no-install-recommends openjdk-11-jdk-headless && apt-get clean
+
+COPY build_and_run_tests.sh /
+

--- a/buildscripts/grpc-java-linux-arm64-tests/build_and_run_tests.sh
+++ b/buildscripts/grpc-java-linux-arm64-tests/build_and_run_tests.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -ex
+
+cp -r /grpc-java /workspace
+cd /workspace
+./gradlew build -PskipAndroid=true -PskipCodegen=true

--- a/buildscripts/grpc-java-linux-arm64-tests/build_and_run_tests.sh
+++ b/buildscripts/grpc-java-linux-arm64-tests/build_and_run_tests.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -ex
-
-cp -r /grpc-java /workspace
-cd /workspace
-./gradlew build -PskipAndroid=true -PskipCodegen=true

--- a/buildscripts/run_arm64_tests_in_docker.sh
+++ b/buildscripts/run_arm64_tests_in_docker.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+
+readonly grpc_java_dir="$(dirname "$(readlink -f "$0")")/.."
+
+# Build magic docker image that can run on x86 host, but looks like an ARM machine
+# from the inside (qemu-user-static is used for emulation)
+# Run "sudo apt install qemu-user-static binfmt-support" install the emulator
+# on the host machine.
+# Also see https://ownyourbits.com/2018/06/27/running-and-building-arm-docker-containers-in-x86/
+cp /usr/bin/qemu-arm-static "${grpc_java_dir}/buildscripts/grpc-java-linux-arm64-tests"
+docker build -t grpc-java-linux-arm64-tests "${grpc_java_dir}/buildscripts/grpc-java-linux-arm64-tests"
+
+if [[ -t 0 ]]; then
+  DOCKER_ARGS="-it"
+else
+  # The input device on kokoro is not a TTY, so -it does not work.
+  DOCKER_ARGS=
+fi
+exec docker run $DOCKER_ARGS --rm=true -v "${grpc_java_dir}":/grpc-java:ro -w /grpc-java \
+  grpc-java-linux-arm64-tests /build_and_run_tests.sh


### PR DESCRIPTION
Not ready to merge, but demonstrates a neat way how to test grpc-java on x86 using a docker container and ARM emulator with just a few commands.

FTR I tried this on my linux workstation and the entire build & tests took ~40mins (which is reasonable considering the fact that the ARM environment is being emulated).

CC @ejona86  

