### PR TITLE
buildscripts: enable fault injection interop test

### DIFF
--- a/buildscripts/kokoro/xds.sh
+++ b/buildscripts/kokoro/xds.sh
@@ -28,7 +28,7 @@ grpc/tools/run_tests/helper_scripts/prep_xds.sh
 # --test_case after they are added into "all".
 JAVA_OPTS=-Djava.util.logging.config.file=grpc-java/buildscripts/xds_logging.properties \
   python3 grpc/tools/run_tests/run_xds_tests.py \
-    --test_case="all,path_matching,header_matching,circuit_breaking,timeout" \
+    --test_case="all,path_matching,header_matching,circuit_breaking,timeout,fault_injection" \
     --project_id=grpc-testing \
     --project_num=830293263384 \
     --source_image=projects/grpc-testing/global/images/xds-test-server-4 \


### PR DESCRIPTION
Tested in https://fusion2.corp.google.com/invocations/e3e74b51-c96e-407c-8571-4b962dc977c3
(fault injection in v2 test can be automatically skipped by the test runner)