### PR TITLE
Clarify the ServerCallHandler API contract.

### DIFF
--- a/api/src/main/java/io/grpc/ServerCallHandler.java
+++ b/api/src/main/java/io/grpc/ServerCallHandler.java
@@ -25,15 +25,20 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public interface ServerCallHandler<RequestT, ResponseT> {
   /**
-   * Produce a non-{@code null} listener for the incoming call. Implementations are free to call
-   * methods on {@code call} before this method has returned.
+   * Starts the next stage of {@code call} processing.
    *
-   * <p>Since {@link Metadata} is not thread-safe, the caller must not access (read or write) {@code
-   * headers} after this point.
+   * <p>Returns a non-{@code null} listener for the incoming call. Callers must arrange for events
+   * associated with {@code call} to be delivered there.
    *
-   * <p>If the implementation throws an exception, {@code call} will be closed with an error.
-   * Implementations must not throw an exception if they started processing that may use {@code
-   * call} on another thread.
+   * <p>Callers of this method transfer their ownership of non-thread-safe {@link ServerCall} and
+   * {@link Metadata} arguments to this {@link ServerCallHandler} for the next stage of asynchronous
+   * processing. Ownership means that an implementation of {@link #startCall} may invoke methods on
+   * {@code call} and {@code headers} while it runs and at any time after it returns normally. On
+   * the other hand, if {@link #startCall} throws, ownership of {@code call} and {@code headers}
+   * reverts to the caller and the {@link ServerCallHandler} implementation must not call any method
+   * on these objects (from some other thread, say).
+   *
+   * <p>If {@link #startCall} throws an exception, the caller must close {@code call} with an error.
    *
    * @param call object for responding to the remote client.
    * @return listener for processing incoming request messages for {@code call}

--- a/api/src/main/java/io/grpc/ServerCallHandler.java
+++ b/api/src/main/java/io/grpc/ServerCallHandler.java
@@ -35,10 +35,10 @@ public interface ServerCallHandler<RequestT, ResponseT> {
    * and the implementation loses the right to call methods on these objects (from some other
    * thread, say).
    *
-   * <p>Ownership also includes the responsibility to eventually close {@code call}. If {@link
-   * #startCall} throws an exception, the caller must handle it by closing {@code call} with an
-   * error. Since {@code call} can only be closed once, an implementation can report errors either
-   * to {@link ServerCall#close} for itself or by throwing an exception, but not both.
+   * <p>Ownership also includes the responsibility to eventually close {@code call}. In particular,
+   * if {@link #startCall} throws an exception, the caller must handle it by closing {@code call}
+   * with an error. Since {@code call} can only be closed once, an implementation can report errors
+   * either to {@link ServerCall#close} for itself or by throwing an exception, but not both.
    *
    * <p>Returns a non-{@code null} listener for the incoming call. Callers of this method must
    * arrange for events associated with {@code call} to be delivered there.

--- a/api/src/main/java/io/grpc/ServerCallHandler.java
+++ b/api/src/main/java/io/grpc/ServerCallHandler.java
@@ -25,7 +25,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public interface ServerCallHandler<RequestT, ResponseT> {
   /**
-   * Passes {@code call} on to the next stage of asynchronous processing.
+   * Starts asynchronous processing of an incoming call.
    *
    * <p>Callers of this method transfer their ownership of the non-thread-safe {@link ServerCall}
    * and {@link Metadata} arguments to the {@link ServerCallHandler} implementation for processing.


### PR DESCRIPTION
- Focus the summary fragment
- Clarify that implementations don't just have access to "call" and "headers" while running -- they in fact take ownership of these arguments from the caller.
- Discuss the owner's obligation to close()
- Make explicit the caller's obligation to the returned Listener.
