### PR TITLE
xds: cache bootstrapInfo in the SslContextProviderFactory to prevent rereading (backport 1.37.x) #8051

### DIFF
--- a/xds/src/main/java/io/grpc/xds/internal/sds/ClientSslContextProviderFactory.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/ClientSslContextProviderFactory.java
@@ -31,6 +31,7 @@ final class ClientSslContextProviderFactory
     implements ValueFactory<UpstreamTlsContext, SslContextProvider> {
 
   private final Bootstrapper bootstrapper;
+  private Bootstrapper.BootstrapInfo bootstrapInfo;
   private final CertProviderClientSslContextProvider.Factory
       certProviderClientSslContextProviderFactory;
 
@@ -54,7 +55,9 @@ final class ClientSslContextProviderFactory
     if (CommonTlsContextUtil.hasCertProviderInstance(
             upstreamTlsContext.getCommonTlsContext())) {
       try {
-        Bootstrapper.BootstrapInfo bootstrapInfo = bootstrapper.bootstrap();
+        if (bootstrapInfo == null) {
+          bootstrapInfo = bootstrapper.bootstrap();
+        }
         return certProviderClientSslContextProviderFactory.getProvider(
                 upstreamTlsContext,
                 bootstrapInfo.getNode().toEnvoyProtoNode(),
@@ -68,9 +71,12 @@ final class ClientSslContextProviderFactory
     } else if (CommonTlsContextUtil.hasAllSecretsUsingSds(
         upstreamTlsContext.getCommonTlsContext())) {
       try {
+        if (bootstrapInfo == null) {
+          bootstrapInfo = bootstrapper.bootstrap();
+        }
         return SdsClientSslContextProvider.getProvider(
             upstreamTlsContext,
-            bootstrapper.bootstrap().getNode().toEnvoyProtoNodeV2(),
+            bootstrapInfo.getNode().toEnvoyProtoNodeV2(),
             Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
                 .setNameFormat("client-sds-sslcontext-provider-%d")
                 .setDaemon(true)

--- a/xds/src/main/java/io/grpc/xds/internal/sds/ServerSslContextProviderFactory.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/ServerSslContextProviderFactory.java
@@ -31,6 +31,7 @@ final class ServerSslContextProviderFactory
     implements ValueFactory<DownstreamTlsContext, SslContextProvider> {
 
   private final Bootstrapper bootstrapper;
+  private Bootstrapper.BootstrapInfo bootstrapInfo;
   private final CertProviderServerSslContextProvider.Factory
       certProviderServerSslContextProviderFactory;
 
@@ -55,7 +56,9 @@ final class ServerSslContextProviderFactory
     if (CommonTlsContextUtil.hasCertProviderInstance(
             downstreamTlsContext.getCommonTlsContext())) {
       try {
-        Bootstrapper.BootstrapInfo bootstrapInfo = bootstrapper.bootstrap();
+        if (bootstrapInfo == null) {
+          bootstrapInfo = bootstrapper.bootstrap();
+        }
         return certProviderServerSslContextProviderFactory.getProvider(
                 downstreamTlsContext,
                 bootstrapInfo.getNode().toEnvoyProtoNode(),
@@ -69,9 +72,12 @@ final class ServerSslContextProviderFactory
     } else if (CommonTlsContextUtil.hasAllSecretsUsingSds(
         downstreamTlsContext.getCommonTlsContext())) {
       try {
+        if (bootstrapInfo == null) {
+          bootstrapInfo = bootstrapper.bootstrap();
+        }
         return SdsServerSslContextProvider.getProvider(
             downstreamTlsContext,
-            bootstrapper.bootstrap().getNode().toEnvoyProtoNodeV2(),
+            bootstrapInfo.getNode().toEnvoyProtoNodeV2(),
             Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
                 .setNameFormat("server-sds-sslcontext-provider-%d")
                 .setDaemon(true)

--- a/xds/src/test/java/io/grpc/xds/internal/sds/ClientSslContextProviderFactoryTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/sds/ClientSslContextProviderFactoryTest.java
@@ -23,6 +23,8 @@ import static io.grpc.xds.internal.sds.CommonTlsContextTestsUtil.CLIENT_PEM_FILE
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
@@ -139,6 +141,11 @@ public class ClientSslContextProviderFactoryTest {
         clientSslContextProviderFactory.create(upstreamTlsContext);
     assertThat(sslContextProvider).isInstanceOf(CertProviderClientSslContextProvider.class);
     verifyWatcher(sslContextProvider, watcherCaptor[0]);
+    // verify that bootstrapInfo is cached...
+    sslContextProvider =
+        clientSslContextProviderFactory.create(upstreamTlsContext);
+    assertThat(sslContextProvider).isInstanceOf(CertProviderClientSslContextProvider.class);
+    verify(bootstrapper, times(1)).bootstrap();
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/internal/sds/ServerSslContextProviderFactoryTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/sds/ServerSslContextProviderFactoryTest.java
@@ -23,6 +23,8 @@ import static io.grpc.xds.internal.sds.CommonTlsContextTestsUtil.CA_PEM_FILE;
 import static io.grpc.xds.internal.sds.CommonTlsContextTestsUtil.SERVER_1_KEY_FILE;
 import static io.grpc.xds.internal.sds.CommonTlsContextTestsUtil.SERVER_1_PEM_FILE;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
@@ -135,6 +137,11 @@ public class ServerSslContextProviderFactoryTest {
         serverSslContextProviderFactory.create(downstreamTlsContext);
     assertThat(sslContextProvider).isInstanceOf(CertProviderServerSslContextProvider.class);
     verifyWatcher(sslContextProvider, watcherCaptor[0]);
+    // verify that bootstrapInfo is cached...
+    sslContextProvider =
+        serverSslContextProviderFactory.create(downstreamTlsContext);
+    assertThat(sslContextProvider).isInstanceOf(CertProviderServerSslContextProvider.class);
+    verify(bootstrapper, times(1)).bootstrap();
   }
 
   @Test


### PR DESCRIPTION
The 2 Factory classes are modified to save bootstrapInfo locally to avoid re-reading bootstrap file.