### PR TITLE
Bump Protobuf to 3.17.2

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -43,11 +43,11 @@ This section is only necessary if you are making changes to the code
 generation. Most users only need to use `skipCodegen=true` as discussed above.
 
 ### Build Protobuf
-The codegen plugin is C++ code and requires protobuf 3.12.0 or later.
+The codegen plugin is C++ code and requires protobuf 3.17.2 or later.
 
 For Linux, Mac and MinGW:
 ```
-$ PROTOBUF_VERSION=3.12.0
+$ PROTOBUF_VERSION=3.17.2
 $ curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protobuf-all-$PROTOBUF_VERSION.tar.gz
 $ tar xzf protobuf-all-$PROTOBUF_VERSION.tar.gz
 $ cd protobuf-$PROTOBUF_VERSION
@@ -80,16 +80,16 @@ When building on Windows and VC++, you need to specify project properties for
 Gradle to find protobuf:
 ```
 .\gradlew publishToMavenLocal ^
-    -PvcProtobufInclude=C:\path\to\protobuf-3.12.0\src ^
-    -PvcProtobufLibs=C:\path\to\protobuf-3.12.0\vsprojects\Release ^
+    -PvcProtobufInclude=C:\path\to\protobuf\src ^
+    -PvcProtobufLibs=C:\path\to\protobuf\vsprojects\Release ^
     -PtargetArch=x86_32
 ```
 
 Since specifying those properties every build is bothersome, you can instead
 create ``<project-root>\gradle.properties`` with contents like:
 ```
-vcProtobufInclude=C:\\path\\to\\protobuf-3.12.0\\src
-vcProtobufLibs=C:\\path\\to\\protobuf-3.12.0\\vsprojects\\Release
+vcProtobufInclude=C:\\path\\to\\protobuf\\src
+vcProtobufLibs=C:\\path\\to\\protobuf\\vsprojects\\Release
 targetArch=x86_32
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ subprojects {
         nettyVersion = '4.1.52.Final'
         guavaVersion = '30.1-android'
         googleauthVersion = '0.22.2'
-        protobufVersion = '3.12.0'
+        protobufVersion = '3.17.2'
         protocVersion = protobufVersion
         opencensusVersion = '0.28.0'
         autovalueVersion = '1.7.4'

--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -1,4 +1,4 @@
-set PROTOBUF_VER=3.12.0
+set PROTOBUF_VER=3.17.2
 set CMAKE_NAME=cmake-3.3.2-win32-x86
 
 if not exist "protobuf-%PROTOBUF_VER%\cmake\build\Release\" (

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -3,7 +3,7 @@
 # Build protoc
 set -evux -o pipefail
 
-PROTOBUF_VERSION=3.12.0
+PROTOBUF_VERSION=3.17.2
 
 # ARCH is x86_64 bit unless otherwise specified.
 ARCH="${ARCH:-x86_64}"

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -14,14 +14,11 @@ binaries for common platforms are available on Maven Central:
 However, if the pre-compiled binaries are not compatible with your system,
 you may want to build your own codegen.
 
-## System requirement
-
-* Linux, Mac OS X with Clang, or Windows with MSYS2
-* Java 7 or up
-* [Protobuf](https://github.com/google/protobuf) 3.12.0 or up
-
 ## Compiling and testing the codegen
-Change to the `compiler` directory:
+
+Set up your system as described in [COMPILING.md](../COMPILING.md).
+
+Then change to the `compiler` directory:
 ```
 $ cd $GRPC_JAVA_ROOT/compiler
 ```

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -32,7 +32,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.12.0' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.17.2' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.39.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -30,7 +30,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.12.0' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.17.2' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.39.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -30,7 +30,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.12.0' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.17.2' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.39.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/android/strictmode/app/build.gradle
+++ b/examples/android/strictmode/app/build.gradle
@@ -31,7 +31,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.12.0' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.17.2' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.39.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -23,7 +23,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.39.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.12.0'
+def protobufVersion = '3.17.2'
 def protocVersion = protobufVersion
 
 dependencies {

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.39.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.12.0'
+def protocVersion = '3.17.2'
 
 dependencies {
     // grpc-alts transitively depends on grpc-netty-shaded, grpc-protobuf, and grpc-stub

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.39.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.12.0'
+def protobufVersion = '3.17.2'
 def protocVersion = protobufVersion
 
 

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.39.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.12.0</protobuf.version>
+    <protobuf.version>3.17.2</protobuf.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.39.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.12.0'
+def protobufVersion = '3.17.2'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-hostname/pom.xml
+++ b/examples/example-hostname/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.39.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protoc.version>3.12.0</protoc.version>
+    <protoc.version>3.17.2</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -23,7 +23,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.39.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.12.0'
+def protobufVersion = '3.17.2'
 def protocVersion = protobufVersion
 
 dependencies {

--- a/examples/example-jwt-auth/pom.xml
+++ b/examples/example-jwt-auth/pom.xml
@@ -14,8 +14,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.39.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.12.0</protobuf.version>
-    <protoc.version>3.12.0</protoc.version>
+    <protobuf.version>3.17.2</protobuf.version>
+    <protoc.version>3.17.2</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.39.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.12.0'
+def protocVersion = '3.17.2'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.39.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protoc.version>3.12.0</protoc.version>
+    <protoc.version>3.17.2</protoc.version>
     <netty.tcnative.version>2.0.34.Final</netty.tcnative.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>

--- a/examples/example-xds/build.gradle
+++ b/examples/example-xds/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.7
 // updating the version in our release process.
 def grpcVersion = '1.39.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 def nettyTcNativeVersion = '2.0.31.Final'
-def protocVersion = '3.12.0'
+def protocVersion = '3.17.2'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.39.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.12.0</protobuf.version>
-    <protoc.version>3.12.0</protoc.version>
+    <protobuf.version>3.17.2</protobuf.version>
+    <protoc.version>3.17.2</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -109,18 +109,18 @@ def com_google_protobuf():
     # This statement defines the @com_google_protobuf repo.
     http_archive(
         name = "com_google_protobuf",
-        sha256 = "b37e96e81842af659605908a421960a5dc809acbc888f6b947bc320f8628e5b1",
-        strip_prefix = "protobuf-3.12.0",
-        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.12.0.zip"],
+        sha256 = "f6042eef01551cee4c663a11c3f429c06360a1f51daa9f4772bf3f13d24cde1f",
+        strip_prefix = "protobuf-3.17.2",
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.17.2.zip"],
     )
 
 def com_google_protobuf_javalite():
     # java_lite_proto_library rules implicitly depend on @com_google_protobuf_javalite
     http_archive(
         name = "com_google_protobuf_javalite",
-        sha256 = "b37e96e81842af659605908a421960a5dc809acbc888f6b947bc320f8628e5b1",
-        strip_prefix = "protobuf-3.12.0",
-        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.12.0.zip"],
+        sha256 = "f6042eef01551cee4c663a11c3f429c06360a1f51daa9f4772bf3f13d24cde1f",
+        strip_prefix = "protobuf-3.17.2",
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.17.2.zip"],
     )
 
 def io_grpc_grpc_proto():


### PR DESCRIPTION
Removed some references to the protobuf version from COMPILING.md and
compiler/README.md to make updates a tiny bit easier.