### PR TITLE
xds: accept an empty defaultValidationContext to support TD sending an LDSupdate like that

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -525,12 +525,12 @@ final class ClientXdsClient extends AbstractXdsClient {
                 + " combined_validation_context");
       }
       if (combinedCertificateValidationContext.hasDefaultValidationContext()) {
-        if (server) {
-          throw new ResourceInvalidException(
-              "default_validation_context only allowed in upstream_tls_context");
-        }
         CertificateValidationContext certificateValidationContext
             = combinedCertificateValidationContext.getDefaultValidationContext();
+        if (certificateValidationContext.getMatchSubjectAltNamesCount() > 0 && server) {
+          throw new ResourceInvalidException(
+              "match_subject_alt_names only allowed in upstream_tls_context");
+        }
         if (certificateValidationContext.hasTrustedCa()) {
           throw new ResourceInvalidException(
               "trusted_ca in default_validation_context is not supported");


### PR DESCRIPTION
This is a workaround for b/194730975 . LDS update from TD has  empty defaultValidationContext. But this is a long standing behavior so gRPC in the mean time should accept it and check that it is empty (until there is a fix in TD)
