### PR TITLE
api: use <scheme,provider> map in nameResoverRegistry

### DIFF
--- a/api/src/main/java/io/grpc/NameResolverProvider.java
+++ b/api/src/main/java/io/grpc/NameResolverProvider.java
@@ -16,6 +16,8 @@
 
 package io.grpc;
 
+import io.grpc.NameResolver.Factory;
+
 /**
  * Provider of name resolvers for name agnostic consumption.
  *
@@ -48,4 +50,16 @@ public abstract class NameResolverProvider extends NameResolver.Factory {
    * @since 1.0.0
    */
   protected abstract int priority();
+
+  /**
+   * Returns the scheme associated with the provider. The provider normally should only create a
+   * {@link NameResolver} when target URI scheme matches the provider scheme. It temporarily
+   * delegates to {@link Factory#getDefaultScheme()} before {@link NameResolver.Factory} is
+   * deprecated in https://github.com/grpc/grpc-java/issues/7133.
+   *
+   * @since 1.40.0
+   * */
+  protected String getScheme() {
+    return getDefaultScheme();
+  }
 }

--- a/api/src/test/java/io/grpc/NameResolverRegistryTest.java
+++ b/api/src/test/java/io/grpc/NameResolverRegistryTest.java
@@ -24,8 +24,8 @@ import io.grpc.NameResolver.ServiceConfigParser;
 import io.grpc.internal.DnsNameResolverProvider;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.net.URI;
-import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -99,7 +99,7 @@ public class NameResolverRegistryTest {
   public void newNameResolver_providerReturnsNull() {
     NameResolverRegistry registry = new NameResolverRegistry();
     registry.register(
-        new BaseProvider(true, 5) {
+        new BaseProvider(true, 5, "noScheme") {
           @Override
           public NameResolver newNameResolver(URI passedUri, NameResolver.Args passedArgs) {
             assertThat(passedUri).isSameInstanceAs(uri);
@@ -108,6 +108,7 @@ public class NameResolverRegistryTest {
           }
         });
     assertThat(registry.asFactory().newNameResolver(uri, args)).isNull();
+    assertThat(registry.asFactory().getDefaultScheme()).isEqualTo("noScheme");
   }
 
   @Test
@@ -148,6 +149,7 @@ public class NameResolverRegistryTest {
           }
         });
     assertThat(registry.asFactory().newNameResolver(uri, args)).isNull();
+    assertThat(registry.asFactory().getDefaultScheme()).isEqualTo(uri.getScheme());
   }
 
   @Test
@@ -195,7 +197,7 @@ public class NameResolverRegistryTest {
 
   @Test
   public void baseProviders() {
-    LinkedHashMap<String, NameResolverProvider> providers =
+    Map<String, NameResolverProvider> providers =
             NameResolverRegistry.getDefaultRegistry().providers();
     assertThat(providers).hasSize(1);
     // 2 name resolvers from grpclb and core, higher priority one is returned.

--- a/xds/src/test/java/io/grpc/xds/XdsSdsClientServerTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsSdsClientServerTest.java
@@ -88,8 +88,11 @@ public class XdsSdsClientServerTest {
   private TlsContextManagerImpl tlsContextManagerForServer;
 
   @Before
-  public void setUp() throws IOException {
+  public void setUp() throws Exception {
     port = XdsServerTestHelper.findFreePort();
+    URI expectedUri = new URI("sdstest://localhost:" + port);
+    fakeNameResolverFactory = new FakeNameResolverFactory.Builder(expectedUri).build();
+    NameResolverRegistry.getDefaultRegistry().register(fakeNameResolverFactory);
   }
 
   @After
@@ -410,9 +413,6 @@ public class XdsSdsClientServerTest {
   private SimpleServiceGrpc.SimpleServiceBlockingStub getBlockingStub(
       final UpstreamTlsContext upstreamTlsContext, String overrideAuthority)
       throws URISyntaxException {
-    URI expectedUri = new URI("sdstest://localhost:" + port);
-    fakeNameResolverFactory = new FakeNameResolverFactory.Builder(expectedUri).build();
-    NameResolverRegistry.getDefaultRegistry().register(fakeNameResolverFactory);
     ManagedChannelBuilder<?> channelBuilder =
         Grpc.newChannelBuilder(
             "sdstest://localhost:" + port,


### PR DESCRIPTION
Part of https://github.com/grpc/grpc-java/issues/7133.
It makes scheme matching more explicit in name resolver API. It slightly changed the existing behaviour because in this PR we pick effective providers early/when refreshing.
But it should not change effectiveness of e.g. `SecretGrpclbNameResolverProvider`.