### PR TITLE
compiler: Add GrpcGenerated annotation to generated class

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-TestService.java.txt binary
-TestServiceLite.java.txt binary
-TestDeprecatedService.java.txt binary
-TestDeprecatedServiceLite.java.txt binary
+TestService.java.txt -text
+TestServiceLite.java.txt -text
+TestDeprecatedService.java.txt -text
+TestDeprecatedServiceLite.java.txt -text

--- a/alts/src/generated/main/grpc/io/grpc/alts/internal/HandshakerServiceGrpc.java
+++ b/alts/src/generated/main/grpc/io/grpc/alts/internal/HandshakerServiceGrpc.java
@@ -7,6 +7,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/gcp/handshaker.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class HandshakerServiceGrpc {
 
   private HandshakerServiceGrpc() {}

--- a/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/LoadBalancerStatsServiceGrpc.java
+++ b/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/LoadBalancerStatsServiceGrpc.java
@@ -10,6 +10,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class LoadBalancerStatsServiceGrpc {
 
   private LoadBalancerStatsServiceGrpc() {}

--- a/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -7,6 +7,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/metrics.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class MetricsServiceGrpc {
 
   private MetricsServiceGrpc() {}

--- a/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -10,6 +10,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class ReconnectServiceGrpc {
 
   private ReconnectServiceGrpc() {}

--- a/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -11,6 +11,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class TestServiceGrpc {
 
   private TestServiceGrpc() {}

--- a/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -11,6 +11,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class UnimplementedServiceGrpc {
 
   private UnimplementedServiceGrpc() {}

--- a/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/XdsUpdateClientConfigureServiceGrpc.java
+++ b/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/XdsUpdateClientConfigureServiceGrpc.java
@@ -10,6 +10,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class XdsUpdateClientConfigureServiceGrpc {
 
   private XdsUpdateClientConfigureServiceGrpc() {}

--- a/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/XdsUpdateHealthServiceGrpc.java
+++ b/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/XdsUpdateHealthServiceGrpc.java
@@ -10,6 +10,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class XdsUpdateHealthServiceGrpc {
 
   private XdsUpdateHealthServiceGrpc() {}

--- a/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/LoadBalancerStatsServiceGrpc.java
+++ b/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/LoadBalancerStatsServiceGrpc.java
@@ -10,6 +10,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class LoadBalancerStatsServiceGrpc {
 
   private LoadBalancerStatsServiceGrpc() {}

--- a/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -7,6 +7,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/metrics.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class MetricsServiceGrpc {
 
   private MetricsServiceGrpc() {}

--- a/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -10,6 +10,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class ReconnectServiceGrpc {
 
   private ReconnectServiceGrpc() {}

--- a/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -11,6 +11,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class TestServiceGrpc {
 
   private TestServiceGrpc() {}

--- a/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -11,6 +11,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class UnimplementedServiceGrpc {
 
   private UnimplementedServiceGrpc() {}

--- a/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/XdsUpdateClientConfigureServiceGrpc.java
+++ b/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/XdsUpdateClientConfigureServiceGrpc.java
@@ -10,6 +10,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class XdsUpdateClientConfigureServiceGrpc {
 
   private XdsUpdateClientConfigureServiceGrpc() {}

--- a/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/XdsUpdateHealthServiceGrpc.java
+++ b/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/XdsUpdateHealthServiceGrpc.java
@@ -10,6 +10,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class XdsUpdateHealthServiceGrpc {
 
   private XdsUpdateHealthServiceGrpc() {}

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
@@ -7,6 +7,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/services.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class BenchmarkServiceGrpc {
 
   private BenchmarkServiceGrpc() {}

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/ReportQpsScenarioServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/ReportQpsScenarioServiceGrpc.java
@@ -7,6 +7,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/services.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class ReportQpsScenarioServiceGrpc {
 
   private ReportQpsScenarioServiceGrpc() {}

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
@@ -7,6 +7,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/services.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class WorkerServiceGrpc {
 
   private WorkerServiceGrpc() {}

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -1086,7 +1086,8 @@ static void PrintService(const ServiceDescriptor* service,
       *vars,
       "@$Generated$(\n"
       "    value = \"by gRPC proto compiler$grpc_version$\",\n"
-      "    comments = \"Source: $file_name$\")\n");
+      "    comments = \"Source: $file_name$\")\n"
+      "@$GrpcGenerated$\n");
 
   if (service->options().deprecated()) {
     p->Print(*vars, "@$Deprecated$\n");
@@ -1201,6 +1202,7 @@ void GenerateService(const ServiceDescriptor* service,
   vars["StreamObserver"] = "io.grpc.stub.StreamObserver";
   vars["Iterator"] = "java.util.Iterator";
   vars["Generated"] = "javax.annotation.Generated";
+  vars["GrpcGenerated"] = "io.grpc.stub.annotations.GrpcGenerated";
   vars["ListenableFuture"] =
       "com.google.common.util.concurrent.ListenableFuture";
 

--- a/compiler/src/test/golden/TestDeprecatedService.java.txt
+++ b/compiler/src/test/golden/TestDeprecatedService.java.txt
@@ -10,6 +10,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler (version 1.40.0-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 @java.lang.Deprecated
 public final class TestDeprecatedServiceGrpc {
 

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -10,6 +10,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler (version 1.40.0-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class TestServiceGrpc {
 
   private TestServiceGrpc() {}

--- a/compiler/src/testLite/golden/TestDeprecatedService.java.txt
+++ b/compiler/src/testLite/golden/TestDeprecatedService.java.txt
@@ -10,6 +10,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler (version 1.40.0-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 @java.lang.Deprecated
 public final class TestDeprecatedServiceGrpc {
 

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -10,6 +10,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler (version 1.40.0-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class TestServiceGrpc {
 
   private TestServiceGrpc() {}

--- a/grpclb/src/generated/main/grpc/io/grpc/lb/v1/LoadBalancerGrpc.java
+++ b/grpclb/src/generated/main/grpc/io/grpc/lb/v1/LoadBalancerGrpc.java
@@ -7,6 +7,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/lb/v1/load_balancer.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class LoadBalancerGrpc {
 
   private LoadBalancerGrpc() {}

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/LoadBalancerStatsServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/LoadBalancerStatsServiceGrpc.java
@@ -10,6 +10,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class LoadBalancerStatsServiceGrpc {
 
   private LoadBalancerStatsServiceGrpc() {}

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -7,6 +7,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/metrics.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class MetricsServiceGrpc {
 
   private MetricsServiceGrpc() {}

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -10,6 +10,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class ReconnectServiceGrpc {
 
   private ReconnectServiceGrpc() {}

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -11,6 +11,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class TestServiceGrpc {
 
   private TestServiceGrpc() {}

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -11,6 +11,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class UnimplementedServiceGrpc {
 
   private UnimplementedServiceGrpc() {}

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/XdsUpdateClientConfigureServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/XdsUpdateClientConfigureServiceGrpc.java
@@ -10,6 +10,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class XdsUpdateClientConfigureServiceGrpc {
 
   private XdsUpdateClientConfigureServiceGrpc() {}

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/XdsUpdateHealthServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/XdsUpdateHealthServiceGrpc.java
@@ -10,6 +10,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/testing/test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class XdsUpdateHealthServiceGrpc {
 
   private XdsUpdateHealthServiceGrpc() {}

--- a/rls/src/generated/main/grpc/io/grpc/lookup/v1/RouteLookupServiceGrpc.java
+++ b/rls/src/generated/main/grpc/io/grpc/lookup/v1/RouteLookupServiceGrpc.java
@@ -7,6 +7,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/lookup/v1/rls.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class RouteLookupServiceGrpc {
 
   private RouteLookupServiceGrpc() {}

--- a/services/src/generated/main/grpc/io/grpc/channelz/v1/ChannelzGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/channelz/v1/ChannelzGrpc.java
@@ -11,6 +11,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/channelz/v1/channelz.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class ChannelzGrpc {
 
   private ChannelzGrpc() {}

--- a/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
@@ -7,6 +7,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/health/v1/health.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class HealthGrpc {
 
   private HealthGrpc() {}

--- a/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
@@ -7,6 +7,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: grpc/reflection/v1alpha/reflection.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class ServerReflectionGrpc {
 
   private ServerReflectionGrpc() {}

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/AnotherDynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/AnotherDynamicServiceGrpc.java
@@ -10,6 +10,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: io/grpc/reflection/testing/dynamic_reflection_test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class AnotherDynamicServiceGrpc {
 
   private AnotherDynamicServiceGrpc() {}

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/AnotherReflectableServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/AnotherReflectableServiceGrpc.java
@@ -7,6 +7,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: io/grpc/reflection/testing/reflection_test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class AnotherReflectableServiceGrpc {
 
   private AnotherReflectableServiceGrpc() {}

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
@@ -10,6 +10,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: io/grpc/reflection/testing/dynamic_reflection_test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class DynamicServiceGrpc {
 
   private DynamicServiceGrpc() {}

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
@@ -7,6 +7,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: io/grpc/reflection/testing/reflection_test.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class ReflectableServiceGrpc {
 
   private ReflectableServiceGrpc() {}

--- a/stub/src/main/java/io/grpc/stub/annotations/GrpcGenerated.java
+++ b/stub/src/main/java/io/grpc/stub/annotations/GrpcGenerated.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.stub.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates that the class is gRPC-generated code to assist
+ * <a href="https://docs.oracle.com/javase/6/docs/api/javax/annotation/processing/Processor.html">
+ * Java Annotation Processors.</a>
+ *
+ * <p>This annotation is used by the gRPC stub compiler to annotate outer classes. Users should not
+ * annotate their own classes with this annotation. Not all stubs may have this annotation, so
+ * consumers should not assume that it is present.
+ *
+ * @since 1.40.0
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+public @interface GrpcGenerated {}

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/protobuf/SimpleServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/protobuf/SimpleServiceGrpc.java
@@ -10,6 +10,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: io/grpc/testing/protobuf/simpleservice.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class SimpleServiceGrpc {
 
   private SimpleServiceGrpc() {}

--- a/xds/src/generated/main/grpc/com/github/udpa/udpa/service/orca/v1/OpenRcaServiceGrpc.java
+++ b/xds/src/generated/main/grpc/com/github/udpa/udpa/service/orca/v1/OpenRcaServiceGrpc.java
@@ -17,6 +17,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: udpa/service/orca/v1/orca.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class OpenRcaServiceGrpc {
 
   private OpenRcaServiceGrpc() {}

--- a/xds/src/generated/main/grpc/com/google/security/meshca/v1/MeshCertificateServiceGrpc.java
+++ b/xds/src/generated/main/grpc/com/google/security/meshca/v1/MeshCertificateServiceGrpc.java
@@ -10,6 +10,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: security/proto/providers/google/meshca.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class MeshCertificateServiceGrpc {
 
   private MeshCertificateServiceGrpc() {}

--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/ClusterDiscoveryServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/ClusterDiscoveryServiceGrpc.java
@@ -10,6 +10,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: envoy/api/v2/cds.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class ClusterDiscoveryServiceGrpc {
 
   private ClusterDiscoveryServiceGrpc() {}

--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/EndpointDiscoveryServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/EndpointDiscoveryServiceGrpc.java
@@ -7,6 +7,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: envoy/api/v2/eds.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class EndpointDiscoveryServiceGrpc {
 
   private EndpointDiscoveryServiceGrpc() {}

--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/ListenerDiscoveryServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/ListenerDiscoveryServiceGrpc.java
@@ -13,6 +13,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: envoy/api/v2/lds.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class ListenerDiscoveryServiceGrpc {
 
   private ListenerDiscoveryServiceGrpc() {}

--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/RouteDiscoveryServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/RouteDiscoveryServiceGrpc.java
@@ -14,6 +14,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: envoy/api/v2/rds.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class RouteDiscoveryServiceGrpc {
 
   private RouteDiscoveryServiceGrpc() {}

--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/ScopedRoutesDiscoveryServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/ScopedRoutesDiscoveryServiceGrpc.java
@@ -16,6 +16,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: envoy/api/v2/srds.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class ScopedRoutesDiscoveryServiceGrpc {
 
   private ScopedRoutesDiscoveryServiceGrpc() {}

--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/VirtualHostDiscoveryServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/VirtualHostDiscoveryServiceGrpc.java
@@ -19,6 +19,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: envoy/api/v2/rds.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class VirtualHostDiscoveryServiceGrpc {
 
   private VirtualHostDiscoveryServiceGrpc() {}

--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/discovery/v2/AggregatedDiscoveryServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/discovery/v2/AggregatedDiscoveryServiceGrpc.java
@@ -15,6 +15,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: envoy/service/discovery/v2/ads.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class AggregatedDiscoveryServiceGrpc {
 
   private AggregatedDiscoveryServiceGrpc() {}

--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/discovery/v2/SecretDiscoveryServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/discovery/v2/SecretDiscoveryServiceGrpc.java
@@ -7,6 +7,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: envoy/service/discovery/v2/sds.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class SecretDiscoveryServiceGrpc {
 
   private SecretDiscoveryServiceGrpc() {}

--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/discovery/v3/AggregatedDiscoveryServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/discovery/v3/AggregatedDiscoveryServiceGrpc.java
@@ -15,6 +15,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: envoy/service/discovery/v3/ads.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class AggregatedDiscoveryServiceGrpc {
 
   private AggregatedDiscoveryServiceGrpc() {}

--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/load_stats/v2/LoadReportingServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/load_stats/v2/LoadReportingServiceGrpc.java
@@ -7,6 +7,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: envoy/service/load_stats/v2/lrs.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class LoadReportingServiceGrpc {
 
   private LoadReportingServiceGrpc() {}

--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/load_stats/v3/LoadReportingServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/load_stats/v3/LoadReportingServiceGrpc.java
@@ -7,6 +7,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: envoy/service/load_stats/v3/lrs.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class LoadReportingServiceGrpc {
 
   private LoadReportingServiceGrpc() {}

--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/status/v3/ClientStatusDiscoveryServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/status/v3/ClientStatusDiscoveryServiceGrpc.java
@@ -12,6 +12,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 @javax.annotation.Generated(
     value = "by gRPC proto compiler",
     comments = "Source: envoy/service/status/v3/csds.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class ClientStatusDiscoveryServiceGrpc {
 
   private ClientStatusDiscoveryServiceGrpc() {}


### PR DESCRIPTION
This can be used by annotation processors to avoid processing the
gRPC-generated code. The normal Generated annotation only has SOURCE
retention, so isn't available to annotation processors.

I don't include the service name within the annotation as that assumes
we'll never have need for any other type of generated class. If there's
a request for exposing service name via an annotation in the future, we
can make an RpcService annotation or the like.

'binary' in gitattributes is a macro for '-text -diff' where -text
disables EOL modification and -diff disables textual diffs. However,
these are text files, so we'd actually rather like to have diff.

Fixes #8158