### PR TITLE
okhttp: Fix okio 2.x API incompatibility

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpReadableBuffer.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpReadableBuffer.java
@@ -40,8 +40,15 @@ class OkHttpReadableBuffer extends AbstractReadableBuffer {
 
   @Override
   public int readUnsignedByte() {
-    return buffer.readByte() & 0x000000FF;
+    try {
+      fakeEofExceptionMethod(); // Okio 2.x can throw EOFException from readByte()
+      return buffer.readByte() & 0x000000FF;
+    } catch (EOFException e) {
+      throw new IndexOutOfBoundsException(e.getMessage());
+    }
   }
+
+  private void fakeEofExceptionMethod() throws EOFException {}
 
   @Override
   public void skipBytes(int length) {


### PR DESCRIPTION
okio 2.x is ABI compatible with 1.x but not API compatible. This hasn't
been a problem as users use binaries from Maven Central so the ABI
compatibility is the important part. However, when building with Bazel
the API compatibily is the important part.

Tested with okio 2.10.0

Fixes #8004

CC @Kernald