### PR TITLE
netty/shaded: Include deps automatically

### DIFF
--- a/netty/shaded/build.gradle
+++ b/netty/shaded/build.gradle
@@ -17,7 +17,9 @@ dependencies {
             project(':grpc-testing-proto'),
             project(':grpc-testing'),
             libraries.truth
-    shadow project(':grpc-core')
+    shadow project(':grpc-netty').configurations.runtimeClasspath.allDependencies.matching {
+        it.group != 'io.netty'
+    }
 }
 
 jar {


### PR DESCRIPTION
Previously it required manually listing the direct deps of grpc-netty
which is error-prone as evidinced by the fact that we were missing
multiple deps (guava, perfmark-api). This didn't cause a problem because
grpc-core happens to bring in these same deps.