### PR TITLE
xds: use defaults for unspecified ring_hash_lb_config values

### DIFF
--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
@@ -187,11 +187,7 @@ final class CdsLoadBalancer2 extends LoadBalancer {
       Object lbConfig = null;
       if (root.result.lbPolicy() == LbPolicy.RING_HASH) {
         lbProvider = lbRegistry.getProvider("ring_hash");
-        lbConfig = new RingHashConfig(
-            root.result.minRingSize() == 0L
-                ? RingHashLoadBalancerProvider.DEFAULT_MIN_RING_SIZE : root.result.minRingSize(),
-            root.result.maxRingSize() == 0L
-                ? RingHashLoadBalancerProvider.DEFAULT_MAX_RING_SIZE : root.result.maxRingSize());
+        lbConfig = new RingHashConfig(root.result.minRingSize(), root.result.maxRingSize());
       } else {
         lbProvider = lbRegistry.getProvider("round_robin");
       }

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
@@ -183,11 +183,15 @@ final class CdsLoadBalancer2 extends LoadBalancer {
         helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(unavailable));
         return;
       }
-      LoadBalancerProvider lbProvider = null;
+      LoadBalancerProvider lbProvider;
       Object lbConfig = null;
       if (root.result.lbPolicy() == LbPolicy.RING_HASH) {
         lbProvider = lbRegistry.getProvider("ring_hash");
-        lbConfig = new RingHashConfig(root.result.minRingSize(), root.result.maxRingSize());
+        lbConfig = new RingHashConfig(
+            root.result.minRingSize() == 0L
+                ? RingHashLoadBalancerProvider.DEFAULT_MIN_RING_SIZE : root.result.minRingSize(),
+            root.result.maxRingSize() == 0L
+                ? RingHashLoadBalancerProvider.DEFAULT_MAX_RING_SIZE : root.result.maxRingSize());
       } else {
         lbProvider = lbRegistry.getProvider("round_robin");
       }

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
@@ -183,7 +183,7 @@ final class CdsLoadBalancer2 extends LoadBalancer {
         helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(unavailable));
         return;
       }
-      LoadBalancerProvider lbProvider;
+      LoadBalancerProvider lbProvider = null;
       Object lbConfig = null;
       if (root.result.lbPolicy() == LbPolicy.RING_HASH) {
         lbProvider = lbRegistry.getProvider("ring_hash");

--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -847,9 +847,9 @@ final class ClientXdsClient extends AbstractXdsClient {
         throw new ResourceInvalidException(
             "Cluster " + cluster.getName() + ": invalid ring_hash_lb_config: " + lbConfig);
       }
-      updateBuilder.lbPolicy(CdsUpdate.LbPolicy.RING_HASH, minRingSize, maxRingSize);
+      updateBuilder.ringHashLbPolicy(minRingSize, maxRingSize);
     } else if (cluster.getLbPolicy() == LbPolicy.ROUND_ROBIN) {
-      updateBuilder.lbPolicy(CdsUpdate.LbPolicy.ROUND_ROBIN);
+      updateBuilder.roundRobinLbPolicy();
     } else {
       throw new ResourceInvalidException(
           "Cluster " + cluster.getName() + ": unsupported lb policy: " + cluster.getLbPolicy());

--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -818,8 +818,7 @@ final class ClientXdsClient extends AbstractXdsClient {
     }
   }
 
