### PR TITLE
xds: import v3 RBAC http filter proto

### DIFF
--- a/xds/third_party/envoy/import.sh
+++ b/xds/third_party/envoy/import.sh
@@ -125,6 +125,7 @@ envoy/config/trace/v3/zipkin.proto
 envoy/extensions/clusters/aggregate/v3/cluster.proto
 envoy/extensions/filters/common/fault/v3/fault.proto
 envoy/extensions/filters/http/fault/v3/fault.proto
+envoy/extensions/filters/http/rbac/v3/rbac.proto
 envoy/extensions/filters/http/router/v3/router.proto
 envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
 envoy/extensions/transport_sockets/tls/v3/cert.proto

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/http/rbac/v3/rbac.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/http/rbac/v3/rbac.proto
@@ -1,0 +1,48 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.http.rbac.v3;
+
+import "envoy/config/rbac/v3/rbac.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.http.rbac.v3";
+option java_outer_classname = "RbacProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: RBAC]
+// Role-Based Access Control :ref:`configuration overview <config_http_filters_rbac>`.
+// [#extension: envoy.filters.http.rbac]
+
+// RBAC filter config.
+message RBAC {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.filter.http.rbac.v2.RBAC";
+
+  // Specify the RBAC rules to be applied globally.
+  // If absent, no enforcing RBAC policy will be applied.
+  config.rbac.v3.RBAC rules = 1;
+
+  // Shadow rules are not enforced by the filter (i.e., returning a 403)
+  // but will emit stats and logs and can be used for rule testing.
+  // If absent, no shadow RBAC policy will be applied.
+  config.rbac.v3.RBAC shadow_rules = 2;
+
+  // If specified, shadow rules will emit stats with the given prefix.
+  // This is useful to distinguish the stat when there are more than 1 RBAC filter configured with
+  // shadow rules.
+  string shadow_rules_stat_prefix = 3;
+}
+
+message RBACPerRoute {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.filter.http.rbac.v2.RBACPerRoute";
+
+  reserved 1;
+
+  // Override the global configuration of the filter with this new config.
+  // If absent, the global RBAC policy will be disabled for this route.
+  RBAC rbac = 2;
+}


### PR DESCRIPTION
#8145 only brings in RBAC configuration protos, but not the http filter protos. We may want to bring in v2 protos as we did for fault injection protos, in case TD sends responses with v2 messages. That would be for logging purposes only and we are not sure if they are necessary. So just import v3 protos for now.