### PR TITLE
Update AndroidComponentAddress to wrap a binding Intent.

### DIFF
--- a/binder/src/androidTest/java/io/grpc/binder/BinderChannelSmokeTest.java
+++ b/binder/src/androidTest/java/io/grpc/binder/BinderChannelSmokeTest.java
@@ -99,7 +99,7 @@ public final class BinderChannelSmokeTest {
     HostServices.configureService(serverAddress,
         HostServices.serviceParamsBuilder()
           .setServerFactory((service, receiver) ->
-              BinderServerBuilder.forService(service, receiver)
+              BinderServerBuilder.forAddress(serverAddress, receiver)
                 .addService(serviceDef)
                 .build())
           .build());

--- a/binder/src/androidTest/java/io/grpc/binder/BinderSecurityTest.java
+++ b/binder/src/androidTest/java/io/grpc/binder/BinderSecurityTest.java
@@ -75,7 +75,7 @@ public final class BinderSecurityTest {
     AndroidComponentAddress addr = HostServices.allocateService(appContext);
     HostServices.configureService(addr,
         HostServices.serviceParamsBuilder()
-          .setServerFactory((service, receiver) -> buildServer(service, receiver, serverPolicy))
+          .setServerFactory((service, receiver) -> buildServer(addr, receiver, serverPolicy))
           .build());
 
     channel =
@@ -85,10 +85,10 @@ public final class BinderSecurityTest {
   }
 
   private Server buildServer(
-      Service service,
+      AndroidComponentAddress listenAddr,
       IBinderReceiver receiver,
       ServerSecurityPolicy serverPolicy) {
-    BinderServerBuilder serverBuilder = BinderServerBuilder.forService(service, receiver);
+    BinderServerBuilder serverBuilder = BinderServerBuilder.forAddress(listenAddr, receiver);
     serverBuilder.securityPolicy(serverPolicy);
 
     MethodDescriptor.Marshaller<Empty> marshaller =

--- a/binder/src/androidTest/java/io/grpc/binder/internal/BinderClientTransportTest.java
+++ b/binder/src/androidTest/java/io/grpc/binder/internal/BinderClientTransportTest.java
@@ -125,7 +125,7 @@ public final class BinderClientTransportTest {
     HostServices.configureService(serverAddress,
         HostServices.serviceParamsBuilder()
           .setServerFactory((service, receiver) ->
-              BinderServerBuilder.forService(service, receiver)
+              BinderServerBuilder.forAddress(serverAddress, receiver)
                 .addService(serviceDef)
                 .build())
           .build());

--- a/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
+++ b/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
@@ -16,66 +16,120 @@
 
 package io.grpc.binder;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import android.content.ComponentName;
 import android.content.Context;
+import android.content.Intent;
 import io.grpc.ExperimentalApi;
 import java.net.SocketAddress;
 
-/** Custom SocketAddress class referencing an Android Component. */
+/**
+ * The target of an Android {@link android.app.Service} binding.
+ *
+ * <p>Consists of a {@link ComponentName} reference to the Service and the action, data URI, type,
+ * and category set for an {@link Intent} used to bind to it. All together, these fields identify
+ * the {@link android.os.IBinder} that would be returned by some implementation of {@link
+ * android.app.Service#onBind(Intent)}. Indeed, the semantics of {@link #equals(Object)} match
+ * Android's internal equivalence relation for caching the result of calling this method. See <a
+ * href="https://developer.android.com/guide/components/bound-services">Bound Services Overview</a>
+ * for more.
+ *
+ * <p>For convenience in the common case where a {@link android.app.Service} exposes just one {@link
+ * android.os.IBinder} IPC interface, we provide default values for the binding {@link Intent}
+ * fields, namely, an action of {@link ApiConstants#ACTION_BIND}, an empty category set and null
+ * type and data URI.
+ */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
 public final class AndroidComponentAddress extends SocketAddress {
-
   private static final long serialVersionUID = 0L;
 
-  private final ComponentName component;
+  private final Intent bindIntent; // An "explicit" Intent. In other words, getComponent() != null.
 
-  private AndroidComponentAddress(ComponentName component) {
-    this.component = component;
+  private AndroidComponentAddress(Intent bindIntent) {
+    checkArgument(bindIntent.getComponent() != null, "Missing required component");
+    this.bindIntent = bindIntent;
   }
 
-  /** Create an address for the given context instance. */
+  /**
+   * Creates an address for the given {@link android.app.Service} instance with the default binding
+   * {@link Intent}.
+   */
   public static AndroidComponentAddress forContext(Context context) {
     return forLocalComponent(context, context.getClass());
   }
 
-  /** Create an address referencing a component within this application. */
+  /**
+   * Creates an address referencing a {@link android.app.Service} hosted by this application and
+   * using the default binding {@link Intent}.
+   */
   public static AndroidComponentAddress forLocalComponent(Context context, Class<?> cls) {
     return forComponent(new ComponentName(context, cls));
   }
 
-  /** Create an address referencing a component (potentially) in another application. */
+  /**
+   * Creates an address referencing a {@link android.app.Service} (potentially) in another
+   * application and using the default binding {@link Intent}.
+   */
   public static AndroidComponentAddress forRemoteComponent(String packageName, String className) {
     return forComponent(new ComponentName(packageName, className));
   }
 
+  /**
+   * Creates a new address that refers to <code>intent</code>'s component and that uses the "filter
+   * matching" fields of <code>intent</code> as the binding {@link Intent}.
+   *
+   * <p>A multi-tenant {@link android.app.Service} can call this from its {@link
+   * android.app.Service#onBind(Intent)} method to locate an appropriate {@link io.grpc.Server} by
+   * listening address.
+   *
+   * @throws IllegalArgumentException if intent's component is null
+   */
+  public static AndroidComponentAddress forBindIntent(Intent intent) {
+    return new AndroidComponentAddress(intent.cloneFilter());
+  }
+
+  /**
+   * Creates an address referencing the specified {@link android.app.Service} component and using
+   * the default binding {@link Intent}.
+   */
   public static AndroidComponentAddress forComponent(ComponentName component) {
-    return new AndroidComponentAddress(component);
+    return new AndroidComponentAddress(
+        new Intent(ApiConstants.ACTION_BIND).setComponent(component));
   }
 
   public String getAuthority() {
-    return component.getPackageName();
+    return getComponent().getPackageName();
   }
 
   public ComponentName getComponent() {
-    return component;
+    return bindIntent.getComponent();
+  }
+
+  /**
+   * Returns this address as an explicit {@link Intent} suitable for passing to {@link
+   * Context#bindService}.
+   */
+  public Intent asBindIntent() {
+    return bindIntent.cloneFilter(); // Intent is mutable so return a copy.
   }
 
   @Override
   public int hashCode() {
-    return component.hashCode();
+    return bindIntent.filterHashCode();
   }
 
   @Override
   public boolean equals(Object obj) {
     if (obj instanceof AndroidComponentAddress) {
       AndroidComponentAddress that = (AndroidComponentAddress) obj;
-      return component.equals(that.component);
+      return bindIntent.filterEquals(that.bindIntent);
     }
     return false;
   }
 
   @Override
   public String toString() {
-    return "AndroidComponentAddress[" + component + "]";
+    return "AndroidComponentAddress[" + bindIntent + "]";
   }
 }

--- a/binder/src/main/java/io/grpc/binder/ApiConstants.java
+++ b/binder/src/main/java/io/grpc/binder/ApiConstants.java
@@ -25,7 +25,8 @@ public final class ApiConstants {
   private ApiConstants() {}
 
   /**
-   * Service Action: Identifies gRPC clients in a {@link android.app.Service#onBind(Intent)} call.
+   * The "action" part of the binding {@link Intent} that gRPC clients use by default to identify
+   * themselves in a {@link android.app.Service#onBind(Intent)} call.
    */
   public static final String ACTION_BIND = "grpc.io.action.BIND";
 }

--- a/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
@@ -69,22 +69,6 @@ public final class BinderServerBuilder
   }
 
   /**
-   * Creates a server builder that will listen for bindings to the specified Service with the
-   * default Intent.
-   *
-   * <p>The listening {@link IBinder} associated with new {@link Server}s will be stored in {@code
-   * binderReceiver} upon {@link #build()}. Callers should return it from {@link
-   * Service#onBind(Intent)} when the binding intent matches.
-   *
-   * @param service the concrete Android Service that will host this server.
-   * @param receiver an "out param" for the new {@link Server}'s listening {@link IBinder}
-   * @return a new builder
-   */
-  public static BinderServerBuilder forService(Service service, IBinderReceiver receiver) {
-    return new BinderServerBuilder(AndroidComponentAddress.forContext(service), receiver);
-  }
-
-  /**
    * Always fails. Call {@link #forService(Service, IBinderReceiver)} instead.
    */
   @DoNotCall("Unsupported. Use forService() instead")

--- a/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
@@ -69,11 +69,11 @@ public final class BinderServerBuilder
   }
 
   /**
-   * Always fails. Call {@link #forService(Service, IBinderReceiver)} instead.
+   * Always fails. Call {@link #forAddress(AndroidComponentAddress, IBinderReceiver)} instead.
    */
-  @DoNotCall("Unsupported. Use forService() instead")
+  @DoNotCall("Unsupported. Use forAddress() instead")
   public static BinderServerBuilder forPort(int port) {
-    throw new UnsupportedOperationException("call forService() instead");
+    throw new UnsupportedOperationException("call forAddress() instead");
   }
 
   private final ServerImplBuilder serverImplBuilder;
@@ -170,7 +170,7 @@ public final class BinderServerBuilder
 
   /**
    * Builds a {@link Server} according to this builder's parameters and stores its listening {@link
-   * IBinder} in the {@link IBinderReceiver} passed to {@link #forService(Service,
+   * IBinder} in the {@link IBinderReceiver} passed to {@link #forAddress(AndroidComponentAddress,
    * IBinderReceiver)}.
    *
    * @return the new Server

--- a/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
@@ -53,17 +53,35 @@ public final class BinderServerBuilder
     extends ForwardingServerBuilder<BinderServerBuilder> {
 
   /**
-   * Creates a server builder that will bind with the given name.
+   * Creates a server builder that will listen for bindings to the specified address.
+   *
+   * <p>The listening {@link IBinder} associated with new {@link Server}s will be stored
+   * in {@code binderReceiver} upon {@link #build()}. Callers should return it from {@link
+   * Service#onBind(Intent)} when the binding intent matches {@code listenAddress}.
+   *
+   * @param listenAddress an Android Service and binding Intent associated with this server.
+   * @param receiver an "out param" for the new {@link Server}'s listening {@link IBinder}
+   * @return a new builder
+   */
+  public static BinderServerBuilder forAddress(AndroidComponentAddress listenAddress,
+      IBinderReceiver receiver) {
+    return new BinderServerBuilder(listenAddress, receiver);
+  }
+
+  /**
+   * Creates a server builder that will listen for bindings to the specified Service with the
+   * default Intent.
    *
    * <p>The listening {@link IBinder} associated with new {@link Server}s will be stored in {@code
-   * binderReceiver} upon {@link #build()}.
+   * binderReceiver} upon {@link #build()}. Callers should return it from {@link
+   * Service#onBind(Intent)} when the binding intent matches.
    *
    * @param service the concrete Android Service that will host this server.
    * @param receiver an "out param" for the new {@link Server}'s listening {@link IBinder}
    * @return a new builder
    */
   public static BinderServerBuilder forService(Service service, IBinderReceiver receiver) {
-    return new BinderServerBuilder(service, receiver);
+    return new BinderServerBuilder(AndroidComponentAddress.forContext(service), receiver);
   }
 
   /**
@@ -80,13 +98,15 @@ public final class BinderServerBuilder
   private ServerSecurityPolicy securityPolicy;
   private InboundParcelablePolicy inboundParcelablePolicy;
 
-  private BinderServerBuilder(Service service, IBinderReceiver binderReceiver) {
+  private BinderServerBuilder(
+      AndroidComponentAddress listenAddress,
+      IBinderReceiver binderReceiver) {
     securityPolicy = SecurityPolicies.serverInternalOnly();
     inboundParcelablePolicy = InboundParcelablePolicy.DEFAULT;
 
     serverImplBuilder = new ServerImplBuilder(streamTracerFactories -> {
       BinderServer server = new BinderServer(
-          AndroidComponentAddress.forContext(service),
+          listenAddress,
           schedulerPool,
           streamTracerFactories,
           securityPolicy,

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -585,8 +585,7 @@ public abstract class BinderTransport
           new ServiceBinding(
               mainThreadExecutor,
               sourceContext,
-              targetAddress.getComponent(),
-              ApiConstants.ACTION_BIND,
+              targetAddress.asBindIntent(),
               bindServiceFlags.toInteger(),
               this);
     }

--- a/binder/src/main/java/io/grpc/binder/internal/ServiceBinding.java
+++ b/binder/src/main/java/io/grpc/binder/internal/ServiceBinding.java
@@ -56,8 +56,7 @@ final class ServiceBinding implements Bindable, ServiceConnection {
     UNBOUND,
   }
 
-  private final ComponentName targetComponent;
-  private final String bindAction;
+  private final Intent bindIntent;
   private final int bindFlags;
   private final Observer observer;
   private final Executor mainThreadExecutor;
@@ -77,15 +76,13 @@ final class ServiceBinding implements Bindable, ServiceConnection {
   ServiceBinding(
       Executor mainThreadExecutor,
       Context sourceContext,
-      ComponentName targetComponent,
-      String bindAction,
+      Intent bindIntent,
       int bindFlags,
       Observer observer) {
     // We need to synchronize here ensure other threads see all
     // non-final fields initialized after the constructor.
     synchronized (this) {
-      this.targetComponent = targetComponent;
-      this.bindAction = bindAction;
+      this.bindIntent = bindIntent;
       this.bindFlags = bindFlags;
       this.observer = observer;
       this.sourceContext = sourceContext;
@@ -120,8 +117,6 @@ final class ServiceBinding implements Bindable, ServiceConnection {
   public synchronized void bind() {
     if (state == State.NOT_BINDING) {
       state = State.BINDING;
-      Intent bindIntent = new Intent(bindAction);
-      bindIntent.setComponent(targetComponent);
       Status bindResult = bindInternal(sourceContext, bindIntent, this, bindFlags);
       if (!bindResult.isOk()) {
         state = State.UNBOUND;

--- a/binder/src/test/java/io/grpc/binder/AndroidComponentAddressTest.java
+++ b/binder/src/test/java/io/grpc/binder/AndroidComponentAddressTest.java
@@ -20,6 +20,8 @@ import static com.google.common.truth.Truth.assertThat;
 
 import android.content.ComponentName;
 import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.common.testing.EqualsTester;
 import org.junit.Test;
@@ -45,9 +47,25 @@ public final class AndroidComponentAddressTest {
   }
 
   @Test
+  public void testAsBindIntent() {
+    Intent bindIntent =
+        new Intent()
+            .setAction("foo")
+            .setComponent(new ComponentName("pkg", "cls"))
+            .setData(Uri.EMPTY)
+            .setType("sometype")
+            .addCategory("some-category")
+            .addCategory("another-category");
+    AndroidComponentAddress addr = AndroidComponentAddress.forBindIntent(bindIntent);
+    assertThat(addr.asBindIntent().filterEquals(bindIntent)).isTrue();
+  }
+
+  @Test
   public void testEquality() {
     new EqualsTester()
         .addEqualityGroup(
+            AndroidComponentAddress.forBindIntent(
+                new Intent(ApiConstants.ACTION_BIND).setComponent(hostComponent)),
             AndroidComponentAddress.forComponent(hostComponent),
             AndroidComponentAddress.forContext(appContext),
             AndroidComponentAddress.forLocalComponent(appContext, appContext.getClass()),
@@ -56,6 +74,15 @@ public final class AndroidComponentAddressTest {
         .addEqualityGroup(
             AndroidComponentAddress.forRemoteComponent("appy.mcappface", ".McActivity"))
         .addEqualityGroup(AndroidComponentAddress.forLocalComponent(appContext, getClass()))
+        .addEqualityGroup(
+            AndroidComponentAddress.forBindIntent(
+                new Intent().setAction("custom-action").setComponent(hostComponent)))
+        .addEqualityGroup(
+            AndroidComponentAddress.forBindIntent(
+                new Intent()
+                    .setAction("custom-action")
+                    .setType("some-type")
+                    .setComponent(hostComponent)))
         .testEquals();
   }
 }

--- a/binder/src/test/java/io/grpc/binder/BinderServerBuilderTest.java
+++ b/binder/src/test/java/io/grpc/binder/BinderServerBuilderTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.binder;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.app.Service;
+import android.content.ComponentName;
+import android.content.Intent;
+import android.os.IBinder;
+import androidx.annotation.Nullable;
+import io.grpc.Server;
+import java.io.IOException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ServiceController;
+
+@RunWith(RobolectricTestRunner.class)
+public final class BinderServerBuilderTest {
+
+  private final IBinderReceiver binderReceiver = new IBinderReceiver();
+
+  @Test
+  public void shouldExposeListeningBinderUponBuild() {
+    ServiceController<SomeService> controller = Robolectric.buildService(SomeService.class);
+    SomeService service = controller.create().get();
+
+    Server server = BinderServerBuilder.forService(service, binderReceiver).build();
+    try {
+      assertThat(binderReceiver.get()).isNotNull();
+    } finally {
+      server.shutdownNow();
+    }
+  }
+
+  @Test
+  public void shouldExposeDefaultListeningAddressUponBuild() throws IOException {
+    ServiceController<SomeService> controller = Robolectric.buildService(SomeService.class);
+    SomeService service = controller.create().get();
+
+    Server server = BinderServerBuilder.forService(service, binderReceiver).build().start();
+    try {
+      assertThat(server.getListenSockets())
+          .containsExactly(AndroidComponentAddress.forContext(service));
+    } finally {
+      server.shutdownNow();
+    }
+  }
+
+  @Test
+  public void shouldExposeSpecifiedListeningAddressUponBuild() throws IOException {
+    AndroidComponentAddress listenAddress =
+        AndroidComponentAddress.forBindIntent(
+            new Intent()
+                .setAction("some-action")
+                .setComponent(new ComponentName("com.foo", "com.foo.SomeService")));
+    Server server = BinderServerBuilder.forAddress(listenAddress, binderReceiver).build().start();
+    try {
+      assertThat(server.getListenSockets()).containsExactly(listenAddress);
+    } finally {
+      server.shutdownNow();
+    }
+  }
+
+  private static class SomeService extends Service {
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+      return null;
+    }
+  }
+}

--- a/binder/src/test/java/io/grpc/binder/BinderServerBuilderTest.java
+++ b/binder/src/test/java/io/grpc/binder/BinderServerBuilderTest.java
@@ -41,23 +41,10 @@ public final class BinderServerBuilderTest {
     ServiceController<SomeService> controller = Robolectric.buildService(SomeService.class);
     SomeService service = controller.create().get();
 
-    Server server = BinderServerBuilder.forService(service, binderReceiver).build();
+    AndroidComponentAddress listenAddress = AndroidComponentAddress.forContext(service);
+    Server server = BinderServerBuilder.forAddress(listenAddress, binderReceiver).build();
     try {
       assertThat(binderReceiver.get()).isNotNull();
-    } finally {
-      server.shutdownNow();
-    }
-  }
-
-  @Test
-  public void shouldExposeDefaultListeningAddressUponBuild() throws IOException {
-    ServiceController<SomeService> controller = Robolectric.buildService(SomeService.class);
-    SomeService service = controller.create().get();
-
-    Server server = BinderServerBuilder.forService(service, binderReceiver).build().start();
-    try {
-      assertThat(server.getListenSockets())
-          .containsExactly(AndroidComponentAddress.forContext(service));
     } finally {
       server.shutdownNow();
     }

--- a/binder/src/test/java/io/grpc/binder/internal/ServiceBindingTest.java
+++ b/binder/src/test/java/io/grpc/binder/internal/ServiceBindingTest.java
@@ -289,8 +289,7 @@ public final class ServiceBindingTest {
   private static class ServiceBindingBuilder {
     private Context sourceContext;
     private Observer observer;
-    private ComponentName targetComponent;
-    private String bindAction;
+    private Intent bindIntent = new Intent();
     private int bindServiceFlags;
 
     public ServiceBindingBuilder setSourceContext(Context sourceContext) {
@@ -299,7 +298,7 @@ public final class ServiceBindingTest {
     }
 
     public ServiceBindingBuilder setBindingAction(String bindAction) {
-      this.bindAction = bindAction;
+      this.bindIntent.setAction(bindAction);
       return this;
     }
 
@@ -309,7 +308,7 @@ public final class ServiceBindingTest {
     }
 
     public ServiceBindingBuilder setTargetComponent(ComponentName targetComponent) {
-      this.targetComponent = targetComponent;
+      this.bindIntent.setComponent(targetComponent);
       return this;
     }
 
@@ -322,8 +321,7 @@ public final class ServiceBindingTest {
       return new ServiceBinding(
           ContextCompat.getMainExecutor(sourceContext),
           sourceContext,
-          targetComponent,
-          bindAction,
+          bindIntent,
           bindServiceFlags,
           observer);
     }


### PR DESCRIPTION
By considering the binding Intent's action, data, type, identity and categories we align gRPC/Binder's addressing with Android's natural equivalence relation for "cached" IBinders.