### PR TITLE
grpclb: skip fallback if the LB is already in fallback mode

### DIFF
--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -573,8 +573,9 @@ final class GrpclbState {
 
     @Override
     public void run() {
-      // Timer should have been cancelled if entered fallback early.
-      checkState(!usingFallbackBackends, "already in fallback");
+      if (usingFallbackBackends) {
+        return;
+      }
       fallbackReason = reason;
       maybeUseFallbackBackends();
       maybeUpdatePicker();


### PR DESCRIPTION
When receiving updated addresses from the resolver with backend addresses only, gRPCLB will executes the fallback task. However, the [invariant check](https://github.com/grpc/grpc-java/blob/91948b26061bb88164e7f5cc791b4ecf398655f3/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java#L577) added by #8035 was trying to ensure the fallback task is never fired if the LB is already in fallback mode (avoid overwriting the `fallbackReason`). But seems #8035 missed the case that the fallback task can be run by receiving updated addresses with backend addresses only.

This change relaxes (precisely speaking, throws away) the invariant check. A _more strictly correct_ approach may be not reuse the `FallbackModeTask` for address updates, but instead do

```java
syncContext.execute(() -> {
  if (usingFallbackBackends) {
    return;
  }
  fallbackReason = NO_LB_ADDRESS_PROVIDED_STATUS;
  maybeUseFallbackBackends();
  maybeUpdatePicker();
});
```

But this is mostly duplicated code, we would rather relax the invariant. Methods like `maybeUseFallbackBackends()` requires fairly weak preconditions, so things won't go very wrong without the invariant check.