### PR TITLE
all: JacocoMerge must run after grpc-interop-testing's tests

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -50,6 +50,7 @@ javadoc {
 
 task jacocoMerge(type: JacocoMerge) {
     dependsOn(subprojects.jacocoTestReport.dependsOn)
+    dependsOn(project(':grpc-interop-testing').jacocoTestReport.dependsOn)
     mustRunAfter(subprojects.jacocoTestReport.mustRunAfter)
     destinationFile = file("${buildDir}/jacoco/test.exec")
     executionData = files(subprojects.jacocoTestReport.executionData)

--- a/all/build.gradle
+++ b/all/build.gradle
@@ -52,6 +52,7 @@ task jacocoMerge(type: JacocoMerge) {
     dependsOn(subprojects.jacocoTestReport.dependsOn)
     dependsOn(project(':grpc-interop-testing').jacocoTestReport.dependsOn)
     mustRunAfter(subprojects.jacocoTestReport.mustRunAfter)
+    mustRunAfter(project(':grpc-interop-testing').jacocoTestReport.mustRunAfter)
     destinationFile = file("${buildDir}/jacoco/test.exec")
     executionData = files(subprojects.jacocoTestReport.executionData)
             .plus(project(':grpc-interop-testing').jacocoTestReport.executionData)


### PR DESCRIPTION
Otherwise the executionData would be out-of-date.