### PR TITLE
xds: add null reference checks in SslContextProviderSupplier

### DIFF
--- a/xds/src/main/java/io/grpc/xds/internal/sds/SslContextProviderSupplier.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/SslContextProviderSupplier.java
@@ -41,8 +41,8 @@ public final class SslContextProviderSupplier implements Closeable {
 
   public SslContextProviderSupplier(
       BaseTlsContext tlsContext, TlsContextManager tlsContextManager) {
-    this.tlsContext = tlsContext;
-    this.tlsContextManager = tlsContextManager;
+    this.tlsContext = checkNotNull(tlsContext, "tlsContext");
+    this.tlsContextManager = checkNotNull(tlsContextManager, "tlsContextManager");
   }
 
   public BaseTlsContext getTlsContext() {
@@ -92,10 +92,12 @@ public final class SslContextProviderSupplier implements Closeable {
   /** Called by consumer when tlsContext changes. */
   @Override
   public synchronized void close() {
-    if (tlsContext instanceof UpstreamTlsContext) {
-      tlsContextManager.releaseClientSslContextProvider(sslContextProvider);
-    } else {
-      tlsContextManager.releaseServerSslContextProvider(sslContextProvider);
+    if (sslContextProvider != null) {
+      if (tlsContext instanceof UpstreamTlsContext) {
+        tlsContextManager.releaseClientSslContextProvider(sslContextProvider);
+      } else {
+        tlsContextManager.releaseServerSslContextProvider(sslContextProvider);
+      }
     }
     shutdown = true;
   }

--- a/xds/src/test/java/io/grpc/xds/internal/sds/SslContextProviderSupplierTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/sds/SslContextProviderSupplierTest.java
@@ -23,7 +23,9 @@ import static io.grpc.xds.internal.sds.CommonTlsContextTestsUtil.CLIENT_PEM_FILE
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -57,7 +59,7 @@ public class SslContextProviderSupplierTest {
     MockitoAnnotations.initMocks(this);
   }
 
-  private void prepareSupplier() {
+  private void prepareSupplier(boolean callUpdateSslContext) {
     upstreamTlsContext =
             CommonTlsContextTestsUtil.buildUpstreamTlsContextFromFilenames(
                     CLIENT_KEY_FILE, CLIENT_PEM_FILE, CA_PEM_FILE);
@@ -65,16 +67,18 @@ public class SslContextProviderSupplierTest {
     doReturn(mockSslContextProvider)
             .when(mockTlsContextManager)
             .findOrCreateClientSslContextProvider(eq(upstreamTlsContext));
-    mockCallback = mock(SslContextProvider.Callback.class);
-    Executor mockExecutor = mock(Executor.class);
-    doReturn(mockExecutor).when(mockCallback).getExecutor();
     supplier = new SslContextProviderSupplier(upstreamTlsContext, mockTlsContextManager);
-    supplier.updateSslContext(mockCallback);
+    if (callUpdateSslContext) {
+      mockCallback = mock(SslContextProvider.Callback.class);
+      Executor mockExecutor = mock(Executor.class);
+      doReturn(mockExecutor).when(mockCallback).getExecutor();
+      supplier.updateSslContext(mockCallback);
+    }
   }
 
   @Test
   public void get_updateSecret() {
-    prepareSupplier();
+    prepareSupplier(true);
     verify(mockTlsContextManager, times(2))
         .findOrCreateClientSslContextProvider(eq(upstreamTlsContext));
     verify(mockTlsContextManager, times(0))
@@ -96,7 +100,7 @@ public class SslContextProviderSupplierTest {
 
   @Test
   public void get_onException() {
-    prepareSupplier();
+    prepareSupplier(true);
     ArgumentCaptor<SslContextProvider.Callback> callbackCaptor = ArgumentCaptor.forClass(null);
     verify(mockSslContextProvider, times(1)).addCallback(callbackCaptor.capture());
     SslContextProvider.Callback capturedCallback = callbackCaptor.getValue();
@@ -108,9 +112,26 @@ public class SslContextProviderSupplierTest {
 
   @Test
   public void testClose() {
-    prepareSupplier();
+    prepareSupplier(true);
     supplier.close();
     verify(mockTlsContextManager, times(1))
+            .releaseClientSslContextProvider(eq(mockSslContextProvider));
+    SslContextProvider.Callback mockCallback = mock(SslContextProvider.Callback.class);
+    try {
+      supplier.updateSslContext(mockCallback);
+      Assert.fail("no exception thrown");
+    } catch (IllegalStateException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo("Supplier is shutdown!");
+    }
+  }
+
+  @Test
+  public void testClose_nullSslContextProvider() {
+    prepareSupplier(false);
+    doThrow(new NullPointerException()).when(mockTlsContextManager)
+            .releaseClientSslContextProvider(null);
+    supplier.close();
+    verify(mockTlsContextManager, never())
             .releaseClientSslContextProvider(eq(mockSslContextProvider));
     SslContextProvider.Callback mockCallback = mock(SslContextProvider.Callback.class);
     try {


### PR DESCRIPTION
Add null checks in SslContextProviderSupplier constructor and `close` (in case `updateSslContext` was never called)