### PR TITLE
netty: Remove Maven pom.properties from netty-shaded

### DIFF
--- a/netty/shaded/build.gradle
+++ b/netty/shaded/build.gradle
@@ -31,6 +31,7 @@ shadowJar {
         include(project(':grpc-netty'))
         include(dependency('io.netty:'))
     }
+    exclude 'META-INF/maven/**'
     relocate 'io.grpc.netty', 'io.grpc.netty.shaded.io.grpc.netty'
     relocate 'io.netty', 'io.grpc.netty.shaded.io.netty'
     // We have to be careful with these replacements as they must not match any


### PR DESCRIPTION
The pom.properties are apparently present to allow tooling to know what
Maven artifact cooresponds to a JAR, just by looking at the JAR. Since
we shade Netty, that produces inaccurate results. This was noticed in
in #8077.

CC @camjohson 