### PR TITLE
Simplify Round-Robin picker logic

### DIFF
--- a/core/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
@@ -297,12 +297,7 @@ final class RoundRobinLoadBalancer extends LoadBalancer {
 
     private Subchannel nextSubchannel() {
       int size = list.size();
-      int i = indexUpdater.incrementAndGet(this);
-      if (i >= size) {
-        int oldi = i;
-        i %= size;
-        indexUpdater.compareAndSet(this, oldi, i);
-      }
+      int i = (indexUpdater.incrementAndGet(this) & 0x7FFFFFFF) % size;
       return list.get(i);
     }
 


### PR DESCRIPTION
With this change, there's no need to detect when we go outside the boundaries of the list and use compareAndSet to reset it.
Instead, we just ensure that the value is positive by removing the sign before applying the modulo.

This should both simplify the code and slightly reduce contention while maintaining an even distribution of usage of subchannels.