### PR TITLE
xds: Fix error prone UnnecessaryJavacSuppressWarnings in a test

### DIFF
--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
@@ -2127,7 +2127,6 @@ public abstract class ClientXdsClientTestBase {
       return buildListener(name, routeConfiguration, Collections.<Message>emptyList());
     }
 
-    @SuppressWarnings("unchecked")
     protected abstract Message buildListener(
         String name, Message routeConfiguration, List<? extends Message> httpFilters);
 


### PR DESCRIPTION
Fix internal check nagging about unnecessary `@SuppressWarnings("unchecked")`.

Error Prone
UnnecessaryJavacSuppressWarnings
Unnecessarily suppressed warnings: unchecked