-  @VisibleForTesting
-  static CdsUpdate parseCluster(Cluster cluster, Set<String> retainedEdsResources)
+  private static CdsUpdate parseCluster(Cluster cluster, Set<String> retainedEdsResources)
       throws ResourceInvalidException {
     StructOrError<CdsUpdate.Builder> structOrError;
     switch (cluster.getClusterDiscoveryTypeCase()) {

--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -839,17 +839,9 @@ final class ClientXdsClient extends AbstractXdsClient {
     CdsUpdate.Builder updateBuilder = structOrError.getStruct();
 
     if (cluster.getLbPolicy() == LbPolicy.RING_HASH) {
-      if (!cluster.hasRingHashLbConfig()) {
-        throw new ResourceInvalidException(
-            "Cluster " + cluster.getName() + ": missing ring_hash_lb_config");
-      }
       RingHashLbConfig lbConfig = cluster.getRingHashLbConfig();
-      if (lbConfig.getHashFunction() != RingHashLbConfig.HashFunction.XX_HASH) {
-        throw new ResourceInvalidException(
-            "Cluster " + cluster.getName() + ": unsupported ring hash function: "
-                + lbConfig.getHashFunction());
-      }
-      if (lbConfig.getMinimumRingSize().getValue() <= 0
+      if (lbConfig.getHashFunction() != RingHashLbConfig.HashFunction.XX_HASH
+          || lbConfig.getMinimumRingSize().getValue() <= 0
           || lbConfig.getMinimumRingSize().getValue() > lbConfig.getMaximumRingSize().getValue()) {
         throw new ResourceInvalidException(
             "Cluster " + cluster.getName() + ": invalid ring_hash_lb_config: " + lbConfig);

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancerProvider.java
@@ -32,6 +32,9 @@ import java.util.Map;
 @Internal
 public final class RingHashLoadBalancerProvider extends LoadBalancerProvider {
 
+  static final long DEFAULT_MIN_RING_SIZE = 1024L;
+  static final long DEFAULT_MAX_RING_SIZE = 8 * 1024 * 1024L;
+
   private static final boolean enableRingHash =
       Boolean.parseBoolean(System.getenv("GRPC_XDS_EXPERIMENTAL_ENABLE_RING_HASH"));
 
@@ -59,9 +62,11 @@ public final class RingHashLoadBalancerProvider extends LoadBalancerProvider {
   public ConfigOrError parseLoadBalancingPolicyConfig(Map<String, ?> rawLoadBalancingPolicyConfig) {
     Long minRingSize = JsonUtil.getNumberAsLong(rawLoadBalancingPolicyConfig, "minRingSize");
     Long maxRingSize = JsonUtil.getNumberAsLong(rawLoadBalancingPolicyConfig, "maxRingSize");
-    if (minRingSize == null || maxRingSize == null) {
-      return ConfigOrError.fromError(Status.INVALID_ARGUMENT.withDescription(
-          "Missing 'mingRingSize'/'maxRingSize'"));
+    if (minRingSize == null) {
+      minRingSize = DEFAULT_MIN_RING_SIZE;
+    }
+    if (maxRingSize == null) {
+      maxRingSize = DEFAULT_MAX_RING_SIZE;
     }
     if (minRingSize <= 0 || maxRingSize <= 0 || minRingSize > maxRingSize) {
       return ConfigOrError.fromError(Status.INVALID_ARGUMENT.withDescription(

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancerProvider.java
@@ -16,6 +16,7 @@
 
 package io.grpc.xds;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.grpc.Internal;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
@@ -32,8 +33,16 @@ import java.util.Map;
 @Internal
 public final class RingHashLoadBalancerProvider extends LoadBalancerProvider {
 
+  // Same as ClientXdsClient.DEFAULT_RING_HASH_LB_POLICY_MIN_RING_SIZE
+  @VisibleForTesting
   static final long DEFAULT_MIN_RING_SIZE = 1024L;
+  // Same as ClientXdsClient.DEFAULT_RING_HASH_LB_POLICY_MAX_RING_SIZE
+  @VisibleForTesting
   static final long DEFAULT_MAX_RING_SIZE = 8 * 1024 * 1024L;
+  // Maximum number of ring entries allowed. Setting this too large can result in slow
+  // ring construction and OOM error.
+  // Same as ClientXdsClient.MAX_RING_HASH_LB_POLICY_RING_SIZE
+  static final long MAX_RING_SIZE = 8 * 1024 * 1024L;
 
   private static final boolean enableRingHash =
       Boolean.parseBoolean(System.getenv("GRPC_XDS_EXPERIMENTAL_ENABLE_RING_HASH"));
@@ -68,7 +77,8 @@ public final class RingHashLoadBalancerProvider extends LoadBalancerProvider {
     if (maxRingSize == null) {
       maxRingSize = DEFAULT_MAX_RING_SIZE;
     }
-    if (minRingSize <= 0 || maxRingSize <= 0 || minRingSize > maxRingSize) {
+    if (minRingSize <= 0 || maxRingSize <= 0 || minRingSize > maxRingSize
+        || maxRingSize > MAX_RING_SIZE) {
       return ConfigOrError.fromError(Status.INVALID_ARGUMENT.withDescription(
           "Invalid 'mingRingSize'/'maxRingSize'"));
     }

--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -289,16 +289,21 @@ abstract class XdsClient {
       // Private, use one of the static factory methods instead.
       protected abstract Builder clusterType(ClusterType clusterType);
 
-      abstract Builder lbPolicy(LbPolicy lbPolicy);
+      // Private, use roundRobinLbPolicy() or ringHashLbPolicy(long, long).
+      protected abstract Builder lbPolicy(LbPolicy lbPolicy);
 
-      Builder lbPolicy(LbPolicy lbPolicy, long minRingSize, long maxRingSize) {
-        return this.lbPolicy(lbPolicy).minRingSize(minRingSize).maxRingSize(maxRingSize);
+      Builder roundRobinLbPolicy() {
+        return this.lbPolicy(LbPolicy.ROUND_ROBIN);
       }
 
-      // Private, use lbPolicy(LbPolicy, long, long).
+      Builder ringHashLbPolicy(long minRingSize, long maxRingSize) {
+        return this.lbPolicy(LbPolicy.RING_HASH).minRingSize(minRingSize).maxRingSize(maxRingSize);
+      }
+
+      // Private, use ringHashLbPolicy(long, long).
       protected abstract Builder minRingSize(long minRingSize);
 
-      // Private, use lbPolicy(.LbPolicy, long, long)
+      // Private, use ringHashLbPolicy(long, long).
       protected abstract Builder maxRingSize(long maxRingSize);
 
       // Private, use CdsUpdate.forEds() instead.

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
@@ -161,27 +161,6 @@ public class CdsLoadBalancer2Test {
   }
 
   @Test
-  public void discoverTopLevelEdsCluster_ringHashLbPolicy() {
-    CdsUpdate update =
-        CdsUpdate.forEds(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_NAME, 100L, upstreamTlsContext)
-            .ringHashLbPolicy(0L, 0L).build();
-    xdsClient.deliverCdsUpdate(CLUSTER, update);
-    assertThat(childBalancers).hasSize(1);
-    FakeLoadBalancer childBalancer = Iterables.getOnlyElement(childBalancers);
-    assertThat(childBalancer.name).isEqualTo(CLUSTER_RESOLVER_POLICY_NAME);
-    ClusterResolverConfig childLbConfig = (ClusterResolverConfig) childBalancer.config;
-    assertThat(childLbConfig.discoveryMechanisms).hasSize(1);
-    DiscoveryMechanism instance = Iterables.getOnlyElement(childLbConfig.discoveryMechanisms);
-    assertDiscoveryMechanism(instance, CLUSTER, DiscoveryMechanism.Type.EDS, EDS_SERVICE_NAME,
-        null, LRS_SERVER_NAME, 100L, upstreamTlsContext);
-    assertThat(childLbConfig.lbPolicy.getProvider().getPolicyName()).isEqualTo("ring_hash");
-    assertThat(((RingHashConfig) childLbConfig.lbPolicy.getConfig()).minRingSize)
-        .isEqualTo(RingHashLoadBalancerProvider.DEFAULT_MIN_RING_SIZE);
-    assertThat(((RingHashConfig) childLbConfig.lbPolicy.getConfig()).maxRingSize)
-        .isEqualTo(RingHashLoadBalancerProvider.DEFAULT_MAX_RING_SIZE);
-  }
-
-  @Test
   public void discoverTopLevelLogicalDnsCluster() {
     CdsUpdate update =
         CdsUpdate.forLogicalDns(CLUSTER, DNS_HOST_NAME, LRS_SERVER_NAME, 100L, upstreamTlsContext)

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
@@ -48,7 +48,6 @@ import io.grpc.xds.ClusterResolverLoadBalancerProvider.ClusterResolverConfig.Dis
 import io.grpc.xds.EnvoyServerProtoData.UpstreamTlsContext;
 import io.grpc.xds.RingHashLoadBalancer.RingHashConfig;
 import io.grpc.xds.XdsClient.CdsUpdate;
-import io.grpc.xds.XdsClient.CdsUpdate.LbPolicy;
 import io.grpc.xds.internal.sds.CommonTlsContextTestsUtil;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -148,7 +147,7 @@ public class CdsLoadBalancer2Test {
   public void discoverTopLevelEdsCluster() {
     CdsUpdate update =
         CdsUpdate.forEds(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_NAME, 100L, upstreamTlsContext)
-            .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+            .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(CLUSTER, update);
     assertThat(childBalancers).hasSize(1);
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(childBalancers);
@@ -165,7 +164,7 @@ public class CdsLoadBalancer2Test {
   public void discoverTopLevelEdsCluster_ringHashLbPolicy() {
     CdsUpdate update =
         CdsUpdate.forEds(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_NAME, 100L, upstreamTlsContext)
-            .lbPolicy(LbPolicy.RING_HASH, 0L, 0L).build();
+            .ringHashLbPolicy(0L, 0L).build();
     xdsClient.deliverCdsUpdate(CLUSTER, update);
     assertThat(childBalancers).hasSize(1);
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(childBalancers);
@@ -186,7 +185,7 @@ public class CdsLoadBalancer2Test {
   public void discoverTopLevelLogicalDnsCluster() {
     CdsUpdate update =
         CdsUpdate.forLogicalDns(CLUSTER, DNS_HOST_NAME, LRS_SERVER_NAME, 100L, upstreamTlsContext)
-            .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+            .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(CLUSTER, update);
     assertThat(childBalancers).hasSize(1);
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(childBalancers);
@@ -213,7 +212,7 @@ public class CdsLoadBalancer2Test {
   public void nonAggregateCluster_resourceUpdate() {
     CdsUpdate update =
         CdsUpdate.forEds(CLUSTER, null, null, 100L, upstreamTlsContext)
-            .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+            .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(CLUSTER, update);
     assertThat(childBalancers).hasSize(1);
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(childBalancers);
@@ -223,7 +222,7 @@ public class CdsLoadBalancer2Test {
         100L, upstreamTlsContext);
 
     update = CdsUpdate.forEds(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_NAME, 200L, null)
-        .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+        .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(CLUSTER, update);
     childLbConfig = (ClusterResolverConfig) childBalancer.config;
     instance = Iterables.getOnlyElement(childLbConfig.discoveryMechanisms);
@@ -235,7 +234,7 @@ public class CdsLoadBalancer2Test {
   public void nonAggregateCluster_resourceRevoked() {
     CdsUpdate update =
         CdsUpdate.forLogicalDns(CLUSTER, DNS_HOST_NAME, null, 100L, upstreamTlsContext)
-            .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+            .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(CLUSTER, update);
     assertThat(childBalancers).hasSize(1);
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(childBalancers);
@@ -261,7 +260,7 @@ public class CdsLoadBalancer2Test {
     // CLUSTER (aggr.) -> [cluster1 (aggr.), cluster2 (logical DNS)]
     CdsUpdate update =
         CdsUpdate.forAggregate(CLUSTER, Arrays.asList(cluster1, cluster2))
-            .lbPolicy(LbPolicy.RING_HASH, 100L, 1000L).build();
+            .ringHashLbPolicy(100L, 1000L).build();
     xdsClient.deliverCdsUpdate(CLUSTER, update);
     assertThat(xdsClient.watchers.keySet()).containsExactly(CLUSTER, cluster1, cluster2);
     assertThat(childBalancers).isEmpty();
@@ -270,24 +269,24 @@ public class CdsLoadBalancer2Test {
     // cluster1 (aggr.) -> [cluster3 (EDS), cluster4 (EDS)]
     CdsUpdate update1 =
         CdsUpdate.forAggregate(cluster1, Arrays.asList(cluster3, cluster4))
-            .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+            .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(cluster1, update1);
     assertThat(xdsClient.watchers.keySet()).containsExactly(
         CLUSTER, cluster1, cluster2, cluster3, cluster4);
     assertThat(childBalancers).isEmpty();
     CdsUpdate update3 =
         CdsUpdate.forEds(cluster3, EDS_SERVICE_NAME, LRS_SERVER_NAME, 200L, upstreamTlsContext)
-            .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+            .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(cluster3, update3);
     assertThat(childBalancers).isEmpty();
     CdsUpdate update2 =
         CdsUpdate.forLogicalDns(cluster2, DNS_HOST_NAME, null, 100L, null)
-            .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+            .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(cluster2, update2);
     assertThat(childBalancers).isEmpty();
     CdsUpdate update4 =
         CdsUpdate.forEds(cluster4, null, LRS_SERVER_NAME, 300L, null)
-            .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+            .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(cluster4, update4);
     assertThat(childBalancers).hasSize(1);  // all non-aggregate clusters discovered
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(childBalancers);
@@ -314,7 +313,7 @@ public class CdsLoadBalancer2Test {
     // CLUSTER (aggr.) -> [cluster1 (EDS)]
     CdsUpdate update =
         CdsUpdate.forAggregate(CLUSTER, Collections.singletonList(cluster1))
-            .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+            .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(CLUSTER, update);
     assertThat(xdsClient.watchers.keySet()).containsExactly(CLUSTER, cluster1);
     xdsClient.deliverResourceNotExist(cluster1);
@@ -332,16 +331,16 @@ public class CdsLoadBalancer2Test {
     // CLUSTER (aggr.) -> [cluster1 (EDS), cluster2 (logical DNS)]
     CdsUpdate update =
         CdsUpdate.forAggregate(CLUSTER, Arrays.asList(cluster1, cluster2))
-            .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+            .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(CLUSTER, update);
     assertThat(xdsClient.watchers.keySet()).containsExactly(CLUSTER, cluster1, cluster2);
     CdsUpdate update1 =
         CdsUpdate.forEds(cluster1, EDS_SERVICE_NAME, LRS_SERVER_NAME, 200L, upstreamTlsContext)
-            .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+            .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(cluster1, update1);
     CdsUpdate update2 =
         CdsUpdate.forLogicalDns(cluster2, DNS_HOST_NAME, LRS_SERVER_NAME, 100L, null)
-            .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+            .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(cluster2, update2);
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(childBalancers);
     ClusterResolverConfig childLbConfig = (ClusterResolverConfig) childBalancer.config;
@@ -379,16 +378,16 @@ public class CdsLoadBalancer2Test {
     // CLUSTER (aggr.) -> [cluster1 (EDS), cluster2 (logical DNS)]
     CdsUpdate update =
         CdsUpdate.forAggregate(CLUSTER, Arrays.asList(cluster1, cluster2))
-            .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+            .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(CLUSTER, update);
     assertThat(xdsClient.watchers.keySet()).containsExactly(CLUSTER, cluster1, cluster2);
     CdsUpdate update1 =
         CdsUpdate.forEds(cluster1, EDS_SERVICE_NAME, LRS_SERVER_NAME, 200L, upstreamTlsContext)
-            .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+            .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(cluster1, update1);
     CdsUpdate update2 =
         CdsUpdate.forLogicalDns(cluster2, DNS_HOST_NAME, LRS_SERVER_NAME, 100L, null)
-            .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+            .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(cluster2, update2);
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(childBalancers);
     ClusterResolverConfig childLbConfig = (ClusterResolverConfig) childBalancer.config;
@@ -416,7 +415,7 @@ public class CdsLoadBalancer2Test {
     // CLUSTER (aggr.) -> [cluster1]
     CdsUpdate update =
         CdsUpdate.forAggregate(CLUSTER, Collections.singletonList(cluster1))
-            .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+            .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(CLUSTER, update);
     assertThat(xdsClient.watchers.keySet()).containsExactly(CLUSTER, cluster1);
 
@@ -424,7 +423,7 @@ public class CdsLoadBalancer2Test {
     String cluster2 = "cluster-02.googleapis.com";
     update =
         CdsUpdate.forAggregate(CLUSTER, Collections.singletonList(cluster2))
-            .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+            .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(CLUSTER, update);
     assertThat(xdsClient.watchers.keySet()).containsExactly(CLUSTER, cluster2);
 
@@ -432,12 +431,12 @@ public class CdsLoadBalancer2Test {
     String cluster3 = "cluster-03.googleapis.com";
     CdsUpdate update2 =
         CdsUpdate.forAggregate(cluster2, Collections.singletonList(cluster3))
-            .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+            .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(cluster2, update2);
     assertThat(xdsClient.watchers.keySet()).containsExactly(CLUSTER, cluster2, cluster3);
     CdsUpdate update3 =
         CdsUpdate.forEds(cluster3, EDS_SERVICE_NAME, LRS_SERVER_NAME, 100L, upstreamTlsContext)
-            .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+            .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(cluster3, update3);
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(childBalancers);
     ClusterResolverConfig childLbConfig = (ClusterResolverConfig) childBalancer.config;
@@ -464,7 +463,7 @@ public class CdsLoadBalancer2Test {
     // CLUSTER (aggr.) -> [cluster1]
     CdsUpdate update =
         CdsUpdate.forAggregate(CLUSTER, Collections.singletonList(cluster1))
-            .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+            .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(CLUSTER, update);
     assertThat(xdsClient.watchers.keySet()).containsExactly(CLUSTER, cluster1);
     Status error = Status.RESOURCE_EXHAUSTED.withDescription("OOM");
@@ -481,11 +480,11 @@ public class CdsLoadBalancer2Test {
     // CLUSTER (aggr.) -> [cluster1 (logical DNS)]
     CdsUpdate update =
         CdsUpdate.forAggregate(CLUSTER, Collections.singletonList(cluster1))
-            .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+            .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(CLUSTER, update);
     CdsUpdate update1 =
         CdsUpdate.forLogicalDns(cluster1, DNS_HOST_NAME, LRS_SERVER_NAME, 200L, null)
-            .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+            .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(cluster1, update1);
     FakeLoadBalancer childLb = Iterables.getOnlyElement(childBalancers);
     ClusterResolverConfig childLbConfig = (ClusterResolverConfig) childLb.config;
@@ -510,7 +509,7 @@ public class CdsLoadBalancer2Test {
   public void handleNameResolutionErrorFromUpstream_afterChildLbCreated_fallThrough() {
     CdsUpdate update =
         CdsUpdate.forEds(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_NAME, 100L, upstreamTlsContext)
-            .lbPolicy(LbPolicy.ROUND_ROBIN).build();
+            .roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(CLUSTER, update);
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(childBalancers);
     assertThat(childBalancer.shutdown).isFalse();

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
@@ -162,6 +162,27 @@ public class CdsLoadBalancer2Test {
   }
 
   @Test
+  public void discoverTopLevelEdsCluster_ringHashLbPolicy() {
+    CdsUpdate update =
+        CdsUpdate.forEds(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_NAME, 100L, upstreamTlsContext)
+            .lbPolicy(LbPolicy.RING_HASH, 0L, 0L).build();
+    xdsClient.deliverCdsUpdate(CLUSTER, update);
+    assertThat(childBalancers).hasSize(1);
+    FakeLoadBalancer childBalancer = Iterables.getOnlyElement(childBalancers);
+    assertThat(childBalancer.name).isEqualTo(CLUSTER_RESOLVER_POLICY_NAME);
+    ClusterResolverConfig childLbConfig = (ClusterResolverConfig) childBalancer.config;
+    assertThat(childLbConfig.discoveryMechanisms).hasSize(1);
+    DiscoveryMechanism instance = Iterables.getOnlyElement(childLbConfig.discoveryMechanisms);
+    assertDiscoveryMechanism(instance, CLUSTER, DiscoveryMechanism.Type.EDS, EDS_SERVICE_NAME,
+        null, LRS_SERVER_NAME, 100L, upstreamTlsContext);
+    assertThat(childLbConfig.lbPolicy.getProvider().getPolicyName()).isEqualTo("ring_hash");
+    assertThat(((RingHashConfig) childLbConfig.lbPolicy.getConfig()).minRingSize)
+        .isEqualTo(RingHashLoadBalancerProvider.DEFAULT_MIN_RING_SIZE);
+    assertThat(((RingHashConfig) childLbConfig.lbPolicy.getConfig()).maxRingSize)
+        .isEqualTo(RingHashLoadBalancerProvider.DEFAULT_MAX_RING_SIZE);
+  }
+
+  @Test
   public void discoverTopLevelLogicalDnsCluster() {
     CdsUpdate update =
         CdsUpdate.forLogicalDns(CLUSTER, DNS_HOST_NAME, LRS_SERVER_NAME, 100L, upstreamTlsContext)

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
@@ -23,9 +23,18 @@ import com.google.protobuf.Any;
 import com.google.protobuf.BoolValue;
 import com.google.protobuf.StringValue;
 import com.google.protobuf.UInt32Value;
+import com.google.protobuf.UInt64Value;
 import com.google.protobuf.util.Durations;
 import com.google.re2j.Pattern;
+import io.envoyproxy.envoy.config.cluster.v3.Cluster;
+import io.envoyproxy.envoy.config.cluster.v3.Cluster.DiscoveryType;
+import io.envoyproxy.envoy.config.cluster.v3.Cluster.EdsClusterConfig;
+import io.envoyproxy.envoy.config.cluster.v3.Cluster.LbPolicy;
+import io.envoyproxy.envoy.config.cluster.v3.Cluster.RingHashLbConfig;
+import io.envoyproxy.envoy.config.cluster.v3.Cluster.RingHashLbConfig.HashFunction;
 import io.envoyproxy.envoy.config.core.v3.Address;
+import io.envoyproxy.envoy.config.core.v3.AggregatedConfigSource;
+import io.envoyproxy.envoy.config.core.v3.ConfigSource;
 import io.envoyproxy.envoy.config.core.v3.ExtensionConfigSource;
 import io.envoyproxy.envoy.config.core.v3.Locality;
 import io.envoyproxy.envoy.config.core.v3.RuntimeFractionalPercent;
@@ -58,6 +67,7 @@ import io.envoyproxy.envoy.type.v3.FractionalPercent;
 import io.envoyproxy.envoy.type.v3.FractionalPercent.DenominatorType;
 import io.envoyproxy.envoy.type.v3.Int64Range;
 import io.grpc.Status.Code;
+import io.grpc.xds.ClientXdsClient.ResourceInvalidException;
 import io.grpc.xds.ClientXdsClient.StructOrError;
 import io.grpc.xds.Endpoints.LbEndpoint;
 import io.grpc.xds.Endpoints.LocalityLbEndpoints;
@@ -71,17 +81,25 @@ import io.grpc.xds.VirtualHost.Route.RouteAction;
 import io.grpc.xds.VirtualHost.Route.RouteAction.ClusterWeight;
 import io.grpc.xds.VirtualHost.Route.RouteAction.HashPolicy;
 import io.grpc.xds.VirtualHost.Route.RouteMatch;
+import io.grpc.xds.XdsClient.CdsUpdate;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class ClientXdsClientDataTest {
+
+  @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void parseRoute_withRouteAction() {
@@ -678,6 +696,80 @@ public class ClientXdsClientDataTest {
         .isEqualTo(
             "HttpFilter [unsupported.filter] is not optional and has an unsupported config type: "
                 + "type.googleapis.com/google.protobuf.StringValue");
+  }
+
+  @Test
+  public void parseCluster_ringHashLbPolicy_defaultLbConfig() throws ResourceInvalidException {
+    Cluster cluster = Cluster.newBuilder()
+        .setName("cluster-foo.googleapis.com")
+        .setType(DiscoveryType.EDS)
+        .setEdsClusterConfig(
+            EdsClusterConfig.newBuilder()
+                .setEdsConfig(
+                    ConfigSource.newBuilder()
+                        .setAds(AggregatedConfigSource.getDefaultInstance()))
+                .setServiceName("service-foo.googleapis.com"))
+        .setLbPolicy(LbPolicy.RING_HASH)
+        .build();
+
+    CdsUpdate update = ClientXdsClient.parseCluster(cluster, new HashSet<String>());
+    assertThat(update.lbPolicy()).isEqualTo(CdsUpdate.LbPolicy.RING_HASH);
+    assertThat(update.minRingSize())
+        .isEqualTo(ClientXdsClient.DEFAULT_RING_HASH_LB_POLICY_MIN_RING_SIZE);
+    assertThat(update.maxRingSize())
+        .isEqualTo(ClientXdsClient.DEFAULT_RING_HASH_LB_POLICY_MAX_RING_SIZE);
+  }
+
+  @Test
+  public void parseCluster_ringHashLbPolicy_invalidRingSizeConfig_minGreaterThanMax()
+      throws ResourceInvalidException {
+    Cluster cluster = Cluster.newBuilder()
+        .setName("cluster-foo.googleapis.com")
+        .setType(DiscoveryType.EDS)
+        .setEdsClusterConfig(
+            EdsClusterConfig.newBuilder()
+                .setEdsConfig(
+                    ConfigSource.newBuilder()
+                        .setAds(AggregatedConfigSource.getDefaultInstance()))
+                .setServiceName("service-foo.googleapis.com"))
+        .setLbPolicy(LbPolicy.RING_HASH)
+        .setRingHashLbConfig(
+            RingHashLbConfig.newBuilder()
+                .setHashFunction(HashFunction.XX_HASH)
+                .setMinimumRingSize(UInt64Value.newBuilder().setValue(1000L))
+                .setMaximumRingSize(UInt64Value.newBuilder().setValue(100L)))
+        .build();
+
+    thrown.expect(ResourceInvalidException.class);
+    thrown.expectMessage("Cluster cluster-foo.googleapis.com: invalid ring_hash_lb_config");
+    ClientXdsClient.parseCluster(cluster, new HashSet<String>());
+  }
+
+  @Test
+  public void parseCluster_ringHashLbPolicy_invalidRingSizeConfig_tooLargeRingSize()
+      throws ResourceInvalidException {
+    Cluster cluster = Cluster.newBuilder()
+        .setName("cluster-foo.googleapis.com")
+        .setType(DiscoveryType.EDS)
+        .setEdsClusterConfig(
+            EdsClusterConfig.newBuilder()
+                .setEdsConfig(
+                    ConfigSource.newBuilder()
+                        .setAds(AggregatedConfigSource.getDefaultInstance()))
+                .setServiceName("service-foo.googleapis.com"))
+        .setLbPolicy(LbPolicy.RING_HASH)
+        .setRingHashLbConfig(
+            RingHashLbConfig.newBuilder()
+                .setHashFunction(HashFunction.XX_HASH)
+                .setMinimumRingSize(UInt64Value.newBuilder().setValue(1000L))
+                .setMaximumRingSize(
+                    UInt64Value.newBuilder()
+                        .setValue(ClientXdsClient.MAX_RING_HASH_LB_POLICY_RING_SIZE + 1)))
+        .build();
+
+    thrown.expect(ResourceInvalidException.class);
+    thrown.expectMessage("Cluster cluster-foo.googleapis.com: invalid ring_hash_lb_config");
+    ClientXdsClient.parseCluster(cluster, new HashSet<String>());
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerProviderTest.java
@@ -93,6 +93,40 @@ public class RingHashLoadBalancerProviderTest {
   }
 
   @Test
+  public void parseLoadBalancingConfig_invalid_negativeSize() throws IOException {
+    String lbConfig = "{\"minRingSize\" : -10}";
+    ConfigOrError configOrError =
+        provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
+    assertThat(configOrError.getError()).isNotNull();
+    assertThat(configOrError.getError().getCode()).isEqualTo(Code.INVALID_ARGUMENT);
+    assertThat(configOrError.getError().getDescription())
+        .isEqualTo("Invalid 'mingRingSize'/'maxRingSize'");
+  }
+
+  @Test
+  public void parseLoadBalancingConfig_invalid_minGreaterThanMax() throws IOException {
+    String lbConfig = "{\"minRingSize\" : 1000, \"maxRingSize\" : 100}";
+    ConfigOrError configOrError =
+        provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
+    assertThat(configOrError.getError()).isNotNull();
+    assertThat(configOrError.getError().getCode()).isEqualTo(Code.INVALID_ARGUMENT);
+    assertThat(configOrError.getError().getDescription())
+        .isEqualTo("Invalid 'mingRingSize'/'maxRingSize'");
+  }
+
+  @Test
+  public void parseLoadBalancingConfig_invalid_ringTooLarge() throws IOException {
+    long ringSize = RingHashLoadBalancerProvider.MAX_RING_SIZE + 1;
+    String lbConfig = String.format("{\"minRingSize\" : 10, \"maxRingSize\" : %d}", ringSize);
+    ConfigOrError configOrError =
+        provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
+    assertThat(configOrError.getError()).isNotNull();
+    assertThat(configOrError.getError().getCode()).isEqualTo(Code.INVALID_ARGUMENT);
+    assertThat(configOrError.getError().getDescription())
+        .isEqualTo("Invalid 'mingRingSize'/'maxRingSize'");
+  }
+
+  @Test
   public void parseLoadBalancingConfig_zeroMinRingSize() throws IOException {
     String lbConfig = "{\"minRingSize\" : 0, \"maxRingSize\" : 100}";
     ConfigOrError configOrError =

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerProviderTest.java
@@ -82,14 +82,14 @@ public class RingHashLoadBalancerProviderTest {
   }
 
   @Test
-  public void parseLoadBalancingConfig_missingRingSize() throws IOException {
-    String lbConfig = "{\"minRingSize\" : 10}";
+  public void parseLoadBalancingConfig_missingRingSize_useDefaults() throws IOException {
+    String lbConfig = "{}";
     ConfigOrError configOrError =
         provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
-    assertThat(configOrError.getError()).isNotNull();
-    assertThat(configOrError.getError().getCode()).isEqualTo(Code.INVALID_ARGUMENT);
-    assertThat(configOrError.getError().getDescription())
-        .isEqualTo("Missing 'mingRingSize'/'maxRingSize'");
+    assertThat(configOrError.getConfig()).isNotNull();
+    RingHashConfig config = (RingHashConfig) configOrError.getConfig();
+    assertThat(config.minRingSize).isEqualTo(RingHashLoadBalancerProvider.DEFAULT_MIN_RING_SIZE);
+    assertThat(config.maxRingSize).isEqualTo(RingHashLoadBalancerProvider.DEFAULT_MAX_RING_SIZE);
   }
 
   @Test


### PR DESCRIPTION
Envoy uses default parameters for ring hash LB config (min_ring_size = 1024, max_ring_size = 8M). https://github.com/grpc/proposal/pull/239 is updated to use the same default as Envoy.

The change follows the way that C-core does this:
- gRPC's ring_hash LB config parser [sets default](https://github.com/grpc/grpc/blob/e8239ceb1d51f82513cf57d198c7895c4292ebd4/src/core/ext/filters/client_channel/lb_policy/ring_hash/ring_hash.cc#L51-L52) values if the raw config does not specify min_ring_size or max_ring_size.
  - Note, for us we need to do this in both ring_hash LB config parser and the CDS LB policy that instantiates the `RingHashConfig` directly.


/cc @apolcyn 