### PR TITLE
netty-shaded: Use compile instead of runtime dep in pom for core

### DIFF
--- a/netty/shaded/build.gradle
+++ b/netty/shaded/build.gradle
@@ -53,6 +53,19 @@ publishing {
             artifact javadocJar
             artifact sourcesJar
 
+            // Avoid confusing error message "class file for
+            // io.grpc.internal.AbstractServerImplBuilder not found"
+            // (https://github.com/grpc/grpc-java/issues/5881). This can be
+            // removed after https://github.com/grpc/grpc-java/issues/7211 is
+            // resolved.
+            pom.withXml {
+                asNode().dependencies.'*'.findAll() { dep ->
+                    dep.artifactId.text() == 'grpc-core'
+                }.each() { core ->
+                    core.scope*.value = "compile"
+                }
+            }
+
             // shadow.component() is run after the main build.gradle's withXml
             pom.withXml {
                 asNode().dependencies.'*'.findAll() { dep ->


### PR DESCRIPTION
This is essentially re-adding #5901 after its behavior was "reverted"
in #8242. At the time grpc-core was the only dependency, so this change
only applies to grpc-core to make it a tiny bit easier to swap to
runtime scope in the future.