### PR TITLE
buildscripts: Fix a typo in xds_url_map.cfg

### DIFF
--- a/buildscripts/kokoro/xds_url_map.cfg
+++ b/buildscripts/kokoro/xds_url_map.cfg
@@ -1,7 +1,7 @@
 # Config file for internal CI
 
 # Location of the continuous shell script in repository.
-build_file: "grpc-java/buildscripts/kokoro/xds-url-map.sh"
+build_file: "grpc-java/buildscripts/kokoro/xds_url_map.sh"
 timeout_mins: 60
 
 action {


### PR DESCRIPTION
As title.

@dapengzhang0 