### PR TITLE
Move pendingDeadline.cancel out of synchronized block

### DIFF
--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -826,17 +826,21 @@ public class Context {
     @CanIgnoreReturnValue
     public boolean cancel(Throwable cause) {
       boolean triggeredCancel = false;
+      ScheduledFuture<?> localPendingDeadline = null;
       synchronized (this) {
         if (!cancelled) {
           cancelled = true;
           if (pendingDeadline != null) {
             // If we have a scheduled cancellation pending attempt to cancel it.
-            pendingDeadline.cancel(false);
+            localPendingDeadline = pendingDeadline;
             pendingDeadline = null;
           }
           this.cancellationCause = cause;
           triggeredCancel = true;
         }
+      }
+      if (localPendingDeadline != null) {
+        localPendingDeadline.cancel(false);
       }
       if (triggeredCancel) {
         notifyAndClearListeners();


### PR DESCRIPTION
When running JFR I found a short lock contention for this code - a thread was blocked for 16 ms.

Stacktrace:

```
io.grpc.Context$CancellableContext.cancel(Throwable)	1
   io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.closedInternal(Status)	1
      io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.closed(Status)	1
         io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1Closed.runInContext()	1
            io.grpc.internal.ContextRunnable.run()	1
               io.grpc.internal.SerializingExecutor.run()	1
                  com.spotify.metrics.core.InstrumentedExecutorService$InstrumentedRunnable.run()	1
                     java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor$Worker)	1
                        java.util.concurrent.ThreadPoolExecutor$Worker.run()	1
                           java.lang.Thread.run()	1
```

This PR is an attempt to reduce the amount of work performed within the synchronized block.