### PR TITLE
all: remove 2-arg ClientStreamListener.closed()

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -41,6 +41,7 @@ import io.grpc.ServerStreamTracer;
 import io.grpc.Status;
 import io.grpc.internal.ClientStream;
 import io.grpc.internal.ClientStreamListener;
+import io.grpc.internal.ClientStreamListener.RpcProgress;
 import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.GrpcUtil;
@@ -240,7 +241,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
         public void start(ClientStreamListener listener) {
           statsTraceCtx.clientOutboundHeaders();
           statsTraceCtx.streamClosed(status);
-          listener.closed(status, new Metadata());
+          listener.closed(status, RpcProgress.PROCESSED, new Metadata());
         }
       };
   }
@@ -469,7 +470,8 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
           closed = true;
           clientStream.statsTraceCtx.clientInboundTrailers(clientNotifyTrailers);
           clientStream.statsTraceCtx.streamClosed(clientNotifyStatus);
-          clientStreamListener.closed(clientNotifyStatus, clientNotifyTrailers);
+          clientStreamListener.closed(
+              clientNotifyStatus, RpcProgress.PROCESSED, clientNotifyTrailers);
         }
         boolean nowReady = clientRequested > 0;
         return !previouslyReady && nowReady;
@@ -579,7 +581,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
             closed = true;
             clientStream.statsTraceCtx.clientInboundTrailers(trailers);
             clientStream.statsTraceCtx.streamClosed(clientStatus);
-            clientStreamListener.closed(clientStatus, trailers);
+            clientStreamListener.closed(clientStatus, RpcProgress.PROCESSED, trailers);
           } else {
             clientNotifyStatus = clientStatus;
             clientNotifyTrailers = trailers;
@@ -615,7 +617,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
           }
         }
         clientStream.statsTraceCtx.streamClosed(clientStatus);
-        clientStreamListener.closed(clientStatus, new Metadata());
+        clientStreamListener.closed(clientStatus, RpcProgress.PROCESSED, new Metadata());
         return true;
       }
 

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -672,11 +672,6 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
     }
 
     @Override
