### PR TITLE
all: Only depend on evaluation of enumerated subprojects

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -24,12 +24,13 @@ def subprojects = [
     project(':grpc-xds'),
 ]
 
-for (subproject in rootProject.subprojects) {
+for (subproject in subprojects) {
     if (subproject == project) {
         continue
     }
     evaluationDependsOn(subproject.path)
 }
+evaluationDependsOn(':grpc-interop-testing')
 
 dependencies {
     api subprojects.minus([project(':grpc-protobuf-lite')])


### PR DESCRIPTION
Back in 10fb206 when this for loop was added, we didn't have the
subprojects list. That was added in 9bd7bab, but I failed to update one
reference to rootProject. So all has had an evaluation dependency on all
projects, even though it only needs a subset.

This should have little impact, but would prevent weird scenarios like
an issue in :grpc-gae-interop-testing-jdk8 preventing :all-all from
being loaded. Not to say things wouldn't still fail to load, but that
this bug could distract from the real problem. I noticed this
during #8049.