### PR TITLE
buildscripts: switch xds-k8s cluster to 1.20.x

### DIFF
--- a/buildscripts/kokoro/xds-k8s.sh
+++ b/buildscripts/kokoro/xds-k8s.sh
@@ -4,9 +4,8 @@ set -eo pipefail
 # Constants
 readonly GITHUB_REPOSITORY_NAME="grpc-java"
 # GKE Cluster
-readonly GKE_CLUSTER_NAME="interop-test-psm-sec-testing-api"
-readonly GKE_CLUSTER_ZONE="us-west1-b"
-export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://test-container.sandbox.googleapis.com/"
+readonly GKE_CLUSTER_NAME="interop-test-psm-sec-v2-us-central1-a"
+readonly GKE_CLUSTER_ZONE="us-central1-a"
 ## xDS test server/client Docker images
 readonly SERVER_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/java-server"
 readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/java-client"


### PR DESCRIPTION
Switch PSM Security interop tests from a testing cluster to the latest compatible prod GKE cluster.
ref b/185153211