### PR TITLE
buildscripts: xds-k8s pin pip to 21.0.1 (backport 1.37.x)

### DIFF
--- a/buildscripts/kokoro/xds-k8s-install-test-driver.sh
+++ b/buildscripts/kokoro/xds-k8s-install-test-driver.sh
@@ -256,9 +256,14 @@ kokoro_setup_python_virtual_environment() {
   eval "$(pyenv virtualenv-init -)"
   py_latest_patch="$(pyenv versions --bare --skip-aliases | grep -E "^${PYTHON_VERSION}\.[0-9]{1,2}$" | sort --version-sort | tail -n 1)"
   echo "Activating python ${py_latest_patch} virtual environment"
-  pyenv virtualenv "${py_latest_patch}" k8s_xds_test_runner
+  pyenv virtualenv --no-pip "${py_latest_patch}" k8s_xds_test_runner
   pyenv local k8s_xds_test_runner
   pyenv activate k8s_xds_test_runner
+  python -m ensurepip
+  # pip is fixed to 21.0.1 due to issue https://github.com/pypa/pip/pull/9835
+  # internal details: b/186411224
+  python -m pip install -U pip==21.0.1
+  pip --version
 }
 
 #######################################


### PR DESCRIPTION
Backports https://github.com/grpc/grpc-java/pull/8115 to `1.37.x`.