### PR TITLE
binder: Allow SecurityPolicy extensions.

### DIFF
--- a/binder/src/main/java/io/grpc/binder/SecurityPolicy.java
+++ b/binder/src/main/java/io/grpc/binder/SecurityPolicy.java
@@ -35,11 +35,7 @@ import javax.annotation.CheckReturnValue;
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
 public abstract class SecurityPolicy {
 
-  /**
-   * Package visible constructor because we want this package to retain control over any new
-   * policies for now.
-   */
-  SecurityPolicy() {}
+  public SecurityPolicy() {}
 
   /**
    * Decides whether the given Android UID is authorized. (Validity is implementation dependent).


### PR DESCRIPTION
Internally this was package visible to retain strict control
over the available policies. However, that kind of strict control
doesn't work with the open-source version, since projects will want
to create their own policies. E.g. There's at least one google-specific
policy internally.