### PR TITLE
Fix aarch64 emulation-triggered flakes

### DIFF
--- a/interop-testing/src/test/java/io/grpc/testing/integration/StressTestClientTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/StressTestClientTest.java
@@ -45,7 +45,7 @@ import org.junit.runners.JUnit4;
 public class StressTestClientTest {
 
   @Rule
-  public final Timeout globalTimeout = Timeout.seconds(5);
+  public final Timeout globalTimeout = Timeout.seconds(10);
 
   @Test
   public void ipv6AddressesShouldBeSupported() {


### PR DESCRIPTION
Because we are emulating aarch64 during testing the tests run slower
than normal. Bumping the timeout seems easy and obvious for
StressTestClientTest. The warmup for BinlogHelperTest mirrors what we've
done with timing-based tests in the past. Hopefully that is enough to
lower variance so that it passes consistently; seems likely. I'd rather
not increase the timing fuzziness if I can avoid it, as that reduces the
test's ability to detect issues.

Fixes #8135 (mostly+hopefully)