### PR TITLE
core: correcting a minor resource releasing issue

### DIFF
--- a/core/src/main/java/io/grpc/util/CertificateUtils.java
+++ b/core/src/main/java/io/grpc/util/CertificateUtils.java
@@ -65,24 +65,26 @@ public final class CertificateUtils {
   public static PrivateKey getPrivateKey(InputStream inputStream)
       throws UnsupportedEncodingException, IOException, NoSuchAlgorithmException,
       InvalidKeySpecException {
-    BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, "UTF-8"));
-    String line;
-    while ((line = reader.readLine()) != null) {
-      if ("-----BEGIN PRIVATE KEY-----".equals(line)) {
-        break;
+    try (InputStreamReader isr = new InputStreamReader(inputStream, "UTF-8");
+        BufferedReader reader = new BufferedReader(isr)) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        if ("-----BEGIN PRIVATE KEY-----".equals(line)) {
+          break;
+        }
       }
-    }
-    StringBuilder keyContent = new StringBuilder();
-    while ((line = reader.readLine()) != null) {
-      if ("-----END PRIVATE KEY-----".equals(line)) {
-        break;
+      StringBuilder keyContent = new StringBuilder();
+      while ((line = reader.readLine()) != null) {
+        if ("-----END PRIVATE KEY-----".equals(line)) {
+          break;
+        }
+        keyContent.append(line);
       }
-      keyContent.append(line);
+      byte[] decodedKeyBytes = BaseEncoding.base64().decode(keyContent.toString());
+      KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+      PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decodedKeyBytes);
+      return keyFactory.generatePrivate(keySpec);
     }
-    byte[] decodedKeyBytes = BaseEncoding.base64().decode(keyContent.toString());
-    KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-    PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decodedKeyBytes);
-    return keyFactory.generatePrivate(keySpec);
   }
 }
 

--- a/core/src/main/java/io/grpc/util/CertificateUtils.java
+++ b/core/src/main/java/io/grpc/util/CertificateUtils.java
@@ -65,8 +65,11 @@ public final class CertificateUtils {
   public static PrivateKey getPrivateKey(InputStream inputStream)
       throws UnsupportedEncodingException, IOException, NoSuchAlgorithmException,
       InvalidKeySpecException {
-    try (InputStreamReader isr = new InputStreamReader(inputStream, "UTF-8");
-        BufferedReader reader = new BufferedReader(isr)) {
+    InputStreamReader isr = null;
+    BufferedReader reader = null;
+    try {
+      isr = new InputStreamReader(inputStream, "UTF-8");
+      reader = new BufferedReader(isr);
       String line;
       while ((line = reader.readLine()) != null) {
         if ("-----BEGIN PRIVATE KEY-----".equals(line)) {
@@ -84,6 +87,13 @@ public final class CertificateUtils {
       KeyFactory keyFactory = KeyFactory.getInstance("RSA");
       PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decodedKeyBytes);
       return keyFactory.generatePrivate(keySpec);
+    } finally {
+      if (null != reader) {
+        reader.close();
+      }
+      if (null != isr) {
+        isr.close();
+      }
     }
   }
 }


### PR DESCRIPTION
This change adds a try-finally block around readers and streams
to control the closing of those objects when the method has completed
rather than relying on the GC to close them.

This issue was flagged by an analysis tool via binary analysis of the
grpc-core package as part of a dependency from another project.

fixes #8311 