### PR TITLE
xds: extend SslContextProviderSupplier to use BaseTlsContext 

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -264,7 +264,7 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
     private void updateSslContextProviderSupplier(@Nullable UpstreamTlsContext tlsContext) {
       UpstreamTlsContext currentTlsContext =
           sslContextProviderSupplier != null
-              ? sslContextProviderSupplier.getUpstreamTlsContext()
+              ? (UpstreamTlsContext)sslContextProviderSupplier.getTlsContext()
               : null;
       if (Objects.equals(currentTlsContext,  tlsContext)) {
         return;

--- a/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
@@ -520,7 +520,7 @@ public class ClusterImplLoadBalancerTest {
       SslContextProviderSupplier supplier =
           eag.getAttributes().get(InternalXdsAttributes.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER);
       if (enableSecurity) {
-        assertThat(supplier.getUpstreamTlsContext()).isEqualTo(upstreamTlsContext);
+        assertThat(supplier.getTlsContext()).isEqualTo(upstreamTlsContext);
       } else {
         assertThat(supplier).isNull();
       }
@@ -554,7 +554,7 @@ public class ClusterImplLoadBalancerTest {
       SslContextProviderSupplier supplier =
           eag.getAttributes().get(InternalXdsAttributes.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER);
       if (enableSecurity) {
-        assertThat(supplier.getUpstreamTlsContext()).isEqualTo(upstreamTlsContext);
+        assertThat(supplier.getTlsContext()).isEqualTo(upstreamTlsContext);
       } else {
         assertThat(supplier).isNull();
       }


### PR DESCRIPTION
This is the precursor to the next PR which will use SslContextProviderSupplier on the server side by passing DownstreamTlsContext and the resulting SslContextProviderSupplier will be used in place of DownstreamTlsContext in the translated Listener object.