### PR TITLE
xds: use the correct resource id template as per xDS server gRFC

### DIFF
--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -106,18 +106,18 @@ public abstract class Bootstrapper {
     private List<ServerInfo> servers;
     private final Node node;
     @Nullable private final Map<String, CertificateProviderInfo> certProviders;
-    @Nullable private final String grpcServerResourceId;
+    @Nullable private final String serverListenerResourceNameTemplate;
 
     @VisibleForTesting
     BootstrapInfo(
         List<ServerInfo> servers,
         Node node,
         Map<String, CertificateProviderInfo> certProviders,
-        String grpcServerResourceId) {
+        String serverListenerResourceNameTemplate) {
       this.servers = servers;
       this.node = node;
       this.certProviders = certProviders;
-      this.grpcServerResourceId = grpcServerResourceId;
+      this.serverListenerResourceNameTemplate = serverListenerResourceNameTemplate;
     }
 
     /**
@@ -140,8 +140,8 @@ public abstract class Bootstrapper {
     }
 
     @Nullable
-    public String getGrpcServerResourceId() {
-      return grpcServerResourceId;
+    public String getServerListenerResourceNameTemplate() {
+      return serverListenerResourceNameTemplate;
     }
   }
 }

--- a/xds/src/main/java/io/grpc/xds/BootstrapperImpl.java
+++ b/xds/src/main/java/io/grpc/xds/BootstrapperImpl.java
@@ -215,7 +215,8 @@ public class BootstrapperImpl extends Bootstrapper {
         certProviders.put(name, certificateProviderInfo);
       }
     }
-    String grpcServerResourceId = JsonUtil.getString(rawData, "grpc_server_resource_name_id");
+    String grpcServerResourceId =
+        JsonUtil.getString(rawData, "server_listener_resource_name_template");
     return new BootstrapInfo(servers, nodeBuilder.build(), certProviders, grpcServerResourceId);
   }
 

--- a/xds/src/main/java/io/grpc/xds/XdsClientWrapperForServerSds.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientWrapperForServerSds.java
@@ -112,7 +112,7 @@ public final class XdsClientWrapperForServerSds {
             .keepAliveTime(5, TimeUnit.MINUTES).build();
     timeService = SharedResourceHolder.get(timeServiceResource);
     newServerApi = serverInfo.isUseProtocolV3();
-    String grpcServerResourceId = bootstrapInfo.getGrpcServerResourceId();
+    String grpcServerResourceId = bootstrapInfo.getServerListenerResourceNameTemplate();
     if (newServerApi && grpcServerResourceId == null) {
       throw new IOException(
           "missing server_listener_resource_name_template value in xds bootstrap");

--- a/xds/src/main/java/io/grpc/xds/XdsClientWrapperForServerSds.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientWrapperForServerSds.java
@@ -114,7 +114,8 @@ public final class XdsClientWrapperForServerSds {
     newServerApi = serverInfo.isUseProtocolV3();
     String grpcServerResourceId = bootstrapInfo.getGrpcServerResourceId();
     if (newServerApi && grpcServerResourceId == null) {
-      throw new IOException("missing grpc_server_resource_name_id value in xds bootstrap");
+      throw new IOException(
+          "missing server_listener_resource_name_template value in xds bootstrap");
     }
     XdsClient xdsClientImpl =
         new ClientXdsClient(
@@ -155,8 +156,7 @@ public final class XdsClientWrapperForServerSds {
             reportError(error.asException(), isResourceAbsent(error));
           }
         };
-    grpcServerResourceId =
-        grpcServerResourceId + "?udpa.resource.listening_address=" + ("0.0.0.0:" + port);
+    grpcServerResourceId = grpcServerResourceId.replaceAll("%s", "0.0.0.0:" + port);
     xdsClient.watchLdsResource(grpcServerResourceId, listenerWatcher);
   }
 

--- a/xds/src/test/java/io/grpc/xds/BootstrapperImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/BootstrapperImplTest.java
@@ -552,7 +552,7 @@ public class BootstrapperImplTest {
 
     bootstrapper.setFileReader(createFileReader(BOOTSTRAP_FILE_PATH, rawData));
     BootstrapInfo info = bootstrapper.bootstrap();
-    assertThat(info.getGrpcServerResourceId()).isEqualTo("grpc/serverx=%s");
+    assertThat(info.getServerListenerResourceNameTemplate()).isEqualTo("grpc/serverx=%s");
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/BootstrapperImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/BootstrapperImplTest.java
@@ -547,12 +547,12 @@ public class BootstrapperImplTest {
   public void parseBootstrap_grpcServerResourceId() throws XdsInitializationException {
     String rawData = "{\n"
             + "  \"xds_servers\": [],\n"
-            + "  \"grpc_server_resource_name_id\": \"grpc/serverx\"\n"
+            + "  \"server_listener_resource_name_template\": \"grpc/serverx=%s\"\n"
             + "}";
 
     bootstrapper.setFileReader(createFileReader(BOOTSTRAP_FILE_PATH, rawData));
     BootstrapInfo info = bootstrapper.bootstrap();
-    assertThat(info.getGrpcServerResourceId()).isEqualTo("grpc/serverx");
+    assertThat(info.getGrpcServerResourceId()).isEqualTo("grpc/serverx=%s");
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/XdsClientWrapperForServerSdsTestMisc.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientWrapperForServerSdsTestMisc.java
@@ -202,6 +202,17 @@ public class XdsClientWrapperForServerSdsTestMisc {
     verify(mockServerWatcher, never()).onError(any(Throwable.class), eq(false));
   }
 
+  @Test
+  public void xdsClientStart_multipleReplacements() {
+    xdsClientWrapperForServerSds.start(xdsClient, "grpc/server?%s and %s and one more %s");
+    ArgumentCaptor<XdsClient.LdsResourceWatcher> listenerWatcherCaptor =
+        ArgumentCaptor.forClass(null);
+    verify(xdsClient)
+        .watchLdsResource(
+            eq("grpc/server?0.0.0.0:7000 and 0.0.0.0:7000 and one more 0.0.0.0:7000"),
+            listenerWatcherCaptor.capture());
+  }
+
   private DownstreamTlsContext sendListenerUpdate(
       SocketAddress localAddress, DownstreamTlsContext tlsContext) throws UnknownHostException {
     when(channel.localAddress()).thenReturn(localAddress);
@@ -218,7 +229,8 @@ public class XdsClientWrapperForServerSdsTestMisc {
     XdsClient mockXdsClient = mock(XdsClient.class);
     XdsClientWrapperForServerSds xdsClientWrapperForServerSds =
         new XdsClientWrapperForServerSds(port);
-    xdsClientWrapperForServerSds.start(mockXdsClient, "grpc/server");
+    xdsClientWrapperForServerSds.start(
+        mockXdsClient, "grpc/server?udpa.resource.listening_address=%s");
     XdsSdsClientServerTest.generateListenerUpdateToWatcher(
         downstreamTlsContext, xdsClientWrapperForServerSds.getListenerWatcher());
     return xdsClientWrapperForServerSds;

--- a/xds/src/test/java/io/grpc/xds/XdsServerTestHelper.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerTestHelper.java
@@ -33,7 +33,8 @@ class XdsServerTestHelper {
       XdsClientWrapperForServerSds xdsClientWrapperForServerSds,
       XdsClient mockXdsClient,
       int port) {
-    xdsClientWrapperForServerSds.start(mockXdsClient, "grpc/server");
+    xdsClientWrapperForServerSds.start(
+        mockXdsClient, "grpc/server?udpa.resource.listening_address=%s");
     ArgumentCaptor<XdsClient.LdsResourceWatcher> listenerWatcherCaptor = ArgumentCaptor
         .forClass(null);
     verify(mockXdsClient)


### PR DESCRIPTION
To match the spec in https://github.com/grpc/proposal/blob/master/A36-xds-for-servers.md#xds-protocol .
