### PR TITLE
xds: reduce the size of ring for testing pick distributions

### DIFF
--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
@@ -567,7 +567,7 @@ public class RingHashLoadBalancerTest {
 
   @Test
   public void hostSelectionProportionalToWeights() {
-    RingHashConfig config = new RingHashConfig(100000, 1000000);  // large ring
+    RingHashConfig config = new RingHashConfig(10000, 100000);  // large ring
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 10, 100); // 1:10:100
     loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
@@ -594,16 +594,16 @@ public class RingHashLoadBalancerTest {
       pickCounts.put(addr, pickCounts.get(addr) + 1);
     }
 
-    // Actual distribution: server0 = 91, server1 = 866, server2 = 9043 (~0.5% tolerance)
+    // Actual distribution: server0 = 104, server1 = 808, server2 = 9088
     double ratio01 = (double) pickCounts.get(servers.get(0)) / pickCounts.get(servers.get(1));
     double ratio12 = (double) pickCounts.get(servers.get(1)) / pickCounts.get(servers.get(2));
-    assertThat(ratio01).isWithin(0.01).of((double) 1 / 10);
-    assertThat(ratio12).isWithin(0.01).of((double) 10 / 100);
+    assertThat(ratio01).isWithin(0.03).of((double) 1 / 10);
+    assertThat(ratio12).isWithin(0.03).of((double) 10 / 100);
   }
 
   @Test
   public void hostSelectionProportionalToRepeatedAddressCount() {
-    RingHashConfig config = new RingHashConfig(100000, 100000);
+    RingHashConfig config = new RingHashConfig(10000, 100000);
     List<EquivalentAddressGroup> servers = createRepeatedServerAddrs(1, 10, 100);  // 1:10:100
     loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
@@ -630,11 +630,11 @@ public class RingHashLoadBalancerTest {
       pickCounts.put(addr, pickCounts.get(addr) + 1);
     }
 
-    // Actual distribution: server0 = 0, server1 = 90, server2 = 9910
+    // Actual distribution: server0 = 104, server1 = 808, server2 = 9088
     double ratio01 = (double) pickCounts.get(servers.get(0)) / pickCounts.get(servers.get(1));
     double ratio12 = (double) pickCounts.get(servers.get(1)) / pickCounts.get(servers.get(11));
-    assertThat(ratio01).isWithin(0.01).of((double) 1 / 10);
-    assertThat(ratio12).isWithin(0.01).of((double) 10 / 100);
+    assertThat(ratio01).isWithin(0.03).of((double) 1 / 10);
+    assertThat(ratio12).isWithin(0.03).of((double) 10 / 100);
   }
 
   @Test


### PR DESCRIPTION
In the ring hash LB policy, building the ring is computationally heavy. Although using a larger ring can make the RPC distribution closer to the actual weights of hosts, it takes long time to finish the test.

Internally, each test class is expected to finish within 1 minute, while each of the test cases for testing pick distribution takes about 30 sec. By reducing the ring size by a factor of 10, the time spent for those test cases reduce to 1-2 seconds. Now we need larger tolerance for the distribution (three hosts with weights 1:10:100):

- With a ring size of 100000, the 10000 RPCs distribution is close to 91 : 866 : 9043
- With a ring size of 10000, the 10000 RPCs distribution is close to 104 : 808 : 9088

Roughly, this is still acceptable.