### PR TITLE
xds: shutDown the scheduledExecutorService when the provider is shutdown

### DIFF
--- a/xds/src/main/java/io/grpc/xds/internal/certprovider/FileWatcherCertificateProvider.java
+++ b/xds/src/main/java/io/grpc/xds/internal/certprovider/FileWatcherCertificateProvider.java
@@ -82,6 +82,7 @@ final class FileWatcherCertificateProvider extends CertificateProvider implement
   @Override
   public synchronized void close() {
     shutdown = true;
+    scheduledExecutorService.shutdownNow();
     if (scheduledFuture != null) {
       scheduledFuture.cancel(true);
       scheduledFuture = null;

--- a/xds/src/test/java/io/grpc/xds/internal/certprovider/FileWatcherCertificateProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/certprovider/FileWatcherCertificateProviderTest.java
@@ -180,6 +180,7 @@ public class FileWatcherCertificateProviderTest {
         .updateCertificate(any(PrivateKey.class), ArgumentMatchers.<X509Certificate>anyList());
     verify(mockWatcher, never()).updateTrustedRoots(ArgumentMatchers.<X509Certificate>anyList());
     verify(timeService, never()).schedule(any(Runnable.class), any(Long.TYPE), any(TimeUnit.class));
+    verify(timeService, times(1)).shutdownNow();
   }
 
 


### PR DESCRIPTION
Make sure threads are shut down when a FileWatcher provider is closed.