### PR TITLE
xds: fix wrong number type for generated raw config

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -310,10 +310,10 @@ final class XdsNameResolver extends NameResolver {
         rawHeaderMatcherBuilder.put("regexMatch", regexMatch.pattern());
       }
       if (rangeMatch != null) {
-        rawHeaderMatcherBuilder
-            .put(
-                "rangeMatch",
-                ImmutableMap.of("start", rangeMatch.getStart(), "end", rangeMatch.getEnd()));
+        rawHeaderMatcherBuilder.put(
+            "rangeMatch",
+            ImmutableMap.of("start", Long.valueOf(rangeMatch.getStart()).doubleValue(),
+                "end", Long.valueOf(rangeMatch.getEnd()).doubleValue()));
       }
       if (presentMatch != null) {
         rawHeaderMatcherBuilder.put("presentMatch", presentMatch);

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -181,7 +181,8 @@ public class XdsNameResolverTest {
     Map<String, ?> rawRoute3 = XdsNameResolver.convertToRawRoute(routeMatch3, "action_foo");
     Map<String, ?> header =
         (Map<String, ?>) Iterables.getOnlyElement((List<?>) rawRoute3.get("headers"));
-    assertThat((Map<String, ?>) header.get("rangeMatch")).containsExactly("start", 0L, "end", 10L);
+    assertThat((Map<String, ?>) header.get("rangeMatch")).containsExactly(
+        "start", (double) 0L, "end", (double) 10L);
 
     RouteMatch routeMatch4 =
         new RouteMatch(


### PR DESCRIPTION
[JsonUtil](https://github.com/grpc/grpc-java/blob/b1daad6f30f064d8b1fd423fc9051fc345cb310f/core/src/main/java/io/grpc/internal/JsonUtil.java#L108-L111) is expecting numbers from parsed JSON string to be `Double`.


--------------
This should the fix interop header matching test failure.
TODO: Need to backport to 1.31 as well.