### PR TITLE
Add a flag to interop clients to allow statically configuring grpclb

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -147,6 +147,7 @@ public class TestServiceClient {
       } else if ("local_handshaker_port".equals(key)) {
         localHandshakerPort = Integer.parseInt(value);
       } else if ("service_config_json".equals(key)) {
+        @SuppressWarnings("unchecked")
         serviceConfig = (Map<String, ?>) JsonParser.parse(value);
       } else {
         System.err.println("Unknown argument: " + key);

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -85,8 +85,7 @@ public class TestServiceClient {
   private String oauthScope;
   private boolean fullStreamDecompression;
   private int localHandshakerPort = -1;
-  private boolean disableServiceConfigLookUp = false;
-  private <String, ?> defaultServiceConfig = null;
+  private <String, ?> serviceConfig = null;
 
   private Tester tester = new Tester();
 
@@ -148,8 +147,7 @@ public class TestServiceClient {
       } else if ("local_handshaker_port".equals(key)) {
         localHandshakerPort = Integer.parseInt(value);
       } else if ("service_config_json".equals(key)) {
-        defaultServiceConfig = (Map<String, ?>) JsonParser.parse(value);
-        disableServiceConfigLookUp = true;
+        serviceConfig = (Map<String, ?>) JsonParser.parse(value);
       } else {
         System.err.println("Unknown argument: " + key);
         usage = true;
@@ -291,11 +289,9 @@ public class TestServiceClient {
         ManagedChannelBuilder<?> builder =
             Grpc.newChannelBuilderForAddress(
                 serverHost, serverPort, ComputeEngineChannelCredentials.create());
-        if (disableServiceConfigLookUp) {
+        if (serviceConfig != null) {
           builder.disableServiceConfigLookUp();
-        }
-        if (defaultServiceConfig != null) {
-          builder.defaultServiceConfig(defaultServiceConfig);
+          builder.defaultServiceConfig(serviceConfig);
         }
         ManagedChannel channel = builder.build();
         try {
@@ -340,11 +336,9 @@ public class TestServiceClient {
         ManagedChannelBuilder<?> builder =
             Grpc.newChannelBuilderForAddress(
                 serverHost, serverPort, GoogleDefaultChannelCredentials.create());
-        if (disableServiceConfigLookUp) {
+        if (serviceConfig != null) {
           builder.disableServiceConfigLookUp();
-        }
-        if (defaultServiceConfig != null) {
-          builder.defaultServiceConfig(defaultServiceConfig);
+          builder.defaultServiceConfig(serviceConfig);
         }
         ManagedChannel channel = builder.build();
         try {
@@ -467,11 +461,9 @@ public class TestServiceClient {
         if (serverHostOverride != null) {
           channelBuilder.overrideAuthority(serverHostOverride);
         }
-        if (disableServiceConfigLookUp) {
+        if (serviceConfig != null) {
           channelBuilder.disableServiceConfigLookUp();
-        }
-        if (defaultServiceConfig != null) {
-          channelBuilder.defaultServiceConfig(defaultServiceConfig);
+          channelBuilder.defaultServiceConfig(serviceConfig);
         }
         return channelBuilder;
       }
@@ -487,11 +479,9 @@ public class TestServiceClient {
         }
         // Disable the default census stats interceptor, use testing interceptor instead.
         InternalNettyChannelBuilder.setStatsEnabled(nettyBuilder, false);
-        if (disableServiceConfigLookUp) {
+        if (serviceConfig != null) {
           nettyBuilder.disableServiceConfigLookUp();
-        }
-        if (defaultServiceConfig != null) {
-          nettyBuilder.defaultServiceConfig(defaultServiceConfig);
+          nettyBuilder.defaultServiceConfig(serviceConfig);
         }
         return nettyBuilder.intercept(createCensusStatsClientInterceptor());
       }
@@ -508,11 +498,9 @@ public class TestServiceClient {
       }
       // Disable the default census stats interceptor, use testing interceptor instead.
       InternalOkHttpChannelBuilder.setStatsEnabled(okBuilder, false);
-      if (disableServiceConfigLookUp) {
-        okBuilder.disableServiceConfigLookUp();
-      }
       if (defaultServiceConfig != null) {
-        okBuilder.defaultServiceConfig(defaultServiceConfig);
+        okBuilder.disableServiceConfigLookUp();
+        okBuilder.defaultServiceConfig(serviceConfig);
       }
       return okBuilder.intercept(createCensusStatsClientInterceptor());
     }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -299,16 +299,16 @@ public class TestServiceClient {
         break;
 
       case COMPUTE_ENGINE_CHANNEL_CREDENTIALS: {
-          ManagedChannelBuilder<?> builder =
-              Grpc.newChannelBuilderForAddress(
-                  serverHost, serverPort, ComputeEngineChannelCredentials.create());
-          if (disableServiceConfigLookUp) {
-            builder.disableServiceConfigLookUp();
-          }
-          if (defaultServiceConfig != null) {
-            builder.defaultServiceConfig(defaultServiceConfig);
-          }
-          ManagedChannel channel = builder.build();
+        ManagedChannelBuilder<?> builder =
+            Grpc.newChannelBuilderForAddress(
+                serverHost, serverPort, ComputeEngineChannelCredentials.create());
+        if (disableServiceConfigLookUp) {
+          builder.disableServiceConfigLookUp();
+        }
+        if (defaultServiceConfig != null) {
+          builder.defaultServiceConfig(defaultServiceConfig);
+        }
+        ManagedChannel channel = builder.build();
         try {
           TestServiceGrpc.TestServiceBlockingStub computeEngineStub =
               TestServiceGrpc.newBlockingStub(channel);
@@ -348,16 +348,16 @@ public class TestServiceClient {
       }
 
       case GOOGLE_DEFAULT_CREDENTIALS: {
-          ManagedChannelBuilder<?> builder =
-              Grpc.newChannelBuilderForAddress(
-                  serverHost, serverPort, GoogleDefaultChannelCredentials.create());
-          if (disableServiceConfigLookUp) {
-            builder.disableServiceConfigLookUp();
-          }
-          if (defaultServiceConfig != null) {
-            builder.defaultServiceConfig(defaultServiceConfig);
-          }
-          ManagedChannel channel = builder.build();
+        ManagedChannelBuilder<?> builder =
+            Grpc.newChannelBuilderForAddress(
+                serverHost, serverPort, GoogleDefaultChannelCredentials.create());
+        if (disableServiceConfigLookUp) {
+          builder.disableServiceConfigLookUp();
+        }
+        if (defaultServiceConfig != null) {
+          builder.defaultServiceConfig(defaultServiceConfig);
+        }
+        ManagedChannel channel = builder.build();
         try {
           TestServiceGrpc.TestServiceBlockingStub googleDefaultStub =
               TestServiceGrpc.newBlockingStub(channel);

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -148,7 +148,8 @@ public class TestServiceClient {
         localHandshakerPort = Integer.parseInt(value);
       } else if ("service_config_json".equals(key)) {
         @SuppressWarnings("unchecked")
-        serviceConfig = (Map<String, ?>) JsonParser.parse(value);
+        Map<String, ?> map = (Map<String, ?>) JsonParser.parse(value);
+        serviceConfig = map;
       } else {
         System.err.println("Unknown argument: " + key);
         usage = true;

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -85,7 +85,7 @@ public class TestServiceClient {
   private String oauthScope;
   private boolean fullStreamDecompression;
   private int localHandshakerPort = -1;
-  private <String, ?> serviceConfig = null;
+  private Map<String, ?> serviceConfig = null;
 
   private Tester tester = new Tester();
 
@@ -498,7 +498,7 @@ public class TestServiceClient {
       }
       // Disable the default census stats interceptor, use testing interceptor instead.
       InternalOkHttpChannelBuilder.setStatsEnabled(okBuilder, false);
-      if (defaultServiceConfig != null) {
+      if (serviceConfig != null) {
         okBuilder.disableServiceConfigLookUp();
         okBuilder.defaultServiceConfig(serviceConfig);
       }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -40,8 +40,8 @@ import io.grpc.okhttp.OkHttpChannelBuilder;
 import java.io.File;
 import java.io.FileInputStream;
 import java.nio.charset.Charset;
-import java.util.concurrent.TimeUnit;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TestServiceClientTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TestServiceClientTest.java
@@ -25,7 +25,7 @@ import org.junit.runners.JUnit4;
 public class TestServiceClientTest {
 
   @Test
-  public void emptyArgumentListShouldNotThrowException() {
+  public void emptyArgumentListShouldNotThrowException() throws Exception {
     TestServiceClient client = new TestServiceClient();
     client.parseArgs(new String[0]);
     client.setUp();


### PR DESCRIPTION
This is needed as a pre-req for internal issue b/175066772 (in order to use a more recent grpc-java in those tests, we need to configure an explicit grpclb service config).

 The same flag also exists in the C++ test clients (added in https://github.com/grpc/grpc/pull/22540).