### PR TITLE
xds: be tolerant for unspecified locality fields in bootstrap

### DIFF
--- a/xds/src/main/java/io/grpc/xds/BootstrapperImpl.java
+++ b/xds/src/main/java/io/grpc/xds/BootstrapperImpl.java
@@ -201,18 +201,20 @@ public class BootstrapperImpl implements Bootstrapper {
       }
       Map<String, ?> rawLocality = JsonUtil.getObject(rawNode, "locality");
       if (rawLocality != null) {
-        String region = JsonUtil.getString(rawLocality, "region");
-        String zone = JsonUtil.getString(rawLocality, "zone");
-        String subZone = JsonUtil.getString(rawLocality, "sub_zone");
-        if (region != null) {
-          logger.log(XdsLogLevel.INFO, "Locality region: {0}", region);
+        String region = "";
+        String zone = "";
+        String subZone = "";
+        if (rawLocality.containsKey("region")) {
+          region = JsonUtil.getString(rawLocality, "region");
         }
         if (rawLocality.containsKey("zone")) {
-          logger.log(XdsLogLevel.INFO, "Locality zone: {0}", zone);
+          zone = JsonUtil.getString(rawLocality, "zone");
         }
         if (rawLocality.containsKey("sub_zone")) {
-          logger.log(XdsLogLevel.INFO, "Locality sub_zone: {0}", subZone);
+          subZone = JsonUtil.getString(rawLocality, "sub_zone");
         }
+        logger.log(XdsLogLevel.INFO, "Locality region: {0}, zone: {0}, subZone: {0}",
+            region, zone, subZone);
         Locality locality = Locality.create(region, zone, subZone);
         nodeBuilder.setLocality(locality);
       }

--- a/xds/src/test/java/io/grpc/xds/BootstrapperImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/BootstrapperImplTest.java
@@ -191,11 +191,7 @@ public class BootstrapperImplTest {
         + "  \"node\": {\n"
         + "    \"id\": \"ENVOY_NODE_ID\",\n"
         + "    \"cluster\": \"ENVOY_CLUSTER\",\n"
-        + "    \"locality\": {\n"
-        + "      \"region\": \"ENVOY_REGION\",\n"
-        + "      \"zone\": \"ENVOY_ZONE\",\n"
-        + "      \"sub_zone\": \"ENVOY_SUBZONE\"\n"
-        + "    },\n"
+        + "    \"locality\": {},\n"
         + "    \"metadata\": {\n"
         + "      \"TRAFFICDIRECTOR_INTERCEPTION_PORT\": \"ENVOY_PORT\",\n"
         + "      \"TRAFFICDIRECTOR_NETWORK_NAME\": \"VPC_NETWORK_NAME\"\n"
@@ -223,7 +219,7 @@ public class BootstrapperImplTest {
         getNodeBuilder()
             .setId("ENVOY_NODE_ID")
             .setCluster("ENVOY_CLUSTER")
-            .setLocality(Locality.create("ENVOY_REGION", "ENVOY_ZONE", "ENVOY_SUBZONE"))
+            .setLocality(Locality.create("", "", ""))
             .setMetadata(
                 ImmutableMap.of(
                     "TRAFFICDIRECTOR_INTERCEPTION_PORT",


### PR DESCRIPTION
Broken by #7863.

Previously this is done in Locality creation. We could also do it, but would be better to just use empty strings outside explicitly.