### PR TITLE
Add support to ppc64le during check artifacts

### DIFF
--- a/compiler/check-artifact.sh
+++ b/compiler/check-artifact.sh
@@ -61,6 +61,8 @@ checkArch ()
         assertEq "$format" "elf64-x86-64" $LINENO
       elif [[ "$ARCH" == aarch_64 ]]; then
         assertEq "$format" "elf64-little" $LINENO
+      elif [[ "$ARCH" == ppcle_64 ]]; then
+        assertEq "$format" "elf64-powerpcle" $LINENO
       else
         fail "Unsupported arch: $ARCH"
       fi
@@ -108,6 +110,8 @@ checkDependencies ()
     elif [[ "$ARCH" == aarch_64 ]]; then
       dump_cmd='aarch64-linux-gnu-objdump -x '"$1"' |grep "NEEDED"'
       white_list="linux-vdso\.so\.1\|libpthread\.so\.0\|libm\.so\.6\|libc\.so\.6\|ld-linux-aarch64\.so\.1"
+    elif [[ "$ARCH" == ppcle_64 ]]; then
+      white_list="linux-vdso64\.so\.1\|libpthread\.so\.0\|libm\.so\.6\|libc\.so\.6\|ld64\.so\.2\|libstdc++\.so\.6\|libgcc_s\.so\.1"
     fi
   elif [[ "$OS" == osx ]]; then
     dump_cmd='otool -L '"$1"' | fgrep dylib'


### PR DESCRIPTION
When we try to build the project on ppc64le platform, we get errors as below 
```> Task :grpc-compiler:checkArtifacts FAILED

Checking format of build/artifacts/java_plugin/protoc-gen-grpc-java.exe
Format=elf64-powerpcle
ERROR: Unsupported arch: ppcle_64


FAILURE: Build failed with an exception.

* Where:
Build file '/grpc-java/compiler/build.gradle' line: 206

* What went wrong:
Execution failed for task ':grpc-compiler:checkArtifacts'.
> Process 'command 'bash'' finished with non-zero exit value 99

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.7.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 11m 16s
195 actionable tasks: 195 executed```  
To fix this, modifying the file to add support to ppc64le arch.