### PR TITLE
api: make AltsServerBuilder extend ForwardingServerBuilder and clean up addServices() API

### DIFF
--- a/alts/src/main/java/io/grpc/alts/AltsServerBuilder.java
+++ b/alts/src/main/java/io/grpc/alts/AltsServerBuilder.java
@@ -20,6 +20,7 @@ import io.grpc.BindableService;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
 import io.grpc.ExperimentalApi;
+import io.grpc.ForwardingServerBuilder;
 import io.grpc.HandlerRegistry;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
@@ -30,7 +31,6 @@ import io.grpc.ServerTransportFilter;
 import io.grpc.netty.NettyServerBuilder;
 import java.io.File;
 import java.net.InetSocketAddress;
-import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
  * a production server on Google Cloud Platform.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4151")
-public final class AltsServerBuilder extends ServerBuilder<AltsServerBuilder> {
+public final class AltsServerBuilder extends ForwardingServerBuilder<AltsServerBuilder> {
   private final NettyServerBuilder delegate;
   private final AltsServerCredentials.Builder credentialsBuilder =
       new AltsServerCredentials.Builder();
@@ -67,6 +67,11 @@ public final class AltsServerBuilder extends ServerBuilder<AltsServerBuilder> {
   public AltsServerBuilder setHandshakerAddressForTesting(String handshakerAddress) {
     credentialsBuilder.setHandshakerAddressForTesting(handshakerAddress);
     return this;
+  }
+
+  @Override
+  protected ServerBuilder<?> delegate() {
+    return delegate;
   }
 
   /** {@inheritDoc} */
@@ -115,13 +120,6 @@ public final class AltsServerBuilder extends ServerBuilder<AltsServerBuilder> {
   @Override
   public AltsServerBuilder addService(BindableService bindableService) {
     delegate.addService(bindableService);
-    return this;
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public AltsServerBuilder addServices(List<ServerServiceDefinition> services) {
-    delegate.addServices(services);
     return this;
   }
 

--- a/api/src/main/java/io/grpc/ForwardingServerBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingServerBuilder.java
@@ -19,7 +19,6 @@ package io.grpc;
 import com.google.common.base.MoreObjects;
 import java.io.File;
 import java.io.InputStream;
-import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
@@ -69,12 +68,6 @@ public abstract class ForwardingServerBuilder<T extends ServerBuilder<T>> extend
   @Override
   public T addService(BindableService bindableService) {
     delegate().addService(bindableService);
-    return thisT();
-  }
-
-  @Override
-  public T addServices(List<ServerServiceDefinition> services) {
-    delegate().addServices(services);
     return thisT();
   }
 

--- a/api/src/main/java/io/grpc/ServerBuilder.java
+++ b/api/src/main/java/io/grpc/ServerBuilder.java
@@ -100,7 +100,7 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
    * @since 1.37.0
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/7925")
-  public T addServices(List<ServerServiceDefinition> services) {
+  public final T addServices(List<ServerServiceDefinition> services) {
     checkNotNull(services, "services");
     for (ServerServiceDefinition service : services) {
       addService(service);

--- a/api/src/test/java/io/grpc/ForwardingServerBuilderTest.java
+++ b/api/src/test/java/io/grpc/ForwardingServerBuilderTest.java
@@ -55,7 +55,9 @@ public class ForwardingServerBuilderTest {
   @Test
   public void allBuilderMethodsReturnThis() throws Exception {
     for (Method method : ServerBuilder.class.getDeclaredMethods()) {
-      if (Modifier.isStatic(method.getModifiers()) || Modifier.isPrivate(method.getModifiers())) {
+      if (Modifier.isStatic(method.getModifiers())
+          || Modifier.isPrivate(method.getModifiers())
+          || Modifier.isFinal(method.getModifiers())) {
         continue;
       }
       if (method.getName().equals("build")) {

--- a/api/src/test/java/io/grpc/ForwardingTestUtil.java
+++ b/api/src/test/java/io/grpc/ForwardingTestUtil.java
@@ -83,6 +83,7 @@ public final class ForwardingTestUtil {
     for (Method method : delegateClass.getDeclaredMethods()) {
       if (Modifier.isStatic(method.getModifiers())
           || Modifier.isPrivate(method.getModifiers())
+          || Modifier.isFinal(method.getModifiers())
           || skippedMethods.contains(method)) {
         continue;
       }

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -30,7 +30,6 @@ import io.grpc.ServerStreamTracer;
 import io.grpc.ServerTransportFilter;
 import java.io.File;
 import java.io.InputStream;
-import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
@@ -83,12 +82,6 @@ public abstract class AbstractServerImplBuilder
   @Override
   public T addService(BindableService bindableService) {
     delegate().addService(bindableService);
-    return thisT();
-  }
-
-  @Override
-  public T addServices(List<ServerServiceDefinition> services) {
-    delegate().addServices(services);
     return thisT();
   }
 

--- a/core/src/test/java/io/grpc/internal/AbstractServerImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerImplBuilderTest.java
@@ -59,7 +59,9 @@ public class AbstractServerImplBuilderTest {
   @Test
   public void allBuilderMethodsReturnThis() throws Exception {
     for (Method method : ServerBuilder.class.getDeclaredMethods()) {
-      if (Modifier.isStatic(method.getModifiers()) || Modifier.isPrivate(method.getModifiers())) {
+      if (Modifier.isStatic(method.getModifiers())
+          || Modifier.isPrivate(method.getModifiers())
+          || Modifier.isFinal(method.getModifiers())) {
         continue;
       }
       if (method.getName().equals("build")) {


### PR DESCRIPTION
Make AltsServerBuilder extend ForwardingServerBuilder so we do not need to worry about method forwarding test.

More context in https://github.com/grpc/grpc-java/pull/7926#issuecomment-790202011

Internal changes: cl/361042897