### PR TITLE
POC: API plumbing for retry stats V2

### DIFF
--- a/api/src/main/java/io/grpc/ClientStreamTracer.java
+++ b/api/src/main/java/io/grpc/ClientStreamTracer.java
@@ -33,6 +33,8 @@ public abstract class ClientStreamTracer extends StreamTracer {
    *
    * @param headers the mutable initial metadata. Modifications to it will be sent to the socket but
    *     not be seen by client interceptors and the application.
+   *
+   * @since 1.40.0
    */
   public void streamCreated(Attributes transportAttrs, Metadata headers) {
   }
@@ -63,13 +65,16 @@ public abstract class ClientStreamTracer extends StreamTracer {
    * Factory class for {@link ClientStreamTracer}.
    */
   public abstract static class Factory {
-
     /**
      * Creates a {@link ClientStreamTracer} for a new client stream.
      *
      * @param info information about the stream
+     *
+     * @since 1.40.0
      */
     public ClientStreamTracer newClientStreamTracer(final StreamInfo info) {
+      // Provide a default implementation of this method for compatibility with old Factory
+      // implementations.
       return new ClientStreamTracer() {
         volatile ClientStreamTracer delegate = new ClientStreamTracer() {};
 
@@ -201,6 +206,11 @@ public abstract class ClientStreamTracer extends StreamTracer {
       return callOptions;
     }
 
+    /**
+     * Whether the stream is a transparent retry.
+     *
+     * @since 1.40.0
+     */
     public boolean isTransparentRetry() {
       return isTransparentRetry;
     }
@@ -211,9 +221,10 @@ public abstract class ClientStreamTracer extends StreamTracer {
      * @since 1.21.0
      */
     public Builder toBuilder() {
-      Builder builder = new Builder();
-      builder.setCallOptions(callOptions);
-      return builder;
+      return new Builder()
+          .setCallOptions(callOptions)
+          .setTransportAttrs(transportAttrs)
+          .setIsTransparentRetry(isTransparentRetry);
     }
 
     /**
@@ -267,6 +278,11 @@ public abstract class ClientStreamTracer extends StreamTracer {
         return this;
       }
 
+      /**
+       * Sets whether the stream is a transparent retry.
+       *
+       * @since 1.40.0
+       */
       public Builder setIsTransparentRetry(boolean isTransparentRetry) {
         this.isTransparentRetry = isTransparentRetry;
         return this;

--- a/api/src/test/java/io/grpc/CallOptionsTest.java
+++ b/api/src/test/java/io/grpc/CallOptionsTest.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.base.Objects;
+import io.grpc.ClientStreamTracer.StreamInfo;
 import io.grpc.internal.SerializingExecutor;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -279,8 +280,7 @@ public class CallOptionsTest {
     }
 
     @Override
-    public ClientStreamTracer newClientStreamTracer(
-        ClientStreamTracer.StreamInfo info, Metadata headers) {
+    public ClientStreamTracer newClientStreamTracer(StreamInfo info) {
       return new ClientStreamTracer() {};
     }
 

--- a/census/src/main/java/io/grpc/census/CensusTracingModule.java
+++ b/census/src/main/java/io/grpc/census/CensusTracingModule.java
@@ -19,6 +19,7 @@ package io.grpc.census;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -241,13 +242,8 @@ final class CensusTracingModule {
     }
 
     @Override
-    public ClientStreamTracer newClientStreamTracer(
-        ClientStreamTracer.StreamInfo info, Metadata headers) {
-      if (span != BlankSpan.INSTANCE) {
-        headers.discardAll(tracingHeader);
-        headers.put(tracingHeader, span.getContext());
-      }
-      return new ClientTracer(span);
+    public ClientStreamTracer newClientStreamTracer(ClientStreamTracer.StreamInfo info) {
+      return new ClientTracer(span, tracingHeader);
     }
 
     /**
@@ -273,9 +269,19 @@ final class CensusTracingModule {
 
   private static final class ClientTracer extends ClientStreamTracer {
     private final Span span;
+    final Metadata.Key<SpanContext> tracingHeader;
 
-    ClientTracer(Span span) {
+    ClientTracer(Span span, Metadata.Key<SpanContext> tracingHeader) {
       this.span = checkNotNull(span, "span");
+      this.tracingHeader = tracingHeader;
+    }
+
+    @Override
+    public void streamCreated(Attributes transportAtts, Metadata headers) {
+      if (span != BlankSpan.INSTANCE) {
+        headers.discardAll(tracingHeader);
+        headers.put(tracingHeader, span.getContext());
+      }
     }
 
     @Override

--- a/census/src/main/java/io/grpc/census/InternalCensusStatsAccessor.java
+++ b/census/src/main/java/io/grpc/census/InternalCensusStatsAccessor.java
@@ -49,14 +49,16 @@ public final class InternalCensusStatsAccessor {
   public static ClientInterceptor getClientInterceptor(
       boolean recordStartedRpcs,
       boolean recordFinishedRpcs,
-      boolean recordRealTimeMetrics) {
+      boolean recordRealTimeMetrics,
+      boolean retryEnabled) {
     CensusStatsModule censusStats =
         new CensusStatsModule(
             STOPWATCH_SUPPLIER,
             true, /* propagateTags */
             recordStartedRpcs,
             recordFinishedRpcs,
-            recordRealTimeMetrics);
+            recordRealTimeMetrics,
+            retryEnabled);
     return censusStats.getClientInterceptor();
   }
 
@@ -71,11 +73,13 @@ public final class InternalCensusStatsAccessor {
       boolean propagateTags,
       boolean recordStartedRpcs,
       boolean recordFinishedRpcs,
-      boolean recordRealTimeMetrics) {
+      boolean recordRealTimeMetrics,
+      boolean retryEnabled) {
     CensusStatsModule censusStats =
         new CensusStatsModule(
             tagger, tagCtxSerializer, statsRecorder, stopwatchSupplier,
-            propagateTags, recordStartedRpcs, recordFinishedRpcs, recordRealTimeMetrics);
+            propagateTags, recordStartedRpcs, recordFinishedRpcs, recordRealTimeMetrics,
+            retryEnabled);
     return censusStats.getClientInterceptor();
   }
 

--- a/census/src/test/java/io/grpc/census/CensusModulesTest.java
+++ b/census/src/test/java/io/grpc/census/CensusModulesTest.java
@@ -295,7 +295,7 @@ public class CensusModulesTest {
         instanceof CensusTracingModule.ClientCallTracer);
     assertTrue(
         capturedCallOptions.get().getStreamTracerFactories().get(1)
-        instanceof CensusStatsModule.ClientCallTracer);
+        instanceof CensusStatsModule.CallAttemptsTracerFactory);
 
     // Make the call
     Metadata headers = new Metadata();
@@ -388,11 +388,10 @@ public class CensusModulesTest {
         new CensusStatsModule(
             tagger, tagCtxSerializer, statsRecorder, fakeClock.getStopwatchSupplier(),
             true, recordStarts, recordFinishes, recordRealTime);
-    CensusStatsModule.ClientCallTracer callTracer =
-        localCensusStats.newClientCallTracer(
-            tagger.empty(), method.getFullMethodName());
-    Metadata headers = new Metadata();
-    ClientStreamTracer tracer = callTracer.newClientStreamTracer(STREAM_INFO, headers);
+    CensusStatsModule.CallAttemptsTracerFactory callAttemptsTracerFactory =
+        new CensusStatsModule.CallAttemptsTracerFactory(
+            localCensusStats, tagger.empty(), method.getFullMethodName());
+    ClientStreamTracer tracer = callAttemptsTracerFactory.newClientStreamTracer(STREAM_INFO);
 
     if (recordStarts) {
       StatsTestUtils.MetricsRecord record = statsRecorder.pollRecord();
@@ -455,7 +454,7 @@ public class CensusModulesTest {
 
     tracer.inboundUncompressedSize(552);
     tracer.streamClosed(Status.OK);
-    callTracer.callEnded(Status.OK);
+    callAttemptsTracerFactory.callEnded(Status.OK);
 
     if (recordFinishes) {
       StatsTestUtils.MetricsRecord record = statsRecorder.pollRecord();
@@ -520,8 +519,8 @@ public class CensusModulesTest {
   public void clientBasicTracingDefaultSpan() {
     CensusTracingModule.ClientCallTracer callTracer =
         censusTracing.newClientCallTracer(null, method);
-    Metadata headers = new Metadata();
-    ClientStreamTracer clientStreamTracer = callTracer.newClientStreamTracer(STREAM_INFO, headers);
+    ClientStreamTracer clientStreamTracer = callTracer.newClientStreamTracer(STREAM_INFO);
+    clientStreamTracer.streamCreated(Attributes.EMPTY, new Metadata());
     verify(tracer).spanBuilderWithExplicitParent(
         eq("Sent.package1.service2.method3"), ArgumentMatchers.<Span>isNull());
     verify(spyClientSpan, never()).end(any(EndSpanOptions.class));
@@ -575,11 +574,14 @@ public class CensusModulesTest {
 
   @Test
   public void clientStreamNeverCreatedStillRecordStats() {
-    CensusStatsModule.ClientCallTracer callTracer =
-        censusStats.newClientCallTracer(tagger.empty(), method.getFullMethodName());
-
+    CensusStatsModule.CallAttemptsTracerFactory callAttemptsTracerFactory =
+        new CensusStatsModule.CallAttemptsTracerFactory(
+            censusStats, tagger.empty(), method.getFullMethodName());
+    ClientStreamTracer streamTracer = callAttemptsTracerFactory.newClientStreamTracer(STREAM_INFO);
     fakeClock.forwardTime(3000, MILLISECONDS);
-    callTracer.callEnded(Status.DEADLINE_EXCEEDED.withDescription("3 seconds"));
+    Status status = Status.DEADLINE_EXCEEDED.withDescription("3 seconds");
+    streamTracer.streamClosed(status);
+    callAttemptsTracerFactory.callEnded(status);
 
     // Upstart record
     StatsTestUtils.MetricsRecord record = statsRecorder.pollRecord();
@@ -680,10 +682,12 @@ public class CensusModulesTest {
             fakeClock.getStopwatchSupplier(),
             propagate, recordStats, recordStats, recordStats);
     Metadata headers = new Metadata();
-    CensusStatsModule.ClientCallTracer callTracer =
-        census.newClientCallTracer(clientCtx, method.getFullMethodName());
+    CensusStatsModule.CallAttemptsTracerFactory callAttemptsTracerFactory =
+        new CensusStatsModule.CallAttemptsTracerFactory(
+            census, clientCtx, method.getFullMethodName());
     // This propagates clientCtx to headers if propagates==true
-    callTracer.newClientStreamTracer(STREAM_INFO, headers);
+    ClientStreamTracer streamTracer = callAttemptsTracerFactory.newClientStreamTracer(STREAM_INFO);
+    streamTracer.streamCreated(Attributes.EMPTY, headers);
     if (recordStats) {
       // Client upstart record
       StatsTestUtils.MetricsRecord clientRecord = statsRecorder.pollRecord();
@@ -746,7 +750,8 @@ public class CensusModulesTest {
 
     // Verifies that the client tracer factory uses clientCtx, which includes the custom tags, to
     // record stats.
-    callTracer.callEnded(Status.OK);
+    streamTracer.streamClosed(Status.OK);
+    callAttemptsTracerFactory.callEnded(Status.OK);
 
     if (recordStats) {
       // Client completion record
@@ -769,10 +774,12 @@ public class CensusModulesTest {
 
   @Test
   public void statsHeadersNotPropagateDefaultContext() {
-    CensusStatsModule.ClientCallTracer callTracer =
-        censusStats.newClientCallTracer(tagger.empty(), method.getFullMethodName());
+    CensusStatsModule.CallAttemptsTracerFactory callAttemptsTracerFactory =
+        new CensusStatsModule.CallAttemptsTracerFactory(
+            censusStats, tagger.empty(), method.getFullMethodName());
     Metadata headers = new Metadata();
-    callTracer.newClientStreamTracer(STREAM_INFO, headers);
+    callAttemptsTracerFactory.newClientStreamTracer(STREAM_INFO)
+        .streamCreated(Attributes.EMPTY, headers);
     assertFalse(headers.containsKey(censusStats.statsHeader));
     // Clear recorded stats to satisfy the assertions in wrapUp()
     statsRecorder.rolloverRecords();
@@ -803,7 +810,8 @@ public class CensusModulesTest {
     CensusTracingModule.ClientCallTracer callTracer =
         censusTracing.newClientCallTracer(fakeClientParentSpan, method);
     Metadata headers = new Metadata();
-    callTracer.newClientStreamTracer(STREAM_INFO, headers);
+    ClientStreamTracer streamTracer = callTracer.newClientStreamTracer(STREAM_INFO);
+    streamTracer.streamCreated(Attributes.EMPTY, headers);
 
     verify(mockTracingPropagationHandler).toByteArray(same(fakeClientSpanContext));
     verifyNoMoreInteractions(mockTracingPropagationHandler);
@@ -831,7 +839,8 @@ public class CensusModulesTest {
         censusTracing.newClientCallTracer(fakeClientParentSpan, method);
     Metadata headers = new Metadata();
 
-    callTracer.newClientStreamTracer(STREAM_INFO, headers);
+    ClientStreamTracer streamTracer = callTracer.newClientStreamTracer(STREAM_INFO);
+    streamTracer.streamCreated(Attributes.EMPTY, headers);
 
     assertThat(headers.keys()).isNotEmpty();
   }
@@ -845,7 +854,7 @@ public class CensusModulesTest {
 
     CensusTracingModule.ClientCallTracer callTracer =
         censusTracing.newClientCallTracer(BlankSpan.INSTANCE, method);
-    callTracer.newClientStreamTracer(STREAM_INFO, headers);
+    callTracer.newClientStreamTracer(STREAM_INFO).streamCreated(Attributes.EMPTY, headers);
 
     assertThat(headers.keys()).isEmpty();
   }
@@ -862,7 +871,7 @@ public class CensusModulesTest {
 
     CensusTracingModule.ClientCallTracer callTracer =
         censusTracing.newClientCallTracer(BlankSpan.INSTANCE, method);
-    callTracer.newClientStreamTracer(STREAM_INFO, headers);
+    callTracer.newClientStreamTracer(STREAM_INFO).streamCreated(Attributes.EMPTY, headers);
 
     assertThat(headers.keys()).containsExactlyElementsIn(originalHeaderKeys);
   }
@@ -1186,13 +1195,16 @@ public class CensusModulesTest {
         tagger, tagCtxSerializer, localStats.getStatsRecorder(), fakeClock.getStopwatchSupplier(),
         false, false, true, false /* real-time */);
 
-    CensusStatsModule.ClientCallTracer callTracer =
-        localCensusStats.newClientCallTracer(
-            tagger.empty(), method.getFullMethodName());
+    CensusStatsModule.CallAttemptsTracerFactory callAttemptsTracerFactory =
+        new CensusStatsModule.CallAttemptsTracerFactory(
+            localCensusStats, tagger.empty(), method.getFullMethodName());
 
-    callTracer.newClientStreamTracer(STREAM_INFO, new Metadata());
+    ClientStreamTracer tracer = callAttemptsTracerFactory.newClientStreamTracer(STREAM_INFO);
+    tracer.streamCreated(Attributes.EMPTY, new Metadata());
     fakeClock.forwardTime(30, MILLISECONDS);
-    callTracer.callEnded(Status.PERMISSION_DENIED.withDescription("No you don't"));
+    Status status = Status.PERMISSION_DENIED.withDescription("No you don't");
+    tracer.streamClosed(status);
+    callAttemptsTracerFactory.callEnded(status);
 
     // Give OpenCensus a chance to update the views asynchronously.
     Thread.sleep(100);

--- a/core/src/jmh/java/io/grpc/internal/StatsTraceContextBenchmark.java
+++ b/core/src/jmh/java/io/grpc/internal/StatsTraceContextBenchmark.java
@@ -17,7 +17,7 @@
 package io.grpc.internal;
 
 import io.grpc.Attributes;
-import io.grpc.CallOptions;
+import io.grpc.ClientStreamTracer;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerStreamTracer;
@@ -50,7 +50,8 @@ public class StatsTraceContextBenchmark {
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public StatsTraceContext newClientContext() {
-    return StatsTraceContext.newClientContext(CallOptions.DEFAULT, Attributes.EMPTY, emptyMetadata);
+    return StatsTraceContext.newClientContext(
+        new ClientStreamTracer[1], Attributes.EMPTY, emptyMetadata);
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -263,6 +263,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
       for (int i = 0; i < factories.size(); i++) {
         tracers[i] = factories.get(i).newClientStreamTracer(streamInfo);
       }
+      tracers[factories.size()] = new ClientStreamTracer() {};
       stream = new FailingClientStream(
           DEADLINE_EXCEEDED.withDescription(
               "ClientCall started after deadline exceeded: " + effectiveDeadline),

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -33,6 +33,8 @@ import com.google.common.base.MoreObjects;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
+import io.grpc.ClientStreamTracer;
+import io.grpc.ClientStreamTracer.StreamInfo;
 import io.grpc.Codec;
 import io.grpc.Compressor;
 import io.grpc.CompressorRegistry;
@@ -52,6 +54,7 @@ import io.perfmark.PerfMark;
 import io.perfmark.Tag;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.Executor;
@@ -254,9 +257,16 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
           effectiveDeadline, context.getDeadline(), callOptions.getDeadline());
       stream = clientStreamProvider.newStream(method, callOptions, headers, context);
     } else {
+      StreamInfo streamInfo = StreamInfo.newBuilder().setCallOptions(callOptions).build();
+      List<ClientStreamTracer.Factory> factories = callOptions.getStreamTracerFactories();
+      ClientStreamTracer[] tracers = new ClientStreamTracer[factories.size() + 1];
+      for (int i = 0; i < factories.size(); i++) {
+        tracers[i] = factories.get(i).newClientStreamTracer(streamInfo);
+      }
       stream = new FailingClientStream(
           DEADLINE_EXCEEDED.withDescription(
-              "ClientCall started after deadline exceeded: " + effectiveDeadline));
+              "ClientCall started after deadline exceeded: " + effectiveDeadline),
+          tracers);
     }
 
     if (callExecutorIsDirect) {

--- a/core/src/main/java/io/grpc/internal/ClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransport.java
@@ -17,6 +17,7 @@
 package io.grpc.internal;
 
 import io.grpc.CallOptions;
+import io.grpc.ClientStreamTracer;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalInstrumented;
 import io.grpc.Metadata;
@@ -46,10 +47,14 @@ public interface ClientTransport extends InternalInstrumented<SocketStats> {
    * @param method the descriptor of the remote method to be called for this stream.
    * @param headers to send at the beginning of the call
    * @param callOptions runtime options of the call
+   * @param tracers a non-empty array of tracers. The last element in it is reserved to be set by
+   *        the load balancer's pick result and otherwise is a no-op tracer.
    * @return the newly created stream.
    */
   // TODO(nmittler): Consider also throwing for stopping.
-  ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions);
+  ClientStream newStream(
+      MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions,
+      ClientStreamTracer[] tracers);
 
   /**
    * Pings a remote endpoint. When an acknowledgement is received, the given callback will be

--- a/core/src/main/java/io/grpc/internal/ClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransport.java
@@ -54,6 +54,7 @@ public interface ClientTransport extends InternalInstrumented<SocketStats> {
   // TODO(nmittler): Consider also throwing for stopping.
   ClientStream newStream(
       MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions,
+      // Using array for tracers instead of a list or composition for better performance.
       ClientStreamTracer[] tracers);
 
   /**

--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -391,6 +391,13 @@ final class DelayedClientTransport implements ManagedClientTransport {
     }
 
     @Override
+    protected void onEarlyCancellation(Status reason) {
+      for (ClientStreamTracer tracer : tracers) {
+        tracer.streamClosed(reason);
+      }
+    }
+
+    @Override
     public void appendTimeoutInsight(InsightBuilder insight) {
       if (args.getCallOptions().isWaitForReady()) {
         insight.append("wait_for_ready");

--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.CallOptions;
+import io.grpc.ClientStreamTracer;
 import io.grpc.Context;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalLogId;
@@ -133,7 +134,8 @@ final class DelayedClientTransport implements ManagedClientTransport {
    */
   @Override
   public final ClientStream newStream(
-      MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
+      MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions,
+      ClientStreamTracer[] tracers) {
     try {
       PickSubchannelArgs args = new PickSubchannelArgsImpl(method, headers, callOptions);
       SubchannelPicker picker = null;
@@ -141,14 +143,14 @@ final class DelayedClientTransport implements ManagedClientTransport {
       while (true) {
         synchronized (lock) {
           if (shutdownStatus != null) {
-            return new FailingClientStream(shutdownStatus);
+            return new FailingClientStream(shutdownStatus, tracers);
           }
           if (lastPicker == null) {
-            return createPendingStream(args);
+            return createPendingStream(args, tracers);
           }
           // Check for second time through the loop, and whether anything changed
           if (picker != null && pickerVersion == lastPickerVersion) {
-            return createPendingStream(args);
+            return createPendingStream(args, tracers);
           }
           picker = lastPicker;
           pickerVersion = lastPickerVersion;
@@ -158,7 +160,8 @@ final class DelayedClientTransport implements ManagedClientTransport {
             callOptions.isWaitForReady());
         if (transport != null) {
           return transport.newStream(
-              args.getMethodDescriptor(), args.getHeaders(), args.getCallOptions());
+              args.getMethodDescriptor(), args.getHeaders(), args.getCallOptions(),
+              tracers);
         }
         // This picker's conclusion is "buffer".  If there hasn't been a newer picker set (possible
         // race with reprocess()), we will buffer it.  Otherwise, will try with the new picker.
@@ -173,8 +176,9 @@ final class DelayedClientTransport implements ManagedClientTransport {
    * schedule tasks on syncContext.
    */
   @GuardedBy("lock")
-  private PendingStream createPendingStream(PickSubchannelArgs args) {
-    PendingStream pendingStream = new PendingStream(args);
+  private PendingStream createPendingStream(
+      PickSubchannelArgs args, ClientStreamTracer[] tracers) {
+    PendingStream pendingStream = new PendingStream(args, tracers);
     pendingStreams.add(pendingStream);
     if (getPendingStreamsCount() == 1) {
       syncContext.executeLater(reportTransportInUse);
@@ -239,7 +243,8 @@ final class DelayedClientTransport implements ManagedClientTransport {
     }
     if (savedReportTransportTerminated != null) {
       for (PendingStream stream : savedPendingStreams) {
-        Runnable runnable = stream.setStream(new FailingClientStream(status, RpcProgress.REFUSED));
+        Runnable runnable = stream.setStream(
+            new FailingClientStream(status, RpcProgress.REFUSED, stream.tracers));
         if (runnable != null) {
           // Drain in-line instead of using an executor as failing stream just throws everything
           // away. This is essentially the same behavior as DelayedStream.cancel() but can be done
@@ -346,9 +351,11 @@ final class DelayedClientTransport implements ManagedClientTransport {
   private class PendingStream extends DelayedStream {
     private final PickSubchannelArgs args;
     private final Context context = Context.current();
+    private final ClientStreamTracer[] tracers;
 
-    private PendingStream(PickSubchannelArgs args) {
+    private PendingStream(PickSubchannelArgs args, ClientStreamTracer[] tracers) {
       this.args = args;
+      this.tracers = tracers;
     }
 
     /** Runnable may be null. */
@@ -357,7 +364,8 @@ final class DelayedClientTransport implements ManagedClientTransport {
       Context origContext = context.attach();
       try {
         realStream = transport.newStream(
-            args.getMethodDescriptor(), args.getHeaders(), args.getCallOptions());
+            args.getMethodDescriptor(), args.getHeaders(), args.getCallOptions(),
+            tracers);
       } finally {
         context.detach(origContext);
       }

--- a/core/src/main/java/io/grpc/internal/DelayedStream.java
+++ b/core/src/main/java/io/grpc/internal/DelayedStream.java
@@ -324,9 +324,13 @@ class DelayedStream implements ClientStream {
       });
     } else {
       drainPendingCalls();
+      onEarlyCancellation(reason);
       // Note that listener is a DelayedStreamListener
       listener.closed(reason, RpcProgress.PROCESSED, new Metadata());
     }
+  }
+
+  protected void onEarlyCancellation(Status reason) {
   }
 
   @GuardedBy("this")

--- a/core/src/main/java/io/grpc/internal/FailingClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/FailingClientTransport.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.CallOptions;
+import io.grpc.ClientStreamTracer;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalLogId;
 import io.grpc.Metadata;
@@ -45,8 +46,9 @@ class FailingClientTransport implements ClientTransport {
 
   @Override
   public ClientStream newStream(
-      MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
-    return new FailingClientStream(error, rpcProgress);
+      MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions,
+      ClientStreamTracer[] tracers) {
+    return new FailingClientStream(error, rpcProgress, tracers);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
@@ -20,6 +20,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
+import io.grpc.ClientStreamTracer;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalLogId;
 import io.grpc.Metadata;
@@ -45,8 +46,9 @@ abstract class ForwardingConnectionClientTransport implements ConnectionClientTr
 
   @Override
   public ClientStream newStream(
-      MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
-    return delegate().newStream(method, headers, callOptions);
+      MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions,
+      ClientStreamTracer[] tracers) {
+    return delegate().newStream(method, headers, callOptions, tracers);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -28,6 +28,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.grpc.CallOptions;
 import io.grpc.ClientStreamTracer;
+import io.grpc.ClientStreamTracer.StreamInfo;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalLogId;
 import io.grpc.InternalMetadata;
@@ -54,6 +55,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -252,6 +254,8 @@ public final class GrpcUtil {
    */
   public static final CallOptions.Key<Boolean> CALL_OPTIONS_RPC_OWNED_BY_BALANCER =
       CallOptions.Key.create("io.grpc.internal.CALL_OPTIONS_RPC_OWNED_BY_BALANCER");
+
+  private static final ClientStreamTracer NOOP_TRACER = new ClientStreamTracer() {};
 
   /**
    * Returns true if an RPC with the given properties should be counted when calculating the
@@ -695,7 +699,8 @@ public final class GrpcUtil {
    * Returns a transport out of a PickResult, or {@code null} if the result is "buffer".
    */
   @Nullable
-  static ClientTransport getTransportFromPickResult(PickResult result, boolean isWaitForReady) {
+  static ClientTransport getTransportFromPickResult(
+      final PickResult result, boolean isWaitForReady) {
     final ClientTransport transport;
     Subchannel subchannel = result.getSubchannel();
     if (subchannel != null) {
@@ -711,9 +716,14 @@ public final class GrpcUtil {
       return new ClientTransport() {
         @Override
         public ClientStream newStream(
-            MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
-          return transport.newStream(
-              method, headers, callOptions.withStreamTracerFactory(streamTracerFactory));
+            MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions,
+            ClientStreamTracer[] tracers) {
+          ClientStreamTracer streamTracer = streamTracerFactory.newClientStreamTracer(
+              StreamInfo.newBuilder()
+                  .setCallOptions(callOptions)
+                  .build());
+          tracers[tracers.length - 1] = streamTracer;
+          return transport.newStream(method, headers, callOptions, tracers);
         }
 
         @Override
@@ -741,6 +751,21 @@ public final class GrpcUtil {
       }
     }
     return null;
+  }
+
+  static ClientStreamTracer[] getClientStreamTracers(
+      CallOptions callOptions, boolean isTransparentRetry) {
+    List<ClientStreamTracer.Factory> factories = callOptions.getStreamTracerFactories();
+    ClientStreamTracer[] tracers = new ClientStreamTracer[factories.size() + 1];
+    StreamInfo streamInfo = StreamInfo.newBuilder()
+        .setCallOptions(callOptions)
+        .setIsTransparentRetry(isTransparentRetry)
+        .build();
+    for (int i = 0; i < factories.size(); i++) {
+      tracers[i] = factories.get(i).newClientStreamTracer(streamInfo);
+    }
+    tracers[tracers.length - 1] = NOOP_TRACER;
+    return tracers;
   }
 
   /** Quietly closes all messages in MessageProducer. */

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -699,8 +699,7 @@ public final class GrpcUtil {
    * Returns a transport out of a PickResult, or {@code null} if the result is "buffer".
    */
   @Nullable
-  static ClientTransport getTransportFromPickResult(
-      final PickResult result, boolean isWaitForReady) {
+  static ClientTransport getTransportFromPickResult(PickResult result, boolean isWaitForReady) {
     final ClientTransport transport;
     Subchannel subchannel = result.getSubchannel();
     if (subchannel != null) {
@@ -753,6 +752,7 @@ public final class GrpcUtil {
     return null;
   }
 
+  /** Gets stream tracers based on CallOptions. */
   static ClientStreamTracer[] getClientStreamTracers(
       CallOptions callOptions, boolean isTransparentRetry) {
     List<ClientStreamTracer.Factory> factories = callOptions.getStreamTracerFactories();

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -34,6 +34,7 @@ import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ChannelLogger;
 import io.grpc.ChannelLogger.ChannelLogLevel;
+import io.grpc.ClientStreamTracer;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
@@ -667,8 +668,9 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
 
     @Override
     public ClientStream newStream(
-        MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
-      final ClientStream streamDelegate = super.newStream(method, headers, callOptions);
+        MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions,
+        ClientStreamTracer[] tracers) {
+      final ClientStream streamDelegate = super.newStream(method, headers, callOptions, tracers);
       return new ForwardingClientStream() {
         @Override
         protected ClientStream delegate() {

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -143,10 +143,6 @@ public final class ManagedChannelImplBuilder
   long retryBufferSize = DEFAULT_RETRY_BUFFER_SIZE_IN_BYTES;
   long perRpcBufferLimit = DEFAULT_PER_RPC_BUFFER_LIMIT_IN_BYTES;
   boolean retryEnabled = false; // TODO(zdapeng): default to true
-  // Temporarily disable retry when stats or tracing is enabled to avoid breakage, until we know
-  // what should be the desired behavior for retry + stats/tracing.
-  // TODO(zdapeng): delete me
-  boolean temporarilyDisableRetry;
 
   InternalChannelz channelz = InternalChannelz.instance();
   int maxTraceEvents;
@@ -460,8 +456,6 @@ public final class ManagedChannelImplBuilder
   @Override
   public ManagedChannelImplBuilder enableRetry() {
     retryEnabled = true;
-    statsEnabled = false;
-    tracingEnabled = false;
     return this;
   }
 
@@ -642,9 +636,7 @@ public final class ManagedChannelImplBuilder
   List<ClientInterceptor> getEffectiveInterceptors() {
     List<ClientInterceptor> effectiveInterceptors =
         new ArrayList<>(this.interceptors);
-    temporarilyDisableRetry = false;
     if (statsEnabled) {
-      temporarilyDisableRetry = true;
       ClientInterceptor statsInterceptor = null;
       try {
         Class<?> censusStatsAccessor =
@@ -654,6 +646,7 @@ public final class ManagedChannelImplBuilder
                 "getClientInterceptor",
                 boolean.class,
                 boolean.class,
+                boolean.class,
                 boolean.class);
         statsInterceptor =
             (ClientInterceptor) getClientInterceptorMethod
@@ -661,7 +654,8 @@ public final class ManagedChannelImplBuilder
                     null,
                     recordStartedRpcs,
                     recordFinishedRpcs,
-                    recordRealTimeMetrics);
+                    recordRealTimeMetrics,
+                    retryEnabled);
       } catch (ClassNotFoundException e) {
         // Replace these separate catch statements with multicatch when Android min-API >= 19
         log.log(Level.FINE, "Unable to apply census stats", e);
@@ -679,7 +673,6 @@ public final class ManagedChannelImplBuilder
       }
     }
     if (tracingEnabled) {
-      temporarilyDisableRetry = true;
       ClientInterceptor tracingInterceptor = null;
       try {
         Class<?> censusTracingAccessor =

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -26,6 +26,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
+import io.grpc.ClientStreamTracer;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.Context;
@@ -86,12 +87,13 @@ final class OobChannel extends ManagedChannel implements InternalInstrumented<Ch
     @Override
     public ClientStream newStream(MethodDescriptor<?, ?> method,
         CallOptions callOptions, Metadata headers, Context context) {
+      ClientStreamTracer[] tracers = GrpcUtil.getClientStreamTracers(callOptions, false);
       Context origContext = context.attach();
       // delayed transport's newStream() always acquires a lock, but concurrent performance doesn't
       // matter here because OOB communication should be sparse, and it's not on application RPC's
       // critical path.
       try {
-        return delayedTransport.newStream(method, headers, callOptions);
+        return delayedTransport.newStream(method, headers, callOptions, tracers);
       } finally {
         context.detach(origContext);
       }

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -87,7 +87,8 @@ final class OobChannel extends ManagedChannel implements InternalInstrumented<Ch
     @Override
     public ClientStream newStream(MethodDescriptor<?, ?> method,
         CallOptions callOptions, Metadata headers, Context context) {
-      ClientStreamTracer[] tracers = GrpcUtil.getClientStreamTracers(callOptions, false);
+      ClientStreamTracer[] tracers = GrpcUtil.getClientStreamTracers(
+          callOptions, /* isTransparentRetry= */ false);
       Context origContext = context.attach();
       // delayed transport's newStream() always acquires a lock, but concurrent performance doesn't
       // matter here because OOB communication should be sparse, and it's not on application RPC's

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -203,21 +203,21 @@ abstract class RetriableStream<ReqT> implements ClientStream {
     }
   }
 
-  private Substream createSubstream(int previousAttemptCount) {
+  private Substream createSubstream(int previousAttemptCount, boolean isTransparentRetry) {
     Substream sub = new Substream(previousAttemptCount);
     // one tracer per substream
     final ClientStreamTracer bufferSizeTracer = new BufferSizeTracer(sub);
     ClientStreamTracer.Factory tracerFactory = new ClientStreamTracer.Factory() {
       @Override
-      public ClientStreamTracer newClientStreamTracer(
-          ClientStreamTracer.StreamInfo info, Metadata headers) {
+      public ClientStreamTracer newClientStreamTracer(ClientStreamTracer.StreamInfo info) {
         return bufferSizeTracer;
       }
     };
 
     Metadata newHeaders = updateHeaders(headers, previousAttemptCount);
+    // TODO: pass real substream id and transparentRetry flag
     // NOTICE: This set _must_ be done before stream.start() and it actually is.
-    sub.stream = newSubstream(tracerFactory, newHeaders);
+    sub.stream = newSubstream(newHeaders, tracerFactory, isTransparentRetry);
     return sub;
   }
 
@@ -226,7 +226,7 @@ abstract class RetriableStream<ReqT> implements ClientStream {
    * Client stream is not yet started.
    */
   abstract ClientStream newSubstream(
-      ClientStreamTracer.Factory tracerFactory, Metadata headers);
+      Metadata headers, ClientStreamTracer.Factory tracerFactory, boolean isTransparentRetry);
 
   /** Adds grpc-previous-rpc-attempts in the headers of a retry/hedging RPC. */
   @VisibleForTesting
@@ -322,7 +322,7 @@ abstract class RetriableStream<ReqT> implements ClientStream {
       state.buffer.add(new StartEntry());
     }
 
-    Substream substream = createSubstream(0);
+    Substream substream = createSubstream(0, false);
     if (isHedging) {
       FutureCanceller scheduledHedgingRef = null;
 
@@ -399,7 +399,7 @@ abstract class RetriableStream<ReqT> implements ClientStream {
               // If this run is not cancelled, the value of state.hedgingAttemptCount won't change
               // until state.addActiveHedge() is called subsequently, even the state could possibly
               // change.
-              Substream newSubstream = createSubstream(state.hedgingAttemptCount);
+              Substream newSubstream = createSubstream(state.hedgingAttemptCount, false);
               boolean cancelled = false;
               FutureCanceller future = null;
 
@@ -784,8 +784,7 @@ abstract class RetriableStream<ReqT> implements ClientStream {
         if (rpcProgress == RpcProgress.REFUSED
             && noMoreTransparentRetry.compareAndSet(false, true)) {
           // transparent retry
-          final Substream newSubstream = createSubstream(
-              substream.previousAttemptCount);
+          final Substream newSubstream = createSubstream(substream.previousAttemptCount, true);
           if (isHedging) {
             boolean commit = false;
             synchronized (lock) {
@@ -863,8 +862,9 @@ abstract class RetriableStream<ReqT> implements ClientStream {
                                 @Override
                                 public void run() {
                                   // retry
-                                  Substream newSubstream =
-                                      createSubstream(substream.previousAttemptCount + 1);
+                                  Substream newSubstream = createSubstream(
+                                      substream.previousAttemptCount + 1,
+                                      false);
                                   drain(newSubstream);
                                 }
                               });

--- a/core/src/main/java/io/grpc/internal/SubchannelChannel.java
+++ b/core/src/main/java/io/grpc/internal/SubchannelChannel.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
+import io.grpc.ClientStreamTracer;
 import io.grpc.Context;
 import io.grpc.InternalConfigSelector;
 import io.grpc.Metadata;
@@ -57,9 +58,10 @@ final class SubchannelChannel extends Channel {
         if (transport == null) {
           transport = notReadyTransport;
         }
+        ClientStreamTracer[] tracers = GrpcUtil.getClientStreamTracers(callOptions, false);
         Context origContext = context.attach();
         try {
-          return transport.newStream(method, headers, callOptions);
+          return transport.newStream(method, headers, callOptions, tracers);
         } finally {
           context.detach(origContext);
         }

--- a/core/src/main/java/io/grpc/internal/SubchannelChannel.java
+++ b/core/src/main/java/io/grpc/internal/SubchannelChannel.java
@@ -58,7 +58,8 @@ final class SubchannelChannel extends Channel {
         if (transport == null) {
           transport = notReadyTransport;
         }
-        ClientStreamTracer[] tracers = GrpcUtil.getClientStreamTracers(callOptions, false);
+        ClientStreamTracer[] tracers = GrpcUtil.getClientStreamTracers(
+            callOptions, /* isTransparentRetry= */ false);
         Context origContext = context.attach();
         try {
           return transport.newStream(method, headers, callOptions, tracers);

--- a/core/src/main/java/io/grpc/util/ForwardingClientStreamTracer.java
+++ b/core/src/main/java/io/grpc/util/ForwardingClientStreamTracer.java
@@ -17,6 +17,7 @@
 package io.grpc.util;
 
 import com.google.common.base.MoreObjects;
+import io.grpc.Attributes;
 import io.grpc.ClientStreamTracer;
 import io.grpc.ExperimentalApi;
 import io.grpc.Metadata;
@@ -26,6 +27,11 @@ import io.grpc.Status;
 public abstract class ForwardingClientStreamTracer extends ClientStreamTracer {
   /** Returns the underlying {@code ClientStreamTracer}. */
   protected abstract ClientStreamTracer delegate();
+
+  @Override
+  public void streamCreated(Attributes transportAttrs, Metadata headers) {
+    delegate().streamCreated(transportAttrs, headers);
+  }
 
   @Override
   public void outboundHeaders() {

--- a/core/src/test/java/io/grpc/ClientStreamTracerTest.java
+++ b/core/src/test/java/io/grpc/ClientStreamTracerTest.java
@@ -34,6 +34,7 @@ public class ClientStreamTracerTest {
       Attributes.newBuilder().set(TRANSPORT_ATTR_KEY, "value").build();
 
   @Test
+  @SuppressWarnings("deprecation") // info.getTransportAttrs()
   public void streamInfo_empty() {
     StreamInfo info = StreamInfo.newBuilder().build();
     assertThat(info.getCallOptions()).isSameInstanceAs(CallOptions.DEFAULT);
@@ -41,6 +42,7 @@ public class ClientStreamTracerTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation") // info.getTransportAttrs()
   public void streamInfo_withInfo() {
     StreamInfo info = StreamInfo.newBuilder()
         .setCallOptions(callOptions).setTransportAttrs(transportAttrs).build();
@@ -49,6 +51,7 @@ public class ClientStreamTracerTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation") // info.setTransportAttrs()
   public void streamInfo_noEquality() {
     StreamInfo info1 = StreamInfo.newBuilder()
         .setCallOptions(callOptions).setTransportAttrs(transportAttrs).build();
@@ -60,6 +63,7 @@ public class ClientStreamTracerTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation") // info.getTransportAttrs()
   public void streamInfo_toBuilder() {
     StreamInfo info1 = StreamInfo.newBuilder()
         .setCallOptions(callOptions).setTransportAttrs(transportAttrs).build();

--- a/core/src/test/java/io/grpc/internal/CallCredentials2ApplyingTest.java
+++ b/core/src/test/java/io/grpc/internal/CallCredentials2ApplyingTest.java
@@ -34,6 +34,7 @@ import io.grpc.CallCredentials.MetadataApplier;
 import io.grpc.CallCredentials.RequestInfo;
 import io.grpc.CallOptions;
 import io.grpc.ChannelLogger;
+import io.grpc.ClientStreamTracer;
 import io.grpc.IntegerMarshaller;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -48,6 +49,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnit;
@@ -105,6 +107,7 @@ public class CallCredentials2ApplyingTest {
   private static final String CREDS_VALUE = "some credentials";
 
   private final Metadata origHeaders = new Metadata();
+  private final ClientStreamTracer[] tracers = new ClientStreamTracer[1];
   private ForwardingConnectionClientTransport transport;
   private CallOptions callOptions;
 
@@ -118,7 +121,9 @@ public class CallCredentials2ApplyingTest {
     origHeaders.put(ORIG_HEADER_KEY, ORIG_HEADER_VALUE);
     when(mockTransportFactory.newClientTransport(address, clientTransportOptions, channelLogger))
         .thenReturn(mockTransport);
-    when(mockTransport.newStream(same(method), any(Metadata.class), any(CallOptions.class)))
+    when(mockTransport.newStream(
+            same(method), any(Metadata.class), any(CallOptions.class),
+            ArgumentMatchers.<ClientStreamTracer[]>any()))
         .thenReturn(mockStream);
     ClientTransportFactory transportFactory = new CallCredentialsApplyingTransportFactory(
         mockTransportFactory, null, mockExecutor);
@@ -134,7 +139,7 @@ public class CallCredentials2ApplyingTest {
     Attributes transportAttrs = Attributes.newBuilder().set(ATTR_KEY, ATTR_VALUE).build();
     when(mockTransport.getAttributes()).thenReturn(transportAttrs);
 
-    transport.newStream(method, origHeaders, callOptions);
+    transport.newStream(method, origHeaders, callOptions, tracers);
 
     ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(null);
     verify(mockCreds).applyRequestMetadata(
@@ -155,7 +160,7 @@ public class CallCredentials2ApplyingTest {
         .build();
     when(mockTransport.getAttributes()).thenReturn(transportAttrs);
 
-    transport.newStream(method, origHeaders, callOptions);
+    transport.newStream(method, origHeaders, callOptions, tracers);
 
     ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(null);
     verify(mockCreds).applyRequestMetadata(
@@ -176,8 +181,10 @@ public class CallCredentials2ApplyingTest {
     when(mockTransport.getAttributes()).thenReturn(transportAttrs);
     Executor anotherExecutor = mock(Executor.class);
 
-    transport.newStream(method, origHeaders,
-        callOptions.withAuthority("calloptions-authority").withExecutor(anotherExecutor));
+    transport.newStream(
+        method, origHeaders,
+        callOptions.withAuthority("calloptions-authority").withExecutor(anotherExecutor),
+        tracers);
 
     ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(null);
     verify(mockCreds).applyRequestMetadata(
@@ -199,13 +206,15 @@ public class CallCredentials2ApplyingTest {
         any(io.grpc.CallCredentials2.MetadataApplier.class));
 
     FailingClientStream stream =
-        (FailingClientStream) transport.newStream(method, origHeaders, callOptions);
+        (FailingClientStream) transport.newStream(method, origHeaders, callOptions, tracers);
 
-    verify(mockTransport, never()).newStream(method, origHeaders, callOptions);
+    verify(mockTransport, never()).newStream(
+        any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class),
+        ArgumentMatchers.<ClientStreamTracer[]>any());
     assertEquals(Status.Code.UNAUTHENTICATED, stream.getError().getCode());
     assertSame(ex, stream.getError().getCause());
     transport.shutdown(Status.UNAVAILABLE);
-    assertTrue(transport.newStream(method, origHeaders, callOptions)
+    assertTrue(transport.newStream(method, origHeaders, callOptions, tracers)
         instanceof FailingClientStream);
     verify(mockTransport).shutdown(Status.UNAVAILABLE);
   }
@@ -226,14 +235,14 @@ public class CallCredentials2ApplyingTest {
           any(RequestInfo.class), same(mockExecutor),
           any(io.grpc.CallCredentials2.MetadataApplier.class));
 
-    ClientStream stream = transport.newStream(method, origHeaders, callOptions);
+    ClientStream stream = transport.newStream(method, origHeaders, callOptions, tracers);
 
-    verify(mockTransport).newStream(method, origHeaders, callOptions);
+    verify(mockTransport).newStream(method, origHeaders, callOptions, tracers);
     assertSame(mockStream, stream);
     assertEquals(CREDS_VALUE, origHeaders.get(CREDS_KEY));
     assertEquals(ORIG_HEADER_VALUE, origHeaders.get(ORIG_HEADER_KEY));
     transport.shutdown(Status.UNAVAILABLE);
-    assertTrue(transport.newStream(method, origHeaders, callOptions)
+    assertTrue(transport.newStream(method, origHeaders, callOptions, tracers)
         instanceof FailingClientStream);
     verify(mockTransport).shutdown(Status.UNAVAILABLE);
   }
@@ -254,12 +263,14 @@ public class CallCredentials2ApplyingTest {
           any(io.grpc.CallCredentials2.MetadataApplier.class));
 
     FailingClientStream stream =
-        (FailingClientStream) transport.newStream(method, origHeaders, callOptions);
+        (FailingClientStream) transport.newStream(method, origHeaders, callOptions, tracers);
 
-    verify(mockTransport, never()).newStream(method, origHeaders, callOptions);
+    verify(mockTransport, never()).newStream(
+        any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class),
+        ArgumentMatchers.<ClientStreamTracer[]>any());
     assertSame(error, stream.getError());
     transport.shutdownNow(Status.UNAVAILABLE);
-    assertTrue(transport.newStream(method, origHeaders, callOptions)
+    assertTrue(transport.newStream(method, origHeaders, callOptions, tracers)
         instanceof FailingClientStream);
     verify(mockTransport).shutdownNow(Status.UNAVAILABLE);
   }
@@ -269,12 +280,15 @@ public class CallCredentials2ApplyingTest {
     when(mockTransport.getAttributes()).thenReturn(Attributes.EMPTY);
 
     // Will call applyRequestMetadata(), which is no-op.
-    DelayedStream stream = (DelayedStream) transport.newStream(method, origHeaders, callOptions);
+    DelayedStream stream = (DelayedStream) transport.newStream(
+        method, origHeaders, callOptions, tracers);
 
     ArgumentCaptor<MetadataApplier> applierCaptor = ArgumentCaptor.forClass(null);
     verify(mockCreds).applyRequestMetadata(
         any(RequestInfo.class), same(mockExecutor), applierCaptor.capture());
-    verify(mockTransport, never()).newStream(method, origHeaders, callOptions);
+    verify(mockTransport, never()).newStream(
+        any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class),
+        ArgumentMatchers.<ClientStreamTracer[]>any());
 
     transport.shutdown(Status.UNAVAILABLE);
     verify(mockTransport, never()).shutdown(Status.UNAVAILABLE);
@@ -283,11 +297,11 @@ public class CallCredentials2ApplyingTest {
     headers.put(CREDS_KEY, CREDS_VALUE);
     applierCaptor.getValue().apply(headers);
 
-    verify(mockTransport).newStream(method, origHeaders, callOptions);
+    verify(mockTransport).newStream(method, origHeaders, callOptions, tracers);
     assertSame(mockStream, stream.getRealStream());
     assertEquals(CREDS_VALUE, origHeaders.get(CREDS_KEY));
     assertEquals(ORIG_HEADER_VALUE, origHeaders.get(ORIG_HEADER_KEY));
-    assertTrue(transport.newStream(method, origHeaders, callOptions)
+    assertTrue(transport.newStream(method, origHeaders, callOptions, tracers)
         instanceof FailingClientStream);
     verify(mockTransport).shutdown(Status.UNAVAILABLE);
   }
@@ -297,7 +311,8 @@ public class CallCredentials2ApplyingTest {
     when(mockTransport.getAttributes()).thenReturn(Attributes.EMPTY);
 
     // Will call applyRequestMetadata(), which is no-op.
-    DelayedStream stream = (DelayedStream) transport.newStream(method, origHeaders, callOptions);
+    DelayedStream stream = (DelayedStream) transport.newStream(
+        method, origHeaders, callOptions, tracers);
 
     ArgumentCaptor<MetadataApplier> applierCaptor = ArgumentCaptor.forClass(null);
     verify(mockCreds).applyRequestMetadata(
@@ -306,11 +321,13 @@ public class CallCredentials2ApplyingTest {
     Status error = Status.FAILED_PRECONDITION.withDescription("channel not secure for creds");
     applierCaptor.getValue().fail(error);
 
-    verify(mockTransport, never()).newStream(method, origHeaders, callOptions);
+    verify(mockTransport, never()).newStream(
+        any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class),
+        ArgumentMatchers.<ClientStreamTracer[]>any());
     FailingClientStream failingStream = (FailingClientStream) stream.getRealStream();
     assertSame(error, failingStream.getError());
     transport.shutdown(Status.UNAVAILABLE);
-    assertTrue(transport.newStream(method, origHeaders, callOptions)
+    assertTrue(transport.newStream(method, origHeaders, callOptions, tracers)
         instanceof FailingClientStream);
     verify(mockTransport).shutdown(Status.UNAVAILABLE);
   }
@@ -318,14 +335,14 @@ public class CallCredentials2ApplyingTest {
   @Test
   public void noCreds() {
     callOptions = callOptions.withCallCredentials(null);
-    ClientStream stream = transport.newStream(method, origHeaders, callOptions);
+    ClientStream stream = transport.newStream(method, origHeaders, callOptions, tracers);
 
-    verify(mockTransport).newStream(method, origHeaders, callOptions);
+    verify(mockTransport).newStream(method, origHeaders, callOptions, tracers);
     assertSame(mockStream, stream);
     assertNull(origHeaders.get(CREDS_KEY));
     assertEquals(ORIG_HEADER_VALUE, origHeaders.get(ORIG_HEADER_KEY));
     transport.shutdown(Status.UNAVAILABLE);
-    assertTrue(transport.newStream(method, origHeaders, callOptions)
+    assertTrue(transport.newStream(method, origHeaders, callOptions, tracers)
         instanceof FailingClientStream);
     verify(mockTransport).shutdown(Status.UNAVAILABLE);
   }

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
@@ -47,6 +48,7 @@ import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 import io.grpc.ClientStreamTracer;
+import io.grpc.ClientStreamTracer.StreamInfo;
 import io.grpc.Codec;
 import io.grpc.Context;
 import io.grpc.Deadline;
@@ -143,6 +145,8 @@ public class ClientCallImplTest {
             any(Metadata.class),
             any(Context.class)))
         .thenReturn(stream);
+    when(streamTracerFactory.newClientStreamTracer(any(StreamInfo.class)))
+        .thenReturn(new ClientStreamTracer() {});
     doAnswer(new Answer<Void>() {
         @Override
         public Void answer(InvocationOnMock in) {
@@ -156,7 +160,7 @@ public class ClientCallImplTest {
 
   @After
   public void tearDown() {
-    verifyNoInteractions(streamTracerFactory);
+    verifyNoMoreInteractions(streamTracerFactory);
   }
 
   @Test
@@ -763,6 +767,7 @@ public class ClientCallImplTest {
         channelCallTracer, configSelector)
             .setDecompressorRegistry(decompressorRegistry);
     call.start(callListener, new Metadata());
+    verify(streamTracerFactory).newClientStreamTracer(any(StreamInfo.class));
     verify(clientStreamProvider, never())
         .newStream(
             (MethodDescriptor<?, ?>) any(MethodDescriptor.class),

--- a/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.grpc.CallOptions;
+import io.grpc.ClientStreamTracer;
 import io.grpc.IntegerMarshaller;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
@@ -57,6 +58,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
@@ -117,14 +119,22 @@ public class DelayedClientTransportTest {
             }
           }));
 
+  private final ClientStreamTracer[] tracers = new ClientStreamTracer[] {
+      new ClientStreamTracer() {}
+  };
+
   @Before public void setUp() {
     when(mockPicker.pickSubchannel(any(PickSubchannelArgs.class)))
         .thenReturn(PickResult.withSubchannel(mockSubchannel));
     when(mockSubchannel.getInternalSubchannel()).thenReturn(mockInternalSubchannel);
     when(mockInternalSubchannel.obtainActiveTransport()).thenReturn(mockRealTransport);
-    when(mockRealTransport.newStream(same(method), same(headers), same(callOptions)))
+    when(mockRealTransport.newStream(
+            same(method), same(headers), same(callOptions),
+            ArgumentMatchers.<ClientStreamTracer[]>any()))
         .thenReturn(mockRealStream);
-    when(mockRealTransport2.newStream(same(method2), same(headers2), same(callOptions2)))
+    when(mockRealTransport2.newStream(
+            same(method2), same(headers2), same(callOptions2),
+            ArgumentMatchers.<ClientStreamTracer[]>any()))
         .thenReturn(mockRealStream2);
     delayedTransport.start(transportListener);
   }
@@ -135,7 +145,8 @@ public class DelayedClientTransportTest {
 
   @Test public void streamStartThenAssignTransport() {
     assertFalse(delayedTransport.hasPendingStreams());
-    ClientStream stream = delayedTransport.newStream(method, headers, callOptions);
+    ClientStream stream = delayedTransport.newStream(
+        method, headers, callOptions, tracers);
     stream.start(streamListener);
     assertEquals(1, delayedTransport.getPendingStreamsCount());
     assertTrue(delayedTransport.hasPendingStreams());
@@ -145,7 +156,9 @@ public class DelayedClientTransportTest {
     assertEquals(0, delayedTransport.getPendingStreamsCount());
     assertFalse(delayedTransport.hasPendingStreams());
     assertEquals(1, fakeExecutor.runDueTasks());
-    verify(mockRealTransport).newStream(same(method), same(headers), same(callOptions));
+    verify(mockRealTransport).newStream(
+        same(method), same(headers), same(callOptions),
+        ArgumentMatchers.<ClientStreamTracer[]>any());
     verify(mockRealStream).start(listenerCaptor.capture());
     verifyNoMoreInteractions(streamListener);
     listenerCaptor.getValue().onReady();
@@ -154,7 +167,7 @@ public class DelayedClientTransportTest {
   }
 
   @Test public void newStreamThenAssignTransportThenShutdown() {
-    ClientStream stream = delayedTransport.newStream(method, headers, callOptions);
+    ClientStream stream = delayedTransport.newStream(method, headers, callOptions, tracers);
     assertEquals(1, delayedTransport.getPendingStreamsCount());
     assertTrue(stream instanceof DelayedStream);
     delayedTransport.reprocess(mockPicker);
@@ -163,7 +176,9 @@ public class DelayedClientTransportTest {
     verify(transportListener).transportShutdown(same(SHUTDOWN_STATUS));
     verify(transportListener).transportTerminated();
     assertEquals(0, fakeExecutor.runDueTasks());
-    verify(mockRealTransport).newStream(same(method), same(headers), same(callOptions));
+    verify(mockRealTransport).newStream(
+        same(method), same(headers), same(callOptions),
+        ArgumentMatchers.<ClientStreamTracer[]>any());
     stream.start(streamListener);
     verify(mockRealStream).start(same(streamListener));
   }
@@ -181,11 +196,13 @@ public class DelayedClientTransportTest {
     delayedTransport.shutdown(SHUTDOWN_STATUS);
     verify(transportListener).transportShutdown(same(SHUTDOWN_STATUS));
     verify(transportListener).transportTerminated();
-    ClientStream stream = delayedTransport.newStream(method, headers, callOptions);
+    ClientStream stream = delayedTransport.newStream(
+        method, headers, callOptions, tracers);
     assertEquals(0, delayedTransport.getPendingStreamsCount());
     assertTrue(stream instanceof FailingClientStream);
     verify(mockRealTransport, never()).newStream(
-        any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class));
+        any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class),
+        ArgumentMatchers.<ClientStreamTracer[]>any());
   }
 
   @Test public void assignTransportThenShutdownNowThenNewStream() {
@@ -193,15 +210,18 @@ public class DelayedClientTransportTest {
     delayedTransport.shutdownNow(Status.UNAVAILABLE);
     verify(transportListener).transportShutdown(any(Status.class));
     verify(transportListener).transportTerminated();
-    ClientStream stream = delayedTransport.newStream(method, headers, callOptions);
+    ClientStream stream = delayedTransport.newStream(
+        method, headers, callOptions, tracers);
     assertEquals(0, delayedTransport.getPendingStreamsCount());
     assertTrue(stream instanceof FailingClientStream);
     verify(mockRealTransport, never()).newStream(
-        any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class));
+        any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class),
+        ArgumentMatchers.<ClientStreamTracer[]>any());
   }
 
   @Test public void startThenCancelStreamWithoutSetTransport() {
-    ClientStream stream = delayedTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+    ClientStream stream = delayedTransport.newStream(
+        method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(streamListener);
     assertEquals(1, delayedTransport.getPendingStreamsCount());
     stream.cancel(Status.CANCELLED);
@@ -213,7 +233,8 @@ public class DelayedClientTransportTest {
   }
 
   @Test public void newStreamThenShutdownTransportThenAssignTransport() {
-    ClientStream stream = delayedTransport.newStream(method, headers, callOptions);
+    ClientStream stream = delayedTransport.newStream(
+        method, headers, callOptions, tracers);
     stream.start(streamListener);
     delayedTransport.shutdown(SHUTDOWN_STATUS);
 
@@ -225,7 +246,8 @@ public class DelayedClientTransportTest {
     // ... and will proceed if a real transport is available
     delayedTransport.reprocess(mockPicker);
     fakeExecutor.runDueTasks();
-    verify(mockRealTransport).newStream(method, headers, callOptions);
+    verify(mockRealTransport).newStream(
+        method, headers, callOptions, tracers);
     verify(mockRealStream).start(any(ClientStreamListener.class));
 
     // Since no more streams are pending, delayed transport is now terminated
@@ -233,7 +255,8 @@ public class DelayedClientTransportTest {
     verify(transportListener).transportTerminated();
 
     // Further newStream() will return a failing stream
-    stream = delayedTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+    stream = delayedTransport.newStream(
+        method, new Metadata(), CallOptions.DEFAULT, tracers);
     verify(streamListener, never()).closed(
         any(Status.class), any(RpcProgress.class), any(Metadata.class));
     stream.start(streamListener);
@@ -247,7 +270,8 @@ public class DelayedClientTransportTest {
   }
 
   @Test public void newStreamThenShutdownTransportThenCancelStream() {
-    ClientStream stream = delayedTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+    ClientStream stream = delayedTransport.newStream(
+        method, new Metadata(), CallOptions.DEFAULT, tracers);
     delayedTransport.shutdown(SHUTDOWN_STATUS);
     verify(transportListener).transportShutdown(same(SHUTDOWN_STATUS));
     verify(transportListener, times(0)).transportTerminated();
@@ -264,7 +288,8 @@ public class DelayedClientTransportTest {
     delayedTransport.shutdown(SHUTDOWN_STATUS);
     verify(transportListener).transportShutdown(same(SHUTDOWN_STATUS));
     verify(transportListener).transportTerminated();
-    ClientStream stream = delayedTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+    ClientStream stream = delayedTransport.newStream(
+        method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(streamListener);
     verify(streamListener).closed(
         statusCaptor.capture(), any(RpcProgress.class), any(Metadata.class));
@@ -272,7 +297,8 @@ public class DelayedClientTransportTest {
   }
 
   @Test public void startStreamThenShutdownNow() {
-    ClientStream stream = delayedTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+    ClientStream stream = delayedTransport.newStream(
+        method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(streamListener);
     delayedTransport.shutdownNow(Status.UNAVAILABLE);
     verify(transportListener).transportShutdown(any(Status.class));
@@ -286,7 +312,8 @@ public class DelayedClientTransportTest {
     delayedTransport.shutdownNow(Status.UNAVAILABLE);
     verify(transportListener).transportShutdown(any(Status.class));
     verify(transportListener).transportTerminated();
-    ClientStream stream = delayedTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+    ClientStream stream = delayedTransport.newStream(
+        method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(streamListener);
     verify(streamListener).closed(
         statusCaptor.capture(), any(RpcProgress.class), any(Metadata.class));
@@ -301,55 +328,59 @@ public class DelayedClientTransportTest {
     AbstractSubchannel subchannel1 = mock(AbstractSubchannel.class);
     AbstractSubchannel subchannel2 = mock(AbstractSubchannel.class);
     AbstractSubchannel subchannel3 = mock(AbstractSubchannel.class);
-    when(mockRealTransport.newStream(any(MethodDescriptor.class), any(Metadata.class),
-        any(CallOptions.class))).thenReturn(mockRealStream);
-    when(mockRealTransport2.newStream(any(MethodDescriptor.class), any(Metadata.class),
-        any(CallOptions.class))).thenReturn(mockRealStream2);
+    when(mockRealTransport.newStream(
+            any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class),
+            ArgumentMatchers.<ClientStreamTracer[]>any()))
+        .thenReturn(mockRealStream);
+    when(mockRealTransport2.newStream(
+            any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class),
+            ArgumentMatchers.<ClientStreamTracer[]>any()))
+        .thenReturn(mockRealStream2);
     when(subchannel1.getInternalSubchannel()).thenReturn(newTransportProvider(mockRealTransport));
     when(subchannel2.getInternalSubchannel()).thenReturn(newTransportProvider(mockRealTransport2));
     when(subchannel3.getInternalSubchannel()).thenReturn(newTransportProvider(null));
 
     // Fail-fast streams
     DelayedStream ff1 = (DelayedStream) delayedTransport.newStream(
-        method, headers, failFastCallOptions);
+        method, headers, failFastCallOptions, tracers);
     ff1.start(mock(ClientStreamListener.class));
     ff1.halfClose();
     PickSubchannelArgsImpl ff1args = new PickSubchannelArgsImpl(method, headers,
         failFastCallOptions);
     verify(transportListener).transportInUse(true);
     DelayedStream ff2 = (DelayedStream) delayedTransport.newStream(
-        method2, headers2, failFastCallOptions);
+        method2, headers2, failFastCallOptions, tracers);
     PickSubchannelArgsImpl ff2args = new PickSubchannelArgsImpl(method2, headers2,
         failFastCallOptions);
     DelayedStream ff3 = (DelayedStream) delayedTransport.newStream(
-        method, headers, failFastCallOptions);
+        method, headers, failFastCallOptions, tracers);
     PickSubchannelArgsImpl ff3args = new PickSubchannelArgsImpl(method, headers,
         failFastCallOptions);
     DelayedStream ff4 = (DelayedStream) delayedTransport.newStream(
-        method2, headers2, failFastCallOptions);
+        method2, headers2, failFastCallOptions, tracers);
     PickSubchannelArgsImpl ff4args = new PickSubchannelArgsImpl(method2, headers2,
         failFastCallOptions);
 
     // Wait-for-ready streams
     FakeClock wfr3Executor = new FakeClock();
     DelayedStream wfr1 = (DelayedStream) delayedTransport.newStream(
-        method, headers, waitForReadyCallOptions);
+        method, headers, waitForReadyCallOptions, tracers);
     PickSubchannelArgsImpl wfr1args = new PickSubchannelArgsImpl(method, headers,
         waitForReadyCallOptions);
     DelayedStream wfr2 = (DelayedStream) delayedTransport.newStream(
-        method2, headers2, waitForReadyCallOptions);
+        method2, headers2, waitForReadyCallOptions, tracers);
     PickSubchannelArgsImpl wfr2args = new PickSubchannelArgsImpl(method2, headers2,
         waitForReadyCallOptions);
     CallOptions wfr3callOptions = waitForReadyCallOptions.withExecutor(
         wfr3Executor.getScheduledExecutorService());
     DelayedStream wfr3 = (DelayedStream) delayedTransport.newStream(
-        method, headers, wfr3callOptions);
+        method, headers, wfr3callOptions, tracers);
     wfr3.start(mock(ClientStreamListener.class));
     wfr3.halfClose();
     PickSubchannelArgsImpl wfr3args = new PickSubchannelArgsImpl(method, headers,
         wfr3callOptions);
     DelayedStream wfr4 = (DelayedStream) delayedTransport.newStream(
-        method2, headers2, waitForReadyCallOptions);
+        method2, headers2, waitForReadyCallOptions, tracers);
     PickSubchannelArgsImpl wfr4args = new PickSubchannelArgsImpl(method2, headers2,
         waitForReadyCallOptions);
 
@@ -386,8 +417,10 @@ public class DelayedClientTransportTest {
     // streams are now owned by a real transport (which should prevent the Channel from
     // terminating).
     // ff1 and wfr1 went through
-    verify(mockRealTransport).newStream(method, headers, failFastCallOptions);
-    verify(mockRealTransport2).newStream(method, headers, waitForReadyCallOptions);
+    verify(mockRealTransport).newStream(
+        method, headers, failFastCallOptions, tracers);
+    verify(mockRealTransport2).newStream(
+        method, headers, waitForReadyCallOptions, tracers);
     assertSame(mockRealStream, ff1.getRealStream());
     assertSame(mockRealStream2, wfr1.getRealStream());
     verify(mockRealStream).start(any(ClientStreamListener.class));
@@ -443,7 +476,7 @@ public class DelayedClientTransportTest {
 
     // New streams will use the last picker
     DelayedStream wfr5 = (DelayedStream) delayedTransport.newStream(
-        method, headers, waitForReadyCallOptions);
+        method, headers, waitForReadyCallOptions, tracers);
     assertNull(wfr5.getRealStream());
     inOrder.verify(picker).pickSubchannel(
         new PickSubchannelArgsImpl(method, headers, waitForReadyCallOptions));
@@ -474,14 +507,17 @@ public class DelayedClientTransportTest {
     when(subchannel.getInternalSubchannel()).thenReturn(mockInternalSubchannel);
     when(picker.pickSubchannel(any(PickSubchannelArgs.class))).thenReturn(
         PickResult.withSubchannel(subchannel));
-    when(mockRealTransport.newStream(any(MethodDescriptor.class), any(Metadata.class),
-            any(CallOptions.class))).thenReturn(mockRealStream);
+    when(mockRealTransport.newStream(
+            any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class),
+            ArgumentMatchers.<ClientStreamTracer[]>any()))
+        .thenReturn(mockRealStream);
     delayedTransport.reprocess(picker);
     verifyNoMoreInteractions(picker);
     verifyNoMoreInteractions(transportListener);
 
     // Though picker was not originally used, it will be saved and serve future streams.
-    ClientStream stream = delayedTransport.newStream(method, headers, CallOptions.DEFAULT);
+    ClientStream stream = delayedTransport.newStream(
+        method, headers, CallOptions.DEFAULT, tracers);
     verify(picker).pickSubchannel(new PickSubchannelArgsImpl(method, headers, CallOptions.DEFAULT));
     verify(mockInternalSubchannel).obtainActiveTransport();
     assertSame(mockRealStream, stream);
@@ -519,7 +555,7 @@ public class DelayedClientTransportTest {
         @Override
         public void run() {
           // Will call pickSubchannel and wait on barrier
-          delayedTransport.newStream(method, headers, callOptions);
+          delayedTransport.newStream(method, headers, callOptions, tracers);
         }
       };
     sideThread.start();
@@ -552,7 +588,7 @@ public class DelayedClientTransportTest {
         @Override
         public void run() {
           // Will call pickSubchannel and wait on barrier
-          delayedTransport.newStream(method, headers2, callOptions);
+          delayedTransport.newStream(method, headers2, callOptions, tracers);
         }
       };
     sideThread2.start();
@@ -600,7 +636,8 @@ public class DelayedClientTransportTest {
     // Because there is no pending stream yet, it will do nothing but save the picker.
     delayedTransport.reprocess(picker);
 
-    ClientStream stream = delayedTransport.newStream(method, headers, callOptions);
+    ClientStream stream = delayedTransport.newStream(
+        method, headers, callOptions, tracers);
     stream.start(streamListener);
     assertTrue(delayedTransport.hasPendingStreams());
     verify(transportListener).transportInUse(true);
@@ -609,7 +646,7 @@ public class DelayedClientTransportTest {
   @Test
   public void pendingStream_appendTimeoutInsight_waitForReady() {
     ClientStream stream = delayedTransport.newStream(
-        method, headers, callOptions.withWaitForReady());
+        method, headers, callOptions.withWaitForReady(), tracers);
     stream.start(streamListener);
     InsightBuilder insight = new InsightBuilder();
     stream.appendTimeoutInsight(insight);

--- a/core/src/test/java/io/grpc/internal/FailingClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/FailingClientStreamTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import io.grpc.ClientStreamTracer;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.ClientStreamListener.RpcProgress;
@@ -33,13 +34,16 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class FailingClientStreamTest {
+  private final ClientStreamTracer[] tracers = new ClientStreamTracer[] {
+      new ClientStreamTracer() {}
+  };
 
   @Test
   public void processedRpcProgressPopulatedToListener() {
     ClientStreamListener listener = mock(ClientStreamListener.class);
     Status status = Status.UNAVAILABLE;
 
-    ClientStream stream = new FailingClientStream(status);
+    ClientStream stream = new FailingClientStream(status, RpcProgress.PROCESSED, tracers);
     stream.start(listener);
     verify(listener).closed(eq(status), eq(RpcProgress.PROCESSED), any(Metadata.class));
   }
@@ -49,7 +53,7 @@ public class FailingClientStreamTest {
     ClientStreamListener listener = mock(ClientStreamListener.class);
     Status status = Status.UNAVAILABLE;
 
-    ClientStream stream = new FailingClientStream(status, RpcProgress.DROPPED);
+    ClientStream stream = new FailingClientStream(status, RpcProgress.DROPPED, tracers);
     stream.start(listener);
     verify(listener).closed(eq(status), eq(RpcProgress.DROPPED), any(Metadata.class));
   }

--- a/core/src/test/java/io/grpc/internal/FailingClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/FailingClientTransportTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import io.grpc.CallOptions;
+import io.grpc.ClientStreamTracer;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.ClientStreamListener.RpcProgress;
@@ -41,8 +42,9 @@ public class FailingClientTransportTest {
     Status error = Status.UNAVAILABLE;
     RpcProgress rpcProgress = RpcProgress.DROPPED;
     FailingClientTransport transport = new FailingClientTransport(error, rpcProgress);
-    ClientStream stream = transport
-        .newStream(TestMethodDescriptors.voidMethod(), new Metadata(), CallOptions.DEFAULT);
+    ClientStream stream = transport.newStream(
+        TestMethodDescriptors.voidMethod(), new Metadata(), CallOptions.DEFAULT,
+        new ClientStreamTracer[] { new ClientStreamTracer() {} });
     ClientStreamListener listener = mock(ClientStreamListener.class);
     stream.start(listener);
 

--- a/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
+++ b/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import io.grpc.CallOptions;
+import io.grpc.ClientStreamTracer;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.Metadata;
 import io.grpc.Status;
@@ -43,6 +44,10 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link GrpcUtil}. */
 @RunWith(JUnit4.class)
 public class GrpcUtilTest {
+
+  private final ClientStreamTracer[] tracers = new ClientStreamTracer[] {
+      new ClientStreamTracer() {}
+  };
 
   @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule public final ExpectedException thrown = ExpectedException.none();
@@ -244,8 +249,9 @@ public class GrpcUtilTest {
 
     assertNotNull(transport);
 
-    ClientStream stream = transport
-        .newStream(TestMethodDescriptors.voidMethod(), new Metadata(), CallOptions.DEFAULT);
+    ClientStream stream = transport.newStream(
+        TestMethodDescriptors.voidMethod(), new Metadata(), CallOptions.DEFAULT,
+        tracers);
     ClientStreamListener listener = mock(ClientStreamListener.class);
     stream.start(listener);
 
@@ -260,8 +266,9 @@ public class GrpcUtilTest {
 
     assertNotNull(transport);
 
-    ClientStream stream = transport
-        .newStream(TestMethodDescriptors.voidMethod(), new Metadata(), CallOptions.DEFAULT);
+    ClientStream stream = transport.newStream(
+        TestMethodDescriptors.voidMethod(), new Metadata(), CallOptions.DEFAULT,
+        tracers);
     ClientStreamListener listener = mock(ClientStreamListener.class);
     stream.start(listener);
 
@@ -276,8 +283,9 @@ public class GrpcUtilTest {
 
     assertNotNull(transport);
 
-    ClientStream stream = transport
-        .newStream(TestMethodDescriptors.voidMethod(), new Metadata(), CallOptions.DEFAULT);
+    ClientStream stream = transport.newStream(
+        TestMethodDescriptors.voidMethod(), new Metadata(), CallOptions.DEFAULT,
+        tracers);
     ClientStreamListener listener = mock(ClientStreamListener.class);
     stream.start(listener);
 

--- a/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
@@ -163,9 +163,10 @@ public class RetriableStreamTest {
     }
 
     @Override
-    ClientStream newSubstream(ClientStreamTracer.Factory tracerFactory, Metadata metadata) {
+    ClientStream newSubstream(
+        Metadata metadata, ClientStreamTracer.Factory tracerFactory, boolean isTransparentRetry) {
       bufferSizeTracer =
-          tracerFactory.newClientStreamTracer(STREAM_INFO, new Metadata());
+          tracerFactory.newClientStreamTracer(STREAM_INFO);
       int actualPreviousRpcAttemptsInHeader = metadata.get(GRPC_PREVIOUS_RPC_ATTEMPTS) == null
           ? 0 : Integer.valueOf(metadata.get(GRPC_PREVIOUS_RPC_ATTEMPTS));
       return retriableStreamRecorder.newSubstream(actualPreviousRpcAttemptsInHeader);

--- a/core/src/test/java/io/grpc/internal/TestUtils.java
+++ b/core/src/test/java/io/grpc/internal/TestUtils.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 import io.grpc.CallOptions;
 import io.grpc.ChannelLogger;
+import io.grpc.ClientStreamTracer;
 import io.grpc.InternalLogId;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
@@ -35,6 +36,7 @@ import java.net.SocketAddress;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import javax.annotation.Nullable;
+import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -118,7 +120,8 @@ public final class TestUtils {
         when(mockTransport.getLogId())
             .thenReturn(InternalLogId.allocate("mocktransport", /*details=*/ null));
         when(mockTransport.newStream(
-                any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class)))
+                any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class),
+                ArgumentMatchers.<ClientStreamTracer[]>any()))
             .thenReturn(mock(ClientStream.class));
         // Save the listener
         doAnswer(new Answer<Runnable>() {

--- a/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
+import io.grpc.ClientStreamTracer;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalLogId;
 import io.grpc.Metadata;
@@ -118,7 +119,7 @@ class CronetClientTransport implements ConnectionClientTransport {
 
   @Override
   public CronetClientStream newStream(final MethodDescriptor<?, ?> method, final Metadata headers,
-      final CallOptions callOptions) {
+      final CallOptions callOptions, ClientStreamTracer[] tracers) {
     Preconditions.checkNotNull(method, "method");
     Preconditions.checkNotNull(headers, "headers");
 
@@ -126,7 +127,7 @@ class CronetClientTransport implements ConnectionClientTransport {
     final String url = "https://" + authority + defaultPath;
 
     final StatsTraceContext statsTraceCtx =
-        StatsTraceContext.newClientContext(callOptions, attrs, headers);
+        StatsTraceContext.newClientContext(tracers, attrs, headers);
     class StartCallback implements Runnable {
       final CronetClientStream clientStream = new CronetClientStream(
           url, userAgent, executor, headers, CronetClientTransport.this, this, lock, maxMessageSize,

--- a/cronet/src/test/java/io/grpc/cronet/CronetChannelBuilderTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetChannelBuilderTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import android.os.Build;
 import io.grpc.CallOptions;
 import io.grpc.ChannelLogger;
+import io.grpc.ClientStreamTracer;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.cronet.CronetChannelBuilder.CronetTransportFactory;
@@ -50,6 +51,8 @@ public final class CronetChannelBuilderTest {
   @Mock private ExperimentalCronetEngine mockEngine;
   @Mock private ChannelLogger channelLogger;
 
+  private final ClientStreamTracer[] tracers =
+      new ClientStreamTracer[]{ new ClientStreamTracer() {} };
   private MethodDescriptor<?, ?> method = TestMethodDescriptors.voidMethod();
 
   @Before
@@ -69,7 +72,8 @@ public final class CronetChannelBuilderTest {
                 new InetSocketAddress("localhost", 443),
                 new ClientTransportOptions(),
                 channelLogger);
-    CronetClientStream stream = transport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+    CronetClientStream stream = transport.newStream(
+        method, new Metadata(), CallOptions.DEFAULT, tracers);
 
     assertTrue(stream.idempotent);
   }
@@ -85,7 +89,8 @@ public final class CronetChannelBuilderTest {
                 new InetSocketAddress("localhost", 443),
                 new ClientTransportOptions(),
                 channelLogger);
-    CronetClientStream stream = transport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+    CronetClientStream stream = transport.newStream(
+        method, new Metadata(), CallOptions.DEFAULT, tracers);
 
     assertFalse(stream.idempotent);
   }

--- a/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import android.os.Build;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
+import io.grpc.ClientStreamTracer;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.SecurityLevel;
@@ -60,6 +61,8 @@ public final class CronetClientTransportTest {
   private static final Attributes EAG_ATTRS =
       Attributes.newBuilder().set(EAG_ATTR_KEY, "value").build();
 
+  private final ClientStreamTracer[] tracers =
+      new ClientStreamTracer[]{ new ClientStreamTracer() {} };
   private CronetClientTransport transport;
   @Mock private StreamBuilderFactory streamFactory;
   @Mock private Executor executor;
@@ -101,9 +104,9 @@ public final class CronetClientTransportTest {
   @Test
   public void shutdownTransport() throws Exception {
     CronetClientStream stream1 =
-        transport.newStream(descriptor, new Metadata(), CallOptions.DEFAULT);
+        transport.newStream(descriptor, new Metadata(), CallOptions.DEFAULT, tracers);
     CronetClientStream stream2 =
-        transport.newStream(descriptor, new Metadata(), CallOptions.DEFAULT);
+        transport.newStream(descriptor, new Metadata(), CallOptions.DEFAULT, tracers);
 
     // Create a transport and start two streams on it.
     ArgumentCaptor<BidirectionalStream.Callback> callbackCaptor =
@@ -137,7 +140,7 @@ public final class CronetClientTransportTest {
   @Test
   public void startStreamAfterShutdown() throws Exception {
     CronetClientStream stream =
-        transport.newStream(descriptor, new Metadata(), CallOptions.DEFAULT);
+        transport.newStream(descriptor, new Metadata(), CallOptions.DEFAULT, tracers);
     transport.shutdown();
     BaseClientStreamListener listener = new BaseClientStreamListener();
     stream.start(listener);

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbClientLoadRecorder.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbClientLoadRecorder.java
@@ -73,8 +73,7 @@ final class GrpclbClientLoadRecorder extends ClientStreamTracer.Factory {
   }
 
   @Override
-  public ClientStreamTracer newClientStreamTracer(
-      ClientStreamTracer.StreamInfo info, Metadata headers) {
+  public ClientStreamTracer newClientStreamTracer(ClientStreamTracer.StreamInfo info) {
     callsStartedUpdater.getAndIncrement(this);
     return new StreamTracer();
   }

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbClientLoadRecorder.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbClientLoadRecorder.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.protobuf.util.Timestamps;
 import io.grpc.ClientStreamTracer;
-import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.TimeProvider;
 import io.grpc.lb.v1.ClientStats;

--- a/grpclb/src/main/java/io/grpc/grpclb/TokenAttachingTracerFactory.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/TokenAttachingTracerFactory.java
@@ -61,6 +61,7 @@ final class TokenAttachingTracerFactory extends ClientStreamTracer.Factory {
         if (token != null) {
           headers.put(GrpclbConstants.TOKEN_METADATA_KEY, token);
         }
+        delegate().streamCreated(transportAttrs, headers);
       }
     }
 

--- a/grpclb/src/main/java/io/grpc/grpclb/TokenAttachingTracerFactory.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/TokenAttachingTracerFactory.java
@@ -23,6 +23,7 @@ import io.grpc.Attributes;
 import io.grpc.ClientStreamTracer;
 import io.grpc.Metadata;
 import io.grpc.internal.GrpcAttributes;
+import io.grpc.util.ForwardingClientStreamTracer;
 import javax.annotation.Nullable;
 
 /**
@@ -40,21 +41,30 @@ final class TokenAttachingTracerFactory extends ClientStreamTracer.Factory {
   }
 
   @Override
-  public ClientStreamTracer newClientStreamTracer(
-      ClientStreamTracer.StreamInfo info, Metadata headers) {
-    Attributes transportAttrs = checkNotNull(info.getTransportAttrs(), "transportAttrs");
-    Attributes eagAttrs =
-        checkNotNull(transportAttrs.get(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS), "eagAttrs");
-    String token = eagAttrs.get(GrpclbConstants.TOKEN_ATTRIBUTE_KEY);
-    headers.discardAll(GrpclbConstants.TOKEN_METADATA_KEY);
-    if (token != null) {
-      headers.put(GrpclbConstants.TOKEN_METADATA_KEY, token);
-    }
-    if (delegate != null) {
-      return delegate.newClientStreamTracer(info, headers);
-    } else {
+  public ClientStreamTracer newClientStreamTracer(ClientStreamTracer.StreamInfo info) {
+    if (delegate == null) {
       return NOOP_TRACER;
     }
+    final ClientStreamTracer clientStreamTracer = delegate.newClientStreamTracer(info);
+    class TokenPropagationTracer extends ForwardingClientStreamTracer {
+      @Override
+      protected ClientStreamTracer delegate() {
+        return clientStreamTracer;
+      }
+
+      @Override
+      public void streamCreated(Attributes transportAttrs, Metadata headers) {
+        Attributes eagAttrs =
+            checkNotNull(transportAttrs.get(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS), "eagAttrs");
+        String token = eagAttrs.get(GrpclbConstants.TOKEN_ATTRIBUTE_KEY);
+        headers.discardAll(GrpclbConstants.TOKEN_METADATA_KEY);
+        if (token != null) {
+          headers.put(GrpclbConstants.TOKEN_METADATA_KEY, token);
+        }
+      }
+    }
+
+    return new TokenPropagationTracer();
   }
 
   @Override

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -480,7 +480,8 @@ public class GrpclbLoadBalancerTest {
         ClientStats.newBuilder().build());
 
     ClientStreamTracer tracer1 =
-        pick1.getStreamTracerFactory().newClientStreamTracer(STREAM_INFO, new Metadata());
+        pick1.getStreamTracerFactory().newClientStreamTracer(STREAM_INFO);
+    tracer1.streamCreated(Attributes.EMPTY, new Metadata());
 
     PickResult pick2 = picker.pickSubchannel(args);
     assertNull(pick2.getSubchannel());
@@ -503,7 +504,8 @@ public class GrpclbLoadBalancerTest {
     assertSame(subchannel2, pick3.getSubchannel());
     assertSame(getLoadRecorder(), pick3.getStreamTracerFactory());
     ClientStreamTracer tracer3 =
-        pick3.getStreamTracerFactory().newClientStreamTracer(STREAM_INFO, new Metadata());
+        pick3.getStreamTracerFactory().newClientStreamTracer(STREAM_INFO);
+    tracer3.streamCreated(Attributes.EMPTY, new Metadata());
 
     // pick3 has sent out headers
     tracer3.outboundHeaders();
@@ -540,7 +542,8 @@ public class GrpclbLoadBalancerTest {
     assertSame(subchannel1, pick1.getSubchannel());
     assertSame(getLoadRecorder(), pick5.getStreamTracerFactory());
     ClientStreamTracer tracer5 =
-        pick5.getStreamTracerFactory().newClientStreamTracer(STREAM_INFO, new Metadata());
+        pick5.getStreamTracerFactory().newClientStreamTracer(STREAM_INFO);
+    tracer5.streamCreated(Attributes.EMPTY, new Metadata());
 
     // pick3 ended without receiving response headers
     tracer3.streamClosed(Status.DEADLINE_EXCEEDED);
@@ -615,7 +618,7 @@ public class GrpclbLoadBalancerTest {
     PickResult pick1p = picker.pickSubchannel(args);
     assertSame(subchannel1, pick1p.getSubchannel());
     assertSame(getLoadRecorder(), pick1p.getStreamTracerFactory());
-    pick1p.getStreamTracerFactory().newClientStreamTracer(STREAM_INFO, new Metadata());
+    pick1p.getStreamTracerFactory().newClientStreamTracer(STREAM_INFO);
 
     // The pick from the new stream will be included in the report
     assertNextReport(

--- a/grpclb/src/test/java/io/grpc/grpclb/TokenAttachingTracerFactoryTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/TokenAttachingTracerFactoryTest.java
@@ -33,7 +33,18 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link TokenAttachingTracerFactory}. */
 @RunWith(JUnit4.class)
 public class TokenAttachingTracerFactoryTest {
-  private static final ClientStreamTracer fakeTracer = new ClientStreamTracer() {};
+  private static final class FakeClientStreamTracer extends ClientStreamTracer {
+    Attributes transportAttrs;
+    Metadata headers;
+
+    @Override
+    public void streamCreated(Attributes transportAttrs, Metadata headers) {
+      this.transportAttrs = transportAttrs;
+      this.headers = headers;
+    }
+  }
+
+  private static final FakeClientStreamTracer fakeTracer = new FakeClientStreamTracer();
 
   private final ClientStreamTracer.Factory delegate = mock(
       ClientStreamTracer.Factory.class,
@@ -41,7 +52,7 @@ public class TokenAttachingTracerFactoryTest {
           new ClientStreamTracer.Factory() {
             @Override
             public ClientStreamTracer newClientStreamTracer(
-                ClientStreamTracer.StreamInfo info, Metadata headers) {
+                ClientStreamTracer.StreamInfo info) {
               return fakeTracer;
             }
           }));
@@ -51,51 +62,51 @@ public class TokenAttachingTracerFactoryTest {
     TokenAttachingTracerFactory factory = new TokenAttachingTracerFactory(delegate);
     Attributes eagAttrs = Attributes.newBuilder()
         .set(GrpclbConstants.TOKEN_ATTRIBUTE_KEY, "token0001").build();
-    ClientStreamTracer.StreamInfo info = ClientStreamTracer.StreamInfo.newBuilder()
-        .setTransportAttrs(
-            Attributes.newBuilder().set(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS, eagAttrs).build())
-        .build();
+    ClientStreamTracer.StreamInfo info = ClientStreamTracer.StreamInfo.newBuilder().build();
     Metadata headers = new Metadata();
     // Preexisting token should be replaced
     headers.put(GrpclbConstants.TOKEN_METADATA_KEY, "preexisting-token");
 
-    ClientStreamTracer tracer = factory.newClientStreamTracer(info, headers);
-    verify(delegate).newClientStreamTracer(same(info), same(headers));
-    assertThat(tracer).isSameInstanceAs(fakeTracer);
+    ClientStreamTracer tracer = factory.newClientStreamTracer(info);
+    verify(delegate).newClientStreamTracer(same(info));
+    Attributes transportAttrs =
+        Attributes.newBuilder().set(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS, eagAttrs).build();
+    tracer.streamCreated(transportAttrs, headers);
+    assertThat(fakeTracer.transportAttrs).isSameInstanceAs(transportAttrs);
+    assertThat(fakeTracer.headers).isSameInstanceAs(headers);
     assertThat(headers.getAll(GrpclbConstants.TOKEN_METADATA_KEY)).containsExactly("token0001");
   }
 
   @Test
   public void noToken() {
     TokenAttachingTracerFactory factory = new TokenAttachingTracerFactory(delegate);
-    ClientStreamTracer.StreamInfo info = ClientStreamTracer.StreamInfo.newBuilder()
-        .setTransportAttrs(
-            Attributes.newBuilder()
-                .set(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS, Attributes.EMPTY).build())
-        .build();
+    ClientStreamTracer.StreamInfo info = ClientStreamTracer.StreamInfo.newBuilder().build();
 
     Metadata headers = new Metadata();
     // Preexisting token should be removed
     headers.put(GrpclbConstants.TOKEN_METADATA_KEY, "preexisting-token");
 
-    ClientStreamTracer tracer = factory.newClientStreamTracer(info, headers);
-    verify(delegate).newClientStreamTracer(same(info), same(headers));
-    assertThat(tracer).isSameInstanceAs(fakeTracer);
+    ClientStreamTracer tracer = factory.newClientStreamTracer(info);
+    verify(delegate).newClientStreamTracer(same(info));
+    Attributes transportAttrs =
+        Attributes.newBuilder().set(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS, Attributes.EMPTY).build();
+    tracer.streamCreated(transportAttrs, headers);
+    assertThat(fakeTracer.transportAttrs).isSameInstanceAs(transportAttrs);
+    assertThat(fakeTracer.headers).isSameInstanceAs(headers);
     assertThat(headers.get(GrpclbConstants.TOKEN_METADATA_KEY)).isNull();
   }
 
   @Test
   public void nullDelegate() {
     TokenAttachingTracerFactory factory = new TokenAttachingTracerFactory(null);
-    ClientStreamTracer.StreamInfo info = ClientStreamTracer.StreamInfo.newBuilder()
-        .setTransportAttrs(
-            Attributes.newBuilder()
-                .set(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS, Attributes.EMPTY).build())
-        .build();
+    ClientStreamTracer.StreamInfo info = ClientStreamTracer.StreamInfo.newBuilder().build();
 
     Metadata headers = new Metadata();
 
-    ClientStreamTracer tracer = factory.newClientStreamTracer(info, headers);
+    ClientStreamTracer tracer = factory.newClientStreamTracer(info);
+    tracer.streamCreated(
+        Attributes.newBuilder().set(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS, Attributes.EMPTY).build(),
+        headers);
     assertThat(tracer).isNotNull();
     assertThat(headers.get(GrpclbConstants.TOKEN_METADATA_KEY)).isNull();
   }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -292,7 +292,7 @@ public abstract class AbstractInteropTest {
       new ClientStreamTracer.Factory() {
         @Override
         public ClientStreamTracer newClientStreamTracer(
-            ClientStreamTracer.StreamInfo info, Metadata headers) {
+            ClientStreamTracer.StreamInfo info) {
           TestClientStreamTracer tracer = new TestClientStreamTracer();
           clientStreamTracers.add(tracer);
           return tracer;
@@ -375,7 +375,9 @@ public abstract class AbstractInteropTest {
             .getClientInterceptor(
                 tagger, tagContextBinarySerializer, clientStatsRecorder,
                 GrpcUtil.STOPWATCH_SUPPLIER,
-                true, true, true, false /* real-time metrics */);
+                true, true, true,
+                /* recordRealTimeMetrics= */ false,
+                /* retryEnabled= */ false);
   }
 
   protected final ServerStreamTracer.Factory createCustomCensusTracerFactory() {
@@ -1179,6 +1181,7 @@ public abstract class AbstractInteropTest {
   public void deadlineExceededServerStreaming() throws Exception {
     // warm up the channel and JVM
     blockingStub.emptyCall(Empty.getDefaultInstance());
+    assertStatsTrace("grpc.testing.TestService/EmptyCall", Status.Code.OK);
     ResponseParameters.Builder responseParameters = ResponseParameters.newBuilder()
         .setSize(1)
         .setIntervalUs(10000);
@@ -1195,7 +1198,6 @@ public abstract class AbstractInteropTest {
     recorder.awaitCompletion();
     assertEquals(Status.DEADLINE_EXCEEDED.getCode(),
         Status.fromThrowable(recorder.getError()).getCode());
-    assertStatsTrace("grpc.testing.TestService/EmptyCall", Status.Code.OK);
     if (metricsExpected()) {
       // Stream may not have been created when deadline is exceeded, thus we don't check tracer
       // stats.
@@ -1239,6 +1241,12 @@ public abstract class AbstractInteropTest {
 
     // warm up the channel
     blockingStub.emptyCall(Empty.getDefaultInstance());
+    if (metricsExpected()) {
+      // clientStartRecord
+      clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
+      // clientEndRecord
+      clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
+    }
     try {
       blockingStub
           .withDeadlineAfter(-10, TimeUnit.SECONDS)
@@ -1249,7 +1257,6 @@ public abstract class AbstractInteropTest {
       assertThat(ex.getStatus().getDescription())
         .startsWith("ClientCall started after deadline exceeded");
     }
-    assertStatsTrace("grpc.testing.TestService/EmptyCall", Status.Code.OK);
     if (metricsExpected()) {
       MetricsRecord clientStartRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
       checkStartTags(clientStartRecord, "grpc.testing.TestService/EmptyCall", true);

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -28,6 +28,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ChannelLogger;
+import io.grpc.ClientStreamTracer;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalLogId;
 import io.grpc.Metadata;
@@ -167,14 +168,15 @@ class NettyClientTransport implements ConnectionClientTransport {
 
   @Override
   public ClientStream newStream(
-      MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
+      MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions,
+      ClientStreamTracer[] tracers) {
     Preconditions.checkNotNull(method, "method");
     Preconditions.checkNotNull(headers, "headers");
     if (channel == null) {
-      return new FailingClientStream(statusExplainingWhyTheChannelIsNull);
+      return new FailingClientStream(statusExplainingWhyTheChannelIsNull, tracers);
     }
     StatsTraceContext statsTraceCtx =
-        StatsTraceContext.newClientContext(callOptions, getAttributes(), headers);
+        StatsTraceContext.newClientContext(tracers, getAttributes(), headers);
     return new NettyClientStream(
         new NettyClientStream.TransportState(
             handler,

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -41,6 +41,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ChannelLogger;
+import io.grpc.ClientStreamTracer;
 import io.grpc.Grpc;
 import io.grpc.InternalChannelz;
 import io.grpc.Metadata;
@@ -828,7 +829,9 @@ public class NettyClientTransportTest {
     }
 
     Rpc(NettyClientTransport transport, Metadata headers) {
-      stream = transport.newStream(METHOD, headers, CallOptions.DEFAULT);
+      stream = transport.newStream(
+          METHOD, headers, CallOptions.DEFAULT,
+          new ClientStreamTracer[]{ new ClientStreamTracer() {} });
       stream.start(listener);
       stream.request(1);
       stream.writeMessage(new ByteArrayInputStream(MESSAGE.getBytes(UTF_8)));

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -56,6 +56,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
+import io.grpc.ClientStreamTracer;
 import io.grpc.HttpConnectProxiedSocketAddress;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalChannelz.TransportStats;
@@ -148,6 +149,9 @@ public class OkHttpClientTransportTest {
   private static final Logger logger = Logger.getLogger(OkHttpClientTransport.class.getName());
 
   @Rule public final Timeout globalTimeout = Timeout.seconds(10);
+  private final ClientStreamTracer[] tracers = new ClientStreamTracer[] {
+      new ClientStreamTracer() {}
+  };
 
   private FrameWriter frameWriter;
 
@@ -299,7 +303,7 @@ public class OkHttpClientTransportTest {
 
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     stream.request(1);
 
@@ -387,7 +391,7 @@ public class OkHttpClientTransportTest {
 
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     stream.request(1);
     assertContainStream(3);
@@ -443,11 +447,11 @@ public class OkHttpClientTransportTest {
     MockStreamListener listener1 = new MockStreamListener();
     MockStreamListener listener2 = new MockStreamListener();
     OkHttpClientStream stream1 =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream1.start(listener1);
     stream1.request(1);
     OkHttpClientStream stream2 =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream2.start(listener2);
     stream2.request(1);
     assertEquals(2, activeStreamCount());
@@ -477,7 +481,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     stream.request(1);
     assertEquals(1, activeStreamCount());
@@ -498,7 +502,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     stream.request(1);
     frameReader.nextFrameAtEndOfStream();
@@ -516,7 +520,7 @@ public class OkHttpClientTransportTest {
     final String message = "Hello Client";
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     stream.request(numMessages);
     assertContainStream(3);
@@ -566,7 +570,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     stream.request(1);
     assertContainStream(3);
@@ -590,7 +594,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     stream.request(1);
     assertContainStream(3);
@@ -610,7 +614,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     assertContainStream(3);
     frameHandler().headers(true, true, 3, 0, grpcResponseTrailers(), HeadersMode.HTTP_20_HEADERS);
@@ -624,7 +628,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     assertContainStream(3);
     frameHandler().rstStream(3, ErrorCode.PROTOCOL_ERROR);
@@ -641,7 +645,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     assertContainStream(3);
     frameHandler().headers(false, false, 3, 0, grpcResponseHeaders(), HeadersMode.HTTP_20_HEADERS);
@@ -661,7 +665,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     getStream(3).cancel(Status.CANCELLED);
     verify(frameWriter, timeout(TIME_OUT_MS)).rstStream(eq(3), eq(ErrorCode.CANCEL));
@@ -676,7 +680,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     Header userAgentHeader = new Header(GrpcUtil.USER_AGENT_KEY.name(),
             GrpcUtil.getGrpcUserAgent("okhttp", null));
@@ -695,7 +699,7 @@ public class OkHttpClientTransportTest {
     startTransport(3, null, true, DEFAULT_MAX_MESSAGE_SIZE, INITIAL_WINDOW_SIZE, "fakeUserAgent");
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     List<Header> expectedHeaders = Arrays.asList(HTTP_SCHEME_HEADER, METHOD_HEADER,
         new Header(Header.TARGET_AUTHORITY, "notarealauthority:80"),
@@ -714,7 +718,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     getStream(3).cancel(Status.DEADLINE_EXCEEDED);
     verify(frameWriter, timeout(TIME_OUT_MS)).rstStream(eq(3), eq(ErrorCode.CANCEL));
@@ -728,7 +732,7 @@ public class OkHttpClientTransportTest {
     final String message = "Hello Server";
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     InputStream input = new ByteArrayInputStream(message.getBytes(UTF_8));
     assertEquals(12, input.available());
@@ -772,12 +776,12 @@ public class OkHttpClientTransportTest {
     MockStreamListener listener1 = new MockStreamListener();
     MockStreamListener listener2 = new MockStreamListener();
     OkHttpClientStream stream1 =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream1.start(listener1);
     stream1.request(2);
 
     OkHttpClientStream stream2 =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream2.start(listener2);
     stream2.request(2);
     assertEquals(2, activeStreamCount());
@@ -838,7 +842,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     int messageLength = INITIAL_WINDOW_SIZE / 2 + 1;
     byte[] fakeMessage = new byte[messageLength];
@@ -874,7 +878,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
 
     // Outbound window always starts at 65535 until changed by Settings.INITIAL_WINDOW_SIZE
@@ -920,7 +924,7 @@ public class OkHttpClientTransportTest {
 
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-            clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+            clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
 
     int messageLength = 75;
@@ -963,7 +967,7 @@ public class OkHttpClientTransportTest {
 
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-            clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+            clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
 
     int messageLength = 100000;
@@ -999,7 +1003,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     int messageLength = 20;
     setInitialWindowSize(HEADER_LENGTH + 10);
@@ -1045,7 +1049,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     int messageLength = 20;
     setInitialWindowSize(HEADER_LENGTH + 10);
@@ -1080,10 +1084,10 @@ public class OkHttpClientTransportTest {
     MockStreamListener listener1 = new MockStreamListener();
     MockStreamListener listener2 = new MockStreamListener();
     OkHttpClientStream stream1 =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream1.start(listener1);
     OkHttpClientStream stream2 =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream2.start(listener2);
     assertEquals(2, activeStreamCount());
     clientTransport.shutdown(SHUTDOWN_REASON);
@@ -1110,11 +1114,11 @@ public class OkHttpClientTransportTest {
     MockStreamListener listener1 = new MockStreamListener();
     MockStreamListener listener2 = new MockStreamListener();
     OkHttpClientStream stream1 =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream1.start(listener1);
     stream1.request(1);
     OkHttpClientStream stream2 =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream2.start(listener2);
     stream2.request(1);
     assertEquals(2, activeStreamCount());
@@ -1168,7 +1172,7 @@ public class OkHttpClientTransportTest {
 
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     stream.request(1);
 
@@ -1204,11 +1208,11 @@ public class OkHttpClientTransportTest {
     final MockStreamListener listener1 = new MockStreamListener();
     final MockStreamListener listener2 = new MockStreamListener();
     OkHttpClientStream stream1 =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream1.start(listener1);
     // The second stream should be pending.
     OkHttpClientStream stream2 =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream2.start(listener2);
     String sentMessage = "hello";
     InputStream input = new ByteArrayInputStream(sentMessage.getBytes(UTF_8));
@@ -1241,7 +1245,7 @@ public class OkHttpClientTransportTest {
     setMaxConcurrentStreams(0);
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     waitForStreamPending(1);
     stream.cancel(Status.CANCELLED);
@@ -1260,11 +1264,11 @@ public class OkHttpClientTransportTest {
     final MockStreamListener listener1 = new MockStreamListener();
     final MockStreamListener listener2 = new MockStreamListener();
     OkHttpClientStream stream1 =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream1.start(listener1);
     // The second stream should be pending.
     OkHttpClientStream stream2 =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream2.start(listener2);
 
     waitForStreamPending(1);
@@ -1290,7 +1294,7 @@ public class OkHttpClientTransportTest {
     final MockStreamListener listener = new MockStreamListener();
     // The second stream should be pending.
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     waitForStreamPending(1);
 
@@ -1314,15 +1318,15 @@ public class OkHttpClientTransportTest {
     final MockStreamListener listener3 = new MockStreamListener();
 
     OkHttpClientStream stream1 =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream1.start(listener1);
 
     // The second and third stream should be pending.
     OkHttpClientStream stream2 =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream2.start(listener2);
     OkHttpClientStream stream3 =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream3.start(listener3);
 
     waitForStreamPending(2);
@@ -1346,7 +1350,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     stream.request(1);
 
@@ -1398,7 +1402,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     verify(frameWriter, timeout(TIME_OUT_MS)).synStream(
         eq(false), eq(false), eq(3), eq(0), ArgumentMatchers.<Header>anyList());
@@ -1415,7 +1419,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     stream.request(1);
     Buffer buffer = createMessageFrame(new byte[1]);
@@ -1437,7 +1441,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     stream.request(1);
     Buffer buffer = createMessageFrame(new byte[1]);
@@ -1459,7 +1463,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     stream.request(1);
     Buffer buffer = createMessageFrame(new byte[1000]);
@@ -1480,7 +1484,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     stream.cancel(Status.CANCELLED);
 
@@ -1507,7 +1511,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     stream.cancel(Status.CANCELLED);
     // This should be ignored.
@@ -1527,7 +1531,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     assertTrue(stream.isReady());
     assertTrue(listener.isOnReadyCalled());
@@ -1545,7 +1549,7 @@ public class OkHttpClientTransportTest {
     setInitialWindowSize(0);
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     assertTrue(stream.isReady());
     // Be notified at the beginning.
@@ -1695,7 +1699,7 @@ public class OkHttpClientTransportTest {
     final String message = "Hello Server";
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     InputStream input = new ByteArrayInputStream(message.getBytes(UTF_8));
     stream.writeMessage(input);
@@ -1720,7 +1724,7 @@ public class OkHttpClientTransportTest {
     final String message = "Hello Server";
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     InputStream input = new ByteArrayInputStream(message.getBytes(UTF_8));
     stream.writeMessage(input);
@@ -1738,7 +1742,7 @@ public class OkHttpClientTransportTest {
     initTransportAndDelayConnected();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     clientTransport.shutdown(SHUTDOWN_REASON);
     allowTransportConnected();
@@ -1810,7 +1814,8 @@ public class OkHttpClientTransportTest {
     assertTrue(status.getCause().toString(), status.getCause() instanceof IOException);
 
     MockStreamListener streamListener = new MockStreamListener();
-    clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT).start(streamListener);
+    clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers)
+        .start(streamListener);
     streamListener.waitUntilStreamClosed();
     assertEquals(Status.UNAVAILABLE.getCode(), streamListener.status.getCode());
   }
@@ -2054,13 +2059,13 @@ public class OkHttpClientTransportTest {
     MockStreamListener listener2 = new MockStreamListener();
     MockStreamListener listener3 = new MockStreamListener();
     OkHttpClientStream stream1 =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream1.start(listener1);
     OkHttpClientStream stream2 =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream2.start(listener2);
     OkHttpClientStream stream3 =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream3.start(listener3);
     waitForStreamPending(1);
 
@@ -2094,13 +2099,13 @@ public class OkHttpClientTransportTest {
     MockStreamListener listener2 = new MockStreamListener();
     MockStreamListener listener3 = new MockStreamListener();
     OkHttpClientStream stream1 =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream1.start(listener1);
     OkHttpClientStream stream2 =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream2.start(listener2);
     OkHttpClientStream stream3 =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream3.start(listener3);
 
     assertEquals(3, activeStreamCount());
@@ -2158,7 +2163,7 @@ public class OkHttpClientTransportTest {
   private void assertNewStreamFail() throws Exception {
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
-        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
     stream.start(listener);
     listener.waitUntilStreamClosed();
     assertFalse(listener.status.isOk());

--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -344,7 +344,7 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
     }
 
     @Override
-    public ClientStreamTracer newClientStreamTracer(StreamInfo info, Metadata headers) {
+    public ClientStreamTracer newClientStreamTracer(StreamInfo info) {
       stats.recordCallStarted();
       inFlights.incrementAndGet();
       if (delegate == null) {
@@ -356,7 +356,7 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
           }
         };
       }
-      final ClientStreamTracer delegatedTracer = delegate.newClientStreamTracer(info, headers);
+      final ClientStreamTracer delegatedTracer = delegate.newClientStreamTracer(info);
       return new ForwardingClientStreamTracer() {
         @Override
         protected ClientStreamTracer delegate() {

--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -29,7 +29,6 @@ import io.grpc.ConnectivityState;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.InternalLogId;
 import io.grpc.LoadBalancer;
-import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.ObjectPool;
 import io.grpc.util.ForwardingClientStreamTracer;

--- a/xds/src/main/java/io/grpc/xds/OrcaPerRequestUtil.java
+++ b/xds/src/main/java/io/grpc/xds/OrcaPerRequestUtil.java
@@ -39,7 +39,7 @@ abstract class OrcaPerRequestUtil {
   private static final ClientStreamTracer.Factory NOOP_CLIENT_STREAM_TRACER_FACTORY =
       new ClientStreamTracer.Factory() {
         @Override
-        public ClientStreamTracer newClientStreamTracer(StreamInfo info, Metadata headers) {
+        public ClientStreamTracer newClientStreamTracer(StreamInfo info) {
           return NOOP_CLIENT_STREAM_TRACER;
         }
       };
@@ -209,7 +209,7 @@ abstract class OrcaPerRequestUtil {
     }
 
     @Override
-    public ClientStreamTracer newClientStreamTracer(StreamInfo info, Metadata headers) {
+    public ClientStreamTracer newClientStreamTracer(StreamInfo info) {
       OrcaReportBroker broker = info.getCallOptions().getOption(ORCA_REPORT_BROKER_KEY);
       boolean augmented = false;
       if (broker == null) {
@@ -221,7 +221,7 @@ abstract class OrcaPerRequestUtil {
         augmented = true;
       }
       broker.addListener(listener);
-      ClientStreamTracer tracer = delegate.newClientStreamTracer(info, headers);
+      ClientStreamTracer tracer = delegate.newClientStreamTracer(info);
       if (augmented) {
         final ClientStreamTracer currTracer = tracer;
         final OrcaReportBroker currBroker = broker;

--- a/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
@@ -37,7 +37,6 @@ import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.ManagedChannel;
-import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.SynchronizationContext;
@@ -209,11 +208,11 @@ public class ClusterImplLoadBalancerTest {
     PickResult result = currentPicker.pickSubchannel(mock(PickSubchannelArgs.class));
     assertThat(result.getStatus().isOk()).isTrue();
     ClientStreamTracer streamTracer1 = result.getStreamTracerFactory().newClientStreamTracer(
-        ClientStreamTracer.StreamInfo.newBuilder().build(), new Metadata());  // first RPC call
+        ClientStreamTracer.StreamInfo.newBuilder().build());  // first RPC call
     ClientStreamTracer streamTracer2 = result.getStreamTracerFactory().newClientStreamTracer(
-        ClientStreamTracer.StreamInfo.newBuilder().build(), new Metadata());  // second RPC call
+        ClientStreamTracer.StreamInfo.newBuilder().build());  // second RPC call
     ClientStreamTracer streamTracer3 = result.getStreamTracerFactory().newClientStreamTracer(
-        ClientStreamTracer.StreamInfo.newBuilder().build(), new Metadata());  // third RPC call
+        ClientStreamTracer.StreamInfo.newBuilder().build());  // third RPC call
     streamTracer1.streamClosed(Status.OK);
     streamTracer2.streamClosed(Status.UNAVAILABLE);
     ClusterStats clusterStats =
@@ -341,8 +340,7 @@ public class ClusterImplLoadBalancerTest {
       PickResult result = currentPicker.pickSubchannel(mock(PickSubchannelArgs.class));
       assertThat(result.getStatus().isOk()).isTrue();
       ClientStreamTracer.Factory streamTracerFactory = result.getStreamTracerFactory();
-      streamTracerFactory.newClientStreamTracer(ClientStreamTracer.StreamInfo.newBuilder().build(),
-          new Metadata());
+      streamTracerFactory.newClientStreamTracer(ClientStreamTracer.StreamInfo.newBuilder().build());
     }
     ClusterStats clusterStats =
         Iterables.getOnlyElement(loadStatsManager.getClusterStatsReports(CLUSTER));
@@ -373,7 +371,7 @@ public class ClusterImplLoadBalancerTest {
     result = currentPicker.pickSubchannel(mock(PickSubchannelArgs.class));
     assertThat(result.getStatus().isOk()).isTrue();
     result.getStreamTracerFactory().newClientStreamTracer(
-        ClientStreamTracer.StreamInfo.newBuilder().build(), new Metadata());  // 101th request
+        ClientStreamTracer.StreamInfo.newBuilder().build());  // 101th request
     clusterStats = Iterables.getOnlyElement(loadStatsManager.getClusterStatsReports(CLUSTER));
     assertThat(clusterStats.clusterServiceName()).isEqualTo(EDS_SERVICE_NAME);
     assertThat(clusterStats.totalDroppedRequests()).isEqualTo(0L);
@@ -429,8 +427,7 @@ public class ClusterImplLoadBalancerTest {
       PickResult result = currentPicker.pickSubchannel(mock(PickSubchannelArgs.class));
       assertThat(result.getStatus().isOk()).isTrue();
       ClientStreamTracer.Factory streamTracerFactory = result.getStreamTracerFactory();
-      streamTracerFactory.newClientStreamTracer(ClientStreamTracer.StreamInfo.newBuilder().build(),
-          new Metadata());
+      streamTracerFactory.newClientStreamTracer(ClientStreamTracer.StreamInfo.newBuilder().build());
     }
     ClusterStats clusterStats =
         Iterables.getOnlyElement(loadStatsManager.getClusterStatsReports(CLUSTER));

--- a/xds/src/test/java/io/grpc/xds/OrcaPerRequestUtilTest.java
+++ b/xds/src/test/java/io/grpc/xds/OrcaPerRequestUtilTest.java
@@ -70,7 +70,7 @@ public class OrcaPerRequestUtilTest {
     ClientStreamTracer fakeTracer = mock(ClientStreamTracer.class);
     doNothing().when(fakeTracer).inboundTrailers(any(Metadata.class));
     when(fakeDelegateFactory.newClientStreamTracer(
-            any(ClientStreamTracer.StreamInfo.class), any(Metadata.class)))
+            any(ClientStreamTracer.StreamInfo.class)))
         .thenReturn(fakeTracer);
 
     // The OrcaReportingTracerFactory will augment the StreamInfo passed to its
@@ -79,10 +79,10 @@ public class OrcaPerRequestUtilTest {
     ClientStreamTracer.Factory factory =
         OrcaPerRequestUtil.getInstance()
             .newOrcaClientStreamTracerFactory(fakeDelegateFactory, orcaListener1);
-    ClientStreamTracer tracer = factory.newClientStreamTracer(STREAM_INFO, new Metadata());
+    ClientStreamTracer tracer = factory.newClientStreamTracer(STREAM_INFO);
     ArgumentCaptor<ClientStreamTracer.StreamInfo> streamInfoCaptor = ArgumentCaptor.forClass(null);
     verify(fakeDelegateFactory)
-        .newClientStreamTracer(streamInfoCaptor.capture(), any(Metadata.class));
+        .newClientStreamTracer(streamInfoCaptor.capture());
     ClientStreamTracer.StreamInfo capturedInfo = streamInfoCaptor.getValue();
     assertThat(capturedInfo).isNotEqualTo(STREAM_INFO);
 
@@ -117,9 +117,9 @@ public class OrcaPerRequestUtilTest {
             .newOrcaClientStreamTracerFactory(parentFactory, orcaListener2);
     // Child factory will augment the StreamInfo and pass it to the parent factory.
     ClientStreamTracer childTracer =
-        childFactory.newClientStreamTracer(STREAM_INFO, new Metadata());
+        childFactory.newClientStreamTracer(STREAM_INFO);
     ArgumentCaptor<ClientStreamTracer.StreamInfo> streamInfoCaptor = ArgumentCaptor.forClass(null);
-    verify(parentFactory).newClientStreamTracer(streamInfoCaptor.capture(), any(Metadata.class));
+    verify(parentFactory).newClientStreamTracer(streamInfoCaptor.capture());
     ClientStreamTracer.StreamInfo parentStreamInfo = streamInfoCaptor.getValue();
     assertThat(parentStreamInfo).isNotEqualTo(STREAM_INFO);
 
@@ -157,7 +157,7 @@ public class OrcaPerRequestUtilTest {
             delegatesTo(OrcaPerRequestUtil.getInstance()
                 .newOrcaClientStreamTracerFactory(parentFactory, orcaListener2)));
     ClientStreamTracer parentTracer =
-        parentFactory.newClientStreamTracer(STREAM_INFO, new Metadata());
+        parentFactory.newClientStreamTracer(STREAM_INFO);
     Metadata trailer = new Metadata();
     trailer.put(
         OrcaReportingTracerFactory.ORCA_ENDPOINT_LOAD_METRICS_KEY,


### PR DESCRIPTION
Based on offline discussion on #8227, use `ClientStreamTracer.Factory` for tracing attempts, and create `ClientStreamTracer` instances (except for the  StreamTracer Factory from PickResult) before picking a subchannel.

API design: go/grpc-stats-api-change-for-retry-java