### PR TITLE
advancedtls: adding AdvancedTlsX509TrustManager and AdvancedTlsX509KeyManager

### DIFF
--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -58,6 +58,7 @@ java_library(
         "@com_google_code_findbugs_jsr305//jar",
         "@com_google_guava_guava//jar",
         "@com_google_j2objc_j2objc_annotations//jar",
+        "@org_codehaus_mojo_animal_sniffer_annotations//jar",
     ],
 )
 

--- a/core/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
+++ b/core/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
@@ -16,6 +16,8 @@
 
 package io.grpc.util;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import io.grpc.ExperimentalApi;
 import java.io.File;
 import java.io.FileInputStream;
@@ -54,12 +56,18 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
 
   @Override
   public PrivateKey getPrivateKey(String alias) {
-    return this.keyInfo.key;
+    if (alias.equals("default")) {
+      return this.keyInfo.key;
+    }
+    return null;
   }
 
   @Override
   public X509Certificate[] getCertificateChain(String alias) {
-    return Arrays.copyOf(this.keyInfo.certs, this.keyInfo.certs.length);
+    if (alias.equals("default")) {
+      return Arrays.copyOf(this.keyInfo.certs, this.keyInfo.certs.length);
+    }
+    return null;
   }
 
   @Override
@@ -102,7 +110,7 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
   public void updateIdentityCredentials(PrivateKey key, X509Certificate[] certs)
       throws CertificateException {
     // TODO(ZhenLian): explore possibilities to do a crypto check here.
-    this.keyInfo = new KeyInfo(key, certs);
+    this.keyInfo = new KeyInfo(checkNotNull(key), checkNotNull(certs));
   }
 
   /**

--- a/core/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
+++ b/core/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
@@ -110,7 +110,7 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
   public void updateIdentityCredentials(PrivateKey key, X509Certificate[] certs)
       throws CertificateException {
     // TODO(ZhenLian): explore possibilities to do a crypto check here.
-    this.keyInfo = new KeyInfo(checkNotNull(key), checkNotNull(certs));
+    this.keyInfo = new KeyInfo(checkNotNull(key, "key"), checkNotNull(certs, "certs"));
   }
 
   /**

--- a/core/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
+++ b/core/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.util;
+
+import io.grpc.ExperimentalApi;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Socket;
+import java.security.NoSuchAlgorithmException;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.security.spec.InvalidKeySpecException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.X509ExtendedKeyManager;
+
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/8024")
+/**
+ * AdvancedTlsX509KeyManager is an {@code X509ExtendedKeyManager} that allows users to configure
+ * advanced TLS features, such as private key and certificate chain reloading, etc.
+ */
+public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
+  private static final Logger log = Logger.getLogger(AdvancedTlsX509KeyManager.class.getName());
+
+  // The private key and the cert chain we will use to send to peers to prove our identity.
+  private volatile PrivateKey key;
+  private volatile X509Certificate[] certs;
+
+  public AdvancedTlsX509KeyManager() { }
+
+  @Override
+  public PrivateKey getPrivateKey(String alias) {
+    // Same question as the trust manager: is it really thread-safe to do this?
+    return this.key;
+  }
+
+  @Override
+  public X509Certificate[] getCertificateChain(String alias) {
+    return this.certs;
+  }
+
+  @Override
+  public String[] getClientAliases(String keyType, Principal[] issuers) {
+    return new String[0];
+  }
+
+  @Override
+  public String chooseClientAlias(String[] keyType, Principal[] issuers, Socket socket) {
+    return "default";
+  }
+
+  @Override
+  public String chooseEngineClientAlias(String[] keyType, Principal[] issuers, SSLEngine engine) {
+    return "default";
+  }
+
+  @Override
+  public String[] getServerAliases(String keyType, Principal[] issuers) {
+    return new String[0];
+  }
+
+  @Override
+  public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
+    return "default";
+  }
+
+  @Override
+  public String chooseEngineServerAlias(String keyType, Principal[] issuers,
+      SSLEngine engine) {
+    return "default";
+  }
+
+  // Update the current cached private key and cert chains.
+  // Users should make sure the private key matches the public key on the leaf certificate of the
+  // certificate chain.
+  // TODO(ZhenLian): explore possibilities to do a crypto check here.
+  public void updateIdentityCredentials(PrivateKey key, X509Certificate[] certs) {
+    // Same question as the trust manager: what to do if copy is not feasible here?
+    this.key = key;
+    this.certs = certs;
+  }
+
+  /**
+   * starts a {@code ScheduledExecutorService} to read private key and certificate chains from the
+   * local file paths periodically, and update the cached identity credentials if they are both
+   * updated.
+   *
+   * @param keyFile  the file on disk holding the private key
+   * @param certFile  the file on disk holding the certificate chain
+   * @param initialDelay the time to delay first read-and-update execution
+   * @param delay the period between successive read-and-update executions
+   * @param unit the time unit of the initialDelay and period parameters
+   * @param executor the execute service we use to start the read-and-update thread
+   * @return an object that caller should close when the scheduled execution is not needed
+   */
+  public Closeable updateIdentityCredentialsFromFile(File keyFile, File certFile,
+      long initialDelay, long delay, TimeUnit unit, ScheduledExecutorService executor) {
+    final ScheduledFuture<?> future =
+        executor.scheduleWithFixedDelay(
+            new LoadFilePathExecution(keyFile, certFile),
+            initialDelay, delay, unit);
+    return new Closeable() {
+      @Override public void close() {
+        future.cancel(false);
+      }
+    };
+  }
+
+  private class LoadFilePathExecution implements Runnable {
+    File keyFile;
+    File certFile;
+    long currentKeyTime;
+    long currentCertTime;
+
+    public LoadFilePathExecution(File keyFile, File certFile) {
+      this.keyFile = keyFile;
+      this.certFile = certFile;
+      this.currentKeyTime = 0;
+      this.currentCertTime = 0;
+    }
+
+    @Override
+    public void run() {
+      try {
+        UpdateResult newResult = readAndUpdate(this.keyFile, this.certFile, this.currentKeyTime,
+            this.currentCertTime);
+        if (newResult.success) {
+          this.currentKeyTime = newResult.keyTime;
+          this.currentCertTime = newResult.certTime;
+        }
+      } catch (CertificateException | IOException | NoSuchAlgorithmException |
+          InvalidKeySpecException e) {
+        log.log(Level.SEVERE, "readAndUpdate() execution thread failed", e);
+      }
+    }
+  }
+
+  private static class UpdateResult {
+    boolean success;
+    long keyTime;
+    long certTime;
+
+    public UpdateResult(boolean success, long keyTime, long certTime) {
+      this.success = success;
+      this.keyTime = keyTime;
+      this.certTime = certTime;
+    }
+  }
+
+  /**
+   * reads the private key and certificates specified in the path locations. Updates |key| and |cert|
+   * if both of their modified time changed since last read.
+   *
+   * @param keyFile  the file on disk holding the private key
+   * @param certFile  the file on disk holding the certificate chain
+   * @param oldKeyTime the time when the private key file is modified during last execution
+   * @param oldCertTime the time when the certificate chain file is modified during last execution
+   * @return the result of this update execution
+   */
+  private UpdateResult readAndUpdate(File keyFile, File certFile, long oldKeyTime, long oldCertTime)
+      throws IOException, CertificateException, NoSuchAlgorithmException, InvalidKeySpecException {
+    long newKeyTime = keyFile.lastModified();
+    long newCertTime = certFile.lastModified();
+    // We only update when both the key and the certs are updated.
+    if (newKeyTime != oldKeyTime && newCertTime != oldCertTime) {
+      PrivateKey key = CertificateUtils.getPrivateKey(new FileInputStream(keyFile));
+      X509Certificate[] certs = CertificateUtils.getX509Certificates(new FileInputStream(certFile));
+      updateIdentityCredentials(key, certs);
+      return new UpdateResult(true, newKeyTime, newCertTime);
+    }
+    return new UpdateResult(false, -1, -1);
+  }
+
+  // Mainly used to avoid throwing IO Exceptions in java.io.Closeable.
+  public interface Closeable extends java.io.Closeable {
+    @Override public void close();
+  }
+}
+

