### PR TITLE
rls: fix wrong server field in lookup request again

### DIFF
--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -63,6 +63,7 @@ import io.grpc.rls.RlsProtoData.RouteLookupResponse;
 import io.grpc.rls.Throttler.ThrottledException;
 import io.grpc.stub.StreamObserver;
 import io.grpc.util.ForwardingLoadBalancerHelper;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
@@ -137,8 +138,9 @@ final class CachingRlsLbClient {
             builder.evictionListener,
             scheduledExecutorService,
             timeProvider);
+    String serverHost = URI.create("//" + helper.getAuthority()).getHost();
     RlsRequestFactory requestFactory = new RlsRequestFactory(
-        lbPolicyConfig.getRouteLookupConfig(), helper.getAuthority());
+        lbPolicyConfig.getRouteLookupConfig(), serverHost);
     rlsPicker = new RlsPicker(requestFactory);
     // It is safe to use helper.getUnsafeChannelCredentials() because the client authenticates the
     // RLS server using the same authority as the backends, even though the RLS server’s addresses

--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -143,11 +143,12 @@ final class CachingRlsLbClient {
     String serverHost = null;
     try {
       serverHost = new URI(null, helper.getAuthority(), null, null, null).getHost();
-    } catch (URISyntaxException e) {
-      logger.log(
-          ChannelLogLevel.DEBUG, "Can not get hostname from authority: {0}", helper.getAuthority());
+    } catch (URISyntaxException ignore) {
+      // handled by the following null check
     }
     if (serverHost == null) {
+      logger.log(
+          ChannelLogLevel.DEBUG, "Can not get hostname from authority: {0}", helper.getAuthority());
       serverHost = helper.getAuthority();
     }
     RlsRequestFactory requestFactory = new RlsRequestFactory(

--- a/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
+++ b/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
@@ -583,7 +583,7 @@ public class CachingRlsLbClientTest {
 
     @Override
     public String getAuthority() {
-      return "bigtable.googleapis.com";
+      return "bigtable.googleapis.com:443";
     }
 
     @Override


### PR DESCRIPTION
The previous fix #7878 didn't work because the [server field](http://go/dynamic-request-routing/#heading=h.eqjtcpo6u8ep) is expected to be full hostname (without port number). Need strip the port part from the authority.