### PR TITLE
Stabilize ChannelCredentials

### DIFF
--- a/alts/src/main/java/io/grpc/alts/ComputeEngineChannelCredentials.java
+++ b/alts/src/main/java/io/grpc/alts/ComputeEngineChannelCredentials.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableList;
 import io.grpc.CallCredentials;
 import io.grpc.ChannelCredentials;
 import io.grpc.CompositeChannelCredentials;
-import io.grpc.ExperimentalApi;
 import io.grpc.Status;
 import io.grpc.alts.internal.AltsProtocolNegotiator.GoogleDefaultProtocolNegotiatorFactory;
 import io.grpc.auth.MoreCallCredentials;
@@ -37,7 +36,6 @@ import javax.net.ssl.SSLException;
  * class sets up a secure channel using ALTS if applicable and using TLS as fallback. It is a subset
  * of the functionality provided by {@link GoogleDefaultChannelCredentials}.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/7479")
 public final class ComputeEngineChannelCredentials {
   private ComputeEngineChannelCredentials() {}
 

--- a/alts/src/main/java/io/grpc/alts/GoogleDefaultChannelCredentials.java
+++ b/alts/src/main/java/io/grpc/alts/GoogleDefaultChannelCredentials.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableList;
 import io.grpc.CallCredentials;
 import io.grpc.ChannelCredentials;
 import io.grpc.CompositeChannelCredentials;
-import io.grpc.ExperimentalApi;
 import io.grpc.Status;
 import io.grpc.alts.internal.AltsProtocolNegotiator.GoogleDefaultProtocolNegotiatorFactory;
 import io.grpc.auth.MoreCallCredentials;
@@ -37,7 +36,6 @@ import javax.net.ssl.SSLException;
  * Credentials appropriate to contact Google services. This class sets up a secure channel using
  * ALTS if applicable and uses TLS as fallback.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/7479")
 public final class GoogleDefaultChannelCredentials {
   private GoogleDefaultChannelCredentials() {}
 
@@ -52,7 +50,6 @@ public final class GoogleDefaultChannelCredentials {
     try {
       callCredentials = MoreCallCredentials.from(GoogleCredentials.getApplicationDefault());
     } catch (IOException e) {
-      // TODO(ejona): Should this just throw?
       callCredentials = new FailingCallCredentials(
           Status.UNAUTHENTICATED
               .withDescription("Failed to get Google default credentials")

--- a/api/src/main/java/io/grpc/ChannelCredentials.java
+++ b/api/src/main/java/io/grpc/ChannelCredentials.java
@@ -34,7 +34,6 @@ package io.grpc;
  * would only be used after {@code instanceof} checks (which must consider
  * {@code ChoiceChannelCredentials}!).
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/7479")
 public abstract class ChannelCredentials {
   /**
    * Returns the ChannelCredentials stripped of its CallCredentials. In the future,

--- a/api/src/main/java/io/grpc/ChoiceChannelCredentials.java
+++ b/api/src/main/java/io/grpc/ChoiceChannelCredentials.java
@@ -26,7 +26,6 @@ import java.util.List;
  * Provides a list of {@link ChannelCredentials}, where any one may be used. The credentials are in
  * preference order.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/7479")
 public final class ChoiceChannelCredentials extends ChannelCredentials {
   /**
    * Constructs with the provided {@code creds} as options, with preferred credentials first.

--- a/api/src/main/java/io/grpc/CompositeCallCredentials.java
+++ b/api/src/main/java/io/grpc/CompositeCallCredentials.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Executor;
  * Uses multiple {@code CallCredentials} as if they were one. If the first credential fails, the
  * second will not be used. Both must succeed to allow the RPC.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/7479")
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
 public final class CompositeCallCredentials extends CallCredentials {
   private final CallCredentials credentials1;
   private final CallCredentials credentials2;

--- a/api/src/main/java/io/grpc/CompositeChannelCredentials.java
+++ b/api/src/main/java/io/grpc/CompositeChannelCredentials.java
@@ -24,7 +24,6 @@ import com.google.common.base.Preconditions;
  * composite credential), then all of the {@code CallCredentials} should be used; one {@code
  * CallCredentials} does not override another.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/7479")
 public final class CompositeChannelCredentials extends ChannelCredentials {
   public static ChannelCredentials create(
       ChannelCredentials channelCreds, CallCredentials callCreds) {

--- a/api/src/main/java/io/grpc/Grpc.java
+++ b/api/src/main/java/io/grpc/Grpc.java
@@ -96,7 +96,6 @@ public final class Grpc {
    *   <li>{@code "[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443"}</li>
    * </ul>
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/7479")
   public static ManagedChannelBuilder<?> newChannelBuilder(
       String target, ChannelCredentials creds) {
     return ManagedChannelRegistry.getDefaultRegistry().newChannelBuilder(target, creds);
@@ -107,7 +106,6 @@ public final class Grpc {
    * form an authority string and then passed to {@link #newChannelBuilder(String,
    * ChannelCredentials)}. IPv6 addresses are properly surrounded by square brackets ("[]").
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/7479")
   public static ManagedChannelBuilder<?> newChannelBuilderForAddress(
       String host, int port, ChannelCredentials creds) {
     return newChannelBuilder(authorityFromHostAndPort(host, port), creds);

--- a/api/src/main/java/io/grpc/InsecureChannelCredentials.java
+++ b/api/src/main/java/io/grpc/InsecureChannelCredentials.java
@@ -17,7 +17,6 @@
 package io.grpc;
 
 /** No client identity, authentication, or encryption is to be used. */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/7479")
 public final class InsecureChannelCredentials extends ChannelCredentials {
   public static ChannelCredentials create() {
     return new InsecureChannelCredentials();

--- a/api/src/main/java/io/grpc/ManagedChannelRegistry.java
+++ b/api/src/main/java/io/grpc/ManagedChannelRegistry.java
@@ -34,7 +34,7 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * @since 1.32.0
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/7479")
+@Internal
 @ThreadSafe
 public final class ManagedChannelRegistry {
   private static final Logger logger = Logger.getLogger(ManagedChannelRegistry.class.getName());

--- a/api/src/main/java/io/grpc/TlsChannelCredentials.java
+++ b/api/src/main/java/io/grpc/TlsChannelCredentials.java
@@ -36,7 +36,6 @@ import javax.net.ssl.TrustManager;
  * incomprehensible()} method. Unless overridden by a {@code Feature}, server verification should
  * use customary default root certificates.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/7479")
 public final class TlsChannelCredentials extends ChannelCredentials {
   /** Use TLS with its defaults. */
   public static ChannelCredentials create() {
@@ -221,7 +220,6 @@ public final class TlsChannelCredentials extends ChannelCredentials {
   }
 
   /** Builder for {@link TlsChannelCredentials}. */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/7479")
   public static final class Builder {
     private boolean fakeFeature;
     private byte[] certificateChain;

--- a/xds/src/main/java/io/grpc/xds/XdsChannelCredentials.java
+++ b/xds/src/main/java/io/grpc/xds/XdsChannelCredentials.java
@@ -24,7 +24,7 @@ import io.grpc.netty.InternalNettyChannelCredentials;
 import io.grpc.netty.InternalProtocolNegotiator;
 import io.grpc.xds.internal.sds.SdsProtocolNegotiators;
 
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/7479")
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/7514")
 public class XdsChannelCredentials {
   private XdsChannelCredentials() {} // prevent instantiation
 


### PR DESCRIPTION
Some of the experimental API annotations were changed to other issues or
became `@Internal` to match their related APIs.

Fixes #7479