### PR TITLE
xds: fix wrong number type for generated raw config (1.31.x backport)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -310,10 +310,10 @@ final class XdsNameResolver extends NameResolver {
         rawHeaderMatcherBuilder.put("regexMatch", regexMatch.pattern());
       }
       if (rangeMatch != null) {
-        rawHeaderMatcherBuilder
-            .put(
-                "rangeMatch",
-                ImmutableMap.of("start", rangeMatch.getStart(), "end", rangeMatch.getEnd()));
+        rawHeaderMatcherBuilder.put(
+            "rangeMatch",
+            ImmutableMap.of("start", Long.valueOf(rangeMatch.getStart()).doubleValue(),
+                "end", Long.valueOf(rangeMatch.getEnd()).doubleValue()));
       }
       if (presentMatch != null) {
         rawHeaderMatcherBuilder.put("presentMatch", presentMatch);

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -180,7 +180,8 @@ public class XdsNameResolverTest {
     Map<String, ?> rawRoute3 = XdsNameResolver.convertToRawRoute(routeMatch3, "action_foo");
     Map<String, ?> header =
         (Map<String, ?>) Iterables.getOnlyElement((List<?>) rawRoute3.get("headers"));
-    assertThat((Map<String, ?>) header.get("rangeMatch")).containsExactly("start", 0L, "end", 10L);
+    assertThat((Map<String, ?>) header.get("rangeMatch")).containsExactly(
+        "start", (double) 0L, "end", (double) 10L);
 
     RouteMatch routeMatch4 =
         new RouteMatch(


### PR DESCRIPTION
JsonUtil is expecting numbers in Map<String, ?> to be Double. The generated raw config (Ma<String, ?>) should use Double for numerical values put into it.


-------------
Backport of #7880 