### PR TITLE
okhttp: During testing, bind to localhost instead of 0.0.0.0

### DIFF
--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -1850,7 +1850,7 @@ public class OkHttpClientTransportTest {
 
   @Test
   public void proxy_200() throws Exception {
-    ServerSocket serverSocket = new ServerSocket(0);
+    ServerSocket serverSocket = new ServerSocket(0, 0, InetAddress.getLoopbackAddress());
     InetSocketAddress targetAddress = InetSocketAddress.createUnresolved("theservice", 80);
     clientTransport = new OkHttpClientTransport(
         targetAddress,
@@ -1907,7 +1907,7 @@ public class OkHttpClientTransportTest {
 
   @Test
   public void proxy_500() throws Exception {
-    ServerSocket serverSocket = new ServerSocket(0);
+    ServerSocket serverSocket = new ServerSocket(0, 0, InetAddress.getLoopbackAddress());
     InetSocketAddress targetAddress = InetSocketAddress.createUnresolved("theservice", 80);
     clientTransport = new OkHttpClientTransport(
         targetAddress,
@@ -1963,7 +1963,7 @@ public class OkHttpClientTransportTest {
 
   @Test
   public void proxy_immediateServerClose() throws Exception {
-    ServerSocket serverSocket = new ServerSocket(0);
+    ServerSocket serverSocket = new ServerSocket(0, 0, InetAddress.getLoopbackAddress());
     InetSocketAddress targetAddress = InetSocketAddress.createUnresolved("theservice", 80);
     clientTransport = new OkHttpClientTransport(
         targetAddress,


### PR DESCRIPTION
The server's address is used by the client to determine where to
connect. When binding to 0.0.0.0 the address returned by
getLocalSocketAddress() is a 0.0.0.0 address, which would seem
inappropriate for the client to use as a destination address. Somehow
this was working. However, on some systems it breaks as seen in #8080.
Using localhost is better for all systems.

Fixes #8080

CC @suztomo