### PR TITLE
advancedtls: Add a Utility Class For Loading Certs/Keys

### DIFF
--- a/core/src/main/java/io/grpc/util/CertificateUtils.java
+++ b/core/src/main/java/io/grpc/util/CertificateUtils.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.util;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.BaseEncoding;
+import com.google.common.io.CharStreams;
+import io.grpc.ExperimentalApi;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.security.KeyException;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Collection;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Contains certificate/key PEM file utility method(s).
+ */
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/XXX")
+public final class CertificateUtils {
+  private static CertificateFactory factory;
+  private static final Pattern KEY_PATTERN = Pattern.compile(
+      "-+BEGIN\\s+.*PRIVATE\\s+KEY[^-]*-+(?:\\s|\\r|\\n)+" + // Header
+          "([a-z0-9+/=\\r\\n]+)" +                             // Base64 text
+          "-+END\\s+.*PRIVATE\\s+KEY[^-]*-+",                  // Footer
+      Pattern.CASE_INSENSITIVE);
+  private static final BaseEncoding BASE64_ENCODING = BaseEncoding.base64();
+
+  private static synchronized void initInstance() throws CertificateException {
+    if (factory == null) {
+      factory = CertificateFactory.getInstance("X.509");
+    }
+  }
+
+  /**
+   * Generates X509Certificate array from a file on disk.
+   *
+   * @param inputStream is a {@link InputStream} from the certificate files
+   */
+  public static X509Certificate[] getX509Certificates(InputStream inputStream)
+      throws CertificateException {
+    initInstance();
+    Collection<? extends Certificate> certs = factory.generateCertificates(inputStream);
+    return certs.toArray(new X509Certificate[0]);
+  }
+
+  /** Generates a {@link PrivateKey} from the {@link InputStream}. */
+  public static PrivateKey getPrivateKey(InputStream inputStream)
+      throws Exception {
+    String key = CharStreams.toString(new InputStreamReader(inputStream, Charsets.UTF_8));
+    Matcher m = KEY_PATTERN.matcher(key);
+    if (!m.find()) {
+      throw new KeyException("could not find a PKCS #8 private key in input stream");
+    }
+    String keyContent = m.group(1).replace("\n", "");
+    byte[] decodedKeyBytes = BASE64_ENCODING.decode(keyContent);
+    KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+    PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decodedKeyBytes);
+    return keyFactory.generatePrivate(keySpec);
+  }
+}
+

--- a/core/src/main/java/io/grpc/util/CertificateUtils.java
+++ b/core/src/main/java/io/grpc/util/CertificateUtils.java
@@ -37,7 +37,7 @@ import java.util.regex.Pattern;
 /**
  * Contains certificate/key PEM file utility method(s).
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/XXX")
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/8024")
 public final class CertificateUtils {
   private static CertificateFactory factory;
   private static final Pattern KEY_PATTERN = Pattern.compile(

--- a/core/src/main/java/io/grpc/util/CertificateUtils.java
+++ b/core/src/main/java/io/grpc/util/CertificateUtils.java
@@ -39,46 +39,45 @@ import java.util.regex.Pattern;
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8024")
 public final class CertificateUtils {
-  private static CertificateFactory factory;
   private static final Pattern KEY_PATTERN = Pattern.compile(
-      "-+BEGIN\\s+.*PRIVATE\\s+KEY[^-]*-+(?:\\s|\\r|\\n)+" + // Header
+      "-----BEGIN\\s+.*PRIVATE\\s+KEY-----" + // Header
           "([a-z0-9+/=\\r\\n]+)" +                             // Base64 text
-          "-+END\\s+.*PRIVATE\\s+KEY[^-]*-+",                  // Footer
+          "-----END\\s+.*PRIVATE\\s+KEY-----",                  // Footer
       Pattern.CASE_INSENSITIVE);
-  private static final BaseEncoding BASE64_ENCODING = BaseEncoding.base64();
-
-  private static synchronized void initInstance() throws CertificateException {
-    if (factory == null) {
-      factory = CertificateFactory.getInstance("X.509");
-    }
-  }
 
   /**
-   * Generates X509Certificate array from a file on disk.
+   * Generates X509Certificate array from a PEM file.
+   * The PEM file should contain one or more items in Base64 encoding, each with
+   * plain-text headers and footers
+   * (e.g. -----BEGIN CERTIFICATE----- and -----END CERTIFICATE-----).
    *
    * @param inputStream is a {@link InputStream} from the certificate files
    */
   public static X509Certificate[] getX509Certificates(InputStream inputStream)
       throws CertificateException {
-    initInstance();
+    CertificateFactory factory = CertificateFactory.getInstance("X.509");
     Collection<? extends Certificate> certs = factory.generateCertificates(inputStream);
     return certs.toArray(new X509Certificate[0]);
   }
 
