### PR TITLE
core: allow per-service/method executor

### DIFF
--- a/api/src/main/java/io/grpc/ForwardingServerBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingServerBuilder.java
@@ -62,6 +62,12 @@ public abstract class ForwardingServerBuilder<T extends ServerBuilder<T>> extend
   }
 
   @Override
+  public T callExecutor(ServerCallExecutorSupplier executorSupplier) {
+    delegate().callExecutor(executorSupplier);
+    return thisT();
+  }
+
+  @Override
   public T addService(ServerServiceDefinition service) {
     delegate().addService(service);
     return thisT();

--- a/api/src/main/java/io/grpc/ServerBuilder.java
+++ b/api/src/main/java/io/grpc/ServerBuilder.java
@@ -74,6 +74,30 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
    */
   public abstract T executor(@Nullable Executor executor);
 
+
+  /**
+   * Allows for defining a way to provide a custom executor to handle the server call.
+   * This executor is the result of calling
+   * {@link ServerCallExecutorSupplier#getExecutor(ServerCall, Metadata)} per RPC.
+   *
+   * <p>It's an optional parameter. If it is provided, the {@link #executor(Executor)} would still
+   * run necessary tasks before the {@link ServerCallExecutorSupplier} is ready to be called, then
+   * it switches over.
+   *
+   * <p>If it is provided, {@link #directExecutor()} optimization is disabled. But if calling
+   * {@link ServerCallExecutorSupplier} returns null, the server call is still handled by the
+   * default {@link #executor(Executor)} as a fallback.
+   *
+   * @param executorSupplier the server call executor provider
+   * @return this
+   * @since 1.39.0
+   *
+   * */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8274")
+  public T callExecutor(ServerCallExecutorSupplier executorSupplier) {
+    return thisT();
+  }
+
   /**
    * Adds a service implementation to the handler registry.
    *

--- a/api/src/main/java/io/grpc/ServerCallExecutorSupplier.java
+++ b/api/src/main/java/io/grpc/ServerCallExecutorSupplier.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import java.util.concurrent.Executor;
+import javax.annotation.Nullable;
+
+/**
+ * Defines what executor the server call is handled, based on each RPC call information at runtime.
+ * */
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/8274")
+public interface ServerCallExecutorSupplier {
+
+  /**
+   * Returns an executor to handle the server call.
+   * It should never throw. It should return null to fallback to the default executor.
+   * */
+  @Nullable
+  <ReqT, RespT> Executor getExecutor(ServerCall<ReqT, RespT> call, Metadata metadata);
+}

--- a/api/src/main/java/io/grpc/ServerCallExecutorSupplier.java
+++ b/api/src/main/java/io/grpc/ServerCallExecutorSupplier.java
@@ -20,7 +20,7 @@ import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
 
 /**
- * Defines what executor the server call is handled, based on each RPC call information at runtime.
+ * Defines what executor handles the server call, based on each RPC call information at runtime.
  * */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8274")
 public interface ServerCallExecutorSupplier {

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -24,6 +24,7 @@ import io.grpc.DecompressorRegistry;
 import io.grpc.HandlerRegistry;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
+import io.grpc.ServerCallExecutorSupplier;
 import io.grpc.ServerInterceptor;
 import io.grpc.ServerServiceDefinition;
 import io.grpc.ServerStreamTracer;
@@ -64,6 +65,12 @@ public abstract class AbstractServerImplBuilder
   @Override
   public T directExecutor() {
     delegate().directExecutor();
+    return thisT();
+  }
+
+  @Override
+  public T callExecutor(ServerCallExecutorSupplier executorSupplier) {
+    delegate().callExecutor(executorSupplier);
     return thisT();
   }
 

--- a/core/src/main/java/io/grpc/internal/SerializingExecutor.java
+++ b/core/src/main/java/io/grpc/internal/SerializingExecutor.java
@@ -59,7 +59,7 @@ public final class SerializingExecutor implements Executor, Runnable {
   private static final int RUNNING = -1;
 
   /** Underlying executor that all submitted Runnable objects are run on. */
-  private final Executor executor;
+  private volatile Executor executor;
 
   /** A list of Runnables to be run in order. */
   private final Queue<Runnable> runQueue = new ConcurrentLinkedQueue<>();
@@ -72,6 +72,11 @@ public final class SerializingExecutor implements Executor, Runnable {
    * @param executor Executor in which tasks should be run. Must not be null.
    */
   public SerializingExecutor(Executor executor) {
+    Preconditions.checkNotNull(executor, "'executor' must not be null.");
+    this.executor = executor;
+  }
+
+  public void setExecutor(Executor executor) {
     Preconditions.checkNotNull(executor, "'executor' must not be null.");
     this.executor = executor;
   }
@@ -118,7 +123,8 @@ public final class SerializingExecutor implements Executor, Runnable {
   public void run() {
     Runnable r;
     try {
-      while ((r = runQueue.poll()) != null) {
+      Executor oldExecutor = executor;
+      while ((r = runQueue.poll()) != null && oldExecutor == executor ) {
         try {
           r.run();
         } catch (RuntimeException e) {

--- a/core/src/main/java/io/grpc/internal/SerializingExecutor.java
+++ b/core/src/main/java/io/grpc/internal/SerializingExecutor.java
@@ -76,6 +76,10 @@ public final class SerializingExecutor implements Executor, Runnable {
     this.executor = executor;
   }
 
+  /**
+   * Only call this from this SerializingExecutor Runnable, so that the executor is immediately
+   * visible to this SerializingExecutor executor.
+   * */
   public void setExecutor(Executor executor) {
     Preconditions.checkNotNull(executor, "'executor' must not be null.");
     this.executor = executor;

--- a/core/src/main/java/io/grpc/internal/SerializingExecutor.java
+++ b/core/src/main/java/io/grpc/internal/SerializingExecutor.java
@@ -59,7 +59,7 @@ public final class SerializingExecutor implements Executor, Runnable {
   private static final int RUNNING = -1;
 
   /** Underlying executor that all submitted Runnable objects are run on. */
-  private volatile Executor executor;
+  private Executor executor;
 
   /** A list of Runnables to be run in order. */
   private final Queue<Runnable> runQueue = new ConcurrentLinkedQueue<>();
@@ -124,7 +124,7 @@ public final class SerializingExecutor implements Executor, Runnable {
     Runnable r;
     try {
       Executor oldExecutor = executor;
-      while ((r = runQueue.poll()) != null && oldExecutor == executor ) {
+      while (oldExecutor == executor && (r = runQueue.poll()) != null ) {
         try {
           r.run();
         } catch (RuntimeException e) {

--- a/core/src/main/java/io/grpc/internal/ServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ServerImplBuilder.java
@@ -32,6 +32,7 @@ import io.grpc.HandlerRegistry;
 import io.grpc.InternalChannelz;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
+import io.grpc.ServerCallExecutorSupplier;
 import io.grpc.ServerInterceptor;
 import io.grpc.ServerMethodDefinition;
 import io.grpc.ServerServiceDefinition;
@@ -93,6 +94,8 @@ public final class ServerImplBuilder extends ServerBuilder<ServerImplBuilder> {
   @Nullable BinaryLog binlog;
   InternalChannelz channelz = InternalChannelz.instance();
   CallTracer.Factory callTracerFactory = CallTracer.getDefaultFactory();
+  @Nullable
+  ServerCallExecutorSupplier executorSupplier;
 
   /**
    * An interface to provide to provide transport specific information for the server. This method
@@ -119,6 +122,12 @@ public final class ServerImplBuilder extends ServerBuilder<ServerImplBuilder> {
   @Override
   public ServerImplBuilder executor(@Nullable Executor executor) {
     this.executorPool = executor != null ? new FixedObjectPool<>(executor) : DEFAULT_EXECUTOR_POOL;
+    return this;
+  }
+
+  @Override
+  public ServerImplBuilder callExecutor(ServerCallExecutorSupplier executorSupplier) {
+    this.executorSupplier = checkNotNull(executorSupplier);
     return this;
   }
 

--- a/core/src/test/java/io/grpc/internal/SerializingExecutorTest.java
+++ b/core/src/test/java/io/grpc/internal/SerializingExecutorTest.java
@@ -209,6 +209,38 @@ public class SerializingExecutorTest {
     assertEquals(Arrays.asList(1, 2, 3), runs);
   }
 
+  @Test
+  public void switchable() {
+    final SerializingExecutor testExecutor =
+            new SerializingExecutor(MoreExecutors.directExecutor());
+    testExecutor.execute(new Runnable() {
+      @Override
+      public void run() {
+        runs.add(1);
+        testExecutor.setExecutor(singleExecutor);
+      }
+    });
+    testExecutor.execute(new AddToRuns(-2));
+    assertThat(runs).isEqualTo(Arrays.asList(1));
+    singleExecutor.drain();
+    assertThat(runs).isEqualTo(Arrays.asList(1, -2));
+  }
+
+  @Test
+  public void notSwitch() {
+    executor.execute(new Runnable() {
+      @Override
+      public void run() {
+        runs.add(1);
+        executor.setExecutor(singleExecutor);
+      }
+    });
+    executor.execute(new AddToRuns(-2));
+    assertThat(runs).isEqualTo(Collections.emptyList());
+    singleExecutor.drain();
+    assertThat(runs).isEqualTo(Arrays.asList(1, -2));
+  }
+
   private static class SingleExecutor implements Executor {
     private Runnable runnable;
 

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -65,6 +65,7 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerCall;
 import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallExecutorSupplier;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.ServerMethodDefinition;
@@ -456,6 +457,125 @@ public class ServerImplTest {
     verify(streamTracerFactory).newServerStreamTracer(eq("Waiter/nonexist"), same(requestHeaders));
     assertNull(streamTracer.getServerCallInfo());
     assertEquals(Status.Code.UNIMPLEMENTED, statusCaptor.getValue().getCode());
+  }
+
+
+  @Test
+  public void executorSupplierSameExecutorBasic() throws Exception {
+    builder.executorSupplier = new ServerCallExecutorSupplier() {
+      @Override
+      public <ReqT, RespT> Executor getExecutor(ServerCall<ReqT, RespT> call, Metadata metadata) {
+        return executor.getScheduledExecutorService();
+      }
+    };
+    basicExchangeSuccessful();
+  }
+
+  @Test
+  public void executorSupplierNullBasic() throws Exception {
+    builder.executorSupplier = new ServerCallExecutorSupplier() {
+      @Override
+      public <ReqT, RespT> Executor getExecutor(ServerCall<ReqT, RespT> call, Metadata metadata) {
+        return null;
+      }
+    };
+    basicExchangeSuccessful();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void executorSupplierSwitchExecutor() throws Exception {
+    SingleExecutor switchingExecutor = new SingleExecutor();
+    ServerCallExecutorSupplier mockSupplier = mock(ServerCallExecutorSupplier.class);
+    when(mockSupplier.getExecutor(any(ServerCall.class), any(Metadata.class)))
+            .thenReturn(switchingExecutor);
+    builder.executorSupplier = mockSupplier;
+    final AtomicReference<ServerCall<String, Integer>> callReference
+            = new AtomicReference<>();
+    mutableFallbackRegistry.addService(ServerServiceDefinition.builder(
+            new ServiceDescriptor("Waiter", METHOD))
+            .addMethod(METHOD,
+                new ServerCallHandler<String, Integer>() {
+                  @Override
+                  public ServerCall.Listener<String> startCall(
+                          ServerCall<String, Integer> call,
+                          Metadata headers) {
+                    callReference.set(call);
+                    return callListener;
+                  }
+                }).build());
+
+    createAndStartServer();
+    ServerTransportListener transportListener
+            = transportServer.registerNewServerTransport(new SimpleServerTransport());
+    transportListener.transportReady(Attributes.EMPTY);
+    Metadata requestHeaders = new Metadata();
+    StatsTraceContext statsTraceCtx =
+            StatsTraceContext.newServerContext(
+                    streamTracerFactories, "Waiter/serve", requestHeaders);
+    when(stream.statsTraceContext()).thenReturn(statsTraceCtx);
+    transportListener.streamCreated(stream, "Waiter/serve", requestHeaders);
+    verify(stream).setListener(isA(ServerStreamListener.class));
+    verify(stream, atLeast(1)).statsTraceContext();
+
+    assertEquals(1, executor.runDueTasks());
+    verify(fallbackRegistry).lookupMethod("Waiter/serve", AUTHORITY);
+    verify(streamTracerFactory).newServerStreamTracer(eq("Waiter/serve"), same(requestHeaders));
+    ArgumentCaptor<ServerCall<?,?>> callCapture = ArgumentCaptor.forClass(ServerCall.class);
+    verify(mockSupplier).getExecutor(callCapture.capture(), eq(requestHeaders));
+
+    assertThat(switchingExecutor.runnable).isNotNull();
+    assertEquals(0, executor.numPendingTasks());
+    switchingExecutor.drain();
+    ServerCall<String, Integer> call = callReference.get();
+    assertNotNull(call);
+    assertThat(call).isEqualTo(callCapture.getValue());
+  }
+
+  @Test
+  public void executorSupplierFutureNotSet() throws Exception {
+    builder.executorSupplier = new ServerCallExecutorSupplier() {
+      @Override
+      public <ReqT, RespT> Executor getExecutor(ServerCall<ReqT, RespT> call, Metadata metadata) {
+        throw new IllegalStateException("Yeah!");
+      }
+    };
+    doThrow(new IllegalStateException("Yeah")).doNothing()
+            .when(stream).close(any(Status.class), any(Metadata.class));
+    final AtomicReference<ServerCall<String, Integer>> callReference
+            = new AtomicReference<>();
+    mutableFallbackRegistry.addService(ServerServiceDefinition.builder(
+        new ServiceDescriptor("Waiter", METHOD))
+        .addMethod(METHOD,
+            new ServerCallHandler<String, Integer>() {
+                @Override
+                public ServerCall.Listener<String> startCall(
+                        ServerCall<String, Integer> call,
+                        Metadata headers) {
+                  callReference.set(call);
+                  return callListener;
+                }
+            }).build());
+
+    createAndStartServer();
+    ServerTransportListener transportListener
+            = transportServer.registerNewServerTransport(new SimpleServerTransport());
+    transportListener.transportReady(Attributes.EMPTY);
+    Metadata requestHeaders = new Metadata();
+    StatsTraceContext statsTraceCtx =
+            StatsTraceContext.newServerContext(
+                    streamTracerFactories, "Waiter/serve", requestHeaders);
+    when(stream.statsTraceContext()).thenReturn(statsTraceCtx);
+    transportListener.streamCreated(stream, "Waiter/serve", requestHeaders);
+    verify(stream).setListener(isA(ServerStreamListener.class));
+    verify(stream, atLeast(1)).statsTraceContext();
+
+    assertEquals(1, executor.runDueTasks());
+    verify(fallbackRegistry).lookupMethod("Waiter/serve", AUTHORITY);
+    assertThat(callReference.get()).isNull();
+    verify(stream, times(2)).close(statusCaptor.capture(), any(Metadata.class));
+    Status status = statusCaptor.getAllValues().get(1);
+    assertEquals(Status.Code.INTERNAL, status.getCode());
   }
 
   @Test
@@ -1513,4 +1633,24 @@ public class ServerImplTest {
 
   /** Allows more precise catch blocks than plain Error to avoid catching AssertionError. */
   private static final class TestError extends Error {}
+
+  private static class SingleExecutor implements Executor {
+    private Runnable runnable;
+
+    @Override
+    public void execute(Runnable r) {
+      if (runnable != null) {
+        fail("Already have runnable scheduled");
+      }
+      runnable = r;
+    }
+
+    public void drain() {
+      if (runnable != null) {
+        Runnable r = runnable;
+        runnable = null;
+        r.run();
+      }
+    }
+  }
 }


### PR DESCRIPTION
For https://github.com/grpc/grpc-java/issues/7874
Technical strategy:
* Split StreamCreated() contextRunnable into two when this feature is needed: one for method lookup, the other for server call handling. methodLookup() runs on default executor, handleServerCall() may run on the executorSupplier executor.
  *  callbacks are queued after methodLookup() and handleServerCall()
* Make executor settable in serializing executor to switch executor for the server call handling runnable as a result of the outcome of the method lookup runnable.


@ejona86  can I get your early feedback

tracking experimental API https://github.com/grpc/grpc-java/issues/8274