### PR TITLE
xds: delete redundant hash function configuration

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -70,7 +70,6 @@ import io.grpc.xds.VirtualHost.Route.RouteAction;
 import io.grpc.xds.VirtualHost.Route.RouteAction.ClusterWeight;
 import io.grpc.xds.VirtualHost.Route.RouteAction.HashPolicy;
 import io.grpc.xds.VirtualHost.Route.RouteMatch;
-import io.grpc.xds.XdsClient.CdsUpdate.HashFunction;
 import io.grpc.xds.XdsLogger.XdsLogLevel;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -762,20 +761,21 @@ final class ClientXdsClient extends AbstractXdsClient {
       String lbPolicy = CaseFormat.UPPER_UNDERSCORE.to(
           CaseFormat.LOWER_UNDERSCORE, cluster.getLbPolicy().name());
       if (cluster.getLbPolicy() == LbPolicy.RING_HASH) {
-        HashFunction hashFunction;
         RingHashLbConfig lbConfig = cluster.getRingHashLbConfig();
-        if (lbConfig.getHashFunction() == RingHashLbConfig.HashFunction.XX_HASH) {
-          hashFunction = HashFunction.XX_HASH;
-        } else {
+        if (lbConfig.getHashFunction() != RingHashLbConfig.HashFunction.XX_HASH) {
           nackResponse(ResourceType.CDS, nonce,
               "Cluster " + clusterName + ": unsupported ring hash function: "
                   + lbConfig.getHashFunction());
           return;
         }
         updateBuilder.lbPolicy(lbPolicy, lbConfig.getMinimumRingSize().getValue(),
-            lbConfig.getMaximumRingSize().getValue(), hashFunction);
-      } else {
+            lbConfig.getMaximumRingSize().getValue());
+      } else if (cluster.getLbPolicy() == LbPolicy.ROUND_ROBIN) {
         updateBuilder.lbPolicy(lbPolicy);
+      } else {
+        nackResponse(ResourceType.CDS, nonce,
+            "Cluster " + clusterName + ": unsupported lb policy: " + cluster.getLbPolicy());
+        return;
       }
       cdsUpdates.put(clusterName, updateBuilder.build());
     }

--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -173,10 +173,6 @@ abstract class XdsClient {
     // Only valid if lbPolicy is "ring_hash".
     abstract long maxRingSize();
 
-    // Only valid if lbPolicy is "ring_hash".
-    @Nullable
-    abstract HashFunction hashFunction();
-
     // Alternative resource name to be used in EDS requests.
     /// Only valid for EDS cluster.
     @Nullable
@@ -242,10 +238,6 @@ abstract class XdsClient {
       EDS, LOGICAL_DNS, AGGREGATE
     }
 
-    enum HashFunction {
-      XX_HASH
-    }
-
     // FIXME(chengyuanzhang): delete this after UpstreamTlsContext's toString() is fixed.
     @Override
     public final String toString() {
@@ -255,7 +247,6 @@ abstract class XdsClient {
           .add("lbPolicy", lbPolicy())
           .add("minRingSize", minRingSize())
           .add("maxRingSize", maxRingSize())
-          .add("hashFunction", hashFunction())
           .add("edsServiceName", edsServiceName())
           .add("lrsServerName", lrsServerName())
           .add("maxConcurrentRequests", maxConcurrentRequests())
@@ -275,10 +266,8 @@ abstract class XdsClient {
       // Private do not use.
       protected abstract Builder lbPolicy(String lbPolicy);
 
-      Builder lbPolicy(String lbPolicy, long minRingSize, long maxRingSize,
-          HashFunction hashFunction) {
-        return this.lbPolicy(lbPolicy).minRingSize(minRingSize).maxRingSize(maxRingSize)
-            .hashFunction(checkNotNull(hashFunction, "hashFunction"));
+      Builder lbPolicy(String lbPolicy, long minRingSize, long maxRingSize) {
+        return this.lbPolicy(lbPolicy).minRingSize(minRingSize).maxRingSize(maxRingSize);
       }
 
       // Private do not use.
@@ -286,9 +275,6 @@ abstract class XdsClient {
 
       // Private do not use.
       protected abstract Builder maxRingSize(long maxRingSize);
-
-      // Private do not use.
-      protected abstract Builder hashFunction(HashFunction hashFunction);
 
       // Private do not use.
       protected abstract Builder edsServiceName(String edsServiceName);

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
@@ -56,7 +56,6 @@ import io.grpc.xds.LoadStatsManager2.ClusterDropStats;
 import io.grpc.xds.XdsClient.CdsResourceWatcher;
 import io.grpc.xds.XdsClient.CdsUpdate;
 import io.grpc.xds.XdsClient.CdsUpdate.ClusterType;
-import io.grpc.xds.XdsClient.CdsUpdate.HashFunction;
 import io.grpc.xds.XdsClient.EdsResourceWatcher;
 import io.grpc.xds.XdsClient.EdsUpdate;
 import io.grpc.xds.XdsClient.LdsResourceWatcher;
@@ -654,7 +653,6 @@ public abstract class ClientXdsClientTestBase {
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.EDS);
     assertThat(cdsUpdate.edsServiceName()).isNull();
     assertThat(cdsUpdate.lbPolicy()).isEqualTo("ring_hash");
-    assertThat(cdsUpdate.hashFunction()).isEqualTo(HashFunction.XX_HASH);
     assertThat(cdsUpdate.minRingSize()).isEqualTo(10L);
     assertThat(cdsUpdate.maxRingSize()).isEqualTo(100L);
     assertThat(cdsUpdate.lrsServerName()).isNull();


### PR DESCRIPTION
Initially we were about to support both xx_hash and murmur_hash. But later we decided to support xx_hash only. So for any hashing we are using in xDS, it's going to be xx_hash. Therefore, we do not need to define and carry this configuration around.