### PR TITLE
all: API refactoring in preparation to support retry stats (backport v1.40.x)

### DIFF
--- a/api/src/main/java/io/grpc/ClientStreamTracer.java
+++ b/api/src/main/java/io/grpc/ClientStreamTracer.java
@@ -19,7 +19,6 @@ package io.grpc;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
-import io.grpc.Grpc;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -28,6 +27,18 @@ import javax.annotation.concurrent.ThreadSafe;
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2861")
 @ThreadSafe
 public abstract class ClientStreamTracer extends StreamTracer {
+
+  /**
+   * The stream is being created on a ready transport.
+   *
+   * @param headers the mutable initial metadata. Modifications to it will be sent to the socket but
+   *     not be seen by client interceptors and the application.
+   *
+   * @since 1.40.0
+   */
+  public void streamCreated(@Grpc.TransportAttr Attributes transportAttrs, Metadata headers) {
+  }
+
   /**
    * Headers has been sent to the socket.
    */
@@ -55,22 +66,6 @@ public abstract class ClientStreamTracer extends StreamTracer {
    */
   public abstract static class Factory {
     /**
-     * Creates a {@link ClientStreamTracer} for a new client stream.
-     *
-     * @param callOptions the effective CallOptions of the call
-     * @param headers the mutable headers of the stream. It can be safely mutated within this
-     *        method.  It should not be saved because it is not safe for read or write after the
-     *        method returns.
-     *
-     * @deprecated use {@link
-     * #newClientStreamTracer(io.grpc.ClientStreamTracer.StreamInfo, io.grpc.Metadata)} instead.
-     */
-    @Deprecated
-    public ClientStreamTracer newClientStreamTracer(CallOptions callOptions, Metadata headers) {
-      throw new UnsupportedOperationException("Not implemented");
-    }
-
-    /**
      * Creates a {@link ClientStreamTracer} for a new client stream.  This is called inside the
      * transport when it's creating the stream.
      *
@@ -81,11 +76,14 @@ public abstract class ClientStreamTracer extends StreamTracer {
      *
      * @since 1.20.0
      */
-    @SuppressWarnings("deprecation")
     public ClientStreamTracer newClientStreamTracer(StreamInfo info, Metadata headers) {
-      return newClientStreamTracer(info.getCallOptions(), headers);
+      throw new UnsupportedOperationException("Not implemented");
     }
   }
+
+  /** An abstract class for internal use only. */
+  @Internal
+  public abstract static class InternalLimitedInfoFactory extends Factory {}
 
   /**
    * Information about a stream.
@@ -99,15 +97,21 @@ public abstract class ClientStreamTracer extends StreamTracer {
   public static final class StreamInfo {
     private final Attributes transportAttrs;
     private final CallOptions callOptions;
+    private final boolean isTransparentRetry;
 
-    StreamInfo(Attributes transportAttrs, CallOptions callOptions) {
+    StreamInfo(Attributes transportAttrs, CallOptions callOptions, boolean isTransparentRetry) {
       this.transportAttrs = checkNotNull(transportAttrs, "transportAttrs");
       this.callOptions = checkNotNull(callOptions, "callOptions");
+      this.isTransparentRetry = isTransparentRetry;
     }
 
     /**
      * Returns the attributes of the transport that this stream was created on.
+     *
+     * @deprecated Use {@link ClientStreamTracer#streamCreated(Attributes, Metadata)} to handle
+     *             the transport Attributes instead.
      */
+    @Deprecated
     @Grpc.TransportAttr
     public Attributes getTransportAttrs() {
       return transportAttrs;
@@ -121,15 +125,24 @@ public abstract class ClientStreamTracer extends StreamTracer {
     }
 
     /**
+     * Whether the stream is a transparent retry.
+     *
+     * @since 1.40.0
+     */
+    public boolean isTransparentRetry() {
+      return isTransparentRetry;
+    }
+
+    /**
      * Converts this StreamInfo into a new Builder.
      *
      * @since 1.21.0
      */
     public Builder toBuilder() {
-      Builder builder = new Builder();
-      builder.setTransportAttrs(transportAttrs);
-      builder.setCallOptions(callOptions);
-      return builder;
+      return new Builder()
+          .setCallOptions(callOptions)
+          .setTransportAttrs(transportAttrs)
+          .setIsTransparentRetry(isTransparentRetry);
     }
 
     /**
@@ -146,6 +159,7 @@ public abstract class ClientStreamTracer extends StreamTracer {
       return MoreObjects.toStringHelper(this)
           .add("transportAttrs", transportAttrs)
           .add("callOptions", callOptions)
+          .add("isTransparentRetry", isTransparentRetry)
           .toString();
     }
 
@@ -157,6 +171,7 @@ public abstract class ClientStreamTracer extends StreamTracer {
     public static final class Builder {
       private Attributes transportAttrs = Attributes.EMPTY;
       private CallOptions callOptions = CallOptions.DEFAULT;
+      private boolean isTransparentRetry;
 
       Builder() {
       }
@@ -164,9 +179,12 @@ public abstract class ClientStreamTracer extends StreamTracer {
       /**
        * Sets the attributes of the transport that this stream was created on.  This field is
        * optional.
+       *
+       * @deprecated Use {@link ClientStreamTracer#streamCreated(Attributes, Metadata)} to handle
+       *             the transport Attributes instead.
        */
-      @Grpc.TransportAttr
-      public Builder setTransportAttrs(Attributes transportAttrs) {
+      @Deprecated
+      public Builder setTransportAttrs(@Grpc.TransportAttr Attributes transportAttrs) {
         this.transportAttrs = checkNotNull(transportAttrs, "transportAttrs cannot be null");
         return this;
       }
@@ -180,10 +198,20 @@ public abstract class ClientStreamTracer extends StreamTracer {
       }
 
       /**
+       * Sets whether the stream is a transparent retry.
+       *
+       * @since 1.40.0
+       */
+      public Builder setIsTransparentRetry(boolean isTransparentRetry) {
+        this.isTransparentRetry = isTransparentRetry;
+        return this;
+      }
+
+      /**
        * Builds a new StreamInfo.
        */
       public StreamInfo build() {
-        return new StreamInfo(transportAttrs, callOptions);
+        return new StreamInfo(transportAttrs, callOptions, isTransparentRetry);
       }
     }
   }

--- a/api/src/test/java/io/grpc/CallOptionsTest.java
+++ b/api/src/test/java/io/grpc/CallOptionsTest.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.base.Objects;
+import io.grpc.ClientStreamTracer.StreamInfo;
 import io.grpc.internal.SerializingExecutor;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -271,7 +272,7 @@ public class CallOptionsTest {
     }
   }
 
-  private static class FakeTracerFactory extends ClientStreamTracer.Factory {
+  private static class FakeTracerFactory extends ClientStreamTracer.InternalLimitedInfoFactory {
     final String name;
 
     FakeTracerFactory(String name) {
@@ -279,8 +280,7 @@ public class CallOptionsTest {
     }
 
     @Override
-    public ClientStreamTracer newClientStreamTracer(
-        ClientStreamTracer.StreamInfo info, Metadata headers) {
+    public ClientStreamTracer newClientStreamTracer(StreamInfo info, Metadata headers) {
       return new ClientStreamTracer() {};
     }
 

--- a/core/src/jmh/java/io/grpc/internal/StatsTraceContextBenchmark.java
+++ b/core/src/jmh/java/io/grpc/internal/StatsTraceContextBenchmark.java
@@ -17,7 +17,7 @@
 package io.grpc.internal;
 
 import io.grpc.Attributes;
-import io.grpc.CallOptions;
+import io.grpc.ClientStreamTracer;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerStreamTracer;
@@ -50,7 +50,8 @@ public class StatsTraceContextBenchmark {
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public StatsTraceContext newClientContext() {
-    return StatsTraceContext.newClientContext(CallOptions.DEFAULT, Attributes.EMPTY, emptyMetadata);
+    return StatsTraceContext.newClientContext(
+        new ClientStreamTracer[] { new ClientStreamTracer() {} }, Attributes.EMPTY, emptyMetadata);
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -33,6 +33,7 @@ import com.google.common.base.MoreObjects;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
+import io.grpc.ClientStreamTracer;
 import io.grpc.Codec;
 import io.grpc.Compressor;
 import io.grpc.CompressorRegistry;
@@ -254,9 +255,11 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
           effectiveDeadline, context.getDeadline(), callOptions.getDeadline());
       stream = clientStreamProvider.newStream(method, callOptions, headers, context);
     } else {
+      ClientStreamTracer[] tracers = GrpcUtil.getClientStreamTracers(callOptions, headers, false);
       stream = new FailingClientStream(
           DEADLINE_EXCEEDED.withDescription(
-              "ClientCall started after deadline exceeded: " + effectiveDeadline));
+              "ClientCall started after deadline exceeded: " + effectiveDeadline),
+          tracers);
     }
 
     if (callExecutorIsDirect) {

--- a/core/src/main/java/io/grpc/internal/ClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransport.java
@@ -17,6 +17,7 @@
 package io.grpc.internal;
 
 import io.grpc.CallOptions;
+import io.grpc.ClientStreamTracer;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalInstrumented;
 import io.grpc.Metadata;
@@ -46,10 +47,15 @@ public interface ClientTransport extends InternalInstrumented<SocketStats> {
    * @param method the descriptor of the remote method to be called for this stream.
    * @param headers to send at the beginning of the call
    * @param callOptions runtime options of the call
+   * @param tracers a non-empty array of tracers. The last element in it is reserved to be set by
+   *        the load balancer's pick result and otherwise is a no-op tracer.
    * @return the newly created stream.
    */
   // TODO(nmittler): Consider also throwing for stopping.
-  ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions);
+  ClientStream newStream(
+      MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions,
+      // Using array for tracers instead of a list or composition for better performance.
+      ClientStreamTracer[] tracers);
 
   /**
    * Pings a remote endpoint. When an acknowledgement is received, the given callback will be

--- a/core/src/main/java/io/grpc/internal/DelayedStream.java
+++ b/core/src/main/java/io/grpc/internal/DelayedStream.java
@@ -324,9 +324,13 @@ class DelayedStream implements ClientStream {
       });
     } else {
       drainPendingCalls();
+      onEarlyCancellation(reason);
       // Note that listener is a DelayedStreamListener
       listener.closed(reason, RpcProgress.PROCESSED, new Metadata());
     }
+  }
+
+  protected void onEarlyCancellation(Status reason) {
   }
 
   @GuardedBy("this")

--- a/core/src/main/java/io/grpc/internal/FailingClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/FailingClientTransport.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.CallOptions;
+import io.grpc.ClientStreamTracer;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalLogId;
 import io.grpc.Metadata;
@@ -45,8 +46,9 @@ class FailingClientTransport implements ClientTransport {
 
   @Override
   public ClientStream newStream(
-      MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
-    return new FailingClientStream(error, rpcProgress);
+      MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions,
+      ClientStreamTracer[] tracers) {
+    return new FailingClientStream(error, rpcProgress, tracers);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ForwardingClientStreamTracer.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingClientStreamTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The gRPC Authors
+ * Copyright 2021 The gRPC Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 
-package io.grpc.util;
+package io.grpc.internal;
 
 import com.google.common.base.MoreObjects;
 import io.grpc.Attributes;
 import io.grpc.ClientStreamTracer;
-import io.grpc.ExperimentalApi;
 import io.grpc.Metadata;
 import io.grpc.Status;
 
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/2861")
 public abstract class ForwardingClientStreamTracer extends ClientStreamTracer {
-  /** Returns the underlying {@code ClientStreamTracer}. */
+
+  /**
+   * Returns the underlying {@code ClientStreamTracer}.
+   */
   protected abstract ClientStreamTracer delegate();
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
@@ -20,6 +20,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
+import io.grpc.ClientStreamTracer;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalLogId;
 import io.grpc.Metadata;
@@ -45,8 +46,9 @@ abstract class ForwardingConnectionClientTransport implements ConnectionClientTr
 
   @Override
   public ClientStream newStream(
-      MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
-    return delegate().newStream(method, headers, callOptions);
+      MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions,
+      ClientStreamTracer[] tracers) {
+    return delegate().newStream(method, headers, callOptions, tracers);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -34,6 +34,7 @@ import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ChannelLogger;
 import io.grpc.ChannelLogger.ChannelLogLevel;
+import io.grpc.ClientStreamTracer;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
@@ -667,8 +668,9 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
 
     @Override
     public ClientStream newStream(
-        MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
-      final ClientStream streamDelegate = super.newStream(method, headers, callOptions);
+        MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions,
+        ClientStreamTracer[] tracers) {
+      final ClientStream streamDelegate = super.newStream(method, headers, callOptions, tracers);
       return new ForwardingClientStream() {
         @Override
         protected ClientStream delegate() {

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -532,8 +532,10 @@ final class ManagedChannelImpl extends ManagedChannel implements
         ClientTransport transport =
             getTransport(new PickSubchannelArgsImpl(method, headers, callOptions));
         Context origContext = context.attach();
+        ClientStreamTracer[] tracers = GrpcUtil.getClientStreamTracers(
+            callOptions, headers, /* isTransparentRetry= */ false);
         try {
-          return transport.newStream(method, headers, callOptions);
+          return transport.newStream(method, headers, callOptions, tracers);
         } finally {
           context.detach(origContext);
         }
@@ -569,13 +571,16 @@ final class ManagedChannelImpl extends ManagedChannel implements
           }
 
           @Override
-          ClientStream newSubstream(ClientStreamTracer.Factory tracerFactory, Metadata newHeaders) {
-            CallOptions newOptions = callOptions.withStreamTracerFactory(tracerFactory);
+          ClientStream newSubstream(
+              Metadata newHeaders, ClientStreamTracer.Factory factory, boolean isTransparentRetry) {
+            CallOptions newOptions = callOptions.withStreamTracerFactory(factory);
+            ClientStreamTracer[] tracers =
+                GrpcUtil.getClientStreamTracers(newOptions, newHeaders, isTransparentRetry);
             ClientTransport transport =
                 getTransport(new PickSubchannelArgsImpl(method, newHeaders, newOptions));
             Context origContext = context.attach();
             try {
-              return transport.newStream(method, newHeaders, newOptions);
+              return transport.newStream(method, newHeaders, newOptions, tracers);
             } finally {
               context.detach(origContext);
             }

--- a/core/src/main/java/io/grpc/internal/SubchannelChannel.java
+++ b/core/src/main/java/io/grpc/internal/SubchannelChannel.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
+import io.grpc.ClientStreamTracer;
 import io.grpc.Context;
 import io.grpc.InternalConfigSelector;
 import io.grpc.Metadata;
@@ -57,9 +58,11 @@ final class SubchannelChannel extends Channel {
         if (transport == null) {
           transport = notReadyTransport;
         }
+        ClientStreamTracer[] tracers = GrpcUtil.getClientStreamTracers(
+            callOptions, headers, /* isTransparentRetry= */ false);
         Context origContext = context.attach();
         try {
-          return transport.newStream(method, headers, callOptions);
+          return transport.newStream(method, headers, callOptions, tracers);
         } finally {
           context.detach(origContext);
         }

--- a/core/src/test/java/io/grpc/ClientStreamTracerTest.java
+++ b/core/src/test/java/io/grpc/ClientStreamTracerTest.java
@@ -34,6 +34,7 @@ public class ClientStreamTracerTest {
       Attributes.newBuilder().set(TRANSPORT_ATTR_KEY, "value").build();
 
   @Test
+  @SuppressWarnings("deprecation") // info.getTransportAttrs()
   public void streamInfo_empty() {
     StreamInfo info = StreamInfo.newBuilder().build();
     assertThat(info.getCallOptions()).isSameInstanceAs(CallOptions.DEFAULT);
@@ -41,6 +42,7 @@ public class ClientStreamTracerTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation") // info.getTransportAttrs()
   public void streamInfo_withInfo() {
     StreamInfo info = StreamInfo.newBuilder()
         .setCallOptions(callOptions).setTransportAttrs(transportAttrs).build();
@@ -49,6 +51,7 @@ public class ClientStreamTracerTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation") // info.setTransportAttrs()
   public void streamInfo_noEquality() {
     StreamInfo info1 = StreamInfo.newBuilder()
         .setCallOptions(callOptions).setTransportAttrs(transportAttrs).build();
@@ -60,6 +63,7 @@ public class ClientStreamTracerTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation") // info.getTransportAttrs()
   public void streamInfo_toBuilder() {
     StreamInfo info1 = StreamInfo.newBuilder()
         .setCallOptions(callOptions).setTransportAttrs(transportAttrs).build();

--- a/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
+++ b/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
@@ -35,6 +35,7 @@ import io.grpc.CallCredentials;
 import io.grpc.CallCredentials.RequestInfo;
 import io.grpc.CallOptions;
 import io.grpc.ChannelLogger;
+import io.grpc.ClientStreamTracer;
 import io.grpc.IntegerMarshaller;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -49,6 +50,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnit;
@@ -86,6 +88,9 @@ public class CallCredentialsApplyingTest {
   @Mock
   private ChannelLogger channelLogger;
 
+  private static final ClientStreamTracer[] tracers = new ClientStreamTracer[] {
+      new ClientStreamTracer() {}
+  };
   private static final String AUTHORITY = "testauthority";
   private static final String USER_AGENT = "testuseragent";
   private static final Attributes.Key<String> ATTR_KEY = Attributes.Key.create("somekey");
@@ -117,7 +122,9 @@ public class CallCredentialsApplyingTest {
     origHeaders.put(ORIG_HEADER_KEY, ORIG_HEADER_VALUE);
     when(mockTransportFactory.newClientTransport(address, clientTransportOptions, channelLogger))
         .thenReturn(mockTransport);
-    when(mockTransport.newStream(same(method), any(Metadata.class), any(CallOptions.class)))
+    when(mockTransport.newStream(
+            same(method), any(Metadata.class), any(CallOptions.class),
+            ArgumentMatchers.<ClientStreamTracer[]>any()))
         .thenReturn(mockStream);
     ClientTransportFactory transportFactory = new CallCredentialsApplyingTransportFactory(
         mockTransportFactory, null, mockExecutor);
@@ -133,7 +140,7 @@ public class CallCredentialsApplyingTest {
     Attributes transportAttrs = Attributes.newBuilder().set(ATTR_KEY, ATTR_VALUE).build();
     when(mockTransport.getAttributes()).thenReturn(transportAttrs);
 
-    transport.newStream(method, origHeaders, callOptions);
+    transport.newStream(method, origHeaders, callOptions, tracers);
 
     ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(null);
     verify(mockCreds).applyRequestMetadata(infoCaptor.capture(), same(mockExecutor),
@@ -154,8 +161,10 @@ public class CallCredentialsApplyingTest {
     when(mockTransport.getAttributes()).thenReturn(transportAttrs);
     Executor anotherExecutor = mock(Executor.class);
 
-    transport.newStream(method, origHeaders,
-        callOptions.withAuthority("calloptions-authority").withExecutor(anotherExecutor));
+    transport.newStream(
+        method, origHeaders,
+        callOptions.withAuthority("calloptions-authority").withExecutor(anotherExecutor),
+        tracers);
 
     ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(null);
     verify(mockCreds).applyRequestMetadata(infoCaptor.capture(),
@@ -175,15 +184,17 @@ public class CallCredentialsApplyingTest {
         any(RequestInfo.class), same(mockExecutor),
         any(CallCredentials.MetadataApplier.class));
 
-    FailingClientStream stream =
-        (FailingClientStream) transport.newStream(method, origHeaders, callOptions);
+    FailingClientStream stream = (FailingClientStream) transport.newStream(
+        method, origHeaders, callOptions, tracers);
 
-    verify(mockTransport, never()).newStream(method, origHeaders, callOptions);
+    verify(mockTransport, never()).newStream(
+        any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class),
+        ArgumentMatchers.<ClientStreamTracer[]>any());
     assertEquals(Status.Code.UNAUTHENTICATED, stream.getError().getCode());
     assertSame(ex, stream.getError().getCause());
 
     transport.shutdown(Status.UNAVAILABLE);
-    assertTrue(transport.newStream(method, origHeaders, callOptions)
+    assertTrue(transport.newStream(method, origHeaders, callOptions, tracers)
         instanceof FailingClientStream);
     verify(mockTransport).shutdown(Status.UNAVAILABLE);
   }
@@ -193,14 +204,15 @@ public class CallCredentialsApplyingTest {
     when(mockTransport.getAttributes()).thenReturn(Attributes.EMPTY);
 
     callOptions = callOptions.withCallCredentials(new FakeCallCredentials(CREDS_KEY, CREDS_VALUE));
-    ClientStream stream = transport.newStream(method, origHeaders, callOptions);
+    ClientStream stream = transport.newStream(
+        method, origHeaders, callOptions, tracers);
 
-    verify(mockTransport).newStream(method, origHeaders, callOptions);
+    verify(mockTransport).newStream(method, origHeaders, callOptions, tracers);
     assertSame(mockStream, stream);
     assertEquals(CREDS_VALUE, origHeaders.get(CREDS_KEY));
     assertEquals(ORIG_HEADER_VALUE, origHeaders.get(ORIG_HEADER_KEY));
     transport.shutdown(Status.UNAVAILABLE);
-    assertTrue(transport.newStream(method, origHeaders, callOptions)
+    assertTrue(transport.newStream(method, origHeaders, callOptions, tracers)
         instanceof FailingClientStream);
     verify(mockTransport).shutdown(Status.UNAVAILABLE);
   }
@@ -220,13 +232,15 @@ public class CallCredentialsApplyingTest {
       }).when(mockCreds).applyRequestMetadata(any(RequestInfo.class),
           same(mockExecutor), any(CallCredentials.MetadataApplier.class));
 
-    FailingClientStream stream =
-        (FailingClientStream) transport.newStream(method, origHeaders, callOptions);
+    FailingClientStream stream = (FailingClientStream) transport.newStream(
+        method, origHeaders, callOptions, tracers);
 
-    verify(mockTransport, never()).newStream(method, origHeaders, callOptions);
+    verify(mockTransport, never()).newStream(
+        any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class),
+        ArgumentMatchers.<ClientStreamTracer[]>any());
     assertSame(error, stream.getError());
     transport.shutdownNow(Status.UNAVAILABLE);
-    assertTrue(transport.newStream(method, origHeaders, callOptions)
+    assertTrue(transport.newStream(method, origHeaders, callOptions, tracers)
         instanceof FailingClientStream);
     verify(mockTransport).shutdownNow(Status.UNAVAILABLE);
   }
@@ -236,23 +250,26 @@ public class CallCredentialsApplyingTest {
     when(mockTransport.getAttributes()).thenReturn(Attributes.EMPTY);
 
     // Will call applyRequestMetadata(), which is no-op.
-    DelayedStream stream = (DelayedStream) transport.newStream(method, origHeaders, callOptions);
+    DelayedStream stream = (DelayedStream) transport.newStream(
+        method, origHeaders, callOptions, tracers);
 
     ArgumentCaptor<CallCredentials.MetadataApplier> applierCaptor = ArgumentCaptor.forClass(null);
     verify(mockCreds).applyRequestMetadata(any(RequestInfo.class),
         same(mockExecutor), applierCaptor.capture());
-    verify(mockTransport, never()).newStream(method, origHeaders, callOptions);
+    verify(mockTransport, never()).newStream(
+        any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class),
+        ArgumentMatchers.<ClientStreamTracer[]>any());
 
     transport.shutdown(Status.UNAVAILABLE);
     verify(mockTransport, never()).shutdown(Status.UNAVAILABLE);
-    assertTrue(transport.newStream(method, origHeaders, callOptions)
+    assertTrue(transport.newStream(method, origHeaders, callOptions, tracers)
         instanceof FailingClientStream);
 
     Metadata headers = new Metadata();
     headers.put(CREDS_KEY, CREDS_VALUE);
     applierCaptor.getValue().apply(headers);
 
-    verify(mockTransport).newStream(method, origHeaders, callOptions);
+    verify(mockTransport).newStream(method, origHeaders, callOptions, tracers);
     assertSame(mockStream, stream.getRealStream());
     assertEquals(CREDS_VALUE, origHeaders.get(CREDS_KEY));
     assertEquals(ORIG_HEADER_VALUE, origHeaders.get(ORIG_HEADER_KEY));
@@ -261,20 +278,20 @@ public class CallCredentialsApplyingTest {
 
   @Test
   public void delayedShutdown_shutdownShutdownNowThenApply() {
-    transport.newStream(method, origHeaders, callOptions);
+    transport.newStream(method, origHeaders, callOptions, tracers);
     ArgumentCaptor<CallCredentials.MetadataApplier> applierCaptor = ArgumentCaptor.forClass(null);
     verify(mockCreds).applyRequestMetadata(any(RequestInfo.class),
         same(mockExecutor), applierCaptor.capture());
     transport.shutdown(Status.UNAVAILABLE);
     transport.shutdownNow(Status.ABORTED);
-    assertTrue(transport.newStream(method, origHeaders, callOptions)
+    assertTrue(transport.newStream(method, origHeaders, callOptions, tracers)
         instanceof FailingClientStream);
     verify(mockTransport, never()).shutdown(any(Status.class));
     verify(mockTransport, never()).shutdownNow(any(Status.class));
     Metadata headers = new Metadata();
     headers.put(CREDS_KEY, CREDS_VALUE);
     applierCaptor.getValue().apply(headers);
-    assertTrue(transport.newStream(method, origHeaders, callOptions)
+    assertTrue(transport.newStream(method, origHeaders, callOptions, tracers)
         instanceof FailingClientStream);
     verify(mockTransport).shutdown(Status.UNAVAILABLE);
     verify(mockTransport).shutdownNow(Status.ABORTED);
@@ -282,12 +299,12 @@ public class CallCredentialsApplyingTest {
 
   @Test
   public void delayedShutdown_shutdownThenApplyThenShutdownNow() {
-    transport.newStream(method, origHeaders, callOptions);
+    transport.newStream(method, origHeaders, callOptions, tracers);
     ArgumentCaptor<CallCredentials.MetadataApplier> applierCaptor = ArgumentCaptor.forClass(null);
     verify(mockCreds).applyRequestMetadata(any(RequestInfo.class),
         same(mockExecutor), applierCaptor.capture());
     transport.shutdown(Status.UNAVAILABLE);
-    assertTrue(transport.newStream(method, origHeaders, callOptions)
+    assertTrue(transport.newStream(method, origHeaders, callOptions, tracers)
         instanceof FailingClientStream);
     verify(mockTransport, never()).shutdown(any(Status.class));
     Metadata headers = new Metadata();
@@ -308,25 +325,25 @@ public class CallCredentialsApplyingTest {
     Metadata headers = new Metadata();
     headers.put(CREDS_KEY, CREDS_VALUE);
 
-    transport.newStream(method, origHeaders, callOptions);
-    transport.newStream(method, origHeaders, callOptions);
-    transport.newStream(method, origHeaders, callOptions);
+    transport.newStream(method, origHeaders, callOptions, tracers);
+    transport.newStream(method, origHeaders, callOptions, tracers);
+    transport.newStream(method, origHeaders, callOptions, tracers);
     ArgumentCaptor<CallCredentials.MetadataApplier> applierCaptor = ArgumentCaptor.forClass(null);
     verify(mockCreds, times(3)).applyRequestMetadata(any(RequestInfo.class),
         same(mockExecutor), applierCaptor.capture());
     applierCaptor.getAllValues().get(1).apply(headers);
     transport.shutdown(Status.UNAVAILABLE);
-    assertTrue(transport.newStream(method, origHeaders, callOptions)
+    assertTrue(transport.newStream(method, origHeaders, callOptions, tracers)
         instanceof FailingClientStream);
     verify(mockTransport, never()).shutdown(Status.UNAVAILABLE);
 
     applierCaptor.getAllValues().get(0).apply(headers);
-    assertTrue(transport.newStream(method, origHeaders, callOptions)
+    assertTrue(transport.newStream(method, origHeaders, callOptions, tracers)
         instanceof FailingClientStream);
     verify(mockTransport, never()).shutdown(Status.UNAVAILABLE);
 
     applierCaptor.getAllValues().get(2).apply(headers);
-    assertTrue(transport.newStream(method, origHeaders, callOptions)
+    assertTrue(transport.newStream(method, origHeaders, callOptions, tracers)
         instanceof FailingClientStream);
     verify(mockTransport).shutdown(Status.UNAVAILABLE);
   }
@@ -336,7 +353,8 @@ public class CallCredentialsApplyingTest {
     when(mockTransport.getAttributes()).thenReturn(Attributes.EMPTY);
 
     // Will call applyRequestMetadata(), which is no-op.
-    DelayedStream stream = (DelayedStream) transport.newStream(method, origHeaders, callOptions);
+    DelayedStream stream = (DelayedStream) transport.newStream(
+        method, origHeaders, callOptions, tracers);
 
     ArgumentCaptor<CallCredentials.MetadataApplier> applierCaptor = ArgumentCaptor.forClass(null);
     verify(mockCreds).applyRequestMetadata(any(RequestInfo.class),
@@ -345,11 +363,13 @@ public class CallCredentialsApplyingTest {
     Status error = Status.FAILED_PRECONDITION.withDescription("channel not secure for creds");
     applierCaptor.getValue().fail(error);
 
-    verify(mockTransport, never()).newStream(method, origHeaders, callOptions);
+    verify(mockTransport, never()).newStream(
+        any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class),
+        ArgumentMatchers.<ClientStreamTracer[]>any());
     FailingClientStream failingStream = (FailingClientStream) stream.getRealStream();
     assertSame(error, failingStream.getError());
     transport.shutdown(Status.UNAVAILABLE);
-    assertTrue(transport.newStream(method, origHeaders, callOptions)
+    assertTrue(transport.newStream(method, origHeaders, callOptions, tracers)
         instanceof FailingClientStream);
     verify(mockTransport).shutdown(Status.UNAVAILABLE);
   }
@@ -357,14 +377,15 @@ public class CallCredentialsApplyingTest {
   @Test
   public void noCreds() {
     callOptions = callOptions.withCallCredentials(null);
-    ClientStream stream = transport.newStream(method, origHeaders, callOptions);
+    ClientStream stream = transport.newStream(
+        method, origHeaders, callOptions, tracers);
 
-    verify(mockTransport).newStream(method, origHeaders, callOptions);
+    verify(mockTransport).newStream(method, origHeaders, callOptions, tracers);
     assertSame(mockStream, stream);
     assertNull(origHeaders.get(CREDS_KEY));
     assertEquals(ORIG_HEADER_VALUE, origHeaders.get(ORIG_HEADER_KEY));
     transport.shutdown(Status.UNAVAILABLE);
-    assertTrue(transport.newStream(method, origHeaders, callOptions)
+    assertTrue(transport.newStream(method, origHeaders, callOptions, tracers)
         instanceof FailingClientStream);
     verify(mockTransport).shutdown(Status.UNAVAILABLE);
   }
@@ -373,7 +394,8 @@ public class CallCredentialsApplyingTest {
   public void justCallOptionCreds() {
     callOptions = callOptions.withCallCredentials(new FakeCallCredentials(CREDS_KEY, CREDS_VALUE));
 
-    ClientStream stream = transport.newStream(method, origHeaders, callOptions);
+    ClientStream stream = transport.newStream(
+        method, origHeaders, callOptions, tracers);
 
     assertSame(mockStream, stream);
     assertEquals(CREDS_VALUE, origHeaders.get(CREDS_KEY));
@@ -388,7 +410,8 @@ public class CallCredentialsApplyingTest {
         transportFactory.newClientTransport(address, clientTransportOptions, channelLogger);
     callOptions = callOptions.withCallCredentials(null);
 
-    ClientStream stream = transport.newStream(method, origHeaders, callOptions);
+    ClientStream stream = transport.newStream(
+        method, origHeaders, callOptions, tracers);
 
     assertSame(mockStream, stream);
     assertEquals(CREDS_VALUE, origHeaders.get(CREDS_KEY));
@@ -406,7 +429,8 @@ public class CallCredentialsApplyingTest {
     String creds2Value = "some more credentials";
     callOptions = callOptions.withCallCredentials(new FakeCallCredentials(creds2Key, creds2Value));
 
-    ClientStream stream = transport.newStream(method, origHeaders, callOptions);
+    ClientStream stream = transport.newStream(
+        method, origHeaders, callOptions, tracers);
 
     assertSame(mockStream, stream);
     assertEquals(CREDS_VALUE, origHeaders.get(CREDS_KEY));

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
@@ -47,6 +48,7 @@ import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 import io.grpc.ClientStreamTracer;
+import io.grpc.ClientStreamTracer.StreamInfo;
 import io.grpc.Codec;
 import io.grpc.Context;
 import io.grpc.Deadline;
@@ -143,6 +145,8 @@ public class ClientCallImplTest {
             any(Metadata.class),
             any(Context.class)))
         .thenReturn(stream);
+    when(streamTracerFactory.newClientStreamTracer(any(StreamInfo.class), any(Metadata.class)))
+        .thenReturn(new ClientStreamTracer() {});
     doAnswer(new Answer<Void>() {
         @Override
         public Void answer(InvocationOnMock in) {
@@ -156,7 +160,7 @@ public class ClientCallImplTest {
 
   @After
   public void tearDown() {
-    verifyNoInteractions(streamTracerFactory);
+    verifyNoMoreInteractions(streamTracerFactory);
   }
 
   @Test
@@ -763,6 +767,7 @@ public class ClientCallImplTest {
         channelCallTracer, configSelector)
             .setDecompressorRegistry(decompressorRegistry);
     call.start(callListener, new Metadata());
+    verify(streamTracerFactory).newClientStreamTracer(any(StreamInfo.class), any(Metadata.class));
     verify(clientStreamProvider, never())
         .newStream(
             (MethodDescriptor<?, ?>) any(MethodDescriptor.class),

--- a/core/src/test/java/io/grpc/internal/FailingClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/FailingClientStreamTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import io.grpc.ClientStreamTracer;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.ClientStreamListener.RpcProgress;
@@ -33,13 +34,16 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class FailingClientStreamTest {
+  private static final ClientStreamTracer[] tracers = new ClientStreamTracer[] {
+      new ClientStreamTracer() {}
+  };
 
   @Test
   public void processedRpcProgressPopulatedToListener() {
     ClientStreamListener listener = mock(ClientStreamListener.class);
     Status status = Status.UNAVAILABLE;
 
-    ClientStream stream = new FailingClientStream(status);
+    ClientStream stream = new FailingClientStream(status, RpcProgress.PROCESSED, tracers);
     stream.start(listener);
     verify(listener).closed(eq(status), eq(RpcProgress.PROCESSED), any(Metadata.class));
   }
@@ -49,7 +53,7 @@ public class FailingClientStreamTest {
     ClientStreamListener listener = mock(ClientStreamListener.class);
     Status status = Status.UNAVAILABLE;
 
-    ClientStream stream = new FailingClientStream(status, RpcProgress.DROPPED);
+    ClientStream stream = new FailingClientStream(status, RpcProgress.DROPPED, tracers);
     stream.start(listener);
     verify(listener).closed(eq(status), eq(RpcProgress.DROPPED), any(Metadata.class));
   }

--- a/core/src/test/java/io/grpc/internal/FailingClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/FailingClientTransportTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import io.grpc.CallOptions;
+import io.grpc.ClientStreamTracer;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.ClientStreamListener.RpcProgress;
@@ -41,8 +42,9 @@ public class FailingClientTransportTest {
     Status error = Status.UNAVAILABLE;
     RpcProgress rpcProgress = RpcProgress.DROPPED;
     FailingClientTransport transport = new FailingClientTransport(error, rpcProgress);
-    ClientStream stream = transport
-        .newStream(TestMethodDescriptors.voidMethod(), new Metadata(), CallOptions.DEFAULT);
+    ClientStream stream = transport.newStream(
+        TestMethodDescriptors.voidMethod(), new Metadata(), CallOptions.DEFAULT,
+        new ClientStreamTracer[] { new ClientStreamTracer() {} });
     ClientStreamListener listener = mock(ClientStreamListener.class);
     stream.start(listener);
 

--- a/core/src/test/java/io/grpc/internal/ForwardingClientStreamTracerTest.java
+++ b/core/src/test/java/io/grpc/internal/ForwardingClientStreamTracerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The gRPC Authors
+ * Copyright 2021 The gRPC Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.grpc.util;
+package io.grpc.internal;
 
 import static org.mockito.Mockito.mock;
 
@@ -40,7 +40,6 @@ public class ForwardingClientStreamTracerTest {
         Collections.<Method>emptyList());
   }
 
-  @SuppressWarnings("deprecation")
   private final class TestClientStreamTracer extends ForwardingClientStreamTracer {
     @Override
     protected ClientStreamTracer delegate() {

--- a/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
+++ b/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
@@ -16,6 +16,7 @@
 
 package io.grpc.internal;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -27,13 +28,17 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import io.grpc.Attributes;
 import io.grpc.CallOptions;
+import io.grpc.ClientStreamTracer;
+import io.grpc.ClientStreamTracer.StreamInfo;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.ClientStreamListener.RpcProgress;
 import io.grpc.internal.GrpcUtil.Http2Error;
 import io.grpc.testing.TestMethodDescriptors;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -43,6 +48,10 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link GrpcUtil}. */
 @RunWith(JUnit4.class)
 public class GrpcUtilTest {
+
+  private static final ClientStreamTracer[] tracers = new ClientStreamTracer[] {
+      new ClientStreamTracer() {}
+  };
 
   @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule public final ExpectedException thrown = ExpectedException.none();
@@ -244,8 +253,9 @@ public class GrpcUtilTest {
 
     assertNotNull(transport);
 
-    ClientStream stream = transport
-        .newStream(TestMethodDescriptors.voidMethod(), new Metadata(), CallOptions.DEFAULT);
+    ClientStream stream = transport.newStream(
+        TestMethodDescriptors.voidMethod(), new Metadata(), CallOptions.DEFAULT,
+        tracers);
     ClientStreamListener listener = mock(ClientStreamListener.class);
     stream.start(listener);
 
@@ -260,8 +270,9 @@ public class GrpcUtilTest {
 
     assertNotNull(transport);
 
-    ClientStream stream = transport
-        .newStream(TestMethodDescriptors.voidMethod(), new Metadata(), CallOptions.DEFAULT);
+    ClientStream stream = transport.newStream(
+        TestMethodDescriptors.voidMethod(), new Metadata(), CallOptions.DEFAULT,
+        tracers);
     ClientStreamListener listener = mock(ClientStreamListener.class);
     stream.start(listener);
 
@@ -276,11 +287,39 @@ public class GrpcUtilTest {
 
     assertNotNull(transport);
 
-    ClientStream stream = transport
-        .newStream(TestMethodDescriptors.voidMethod(), new Metadata(), CallOptions.DEFAULT);
+    ClientStream stream = transport.newStream(
+        TestMethodDescriptors.voidMethod(), new Metadata(), CallOptions.DEFAULT,
+        tracers);
     ClientStreamListener listener = mock(ClientStreamListener.class);
     stream.start(listener);
 
     verify(listener).closed(eq(status), eq(RpcProgress.DROPPED), any(Metadata.class));
+  }
+
+  @Test
+  public void clientStreamTracerFactoryBackwardCompatibility() {
+    final AtomicReference<Attributes> transportAttrsRef = new AtomicReference<>();
+    final ClientStreamTracer mockTracer = mock(ClientStreamTracer.class);
+    final Metadata.Key<String> key = Metadata.Key.of("fake-key", Metadata.ASCII_STRING_MARSHALLER);
+    ClientStreamTracer.Factory oldFactoryImpl = new ClientStreamTracer.Factory() {
+      @SuppressWarnings("deprecation")
+      @Override
+      public ClientStreamTracer newClientStreamTracer(StreamInfo info, Metadata headers) {
+        transportAttrsRef.set(info.getTransportAttrs());
+        headers.put(key, "fake-value");
+        return mockTracer;
+      }
+    };
+
+    StreamInfo info =
+        StreamInfo.newBuilder().setCallOptions(CallOptions.DEFAULT.withWaitForReady()).build();
+    Metadata metadata = new Metadata();
+    Attributes transAttrs =
+        Attributes.newBuilder().set(Attributes.Key.<String>create("foo"), "bar").build();
+    ClientStreamTracer tracer = GrpcUtil.newClientStreamTracer(oldFactoryImpl, info, metadata);
+    tracer.streamCreated(transAttrs, metadata);
+
+    assertThat(transportAttrsRef.get()).isEqualTo(transAttrs);
+    assertThat(metadata.get(key)).isEqualTo("fake-value");
   }
 }

--- a/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
@@ -163,9 +163,10 @@ public class RetriableStreamTest {
     }
 
     @Override
-    ClientStream newSubstream(ClientStreamTracer.Factory tracerFactory, Metadata metadata) {
+    ClientStream newSubstream(
+        Metadata metadata, ClientStreamTracer.Factory tracerFactory, boolean isTransparentRetry) {
       bufferSizeTracer =
-          tracerFactory.newClientStreamTracer(STREAM_INFO, new Metadata());
+          tracerFactory.newClientStreamTracer(STREAM_INFO, metadata);
       int actualPreviousRpcAttemptsInHeader = metadata.get(GRPC_PREVIOUS_RPC_ATTEMPTS) == null
           ? 0 : Integer.valueOf(metadata.get(GRPC_PREVIOUS_RPC_ATTEMPTS));
       return retriableStreamRecorder.newSubstream(actualPreviousRpcAttemptsInHeader);

--- a/core/src/test/java/io/grpc/internal/TestUtils.java
+++ b/core/src/test/java/io/grpc/internal/TestUtils.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 import io.grpc.CallOptions;
 import io.grpc.ChannelLogger;
+import io.grpc.ClientStreamTracer;
 import io.grpc.InternalLogId;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
@@ -35,6 +36,7 @@ import java.net.SocketAddress;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import javax.annotation.Nullable;
+import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -118,7 +120,8 @@ public final class TestUtils {
         when(mockTransport.getLogId())
             .thenReturn(InternalLogId.allocate("mocktransport", /*details=*/ null));
         when(mockTransport.newStream(
-                any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class)))
+                any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class),
+                ArgumentMatchers.<ClientStreamTracer[]>any()))
             .thenReturn(mock(ClientStream.class));
         // Save the listener
         doAnswer(new Answer<Runnable>() {

--- a/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
+import io.grpc.ClientStreamTracer;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalLogId;
 import io.grpc.Metadata;
@@ -118,7 +119,7 @@ class CronetClientTransport implements ConnectionClientTransport {
 
   @Override
   public CronetClientStream newStream(final MethodDescriptor<?, ?> method, final Metadata headers,
-      final CallOptions callOptions) {
+      final CallOptions callOptions, ClientStreamTracer[] tracers) {
     Preconditions.checkNotNull(method, "method");
     Preconditions.checkNotNull(headers, "headers");
 
@@ -126,7 +127,7 @@ class CronetClientTransport implements ConnectionClientTransport {
     final String url = "https://" + authority + defaultPath;
 
     final StatsTraceContext statsTraceCtx =
-        StatsTraceContext.newClientContext(callOptions, attrs, headers);
+        StatsTraceContext.newClientContext(tracers, attrs, headers);
     class StartCallback implements Runnable {
       final CronetClientStream clientStream = new CronetClientStream(
           url, userAgent, executor, headers, CronetClientTransport.this, this, lock, maxMessageSize,

--- a/cronet/src/test/java/io/grpc/cronet/CronetChannelBuilderTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetChannelBuilderTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import android.os.Build;
 import io.grpc.CallOptions;
 import io.grpc.ChannelLogger;
+import io.grpc.ClientStreamTracer;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.cronet.CronetChannelBuilder.CronetTransportFactory;
@@ -50,6 +51,8 @@ public final class CronetChannelBuilderTest {
   @Mock private ExperimentalCronetEngine mockEngine;
   @Mock private ChannelLogger channelLogger;
 
+  private final ClientStreamTracer[] tracers =
+      new ClientStreamTracer[]{ new ClientStreamTracer() {} };
   private MethodDescriptor<?, ?> method = TestMethodDescriptors.voidMethod();
 
   @Before
@@ -69,7 +72,8 @@ public final class CronetChannelBuilderTest {
                 new InetSocketAddress("localhost", 443),
                 new ClientTransportOptions(),
                 channelLogger);
-    CronetClientStream stream = transport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+    CronetClientStream stream = transport.newStream(
+        method, new Metadata(), CallOptions.DEFAULT, tracers);
 
     assertTrue(stream.idempotent);
   }
@@ -85,7 +89,8 @@ public final class CronetChannelBuilderTest {
                 new InetSocketAddress("localhost", 443),
                 new ClientTransportOptions(),
                 channelLogger);
-    CronetClientStream stream = transport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+    CronetClientStream stream = transport.newStream(
+        method, new Metadata(), CallOptions.DEFAULT, tracers);
 
     assertFalse(stream.idempotent);
   }

--- a/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import android.os.Build;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
+import io.grpc.ClientStreamTracer;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.SecurityLevel;
@@ -60,6 +61,8 @@ public final class CronetClientTransportTest {
   private static final Attributes EAG_ATTRS =
       Attributes.newBuilder().set(EAG_ATTR_KEY, "value").build();
 
+  private final ClientStreamTracer[] tracers =
+      new ClientStreamTracer[]{ new ClientStreamTracer() {} };
   private CronetClientTransport transport;
   @Mock private StreamBuilderFactory streamFactory;
   @Mock private Executor executor;
@@ -101,9 +104,9 @@ public final class CronetClientTransportTest {
   @Test
   public void shutdownTransport() throws Exception {
     CronetClientStream stream1 =
-        transport.newStream(descriptor, new Metadata(), CallOptions.DEFAULT);
+        transport.newStream(descriptor, new Metadata(), CallOptions.DEFAULT, tracers);
     CronetClientStream stream2 =
-        transport.newStream(descriptor, new Metadata(), CallOptions.DEFAULT);
+        transport.newStream(descriptor, new Metadata(), CallOptions.DEFAULT, tracers);
 
     // Create a transport and start two streams on it.
     ArgumentCaptor<BidirectionalStream.Callback> callbackCaptor =
@@ -137,7 +140,7 @@ public final class CronetClientTransportTest {
   @Test
   public void startStreamAfterShutdown() throws Exception {
     CronetClientStream stream =
-        transport.newStream(descriptor, new Metadata(), CallOptions.DEFAULT);
+        transport.newStream(descriptor, new Metadata(), CallOptions.DEFAULT, tracers);
     transport.shutdown();
     BaseClientStreamListener listener = new BaseClientStreamListener();
     stream.start(listener);

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbClientLoadRecorder.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbClientLoadRecorder.java
@@ -37,7 +37,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * span of an LB stream with the remote load-balancer.
  */
 @ThreadSafe
-final class GrpclbClientLoadRecorder extends ClientStreamTracer.Factory {
+final class GrpclbClientLoadRecorder extends ClientStreamTracer.InternalLimitedInfoFactory {
 
   private static final AtomicLongFieldUpdater<GrpclbClientLoadRecorder> callsStartedUpdater =
       AtomicLongFieldUpdater.newUpdater(GrpclbClientLoadRecorder.class, "callsStarted");

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -481,6 +481,7 @@ public class GrpclbLoadBalancerTest {
 
     ClientStreamTracer tracer1 =
         pick1.getStreamTracerFactory().newClientStreamTracer(STREAM_INFO, new Metadata());
+    tracer1.streamCreated(Attributes.EMPTY, new Metadata());
 
     PickResult pick2 = picker.pickSubchannel(args);
     assertNull(pick2.getSubchannel());
@@ -504,6 +505,7 @@ public class GrpclbLoadBalancerTest {
     assertSame(getLoadRecorder(), pick3.getStreamTracerFactory());
     ClientStreamTracer tracer3 =
         pick3.getStreamTracerFactory().newClientStreamTracer(STREAM_INFO, new Metadata());
+    tracer3.streamCreated(Attributes.EMPTY, new Metadata());
 
     // pick3 has sent out headers
     tracer3.outboundHeaders();
@@ -541,6 +543,7 @@ public class GrpclbLoadBalancerTest {
     assertSame(getLoadRecorder(), pick5.getStreamTracerFactory());
     ClientStreamTracer tracer5 =
         pick5.getStreamTracerFactory().newClientStreamTracer(STREAM_INFO, new Metadata());
+    tracer5.streamCreated(Attributes.EMPTY, new Metadata());
 
     // pick3 ended without receiving response headers
     tracer3.streamClosed(Status.DEADLINE_EXCEEDED);

--- a/grpclb/src/test/java/io/grpc/grpclb/TokenAttachingTracerFactoryTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/TokenAttachingTracerFactoryTest.java
@@ -33,12 +33,23 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link TokenAttachingTracerFactory}. */
 @RunWith(JUnit4.class)
 public class TokenAttachingTracerFactoryTest {
-  private static final ClientStreamTracer fakeTracer = new ClientStreamTracer() {};
+  private static final class FakeClientStreamTracer extends ClientStreamTracer {
+    Attributes transportAttrs;
+    Metadata headers;
+
+    @Override
+    public void streamCreated(Attributes transportAttrs, Metadata headers) {
+      this.transportAttrs = transportAttrs;
+      this.headers = headers;
+    }
+  }
+
+  private static final FakeClientStreamTracer fakeTracer = new FakeClientStreamTracer();
 
   private final ClientStreamTracer.Factory delegate = mock(
       ClientStreamTracer.Factory.class,
       delegatesTo(
-          new ClientStreamTracer.Factory() {
+          new ClientStreamTracer.InternalLimitedInfoFactory() {
             @Override
             public ClientStreamTracer newClientStreamTracer(
                 ClientStreamTracer.StreamInfo info, Metadata headers) {
@@ -51,28 +62,25 @@ public class TokenAttachingTracerFactoryTest {
     TokenAttachingTracerFactory factory = new TokenAttachingTracerFactory(delegate);
     Attributes eagAttrs = Attributes.newBuilder()
         .set(GrpclbConstants.TOKEN_ATTRIBUTE_KEY, "token0001").build();
-    ClientStreamTracer.StreamInfo info = ClientStreamTracer.StreamInfo.newBuilder()
-        .setTransportAttrs(
-            Attributes.newBuilder().set(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS, eagAttrs).build())
-        .build();
+    ClientStreamTracer.StreamInfo info = ClientStreamTracer.StreamInfo.newBuilder().build();
     Metadata headers = new Metadata();
     // Preexisting token should be replaced
     headers.put(GrpclbConstants.TOKEN_METADATA_KEY, "preexisting-token");
 
     ClientStreamTracer tracer = factory.newClientStreamTracer(info, headers);
     verify(delegate).newClientStreamTracer(same(info), same(headers));
-    assertThat(tracer).isSameInstanceAs(fakeTracer);
+    Attributes transportAttrs =
+        Attributes.newBuilder().set(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS, eagAttrs).build();
+    tracer.streamCreated(transportAttrs, headers);
+    assertThat(fakeTracer.transportAttrs).isSameInstanceAs(transportAttrs);
+    assertThat(fakeTracer.headers).isSameInstanceAs(headers);
     assertThat(headers.getAll(GrpclbConstants.TOKEN_METADATA_KEY)).containsExactly("token0001");
   }
 
   @Test
   public void noToken() {
     TokenAttachingTracerFactory factory = new TokenAttachingTracerFactory(delegate);
-    ClientStreamTracer.StreamInfo info = ClientStreamTracer.StreamInfo.newBuilder()
-        .setTransportAttrs(
-            Attributes.newBuilder()
-                .set(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS, Attributes.EMPTY).build())
-        .build();
+    ClientStreamTracer.StreamInfo info = ClientStreamTracer.StreamInfo.newBuilder().build();
 
     Metadata headers = new Metadata();
     // Preexisting token should be removed
@@ -80,22 +88,25 @@ public class TokenAttachingTracerFactoryTest {
 
     ClientStreamTracer tracer = factory.newClientStreamTracer(info, headers);
     verify(delegate).newClientStreamTracer(same(info), same(headers));
-    assertThat(tracer).isSameInstanceAs(fakeTracer);
+    Attributes transportAttrs =
+        Attributes.newBuilder().set(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS, Attributes.EMPTY).build();
+    tracer.streamCreated(transportAttrs, headers);
+    assertThat(fakeTracer.transportAttrs).isSameInstanceAs(transportAttrs);
+    assertThat(fakeTracer.headers).isSameInstanceAs(headers);
     assertThat(headers.get(GrpclbConstants.TOKEN_METADATA_KEY)).isNull();
   }
 
   @Test
   public void nullDelegate() {
     TokenAttachingTracerFactory factory = new TokenAttachingTracerFactory(null);
-    ClientStreamTracer.StreamInfo info = ClientStreamTracer.StreamInfo.newBuilder()
-        .setTransportAttrs(
-            Attributes.newBuilder()
-                .set(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS, Attributes.EMPTY).build())
-        .build();
+    ClientStreamTracer.StreamInfo info = ClientStreamTracer.StreamInfo.newBuilder().build();
 
     Metadata headers = new Metadata();
 
     ClientStreamTracer tracer = factory.newClientStreamTracer(info, headers);
+    tracer.streamCreated(
+        Attributes.newBuilder().set(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS, Attributes.EMPTY).build(),
+        headers);
     assertThat(tracer).isNotNull();
     assertThat(headers.get(GrpclbConstants.TOKEN_METADATA_KEY)).isNull();
   }

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -28,6 +28,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ChannelLogger;
+import io.grpc.ClientStreamTracer;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalLogId;
 import io.grpc.Metadata;
@@ -167,14 +168,15 @@ class NettyClientTransport implements ConnectionClientTransport {
 
   @Override
   public ClientStream newStream(
-      MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
+      MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions,
+      ClientStreamTracer[] tracers) {
     Preconditions.checkNotNull(method, "method");
     Preconditions.checkNotNull(headers, "headers");
     if (channel == null) {
-      return new FailingClientStream(statusExplainingWhyTheChannelIsNull);
+      return new FailingClientStream(statusExplainingWhyTheChannelIsNull, tracers);
     }
     StatsTraceContext statsTraceCtx =
-        StatsTraceContext.newClientContext(callOptions, getAttributes(), headers);
+        StatsTraceContext.newClientContext(tracers, getAttributes(), headers);
     return new NettyClientStream(
         new NettyClientStream.TransportState(
             handler,

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -41,6 +41,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ChannelLogger;
+import io.grpc.ClientStreamTracer;
 import io.grpc.Grpc;
 import io.grpc.InternalChannelz;
 import io.grpc.Metadata;
@@ -828,7 +829,9 @@ public class NettyClientTransportTest {
     }
 
     Rpc(NettyClientTransport transport, Metadata headers) {
-      stream = transport.newStream(METHOD, headers, CallOptions.DEFAULT);
+      stream = transport.newStream(
+          METHOD, headers, CallOptions.DEFAULT,
+          new ClientStreamTracer[]{ new ClientStreamTracer() {} });
       stream.start(listener);
       stream.request(1);
       stream.writeMessage(new ByteArrayInputStream(MESSAGE.getBytes(UTF_8)));

--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -31,8 +31,8 @@ import io.grpc.InternalLogId;
 import io.grpc.LoadBalancer;
 import io.grpc.Metadata;
 import io.grpc.Status;
+import io.grpc.internal.ForwardingClientStreamTracer;
 import io.grpc.internal.ObjectPool;
-import io.grpc.util.ForwardingClientStreamTracer;
 import io.grpc.util.ForwardingLoadBalancerHelper;
 import io.grpc.util.ForwardingSubchannel;
 import io.grpc.xds.ClusterImplLoadBalancerProvider.ClusterImplConfig;
@@ -329,7 +329,8 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
     }
   }
 
-  private static final class CountingStreamTracerFactory extends ClientStreamTracer.Factory {
+  private static final class CountingStreamTracerFactory extends
+      ClientStreamTracer.InternalLimitedInfoFactory {
     private ClusterLocalityStats stats;
     private final AtomicLong inFlights;
     @Nullable

--- a/xds/src/main/java/io/grpc/xds/OrcaPerRequestUtil.java
+++ b/xds/src/main/java/io/grpc/xds/OrcaPerRequestUtil.java
@@ -25,8 +25,8 @@ import io.grpc.ClientStreamTracer;
 import io.grpc.ClientStreamTracer.StreamInfo;
 import io.grpc.LoadBalancer;
 import io.grpc.Metadata;
+import io.grpc.internal.ForwardingClientStreamTracer;
 import io.grpc.protobuf.ProtoUtils;
-import io.grpc.util.ForwardingClientStreamTracer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,7 +37,7 @@ import java.util.List;
 abstract class OrcaPerRequestUtil {
   private static final ClientStreamTracer NOOP_CLIENT_STREAM_TRACER = new ClientStreamTracer() {};
   private static final ClientStreamTracer.Factory NOOP_CLIENT_STREAM_TRACER_FACTORY =
-      new ClientStreamTracer.Factory() {
+      new ClientStreamTracer.InternalLimitedInfoFactory() {
         @Override
         public ClientStreamTracer newClientStreamTracer(StreamInfo info, Metadata headers) {
           return NOOP_CLIENT_STREAM_TRACER;
@@ -189,7 +189,8 @@ abstract class OrcaPerRequestUtil {
    * per-request ORCA reports and push to registered listeners for calls they trace.
    */
   @VisibleForTesting
-  static final class OrcaReportingTracerFactory extends ClientStreamTracer.Factory {
+  static final class OrcaReportingTracerFactory extends
+      ClientStreamTracer.InternalLimitedInfoFactory {
 
     @VisibleForTesting
     static final Metadata.Key<OrcaLoadReport> ORCA_ENDPOINT_LOAD_METRICS_KEY =

--- a/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
@@ -341,8 +341,8 @@ public class ClusterImplLoadBalancerTest {
       PickResult result = currentPicker.pickSubchannel(mock(PickSubchannelArgs.class));
       assertThat(result.getStatus().isOk()).isTrue();
       ClientStreamTracer.Factory streamTracerFactory = result.getStreamTracerFactory();
-      streamTracerFactory.newClientStreamTracer(ClientStreamTracer.StreamInfo.newBuilder().build(),
-          new Metadata());
+      streamTracerFactory.newClientStreamTracer(
+          ClientStreamTracer.StreamInfo.newBuilder().build(), new Metadata());
     }
     ClusterStats clusterStats =
         Iterables.getOnlyElement(loadStatsManager.getClusterStatsReports(CLUSTER));
@@ -429,8 +429,8 @@ public class ClusterImplLoadBalancerTest {
       PickResult result = currentPicker.pickSubchannel(mock(PickSubchannelArgs.class));
       assertThat(result.getStatus().isOk()).isTrue();
       ClientStreamTracer.Factory streamTracerFactory = result.getStreamTracerFactory();
-      streamTracerFactory.newClientStreamTracer(ClientStreamTracer.StreamInfo.newBuilder().build(),
-          new Metadata());
+      streamTracerFactory.newClientStreamTracer(
+          ClientStreamTracer.StreamInfo.newBuilder().build(), new Metadata());
     }
     ClusterStats clusterStats =
         Iterables.getOnlyElement(loadStatsManager.getClusterStatsReports(CLUSTER));


### PR DESCRIPTION
This is backport of #8355 

Rebased PR #8343 into the first commit of this PR, then (the 2nd commit) reverted the part for metric recording of retry attempts. The PR as a whole is mechanical refactoring. No behavior change (except that some of the old code path when tracer is created is moved into the new method `streamCreated()`).

The API change is documented in go/grpc-stats-api-change-for-retry-java