### PR TITLE
xds: parse HttpFault filter from LDS/RDS response

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -17,7 +17,10 @@
 package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.grpc.xds.EnvoyProtoData.HTTP_FAULT_FILTER_NAME;
 import static io.grpc.xds.EnvoyProtoData.TRANSPORT_SOCKET_NAME_TLS;
+import static io.grpc.xds.EnvoyProtoData.decodeFaultFilterConfig;
+import static io.grpc.xds.EnvoyProtoData.parseHttpFaultFilter;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
@@ -38,12 +41,14 @@ import io.envoyproxy.envoy.config.listener.v3.Listener;
 import io.envoyproxy.envoy.config.route.v3.RouteConfiguration;
 import io.envoyproxy.envoy.config.route.v3.VirtualHost;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager;
+import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.Rds;
 import io.grpc.ManagedChannel;
 import io.grpc.Status;
 import io.grpc.SynchronizationContext.ScheduledHandle;
 import io.grpc.internal.BackoffPolicy;
 import io.grpc.xds.EnvoyProtoData.DropOverload;
+import io.grpc.xds.EnvoyProtoData.HttpFault;
 import io.grpc.xds.EnvoyProtoData.Locality;
 import io.grpc.xds.EnvoyProtoData.LocalityLbEndpoints;
 import io.grpc.xds.EnvoyProtoData.Node;
@@ -163,6 +168,28 @@ final class ClientXdsClient extends AbstractXdsClient {
           maxStreamDuration = Durations.toNanos(options.getMaxStreamDuration());
         }
       }
