### PR TITLE
xds: change google_default/compute_engine creds protocol negotiator selection for DirectPath with xDS

### DIFF
--- a/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
@@ -65,6 +65,8 @@ public final class AltsProtocolNegotiator {
 
   private static final AsciiString SCHEME = AsciiString.of("https");
 
+  private static final String DIRECT_PATH_SERVICE_CFE_CLUSTER_PREFIX = "google_cfe_";
+
   /**
    * ClientAltsProtocolNegotiatorFactory is a factory for doing client side negotiation of an ALTS
    * channel.
@@ -282,7 +284,8 @@ public final class AltsProtocolNegotiator {
       boolean isXdsDirectPath = false;
       if (clusterNameAttrKey != null) {
         String clusterName = grpcHandler.getEagAttributes().get(clusterNameAttrKey);
-        if (clusterName != null && !clusterName.equals("google_cfe")) {
+        if (clusterName != null
+            && !clusterName.startsWith(DIRECT_PATH_SERVICE_CFE_CLUSTER_PREFIX)) {
           isXdsDirectPath = true;
         }
       }

--- a/alts/src/test/java/io/grpc/alts/internal/GoogleDefaultProtocolNegotiatorTest.java
+++ b/alts/src/test/java/io/grpc/alts/internal/GoogleDefaultProtocolNegotiatorTest.java
@@ -181,8 +181,8 @@ public final class GoogleDefaultProtocolNegotiatorTest {
 
     @Test
     public void tlsHandler_googleCfe() {
-      Attributes attrs =
-          Attributes.newBuilder().set(XDS_CLUSTER_NAME_ATTR_KEY, "google_cfe").build();
+      Attributes attrs = Attributes.newBuilder().set(
+          XDS_CLUSTER_NAME_ATTR_KEY, "google_cfe_api.googleapis.com").build();
       subtest_tlsHandler(attrs);
     }
   }


### PR DESCRIPTION
gRPC client needs to be able to identify the CFE clusters in order for GoogleDefaultCredentials to choose between ALTS and TLS.  The current design has the client identifying the CFE cluster based on the name "google_cfe", but that won't work if there's a different CFE cluster (with a different name) for each DirectPath service.

Based on the new design, TD will generate a CFE cluster called "google_cfe_${service_name}" (e.g., for DirectPath service "cloud-bigtable.googleapis.com", the cluster name will be "google_cfe_cloud-bigtable.googleapis.com") for each DirectPath service. GoogleDefaultCreds will identify CFE clusters by the name having the prefix "google_cfe_".