### PR TITLE
xds: pretty print http filters

### DIFF
--- a/xds/src/main/java/io/grpc/xds/MessagePrinter.java
+++ b/xds/src/main/java/io/grpc/xds/MessagePrinter.java
@@ -25,8 +25,8 @@ import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
 import io.envoyproxy.envoy.config.listener.v3.Listener;
 import io.envoyproxy.envoy.config.route.v3.RouteConfiguration;
 import io.envoyproxy.envoy.extensions.filters.http.fault.v3.HTTPFault;
+import io.envoyproxy.envoy.extensions.filters.http.router.v3.Router;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager;
-import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext;
 
@@ -43,10 +43,12 @@ final class MessagePrinter {
             .add(Listener.getDescriptor())
             .add(io.envoyproxy.envoy.api.v2.Listener.getDescriptor())
             .add(HttpConnectionManager.getDescriptor())
-            .add(HttpFilter.getDescriptor())
-            .add(HTTPFault.getDescriptor())
             .add(io.envoyproxy.envoy.config.filter.network.http_connection_manager.v2
                 .HttpConnectionManager.getDescriptor())
+            .add(HTTPFault.getDescriptor())
+            .add(io.envoyproxy.envoy.config.filter.http.fault.v2.HTTPFault.getDescriptor())
+            .add(Router.getDescriptor())
+            .add(io.envoyproxy.envoy.config.filter.http.router.v2.Router.getDescriptor())
             // UpstreamTlsContext and DownstreamTlsContext in v3 are not transitively imported
             // by top-level resource types.
             .add(UpstreamTlsContext.getDescriptor())

--- a/xds/third_party/envoy/import.sh
+++ b/xds/third_party/envoy/import.sh
@@ -88,6 +88,7 @@ envoy/config/endpoint/v3/load_report.proto
 envoy/config/filter/accesslog/v2/accesslog.proto
 envoy/config/filter/fault/v2/fault.proto
 envoy/config/filter/http/fault/v2/fault.proto
+envoy/config/filter/http/router/v2/router.proto
 envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
 envoy/config/listener/v2/api_listener.proto
 envoy/config/listener/v3/api_listener.proto
@@ -117,6 +118,7 @@ envoy/config/trace/v3/zipkin.proto
 envoy/extensions/clusters/aggregate/v3/cluster.proto
 envoy/extensions/filters/common/fault/v3/fault.proto
 envoy/extensions/filters/http/fault/v3/fault.proto
+envoy/extensions/filters/http/router/v3/router.proto
 envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
 envoy/extensions/transport_sockets/tls/v3/cert.proto
 envoy/extensions/transport_sockets/tls/v3/common.proto

--- a/xds/third_party/envoy/src/main/proto/envoy/config/filter/http/router/v2/router.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/filter/http/router/v2/router.proto
@@ -1,0 +1,79 @@
+syntax = "proto3";
+
+package envoy.config.filter.http.router.v2;
+
+import "envoy/config/filter/accesslog/v2/accesslog.proto";
+
+import "google/protobuf/wrappers.proto";
+
+import "udpa/annotations/migrate.proto";
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.config.filter.http.router.v2";
+option java_outer_classname = "RouterProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.filters.http.router.v3";
+option (udpa.annotations.file_status).package_version_status = FROZEN;
+
+// [#protodoc-title: Router]
+// Router :ref:`configuration overview <config_http_filters_router>`.
+// [#extension: envoy.filters.http.router]
+
+// [#next-free-field: 7]
+message Router {
+  // Whether the router generates dynamic cluster statistics. Defaults to
+  // true. Can be disabled in high performance scenarios.
+  google.protobuf.BoolValue dynamic_stats = 1;
+
+  // Whether to start a child span for egress routed calls. This can be
+  // useful in scenarios where other filters (auth, ratelimit, etc.) make
+  // outbound calls and have child spans rooted at the same ingress
+  // parent. Defaults to false.
+  bool start_child_span = 2;
+
+  // Configuration for HTTP upstream logs emitted by the router. Upstream logs
+  // are configured in the same way as access logs, but each log entry represents
+  // an upstream request. Presuming retries are configured, multiple upstream
+  // requests may be made for each downstream (inbound) request.
+  repeated accesslog.v2.AccessLog upstream_log = 3;
+
+  // Do not add any additional *x-envoy-* headers to requests or responses. This
+  // only affects the :ref:`router filter generated *x-envoy-* headers
+  // <config_http_filters_router_headers_set>`, other Envoy filters and the HTTP
+  // connection manager may continue to set *x-envoy-* headers.
+  bool suppress_envoy_headers = 4;
+
+  // Specifies a list of HTTP headers to strictly validate. Envoy will reject a
+  // request and respond with HTTP status 400 if the request contains an invalid
+  // value for any of the headers listed in this field. Strict header checking
+  // is only supported for the following headers:
+  //
+  // Value must be a ','-delimited list (i.e. no spaces) of supported retry
+  // policy values:
+  //
+  // * :ref:`config_http_filters_router_x-envoy-retry-grpc-on`
+  // * :ref:`config_http_filters_router_x-envoy-retry-on`
+  //
+  // Value must be an integer:
+  //
+  // * :ref:`config_http_filters_router_x-envoy-max-retries`
+  // * :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms`
+  // * :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`
+  repeated string strict_check_headers = 5 [(validate.rules).repeated = {
+    items {
+      string {
+        in: "x-envoy-upstream-rq-timeout-ms"
+        in: "x-envoy-upstream-rq-per-try-timeout-ms"
+        in: "x-envoy-max-retries"
+        in: "x-envoy-retry-grpc-on"
+        in: "x-envoy-retry-on"
+      }
+    }
+  }];
+
+  // If not set, ingress Envoy will ignore
+  // :ref:`config_http_filters_router_x-envoy-expected-rq-timeout-ms` header, populated by egress
+  // Envoy, when deriving timeout for upstream cluster.
+  bool respect_expected_rq_timeout = 6;
+}

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/http/router/v3/router.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/http/router/v3/router.proto
@@ -1,0 +1,81 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.http.router.v3;
+
+import "envoy/config/accesslog/v3/accesslog.proto";
+
+import "google/protobuf/wrappers.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.http.router.v3";
+option java_outer_classname = "RouterProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Router]
+// Router :ref:`configuration overview <config_http_filters_router>`.
+// [#extension: envoy.filters.http.router]
+
+// [#next-free-field: 7]
+message Router {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.filter.http.router.v2.Router";
+
+  // Whether the router generates dynamic cluster statistics. Defaults to
+  // true. Can be disabled in high performance scenarios.
+  google.protobuf.BoolValue dynamic_stats = 1;
+
+  // Whether to start a child span for egress routed calls. This can be
+  // useful in scenarios where other filters (auth, ratelimit, etc.) make
+  // outbound calls and have child spans rooted at the same ingress
+  // parent. Defaults to false.
+  bool start_child_span = 2;
+
+  // Configuration for HTTP upstream logs emitted by the router. Upstream logs
+  // are configured in the same way as access logs, but each log entry represents
+  // an upstream request. Presuming retries are configured, multiple upstream
+  // requests may be made for each downstream (inbound) request.
+  repeated config.accesslog.v3.AccessLog upstream_log = 3;
+
+  // Do not add any additional *x-envoy-* headers to requests or responses. This
+  // only affects the :ref:`router filter generated *x-envoy-* headers
+  // <config_http_filters_router_headers_set>`, other Envoy filters and the HTTP
+  // connection manager may continue to set *x-envoy-* headers.
+  bool suppress_envoy_headers = 4;
+
+  // Specifies a list of HTTP headers to strictly validate. Envoy will reject a
+  // request and respond with HTTP status 400 if the request contains an invalid
+  // value for any of the headers listed in this field. Strict header checking
+  // is only supported for the following headers:
+  //
+  // Value must be a ','-delimited list (i.e. no spaces) of supported retry
+  // policy values:
+  //
+  // * :ref:`config_http_filters_router_x-envoy-retry-grpc-on`
+  // * :ref:`config_http_filters_router_x-envoy-retry-on`
+  //
+  // Value must be an integer:
+  //
+  // * :ref:`config_http_filters_router_x-envoy-max-retries`
+  // * :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms`
+  // * :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`
+  repeated string strict_check_headers = 5 [(validate.rules).repeated = {
+    items {
+      string {
+        in: "x-envoy-upstream-rq-timeout-ms"
+        in: "x-envoy-upstream-rq-per-try-timeout-ms"
+        in: "x-envoy-max-retries"
+        in: "x-envoy-retry-grpc-on"
+        in: "x-envoy-retry-on"
+      }
+    }
+  }];
+
+  // If not set, ingress Envoy will ignore
+  // :ref:`config_http_filters_router_x-envoy-expected-rq-timeout-ms` header, populated by egress
+  // Envoy, when deriving timeout for upstream cluster.
+  bool respect_expected_rq_timeout = 6;
+}


### PR DESCRIPTION
Interop test logs showed that router filter in v3 can not be printed, and router filter as well as fault filter in v2 can not be printed. Imported protos and added proto descriptors to `MessagePrinter`.