### PR TITLE
Swap from the Lock GH App to lock-threads GH Action

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,2 +1,0 @@
-daysUntilLock: 90
-lockComment: false

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,20 @@
+name: 'Lock Threads'
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '37 3 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2
+        with:
+          github-token: ${{ github.token }}
+          issue-lock-inactive-days: 90
+￼         pr-lock-inactive-days: 90


### PR DESCRIPTION
The Lock App [is unhealthy][1]. GitHub Actions now has [a better
security model][2] such that we think we can safely use it.

The time of day to run the action was randomly generated.

[1]: https://github.com/dessant/lock-threads-app/issues/2
[2]: https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/