### PR TITLE
examples: export the manualflowcontrol example to the bin output folder

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -126,6 +126,20 @@ task compressingHelloWorldClient(type: CreateStartScripts) {
     classpath = startScripts.classpath
 }
 
+task manualFlowControlClient(type: CreateStartScripts) {
+    mainClassName = 'io.grpc.examples.manualflowcontrol.ManualFlowControlClient'
+    applicationName = 'manual-flow-control-client'
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = startScripts.classpath
+}
+
+task manualFlowControlServer(type: CreateStartScripts) {
+    mainClassName = 'io.grpc.examples.manualflowcontrol.ManualFlowControlServer'
+    applicationName = 'manual-flow-control-server'
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = startScripts.classpath
+}
+
 applicationDistribution.into('bin') {
     from(routeGuideServer)
     from(routeGuideClient)
@@ -136,5 +150,7 @@ applicationDistribution.into('bin') {
     from(retryingHelloWorldClient)
     from(retryingHelloWorldServer)
     from(compressingHelloWorldClient)
+    from(manualFlowControlClient)
+    from(manualFlowControlServer)
     fileMode = 0755
 }


### PR DESCRIPTION
This PR will output the [Flow control example](https://github.com/grpc/grpc-java/tree/master/examples/src/main/java/io/grpc/examples/manualflowcontrol) client & server to:

- ./examples/build/install/examples/bin/manual-flow-control-client
- ./examples/build/install/examples/bin/manual-flow-control-server

The [examples README.md](https://github.com/grpc/grpc-java/blob/master/examples/README.md#-to-build-the-examples) states that the script should be present, but it currently isn't.

This PR improves gRPC to honour the [examples README.md](https://github.com/grpc/grpc-java/blob/master/examples/README.md#-to-build-the-examples) and to quickly find out this example exists, instead of having to go through the source code. 