### PR TITLE
buildscripts: increase xds job timeouts (backport to 1.33.x of #7831)

### DIFF
--- a/buildscripts/kokoro/xds.cfg
+++ b/buildscripts/kokoro/xds.cfg
@@ -2,7 +2,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-java/buildscripts/kokoro/xds.sh"
-timeout_mins: 90
+timeout_mins: 120
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
b/178686084

@menghanl 