### PR TITLE
xds: implement toString() for pickers to visualize selectable hosts

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static io.grpc.xds.XdsSubchannelPickers.BUFFER_PICKER;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 import io.grpc.Attributes;
 import io.grpc.ClientStreamTracer;
@@ -321,6 +322,11 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
           return PickResult.withSubchannel(result.getSubchannel(), tracerFactory);
         }
         return result;
+      }
+
+      @Override
+      public String toString() {
+        return MoreObjects.toStringHelper(this).add("delegate", delegate).toString();
       }
     }
   }

--- a/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
@@ -24,6 +24,7 @@ import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 import static io.grpc.xds.XdsSubchannelPickers.BUFFER_PICKER;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
 import io.grpc.ConnectivityState;
 import io.grpc.InternalLogId;
 import io.grpc.LoadBalancer;
@@ -150,6 +151,11 @@ class ClusterManagerLoadBalancer extends LoadBalancer {
                     Status.UNAVAILABLE.withDescription("Unable to find cluster " + clusterName));
           }
           return delegate.pickSubchannel(args);
+        }
+
+        @Override
+        public String toString() {
+          return MoreObjects.toStringHelper(this).add("pickers", childPickers).toString();
         }
       };
       helper.updateBalancingState(overallState, picker);


### PR DESCRIPTION
Implements toString() for the wrapping SubchannelPickers so that we are able to see how hosts are selected when sending out RPCs.