### PR TITLE
all: publish grpc-rls

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -32,7 +32,7 @@ for (subproject in rootProject.subprojects) {
 }
 
 dependencies {
-    api subprojects.minus([project(':grpc-protobuf-lite'), project(':grpc-rls')])
+    api subprojects.minus([project(':grpc-protobuf-lite')])
 }
 
 javadoc {

--- a/bom/build.gradle
+++ b/bom/build.gradle
@@ -12,7 +12,7 @@ publishing {
 
       pom.withXml {
         // Generate bom using subprojects
-        def internalProjects = [project.name, 'grpc-gae-interop-testing-jdk8', 'grpc-compiler', 'grpc-rls']
+        def internalProjects = [project.name, 'grpc-gae-interop-testing-jdk8', 'grpc-compiler']
 
         def dependencyManagement = asNode().appendNode('dependencyManagement')
         def dependencies = dependencyManagement.appendNode('dependencies')

--- a/rls/build.gradle
+++ b/rls/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id "maven-publish"
     id "com.google.protobuf"
     id "jacoco"
+    id "ru.vyarus.animalsniffer"
 }
 
 description = "gRPC: RouteLookupService Loadbalancing plugin"
@@ -19,12 +20,15 @@ dependencies {
             project(':grpc-testing'),
             project(':grpc-testing-proto'),
             project(':grpc-core').sourceSets.test.output  // for FakeClock
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
 }
 
 javadoc {
+    // Do not publish javadoc since currently there is no public API.
+    failOnError false  // no public or protected classes found to document
+    exclude 'io/grpc/lookup/v1/**'
     exclude 'io/grpc/rls/internal/**'
-    // do not publish javadoc since it is not published yet
-    exclude 'io/grpc/rls/**'
+    exclude 'io/grpc/rls/Internal*'
 }
 
 jacocoTestReport {
@@ -34,6 +38,3 @@ jacocoTestReport {
 }
 
 configureProtoCompilation()
-
-// do not publish 'grpc-rls'
-[publishMavenPublicationToMavenRepository]*.onlyIf { false }


### PR DESCRIPTION
Making `io.grpc:grpc-rls` a maven artifact from next release.