### PR TITLE
xds: change system property for reading bootstrap config (backport v1.36.x)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/BootstrapperImpl.java
+++ b/xds/src/main/java/io/grpc/xds/BootstrapperImpl.java
@@ -54,9 +54,9 @@ public class BootstrapperImpl implements Bootstrapper {
   private static final String BOOTSTRAP_CONFIG_SYS_ENV_VAR = "GRPC_XDS_BOOTSTRAP_CONFIG";
   @VisibleForTesting
   static String bootstrapConfigFromEnvVar = System.getenv(BOOTSTRAP_CONFIG_SYS_ENV_VAR);
-  private static final String BOOTSTRAP_CONFIG_SYS_PROPERTY_VAR = "io.grpc.xds.bootstrapValue";
+  private static final String BOOTSTRAP_CONFIG_SYS_PROPERTY = "io.grpc.xds.bootstrapConfig";
   @VisibleForTesting
-  static String bootstrapConfigFromSysProp = System.getProperty(BOOTSTRAP_CONFIG_SYS_PROPERTY_VAR);
+  static String bootstrapConfigFromSysProp = System.getProperty(BOOTSTRAP_CONFIG_SYS_PROPERTY);
   private static final String XDS_V3_SERVER_FEATURE = "xds_v3";
   @VisibleForTesting
   static final String CLIENT_FEATURE_DISABLE_OVERPROVISIONING =
@@ -106,7 +106,7 @@ public class BootstrapperImpl implements Bootstrapper {
             + "- " + BOOTSTRAP_CONFIG_SYS_ENV_VAR + "\n\n"
             + "Java System Properties searched:\n"
             + "- " + BOOTSTRAP_PATH_SYS_PROPERTY + "\n"
-            + "- " + BOOTSTRAP_CONFIG_SYS_PROPERTY_VAR + "\n\n");
+            + "- " + BOOTSTRAP_CONFIG_SYS_PROPERTY + "\n\n");
   }
 
   @VisibleForTesting


### PR DESCRIPTION
Changes from "io.grpc.xds.bootstrapValue" to "io.grpc.xds.bootstrapConfig".


-------------------
Backport of #7961