### PR TITLE
xds: equally weight endpoints within locality if endpoint-level weight unspecified

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
@@ -389,11 +389,13 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
                   discard = false;
                   long weight =
                       (long) localityLbInfo.localityWeight() * endpoint.loadBalancingWeight();
-                  Attributes attr = endpoint.eag().getAttributes().toBuilder()
-                      .set(InternalXdsAttributes.ATTR_LOCALITY, locality)
-                      .set(InternalXdsAttributes.ATTR_SERVER_WEIGHT, weight).build();
-                  EquivalentAddressGroup eag =
-                      new EquivalentAddressGroup(endpoint.eag().getAddresses(), attr);
+                  Attributes.Builder attrBuilder = endpoint.eag().getAttributes().toBuilder();
+                  attrBuilder.set(InternalXdsAttributes.ATTR_LOCALITY, locality);
+                  if (weight != 0L) {
+                    attrBuilder.set(InternalXdsAttributes.ATTR_SERVER_WEIGHT, weight);
+                  }
+                  EquivalentAddressGroup eag = new EquivalentAddressGroup(
+                      endpoint.eag().getAddresses(), attrBuilder.build());
                   eag = AddressFilter.setPathFilter(
                       eag, Arrays.asList(priorityName, localityName(locality)));
                   addresses.add(eag);

