### PR TITLE
xds: update (local) configurations atomically for each LDS/RDS resource update

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -655,7 +655,7 @@ final class XdsNameResolver extends NameResolver {
           logger.log(XdsLogLevel.INFO, "Receive LDS resource update: {0}", update);
           List<VirtualHost> virtualHosts = update.virtualHosts;
           String rdsName = update.rdsName;
-          cleanUpRouteConfigState();
+          cleanUpRouteDiscoveryState();
           if (virtualHosts != null) {
             updateRoutes(virtualHosts, update.httpMaxStreamDurationNano, update.filterChain);
           } else {
@@ -690,7 +690,7 @@ final class XdsNameResolver extends NameResolver {
             return;
           }
           logger.log(XdsLogLevel.INFO, "LDS resource {0} unavailable", resourceName);
-          cleanUpRouteConfigState();
+          cleanUpRouteDiscoveryState();
           cleanUpRoutes();
         }
       });
@@ -704,7 +704,7 @@ final class XdsNameResolver extends NameResolver {
     private void stop() {
       logger.log(XdsLogLevel.INFO, "Stop watching LDS resource {0}", authority);
       stopped = true;
-      cleanUpRouteConfigState();
+      cleanUpRouteDiscoveryState();
       xdsClient.cancelLdsResourceWatch(authority, this);
     }
 
@@ -806,7 +806,7 @@ final class XdsNameResolver extends NameResolver {
       listener.onResult(emptyResult);
     }
 
-    private void cleanUpRouteConfigState() {
+    private void cleanUpRouteDiscoveryState() {
       if (routeDiscoveryState != null) {
         String rdsName = routeDiscoveryState.resourceName;
         logger.log(XdsLogLevel.INFO, "Stop watching RDS resource {0}", rdsName);


### PR DESCRIPTION
XdsNameResolver is stateful in terms of received xDS configurations (e.g., routes, httpMaxStreamDuration, clusters being exposed in service config). The full suite of configurations should always be updated whenever receiving new resource updates, including updates that revoke currently in-use resources. Reference counts for currently in-use clusters should also be cleaned up properly. Otherwise, re-receiving (after being revoked) the same resource can be treated as if the configuration never changed.

In short, all of XdsNameResolver's states should always be consistent with the most recent xDS update, including the updates for revoking resources.

-------------
Fixes #8009 