### PR TITLE
api: clean up duplicated method in InternalServerInterceptors

### DIFF
--- a/api/src/main/java/io/grpc/InternalServerInterceptors.java
+++ b/api/src/main/java/io/grpc/InternalServerInterceptors.java
@@ -21,11 +21,6 @@ package io.grpc;
  */
 @Internal
 public final class InternalServerInterceptors {
-  public static <ReqT, RespT> ServerCallHandler<ReqT, RespT> interceptCallHandler(
-      ServerInterceptor interceptor, ServerCallHandler<ReqT, RespT> callHandler) {
-    return ServerInterceptors.InterceptCallHandler.create(interceptor, callHandler);
-  }
-
   public static <OrigReqT, OrigRespT, WrapReqT, WrapRespT>
       ServerMethodDefinition<WrapReqT, WrapRespT> wrapMethod(
       final ServerMethodDefinition<OrigReqT, OrigRespT> definition,

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -604,7 +604,7 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
               stream.getAuthority()));
       ServerCallHandler<ReqT, RespT> handler = methodDef.getServerCallHandler();
       for (ServerInterceptor interceptor : interceptors) {
-        handler = InternalServerInterceptors.interceptCallHandler(interceptor, handler);
+        handler = InternalServerInterceptors.interceptCallHandlerCreate(interceptor, handler);
       }
       ServerMethodDefinition<ReqT, RespT> interceptedDef = methodDef.withServerCallHandler(handler);
       ServerMethodDefinition<?, ?> wMethodDef = binlog == null


### PR DESCRIPTION
`interceptCallHandler()` and `interceptCallHandlerCreate()` appear to be exactly the same. Deleting the former.