--- a/core/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
+++ b/core/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
@@ -20,7 +20,6 @@ import io.grpc.ExperimentalApi;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.Socket;
 import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
@@ -92,10 +91,15 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
     return "default";
   }
 
-  // Update the current cached private key and cert chains.
-  // Users should make sure the private key matches the public key on the leaf certificate of the
-  // certificate chain.
-  // TODO(ZhenLian): explore possibilities to do a crypto check here.
+  /**
+   * Updates the current cached private key and cert chains.
+   * Right now, callers should make sure |key| matches the public key on the leaf certificate of
+   * |certs|.
+   * TODO(ZhenLian): explore possibilities to do a crypto check here.
+   *
+   * @param key  the private key that is going to be used
+   * @param certs  the certificate chain that is going to be used
+   */
   public void updateIdentityCredentials(PrivateKey key, X509Certificate[] certs) {
     // Same question as the trust manager: what to do if copy is not feasible here?
     this.key = key;
@@ -150,8 +154,8 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
           this.currentKeyTime = newResult.keyTime;
           this.currentCertTime = newResult.certTime;
         }
-      } catch (CertificateException | IOException | NoSuchAlgorithmException |
-          InvalidKeySpecException e) {
+      } catch (CertificateException | IOException | NoSuchAlgorithmException
+          | InvalidKeySpecException e) {
         log.log(Level.SEVERE, "readAndUpdate() execution thread failed", e);
       }
     }
