### PR TITLE
xds: use load assignment endpoint address in Cluster as the DNS hostname for LOGICAL_DNS

### DIFF
--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
@@ -161,8 +161,8 @@ final class CdsLoadBalancer2 extends LoadBalancer {
                   clusterState.result.upstreamTlsContext());
             } else {  // logical DNS
               instance = DiscoveryMechanism.forLogicalDns(
-                  clusterState.name, clusterState.result.lrsServerName(),
-                  clusterState.result.maxConcurrentRequests(),
+                  clusterState.name, clusterState.result.dnsHostName(),
+                  clusterState.result.lrsServerName(), clusterState.result.maxConcurrentRequests(),
                   clusterState.result.upstreamTlsContext());
             }
             instances.add(instance);

--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -41,6 +41,8 @@ import io.envoyproxy.envoy.config.cluster.v3.Cluster.LbPolicy;
 import io.envoyproxy.envoy.config.cluster.v3.Cluster.RingHashLbConfig;
 import io.envoyproxy.envoy.config.core.v3.HttpProtocolOptions;
 import io.envoyproxy.envoy.config.core.v3.RoutingPriority;
+import io.envoyproxy.envoy.config.core.v3.SocketAddress;
+import io.envoyproxy.envoy.config.core.v3.SocketAddress.PortSpecifierCase;
 import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
 import io.envoyproxy.envoy.config.listener.v3.Listener;
 import io.envoyproxy.envoy.config.route.v3.RouteConfiguration;
@@ -925,8 +927,40 @@ final class ClientXdsClient extends AbstractXdsClient {
       return StructOrError.fromStruct(CdsUpdate.forEds(
           clusterName, edsServiceName, lrsServerName, maxConcurrentRequests, upstreamTlsContext));
     } else if (type.equals(DiscoveryType.LOGICAL_DNS)) {
+      if (!cluster.hasLoadAssignment()) {
+        return StructOrError.fromError(
+            "Cluster " + clusterName + ": LOGICAL_DNS clusters must have a single host");
+      }
+      ClusterLoadAssignment assignment = cluster.getLoadAssignment();
+      if (assignment.getEndpointsCount() != 1
+          || assignment.getEndpoints(0).getLbEndpointsCount() != 1) {
+        return StructOrError.fromError(
+            "Cluster " + clusterName + ": LOGICAL_DNS clusters must have a single "
+                + "locality_lb_endpoint and a single lb_endpoint");
+      }
+      io.envoyproxy.envoy.config.endpoint.v3.LbEndpoint lbEndpoint =
+          assignment.getEndpoints(0).getLbEndpoints(0);
+      if (!lbEndpoint.hasEndpoint() || !lbEndpoint.getEndpoint().hasAddress()
+          || !lbEndpoint.getEndpoint().getAddress().hasSocketAddress()) {
+        return StructOrError.fromError(
+            "Cluster " + clusterName
+                + ": LOGICAL_DNS clusters must have an endpoint with address and socket_address");
+      }
+      SocketAddress socketAddress = lbEndpoint.getEndpoint().getAddress().getSocketAddress();
+      if (!socketAddress.getResolverName().isEmpty()) {
+        return StructOrError.fromError(
+            "Cluster " + clusterName
+                + ": LOGICAL DNS clusters must NOT have a custom resolver name set");
+      }
+      if (socketAddress.getPortSpecifierCase() != PortSpecifierCase.PORT_VALUE) {
+        return StructOrError.fromError(
+            "Cluster " + clusterName
+                + ": LOGICAL DNS clusters socket_address must have port_value");
+      }
+      String dnsHostName =
+          String.format("%s:%d", socketAddress.getAddress(), socketAddress.getPortValue());
       return StructOrError.fromStruct(CdsUpdate.forLogicalDns(
-          clusterName, lrsServerName, maxConcurrentRequests, upstreamTlsContext));
+          clusterName, dnsHostName, lrsServerName, maxConcurrentRequests, upstreamTlsContext));
     }
     return StructOrError.fromError(
         "Cluster " + clusterName + ": unsupported built-in discovery type: " + type);

