### PR TITLE
xds: gate HttpFilter parsing by env flag

### DIFF
--- a/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
@@ -195,10 +195,6 @@ abstract class AbstractXdsClient extends XdsClient {
     return shutdown;
   }
 
-  final boolean useProtocolV3() {
-    return useProtocolV3;
-  }
-
   @Override
   public String toString() {
     return logId.toString();

--- a/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
@@ -195,6 +195,10 @@ abstract class AbstractXdsClient extends XdsClient {
     return shutdown;
   }
 
+  final boolean useProtocolV3() {
+    return useProtocolV3;
+  }
+
   @Override
   public String toString() {
     return logId.toString();

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
@@ -170,9 +170,11 @@ public abstract class ClientXdsClientTestBase {
 
   private ManagedChannel channel;
   private ClientXdsClient xdsClient;
+  private boolean originalEnableFaultInjection;
 
   @Before
   public void setUp() throws IOException {
+    originalEnableFaultInjection = ClientXdsClient.enableFaultInjection;
     ClientXdsClient.enableFaultInjection = true;
     MockitoAnnotations.initMocks(this);
     when(backoffPolicyProvider.get()).thenReturn(backoffPolicy1, backoffPolicy2);
@@ -206,6 +208,7 @@ public abstract class ClientXdsClientTestBase {
 
   @After
   public void tearDown() {
+    ClientXdsClient.enableFaultInjection = originalEnableFaultInjection;
     xdsClient.shutdown();
     channel.shutdown();  // channel not owned by XdsClient
     assertThat(adsEnded.get()).isTrue();

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
@@ -70,6 +70,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -172,6 +173,7 @@ public abstract class ClientXdsClientTestBase {
 
   @Before
   public void setUp() throws IOException {
+    ClientXdsClient.enableFaultInjection = true;
     MockitoAnnotations.initMocks(this);
     when(backoffPolicyProvider.get()).thenReturn(backoffPolicy1, backoffPolicy2);
     when(backoffPolicy1.nextBackoffNanos()).thenReturn(10L, 100L);
@@ -330,6 +332,7 @@ public abstract class ClientXdsClientTestBase {
 
   @Test
   public void ldsResourceUpdate_withFaultInjection() {
+    Assume.assumeTrue(useProtocolV3());
     DiscoveryRpcCall call =
         startResourceWatcher(ResourceType.LDS, LDS_RESOURCE, ldsResourceWatcher);
     List<Any> listeners = ImmutableList.of(

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientV2Test.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientV2Test.java
@@ -71,11 +71,6 @@ import io.envoyproxy.envoy.api.v2.route.RouteAction;
 import io.envoyproxy.envoy.api.v2.route.RouteMatch;
 import io.envoyproxy.envoy.api.v2.route.VirtualHost;
 import io.envoyproxy.envoy.config.cluster.aggregate.v2alpha.ClusterConfig;
-import io.envoyproxy.envoy.config.filter.fault.v2.FaultDelay;
-import io.envoyproxy.envoy.config.filter.fault.v2.FaultDelay.HeaderDelay;
-import io.envoyproxy.envoy.config.filter.http.fault.v2.FaultAbort;
-import io.envoyproxy.envoy.config.filter.http.fault.v2.FaultAbort.HeaderAbort;
-import io.envoyproxy.envoy.config.filter.http.fault.v2.HTTPFault;
 import io.envoyproxy.envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager;
 import io.envoyproxy.envoy.config.filter.network.http_connection_manager.v2.HttpFilter;
 import io.envoyproxy.envoy.config.filter.network.http_connection_manager.v2.Rds;
@@ -282,11 +277,7 @@ public class ClientXdsClientV2Test extends ClientXdsClientTestBase {
 
     @Override
     protected Message buildHttpFilter(String name, @Nullable Any typedConfig) {
-      HttpFilter.Builder builder = HttpFilter.newBuilder().setName(name);
-      if (typedConfig != null) {
-        builder.setTypedConfig(typedConfig);
-      }
-      return builder.build();
+      throw new UnsupportedOperationException();
     }
 
     @Override
@@ -294,40 +285,7 @@ public class ClientXdsClientV2Test extends ClientXdsClientTestBase {
         @Nullable Long delayNanos, @Nullable Integer delayRate, String upstreamCluster,
         List<String> downstreamNodes, @Nullable Integer maxActiveFaults, @Nullable Status status,
         @Nullable Integer httpCode, @Nullable Integer abortRate) {
-      HTTPFault.Builder builder = HTTPFault.newBuilder();
-      if (delayRate != null) {
-        FaultDelay.Builder delayBuilder
-            = FaultDelay.newBuilder();
-        delayBuilder.setPercentage(
-            FractionalPercent.newBuilder()
-                .setNumerator(delayRate).setDenominator(DenominatorType.MILLION));
-        if (delayNanos != null) {
-          delayBuilder.setFixedDelay(Durations.fromNanos(delayNanos));
-        } else {
-          delayBuilder.setHeaderDelay(HeaderDelay.newBuilder());
-        }
-        builder.setDelay(delayBuilder);
-      }
-      if (abortRate != null) {
-        FaultAbort.Builder abortBuilder = FaultAbort.newBuilder();
-        abortBuilder.setPercentage(
-            FractionalPercent.newBuilder()
-                .setNumerator(abortRate).setDenominator(DenominatorType.MILLION));
-        if (status != null) {
-          throw new UnsupportedOperationException();
-        } else if (httpCode != null) {
-          abortBuilder.setHttpStatus(httpCode);
-        } else {
-          abortBuilder.setHeaderAbort(HeaderAbort.newBuilder());
-        }
-        builder.setAbort(abortBuilder);
-      }
-      builder.setUpstreamCluster(upstreamCluster);
-      builder.addAllDownstreamNodes(downstreamNodes);
-      if (maxActiveFaults != null) {
-        builder.setMaxActiveFaults(UInt32Value.of(maxActiveFaults));
-      }
-      return Any.pack(builder.build());
+      throw new UnsupportedOperationException();
     }
 
     @Override


### PR DESCRIPTION
New features should be env flag protected even for proto parsing, because otherwise if there is a bug in parsing the new fields, users will break even if they are not using new feature.