### PR TITLE
Stabilize ServerCredentials

### DIFF
--- a/alts/src/main/java/io/grpc/alts/AltsServerCredentials.java
+++ b/alts/src/main/java/io/grpc/alts/AltsServerCredentials.java
@@ -32,7 +32,7 @@ import java.util.logging.Logger;
  * gRPC secure server builder used for ALTS. This class adds on the necessary ALTS support to create
  * a production server on Google Cloud Platform.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/7621")
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/4151")
 public final class AltsServerCredentials {
   private static final Logger logger = Logger.getLogger(AltsServerCredentials.class.getName());
 
@@ -46,7 +46,7 @@ public final class AltsServerCredentials {
     return new Builder();
   }
 
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/7621")
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4151")
   public static final class Builder {
     private ObjectPool<Channel> handshakerChannelPool =
         SharedResourcePool.forResource(HandshakerServiceChannel.SHARED_HANDSHAKER_CHANNEL);

--- a/api/src/main/java/io/grpc/ChoiceServerCredentials.java
+++ b/api/src/main/java/io/grpc/ChoiceServerCredentials.java
@@ -25,7 +25,6 @@ import java.util.List;
  * Provides a list of {@link ServerCredentials}, where any one may be used. The credentials are in
  * preference order.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/7621")
 public final class ChoiceServerCredentials extends ServerCredentials {
   /**
    * Constructs with the provided {@code creds} as options, with preferred credentials first.

--- a/api/src/main/java/io/grpc/Grpc.java
+++ b/api/src/main/java/io/grpc/Grpc.java
@@ -131,7 +131,6 @@ public final class Grpc {
    * @param port the port to listen on
    * @param creds the server identity
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/7621")
   public static ServerBuilder<?> newServerBuilderForPort(int port, ServerCredentials creds) {
     return ServerRegistry.getDefaultRegistry().newServerBuilderForPort(port, creds);
   }

--- a/api/src/main/java/io/grpc/InsecureServerCredentials.java
+++ b/api/src/main/java/io/grpc/InsecureServerCredentials.java
@@ -17,7 +17,6 @@
 package io.grpc;
 
 /** No server identity or encryption is to be used. */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/7621")
 public final class InsecureServerCredentials extends ServerCredentials {
   public static ServerCredentials create() {
     return new InsecureServerCredentials();

--- a/api/src/main/java/io/grpc/ServerCredentials.java
+++ b/api/src/main/java/io/grpc/ServerCredentials.java
@@ -33,5 +33,4 @@ package io.grpc;
  * would only be used after {@code instanceof} checks (which must consider
  * {@code ChoiceServerCredentials}!).
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/7621")
 public abstract class ServerCredentials {}

--- a/api/src/main/java/io/grpc/ServerRegistry.java
+++ b/api/src/main/java/io/grpc/ServerRegistry.java
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * Registry of {@link ServerProvider}s. The {@link #getDefaultRegistry default instance} loads
  * providers at runtime through the Java service provider mechanism.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/7621")
+@Internal
 @ThreadSafe
 public final class ServerRegistry {
   private static final Logger logger = Logger.getLogger(ServerRegistry.class.getName());

--- a/api/src/main/java/io/grpc/TlsServerCredentials.java
+++ b/api/src/main/java/io/grpc/TlsServerCredentials.java
@@ -37,7 +37,6 @@ import javax.net.ssl.TrustManager;
  * method. Unless overridden by a {@code Feature}, server identity is provided via {@link
  * #getCertificateChain}, {@link #getPrivateKey}, and {@link #getPrivateKeyPassword}.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/7621")
 public final class TlsServerCredentials extends ServerCredentials {
   /**
    * Creates an instance using provided certificate chain and private key. Generally they should be
@@ -239,7 +238,6 @@ public final class TlsServerCredentials extends ServerCredentials {
   }
 
   /** Builder for {@link TlsServerCredentials}. */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/7621")
   public static final class Builder {
     private boolean fakeFeature;
     private byte[] certificateChain;

--- a/xds/src/main/java/io/grpc/xds/XdsServerCredentials.java
+++ b/xds/src/main/java/io/grpc/xds/XdsServerCredentials.java
@@ -24,7 +24,7 @@ import io.grpc.netty.InternalNettyServerCredentials;
 import io.grpc.netty.InternalProtocolNegotiator;
 import io.grpc.xds.internal.sds.SdsProtocolNegotiators;
 
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/7621")
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/7514")
 public class XdsServerCredentials {
   private XdsServerCredentials() {} // prevent instantiation
 


### PR DESCRIPTION
Some of the experimental API annotations were changed to other issues or
became @Internal to match their related APIs.

Fixes #7621