### PR TITLE
Bump Protobuf Gradle Plugin to 0.8.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ For non-Android protobuf-based codegen integrated with the Gradle build system,
 you can use [protobuf-gradle-plugin][]:
 ```gradle
 plugins {
-    id 'com.google.protobuf' version '0.8.15'
+    id 'com.google.protobuf' version '0.8.16'
 }
 
 protobuf {
@@ -167,7 +167,7 @@ use protobuf-gradle-plugin but specify the 'lite' options:
 
 ```gradle
 plugins {
-    id 'com.google.protobuf' version '0.8.15'
+    id 'com.google.protobuf' version '0.8.16'
 }
 
 protobuf {

--- a/examples/android/clientcache/build.gradle
+++ b/examples/android/clientcache/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.15"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.16"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/android/helloworld/build.gradle
+++ b/examples/android/helloworld/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.15"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.16"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/android/routeguide/build.gradle
+++ b/examples/android/routeguide/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.15"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.16"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/android/strictmode/build.gradle
+++ b/examples/android/strictmode/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.15"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.16"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -2,7 +2,7 @@ plugins {
     // Provide convenience executables for trying out the examples.
     id 'application'
     // ASSUMES GRADLE 5.6 OR HIGHER. Use plugin version 0.8.10 with earlier gradle versions
-    id 'com.google.protobuf' version '0.8.15'
+    id 'com.google.protobuf' version '0.8.16'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
 }

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -2,7 +2,7 @@ plugins {
     // Provide convenience executables for trying out the examples.
     id 'application'
     // ASSUMES GRADLE 5.6 OR HIGHER. Use plugin version 0.8.10 with earlier gradle versions
-    id 'com.google.protobuf' version '0.8.15'
+    id 'com.google.protobuf' version '0.8.16'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
 }

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -2,7 +2,7 @@ plugins {
     // Provide convenience executables for trying out the examples.
     id 'application'
     // ASSUMES GRADLE 5.6 OR HIGHER. Use plugin version 0.8.10 with earlier gradle versions
-    id 'com.google.protobuf' version '0.8.15'
+    id 'com.google.protobuf' version '0.8.16'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
 }

--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'application' // Provide convenience executables for trying out the examples.
     id 'java'
 
-    id "com.google.protobuf" version "0.8.15"
+    id "com.google.protobuf" version "0.8.16"
     id 'com.google.cloud.tools.jib' version '2.7.0' // For releasing to Docker Hub
 }
 

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -2,7 +2,7 @@ plugins {
     // Provide convenience executables for trying out the examples.
     id 'application'
     // ASSUMES GRADLE 5.6 OR HIGHER. Use plugin version 0.8.10 with earlier gradle versions
-    id 'com.google.protobuf' version '0.8.15'
+    id 'com.google.protobuf' version '0.8.16'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
 }

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -2,7 +2,7 @@ plugins {
     // Provide convenience executables for trying out the examples.
     id 'application'
     // ASSUMES GRADLE 5.6 OR HIGHER. Use plugin version 0.8.10 with earlier gradle versions
-    id 'com.google.protobuf' version '0.8.15'
+    id 'com.google.protobuf' version '0.8.16'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
 }

--- a/examples/example-xds/build.gradle
+++ b/examples/example-xds/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'application' // Provide convenience executables for trying out the examples.
     // ASSUMES GRADLE 5.6 OR HIGHER. Use plugin version 0.8.10 with earlier gradle versions
-    id 'com.google.protobuf' version '0.8.15'
+    id 'com.google.protobuf' version '0.8.16'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
     id 'java'

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ pluginManagement {
         id "com.github.johnrengelman.shadow" version "6.1.0"
         id "com.github.kt3k.coveralls" version "2.10.2"
         id "com.google.osdetector" version "1.6.2"
-        id "com.google.protobuf" version "0.8.15"
+        id "com.google.protobuf" version "0.8.16"
         id "digital.wup.android-maven-publish" version "3.6.2"
         id "me.champeau.gradle.japicmp" version "0.2.5"
         id "me.champeau.gradle.jmh" version "0.5.2"


### PR DESCRIPTION
This version works around a warning about DuplicateStrategy in Gradle 6
that will be an error in Gradle 7 caused by [a bug in the plugin][1].
Bumping the version makes a clean build with `--warning-mode all` (at
least if skipping Android and codegen).

[1]: https://github.com/google/protobuf-gradle-plugin/issues/470