### PR TITLE
bom: Do not include grpc-binder (1.37.x backport)

### DIFF
--- a/bom/build.gradle
+++ b/bom/build.gradle
@@ -12,7 +12,12 @@ publishing {
 
       pom.withXml {
         // Generate bom using subprojects
-        def internalProjects = [project.name, 'grpc-gae-interop-testing-jdk8', 'grpc-compiler']
+        def internalProjects = [
+          project.name,
+          'grpc-binder',
+          'grpc-compiler',
+          'grpc-gae-interop-testing-jdk8',
+        ]
 
         def dependencyManagement = asNode().appendNode('dependencyManagement')
         def dependencies = dependencyManagement.appendNode('dependencies')


### PR DESCRIPTION
Binder is not yet being published, so this artifact wouldn't exist.

CC @markb74 

Backport of #8038