+      boolean hasFaultInjection = false;
+      HttpFault httpFault = null;
+      List<HttpFilter> httpFilters = hcm.getHttpFiltersList();
+      if (parseHttpFaultFilter()) {
+        for (HttpFilter httpFilter : httpFilters) {
+          if (HTTP_FAULT_FILTER_NAME.equals(httpFilter.getName())) {
+            hasFaultInjection = true;
+            if (httpFilter.hasTypedConfig()) {
+              StructOrError<HttpFault> httpFaultOrError =
+                  decodeFaultFilterConfig(httpFilter.getTypedConfig());
+              if (httpFaultOrError.getErrorDetail() != null) {
+                nackResponse(ResourceType.LDS, nonce,
+                    "Listener " + listenerName + " contains invalid HttpFault filter: "
+                        + httpFaultOrError.getErrorDetail());
+                return;
+              }
+              httpFault = httpFaultOrError.getStruct();
+            }
+            break;
+          }
+        }
+      }
       if (hcm.hasRouteConfig()) {
         List<EnvoyProtoData.VirtualHost> virtualHosts = new ArrayList<>();
         for (VirtualHost virtualHostProto : hcm.getRouteConfig().getVirtualHostsList()) {
@@ -176,7 +203,7 @@ final class ClientXdsClient extends AbstractXdsClient {
           }
           virtualHosts.add(virtualHost.getStruct());
         }
-        update = new LdsUpdate(maxStreamDuration, virtualHosts);
+        update = new LdsUpdate(maxStreamDuration, virtualHosts, hasFaultInjection, httpFault);
       } else if (hcm.hasRds()) {
         Rds rds = hcm.getRds();
         if (!rds.getConfigSource().hasAds()) {
@@ -184,7 +211,8 @@ final class ClientXdsClient extends AbstractXdsClient {
               "Listener " + listenerName + " with RDS config_source not set to ADS");
           return;
         }
-        update = new LdsUpdate(maxStreamDuration, rds.getRouteConfigName());
+        update = new LdsUpdate(
+            maxStreamDuration, rds.getRouteConfigName(), hasFaultInjection, httpFault);
         rdsNames.add(rds.getRouteConfigName());
       } else {
         nackResponse(ResourceType.LDS, nonce,

--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -19,7 +19,6 @@ package io.grpc.xds;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.grpc.xds.EnvoyProtoData.HTTP_FAULT_FILTER_NAME;
 import static io.grpc.xds.EnvoyProtoData.TRANSPORT_SOCKET_NAME_TLS;
-import static io.grpc.xds.EnvoyProtoData.decodeFaultFilterConfig;
 import static io.grpc.xds.EnvoyProtoData.parseHttpFaultFilter;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -177,7 +176,7 @@ final class ClientXdsClient extends AbstractXdsClient {
             hasFaultInjection = true;
             if (httpFilter.hasTypedConfig()) {
               StructOrError<HttpFault> httpFaultOrError =
-                  decodeFaultFilterConfig(httpFilter.getTypedConfig());
+                  HttpFault.decodeFaultFilterConfig(httpFilter.getTypedConfig());
               if (httpFaultOrError.getErrorDetail() != null) {
                 nackResponse(ResourceType.LDS, nonce,
                     "Listener " + listenerName + " contains invalid HttpFault filter: "

--- a/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
@@ -22,6 +22,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.ListValue;
 import com.google.protobuf.NullValue;
 import com.google.protobuf.Struct;
@@ -29,9 +31,12 @@ import com.google.protobuf.Value;
 import com.google.protobuf.util.Durations;
 import com.google.re2j.Pattern;
 import com.google.re2j.PatternSyntaxException;
+import io.envoyproxy.envoy.extensions.filters.http.fault.v3.HTTPFault;
 import io.envoyproxy.envoy.type.v3.FractionalPercent;
 import io.envoyproxy.envoy.type.v3.FractionalPercent.DenominatorType;
 import io.grpc.EquivalentAddressGroup;
+import io.grpc.Status;
+import io.grpc.Status.Code;
 import io.grpc.xds.RouteMatch.FractionMatcher;
 import io.grpc.xds.RouteMatch.HeaderMatcher;
 import io.grpc.xds.RouteMatch.PathMatcher;
@@ -61,6 +66,10 @@ import javax.annotation.Nullable;
 // TODO(chengyuanzhang): put data types into smaller categories.
 final class EnvoyProtoData {
   static final String TRANSPORT_SOCKET_NAME_TLS = "envoy.transport_sockets.tls";
+  static final String HTTP_FAULT_FILTER_NAME = "envoy.fault";
+  @VisibleForTesting
+  static boolean enableFaultInjection =
+      Boolean.parseBoolean(System.getenv("GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION"));
 
   // Prevent instantiation.
   private EnvoyProtoData() {
@@ -756,54 +765,7 @@ final class EnvoyProtoData {
     static DropOverload fromEnvoyProtoDropOverload(
         io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment.Policy.DropOverload proto) {
       FractionalPercent percent = proto.getDropPercentage();
-      int numerator = percent.getNumerator();
-      DenominatorType type = percent.getDenominator();
-      switch (type) {
-        case TEN_THOUSAND:
-          numerator *= 100;
-          break;
-        case HUNDRED:
-          numerator *= 10_000;
-          break;
-        case MILLION:
-          break;
-        case UNRECOGNIZED:
-        default:
-          throw new IllegalArgumentException("Unknown denominator type of " + percent);
-      }
-
-      if (numerator > 1_000_000) {
-        numerator = 1_000_000;
-      }
-
-      return new DropOverload(proto.getCategory(), numerator);
-    }
-
-    @VisibleForTesting
-    static DropOverload fromEnvoyProtoDropOverloadV2(
-        io.envoyproxy.envoy.api.v2.ClusterLoadAssignment.Policy.DropOverload proto) {
-      io.envoyproxy.envoy.type.FractionalPercent percent = proto.getDropPercentage();
-      int numerator = percent.getNumerator();
-      io.envoyproxy.envoy.type.FractionalPercent.DenominatorType type = percent.getDenominator();
-      switch (type) {
-        case TEN_THOUSAND:
-          numerator *= 100;
-          break;
-        case HUNDRED:
-          numerator *= 10_000;
-          break;
-        case MILLION:
-          break;
-        case UNRECOGNIZED:
-        default:
-          throw new IllegalArgumentException("Unknown denominator type of " + percent);
-      }
-
-      if (numerator > 1_000_000) {
-        numerator = 1_000_000;
-      }
-
-      return new DropOverload(proto.getCategory(), numerator);
+      return new DropOverload(proto.getCategory(), getRatePerMillion(percent));
     }
 
     String getCategory() {
@@ -849,12 +811,19 @@ final class EnvoyProtoData {
     private final List<String> domains;
     // The list of routes that will be matched, in order, for incoming requests.
     private final List<Route> routes;
+    @Nullable
+    private final HttpFault httpFault;
 
     @VisibleForTesting
     VirtualHost(String name, List<String> domains, List<Route> routes) {
+      this(name, domains, routes, null);
+    }
+
+    VirtualHost(String name, List<String> domains, List<Route> routes, HttpFault httpFault) {
       this.name = name;
       this.domains = domains;
       this.routes = routes;
+      this.httpFault = httpFault;
     }
 
     String getName() {
@@ -869,13 +838,21 @@ final class EnvoyProtoData {
       return routes;
     }
 
+    @Nullable
+    HttpFault getHttpFault() {
+      return httpFault;
+    }
+
     @Override
     public String toString() {
-      return MoreObjects.toStringHelper(this)
+      ToStringHelper toStringHelper = MoreObjects.toStringHelper(this)
           .add("name", name)
           .add("domains", domains)
-          .add("routes", routes)
-          .toString();
+          .add("routes", routes);
+      if (httpFault != null) {
+        toStringHelper.add("httpFault", httpFault);
+      }
+      return toStringHelper.toString();
     }
 
     static StructOrError<VirtualHost> fromEnvoyProtoVirtualHost(
@@ -893,9 +870,25 @@ final class EnvoyProtoData {
         }
         routes.add(route.getStruct());
       }
+      HttpFault httpFault = null;
+      if (parseHttpFaultFilter()) {
+        Map<String, Any> filterConfigMap = proto.getTypedPerFilterConfigMap();
+        if (filterConfigMap.containsKey(HTTP_FAULT_FILTER_NAME)) {
+          Any rawFaultFilterConfig = filterConfigMap.get(HTTP_FAULT_FILTER_NAME);
+          StructOrError<HttpFault> httpFaultOrError = decodeFaultFilterConfig(rawFaultFilterConfig);
+          if (httpFaultOrError.getErrorDetail() != null) {
+            return StructOrError.fromError(
+                "Virtual host [" + name + "] contains invalid HttpFault filter : "
+                    + httpFaultOrError.getErrorDetail());
+          }
+          httpFault = httpFaultOrError.getStruct();
+        }
+      }
       return StructOrError.fromStruct(
-          new VirtualHost(name, Collections.unmodifiableList(proto.getDomainsList()),
-              Collections.unmodifiableList(routes)));
+          new VirtualHost(
+              name, Collections.unmodifiableList(proto.getDomainsList()),
+              Collections.unmodifiableList(routes),
+              httpFault));
     }
   }
 
@@ -903,11 +896,18 @@ final class EnvoyProtoData {
   static final class Route {
     private final RouteMatch routeMatch;
     private final RouteAction routeAction;
+    @Nullable
+    private final HttpFault httpFault;
 
     @VisibleForTesting
-    Route(RouteMatch routeMatch, @Nullable RouteAction routeAction) {
+    Route(RouteMatch routeMatch, RouteAction routeAction) {
+      this(routeMatch, routeAction, null);
+    }
+
+    Route(RouteMatch routeMatch, RouteAction routeAction, @Nullable HttpFault httpFault) {
       this.routeMatch = routeMatch;
       this.routeAction = routeAction;
+      this.httpFault = httpFault;
     }
 
     RouteMatch getRouteMatch() {
@@ -916,6 +916,11 @@ final class EnvoyProtoData {
 
     RouteAction getRouteAction() {
       return routeAction;
+    }
+
+    @Nullable
+    HttpFault getHttpFault() {
+      return httpFault;
     }
 
     @Override
@@ -928,20 +933,24 @@ final class EnvoyProtoData {
       }
       Route route = (Route) o;
       return Objects.equals(routeMatch, route.routeMatch)
-          && Objects.equals(routeAction, route.routeAction);
+          && Objects.equals(routeAction, route.routeAction)
+          && Objects.equals(httpFault, route.httpFault);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(routeMatch, routeAction);
+      return Objects.hash(routeMatch, routeAction, httpFault);
     }
 
     @Override
     public String toString() {
-      return MoreObjects.toStringHelper(this)
+      ToStringHelper toStringHelper = MoreObjects.toStringHelper(this)
           .add("routeMatch", routeMatch)
-          .add("routeAction", routeAction)
-          .toString();
+          .add("routeAction", routeAction);
+      if (httpFault != null) {
+        toStringHelper.add("httpFault", httpFault);
+      }
+      return toStringHelper.toString();
     }
 
     @Nullable
@@ -978,7 +987,23 @@ final class EnvoyProtoData {
         return StructOrError.fromError(
             "Invalid route [" + proto.getName() + "]: " + routeAction.getErrorDetail());
       }
-      return StructOrError.fromStruct(new Route(routeMatch.getStruct(), routeAction.getStruct()));
+
+      HttpFault httpFault = null;
+      if (parseHttpFaultFilter()) {
+        Map<String, Any> filterConfigMap = proto.getTypedPerFilterConfigMap();
+        if (filterConfigMap.containsKey(HTTP_FAULT_FILTER_NAME)) {
+          Any rawFaultFilterConfig = filterConfigMap.get(HTTP_FAULT_FILTER_NAME);
+          StructOrError<HttpFault> httpFaultOrError = decodeFaultFilterConfig(rawFaultFilterConfig);
+          if (httpFaultOrError.getErrorDetail() != null) {
+            return StructOrError.fromError(
+                "Route [" + proto.getName() + "] contains invalid HttpFault filter: "
+                    + httpFaultOrError.getErrorDetail());
+          }
+          httpFault = httpFaultOrError.getStruct();
+        }
+      }
+      return StructOrError.fromStruct(
+          new Route(routeMatch.getStruct(), routeAction.getStruct(), httpFault));
     }
 
     @VisibleForTesting
@@ -1113,6 +1138,270 @@ final class EnvoyProtoData {
     }
   }
 
+  static StructOrError<HttpFault> decodeFaultFilterConfig(Any rawFaultFilterConfig) {
+    if (rawFaultFilterConfig.getTypeUrl().equals(
+        "type.googleapis.com/envoy.config.filter.http.fault.v2.HTTPFault")) {
+      rawFaultFilterConfig = rawFaultFilterConfig.toBuilder().setTypeUrl(
+          "type.googleapis.com/envoy.extensions.filter.http.fault.v3.HTTPFault").build();
+    }
+    if (rawFaultFilterConfig.getTypeUrl().equals(
+        "type.googleapis.com/envoy.extensions.filter.http.fault.v3.HTTPFault")) {
+      HTTPFault httpFaultProto;
+      try {
+        httpFaultProto = rawFaultFilterConfig.unpack(HTTPFault.class);
+      } catch (InvalidProtocolBufferException e) {
+        return StructOrError.fromError("Invalid proto: " + e);
+      }
+      return HttpFault.fromEnvoyProtoHttpFault(httpFaultProto);
+    }
+    return StructOrError.fromError(
+        "Invalid type url for envoy.fault filter: " + rawFaultFilterConfig.getTypeUrl());
+  }
+
+  static boolean parseHttpFaultFilter() {
+    return enableFaultInjection;
+  }
+
+  /**
+   * See corresponding Envoy proto message {@link
+   * io.envoyproxy.envoy.extensions.filters.http.fault.v3.HTTPFault}.
+   */
+  static final class HttpFault {
+    @Nullable
+    final FaultDelay faultDelay;
+    @Nullable
+    final FaultAbort faultAbort;
+
+    HttpFault(@Nullable FaultDelay faultDelay, @Nullable FaultAbort faultAbort) {
+      this.faultDelay = faultDelay;
+      this.faultAbort = faultAbort;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      HttpFault httpFault = (HttpFault) o;
+      return Objects.equals(faultDelay, httpFault.faultDelay)
+          && Objects.equals(faultAbort, httpFault.faultAbort);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(faultDelay, faultAbort);
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("faultDelay", faultDelay)
+          .add("faultAbort", faultAbort)
+          .toString();
+    }
+
+    static StructOrError<HttpFault> fromEnvoyProtoHttpFault(HTTPFault httpFault) {
+      FaultDelay faultDelay = null;
+      FaultAbort faultAbort = null;
+      if (httpFault.hasDelay()) {
+        faultDelay = FaultDelay.fromEnvoyProtoFaultDelay(httpFault.getDelay());
+      }
+      if (httpFault.hasAbort()) {
+        StructOrError<FaultAbort> faultAbortOrError =
+            FaultAbort.fromEnvoyProtoFaultAbort(httpFault.getAbort());
+        if (faultAbortOrError.getErrorDetail() != null) {
+          return StructOrError.fromError(
+              "HttpFault contains invalid FaultAbort: " + faultAbortOrError.getErrorDetail());
+        }
+        faultAbort = faultAbortOrError.getStruct();
+      }
+      if (faultDelay == null && faultAbort == null) {
+        return StructOrError.fromError(
+            "Invalid HttpFault: neither fault_delay nor fault_abort is specified");
+      }
+      return StructOrError.fromStruct(new HttpFault(faultDelay, faultAbort));
+    }
+  }
+
+  /**
+   * See corresponding Envoy proto message {@link
+   * io.envoyproxy.envoy.extensions.filters.common.fault.v3.FaultDelay}.
+   */
+  static final class FaultDelay {
+    @Nullable
+    final Long delayNanos;
+    final int ratePerMillion;
+
+    FaultDelay(@Nullable Long delayNanos, int ratePerMillion) {
+      this.delayNanos = delayNanos;
+      this.ratePerMillion = ratePerMillion;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      FaultDelay that = (FaultDelay) o;
+      return ratePerMillion == that.ratePerMillion
+          && Objects.equals(delayNanos, that.delayNanos);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(delayNanos, ratePerMillion);
+    }
+
+    @Override
+    public String toString() {
+      ToStringHelper toStringHelper = MoreObjects.toStringHelper(this)
+          .add("ratePerMillion", ratePerMillion);
+      if (delayNanos != null) {
+        toStringHelper.add("type", "fixed delay");
+        toStringHelper.add("delayNanos", delayNanos);
+      } else {
+        toStringHelper.add("type", "header delay");
+      }
+      return toStringHelper.toString();
+    }
+
+    private static FaultDelay fromEnvoyProtoFaultDelay(
+        io.envoyproxy.envoy.extensions.filters.common.fault.v3.FaultDelay faultDelay) {
+      int rate = getRatePerMillion(faultDelay.getPercentage());
+      if (faultDelay.hasHeaderDelay()) {
+        return new FaultDelay(null, rate);
+      }
+      long delay = Durations.toNanos(faultDelay.getFixedDelay());
+      return new FaultDelay(delay, rate);
+    }
+  }
+
+  /**
+   * See corresponding Envoy proto message {@link
+   * io.envoyproxy.envoy.extensions.filters.http.fault.v3.FaultAbort}.
+   */
+  static final class FaultAbort {
+    @Nullable
+    final Status status;
+    final int ratePerMillion;
+
+    FaultAbort(@Nullable Status status, int ratePerMillion) {
+      this.status = status;
+      this.ratePerMillion = ratePerMillion;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      FaultAbort that = (FaultAbort) o;
+      return ratePerMillion == that.ratePerMillion
+          && Objects.equals(status, that.status);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(status, ratePerMillion);
+    }
+
+    @Override
+    public String toString() {
+      ToStringHelper toStringHelper = MoreObjects.toStringHelper(this)
+          .add("ratePerMillion", ratePerMillion);
+      if (status != null) {
+        toStringHelper.add("type", "fixed status");
+        toStringHelper.add("status", status);
+      } else {
+        toStringHelper.add("type", "header abort");
+      }
+      return toStringHelper.toString();
+    }
+
+    private static StructOrError<FaultAbort> fromEnvoyProtoFaultAbort(
+        io.envoyproxy.envoy.extensions.filters.http.fault.v3.FaultAbort faultAbort) {
+      int rate = getRatePerMillion(faultAbort.getPercentage());
+      switch (faultAbort.getErrorTypeCase()) {
+        case HEADER_ABORT:
+          return StructOrError.fromStruct(new FaultAbort(null, rate));
+        case HTTP_STATUS:
+          Status status = convertHttpStatus(faultAbort.getHttpStatus());
+          return StructOrError.fromStruct(new FaultAbort(status, rate));
+        case GRPC_STATUS:
+          Code code;
+          try {
+            code = Code.values()[faultAbort.getGrpcStatus()];
+          } catch (ArrayIndexOutOfBoundsException e) {
+            return StructOrError.fromError("Unknown GRPC_STATUS: " + faultAbort.getGrpcStatus());
+          }
+          return StructOrError.fromStruct(new FaultAbort(code.toStatus(), rate));
+        case ERRORTYPE_NOT_SET:
+        default:
+          return StructOrError.fromError(
+              "Unknown error type case: " + faultAbort.getErrorTypeCase());
+      }
+    }
+
+    private static Status convertHttpStatus(int httpCode) {
+      Status status;
+      switch (httpCode) {
+        case 400:
+          status = Status.INTERNAL;
+          break;
+        case 401:
+          status = Status.UNAUTHENTICATED;
+          break;
+        case 403:
+          status = Status.PERMISSION_DENIED;
+          break;
+        case 404:
+          status = Status.UNIMPLEMENTED;
+          break;
+        case 429:
+        case 502:
+        case 503:
+        case 504:
+          status = Status.UNAVAILABLE;
+          break;
+        default:
+          status = Status.UNKNOWN;
+      }
+      return status.withDescription("HTTP code: " + httpCode);
+    }
+  }
+
+  private static int getRatePerMillion(FractionalPercent percent) {
+    int numerator = percent.getNumerator();
+    DenominatorType type = percent.getDenominator();
+    switch (type) {
+      case TEN_THOUSAND:
+        numerator *= 100;
+        break;
+      case HUNDRED:
+        numerator *= 10_000;
+        break;
+      case MILLION:
+        break;
+      case UNRECOGNIZED:
+      default:
+        throw new IllegalArgumentException("Unknown denominator type of " + percent);
+    }
+
+    if (numerator > 1_000_000 || numerator < 0) {
+      numerator = 1_000_000;
+    }
+    return numerator;
+  }
+
   /**
    * See corresponding Envoy proto message {@link io.envoyproxy.envoy.config.route.v3.RouteAction}.
    */
@@ -1203,7 +1492,13 @@ final class EnvoyProtoData {
           weightedClusters = new ArrayList<>();
           for (io.envoyproxy.envoy.config.route.v3.WeightedCluster.ClusterWeight clusterWeight
               : clusterWeights) {
-            weightedClusters.add(ClusterWeight.fromEnvoyProtoClusterWeight(clusterWeight));
+            StructOrError<ClusterWeight> clusterWeightOrError =
+                ClusterWeight.fromEnvoyProtoClusterWeight(clusterWeight);
+            if (clusterWeightOrError.getErrorDetail() != null) {
+              return StructOrError.fromError("RouteAction contains invalid ClusterWeight: "
+                  + clusterWeightOrError.getErrorDetail());
+            }
+            weightedClusters.add(clusterWeightOrError.getStruct());
           }
           // TODO(chengyuanzhang): validate if the sum of weights equals to total weight.
           break;
@@ -1233,11 +1528,14 @@ final class EnvoyProtoData {
   static final class ClusterWeight {
     private final String name;
     private final int weight;
+    @Nullable
+    private final HttpFault httpFault;
 
     @VisibleForTesting
-    ClusterWeight(String name, int weight) {
+    ClusterWeight(String name, int weight, @Nullable HttpFault httpFault) {
       this.name = name;
       this.weight = weight;
+      this.httpFault = httpFault;
     }
 
     String getName() {
@@ -1246,6 +1544,11 @@ final class EnvoyProtoData {
 
     int getWeight() {
       return weight;
+    }
+
+    @Nullable
+    HttpFault getHttpFault() {
+      return httpFault;
     }
 
     @Override
@@ -1257,26 +1560,45 @@ final class EnvoyProtoData {
         return false;
       }
       ClusterWeight that = (ClusterWeight) o;
-      return weight == that.weight && Objects.equals(name, that.name);
+      return weight == that.weight && Objects.equals(name, that.name)
+          && Objects.equals(httpFault, that.httpFault);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(name, weight);
+      return Objects.hash(name, weight, httpFault);
     }
 
     @Override
     public String toString() {
-      return MoreObjects.toStringHelper(this)
+      ToStringHelper toStringHelper = MoreObjects.toStringHelper(this)
           .add("name", name)
-          .add("weight", weight)
-          .toString();
+          .add("weight", weight);
+      if (httpFault != null) {
+        toStringHelper.add("httpFault", httpFault);
+      }
+      return toStringHelper.toString();
     }
 
     @VisibleForTesting
-    static ClusterWeight fromEnvoyProtoClusterWeight(
+    static StructOrError<ClusterWeight> fromEnvoyProtoClusterWeight(
         io.envoyproxy.envoy.config.route.v3.WeightedCluster.ClusterWeight proto) {
-      return new ClusterWeight(proto.getName(), proto.getWeight().getValue());
+      HttpFault httpFault = null;
+      if (parseHttpFaultFilter()) {
+        Map<String, Any> filterConfigMap = proto.getTypedPerFilterConfigMap();
+        if (filterConfigMap.containsKey(HTTP_FAULT_FILTER_NAME)) {
+          Any rawFaultFilterConfig = filterConfigMap.get(HTTP_FAULT_FILTER_NAME);
+          StructOrError<HttpFault> httpFaultOrError = decodeFaultFilterConfig(rawFaultFilterConfig);
+          if (httpFaultOrError.getErrorDetail() != null) {
+            return StructOrError.fromError(
+                "ClusterWeight [" + proto.getName() + "] contains invalid HttpFault filter: "
+                    + httpFaultOrError.getErrorDetail());
+          }
+          httpFault = httpFaultOrError.getStruct();
+        }
+      }
+      return StructOrError.fromStruct(
+          new ClusterWeight(proto.getName(), proto.getWeight().getValue(), httpFault));
     }
   }
 

--- a/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
@@ -874,7 +874,8 @@ final class EnvoyProtoData {
         Map<String, Any> filterConfigMap = proto.getTypedPerFilterConfigMap();
         if (filterConfigMap.containsKey(HTTP_FAULT_FILTER_NAME)) {
           Any rawFaultFilterConfig = filterConfigMap.get(HTTP_FAULT_FILTER_NAME);
-          StructOrError<HttpFault> httpFaultOrError = decodeFaultFilterConfig(rawFaultFilterConfig);
+          StructOrError<HttpFault> httpFaultOrError =
+              HttpFault.decodeFaultFilterConfig(rawFaultFilterConfig);
           if (httpFaultOrError.getErrorDetail() != null) {
             return StructOrError.fromError(
                 "Virtual host [" + name + "] contains invalid HttpFault filter : "
@@ -992,7 +993,8 @@ final class EnvoyProtoData {
         Map<String, Any> filterConfigMap = proto.getTypedPerFilterConfigMap();
         if (filterConfigMap.containsKey(HTTP_FAULT_FILTER_NAME)) {
           Any rawFaultFilterConfig = filterConfigMap.get(HTTP_FAULT_FILTER_NAME);
-          StructOrError<HttpFault> httpFaultOrError = decodeFaultFilterConfig(rawFaultFilterConfig);
+          StructOrError<HttpFault> httpFaultOrError =
+              HttpFault.decodeFaultFilterConfig(rawFaultFilterConfig);
           if (httpFaultOrError.getErrorDetail() != null) {
             return StructOrError.fromError(
                 "Route [" + proto.getName() + "] contains invalid HttpFault filter: "
@@ -1137,26 +1139,6 @@ final class EnvoyProtoData {
     }
   }
 
-  static StructOrError<HttpFault> decodeFaultFilterConfig(Any rawFaultFilterConfig) {
-    if (rawFaultFilterConfig.getTypeUrl().equals(
-        "type.googleapis.com/envoy.config.filter.http.fault.v2.HTTPFault")) {
-      rawFaultFilterConfig = rawFaultFilterConfig.toBuilder().setTypeUrl(
-          "type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault").build();
-    }
-    if (rawFaultFilterConfig.getTypeUrl().equals(
-        "type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault")) {
-      HTTPFault httpFaultProto;
-      try {
-        httpFaultProto = rawFaultFilterConfig.unpack(HTTPFault.class);
-      } catch (InvalidProtocolBufferException e) {
-        return StructOrError.fromError("Invalid proto: " + e);
-      }
-      return HttpFault.fromEnvoyProtoHttpFault(httpFaultProto);
-    }
-    return StructOrError.fromError(
-        "Invalid type url for envoy.fault filter: " + rawFaultFilterConfig.getTypeUrl());
-  }
-
   static boolean parseHttpFaultFilter() {
     return enableFaultInjection;
   }
@@ -1223,7 +1205,22 @@ final class EnvoyProtoData {
           .toString();
     }
 
-    static StructOrError<HttpFault> fromEnvoyProtoHttpFault(HTTPFault httpFault) {
+    static StructOrError<HttpFault> decodeFaultFilterConfig(Any rawFaultFilterConfig) {
+      if (rawFaultFilterConfig.getTypeUrl().equals(
+          "type.googleapis.com/envoy.config.filter.http.fault.v2.HTTPFault")) {
+        rawFaultFilterConfig = rawFaultFilterConfig.toBuilder().setTypeUrl(
+            "type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault").build();
+      }
+      HTTPFault httpFaultProto;
+      try {
+        httpFaultProto = rawFaultFilterConfig.unpack(HTTPFault.class);
+      } catch (InvalidProtocolBufferException e) {
+        return StructOrError.fromError("Invalid proto: " + e);
+      }
+      return fromEnvoyProtoHttpFault(httpFaultProto);
+    }
+
+    private static StructOrError<HttpFault> fromEnvoyProtoHttpFault(HTTPFault httpFault) {
       FaultDelay faultDelay = null;
       FaultAbort faultAbort = null;
       if (httpFault.hasDelay()) {
@@ -1627,7 +1624,8 @@ final class EnvoyProtoData {
         Map<String, Any> filterConfigMap = proto.getTypedPerFilterConfigMap();
         if (filterConfigMap.containsKey(HTTP_FAULT_FILTER_NAME)) {
           Any rawFaultFilterConfig = filterConfigMap.get(HTTP_FAULT_FILTER_NAME);
-          StructOrError<HttpFault> httpFaultOrError = decodeFaultFilterConfig(rawFaultFilterConfig);
+          StructOrError<HttpFault> httpFaultOrError =
+              HttpFault.decodeFaultFilterConfig(rawFaultFilterConfig);
           if (httpFaultOrError.getErrorDetail() != null) {
             return StructOrError.fromError(
                 "ClusterWeight [" + proto.getName() + "] contains invalid HttpFault filter: "

--- a/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
@@ -66,9 +66,6 @@ import javax.annotation.Nullable;
 final class EnvoyProtoData {
   static final String TRANSPORT_SOCKET_NAME_TLS = "envoy.transport_sockets.tls";
   static final String HTTP_FAULT_FILTER_NAME = "envoy.fault";
-  @VisibleForTesting
-  static boolean enableFaultInjection =
-      Boolean.parseBoolean(System.getenv("GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION"));
 
   // Prevent instantiation.
   private EnvoyProtoData() {
@@ -870,19 +867,17 @@ final class EnvoyProtoData {
         routes.add(route.getStruct());
       }
       HttpFault httpFault = null;
-      if (parseHttpFaultFilter()) {
-        Map<String, Any> filterConfigMap = proto.getTypedPerFilterConfigMap();
-        if (filterConfigMap.containsKey(HTTP_FAULT_FILTER_NAME)) {
-          Any rawFaultFilterConfig = filterConfigMap.get(HTTP_FAULT_FILTER_NAME);
-          StructOrError<HttpFault> httpFaultOrError =
-              HttpFault.decodeFaultFilterConfig(rawFaultFilterConfig);
-          if (httpFaultOrError.getErrorDetail() != null) {
-            return StructOrError.fromError(
-                "Virtual host [" + name + "] contains invalid HttpFault filter : "
-                    + httpFaultOrError.getErrorDetail());
-          }
-          httpFault = httpFaultOrError.getStruct();
+      Map<String, Any> filterConfigMap = proto.getTypedPerFilterConfigMap();
+      if (filterConfigMap.containsKey(HTTP_FAULT_FILTER_NAME)) {
+        Any rawFaultFilterConfig = filterConfigMap.get(HTTP_FAULT_FILTER_NAME);
+        StructOrError<HttpFault> httpFaultOrError =
+            HttpFault.decodeFaultFilterConfig(rawFaultFilterConfig);
+        if (httpFaultOrError.getErrorDetail() != null) {
+          return StructOrError.fromError(
+              "Virtual host [" + name + "] contains invalid HttpFault filter : "
+                  + httpFaultOrError.getErrorDetail());
         }
+        httpFault = httpFaultOrError.getStruct();
       }
       return StructOrError.fromStruct(
           new VirtualHost(
@@ -989,19 +984,17 @@ final class EnvoyProtoData {
       }
 
       HttpFault httpFault = null;
-      if (parseHttpFaultFilter()) {
-        Map<String, Any> filterConfigMap = proto.getTypedPerFilterConfigMap();
-        if (filterConfigMap.containsKey(HTTP_FAULT_FILTER_NAME)) {
-          Any rawFaultFilterConfig = filterConfigMap.get(HTTP_FAULT_FILTER_NAME);
-          StructOrError<HttpFault> httpFaultOrError =
-              HttpFault.decodeFaultFilterConfig(rawFaultFilterConfig);
-          if (httpFaultOrError.getErrorDetail() != null) {
-            return StructOrError.fromError(
-                "Route [" + proto.getName() + "] contains invalid HttpFault filter: "
-                    + httpFaultOrError.getErrorDetail());
-          }
-          httpFault = httpFaultOrError.getStruct();
+      Map<String, Any> filterConfigMap = proto.getTypedPerFilterConfigMap();
+      if (filterConfigMap.containsKey(HTTP_FAULT_FILTER_NAME)) {
+        Any rawFaultFilterConfig = filterConfigMap.get(HTTP_FAULT_FILTER_NAME);
+        StructOrError<HttpFault> httpFaultOrError =
+            HttpFault.decodeFaultFilterConfig(rawFaultFilterConfig);
+        if (httpFaultOrError.getErrorDetail() != null) {
+          return StructOrError.fromError(
+              "Route [" + proto.getName() + "] contains invalid HttpFault filter: "
+                  + httpFaultOrError.getErrorDetail());
         }
+        httpFault = httpFaultOrError.getStruct();
       }
       return StructOrError.fromStruct(
           new Route(routeMatch.getStruct(), routeAction.getStruct(), httpFault));
@@ -1137,10 +1130,6 @@ final class EnvoyProtoData {
               proto.getName(), exactMatch, safeRegExMatch, rangeMatch, presentMatch,
               prefixMatch, suffixMatch, proto.getInvertMatch()));
     }
-  }
-
-  static boolean parseHttpFaultFilter() {
-    return enableFaultInjection;
   }
 
   /**
@@ -1627,19 +1616,17 @@ final class EnvoyProtoData {
     static StructOrError<ClusterWeight> fromEnvoyProtoClusterWeight(
         io.envoyproxy.envoy.config.route.v3.WeightedCluster.ClusterWeight proto) {
       HttpFault httpFault = null;
-      if (parseHttpFaultFilter()) {
-        Map<String, Any> filterConfigMap = proto.getTypedPerFilterConfigMap();
-        if (filterConfigMap.containsKey(HTTP_FAULT_FILTER_NAME)) {
-          Any rawFaultFilterConfig = filterConfigMap.get(HTTP_FAULT_FILTER_NAME);
-          StructOrError<HttpFault> httpFaultOrError =
-              HttpFault.decodeFaultFilterConfig(rawFaultFilterConfig);
-          if (httpFaultOrError.getErrorDetail() != null) {
-            return StructOrError.fromError(
-                "ClusterWeight [" + proto.getName() + "] contains invalid HttpFault filter: "
-                    + httpFaultOrError.getErrorDetail());
-          }
-          httpFault = httpFaultOrError.getStruct();
+      Map<String, Any> filterConfigMap = proto.getTypedPerFilterConfigMap();
+      if (filterConfigMap.containsKey(HTTP_FAULT_FILTER_NAME)) {
+        Any rawFaultFilterConfig = filterConfigMap.get(HTTP_FAULT_FILTER_NAME);
+        StructOrError<HttpFault> httpFaultOrError =
+            HttpFault.decodeFaultFilterConfig(rawFaultFilterConfig);
+        if (httpFaultOrError.getErrorDetail() != null) {
+          return StructOrError.fromError(
+              "ClusterWeight [" + proto.getName() + "] contains invalid HttpFault filter: "
+                  + httpFaultOrError.getErrorDetail());
         }
+        httpFault = httpFaultOrError.getStruct();
       }
       return StructOrError.fromStruct(
           new ClusterWeight(proto.getName(), proto.getWeight().getValue(), httpFault));

--- a/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyProtoData.java
@@ -1142,10 +1142,10 @@ final class EnvoyProtoData {
     if (rawFaultFilterConfig.getTypeUrl().equals(
         "type.googleapis.com/envoy.config.filter.http.fault.v2.HTTPFault")) {
       rawFaultFilterConfig = rawFaultFilterConfig.toBuilder().setTypeUrl(
-          "type.googleapis.com/envoy.extensions.filter.http.fault.v3.HTTPFault").build();
+          "type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault").build();
     }
     if (rawFaultFilterConfig.getTypeUrl().equals(
-        "type.googleapis.com/envoy.extensions.filter.http.fault.v3.HTTPFault")) {
+        "type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault")) {
       HTTPFault httpFaultProto;
       try {
         httpFaultProto = rawFaultFilterConfig.unpack(HTTPFault.class);

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
@@ -25,9 +25,11 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.protobuf.Any;
 import com.google.protobuf.Message;
+import com.google.protobuf.StringValue;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.SdsSecretConfig;
 import io.grpc.BindableService;
 import io.grpc.ManagedChannel;
@@ -42,6 +44,7 @@ import io.grpc.internal.FakeClock.TaskFilter;
 import io.grpc.testing.GrpcCleanupRule;
 import io.grpc.xds.AbstractXdsClient.ResourceType;
 import io.grpc.xds.EnvoyProtoData.DropOverload;
+import io.grpc.xds.EnvoyProtoData.HttpFault;
 import io.grpc.xds.EnvoyProtoData.LbEndpoint;
 import io.grpc.xds.EnvoyProtoData.Locality;
 import io.grpc.xds.EnvoyProtoData.LocalityLbEndpoints;
@@ -65,6 +68,7 @@ import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -169,9 +173,11 @@ public abstract class ClientXdsClientTestBase {
 
   private ManagedChannel channel;
   private ClientXdsClient xdsClient;
+  private boolean originalIsFaultInjectionEnabled;
 
   @Before
   public void setUp() throws IOException {
+    originalIsFaultInjectionEnabled = EnvoyProtoData.enableFaultInjection;
     MockitoAnnotations.initMocks(this);
     when(backoffPolicyProvider.get()).thenReturn(backoffPolicy1, backoffPolicy2);
     when(backoffPolicy1.nextBackoffNanos()).thenReturn(10L, 100L);
@@ -204,6 +210,7 @@ public abstract class ClientXdsClientTestBase {
 
   @After
   public void tearDown() {
+    EnvoyProtoData.enableFaultInjection = originalIsFaultInjectionEnabled;
     xdsClient.shutdown();
     channel.shutdown();  // channel not owned by XdsClient
     assertThat(adsEnded.get()).isTrue();
@@ -326,6 +333,55 @@ public abstract class ClientXdsClientTestBase {
         "0001");
     verify(ldsResourceWatcher, times(2)).onChanged(ldsUpdateCaptor.capture());
     assertThat(ldsUpdateCaptor.getValue().rdsName).isEqualTo(RDS_RESOURCE);
+  }
+
+  @Test
+  public void ldsResourceUpdate_withFaultInjection() {
+    EnvoyProtoData.enableFaultInjection = true;
+
+    DiscoveryRpcCall call =
+        startResourceWatcher(ResourceType.LDS, LDS_RESOURCE, ldsResourceWatcher);
+    List<Any> listeners = ImmutableList.of(
+        Any.pack(mf.buildListener(
+            LDS_RESOURCE,
+            mf.buildRouteConfiguration(
+                "do not care",
+                ImmutableList.of(
+                    mf.buildVirtualHost(
+                        mf.buildOpaqueRoutes(1),
+                        ImmutableMap.of(
+                            "irrelevant",
+                            Any.pack(StringValue.of("irrelevant")),
+                            "envoy.fault",
+                            mf.buildHttpFaultTypedConfig(300L, 1000, null, null, null))),
+                    mf.buildVirtualHost(
+                        mf.buildOpaqueRoutes(2),
+                        ImmutableMap.of(
+                            "envoy.fault",
+                            mf.buildHttpFaultTypedConfig(null, null, null, 503, 2000)))
+                )),
+            ImmutableList.of(
+                mf.buildHttpFilter("irrelevant", null),
+                mf.buildHttpFilter("envoy.fault", null)
+            ))));
+    call.sendResponse("0", listeners, ResourceType.LDS, "0000");
+
+    // Client sends an ACK LDS request.
+    call.verifyRequest(NODE, "0", Collections.singletonList(LDS_RESOURCE), ResourceType.LDS,
+        "0000");
+    verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
+    LdsUpdate ldsUpdate = ldsUpdateCaptor.getValue();
+    assertThat(ldsUpdate.virtualHosts).hasSize(2);
+    assertThat(ldsUpdate.hasFaultInjection).isTrue();
+    assertThat(ldsUpdate.httpFault).isNull();
+    HttpFault httpFault = ldsUpdate.virtualHosts.get(0).getHttpFault();
+    assertThat(httpFault.faultDelay.delayNanos).isEqualTo(300);
+    assertThat(httpFault.faultDelay.ratePerMillion).isEqualTo(1000);
+    assertThat(httpFault.faultAbort).isNull();
+    httpFault = ldsUpdate.virtualHosts.get(1).getHttpFault();
+    assertThat(httpFault.faultDelay).isNull();
+    assertThat(httpFault.faultAbort.status.getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+    assertThat(httpFault.faultAbort.ratePerMillion).isEqualTo(2000);
   }
 
   @Test
@@ -1445,14 +1501,31 @@ public abstract class ClientXdsClientTestBase {
 
   protected abstract static class MessageFactory {
 
-    protected abstract Message buildListener(String name, Message routeConfiguration);
+    protected final Message buildListener(String name, Message routeConfiguration) {
+      return buildListener(name, routeConfiguration, Collections.<Message>emptyList());
+    }
+
+    @SuppressWarnings("unchecked")
+    protected abstract Message buildListener(
+        String name, Message routeConfiguration, List<? extends Message> httpFilters);
 
     protected abstract Message buildListenerForRds(String name, String rdsResourceName);
+
+    protected abstract Message buildHttpFilter(String name, @Nullable Any typedConfig);
+
+    protected abstract Any buildHttpFaultTypedConfig(
+        @Nullable Long delayNanos, @Nullable Integer delayRate,
+        @Nullable Status status, @Nullable Integer httpCode, @Nullable Integer abortRate);
 
     protected abstract Message buildRouteConfiguration(String name,
         List<Message> virtualHostList);
 
     protected abstract List<Message> buildOpaqueVirtualHosts(int num);
+
+    protected abstract Message buildVirtualHost(
+        List<? extends Message> routes, Map<String, Any> typedConfigMap);
+
+    protected abstract List<? extends Message> buildOpaqueRoutes(int num);
 
     protected abstract Message buildEdsCluster(String clusterName, @Nullable String edsServiceName,
         boolean enableLrs, @Nullable Message upstreamTlsContext,

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
@@ -173,11 +173,9 @@ public abstract class ClientXdsClientTestBase {
 
   private ManagedChannel channel;
   private ClientXdsClient xdsClient;
-  private boolean originalIsFaultInjectionEnabled;
 
   @Before
   public void setUp() throws IOException {
-    originalIsFaultInjectionEnabled = EnvoyProtoData.enableFaultInjection;
     MockitoAnnotations.initMocks(this);
     when(backoffPolicyProvider.get()).thenReturn(backoffPolicy1, backoffPolicy2);
     when(backoffPolicy1.nextBackoffNanos()).thenReturn(10L, 100L);
@@ -210,7 +208,6 @@ public abstract class ClientXdsClientTestBase {
 
   @After
   public void tearDown() {
-    EnvoyProtoData.enableFaultInjection = originalIsFaultInjectionEnabled;
     xdsClient.shutdown();
     channel.shutdown();  // channel not owned by XdsClient
     assertThat(adsEnded.get()).isTrue();
@@ -337,8 +334,6 @@ public abstract class ClientXdsClientTestBase {
 
   @Test
   public void ldsResourceUpdate_withFaultInjection() {
-    EnvoyProtoData.enableFaultInjection = true;
-
     DiscoveryRpcCall call =
         startResourceWatcher(ResourceType.LDS, LDS_RESOURCE, ldsResourceWatcher);
     List<Any> listeners = ImmutableList.of(

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientV2Test.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientV2Test.java
@@ -65,9 +65,16 @@ import io.envoyproxy.envoy.api.v2.endpoint.LocalityLbEndpoints;
 import io.envoyproxy.envoy.api.v2.listener.FilterChain;
 import io.envoyproxy.envoy.api.v2.route.Route;
 import io.envoyproxy.envoy.api.v2.route.RouteAction;
+import io.envoyproxy.envoy.api.v2.route.RouteMatch;
 import io.envoyproxy.envoy.api.v2.route.VirtualHost;
 import io.envoyproxy.envoy.config.cluster.aggregate.v2alpha.ClusterConfig;
+import io.envoyproxy.envoy.config.filter.fault.v2.FaultDelay;
+import io.envoyproxy.envoy.config.filter.fault.v2.FaultDelay.HeaderDelay;
+import io.envoyproxy.envoy.config.filter.http.fault.v2.FaultAbort;
+import io.envoyproxy.envoy.config.filter.http.fault.v2.FaultAbort.HeaderAbort;
+import io.envoyproxy.envoy.config.filter.http.fault.v2.HTTPFault;
 import io.envoyproxy.envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager;
+import io.envoyproxy.envoy.config.filter.network.http_connection_manager.v2.HttpFilter;
 import io.envoyproxy.envoy.config.filter.network.http_connection_manager.v2.Rds;
 import io.envoyproxy.envoy.config.listener.v2.ApiListener;
 import io.envoyproxy.envoy.service.discovery.v2.AggregatedDiscoveryServiceGrpc.AggregatedDiscoveryServiceImplBase;
@@ -79,12 +86,14 @@ import io.envoyproxy.envoy.type.FractionalPercent.DenominatorType;
 import io.grpc.BindableService;
 import io.grpc.Context;
 import io.grpc.Context.CancellationListener;
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.grpc.xds.AbstractXdsClient.ResourceType;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.junit.runner.RunWith;
@@ -232,8 +241,10 @@ public class ClientXdsClientV2Test extends ClientXdsClientTestBase {
 
   private static class MessageFactoryV2 extends MessageFactory {
 
+    @SuppressWarnings("unchecked")
     @Override
-    protected Message buildListener(String name, Message routeConfiguration) {
+    protected Message buildListener(
+        String name, Message routeConfiguration, List<? extends Message> httpFilters) {
       return Listener.newBuilder()
           .setName(name)
           .setAddress(Address.getDefaultInstance())
@@ -241,7 +252,9 @@ public class ClientXdsClientV2Test extends ClientXdsClientTestBase {
           .setApiListener(
               ApiListener.newBuilder().setApiListener(Any.pack(
                   HttpConnectionManager.newBuilder()
-                      .setRouteConfig((RouteConfiguration) routeConfiguration).build())))
+                      .setRouteConfig((RouteConfiguration) routeConfiguration)
+                      .addAllHttpFilters((List<HttpFilter>) httpFilters)
+                      .build())))
           .build();
     }
 
@@ -265,6 +278,50 @@ public class ClientXdsClientV2Test extends ClientXdsClientTestBase {
     }
 
     @Override
+    protected Message buildHttpFilter(String name, @Nullable Any typedConfig) {
+      HttpFilter.Builder builder = HttpFilter.newBuilder().setName(name);
+      if (typedConfig != null) {
+        builder.setTypedConfig(typedConfig);
+      }
+      return builder.build();
+    }
+
+    @Override
+    protected Any buildHttpFaultTypedConfig(
+        @Nullable Long delayNanos, @Nullable Integer delayRate,
+        @Nullable Status status, @Nullable Integer httpCode, @Nullable Integer abortRate) {
+      HTTPFault.Builder builder = HTTPFault.newBuilder();
+      if (delayRate != null) {
+        FaultDelay.Builder delayBuilder
+            = FaultDelay.newBuilder();
+        delayBuilder.setPercentage(
+            FractionalPercent.newBuilder()
+                .setNumerator(delayRate).setDenominator(DenominatorType.MILLION));
+        if (delayNanos != null) {
+          delayBuilder.setFixedDelay(Durations.fromNanos(delayNanos));
+        } else {
+          delayBuilder.setHeaderDelay(HeaderDelay.newBuilder());
+        }
+        builder.setDelay(delayBuilder);
+      }
+      if (abortRate != null) {
+        FaultAbort.Builder abortBuilder = FaultAbort.newBuilder();
+        abortBuilder.setPercentage(
+            FractionalPercent.newBuilder()
+                .setNumerator(abortRate).setDenominator(DenominatorType.MILLION));
+        if (status != null) {
+          throw new UnsupportedOperationException();
+        } else if (httpCode != null) {
+          abortBuilder.setHttpStatus(httpCode);
+        } else {
+          abortBuilder.setHeaderAbort(HeaderAbort.newBuilder());
+        }
+        builder.setAbort(abortBuilder);
+      }
+      return Any.pack(builder.build());
+    }
+
+    @Override
     protected Message buildRouteConfiguration(String name, List<Message> virtualHostList) {
       RouteConfiguration.Builder builder = RouteConfiguration.newBuilder();
       builder.setName(name);
@@ -285,12 +342,38 @@ public class ClientXdsClientV2Test extends ClientXdsClientTestBase {
                 .addRoutes(
                     Route.newBuilder()
                         .setRoute(RouteAction.newBuilder().setCluster("do not care"))
-                        .setMatch(io.envoyproxy.envoy.api.v2.route.RouteMatch.newBuilder()
+                        .setMatch(RouteMatch.newBuilder()
                             .setPrefix("do not care")))
                 .build();
         virtualHosts.add(virtualHost);
       }
       return virtualHosts;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected Message buildVirtualHost(
+        List<? extends Message> routes, Map<String, Any> typedConfigMap) {
+      return VirtualHost.newBuilder()
+          .setName("do not care")
+          .addDomains("do not care")
+          .addAllRoutes((List<Route>) routes)
+          .putAllTypedPerFilterConfig(typedConfigMap)
+          .build();
+    }
+
+    @Override
+    protected List<? extends Message> buildOpaqueRoutes(int num) {
+      List<Route> routes = new ArrayList<>(num);
+      for (int i = 0; i < num; i++) {
+        Route route =
+            Route.newBuilder()
+                .setRoute(RouteAction.newBuilder().setCluster("do not care"))
+                .setMatch(RouteMatch.newBuilder().setPrefix("do not care"))
+                .build();
+        routes.add(route);
+      }
+      return routes;
     }
 
     @Override

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientV2Test.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientV2Test.java
@@ -288,8 +288,9 @@ public class ClientXdsClientV2Test extends ClientXdsClientTestBase {
 
     @Override
     protected Any buildHttpFaultTypedConfig(
-        @Nullable Long delayNanos, @Nullable Integer delayRate,
-        @Nullable Status status, @Nullable Integer httpCode, @Nullable Integer abortRate) {
+        @Nullable Long delayNanos, @Nullable Integer delayRate, String upstreamCluster,
+        List<String> downstreamNodes, @Nullable Integer maxActiveFaults, @Nullable Status status,
+        @Nullable Integer httpCode, @Nullable Integer abortRate) {
       HTTPFault.Builder builder = HTTPFault.newBuilder();
       if (delayRate != null) {
         FaultDelay.Builder delayBuilder
@@ -317,6 +318,11 @@ public class ClientXdsClientV2Test extends ClientXdsClientTestBase {
           abortBuilder.setHeaderAbort(HeaderAbort.newBuilder());
         }
         builder.setAbort(abortBuilder);
+      }
+      builder.setUpstreamCluster(upstreamCluster);
+      builder.addAllDownstreamNodes(downstreamNodes);
+      if (maxActiveFaults != null) {
+        builder.setMaxActiveFaults(UInt32Value.of(maxActiveFaults));
       }
       return Any.pack(builder.build());
     }

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientV3Test.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientV3Test.java
@@ -64,7 +64,13 @@ import io.envoyproxy.envoy.config.route.v3.RouteConfiguration;
 import io.envoyproxy.envoy.config.route.v3.RouteMatch;
 import io.envoyproxy.envoy.config.route.v3.VirtualHost;
 import io.envoyproxy.envoy.extensions.clusters.aggregate.v3.ClusterConfig;
+import io.envoyproxy.envoy.extensions.filters.common.fault.v3.FaultDelay;
+import io.envoyproxy.envoy.extensions.filters.common.fault.v3.FaultDelay.HeaderDelay;
+import io.envoyproxy.envoy.extensions.filters.http.fault.v3.FaultAbort;
+import io.envoyproxy.envoy.extensions.filters.http.fault.v3.FaultAbort.HeaderAbort;
+import io.envoyproxy.envoy.extensions.filters.http.fault.v3.HTTPFault;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager;
+import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.Rds;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.SdsSecretConfig;
@@ -80,12 +86,14 @@ import io.envoyproxy.envoy.type.v3.FractionalPercent.DenominatorType;
 import io.grpc.BindableService;
 import io.grpc.Context;
 import io.grpc.Context.CancellationListener;
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.grpc.xds.AbstractXdsClient.ResourceType;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.junit.runner.RunWith;
@@ -233,8 +241,10 @@ public class ClientXdsClientV3Test extends ClientXdsClientTestBase {
 
   private static class MessageFactoryV3 extends MessageFactory {
 
+    @SuppressWarnings("unchecked")
     @Override
-    protected Message buildListener(String name, Message routeConfiguration) {
+    protected Message buildListener(
+        String name, Message routeConfiguration, List<? extends Message> httpFilters) {
       return Listener.newBuilder()
           .setName(name)
           .setAddress(Address.getDefaultInstance())
@@ -242,7 +252,9 @@ public class ClientXdsClientV3Test extends ClientXdsClientTestBase {
           .setApiListener(
               ApiListener.newBuilder().setApiListener(Any.pack(
                   HttpConnectionManager.newBuilder()
-                      .setRouteConfig((RouteConfiguration) routeConfiguration).build())))
+                      .setRouteConfig((RouteConfiguration) routeConfiguration)
+                      .addAllHttpFilters((List<HttpFilter>) httpFilters)
+                      .build())))
           .build();
     }
 
@@ -263,6 +275,49 @@ public class ClientXdsClientV3Test extends ClientXdsClientTestBase {
                                       .setAds(AggregatedConfigSource.getDefaultInstance())))
                       .build())))
           .build();
+    }
+
+    @Override
+    protected Message buildHttpFilter(String name, @Nullable Any typedConfig) {
+      HttpFilter.Builder builder = HttpFilter.newBuilder().setName(name);
+      if (typedConfig != null) {
+        builder.setTypedConfig(typedConfig);
+      }
+      return builder.build();
+    }
+
+    @Override
+    protected Any buildHttpFaultTypedConfig(
+        @Nullable Long delayNanos, @Nullable Integer delayRate,
+        @Nullable Status status, @Nullable Integer httpCode, @Nullable Integer abortRate) {
+      HTTPFault.Builder builder = HTTPFault.newBuilder();
+      if (delayRate != null) {
+        FaultDelay.Builder delayBuilder = FaultDelay.newBuilder();
+        delayBuilder.setPercentage(
+            FractionalPercent.newBuilder()
+                .setNumerator(delayRate).setDenominator(DenominatorType.MILLION));
+        if (delayNanos != null) {
+          delayBuilder.setFixedDelay(Durations.fromNanos(delayNanos));
+        } else {
+          delayBuilder.setHeaderDelay(HeaderDelay.newBuilder());
+        }
+        builder.setDelay(delayBuilder);
+      }
+      if (abortRate != null) {
+        FaultAbort.Builder abortBuilder = FaultAbort.newBuilder();
+        abortBuilder.setPercentage(
+            FractionalPercent.newBuilder()
+                .setNumerator(abortRate).setDenominator(DenominatorType.MILLION));
+        if (status != null) {
+          abortBuilder.setGrpcStatus(status.getCode().value());
+        } else if (httpCode != null) {
+          abortBuilder.setHttpStatus(httpCode);
+        } else {
+          abortBuilder.setHeaderAbort(HeaderAbort.newBuilder());
+        }
+        builder.setAbort(abortBuilder);
+      }
+      return Any.pack(builder.build());
     }
 
     @Override
@@ -291,6 +346,32 @@ public class ClientXdsClientV3Test extends ClientXdsClientTestBase {
         virtualHosts.add(virtualHost);
       }
       return virtualHosts;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected Message buildVirtualHost(
+        List<? extends Message> routes, Map<String, Any> typedConfigMap) {
+      return VirtualHost.newBuilder()
+          .setName("do not care")
+          .addDomains("do not care")
+          .addAllRoutes((List<Route>) routes)
+          .putAllTypedPerFilterConfig(typedConfigMap)
+          .build();
+    }
+
+    @Override
+    protected List<? extends Message> buildOpaqueRoutes(int num) {
+      List<Route> routes = new ArrayList<>(num);
+      for (int i = 0; i < num; i++) {
+        Route route =
+            Route.newBuilder()
+                .setRoute(RouteAction.newBuilder().setCluster("do not care"))
+                .setMatch(RouteMatch.newBuilder().setPrefix("do not care"))
+                .build();
+        routes.add(route);
+      }
+      return routes;
     }
 
     @Override

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientV3Test.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientV3Test.java
@@ -288,8 +288,9 @@ public class ClientXdsClientV3Test extends ClientXdsClientTestBase {
 
     @Override
     protected Any buildHttpFaultTypedConfig(
-        @Nullable Long delayNanos, @Nullable Integer delayRate,
-        @Nullable Status status, @Nullable Integer httpCode, @Nullable Integer abortRate) {
+        @Nullable Long delayNanos, @Nullable Integer delayRate, String upstreamCluster,
+        List<String> downstreamNodes, @Nullable Integer maxActiveFaults, @Nullable Status status,
+        @Nullable Integer httpCode, @Nullable Integer abortRate) {
       HTTPFault.Builder builder = HTTPFault.newBuilder();
       if (delayRate != null) {
         FaultDelay.Builder delayBuilder = FaultDelay.newBuilder();
@@ -316,6 +317,11 @@ public class ClientXdsClientV3Test extends ClientXdsClientTestBase {
           abortBuilder.setHeaderAbort(HeaderAbort.newBuilder());
         }
         builder.setAbort(abortBuilder);
+      }
+      builder.setUpstreamCluster(upstreamCluster);
+      builder.addAllDownstreamNodes(downstreamNodes);
+      if (maxActiveFaults != null) {
+        builder.setMaxActiveFaults(UInt32Value.of(maxActiveFaults));
       }
       return Any.pack(builder.build());
     }

--- a/xds/src/test/java/io/grpc/xds/EnvoyProtoDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/EnvoyProtoDataTest.java
@@ -402,7 +402,7 @@ public class EnvoyProtoDataTest {
     assertThat(struct.getErrorDetail()).isNull();
     assertThat(struct.getStruct().getCluster()).isNull();
     assertThat(struct.getStruct().getWeightedCluster()).containsExactly(
-        new ClusterWeight("cluster-foo", 30), new ClusterWeight("cluster-bar", 70));
+        new ClusterWeight("cluster-foo", 30, null), new ClusterWeight("cluster-bar", 70, null));
   }
 
   @Test
@@ -547,7 +547,7 @@ public class EnvoyProtoDataTest {
         io.envoyproxy.envoy.config.route.v3.WeightedCluster.ClusterWeight.newBuilder()
             .setName("cluster-foo")
             .setWeight(UInt32Value.newBuilder().setValue(30)).build();
-    ClusterWeight struct = ClusterWeight.fromEnvoyProtoClusterWeight(proto);
+    ClusterWeight struct = ClusterWeight.fromEnvoyProtoClusterWeight(proto).getStruct();
     assertThat(struct.getName()).isEqualTo("cluster-foo");
     assertThat(struct.getWeight()).isEqualTo(30);
   }

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -437,7 +437,8 @@ public class XdsNameResolverTest {
                 new RouteAction(
                     TimeUnit.SECONDS.toNanos(20L), null,
                     Arrays.asList(
-                        new ClusterWeight(cluster1, 20), new ClusterWeight(cluster2, 80))))));
+                        new ClusterWeight(cluster1, 20, null),
+                        new ClusterWeight(cluster2, 80, null))))));
     verify(mockListener).onResult(resolutionResultCaptor.capture());
     ResolutionResult result = resolutionResultCaptor.getValue();
     assertThat(result.getAddresses()).isEmpty();
@@ -744,7 +745,7 @@ public class XdsNameResolverTest {
           if (!resourceName.equals(ldsResource)) {
             return;
           }
-          ldsWatcher.onChanged(new LdsUpdate(httpMaxStreamDurationNano, virtualHosts));
+          ldsWatcher.onChanged(new LdsUpdate(httpMaxStreamDurationNano, virtualHosts, false, null));
         }
       });
     }
@@ -758,7 +759,8 @@ public class XdsNameResolverTest {
           }
           VirtualHost virtualHost =
               new VirtualHost("virtual-host", Collections.singletonList(AUTHORITY), routes);
-          ldsWatcher.onChanged(new LdsUpdate(0, Collections.singletonList(virtualHost)));
+          ldsWatcher.onChanged(
+              new LdsUpdate(0, Collections.singletonList(virtualHost), false, null));
         }
       });
     }
@@ -770,7 +772,7 @@ public class XdsNameResolverTest {
           if (!resourceName.equals(ldsResource)) {
             return;
           }
-          ldsWatcher.onChanged(new LdsUpdate(0, rdsName));
+          ldsWatcher.onChanged(new LdsUpdate(0, rdsName, false, null));
         }
       });
     }


### PR DESCRIPTION
Parse [HTTPFault](https://github.com/envoyproxy/envoy/blob/18db4c90e3295fb2c39bfc7b2ce641cfd6c3fbed/api/envoy/extensions/filters/http/fault/v3/fault.proto#L57) from 3 possible places:

- HttpFilters in HttpConnectionManager in LDS response
  - `EnvoyProtoData.HttpFault` will be a field of `LdsUpdate`
- TypedPerFilterConfigMap in VirtualHost
  - `EnvoyProtoData.HttpFault` will be a field of `EnvoyProtoData.VirtualHost`
- TypedPerFilterConfigMap in Route
  - `EnvoyProtoData.HttpFault` will be a field of `EnvoyProtoData.Route`
- TypedPerFilterConfigMap in ClusterWeight
  - `EnvoyProtoData.HttpFault` will be a field of `EnvoyProtoData.ClusterWeight`

Design doc: https://github.com/grpc/proposal/pull/201