### PR TITLE
Extend the xDS interop tests timeout to 360 mins

### DIFF
--- a/buildscripts/kokoro/xds.cfg
+++ b/buildscripts/kokoro/xds.cfg
@@ -2,7 +2,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-java/buildscripts/kokoro/xds.sh"
-timeout_mins: 120
+timeout_mins: 360
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/buildscripts/kokoro/xds_v3.cfg
+++ b/buildscripts/kokoro/xds_v3.cfg
@@ -2,7 +2,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-java/buildscripts/kokoro/xds_v3.sh"
-timeout_mins: 120
+timeout_mins: 360
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
Related https://github.com/grpc/grpc/pull/26090

With config update timeout pushed to 600s, we might need longer Kokoro build timeout as well.