### PR TITLE
api: Add nullable annotation to trailersFromThrowable

### DIFF
--- a/api/src/main/java/io/grpc/Status.java
+++ b/api/src/main/java/io/grpc/Status.java
@@ -413,6 +413,7 @@ public final class Status {
    *
    * @return the trailers or {@code null} if not found.
    */
+  @Nullable
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4683")
   public static Metadata trailersFromThrowable(Throwable t) {
     Throwable cause = checkNotNull(t, "t");


### PR DESCRIPTION
At the moment `Status.trailersFromThrowable()` does not play well with Kotlin since compiler treats this functions as a null safe even though it is not. 