-    public void closed(Status status, Metadata trailers) {
-      closed(status, RpcProgress.PROCESSED, trailers);
-    }
-
-    @Override
     public void closed(Status status, RpcProgress rpcProgress, Metadata trailers) {
       PerfMark.startTask("ClientStreamListener.closed", tag);
       try {

--- a/core/src/main/java/io/grpc/internal/ClientStreamListener.java
+++ b/core/src/main/java/io/grpc/internal/ClientStreamListener.java
@@ -25,28 +25,13 @@ public interface ClientStreamListener extends StreamListener {
    * Called upon receiving all header information from the remote end-point. Note that transports
    * are not required to call this method if no header information is received, this would occur
    * when a stream immediately terminates with an error and only
-   * {@link #closed(io.grpc.Status, Metadata)} is called.
+   * {@link #closed(io.grpc.Status, RpcProgress, Metadata)} is called.
    *
    * <p>This method should return quickly, as the same thread may be used to process other streams.
    *
    * @param headers the fully buffered received headers.
    */
   void headersRead(Metadata headers);
-
-  /**
-   * Called when the stream is fully closed. {@link
-   * io.grpc.Status.Code#OK} is the only status code that is guaranteed
-   * to have been sent from the remote server. Any other status code may have been caused by
-   * abnormal stream termination. This is guaranteed to always be the final call on a listener. No
-   * further callbacks will be issued.
-   *
-   * <p>This method should return quickly, as the same thread may be used to process other streams.
-   *
-   * @param status details about the remote closure
-   * @param trailers trailing metadata
-   */
-  // TODO(zdapeng): remove this method in favor of the 3-arg one.
-  void closed(Status status, Metadata trailers);
 
   /**
    * Called when the stream is fully closed. {@link

--- a/core/src/main/java/io/grpc/internal/DelayedStream.java
+++ b/core/src/main/java/io/grpc/internal/DelayedStream.java
@@ -26,6 +26,7 @@ import io.grpc.Deadline;
 import io.grpc.DecompressorRegistry;
 import io.grpc.Metadata;
 import io.grpc.Status;
+import io.grpc.internal.ClientStreamListener.RpcProgress;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -235,7 +236,7 @@ class DelayedStream implements ClientStream {
       startTimeNanos = System.nanoTime();
     }
     if (savedError != null) {
-      listener.closed(savedError, new Metadata());
+      listener.closed(savedError, RpcProgress.PROCESSED, new Metadata());
       return;
     }
 
@@ -324,7 +325,7 @@ class DelayedStream implements ClientStream {
     } else {
       drainPendingCalls();
       // Note that listener is a DelayedStreamListener
-      listener.closed(reason, new Metadata());
+      listener.closed(reason, RpcProgress.PROCESSED, new Metadata());
     }
   }
 
@@ -491,16 +492,6 @@ class DelayedStream implements ClientStream {
         @Override
         public void run() {
           realListener.headersRead(headers);
-        }
-      });
-    }
-
-    @Override
-    public void closed(final Status status, final Metadata trailers) {
-      delayOrExecute(new Runnable() {
-        @Override
-        public void run() {
-          realListener.closed(status, trailers);
         }
       });
     }

--- a/core/src/main/java/io/grpc/internal/ForwardingClientStreamListener.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingClientStreamListener.java
@@ -30,11 +30,6 @@ abstract class ForwardingClientStreamListener implements ClientStreamListener {
   }
 
   @Override
-  public void closed(Status status, Metadata trailers) {
-    delegate().closed(status, trailers);
-  }
-
-  @Override
   public void closed(Status status, RpcProgress rpcProgress, Metadata trailers) {
     delegate().closed(status, rpcProgress, trailers);
   }

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -685,12 +685,6 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
             }
 
             @Override
-            public void closed(Status status, Metadata trailers) {
-              callTracer.reportCallEnded(status.isOk());
-              super.closed(status, trailers);
-            }
-
-            @Override
             public void closed(
                 Status status, RpcProgress rpcProgress, Metadata trailers) {
               callTracer.reportCallEnded(status.isOk());

--- a/core/src/test/java/io/grpc/internal/AbstractTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractTransportTest.java
@@ -1157,12 +1157,6 @@ public abstract class AbstractTransportTest {
     final ClientStream clientStream =
         client.newStream(methodDescriptor, new Metadata(), callOptions);
     ClientStreamListenerBase clientStreamListener = new ClientStreamListenerBase() {
-      @Override
-      public void closed(Status status, Metadata trailers) {
-        super.closed(status, trailers);
-        // This simulates the blocking calls which can trigger clientStream.cancel().
-        clientStream.cancel(Status.CANCELLED.withCause(status.asRuntimeException()));
-      }
 
       @Override
       public void closed(
@@ -1243,11 +1237,6 @@ public abstract class AbstractTransportTest {
 
       @Override
       public void headersRead(Metadata headers) {
-      }
-
-      @Override
-      public void closed(Status status, Metadata trailers) {
-        closed(status, RpcProgress.PROCESSED, trailers);
       }
 
       @Override
@@ -2287,11 +2276,6 @@ public abstract class AbstractTransportTest {
         fail("headersRead invoked after closed");
       }
       this.headers.set(headers);
-    }
-
-    @Override
-    public void closed(Status status, Metadata trailers) {
-      closed(status, RpcProgress.PROCESSED, trailers);
     }
 
     @Override

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -17,6 +17,7 @@
 package io.grpc.internal;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.grpc.internal.ClientStreamListener.RpcProgress.PROCESSED;
 import static io.grpc.internal.GrpcUtil.ACCEPT_ENCODING_SPLITTER;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
@@ -173,7 +174,7 @@ public class ClientCallImplTest {
     final ClientStreamListener streamListener = listenerArgumentCaptor.getValue();
     streamListener.headersRead(new Metadata());
     Status status = Status.RESOURCE_EXHAUSTED.withDescription("simulated");
-    streamListener.closed(status , new Metadata());
+    streamListener.closed(status , PROCESSED, new Metadata());
     executor.release();
 
     verify(callListener).onClose(same(status), ArgumentMatchers.isA(Metadata.class));
@@ -205,7 +206,7 @@ public class ClientCallImplTest {
      */
     streamListener
         .messagesAvailable(new SingleMessageProducer(new ByteArrayInputStream(new byte[]{})));
-    streamListener.closed(Status.OK, new Metadata());
+    streamListener.closed(Status.OK, PROCESSED, new Metadata());
     executor.release();
 
     verify(callListener).onClose(statusArgumentCaptor.capture(),
@@ -240,7 +241,7 @@ public class ClientCallImplTest {
      * the call being counted as successful.
      */
     streamListener.headersRead(new Metadata());
-    streamListener.closed(Status.OK, new Metadata());
+    streamListener.closed(Status.OK, PROCESSED, new Metadata());
     executor.release();
 
     verify(callListener).onClose(statusArgumentCaptor.capture(),
@@ -292,7 +293,7 @@ public class ClientCallImplTest {
     final ClientStreamListener streamListener = listenerArgumentCaptor.getValue();
 
     streamListener.headersRead(new Metadata());
-    streamListener.closed(Status.OK, new Metadata());
+    streamListener.closed(Status.OK, PROCESSED, new Metadata());
   }
 
   @Test
@@ -319,7 +320,7 @@ public class ClientCallImplTest {
      * the call being counted as successful.
      */
     streamListener.onReady();
-    streamListener.closed(Status.OK, new Metadata());
+    streamListener.closed(Status.OK, PROCESSED, new Metadata());
     executor.release();
 
     verify(callListener).onClose(statusArgumentCaptor.capture(),
@@ -664,7 +665,7 @@ public class ClientCallImplTest {
     listener.headersRead(new Metadata());
     listener.messagesAvailable(new SingleMessageProducer(new ByteArrayInputStream(new byte[0])));
     listener.messagesAvailable(new SingleMessageProducer(new ByteArrayInputStream(new byte[0])));
-    listener.closed(Status.OK, new Metadata());
+    listener.closed(Status.OK, PROCESSED, new Metadata());
 
     assertTrue(latch.await(5, TimeUnit.SECONDS));
 

--- a/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
@@ -206,7 +206,8 @@ public class DelayedClientTransportTest {
     assertEquals(1, delayedTransport.getPendingStreamsCount());
     stream.cancel(Status.CANCELLED);
     assertEquals(0, delayedTransport.getPendingStreamsCount());
-    verify(streamListener).closed(same(Status.CANCELLED), any(Metadata.class));
+    verify(streamListener).closed(
+        same(Status.CANCELLED), same(RpcProgress.PROCESSED), any(Metadata.class));
     verifyNoMoreInteractions(mockRealTransport);
     verifyNoMoreInteractions(mockRealStream);
   }
@@ -233,7 +234,8 @@ public class DelayedClientTransportTest {
 
     // Further newStream() will return a failing stream
     stream = delayedTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
-    verify(streamListener, never()).closed(any(Status.class), any(Metadata.class));
+    verify(streamListener, never()).closed(
+        any(Status.class), any(RpcProgress.class), any(Metadata.class));
     stream.start(streamListener);
     verify(streamListener).closed(
         statusCaptor.capture(), any(RpcProgress.class), any(Metadata.class));

--- a/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
@@ -41,6 +41,7 @@ import io.grpc.Deadline;
 import io.grpc.DecompressorRegistry;
 import io.grpc.Metadata;
 import io.grpc.Status;
+import io.grpc.internal.ClientStreamListener.RpcProgress;
 import io.grpc.internal.testing.SingleMessageProducer;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -312,7 +313,7 @@ public class DelayedStreamTest {
   public void startThenCancelled() {
     stream.start(listener);
     stream.cancel(Status.CANCELLED);
-    verify(listener).closed(eq(Status.CANCELLED), any(Metadata.class));
+    verify(listener).closed(eq(Status.CANCELLED), any(RpcProgress.class), any(Metadata.class));
   }
 
   @Test
@@ -408,7 +409,7 @@ public class DelayedStreamTest {
         passedListener.messagesAvailable(producer1);
         passedListener.onReady();
         passedListener.messagesAvailable(producer2);
-        passedListener.closed(status, trailers);
+        passedListener.closed(status, RpcProgress.PROCESSED, trailers);
 
         verifyNoMoreInteractions(listener);
       }
@@ -418,7 +419,7 @@ public class DelayedStreamTest {
     inOrder.verify(listener).messagesAvailable(producer1);
     inOrder.verify(listener).onReady();
     inOrder.verify(listener).messagesAvailable(producer2);
-    inOrder.verify(listener).closed(status, trailers);
+    inOrder.verify(listener).closed(status, RpcProgress.PROCESSED, trailers);
   }
 
   @Test
@@ -439,8 +440,8 @@ public class DelayedStreamTest {
     verify(listener).headersRead(headers);
     delayedListener.messagesAvailable(producer);
     verify(listener).messagesAvailable(producer);
-    delayedListener.closed(status, trailers);
-    verify(listener).closed(status, trailers);
+    delayedListener.closed(status, RpcProgress.PROCESSED, trailers);
+    verify(listener).closed(status, RpcProgress.PROCESSED, trailers);
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ForwardingClientStreamListenerTest.java
+++ b/core/src/test/java/io/grpc/internal/ForwardingClientStreamListenerTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 import io.grpc.ForwardingTestUtil;
 import io.grpc.Metadata;
 import io.grpc.Status;
+import io.grpc.internal.ClientStreamListener.RpcProgress;
 import io.grpc.internal.StreamListener.MessageProducer;
 import java.lang.reflect.Method;
 import java.util.Collections;
@@ -61,8 +62,8 @@ public class ForwardingClientStreamListenerTest {
   public void closedTest() {
     Status status = Status.UNKNOWN;
     Metadata trailers = new Metadata();
-    forward.closed(status, trailers);
-    verify(mock).closed(same(status), same(trailers));
+    forward.closed(status, RpcProgress.PROCESSED, trailers);
+    verify(mock).closed(same(status), same(RpcProgress.PROCESSED), same(trailers));
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -25,6 +25,7 @@ import static io.grpc.ConnectivityState.READY;
 import static io.grpc.ConnectivityState.SHUTDOWN;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 import static io.grpc.EquivalentAddressGroup.ATTR_AUTHORITY_OVERRIDE;
+import static io.grpc.internal.ClientStreamListener.RpcProgress.PROCESSED;
 import static junit.framework.TestCase.assertNotSame;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1038,7 +1039,7 @@ public class ManagedChannelImplTest {
     ClientStreamListener streamListener = streamListenerCaptor.getValue();
     Metadata trailers = new Metadata();
     assertEquals(0, callExecutor.numPendingTasks());
-    streamListener.closed(Status.CANCELLED, trailers);
+    streamListener.closed(Status.CANCELLED, PROCESSED, trailers);
     verify(mockCallListener, never()).onClose(same(Status.CANCELLED), same(trailers));
     assertEquals(1, callExecutor.runDueTasks());
     verify(mockCallListener).onClose(same(Status.CANCELLED), same(trailers));
@@ -3423,7 +3424,8 @@ public class ManagedChannelImplTest {
     // closing stream listener affects subchannel stats immediately
     assertEquals(0, getStats(subchannel).callsSucceeded);
     assertEquals(0, getStats(subchannel).callsFailed);
-    streamListener.closed(success ? Status.OK : Status.UNKNOWN, new Metadata());
+    streamListener.closed(
+        success ? Status.OK : Status.UNKNOWN, PROCESSED, new Metadata());
     if (success) {
       assertEquals(1, getStats(subchannel).callsSucceeded);
       assertEquals(0, getStats(subchannel).callsFailed);
@@ -3493,7 +3495,7 @@ public class ManagedChannelImplTest {
     // closing stream listener affects subchannel stats immediately
     assertEquals(0, getStats(oobSubchannel).callsSucceeded);
     assertEquals(0, getStats(oobSubchannel).callsFailed);
-    streamListener.closed(success ? Status.OK : Status.UNKNOWN, new Metadata());
+    streamListener.closed(success ? Status.OK : Status.UNKNOWN, PROCESSED, new Metadata());
     if (success) {
       assertEquals(1, getStats(oobSubchannel).callsSucceeded);
       assertEquals(0, getStats(oobSubchannel).callsFailed);
@@ -3660,7 +3662,8 @@ public class ManagedChannelImplTest {
     assertThat(timer.getPendingTasks()).isEmpty();
 
     // trigger retry
-    streamListenerCaptor.getValue().closed(Status.UNAVAILABLE, new Metadata());
+    streamListenerCaptor.getValue().closed(
+        Status.UNAVAILABLE, PROCESSED, new Metadata());
 
     // in backoff
     timer.forwardTime(5, TimeUnit.SECONDS);
@@ -3690,7 +3693,8 @@ public class ManagedChannelImplTest {
         "channel.isTerminated() is expected to be false but was true",
         channel.isTerminated());
 
-    streamListenerCaptor.getValue().closed(Status.INTERNAL, new Metadata());
+    streamListenerCaptor.getValue().closed(
+        Status.INTERNAL, PROCESSED, new Metadata());
     verify(mockLoadBalancer).shutdown();
     // simulating the shutdown of load balancer triggers the shutdown of subchannel
     shutdownSafely(helper, subchannel);
@@ -3764,7 +3768,8 @@ public class ManagedChannelImplTest {
     timer.forwardTime(5, TimeUnit.SECONDS);
     assertThat(timer.numPendingTasks()).isEqualTo(1);
     // first hedge fails
-    streamListenerCaptor.getValue().closed(Status.UNAVAILABLE, new Metadata());
+    streamListenerCaptor.getValue().closed(
+        Status.UNAVAILABLE, PROCESSED, new Metadata());
     verify(mockStream2, never()).start(any(ClientStreamListener.class));
 
     // shutdown during backoff period
@@ -3790,7 +3795,8 @@ public class ManagedChannelImplTest {
         "channel.isTerminated() is expected to be false but was true",
         channel.isTerminated());
 
-    streamListenerCaptor.getValue().closed(Status.INTERNAL, new Metadata());
+    streamListenerCaptor.getValue().closed(
+        Status.INTERNAL, PROCESSED, new Metadata());
     assertThat(timer.numPendingTasks()).isEqualTo(0);
     verify(mockLoadBalancer).shutdown();
     // simulating the shutdown of load balancer triggers the shutdown of subchannel

--- a/core/src/test/java/io/grpc/internal/NoopClientStreamListener.java
+++ b/core/src/test/java/io/grpc/internal/NoopClientStreamListener.java
@@ -33,8 +33,5 @@ public class NoopClientStreamListener implements ClientStreamListener {
   public void headersRead(Metadata headers) {}
 
   @Override
-  public void closed(Status status, Metadata trailers) {}
-
-  @Override
   public void closed(Status status, RpcProgress rpcProgress, Metadata trailers) {}
 }

--- a/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
@@ -158,9 +158,6 @@ public final class CronetClientTransportTest {
     public void headersRead(Metadata headers) {}
 
     @Override
-    public void closed(Status status, Metadata trailers) {}
-
-    @Override
     public void closed(Status status, RpcProgress rpcProgress, Metadata trailers) {
       this.status = status;
     }

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -345,8 +345,6 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
     ChannelFuture future = enqueue(newCreateStreamCommand(grpcHeaders, streamTransportState));
     channelRead(goAwayFrame(streamId));
     verify(streamListener, never())
-        .closed(any(Status.class), any(Metadata.class));
-    verify(streamListener, never())
         .closed(any(Status.class), any(RpcProgress.class), any(Metadata.class));
     assertTrue(future.isDone());
   }
@@ -357,8 +355,6 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
     ChannelFuture future = writeQueue().enqueue(
         newCreateStreamCommand(grpcHeaders, streamTransportState), true);
     channelRead(goAwayFrame(streamId));
-    verify(streamListener, never())
-        .closed(any(Status.class), any(Metadata.class));
     verify(streamListener, never())
         .closed(any(Status.class), any(RpcProgress.class), any(Metadata.class));
     assertTrue(future.isDone());

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -50,6 +50,7 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.internal.ClientStreamListener;
+import io.grpc.internal.ClientStreamListener.RpcProgress;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.StatsTraceContext;
 import io.grpc.internal.StreamListener;
@@ -304,7 +305,8 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
     // Remove once b/16290036 is fixed.
     headers.status(new AsciiString("500"));
     stream().transportState().transportHeadersReceived(headers, false);
-    verify(listener, never()).closed(any(Status.class), any(Metadata.class));
+    verify(listener, never()).closed(
+        any(Status.class), any(RpcProgress.class), any(Metadata.class));
 
     // We are now waiting for 100 bytes of error context on the stream, cancel has not yet been
     // sent

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -858,11 +858,6 @@ public class NettyClientTransportTest {
     }
 
     @Override
-    public void closed(Status status, Metadata trailers) {
-      closed(status, RpcProgress.PROCESSED, trailers);
-    }
-
-    @Override
     public void closed(Status status, RpcProgress rpcProgress, Metadata trailers) {
       if (status.isOk()) {
         closedFuture.set(null);

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -2303,11 +2303,6 @@ public class OkHttpClientTransportTest {
     }
 
     @Override
-    public void closed(Status status, Metadata trailers) {
-      closed(status, PROCESSED, trailers);
-    }
-
-    @Override
     public void closed(Status status, RpcProgress rpcProgress, Metadata trailers) {
       this.status = status;
       this.trailers = trailers;


### PR DESCRIPTION
We used to have two `ClientStreamListener.closed()` methods. One is simply calling the other with default arg. This doubles debugging (e.g. #7921) and sometimes unit testing work. Deleting the 2-arg method to cleanup. 

This PR is purely refactoring.