### PR TITLE
rls: fix rls oobChannel grpclb config service name

### DIFF
--- a/rls/build.gradle
+++ b/rls/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     guavaDependency 'implementation'
     compileOnly libraries.javax_annotation
     testImplementation libraries.truth,
+            project(':grpc-grpclb'),
             project(':grpc-testing'),
             project(':grpc-testing-proto'),
             project(':grpc-core').sourceSets.test.output  // for FakeClock

--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -162,11 +162,13 @@ final class CachingRlsLbClient {
         rlsConfig.getLookupService(), helper.getUnsafeChannelCredentials());
     rlsChannelBuilder.overrideAuthority(helper.getAuthority());
     if (enableOobChannelDirectPath) {
+      Map<String, ?> directPathServiceConfig =
+          getDirectPathServiceConfig(rlsConfig.getLookupService());
       logger.log(
           ChannelLogLevel.DEBUG,
           "RLS channel direct path enabled. RLS channel service config: {0}",
-          getDirectpathServiceConfig());
-      rlsChannelBuilder.defaultServiceConfig(getDirectpathServiceConfig());
+          directPathServiceConfig);
+      rlsChannelBuilder.defaultServiceConfig(directPathServiceConfig);
       rlsChannelBuilder.disableServiceConfigLookUp();
     }
     rlsChannel = rlsChannelBuilder.build();
@@ -183,12 +185,14 @@ final class CachingRlsLbClient {
     logger.log(ChannelLogLevel.DEBUG, "CachingRlsLbClient created");
   }
 
-  private static ImmutableMap<String, Object> getDirectpathServiceConfig() {
+  private static ImmutableMap<String, Object> getDirectPathServiceConfig(String serviceName) {
     ImmutableMap<String, Object> pickFirstStrategy =
         ImmutableMap.<String, Object>of("pick_first", ImmutableMap.of());
 
     ImmutableMap<String, Object> childPolicy =
-        ImmutableMap.<String, Object>of("childPolicy", ImmutableList.of(pickFirstStrategy));
+        ImmutableMap.<String, Object>of(
+            "childPolicy", ImmutableList.of(pickFirstStrategy),
+            "serviceName", serviceName);
 
     ImmutableMap<String, Object> grpcLbPolicy =
         ImmutableMap.<String, Object>of("grpclb", childPolicy);


### PR DESCRIPTION
The `serviceName` field in oobChannel grpclb config should not be null, otherwise it will default to the `lbHelper.getAuthority()`, which perviously defaulted to the lookup service before #7852,  but has been overridden to the backend service for authentication in #7852.