### PR TITLE
android, cronet: bump AGP version and migrate from digital.wup.android-maven-publish plugin

### DIFF
--- a/android-interop-testing/gradle.properties
+++ b/android-interop-testing/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,6 @@
 plugins {
     id "maven-publish"
-
     id "com.android.library"
-    id "digital.wup.android-maven-publish"
 }
 
 description = 'gRPC: Android'
@@ -64,13 +62,15 @@ task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
 }
 
-publishing {
-    publications {
-        maven {
-            from components.android
+afterEvaluate {
+    publishing {
+        publications {
+            maven {
+                from components.release
 
-            artifact javadocJar
-            artifact sourcesJar
+                artifact javadocJar
+                artifact sourcesJar
+            }
         }
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,12 +53,12 @@ task javadocs(type: Javadoc) {
 }
 
 task javadocJar(type: Jar, dependsOn: javadocs) {
-    classifier = 'javadoc'
+    archiveClassifier = 'javadoc'
     from javadocs.destinationDir
 }
 
 task sourcesJar(type: Jar) {
-    classifier = 'sources'
+    archiveClassifier = 'sources'
     from android.sourceSets.main.java.srcDirs
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -1,8 +1,6 @@
 plugins {
     id "maven-publish"
-
     id "com.android.library"
-    id "digital.wup.android-maven-publish"
 }
 
 description = "gRPC: Cronet Android"
@@ -75,13 +73,15 @@ task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
 }
 
-publishing {
-    publications {
-        maven {
-            from components.android
+afterEvaluate {
+    publishing {
+        publications {
+            maven {
+                from components.release
 
-            artifact javadocJar
-            artifact sourcesJar
+                artifact javadocJar
+                artifact sourcesJar
+            }
         }
     }
 }

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -64,12 +64,12 @@ task javadocs(type: Javadoc) {
 }
 
 task javadocJar(type: Jar, dependsOn: javadocs) {
-    classifier = 'javadoc'
+    archiveClassifier = 'javadoc'
     from javadocs.destinationDir
 }
 
 task sourcesJar(type: Jar) {
-    classifier = 'sources'
+    archiveClassifier = 'sources'
     from android.sourceSets.main.java.srcDirs
 }
 

--- a/cronet/gradle.properties
+++ b/cronet/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,6 @@ pluginManagement {
         id "com.github.kt3k.coveralls" version "2.10.2"
         id "com.google.osdetector" version "1.6.2"
         id "com.google.protobuf" version "0.8.14"
-        id "digital.wup.android-maven-publish" version "3.6.2"
         id "me.champeau.gradle.japicmp" version "0.2.5"
         id "me.champeau.gradle.jmh" version "0.5.2"
         id "net.ltgt.errorprone" version "1.3.0"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
     plugins {
-        id "com.android.application" version "3.5.0"
-        id "com.android.library" version "3.5.0"
+        id "com.android.application" version "4.1.0"
+        id "com.android.library" version "4.1.0"
         id "com.github.johnrengelman.shadow" version "6.1.0"
         id "com.github.kt3k.coveralls" version "2.10.2"
         id "com.google.osdetector" version "1.6.2"


### PR DESCRIPTION
Bump AGP version to 4.1.0 and eliminate digital.wup.android-maven-publish plugin as maven-publish is supported by AGP (>= 3.6).


--------------
Resolves #7736