--- a/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
@@ -562,8 +562,8 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
                 addresses.add(eag);
               }
               PriorityChildConfig priorityChildConfig = generateDnsBasedPriorityChildConfig(
-                  name, null, lrsServerName, maxConcurrentRequests, tlsContext,
-                  lbRegistry, Collections.<DropOverload>emptyList());
+                  name, lrsServerName, maxConcurrentRequests, tlsContext, lbRegistry,
+                  Collections.<DropOverload>emptyList());
               status = Status.OK;
               resolved = true;
               result = new ClusterResolutionResult(addresses, priorityName, priorityChildConfig);
@@ -643,14 +643,14 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
    * <p>priority LB -> cluster_impl LB (single hardcoded priority) -> pick_first
    */
   private static PriorityChildConfig generateDnsBasedPriorityChildConfig(
-      String cluster, @Nullable String edsServiceName, @Nullable String lrsServerName,
-      @Nullable Long maxConcurrentRequests, @Nullable UpstreamTlsContext tlsContext,
-      LoadBalancerRegistry lbRegistry, List<DropOverload> dropOverloads) {
+      String cluster, @Nullable String lrsServerName, @Nullable Long maxConcurrentRequests,
+      @Nullable UpstreamTlsContext tlsContext, LoadBalancerRegistry lbRegistry,
+      List<DropOverload> dropOverloads) {
     // Override endpoint-level LB policy with pick_first for logical DNS cluster.
     PolicySelection endpointLbPolicy =
         new PolicySelection(lbRegistry.getProvider("pick_first"), null);
     ClusterImplConfig clusterImplConfig =
-        new ClusterImplConfig(cluster, edsServiceName, lrsServerName, maxConcurrentRequests,
+        new ClusterImplConfig(cluster, null, lrsServerName, maxConcurrentRequests,
             dropOverloads, endpointLbPolicy, tlsContext);
     LoadBalancerProvider clusterImplLbProvider =
         lbRegistry.getProvider(XdsLbPolicies.CLUSTER_IMPL_POLICY_NAME);

--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -191,6 +191,12 @@ abstract class XdsClient {
     @Nullable
     abstract String edsServiceName();
 
+    // Corresponding DNS name to be used if upstream endpoints of the cluster is resolvable
+    // via DNS.
+    // Only valid for LOGICAL_DNS cluster.
+    @Nullable
+    abstract String dnsHostName();
+
     // Load report server name for reporting loads via LRS.
     // Only valid for EDS or LOGICAL_DNS cluster.
     @Nullable
@@ -235,13 +241,15 @@ abstract class XdsClient {
           .upstreamTlsContext(upstreamTlsContext);
     }
 
-    static Builder forLogicalDns(String clusterName, @Nullable String lrsServerName,
-        @Nullable Long maxConcurrentRequests, @Nullable UpstreamTlsContext upstreamTlsContext) {
+    static Builder forLogicalDns(String clusterName, String dnsHostName,
+        @Nullable String lrsServerName, @Nullable Long maxConcurrentRequests,
+        @Nullable UpstreamTlsContext upstreamTlsContext) {
       return new AutoValue_XdsClient_CdsUpdate.Builder()
           .clusterName(clusterName)
           .clusterType(ClusterType.LOGICAL_DNS)
           .minRingSize(0)
           .maxRingSize(0)
+          .dnsHostName(dnsHostName)
           .lrsServerName(lrsServerName)
           .maxConcurrentRequests(maxConcurrentRequests)
           .upstreamTlsContext(upstreamTlsContext);
@@ -265,6 +273,7 @@ abstract class XdsClient {
           .add("minRingSize", minRingSize())
           .add("maxRingSize", maxRingSize())
           .add("edsServiceName", edsServiceName())
+          .add("dnsHostName", dnsHostName())
           .add("lrsServerName", lrsServerName())
           .add("maxConcurrentRequests", maxConcurrentRequests())
           // Exclude upstreamTlsContext as its string representation is cumbersome.
@@ -294,6 +303,9 @@ abstract class XdsClient {
 
       // Private, use CdsUpdate.forEds() instead.
       protected abstract Builder edsServiceName(String edsServiceName);
+
+      // Private, use CdsUpdate.forLogicalDns() instead.
+      protected abstract Builder dnsHostName(String dnsHostName);
 
       // Private, use one of the static factory methods instead.
       protected abstract Builder lrsServerName(String lrsServerName);

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
@@ -1227,8 +1227,8 @@ public abstract class ClientXdsClientTestBase {
             null, true,
             mf.buildUpstreamTlsContext("secret1", "unix:/var/uds2"), null));
     List<Any> clusters = ImmutableList.of(
-        Any.pack(mf.buildLogicalDnsCluster("cluster-bar.googleapis.com", "round_robin", null,
-            false, null, null)),
+        Any.pack(mf.buildLogicalDnsCluster("cluster-bar.googleapis.com",
+            "dns-service-bar.googleapis.com", 443, "round_robin", null, false, null, null)),
         clusterEds,
         Any.pack(mf.buildEdsCluster("cluster-baz.googleapis.com", null, "round_robin", null, false,
             null, null)));
@@ -1299,14 +1299,18 @@ public abstract class ClientXdsClientTestBase {
     verifyResourceMetadataRequested(CDS, CDS_RESOURCE);
 
     // Initial CDS response.
+    String dnsHostAddr = "dns-service-bar.googleapis.com";
+    int dnsHostPort = 443;
     Any clusterDns =
-        Any.pack(mf.buildLogicalDnsCluster(CDS_RESOURCE, "round_robin", null, false, null, null));
+        Any.pack(mf.buildLogicalDnsCluster(CDS_RESOURCE, dnsHostAddr, dnsHostPort, "round_robin",
+            null, false, null, null));
     call.sendResponse(CDS, clusterDns, VERSION_1, "0000");
     call.verifyRequest(CDS, CDS_RESOURCE, VERSION_1, "0000", NODE);
     verify(cdsResourceWatcher).onChanged(cdsUpdateCaptor.capture());
     CdsUpdate cdsUpdate = cdsUpdateCaptor.getValue();
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.LOGICAL_DNS);
+    assertThat(cdsUpdate.dnsHostName()).isEqualTo(dnsHostAddr + ":" + dnsHostPort);
     assertThat(cdsUpdate.lbPolicy()).isEqualTo(LbPolicy.ROUND_ROBIN);
     assertThat(cdsUpdate.lrsServerName()).isNull();
     assertThat(cdsUpdate.maxConcurrentRequests()).isNull();
@@ -1383,9 +1387,12 @@ public abstract class ClientXdsClientTestBase {
     verifyResourceMetadataDoesNotExist(CDS, cdsResourceTwo);
     verifySubscribedResourcesMetadataSizes(0, 2, 0, 0);
 
+    String dnsHostAddr = "dns-service-bar.googleapis.com";
+    int dnsHostPort = 443;
     String edsService = "eds-service-bar.googleapis.com";
     List<Any> clusters = ImmutableList.of(
-        Any.pack(mf.buildLogicalDnsCluster(CDS_RESOURCE, "round_robin", null, false, null, null)),
+        Any.pack(mf.buildLogicalDnsCluster(CDS_RESOURCE, dnsHostAddr, dnsHostPort, "round_robin",
+            null, false, null, null)),
         Any.pack(mf.buildEdsCluster(cdsResourceTwo, edsService, "round_robin", null, true, null,
             null)));
     call.sendResponse(CDS, clusters, VERSION_1, "0000");
@@ -1393,6 +1400,7 @@ public abstract class ClientXdsClientTestBase {
     CdsUpdate cdsUpdate = cdsUpdateCaptor.getValue();
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.LOGICAL_DNS);
+    assertThat(cdsUpdate.dnsHostName()).isEqualTo(dnsHostAddr + ":" + dnsHostPort);
     assertThat(cdsUpdate.lbPolicy()).isEqualTo(LbPolicy.ROUND_ROBIN);
     assertThat(cdsUpdate.lrsServerName()).isNull();
     assertThat(cdsUpdate.maxConcurrentRequests()).isNull();
@@ -2161,8 +2169,8 @@ public abstract class ClientXdsClientTestBase {
         String lbPolicy, @Nullable Message ringHashLbConfig, boolean enableLrs,
         @Nullable Message upstreamTlsContext, @Nullable Message circuitBreakers);
 
-    protected abstract Message buildLogicalDnsCluster(String clusterName, String lbPolicy,
-        @Nullable Message ringHashLbConfig, boolean enableLrs,
+    protected abstract Message buildLogicalDnsCluster(String clusterName, String dnsHostAddr,
+        int dnsHostPort, String lbPolicy, @Nullable Message ringHashLbConfig, boolean enableLrs,
         @Nullable Message upstreamTlsContext, @Nullable Message circuitBreakers);
 
     protected abstract Message buildAggregateCluster(String clusterName, String lbPolicy,

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientV2Test.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientV2Test.java
@@ -408,12 +408,20 @@ public class ClientXdsClientV2Test extends ClientXdsClientTestBase {
     }
 
     @Override
-    protected Message buildLogicalDnsCluster(String clusterName, String lbPolicy,
-        @Nullable Message ringHashLbConfig, boolean enableLrs,
+    protected Message buildLogicalDnsCluster(String clusterName, String dnsHostAddr,
+        int dnsHostPort, String lbPolicy, @Nullable Message ringHashLbConfig, boolean enableLrs,
         @Nullable Message upstreamTlsContext, @Nullable Message circuitBreakers) {
       Cluster.Builder builder = initClusterBuilder(clusterName, lbPolicy, ringHashLbConfig,
           enableLrs, upstreamTlsContext, circuitBreakers);
       builder.setType(DiscoveryType.LOGICAL_DNS);
+      builder.setLoadAssignment(
+          ClusterLoadAssignment.newBuilder().addEndpoints(
+              LocalityLbEndpoints.newBuilder().addLbEndpoints(
+                  LbEndpoint.newBuilder().setEndpoint(
+                      Endpoint.newBuilder().setAddress(
+                          Address.newBuilder().setSocketAddress(
+                              SocketAddress.newBuilder()
+                                  .setAddress(dnsHostAddr).setPortValue(dnsHostPort)))))).build());
       return builder.build();
     }
 

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientV3Test.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientV3Test.java
@@ -453,12 +453,20 @@ public class ClientXdsClientV3Test extends ClientXdsClientTestBase {
     }
 
     @Override
-    protected Message buildLogicalDnsCluster(String clusterName, String lbPolicy,
-        @Nullable Message ringHashLbConfig, boolean enableLrs,
+    protected Message buildLogicalDnsCluster(String clusterName, String dnsHostAddr,
+        int dnsHostPort, String lbPolicy, @Nullable Message ringHashLbConfig, boolean enableLrs,
         @Nullable Message upstreamTlsContext, @Nullable Message circuitBreakers) {
       Cluster.Builder builder = initClusterBuilder(clusterName, lbPolicy, ringHashLbConfig,
           enableLrs, upstreamTlsContext, circuitBreakers);
       builder.setType(DiscoveryType.LOGICAL_DNS);
+      builder.setLoadAssignment(
+          ClusterLoadAssignment.newBuilder().addEndpoints(
+              LocalityLbEndpoints.newBuilder().addLbEndpoints(
+                  LbEndpoint.newBuilder().setEndpoint(
+                      Endpoint.newBuilder().setAddress(
+                          Address.newBuilder().setSocketAddress(
+                              SocketAddress.newBuilder()
+                                  .setAddress(dnsHostAddr).setPortValue(dnsHostPort)))))).build());
       return builder.build();
     }
 

--- a/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
@@ -102,6 +102,7 @@ public class ClusterResolverLoadBalancerTest {
   private static final String CLUSTER_DNS = "cluster-dns.googleapis.com";
   private static final String EDS_SERVICE_NAME1 = "backend-service-foo.googleapis.com";
   private static final String EDS_SERVICE_NAME2 = "backend-service-bar.googleapis.com";
+  private static final String DNS_HOST_NAME = "dns-service.googleapis.com";
   private static final String LRS_SERVER_NAME = "lrs.googleapis.com";
   private final Locality locality1 =
       Locality.create("test-region-1", "test-zone-1", "test-subzone-1");
@@ -119,7 +120,7 @@ public class ClusterResolverLoadBalancerTest {
   private final DiscoveryMechanism edsDiscoveryMechanism2 =
       DiscoveryMechanism.forEds(CLUSTER2, EDS_SERVICE_NAME2, LRS_SERVER_NAME, 200L, tlsContext);
   private final DiscoveryMechanism logicalDnsDiscoveryMechanism =
-      DiscoveryMechanism.forLogicalDns(CLUSTER_DNS, LRS_SERVER_NAME, 300L, null);
+      DiscoveryMechanism.forLogicalDns(CLUSTER_DNS, DNS_HOST_NAME, LRS_SERVER_NAME, 300L, null);
 
   private final SynchronizationContext syncContext = new SynchronizationContext(
       new Thread.UncaughtExceptionHandler() {
@@ -516,11 +517,10 @@ public class ClusterResolverLoadBalancerTest {
     ClusterResolverConfig config = new ClusterResolverConfig(
         Collections.singletonList(logicalDnsDiscoveryMechanism), roundRobin);
     deliverLbConfig(config);
-    assertThat(resolvers).hasSize(1);
+    FakeNameResolver resolver = assertResolverCreated("/" + DNS_HOST_NAME);
     assertThat(childBalancers).isEmpty();
     EquivalentAddressGroup endpoint1 = makeAddress("endpoint-addr-1");
     EquivalentAddressGroup endpoint2 = makeAddress("endpoint-addr-2");
-    FakeNameResolver resolver = Iterables.getOnlyElement(resolvers);
     resolver.deliverEndpointAddresses(Arrays.asList(endpoint1, endpoint2));
 
     assertThat(childBalancers).hasSize(1);
@@ -544,11 +544,10 @@ public class ClusterResolverLoadBalancerTest {
     ClusterResolverConfig config = new ClusterResolverConfig(
         Collections.singletonList(logicalDnsDiscoveryMechanism), roundRobin);
     deliverLbConfig(config);
-    assertThat(resolvers).hasSize(1);
+    FakeNameResolver resolver = assertResolverCreated("/" + DNS_HOST_NAME);
     assertThat(childBalancers).isEmpty();
     EquivalentAddressGroup endpoint1 = makeAddress("endpoint-addr-1");
     EquivalentAddressGroup endpoint2 = makeAddress("endpoint-addr-2");
-    FakeNameResolver resolver = Iterables.getOnlyElement(resolvers);
     resolver.deliverEndpointAddresses(Arrays.asList(endpoint1, endpoint2));
     assertThat(resolver.refreshCount).isEqualTo(0);
     verify(helper).ignoreRefreshNameResolutionCheck();
@@ -564,9 +563,8 @@ public class ClusterResolverLoadBalancerTest {
     ClusterResolverConfig config = new ClusterResolverConfig(
         Collections.singletonList(logicalDnsDiscoveryMechanism), roundRobin);
     deliverLbConfig(config);
-    assertThat(resolvers).hasSize(1);
+    FakeNameResolver resolver = assertResolverCreated("/" + DNS_HOST_NAME);
     assertThat(childBalancers).isEmpty();
-    FakeNameResolver resolver = Iterables.getOnlyElement(resolvers);
     Status error = Status.UNAVAILABLE.withDescription("cannot reach DNS server");
     resolver.deliverError(error);
     inOrder.verify(helper).updateBalancingState(
@@ -611,10 +609,9 @@ public class ClusterResolverLoadBalancerTest {
     ClusterResolverConfig config = new ClusterResolverConfig(
         Collections.singletonList(logicalDnsDiscoveryMechanism), roundRobin);
     deliverLbConfig(config);
-    assertThat(resolvers).hasSize(1);
+    FakeNameResolver resolver = assertResolverCreated("/" + DNS_HOST_NAME);
     assertThat(childBalancers).isEmpty();
     EquivalentAddressGroup endpoint = makeAddress("endpoint-addr");
-    FakeNameResolver resolver = Iterables.getOnlyElement(resolvers);
     resolver.deliverEndpointAddresses(Collections.singletonList(endpoint));
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(childBalancers);
     assertAddressesEqual(Collections.singletonList(endpoint), childBalancer.addresses);
@@ -652,12 +649,11 @@ public class ClusterResolverLoadBalancerTest {
         Arrays.asList(edsDiscoveryMechanism1, logicalDnsDiscoveryMechanism), roundRobin);
     deliverLbConfig(config);
     assertThat(xdsClient.watchers.keySet()).containsExactly(EDS_SERVICE_NAME1);
-    assertThat(resolvers).hasSize(1);
+    FakeNameResolver resolver = assertResolverCreated("/" + DNS_HOST_NAME);
     assertThat(childBalancers).isEmpty();
     EquivalentAddressGroup endpoint1 = makeAddress("endpoint-addr-1");  // DNS endpoint
     EquivalentAddressGroup endpoint2 = makeAddress("endpoint-addr-2");  // DNS endpoint
     EquivalentAddressGroup endpoint3 = makeAddress("endpoint-addr-3");  // EDS endpoint
-    FakeNameResolver resolver = Iterables.getOnlyElement(resolvers);
     resolver.deliverEndpointAddresses(Arrays.asList(endpoint1, endpoint2));
     LocalityLbEndpoints localityLbEndpoints =
         LocalityLbEndpoints.create(
@@ -687,7 +683,7 @@ public class ClusterResolverLoadBalancerTest {
         Arrays.asList(edsDiscoveryMechanism1, logicalDnsDiscoveryMechanism), roundRobin);
     deliverLbConfig(config);
     assertThat(xdsClient.watchers.keySet()).containsExactly(EDS_SERVICE_NAME1);
-    assertThat(resolvers).hasSize(1);
+    FakeNameResolver resolver = assertResolverCreated("/" + DNS_HOST_NAME);
     assertThat(childBalancers).isEmpty();
     reset(helper);
     xdsClient.deliverResourceNotFound(EDS_SERVICE_NAME1);
@@ -696,7 +692,6 @@ public class ClusterResolverLoadBalancerTest {
     assertThat(result.getStatus().isOk()).isTrue();
     assertThat(result.getSubchannel()).isNull();  // buffer picker expected, waiting for DNS
 
-    FakeNameResolver resolver = Iterables.getOnlyElement(resolvers);
     EquivalentAddressGroup endpoint1 = makeAddress("endpoint-addr-1");
     EquivalentAddressGroup endpoint2 = makeAddress("endpoint-addr-2");
     resolver.deliverEndpointAddresses(Arrays.asList(endpoint1, endpoint2));
@@ -714,7 +709,7 @@ public class ClusterResolverLoadBalancerTest {
         Arrays.asList(edsDiscoveryMechanism1, logicalDnsDiscoveryMechanism), roundRobin);
     deliverLbConfig(config);
     assertThat(xdsClient.watchers.keySet()).containsExactly(EDS_SERVICE_NAME1);
-    assertThat(resolvers).hasSize(1);
+    FakeNameResolver resolver = assertResolverCreated("/" + DNS_HOST_NAME);
     assertThat(childBalancers).isEmpty();
     reset(helper);
     EquivalentAddressGroup endpoint = makeAddress("endpoint-addr-1");
@@ -724,7 +719,6 @@ public class ClusterResolverLoadBalancerTest {
             10 /* localityWeight */, 1 /* priority */);
     xdsClient.deliverClusterLoadAssignment(
         EDS_SERVICE_NAME1, Collections.singletonMap(locality1, localityLbEndpoints));
-    FakeNameResolver resolver = Iterables.getOnlyElement(resolvers);
     resolver.deliverError(Status.UNKNOWN.withDescription("I am lost"));
     assertThat(childBalancers).hasSize(1);
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(childBalancers);
@@ -746,7 +740,7 @@ public class ClusterResolverLoadBalancerTest {
         Arrays.asList(edsDiscoveryMechanism1, logicalDnsDiscoveryMechanism), roundRobin);
     deliverLbConfig(config);
     assertThat(xdsClient.watchers.keySet()).containsExactly(EDS_SERVICE_NAME1);
-    assertThat(resolvers).hasSize(1);
+    FakeNameResolver resolver = assertResolverCreated("/" + DNS_HOST_NAME);
     assertThat(childBalancers).isEmpty();
     reset(helper);
     EquivalentAddressGroup endpoint = makeAddress("endpoint-addr-1");
@@ -757,7 +751,6 @@ public class ClusterResolverLoadBalancerTest {
     xdsClient.deliverClusterLoadAssignment(
         EDS_SERVICE_NAME1, Collections.singletonMap(locality1, localityLbEndpoints));
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(childBalancers);  // child LB created
-    FakeNameResolver resolver = Iterables.getOnlyElement(resolvers);
     resolver.deliverError(Status.UNKNOWN.withDescription("I am lost"));
     assertThat(childBalancer.upstreamError).isNull();  // should not propagate error to child LB
     xdsClient.deliverError(Status.RESOURCE_EXHAUSTED.withDescription("out of memory"));
@@ -775,14 +768,13 @@ public class ClusterResolverLoadBalancerTest {
         Arrays.asList(edsDiscoveryMechanism1, logicalDnsDiscoveryMechanism), roundRobin);
     deliverLbConfig(config);
     assertThat(xdsClient.watchers.keySet()).containsExactly(EDS_SERVICE_NAME1);
-    assertThat(resolvers).hasSize(1);
+    FakeNameResolver resolver = assertResolverCreated("/" + DNS_HOST_NAME);
     assertThat(childBalancers).isEmpty();
     reset(helper);
     xdsClient.deliverError(Status.UNIMPLEMENTED.withDescription("not found"));
     assertThat(childBalancers).isEmpty();
     verify(helper, never()).updateBalancingState(
         eq(ConnectivityState.TRANSIENT_FAILURE), any(SubchannelPicker.class));  // wait for DNS
-    FakeNameResolver resolver = Iterables.getOnlyElement(resolvers);
     Status dnsError = Status.UNKNOWN.withDescription("I am lost");
     resolver.deliverError(dnsError);
     verify(helper).updateBalancingState(
@@ -796,7 +788,7 @@ public class ClusterResolverLoadBalancerTest {
         Arrays.asList(edsDiscoveryMechanism1, logicalDnsDiscoveryMechanism), roundRobin);
     deliverLbConfig(config);
     assertThat(xdsClient.watchers.keySet()).containsExactly(EDS_SERVICE_NAME1);
-    assertThat(resolvers).hasSize(1);
+    assertResolverCreated("/" + DNS_HOST_NAME);
     assertThat(childBalancers).isEmpty();
     reset(helper);
     Status upstreamError = Status.UNAVAILABLE.withDescription("unreachable");
@@ -812,7 +804,7 @@ public class ClusterResolverLoadBalancerTest {
         Arrays.asList(edsDiscoveryMechanism1, logicalDnsDiscoveryMechanism), roundRobin);
     deliverLbConfig(config);
     assertThat(xdsClient.watchers.keySet()).containsExactly(EDS_SERVICE_NAME1);
-    assertThat(resolvers).hasSize(1);
+    FakeNameResolver resolver = assertResolverCreated("/" + DNS_HOST_NAME);
     assertThat(childBalancers).isEmpty();
     reset(helper);
     EquivalentAddressGroup endpoint1 = makeAddress("endpoint-addr-1");
@@ -823,7 +815,6 @@ public class ClusterResolverLoadBalancerTest {
             10 /* localityWeight */, 1 /* priority */);
     xdsClient.deliverClusterLoadAssignment(
         EDS_SERVICE_NAME1, Collections.singletonMap(locality1, localityLbEndpoints));
-    FakeNameResolver resolver = Iterables.getOnlyElement(resolvers);
     resolver.deliverEndpointAddresses(Collections.singletonList(endpoint2));
     assertThat(childBalancers).hasSize(1);
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(childBalancers);
@@ -849,6 +840,13 @@ public class ClusterResolverLoadBalancerTest {
                     .build())
             .setLoadBalancingPolicyConfig(config)
             .build());
+  }
+
+  private FakeNameResolver assertResolverCreated(String uriPath) {
+    assertThat(resolvers).hasSize(1);
+    FakeNameResolver resolver = Iterables.getOnlyElement(resolvers);
+    assertThat(resolver.targetUri.getPath()).isEqualTo(uriPath);
+    return resolver;
   }
 
   private static void assertPicker(SubchannelPicker picker, Status expectedStatus,
@@ -964,8 +962,7 @@ public class ClusterResolverLoadBalancerTest {
     @Override
     public NameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
       assertThat(targetUri.getScheme()).isEqualTo("dns");
-      assertThat(targetUri.getPath()).isEqualTo("/" + AUTHORITY);
-      FakeNameResolver resolver = new FakeNameResolver();
+      FakeNameResolver resolver = new FakeNameResolver(targetUri);
       resolvers.add(resolver);
       return resolver;
     }
@@ -987,8 +984,13 @@ public class ClusterResolverLoadBalancerTest {
   }
 
   private class FakeNameResolver extends NameResolver {
+    private final URI targetUri;
     private Listener2 listener;
     private int refreshCount;
+
+    private FakeNameResolver(URI targetUri) {
+      this.targetUri = targetUri;
+    }
 
     @Override
     public String getServiceAuthority() {


### PR DESCRIPTION
This change includes: 

- parse the _single_ endpoint address from the embedded `Cluster` resource in CDS responses as the DNS hostname for LOGICAL_DNS cluster and include it in CdsUpdate being notified to the CDS LB policy.
- propagate the DNS hostname to the cluster_resolver LB policy via its LB config (DiscoveryMechanism for LOGICAL_DNS cluster).
- cluster_resolver LB policy takes the DNS hostname from the DiscoveryMechanism for LOGICAL_DNS cluster and use it as the name for DNS resolution.