### PR TITLE
xds: google_default should use TLS if address contains no cluster name 

### DIFF
--- a/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
@@ -247,8 +247,13 @@ public final class AltsProtocolNegotiator {
     public ChannelHandler newHandler(GrpcHttp2ConnectionHandler grpcHandler) {
       ChannelHandler gnh = InternalProtocolNegotiators.grpcNegotiationHandler(grpcHandler);
       ChannelHandler securityHandler;
-      boolean isXdsDirectPath = clusterNameAttrKey != null
-          && !"google_cfe".equals(grpcHandler.getEagAttributes().get(clusterNameAttrKey));
+      boolean isXdsDirectPath = false;
+      if (clusterNameAttrKey != null) {
+        String clusterName = grpcHandler.getEagAttributes().get(clusterNameAttrKey);
+        if (clusterName != null && !clusterName.equals("google_cfe")) {
+          isXdsDirectPath = true;
+        }
+      }
       if (grpcHandler.getEagAttributes().get(GrpclbConstants.ATTR_LB_ADDR_AUTHORITY) != null
           || grpcHandler.getEagAttributes().get(GrpclbConstants.ATTR_LB_PROVIDED_BACKEND) != null
           || isXdsDirectPath) {


### PR DESCRIPTION
A bug was introduced in #7783 that made google_default creds select ALTS for connections to TD (should be TLS instead), which cased recent CI failures. More specifically, [`!"google_cfe".equals(grpcHandler.getEagAttributes().get(clusterNameAttrKey))`](https://github.com/grpc/grpc-java/blob/1b23cf4f39ab26728336edbda8bb6af22dfe0a01/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java#L251) is the buggy line that oversees the case for TD's address.