### PR TITLE
grpclb: fix race between address update and LB stream recreation

### DIFF
--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -244,6 +244,7 @@ final class GrpclbState {
       // newLbAddressGroups, but we're considering that "okay". If we detected the RPC is to an
       // outdated backend, we could choose to re-create the RPC.
       if (lbStream == null) {
+        cancelLbRpcRetryTimer();
         startLbRpc();
       }
       // Start the fallback timer if it's never started
@@ -368,6 +369,7 @@ final class GrpclbState {
   private void cancelLbRpcRetryTimer() {
     if (lbRpcRetryTimer != null) {
       lbRpcRetryTimer.cancel();
+      lbRpcRetryTimer = null;
     }
   }
 


### PR DESCRIPTION
Race scenario:
The LB stream was closed and a retry task has been scheduled. Receiving a ResolvedAddress update with LB addresses immediately creates a new RPC stream again. Then when the retry task fires, a LB stream already exists.

There are a couple of ways to mitigate the race. This change cancels the retry task when the address update causing a new LB stream to be created.

See b/181708023