### PR TITLE
xds: Fix validation of HCM filter and Router httpFilter

### DIFF
--- a/xds/src/main/java/io/grpc/xds/EnvoyServerProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyServerProtoData.java
@@ -386,9 +386,6 @@ public final class EnvoyServerProtoData {
 
     private static void validateFilter(Filter filter)
         throws InvalidProtocolBufferException, IllegalArgumentException {
-      if (!"envoy.http_connection_manager".equals(filter.getName())) {
-        throw new IllegalArgumentException("filter " + filter.getName() + " not supported.");
-      }
       if (filter.hasConfigDiscovery()) {
         throw new IllegalArgumentException(
             "filter " + filter.getName() + " with config_discovery not supported");
@@ -417,10 +414,6 @@ public final class EnvoyServerProtoData {
               "http-connection-manager has non-unique http-filter name:" + httpFilterName);
         }
         if (!httpFilter.getIsOptional()) {
-          if (!"envoy.router".equals(httpFilterName)) {
-            throw new IllegalArgumentException(
-                "http-connection-manager has unsupported http-filter:" + httpFilterName);
-          }
           if (httpFilter.hasConfigDiscovery()) {
             throw new IllegalArgumentException(
                 "http-connection-manager http-filter " + httpFilterName
@@ -564,7 +557,7 @@ public final class EnvoyServerProtoData {
       // reject if filer-chain-match
       // - has server_name
       // - transport protocol is other than "raw_buffer"
-      // - application_protocols is non-empty (for now accept "managed-mtls")
+      // - application_protocols is non-empty
       if (!filterChainMatch.getServerNamesList().isEmpty()) {
         return false;
       }
@@ -573,8 +566,7 @@ public final class EnvoyServerProtoData {
         return false;
       }
       List<String> appProtocols = filterChainMatch.getApplicationProtocolsList();
-      return appProtocols.isEmpty()
-          || appProtocols.contains("managed-mtls"); // TODO(sanjaypujare): remove once TD fixed
+      return appProtocols.isEmpty();
     }
 
     public String getName() {

--- a/xds/src/main/java/io/grpc/xds/EnvoyServerProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyServerProtoData.java
@@ -427,6 +427,12 @@ public final class EnvoyServerProtoData {
                   "http-connection-manager http-filter " + httpFilterName
                       + " has unsupported typed-config type:" + any.getTypeUrl());
             }
+          } else {
+            throw new IllegalArgumentException(
+                "http-connection-manager http-filter "
+                    + httpFilterName
+                    + " should have typed-config type "
+                    + "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router");
           }
         }
       }

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
@@ -884,6 +884,28 @@ public class ClientXdsClientDataTest {
                 + "type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault");
   }
 
+  @Test
+  public void parseServerSideListener_missingTypeUrlHttpFilter() {
+    Filter filter =
+        buildHttpConnectionManager(
+            "envoy.http_connection_manager",
+            HttpFilter.newBuilder().setName("envoy.filters.http.router").build());
+    FilterChain filterChain = buildFilterChain(filter);
+    Listener listener =
+        Listener.newBuilder()
+            .setName("listener1")
+            .setTrafficDirection(TrafficDirection.INBOUND)
+            .addFilterChains(filterChain)
+            .build();
+    StructOrError<io.grpc.xds.EnvoyServerProtoData.Listener> struct =
+        ClientXdsClient.parseServerSideListener(listener);
+    assertThat(struct.getErrorDetail())
+        .isEqualTo(
+            "http-connection-manager http-filter envoy.filters.http.router should have "
+                + "typed-config type "
+                + "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router");
+  }
+
   static Filter buildHttpConnectionManager(String name, HttpFilter... httpFilters) {
     return Filter.newBuilder()
         .setName(name)

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
@@ -759,25 +759,6 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
-  public void parseServerSideListener_nonHcmFilter() {
-    FilterChain filterChain =
-        buildFilterChain(
-            Filter.newBuilder()
-                .setName("xyz")
-                .setTypedConfig(Any.pack(HttpConnectionManager.getDefaultInstance()))
-                .build());
-    Listener listener =
-        Listener.newBuilder()
-            .setName("listener1")
-            .setTrafficDirection(TrafficDirection.INBOUND)
-            .addFilterChains(filterChain)
-            .build();
-    StructOrError<io.grpc.xds.EnvoyServerProtoData.Listener> struct =
-        ClientXdsClient.parseServerSideListener(listener);
-    assertThat(struct.getErrorDetail()).isEqualTo("filter xyz not supported.");
-  }
-
-  @Test
   public void parseServerSideListener_configDiscoveryFilter() {
     Filter filter =
         Filter.newBuilder()
@@ -855,24 +836,6 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
-  public void parseServerSideListener_unsupportedHttpFilter() {
-    Filter filter =
-        buildHttpConnectionManager(
-            "envoy.http_connection_manager", HttpFilter.newBuilder().setName("hf").build());
-    FilterChain filterChain = buildFilterChain(filter);
-    Listener listener =
-        Listener.newBuilder()
-            .setName("listener1")
-            .setTrafficDirection(TrafficDirection.INBOUND)
-            .addFilterChains(filterChain)
-            .build();
-    StructOrError<io.grpc.xds.EnvoyServerProtoData.Listener> struct =
-        ClientXdsClient.parseServerSideListener(listener);
-    assertThat(struct.getErrorDetail())
-        .isEqualTo("http-connection-manager has unsupported http-filter:hf");
-  }
-
-  @Test
   public void parseServerSideListener_configDiscoveryHttpFilter() {
     Filter filter =
         buildHttpConnectionManager(
@@ -937,7 +900,6 @@ public class ClientXdsClientDataTest {
     return FilterChain.newBuilder()
         .setFilterChainMatch(
             FilterChainMatch.newBuilder()
-                .addAllApplicationProtocols(Arrays.asList("managed-mtls"))
                 .build())
         .setTransportSocket(TransportSocket.getDefaultInstance())
         .addAllFilters(Arrays.asList(filters))

--- a/xds/src/test/java/io/grpc/xds/EnvoyServerProtoDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/EnvoyServerProtoDataTest.java
@@ -73,7 +73,7 @@ public class EnvoyServerProtoDataTest {
     EnvoyServerProtoData.FilterChainMatch inFilterChainMatch = inFilter.getFilterChainMatch();
     assertThat(inFilterChainMatch).isNotNull();
     assertThat(inFilterChainMatch.getDestinationPort()).isEqualTo(8000);
-    assertThat(inFilterChainMatch.getApplicationProtocols()).containsExactly("managed-mtls");
+    assertThat(inFilterChainMatch.getApplicationProtocols()).isEmpty();
     assertThat(inFilterChainMatch.getPrefixRanges())
         .containsExactly(new EnvoyServerProtoData.CidrRange("10.20.0.15", 32));
     assertThat(inFilterChainMatch.getSourcePrefixRanges())
@@ -114,7 +114,6 @@ public class EnvoyServerProtoDataTest {
                             .setAddressPrefix("10.30.3.0")
                             .setPrefixLen(UInt32Value.of(24))
                             .build())
-                    .addApplicationProtocols("managed-mtls")
                     .setSourceType(FilterChainMatch.ConnectionSourceType.EXTERNAL)
                     .addSourcePorts(200)
                     .addSourcePorts(300)


### PR DESCRIPTION
- Don't enforce a specific name-match for HCM and Router httpFilter
- Don't allow "managed-mtls" in the application-protocols

CC @ejona86 