### PR TITLE
tsan, xds: fix data races in ServerWrapperForXds

### DIFF
--- a/xds/src/test/java/io/grpc/xds/ServerWrapperForXdsTest.java
+++ b/xds/src/test/java/io/grpc/xds/ServerWrapperForXdsTest.java
@@ -99,7 +99,12 @@ public class ServerWrapperForXdsTest {
       }
     });
     // wait until xdsClientWrapperForServerSds.serverWatchers populated
-    for (int i = 0; i < 10 && xdsClientWrapperForServerSds.serverWatchers.isEmpty(); i++) {
+    for (int i = 0; i < 10; i++) {
+      synchronized (xdsClientWrapperForServerSds.serverWatchers) {
+        if (!xdsClientWrapperForServerSds.serverWatchers.isEmpty()) {
+          break;
+        }
+      }
       Thread.sleep(100L);
     }
     return settableFuture;


### PR DESCRIPTION
fix tsan [complain](https://fusion2.corp.google.com/invocations;query=user:zivy%20tsan%20367298356%20failed;page_size=100/25354208-d976-4ecc-a390-487bc85d9d48/targets/%2F%2Fthird_party%2Fjava_src%2Fgrpc%2Fxds:src%2Ftest%2Fjava%2Fio%2Fgrpc%2Fxds%2FServerWrapperForXdsTest/tests)