--- a/xds/src/main/java/io/grpc/xds/Endpoints.java
+++ b/xds/src/main/java/io/grpc/xds/Endpoints.java
@@ -33,7 +33,7 @@ final class Endpoints {
     // Endpoints to be load balanced.
     abstract ImmutableList<LbEndpoint> endpoints();
 
-    // Locality's weight for inter-locality load balancing.
+    // Locality's weight for inter-locality load balancing. If unspecified, value of 0 is returned.
     abstract int localityWeight();
 
     // Locality's priority level.
@@ -52,7 +52,7 @@ final class Endpoints {
     // The endpoint address to be connected to.
     abstract EquivalentAddressGroup eag();
 
-    // Endpoint's wight for load balancing.
+    // Endpoint's weight for load balancing. If unspecified, value of 0 is returned.
     abstract int loadBalancingWeight();
 
     // Whether the endpoint is healthy.

--- a/xds/src/main/java/io/grpc/xds/Endpoints.java
+++ b/xds/src/main/java/io/grpc/xds/Endpoints.java
@@ -16,6 +16,8 @@
 
 package io.grpc.xds;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -33,7 +35,7 @@ final class Endpoints {
     // Endpoints to be load balanced.
     abstract ImmutableList<LbEndpoint> endpoints();
 
-    // Locality's weight for inter-locality load balancing. If unspecified, value of 0 is returned.
+    // Locality's weight for inter-locality load balancing. Guaranteed to be greater than 0.
     abstract int localityWeight();
 
     // Locality's priority level.
@@ -41,6 +43,7 @@ final class Endpoints {
 
     static LocalityLbEndpoints create(List<LbEndpoint> endpoints, int localityWeight,
         int priority) {
+      checkArgument(localityWeight > 0, "localityWeight must be greater than 0");
       return new AutoValue_Endpoints_LocalityLbEndpoints(
           ImmutableList.copyOf(endpoints), localityWeight, priority);
     }

--- a/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
@@ -217,29 +217,37 @@ public class ClusterResolverLoadBalancerTest {
     // One priority with two localities of different weights.
     EquivalentAddressGroup endpoint1 = makeAddress("endpoint-addr-1");
     EquivalentAddressGroup endpoint2 = makeAddress("endpoint-addr-2");
+    EquivalentAddressGroup endpoint3 = makeAddress("endpoint-addr-3");
     LocalityLbEndpoints localityLbEndpoints1 =
         LocalityLbEndpoints.create(
-            Collections.singletonList(
-                LbEndpoint.create(endpoint1, 0 /* loadBalancingWeight */, true)),
+            Arrays.asList(
+                LbEndpoint.create(endpoint1, 0 /* loadBalancingWeight */, true),
+                LbEndpoint.create(endpoint2, 0 /* loadBalancingWeight */, true)),
             10 /* localityWeight */, 1 /* priority */);
     LocalityLbEndpoints localityLbEndpoints2 =
         LocalityLbEndpoints.create(
             Collections.singletonList(
-                LbEndpoint.create(endpoint2, 60 /* loadBalancingWeight */, true)),
+                LbEndpoint.create(endpoint3, 60 /* loadBalancingWeight */, true)),
             50 /* localityWeight */, 1 /* priority */);
     xdsClient.deliverClusterLoadAssignment(
         EDS_SERVICE_NAME1,
         ImmutableMap.of(locality1, localityLbEndpoints1, locality2, localityLbEndpoints2));
     assertThat(childBalancers).hasSize(1);
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(childBalancers);
-    assertThat(childBalancer.addresses).hasSize(2);
+    assertThat(childBalancer.addresses).hasSize(3);
     EquivalentAddressGroup addr1 = childBalancer.addresses.get(0);
     EquivalentAddressGroup addr2 = childBalancer.addresses.get(1);
+    EquivalentAddressGroup addr3 = childBalancer.addresses.get(2);
+    // Endpoints in locality1 have no endpoint-level weight specified, so all endpoints within
+    // locality1 are equally weighted.
     assertThat(addr1.getAddresses()).isEqualTo(endpoint1.getAddresses());
     assertThat(addr1.getAttributes().get(InternalXdsAttributes.ATTR_SERVER_WEIGHT))
-        .isNull();  // weight attribute unspecified since endpoint-level weight is unspecified
+        .isEqualTo(10);
     assertThat(addr2.getAddresses()).isEqualTo(endpoint2.getAddresses());
     assertThat(addr2.getAttributes().get(InternalXdsAttributes.ATTR_SERVER_WEIGHT))
+        .isEqualTo(10);
+    assertThat(addr3.getAddresses()).isEqualTo(endpoint3.getAddresses());
+    assertThat(addr3.getAttributes().get(InternalXdsAttributes.ATTR_SERVER_WEIGHT))
         .isEqualTo(50 * 60);
     assertThat(childBalancer.name).isEqualTo(PRIORITY_POLICY_NAME);
     PriorityLbConfig priorityLbConfig = (PriorityLbConfig) childBalancer.config;

--- a/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
@@ -214,33 +214,46 @@ public class ClusterResolverLoadBalancerTest {
     assertThat(xdsClient.watchers.keySet()).containsExactly(EDS_SERVICE_NAME1);
     assertThat(childBalancers).isEmpty();
 
-    // One priority with two localities of different weights.
+    // One priority with three localities of different weights.
     EquivalentAddressGroup endpoint1 = makeAddress("endpoint-addr-1");
     EquivalentAddressGroup endpoint2 = makeAddress("endpoint-addr-2");
+    EquivalentAddressGroup endpoint3 = makeAddress("endpoint-addr-3");
     LocalityLbEndpoints localityLbEndpoints1 =
         LocalityLbEndpoints.create(
             Collections.singletonList(
-                LbEndpoint.create(endpoint1, 100 /* loadBalancingWeight */, true)),
+                LbEndpoint.create(endpoint1, 0 /* loadBalancingWeight */, true)),
             10 /* localityWeight */, 1 /* priority */);
     LocalityLbEndpoints localityLbEndpoints2 =
         LocalityLbEndpoints.create(
             Collections.singletonList(
                 LbEndpoint.create(endpoint2, 60 /* loadBalancingWeight */, true)),
             50 /* localityWeight */, 1 /* priority */);
+    LocalityLbEndpoints localityLbEndpoints3 =
+        LocalityLbEndpoints.create(
+            Collections.singletonList(
+                LbEndpoint.create(endpoint3, 100 /* loadBalancingWeight */, true)),
+            0 /* localityWeight */, 1 /* priority */);  // locality level weight unspecified
     xdsClient.deliverClusterLoadAssignment(
         EDS_SERVICE_NAME1,
-        ImmutableMap.of(locality1, localityLbEndpoints1, locality2, localityLbEndpoints2));
+        ImmutableMap.of(
+            locality1, localityLbEndpoints1,
+            locality2, localityLbEndpoints2,
+            locality3, localityLbEndpoints3));
     assertThat(childBalancers).hasSize(1);
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(childBalancers);
-    assertThat(childBalancer.addresses).hasSize(2);
+    assertThat(childBalancer.addresses).hasSize(3);
     EquivalentAddressGroup addr1 = childBalancer.addresses.get(0);
     EquivalentAddressGroup addr2 = childBalancer.addresses.get(1);
+    EquivalentAddressGroup addr3 = childBalancer.addresses.get(2);
     assertThat(addr1.getAddresses()).isEqualTo(endpoint1.getAddresses());
     assertThat(addr1.getAttributes().get(InternalXdsAttributes.ATTR_SERVER_WEIGHT))
-        .isEqualTo(10 * 100);
+        .isNull();  // weight attribute unspecified since endpoint-level weight is unspecified
     assertThat(addr2.getAddresses()).isEqualTo(endpoint2.getAddresses());
     assertThat(addr2.getAttributes().get(InternalXdsAttributes.ATTR_SERVER_WEIGHT))
         .isEqualTo(50 * 60);
+    assertThat(addr3.getAddresses()).isEqualTo(endpoint3.getAddresses());
+    assertThat(addr3.getAttributes().get(InternalXdsAttributes.ATTR_SERVER_WEIGHT))
+        .isNull();  // weight attribute unspecified since locality-level weight is unspecified
     assertThat(childBalancer.name).isEqualTo(PRIORITY_POLICY_NAME);
     PriorityLbConfig priorityLbConfig = (PriorityLbConfig) childBalancer.config;
     assertThat(priorityLbConfig.priorities).containsExactly(CLUSTER1 + "[priority1]");


### PR DESCRIPTION
In xDS proto definition, the `load_balancing_weight` field of [LbEndpoint](https://github.com/grpc/grpc-java/blob/d4c31ffad4191afd08f6e1ddae790b90f5b24ebc/xds/third_party/envoy/src/main/proto/envoy/config/endpoint/v3/endpoint_components.proto#L108)) is optional. When parsing the LbEndpoint, the presence information is discarded. That is, if not specified in EDS, the parsed LbEndpoint will have a weight of 0. Then when computing the overall weights for endpoint-level load balancing (e.g., ring_hash), those endpoint will have an explicit attribute of 0 weight. This may cause trouble for the load balancing algorithm (e.g., in ring_hash if some endpoints have 0 weight, those endpoints will never have RPCs routed to; if all endpoints have 0 weight, the algorithm is broken).

The semantics of unspecified LbEndpoint weight in xDS is to treat all endpoints _within the locality_ equally. So the cluster_resolver LB policy should just use the enclosing locality's weight as the overall endpoint weight for mixing-locality load balancing.

Note the locality-level load balancing weight is always greater than 0, as otherwise the LocalityLbEndpoints [would have not been parsed](https://github.com/grpc/grpc-java/blob/b7f3fddc76ecfe854c6039c000ff6d168205ab06/xds/src/main/java/io/grpc/xds/ClientXdsClient.java#L1091-L1094).

See how C-core handles this: https://github.com/grpc/grpc/blob/e22fefb39af8bc1f4deb9e92fe9208957df10450/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc#L844-L850