### PR TITLE
xds: support reading bootstrap config directly from env var or system property values

### DIFF
--- a/xds/src/main/java/io/grpc/xds/BootstrapperImpl.java
+++ b/xds/src/main/java/io/grpc/xds/BootstrapperImpl.java
@@ -55,7 +55,7 @@ public class BootstrapperImpl implements Bootstrapper {
   private static final String BOOTSTRAP_CONFIG_SYS_ENV_VAR = "GRPC_XDS_BOOTSTRAP_CONFIG";
   @VisibleForTesting
   static String bootstrapConfigFromEnvVar = System.getenv(BOOTSTRAP_CONFIG_SYS_ENV_VAR);
-  private static final String BOOTSTRAP_CONFIG_SYS_PROPERTY_VAR = "io.grpc.xds.bootstrap_value";
+  private static final String BOOTSTRAP_CONFIG_SYS_PROPERTY_VAR = "io.grpc.xds.bootstrapValue";
   @VisibleForTesting
   static String bootstrapConfigFromSysProp = System.getProperty(BOOTSTRAP_CONFIG_SYS_PROPERTY_VAR);
   private static final String XDS_V3_SERVER_FEATURE = "xds_v3";

--- a/xds/src/main/java/io/grpc/xds/BootstrapperImpl.java
+++ b/xds/src/main/java/io/grpc/xds/BootstrapperImpl.java
@@ -52,6 +52,12 @@ public class BootstrapperImpl implements Bootstrapper {
   private static final String BOOTSTRAP_PATH_SYS_PROPERTY = "io.grpc.xds.bootstrap";
   @VisibleForTesting
   static String bootstrapPathFromSysProp = System.getProperty(BOOTSTRAP_PATH_SYS_PROPERTY);
+  private static final String BOOTSTRAP_CONFIG_SYS_ENV_VAR = "GRPC_XDS_BOOTSTRAP_CONFIG";
+  @VisibleForTesting
+  static String bootstrapConfigFromEnvVar = System.getenv(BOOTSTRAP_CONFIG_SYS_ENV_VAR);
+  private static final String BOOTSTRAP_CONFIG_SYS_PROPERTY_VAR = "io.grpc.xds.bootstrap_value";
+  @VisibleForTesting
+  static String bootstrapConfigFromSysProp = System.getProperty(BOOTSTRAP_CONFIG_SYS_PROPERTY_VAR);
   private static final String XDS_V3_SERVER_FEATURE = "xds_v3";
   @VisibleForTesting
   static boolean enableV3Protocol = Boolean.parseBoolean(
@@ -67,23 +73,44 @@ public class BootstrapperImpl implements Bootstrapper {
     logger = XdsLogger.withLogId(InternalLogId.allocate("bootstrapper", null));
   }
 
+  /**
+   * Reads and parses bootstrap config. Searches the config (or file of config) with the
+   * following order:
+   *
+   * <ol>
+   *   <li>A filesystem path defined by environment variable "GRPC_XDS_BOOTSTRAP"</li>
+   *   <li>A filesystem path defined by Java System Property "io.grpc.xds.bootstrap"</li>
+   *   <li>Environment variable value of "GRPC_XDS_BOOTSTRAP_CONFIG"</li>
+   *   <li>Java System Property value of "io.grpc.xds.bootstrap_value"</li>
+   * </ol>
+   */
   @Override
   public BootstrapInfo bootstrap() throws XdsInitializationException {
     String filePath =
         bootstrapPathFromEnvVar != null ? bootstrapPathFromEnvVar : bootstrapPathFromSysProp;
-    if (filePath == null) {
-      throw new XdsInitializationException(
-          "Environment variable " + BOOTSTRAP_PATH_SYS_ENV_VAR
-              + " or Java System Property " + BOOTSTRAP_PATH_SYS_PROPERTY + " not defined.");
+    String rawBootstrap;
+    if (filePath != null) {
+      logger.log(XdsLogLevel.INFO, "Reading bootstrap file from {0}", filePath);
+      try {
+        rawBootstrap = reader.readFile(filePath);
+      } catch (IOException e) {
+        throw new XdsInitializationException("Fail to read bootstrap file", e);
+      }
+    } else {
+      rawBootstrap = bootstrapConfigFromEnvVar != null
+          ? bootstrapConfigFromEnvVar : bootstrapConfigFromSysProp;
     }
-    logger.log(XdsLogLevel.INFO, "Reading bootstrap file from {0}", filePath);
-    String fileContent;
-    try {
-      fileContent = reader.readFile(filePath);
-    } catch (IOException e) {
-      throw new XdsInitializationException("Fail to read bootstrap file", e);
+    if (rawBootstrap != null) {
+      return parseConfig(rawBootstrap);
     }
-    return parseConfig(fileContent);
+    throw new XdsInitializationException(
+        "Cannot find bootstrap configuration\n"
+            + "Environment variables searched:\n"
+            + "- " + BOOTSTRAP_PATH_SYS_ENV_VAR + "\n"
+            + "- " + BOOTSTRAP_CONFIG_SYS_ENV_VAR + "\n\n"
+            + "Java System Properties searched:\n"
+            + "- " + BOOTSTRAP_PATH_SYS_PROPERTY + "\n"
+            + "- " + BOOTSTRAP_CONFIG_SYS_PROPERTY_VAR + "\n\n");
   }
 
   @VisibleForTesting

--- a/xds/src/test/java/io/grpc/xds/XdsClientWrapperForServerSdsTestMisc.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientWrapperForServerSdsTestMisc.java
@@ -201,9 +201,7 @@ public class XdsClientWrapperForServerSdsTestMisc {
     } catch (IOException expected) {
       assertThat(expected)
               .hasMessageThat()
-              .contains(
-                      "Environment variable GRPC_XDS_BOOTSTRAP"
-                      + " or Java System Property io.grpc.xds.bootstrap not defined.");
+              .contains("Cannot find bootstrap configuration");
     }
     ArgumentCaptor<Status> argCaptor = ArgumentCaptor.forClass(null);
     verify(mockServerWatcher).onError(argCaptor.capture());
@@ -212,9 +210,7 @@ public class XdsClientWrapperForServerSdsTestMisc {
     assertThat(captured.getCause()).isInstanceOf(XdsInitializationException.class);
     assertThat(captured.getCause())
         .hasMessageThat()
-        .contains(
-                "Environment variable GRPC_XDS_BOOTSTRAP"
-                + " or Java System Property io.grpc.xds.bootstrap not defined.");
+        .contains("Cannot find bootstrap configuration");
   }
 
   private DownstreamTlsContext sendListenerUpdate(

--- a/xds/src/test/java/io/grpc/xds/XdsServerBuilderTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerBuilderTest.java
@@ -234,9 +234,7 @@ public class XdsServerBuilderTest {
     } catch (IOException expected) {
       assertThat(expected)
               .hasMessageThat()
-              .contains(
-                      "Environment variable GRPC_XDS_BOOTSTRAP"
-                      + " or Java System Property io.grpc.xds.bootstrap not defined.");
+              .contains("Cannot find bootstrap configuration");
     }
     ArgumentCaptor<Status> argCaptor = ArgumentCaptor.forClass(null);
     verify(mockErrorNotifier).onError(argCaptor.capture());
@@ -245,9 +243,7 @@ public class XdsServerBuilderTest {
     assertThat(captured.getCause()).isInstanceOf(XdsInitializationException.class);
     assertThat(captured.getCause())
             .hasMessageThat()
-            .contains(
-                    "Environment variable GRPC_XDS_BOOTSTRAP"
-                    + " or Java System Property io.grpc.xds.bootstrap not defined.");
+            .contains("Cannot find bootstrap configuration");
   }
 
   @Test


### PR DESCRIPTION
Currently, gRPC uses the `GRPC_XDS_BOOSTRAP` env variable to find the bootstrap file. There are use cases where file based bootstrap config is not optimal like when a file system is not mounted. We want to have an option to input bootstrap config directly via an env variable. This change supports reading the bootstrap config from the following places (in order):

- If `GRPC_XDS_BOOTSTRAP` exists then use its value as the name of the bootstrap file. If the file is missing or the contents of the file are malformed, return an error.
 
- Else if `io.grpc.xds.bootstrap` exists then use its value as the name of the bootstrap file. If the file is missing or the contents are malformed, return an error.
 
- Else, if `GRPC_XDS_BOOTSTRAP_CONFIG` exists then use its value as the bootstrap config. If the value is malformed, return an error.
 
- Else, if `io.grpc.xds.bootstrapValue` exists then use its value as the bootstrap config. If the value is malformed, return an error.