### PR TITLE
xds: implement new stats object for recording drops and requests independently

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
+++ b/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
@@ -22,6 +22,7 @@ import com.github.udpa.udpa.data.orca.v1.OrcaLoadReport;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Stopwatch;
+import com.google.common.base.Supplier;
 import io.grpc.ClientStreamTracer;
 import io.grpc.ClientStreamTracer.StreamInfo;
 import io.grpc.LoadBalancer.PickResult;
@@ -59,14 +60,14 @@ final class ClientLoadCounter {
 
   // TODO(chengyuanzhang): should not use this after eliminating LoadStatsStore.
   ClientLoadCounter() {
-    this(GrpcUtil.STOPWATCH_SUPPLIER.get());
+    this(GrpcUtil.STOPWATCH_SUPPLIER);
   }
 
-  ClientLoadCounter(Stopwatch stopwatch) {
+  ClientLoadCounter(Supplier<Stopwatch> stopwatchSupplier) {
     for (int i = 0; i < THREAD_BALANCING_FACTOR; i++) {
       metricRecorders[i] = new MetricRecorder();
     }
-    this.stopwatch = checkNotNull(stopwatch, "stopwatch");
+    this.stopwatch = checkNotNull(stopwatchSupplier, "stopwatchSupplier").get();
     stopwatch.reset().start();
   }
 

--- a/xds/src/main/java/io/grpc/xds/DropStatsCounter.java
+++ b/xds/src/main/java/io/grpc/xds/DropStatsCounter.java
@@ -39,7 +39,7 @@ import javax.annotation.concurrent.ThreadSafe;
 final class DropStatsCounter {
 
   private final AtomicLong uncategorizedDrops = new AtomicLong();
-  private volatile ConcurrentMap<String, AtomicLong> categorizedDrops = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, AtomicLong> categorizedDrops = new ConcurrentHashMap<>();
   private final Stopwatch stopwatch;
 
   DropStatsCounter(Supplier<Stopwatch> stopwatchSupplier) {
@@ -61,12 +61,11 @@ final class DropStatsCounter {
   }
 
   synchronized DropStatsSnapshot snapshot() {
-    Map<String, AtomicLong> categorizedDropsCopy = categorizedDrops;
-    categorizedDrops = new ConcurrentHashMap<>();
     Map<String, Long> drops = new HashMap<>();
-    for (Map.Entry<String, AtomicLong> entry : categorizedDropsCopy.entrySet()) {
+    for (Map.Entry<String, AtomicLong> entry : categorizedDrops.entrySet()) {
       drops.put(entry.getKey(), entry.getValue().get());
     }
+    categorizedDrops.clear();
     long duration = stopwatch.elapsed(TimeUnit.NANOSECONDS);
     stopwatch.reset().start();
     return new DropStatsSnapshot(drops, uncategorizedDrops.getAndSet(0), duration);

--- a/xds/src/main/java/io/grpc/xds/DropStatsCounter.java
+++ b/xds/src/main/java/io/grpc/xds/DropStatsCounter.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Stopwatch;
+import com.google.common.base.Supplier;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -41,8 +42,8 @@ final class DropStatsCounter {
   private volatile ConcurrentMap<String, AtomicLong> categorizedDrops = new ConcurrentHashMap<>();
   private final Stopwatch stopwatch;
 
-  DropStatsCounter(Stopwatch stopwatch) {
-    this.stopwatch = checkNotNull(stopwatch, "stopwatch");
+  DropStatsCounter(Supplier<Stopwatch> stopwatchSupplier) {
+    this.stopwatch = checkNotNull(stopwatchSupplier, "stopwatchSupplier").get();
     stopwatch.reset().start();
   }
 

--- a/xds/src/main/java/io/grpc/xds/DropStatsCounter.java
+++ b/xds/src/main/java/io/grpc/xds/DropStatsCounter.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 20121 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Stopwatch;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Recorder for dropped requests.
+ */
+// TODO(chengyuanzhang): this class can be moved into LoadStatsManager.
+@ThreadSafe
+final class DropStatsCounter {
+
+  private final AtomicLong uncategorizedDrops = new AtomicLong();
+  private volatile ConcurrentMap<String, AtomicLong> categorizedDrops = new ConcurrentHashMap<>();
+  private final Stopwatch stopwatch;
+
+  DropStatsCounter(Stopwatch stopwatch) {
+    this.stopwatch = checkNotNull(stopwatch, "stopwatch");
+    stopwatch.reset().start();
+  }
+
+  void recordDroppedRequest(String category) {
+    AtomicLong counter = categorizedDrops.putIfAbsent(category, new AtomicLong(1L));
+    // There is a race between incrementing an existing atomic and snapshot, causing the one
+    // drop recorded but not included in the snapshot. This is acceptable and the race window is
+    // extremely small.
+    if (counter != null) {
+      counter.getAndIncrement();
+    }
+  }
+
+  void recordDroppedRequest() {
+    uncategorizedDrops.getAndIncrement();
+  }
+
+  synchronized DropStatsSnapshot snapshot() {
+    Map<String, AtomicLong> categorizedDropsCopy = categorizedDrops;
+    categorizedDrops = new ConcurrentHashMap<>();
+    Map<String, Long> drops = new HashMap<>();
+    for (Map.Entry<String, AtomicLong> entry : categorizedDropsCopy.entrySet()) {
+      drops.put(entry.getKey(), entry.getValue().get());
+    }
+    long duration = stopwatch.elapsed(TimeUnit.NANOSECONDS);
+    stopwatch.reset().start();
+    return new DropStatsSnapshot(drops, uncategorizedDrops.getAndSet(0), duration);
+  }
+
+  /**
+   * A read-only snapshot for a {@link DropStatsCounter}.
+   */
+  @Immutable
+  static final class DropStatsSnapshot {
+    private final Map<String, Long> categorizedDrops;
+    private final long uncategorizedDrops;
+    private final long durationNano;
+
+    private DropStatsSnapshot(
+        Map<String, Long> categorizedDrops, long uncategorizedDrops, long durationNano) {
+      this.categorizedDrops = Collections.unmodifiableMap(
+          checkNotNull(categorizedDrops, "categorizedDrops"));
+      this.uncategorizedDrops = uncategorizedDrops;
+      this.durationNano = durationNano;
+    }
+
+    Map<String, Long> getCategorizedDrops() {
+      return categorizedDrops;
+    }
+
+    long getUncategorizedDrops() {
+      return uncategorizedDrops;
+    }
+
+    long getDurationNano() {
+      return durationNano;
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("categorizedDrops", categorizedDrops)
+          .add("uncategorizedDrops", uncategorizedDrops)
+          .add("durationNano", durationNano)
+          .toString();
+    }
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/DropStatsCounter.java
+++ b/xds/src/main/java/io/grpc/xds/DropStatsCounter.java
@@ -47,10 +47,9 @@ final class DropStatsCounter {
   }
 
   void recordDroppedRequest(String category) {
+    // There is a race between this method and snapshot(), causing one drop recorded but may not
+    // be included in any snapshot. This is acceptable and the race window is extremely small.
     AtomicLong counter = categorizedDrops.putIfAbsent(category, new AtomicLong(1L));
-    // There is a race between incrementing an existing atomic and snapshot, causing the one
-    // drop recorded but not included in the snapshot. This is acceptable and the race window is
-    // extremely small.
     if (counter != null) {
       counter.getAndIncrement();
     }

--- a/xds/src/main/java/io/grpc/xds/DropStatsCounter.java
+++ b/xds/src/main/java/io/grpc/xds/DropStatsCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 20121 The gRPC Authors
+ * Copyright 2021 The gRPC Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
@@ -1448,6 +1448,10 @@ final class EnvoyProtoData {
         return this;
       }
 
+      long getLoadReportIntervalNanos() {
+        return loadReportIntervalNanos;
+      }
+
       Builder addUpstreamLocalityStats(UpstreamLocalityStats upstreamLocalityStats) {
         upstreamLocalityStatsList.add(checkNotNull(upstreamLocalityStats, "upstreamLocalityStats"));
         return this;

--- a/xds/src/main/java/io/grpc/xds/LoadStatsManager2.java
+++ b/xds/src/main/java/io/grpc/xds/LoadStatsManager2.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.base.Supplier;
+import com.google.common.collect.Sets;
+import io.grpc.xds.ClientLoadCounter.ClientLoadSnapshot;
+import io.grpc.xds.ClientLoadCounter.MetricValue;
+import io.grpc.xds.DropStatsCounter.DropStatsSnapshot;
+import io.grpc.xds.EnvoyProtoData.ClusterStats;
+import io.grpc.xds.EnvoyProtoData.ClusterStats.DroppedRequests;
+import io.grpc.xds.EnvoyProtoData.EndpointLoadMetricStats;
+import io.grpc.xds.EnvoyProtoData.Locality;
+import io.grpc.xds.EnvoyProtoData.UpstreamLocalityStats;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Manages client side traffic stats. Drop stats are maintained in cluster (with edsServiceName)
+ * granularity and load stats (request counts and backend metrics) are maintained in locality
+ * granularity.
+ */
+@ThreadSafe
+final class LoadStatsManager2 {
+  // Recorders for drops of each cluster:edsServiceName.
+  private final Map<String, Map<String, ReferenceCounted<DropStatsCounter>>> dropStats =
+      new HashMap<>();
+  // Recorders for loads of each cluster:edsServiceName:locality.
+  private final Map<String, Map<String,
+      Map<Locality, ReferenceCounted<ClientLoadCounter>>>> loadStats = new HashMap<>();
+  private final Supplier<Stopwatch> stopwatchSupplier;
+
+  LoadStatsManager2(Supplier<Stopwatch> stopwatchSupplier) {
+    this.stopwatchSupplier = checkNotNull(stopwatchSupplier, "stopwatchSupplier");
+  }
+
+  /**
+   * Gets the counter for recording drops for the specified cluster with edsServiceName.
+   * The returned counter is reference counted and the caller should use {@link
+   * #releaseDropCounter} to release its <i>hard</i> reference when it is safe to discard the
+   * counter in the future.
+   */
+  synchronized DropStatsCounter getDropCounter(String cluster, @Nullable String edsServiceName) {
+    if (!dropStats.containsKey(cluster)) {
+      dropStats.put(cluster, new HashMap<String, ReferenceCounted<DropStatsCounter>>());
+    }
+    Map<String, ReferenceCounted<DropStatsCounter>> clusterDropStats = dropStats.get(cluster);
+    if (!clusterDropStats.containsKey(edsServiceName)) {
+      clusterDropStats.put(
+          edsServiceName, ReferenceCounted.wrap(new DropStatsCounter(stopwatchSupplier.get())));
+    }
+    ReferenceCounted<DropStatsCounter> ref = clusterDropStats.get(edsServiceName);
+    ref.retain();
+    return ref.get();
+  }
+
+  /**
+   * Release the <i>hard</i> reference for the counter previously obtained from {@link
+   * #getDropCounter} for the specified cluster with edsServiceName. The counter released may
+   * still be recording drops after this method, but there is no guarantee drops recorded after
+   * this point will be included in load reports.
+   */
+  synchronized void releaseDropCounter(String cluster, @Nullable String edsServiceName) {
+    checkState(dropStats.containsKey(cluster)
+            && dropStats.get(cluster).containsKey(edsServiceName),
+        "stats for cluster %s, edsServiceName %s not exits", cluster, edsServiceName);
+    ReferenceCounted<DropStatsCounter> ref = dropStats.get(cluster).get(edsServiceName);
+    ref.release();
+  }
+
+  /**
+   * Gets the counter for recording loads for the specified locality (in the specified cluster
+   * with edsServiceName). The returned counter is reference counted and the caller should use
+   * {@link #releaseLoadCounter} to release its <i>hard</i> reference when it is safe to discard
+   * the counter in the future.
+   */
+  synchronized ClientLoadCounter getLoadCounter(
+      String cluster, @Nullable String edsServiceName, Locality locality) {
+    if (!loadStats.containsKey(cluster)) {
+      loadStats.put(
+          cluster, new HashMap<String, Map<Locality, ReferenceCounted<ClientLoadCounter>>>());
+    }
+    Map<String, Map<Locality, ReferenceCounted<ClientLoadCounter>>> clusterLoadStats =
+        loadStats.get(cluster);
+    if (!clusterLoadStats.containsKey(edsServiceName)) {
+      clusterLoadStats.put(
+          edsServiceName, new HashMap<Locality, ReferenceCounted<ClientLoadCounter>>());
+    }
+    Map<Locality, ReferenceCounted<ClientLoadCounter>> localityLoadStats =
+        clusterLoadStats.get(edsServiceName);
+    if (!localityLoadStats.containsKey(locality)) {
+      localityLoadStats.put(
+          locality, ReferenceCounted.wrap(new ClientLoadCounter(stopwatchSupplier.get())));
+    }
+    ReferenceCounted<ClientLoadCounter> ref = localityLoadStats.get(locality);
+    ref.retain();
+    return ref.get();
+  }
+
+  /**
+   * Release the <i>hard</i> reference for the counter previously obtained from {@link
+   * #getLoadCounter} for the specified locality. The counter released may still be recording
+   * loads after this method, but there is no guarantee loads recorded after this point will be
+   * included in load reports.
+   */
+  synchronized void releaseLoadCounter(
+      String cluster, @Nullable String edsServiceName, Locality locality) {
+    checkState(loadStats.containsKey(cluster)
+            && loadStats.get(cluster).containsKey(edsServiceName)
+            && loadStats.get(cluster).get(edsServiceName).containsKey(locality),
+        "stats for cluster %s, edsServiceName %s, locality %s not exits",
+        cluster, edsServiceName, locality);
+    ReferenceCounted<ClientLoadCounter> ref =
+        loadStats.get(cluster).get(edsServiceName).get(locality);
+    ref.release();
+  }
+
+  /**
+   * Gets the traffic stats (drops and loads) as a list of {@link ClusterStats} recorded for the
+   * specified cluster since the previous call of this method or {@link
+   * #getAllClusterStatsReports}. A {@link ClusterStats} includes stats for a specific cluster with
+   * edsServiceName.
+   */
+  synchronized List<ClusterStats> getClusterStatsReports(String cluster) {
+    if (!dropStats.containsKey(cluster) && !loadStats.containsKey(cluster)) {
+      return Collections.emptyList();
+    }
+    Map<String, ReferenceCounted<DropStatsCounter>> clusterDropStats = dropStats.get(cluster);
+    Map<String, Map<Locality, ReferenceCounted<ClientLoadCounter>>> clusterLoadStats =
+        loadStats.get(cluster);
+    Map<String, ClusterStats.Builder> statsReportBuilders = new HashMap<>();
+    if (clusterDropStats != null) {
+      Set<String> toDiscard = new HashSet<>();
+      for (String edsServiceName : clusterDropStats.keySet()) {
+        ClusterStats.Builder builder = ClusterStats.newBuilder().setClusterName(cluster);
+        if (edsServiceName != null) {
+          builder.setClusterServiceName(edsServiceName);
+        }
+        ReferenceCounted<DropStatsCounter> ref = clusterDropStats.get(edsServiceName);
+        if (ref.getReferenceCount() == 0) {  // counter no longer needed after snapshot
+          toDiscard.add(edsServiceName);
+        }
+        DropStatsSnapshot dropStatsSnapshot = ref.get().snapshot();
+        long totalCategorizedDrops = 0L;
+        for (Map.Entry<String, Long> entry : dropStatsSnapshot.getCategorizedDrops().entrySet()) {
+          builder.addDroppedRequests(new DroppedRequests(entry.getKey(), entry.getValue()));
+          totalCategorizedDrops += entry.getValue();
+        }
+        builder.setTotalDroppedRequests(
+            totalCategorizedDrops + dropStatsSnapshot.getUncategorizedDrops());
+        builder.setLoadReportIntervalNanos(dropStatsSnapshot.getDurationNano());
+        statsReportBuilders.put(edsServiceName, builder);
+      }
+      clusterDropStats.keySet().removeAll(toDiscard);
+    }
+    if (clusterLoadStats != null) {
+      Set<String> toDiscard = new HashSet<>();
+      for (String edsServiceName : clusterLoadStats.keySet()) {
+        ClusterStats.Builder builder = statsReportBuilders.get(edsServiceName);
+        if (builder == null) {
+          builder = ClusterStats.newBuilder().setClusterName(cluster);
+          if (edsServiceName != null) {
+            builder.setClusterServiceName(edsServiceName);
+          }
+          statsReportBuilders.put(edsServiceName, builder);
+        }
+        Map<Locality, ReferenceCounted<ClientLoadCounter>> localityStats =
+            clusterLoadStats.get(edsServiceName);
+        Set<Locality> localitiesToDiscard = new HashSet<>();
+        for (Locality locality : localityStats.keySet()) {
+          ReferenceCounted<ClientLoadCounter> ref = localityStats.get(locality);
+          ClientLoadSnapshot snapshot = ref.get().snapshot();
+          // may still want to report all in-flight requests
+          if (ref.getReferenceCount() == 0 && snapshot.getCallsInProgress() == 0) {
+            localitiesToDiscard.add(locality);
+          }
+          builder.addUpstreamLocalityStats(buildUpstreamLocalityStats(locality, snapshot));
+          // Use the max (drops/loads) recording interval as the overall interval for the
+          // cluster's stats.
+          builder.setLoadReportIntervalNanos(
+              Math.max(builder.getLoadReportIntervalNanos(), snapshot.getDurationNano()));
+        }
+        localityStats.keySet().removeAll(localitiesToDiscard);
+        if (localityStats.isEmpty()) {
+          toDiscard.add(edsServiceName);
+        }
+      }
+      clusterLoadStats.keySet().removeAll(toDiscard);
+    }
+    List<ClusterStats> res = new ArrayList<>();
+    for (ClusterStats.Builder builder : statsReportBuilders.values()) {
+      res.add(builder.build());
+    }
+    return Collections.unmodifiableList(res);
+  }
+
+  /**
+   * Gets the traffic stats (drops and loads) as a list of {@link ClusterStats} recorded for all
+   * clusters since the previous call of this method or {@link #getClusterStatsReports} for each
+   * specific cluster. A {@link ClusterStats} includes stats for a specific cluster with
+   * edsServiceName.
+   */
+  synchronized List<ClusterStats> getAllClusterStatsReports() {
+    Set<String> allClusters = Sets.union(dropStats.keySet(), loadStats.keySet());
+    List<ClusterStats> res = new ArrayList<>();
+    for (String cluster : allClusters) {
+      res.addAll(getClusterStatsReports(cluster));
+    }
+    return Collections.unmodifiableList(res);
+  }
+
+  private static UpstreamLocalityStats buildUpstreamLocalityStats(
+      Locality locality, ClientLoadSnapshot snapshot) {
+    UpstreamLocalityStats.Builder builder = UpstreamLocalityStats.newBuilder();
+    builder.setLocality(locality);
+    builder.setTotalIssuedRequests(snapshot.getCallsIssued());
+    builder.setTotalSuccessfulRequests(snapshot.getCallsSucceeded());
+    builder.setTotalErrorRequests(snapshot.getCallsFailed());
+    builder.setTotalRequestsInProgress(snapshot.getCallsInProgress());
+    for (Map.Entry<String, MetricValue> metric : snapshot.getMetricValues().entrySet()) {
+      EndpointLoadMetricStats metrics =
+          EndpointLoadMetricStats.newBuilder()
+              .setMetricName(metric.getKey())
+              .setNumRequestsFinishedWithMetric(metric.getValue().getNumReports())
+              .setTotalMetricValue(metric.getValue().getTotalValue())
+              .build();
+      builder.addLoadMetricStats(metrics);
+    }
+    return builder.build();
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/LoadStatsManager2.java
+++ b/xds/src/main/java/io/grpc/xds/LoadStatsManager2.java
@@ -72,7 +72,7 @@ final class LoadStatsManager2 {
     Map<String, ReferenceCounted<DropStatsCounter>> clusterDropStats = dropStats.get(cluster);
     if (!clusterDropStats.containsKey(edsServiceName)) {
       clusterDropStats.put(
-          edsServiceName, ReferenceCounted.wrap(new DropStatsCounter(stopwatchSupplier.get())));
+          edsServiceName, ReferenceCounted.wrap(new DropStatsCounter(stopwatchSupplier)));
     }
     ReferenceCounted<DropStatsCounter> ref = clusterDropStats.get(edsServiceName);
     ref.retain();
@@ -115,7 +115,7 @@ final class LoadStatsManager2 {
         clusterLoadStats.get(edsServiceName);
     if (!localityLoadStats.containsKey(locality)) {
       localityLoadStats.put(
-          locality, ReferenceCounted.wrap(new ClientLoadCounter(stopwatchSupplier.get())));
+          locality, ReferenceCounted.wrap(new ClientLoadCounter(stopwatchSupplier)));
     }
     ReferenceCounted<ClientLoadCounter> ref = localityLoadStats.get(locality);
     ref.retain();

--- a/xds/src/main/java/io/grpc/xds/LoadStatsStoreImpl.java
+++ b/xds/src/main/java/io/grpc/xds/LoadStatsStoreImpl.java
@@ -124,7 +124,7 @@ final class LoadStatsStoreImpl implements LoadStatsStore {
   public synchronized ClientLoadCounter addLocality(final Locality locality) {
     ReferenceCounted<ClientLoadCounter> counter = localityLoadCounters.get(locality);
     if (counter == null) {
-      counter = ReferenceCounted.wrap(new ClientLoadCounter(stopwatchSupplier.get()));
+      counter = ReferenceCounted.wrap(new ClientLoadCounter(stopwatchSupplier));
       localityLoadCounters.put(locality, counter);
     }
     counter.retain();

--- a/xds/src/test/java/io/grpc/xds/ClientLoadCounterTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClientLoadCounterTest.java
@@ -63,8 +63,7 @@ public class ClientLoadCounterTest {
       };
 
   private final FakeClock fakeClock = new FakeClock();
-  private ClientLoadCounter counter =
-      new ClientLoadCounter(fakeClock.getStopwatchSupplier().get());
+  private ClientLoadCounter counter = new ClientLoadCounter(fakeClock.getStopwatchSupplier());
 
   @Test
   public void recordAndSnapshot() {
@@ -254,9 +253,9 @@ public class ClientLoadCounterTest {
         .thenReturn(mockTracer);
 
     ClientLoadCounter localityCounter1 =
-        new ClientLoadCounter(fakeClock.getStopwatchSupplier().get());
+        new ClientLoadCounter(fakeClock.getStopwatchSupplier());
     ClientLoadCounter localityCounter2 =
-        new ClientLoadCounter(fakeClock.getStopwatchSupplier().get());
+        new ClientLoadCounter(fakeClock.getStopwatchSupplier());
     final PickResult pickResult1 = PickResult.withSubchannel(mock(Subchannel.class), mockFactory);
     final PickResult pickResult2 = PickResult.withSubchannel(mock(Subchannel.class));
     SubchannelPicker picker1 = new SubchannelPicker() {

--- a/xds/src/test/java/io/grpc/xds/DropStatsCounterTest.java
+++ b/xds/src/test/java/io/grpc/xds/DropStatsCounterTest.java
@@ -30,7 +30,7 @@ public class DropStatsCounterTest {
 
   private final FakeClock fakeClock = new FakeClock();
   private final DropStatsCounter dropStatsCounter =
-      new DropStatsCounter(fakeClock.getStopwatchSupplier().get());
+      new DropStatsCounter(fakeClock.getStopwatchSupplier());
 
   @Test
   public void recordAndSnapshot() {

--- a/xds/src/test/java/io/grpc/xds/DropStatsCounterTest.java
+++ b/xds/src/test/java/io/grpc/xds/DropStatsCounterTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.grpc.internal.FakeClock;
+import io.grpc.xds.DropStatsCounter.DropStatsSnapshot;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class DropStatsCounterTest {
+
+  private final FakeClock fakeClock = new FakeClock();
+  private final DropStatsCounter dropStatsCounter =
+      new DropStatsCounter(fakeClock.getStopwatchSupplier().get());
+
+  @Test
+  public void recordAndSnapshot() {
+    for (int i = 0; i < 1241; i++) {
+      dropStatsCounter.recordDroppedRequest("lb");
+    }
+    fakeClock.forwardTime(10L, TimeUnit.SECONDS);
+    for (int i = 0; i < 999; i++) {
+      dropStatsCounter.recordDroppedRequest("throttle");
+    }
+    fakeClock.forwardTime(15L, TimeUnit.SECONDS);
+    for (int i = 0; i < 51; i++) {
+      dropStatsCounter.recordDroppedRequest();  // uncategorized
+    }
+    fakeClock.forwardTime(5L, TimeUnit.SECONDS);
+    DropStatsSnapshot snapshot = dropStatsCounter.snapshot();
+    assertThat(snapshot.getCategorizedDrops()).containsExactly("lb", 1241L, "throttle", 999L);
+    assertThat(snapshot.getUncategorizedDrops()).isEqualTo(51L);
+    assertThat(snapshot.getDurationNano()).isEqualTo(TimeUnit.SECONDS.toNanos(10L + 15L + 5L));
+
+    dropStatsCounter.recordDroppedRequest("reset");
+    dropStatsCounter.recordDroppedRequest();  // uncategorized
+    fakeClock.forwardTime(3L, TimeUnit.MILLISECONDS);
+    snapshot = dropStatsCounter.snapshot();
+    assertThat(snapshot.getCategorizedDrops()).containsExactly("reset", 1L);
+    assertThat(snapshot.getUncategorizedDrops()).isEqualTo(1L);
+    assertThat(snapshot.getDurationNano()).isEqualTo(TimeUnit.MILLISECONDS.toNanos(3L));
+  }
+}

--- a/xds/src/test/java/io/grpc/xds/LoadStatsManager2Test.java
+++ b/xds/src/test/java/io/grpc/xds/LoadStatsManager2Test.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.Iterables;
+import io.grpc.Status;
+import io.grpc.internal.FakeClock;
+import io.grpc.xds.EnvoyProtoData.ClusterStats;
+import io.grpc.xds.EnvoyProtoData.ClusterStats.DroppedRequests;
+import io.grpc.xds.EnvoyProtoData.Locality;
+import io.grpc.xds.EnvoyProtoData.UpstreamLocalityStats;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link LoadStatsManager2}.
+ */
+@RunWith(JUnit4.class)
+public class LoadStatsManager2Test {
+  private static final String CLUSTER_NAME1 = "cluster-foo.googleapis.com";
+  private static final String CLUSTER_NAME2 = "cluster-bar.googleapis.com";
+  private static final String EDS_SERVICE_NAME1 = "backend-service-foo.googleapis.com";
+  private static final String EDS_SERVICE_NAME2 = "backend-service-bar.googleapis.com";
+  private static final Locality LOCALITY1 =
+      new Locality("test_region1", "test_zone1", "test_subzone1");
+  private static final Locality LOCALITY2 =
+      new Locality("test_region2", "test_zone2", "test_subzone2");
+  private static final Locality LOCALITY3 =
+      new Locality("test_region3", "test_zone3", "test_subzone3");
+
+  private final FakeClock fakeClock = new FakeClock();
+  private final LoadStatsManager2 loadStatsManager =
+      new LoadStatsManager2(fakeClock.getStopwatchSupplier());
+
+  @Test
+  public void recordAndGetReport() {
+    DropStatsCounter dropCounter1 =
+        loadStatsManager.getDropCounter(CLUSTER_NAME1, EDS_SERVICE_NAME1);
+    DropStatsCounter dropCounter2 =
+        loadStatsManager.getDropCounter(CLUSTER_NAME1, EDS_SERVICE_NAME2);
+    ClientLoadCounter loadCounter1 =
+        loadStatsManager.getLoadCounter(CLUSTER_NAME1, EDS_SERVICE_NAME1, LOCALITY1);
+    ClientLoadCounter loadCounter2 =
+        loadStatsManager.getLoadCounter(CLUSTER_NAME1, EDS_SERVICE_NAME1, LOCALITY2);
+    ClientLoadCounter loadCounter3 =
+        loadStatsManager.getLoadCounter(CLUSTER_NAME2, null, LOCALITY3);
+    dropCounter1.recordDroppedRequest("lb");
+    dropCounter1.recordDroppedRequest("throttle");
+    for (int i = 0; i < 19; i++) {
+      loadCounter1.recordCallStarted();
+    }
+    fakeClock.forwardTime(5L, TimeUnit.SECONDS);
+    dropCounter2.recordDroppedRequest();
+    loadCounter1.recordCallFinished(Status.OK);
+    for (int i = 0; i < 9; i++) {
+      loadCounter2.recordCallStarted();
+    }
+    loadCounter2.recordCallFinished(Status.UNAVAILABLE);
+    fakeClock.forwardTime(10L, TimeUnit.SECONDS);
+    loadCounter3.recordCallStarted();
+    List<ClusterStats> allStats = loadStatsManager.getAllClusterStatsReports();
+    assertThat(allStats).hasSize(3);  // three cluster:edsServiceName
+
+    ClusterStats stats1 = findClusterStats(allStats, CLUSTER_NAME1, EDS_SERVICE_NAME1);
+    assertThat(stats1.getLoadReportIntervalNanos()).isEqualTo(TimeUnit.SECONDS.toNanos(5L + 10L));
+    assertThat(stats1.getDroppedRequestsList()).hasSize(2);
+    assertThat(findDroppedRequestCount(stats1.getDroppedRequestsList(), "lb")).isEqualTo(1L);
+    assertThat(findDroppedRequestCount(stats1.getDroppedRequestsList(), "throttle")).isEqualTo(1L);
+    assertThat(stats1.getTotalDroppedRequests()).isEqualTo(1L + 1L);
+    assertThat(stats1.getUpstreamLocalityStatsList()).hasSize(2);  // two localities
+    UpstreamLocalityStats loadStats1 =
+        findLocalityStats(stats1.getUpstreamLocalityStatsList(), LOCALITY1);
+    assertThat(loadStats1.getTotalIssuedRequests()).isEqualTo(19L);
+    assertThat(loadStats1.getTotalSuccessfulRequests()).isEqualTo(1L);
+    assertThat(loadStats1.getTotalErrorRequests()).isEqualTo(0L);
+    assertThat(loadStats1.getTotalRequestsInProgress()).isEqualTo(19L - 1L);
+
+    UpstreamLocalityStats loadStats2 =
+        findLocalityStats(stats1.getUpstreamLocalityStatsList(), LOCALITY2);
+    assertThat(loadStats2.getTotalIssuedRequests()).isEqualTo(9L);
+    assertThat(loadStats2.getTotalSuccessfulRequests()).isEqualTo(0L);
+    assertThat(loadStats2.getTotalErrorRequests()).isEqualTo(1L);
+    assertThat(loadStats2.getTotalRequestsInProgress()).isEqualTo(9L - 1L);
+
+    ClusterStats stats2 = findClusterStats(allStats, CLUSTER_NAME1, EDS_SERVICE_NAME2);
+    assertThat(stats2.getLoadReportIntervalNanos()).isEqualTo(TimeUnit.SECONDS.toNanos(5L + 10L));
+    assertThat(stats2.getDroppedRequestsList()).isEmpty();  // no categorized drops
+    assertThat(stats2.getTotalDroppedRequests()).isEqualTo(1L);
+    assertThat(stats2.getUpstreamLocalityStatsList()).isEmpty();  // no per-locality stats
+
+    ClusterStats stats3 = findClusterStats(allStats, CLUSTER_NAME2, null);
+    assertThat(stats3.getLoadReportIntervalNanos()).isEqualTo(TimeUnit.SECONDS.toNanos(5L + 10L));
+    assertThat(stats3.getDroppedRequestsList()).isEmpty();
+    assertThat(stats3.getTotalDroppedRequests()).isEqualTo(0L);  // no drops recorded
+    assertThat(stats3.getUpstreamLocalityStatsList()).hasSize(1);  // one localities
+    UpstreamLocalityStats loadStats3 =
+        Iterables.getOnlyElement(stats3.getUpstreamLocalityStatsList());
+    assertThat(loadStats3.getTotalIssuedRequests()).isEqualTo(1L);
+    assertThat(loadStats3.getTotalSuccessfulRequests()).isEqualTo(0L);
+    assertThat(loadStats3.getTotalErrorRequests()).isEqualTo(0L);
+    assertThat(loadStats3.getTotalRequestsInProgress()).isEqualTo(1L);
+
+    fakeClock.forwardTime(3L, TimeUnit.SECONDS);
+    List<ClusterStats> clusterStatsList = loadStatsManager.getClusterStatsReports(CLUSTER_NAME1);
+    assertThat(clusterStatsList).hasSize(2);
+    stats1 = findClusterStats(clusterStatsList, CLUSTER_NAME1, EDS_SERVICE_NAME1);
+    assertThat(stats1.getLoadReportIntervalNanos()).isEqualTo(TimeUnit.SECONDS.toNanos(3L));
+    assertThat(stats1.getDroppedRequestsList()).isEmpty();
+    assertThat(stats1.getTotalDroppedRequests()).isEqualTo(0L);  // no new drops recorded
+    assertThat(stats1.getUpstreamLocalityStatsList()).hasSize(2);  // two localities
+    loadStats1 = findLocalityStats(stats1.getUpstreamLocalityStatsList(), LOCALITY1);
+    assertThat(loadStats1.getTotalIssuedRequests()).isEqualTo(0L);
+    assertThat(loadStats1.getTotalSuccessfulRequests()).isEqualTo(0L);
+    assertThat(loadStats1.getTotalErrorRequests()).isEqualTo(0L);
+    assertThat(loadStats1.getTotalRequestsInProgress()).isEqualTo(18L);  // still in-progress
+    loadStats2 = findLocalityStats(stats1.getUpstreamLocalityStatsList(), LOCALITY2);
+    assertThat(loadStats2.getTotalIssuedRequests()).isEqualTo(0L);
+    assertThat(loadStats2.getTotalSuccessfulRequests()).isEqualTo(0L);
+    assertThat(loadStats2.getTotalErrorRequests()).isEqualTo(0L);
+    assertThat(loadStats2.getTotalRequestsInProgress()).isEqualTo(8L);  // still in-progress
+
+    stats2 = findClusterStats(clusterStatsList, CLUSTER_NAME1, EDS_SERVICE_NAME2);
+    assertThat(stats2.getLoadReportIntervalNanos()).isEqualTo(TimeUnit.SECONDS.toNanos(3L));
+    assertThat(stats2.getDroppedRequestsList()).isEmpty();
+    assertThat(stats2.getTotalDroppedRequests()).isEqualTo(0L);  // no new drops recorded
+    assertThat(stats2.getUpstreamLocalityStatsList()).isEmpty();  // no per-locality stats
+  }
+
+  @Test
+  public void sharedDropCounterStatsAggregation() {
+    DropStatsCounter ref1 = loadStatsManager.getDropCounter(CLUSTER_NAME1, EDS_SERVICE_NAME1);
+    DropStatsCounter ref2 = loadStatsManager.getDropCounter(CLUSTER_NAME1, EDS_SERVICE_NAME1);
+    ref1.recordDroppedRequest("lb");
+    ref2.recordDroppedRequest("throttle");
+    ref1.recordDroppedRequest();
+    ref2.recordDroppedRequest();
+
+    ClusterStats stats = Iterables.getOnlyElement(
+        loadStatsManager.getClusterStatsReports(CLUSTER_NAME1));
+    assertThat(stats.getDroppedRequestsList()).hasSize(2);
+    assertThat(findDroppedRequestCount(stats.getDroppedRequestsList(), "lb")).isEqualTo(1L);
+    assertThat(findDroppedRequestCount(stats.getDroppedRequestsList(), "throttle")).isEqualTo(1L);
+    assertThat(stats.getTotalDroppedRequests()).isEqualTo(4L);  // 2 cagetorized + 2 uncategoized
+  }
+
+  @Test
+  public void dropCounterDelayedDeletionAfterReported() {
+    DropStatsCounter counter = loadStatsManager.getDropCounter(CLUSTER_NAME1, EDS_SERVICE_NAME1);
+    counter.recordDroppedRequest("lb");
+    ClusterStats stats = Iterables.getOnlyElement(
+        loadStatsManager.getClusterStatsReports(CLUSTER_NAME1));
+    assertThat(stats.getDroppedRequestsList()).hasSize(1);
+    assertThat(Iterables.getOnlyElement(stats.getDroppedRequestsList()).getDroppedCount())
+        .isEqualTo(1L);
+    assertThat(stats.getTotalDroppedRequests()).isEqualTo(1L);
+
+    loadStatsManager.releaseDropCounter(CLUSTER_NAME1, EDS_SERVICE_NAME1);
+    stats = Iterables.getOnlyElement(loadStatsManager.getClusterStatsReports(CLUSTER_NAME1));
+    assertThat(stats.getDroppedRequestsList()).isEmpty();
+    assertThat(stats.getTotalDroppedRequests()).isEqualTo(0L);
+
+    assertThat(loadStatsManager.getClusterStatsReports(CLUSTER_NAME1)).isEmpty();
+  }
+
+  @Test
+  public void sharedLoadCounterStatsAggregation() {
+    ClientLoadCounter ref1 =
+        loadStatsManager.getLoadCounter(CLUSTER_NAME1, EDS_SERVICE_NAME1, LOCALITY1);
+    ClientLoadCounter ref2 =
+        loadStatsManager.getLoadCounter(CLUSTER_NAME1, EDS_SERVICE_NAME1, LOCALITY1);
+    ref1.recordCallStarted();
+    ref1.recordCallFinished(Status.OK);
+    ref2.recordCallStarted();
+    ref2.recordCallStarted();
+    ref2.recordCallFinished(Status.UNAVAILABLE);
+
+    ClusterStats stats = Iterables.getOnlyElement(
+        loadStatsManager.getClusterStatsReports(CLUSTER_NAME1));
+    UpstreamLocalityStats localityStats =
+        Iterables.getOnlyElement(stats.getUpstreamLocalityStatsList());
+    assertThat(localityStats.getTotalIssuedRequests()).isEqualTo(1L + 2L);
+    assertThat(localityStats.getTotalSuccessfulRequests()).isEqualTo(1L);
+    assertThat(localityStats.getTotalErrorRequests()).isEqualTo(1L);
+    assertThat(localityStats.getTotalRequestsInProgress()).isEqualTo(1L + 2L - 1L - 1L);
+  }
+
+  @Test
+  public void loadCounterDelayedDeletionAfterAllInProgressRequestsReported() {
+    ClientLoadCounter counter =
+        loadStatsManager.getLoadCounter(CLUSTER_NAME1, EDS_SERVICE_NAME1, LOCALITY1);
+    counter.recordCallStarted();
+    counter.recordCallStarted();
+
+    ClusterStats stats = Iterables.getOnlyElement(
+        loadStatsManager.getClusterStatsReports(CLUSTER_NAME1));
+    UpstreamLocalityStats localityStats =
+        Iterables.getOnlyElement(stats.getUpstreamLocalityStatsList());
+    assertThat(localityStats.getTotalIssuedRequests()).isEqualTo(2L);
+    assertThat(localityStats.getTotalSuccessfulRequests()).isEqualTo(0L);
+    assertThat(localityStats.getTotalErrorRequests()).isEqualTo(0L);
+    assertThat(localityStats.getTotalRequestsInProgress()).isEqualTo(2L);
+
+    // release the counter, but requests still in-flight
+    loadStatsManager.releaseLoadCounter(CLUSTER_NAME1, EDS_SERVICE_NAME1, LOCALITY1);
+    stats = Iterables.getOnlyElement(loadStatsManager.getClusterStatsReports(CLUSTER_NAME1));
+    localityStats = Iterables.getOnlyElement(stats.getUpstreamLocalityStatsList());
+    assertThat(localityStats.getTotalIssuedRequests()).isEqualTo(0L);
+    assertThat(localityStats.getTotalSuccessfulRequests()).isEqualTo(0L);
+    assertThat(localityStats.getTotalErrorRequests()).isEqualTo(0L);
+    assertThat(localityStats.getTotalRequestsInProgress())
+        .isEqualTo(2L);  // retained by in-flight calls
+
+    counter.recordCallFinished(Status.OK);
+    counter.recordCallFinished(Status.UNAVAILABLE);
+    stats = Iterables.getOnlyElement(loadStatsManager.getClusterStatsReports(CLUSTER_NAME1));
+    localityStats = Iterables.getOnlyElement(stats.getUpstreamLocalityStatsList());
+    assertThat(localityStats.getTotalIssuedRequests()).isEqualTo(0L);
+    assertThat(localityStats.getTotalSuccessfulRequests()).isEqualTo(1L);
+    assertThat(localityStats.getTotalErrorRequests()).isEqualTo(1L);
+    assertThat(localityStats.getTotalRequestsInProgress()).isEqualTo(0L);
+
+    assertThat(loadStatsManager.getClusterStatsReports(CLUSTER_NAME1)).isEmpty();
+  }
+
+  @Nullable
+  private static ClusterStats findClusterStats(
+      List<ClusterStats> statsList, String cluster, @Nullable String edsServiceName) {
+    for (ClusterStats stats : statsList) {
+      if (stats.getClusterName().equals(cluster)
+          && Objects.equals(stats.getClusterServiceName(), edsServiceName)) {
+        return stats;
+      }
+    }
+    return null;
+  }
+
+  @Nullable
+  private static UpstreamLocalityStats findLocalityStats(
+      List<UpstreamLocalityStats> localityStatsList, Locality locality) {
+    for (UpstreamLocalityStats stats : localityStatsList) {
+      if (stats.getLocality().equals(locality)) {
+        return stats;
+      }
+    }
+    return null;
+  }
+
+  private static long findDroppedRequestCount(
+      List<DroppedRequests> droppedRequestsLists, String category) {
+    DroppedRequests drop = null;
+    for (DroppedRequests stats : droppedRequestsLists) {
+      if (stats.getCategory().equals(category)) {
+        drop = stats;
+      }
+    }
+    assertThat(drop).isNotNull();
+    return drop.getDroppedCount();
+  }
+}

--- a/xds/src/test/java/io/grpc/xds/LoadStatsStoreImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/LoadStatsStoreImplTest.java
@@ -18,7 +18,6 @@ package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
 import io.grpc.internal.FakeClock;
 import io.grpc.xds.ClientLoadCounter.MetricValue;
@@ -53,8 +52,7 @@ public class LoadStatsStoreImplTest {
 
   @Before
   public void setUp() {
-    Stopwatch stopwatch = fakeClock.getStopwatchSupplier().get();
-    loadStatsStore = new LoadStatsStoreImpl(CLUSTER_NAME, null, stopwatch);
+    loadStatsStore = new LoadStatsStoreImpl(CLUSTER_NAME, null, fakeClock.getStopwatchSupplier());
   }
 
   private static List<EndpointLoadMetricStats> buildEndpointLoadMetricStatsList(


### PR DESCRIPTION
The existing `LoadStatsStore` came from the old time when dropped request (per cluster) and normal requests (per locality) are recorded in a single LB policy. Now we want to build separate XdsClient APIs for dropped requests and normal requests, we want to decouple the objects for them as much as possible.

This change introduces `DropStatsCounter` which is used to record dropped requests. It has a stopwatch to time the interval from being created (aka, start recording) and taking snapshot (aka, reported to LRS server). Similarly, also add a stopwatch to `ClientLoadCounter` for normal requests. A new `LoadStatsManager2` is introduced that directly book keeps a set of `DropStatsCounter`s (for each cluster with edsServiceName) and a set of `ClientLoadCounter`s (for each locality). 

In next steps, `LoadStatsStore` will be deprecated and will replace `LoadStatsManager` with `LoadStatsManager2`, which hands stats objects to LB policies directly (without through `LoadStatsStore`).