@@ -170,8 +174,8 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
   }
 
   /**
-   * reads the private key and certificates specified in the path locations. Updates |key| and |cert|
-   * if both of their modified time changed since last read.
+   * reads the private key and certificates specified in the path locations. Updates |key| and
+   * |cert| if both of their modified time changed since last read.
    *
    * @param keyFile  the file on disk holding the private key
    * @param certFile  the file on disk holding the certificate chain

--- a/core/src/main/java/io/grpc/util/AdvancedTlsX509TrustManager.java
+++ b/core/src/main/java/io/grpc/util/AdvancedTlsX509TrustManager.java
@@ -1,0 +1,391 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.util;
+
+import io.grpc.ExperimentalApi;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.Socket;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509ExtendedTrustManager;
+
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/8024")
+/**
+ * AdvancedTlsX509TrustManager is an {@code X509ExtendedTrustManager} that allows users to configure
+ * advanced TLS features, such as root certificate reloading, peer cert custom verification, etc.
+ */
+public final class AdvancedTlsX509TrustManager extends X509ExtendedTrustManager {
+  private static final Logger log = Logger.getLogger(AdvancedTlsX509TrustManager.class.getName());
+
+  private Verification verification;
+  private PeerVerifier peerVerifier;
+  private SSLSocketPeerVerifier sslSocketPeerVerifier;
+  private SSLEnginePeerVerifier sslEnginePeerVerifier;
+  // The trust certs we will use to verify peer certificate chain.
+  private volatile X509Certificate[] trustCerts;
+
+  private AdvancedTlsX509TrustManager(Verification verification,  PeerVerifier peerVerifier,
+      SSLSocketPeerVerifier socketPeerVerifier, SSLEnginePeerVerifier enginePeerVerifier) {
+    this.verification = verification;
+    this.peerVerifier = peerVerifier;
+    this.sslSocketPeerVerifier = socketPeerVerifier;
+    this.sslEnginePeerVerifier = enginePeerVerifier;
+  }
+
+  @Override
+  public void checkClientTrusted(X509Certificate[] chain, String authType)
+      throws CertificateException {
+    checkTrusted(chain, authType, null, null, false);
+  }
+
+  @Override
+  public void checkServerTrusted(X509Certificate[] chain, String authType)
+      throws CertificateException {
+    checkTrusted(chain, authType, null, null, true);
+  }
+
+  @Override
+  public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket)
+      throws CertificateException {
+    checkTrusted(chain, authType, null, socket, false);
+  }
+
+  @Override
+  public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket)
+      throws CertificateException {
+    checkTrusted(chain, authType, null, socket, true);
+  }
+
+  @Override
+  public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
+      throws CertificateException {
+    checkTrusted(chain, authType, engine, null, false);
+  }
+
+  @Override
+  public void checkServerTrusted(X509Certificate[] chain,  String authType, SSLEngine engine)
+      throws CertificateException {
+    checkTrusted(chain, authType, engine, null, true);
+  }
+
+  @Override
+  public X509Certificate[] getAcceptedIssuers() {
+    return trustCerts;
+  }
+
+  // If this is set, we will use the default trust certificates stored on user's local system.
+  // After this is used, functions that will update this.trustCerts(e.g. updateTrustCredentials(),
+  // updateTrustCredentialsFromFile()) should not be called.
+  public void useSystemDefaultTrustCerts() {
+    this.trustCerts = new X509Certificate[0];
+  }
+
+  // Update the current cached trust certs.
+  public void updateTrustCredentials(X509Certificate[] trustCerts) {
+    // Question: in design, we will do an copy of trustCerts, but that seems not easy, since
+    // X509Certificate is an abstract class without copy constructor.
+    // Can we document in the API that trustCerts shouldn't be modified once set?
+    this.trustCerts = trustCerts;
+  }
+
+  public void checkTrusted(X509Certificate[] chain, String authType, SSLEngine sslEngine,
+      Socket socket, boolean checkingServer) throws CertificateException {
+    if (this.verification == Verification.CertificateAndHostNameVerification
+        || this.verification == Verification.CertificateOnlyVerification) {
+      if (chain == null || chain.length == 0) {
+        throw new CertificateException(
+            "Want certificate verification but got null or empty certificates");
+      }
+      // Set the cached trust certificates into a key store.
+      KeyStore ks;
+      try {
+        ks = KeyStore.getInstance(KeyStore.getDefaultType());
+        ks.load(null, null);
+      } catch (KeyStoreException | IOException | NoSuchAlgorithmException e) {
+        throw new CertificateException("Failed to create KeyStore", e);
+      }
+      int i = 1;
+      // Question: I know we've already made this.trustCerts volatile, but shouldn't we require a
+      // lock around it as well? Otherwise, while we are reading here, the updating thread might
+      // change it as well?
+      // I could be wrong, but my current understanding about "volatile" is that it guarantees we
+      // store value in memory instead of cache, so there wouldn't be problems like dirty read,
+      // etc, but it doesn't eliminate race conditions.
+      for (X509Certificate cert: this.trustCerts) {
+        String alias = Integer.toString(i);
+        try {
+          ks.setCertificateEntry(alias, cert);
+        } catch (KeyStoreException e) {
+          throw new CertificateException("Failed to load trust certificate into KeyStore", e);
+        }
+        i++;
+      }
+      // Use the key store to create a delegated trust manager.
+      X509ExtendedTrustManager delegateManager = null;
+      TrustManagerFactory tmf;
+      try {
+        tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(ks);
+      } catch (KeyStoreException | NoSuchAlgorithmException e) {
+        throw new CertificateException("Failed to create delegate TrustManagerFactory", e);
+      }
+      TrustManager[] tms = tmf.getTrustManagers();
+      // Iterate over the returned trust managers, looking for an instance of X509TrustManager.
+      // If found, use that as the delegate trust manager.
+      for (i = 0; i < tms.length; i++) {
+        if (tms[i] instanceof X509ExtendedTrustManager) {
+          delegateManager = (X509ExtendedTrustManager) tms[i];
+          break;
+        }
+      }
+      if (delegateManager == null) {
+        throw new CertificateException(
+            "Instance delegateX509TrustManager is null. Failed to initialize");
+      }
+      // Configure the delegated trust manager based on users' input.
+      if (checkingServer) {
+        if (this.verification == Verification.CertificateAndHostNameVerification ||
+            this.verification == Verification.CertificateOnlyVerification) {
+          if (sslEngine == null) {
+            throw new CertificateException(
+                "SSLEngine is null. Couldn't check host name");
+          }
+          String algorithm = this.verification == Verification.CertificateAndHostNameVerification
+              ? "HTTPS" : "";
+          SSLParameters sslParams = sslEngine.getSSLParameters();
+          sslParams.setEndpointIdentificationAlgorithm(algorithm);
+          sslEngine.setSSLParameters(sslParams);
+        }
+        delegateManager.checkServerTrusted(chain, authType, sslEngine);
+      } else {
+        delegateManager.checkClientTrusted(chain, authType, sslEngine);
+      }
+    }
+    // Perform the additional peer cert check.
+    if (sslEngine != null && sslEnginePeerVerifier != null) {
+      sslEnginePeerVerifier.verifyPeerCertificate(chain, authType, sslEngine);
+    }
+    if (socket != null && sslSocketPeerVerifier != null) {
+      sslSocketPeerVerifier.verifyPeerCertificate(chain, authType, socket);
+    }
+    if (peerVerifier != null) {
+      peerVerifier.verifyPeerCertificate(chain, authType);
+    }
+    if (sslEnginePeerVerifier == null && sslSocketPeerVerifier == null && peerVerifier == null) {
+      log.log(Level.INFO, "No peer verifier is specified");
+    }
+  }
+
+  /**
+   * starts a {@code ScheduledExecutorService} to read trust certificates from a local file path
+   * periodically, and update the cached trust certs if there is an update.
+   *
+   * @param trustCertFile  the file on disk holding the trust certificates
+   * @param initialDelay the time to delay first read-and-update execution
+   * @param delay the period between successive read-and-update executions
+   * @param unit the time unit of the initialDelay and period parameters
+   * @param executor the execute service we use to start the read-and-update thread
+   * @return an object that caller should close when the scheduled execution is not needed
+   */
+  public Closeable updateTrustCredentialsFromFile(File trustCertFile, long initialDelay,
+      long delay, TimeUnit unit, ScheduledExecutorService executor) {
+    final ScheduledFuture<?> future =
+        executor.scheduleWithFixedDelay(
+            new LoadFilePathExecution(trustCertFile),
+            initialDelay, delay, unit);
+    return new Closeable() {
+      @Override public void close() {
+        future.cancel(false);
+      }
+    };
+  }
+
+  private class LoadFilePathExecution implements Runnable {
+    File file;
+    long currentTime;
+
+    public LoadFilePathExecution(File file) {
+      this.file = file;
+      this.currentTime = 0;
+    }
+
+    @Override
+    public void run() {
+      try {
+        long newUpdateTime = readAndUpdate(this.file, this.currentTime);
+        if (newUpdateTime != 0) {
+          this.currentTime = newUpdateTime;
+        }
+      } catch (FileNotFoundException | CertificateException e) {
+        log.log(Level.SEVERE, "readAndUpdate() execution thread failed", e);
+
+      }
+    }
+  }
+
+  /**
+   * reads the trust certificates specified in the path location, and update |trustCerts| if the
+   * modified time has changed since last read.
+   *
+   * @param trustCertFile  the file on disk holding the trust certificates
+   * @param oldTime the time when the trust file is modified during last execution
+   * @return 0 if something wrong with this execution or the modified time is not changed since last
+   * execution, otherwise the modified time during this execution
+   */
+  private long readAndUpdate(File trustCertFile, long oldTime)
+      throws FileNotFoundException, CertificateException {
+    long newTime = trustCertFile.lastModified();
+    if (newTime != oldTime) {
+      X509Certificate[] certificates = CertificateUtils.getX509Certificates(
+          new FileInputStream(trustCertFile));
+      updateTrustCredentials(certificates);
+      return newTime;
+    }
+    return 0;
+  }
+
+  // Mainly used to avoid throwing IO Exceptions in java.io.Closeable.
+  public interface Closeable extends java.io.Closeable {
+    @Override public void close();
+  }
+
+  public static Builder newBuilder() {
+    return new Builder().setVerification(Verification.CertificateAndHostNameVerification);
+  }
+
+  // The verification mode when authenticating the peer certificate.
+  public enum Verification {
+    // This is the DEFAULT and RECOMMENDED mode for most applications.
+    // Setting this on the client side will do the certificate and hostname verification, while
+    // setting this on the server side will only do the certificate verification.
+    CertificateAndHostNameVerification,
+    // This SHOULD be chosen only when you know what the implication this will bring, and have a
+    // basic understanding about TLS.
+    // It SHOULD be accompanied with proper additional peer identity checks set through
+    // {@code PeerVerifier}(nit: why this @code not working?). Failing to do so will leave
+    // applications to MITM attack.
+    // Also note that this will only take effect if the underlying SDK implementation invokes
+    // checkClientTrusted/checkServerTrusted with the {@code SSLEngine} parameter while doing
+    // verification.
+    // Setting this on either side will only do the certificate verification.
+    CertificateOnlyVerification,
+    // Setting is very DANGEROUS. Please try to avoid this in a real production environment, unless
+    // you are a super advanced user intended to re-implement the whole verification logic on your
+    // own. A secure verification might include:
+    // 1. proper verification on the peer certificate chain
+    // 2. proper checks on the identity of the peer certificate
+    InsecurelySkipAllVerification,
+  }
+
+  // Additional custom peer verification check.
+  // It will be used when checkClientTrusted/checkServerTrusted is called without
+  // {@code Socket}/{@code SSLEngine} parameter.
+  public interface PeerVerifier {
+    /**
+     * Verifies the peer certificate chain. For more information, please refer to
+     * {@code X509ExtendedTrustManager}.
+     *
+     * @param  peerCertChain  the certificate chain sent from the peer
+     * @param  authType the key exchange algorithm used, e.g. "RSA", "DHE_DSS", etc
+     */
+    void verifyPeerCertificate(X509Certificate[] peerCertChain, String authType)
+        throws CertificateException;
+  }
+  // Additional custom peer verification check.
+  // It will be used when checkClientTrusted/checkServerTrusted is called with the {@code Socket}
+  // parameter.
+  public interface SSLSocketPeerVerifier {
+    /**
+     * Verifies the peer certificate chain. For more information, please refer to
+     * {@code X509ExtendedTrustManager}.
+     *
+     * @param  peerCertChain  the certificate chain sent from the peer
+     * @param  authType the key exchange algorithm used, e.g. "RSA", "DHE_DSS", etc
+     * @param  socket the socket used for this connection. This parameter can be null, which
+     *         indicates that implementations need not check the ssl parameters
+     */
+    void verifyPeerCertificate(X509Certificate[] peerCertChain,  String authType, Socket socket)
+        throws CertificateException;
+  }
+  // Additional custom peer verification check.
+  // It will be used when checkClientTrusted/checkServerTrusted is called with the {@code SSLEngine}
+  // parameter.
+  public interface SSLEnginePeerVerifier {
+    /**
+     * Verifies the peer certificate chain. For more information, please refer to
+     * {@code X509ExtendedTrustManager}.
+     *
+     * @param  peerCertChain  the certificate chain sent from the peer
+     * @param  authType the key exchange algorithm used, e.g. "RSA", "DHE_DSS", etc
+     * @param  engine the engine used for this connection. This parameter can be null, which
+     *         indicates that implementations need not check the ssl parameters
+     */
+    void verifyPeerCertificate(X509Certificate[] peerCertChain, String authType, SSLEngine engine)
+        throws CertificateException;
+  }
+
+  public static final class Builder {
+
+    private Verification verification;
+    private PeerVerifier peerVerifier;
+    private SSLSocketPeerVerifier socketPeerVerifier;
+    private SSLEnginePeerVerifier enginePeerVerifier;
+
+    public Builder setVerification(Verification verification) {
+      this.verification = verification;
+      return this;
+    }
+
+    public Builder setPeerVerifier(PeerVerifier peerVerifier) {
+      this.peerVerifier = peerVerifier;
+      return this;
+    }
+
+    public Builder setSSLSocketPeerVerifier(SSLSocketPeerVerifier peerVerifier) {
+      this.socketPeerVerifier = peerVerifier;
+      return this;
+    }
+
+    public Builder setSSLEnginePeerVerifier(SSLEnginePeerVerifier peerVerifier) {
+      this.enginePeerVerifier = peerVerifier;
+      return this;
+    }
+
+    // Question: shall we do some sanity checks here, to make sure all three verifiers are set, to
+    // be more secure?
+    public AdvancedTlsX509TrustManager build() {
+      return new AdvancedTlsX509TrustManager(this.verification, this.peerVerifier,
+          this.socketPeerVerifier, this.enginePeerVerifier);
+    }
+  }
+}
+

