### PR TITLE
xds: throw away subchannel references after ring_hash is shutdown

### DIFF
--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -188,6 +188,7 @@ final class RingHashLoadBalancer extends LoadBalancer {
     for (Subchannel subchannel : subchannels.values()) {
       shutdownSubchannel(subchannel);
     }
+    subchannels.clear();
   }
 
   private void updateBalancingState() {


### PR DESCRIPTION
Same as #8132.

Clean up subchannels after the RingHashLoadBalancer itself is shutdown to prevent further balancing state updates being propagated to the upstream.

Note this should not be considered as a fix for any problem anybody is noticing. Upstreams of RingHashLoadBalancer should not rely on this, it should still have its own logic for maintaining the lifecycle of downstream LB and ignore invalid upcalls when necessary.