### PR TITLE
xds: fix order of processing resolution errors with original cluster ordering 

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
@@ -254,7 +254,8 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
     private void handleEndpointResolutionError() {
       boolean allInError = true;
       Status error = null;
-      for (ClusterState state :  clusterStates.values()) {
+      for (String cluster : clusters) {
+        ClusterState state = clusterStates.get(cluster);
         if (state.status.isOk()) {
           allInError = false;
         } else {


### PR DESCRIPTION
When aggregating the endpoint resolution errors of the list of clusters in ClusterResolverLoadBalancer, clusters should be processed in its original order as received in the LB config. The last cluster's error is used as the overall error status.

---------
Fixes test flakiness https://fusion2.corp.google.com/invocations/c547cc03-f0b3-4b88-8322-c000aaf71932/targets/%2F%2Fthird_party%2Fjava_src%2Fgrpc%2Fxds:src%2Ftest%2Fjava%2Fio%2Fgrpc%2Fxds%2FClusterResolverLoadBalancerTest/tests