--- a/core/src/main/java/io/grpc/util/AdvancedTlsX509TrustManager.java
+++ b/core/src/main/java/io/grpc/util/AdvancedTlsX509TrustManager.java
@@ -162,7 +162,7 @@ public final class AdvancedTlsX509TrustManager extends X509ExtendedTrustManager 
   }
 
   private void checkTrusted(X509Certificate[] chain, String authType, SSLEngine sslEngine,
-      Socket socket, boolean checkingServer) throws CertificateException, IllegalArgumentException {
+      Socket socket, boolean checkingServer) throws CertificateException {
     if (chain == null || chain.length == 0) {
       throw new IllegalArgumentException(
           "Want certificate verification but got null or empty certificates");

--- a/core/src/main/java/io/grpc/util/AdvancedTlsX509TrustManager.java
+++ b/core/src/main/java/io/grpc/util/AdvancedTlsX509TrustManager.java
@@ -65,7 +65,7 @@ public final class AdvancedTlsX509TrustManager extends X509ExtendedTrustManager 
   public void checkClientTrusted(X509Certificate[] chain, String authType)
       throws CertificateException {
     throw new CertificateException(
-        "Either SSLEngine or Socket should be available. Consider upgrading your java version");
+        "Not enough information to validate peer. SSLEngine or Socket required.");
   }
 
   @Override
@@ -90,7 +90,7 @@ public final class AdvancedTlsX509TrustManager extends X509ExtendedTrustManager 
   public void checkServerTrusted(X509Certificate[] chain, String authType)
       throws CertificateException {
     throw new CertificateException(
-        "Either SSLEngine or Socket should be available. Consider upgrading your java version");
+        "Not enough information to validate peer. SSLEngine or Socket required.");
   }
 
   @Override
