### PR TITLE
grpclb: use a standalone Context for gRPCLB control plane RPCs

### DIFF
--- a/grpclb/BUILD.bazel
+++ b/grpclb/BUILD.bazel
@@ -9,6 +9,7 @@ java_library(
     deps = [
         ":load_balancer_java_grpc",
         "//api",
+        "//context",
         "//core:internal",
         "//core:util",
         "//stub",

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 import io.grpc.Attributes;
 import io.grpc.ChannelLogger.ChannelLogLevel;
+import io.grpc.Context;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
 import io.grpc.Status;
@@ -45,6 +46,7 @@ class GrpclbLoadBalancer extends LoadBalancer {
   private static final GrpclbConfig DEFAULT_CONFIG = GrpclbConfig.create(Mode.ROUND_ROBIN);
 
   private final Helper helper;
+  private final Context context;
   private final TimeProvider time;
   private final Stopwatch stopwatch;
   private final SubchannelPool subchannelPool;
@@ -58,11 +60,13 @@ class GrpclbLoadBalancer extends LoadBalancer {
 
   GrpclbLoadBalancer(
       Helper helper,
+      Context context,
       SubchannelPool subchannelPool,
       TimeProvider time,
       Stopwatch stopwatch,
       BackoffPolicy.Provider backoffPolicyProvider) {
     this.helper = checkNotNull(helper, "helper");
+    this.context = checkNotNull(context, "context");
     this.time = checkNotNull(time, "time provider");
     this.stopwatch = checkNotNull(stopwatch, "stopwatch");
     this.backoffPolicyProvider = checkNotNull(backoffPolicyProvider, "backoffPolicyProvider");
@@ -131,7 +135,7 @@ class GrpclbLoadBalancer extends LoadBalancer {
     checkState(grpclbState == null, "Should've been cleared");
     grpclbState =
         new GrpclbState(
-            config, helper, subchannelPool, time, stopwatch, backoffPolicyProvider);
+            config, helper, context, subchannelPool, time, stopwatch, backoffPolicyProvider);
   }
 
   @Override

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancerProvider.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancerProvider.java
@@ -17,6 +17,7 @@
 package io.grpc.grpclb;
 
 import com.google.common.base.Stopwatch;
+import io.grpc.Context;
 import io.grpc.Internal;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancerProvider;
@@ -62,6 +63,7 @@ public final class GrpclbLoadBalancerProvider extends LoadBalancerProvider {
     return
         new GrpclbLoadBalancer(
             helper,
+            Context.ROOT,
             new CachedSubchannelPool(helper),
             TimeProvider.SYSTEM_TIME_PROVIDER,
             Stopwatch.createUnstarted(),

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -372,11 +372,11 @@ final class GrpclbState {
     checkState(lbStream == null, "previous lbStream has not been cleared yet");
     LoadBalancerGrpc.LoadBalancerStub stub = LoadBalancerGrpc.newStub(lbCommChannel);
     lbStream = new LbStream(stub);
-    Context baseContext = context.attach();
+    Context prevContext = context.attach();
     try {
       lbStream.start();
     } finally {
-      context.detach(baseContext);
+      context.detach(prevContext);
     }
     stopwatch.reset().start();
 

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -35,6 +35,7 @@ import io.grpc.ChannelLogger;
 import io.grpc.ChannelLogger.ChannelLogLevel;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
+import io.grpc.Context;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer.CreateSubchannelArgs;
 import io.grpc.LoadBalancer.Helper;
@@ -132,6 +133,7 @@ final class GrpclbState {
 
   private final String serviceName;
   private final Helper helper;
+  private final Context context;
   private final SynchronizationContext syncContext;
   @Nullable
   private final SubchannelPool subchannelPool;
@@ -182,12 +184,14 @@ final class GrpclbState {
   GrpclbState(
       GrpclbConfig config,
       Helper helper,
+      Context context,
       SubchannelPool subchannelPool,
       TimeProvider time,
       Stopwatch stopwatch,
       BackoffPolicy.Provider backoffPolicyProvider) {
     this.config = checkNotNull(config, "config");
     this.helper = checkNotNull(helper, "helper");
+    this.context = checkNotNull(context, "context");
     this.syncContext = checkNotNull(helper.getSynchronizationContext(), "syncContext");
     if (config.getMode() == Mode.ROUND_ROBIN) {
       this.subchannelPool = checkNotNull(subchannelPool, "subchannelPool");
@@ -368,7 +372,12 @@ final class GrpclbState {
     checkState(lbStream == null, "previous lbStream has not been cleared yet");
     LoadBalancerGrpc.LoadBalancerStub stub = LoadBalancerGrpc.newStub(lbCommChannel);
     lbStream = new LbStream(stub);
-    lbStream.start();
+    Context baseContext = context.attach();
+    try {
+      lbStream.start();
+    } finally {
+      context.detach(baseContext);
+    }
     stopwatch.reset().start();
 
     LoadBalanceRequest initRequest = LoadBalanceRequest.newBuilder()

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -2707,11 +2707,13 @@ public class GrpclbLoadBalancerTest {
               .setInitialRequest(
                   InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
               .build()));
+      lbResponseObserver.onNext(buildInitialResponse());
 
       // The inbound RPC finishes and closes its context. The outbound RPC's control plane RPC
-      // should not be impacted.
+      // should not be impacted (no retry).
       cancellableContext.close();
-      verify(lbRequestObserver, never()).onError(any(Throwable.class));
+      assertEquals(0, fakeClock.numPendingTasks(LB_RPC_RETRY_TASK_FILTER));
+      verifyNoMoreInteractions(mockLbService);
     } finally {
       cancellableContext.detach(prevContext);
     }

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -2690,7 +2690,7 @@ public class GrpclbLoadBalancerTest {
   public void useIndependentRpcContext() {
     // Simulates making RPCs within the context of an inbound RPC.
     CancellableContext cancellableContext = Context.current().withCancellation();
-    Context baseContext = cancellableContext.attach();
+    Context prevContext = cancellableContext.attach();
     try {
       List<EquivalentAddressGroup> backendList = createResolvedBackendAddresses(2);
       List<EquivalentAddressGroup> grpclbBalancerList = createResolvedBalancerAddresses(2);
@@ -2713,7 +2713,7 @@ public class GrpclbLoadBalancerTest {
       cancellableContext.close();
       verify(lbRequestObserver, never()).onError(any(Throwable.class));
     } finally {
-      cancellableContext.detach(baseContext);
+      cancellableContext.detach(prevContext);
     }
   }
 

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -55,6 +55,7 @@ import io.grpc.ChannelLogger;
 import io.grpc.ClientStreamTracer;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
+import io.grpc.Context;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer.CreateSubchannelArgs;
 import io.grpc.LoadBalancer.Helper;
@@ -229,6 +230,7 @@ public class GrpclbLoadBalancerTest {
     when(backoffPolicyProvider.get()).thenReturn(backoffPolicy1, backoffPolicy2);
     balancer = new GrpclbLoadBalancer(
         helper,
+        Context.ROOT,
         subchannelPool,
         fakeClock.getTimeProvider(),
         fakeClock.getStopwatchSupplier().get(),


### PR DESCRIPTION
Similar to #8153 for gRPCLB.

Control plane RPCs are independent of application RPCs, they can stand for completely different lifetime. So the context for making application RPCs should not be propagated to control plane RPCs.