### PR TITLE
Migrate away from Jcenter

### DIFF
--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -7,7 +7,7 @@ description = 'gRPC: Android Integration Testing'
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 android {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,7 @@ android {
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/binder/build.gradle
+++ b/binder/build.gradle
@@ -24,7 +24,7 @@ android {
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -9,7 +9,7 @@ description = "gRPC: Cronet Android"
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 android {

--- a/examples/android/clientcache/build.gradle
+++ b/examples/android/clientcache/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0'
@@ -17,9 +17,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
-        // Some grpc-java releases may be missing in JCenter.
-        // See https://github.com/grpc/grpc-java/issues/5782
         mavenCentral()
         mavenLocal()
     }

--- a/examples/android/helloworld/build.gradle
+++ b/examples/android/helloworld/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0'
@@ -17,9 +17,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
-        // Some grpc-java releases may be missing in JCenter.
-        // See https://github.com/grpc/grpc-java/issues/5782
         mavenCentral()
         mavenLocal()
     }

--- a/examples/android/routeguide/build.gradle
+++ b/examples/android/routeguide/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0'
@@ -17,9 +17,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
-        // Some grpc-java releases may be missing in JCenter.
-        // See https://github.com/grpc/grpc-java/issues/5782
         mavenCentral()
         mavenLocal()
     }

--- a/examples/android/strictmode/build.gradle
+++ b/examples/android/strictmode/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0'
@@ -17,9 +17,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
-        // Some grpc-java releases may be missing in JCenter.
-        // See https://github.com/grpc/grpc-java/issues/5782
         mavenCentral()
         mavenLocal()
     }

--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -15,7 +15,6 @@
 buildscript {
     // Configuration for building
     repositories {
-        jcenter()    // Bintray's repository - a fast Maven Central mirror & more
         maven { // The google mirror is less flaky than mavenCentral()
             url "https://maven-central.storage-download.googleapis.com/maven2/" }
     }
@@ -37,7 +36,6 @@ repositories {
     mavenLocal()
     maven { // The google mirror is less flaky than mavenCentral()
         url "https://maven-central.storage-download.googleapis.com/maven2/" }
-    jcenter()
 }
 
 apply plugin: 'com.google.cloud.tools.appengine'  // App Engine tasks


### PR DESCRIPTION
Fixes #7990 

Replaces jcenter with mavenCentral.

If we found it to be too flaky, we can change to use google's mirror as gae-interop-testing is already doing.