### PR TITLE
Add .ijwb to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ bazel-testlogs
 *.iml
 *.ipr
 *.iws
+.ijwb
 
 # Eclipse
 .classpath


### PR DESCRIPTION
.ijwb is used for the Bazel IntelliJ plugin.