### PR TITLE
xds: ignore unknown SAN name type instead of throwing exception

### DIFF
--- a/xds/src/main/java/io/grpc/xds/internal/sds/trust/SdsX509TrustManager.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/trust/SdsX509TrustManager.java
@@ -158,7 +158,7 @@ final class SdsX509TrustManager extends X509ExtendedTrustManager implements X509
       case ALT_IPA_NAME:
         return verifyDnsNameInSanList(altNameFromCert, verifySanList);
       default:
-        throw new CertificateParsingException("Unsupported altNameType: " + altNameType);
+        return false;
     }
   }
 

--- a/xds/src/main/java/io/grpc/xds/internal/sds/trust/SdsX509TrustManager.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/trust/SdsX509TrustManager.java
@@ -151,12 +151,11 @@ final class SdsX509TrustManager extends X509ExtendedTrustManager implements X509
     if (altNameType == null) {
       throw new CertificateParsingException("Invalid SAN entry: null altNameType");
     }
-    String altNameFromCert = (String) entry.get(1);
     switch (altNameType) {
       case ALT_DNS_NAME:
       case ALT_URI_NAME:
       case ALT_IPA_NAME:
-        return verifyDnsNameInSanList(altNameFromCert, verifySanList);
+        return verifyDnsNameInSanList((String) entry.get(1), verifySanList);
       default:
         return false;
     }


### PR DESCRIPTION
fixes #8182 
