### PR TITLE
buildscripts: fix execution path of xds.sh in xds_v3.sh

### DIFF
--- a/buildscripts/kokoro/xds_v3.sh
+++ b/buildscripts/kokoro/xds_v3.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-XDS_V3_OPT="--xds_v3_support" xds.sh
+XDS_V3_OPT="--xds_v3_support" `dirname $0`/xds.sh


### PR DESCRIPTION
Manual test:
http://sponge2/63654a23-efdd-4acd-a274-ecf67856968b