### PR TITLE
core: throw away subchannel references after round_robin is shutdown

### DIFF
--- a/core/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
@@ -166,6 +166,7 @@ final class RoundRobinLoadBalancer extends LoadBalancer {
     for (Subchannel subchannel : getSubchannels()) {
       shutdownSubchannel(subchannel);
     }
+    subchannels.clear();
   }
 
   private static final Status EMPTY_OK = Status.OK.withDescription("no subchannels ready");


### PR DESCRIPTION
After shutting down a Subchannel, (after 5s delay) its state listener will receive a [connectivity state update](https://github.com/grpc/grpc-java/blob/02ff64fa210d8b621dbeb6701c64b89a0d158874/core/src/main/java/io/grpc/internal/InternalSubchannel.java#L417) with SHUTDOWN state. Round_robin will pick up that state update and trigger a balancing state update with [TRANSIENT_FAILURE and an empty picker that buffers RPCs](https://github.com/grpc/grpc-java/blob/02ff64fa210d8b621dbeb6701c64b89a0d158874/core/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java#L195) to the upstream.

This can cause extremely-hard-to-debug problems such as when round_robin is shut down (e.g., switching to another LB policy, or in complex cases like xDS where endpoint-level load balancing is turned off due to EDS resource being revoked) while its replacement has not yet produced a picker, the Channel updates the picker to _buffer RPCs_ (instead of keep using the current one or fail RPCs).

Note the same thing is fairly safe in pick_first: any subchannel state updates after _LB's view of the subchannel's state has become SHUTDOWN_ will be [ignored](https://github.com/grpc/grpc-java/blob/02ff64fa210d8b621dbeb6701c64b89a0d158874/core/src/main/java/io/grpc/internal/PickFirstLoadBalancer.java#L85).