### PR TITLE
netty: fix StreamBufferingEncoder GOAWAY bug (backport v1.36.x) 

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -562,20 +562,22 @@ class NettyClientHandler extends AbstractNettyHandler {
       }
       return;
     }
-    if (connection().goAwayReceived()
-        && streamId > connection().local().lastStreamKnownByPeer()) {
-      // This should only be reachable during onGoAwayReceived, as otherwise
-      // getShutdownThrowable() != null
-      command.stream().setNonExistent();
-      Status s = abruptGoAwayStatus;
-      if (s == null) {
-        // Should be impossible, but handle psuedo-gracefully
-        s = Status.INTERNAL.withDescription(
-            "Failed due to abrupt GOAWAY, but can't find GOAWAY details");
+    if (connection().goAwayReceived()) {
+      if (streamId > connection().local().lastStreamKnownByPeer()
+           || connection().local().numActiveStreams() == connection().local().maxActiveStreams()) {
+        // This should only be reachable during onGoAwayReceived, as otherwise
+        // getShutdownThrowable() != null
+        command.stream().setNonExistent();
+        Status s = abruptGoAwayStatus;
+        if (s == null) {
+          // Should be impossible, but handle psuedo-gracefully
+          s = Status.INTERNAL.withDescription(
+              "Failed due to abrupt GOAWAY, but can't find GOAWAY details");
+        }
+        command.stream().transportReportStatus(s, RpcProgress.REFUSED, true, new Metadata());
+        promise.setFailure(s.asRuntimeException());
+        return;
       }
-      command.stream().transportReportStatus(s, RpcProgress.REFUSED, true, new Metadata());
-      promise.setFailure(s.asRuntimeException());
-      return;
     }
 
     NettyClientStream.TransportState stream = command.stream();

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -563,17 +563,23 @@ class NettyClientHandler extends AbstractNettyHandler {
       return;
     }
     if (connection().goAwayReceived()) {
-      if (streamId > connection().local().lastStreamKnownByPeer()
-           || connection().local().numActiveStreams() == connection().local().maxActiveStreams()) {
+      Status s = abruptGoAwayStatus;
+      int maxActiveStreams = connection().local().maxActiveStreams();
+      int lastStreamId = connection().local().lastStreamKnownByPeer();
+      if (s == null) {
+        // Should be impossible, but handle pseudo-gracefully
+        s = Status.INTERNAL.withDescription(
+            "Failed due to abrupt GOAWAY, but can't find GOAWAY details");
+      } else if (streamId > lastStreamId) {
+        s = s.augmentDescription(
+            "stream id: " + streamId + ", GOAWAY Last-Stream-ID:" + lastStreamId);
+      } else if (connection().local().numActiveStreams() == maxActiveStreams) {
+        s = s.augmentDescription("At MAX_CONCURRENT_STREAMS limit. limit: " + maxActiveStreams);
+      }
+      if (streamId > lastStreamId || connection().local().numActiveStreams() == maxActiveStreams) {
         // This should only be reachable during onGoAwayReceived, as otherwise
         // getShutdownThrowable() != null
         command.stream().setNonExistent();
-        Status s = abruptGoAwayStatus;
-        if (s == null) {
-          // Should be impossible, but handle psuedo-gracefully
-          s = Status.INTERNAL.withDescription(
-              "Failed due to abrupt GOAWAY, but can't find GOAWAY details");
-        }
         command.stream().transportReportStatus(s, RpcProgress.REFUSED, true, new Metadata());
         promise.setFailure(s.asRuntimeException());
         return;

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -378,7 +378,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
     assertEquals(Status.UNAVAILABLE.getCode(), captor.getValue().getCode());
     assertEquals(
         "Abrupt GOAWAY closed unsent stream. HTTP/2 error code: CANCEL, "
-          + "debug data: this is a test",
+          + "debug data: this is a test\nstream id: 3, GOAWAY Last-Stream-ID:0",
         captor.getValue().getDescription());
     assertTrue(future.isDone());
   }
@@ -411,6 +411,8 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
     assertThat(Status.fromThrowable(future2.cause()).getCode()).isEqualTo(Status.Code.UNAVAILABLE);
     assertThat(future2.cause().getMessage()).contains(
         "Abrupt GOAWAY closed unsent stream. HTTP/2 error code: NO_ERROR");
+    assertThat(future2.cause().getMessage()).contains(
+        "At MAX_CONCURRENT_STREAMS limit");
   }
 
   @Test


### PR DESCRIPTION
backport of #8020, #8098