### PR TITLE
Move protoc aarch64 artifact build to linux_aarch64 job

### DIFF
--- a/buildscripts/grpc-java-artifacts-aarch64/Dockerfile
+++ b/buildscripts/grpc-java-artifacts-aarch64/Dockerfile
@@ -1,0 +1,13 @@
+FROM dockcross/manylinux2014-aarch64
+
+RUN yum install -y java-1.8.0-openjdk-devel && \
+    yum clean all
+
+# Install Maven
+RUN curl -Ls http://apache.cs.utah.edu/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz | \
+    tar xz -C /var/local
+ENV PATH /var/local/apache-maven-3.3.9/bin:$PATH
+
+# compiler/build.gradle expects to find binaries named "aarch64-linux-gnu-g++" and "aarch64-linux-gnu-objdump"
+RUN ln -s /usr/xcc/aarch64-unknown-linux-gnueabi/bin/aarch64-unknown-linux-gnueabi-g++ /usr/local/bin/aarch64-linux-gnu-g++
+RUN ln -s /usr/xcc/aarch64-unknown-linux-gnueabi/bin/aarch64-unknown-linux-gnueabi-objdump /usr/local/bin/aarch64-linux-gnu-objdump

--- a/buildscripts/grpc-java-artifacts/Dockerfile
+++ b/buildscripts/grpc-java-artifacts/Dockerfile
@@ -19,6 +19,10 @@ RUN yum install -y \
             && \
     yum clean all
 
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    yum install -y gcc-c++-aarch64-linux-gnu && \
+    yum clean all
+
 # Install Maven
 RUN curl -Ls http://apache.cs.utah.edu/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz | \
     tar xz -C /var/local

--- a/buildscripts/kokoro/linux_artifacts.sh
+++ b/buildscripts/kokoro/linux_artifacts.sh
@@ -31,7 +31,3 @@ popd
 readonly MVN_ARTIFACT_DIR="${MVN_ARTIFACT_DIR:-$GRPC_JAVA_DIR/mvn-artifacts}"
 mkdir -p "$MVN_ARTIFACT_DIR"
 cp -r "$LOCAL_MVN_TEMP"/* "$MVN_ARTIFACT_DIR"/
-
-# for aarch64 platform
-sudo apt-get install -y g++-aarch64-linux-gnu
-SKIP_TESTS=true ARCH=aarch_64 "$GRPC_JAVA_DIR"/buildscripts/kokoro/unix.sh

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -87,11 +87,6 @@ fi
 LOCAL_MVN_TEMP=$(mktemp -d)
 # Note that this disables parallel=true from GRADLE_FLAGS
 if [[ -z "${ALL_ARTIFACTS:-}" ]]; then
-  if [[ $ARCH == "aarch_64" ]]; then
-    GRADLE_FLAGS+=" -x grpc-compiler:generateTestProto -x grpc-compiler:generateTestLiteProto"
-    GRADLE_FLAGS+=" -x grpc-compiler:testGolden -x grpc-compiler:testLiteGolden"
-    GRADLE_FLAGS+=" -x grpc-compiler:testDeprecatedGolden -x grpc-compiler:testDeprecatedLiteGolden"
-  fi
   ./gradlew grpc-compiler:build grpc-compiler:publish $GRADLE_FLAGS \
     -Dorg.gradle.parallel=false -PrepositoryDir=$LOCAL_MVN_TEMP
 else


### PR DESCRIPTION
Followup for https://github.com/grpc/grpc-java/pull/8113.

We should only merge this once the [linux_aarch64 job](https://fusion.corp.google.com/projectanalysis/summary/KOKORO/prod:grpc%2Fjava%2Fmaster%2Fbranch%2Flinux_aarch64?search_pattern=linux_aarch64&project_types=KOKORO&include_inactive_projects=false)  is reliably green (otherwise we could negatively affect the release process).