### PR TITLE
xds: implement ring_hash load balancing policy

### DIFF
--- a/xds/src/main/java/io/grpc/xds/InternalXdsAttributes.java
+++ b/xds/src/main/java/io/grpc/xds/InternalXdsAttributes.java
@@ -68,5 +68,12 @@ public final class InternalXdsAttributes {
   static final Attributes.Key<Locality> ATTR_LOCALITY =
       Attributes.Key.create("io.grpc.xds.InternalXdsAttributes.locality");
 
+  /**
+   * Endpoint weight for load balancing purposes.
+   */
+  @EquivalentAddressGroup.Attr
+  static final Attributes.Key<Long> ATTR_SERVER_WEIGHT =
+      Attributes.Key.create("io.grpc.xds.InternalXdsAttributes.serverWeight");
+
   private InternalXdsAttributes() {}
 }

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -252,7 +252,7 @@ final class RingHashLoadBalancer extends LoadBalancer {
         hasIdle = true;
       }
     }
-    if (failureCount > 2) {
+    if (failureCount >= 2) {
       return TRANSIENT_FAILURE;
     }
     if (hasConnecting) {

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -44,7 +44,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 
@@ -63,8 +62,7 @@ final class RingHashLoadBalancer extends LoadBalancer {
   private final XdsLogger logger = XdsLogger.withLogId(
       InternalLogId.allocate("ring_hash_lb", null));
   private final XxHash64 hashFunc = XxHash64.INSTANCE;
-  private final ConcurrentMap<EquivalentAddressGroup, Subchannel> subchannels =
-      Maps.newConcurrentMap();
+  private final Map<EquivalentAddressGroup, Subchannel> subchannels = Maps.newHashMap();
   private final Helper helper;
 
   private ConnectivityState currentState;
@@ -266,7 +264,7 @@ final class RingHashLoadBalancer extends LoadBalancer {
 
   private static final class RingHashPicker extends SubchannelPicker {
     private final List<RingEntry> ring;
-    // shadow copy of subchannels
+    // shallow copy of subchannels
     private final Map<EquivalentAddressGroup, Subchannel> pickableSubchannels;
 
     private RingHashPicker(

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -59,8 +59,7 @@ final class RingHashLoadBalancer extends LoadBalancer {
   private static final Attributes.Key<AtomicReference<ConnectivityStateInfo>> STATE_INFO =
       Attributes.Key.create("state-info");
 
-  private final XdsLogger logger = XdsLogger.withLogId(
-      InternalLogId.allocate("ring_hash_lb", null));
+  private final XdsLogger logger;
   private final XxHash64 hashFunc = XxHash64.INSTANCE;
   private final Map<EquivalentAddressGroup, Subchannel> subchannels = Maps.newHashMap();
   private final Helper helper;
@@ -71,6 +70,8 @@ final class RingHashLoadBalancer extends LoadBalancer {
 
   RingHashLoadBalancer(Helper helper) {
     this.helper = checkNotNull(helper, "helper");
+    logger = XdsLogger.withLogId(InternalLogId.allocate("ring_hash_lb", helper.getAuthority()));
+    logger.log(XdsLogLevel.INFO, "Created");
   }
 
   @Override
@@ -180,6 +181,7 @@ final class RingHashLoadBalancer extends LoadBalancer {
 
   @Override
   public void shutdown() {
+    logger.log(XdsLogLevel.INFO, "Shutdown");
     for (Subchannel subchannel : subchannels.values()) {
       shutdownSubchannel(subchannel);
     }

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -227,7 +227,7 @@ final class RingHashLoadBalancer extends LoadBalancer {
    * <p>Aggregation rules (in order of dominance):
    * <ol>
    *   <li>If there is at least one subchannel in READY state, overall state is READY</li>
-   *   <li>If there are <em>more than 2</em> subchannels in TRANSIENT_FAILURE, overall state is
+   *   <li>If there are <em>2 or more</em> subchannels in TRANSIENT_FAILURE, overall state is
    *   TRANSIENT_FAILURE</li>
    *   <li>If there is at least one subchannel in CONNECTING state, overall state is
    *   CONNECTING</li>

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -58,10 +58,10 @@ final class RingHashLoadBalancer extends LoadBalancer {
       Attributes.Key.create("state-info");
   private static final Status RPC_HASH_NOT_FOUND =
       Status.INTERNAL.withDescription("RPC hash not found");
+  private static final XxHash64 hashFunc = XxHash64.INSTANCE;
 
   private final XdsLogger logger;
   private final SynchronizationContext syncContext;
-  private final XxHash64 hashFunc = XxHash64.INSTANCE;
   private final Map<EquivalentAddressGroup, Subchannel> subchannels = new HashMap<>();
   private final Helper helper;
 
@@ -153,7 +153,7 @@ final class RingHashLoadBalancer extends LoadBalancer {
     }
   }
 
-  private List<RingEntry> buildRing(
+  private static List<RingEntry> buildRing(
       Map<EquivalentAddressGroup, Long> serverWeights, long totalWeight, double scale) {
     List<RingEntry> ring = new ArrayList<>();
     double currentHashes = 0.0;

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -344,10 +344,7 @@ final class RingHashLoadBalancer extends LoadBalancer {
 
     @Override
     public int compareTo(RingEntry entry) {
-      if (this.hash == entry.hash) {
-        return 0;
-      }
-      return this.hash > entry.hash ? 1 : -1;  // don't narrow cast, it may overflow
+      return Long.compare(hash, entry.hash);
     }
   }
 

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -58,7 +58,7 @@ final class RingHashLoadBalancer extends LoadBalancer {
       Attributes.Key.create("state-info");
 
   private final XdsLogger logger = XdsLogger.withLogId(
-      InternalLogId.allocate(RingHashLoadBalancer.class, null));
+      InternalLogId.allocate("ring_hash_lb", null));
   private final XxHash64 hashFunc = XxHash64.INSTANCE;
   private final ConcurrentMap<EquivalentAddressGroup, Subchannel> subchannels =
       Maps.newConcurrentMap();

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -312,9 +312,6 @@ final class RingHashLoadBalancer extends LoadBalancer {
       if (requestHash == null) {
         return PickResult.withError(RPC_HASH_NOT_FOUND);
       }
-      if (ring.isEmpty()) {
-        return PickResult.withNoResult();
-      }
 
       // Find the ring entry with hash next to (clockwise) the RPC's hash.
       int low = 0;

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -49,7 +49,7 @@ import java.util.Set;
  * A {@link LoadBalancer} that provides consistent hashing based load balancing to upstream hosts.
  * It implements the "Ketama" hashing that maps hosts onto a circle (the "ring") by hashing its
  * addresses. Each request is routed to a host by hashing some property of the request and finding
- * the neaerest corresponding host clockwise around the ring. Each host is placed on the ring some
+ * the nearest corresponding host clockwise around the ring. Each host is placed on the ring some
  * number of times proportional to its weight. With the ring partitioned appropriately, the
  * addition or removal of one host from a set of N hosts will affect only 1/N requests.
  */
@@ -172,7 +172,7 @@ final class RingHashLoadBalancer extends LoadBalancer {
         ring.add(new RingEntry(hash, addrKey));
         i++;
         currentHashes++;
-        sb.deleteCharAt(sb.length() - 1);
+        sb.setLength(sb.length() - 1);
       }
     }
     Collections.sort(ring);

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -275,7 +275,10 @@ final class RingHashLoadBalancer extends LoadBalancer {
 
     @Override
     public PickResult pickSubchannel(PickSubchannelArgs args) {
-      long requestHash = args.getCallOptions().getOption(XdsNameResolver.RPC_HASH_KEY);
+      Long requestHash = args.getCallOptions().getOption(XdsNameResolver.RPC_HASH_KEY);
+      if (requestHash == null) {
+        return PickResult.withError(Status.INTERNAL.withDescription("RPC hash not found"));
+      }
       if (ring.isEmpty()) {
         return PickResult.withNoResult();
       }

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -347,7 +347,7 @@ final class RingHashLoadBalancer extends LoadBalancer {
 
       // Try finding a READY subchannel. Starting from the ring entry next to the RPC's hash.
       // If the one of the first two subchannels is not in TRANSIENT_FAILURE, return result
-      // based on that subchaannel. Otherwise, fail the pick unless a READY subchannel is found.
+      // based on that subchannel. Otherwise, fail the pick unless a READY subchannel is found.
       // Meanwhile, trigger connection for the first subchannel that is in IDLE if no subchannel
       // before it is in CONNECTING or READY.
       boolean hasPending = false;

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -109,7 +109,7 @@ final class RingHashLoadBalancer extends LoadBalancer {
     double normalizedMinWeight = (double) minWeight / totalWeight;
     // Scale up the number of hashes per host such that the least-weiighted host gets a whole
     // number of hashes on the the ring. Other hosts might not end up with whole numbers, and
-    // that's fine (the ring-building algorithm can handle this). This preserves teh original
+    // that's fine (the ring-building algorithm can handle this). This preserves the original
     // implementation's behavior: when weights aren't provided, all hosts should get an equal
     // number of hashes. In the case where this number exceeds the max_ring_size, it's scaled
     // back down to fit.
@@ -292,8 +292,8 @@ final class RingHashLoadBalancer extends LoadBalancer {
             processSubchannelState(finalSubchannel, newState);
           }
         });
+        subchannels.put(addrKey, subchannel);
       }
-      subchannels.put(addrKey, subchannel);
       subchannel.requestConnection();
       // Return no result to queue the pick and re-attempt later.
       return PickResult.withNoResult();

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.grpc.ConnectivityState.CONNECTING;
+import static io.grpc.ConnectivityState.IDLE;
+import static io.grpc.ConnectivityState.READY;
+import static io.grpc.ConnectivityState.SHUTDOWN;
+import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import io.grpc.Attributes;
+import io.grpc.ConnectivityState;
+import io.grpc.ConnectivityStateInfo;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.InternalLogId;
+import io.grpc.LoadBalancer;
+import io.grpc.Status;
+import io.grpc.xds.XdsLogger.XdsLogLevel;
+import io.grpc.xds.XdsSubchannelPickers.ErrorPicker;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A {@link LoadBalancer} that provides consistent hashing based load balancing to upstream hosts.
+ * It implements the "Ketama" hashing that maps hosts onto a circle (the "ring") by hashing its
+ * addresses. Each request is routed to a host by hashing some property of the request and finding
+ * the neaerest corresponding host clockwise around the ring. Each host is placed on the ring some
+ * number of times proportional to its weight. With the ring partitioned appropriately, the
+ * addition or removal of one host from a set of N hosts will affect only 1/N requests.
+ */
+final class RingHashLoadBalancer extends LoadBalancer {
+  private static final Attributes.Key<AtomicReference<ConnectivityStateInfo>> STATE_INFO =
+      Attributes.Key.create("state-info");
+
+  private final XdsLogger logger = XdsLogger.withLogId(
+      InternalLogId.allocate(RingHashLoadBalancer.class, null));
+  private final XxHash64 hashFunc = XxHash64.INSTANCE;
+  private final ConcurrentMap<EquivalentAddressGroup, Subchannel> subchannels =
+      Maps.newConcurrentMap();
+  private final Helper helper;
+
+  private ConnectivityState currentState;
+  private SubchannelPicker currentPicker;
+  private boolean subchannelEnteredReady;
+
+  RingHashLoadBalancer(Helper helper) {
+    this.helper = checkNotNull(helper, "helper");
+  }
+
+  @Override
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
+    List<EquivalentAddressGroup> addrList = resolvedAddresses.getAddresses();
+    if (addrList.isEmpty()) {
+      handleNameResolutionError(Status.UNAVAILABLE.withDescription("No server addresses found"));
+      return;
+    }
+    Map<EquivalentAddressGroup, EquivalentAddressGroup> latestAddrs = stripAttrs(addrList);
+    Set<EquivalentAddressGroup> removedAddrs =
+        Sets.newHashSet(Sets.difference(subchannels.keySet(), latestAddrs.keySet()));
+    RingHashConfig config = (RingHashConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
+    Map<EquivalentAddressGroup, Long> serverWeights = new HashMap<>();
+    long totalWeight = 0L;
+    long minWeight = Long.MAX_VALUE;
+    long maxWeight = Long.MIN_VALUE;
+    for (EquivalentAddressGroup eag : addrList) {
+      Long weight = eag.getAttributes().get(InternalXdsAttributes.ATTR_SERVER_WEIGHT);
+      // Support two ways of server weighing: either multiple instances of the same address
+      // or each address contains a per-address weight attribute. If a weight is not provided,
+      // each occurrence of the address will be counted a weight value of one.
+      if (weight == null) {
+        weight = 1L;
+      }
+      minWeight = Math.min(minWeight, weight);
+      maxWeight = Math.max(maxWeight, weight);
+      totalWeight += weight;
+      EquivalentAddressGroup addrKey = stripAttrs(eag);
+      if (serverWeights.containsKey(addrKey)) {
+        serverWeights.put(addrKey, serverWeights.get(addrKey) + weight);
+      } else {
+        serverWeights.put(addrKey, weight);
+      }
+    }
+    double normalizedMinWeight = (double) minWeight / totalWeight;
+    // Scale up the number of hashes per host such that the least-weiighted host gets a whole
+    // number of hashes on the the ring. Other hosts might not end up with whole numbers, and
+    // that's fine (the ring-building algorithm can handle this). This preserves teh original
+    // implementation's behavior: when weights aren't provided, all hosts should get an equal
+    // number of hashes. In the case where this number exceeds the max_ring_size, it's scaled
+    // back down to fit.
+    double scale = Math.min(
+        Math.ceil(normalizedMinWeight * config.minRingSize) / normalizedMinWeight,
+        (double) config.maxRingSize);
+    List<RingEntry> ring = new ArrayList<>();
+
+    double currentHashes = 0.0;
+    double targetHashes = 0.0;
+    for (Map.Entry<EquivalentAddressGroup, Long> entry : serverWeights.entrySet()) {
+      EquivalentAddressGroup eag = entry.getKey();
+      double normalizedWeight = (double) entry.getValue() / totalWeight;
+      // TODO(chengyuanzhang): is using the list of socket address correct?
+      StringBuilder sb = new StringBuilder(eag.getAddresses().toString());
+      sb.append('_');
+      targetHashes += scale * normalizedWeight;
+      long i = 0L;
+      while (currentHashes < targetHashes) {
+        sb.append(i);
+        long hash = hashFunc.hashAsciiString(sb.toString());
+        ring.add(new RingEntry(hash, latestAddrs.get(eag)));
+        i++;
+        currentHashes++;
+        sb.deleteCharAt(sb.length() - 1);
+      }
+    }
+    Collections.sort(ring);
+    List<Subchannel> removedSubchannels = new ArrayList<>();
+    for (EquivalentAddressGroup addr : removedAddrs) {
+      removedSubchannels.add(subchannels.remove(addr));
+    }
+
+    // Update the picker before shutting down the subchannels, to reduce the chance of race
+    // between picking a subchannel and shutting it down.
+    updateBalancingState(new RingHashPicker(Collections.unmodifiableList(ring)));
+    for (Subchannel subchann : removedSubchannels) {
+      shutdownSubchannel(subchann);
+    }
+  }
+
+  private static void shutdownSubchannel(Subchannel subchannel) {
+    subchannel.shutdown();
+    getSubchannelStateInfoRef(subchannel).set(ConnectivityStateInfo.forNonError(SHUTDOWN));
+  }
+
+  /**
+   * Converts list of {@link EquivalentAddressGroup} to {@link EquivalentAddressGroup} set and
+   * remove all attributes. The values are the original EAGs.
+   */
+  private static Map<EquivalentAddressGroup, EquivalentAddressGroup> stripAttrs(
+      List<EquivalentAddressGroup> groupList) {
+    Map<EquivalentAddressGroup, EquivalentAddressGroup> addrs = new HashMap<>(groupList.size() * 2);
+    for (EquivalentAddressGroup group : groupList) {
+      addrs.put(stripAttrs(group), group);
+    }
+    return addrs;
+  }
+
+  private static EquivalentAddressGroup stripAttrs(EquivalentAddressGroup eag) {
+    return new EquivalentAddressGroup(eag.getAddresses());
+  }
+
+  @Override
+  public void handleNameResolutionError(Status error) {
+    if (currentState != READY) {
+      helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(error));
+    }
+  }
+
+  @Override
+  public void shutdown() {
+    for (Subchannel subchannel : subchannels.values()) {
+      shutdownSubchannel(subchannel);
+    }
+  }
+
+  private void updateBalancingState(SubchannelPicker picker) {
+    ConnectivityState overallState = IDLE;
+    for (Subchannel subchannel : subchannels.values()) {
+      ConnectivityStateInfo stateInfo = getSubchannelStateInfoRef(subchannel).get();
+      overallState = aggregateState(overallState, stateInfo.getState());
+    }
+    if (overallState != currentState || picker != currentPicker || subchannelEnteredReady) {
+      helper.updateBalancingState(overallState, picker);
+      currentState = overallState;
+      currentPicker = picker;
+      subchannelEnteredReady = false;
+    }
+  }
+
+  private static ConnectivityState aggregateState(
+      ConnectivityState overallState, ConnectivityState state) {
+    if (overallState == READY || state == READY) {
+      return READY;
+    }
+    if (overallState == CONNECTING || state == CONNECTING) {
+      return CONNECTING;
+    }
+    if (overallState == IDLE || state == IDLE) {
+      return IDLE;
+    }
+    return overallState;
+  }
+
+  private void processSubchannelState(Subchannel subchannel, ConnectivityStateInfo stateInfo) {
+    if (subchannels.get(stripAttrs(subchannel.getAddresses())) != subchannel) {
+      return;
+    }
+    AtomicReference<ConnectivityStateInfo> subchannelStateRef =
+        getSubchannelStateInfoRef(subchannel);
+    if (!subchannelStateRef.get().getState().equals(READY) && stateInfo.getState().equals(READY)) {
+      subchannelEnteredReady = true;
+    }
+
+    // Do not proactively reconnect even if the subchannel is previously connected.
+    subchannelStateRef.set(stateInfo);
+    updateBalancingState(currentPicker);
+  }
+
+  private static AtomicReference<ConnectivityStateInfo> getSubchannelStateInfoRef(
+      Subchannel subchannel) {
+    return checkNotNull(subchannel.getAttributes().get(STATE_INFO), "STATE_INFO");
+  }
+
+  private final class RingHashPicker extends SubchannelPicker {
+    private final List<RingEntry> ring;
+
+    private RingHashPicker(List<RingEntry> ring) {
+      this.ring = ring;
+    }
+
+    @Override
+    public PickResult pickSubchannel(PickSubchannelArgs args) {
+      long requestHash = args.getCallOptions().getOption(XdsNameResolver.RPC_HASH_KEY);
+      if (ring.isEmpty()) {
+        return PickResult.withNoResult();
+      }
+      // Find the nearest corresponding host clockwise around the ring.
+      int low = 0;
+      int high = ring.size();
+      int mid;
+      while (true) {
+        mid = (low + high) / 2;
+        if (mid == ring.size()) {
+          mid = 0;
+          break;
+        }
+        long midVal = ring.get(mid).hash;
+        long midValL = mid == 0 ? 0 : ring.get(mid - 1).hash;
+        if (requestHash <= midVal && requestHash > midValL) {
+          break;
+        }
+        if (midVal < requestHash) {
+          low = mid + 1;
+        } else {
+          high =  mid - 1;
+        }
+        if (low > high) {
+          mid = 0;
+          break;
+        }
+      }
+      EquivalentAddressGroup serverAddr = ring.get(mid).eag;
+      EquivalentAddressGroup addrKey = stripAttrs(serverAddr);
+      Subchannel subchannel = subchannels.get(addrKey);
+      if (subchannel != null && getSubchannelStateInfoRef(subchannel).get().getState() == READY) {
+        return PickResult.withSubchannel(subchannel);
+      }
+      if (subchannel == null) {
+        Attributes attr = Attributes.newBuilder().set(
+            STATE_INFO, new AtomicReference<>(ConnectivityStateInfo.forNonError(IDLE))).build();
+        subchannel = helper.createSubchannel(
+            CreateSubchannelArgs.newBuilder()
+                .setAddresses(serverAddr).setAttributes(attr).build());
+        final Subchannel finalSubchannel = subchannel;
+        subchannel.start(new SubchannelStateListener() {
+          @Override
+          public void onSubchannelState(ConnectivityStateInfo newState) {
+            processSubchannelState(finalSubchannel, newState);
+          }
+        });
+      }
+      subchannels.put(addrKey, subchannel);
+      subchannel.requestConnection();
+      // Return no result to queue the pick and re-attempt later.
+      return PickResult.withNoResult();
+    }
+  }
+
+  private static final class RingEntry implements Comparable<RingEntry> {
+    private final long hash;
+    private final EquivalentAddressGroup eag;
+
+    private RingEntry(long hash, EquivalentAddressGroup eag) {
+      this.hash = hash;
+      this.eag = eag;
+    }
+
+    @Override
+    public int compareTo(RingEntry entry) {
+      if (this.hash == entry.hash) {
+        return 0;
+      }
+      return this.hash > entry.hash ? 1 : -1;  // don't narrow cast, it may overflow
+    }
+  }
+
+  /**
+   * Configures the ring property. The larger the ring is (that is, the more hashes there are
+   * for each provided host) the better the request distribution will reflect the desired weights.
+   */
+  static final class RingHashConfig {
+    final long minRingSize;
+    final long maxRingSize;
+
+    RingHashConfig(long minRingSize, long maxRingSize) {
+      checkArgument(minRingSize > 0, "minRingSize <= 0");
+      checkArgument(maxRingSize > 0, "maxRingSize <= 0");
+      checkArgument(minRingSize <= maxRingSize, "minRingSize > maxRingSize");
+      this.minRingSize = minRingSize;
+      this.maxRingSize = maxRingSize;
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("minRingSize", minRingSize)
+          .add("maxRingSize", maxRingSize)
+          .toString();
+    }
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancerProvider.java
@@ -32,6 +32,9 @@ import java.util.Map;
 @Internal
 public final class RingHashLoadBalancerProvider extends LoadBalancerProvider {
 
+  private static final boolean enableRingHash =
+      Boolean.parseBoolean(System.getenv("GRPC_XDS_EXPERIMENTAL_ENABLE_RING_HASH"));
+
   @Override
   public LoadBalancer newLoadBalancer(Helper helper) {
     return new RingHashLoadBalancer(helper);
@@ -39,7 +42,7 @@ public final class RingHashLoadBalancerProvider extends LoadBalancerProvider {
 
   @Override
   public boolean isAvailable() {
-    return true;
+    return enableRingHash;
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancerProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import io.grpc.Internal;
+import io.grpc.LoadBalancer;
+import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancerProvider;
+import io.grpc.NameResolver.ConfigOrError;
+import io.grpc.Status;
+import io.grpc.internal.JsonUtil;
+import io.grpc.xds.RingHashLoadBalancer.RingHashConfig;
+import java.util.Map;
+
+/**
+ * The provider for the "ring_hash" balancing policy.
+ */
+@Internal
+public final class RingHashLoadBalancerProvider extends LoadBalancerProvider {
+
+  @Override
+  public LoadBalancer newLoadBalancer(Helper helper) {
+    return new RingHashLoadBalancer(helper);
+  }
+
+  @Override
+  public boolean isAvailable() {
+    return true;
+  }
+
+  @Override
+  public int getPriority() {
+    return 5;
+  }
+
+  @Override
+  public String getPolicyName() {
+    return "ring_hash";
+  }
+
+  @Override
+  public ConfigOrError parseLoadBalancingPolicyConfig(Map<String, ?> rawLoadBalancingPolicyConfig) {
+    Long minRingSize = JsonUtil.getNumberAsLong(rawLoadBalancingPolicyConfig, "minRingSize");
+    Long maxRingSize = JsonUtil.getNumberAsLong(rawLoadBalancingPolicyConfig, "maxRingSize");
+    if (minRingSize == null || maxRingSize == null) {
+      return ConfigOrError.fromError(Status.INVALID_ARGUMENT.withDescription(
+          "Missing 'mingRingSize'/'maxRingSize'"));
+    }
+    if (minRingSize <= 0 || maxRingSize <= 0 || minRingSize > maxRingSize) {
+      return ConfigOrError.fromError(Status.INVALID_ARGUMENT.withDescription(
+          "Invalid 'mingRingSize'/'maxRingSize'"));
+    }
+    return ConfigOrError.fromConfig(new RingHashConfig(minRingSize, maxRingSize));
+  }
+}

--- a/xds/src/main/resources/META-INF/services/io.grpc.LoadBalancerProvider
+++ b/xds/src/main/resources/META-INF/services/io.grpc.LoadBalancerProvider
@@ -4,3 +4,4 @@ io.grpc.xds.WeightedTargetLoadBalancerProvider
 io.grpc.xds.ClusterManagerLoadBalancerProvider
 io.grpc.xds.ClusterResolverLoadBalancerProvider
 io.grpc.xds.ClusterImplLoadBalancerProvider
+io.grpc.xds.RingHashLoadBalancerProvider

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerProviderTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancerRegistry;
+import io.grpc.NameResolver.ConfigOrError;
+import io.grpc.Status.Code;
+import io.grpc.internal.JsonParser;
+import io.grpc.xds.RingHashLoadBalancer.RingHashConfig;
+import java.io.IOException;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link RingHashLoadBalancerProvider}. */
+@RunWith(JUnit4.class)
+public class RingHashLoadBalancerProviderTest {
+
+  private final RingHashLoadBalancerProvider provider = new RingHashLoadBalancerProvider();
+
+  @Test
+  public void provided() {
+    LoadBalancerRegistry registry = LoadBalancerRegistry.getDefaultRegistry();
+    assertThat(registry.getProvider("ring_hash")).isInstanceOf(RingHashLoadBalancerProvider.class);
+  }
+
+  @Test
+  public void providesLoadBalancer() {
+    assertThat(provider.newLoadBalancer(mock(Helper.class)))
+        .isInstanceOf(RingHashLoadBalancer.class);
+  }
+
+  @Test
+  public void parseLoadBalancingConfig_valid() throws IOException {
+    String lbConfig = "{\"minRingSize\" : 10, \"maxRingSize\" : 100}";
+    ConfigOrError configOrError =
+        provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
+    assertThat(configOrError.getConfig()).isNotNull();
+    RingHashConfig config = (RingHashConfig) configOrError.getConfig();
+    assertThat(config.minRingSize).isEqualTo(10L);
+    assertThat(config.maxRingSize).isEqualTo(100L);
+  }
+
+  @Test
+  public void parseLoadBalancingConfig_missingRingSize() throws IOException {
+    String lbConfig = "{\"minRingSize\" : 10}";
+    ConfigOrError configOrError =
+        provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
+    assertThat(configOrError.getError()).isNotNull();
+    assertThat(configOrError.getError().getCode()).isEqualTo(Code.INVALID_ARGUMENT);
+    assertThat(configOrError.getError().getDescription())
+        .isEqualTo("Missing 'mingRingSize'/'maxRingSize'");
+  }
+
+  @Test
+  public void parseLoadBalancingConfig_zeroMinRingSize() throws IOException {
+    String lbConfig = "{\"minRingSize\" : 0, \"maxRingSize\" : 100}";
+    ConfigOrError configOrError =
+        provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
+    assertThat(configOrError.getError()).isNotNull();
+    assertThat(configOrError.getError().getCode()).isEqualTo(Code.INVALID_ARGUMENT);
+    assertThat(configOrError.getError().getDescription())
+        .isEqualTo("Invalid 'mingRingSize'/'maxRingSize'");
+  }
+
+  @Test
+  public void parseLoadBalancingConfig_minRingSizeGreaterThanMaxRingSize() throws IOException {
+    String lbConfig = "{\"minRingSize\" : 100, \"maxRingSize\" : 10}";
+    ConfigOrError configOrError =
+        provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
+    assertThat(configOrError.getError()).isNotNull();
+    assertThat(configOrError.getError().getCode()).isEqualTo(Code.INVALID_ARGUMENT);
+    assertThat(configOrError.getError().getDescription())
+        .isEqualTo("Invalid 'mingRingSize'/'maxRingSize'");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, ?> parseJsonObject(String json) throws IOException {
+    return (Map<String, ?>) JsonParser.parse(json);
+  }
+}

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerProviderTest.java
@@ -17,11 +17,13 @@
 package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.grpc.InternalServiceProviders;
 import io.grpc.LoadBalancer.Helper;
-import io.grpc.LoadBalancerRegistry;
+import io.grpc.LoadBalancerProvider;
 import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.Status.Code;
 import io.grpc.SynchronizationContext;
@@ -50,8 +52,13 @@ public class RingHashLoadBalancerProviderTest {
 
   @Test
   public void provided() {
-    LoadBalancerRegistry registry = LoadBalancerRegistry.getDefaultRegistry();
-    assertThat(registry.getProvider("ring_hash")).isInstanceOf(RingHashLoadBalancerProvider.class);
+    for (LoadBalancerProvider current : InternalServiceProviders.getCandidatesViaServiceLoader(
+        LoadBalancerProvider.class, getClass().getClassLoader())) {
+      if (current instanceof RingHashLoadBalancerProvider) {
+        return;
+      }
+    }
+    fail("RingHashLoadBalancerProvider not registered");
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.grpc.ConnectivityState.CONNECTING;
+import static io.grpc.ConnectivityState.IDLE;
+import static io.grpc.ConnectivityState.READY;
+import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Iterables;
+import io.grpc.Attributes;
+import io.grpc.CallOptions;
+import io.grpc.ConnectivityStateInfo;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancer.CreateSubchannelArgs;
+import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancer.PickResult;
+import io.grpc.LoadBalancer.PickSubchannelArgs;
+import io.grpc.LoadBalancer.ResolvedAddresses;
+import io.grpc.LoadBalancer.Subchannel;
+import io.grpc.LoadBalancer.SubchannelPicker;
+import io.grpc.LoadBalancer.SubchannelStateListener;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.Status.Code;
+import io.grpc.internal.PickSubchannelArgsImpl;
+import io.grpc.testing.TestMethodDescriptors;
+import io.grpc.xds.RingHashLoadBalancer.RingHashConfig;
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.stubbing.Answer;
+
+/** Unit test for {@link io.grpc.LoadBalancer}. */
+@RunWith(JUnit4.class)
+public class RingHashLoadBalancerTest {
+  @Rule
+  public final MockitoRule mocks = MockitoJUnit.rule();
+
+  private final Map<List<EquivalentAddressGroup>, Subchannel> subchannels = new HashMap<>();
+  private final Map<Subchannel, SubchannelStateListener> subchannelStateListeners =
+      new HashMap<>();
+  private final XxHash64 hashFunc = XxHash64.INSTANCE;
+  @Mock
+  private Helper helper;
+  @Captor
+  private ArgumentCaptor<SubchannelPicker> pickerCaptor;
+  private RingHashLoadBalancer loadBalancer;
+
+  @Before
+  public void setUp() {
+    when(helper.createSubchannel(any(CreateSubchannelArgs.class))).thenAnswer(
+        new Answer<Subchannel>() {
+          @Override
+          public Subchannel answer(InvocationOnMock invocation) throws Throwable {
+            CreateSubchannelArgs args = (CreateSubchannelArgs) invocation.getArguments()[0];
+            final Subchannel subchannel = mock(Subchannel.class);
+            when(subchannel.getAllAddresses()).thenReturn(args.getAddresses());
+            when(subchannel.getAttributes()).thenReturn(args.getAttributes());
+            subchannels.put(args.getAddresses(), subchannel);
+            doAnswer(new Answer<Void>() {
+              @Override
+              public Void answer(InvocationOnMock invocation) throws Throwable {
+                subchannelStateListeners.put(
+                    subchannel, (SubchannelStateListener) invocation.getArguments()[0]);
+                return null;
+              }
+            }).when(subchannel).start(any(SubchannelStateListener.class));
+            return subchannel;
+          }
+        });
+    loadBalancer = new RingHashLoadBalancer(helper);
+  }
+
+  @After
+  public void tearDown() {
+    loadBalancer.shutdown();
+    for (Subchannel subchannel : subchannels.values()) {
+      verify(subchannel).shutdown();
+    }
+  }
+
+  @Test
+  public void subchannelLazyConnectUntilPicked() {
+    RingHashConfig config = new RingHashConfig(10, 100);
+    List<EquivalentAddressGroup> servers = createServers(1, 1, 1);
+    loadBalancer.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
+    assertThat(subchannels).isEmpty();
+    verify(helper).updateBalancingState(eq(IDLE), pickerCaptor.capture());
+
+    // Picking subchannel triggers connection.
+    PickSubchannelArgs args = new PickSubchannelArgsImpl(
+        TestMethodDescriptors.voidMethod(), new Metadata(),
+        CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, hashFunc.hashVoid()));
+    PickResult result = pickerCaptor.getValue().pickSubchannel(args);
+    assertThat(result.getStatus().isOk()).isTrue();
+    assertThat(result.getSubchannel()).isNull();
+    verify(helper).createSubchannel(any(CreateSubchannelArgs.class));
+    assertThat(subchannels).hasSize(1);
+    Subchannel subchannel = Iterables.getOnlyElement(subchannels.values());
+    verify(subchannel).requestConnection();
+    deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(CONNECTING));
+    verify(helper).updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
+
+    // Subchannel becomes ready, triggers pick again.
+    deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(READY));
+    verify(helper).updateBalancingState(eq(READY), pickerCaptor.capture());
+    result = pickerCaptor.getValue().pickSubchannel(args);
+    assertThat(result.getSubchannel()).isSameInstanceAs(subchannel);
+  }
+
+  @Test
+  public void subchannelNotAutoReconnectAfterDisconnected() {
+    RingHashConfig config = new RingHashConfig(10, 100);
+    List<EquivalentAddressGroup> servers = createServers(1, 1, 1);
+    loadBalancer.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
+    verify(helper).updateBalancingState(eq(IDLE), pickerCaptor.capture());
+
+    // Picking subchannel triggers connection.
+    PickSubchannelArgs args = new PickSubchannelArgsImpl(
+        TestMethodDescriptors.voidMethod(), new Metadata(),
+        CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, hashFunc.hashVoid()));
+    pickerCaptor.getValue().pickSubchannel(args);
+    verify(helper).createSubchannel(any(CreateSubchannelArgs.class));
+    Subchannel subchannel = Iterables.getOnlyElement(subchannels.values());
+    verify(subchannel, times(1)).requestConnection();
+    deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(READY));
+    verify(helper).updateBalancingState(eq(READY), any(SubchannelPicker.class));
+    deliverSubchannelState(subchannel, ConnectivityStateInfo.forTransientFailure(
+        Status.UNAUTHENTICATED.withDescription("Permission denied")));
+    verify(helper, times(2)).updateBalancingState(eq(IDLE), pickerCaptor.capture());
+    verify(subchannel, times(1)).requestConnection();
+
+    // Picking again triggers reconnection.
+    pickerCaptor.getValue().pickSubchannel(args);
+    verify(subchannel, times(2)).requestConnection();
+  }
+
+  @Test
+  public void deterministicPickWithHostsPartiallyRemoved() {
+    RingHashConfig config = new RingHashConfig(10, 100);
+    List<EquivalentAddressGroup> servers = createServers(1, 1, 1, 1, 1);
+    loadBalancer.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
+    verify(helper).updateBalancingState(eq(IDLE), pickerCaptor.capture());
+
+    // Simulate rpc hash hits one ring entry exactly.
+    long rpcHash = hashFunc.hashAsciiString("[FakeSocketAddress-server1]_0");
+    PickSubchannelArgs args = new PickSubchannelArgsImpl(
+        TestMethodDescriptors.voidMethod(), new Metadata(),
+        CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, rpcHash));
+    pickerCaptor.getValue().pickSubchannel(args);
+    deliverSubchannelState(
+        Iterables.getOnlyElement(subchannels.values()), ConnectivityStateInfo.forNonError(READY));
+    verify(helper).updateBalancingState(eq(READY), pickerCaptor.capture());
+    PickResult result = pickerCaptor.getValue().pickSubchannel(args);
+    Subchannel subchannel = result.getSubchannel();
+    assertThat(subchannel.getAddresses()).isEqualTo(servers.get(1));
+
+    servers = servers.subList(0, 2);  // only server0 and server1 left
+    loadBalancer.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
+    verify(helper, times(2)).updateBalancingState(eq(READY), pickerCaptor.capture());
+    assertThat(pickerCaptor.getValue().pickSubchannel(args).getSubchannel())
+        .isSameInstanceAs(subchannel);
+  }
+
+  @Test
+  public void deterministicPickWithNewHostsAdded() {
+    RingHashConfig config = new RingHashConfig(10, 100);
+    List<EquivalentAddressGroup> servers = createServers(1, 1);  // server0 and server1
+    loadBalancer.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
+    verify(helper).updateBalancingState(eq(IDLE), pickerCaptor.capture());
+
+    // Simulate rpc hash hits one ring entry exactly.
+    long rpcHash = hashFunc.hashAsciiString("[FakeSocketAddress-server1]_0");
+    PickSubchannelArgs args = new PickSubchannelArgsImpl(
+        TestMethodDescriptors.voidMethod(), new Metadata(),
+        CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, rpcHash));
+    pickerCaptor.getValue().pickSubchannel(args);
+    deliverSubchannelState(
+        Iterables.getOnlyElement(subchannels.values()), ConnectivityStateInfo.forNonError(READY));
+    verify(helper).updateBalancingState(eq(READY), pickerCaptor.capture());
+    PickResult result = pickerCaptor.getValue().pickSubchannel(args);
+    Subchannel subchannel = result.getSubchannel();
+    assertThat(subchannel.getAddresses()).isEqualTo(servers.get(1));
+
+    servers = createServers(1, 1, 1, 1, 1);  // server2, server3, server4 added
+    loadBalancer.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
+    verify(helper, times(2)).updateBalancingState(eq(READY), pickerCaptor.capture());
+    assertThat(pickerCaptor.getValue().pickSubchannel(args).getSubchannel())
+        .isSameInstanceAs(subchannel);
+  }
+
+  @Test
+  public void hostSelectionProportionalToWeights() {
+    RingHashConfig config = new RingHashConfig(11100, 111000);
+    List<EquivalentAddressGroup> servers = createServers(1, 100, 10000);  // 1:100:10000
+    loadBalancer.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
+    verify(helper).updateBalancingState(eq(IDLE), pickerCaptor.capture());
+
+    // Warm up by trying to connect to all servers.
+    for (int i = 0; i < 3; i++) {
+      long rpcHash = hashFunc.hashAsciiString(String.format("[FakeSocketAddress-server%d]_0", i));
+      PickSubchannelArgs args = new PickSubchannelArgsImpl(
+          TestMethodDescriptors.voidMethod(), new Metadata(),
+          CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, rpcHash));
+      pickerCaptor.getValue().pickSubchannel(args);
+      verify(helper, times(i + 1)).createSubchannel(any(CreateSubchannelArgs.class));
+    }
+    assertThat(subchannels).hasSize(3);
+
+    // Bring all subchannels to READY.
+    Map<EquivalentAddressGroup, Integer> pickCounts = new HashMap<>();
+    for (Subchannel subchannel : subchannels.values()) {
+      verify(subchannel).requestConnection();
+      deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(READY));
+      pickCounts.put(subchannel.getAddresses(), 0);
+    }
+    verify(helper, times(3)).updateBalancingState(eq(READY), pickerCaptor.capture());
+    SubchannelPicker picker = pickerCaptor.getValue();
+
+    for (int i = 0; i < 10000; i++) {
+      long hash = hashFunc.hashInt(i);
+      PickSubchannelArgs args = new PickSubchannelArgsImpl(
+          TestMethodDescriptors.voidMethod(), new Metadata(),
+          CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, hash));
+      Subchannel pickedSubchannel = picker.pickSubchannel(args).getSubchannel();
+      EquivalentAddressGroup addr = pickedSubchannel.getAddresses();
+      pickCounts.put(addr, pickCounts.get(addr) + 1);
+    }
+
+    // Actual distribution: server0 = 0, server1 = 90, server2 = 9910
+    double ratio01 = (double) pickCounts.get(servers.get(0)) / pickCounts.get(servers.get(1));
+    double ratio12 = (double) pickCounts.get(servers.get(1)) / pickCounts.get(servers.get(2));
+    assertThat(ratio01).isWithin(0.01).of((double) 1 / 100);
+    assertThat(ratio12).isWithin(0.01).of((double) 100 / 10000);
+  }
+
+  @Test
+  public void nameResolutionErrorWithNoActiveSubchannels() {
+    Status error = Status.UNAVAILABLE.withDescription("not reachable");
+    loadBalancer.handleNameResolutionError(error);
+    verify(helper).updateBalancingState(eq(TRANSIENT_FAILURE), pickerCaptor.capture());
+    PickResult result = pickerCaptor.getValue().pickSubchannel(mock(PickSubchannelArgs.class));
+    assertThat(result.getStatus().getCode()).isEqualTo(Code.UNAVAILABLE);
+    assertThat(result.getStatus().getDescription()).isEqualTo("not reachable");
+    assertThat(result.getSubchannel()).isNull();
+    verifyNoMoreInteractions(helper);
+  }
+
+  @Test
+  public void nameResolutionErrorWithActiveSubchannels() {
+    RingHashConfig config = new RingHashConfig(10, 100);
+    List<EquivalentAddressGroup> servers = createServers(1, 1, 1);
+    loadBalancer.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
+    verify(helper).updateBalancingState(eq(IDLE), pickerCaptor.capture());
+
+    // Picking subchannel triggers subchannel creation and connection.
+    PickSubchannelArgs args = new PickSubchannelArgsImpl(
+        TestMethodDescriptors.voidMethod(), new Metadata(),
+        CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, hashFunc.hashVoid()));
+    pickerCaptor.getValue().pickSubchannel(args);
+    verify(helper).createSubchannel(any(CreateSubchannelArgs.class));
+    Subchannel subchannel = Iterables.getOnlyElement(subchannels.values());
+    verify(subchannel).requestConnection();
+    deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(READY));
+    verify(helper).updateBalancingState(eq(READY), any(SubchannelPicker.class));
+
+    loadBalancer.handleNameResolutionError(Status.NOT_FOUND.withDescription("target not found"));
+    verifyNoMoreInteractions(helper);
+  }
+
+  private static List<EquivalentAddressGroup> createServers(long... weights) {
+    List<EquivalentAddressGroup> res = new ArrayList<>();
+    for (int i = 0; i < weights.length; i++) {
+      SocketAddress addr = new FakeSocketAddress("server" + i);
+      Attributes attr = Attributes.newBuilder().set(
+          InternalXdsAttributes.ATTR_SERVER_WEIGHT, weights[i]).build();
+      EquivalentAddressGroup eag = new EquivalentAddressGroup(addr, attr);
+      res.add(eag);
+    }
+    return res;
+  }
+
+  private void deliverSubchannelState(Subchannel subchannel, ConnectivityStateInfo state) {
+    subchannelStateListeners.get(subchannel).onSubchannelState(state);
+  }
+
+  private static class FakeSocketAddress extends SocketAddress {
+    private final String name;
+
+    FakeSocketAddress(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public int hashCode() {
+      return name.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (!(other instanceof FakeSocketAddress)) {
+        return false;
+      }
+      return name.equals(((FakeSocketAddress) other).name);
+    }
+
+    @Override
+    public String toString() {
+      return "FakeSocketAddress-" +  name;
+    }
+  }
+}

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
@@ -75,6 +75,7 @@ import org.mockito.stubbing.Answer;
 /** Unit test for {@link io.grpc.LoadBalancer}. */
 @RunWith(JUnit4.class)
 public class RingHashLoadBalancerTest {
+  private static final String AUTHORITY = "foo.googleapis.com";
   private static final Attributes.Key<String> CUSTOM_KEY = Attributes.Key.create("custom-key");
 
   @Rule
@@ -91,6 +92,7 @@ public class RingHashLoadBalancerTest {
 
   @Before
   public void setUp() {
+    when(helper.getAuthority()).thenReturn(AUTHORITY);
     when(helper.createSubchannel(any(CreateSubchannelArgs.class))).thenAnswer(
         new Answer<Subchannel>() {
           @Override
@@ -112,6 +114,7 @@ public class RingHashLoadBalancerTest {
           }
         });
     loadBalancer = new RingHashLoadBalancer(helper);
+    verify(helper).getAuthority();  // skip this interaction
   }
 
   @After

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
@@ -669,11 +669,6 @@ public class RingHashLoadBalancerTest {
     verifyNoMoreInteractions(helper);
   }
 
-  @Test
-  public void aggregateSubchannelStates() {
-
-  }
-
   private static List<EquivalentAddressGroup> createWeightedServerAddrs(long... weights) {
     List<EquivalentAddressGroup> addrs = new ArrayList<>();
     for (int i = 0; i < weights.length; i++) {

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
@@ -669,6 +669,10 @@ public class RingHashLoadBalancerTest {
     verifyNoMoreInteractions(helper);
   }
 
+  private void deliverSubchannelState(Subchannel subchannel, ConnectivityStateInfo state) {
+    subchannelStateListeners.get(subchannel).onSubchannelState(state);
+  }
+
   private static List<EquivalentAddressGroup> createWeightedServerAddrs(long... weights) {
     List<EquivalentAddressGroup> addrs = new ArrayList<>();
     for (int i = 0; i < weights.length; i++) {
@@ -691,10 +695,6 @@ public class RingHashLoadBalancerTest {
       }
     }
     return addrs;
-  }
-
-  private void deliverSubchannelState(Subchannel subchannel, ConnectivityStateInfo state) {
-    subchannelStateListeners.get(subchannel).onSubchannelState(state);
   }
 
   private static class FakeSocketAddress extends SocketAddress {


### PR DESCRIPTION
Implements the [ring hash](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#ring-hash) load balancing policy.

- The policy can accept addresses weighted by the per-address weight attribute or having multiple instances of the same address. E.g., [addr0(ATTR=1), addr1(ATTR=2)] is equivalent to [addr0, addr1, addr1].
- The ring hash policy will not proactively connect to all addresses. Instead, it will wait for a request to hit a given address before it attempts to connect. 

Special subchannel and picker behaviors:
- At any point of time, there will be at least one subchannel making connection (or has been connected). This comes with the following picking algorithm:
  - If the host hit by RPC's hash is connected, return the READY subchannel to that host.
  - If the subchannel hit by RPC's hash is in IDLE or CONNECTING, buffer the picker while request connection if it's IDLE.
  - If the subchannel hit by RPC's hash is in TRANSIENT_FAILURE, try next subchannel following the ring clockwise:
     - If the subchannel is in READY, CONNECTING or IDLE, do the same as above.
     - If the subchannel is in TRANSIENT_FAILURE, try iterating through all the remaining subchannels:
        - If a READY subchannel is found, done pick with that subchannel.
        - Kick off connection for the first IDLE subchannel, if none of the previous ones are in CONNECTING. The pick would still fail the RPC. Note the iteration should keep going and only exit when a READY subchannel is found or the ring is exhausted.

- Given Java's subchannel implementation performs auto-reconnection itself if connection fails, nothing needs to be done on the load balancer level for _subchannels in TRANSIENT_FAILURE_.

With this picking algorithm, the ring hash load balancer should only reports TRANSIENT_FAILURE (to its parent load balancer or Channel) if there are _two or more_ subchannels in TRANSIENT_FAILURE.