### PR TITLE
core: fix boq conformance failures

### DIFF
--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -28,6 +28,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
@@ -611,7 +612,7 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
             if (future.isCancelled()) {
               return;
             }
-            if (!future.isDone() || (callParameters = future.get()) == null) {
+            if (!future.isDone() || (callParameters = Futures.getDone(future)) == null) {
               Status status = Status.INTERNAL.withDescription(
                       "Unexpected failure retrieving server call parameters.");
               throw new StatusException(status);

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -54,7 +54,6 @@ import io.grpc.ServerMethodDefinition;
 import io.grpc.ServerServiceDefinition;
 import io.grpc.ServerTransportFilter;
 import io.grpc.Status;
-import io.grpc.StatusException;
 import io.perfmark.Link;
 import io.perfmark.PerfMark;
 import io.perfmark.Tag;
@@ -607,17 +606,11 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
 
         private void runInternal() {
           ServerStreamListener listener = NOOP_LISTENER;
-          ServerCallParameters<?,?> callParameters;
           try {
             if (future.isCancelled()) {
               return;
             }
-            if (!future.isDone() || (callParameters = Futures.getDone(future)) == null) {
-              Status status = Status.INTERNAL.withDescription(
-                      "Unexpected failure retrieving server call parameters.");
-              throw new StatusException(status);
-            }
-            listener = startWrappedCall(methodName, callParameters, headers);
+            listener = startWrappedCall(methodName, Futures.getDone(future), headers);
           } catch (Throwable ex) {
             stream.close(Status.fromThrowable(ex), new Metadata());
             context.cancel(null);

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -74,6 +74,7 @@ import io.grpc.ServerStreamTracer;
 import io.grpc.ServerTransportFilter;
 import io.grpc.ServiceDescriptor;
 import io.grpc.Status;
+import io.grpc.Status.Code;
 import io.grpc.StringMarshaller;
 import io.grpc.internal.ServerImpl.JumpToApplicationThreadServerStreamListener;
 import io.grpc.internal.ServerImplBuilder.ClientTransportServersBuilder;
@@ -533,6 +534,7 @@ public class ServerImplTest {
   }
 
   @Test
+  @SuppressWarnings("CheckReturnValue")
   public void executorSupplierFutureNotSet() throws Exception {
     builder.executorSupplier = new ServerCallExecutorSupplier() {
       @Override
@@ -575,7 +577,8 @@ public class ServerImplTest {
     assertThat(callReference.get()).isNull();
     verify(stream, times(2)).close(statusCaptor.capture(), any(Metadata.class));
     Status status = statusCaptor.getAllValues().get(1);
-    assertEquals(Status.Code.INTERNAL, status.getCode());
+    assertEquals(Code.UNKNOWN, status.getCode());
+    assertThat(status.getCause() instanceof IllegalStateException);
   }
 
   @Test


### PR DESCRIPTION
Conformance failure due to blocking IO call (future.get())
[reproduced](https://fusion2.corp.google.com/invocations/7bd216bf-aebd-494a-83b4-238726e00c74/targets/%2F%2Fjavatests%2Fcom%2Fgoogle%2Fsocial%2Fboq%2Fhangouts%2Fbot%2Fbots%2Fomg%2Fdynamite%2Fbot%2Fspanner:inspection_conformance_test/tests) and [verified the fix](https://fusion2.corp.google.com/invocations/45574c99-d34e-460c-94b2-c52589ed8de8)

reference: go/boq-conformance-violations/BLOCKING#what-should-i-do-instead