### PR TITLE
buildscript: use different xds-k8s cluster (v1.37.x backport)

### DIFF
--- a/buildscripts/kokoro/xds-k8s.sh
+++ b/buildscripts/kokoro/xds-k8s.sh
@@ -4,8 +4,8 @@ set -eo pipefail
 # Constants
 readonly GITHUB_REPOSITORY_NAME="grpc-java"
 # GKE Cluster
-readonly GKE_CLUSTER_NAME="interop-test-psm-sec1-us-central1"
-readonly GKE_CLUSTER_ZONE="us-central1-a"
+readonly GKE_CLUSTER_NAME="interop-test-psm-sec-testing-api"
+readonly GKE_CLUSTER_ZONE="us-west1-b"
 ## xDS test server/client Docker images
 readonly SERVER_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/java-server"
 readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/java-client"

--- a/buildscripts/kokoro/xds-k8s.sh
+++ b/buildscripts/kokoro/xds-k8s.sh
@@ -6,6 +6,7 @@ readonly GITHUB_REPOSITORY_NAME="grpc-java"
 # GKE Cluster
 readonly GKE_CLUSTER_NAME="interop-test-psm-sec-testing-api"
 readonly GKE_CLUSTER_ZONE="us-west1-b"
+export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://test-container.sandbox.googleapis.com/"
 ## xDS test server/client Docker images
 readonly SERVER_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/java-server"
 readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/java-client"


### PR DESCRIPTION
ref:
https://github.com/grpc/grpc-java/pull/8063
https://github.com/grpc/grpc-java/pull/8064