### PR TITLE
grpclb: use a standalone Context for gRPCLB control plane RPCs (v1.36.x backport)

### DIFF
--- a/grpclb/BUILD.bazel
+++ b/grpclb/BUILD.bazel
@@ -9,6 +9,7 @@ java_library(
     deps = [
         ":load_balancer_java_grpc",
         "//api",
+        "//context",
         "//core:internal",
         "//core:util",
         "//stub",

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 import io.grpc.Attributes;
 import io.grpc.ChannelLogger.ChannelLogLevel;
+import io.grpc.Context;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
 import io.grpc.Status;
@@ -45,6 +46,7 @@ class GrpclbLoadBalancer extends LoadBalancer {
   private static final GrpclbConfig DEFAULT_CONFIG = GrpclbConfig.create(Mode.ROUND_ROBIN);
 
   private final Helper helper;
+  private final Context context;
   private final TimeProvider time;
   private final Stopwatch stopwatch;
   private final SubchannelPool subchannelPool;
@@ -58,11 +60,13 @@ class GrpclbLoadBalancer extends LoadBalancer {
 
   GrpclbLoadBalancer(
       Helper helper,
+      Context context,
       SubchannelPool subchannelPool,
       TimeProvider time,
       Stopwatch stopwatch,
       BackoffPolicy.Provider backoffPolicyProvider) {
     this.helper = checkNotNull(helper, "helper");
+    this.context = checkNotNull(context, "context");
     this.time = checkNotNull(time, "time provider");
     this.stopwatch = checkNotNull(stopwatch, "stopwatch");
     this.backoffPolicyProvider = checkNotNull(backoffPolicyProvider, "backoffPolicyProvider");
@@ -128,7 +132,7 @@ class GrpclbLoadBalancer extends LoadBalancer {
     checkState(grpclbState == null, "Should've been cleared");
     grpclbState =
         new GrpclbState(
-            config, helper, subchannelPool, time, stopwatch, backoffPolicyProvider);
+            config, helper, context, subchannelPool, time, stopwatch, backoffPolicyProvider);
   }
 
   @Override

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancerProvider.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancerProvider.java
@@ -17,6 +17,7 @@
 package io.grpc.grpclb;
 
 import com.google.common.base.Stopwatch;
+import io.grpc.Context;
 import io.grpc.Internal;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancerProvider;
@@ -62,6 +63,7 @@ public final class GrpclbLoadBalancerProvider extends LoadBalancerProvider {
     return
         new GrpclbLoadBalancer(
             helper,
+            Context.ROOT,
             new CachedSubchannelPool(helper),
             TimeProvider.SYSTEM_TIME_PROVIDER,
             Stopwatch.createUnstarted(),

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -35,6 +35,7 @@ import io.grpc.ChannelLogger;
 import io.grpc.ChannelLogger.ChannelLogLevel;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
+import io.grpc.Context;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer.CreateSubchannelArgs;
 import io.grpc.LoadBalancer.Helper;
@@ -116,6 +117,7 @@ final class GrpclbState {
 
   private final String serviceName;
   private final Helper helper;
+  private final Context context;
   private final SynchronizationContext syncContext;
   @Nullable
   private final SubchannelPool subchannelPool;
@@ -163,12 +165,14 @@ final class GrpclbState {
   GrpclbState(
       GrpclbConfig config,
       Helper helper,
+      Context context,
       SubchannelPool subchannelPool,
       TimeProvider time,
       Stopwatch stopwatch,
       BackoffPolicy.Provider backoffPolicyProvider) {
     this.config = checkNotNull(config, "config");
     this.helper = checkNotNull(helper, "helper");
+    this.context = checkNotNull(context, "context");
     this.syncContext = checkNotNull(helper.getSynchronizationContext(), "syncContext");
     if (config.getMode() == Mode.ROUND_ROBIN) {
       this.subchannelPool = checkNotNull(subchannelPool, "subchannelPool");
@@ -342,7 +346,12 @@ final class GrpclbState {
     checkState(lbStream == null, "previous lbStream has not been cleared yet");
     LoadBalancerGrpc.LoadBalancerStub stub = LoadBalancerGrpc.newStub(lbCommChannel);
     lbStream = new LbStream(stub);
-    lbStream.start();
+    Context prevContext = context.attach();
+    try {
+      lbStream.start();
+    } finally {
+      context.detach(prevContext);
+    }
     stopwatch.reset().start();
 
     LoadBalanceRequest initRequest = LoadBalanceRequest.newBuilder()


### PR DESCRIPTION
Inject a standalone Context that is independent of application RPCs to GrpclbLoadBalancer for control plane RPCs. The control plane RPC should be independent and not impacted by the lifetime of Context used for application RPCs.


-----------------
Backport of #8154