### PR TITLE
core, netty: Support SocketAddress with ChannelCredentials

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -283,9 +283,24 @@ public final class ManagedChannelImplBuilder
   public ManagedChannelImplBuilder(SocketAddress directServerAddress, String authority,
       ClientTransportFactoryBuilder clientTransportFactoryBuilder,
       @Nullable ChannelBuilderDefaultPortProvider channelBuilderDefaultPortProvider) {
+      this(directServerAddress, authority, null, null, clientTransportFactoryBuilder, channelBuilderDefaultPortProvider);
+  }
+
+  /**
+   * Creates a new managed channel builder with the given server address, authority string of the
+   * channel. Transport implementors must provide client transport factory builder, and may set
+   * custom channel default port provider.
+   * 
+   * @param channelCreds The ChannelCredentials provided by the user. These may be used when
+   *     creating derivative channels.
+   */
+  public ManagedChannelImplBuilder(SocketAddress directServerAddress, String authority,
+      @Nullable ChannelCredentials channelCreds, @Nullable CallCredentials callCreds,
+      ClientTransportFactoryBuilder clientTransportFactoryBuilder,
+      @Nullable ChannelBuilderDefaultPortProvider channelBuilderDefaultPortProvider) {
     this.target = makeTargetStringForDirectAddress(directServerAddress);
-    this.channelCredentials = null;
-    this.callCredentials = null;
+    this.channelCredentials = channelCreds;
+    this.callCredentials = callCreds;
     this.clientTransportFactoryBuilder = Preconditions
         .checkNotNull(clientTransportFactoryBuilder, "clientTransportFactoryBuilder");
     this.directServerAddress = directServerAddress;

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -284,7 +284,7 @@ public final class ManagedChannelImplBuilder
       ClientTransportFactoryBuilder clientTransportFactoryBuilder,
       @Nullable ChannelBuilderDefaultPortProvider channelBuilderDefaultPortProvider) {
       this(directServerAddress, authority, null, null, clientTransportFactoryBuilder,
-	      channelBuilderDefaultPortProvider);
+          channelBuilderDefaultPortProvider);
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -283,7 +283,8 @@ public final class ManagedChannelImplBuilder
   public ManagedChannelImplBuilder(SocketAddress directServerAddress, String authority,
       ClientTransportFactoryBuilder clientTransportFactoryBuilder,
       @Nullable ChannelBuilderDefaultPortProvider channelBuilderDefaultPortProvider) {
-      this(directServerAddress, authority, null, null, clientTransportFactoryBuilder, channelBuilderDefaultPortProvider);
+      this(directServerAddress, authority, null, null, clientTransportFactoryBuilder,
+	      channelBuilderDefaultPortProvider);
   }
 
   /**

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -135,7 +135,8 @@ public final class NettyChannelBuilder extends
    * unresolved.
    */
   @CheckReturnValue
