### PR TITLE
xds: use singleton XdsClient for server side

### DIFF
--- a/xds/src/main/java/io/grpc/xds/internal/sds/ServerWrapperForXds.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/ServerWrapperForXds.java
@@ -113,9 +113,7 @@ public final class ServerWrapperForXds extends Server {
     checkState(started.compareAndSet(false, true), "Already started");
     currentServingState = ServingState.STARTING;
     SettableFuture<Throwable> future = addServerWatcher();
-    if (!xdsClientWrapperForServerSds.hasXdsClient()) {
-      xdsClientWrapperForServerSds.createXdsClientAndStart();
-    }
+    xdsClientWrapperForServerSds.start();
     try {
       Throwable throwable = future.get();
       if (throwable != null) {

--- a/xds/src/test/java/io/grpc/xds/FilterChainMatchTest.java
+++ b/xds/src/test/java/io/grpc/xds/FilterChainMatchTest.java
@@ -45,7 +45,6 @@ public class FilterChainMatchTest {
   private static final String LOCAL_IP = "10.1.2.3";  // dest
   private static final String REMOTE_IP = "10.4.2.3"; // source
 
-  @Mock private XdsClient xdsClient;
   @Mock private Channel channel;
 
   private XdsClientWrapperForServerSds xdsClientWrapperForServerSds;
@@ -54,9 +53,9 @@ public class FilterChainMatchTest {
   @Before
   public void setUp() throws IOException {
     MockitoAnnotations.initMocks(this);
-    xdsClientWrapperForServerSds = new XdsClientWrapperForServerSds(PORT);
+    xdsClientWrapperForServerSds = XdsServerTestHelper.createXdsClientWrapperForServerSds(PORT);
     registeredWatcher =
-            XdsServerTestHelper.startAndGetWatcher(xdsClientWrapperForServerSds, xdsClient, PORT);
+            XdsServerTestHelper.startAndGetWatcher(xdsClientWrapperForServerSds);
   }
 
   @After

--- a/xds/src/test/java/io/grpc/xds/ServerWrapperForXdsTest.java
+++ b/xds/src/test/java/io/grpc/xds/ServerWrapperForXdsTest.java
@@ -64,7 +64,6 @@ public class ServerWrapperForXdsTest {
   private int port;
   private XdsClientWrapperForServerSds xdsClientWrapperForServerSds;
   private XdsServerBuilder.XdsServingStatusListener mockXdsServingStatusListener;
-  private XdsClient mockXdsClient;
   private XdsClient.LdsResourceWatcher listenerWatcher;
   private Server mockServer;
 
@@ -72,11 +71,10 @@ public class ServerWrapperForXdsTest {
   public void setUp() throws IOException {
     port = XdsServerTestHelper.findFreePort();
     mockDelegateBuilder = mock(ServerBuilder.class);
-    xdsClientWrapperForServerSds = new XdsClientWrapperForServerSds(port);
+    xdsClientWrapperForServerSds = XdsServerTestHelper.createXdsClientWrapperForServerSds(port);
     mockXdsServingStatusListener = mock(XdsServerBuilder.XdsServingStatusListener.class);
-    mockXdsClient = mock(XdsClient.class);
     listenerWatcher =
-        XdsServerTestHelper.startAndGetWatcher(xdsClientWrapperForServerSds, mockXdsClient, port);
+        XdsServerTestHelper.startAndGetWatcher(xdsClientWrapperForServerSds);
     mockServer = mock(Server.class);
     when(mockDelegateBuilder.build()).thenReturn(mockServer);
     serverWrapperForXds = new ServerWrapperForXds(mockDelegateBuilder,

--- a/xds/src/test/java/io/grpc/xds/XdsSdsClientServerTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsSdsClientServerTest.java
@@ -333,10 +333,9 @@ public class XdsSdsClientServerTest {
   private void buildServerWithTlsContext(
       DownstreamTlsContext downstreamTlsContext, ServerCredentials fallbackCredentials)
       throws IOException {
-    XdsClient mockXdsClient = mock(XdsClient.class);
     XdsClientWrapperForServerSds xdsClientWrapperForServerSds =
-        new XdsClientWrapperForServerSds(port);
-    xdsClientWrapperForServerSds.start(mockXdsClient, "grpc/server");
+        createXdsClientWrapperForServerSds(port);
+    xdsClientWrapperForServerSds.start();
     buildServerWithFallbackServerCredentials(
         xdsClientWrapperForServerSds, fallbackCredentials, downstreamTlsContext);
   }
@@ -352,10 +351,9 @@ public class XdsSdsClientServerTest {
 
   /** Creates XdsClientWrapperForServerSds. */
   private static XdsClientWrapperForServerSds createXdsClientWrapperForServerSds(int port) {
-    XdsClient mockXdsClient = mock(XdsClient.class);
     XdsClientWrapperForServerSds xdsClientWrapperForServerSds =
-        new XdsClientWrapperForServerSds(port);
-    xdsClientWrapperForServerSds.start(mockXdsClient, "grpc/server");
+        XdsServerTestHelper.createXdsClientWrapperForServerSds(port);
+    xdsClientWrapperForServerSds.start();
     return xdsClientWrapperForServerSds;
   }
 


### PR DESCRIPTION
Use the `XdsClientPoolFactory` on the server side so that a singleton ClientXdsClient is used for both client and server side uses