### PR TITLE
buildscripts: fix buildscript unbound variable error

### DIFF
--- a/buildscripts/kokoro/xds.sh
+++ b/buildscripts/kokoro/xds.sh
@@ -35,7 +35,7 @@ JAVA_OPTS=-Djava.util.logging.config.file=grpc-java/buildscripts/xds_logging.pro
     --path_to_server_binary=/java_server/grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-server \
     --gcp_suffix=$(date '+%s') \
     --verbose \
-    ${XDS_V3_OPT} \
+    ${XDS_V3_OPT+x} \
     --client_cmd="grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-client \
       --server=xds:///{server_uri} \
       --stats_port={stats_port} \

--- a/buildscripts/kokoro/xds.sh
+++ b/buildscripts/kokoro/xds.sh
@@ -35,7 +35,7 @@ JAVA_OPTS=-Djava.util.logging.config.file=grpc-java/buildscripts/xds_logging.pro
     --path_to_server_binary=/java_server/grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-server \
     --gcp_suffix=$(date '+%s') \
     --verbose \
-    ${XDS_V3_OPT+x} \
+    ${XDS_V3_OPT-} \
     --client_cmd="grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-client \
       --server=xds:///{server_uri} \
       --stats_port={stats_port} \


### PR DESCRIPTION
Didn't notice there is `set -u` in xds.sh.

Failure:
http://sponge2.corp.google.com/3224b1bd-d6b2-472d-b8ae-4e61898de598

Manual test of the fix:
https://sponge2.corp.google.com/df820274-0ff0-4d9b-aaf8-8528437e0f93