@@ -162,13 +162,14 @@ public final class AdvancedTlsX509TrustManager extends X509ExtendedTrustManager 
   }
 
   private void checkTrusted(X509Certificate[] chain, String authType, SSLEngine sslEngine,
-      Socket socket, boolean checkingServer) throws CertificateException {
+      Socket socket, boolean checkingServer) throws CertificateException, IllegalArgumentException {
     if (chain == null || chain.length == 0) {
-      throw new CertificateException(
+      throw new IllegalArgumentException(
           "Want certificate verification but got null or empty certificates");
     }
     if (sslEngine == null && socket == null) {
-      throw new CertificateException("Either SSLEngine or socket should be available");
+      throw new CertificateException(
+          "Not enough information to validate peer. SSLEngine or Socket required.");
     }
     if (this.verification != Verification.InsecurelySkipAllVerification) {
       X509ExtendedTrustManager currentDelegateManager = this.delegateManager;

--- a/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
+++ b/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
@@ -414,8 +414,8 @@ public class AdvancedTlsTest {
   @Test
   public void trustManagerCheckClientTrustedWithoutParameterTest() throws Exception {
     exceptionRule.expect(CertificateException.class);
-    exceptionRule.expectMessage("Either SSLEngine or Socket should be available. "
-            + "Consider upgrading your java version");
+    exceptionRule.expectMessage(
+        "Not enough information to validate peer. SSLEngine or Socket required.");
     AdvancedTlsX509TrustManager tm = AdvancedTlsX509TrustManager.newBuilder()
         .setVerification(Verification.InsecurelySkipAllVerification).build();
     tm.checkClientTrusted(serverCert0, "RSA");
@@ -424,8 +424,8 @@ public class AdvancedTlsTest {
   @Test
   public void trustManagerCheckServerTrustedWithoutParameterTest() throws Exception {
     exceptionRule.expect(CertificateException.class);
-    exceptionRule.expectMessage("Either SSLEngine or Socket should be available. "
-        + "Consider upgrading your java version");
+    exceptionRule.expectMessage(
+        "Not enough information to validate peer. SSLEngine or Socket required.");
     AdvancedTlsX509TrustManager tm = AdvancedTlsX509TrustManager.newBuilder()
         .setVerification(Verification.InsecurelySkipAllVerification).build();
     tm.checkServerTrusted(serverCert0, "RSA");
@@ -433,7 +433,7 @@ public class AdvancedTlsTest {
 
   @Test
   public void trustManagerEmptyChainTest() throws Exception {
-    exceptionRule.expect(CertificateException.class);
+    exceptionRule.expect(IllegalArgumentException.class);
     exceptionRule.expectMessage(
         "Want certificate verification but got null or empty certificates");
     AdvancedTlsX509TrustManager tm = AdvancedTlsX509TrustManager.newBuilder()

--- a/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
+++ b/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.netty;
+
+import static org.junit.Assert.fail;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import io.grpc.ChannelCredentials;
+import io.grpc.Grpc;
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.ServerCredentials;
+import io.grpc.StatusRuntimeException;
+import io.grpc.TlsChannelCredentials;
+import io.grpc.TlsServerCredentials;
+import io.grpc.TlsServerCredentials.ClientAuth;
+import io.grpc.internal.testing.TestUtils;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.protobuf.SimpleRequest;
+import io.grpc.testing.protobuf.SimpleResponse;
+import io.grpc.testing.protobuf.SimpleServiceGrpc;
+import io.grpc.util.AdvancedTlsX509KeyManager;
+import io.grpc.util.AdvancedTlsX509TrustManager;
+import io.grpc.util.AdvancedTlsX509TrustManager.Verification;
+import io.grpc.util.CertificateUtils;
+
+import io.netty.handler.ssl.OpenSsl;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+import java.io.File;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+import java.util.Arrays;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLContext;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AdvancedTlsTest {
+
+
+  public static final String SERVER_0_KEY_FILE = "server0.key";
+  public static final String SERVER_0_PEM_FILE = "server0.pem";
+  public static final String CLIENT_0_KEY_FILE = "client.key";
+  public static final String CLIENT_0_PEM_FILE = "client.pem";
+  public static final String CA_PEM_FILE = "ca.pem";
+
+  private ScheduledExecutorService executor;
+  private Server server;
+  private ManagedChannel channel;
+
+  @Before
+  public void setUp() throws NoSuchAlgorithmException {
+    executor = Executors.newSingleThreadScheduledExecutor();
+  }
+
+  @After
+  public void tearDown() {
+    if (server != null) {
+      server.shutdown();
+    }
+    if (channel != null) {
+      channel.shutdown();
+    }
+    MoreExecutors.shutdownAndAwaitTermination(executor, 5, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void basicMutualTlsTest() throws Exception {
+    File caCert = TestUtils.loadCert("ca.pem");
+    File serverKey0 = TestUtils.loadCert("server0.key");
+    File serverCert0 = TestUtils.loadCert("server0.pem");
+    File clientKey0 = TestUtils.loadCert("client.key");
+    File clientCert0 = TestUtils.loadCert("client.pem");
+
+    // Create & start a server.
+
+    ServerCredentials serverCredentials = TlsServerCredentials.newBuilder()
+        .keyManager(serverCert0, serverKey0).trustManager(caCert)
+        .clientAuth(ClientAuth.REQUIRE).build();
+    server = Grpc.newServerBuilderForPort(0, serverCredentials).addService(
+        new SimpleServiceImpl()).build().start();
+
+    // Create a client to connect.
+    ChannelCredentials channelCredentials = TlsChannelCredentials.newBuilder()
+        .keyManager(clientCert0, clientKey0).trustManager(caCert).build();
+    channel = Grpc.newChannelBuilderForAddress(
+        "localhost", server.getPort(), channelCredentials).build();
+
+
+    try {
+      SimpleServiceGrpc.SimpleServiceBlockingStub client =
+          SimpleServiceGrpc.newBlockingStub(channel);
+      // Send an actual request, via the full GRPC & network stack, and check that a proper
+      // response comes back.
+      client.unaryRpc(SimpleRequest.getDefaultInstance());
+    } catch (StatusRuntimeException e) {
+      fail("Find error: " + e.getMessage());
+    }
+  }
+
+  /*@Test
+  public void AdvancedTlsKeyManagerTrustManagerMutualTlsTest() throws Exception {
+    X509Certificate[] caCert = CertificateUtils.getX509Certificates(
+        TestUtils.class.getResourceAsStream("/certs/" + CA_PEM_FILE));
+    PrivateKey serverKey0 = CertificateUtils.getPrivateKey(
+        TestUtils.class.getResourceAsStream("/certs/" + SERVER_0_KEY_FILE));
+    X509Certificate[] serverCert0 = CertificateUtils.getX509Certificates(
+        TestUtils.class.getResourceAsStream("/certs/" + SERVER_0_PEM_FILE));
+    PrivateKey clientKey0 = CertificateUtils.getPrivateKey(
+        TestUtils.class.getResourceAsStream("/certs/" + CLIENT_0_KEY_FILE));
+    X509Certificate[] clientCert0 = CertificateUtils.getX509Certificates(
+        TestUtils.class.getResourceAsStream("/certs/" + CLIENT_0_PEM_FILE));
+
+
+    // Create & start a server.
+    AdvancedTlsX509KeyManager serverKeyManager = new AdvancedTlsX509KeyManager();
+    serverKeyManager.updateIdentityCredentials(serverKey0, serverCert0);
+    AdvancedTlsX509TrustManager serverTrustManager = AdvancedTlsX509TrustManager.newBuilder()
+        .setVerification(Verification.CertificateOnlyVerification)
+        .build();
+    serverTrustManager.updateTrustCredentials(caCert);
+    ServerCredentials serverCredentials = TlsServerCredentials.newBuilder()
+        .keyManager(serverKeyManager).trustManager(serverTrustManager)
+        .clientAuth(ClientAuth.REQUIRE).build();
+    Server server = Grpc.newServerBuilderForPort(0, serverCredentials).addService(
+        new SimpleServiceImpl()).build().start();
+
+    // Create a client to connect.
+    AdvancedTlsX509KeyManager clientKeyManager = new AdvancedTlsX509KeyManager();
+    clientKeyManager.updateIdentityCredentials(clientKey0, clientCert0);
+    AdvancedTlsX509TrustManager clientTrustManager = AdvancedTlsX509TrustManager.newBuilder()
+        .setVerification(Verification.CertificateAndHostNameVerification)
+        .build();
+    clientTrustManager.updateTrustCredentials(caCert);
+    ChannelCredentials channelCredentials = TlsChannelCredentials.newBuilder()
+        .keyManager(clientKeyManager).trustManager(clientTrustManager).build();
+    ManagedChannel channel = Grpc.newChannelBuilderForAddress(
+        "localhost", server.getPort(), channelCredentials).build();
+
+
+    try {
+      SimpleServiceGrpc.SimpleServiceBlockingStub client =
+          SimpleServiceGrpc.newBlockingStub(channel);
+      // Send an actual request, via the full GRPC & network stack, and check that a proper
+      // response comes back.
+      client.unaryRpc(SimpleRequest.getDefaultInstance());
+    } catch (StatusRuntimeException e) {
+      fail("Find error: " + e.getMessage());
+    }
+
+    server.shutdown();
+    channel.shutdown();
+  }*/
+
+  private static class SimpleServiceImpl extends SimpleServiceGrpc.SimpleServiceImplBase {
+    @Override
+    public void unaryRpc(SimpleRequest req, StreamObserver<SimpleResponse> respOb) {
+      respOb.onNext(SimpleResponse.getDefaultInstance());
+      respOb.onCompleted();
+    }
+  }
+}

--- a/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
+++ b/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
@@ -36,8 +36,8 @@ import io.grpc.testing.protobuf.SimpleServiceGrpc;
 import io.grpc.util.AdvancedTlsX509KeyManager;
 import io.grpc.util.AdvancedTlsX509TrustManager;
 import io.grpc.util.AdvancedTlsX509TrustManager.PeerVerifier;
-import io.grpc.util.AdvancedTlsX509TrustManager.SSLEnginePeerVerifier;
-import io.grpc.util.AdvancedTlsX509TrustManager.SSLSocketPeerVerifier;
+import io.grpc.util.AdvancedTlsX509TrustManager.SslEnginePeerVerifier;
+import io.grpc.util.AdvancedTlsX509TrustManager.SslSocketPeerVerifier;
 import io.grpc.util.AdvancedTlsX509TrustManager.Verification;
 import io.grpc.util.CertificateUtils;
 
@@ -45,10 +45,10 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.net.Socket;
+import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -140,7 +140,7 @@ public class AdvancedTlsTest {
   }
 
   @Test
-  public void AdvancedTlsKeyManagerTrustManagerMutualTlsTest() throws Exception {
+  public void advancedTlsKeyManagerTrustManagerMutualTlsTest() throws Exception {
     // Create & start a server.
     AdvancedTlsX509KeyManager serverKeyManager = new AdvancedTlsX509KeyManager();
     serverKeyManager.updateIdentityCredentials(serverKey0, serverCert0);
@@ -178,14 +178,14 @@ public class AdvancedTlsTest {
   }
 
   @Test
-  public void TrustManagerCustomVerifierMutualTlsTest() throws Exception {
+  public void trustManagerCustomVerifierMutualTlsTest() throws Exception {
     // Create & start a server.
     AdvancedTlsX509KeyManager serverKeyManager = new AdvancedTlsX509KeyManager();
     serverKeyManager.updateIdentityCredentials(serverKey0, serverCert0);
     AdvancedTlsX509TrustManager serverTrustManager = AdvancedTlsX509TrustManager.newBuilder()
         .setVerification(Verification.CertificateOnlyVerification)
-        .setSSLEnginePeerVerifier(
-            new SSLEnginePeerVerifier() {
+        .setSslEnginePeerVerifier(
+            new SslEnginePeerVerifier() {
               @Override
               public void verifyPeerCertificate(X509Certificate[] peerCertChain, String authType,
                   SSLEngine engine) throws CertificateException {
@@ -198,7 +198,7 @@ public class AdvancedTlsTest {
                 }
               }
             })
-        .setSSLSocketPeerVerifier(new SSLSocketPeerVerifier() {
+        .setSslSocketPeerVerifier(new SslSocketPeerVerifier() {
           @Override
           public void verifyPeerCertificate(X509Certificate[] peerCertChain, String authType,
               Socket socket) throws CertificateException {
@@ -236,8 +236,8 @@ public class AdvancedTlsTest {
     clientKeyManager.updateIdentityCredentials(clientKey0, clientCert0);
     AdvancedTlsX509TrustManager clientTrustManager = AdvancedTlsX509TrustManager.newBuilder()
         .setVerification(Verification.CertificateOnlyVerification)
-        .setSSLEnginePeerVerifier(
-            new SSLEnginePeerVerifier() {
+        .setSslEnginePeerVerifier(
+            new SslEnginePeerVerifier() {
               @Override
               public void verifyPeerCertificate(X509Certificate[] peerCertChain, String authType,
                   SSLEngine engine) throws CertificateException {
@@ -250,7 +250,7 @@ public class AdvancedTlsTest {
                 }
               }
             })
-        .setSSLSocketPeerVerifier(new SSLSocketPeerVerifier() {
+        .setSslSocketPeerVerifier(new SslSocketPeerVerifier() {
           @Override
           public void verifyPeerCertificate(X509Certificate[] peerCertChain, String authType,
               Socket socket) throws CertificateException {
@@ -296,7 +296,7 @@ public class AdvancedTlsTest {
   }
 
   @Test
-  public void OnFileReloadingKeyManagerTrustManagerTest() throws Exception {
+  public void onFileReloadingKeyManagerTrustManagerTest() throws Exception {
     // Create & start a server.
     AdvancedTlsX509KeyManager serverKeyManager = new AdvancedTlsX509KeyManager();
     Closeable serverKeyShutdown = serverKeyManager.updateIdentityCredentialsFromFile(serverKey0File,

--- a/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
+++ b/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
@@ -153,6 +153,7 @@ public class AdvancedTlsTest {
         .clientAuth(ClientAuth.REQUIRE).build();
     server = Grpc.newServerBuilderForPort(0, serverCredentials).addService(
         new SimpleServiceImpl()).build().start();
+    TimeUnit.SECONDS.sleep(5);
     // Create a client to connect.
     AdvancedTlsX509KeyManager clientKeyManager = new AdvancedTlsX509KeyManager();
     clientKeyManager.updateIdentityCredentials(clientKey0, clientCert0);
@@ -231,6 +232,7 @@ public class AdvancedTlsTest {
         .clientAuth(ClientAuth.REQUIRE).build();
     server = Grpc.newServerBuilderForPort(0, serverCredentials).addService(
         new SimpleServiceImpl()).build().start();
+    TimeUnit.SECONDS.sleep(5);
     // Create a client to connect.
     AdvancedTlsX509KeyManager clientKeyManager = new AdvancedTlsX509KeyManager();
     clientKeyManager.updateIdentityCredentials(clientKey0, clientCert0);
@@ -311,6 +313,7 @@ public class AdvancedTlsTest {
         .clientAuth(ClientAuth.REQUIRE).build();
     server = Grpc.newServerBuilderForPort(0, serverCredentials).addService(
         new SimpleServiceImpl()).build().start();
+    TimeUnit.SECONDS.sleep(5);
     // Create a client to connect.
     AdvancedTlsX509KeyManager clientKeyManager = new AdvancedTlsX509KeyManager();
     Closeable clientKeyShutdown = clientKeyManager.updateIdentityCredentialsFromFile(clientKey0File,

--- a/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
+++ b/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
@@ -149,7 +149,7 @@ public class AdvancedTlsTest {
   public void advancedTlsKeyManagerTrustManagerMutualTlsTest() throws Exception {
     // Create & start a server.
     AdvancedTlsX509KeyManager serverKeyManager = new AdvancedTlsX509KeyManager();
-    serverKeyManager.updateIdentityCredentials(serverKey0, serverCert0);
+    serverKeyManager.updateIdentityCredentials(serverKey0, serverCert0, "");
     AdvancedTlsX509TrustManager serverTrustManager = AdvancedTlsX509TrustManager.newBuilder()
         .setVerification(Verification.CertificateOnlyVerification)
         .build();
@@ -162,7 +162,7 @@ public class AdvancedTlsTest {
     TimeUnit.SECONDS.sleep(5);
     // Create a client to connect.
     AdvancedTlsX509KeyManager clientKeyManager = new AdvancedTlsX509KeyManager();
-    clientKeyManager.updateIdentityCredentials(clientKey0, clientCert0);
+    clientKeyManager.updateIdentityCredentials(clientKey0, clientCert0, "");
     AdvancedTlsX509TrustManager clientTrustManager = AdvancedTlsX509TrustManager.newBuilder()
         .setVerification(Verification.CertificateAndHostNameVerification)
         .build();
@@ -188,7 +188,7 @@ public class AdvancedTlsTest {
   public void trustManagerCustomVerifierMutualTlsTest() throws Exception {
     // Create & start a server.
     AdvancedTlsX509KeyManager serverKeyManager = new AdvancedTlsX509KeyManager();
-    serverKeyManager.updateIdentityCredentials(serverKey0, serverCert0);
+    serverKeyManager.updateIdentityCredentials(serverKey0, serverCert0, "");
     AdvancedTlsX509TrustManager serverTrustManager = AdvancedTlsX509TrustManager.newBuilder()
         .setVerification(Verification.CertificateOnlyVerification)
         .setSslSocketAndEnginePeerVerifier(
@@ -240,7 +240,7 @@ public class AdvancedTlsTest {
     TimeUnit.SECONDS.sleep(5);
     // Create a client to connect.
     AdvancedTlsX509KeyManager clientKeyManager = new AdvancedTlsX509KeyManager();
-    clientKeyManager.updateIdentityCredentials(clientKey0, clientCert0);
+    clientKeyManager.updateIdentityCredentials(clientKey0, clientCert0, "");
     AdvancedTlsX509TrustManager clientTrustManager = AdvancedTlsX509TrustManager.newBuilder()
         .setVerification(Verification.CertificateOnlyVerification)
         .setSslSocketAndEnginePeerVerifier(
@@ -306,7 +306,7 @@ public class AdvancedTlsTest {
     // Create & start a server.
     AdvancedTlsX509KeyManager serverKeyManager = new AdvancedTlsX509KeyManager();
     Closeable serverKeyShutdown = serverKeyManager.updateIdentityCredentialsFromFile(serverKey0File,
-        serverCert0File,  100, TimeUnit.MILLISECONDS, executor);
+        serverCert0File, "", 100, TimeUnit.MILLISECONDS, executor);
     AdvancedTlsX509TrustManager serverTrustManager = AdvancedTlsX509TrustManager.newBuilder()
         .setVerification(Verification.CertificateOnlyVerification)
         .build();
@@ -321,7 +321,7 @@ public class AdvancedTlsTest {
     // Create a client to connect.
     AdvancedTlsX509KeyManager clientKeyManager = new AdvancedTlsX509KeyManager();
     Closeable clientKeyShutdown = clientKeyManager.updateIdentityCredentialsFromFile(clientKey0File,
-        clientCert0File, 100, TimeUnit.MILLISECONDS, executor);
+        clientCert0File, "",100, TimeUnit.MILLISECONDS, executor);
     AdvancedTlsX509TrustManager clientTrustManager = AdvancedTlsX509TrustManager.newBuilder()
         .setVerification(Verification.CertificateAndHostNameVerification)
         .build();


### PR DESCRIPTION
This pull request adds the following classes to `io.grpc.util`:

1. an `AdvancedTlsX509TrustManager` that supports 
   -  reloading root certificates from the file system or memory
   -  disabling host name verification check, and applying any custom-implemented  in-handshake verification checks 
2. an `AdvancedTlsX509KeyManager` that supports
   -  reloading identity credentials(private key and certificate chain)  from the file system or memory

This also adds the integration tests to `io.grpc.netty`.