### PR TITLE
core: fix NPE in ConfigSelectingClientCall (backport v1.37.x)

### DIFF
--- a/core/src/test/java/io/grpc/internal/ConfigSelectingClientCallTest.java
+++ b/core/src/test/java/io/grpc/internal/ConfigSelectingClientCallTest.java
@@ -135,6 +135,9 @@ public class ConfigSelectingClientCallTest {
     ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(null);
     verify(callListener).onClose(statusCaptor.capture(), any(Metadata.class));
     assertThat(statusCaptor.getValue().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
+
+    // The call should not delegate to null and fail methods with NPE.
+    configSelectingClientCall.request(1);
   }
 
   private final class TestChannel extends Channel {


### PR DESCRIPTION
backport of #8087 

Fix the following bug:

ManagedChannelImpl.ConfigSelectingClientCall may return early in start() leaving delegate null, and fails request() method after start().

Currently the bug can only be triggered when using xDS.