### PR TITLE
buildscripts: Build android instrumentation tests in android CI

### DIFF
--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -31,6 +31,8 @@ buildscripts/make_dependencies.sh
     :grpc-android-interop-testing:build \
     :grpc-android:build \
     :grpc-cronet:build \
+    :grpc-binder:build \
+    assembleAndroidTest \
     publishToMavenLocal
 
 if [[ ! -z $(git status --porcelain) ]]; then

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -28,6 +28,10 @@ android {
             consumerProguardFiles 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
     testOptions { unitTests { includeAndroidResources = true } }
     lintOptions { disable 'InvalidPackage' }
 }


### PR DESCRIPTION
Binder's :build was missing. Cronet build failed without specifying
Java 8 because of the transitive Guava dependency.

-----

This will still fail to build until the `newStream()` API changes are integrated in the binder instrumentation tests. But as soon as that is in this should begin working (tested on older commit). I'll delay merging this until the newStream fixes are in and confirmed CI goes green.