### PR TITLE
Add Info log for gRPC-LB's initial response

### DIFF
--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -690,11 +690,12 @@ final class GrpclbState {
       if (closed) {
         return;
       }
-      logger.log(
-          ChannelLogLevel.DEBUG, "[grpclb-<{0}>] Got an LB response: {1}", serviceName, response);
 
       LoadBalanceResponseTypeCase typeCase = response.getLoadBalanceResponseTypeCase();
       if (!initialResponseReceived) {
+        logger.log(
+            ChannelLogLevel.INFO,
+            "[grpclb-<{0}>] Got an LB initial response: {1}", serviceName, response);
         if (typeCase != LoadBalanceResponseTypeCase.INITIAL_RESPONSE) {
           logger.log(
               ChannelLogLevel.WARNING,
@@ -709,6 +710,9 @@ final class GrpclbState {
         scheduleNextLoadReport();
         return;
       }
+
+      logger.log(
+          ChannelLogLevel.DEBUG, "[grpclb-<{0}>] Got an LB response: {1}", serviceName, response);
 
       if (typeCase == LoadBalanceResponseTypeCase.FALLBACK_RESPONSE) {
         // Force entering fallback requested by balancer.

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -929,7 +929,7 @@ public class GrpclbLoadBalancerTest {
     logs.clear();
     lbResponseObserver.onNext(buildInitialResponse());
     assertThat(logs).containsExactly(
-        "DEBUG: [grpclb-<api.google.com>] Got an LB response: " + buildInitialResponse());
+        "INFO: [grpclb-<api.google.com>] Got an LB initial response: " + buildInitialResponse());
     logs.clear();
     lbResponseObserver.onNext(buildLbResponse(backends1));
 
@@ -2522,7 +2522,7 @@ public class GrpclbLoadBalancerTest {
     logs.clear();
     lbResponseObserver.onNext(buildInitialResponse());
     assertThat(logs).containsExactly(
-        "DEBUG: [grpclb-<api.google.com>] Got an LB response: " + buildInitialResponse());
+        "INFO: [grpclb-<api.google.com>] Got an LB initial response: " + buildInitialResponse());
     logs.clear();
     lbResponseObserver.onNext(buildLbResponse(backends1));
 


### PR DESCRIPTION
It would be helpful to debug with the gRPC-LB's initial response info.
Change the log level to INFO so we can see this log in the ChannelTracer.