### PR TITLE
Upgrading Google auth library to 0.25.2 with dependency exclusion

### DIFF
--- a/auth/src/test/java/io/grpc/auth/GoogleAuthLibraryCallCredentialsTest.java
+++ b/auth/src/test/java/io/grpc/auth/GoogleAuthLibraryCallCredentialsTest.java
@@ -394,7 +394,11 @@ public class GoogleAuthLibraryCallCredentialsTest {
     Map<?, ?> header = (Map<?, ?>) JsonParser.parse(jsonHeader);
     assertEquals("test-private-key-id", header.get("kid"));
     Map<?, ?> payload = (Map<?, ?>) JsonParser.parse(jsonPayload);
-    assertEquals("https://example.com/", payload.get("aud"));
+    // google-auth-library-java 0.25.2 began stripping the grpc service name from the audience.
+    // Allow tests to pass with both the old and new versions for a while to avoid an atomic upgrade
+    // everywhere google-auth-library-java is used.
+    assertTrue("https://example.com/".equals(payload.get("aud"))
+        || "https://example.com:123/a.service".equals(payload.get("aud")));
     assertEquals("test-email@example.com", payload.get("iss"));
     assertEquals("test-email@example.com", payload.get("sub"));
   }

--- a/auth/src/test/java/io/grpc/auth/GoogleAuthLibraryCallCredentialsTest.java
+++ b/auth/src/test/java/io/grpc/auth/GoogleAuthLibraryCallCredentialsTest.java
@@ -394,7 +394,7 @@ public class GoogleAuthLibraryCallCredentialsTest {
     Map<?, ?> header = (Map<?, ?>) JsonParser.parse(jsonHeader);
     assertEquals("test-private-key-id", header.get("kid"));
     Map<?, ?> payload = (Map<?, ?>) JsonParser.parse(jsonPayload);
-    assertEquals("https://example.com:123/a.service", payload.get("aud"));
+    assertEquals("https://example.com/", payload.get("aud"));
     assertEquals("test-email@example.com", payload.get("iss"));
     assertEquals("test-email@example.com", payload.get("sub"));
   }

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ subprojects {
 
         nettyVersion = '4.1.52.Final'
         guavaVersion = '30.0-android'
-        googleauthVersion = '0.22.2'
+        googleauthVersion = '0.25.2'
         protobufVersion = '3.12.0'
         protocVersion = protobufVersion
         opencensusVersion = '0.28.0'

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ subprojects {
         nettyVersion = '4.1.52.Final'
         guavaVersion = '30.0-android'
         googleauthVersion = '0.25.2'
+        googlehttpVersion = '1.39.1'
         protobufVersion = '3.12.0'
         protocVersion = protobufVersion
         opencensusVersion = '0.28.0'
@@ -155,6 +156,7 @@ subprojects {
             google_api_protos: 'com.google.api.grpc:proto-google-common-protos:2.0.1',
             google_auth_credentials: "com.google.auth:google-auth-library-credentials:${googleauthVersion}",
             google_auth_oauth2_http: "com.google.auth:google-auth-library-oauth2-http:${googleauthVersion}",
+            google_http_client_jackson2: "com.google.http-client:google-http-client-jackson2:${googlehttpVersion}",
             okhttp: 'com.squareup.okhttp:okhttp:2.7.4',
             okio: 'com.squareup.okio:okio:1.17.5',
             opencensus_api: "io.opencensus:opencensus-api:${opencensusVersion}",
@@ -254,16 +256,6 @@ subprojects {
             dependencies.runtimeOnly project(':grpc-context')
             censusApiDependency 'runtimeOnly'
             guavaDependency 'runtimeOnly'
-
-            // We can remove this dependency override once org.apache.httpcomponents:httpclient:4.5.13
-            // is released with org.apache.httpcomponents:httpcore:4.4.14 dependency, and
-            // com.google.http-client:google-http-client:1.39.1 is upgraded with them.
-            // https://github.com/grpc/grpc-java/issues/8037
-            configurations.all {
-                resolutionStrategy {
-                    force 'org.apache.httpcomponents:httpcore:4.4.14'
-                }
-            }
         }
 
         // A util function to config perfmark dependency with transitive
@@ -299,6 +291,16 @@ subprojects {
         ])) {
             runtimeClasspath {
                 resolutionStrategy.failOnVersionConflict()
+
+                // We can remove this dependency override once org.apache.httpcomponents:httpclient:4.5.13
+                // is released with org.apache.httpcomponents:httpcore:4.4.14 dependency, and
+                // com.google.http-client:google-http-client:1.39.1 is upgraded with them.
+                // https://github.com/grpc/grpc-java/issues/8037
+                configurations.all {
+                    resolutionStrategy {
+                        force 'org.apache.httpcomponents:httpcore:4.4.14'
+                    }
+                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -151,6 +151,7 @@ subprojects {
             cronet_embedded: 'org.chromium.net:cronet-embedded:66.3359.158',
             gson: "com.google.code.gson:gson:2.8.6",
             guava: "com.google.guava:guava:${guavaVersion}",
+            httpcore: "org.apache.httpcomponents:httpcore:4.4.14",
             javax_annotation: 'org.apache.tomcat:annotations-api:6.0.53',
             jsr305: 'com.google.code.findbugs:jsr305:3.0.2',
             google_api_protos: 'com.google.api.grpc:proto-google-common-protos:2.0.1',
@@ -252,10 +253,12 @@ subprojects {
                 exclude group: 'com.google.guava', module: 'guava'
                 exclude group: 'io.grpc', module: 'grpc-context'
                 exclude group: 'io.opencensus', module: 'opencensus-api'
+                exclude group: 'org.apache.httpcomponents', module: 'httpcore'
             }
             dependencies.runtimeOnly project(':grpc-context')
             censusApiDependency 'runtimeOnly'
             guavaDependency 'runtimeOnly'
+            dependencies.runtimeOnly libraries.httpcore
         }
 
         // A util function to config perfmark dependency with transitive
@@ -291,16 +294,6 @@ subprojects {
         ])) {
             runtimeClasspath {
                 resolutionStrategy.failOnVersionConflict()
-
-                // We can remove this dependency override once org.apache.httpcomponents:httpclient:4.5.13
-                // is released with org.apache.httpcomponents:httpcore:4.4.14 dependency, and
-                // com.google.http-client:google-http-client:1.39.1 is upgraded with them.
-                // https://github.com/grpc/grpc-java/issues/8037
-                configurations.all {
-                    resolutionStrategy {
-                        force 'org.apache.httpcomponents:httpcore:4.4.14'
-                    }
-                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -254,6 +254,16 @@ subprojects {
             dependencies.runtimeOnly project(':grpc-context')
             censusApiDependency 'runtimeOnly'
             guavaDependency 'runtimeOnly'
+
+            // We can remove this dependency override once org.apache.httpcomponents:httpclient:4.5.13
+            // is released with org.apache.httpcomponents:httpcore:4.4.14 dependency, and
+            // com.google.http-client:google-http-client:1.39.1 is upgraded with them.
+            // https://github.com/grpc/grpc-java/issues/8037
+            configurations.all {
+                resolutionStrategy {
+                    force 'org.apache.httpcomponents:httpcore:4.4.14'
+                }
+            }
         }
 
         // A util function to config perfmark dependency with transitive

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -56,7 +56,9 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
         exclude group: 'io.grpc', module: 'grpc-context'
+        exclude group: 'org.apache.httpcomponents', module: 'httpcore'
     }
+    runtimeOnly libraries.httpcore
 
     testImplementation project(':grpc-core').sourceSets.test.output
 

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -37,6 +37,7 @@ dependencies {
             libraries.re2j,
             libraries.bouncycastle,
             libraries.autovalue_annotation
+
     def nettyDependency = implementation project(':grpc-netty')
 
     implementation (libraries.opencensus_proto) {
@@ -49,6 +50,12 @@ dependencies {
         // prefer our own versions instead of protobuf-util's dependency
         exclude group: 'com.google.guava', module: 'guava'
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+    }
+
+    implementation (libraries.google_http_client_jackson2) {
+        exclude group: 'com.google.guava', module: 'guava'
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+        exclude group: 'io.grpc', module: 'grpc-context'
     }
 
     testImplementation project(':grpc-core').sourceSets.test.output

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -57,6 +57,7 @@ dependencies {
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
         exclude group: 'io.grpc', module: 'grpc-context'
         exclude group: 'org.apache.httpcomponents', module: 'httpcore'
+        exclude group: 'junit', module: 'junit'
     }
     runtimeOnly libraries.httpcore
 


### PR DESCRIPTION
Fixes #8037 

# Why dependency exclusion of httpcore?

Previous attempt failed (https://github.com/grpc/grpc-java/pull/8044) due to `failOnVersionConflict`, and there's no planned upcoming release for `org.apache.httpcomponents:httpclient` 4.5.X, which would fix the discrepancy.

```
suztomo-macbookpro44% ./gradlew     :grpc-all:dependencyInsight --configuration runtimeClasspath --dependency org.apache.httpcomponents:httpcore                                                                                 
*** Skipping the build of codegen and compilation of proto files because skipCodegen=true
  * Skipping the build of Android projects because skipAndroid=true

> Task :grpc-all:dependencyInsight
Dependency resolution failed because of conflict(s) on the following module(s):
   - org.apache.httpcomponents:httpcore between versions 4.4.14 and 4.4.13

org.apache.httpcomponents:httpcore:4.4.14
   variant "runtime" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-runtime
      org.gradle.libraryelements     = jar
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.version         = 7
   ]
   Selection reasons:
      - By conflict resolution : between versions 4.4.14 and 4.4.13

org.apache.httpcomponents:httpcore:4.4.14
\--- com.google.http-client:google-http-client:1.39.1
     +--- com.google.auth:google-auth-library-oauth2-http:0.25.2
     |    \--- project :grpc-alts
     |         \--- project :grpc-xds
     |              \--- runtimeClasspath
     \--- com.google.http-client:google-http-client-gson:1.39.1
          \--- com.google.auth:google-auth-library-oauth2-http:0.25.2 (*)

org.apache.httpcomponents:httpcore:4.4.13 -> 4.4.14
\--- org.apache.httpcomponents:httpclient:4.5.13
     \--- com.google.http-client:google-http-client:1.39.1
          +--- com.google.auth:google-auth-library-oauth2-http:0.25.2
          |    \--- project :grpc-alts
          |         \--- project :grpc-xds
          |              \--- runtimeClasspath
          \--- com.google.http-client:google-http-client-gson:1.39.1
               \--- com.google.auth:google-auth-library-oauth2-http:0.25.2 (*)
```

Initially this PR tried to overwrite the httpcore dependency, but it does not have effect in the pom.xml consumed by gRPC users. Therefore this PR now excludes httpcore dependency and redeclare it as direct dependencies.