### PR TITLE
buildscripts: xds-k8s pin pip to 21.0.1

### DIFF
--- a/buildscripts/kokoro/xds-k8s-install-test-driver.sh
+++ b/buildscripts/kokoro/xds-k8s-install-test-driver.sh
@@ -256,9 +256,14 @@ kokoro_setup_python_virtual_environment() {
   eval "$(pyenv virtualenv-init -)"
   py_latest_patch="$(pyenv versions --bare --skip-aliases | grep -E "^${PYTHON_VERSION}\.[0-9]{1,2}$" | sort --version-sort | tail -n 1)"
   echo "Activating python ${py_latest_patch} virtual environment"
-  pyenv virtualenv "${py_latest_patch}" k8s_xds_test_runner
+  pyenv virtualenv --no-pip "${py_latest_patch}" k8s_xds_test_runner
   pyenv local k8s_xds_test_runner
   pyenv activate k8s_xds_test_runner
+  python -m ensurepip
+  # pip is fixed to 21.0.1 due to issue https://github.com/pypa/pip/pull/9835
+  # internal details: b/186411224
+  python -m pip install -U pip==21.0.1
+  pip --version
 }
 
 #######################################


### PR DESCRIPTION
[`pip 21.1`](https://pypi.org/project/pip/21.1/) released on Apr 24 introduced a regression for `python 3.6.1`.

The regression was [identified](https://github.com/pypa/pip/issues/9831) on Apr 24, [the fix](https://github.com/pypa/pip/pull/9835) merged on Apr 25.
The fix is expected to be delivered in the [`21.1.1`](https://github.com/pypa/pip/milestone/50) patch.

There's no clear date when `21.1.1` will be released at the moment. Until then, I'll temporarily pin pip to the previous release, `21.0.1`.

Related: grpc/grpc#26087