-  /** Generates a {@link PrivateKey} from the {@link InputStream}. */
+  /**
+   * Generates a {@link PrivateKey} from a PEM file.
+   * The key should be PKCS #8 formatted.
+   * The PEM file should contain one item in Base64 encoding, with plain-text headers and footers
+   * (e.g. -----BEGIN PRIVATE KEY----- and -----END PRIVATE KEY-----).
+   *
+   * @param inputStream is a {@link InputStream} from the private key file
+   */
   public static PrivateKey getPrivateKey(InputStream inputStream)
       throws Exception {
     String key = CharStreams.toString(new InputStreamReader(inputStream, Charsets.UTF_8));
     Matcher m = KEY_PATTERN.matcher(key);
-    if (!m.find()) {
+    if (!m.find() || m.groupCount() != 1) {
       throw new KeyException("could not find a PKCS #8 private key in input stream");
     }
-    // Using System.lineSeparator() here would cause
-    // [Undefined reference | android-api-level-14-4.0_r4] io.grpc.util.(CertificateUtils.java:76)
-    // Is it not supported on Android?
     String keyContent =
         m.group(1).replace(System.getProperty("line.separator"), "");
-    byte[] decodedKeyBytes = BASE64_ENCODING.decode(keyContent);
+    byte[] decodedKeyBytes = BaseEncoding.base64().decode(keyContent);
     KeyFactory keyFactory = KeyFactory.getInstance("RSA");
     PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decodedKeyBytes);
     return keyFactory.generatePrivate(keySpec);

--- a/core/src/main/java/io/grpc/util/CertificateUtils.java
+++ b/core/src/main/java/io/grpc/util/CertificateUtils.java
@@ -73,7 +73,11 @@ public final class CertificateUtils {
     if (!m.find()) {
       throw new KeyException("could not find a PKCS #8 private key in input stream");
     }
-    String keyContent = m.group(1).replace("\n", "");
+    // Using System.lineSeparator() here would cause
+    // [Undefined reference | android-api-level-14-4.0_r4] io.grpc.util.(CertificateUtils.java:76)
+    // Is it not supported on Android?
+    String keyContent =
+        m.group(1).replace(System.getProperty("line.separator"), "");
     byte[] decodedKeyBytes = BASE64_ENCODING.decode(keyContent);
     KeyFactory keyFactory = KeyFactory.getInstance("RSA");
     PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decodedKeyBytes);

--- a/core/src/main/java/io/grpc/util/CertificateUtils.java
+++ b/core/src/main/java/io/grpc/util/CertificateUtils.java
@@ -19,14 +19,18 @@ package io.grpc.util;
 import com.google.common.io.BaseEncoding;
 import io.grpc.ExperimentalApi;
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Collection;
 
@@ -59,18 +63,17 @@ public final class CertificateUtils {
    * @param inputStream is a {@link InputStream} from the private key file
    */
   public static PrivateKey getPrivateKey(InputStream inputStream)
-      throws Exception {
+      throws UnsupportedEncodingException, IOException, NoSuchAlgorithmException,
+      InvalidKeySpecException {
     BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, "UTF-8"));
     String line;
     while ((line = reader.readLine()) != null) {
-      line = line.replace(System.getProperty("line.separator"), "");
       if ("-----BEGIN PRIVATE KEY-----".equals(line)) {
         break;
       }
     }
     StringBuilder keyContent = new StringBuilder();
     while ((line = reader.readLine()) != null) {
-      line = line.replace(System.getProperty("line.separator"), "");
       if ("-----END PRIVATE KEY-----".equals(line)) {
         break;
       }

--- a/core/src/test/java/io/grpc/util/CertificateUtilsTest.java
+++ b/core/src/test/java/io/grpc/util/CertificateUtilsTest.java
@@ -98,9 +98,7 @@ public class CertificateUtilsTest {
       CertificateUtils.getPrivateKey(in);
       Assert.fail("no exception thrown");
     } catch (InvalidKeySpecException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .contains("Detect premature EOF");
+      // The error messages for OpenJDK 11 and 8 are different, so only check if an error is thrown.
     }
   }
 

--- a/core/src/test/java/io/grpc/util/CertificateUtilsTest.java
+++ b/core/src/test/java/io/grpc/util/CertificateUtilsTest.java
@@ -84,10 +84,8 @@ public class CertificateUtilsTest {
       CertificateUtils.getPrivateKey(in);
       Assert.fail("no exception thrown");
     } catch (InvalidKeySpecException expected) {
-      System.out.println(expected.toString());
-      assertThat(expected)
-          .hasMessageThat()
-          .contains("Short read of DER length");
+      // The error messages for OpenJDK 11 and 8 are different, and for Windows it will generate a
+      // different exception, so we only check if a general exception is thrown.
     }
   }
 

--- a/core/src/test/java/io/grpc/util/CertificateUtilsTest.java
+++ b/core/src/test/java/io/grpc/util/CertificateUtilsTest.java
@@ -28,7 +28,6 @@ import java.security.KeyException;
 import java.security.PrivateKey;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.security.spec.InvalidKeySpecException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -92,13 +91,14 @@ public class CertificateUtilsTest {
   }
 
   @Test
-  public void readBadContentKeyFile() throws Exception {
+  public void readBadContentKeyFile() {
     InputStream in = new ByteArrayInputStream(BAD_PEM_CONTENT.getBytes(Charsets.UTF_8));
     try {
       CertificateUtils.getPrivateKey(in);
       Assert.fail("no exception thrown");
-    } catch (InvalidKeySpecException expected) {
-      // The error messages for OpenJDK 11 and 8 are different, so only check if an error is thrown.
+    } catch (Exception expected) {
+      // The error messages for OpenJDK 11 and 8 are different, and for Windows it will generate a
+      // different exception, so we only check if a general exception is thrown.
     }
   }
 

--- a/core/src/test/java/io/grpc/util/CertificateUtilsTest.java
+++ b/core/src/test/java/io/grpc/util/CertificateUtilsTest.java
@@ -24,10 +24,10 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
-import java.security.KeyException;
 import java.security.PrivateKey;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.security.spec.InvalidKeySpecException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -83,10 +83,11 @@ public class CertificateUtilsTest {
     try {
       CertificateUtils.getPrivateKey(in);
       Assert.fail("no exception thrown");
-    } catch (KeyException expected) {
+    } catch (InvalidKeySpecException expected) {
+      System.out.println(expected.toString());
       assertThat(expected)
           .hasMessageThat()
-          .contains("could not find a PKCS #8 private key in input stream");
+          .contains("Short read of DER length");
     }
   }
 

--- a/core/src/test/java/io/grpc/util/CertificateUtilsTest.java
+++ b/core/src/test/java/io/grpc/util/CertificateUtilsTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.util;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.base.Charsets;
+import io.grpc.internal.testing.TestUtils;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigInteger;
+import java.security.KeyException;
+import java.security.PrivateKey;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.security.spec.InvalidKeySpecException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link CertificateUtilsTest}. */
+@RunWith(JUnit4.class)
+public class CertificateUtilsTest {
+  public static final String SERVER_0_PEM_FILE = "server0.pem";
+  public static final String SERVER_0_KEY_FILE = "server0.key";
+  public static final String CA_PEM_FILE = "ca.pem";
+  public static final String BAD_PEM_FORMAT = "This is a bad key pem format";
+  public static final String BAD_PEM_CONTENT = "----BEGIN PRIVATE KEY-----\n"
+      + "MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDvdzKDTYvRgjBO\n"
+      + "-----END PRIVATE KEY-----";
+
+  @Test
+  public void readPemCertFile() throws CertificateException, IOException {
+    InputStream in = TestUtils.class.getResourceAsStream("/certs/" + SERVER_0_PEM_FILE);
+    X509Certificate[] cert = CertificateUtils.getX509Certificates(in);
+    assertThat(cert.length).isEqualTo(1);
+    // Checks some information on the test certificate.
+    assertThat(cert[0].getSerialNumber()).isEqualTo(new BigInteger(
+        "6c97d344427a93affea089d6855d4ed63dd94f38", 16));
+    assertThat(cert[0].getSubjectDN().getName()).isEqualTo(
+        "CN=*.test.google.com.au, O=Internet Widgits Pty Ltd, ST=Some-State, C=AU");
+  }
+
+  @Test
+  public void readPemKeyFile() throws Exception {
+    InputStream in = TestUtils.class.getResourceAsStream("/certs/" + SERVER_0_KEY_FILE);
+    PrivateKey key = CertificateUtils.getPrivateKey(in);
+    // Checks some information on the test key.
+    assertThat(key.getAlgorithm()).isEqualTo("RSA");
+    assertThat(key.getFormat()).isEqualTo("PKCS#8");
+  }
+
+  @Test
+  public void readCaPemFile() throws CertificateException, IOException {
+    InputStream in = TestUtils.class.getResourceAsStream("/certs/" + CA_PEM_FILE);
+    X509Certificate[] cert = CertificateUtils.getX509Certificates(in);
+    assertThat(cert.length).isEqualTo(1);
+    // Checks some information on the test certificate.
+    assertThat(cert[0].getSerialNumber()).isEqualTo(new BigInteger(
+        "5ab3f456f1dccbe2cfe94b9836d88bf600610f9a", 16));
+    assertThat(cert[0].getSubjectDN().getName()).isEqualTo(
+        "CN=testca, O=Internet Widgits Pty Ltd, ST=Some-State, C=AU");
+  }
+
+  @Test
+  public void readBadFormatKeyFile() throws Exception {
+    InputStream in = new ByteArrayInputStream(BAD_PEM_FORMAT.getBytes(Charsets.UTF_8));
+    try {
+      CertificateUtils.getPrivateKey(in);
+      Assert.fail("no exception thrown");
+    } catch (KeyException expected) {
+      assertThat(expected)
+          .hasMessageThat()
+          .contains("could not find a PKCS #8 private key in input stream");
+    }
+  }
+
+  @Test
+  public void readBadContentKeyFile() throws Exception {
+    InputStream in = new ByteArrayInputStream(BAD_PEM_CONTENT.getBytes(Charsets.UTF_8));
+    try {
+      CertificateUtils.getPrivateKey(in);
+      Assert.fail("no exception thrown");
+    } catch (InvalidKeySpecException expected) {
+      assertThat(expected)
+          .hasMessageThat()
+          .contains("Detect premature EOF");
+    }
+  }
+
+}


### PR DESCRIPTION
This is to add a certificate/key loading class in `io.grpc.util`, under the help of base64 decoding support by Guava.
@ejona86 @sanjaypujare Feel free to take a look and let me know anything need to be improved. Thank you so much! 