### PR TITLE
xds: replace DownstreamTlsContext by SslContextProviderSupplier in the Listener

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -285,10 +285,10 @@ final class ClientXdsClient extends AbstractXdsClient {
         "HttpConnectionManager neither has inlined route_config nor RDS.");
   }
 
-  private static LdsUpdate processServerSideListener(Listener listener)
+  private LdsUpdate processServerSideListener(Listener listener)
       throws ResourceInvalidException {
     StructOrError<EnvoyServerProtoData.Listener> convertedListener =
-        parseServerSideListener(listener);
+        parseServerSideListener(listener, tlsContextManager);
     if (convertedListener.getErrorDetail() != null) {
       throw new ResourceInvalidException(convertedListener.getErrorDetail());
     }
@@ -367,10 +367,10 @@ final class ClientXdsClient extends AbstractXdsClient {
   }
 
   @VisibleForTesting static StructOrError<EnvoyServerProtoData.Listener> parseServerSideListener(
-      Listener listener) {
+      Listener listener, TlsContextManager tlsContextManager) {
     try {
       return StructOrError.fromStruct(
-          EnvoyServerProtoData.Listener.fromEnvoyProtoListener(listener));
+          EnvoyServerProtoData.Listener.fromEnvoyProtoListener(listener, tlsContextManager));
     } catch (InvalidProtocolBufferException e) {
       return StructOrError.fromError(
           "Failed to unpack Listener " + listener.getName() + ":" + e.getMessage());

--- a/xds/src/main/java/io/grpc/xds/EnvoyServerProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyServerProtoData.java
@@ -28,6 +28,7 @@ import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext;
 import io.grpc.Internal;
+import io.grpc.xds.internal.sds.SslContextProviderSupplier;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -354,17 +355,21 @@ public final class EnvoyServerProtoData {
     // TODO(sanjaypujare): flatten structure by moving FilterChainMatch class members here.
     private final FilterChainMatch filterChainMatch;
     @Nullable
-    private final DownstreamTlsContext downstreamTlsContext;
+    private final SslContextProviderSupplier sslContextProviderSupplier;
 
     @VisibleForTesting
     FilterChain(
-        FilterChainMatch filterChainMatch, @Nullable DownstreamTlsContext downstreamTlsContext) {
+        FilterChainMatch filterChainMatch, @Nullable DownstreamTlsContext downstreamTlsContext,
+        TlsContextManager tlsContextManager) {
+      SslContextProviderSupplier sslContextProviderSupplier1 = downstreamTlsContext == null ? null
+          : new SslContextProviderSupplier(downstreamTlsContext, tlsContextManager);
       this.filterChainMatch = filterChainMatch;
-      this.downstreamTlsContext = downstreamTlsContext;
+      this.sslContextProviderSupplier = sslContextProviderSupplier1;
     }
 
     static FilterChain fromEnvoyProtoFilterChain(
-        io.envoyproxy.envoy.config.listener.v3.FilterChain proto, boolean isDefaultFilterChain)
+        io.envoyproxy.envoy.config.listener.v3.FilterChain proto,
+        TlsContextManager tlsContextManager, boolean isDefaultFilterChain)
         throws InvalidProtocolBufferException {
       if (!isDefaultFilterChain && proto.getFiltersList().isEmpty()) {
         throw new IllegalArgumentException(
@@ -380,7 +385,8 @@ public final class EnvoyServerProtoData {
       }
       return new FilterChain(
           FilterChainMatch.fromEnvoyProtoFilterChainMatch(proto.getFilterChainMatch()),
-          getTlsContextFromFilterChain(proto)
+          getTlsContextFromFilterChain(proto),
+          tlsContextManager
       );
     }
 
@@ -456,9 +462,8 @@ public final class EnvoyServerProtoData {
       return filterChainMatch;
     }
 
-    @Nullable
-    public DownstreamTlsContext getDownstreamTlsContext() {
-      return downstreamTlsContext;
+    public SslContextProviderSupplier getSslContextProviderSupplier() {
+      return sslContextProviderSupplier;
     }
 
     @Override
@@ -471,19 +476,19 @@ public final class EnvoyServerProtoData {
       }
       FilterChain that = (FilterChain) o;
       return java.util.Objects.equals(filterChainMatch, that.filterChainMatch)
-          && java.util.Objects.equals(downstreamTlsContext, that.downstreamTlsContext);
+          && java.util.Objects.equals(sslContextProviderSupplier, that.sslContextProviderSupplier);
     }
 
     @Override
     public int hashCode() {
-      return java.util.Objects.hash(filterChainMatch, downstreamTlsContext);
+      return java.util.Objects.hash(filterChainMatch, sslContextProviderSupplier);
     }
 
     @Override
     public String toString() {
       return "FilterChain{"
           + "filterChainMatch=" + filterChainMatch
-          + ", downstreamTlsContext=" + downstreamTlsContext
+          + ", sslContextProviderSupplier=" + sslContextProviderSupplier
           + '}';
     }
   }
@@ -524,7 +529,8 @@ public final class EnvoyServerProtoData {
       return null;
     }
 
-    static Listener fromEnvoyProtoListener(io.envoyproxy.envoy.config.listener.v3.Listener proto)
+    static Listener fromEnvoyProtoListener(io.envoyproxy.envoy.config.listener.v3.Listener proto,
+        TlsContextManager tlsContextManager)
         throws InvalidProtocolBufferException {
       if (!proto.getTrafficDirection().equals(TrafficDirection.INBOUND)) {
         throw new IllegalArgumentException("Listener " + proto.getName() + " is not INBOUND");
@@ -537,21 +543,25 @@ public final class EnvoyServerProtoData {
         throw new IllegalArgumentException(
             "Listener " + proto.getName() + " cannot have use_original_dst set to true");
       }
-      List<FilterChain> filterChains = validateAndSelectFilterChains(proto.getFilterChainsList());
+      List<FilterChain> filterChains = validateAndSelectFilterChains(proto.getFilterChainsList(),
+          tlsContextManager);
       return new Listener(
           proto.getName(),
           convertEnvoyAddressToString(proto.getAddress()),
-          filterChains, FilterChain.fromEnvoyProtoFilterChain(proto.getDefaultFilterChain(), true));
+          filterChains, FilterChain
+          .fromEnvoyProtoFilterChain(proto.getDefaultFilterChain(), tlsContextManager, true));
     }
 
     private static List<FilterChain> validateAndSelectFilterChains(
-        List<io.envoyproxy.envoy.config.listener.v3.FilterChain> inputFilterChains)
+        List<io.envoyproxy.envoy.config.listener.v3.FilterChain> inputFilterChains,
+        TlsContextManager tlsContextManager)
         throws InvalidProtocolBufferException {
       List<FilterChain> filterChains = new ArrayList<>(inputFilterChains.size());
       for (io.envoyproxy.envoy.config.listener.v3.FilterChain filterChain :
           inputFilterChains) {
         if (isAcceptable(filterChain.getFilterChainMatch())) {
-          filterChains.add(FilterChain.fromEnvoyProtoFilterChain(filterChain, false));
+          filterChains
+              .add(FilterChain.fromEnvoyProtoFilterChain(filterChain, tlsContextManager, false));
         }
       }
       return filterChains;

--- a/xds/src/main/java/io/grpc/xds/XdsClientWrapperForServerSds.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientWrapperForServerSds.java
@@ -27,9 +27,9 @@ import io.grpc.Status;
 import io.grpc.internal.ObjectPool;
 import io.grpc.internal.SharedResourceHolder;
 import io.grpc.xds.EnvoyServerProtoData.CidrRange;
-import io.grpc.xds.EnvoyServerProtoData.DownstreamTlsContext;
 import io.grpc.xds.EnvoyServerProtoData.FilterChain;
 import io.grpc.xds.EnvoyServerProtoData.FilterChainMatch;
+import io.grpc.xds.internal.sds.SslContextProviderSupplier;
 import io.netty.channel.Channel;
 import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollEventLoopGroup;
@@ -114,14 +114,14 @@ public final class XdsClientWrapperForServerSds {
         new XdsClient.LdsResourceWatcher() {
           @Override
           public void onChanged(XdsClient.LdsUpdate update) {
-            curListener.set(update.listener);
+            releaseOldSuppliers(curListener.getAndSet(update.listener));
             reportSuccess();
           }
 
           @Override
           public void onResourceDoesNotExist(String resourceName) {
             logger.log(Level.WARNING, "Resource {0} is unavailable", resourceName);
-            curListener.set(null);
+            releaseOldSuppliers(curListener.getAndSet(null));
             reportError(Status.NOT_FOUND.asException(), true);
           }
 
@@ -129,7 +129,12 @@ public final class XdsClientWrapperForServerSds {
           public void onError(Status error) {
             logger.log(
                 Level.WARNING, "LdsResourceWatcher in XdsClientWrapperForServerSds: {0}", error);
-            reportError(error.asException(), isResourceAbsent(error));
+            if (isResourceAbsent(error)) {
+              releaseOldSuppliers(curListener.getAndSet(null));
+              reportError(error.asException(), true);
+            } else {
+              reportError(error.asException(), false);
+            }
           }
         };
     String grpcServerResourceId = xdsClient.getBootstrapInfo()
@@ -143,6 +148,27 @@ public final class XdsClientWrapperForServerSds {
     }
     grpcServerResourceId = grpcServerResourceId.replaceAll("%s", "0.0.0.0:" + port);
     xdsClient.watchLdsResource(grpcServerResourceId, listenerWatcher);
+  }
+
+  // go thru the old listener and release all the old SslContextProviderSupplier
+  private void releaseOldSuppliers(EnvoyServerProtoData.Listener oldListener) {
+    if (oldListener != null) {
+      List<FilterChain> filterChains = oldListener.getFilterChains();
+      for (FilterChain filterChain : filterChains) {
+        releaseSupplier(filterChain);
+      }
+      releaseSupplier(oldListener.getDefaultFilterChain());
+    }
+  }
+
+  private static void releaseSupplier(FilterChain filterChain) {
+    if (filterChain != null) {
+      SslContextProviderSupplier sslContextProviderSupplier =
+          filterChain.getSslContextProviderSupplier();
+      if (sslContextProviderSupplier != null) {
+        sslContextProviderSupplier.close();
+      }
+    }
   }
 
   /** Whether the throwable indicates our listener resource is absent/deleted. */
@@ -162,10 +188,10 @@ public final class XdsClientWrapperForServerSds {
 
   /**
    * Locates the best matching FilterChain to the channel from the current listener and if found
-   * returns the DownstreamTlsContext from that FilterChain, else null.
+   * returns the SslContextProviderSupplier from that FilterChain, else null.
    */
   @Nullable
-  public DownstreamTlsContext getDownstreamTlsContext(Channel channel) {
+  public SslContextProviderSupplier getSslContextProviderSupplier(Channel channel) {
     EnvoyServerProtoData.Listener copyListener = curListener.get();
     if (copyListener != null && channel != null) {
       SocketAddress localAddress = channel.localAddress();
@@ -176,7 +202,7 @@ public final class XdsClientWrapperForServerSds {
         checkState(
             port == localInetAddr.getPort(),
             "Channel localAddress port does not match requested listener port");
-        return getDownstreamTlsContext(localInetAddr, remoteInetAddr, copyListener);
+        return getSslContextProviderSupplier(localInetAddr, remoteInetAddr, copyListener);
       }
     }
     return null;
@@ -185,13 +211,13 @@ public final class XdsClientWrapperForServerSds {
   /**
    * Using the logic specified at
    * https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener/listener_components.proto.html?highlight=filter%20chain#listener-filterchainmatch
-   * locate a matching filter and return the corresponding DownstreamTlsContext or else return one
-   * from default filter chain.
+   * locate a matching filter and return the corresponding SslContextProviderSupplier or else
+   * return one from default filter chain.
    *
    * @param localInetAddr dest address of the inbound connection
    * @param remoteInetAddr source address of the inbound connection
    */
-  private static DownstreamTlsContext getDownstreamTlsContext(
+  private static SslContextProviderSupplier getSslContextProviderSupplier(
       InetSocketAddress localInetAddr, InetSocketAddress remoteInetAddr,
       EnvoyServerProtoData.Listener listener) {
     List<FilterChain> filterChains = listener.getFilterChains();
@@ -207,9 +233,9 @@ public final class XdsClientWrapperForServerSds {
       // close the connection
       throw new IllegalStateException("Found 2 matching filter-chains");
     } else if (filterChains.size() == 1) {
-      return filterChains.get(0).getDownstreamTlsContext();
+      return filterChains.get(0).getSslContextProviderSupplier();
     }
-    return listener.getDefaultFilterChain().getDownstreamTlsContext();
+    return listener.getDefaultFilterChain().getSslContextProviderSupplier();
   }
 
   // destination_port present => Always fail match
@@ -422,6 +448,7 @@ public final class XdsClientWrapperForServerSds {
   /** Shutdown this instance and release resources. */
   public void shutdown() {
     logger.log(Level.FINER, "Shutdown");
+    releaseOldSuppliers(curListener.get());
     if (xdsClient != null) {
       xdsClient = xdsClientPool.returnObject(xdsClient);
     }

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
@@ -688,7 +688,7 @@ public class ClientXdsClientDataTest {
             .setTrafficDirection(TrafficDirection.OUTBOUND)
             .build();
     StructOrError<io.grpc.xds.EnvoyServerProtoData.Listener> struct =
-        ClientXdsClient.parseServerSideListener(listener);
+        ClientXdsClient.parseServerSideListener(listener, null);
     assertThat(struct.getErrorDetail()).isEqualTo("Listener listener1 is not INBOUND");
   }
 
@@ -701,7 +701,7 @@ public class ClientXdsClientDataTest {
             .addListenerFilters(ListenerFilter.newBuilder().build())
             .build();
     StructOrError<io.grpc.xds.EnvoyServerProtoData.Listener> struct =
-        ClientXdsClient.parseServerSideListener(listener);
+        ClientXdsClient.parseServerSideListener(listener, null);
     assertThat(struct.getErrorDetail())
         .isEqualTo("Listener listener1 cannot have listener_filters");
   }
@@ -715,7 +715,7 @@ public class ClientXdsClientDataTest {
             .setUseOriginalDst(BoolValue.of(true))
             .build();
     StructOrError<io.grpc.xds.EnvoyServerProtoData.Listener> struct =
-        ClientXdsClient.parseServerSideListener(listener);
+        ClientXdsClient.parseServerSideListener(listener, null);
     assertThat(struct.getErrorDetail())
         .isEqualTo("Listener listener1 cannot have use_original_dst set to true");
   }
@@ -729,7 +729,7 @@ public class ClientXdsClientDataTest {
             .addFilterChains(FilterChain.newBuilder().build())
             .build();
     StructOrError<io.grpc.xds.EnvoyServerProtoData.Listener> struct =
-        ClientXdsClient.parseServerSideListener(listener);
+        ClientXdsClient.parseServerSideListener(listener, null);
     assertThat(struct.getErrorDetail())
         .isEqualTo("filerChain  has to have envoy.http_connection_manager");
   }
@@ -753,7 +753,7 @@ public class ClientXdsClientDataTest {
             .addFilterChains(filterChain)
             .build();
     StructOrError<io.grpc.xds.EnvoyServerProtoData.Listener> struct =
-        ClientXdsClient.parseServerSideListener(listener);
+        ClientXdsClient.parseServerSideListener(listener, null);
     assertThat(struct.getErrorDetail())
         .isEqualTo("filerChain  has non-unique filter name:envoy.http_connection_manager");
   }
@@ -773,7 +773,7 @@ public class ClientXdsClientDataTest {
             .addFilterChains(filterChain)
             .build();
     StructOrError<io.grpc.xds.EnvoyServerProtoData.Listener> struct =
-        ClientXdsClient.parseServerSideListener(listener);
+        ClientXdsClient.parseServerSideListener(listener, null);
     assertThat(struct.getErrorDetail())
         .isEqualTo("filter envoy.http_connection_manager with config_discovery not supported");
   }
@@ -789,7 +789,7 @@ public class ClientXdsClientDataTest {
             .addFilterChains(filterChain)
             .build();
     StructOrError<io.grpc.xds.EnvoyServerProtoData.Listener> struct =
-        ClientXdsClient.parseServerSideListener(listener);
+        ClientXdsClient.parseServerSideListener(listener, null);
     assertThat(struct.getErrorDetail())
         .isEqualTo("filter envoy.http_connection_manager expected to have typed_config");
   }
@@ -809,7 +809,7 @@ public class ClientXdsClientDataTest {
             .addFilterChains(filterChain)
             .build();
     StructOrError<io.grpc.xds.EnvoyServerProtoData.Listener> struct =
-        ClientXdsClient.parseServerSideListener(listener);
+        ClientXdsClient.parseServerSideListener(listener, null);
     assertThat(struct.getErrorDetail())
         .isEqualTo(
             "filter envoy.http_connection_manager with unsupported typed_config type:badTypeUrl");
@@ -830,7 +830,7 @@ public class ClientXdsClientDataTest {
             .addFilterChains(filterChain)
             .build();
     StructOrError<io.grpc.xds.EnvoyServerProtoData.Listener> struct =
-        ClientXdsClient.parseServerSideListener(listener);
+        ClientXdsClient.parseServerSideListener(listener, null);
     assertThat(struct.getErrorDetail())
         .isEqualTo("http-connection-manager has non-unique http-filter name:hf");
   }
@@ -852,7 +852,7 @@ public class ClientXdsClientDataTest {
             .addFilterChains(filterChain)
             .build();
     StructOrError<io.grpc.xds.EnvoyServerProtoData.Listener> struct =
-        ClientXdsClient.parseServerSideListener(listener);
+        ClientXdsClient.parseServerSideListener(listener, null);
     assertThat(struct.getErrorDetail())
         .isEqualTo(
             "http-connection-manager http-filter envoy.router uses "
@@ -877,7 +877,7 @@ public class ClientXdsClientDataTest {
             .addFilterChains(filterChain)
             .build();
     StructOrError<io.grpc.xds.EnvoyServerProtoData.Listener> struct =
-        ClientXdsClient.parseServerSideListener(listener);
+        ClientXdsClient.parseServerSideListener(listener, null);
     assertThat(struct.getErrorDetail())
         .isEqualTo(
             "http-connection-manager http-filter envoy.router has unsupported typed-config type:"
@@ -898,7 +898,7 @@ public class ClientXdsClientDataTest {
             .addFilterChains(filterChain)
             .build();
     StructOrError<io.grpc.xds.EnvoyServerProtoData.Listener> struct =
-        ClientXdsClient.parseServerSideListener(listener);
+        ClientXdsClient.parseServerSideListener(listener, null);
     assertThat(struct.getErrorDetail())
         .isEqualTo(
             "http-connection-manager http-filter envoy.filters.http.router should have "

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
@@ -234,6 +234,8 @@ public abstract class ClientXdsClientTestBase {
   private CdsResourceWatcher cdsResourceWatcher;
   @Mock
   private EdsResourceWatcher edsResourceWatcher;
+  @Mock
+  private TlsContextManager tlsContextManager;
 
   private ManagedChannel channel;
   private ClientXdsClient xdsClient;
@@ -279,7 +281,7 @@ public abstract class ClientXdsClientTestBase {
             backoffPolicyProvider,
             fakeClock.getStopwatchSupplier(),
             timeProvider,
-            mock(TlsContextManager.class));
+            tlsContextManager);
 
     assertThat(resourceDiscoveryCalls).isEmpty();
     assertThat(loadReportCalls).isEmpty();
@@ -2013,7 +2015,7 @@ public abstract class ClientXdsClientTestBase {
     ClientXdsClientTestBase.DiscoveryRpcCall call =
         startResourceWatcher(LDS, LISTENER_RESOURCE, ldsResourceWatcher);
     Message listener =
-            mf.buildListenerWithFilterChain(
+        mf.buildListenerWithFilterChain(
             LISTENER_RESOURCE, 7000, "0.0.0.0", "google-sds-config-default", "ROOTCA");
     List<Any> listeners = ImmutableList.of(Any.pack(listener));
     call.sendResponse(ResourceType.LDS, listeners, "0", "0000");
@@ -2022,10 +2024,11 @@ public abstract class ClientXdsClientTestBase {
         ResourceType.LDS, Collections.singletonList(LISTENER_RESOURCE), "0", "0000", NODE);
     verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
     assertThat(ldsUpdateCaptor.getValue().listener)
-        .isEqualTo(EnvoyServerProtoData.Listener.fromEnvoyProtoListener((Listener)listener));
+        .isEqualTo(EnvoyServerProtoData.Listener
+            .fromEnvoyProtoListener((Listener) listener, tlsContextManager));
 
     listener =
-            mf.buildListenerWithFilterChain(
+        mf.buildListenerWithFilterChain(
             LISTENER_RESOURCE, 7000, "0.0.0.0", "CERT2", "ROOTCA2");
     listeners = ImmutableList.of(Any.pack(listener));
     call.sendResponse(ResourceType.LDS, listeners, "1", "0001");
@@ -2035,7 +2038,8 @@ public abstract class ClientXdsClientTestBase {
         ResourceType.LDS, Collections.singletonList(LISTENER_RESOURCE), "1", "0001", NODE);
     verify(ldsResourceWatcher, times(2)).onChanged(ldsUpdateCaptor.capture());
     assertThat(ldsUpdateCaptor.getValue().listener)
-        .isEqualTo(EnvoyServerProtoData.Listener.fromEnvoyProtoListener((Listener)listener));
+        .isEqualTo(EnvoyServerProtoData.Listener
+            .fromEnvoyProtoListener((Listener) listener, tlsContextManager));
 
     assertThat(fakeClock.getPendingTasks(LDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
   }

--- a/xds/src/test/java/io/grpc/xds/ServerWrapperForXdsTest.java
+++ b/xds/src/test/java/io/grpc/xds/ServerWrapperForXdsTest.java
@@ -66,13 +66,15 @@ public class ServerWrapperForXdsTest {
   private XdsServerBuilder.XdsServingStatusListener mockXdsServingStatusListener;
   private XdsClient.LdsResourceWatcher listenerWatcher;
   private Server mockServer;
+  private TlsContextManager tlsContextManager;
 
   @Before
   public void setUp() throws IOException {
     port = XdsServerTestHelper.findFreePort();
     mockDelegateBuilder = mock(ServerBuilder.class);
+    tlsContextManager = mock(TlsContextManager.class);
     xdsClientWrapperForServerSds = XdsServerTestHelper
-        .createXdsClientWrapperForServerSds(port, null);
+        .createXdsClientWrapperForServerSds(port, tlsContextManager);
     mockXdsServingStatusListener = mock(XdsServerBuilder.XdsServingStatusListener.class);
     listenerWatcher =
         XdsServerTestHelper.startAndGetWatcher(xdsClientWrapperForServerSds);
@@ -117,8 +119,8 @@ public class ServerWrapperForXdsTest {
     verifyCapturedCodeAndNotServing(Status.Code.ABORTED, ServerWrapperForXds.ServingState.STARTING);
     XdsServerTestHelper.generateListenerUpdate(
         listenerWatcher,
-        CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT1", "VA1")
-    );
+        CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT1", "VA1"),
+        tlsContextManager);
     Throwable exception = future.get(2, TimeUnit.SECONDS);
     assertThat(exception).isNull();
     assertThat(serverWrapperForXds.getCurrentServingState())
@@ -163,8 +165,8 @@ public class ServerWrapperForXdsTest {
       public void run() {
         XdsServerTestHelper.generateListenerUpdate(
             listenerWatcher,
-            CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT2", "VA2")
-        );
+            CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT2", "VA2"),
+            tlsContextManager);
       }
     }).start();
     assertThat(settableFutureToSignalStart.get()).isNull();
@@ -197,9 +199,9 @@ public class ServerWrapperForXdsTest {
       @Override
       public void run() {
         XdsServerTestHelper.generateListenerUpdate(
-                listenerWatcher,
-                CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT2", "VA2")
-        );
+            listenerWatcher,
+            CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT2", "VA2"),
+            tlsContextManager);
       }
     }).start();
     Throwable exception = future.get(2, TimeUnit.SECONDS);
@@ -242,8 +244,8 @@ public class ServerWrapperForXdsTest {
     Future<Throwable> future = startServerAsync();
     XdsServerTestHelper.generateListenerUpdate(
         listenerWatcher,
-        CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT2", "VA2")
-    );
+        CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT2", "VA2"),
+        tlsContextManager);
     Throwable exception = future.get(2, TimeUnit.SECONDS);
     assertThat(exception).isNull();
     assertThat(serverWrapperForXds.getCurrentServingState())
@@ -256,8 +258,8 @@ public class ServerWrapperForXdsTest {
     when(mockDelegateBuilder.build()).thenReturn(mockServer);
     XdsServerTestHelper.generateListenerUpdate(
         listenerWatcher,
-        CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT3", "VA3")
-    );
+        CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT3", "VA3"),
+        tlsContextManager);
     Thread.sleep(100L);
     assertThat(serverWrapperForXds.getCurrentServingState())
         .isEqualTo(ServerWrapperForXds.ServingState.SHUTDOWN);
@@ -269,8 +271,8 @@ public class ServerWrapperForXdsTest {
     Future<Throwable> future = startServerAsync();
     XdsServerTestHelper.generateListenerUpdate(
         listenerWatcher,
-        CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT2", "VA2")
-    );
+        CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT2", "VA2"),
+        tlsContextManager);
     Throwable exception = future.get(2, TimeUnit.SECONDS);
     assertThat(exception).isNull();
     assertThat(serverWrapperForXds.getCurrentServingState())
@@ -302,8 +304,8 @@ public class ServerWrapperForXdsTest {
       public void run() {
         XdsServerTestHelper.generateListenerUpdate(
             listenerWatcher,
-            CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT2", "VA2")
-        );
+            CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT2", "VA2"),
+            tlsContextManager);
       }
     }).start();
     assertThat(settableFutureToSignalStart.get()).isNull();

--- a/xds/src/test/java/io/grpc/xds/XdsClientWrapperForServerSdsTestMisc.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientWrapperForServerSdsTestMisc.java
@@ -189,7 +189,11 @@ public class XdsClientWrapperForServerSdsTestMisc {
     InetSocketAddress remoteAddress = new InetSocketAddress(ipRemoteAddress, 1111);
     when(channel.remoteAddress()).thenReturn(remoteAddress);
     callUpdateSslContext(channel);
+    XdsClient mockXdsClient = xdsClientWrapperForServerSds.getXdsClient();
     xdsClientWrapperForServerSds.shutdown();
+    verify(mockXdsClient, times(1))
+        .cancelLdsResourceWatch(eq("grpc/server?udpa.resource.listening_address=0.0.0.0:" + PORT),
+            eq(registeredWatcher));
     verify(tlsContextManager, never()).releaseServerSslContextProvider(eq(sslContextProvider1));
     verify(tlsContextManager, times(1)).releaseServerSslContextProvider(eq(sslContextProvider2));
     verify(tlsContextManager, times(1)).releaseServerSslContextProvider(eq(sslContextProvider3));

--- a/xds/src/test/java/io/grpc/xds/XdsClientWrapperForServerSdsTestMisc.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientWrapperForServerSdsTestMisc.java
@@ -19,9 +19,11 @@ package io.grpc.xds;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -30,12 +32,15 @@ import io.grpc.StatusException;
 import io.grpc.inprocess.InProcessSocketAddress;
 import io.grpc.xds.EnvoyServerProtoData.DownstreamTlsContext;
 import io.grpc.xds.internal.sds.CommonTlsContextTestsUtil;
+import io.grpc.xds.internal.sds.SslContextProvider;
+import io.grpc.xds.internal.sds.SslContextProviderSupplier;
 import io.netty.channel.Channel;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
+import java.util.Arrays;
 import java.util.Collections;
 import org.junit.After;
 import org.junit.Before;
@@ -53,15 +58,27 @@ public class XdsClientWrapperForServerSdsTestMisc {
   private static final int PORT = 7000;
 
   @Mock private Channel channel;
+  @Mock private TlsContextManager tlsContextManager;
+  @Mock private XdsClientWrapperForServerSds.ServerWatcher mockServerWatcher;
 
   private XdsClientWrapperForServerSds xdsClientWrapperForServerSds;
   private XdsClient.LdsResourceWatcher registeredWatcher;
+  private InetSocketAddress localAddress;
+  private DownstreamTlsContext tlsContext1;
+  private DownstreamTlsContext tlsContext2;
+  private DownstreamTlsContext tlsContext3;
 
   @Before
   public void setUp() throws IOException {
     MockitoAnnotations.initMocks(this);
+    tlsContext1 =
+            CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT1", "VA1");
+    tlsContext2 =
+            CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT2", "VA2");
+    tlsContext3 =
+            CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT3", "VA3");
     xdsClientWrapperForServerSds = XdsServerTestHelper
-        .createXdsClientWrapperForServerSds(PORT, null);
+        .createXdsClientWrapperForServerSds(PORT, tlsContextManager);
   }
 
   @After
@@ -73,7 +90,9 @@ public class XdsClientWrapperForServerSdsTestMisc {
   public void nonInetSocketAddress_expectNull() throws UnknownHostException {
     registeredWatcher =
         XdsServerTestHelper.startAndGetWatcher(xdsClientWrapperForServerSds);
-    assertThat(sendListenerUpdate(new InProcessSocketAddress("test1"), null)).isNull();
+    assertThat(
+        sendListenerUpdate(new InProcessSocketAddress("test1"), null, null, tlsContextManager))
+        .isNull();
   }
 
   @Test
@@ -83,7 +102,7 @@ public class XdsClientWrapperForServerSdsTestMisc {
     try {
       InetAddress ipLocalAddress = InetAddress.getByName("10.1.2.3");
       InetSocketAddress localAddress = new InetSocketAddress(ipLocalAddress, PORT + 1);
-      DownstreamTlsContext unused = sendListenerUpdate(localAddress, null);
+      sendListenerUpdate(localAddress, null, null, tlsContextManager);
       fail("exception expected");
     } catch (IllegalStateException expected) {
       assertThat(expected)
@@ -114,86 +133,166 @@ public class XdsClientWrapperForServerSdsTestMisc {
             null);
     XdsClient.LdsUpdate listenerUpdate = new XdsClient.LdsUpdate(listener);
     registeredWatcher.onChanged(listenerUpdate);
-    DownstreamTlsContext tlsContext = xdsClientWrapperForServerSds.getDownstreamTlsContext(channel);
+    DownstreamTlsContext tlsContext = getDownstreamTlsContext();
     assertThat(tlsContext).isNull();
   }
 
   @Test
-  public void registerServerWatcher() throws UnknownHostException {
-    registeredWatcher =
-            XdsServerTestHelper.startAndGetWatcher(xdsClientWrapperForServerSds);
-    XdsClientWrapperForServerSds.ServerWatcher mockServerWatcher =
-        mock(XdsClientWrapperForServerSds.ServerWatcher.class);
-    xdsClientWrapperForServerSds.addServerWatcher(mockServerWatcher);
-    InetAddress ipLocalAddress = InetAddress.getByName("10.1.2.3");
-    InetSocketAddress localAddress = new InetSocketAddress(ipLocalAddress, PORT);
-    EnvoyServerProtoData.DownstreamTlsContext tlsContext =
-        CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT1", "VA1");
-    verify(mockServerWatcher, never())
-        .onListenerUpdate();
-    DownstreamTlsContext returnedTlsContext = sendListenerUpdate(localAddress, tlsContext);
-    assertThat(returnedTlsContext).isSameInstanceAs(tlsContext);
-    verify(mockServerWatcher).onListenerUpdate();
-    xdsClientWrapperForServerSds.removeServerWatcher(mockServerWatcher);
-  }
-
-  @Test
   public void registerServerWatcher_afterListenerUpdate() throws UnknownHostException {
-    registeredWatcher =
-            XdsServerTestHelper.startAndGetWatcher(xdsClientWrapperForServerSds);
-    InetAddress ipLocalAddress = InetAddress.getByName("10.1.2.3");
-    InetSocketAddress localAddress = new InetSocketAddress(ipLocalAddress, PORT);
-    EnvoyServerProtoData.DownstreamTlsContext tlsContext =
-            CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT1", "VA1");
-    DownstreamTlsContext returnedTlsContext = sendListenerUpdate(localAddress, tlsContext);
-    assertThat(returnedTlsContext).isSameInstanceAs(tlsContext);
-    XdsClientWrapperForServerSds.ServerWatcher mockServerWatcher =
-            mock(XdsClientWrapperForServerSds.ServerWatcher.class);
-    xdsClientWrapperForServerSds.addServerWatcher(mockServerWatcher);
+    registerWatcherAndCreateListenerUpdate(tlsContext1);
     verify(mockServerWatcher).onListenerUpdate();
   }
 
   @Test
-  public void registerServerWatcher_notifyError() throws UnknownHostException {
-    registeredWatcher =
-            XdsServerTestHelper.startAndGetWatcher(xdsClientWrapperForServerSds);
-    XdsClientWrapperForServerSds.ServerWatcher mockServerWatcher =
-        mock(XdsClientWrapperForServerSds.ServerWatcher.class);
-    xdsClientWrapperForServerSds.addServerWatcher(mockServerWatcher);
+  public void registerServerWatcher_notifyNotFound() throws UnknownHostException {
+    commonErrorCheck(true, Status.NOT_FOUND, true);
+  }
+
+  @Test
+  public void registerServerWatcher_notifyInternalError() throws UnknownHostException {
+    commonErrorCheck(false, Status.INTERNAL, false);
+  }
+
+  @Test
+  public void registerServerWatcher_notifyPermDeniedError() throws UnknownHostException {
+    commonErrorCheck(false, Status.PERMISSION_DENIED, true);
+  }
+
+  @Test
+  public void releaseOldSupplierOnChanged_noCloseDueToLazyLoading() throws UnknownHostException {
+    registerWatcherAndCreateListenerUpdate(tlsContext1);
+    XdsServerTestHelper.generateListenerUpdate(registeredWatcher, tlsContext2, tlsContextManager);
+    verify(tlsContextManager, never())
+        .findOrCreateServerSslContextProvider(any(DownstreamTlsContext.class));
+  }
+
+  @Test
+  public void releaseOldSupplierOnChangedOnShutdown_verifyClose() throws UnknownHostException {
+    SslContextProvider sslContextProvider1 = mock(SslContextProvider.class);
+    when(tlsContextManager.findOrCreateServerSslContextProvider(eq(tlsContext1)))
+        .thenReturn(sslContextProvider1);
+    registerWatcherAndCreateListenerUpdate(tlsContext1);
+    callUpdateSslContext(channel);
+    XdsServerTestHelper
+        .generateListenerUpdate(registeredWatcher, Arrays.<Integer>asList(1234), tlsContext2,
+            tlsContext3, tlsContextManager);
+    verify(tlsContextManager, times(1)).releaseServerSslContextProvider(eq(sslContextProvider1));
+    reset(tlsContextManager);
+    SslContextProvider sslContextProvider2 = mock(SslContextProvider.class);
+    when(tlsContextManager.findOrCreateServerSslContextProvider(eq(tlsContext2)))
+            .thenReturn(sslContextProvider2);
+    SslContextProvider sslContextProvider3 = mock(SslContextProvider.class);
+    when(tlsContextManager.findOrCreateServerSslContextProvider(eq(tlsContext3)))
+            .thenReturn(sslContextProvider3);
+    callUpdateSslContext(channel);
+    InetAddress ipRemoteAddress = InetAddress.getByName("10.4.5.6");
+    InetSocketAddress remoteAddress = new InetSocketAddress(ipRemoteAddress, 1111);
+    when(channel.remoteAddress()).thenReturn(remoteAddress);
+    callUpdateSslContext(channel);
+    xdsClientWrapperForServerSds.shutdown();
+    verify(tlsContextManager, never()).releaseServerSslContextProvider(eq(sslContextProvider1));
+    verify(tlsContextManager, times(1)).releaseServerSslContextProvider(eq(sslContextProvider2));
+    verify(tlsContextManager, times(1)).releaseServerSslContextProvider(eq(sslContextProvider3));
+  }
+
+  @Test
+  public void releaseOldSupplierOnNotFound_verifyClose() throws UnknownHostException {
+    SslContextProvider sslContextProvider1 = mock(SslContextProvider.class);
+    when(tlsContextManager.findOrCreateServerSslContextProvider(eq(tlsContext1)))
+            .thenReturn(sslContextProvider1);
+    registerWatcherAndCreateListenerUpdate(tlsContext1);
+    callUpdateSslContext(channel);
+    registeredWatcher.onResourceDoesNotExist("not-found Error");
+    verify(tlsContextManager, times(1)).releaseServerSslContextProvider(eq(sslContextProvider1));
+  }
+
+  @Test
+  public void releaseOldSupplierOnPermDeniedError_verifyClose() throws UnknownHostException {
+    SslContextProvider sslContextProvider1 = mock(SslContextProvider.class);
+    when(tlsContextManager.findOrCreateServerSslContextProvider(eq(tlsContext1)))
+            .thenReturn(sslContextProvider1);
+    registerWatcherAndCreateListenerUpdate(tlsContext1);
+    callUpdateSslContext(channel);
+    registeredWatcher.onError(Status.PERMISSION_DENIED);
+    verify(tlsContextManager, times(1)).releaseServerSslContextProvider(eq(sslContextProvider1));
+  }
+
+  @Test
+  public void releaseOldSupplierOnInternalError_noClose() throws UnknownHostException {
+    SslContextProvider sslContextProvider1 = mock(SslContextProvider.class);
+    when(tlsContextManager.findOrCreateServerSslContextProvider(eq(tlsContext1)))
+            .thenReturn(sslContextProvider1);
+    registerWatcherAndCreateListenerUpdate(tlsContext1);
+    callUpdateSslContext(channel);
     registeredWatcher.onError(Status.INTERNAL);
+    verify(tlsContextManager, never()).releaseServerSslContextProvider(eq(sslContextProvider1));
+  }
+
+  private void callUpdateSslContext(Channel channel) {
+    SslContextProviderSupplier sslContextProviderSupplier =
+        xdsClientWrapperForServerSds.getSslContextProviderSupplier(channel);
+    assertThat(sslContextProviderSupplier).isNotNull();
+    SslContextProvider.Callback callback = mock(SslContextProvider.Callback.class);
+    sslContextProviderSupplier.updateSslContext(callback);
+  }
+
+  private void registerWatcherAndCreateListenerUpdate(DownstreamTlsContext tlsContext)
+      throws UnknownHostException {
+    registeredWatcher =
+        XdsServerTestHelper.startAndGetWatcher(xdsClientWrapperForServerSds);
+    InetAddress ipLocalAddress = InetAddress.getByName("10.1.2.3");
+    localAddress = new InetSocketAddress(ipLocalAddress, PORT);
+    xdsClientWrapperForServerSds.addServerWatcher(mockServerWatcher);
+    DownstreamTlsContext returnedTlsContext = sendListenerUpdate(localAddress, tlsContext, null,
+        tlsContextManager);
+    assertThat(returnedTlsContext).isSameInstanceAs(tlsContext);
+  }
+
+  private void commonErrorCheck(boolean generateResourceDoesNotExist, Status status,
+      boolean isAbsent) throws UnknownHostException {
+    registerWatcherAndCreateListenerUpdate(tlsContext1);
+    reset(mockServerWatcher);
+    if (generateResourceDoesNotExist) {
+      registeredWatcher.onResourceDoesNotExist("not-found Error");
+    } else {
+      registeredWatcher.onError(status);
+    }
     ArgumentCaptor<Throwable> argCaptor = ArgumentCaptor.forClass(null);
-    verify(mockServerWatcher).onError(argCaptor.capture(), eq(false));
+    verify(mockServerWatcher).onError(argCaptor.capture(), eq(isAbsent));
     Throwable throwable = argCaptor.getValue();
     assertThat(throwable).isInstanceOf(StatusException.class);
-    Status captured = ((StatusException)throwable).getStatus();
-    assertThat(captured.getCode()).isEqualTo(Status.Code.INTERNAL);
-    reset(mockServerWatcher);
-    registeredWatcher.onResourceDoesNotExist("not-found Error");
-    ArgumentCaptor<Throwable> argCaptor1 = ArgumentCaptor.forClass(null);
-    verify(mockServerWatcher).onError(argCaptor1.capture(), eq(true));
-    throwable = argCaptor1.getValue();
-    assertThat(throwable).isInstanceOf(StatusException.class);
-    captured = ((StatusException)throwable).getStatus();
-    assertThat(captured.getCode()).isEqualTo(Status.Code.NOT_FOUND);
-    InetAddress ipLocalAddress = InetAddress.getByName("10.1.2.3");
-    InetSocketAddress localAddress = new InetSocketAddress(ipLocalAddress, PORT);
-    EnvoyServerProtoData.DownstreamTlsContext tlsContext =
-        CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT1", "VA1");
-    verify(mockServerWatcher, never())
-        .onListenerUpdate();
-    DownstreamTlsContext returnedTlsContext = sendListenerUpdate(localAddress, tlsContext);
-    assertThat(returnedTlsContext).isSameInstanceAs(tlsContext);
-    verify(mockServerWatcher).onListenerUpdate();
+    Status captured = ((StatusException) throwable).getStatus();
+    assertThat(captured.getCode()).isEqualTo(status.getCode());
+    if (isAbsent) {
+      assertThat(xdsClientWrapperForServerSds.getSslContextProviderSupplier(channel)).isNull();
+    } else {
+      assertThat(xdsClientWrapperForServerSds.getSslContextProviderSupplier(channel)).isNotNull();
+    }
   }
 
   private DownstreamTlsContext sendListenerUpdate(
-      SocketAddress localAddress, DownstreamTlsContext tlsContext) throws UnknownHostException {
+      SocketAddress localAddress, DownstreamTlsContext tlsContext,
+      DownstreamTlsContext tlsContextForDefaultFilterChain, TlsContextManager tlsContextManager)
+      throws UnknownHostException {
     when(channel.localAddress()).thenReturn(localAddress);
     InetAddress ipRemoteAddress = InetAddress.getByName("10.4.5.6");
     InetSocketAddress remoteAddress = new InetSocketAddress(ipRemoteAddress, 1234);
     when(channel.remoteAddress()).thenReturn(remoteAddress);
-    XdsServerTestHelper.generateListenerUpdate(registeredWatcher, tlsContext);
-    return xdsClientWrapperForServerSds.getDownstreamTlsContext(channel);
+    XdsServerTestHelper
+        .generateListenerUpdate(registeredWatcher, Arrays.<Integer>asList(), tlsContext,
+            tlsContextForDefaultFilterChain, tlsContextManager);
+    return getDownstreamTlsContext();
+  }
+
+  private DownstreamTlsContext getDownstreamTlsContext() {
+    SslContextProviderSupplier sslContextProviderSupplier =
+            xdsClientWrapperForServerSds.getSslContextProviderSupplier(channel);
+    if (sslContextProviderSupplier != null) {
+      EnvoyServerProtoData.BaseTlsContext tlsContext = sslContextProviderSupplier.getTlsContext();
+      assertThat(tlsContext).isInstanceOf(DownstreamTlsContext.class);
+      return (DownstreamTlsContext)tlsContext;
+    }
+    return null;
   }
 
   /** Creates XdsClientWrapperForServerSds: also used by other classes. */
@@ -203,7 +302,7 @@ public class XdsClientWrapperForServerSdsTestMisc {
         XdsServerTestHelper.createXdsClientWrapperForServerSds(port, tlsContextManager);
     xdsClientWrapperForServerSds.start();
     XdsSdsClientServerTest.generateListenerUpdateToWatcher(
-        downstreamTlsContext, xdsClientWrapperForServerSds.getListenerWatcher());
+        downstreamTlsContext, xdsClientWrapperForServerSds.getListenerWatcher(), tlsContextManager);
     return xdsClientWrapperForServerSds;
   }
 }

--- a/xds/src/test/java/io/grpc/xds/XdsServerBuilderTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerBuilderTest.java
@@ -63,6 +63,7 @@ public class XdsServerBuilderTest {
   private XdsClient.LdsResourceWatcher listenerWatcher;
   private int port;
   private XdsClientWrapperForServerSds xdsClientWrapperForServerSds;
+  private TlsContextManager tlsContextManager;
 
   private void buildServer(XdsServerBuilder.XdsServingStatusListener xdsServingStatusListener)
       throws IOException {
@@ -79,8 +80,9 @@ public class XdsServerBuilderTest {
     if (xdsServingStatusListener != null) {
       builder = builder.xdsServingStatusListener(xdsServingStatusListener);
     }
+    tlsContextManager = mock(TlsContextManager.class);
     xdsClientWrapperForServerSds = XdsServerTestHelper
-        .createXdsClientWrapperForServerSds(port, null);
+        .createXdsClientWrapperForServerSds(port, tlsContextManager);
     listenerWatcher = XdsServerTestHelper.startAndGetWatcher(xdsClientWrapperForServerSds);
   }
 
@@ -145,8 +147,8 @@ public class XdsServerBuilderTest {
     Future<Throwable> future = startServerAsync();
     XdsServerTestHelper.generateListenerUpdate(
         listenerWatcher,
-        CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT1", "VA1")
-    );
+        CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT1", "VA1"),
+            tlsContextManager);
     verifyServer(future, null, null);
     verifyShutdown();
   }
@@ -157,8 +159,8 @@ public class XdsServerBuilderTest {
     buildServer(null);
     XdsServerTestHelper.generateListenerUpdate(
             listenerWatcher,
-            CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT1", "VA1")
-    );
+            CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT1", "VA1"),
+            tlsContextManager);
     xdsServer.start();
     try {
       xdsServer.start();
@@ -178,8 +180,8 @@ public class XdsServerBuilderTest {
     Future<Throwable> future = startServerAsync();
     XdsServerTestHelper.generateListenerUpdate(
         listenerWatcher,
-        CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT1", "VA1")
-    );
+        CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT1", "VA1"),
+            tlsContextManager);
     verifyServer(future, mockXdsServingStatusListener, null);
   }
 
@@ -219,8 +221,8 @@ public class XdsServerBuilderTest {
     reset(mockXdsServingStatusListener);
     XdsServerTestHelper.generateListenerUpdate(
         listenerWatcher,
-        CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT1", "VA1")
-    );
+        CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT1", "VA1"),
+            tlsContextManager);
     verifyServer(future, mockXdsServingStatusListener, null);
   }
 
@@ -235,8 +237,8 @@ public class XdsServerBuilderTest {
     ServerSocket serverSocket = new ServerSocket(port);
     XdsServerTestHelper.generateListenerUpdate(
         listenerWatcher,
-        CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT1", "VA1")
-    );
+        CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT1", "VA1"),
+            tlsContextManager);
     Throwable exception = future.get(5, TimeUnit.SECONDS);
     assertThat(exception).isInstanceOf(IOException.class);
     assertThat(exception).hasMessageThat().contains("Failed to bind");
@@ -253,12 +255,12 @@ public class XdsServerBuilderTest {
     Future<Throwable> future = startServerAsync();
     XdsServerTestHelper.generateListenerUpdate(
         listenerWatcher,
-        CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT1", "VA1")
-    );
+        CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT1", "VA1"),
+            tlsContextManager);
     XdsServerTestHelper.generateListenerUpdate(
         listenerWatcher,
-        CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT1", "VA1")
-    );
+        CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT1", "VA1"),
+            tlsContextManager);
     verify(mockXdsServingStatusListener, never()).onNotServing(any(Throwable.class));
     verifyServer(future, mockXdsServingStatusListener, null);
     listenerWatcher.onError(Status.ABORTED);

--- a/xds/src/test/java/io/grpc/xds/internal/sds/SdsProtocolNegotiatorsTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/sds/SdsProtocolNegotiatorsTest.java
@@ -297,7 +297,7 @@ public class SdsProtocolNegotiatorsTest {
 
     XdsClientWrapperForServerSds xdsClientWrapperForServerSds =
         XdsClientWrapperForServerSdsTestMisc.createXdsClientWrapperForServerSds(
-            80, downstreamTlsContext, null);
+            80, downstreamTlsContext, mock(TlsContextManager.class));
     SdsProtocolNegotiators.HandlerPickerHandler handlerPickerHandler =
         new SdsProtocolNegotiators.HandlerPickerHandler(
             grpcHandler, xdsClientWrapperForServerSds, mockProtocolNegotiator);


### PR DESCRIPTION
Use SslContextProviderSupplier instead of DownstreamTlsContext to ensure reference counting and lazy loading of SslContextProvider's in the current Listener object.