-  public static NettyChannelBuilder forTarget(SocketAddress serverAddress, ChannelCredentials creds) {
+  public static NettyChannelBuilder forAddress(SocketAddress serverAddress,
+      ChannelCredentials creds) {
     FromChannelCredentialsResult result = ProtocolNegotiators.from(creds);
     if (result.error != null) {
       throw new IllegalArgumentException(result.error);

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -128,6 +128,22 @@ public final class NettyChannelBuilder extends
   }
 
   /**
+   * Creates a new builder with the given server address. This factory method is primarily intended
+   * for using Netty Channel types other than SocketChannel. {@link #forAddress(String, int)} should
+   * generally be preferred over this method, since that API permits delaying DNS lookups and
+   * noticing changes to DNS. If an unresolved InetSocketAddress is passed in, then it will remain
+   * unresolved.
+   */
+  @CheckReturnValue
+  public static NettyChannelBuilder forTarget(SocketAddress serverAddress, ChannelCredentials creds) {
+    FromChannelCredentialsResult result = ProtocolNegotiators.from(creds);
+    if (result.error != null) {
+      throw new IllegalArgumentException(result.error);
+    }
+    return new NettyChannelBuilder(serverAddress, creds, result.callCredentials, result.negotiator);
+  }
+
+  /**
    * Creates a new builder with the given host and port.
    */
   @CheckReturnValue
@@ -205,6 +221,18 @@ public final class NettyChannelBuilder extends
         new NettyChannelTransportFactoryBuilder(),
         new NettyChannelDefaultPortProvider());
     this.freezeProtocolNegotiatorFactory = false;
+  }
+
+  NettyChannelBuilder(
+      SocketAddress address, ChannelCredentials channelCreds, CallCredentials callCreds,
+      ProtocolNegotiator.ClientFactory negotiator) {
+    managedChannelImplBuilder = new ManagedChannelImplBuilder(address,
+        getAuthorityFromAddress(address),
+        channelCreds, callCreds,
+        new NettyChannelTransportFactoryBuilder(),
+        new NettyChannelDefaultPortProvider());
+    this.protocolNegotiatorFactory = checkNotNull(negotiator, "negotiator");
+    this.freezeProtocolNegotiatorFactory = true;
   }
 
   @Internal

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -129,10 +129,10 @@ public final class NettyChannelBuilder extends
 
   /**
    * Creates a new builder with the given server address. This factory method is primarily intended
-   * for using Netty Channel types other than SocketChannel. {@link #forAddress(String, int)} should
-   * generally be preferred over this method, since that API permits delaying DNS lookups and
-   * noticing changes to DNS. If an unresolved InetSocketAddress is passed in, then it will remain
-   * unresolved.
+   * for using Netty Channel types other than SocketChannel.
+   * {@link #forAddress(String, int, ChannelCredentials)} should generally be preferred over this
+   * method, since that API permits delaying DNS lookups and noticing changes to DNS. If an
+   * unresolved InetSocketAddress is passed in, then it will remain unresolved.
    */
   @CheckReturnValue
   public static NettyChannelBuilder forAddress(SocketAddress serverAddress,

--- a/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
@@ -23,8 +23,8 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import io.grpc.ChannelCredentials;
-import io.grpc.ManagedChannel;
 import io.grpc.InsecureChannelCredentials;
+import io.grpc.ManagedChannel;
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.ClientTransportFactory.SwapChannelCredentialsResult;
 import io.grpc.netty.NettyTestUtil.TrackingObjectPoolForTest;

--- a/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 
 import io.grpc.ChannelCredentials;
 import io.grpc.ManagedChannel;
+import io.grpc.InsecureChannelCredentials;
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.ClientTransportFactory.SwapChannelCredentialsResult;
 import io.grpc.netty.NettyTestUtil.TrackingObjectPoolForTest;

--- a/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
@@ -154,6 +154,28 @@ public class NettyChannelBuilderTest {
   }
 
   @Test
+  public void failNegotiationTypeWithChannelCredentials_target() {
+    NettyChannelBuilder builder = NettyChannelBuilder.forTarget(
+        "fakeTarget", InsecureChannelCredentials.create());
+
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("Cannot change security when using ChannelCredentials");
+
+    builder.negotiationType(NegotiationType.TLS);
+  }
+
+  @Test
+  public void failNegotiationTypeWithChannelCredentials_socketAddress() {
+    NettyChannelBuilder builder = NettyChannelBuilder.forAddress(
+        new SocketAddress(){}, InsecureChannelCredentials.create());
+
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("Cannot change security when using ChannelCredentials");
+
+    builder.negotiationType(NegotiationType.TLS);
+  }
+
+  @Test
   public void createProtocolNegotiatorByType_plaintext() {
     ProtocolNegotiator negotiator = NettyChannelBuilder.createProtocolNegotiatorByType(
         NegotiationType.PLAINTEXT,


### PR DESCRIPTION
This adds support for creating a Netty Channel with SocketAddress and ChannelCredentials.

This aligns with NettyServerBuilder.forAddress(SocketAddress address, ServerCredentials creds).

(sorry for all the commits, I don't have a local build environment, please squash)