### PR TITLE
services: add support for channelz.GetServer()

### DIFF
--- a/api/src/main/java/io/grpc/InternalChannelz.java
+++ b/api/src/main/java/io/grpc/InternalChannelz.java
@@ -179,6 +179,12 @@ public final class InternalChannelz {
     return new ServerList(serverList, !iterator.hasNext());
   }
 
+  /** Returns a server. */
+  @Nullable
+  public InternalInstrumented<ServerStats> getServer(long id) {
+    return servers.get(id);
+  }
+
   /** Returns socket refs for a server. */
   @Nullable
   public ServerSocketsList getServerSockets(long serverId, long fromId, int maxPageSize) {


### PR DESCRIPTION
Add support for `grpc.channelz.v1.Channelz.GetServer`, as defined in [`channelz.proto`](https://github.com/grpc/grpc-proto/blob/f5c9cf6eecbe948b8744bd0398a1ddc937ec5237/grpc/channelz/v1/channelz.proto#L429-L430):

```proto
  // Returns a single Server, or else a NOT_FOUND code.
  rpc GetServer(GetServerRequest) returns (GetServerResponse);
```