### PR TITLE
Upgrading netty-tcnative to 2.0.36.Final for ARM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,7 @@ subprojects {
             // SECURITY.md (multiple occurrences)
             // examples/example-tls/build.gradle
             // examples/example-tls/pom.xml
-            netty_tcnative: 'io.netty:netty-tcnative-boringssl-static:2.0.34.Final',
+            netty_tcnative: 'io.netty:netty-tcnative-boringssl-static:2.0.36.Final',
 
             conscrypt: 'org.conscrypt:conscrypt-openjdk-uber:2.5.1',
             re2j: 'com.google.re2j:re2j:1.5',

--- a/examples/example-xds/build.gradle
+++ b/examples/example-xds/build.gradle
@@ -23,7 +23,6 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.37.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def nettyTcNativeVersion = '2.0.31.Final'
 def protocVersion = '3.12.0'
 
 dependencies {

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -32,7 +32,7 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "io.netty:netty-handler-proxy:4.1.52.Final",
     "io.netty:netty-handler:4.1.52.Final",
     "io.netty:netty-resolver:4.1.52.Final",
-    "io.netty:netty-tcnative-boringssl-static:2.0.34.Final",
+    "io.netty:netty-tcnative-boringssl-static:2.0.36.Final",
     "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.52.Final",
     "io.netty:netty-transport:4.1.52.Final",
     "io.opencensus:opencensus-api:0.24.0",


### PR DESCRIPTION
Netty-tcnative was not working for ARM machine (aarch64) before 2.0.36.Final, because of the filename mismatch when loading "libnetty_tcnative_linux_aarch_64.so".

Here is my project to reproduce the problem on ARM machines: https://github.com/suztomo/netty-shaded-openssl

The problem has been fixed in 2.0.36.Final (latest) netty/netty-tcnative#552 (comment). With this version, my project above passes the test.

Reference: previous commit that touched netty-tcnative version: https://github.com/grpc/grpc-java/commit/8359d0b710a7fff96794115931a5105a1f013415#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7R177