### PR TITLE
core: clarify exception message

### DIFF
--- a/core/src/main/java/io/grpc/internal/MessageDeframer.java
+++ b/core/src/main/java/io/grpc/internal/MessageDeframer.java
@@ -517,8 +517,8 @@ public class MessageDeframer implements Closeable, Deframer {
     private void verifySize() {
       if (count > maxMessageSize) {
         throw Status.RESOURCE_EXHAUSTED.withDescription(String.format(
-                "Compressed gRPC message exceeds maximum size %d: %d bytes read",
-                maxMessageSize, count)).asRuntimeException();
+                "Decompressed gRPC message exceeds maximum size %d",
+                maxMessageSize)).asRuntimeException();
       }
     }
   }

--- a/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
+++ b/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
@@ -378,7 +378,7 @@ public class MessageDeframerTest {
 
       try {
         thrown.expect(StatusRuntimeException.class);
-        thrown.expectMessage("RESOURCE_EXHAUSTED: Compressed gRPC message exceeds");
+        thrown.expectMessage("RESOURCE_EXHAUSTED: Decompressed gRPC message exceeds");
 
         while (stream.read() != -1) {
         }
@@ -424,7 +424,7 @@ public class MessageDeframerTest {
 
       try {
         thrown.expect(StatusRuntimeException.class);
-        thrown.expectMessage("RESOURCE_EXHAUSTED: Compressed gRPC message exceeds");
+        thrown.expectMessage("RESOURCE_EXHAUSTED: Decompressed gRPC message exceeds");
 
         stream.read(buf, 0, buf.length);
       } finally {
@@ -467,7 +467,7 @@ public class MessageDeframerTest {
 
       try {
         thrown.expect(StatusRuntimeException.class);
-        thrown.expectMessage("RESOURCE_EXHAUSTED: Compressed gRPC message exceeds");
+        thrown.expectMessage("RESOURCE_EXHAUSTED: Decompressed gRPC message exceeds");
 
         stream.skip(4);
       } finally {


### PR DESCRIPTION
`SizeEnforcingInputStream` is applied on the decompressed stream. It looks like it has been the case since it was introduced in https://github.com/grpc/grpc-java/commit/15f02ba19c4a2c21afee39cb73cd0340ad2f9d1d.