### PR TITLE
api: Fix Javadoc reference to NameResolver.Args

### DIFF
--- a/api/src/main/java/io/grpc/ProxyDetector.java
+++ b/api/src/main/java/io/grpc/ProxyDetector.java
@@ -32,7 +32,7 @@ import javax.annotation.Nullable;
  * underlying transport need to work together.
  *
  * <p>The {@link NameResolver} should invoke the {@link ProxyDetector} retrieved from the {@link
- * NameResolver.Helper#getProxyDetector}, and pass the returned {@link ProxiedSocketAddress} to
+ * NameResolver.Args#getProxyDetector}, and pass the returned {@link ProxiedSocketAddress} to
  * {@link NameResolver.Listener#onAddresses}.  The DNS name resolver shipped with gRPC is already
  * doing so.
  *


### PR DESCRIPTION
NameResolver.Helper was a short-lived class that didn't get very far. We
chose NameResolver.Args instead and didn't mirror LoadBalancer.