### PR TITLE
Allow using TestServiceClient for making Traffic Director RPCs

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -288,14 +288,14 @@ public class TestServiceClient {
         break;
 
       case COMPUTE_ENGINE_CHANNEL_CREDENTIALS: {
-          ManagedChannelBuilder<?> builder;
-          if (serverPort == 0) {
-            builder = Grpc.newChannelBuilder(serverHost, ComputeEngineChannelCredentials.create());
-          } else {
-            builder =
-                Grpc.newChannelBuilderForAddress(
-                    serverHost, serverPort, ComputeEngineChannelCredentials.create());
-          }
+        ManagedChannelBuilder<?> builder;
+        if (serverPort == 0) {
+          builder = Grpc.newChannelBuilder(serverHost, ComputeEngineChannelCredentials.create());
+        } else {
+          builder =
+              Grpc.newChannelBuilderForAddress(
+                  serverHost, serverPort, ComputeEngineChannelCredentials.create());
+        }
         if (serviceConfig != null) {
           builder.disableServiceConfigLookUp();
           builder.defaultServiceConfig(serviceConfig);
@@ -340,14 +340,14 @@ public class TestServiceClient {
       }
 
       case GOOGLE_DEFAULT_CREDENTIALS: {
-          ManagedChannelBuilder<?> builder;
-          if (serverPort == 0) {
-            builder = Grpc.newChannelBuilder(serverHost, GoogleDefaultChannelCredentials.create());
-          } else {
-            builder =
-                Grpc.newChannelBuilderForAddress(
-                    serverHost, serverPort, GoogleDefaultChannelCredentials.create());
-          }
+        ManagedChannelBuilder<?> builder;
+        if (serverPort == 0) {
+          builder = Grpc.newChannelBuilder(serverHost, GoogleDefaultChannelCredentials.create());
+        } else {
+          builder =
+              Grpc.newChannelBuilderForAddress(
+                  serverHost, serverPort, GoogleDefaultChannelCredentials.create());
+        }
         if (serviceConfig != null) {
           builder.disableServiceConfigLookUp();
           builder.defaultServiceConfig(serviceConfig);

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -288,9 +288,14 @@ public class TestServiceClient {
         break;
 
       case COMPUTE_ENGINE_CHANNEL_CREDENTIALS: {
-        ManagedChannelBuilder<?> builder =
-            Grpc.newChannelBuilderForAddress(
-                serverHost, serverPort, ComputeEngineChannelCredentials.create());
+          ManagedChannelBuilder<?> builder;
+          if (serverPort == 0) {
+            builder = Grpc.newChannelBuilder(serverHost, ComputeEngineChannelCredentials.create());
+          } else {
+            builder =
+                Grpc.newChannelBuilderForAddress(
+                    serverHost, serverPort, ComputeEngineChannelCredentials.create());
+          }
         if (serviceConfig != null) {
           builder.disableServiceConfigLookUp();
           builder.defaultServiceConfig(serviceConfig);
@@ -335,9 +340,14 @@ public class TestServiceClient {
       }
 
       case GOOGLE_DEFAULT_CREDENTIALS: {
-        ManagedChannelBuilder<?> builder =
-            Grpc.newChannelBuilderForAddress(
-                serverHost, serverPort, GoogleDefaultChannelCredentials.create());
+          ManagedChannelBuilder<?> builder;
+          if (serverPort == 0) {
+            builder = Grpc.newChannelBuilder(serverHost, GoogleDefaultChannelCredentials.create());
+          } else {
+            builder =
+                Grpc.newChannelBuilderForAddress(
+                    serverHost, serverPort, GoogleDefaultChannelCredentials.create());
+          }
         if (serviceConfig != null) {
           builder.disableServiceConfigLookUp();
           builder.defaultServiceConfig(serviceConfig);
@@ -458,8 +468,13 @@ public class TestServiceClient {
         }
       }
       if (useGeneric) {
-        ManagedChannelBuilder<?> channelBuilder =
-            Grpc.newChannelBuilderForAddress(serverHost, serverPort, channelCredentials);
+        ManagedChannelBuilder<?> channelBuilder;
+        if (serverPort == 0) {
+          channelBuilder = Grpc.newChannelBuilder(serverHost, channelCredentials);
+        } else {
+          channelBuilder =
+              Grpc.newChannelBuilderForAddress(serverHost, serverPort, channelCredentials);
+        }
         if (serverHostOverride != null) {
           channelBuilder.overrideAuthority(serverHostOverride);
         }
@@ -470,9 +485,13 @@ public class TestServiceClient {
         return channelBuilder;
       }
       if (!useOkHttp) {
-        NettyChannelBuilder nettyBuilder =
-            NettyChannelBuilder.forAddress(serverHost, serverPort, channelCredentials)
-                .flowControlWindow(AbstractInteropTest.TEST_FLOW_CONTROL_WINDOW);
+        NettyChannelBuilder nettyBuilder;
+        if (serverPort == 0) {
+          nettyBuilder = NettyChannelBuilder.forTarget(serverHost, channelCredentials);
+        } else {
+          nettyBuilder = NettyChannelBuilder.forAddress(serverHost, serverPort, channelCredentials);
+        }
+        nettyBuilder.flowControlWindow(AbstractInteropTest.TEST_FLOW_CONTROL_WINDOW);
         if (serverHostOverride != null) {
           nettyBuilder.overrideAuthority(serverHostOverride);
         }
@@ -488,8 +507,12 @@ public class TestServiceClient {
         return nettyBuilder.intercept(createCensusStatsClientInterceptor());
       }
 
-      OkHttpChannelBuilder okBuilder =
-          OkHttpChannelBuilder.forAddress(serverHost, serverPort, channelCredentials);
+      OkHttpChannelBuilder okBuilder;
+      if (serverPort == 0) {
+        okBuilder = OkHttpChannelBuilder.forTarget(serverHost, channelCredentials);
+      } else {
+        okBuilder = OkHttpChannelBuilder.forAddress(serverHost, serverPort, channelCredentials);
+      }
       if (serverHostOverride != null) {
         // Force the hostname to match the cert the server uses.
         okBuilder.overrideAuthority(

--- a/xds/src/main/java/io/grpc/xds/GoogleCloudToProdNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/GoogleCloudToProdNameResolver.java
@@ -62,6 +62,9 @@ final class GoogleCloudToProdNameResolver extends NameResolver {
           || System.getenv("GRPC_XDS_BOOTSTRAP_CONFIG") != null
           || System.getProperty("io.grpc.xds.bootstrapConfig") != null;
 
+  private static final String serverUriOverride =
+      System.getenv("GRPC_TEST_ONLY_GOOGLE_C2P_RESOLVER_TRAFFIC_DIRECTOR_URI");
+
   private HttpConnectionProvider httpConnectionProvider = HttpConnectionFactory.INSTANCE;
   private final String authority;
   private final SynchronizationContext syncContext;
@@ -177,7 +180,11 @@ final class GoogleCloudToProdNameResolver extends NameResolver {
           ImmutableMap.of("TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE", true));
     }
     ImmutableMap.Builder<String, Object> serverBuilder = ImmutableMap.builder();
-    serverBuilder.put("server_uri", "directpath-trafficdirector.googleapis.com");
+    String server_uri = "directpath-trafficdirector.googleapis.com";
+    if (serverUriOverride != null && serverUriOverride.length() > 0) {
+      server_uri = serverUriOverride;
+    }
+    serverBuilder.put("server_uri", server_uri);
     serverBuilder.put("channel_creds",
         ImmutableList.of(ImmutableMap.of("type", "google_default")));
     return ImmutableMap.of(


### PR DESCRIPTION
Internal issue b/183205647 for context.

The need to configure channels without an explicit port has more context in b/181142141 (and is the method currently used for C++)

The `GRPC_TEST_ONLY_GOOGLE_C2P_RESOLVER_TRAFFIC_DIRECTOR_URI` env var is needed to reach alternative instances of TD for testing, and is supported by Go and C++.