### PR TITLE
grpc-core: correcting a minor resource releasing issue

### DIFF
--- a/core/src/main/java/io/grpc/util/CertificateUtils.java
+++ b/core/src/main/java/io/grpc/util/CertificateUtils.java
@@ -65,24 +65,26 @@ public final class CertificateUtils {
   public static PrivateKey getPrivateKey(InputStream inputStream)
       throws UnsupportedEncodingException, IOException, NoSuchAlgorithmException,
       InvalidKeySpecException {
-    BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, "UTF-8"));
-    String line;
-    while ((line = reader.readLine()) != null) {
-      if ("-----BEGIN PRIVATE KEY-----".equals(line)) {
-        break;
+    try (InputStreamReader isr = new InputStreamReader(inputStream, "UTF-8");
+        BufferedReader reader = new BufferedReader(isr)) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        if ("-----BEGIN PRIVATE KEY-----".equals(line)) {
+          break;
+        }
       }
-    }
-    StringBuilder keyContent = new StringBuilder();
-    while ((line = reader.readLine()) != null) {
-      if ("-----END PRIVATE KEY-----".equals(line)) {
-        break;
+      StringBuilder keyContent = new StringBuilder();
+      while ((line = reader.readLine()) != null) {
+        if ("-----END PRIVATE KEY-----".equals(line)) {
+          break;
+        }
+        keyContent.append(line);
       }
-      keyContent.append(line);
+      byte[] decodedKeyBytes = BaseEncoding.base64().decode(keyContent.toString());
+      KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+      PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decodedKeyBytes);
+      return keyFactory.generatePrivate(keySpec);
     }
-    byte[] decodedKeyBytes = BaseEncoding.base64().decode(keyContent.toString());
-    KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-    PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decodedKeyBytes);
-    return keyFactory.generatePrivate(keySpec);
   }
 }
 


### PR DESCRIPTION
This change adds a try-with-resources block around readers and streams
to control the closing of those objects when the method has completed
rather than relying on the GC to deal with them.

This issue was flagged by an analysis tool via binary analysis of the
grpc-core package as part of a dependency from another project.