### PR TITLE
binder: Updates to support migrations to this API from internal versions.

### DIFF
--- a/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
+++ b/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
@@ -41,7 +41,7 @@ import java.net.SocketAddress;
  * type and data URI.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
-public final class AndroidComponentAddress extends SocketAddress {
+public class AndroidComponentAddress extends SocketAddress { // NOTE: Only temporarily non-final.
   private static final long serialVersionUID = 0L;
 
   private final Intent bindIntent; // An "explicit" Intent. In other words, getComponent() != null.

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransportSecurity.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransportSecurity.java
@@ -17,6 +17,7 @@
 package io.grpc.binder.internal;
 
 import io.grpc.Attributes;
+import io.grpc.Internal;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.SecurityLevel;
@@ -48,6 +49,7 @@ public final class BinderTransportSecurity {
    *
    * @param serverBuilder The ServerBuilder being used to create the server.
    */
+  @Internal
   public static void installAuthInterceptor(ServerBuilder<?> serverBuilder) {
     serverBuilder.intercept(new ServerAuthInterceptor());
   }
@@ -60,7 +62,8 @@ public final class BinderTransportSecurity {
    * @param remoteUid The remote UID of the transport.
    * @param securityPolicy The policy to enforce on this transport.
    */
-  static void attachAuthAttrs(
+  @Internal
+  public static void attachAuthAttrs(
       Attributes.Builder builder, int remoteUid, ServerSecurityPolicy securityPolicy) {
     builder
         .set(


### PR DESCRIPTION
Make BinderTransportSecurity.attachAuthAttrs public.
The class is internal, but make the method public so we can call it from
other internal packages. (Specifically google internal code being migrated to these APIs).

Also make AndroidComponentAddress non-final.