### PR TITLE
xds: make XdsAttributes really public internal

### DIFF
--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -94,6 +94,7 @@ javadoc {
     exclude 'io/grpc/xds/XdsInitializationException.java'
     exclude 'io/grpc/xds/XdsNameResolverProvider.java'
     exclude 'io/grpc/xds/internal/**'
+    exclude 'io/grpc/xds/Internal*'
 }
 
 shadowJar {

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
@@ -86,7 +86,7 @@ final class CdsLoadBalancer2 extends LoadBalancer {
     }
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     this.resolvedAddresses = resolvedAddresses;
-    xdsClientPool = resolvedAddresses.getAttributes().get(XdsAttributes.XDS_CLIENT_POOL);
+    xdsClientPool = resolvedAddresses.getAttributes().get(InternalXdsAttributes.XDS_CLIENT_POOL);
     xdsClient = xdsClientPool.getObject();
     CdsConfig config = (CdsConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
     logger.log(XdsLogLevel.INFO, "Config: {0}", config);

--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -102,11 +102,11 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     Attributes attributes = resolvedAddresses.getAttributes();
     if (xdsClientPool == null) {
-      xdsClientPool = attributes.get(XdsAttributes.XDS_CLIENT_POOL);
+      xdsClientPool = attributes.get(InternalXdsAttributes.XDS_CLIENT_POOL);
       xdsClient = xdsClientPool.getObject();
     }
     if (callCounterProvider == null) {
-      callCounterProvider = attributes.get(XdsAttributes.CALL_COUNTER_PROVIDER);
+      callCounterProvider = attributes.get(InternalXdsAttributes.CALL_COUNTER_PROVIDER);
     }
     ClusterImplConfig config =
         (ClusterImplConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
@@ -130,7 +130,7 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
     childLbHelper.updateSslContextProviderSupplier(config.tlsContext);
     if (loadStatsStore != null) {
       attributes = attributes.toBuilder()
-          .set(XdsAttributes.ATTR_CLUSTER_SERVICE_LOAD_STATS_STORE, loadStatsStore).build();
+          .set(InternalXdsAttributes.ATTR_CLUSTER_SERVICE_LOAD_STATS_STORE, loadStatsStore).build();
     }
     childLb.handleResolvedAddresses(
         resolvedAddresses.toBuilder()
@@ -200,7 +200,7 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
         for (EquivalentAddressGroup eag : args.getAddresses()) {
           Attributes attributes =
               eag.getAttributes().toBuilder()
-                  .set(XdsAttributes.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER,
+                  .set(InternalXdsAttributes.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER,
                       sslContextProviderSupplier)
                   .build();
           addresses.add(new EquivalentAddressGroup(eag.getAddresses(), attributes));

--- a/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
@@ -114,7 +114,7 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
   public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     if (xdsClientPool == null) {
-      xdsClientPool = resolvedAddresses.getAttributes().get(XdsAttributes.XDS_CLIENT_POOL);
+      xdsClientPool = resolvedAddresses.getAttributes().get(InternalXdsAttributes.XDS_CLIENT_POOL);
       xdsClient = xdsClientPool.getObject();
     }
     ClusterResolverConfig config =

--- a/xds/src/main/java/io/grpc/xds/InternalXdsAttributes.java
+++ b/xds/src/main/java/io/grpc/xds/InternalXdsAttributes.java
@@ -26,17 +26,21 @@ import io.grpc.xds.XdsNameResolverProvider.CallCounterProvider;
 import io.grpc.xds.internal.sds.SslContextProviderSupplier;
 
 /**
- * Special attributes that are only useful to gRPC in the XDS context.
+ * Internal attributes used for xDS implementation. Do not use.
  */
 @Internal
-public final class XdsAttributes {
+public final class InternalXdsAttributes {
 
+  // TODO(sanjaypujare): move to xds internal package.
   /** Attribute key for SslContextProviderSupplier (used from client) for a subchannel. */
   @Grpc.TransportAttr
   public static final Attributes.Key<SslContextProviderSupplier>
       ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER =
           Attributes.Key.create("io.grpc.xds.internal.sds.SslContextProviderSupplier");
 
+  /**
+   * Attribute key for passing around the XdsClient object pool across NameResolver/LoadBalancers.
+   */
   @NameResolver.ResolutionResultAttr
   static final Attributes.Key<ObjectPool<XdsClient>> XDS_CLIENT_POOL =
       Attributes.Key.create("io.grpc.xds.XdsAttributes.xdsClientPool");
@@ -54,5 +58,5 @@ public final class XdsAttributes {
   static final Attributes.Key<LoadStatsStore> ATTR_CLUSTER_SERVICE_LOAD_STATS_STORE =
       Attributes.Key.create("io.grpc.xds.XdsAttributes.loadStatsStore");
 
-  private XdsAttributes() {}
+  private InternalXdsAttributes() {}
 }

--- a/xds/src/main/java/io/grpc/xds/LrsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/LrsLoadBalancer.java
@@ -52,8 +52,8 @@ final class LrsLoadBalancer extends LoadBalancer {
   @Override
   public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     LrsConfig config = (LrsConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
-    LoadStatsStore store =
-        resolvedAddresses.getAttributes().get(XdsAttributes.ATTR_CLUSTER_SERVICE_LOAD_STATS_STORE);
+    LoadStatsStore store = resolvedAddresses.getAttributes().get(
+        InternalXdsAttributes.ATTR_CLUSTER_SERVICE_LOAD_STATS_STORE);
     checkNotNull(config, "missing LRS lb config");
     checkNotNull(store, "missing cluster service stats object");
     checkAndSetUp(config, store);

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -190,8 +190,8 @@ final class XdsNameResolver extends NameResolver {
     ConfigOrError parsedServiceConfig = serviceConfigParser.parseServiceConfig(rawServiceConfig);
     Attributes attrs =
         Attributes.newBuilder()
-            .set(XdsAttributes.XDS_CLIENT_POOL, xdsClientPool)
-            .set(XdsAttributes.CALL_COUNTER_PROVIDER, callCounterProvider)
+            .set(InternalXdsAttributes.XDS_CLIENT_POOL, xdsClientPool)
+            .set(InternalXdsAttributes.CALL_COUNTER_PROVIDER, callCounterProvider)
             .set(InternalConfigSelector.KEY, configSelector)
             .build();
     ResolutionResult result =

--- a/xds/src/main/java/io/grpc/xds/internal/sds/SdsProtocolNegotiators.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/SdsProtocolNegotiators.java
@@ -32,7 +32,7 @@ import io.grpc.netty.InternalProtocolNegotiators;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.ProtocolNegotiationEvent;
 import io.grpc.xds.EnvoyServerProtoData.DownstreamTlsContext;
-import io.grpc.xds.XdsAttributes;
+import io.grpc.xds.InternalXdsAttributes;
 import io.grpc.xds.XdsClientWrapperForServerSds;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerAdapter;
@@ -189,7 +189,8 @@ public final class SdsProtocolNegotiators {
     public ChannelHandler newHandler(GrpcHttp2ConnectionHandler grpcHandler) {
       // check if SslContextProviderSupplier was passed via attributes
       SslContextProviderSupplier localSslContextProviderSupplier =
-          grpcHandler.getEagAttributes().get(XdsAttributes.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER);
+          grpcHandler.getEagAttributes().get(
+              InternalXdsAttributes.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER);
       if (localSslContextProviderSupplier == null) {
         checkNotNull(
             fallbackProtocolNegotiator, "No TLS config and no fallbackProtocolNegotiator!");

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
@@ -130,7 +130,9 @@ public class CdsLoadBalancer2Test {
             .setAddresses(Collections.<EquivalentAddressGroup>emptyList())
             .setAttributes(
                 // Other attributes not used by cluster_resolver LB are omitted.
-                Attributes.newBuilder().set(XdsAttributes.XDS_CLIENT_POOL, xdsClientPool).build())
+                Attributes.newBuilder()
+                    .set(InternalXdsAttributes.XDS_CLIENT_POOL, xdsClientPool)
+                    .build())
             .setLoadBalancingPolicyConfig(new CdsConfig(CLUSTER))
             .build());
     assertThat(Iterables.getOnlyElement(xdsClient.watchers.keySet())).isEqualTo(CLUSTER);

--- a/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
@@ -154,10 +154,10 @@ public class ClusterImplLoadBalancerTest {
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(downstreamBalancers);
     assertThat(Iterables.getOnlyElement(childBalancer.addresses)).isEqualTo(endpoint);
     assertThat(childBalancer.config).isSameInstanceAs(weightedTargetConfig);
-    assertThat(childBalancer.attributes.get(XdsAttributes.XDS_CLIENT_POOL))
+    assertThat(childBalancer.attributes.get(InternalXdsAttributes.XDS_CLIENT_POOL))
         .isSameInstanceAs(xdsClientPool);
-    assertThat(childBalancer.attributes.get(XdsAttributes.ATTR_CLUSTER_SERVICE_LOAD_STATS_STORE))
-        .isNotNull();
+    assertThat(childBalancer.attributes.get(
+        InternalXdsAttributes.ATTR_CLUSTER_SERVICE_LOAD_STATS_STORE)).isNotNull();
   }
 
   @Test
@@ -224,7 +224,9 @@ public class ClusterImplLoadBalancerTest {
         ResolvedAddresses.newBuilder()
             .setAddresses(Collections.singletonList(endpoint))
             .setAttributes(
-                Attributes.newBuilder().set(XdsAttributes.XDS_CLIENT_POOL, xdsClientPool).build())
+                Attributes.newBuilder()
+                    .set(InternalXdsAttributes.XDS_CLIENT_POOL, xdsClientPool)
+                    .build())
             .setLoadBalancingPolicyConfig(config)
             .build());
     result = currentPicker.pickSubchannel(mock(PickSubchannelArgs.class));
@@ -409,7 +411,7 @@ public class ClusterImplLoadBalancerTest {
     Subchannel subchannel = leafBalancer.helper.createSubchannel(args);
     for (EquivalentAddressGroup eag : subchannel.getAllAddresses()) {
       SslContextProviderSupplier supplier =
-          eag.getAttributes().get(XdsAttributes.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER);
+          eag.getAttributes().get(InternalXdsAttributes.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER);
       if (enableSecurity) {
         assertThat(supplier.getUpstreamTlsContext()).isEqualTo(upstreamTlsContext);
       } else {
@@ -425,7 +427,7 @@ public class ClusterImplLoadBalancerTest {
     assertThat(Iterables.getOnlyElement(downstreamBalancers)).isSameInstanceAs(leafBalancer);
     subchannel = leafBalancer.helper.createSubchannel(args);  // creates new connections
     for (EquivalentAddressGroup eag : subchannel.getAllAddresses()) {
-      assertThat(eag.getAttributes().get(XdsAttributes.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER))
+      assertThat(eag.getAttributes().get(InternalXdsAttributes.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER))
           .isNull();
     }
 
@@ -443,7 +445,7 @@ public class ClusterImplLoadBalancerTest {
     subchannel = leafBalancer.helper.createSubchannel(args);  // creates new connections
     for (EquivalentAddressGroup eag : subchannel.getAllAddresses()) {
       SslContextProviderSupplier supplier =
-          eag.getAttributes().get(XdsAttributes.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER);
+          eag.getAttributes().get(InternalXdsAttributes.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER);
       if (enableSecurity) {
         assertThat(supplier.getUpstreamTlsContext()).isEqualTo(upstreamTlsContext);
       } else {
@@ -459,8 +461,8 @@ public class ClusterImplLoadBalancerTest {
             .setAddresses(addresses)
             .setAttributes(
                 Attributes.newBuilder()
-                    .set(XdsAttributes.XDS_CLIENT_POOL, xdsClientPool)
-                    .set(XdsAttributes.CALL_COUNTER_PROVIDER, callCounterProvider)
+                    .set(InternalXdsAttributes.XDS_CLIENT_POOL, xdsClientPool)
+                    .set(InternalXdsAttributes.CALL_COUNTER_PROVIDER, callCounterProvider)
                     .build())
             .setLoadBalancingPolicyConfig(config)
             .build());

--- a/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
@@ -736,7 +736,9 @@ public class ClusterResolverLoadBalancerTest {
             .setAddresses(Collections.<EquivalentAddressGroup>emptyList())
             .setAttributes(
                 // Other attributes not used by cluster_resolver LB are omitted.
-                Attributes.newBuilder().set(XdsAttributes.XDS_CLIENT_POOL, xdsClientPool).build())
+                Attributes.newBuilder()
+                    .set(InternalXdsAttributes.XDS_CLIENT_POOL, xdsClientPool)
+                    .build())
             .setLoadBalancingPolicyConfig(config)
             .build());
   }

--- a/xds/src/test/java/io/grpc/xds/LrsLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/LrsLoadBalancerTest.java
@@ -158,7 +158,7 @@ public class LrsLoadBalancerTest {
             .setAddresses(addresses)
             .setAttributes(
                 Attributes.newBuilder()
-                    .set(XdsAttributes.ATTR_CLUSTER_SERVICE_LOAD_STATS_STORE, loadRecorder)
+                    .set(InternalXdsAttributes.ATTR_CLUSTER_SERVICE_LOAD_STATS_STORE, loadRecorder)
                     .build())
             .setLoadBalancingPolicyConfig(config)
             .build();

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -444,7 +444,7 @@ public class XdsNameResolverTest {
     assertThat(result.getAddresses()).isEmpty();
     assertServiceConfigForLoadBalancingConfig(
         Arrays.asList(cluster1, cluster2), (Map<String, ?>) result.getServiceConfig().getConfig());
-    assertThat(result.getAttributes().get(XdsAttributes.XDS_CLIENT_POOL)).isNotNull();
+    assertThat(result.getAttributes().get(InternalXdsAttributes.XDS_CLIENT_POOL)).isNotNull();
     InternalConfigSelector configSelector = result.getAttributes().get(InternalConfigSelector.KEY);
     assertCallSelectResult(call1, configSelector, cluster2, 20.0);
     assertCallSelectResult(call1, configSelector, cluster1, 20.0);
@@ -504,8 +504,8 @@ public class XdsNameResolverTest {
     assertThat(result.getAddresses()).isEmpty();
     assertServiceConfigForLoadBalancingConfig(
         Arrays.asList(cluster1, cluster2), (Map<String, ?>) result.getServiceConfig().getConfig());
-    assertThat(result.getAttributes().get(XdsAttributes.XDS_CLIENT_POOL)).isNotNull();
-    assertThat(result.getAttributes().get(XdsAttributes.CALL_COUNTER_PROVIDER)).isNotNull();
+    assertThat(result.getAttributes().get(InternalXdsAttributes.XDS_CLIENT_POOL)).isNotNull();
+    assertThat(result.getAttributes().get(InternalXdsAttributes.CALL_COUNTER_PROVIDER)).isNotNull();
     return result.getAttributes().get(InternalConfigSelector.KEY);
   }
 

--- a/xds/src/test/java/io/grpc/xds/XdsSdsClientServerTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsSdsClientServerTest.java
@@ -396,7 +396,7 @@ public class XdsSdsClientServerTest {
     Attributes attrs =
         (upstreamTlsContext != null)
             ? Attributes.newBuilder()
-                .set(XdsAttributes.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER,
+                .set(InternalXdsAttributes.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER,
                     new SslContextProviderSupplier(
                         upstreamTlsContext, new TlsContextManagerImpl(mockBootstrapper)))
                 .build()
@@ -425,7 +425,7 @@ public class XdsSdsClientServerTest {
     Attributes attrs =
         (upstreamTlsContext != null)
             ? Attributes.newBuilder()
-                .set(XdsAttributes.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER,
+                .set(InternalXdsAttributes.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER,
                     new SslContextProviderSupplier(
                         upstreamTlsContext, new TlsContextManagerImpl(mockBootstrapper)))
                 .build()

--- a/xds/src/test/java/io/grpc/xds/internal/sds/SdsProtocolNegotiatorsTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/sds/SdsProtocolNegotiatorsTest.java
@@ -41,7 +41,7 @@ import io.grpc.netty.InternalProtocolNegotiator.ProtocolNegotiator;
 import io.grpc.netty.InternalProtocolNegotiators;
 import io.grpc.xds.EnvoyServerProtoData.DownstreamTlsContext;
 import io.grpc.xds.EnvoyServerProtoData.UpstreamTlsContext;
-import io.grpc.xds.XdsAttributes;
+import io.grpc.xds.InternalXdsAttributes;
 import io.grpc.xds.XdsClientWrapperForServerSds;
 import io.grpc.xds.XdsClientWrapperForServerSdsTest;
 import io.grpc.xds.internal.sds.SdsProtocolNegotiators.ClientSdsHandler;
@@ -183,7 +183,7 @@ public class SdsProtocolNegotiatorsTest {
     when(mockHandler.getEagAttributes())
         .thenReturn(
             Attributes.newBuilder()
-                .set(XdsAttributes.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER,
+                .set(InternalXdsAttributes.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER,
                     new SslContextProviderSupplier(upstreamTlsContext, mockTlsContextManager))
                 .build());
     ChannelHandler newHandler = pn.newHandler(mockHandler);


### PR DESCRIPTION
The real change is in `XdsAttributes` -> `InternalXdsAttributes`.