### PR TITLE
xds: move the unsupported filterChainMatch matchers to the ranking stage for correct outcomes

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsClientWrapperForServerSds.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientWrapperForServerSds.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.UInt32Value;
 import io.grpc.Internal;
@@ -225,6 +226,9 @@ public final class XdsClientWrapperForServerSds {
 
     filterChains = filterOnDestinationPort(filterChains);
     filterChains = filterOnIpAddress(filterChains, localInetAddr.getAddress(), true);
+    filterChains = filterOnServerNames(filterChains);
+    filterChains = filterOnTransportProtocol(filterChains);
+    filterChains = filterOnApplicationProtocols(filterChains);
     filterChains =
         filterOnSourceType(filterChains, remoteInetAddr.getAddress(), localInetAddr.getAddress());
     filterChains = filterOnIpAddress(filterChains, remoteInetAddr.getAddress(), false);
@@ -237,6 +241,46 @@ public final class XdsClientWrapperForServerSds {
       return filterChains.get(0).getSslContextProviderSupplier();
     }
     return listener.getDefaultFilterChain().getSslContextProviderSupplier();
+  }
+
+  // reject if filer-chain-match has non-empty application_protocols
+  private static List<FilterChain> filterOnApplicationProtocols(List<FilterChain> filterChains) {
+    ArrayList<FilterChain> filtered = new ArrayList<>(filterChains.size());
+    for (FilterChain filterChain : filterChains) {
+      FilterChainMatch filterChainMatch = filterChain.getFilterChainMatch();
+
+      if (filterChainMatch.getApplicationProtocols().isEmpty()) {
+        filtered.add(filterChain);
+      }
+    }
+    return filtered;
+  }
+
+  // reject if filer-chain-match has non-empty transport protocol other than "raw_buffer"
+  private static List<FilterChain> filterOnTransportProtocol(List<FilterChain> filterChains) {
+    ArrayList<FilterChain> filtered = new ArrayList<>(filterChains.size());
+    for (FilterChain filterChain : filterChains) {
+      FilterChainMatch filterChainMatch = filterChain.getFilterChainMatch();
+
+      String transportProtocol = filterChainMatch.getTransportProtocol();
+      if ( Strings.isNullOrEmpty(transportProtocol) || "raw_buffer".equals(transportProtocol)) {
+        filtered.add(filterChain);
+      }
+    }
+    return filtered;
+  }
+
+  // reject if filer-chain-match has server_name(s)
+  private static List<FilterChain> filterOnServerNames(List<FilterChain> filterChains) {
+    ArrayList<FilterChain> filtered = new ArrayList<>(filterChains.size());
+    for (FilterChain filterChain : filterChains) {
+      FilterChainMatch filterChainMatch = filterChain.getFilterChainMatch();
+
+      if (filterChainMatch.getServerNames().isEmpty()) {
+        filtered.add(filterChain);
+      }
+    }
+    return filtered;
   }
 
   // destination_port present => Always fail match

--- a/xds/src/test/java/io/grpc/xds/EnvoyServerProtoDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/EnvoyServerProtoDataTest.java
@@ -36,6 +36,7 @@ import io.grpc.xds.EnvoyServerProtoData.DownstreamTlsContext;
 import io.grpc.xds.EnvoyServerProtoData.Listener;
 import io.grpc.xds.internal.sds.CommonTlsContextTestsUtil;
 import io.grpc.xds.internal.sds.SslContextProviderSupplier;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -75,7 +76,11 @@ public class EnvoyServerProtoDataTest {
     EnvoyServerProtoData.FilterChainMatch inFilterChainMatch = inFilter.getFilterChainMatch();
     assertThat(inFilterChainMatch).isNotNull();
     assertThat(inFilterChainMatch.getDestinationPort()).isEqualTo(8000);
-    assertThat(inFilterChainMatch.getApplicationProtocols()).isEmpty();
+    assertThat(inFilterChainMatch.getApplicationProtocols())
+        .containsExactlyElementsIn(Arrays.asList("managed-mtls", "h2"));
+    assertThat(inFilterChainMatch.getServerNames())
+        .containsExactlyElementsIn(Arrays.asList("server1", "server2"));
+    assertThat(inFilterChainMatch.getTransportProtocol()).isEqualTo("tls");
     assertThat(inFilterChainMatch.getPrefixRanges())
         .containsExactly(new EnvoyServerProtoData.CidrRange("10.20.0.15", 32));
     assertThat(inFilterChainMatch.getSourcePrefixRanges())
@@ -111,6 +116,9 @@ public class EnvoyServerProtoDataTest {
             .setFilterChainMatch(
                 FilterChainMatch.newBuilder()
                     .setDestinationPort(UInt32Value.of(8000))
+                    .addAllServerNames(Arrays.asList("server1", "server2"))
+                    .setTransportProtocol("tls")
+                    .addAllApplicationProtocols(Arrays.asList("managed-mtls", "h2"))
                     .addPrefixRanges(CidrRange.newBuilder()
                         .setAddressPrefix("10.20.0.15")
                         .setPrefixLen(UInt32Value.of(32))

--- a/xds/src/test/java/io/grpc/xds/XdsSdsClientServerTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsSdsClientServerTest.java
@@ -374,7 +374,9 @@ public class XdsSdsClientServerTest {
             Arrays.<String>asList(),
             Arrays.<EnvoyServerProtoData.CidrRange>asList(),
             null,
-            Arrays.<Integer>asList());
+            Arrays.<Integer>asList(),
+            Arrays.<String>asList(),
+            null);
     EnvoyServerProtoData.FilterChain defaultFilterChain =
         new EnvoyServerProtoData.FilterChain(filterChainMatch, tlsContext, tlsContextManager);
     EnvoyServerProtoData.Listener listener =

--- a/xds/src/test/java/io/grpc/xds/XdsServerTestHelper.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerTestHelper.java
@@ -155,7 +155,9 @@ class XdsServerTestHelper {
             Arrays.<String>asList(),
             Arrays.<EnvoyServerProtoData.CidrRange>asList(),
             null,
-            sourcePorts);
+            sourcePorts,
+            Arrays.<String>asList(),
+            null);
     EnvoyServerProtoData.FilterChain filterChain1 =
         new EnvoyServerProtoData.FilterChain(filterChainMatch1, tlsContext, tlsContextManager);
     EnvoyServerProtoData.FilterChain defaultFilterChain =


### PR DESCRIPTION
reference b/183428450

Don't prune out "always-failing" filter chains at validation time. But remove them when we rank all the filter chains so that we get the correct outcome (matching Envoy and other gRPC languages)