### PR TITLE
Rename netty-shaded native resources directory to avoid collisions

### DIFF
--- a/netty/shaded/build.gradle
+++ b/netty/shaded/build.gradle
@@ -107,8 +107,9 @@ class NettyResourceTransformer implements Transformer {
 
     @Override
     void transform(TransformerContext context) {
+        String updatedPath = context.path.replace("io.netty", "io.grpc.netty.shaded.io.netty")
         String updatedContent = context.is.getText().replace("io.netty", "io.grpc.netty.shaded.io.netty")
-        resources.put(context.path, updatedContent)
+        resources.put(updatedPath, updatedContent)
     }
 
     @Override

--- a/netty/shaded/src/testShadow/java/io/grpc/netty/shaded/ShadingTest.java
+++ b/netty/shaded/src/testShadow/java/io/grpc/netty/shaded/ShadingTest.java
@@ -78,7 +78,8 @@ public final class ShadingTest {
   @Test
   public void nettyResourcesUpdated() throws IOException {
     InputStream inputStream = NettyChannelBuilder.class.getClassLoader()
-        .getResourceAsStream("META-INF/native-image/io.netty/transport/reflection-config.json");
+        .getResourceAsStream(
+            "META-INF/native-image/io.grpc.netty.shaded.io.netty/transport/reflection-config.json");
     assertThat(inputStream).isNotNull();
 
     Scanner s = new Scanner(inputStream, StandardCharsets.UTF_8.name()).useDelimiter("\\A");


### PR DESCRIPTION
This renames the netty-shaded resource folder to avoid configuration collisions with standard netty. Followup to: https://github.com/grpc/grpc-java/pull/8258#discussion_r652729213