### PR TITLE
Re-enable previously disabled aarch64 tests

### DIFF
--- a/buildscripts/run_arm64_tests_in_docker.sh
+++ b/buildscripts/run_arm64_tests_in_docker.sh
@@ -32,11 +32,8 @@ docker run $DOCKER_ARGS --rm=true -v "${grpc_java_dir}":/grpc-java -w /grpc-java
 # A note on the "docker run" args used:
 # - run docker container under current user's UID to avoid polluting the workspace
 # - set the user.home property to avoid creating a "?" directory under grpc-java
-# TODO(jtattermusch): avoid skipping ":grpc-netty:test" once https://github.com/grpc/grpc-java/issues/7830 is fixed.
-# TODO(jtattermusch): avoid skipping ":grpc-xds:test" once https://github.com/grpc/grpc-java/issues/8118 is fixed.
-# TODO(jtattermusch): avoid skipping "grpc-netty-shaded:testShadow" once it's stable
 docker run $DOCKER_ARGS --rm=true -v "${grpc_java_dir}":/grpc-java -w /grpc-java \
   --user "$(id -u):$(id -g)" \
   -e "JAVA_OPTS=-Duser.home=/grpc-java/.current-user-home -Djava.util.prefs.userRoot=/grpc-java/.current-user-home/.java/.userPrefs" \
   arm64v8/openjdk:11-jdk-slim-buster \
-  ./gradlew build -PskipAndroid=true -PskipCodegen=true -x :grpc-netty:test -x :grpc-netty-shaded:testShadow -x :grpc-xds:test
+  ./gradlew build -PskipAndroid=true -PskipCodegen=true


### PR DESCRIPTION
~~Based on https://github.com/grpc/grpc-java/pull/8126 (only the last commit is the actual change).~~

My experiments show that after upgrading netty-tcnative-boringssl-static, the tests are reasonably stable (i got a few consecutive passing runs).