### PR TITLE
buildscripts: increase xds job timeouts

### DIFF
--- a/buildscripts/kokoro/xds.cfg
+++ b/buildscripts/kokoro/xds.cfg
@@ -2,7 +2,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-java/buildscripts/kokoro/xds.sh"
-timeout_mins: 90
+timeout_mins: 120
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/buildscripts/kokoro/xds_v3.cfg
+++ b/buildscripts/kokoro/xds_v3.cfg
@@ -2,7 +2,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-java/buildscripts/kokoro/xds_v3.sh"
-timeout_mins: 90
+timeout_mins: 120
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
We have lots more test cases now, and we've been seeing the average run time creep towards 90 minutes - which means we've gotten some failure when test teardown hasn't completed by then and the VM is terminated.