### PR TITLE
Use @DoNotCall for static methods in Builders that throw

### DIFF
--- a/api/BUILD.bazel
+++ b/api/BUILD.bazel
@@ -7,6 +7,7 @@ java_library(
     deps = [
         "//context",
         "@com_google_code_findbugs_jsr305//jar",
+        "@com_google_errorprone_error_prone_annotations//jar",
         "@com_google_guava_failureaccess//jar",  # future transitive dep of Guava. See #5214
         "@com_google_guava_guava//jar",
         "@com_google_j2objc_j2objc_annotations//jar",

--- a/api/BUILD.bazel
+++ b/api/BUILD.bazel
@@ -3,6 +3,7 @@ java_library(
     srcs = glob([
         "src/main/java/**/*.java",
     ]),
+    javacopts = ["-Xep:DoNotCall:OFF"],  # Remove once requiring Bazel 3.4.0+; allows non-final
     visibility = ["//visibility:public"],
     deps = [
         "//context",

--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -17,6 +17,7 @@
 package io.grpc;
 
 import com.google.common.base.MoreObjects;
+import com.google.errorprone.annotations.DoNotCall;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
@@ -43,6 +44,7 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
   /**
    * This method serves to force sub classes to "hide" this static factory.
    */
+  @DoNotCall("Unsupported")
   public static ManagedChannelBuilder<?> forAddress(String name, int port) {
     throw new UnsupportedOperationException("Subclass failed to hide static factory");
   }
@@ -50,6 +52,7 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
   /**
    * This method serves to force sub classes to "hide" this static factory.
    */
+  @DoNotCall("Unsupported")
   public static ManagedChannelBuilder<?> forTarget(String target) {
     throw new UnsupportedOperationException("Subclass failed to hide static factory");
   }

--- a/api/src/main/java/io/grpc/ForwardingServerBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingServerBuilder.java
@@ -17,6 +17,7 @@
 package io.grpc;
 
 import com.google.common.base.MoreObjects;
+import com.google.errorprone.annotations.DoNotCall;
 import java.io.File;
 import java.io.InputStream;
 import java.util.concurrent.Executor;
@@ -38,6 +39,7 @@ public abstract class ForwardingServerBuilder<T extends ServerBuilder<T>> extend
   /**
    * This method serves to force sub classes to "hide" this static factory.
    */
+  @DoNotCall("Unsupported")
   public static ServerBuilder<?> forPort(int port) {
     throw new UnsupportedOperationException("Subclass failed to hide static factory");
   }

--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -15,9 +15,9 @@ java_library(
         "//api",
         "//context",
         "@com_google_code_findbugs_jsr305//jar",
+        "@com_google_errorprone_error_prone_annotations//jar",
         "@com_google_guava_guava//jar",
         "@com_google_j2objc_j2objc_annotations//jar",
-        "@maven//:com_google_errorprone_error_prone_annotations",
     ],
 )
 

--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -17,6 +17,7 @@ java_library(
         "@com_google_code_findbugs_jsr305//jar",
         "@com_google_guava_guava//jar",
         "@com_google_j2objc_j2objc_annotations//jar",
+        "@maven//:com_google_errorprone_error_prone_annotations",
     ],
 )
 
@@ -25,6 +26,7 @@ java_library(
     srcs = glob([
         "src/main/java/io/grpc/internal/*.java",
     ]),
+    javacopts = ["-Xep:DoNotCall:OFF"],  # Remove once requiring Bazel 3.4.0+; allows non-final
     resources = glob([
         "src/bazel-internal/resources/**",
     ]),

--- a/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -19,6 +19,7 @@ package io.grpc.inprocess;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.errorprone.annotations.DoNotCall;
 import io.grpc.ChannelCredentials;
 import io.grpc.ChannelLogger;
 import io.grpc.ExperimentalApi;
@@ -60,6 +61,7 @@ public final class InProcessChannelBuilder extends
   /**
    * Always fails.  Call {@link #forName} instead.
    */
+  @DoNotCall("Unsupported. Use forName() instead")
   public static InProcessChannelBuilder forTarget(String target) {
     throw new UnsupportedOperationException("call forName() instead");
   }
@@ -67,6 +69,7 @@ public final class InProcessChannelBuilder extends
   /**
    * Always fails.  Call {@link #forName} instead.
    */
+  @DoNotCall("Unsupported. Use forName() instead")
   public static InProcessChannelBuilder forAddress(String name, int port) {
     throw new UnsupportedOperationException("call forName() instead");
   }

--- a/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
@@ -19,6 +19,7 @@ package io.grpc.inprocess;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Preconditions;
+import com.google.errorprone.annotations.DoNotCall;
 import io.grpc.Deadline;
 import io.grpc.ExperimentalApi;
 import io.grpc.Internal;
@@ -86,6 +87,7 @@ public final class InProcessServerBuilder extends
   /**
    * Always fails.  Call {@link #forName} instead.
    */
+  @DoNotCall("Unsupported. Use forName() instead")
   public static InProcessServerBuilder forPort(int port) {
     throw new UnsupportedOperationException("call forName() instead");
   }

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -17,6 +17,7 @@
 package io.grpc.internal;
 
 import com.google.common.base.MoreObjects;
+import com.google.errorprone.annotations.DoNotCall;
 import io.grpc.BinaryLog;
 import io.grpc.ClientInterceptor;
 import io.grpc.CompressorRegistry;
@@ -49,6 +50,7 @@ public abstract class AbstractManagedChannelImplBuilder
   /**
    * This method serves to force sub classes to "hide" this static factory.
    */
+  @DoNotCall("Unsupported")
   public static ManagedChannelBuilder<?> forAddress(String name, int port) {
     throw new UnsupportedOperationException("Subclass failed to hide static factory");
   }
@@ -56,6 +58,7 @@ public abstract class AbstractManagedChannelImplBuilder
   /**
    * This method serves to force sub classes to "hide" this static factory.
    */
+  @DoNotCall("Unsupported")
   public static ManagedChannelBuilder<?> forTarget(String target) {
     throw new UnsupportedOperationException("Subclass failed to hide static factory");
   }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.errorprone.annotations.DoNotCall;
 import io.grpc.Attributes;
 import io.grpc.BinaryLog;
 import io.grpc.CallCredentials;
@@ -61,11 +62,13 @@ public final class ManagedChannelImplBuilder
 
   private static final Logger log = Logger.getLogger(ManagedChannelImplBuilder.class.getName());
 
+  @DoNotCall("ClientTransportFactoryBuilder is required, use a constructor")
   public static ManagedChannelBuilder<?> forAddress(String name, int port) {
     throw new UnsupportedOperationException(
         "ClientTransportFactoryBuilder is required, use a constructor");
   }
 
+  @DoNotCall("ClientTransportFactoryBuilder is required, use a constructor")
   public static ManagedChannelBuilder<?> forTarget(String target) {
     throw new UnsupportedOperationException(
         "ClientTransportFactoryBuilder is required, use a constructor");

--- a/core/src/main/java/io/grpc/internal/ServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ServerImplBuilder.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.errorprone.annotations.DoNotCall;
 import io.grpc.BinaryLog;
 import io.grpc.BindableService;
 import io.grpc.CompressorRegistry;
@@ -55,6 +56,7 @@ public final class ServerImplBuilder extends ServerBuilder<ServerImplBuilder> {
 
   private static final Logger log = Logger.getLogger(ServerImplBuilder.class.getName());
 
+  @DoNotCall("ClientTransportServersBuilder is required, use a constructor")
   public static ServerBuilder<?> forPort(int port) {
     throw new UnsupportedOperationException(
         "ClientTransportServersBuilder is required, use a constructor");

--- a/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
@@ -24,6 +24,7 @@ import android.util.Log;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.errorprone.annotations.DoNotCall;
 import io.grpc.ChannelCredentials;
 import io.grpc.ChannelLogger;
 import io.grpc.ExperimentalApi;
@@ -71,6 +72,7 @@ public final class CronetChannelBuilder
   /**
    * Always fails.  Call {@link #forAddress(String, int, CronetEngine)} instead.
    */
+  @DoNotCall("Unsupported. Use forAddress(String, int, CronetEngine) instead")
   public static CronetChannelBuilder forTarget(String target) {
     throw new UnsupportedOperationException("call forAddress() instead");
   }
@@ -78,6 +80,7 @@ public final class CronetChannelBuilder
   /**
    * Always fails.  Call {@link #forAddress(String, int, CronetEngine)} instead.
    */
+  @DoNotCall("Unsupported. Use forAddress(String, int, CronetEngine) instead")
   public static CronetChannelBuilder forAddress(String name, int port) {
     throw new UnsupportedOperationException("call forAddress(String, int, CronetEngine) instead");
   }

--- a/xds/src/main/java/io/grpc/xds/XdsServerBuilder.java
+++ b/xds/src/main/java/io/grpc/xds/XdsServerBuilder.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.errorprone.annotations.DoNotCall;
 import io.grpc.Attributes;
 import io.grpc.ExperimentalApi;
 import io.grpc.ForwardingServerBuilder;
@@ -69,6 +70,7 @@ public final class XdsServerBuilder extends ForwardingServerBuilder<XdsServerBui
   /**
    * Unsupported call. Users should only use {@link #forPort(int, ServerCredentials)}.
    */
+  @DoNotCall("Unsupported. Use forPort(int, ServerCredentials) instead")
   public static ServerBuilder<?> forPort(int port) {
     throw new UnsupportedOperationException(
         "Unsupported call - use forPort(int, ServerCredentials)");


### PR DESCRIPTION
Since static methods are pseudo-inherited by Builder implementations but
are trivially accidentally used, we re-define static methods in each
builder to make them behave more like the caller would expect. However,
not all the methods actually work; some just throw because the caller
was certainly not getting what they would expect.

Annotating with `@DoNotCall` can expose the problems at compile time
instead of runtime. While `@Deprecated` would also be an option, it is a
bit harder to figure out the ramifications and whether we want to go
that route.

This change was suggested by a lint tool for XdsServerBuilder and it
seems appropriate so I applied it to the other similar cases I could
find.