### PR TITLE
xds: expose bootstrap through XdsClient interface

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -58,7 +58,6 @@ import io.grpc.internal.TimeProvider;
 import io.grpc.xds.Endpoints.DropOverload;
 import io.grpc.xds.Endpoints.LbEndpoint;
 import io.grpc.xds.Endpoints.LocalityLbEndpoints;
-import io.grpc.xds.EnvoyProtoData.Node;
 import io.grpc.xds.EnvoyServerProtoData.UpstreamTlsContext;
 import io.grpc.xds.Filter.ConfigOrError;
 import io.grpc.xds.Filter.FilterConfig;
@@ -134,13 +133,14 @@ final class ClientXdsClient extends AbstractXdsClient {
   private boolean reportingLoad;
 
   ClientXdsClient(
-      ManagedChannel channel, boolean useProtocolV3, Node node,
+      ManagedChannel channel, Bootstrapper.BootstrapInfo bootstrapInfo,
       ScheduledExecutorService timeService, BackoffPolicy.Provider backoffPolicyProvider,
       Supplier<Stopwatch> stopwatchSupplier, TimeProvider timeProvider) {
-    super(channel, useProtocolV3, node, timeService, backoffPolicyProvider, stopwatchSupplier);
+    super(channel, bootstrapInfo, timeService, backoffPolicyProvider, stopwatchSupplier);
     loadStatsManager = new LoadStatsManager2(stopwatchSupplier);
     this.timeProvider = timeProvider;
-    lrsClient = new LoadReportClient(loadStatsManager, channel, useProtocolV3, node,
+    lrsClient = new LoadReportClient(loadStatsManager, channel,
+        bootstrapInfo.getServers().get(0).isUseProtocolV3(), bootstrapInfo.getNode(),
         getSyncContext(), timeService, backoffPolicyProvider, stopwatchSupplier);
   }
 

--- a/xds/src/main/java/io/grpc/xds/CsdsService.java
+++ b/xds/src/main/java/io/grpc/xds/CsdsService.java
@@ -162,7 +162,7 @@ public final class CsdsService extends
         xdsClient.getSubscribedResourcesMetadata(ResourceType.EDS));
 
     return ClientConfig.newBuilder()
-        .setNode(xdsClient.getNode().toEnvoyProtoNode())
+        .setNode(xdsClient.getBootstrapInfo().getNode().toEnvoyProtoNode())
         .addXdsConfig(PerXdsConfig.newBuilder().setListenerConfig(ldsConfig))
         .addXdsConfig(PerXdsConfig.newBuilder().setRouteConfig(rdsConfig))
         .addXdsConfig(PerXdsConfig.newBuilder().setClusterConfig(cdsConfig))

--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -27,7 +27,6 @@ import io.grpc.Status;
 import io.grpc.xds.AbstractXdsClient.ResourceType;
 import io.grpc.xds.Endpoints.DropOverload;
 import io.grpc.xds.Endpoints.LocalityLbEndpoints;
-import io.grpc.xds.EnvoyProtoData.Node;
 import io.grpc.xds.EnvoyServerProtoData.Listener;
 import io.grpc.xds.EnvoyServerProtoData.UpstreamTlsContext;
 import io.grpc.xds.Filter.NamedFilterConfig;
@@ -529,9 +528,9 @@ abstract class XdsClient {
   }
 
   /**
-   * Returns gRPC representation of {@link io.envoyproxy.envoy.config.core.v3.Node}.
+   * Returns {@link Bootstrapper.BootstrapInfo}.
    */
-  Node getNode() {
+  Bootstrapper.BootstrapInfo getBootstrapInfo() {
     throw new UnsupportedOperationException();
   }
 

--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -528,7 +528,7 @@ abstract class XdsClient {
   }
 
   /**
-   * Returns {@link Bootstrapper.BootstrapInfo}.
+   * Returns the config used to bootstrap this XdsClient {@link Bootstrapper.BootstrapInfo}.
    */
   Bootstrapper.BootstrapInfo getBootstrapInfo() {
     throw new UnsupportedOperationException();

--- a/xds/src/main/java/io/grpc/xds/XdsClientWrapperForServerSds.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientWrapperForServerSds.java
@@ -30,7 +30,6 @@ import io.grpc.internal.ExponentialBackoffPolicy;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.SharedResourceHolder;
 import io.grpc.internal.TimeProvider;
-import io.grpc.xds.EnvoyProtoData.Node;
 import io.grpc.xds.EnvoyServerProtoData.CidrRange;
 import io.grpc.xds.EnvoyServerProtoData.DownstreamTlsContext;
 import io.grpc.xds.EnvoyServerProtoData.FilterChain;
@@ -106,7 +105,6 @@ public final class XdsClientWrapperForServerSds {
     } catch (XdsInitializationException e) {
       throw new IOException(e);
     }
-    Node node = bootstrapInfo.getNode();
     Bootstrapper.ServerInfo serverInfo = bootstrapInfo.getServers().get(0);  // use first server
     ManagedChannel channel =
         Grpc.newChannelBuilder(serverInfo.getTarget(), serverInfo.getChannelCredentials())
@@ -121,8 +119,7 @@ public final class XdsClientWrapperForServerSds {
     XdsClient xdsClientImpl =
         new ClientXdsClient(
             channel,
-            serverInfo.isUseProtocolV3(),
-            node,
+            bootstrapInfo,
             timeService,
             new ExponentialBackoffPolicy.Provider(),
             GrpcUtil.STOPWATCH_SUPPLIER,

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
@@ -102,6 +102,7 @@ import org.mockito.MockitoAnnotations;
  */
 @RunWith(JUnit4.class)
 public abstract class ClientXdsClientTestBase {
+  private static final String SERVER_URI = "trafficdirector.googleapis.com";
   private static final String LDS_RESOURCE = "listener.googleapis.com";
   private static final String RDS_RESOURCE = "route-configuration.googleapis.com";
   private static final String CDS_RESOURCE = "cluster.googleapis.com";
@@ -260,7 +261,7 @@ public abstract class ClientXdsClientTestBase {
         new Bootstrapper.BootstrapInfo(
             Arrays.asList(
                 new Bootstrapper.ServerInfo(
-                    "", InsecureChannelCredentials.create(), useProtocolV3())),
+                    SERVER_URI, InsecureChannelCredentials.create(), useProtocolV3())),
             EnvoyProtoData.Node.newBuilder().build(),
             null,
             null);

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
@@ -40,6 +40,7 @@ import io.envoyproxy.envoy.config.listener.v3.Listener;
 import io.envoyproxy.envoy.config.route.v3.FilterConfig;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.SdsSecretConfig;
 import io.grpc.BindableService;
+import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
 import io.grpc.Status;
 import io.grpc.Status.Code;
@@ -255,11 +256,18 @@ public abstract class ClientXdsClientTestBase {
     channel =
         cleanupRule.register(InProcessChannelBuilder.forName(serverName).directExecutor().build());
 
+    Bootstrapper.BootstrapInfo bootstrapInfo =
+        new Bootstrapper.BootstrapInfo(
+            Arrays.asList(
+                new Bootstrapper.ServerInfo(
+                    "", InsecureChannelCredentials.create(), useProtocolV3())),
+            EnvoyProtoData.Node.newBuilder().build(),
+            null,
+            null);
     xdsClient =
         new ClientXdsClient(
             channel,
-            useProtocolV3(),
-            EnvoyProtoData.Node.newBuilder().build(),
+            bootstrapInfo,
             fakeClock.getScheduledExecutorService(),
             backoffPolicyProvider,
             fakeClock.getStopwatchSupplier(),

--- a/xds/src/test/java/io/grpc/xds/CsdsServiceTest.java
+++ b/xds/src/test/java/io/grpc/xds/CsdsServiceTest.java
@@ -76,6 +76,7 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link CsdsService}. */
 @RunWith(Enclosed.class)
 public class CsdsServiceTest {
+  private static final String SERVER_URI = "trafficdirector.googleapis.com";
   private static final String NODE_ID =
       "projects/42/networks/default/nodes/5c85b298-6f5b-4722-b74a-f7d1f0ccf5ad";
   private static final EnvoyProtoData.Node BOOTSTRAP_NODE =
@@ -85,7 +86,7 @@ public class CsdsServiceTest {
     Bootstrapper.BootstrapInfo getBootstrapInfo() {
       return new Bootstrapper.BootstrapInfo(
           Arrays.asList(
-             new Bootstrapper.ServerInfo("", InsecureChannelCredentials.create(), false)),
+             new Bootstrapper.ServerInfo(SERVER_URI, InsecureChannelCredentials.create(), false)),
           BOOTSTRAP_NODE,
           null,
           null);
@@ -696,7 +697,7 @@ public class CsdsServiceTest {
         Bootstrapper.BootstrapInfo getBootstrapInfo() {
           return new Bootstrapper.BootstrapInfo(Arrays.asList(
                   new Bootstrapper.ServerInfo(
-                              "", InsecureChannelCredentials.create(), false)),
+                          SERVER_URI, InsecureChannelCredentials.create(), false)),
                   BOOTSTRAP_NODE, null,null);
         }
 

--- a/xds/src/test/java/io/grpc/xds/CsdsServiceTest.java
+++ b/xds/src/test/java/io/grpc/xds/CsdsServiceTest.java
@@ -49,6 +49,7 @@ import io.envoyproxy.envoy.service.status.v3.ClientStatusRequest;
 import io.envoyproxy.envoy.service.status.v3.ClientStatusResponse;
 import io.envoyproxy.envoy.service.status.v3.PerXdsConfig;
 import io.envoyproxy.envoy.type.matcher.v3.NodeMatcher;
+import io.grpc.InsecureChannelCredentials;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
@@ -60,6 +61,7 @@ import io.grpc.xds.AbstractXdsClient.ResourceType;
 import io.grpc.xds.XdsClient.ResourceMetadata;
 import io.grpc.xds.XdsClient.ResourceMetadata.ResourceMetadataStatus;
 import io.grpc.xds.XdsNameResolverProvider.XdsClientPoolFactory;
+import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -80,8 +82,13 @@ public class CsdsServiceTest {
       EnvoyProtoData.Node.newBuilder().setId(NODE_ID).build();
   private static final XdsClient XDS_CLIENT_NO_RESOURCES = new XdsClient() {
     @Override
-    EnvoyProtoData.Node getNode() {
-      return BOOTSTRAP_NODE;
+    Bootstrapper.BootstrapInfo getBootstrapInfo() {
+      return new Bootstrapper.BootstrapInfo(
+          Arrays.asList(
+             new Bootstrapper.ServerInfo("", InsecureChannelCredentials.create(), false)),
+          BOOTSTRAP_NODE,
+          null,
+          null);
     }
 
     @Override
@@ -686,8 +693,11 @@ public class CsdsServiceTest {
     public void getClientConfigForXdsClient_subscribedResourcesToPerXdsConfig() {
       ClientConfig clientConfig = CsdsService.getClientConfigForXdsClient(new XdsClient() {
         @Override
-        EnvoyProtoData.Node getNode() {
-          return BOOTSTRAP_NODE;
+        Bootstrapper.BootstrapInfo getBootstrapInfo() {
+          return new Bootstrapper.BootstrapInfo(Arrays.asList(
+                  new Bootstrapper.ServerInfo(
+                              "", InsecureChannelCredentials.create(), false)),
+                  BOOTSTRAP_NODE, null,null);
         }
 
         @Override

--- a/xds/src/test/java/io/grpc/xds/SharedXdsClientPoolProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/SharedXdsClientPoolProviderTest.java
@@ -85,8 +85,10 @@ public class SharedXdsClientPoolProviderTest {
 
   @Test
   public void refCountedXdsClientObjectPool_delayedCreation() {
-    RefCountedXdsClientObjectPool xdsClientPool = new RefCountedXdsClientObjectPool(
-        SERVER_URI, InsecureChannelCredentials.create(), false, node);
+    ServerInfo server = new ServerInfo(SERVER_URI, InsecureChannelCredentials.create(), false);
+    BootstrapInfo bootstrapInfo =
+        new BootstrapInfo(Collections.singletonList(server), node, null, null);
+    RefCountedXdsClientObjectPool xdsClientPool = new RefCountedXdsClientObjectPool(bootstrapInfo);
     assertThat(xdsClientPool.getXdsClientForTest()).isNull();
     assertThat(xdsClientPool.getChannelForTest()).isNull();
     XdsClient xdsClient = xdsClientPool.getObject();
@@ -96,8 +98,10 @@ public class SharedXdsClientPoolProviderTest {
 
   @Test
   public void refCountedXdsClientObjectPool_refCounted() {
-    RefCountedXdsClientObjectPool xdsClientPool = new RefCountedXdsClientObjectPool(
-        SERVER_URI, InsecureChannelCredentials.create(), false, node);
+    ServerInfo server = new ServerInfo(SERVER_URI, InsecureChannelCredentials.create(), false);
+    BootstrapInfo bootstrapInfo =
+        new BootstrapInfo(Collections.singletonList(server), node, null, null);
+    RefCountedXdsClientObjectPool xdsClientPool = new RefCountedXdsClientObjectPool(bootstrapInfo);
     // getObject once
     XdsClient xdsClient = xdsClientPool.getObject();
     assertThat(xdsClient).isNotNull();
@@ -114,8 +118,10 @@ public class SharedXdsClientPoolProviderTest {
 
   @Test
   public void refCountedXdsClientObjectPool_getObjectCreatesNewInstanceIfAlreadyShutdown() {
-    RefCountedXdsClientObjectPool xdsClientPool = new RefCountedXdsClientObjectPool(
-        SERVER_URI, InsecureChannelCredentials.create(), false, node);
+    ServerInfo server = new ServerInfo(SERVER_URI, InsecureChannelCredentials.create(), false);
+    BootstrapInfo bootstrapInfo =
+        new BootstrapInfo(Collections.singletonList(server), node, null, null);
+    RefCountedXdsClientObjectPool xdsClientPool = new RefCountedXdsClientObjectPool(bootstrapInfo);
     XdsClient xdsClient1 = xdsClientPool.getObject();
     ManagedChannel channel1 = xdsClientPool.getChannelForTest();
     assertThat(xdsClientPool.returnObject(xdsClient1)).isNull();


### PR DESCRIPTION
This PR is needed for further changes to eliminate the Bootstrapper from TlsContextManagrerImpl and related classes.