### PR TITLE
rls: fix wrong server field in lookup request

### DIFF
--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -137,7 +137,8 @@ final class CachingRlsLbClient {
             builder.evictionListener,
             scheduledExecutorService,
             timeProvider);
-    RlsRequestFactory requestFactory = new RlsRequestFactory(lbPolicyConfig.getRouteLookupConfig());
+    RlsRequestFactory requestFactory = new RlsRequestFactory(
+        lbPolicyConfig.getRouteLookupConfig(), helper.getAuthority());
     rlsPicker = new RlsPicker(requestFactory);
     // It is safe to use helper.getUnsafeChannelCredentials() because the client authenticates the
     // RLS server using the same authority as the backends, even though the RLS server’s addresses

--- a/rls/src/main/java/io/grpc/rls/RlsRequestFactory.java
+++ b/rls/src/main/java/io/grpc/rls/RlsRequestFactory.java
@@ -45,9 +45,9 @@ final class RlsRequestFactory {
    */
   private final Table<String, String, NameMatcher> keyBuilderTable;
 
-  RlsRequestFactory(RouteLookupConfig rlsConfig) {
+  RlsRequestFactory(RouteLookupConfig rlsConfig, String target) {
     checkNotNull(rlsConfig, "rlsConfig");
-    this.target = rlsConfig.getLookupService();
+    this.target = checkNotNull(target, "target");
     this.keyBuilderTable = createKeyBuilderTable(rlsConfig);
   }
 
@@ -109,7 +109,7 @@ final class RlsRequestFactory {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("lookupService", target)
+        .add("target", target)
         .add("keyBuilderTable", keyBuilderTable)
         .toString();
   }

--- a/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
+++ b/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
@@ -187,7 +187,8 @@ public class CachingRlsLbClientTest {
   public void get_noError_lifeCycle() throws Exception {
     InOrder inOrder = inOrder(evictionListener);
     RouteLookupRequest routeLookupRequest =
-        new RouteLookupRequest("server", "/foo/bar", "grpc", ImmutableMap.<String, String>of());
+        new RouteLookupRequest(
+            "bigtable.googleapis.com", "/foo/bar", "grpc", ImmutableMap.<String, String>of());
     rlsServerImpl.setLookupTable(
         ImmutableMap.of(
             routeLookupRequest,
@@ -277,7 +278,8 @@ public class CachingRlsLbClientTest {
   public void get_updatesLbState() throws Exception {
     InOrder inOrder = inOrder(helper);
     RouteLookupRequest routeLookupRequest =
-        new RouteLookupRequest("service1", "/foo/bar", "grpc", ImmutableMap.<String, String>of());
+        new RouteLookupRequest(
+            "bigtable.googleapis.com", "/foo/bar", "grpc", ImmutableMap.<String, String>of());
     rlsServerImpl.setLookupTable(
         ImmutableMap.of(
             routeLookupRequest,
@@ -317,7 +319,7 @@ public class CachingRlsLbClientTest {
     // try to get invalid
     RouteLookupRequest invalidRouteLookupRequest =
         new RouteLookupRequest(
-            "service1", "/doesn/exists", "grpc", ImmutableMap.<String, String>of());
+            "bigtable.googleapis.com", "/doesn/exists", "grpc", ImmutableMap.<String, String>of());
     CachedRouteLookupResponse errorResp = getInSyncContext(invalidRouteLookupRequest);
     assertThat(errorResp.isPending()).isTrue();
     fakeTimeProvider.forwardTime(SERVER_LATENCY_MILLIS, TimeUnit.MILLISECONDS);
@@ -581,7 +583,7 @@ public class CachingRlsLbClientTest {
 
     @Override
     public String getAuthority() {
-      return DEFAULT_TARGET;
+      return "bigtable.googleapis.com";
     }
 
     @Override

--- a/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
@@ -145,10 +145,12 @@ public class RlsLoadBalancerTest {
     fakeRlsServerImpl.setLookupTable(
         ImmutableMap.of(
             new RouteLookupRequest(
-                "localhost:8972", "/com.google/Search", "grpc", ImmutableMap.<String, String>of()),
+                "fake-bigtable.googleapis.com", "/com.google/Search", "grpc",
+                ImmutableMap.<String, String>of()),
             new RouteLookupResponse(ImmutableList.of("wilderness"), "where are you?"),
             new RouteLookupRequest(
-                "localhost:8972", "/com.google/Rescue", "grpc", ImmutableMap.<String, String>of()),
+                "fake-bigtable.googleapis.com", "/com.google/Rescue", "grpc",
+                ImmutableMap.<String, String>of()),
             new RouteLookupResponse(ImmutableList.of("civilization"), "you are safe")));
 
     rlsLb = (RlsLoadBalancer) provider.newLoadBalancer(helper);

--- a/rls/src/test/java/io/grpc/rls/RlsRequestFactoryTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsRequestFactoryTest.java
@@ -58,7 +58,7 @@ public class RlsRequestFactoryTest {
                   ImmutableList.of(new Name("com.google.service3")),
                   ImmutableList.of(
                       new NameMatcher("user", ImmutableList.of("User", "Parent"), true)))),
-          /* lookupService= */ "foo.google.com",
+          /* lookupService= */ "bigtable-rls.googleapis.com",
           /* lookupServiceTimeoutInMillis= */ TimeUnit.SECONDS.toMillis(2),
           /* maxAgeInMillis= */ TimeUnit.SECONDS.toMillis(300),
           /* staleAgeInMillis= */ TimeUnit.SECONDS.toMillis(240),
@@ -66,7 +66,8 @@ public class RlsRequestFactoryTest {
           /* validTargets= */ ImmutableList.of("a valid target"),
           /* defaultTarget= */ "us_east_1.cloudbigtable.googleapis.com");
 
-  private final RlsRequestFactory factory = new RlsRequestFactory(RLS_CONFIG);
+  private final RlsRequestFactory factory = new RlsRequestFactory(
+      RLS_CONFIG, "bigtable.googleapis.com");
 
   @Test
   public void create_pathMatches() {
@@ -78,7 +79,7 @@ public class RlsRequestFactoryTest {
     RouteLookupRequest request = factory.create("com.google.service1", "Create", metadata);
     assertThat(request.getTargetType()).isEqualTo("grpc");
     assertThat(request.getPath()).isEqualTo("/com.google.service1/Create");
-    assertThat(request.getServer()).isEqualTo("foo.google.com");
+    assertThat(request.getServer()).isEqualTo("bigtable.googleapis.com");
     assertThat(request.getKeyMap()).containsExactly("user", "test", "id", "123");
   }
 
@@ -107,7 +108,7 @@ public class RlsRequestFactoryTest {
 
     assertThat(request.getTargetType()).isEqualTo("grpc");
     assertThat(request.getPath()).isEqualTo("/com.google.service1/Update");
-    assertThat(request.getServer()).isEqualTo("foo.google.com");
+    assertThat(request.getServer()).isEqualTo("bigtable.googleapis.com");
     assertThat(request.getKeyMap()).containsExactly("user", "test", "password", "hunter2");
   }
 
@@ -122,7 +123,7 @@ public class RlsRequestFactoryTest {
 
     assertThat(request.getTargetType()).isEqualTo("grpc");
     assertThat(request.getPath()).isEqualTo("/com.google.service1/Update");
-    assertThat(request.getServer()).isEqualTo("foo.google.com");
+    assertThat(request.getServer()).isEqualTo("bigtable.googleapis.com");
     assertThat(request.getKeyMap()).containsExactly("user", "test");
   }
 
@@ -137,7 +138,7 @@ public class RlsRequestFactoryTest {
 
     assertThat(request.getTargetType()).isEqualTo("grpc");
     assertThat(request.getPath()).isEqualTo("/abc.def.service999/Update");
-    assertThat(request.getServer()).isEqualTo("foo.google.com");
+    assertThat(request.getServer()).isEqualTo("bigtable.googleapis.com");
     assertThat(request.getKeyMap()).isEmpty();
   }
 
@@ -152,7 +153,7 @@ public class RlsRequestFactoryTest {
 
     assertThat(request.getTargetType()).isEqualTo("grpc");
     assertThat(request.getPath()).isEqualTo("/com.google.service3/Update");
-    assertThat(request.getServer()).isEqualTo("foo.google.com");
+    assertThat(request.getServer()).isEqualTo("bigtable.googleapis.com");
     assertThat(request.getKeyMap()).containsExactly("user", "test");
   }
 }


### PR DESCRIPTION
The server filed in lookup request as specified in go/dynamic-request-routing/#heading=h.eqjtcpo6u8ep should be the original target, not the RLS server where the lookup request is sent to.

(It was wrong from the beginning of java implementation. In the past, we made a [hack](https://github.com/dapengzhang0/grpc-java/commit/021d33a240ee0d1d14e8e49a73d87cc7fa39433b) for testing, because it worked only for "test-directpath.cloudbigtable.sandbox.....", and did not work with the original target either.)