### PR TITLE
xds: remove the env var GRPC_XDS_EXPERIMENTAL_NEW_SERVER_API

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ServerXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ServerXdsClient.java
@@ -70,11 +70,10 @@ final class ServerXdsClient extends AbstractXdsClient {
       ScheduledExecutorService timeService,
       BackoffPolicy.Provider backoffPolicyProvider,
       Supplier<Stopwatch> stopwatchSupplier,
-      boolean useNewApiForListenerQuery,
       String instanceIp,
       String grpcServerResourceId) {
     super(channel, useProtocolV3, node, timeService, backoffPolicyProvider, stopwatchSupplier);
-    this.useNewApiForListenerQuery = useProtocolV3 && useNewApiForListenerQuery;
+    this.useNewApiForListenerQuery = useProtocolV3;
     this.instanceIp = (instanceIp != null ? instanceIp : "0.0.0.0");
     this.grpcServerResourceId = grpcServerResourceId;
   }

--- a/xds/src/main/java/io/grpc/xds/XdsClientWrapperForServerSds.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientWrapperForServerSds.java
@@ -70,10 +70,6 @@ public final class XdsClientWrapperForServerSds {
   private static final TimeServiceResource timeServiceResource =
       new TimeServiceResource("GrpcServerXdsClient");
 
-  @VisibleForTesting
-  static boolean experimentalNewServerApiEnvVar = Boolean.parseBoolean(
-          System.getenv("GRPC_XDS_EXPERIMENTAL_NEW_SERVER_API"));
-
   private EnvoyServerProtoData.Listener curListener;
   @SuppressWarnings("unused")
   @Nullable private XdsClient xdsClient;
@@ -115,7 +111,7 @@ public final class XdsClientWrapperForServerSds {
         Grpc.newChannelBuilder(serverInfo.getTarget(), serverInfo.getChannelCredentials())
             .keepAliveTime(5, TimeUnit.MINUTES).build();
     timeService = SharedResourceHolder.get(timeServiceResource);
-    newServerApi = serverInfo.isUseProtocolV3() && experimentalNewServerApiEnvVar;
+    newServerApi = serverInfo.isUseProtocolV3();
     String grpcServerResourceId = bootstrapInfo.getGrpcServerResourceId();
     if (newServerApi && grpcServerResourceId == null) {
       throw new IOException("missing grpc_server_resource_name_id value in xds bootstrap");
@@ -128,7 +124,6 @@ public final class XdsClientWrapperForServerSds {
             timeService,
             new ExponentialBackoffPolicy.Provider(),
             GrpcUtil.STOPWATCH_SUPPLIER,
-            experimentalNewServerApiEnvVar,
             "0.0.0.0",
             grpcServerResourceId);
     start(xdsClientImpl);

--- a/xds/src/test/java/io/grpc/xds/ServerXdsClientNewServerApiTest.java
+++ b/xds/src/test/java/io/grpc/xds/ServerXdsClientNewServerApiTest.java
@@ -186,7 +186,7 @@ public class ServerXdsClientNewServerApiTest {
     xdsClient =
         new ServerXdsClient(channel, true, NODE,
             fakeClock.getScheduledExecutorService(), backoffPolicyProvider,
-            fakeClock.getStopwatchSupplier(), true, INSTANCE_IP, "test/value");
+            fakeClock.getStopwatchSupplier(), INSTANCE_IP, "test/value");
     // Only the connection to management server is established, no RPC request is sent until at
     // least one watcher is registered.
     assertThat(responseObservers).isEmpty();

--- a/xds/src/test/java/io/grpc/xds/ServerXdsClientTest.java
+++ b/xds/src/test/java/io/grpc/xds/ServerXdsClientTest.java
@@ -189,7 +189,7 @@ public class ServerXdsClientTest {
     xdsClient =
         new ServerXdsClient(channel, /* useProtocolV3= */ false, NODE,
             fakeClock.getScheduledExecutorService(), backoffPolicyProvider,
-            fakeClock.getStopwatchSupplier(), false, INSTANCE_IP, "grpc/server");
+            fakeClock.getStopwatchSupplier(), INSTANCE_IP, "grpc/server");
     // Only the connection to management server is established, no RPC request is sent until at
     // least one watcher is registered.
     assertThat(responseObservers).isEmpty();


### PR DESCRIPTION
remove dependency on the env var GRPC_XDS_EXPERIMENTAL_NEW_SERVER_API so the change in https://github.com/grpc/grpc/pull/25529 wouldn't be needed.