### PR TITLE
Revert "core: correcting a minor resource releasing issue" (v1.40.x backport)

### DIFF
--- a/core/src/main/java/io/grpc/util/CertificateUtils.java
+++ b/core/src/main/java/io/grpc/util/CertificateUtils.java
@@ -65,36 +65,24 @@ public final class CertificateUtils {
   public static PrivateKey getPrivateKey(InputStream inputStream)
       throws UnsupportedEncodingException, IOException, NoSuchAlgorithmException,
       InvalidKeySpecException {
-    InputStreamReader isr = null;
-    BufferedReader reader = null;
-    try {
-      isr = new InputStreamReader(inputStream, "UTF-8");
-      reader = new BufferedReader(isr);
-      String line;
-      while ((line = reader.readLine()) != null) {
-        if ("-----BEGIN PRIVATE KEY-----".equals(line)) {
-          break;
-        }
-      }
-      StringBuilder keyContent = new StringBuilder();
-      while ((line = reader.readLine()) != null) {
-        if ("-----END PRIVATE KEY-----".equals(line)) {
-          break;
-        }
-        keyContent.append(line);
-      }
-      byte[] decodedKeyBytes = BaseEncoding.base64().decode(keyContent.toString());
-      KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-      PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decodedKeyBytes);
-      return keyFactory.generatePrivate(keySpec);
-    } finally {
-      if (null != reader) {
-        reader.close();
-      }
-      if (null != isr) {
-        isr.close();
+    BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, "UTF-8"));
+    String line;
+    while ((line = reader.readLine()) != null) {
+      if ("-----BEGIN PRIVATE KEY-----".equals(line)) {
+        break;
       }
     }
+    StringBuilder keyContent = new StringBuilder();
+    while ((line = reader.readLine()) != null) {
+      if ("-----END PRIVATE KEY-----".equals(line)) {
+        break;
+      }
+      keyContent.append(line);
+    }
+    byte[] decodedKeyBytes = BaseEncoding.base64().decode(keyContent.toString());
+    KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+    PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decodedKeyBytes);
+    return keyFactory.generatePrivate(keySpec);
   }
 }
 


### PR DESCRIPTION
This reverts commit b9becb5c8e797f202ed0e566e752bd7a91e599e1. It is the
caller's responsibility to close their InputStream. The change ended up
closing the passed InputStream.

-----

This is a backport of #8361