### PR TITLE
build.gradle: Remove non-standard MANIFEST.MF attributes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -269,11 +269,7 @@ subprojects {
 
         jar.manifest {
             attributes('Implementation-Title': name,
-            'Implementation-Version': version,
-            'Built-By': System.getProperty('user.name'),
-            'Built-JDK': System.getProperty('java.version'),
-            'Source-Compatibility': sourceCompatibility,
-            'Target-Compatibility': targetCompatibility)
+            'Implementation-Version': version)
         }
 
         javadoc.options {


### PR DESCRIPTION
Including the build user's name doesn't provide much value and may
surprise some people. Built-JDK is actually wrong, as it is reporting
Gradle's Java version, not the javac version. And Source-/Target-
Compatibility isn't useful if nobody looks at it. Generally people just
look at the bytecode version itself, which is much more reliable and
doesn't have questions as to whether it should be '8' or '1.8'.