### PR TITLE
interop-testing: fix alts handshaking race

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AltsHandshakerTestService.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AltsHandshakerTestService.java
@@ -72,36 +72,25 @@ public class AltsHandshakerTestService extends HandshakerServiceImplBase {
                   .build();
               log.log(Level.FINE, "init server response" + initServer);
               responseObserver.onNext(initServer);
-              expectState = State.CLIENT_NEXT;
-              break;
-            case CLIENT_NEXT:
-              checkState(NEXT.equals(value.getReqOneofCase()));
-              HandshakerResp resp = HandshakerResp.newBuilder()
-                  .setBytesConsumed(FIXED_LENGTH_OUTPUT)
-                  .setOutFrames(fakeOutput)
-                  .build();
-              log.log(Level.FINE, "client response" + resp);
-              responseObserver.onNext(resp);
-              expectState = State.SERVER_FINISH;
-              break;
-            case SERVER_FINISH:
-              checkState(NEXT.equals(value.getReqOneofCase()));
-              resp = HandshakerResp.newBuilder()
-                  .setResult(getResult())
-                  .setOutFrames(fakeOutput)
-                  .setBytesConsumed(FIXED_LENGTH_OUTPUT)
-                  .build();
-              log.log(Level.FINE, "server finished response " + resp);
-              responseObserver.onNext(resp);
               expectState = State.CLIENT_FINISH;
               break;
             case CLIENT_FINISH:
               checkState(NEXT.equals(value.getReqOneofCase()));
+              HandshakerResp resp = HandshakerResp.newBuilder()
+                  .setResult(getResult())
+                  .setBytesConsumed(FIXED_LENGTH_OUTPUT)
+                  .setOutFrames(fakeOutput)
+                  .build();
+              log.log(Level.FINE, "client finished response " + resp);
+              responseObserver.onNext(resp);
+              expectState = State.SERVER_FINISH;
+              break;
+            case SERVER_FINISH:
               resp = HandshakerResp.newBuilder()
                   .setResult(getResult())
                   .setBytesConsumed(FIXED_LENGTH_OUTPUT)
                   .build();
-              log.log(Level.FINE, "client finished response " + resp);
+              log.log(Level.FINE, "server finished response " + resp);
               responseObserver.onNext(resp);
               expectState = State.CLIENT_INIT;
               break;
@@ -151,8 +140,7 @@ public class AltsHandshakerTestService extends HandshakerServiceImplBase {
   private enum State {
     CLIENT_INIT,
     SERVER_INIT,
-    CLIENT_NEXT,
-    SERVER_FINISH,
     CLIENT_FINISH,
+    SERVER_FINISH
   }
 }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AltsHandshakerTestService.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AltsHandshakerTestService.java
@@ -72,25 +72,36 @@ public class AltsHandshakerTestService extends HandshakerServiceImplBase {
                   .build();
               log.log(Level.FINE, "init server response" + initServer);
               responseObserver.onNext(initServer);
-              expectState = State.CLIENT_FINISH;
+              expectState = State.CLIENT_NEXT;
               break;
-            case CLIENT_FINISH:
+            case CLIENT_NEXT:
               checkState(NEXT.equals(value.getReqOneofCase()));
               HandshakerResp resp = HandshakerResp.newBuilder()
-                  .setResult(getResult())
                   .setBytesConsumed(FIXED_LENGTH_OUTPUT)
                   .setOutFrames(fakeOutput)
                   .build();
-              log.log(Level.FINE, "client finished response " + resp);
+              log.log(Level.FINE, "client response" + resp);
               responseObserver.onNext(resp);
               expectState = State.SERVER_FINISH;
               break;
             case SERVER_FINISH:
+              checkState(NEXT.equals(value.getReqOneofCase()));
+              resp = HandshakerResp.newBuilder()
+                  .setResult(getResult())
+                  .setOutFrames(fakeOutput)
+                  .setBytesConsumed(FIXED_LENGTH_OUTPUT)
+                  .build();
+              log.log(Level.FINE, "server finished response " + resp);
+              responseObserver.onNext(resp);
+              expectState = State.CLIENT_FINISH;
+              break;
+            case CLIENT_FINISH:
+              checkState(NEXT.equals(value.getReqOneofCase()));
               resp = HandshakerResp.newBuilder()
                   .setResult(getResult())
                   .setBytesConsumed(FIXED_LENGTH_OUTPUT)
                   .build();
-              log.log(Level.FINE, "server finished response " + resp);
+              log.log(Level.FINE, "client finished response " + resp);
               responseObserver.onNext(resp);
               expectState = State.CLIENT_INIT;
               break;
@@ -140,7 +151,8 @@ public class AltsHandshakerTestService extends HandshakerServiceImplBase {
   private enum State {
     CLIENT_INIT,
     SERVER_INIT,
+    CLIENT_NEXT,
+    SERVER_FINISH,
     CLIENT_FINISH,
-    SERVER_FINISH
   }
 }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AltsHandshakerTestService.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AltsHandshakerTestService.java
@@ -33,7 +33,6 @@ import io.grpc.stub.StreamObserver;
 import java.util.Random;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.concurrent.GuardedBy;
 
 /**
  * A fake HandshakeService for ALTS integration testing in non-gcp environments.
@@ -45,8 +44,6 @@ public class AltsHandshakerTestService extends HandshakerServiceImplBase {
   private static final int FIXED_LENGTH_OUTPUT = 16;
   private final ByteString fakeOutput = data(FIXED_LENGTH_OUTPUT);
   private final ByteString secret = data(128);
-  private static final Object lock = new Object();
-  @GuardedBy("lock")
   private State expectState = State.CLIENT_INIT;
 
   @Override
@@ -56,7 +53,7 @@ public class AltsHandshakerTestService extends HandshakerServiceImplBase {
       @Override
       public void onNext(HandshakerReq value) {
         log.log(Level.FINE, "request received: " + value);
-        synchronized (lock) {
+        synchronized (AltsHandshakerTestService.this) {
           switch (expectState) {
             case CLIENT_INIT:
               checkState(CLIENT_START.equals(value.getReqOneofCase()));


### PR DESCRIPTION
 https://travis-ci.org/github/grpc/grpc-java/jobs/758605192

```
io.grpc.testing.integration.AltsHandshakerTest > testAlts FAILED
    io.grpc.StatusRuntimeException: UNKNOWN
        at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:262)
        at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:243)
        at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:156)
        at io.grpc.testing.integration.TestServiceGrpc$TestServiceBlockingStub.unaryCall(TestServiceGrpc.java:624)
        at io.grpc.testing.integration.AltsHandshakerTest.testAlts(AltsHandshakerTest.java:98)
        Caused by:
        io.grpc.netty.shaded.io.netty.handler.codec.DecoderException: java.lang.IllegalArgumentException: Invalid header field: frame size too small
            at io.grpc.netty.shaded.io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:471)
            at io.grpc.netty.shaded.io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:276)
            at io.grpc.netty.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
            at io.grpc.netty.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
            at io.grpc.netty.shaded.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
            at io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
            at io.grpc.netty.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
            at io.grpc.netty.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
            at io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
            at io.grpc.netty.shaded.io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:795)
            at io.grpc.netty.shaded.io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:475)
            at io.grpc.netty.shaded.io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:378)
            at io.grpc.netty.shaded.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
            at io.grpc.netty.shaded.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
            at io.grpc.netty.shaded.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
            at java.lang.Thread.run(Thread.java:748)
            Caused by:
            java.lang.IllegalArgumentException: Invalid header field: frame size too small
                at com.google.common.base.Preconditions.checkArgument(Preconditions.java:142)
                at io.grpc.alts.internal.AltsTsiFrameProtector$Unprotector.handleHeader(AltsTsiFrameProtector.java:267)
                at io.grpc.alts.internal.AltsTsiFrameProtector$Unprotector.decodeFrame(AltsTsiFrameProtector.java:235)
                at io.grpc.alts.internal.AltsTsiFrameProtector$Unprotector.unprotect(AltsTsiFrameProtector.java:224)
                at io.grpc.alts.internal.AltsTsiFrameProtector.unprotect(AltsTsiFrameProtector.java:91)
                at io.grpc.alts.internal.TsiFrameHandler.decode(TsiFrameHandler.java:63)
                at io.grpc.netty.shaded.io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:501)
                at io.grpc.netty.shaded.io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:440)
                ... 15 more
```