### PR TITLE
Update netty version to fix CVE-2021-21290

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ subprojects {
         protocPluginBaseName = 'protoc-gen-grpc-java'
         javaPluginPath = "$rootDir/compiler/build/exe/java_plugin/$protocPluginBaseName$exeSuffix"
 
-        nettyVersion = '4.1.52.Final'
+        nettyVersion = '4.1.59.Final'
         guavaVersion = '30.0-android'
         googleauthVersion = '0.22.2'
         protobufVersion = '3.12.0'

--- a/core/src/test/java/io/grpc/internal/AbstractTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractTransportTest.java
@@ -1920,7 +1920,8 @@ public abstract class AbstractTransportTest {
     // If this times out, the server probably isn't noticing the metadata size
     Status status = clientStreamListener.status.get(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     List<Status.Code> codeOptions = Arrays.asList(
-        Status.Code.UNKNOWN, Status.Code.RESOURCE_EXHAUSTED, Status.Code.INTERNAL);
+        Status.Code.UNKNOWN, Status.Code.RESOURCE_EXHAUSTED, Status.Code.INTERNAL,
+        Status.Code.UNAVAILABLE);
     if (!codeOptions.contains(status.getCode())) {
       fail("Status code was not expected: " + status);
     }

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
@@ -101,10 +101,4 @@ public class OkHttpTransportTest extends AbstractTransportTest {
     return true;
   }
 
-  @Override
-  @org.junit.Test
-  @org.junit.Ignore
-  public void clientChecksInboundMetadataSize_trailer() {
-    // Server-side is flaky due to https://github.com/netty/netty/pull/8332
-  }
 }


### PR DESCRIPTION
Upgrade the netty version to remediate the [CVE-2021-21290](https://nvd.nist.gov/vuln/detail/CVE-2021-21290) vulnerability.