### PR TITLE
Upgrade netty-tcnative-boringssl-static to 2.0.35.Final

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -404,7 +404,8 @@ grpc-netty version | netty-handler version | netty-tcnative-boringssl-static ver
 1.28.x             | 4.1.45.Final          | 2.0.28.Final
 1.29.x-1.31.x      | 4.1.48.Final          | 2.0.30.Final
 1.32.x-1.34.x      | 4.1.51.Final          | 2.0.31.Final
-1.35.x-            | 4.1.52.Final          | 2.0.34.Final
+1.35.x-1.37.x      | 4.1.52.Final          | 2.0.34.Final
+1.38.x-            | 4.1.52.Final          | 2.0.35.Final
 
 _(grpc-netty-shaded avoids issues with keeping these versions in sync.)_
 

--- a/build.gradle
+++ b/build.gradle
@@ -174,9 +174,8 @@ subprojects {
 
             // Keep the following references of tcnative version in sync whenever it's updated
             // SECURITY.md (multiple occurrences)
-            // examples/example-tls/build.gradle
             // examples/example-tls/pom.xml
-            netty_tcnative: 'io.netty:netty-tcnative-boringssl-static:2.0.34.Final',
+            netty_tcnative: 'io.netty:netty-tcnative-boringssl-static:2.0.35.Final',
 
             conscrypt: 'org.conscrypt:conscrypt-openjdk-uber:2.5.1',
             re2j: 'com.google.re2j:re2j:1.5',

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -14,7 +14,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.38.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protoc.version>3.12.0</protoc.version>
-    <netty.tcnative.version>2.0.34.Final</netty.tcnative.version>
+    <netty.tcnative.version>2.0.35.Final</netty.tcnative.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -32,7 +32,7 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "io.netty:netty-handler-proxy:4.1.52.Final",
     "io.netty:netty-handler:4.1.52.Final",
     "io.netty:netty-resolver:4.1.52.Final",
-    "io.netty:netty-tcnative-boringssl-static:2.0.34.Final",
+    "io.netty:netty-tcnative-boringssl-static:2.0.35.Final",
     "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.52.Final",
     "io.netty:netty-transport:4.1.52.Final",
     "io.opencensus:opencensus-api:0.24.0",


### PR DESCRIPTION
Should fix https://github.com/grpc/grpc-java/issues/7830 (as per the analysis here: https://github.com/grpc/grpc-java/issues/7830#issuecomment-828851471)

Related PR from other contributor https://github.com/grpc/grpc-java/pull/7979 (which is likely superseded by this PR?)

