### PR TITLE
api: delete deprecated NameResolver APIs

### DIFF
--- a/api/src/main/java/io/grpc/NameResolverProvider.java
+++ b/api/src/main/java/io/grpc/NameResolverProvider.java
@@ -16,8 +16,6 @@
 
 package io.grpc;
 
-import java.util.List;
-
 /**
  * Provider of name resolvers for name agnostic consumption.
  *
@@ -33,38 +31,6 @@ import java.util.List;
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4159")
 public abstract class NameResolverProvider extends NameResolver.Factory {
-
-  /**
-   * The port number used in case the target or the underlying naming system doesn't provide a
-   * port number.
-   *
-   * @since 1.0.0
-   */
-  @SuppressWarnings("unused") // Avoids outside callers accidentally depending on the super class.
-  @Deprecated
-  public static final Attributes.Key<Integer> PARAMS_DEFAULT_PORT =
-      NameResolver.Factory.PARAMS_DEFAULT_PORT;
-
-  /**
-   * Returns non-{@code null} ClassLoader-wide providers, in preference order.
-   *
-   * @since 1.0.0
-   * @deprecated Has no replacement
-   */
-  @Deprecated
-  public static List<NameResolverProvider> providers() {
-    return NameResolverRegistry.getDefaultRegistry().providers();
-  }
-
-  /**
-   * @since 1.0.0
-   * @deprecated Use NameResolverRegistry.getDefaultRegistry().asFactory()
-   */
-  @Deprecated
-  public static NameResolver.Factory asFactory() {
-    return NameResolverRegistry.getDefaultRegistry().asFactory();
-  }
-
   /**
    * Whether this provider is available for use, taking the current environment into consideration.
    * If {@code false}, no other methods are safe to be called.

--- a/api/src/test/java/io/grpc/NameResolverTest.java
+++ b/api/src/test/java/io/grpc/NameResolverTest.java
@@ -17,23 +17,13 @@
 package io.grpc;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.same;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.NameResolver.ServiceConfigParser;
 import java.lang.Thread.UncaughtExceptionHandler;
-import java.net.URI;
-import java.util.Collections;
-import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.atomic.AtomicReference;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -50,13 +40,6 @@ public class NameResolverTest {
       mock(ScheduledExecutorService.class);
   private final ChannelLogger channelLogger = mock(ChannelLogger.class);
   private final Executor executor = Executors.newSingleThreadExecutor();
-  private URI uri;
-  private final NameResolver nameResolver = mock(NameResolver.class);
-
-  @Before
-  public void setUp() throws Exception {
-    uri = new URI("fake://service");
-  }
 
   @Test
   public void args() {
@@ -80,177 +63,6 @@ public class NameResolverTest {
 
     assertThat(args2).isNotSameInstanceAs(args);
     assertThat(args2).isNotEqualTo(args);
-  }
-
-  @Deprecated
-  @Test
-  public void newNameResolver_Api2DelegatesToApi1() {
-    final AtomicReference<Attributes> paramsCapture = new AtomicReference<>();
-    NameResolver.Factory factory = new NameResolver.Factory() {
-        @Deprecated
-        @Override
-        public NameResolver newNameResolver(URI targetUri, Attributes params) {
-          assertThat(targetUri).isSameInstanceAs(uri);
-          paramsCapture.set(params);
-          return nameResolver;
-        }
-
-        @Override
-        public String getDefaultScheme() {
-          throw new AssertionError();
-        }
-      };
-    assertThat(factory.newNameResolver(uri, new NameResolver.Helper() {
-        @Override
-        public int getDefaultPort() {
-          return defaultPort;
-        }
-
-        @Override
-        public ProxyDetector getProxyDetector() {
-          return proxyDetector;
-        }
-
-        @Override
-        public SynchronizationContext getSynchronizationContext() {
-          return syncContext;
-        }
-      })).isSameInstanceAs(nameResolver);
-    Attributes params = paramsCapture.get();
-    assertThat(params.get(NameResolver.Factory.PARAMS_DEFAULT_PORT)).isEqualTo(defaultPort);
-    assertThat(params.get(NameResolver.Factory.PARAMS_PROXY_DETECTOR))
-        .isSameInstanceAs(proxyDetector);
-  }
-
-  @Deprecated
-  @SuppressWarnings("unchecked")
-  @Test
-  public void newNameResolver_Api3DelegatesToApi2() {
-    final AtomicReference<NameResolver.Helper> helperCapture = new AtomicReference<>();
-    NameResolver.Factory factory = new NameResolver.Factory() {
-        @Deprecated
-        @Override
-        public NameResolver newNameResolver(URI targetUri, NameResolver.Helper helper) {
-          assertThat(targetUri).isSameInstanceAs(uri);
-          helperCapture.set(helper);
-          return nameResolver;
-        }
-
-        @Override
-        public String getDefaultScheme() {
-          return "fake";
-        }
-      };
-    assertThat(factory.newNameResolver(uri, createArgs())).isSameInstanceAs(nameResolver);
-    NameResolver.Helper helper = helperCapture.get();
-    assertThat(helper.getDefaultPort()).isEqualTo(defaultPort);
-    assertThat(helper.getProxyDetector()).isSameInstanceAs(proxyDetector);
-    assertThat(helper.getSynchronizationContext()).isSameInstanceAs(syncContext);
-
-    // Test service config parsing
-    ConfigOrError coe = ConfigOrError.fromConfig("A config");
-    when(parser.parseServiceConfig(any(Map.class))).thenReturn(coe);
-    Map<String, ?> rawConfig = Collections.singletonMap("Key", "value");
-    assertThat(helper.parseServiceConfig(rawConfig)).isSameInstanceAs(coe);
-    verify(parser).parseServiceConfig(same(rawConfig));
-  }
-
-  // Tests that a forwarding factory on API1 can correctly delegate to a factory already migrated
-  // to API3 without losing information.
-  @Deprecated
-  @SuppressWarnings("unchecked")
-  @Test
-  public void newNameResolver_forwardingFactory1DelegatesToApi3() {
-    final AtomicReference<NameResolver.Args> argsCapture = new AtomicReference<>();
-    final NameResolver.Factory delegate = new NameResolver.Factory() {
-        @Override
-        public NameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
-          assertThat(targetUri).isSameInstanceAs(uri);
-          argsCapture.set(args);
-          return nameResolver;
-        }
-
-        @Override
-        public String getDefaultScheme() {
-          throw new AssertionError();
-        }
-      };
-
-    NameResolver.Factory forwarding = new NameResolver.Factory() {
-        @Deprecated
-        public NameResolver newNameResolver(URI targetUri, Attributes attrs) {
-          return delegate.newNameResolver(targetUri, attrs);
-        }
-
-        @Override
-        public String getDefaultScheme() {
-          throw new AssertionError();
-        }
-      };
-
-    // gRPC channel is calling forwarding with API3.
-    assertThat(forwarding.newNameResolver(uri, createArgs())).isSameInstanceAs(nameResolver);
-
-    NameResolver.Args args = argsCapture.get();
-    assertThat(args.getDefaultPort()).isEqualTo(defaultPort);
-    assertThat(args.getProxyDetector()).isSameInstanceAs(proxyDetector);
-    assertThat(args.getSynchronizationContext()).isSameInstanceAs(syncContext);
-
-    ServiceConfigParser passedParser = args.getServiceConfigParser();
-    ConfigOrError coe = ConfigOrError.fromConfig("A config");
-    when(parser.parseServiceConfig(any(Map.class))).thenReturn(coe);
-    Map<String, ?> rawConfig = Collections.singletonMap("Key", "value");
-    assertThat(passedParser.parseServiceConfig(rawConfig)).isSameInstanceAs(coe);
-    verify(parser).parseServiceConfig(same(rawConfig));
-  }
-
-  // Tests that a forwarding factory on API2 can correctly delegate to a factory already migrated
-  // to API3 without losing information.
-  @Deprecated
-  @SuppressWarnings("unchecked")
-  @Test
-  public void newNameResolver_forwardingFactory2DelegatesToApi3() {
-    final AtomicReference<NameResolver.Args> argsCapture = new AtomicReference<>();
-    final NameResolver.Factory delegate = new NameResolver.Factory() {
-        @Override
-        public NameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
-          assertThat(targetUri).isSameInstanceAs(uri);
-          argsCapture.set(args);
-          return nameResolver;
-        }
-
-        @Override
-        public String getDefaultScheme() {
-          throw new AssertionError();
-        }
-      };
-
-    NameResolver.Factory forwarding = new NameResolver.Factory() {
-        @Deprecated
-        public NameResolver newNameResolver(URI targetUri, NameResolver.Helper helper) {
-          return delegate.newNameResolver(targetUri, helper);
-        }
-
-        @Override
-        public String getDefaultScheme() {
-          throw new AssertionError();
-        }
-      };
-
-    // gRPC channel is calling forwarding with API3.
-    assertThat(forwarding.newNameResolver(uri, createArgs())).isSameInstanceAs(nameResolver);
-
-    NameResolver.Args args = argsCapture.get();
-    assertThat(args.getDefaultPort()).isEqualTo(defaultPort);
-    assertThat(args.getProxyDetector()).isSameInstanceAs(proxyDetector);
-    assertThat(args.getSynchronizationContext()).isSameInstanceAs(syncContext);
-
-    ServiceConfigParser passedParser = args.getServiceConfigParser();
-    ConfigOrError coe = ConfigOrError.fromConfig("A config");
-    when(parser.parseServiceConfig(any(Map.class))).thenReturn(coe);
-    Map<String, ?> rawConfig = Collections.singletonMap("Key", "value");
-    assertThat(passedParser.parseServiceConfig(rawConfig)).isSameInstanceAs(coe);
-    verify(parser).parseServiceConfig(same(rawConfig));
   }
 
   private NameResolver.Args createArgs() {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -3791,61 +3791,6 @@ public class ManagedChannelImplTest {
     mychannel.shutdownNow();
   }
 
-  @Deprecated
-  @Test
-  public void nameResolver_forwardingStartOldApi() {
-    final AtomicReference<NameResolver.Listener2> listenerCapture = new AtomicReference<>();
-    final NameResolver noopResolver = new NameResolver() {
-        @Override
-        public String getServiceAuthority() {
-          return "fake-authority";
-        }
-
-        @Override
-        public void start(Listener2 listener) {
-          listenerCapture.set(listener);
-        }
-
-        @Override
-        public void shutdown() {}
-      };
-
-    // This forwarding resolver is still on the old start() API.  Despite that, the delegate
-    // resolver which is on the new API should get the new Listener2.
-    final NameResolver oldApiForwardingResolver = new NameResolver() {
-        @Override
-        public String getServiceAuthority() {
-          return noopResolver.getServiceAuthority();
-        }
-
-        @Override
-        public void start(Listener listener) {
-          noopResolver.start(listener);
-        }
-
-        @Override
-        public void shutdown() {
-          noopResolver.shutdown();
-        }
-      };
-
-    NameResolver.Factory oldApiResolverFactory = new NameResolver.Factory() {
-        @Override
-        public NameResolver newNameResolver(URI targetUri, NameResolver.Helper helper) {
-          return oldApiForwardingResolver;
-        }
-
-        @Override
-        public String getDefaultScheme() {
-          return "fakescheme";
-        }
-      };
-    channelBuilder.nameResolverFactory(oldApiResolverFactory);
-    createChannel();
-
-    assertThat(listenerCapture.get()).isNotNull();
-  }
-
   @Test
   public void nameResolverArgsPropagation() {
     final AtomicReference<NameResolver.Args> capturedArgs = new AtomicReference<>();


### PR DESCRIPTION
I am trying to add a new API for exposing some unique ID that represents the Channel to its resolver. It could just be `ManagedChannelImpl`'s logId (the `long` value). 

We want this to be a required attribute for `NameResolver.Args` to avoid confusion. So deleting old APIs (`NameResolver.Helper`) without the necessity to add such an attribute for it as well.