### PR TITLE
api,core: add InternalRetryTracer API for circuit breaker 

### DIFF
--- a/api/src/main/java/io/grpc/InternalRetryTracer.java
+++ b/api/src/main/java/io/grpc/InternalRetryTracer.java
@@ -16,8 +16,11 @@
 
 package io.grpc;
 
+import javax.annotation.concurrent.ThreadSafe;
+
 /** API for tracing retry events. */
 @Internal
+@ThreadSafe
 public interface InternalRetryTracer {
   /** A CallOptions Key to populate the InternalRetryTracer. */
   CallOptions.Key<InternalRetryTracer> KEY = CallOptions.Key.create("io.grpc.InternalRetryTracer");

--- a/api/src/main/java/io/grpc/InternalRetryTracer.java
+++ b/api/src/main/java/io/grpc/InternalRetryTracer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+/** API for tracing retry events. */
+@Internal
+public interface InternalRetryTracer {
+  /** A CallOptions Key to populate the InternalRetryTracer. */
+  CallOptions.Key<InternalRetryTracer> KEY = CallOptions.Key.create("io.grpc.InternalRetryTracer");
+
+  /** Determines if a failed attempt can be finally retried. */
+  boolean shouldRetry();
+
+  /** The overall RPC is committed. */
+  void commit();
+}

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -56,6 +56,7 @@ import io.grpc.InternalChannelz.ChannelTrace;
 import io.grpc.InternalConfigSelector;
 import io.grpc.InternalInstrumented;
 import io.grpc.InternalLogId;
+import io.grpc.InternalRetryTracer;
 import io.grpc.InternalWithLogId;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.CreateSubchannelArgs;
@@ -539,6 +540,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
         }
       } else {
         final Throttle throttle = lastServiceConfig.getRetryThrottling();
+        final InternalRetryTracer retryTracer = callOptions.getOption(InternalRetryTracer.KEY);
         MethodInfo methodInfo = callOptions.getOption(MethodInfo.KEY);
         final RetryPolicy retryPolicy = methodInfo == null ? null : methodInfo.retryPolicy;
         final HedgingPolicy hedgingPolicy = methodInfo == null ? null : methodInfo.hedgingPolicy;
@@ -555,7 +557,8 @@ final class ManagedChannelImpl extends ManagedChannel implements
                 transportFactory.getScheduledExecutorService(),
                 retryPolicy,
                 hedgingPolicy,
-                throttle);
+                throttle,
+                retryTracer);
           }
 
           @Override

--- a/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
@@ -154,7 +154,8 @@ public class RetriableStreamTest {
           scheduledExecutorService,
           retryPolicy,
           hedgingPolicy,
-          throttle);
+          throttle,
+          null);
     }
 
     @Override


### PR DESCRIPTION
Add InternalRetryTracer API for circuit breaker as originally designed (go/grpc-xds-retry). There might be better alternatives, but this is internal API and we can change anytime.
