### PR TITLE
xds: log error and fail start() if server-listener-resource-name-template not set or not using xds_v3 (backport to v1.39.x) (#8375)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsClientWrapperForServerSds.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientWrapperForServerSds.java
@@ -137,14 +137,22 @@ public final class XdsClientWrapperForServerSds {
             }
           }
         };
+    newServerApi = xdsClient.getBootstrapInfo().getServers().get(0).isUseProtocolV3();
+    if (!newServerApi) {
+      reportError(
+          new XdsInitializationException(
+              "requires use of xds_v3 in xds bootstrap"),
+          true);
+      return;
+    }
     grpcServerResourceId = xdsClient.getBootstrapInfo()
         .getServerListenerResourceNameTemplate();
-    newServerApi = xdsClient.getBootstrapInfo().getServers().get(0).isUseProtocolV3();
-    if (newServerApi && grpcServerResourceId == null) {
+    if (grpcServerResourceId == null) {
       reportError(
           new XdsInitializationException(
               "missing server_listener_resource_name_template value in xds bootstrap"),
           true);
+      return;
     }
     grpcServerResourceId = grpcServerResourceId.replaceAll("%s", "0.0.0.0:" + port);
     xdsClient.watchLdsResource(grpcServerResourceId, listenerWatcher);

--- a/xds/src/test/java/io/grpc/xds/XdsServerTestHelper.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerTestHelper.java
@@ -44,7 +44,7 @@ class XdsServerTestHelper {
   static final Bootstrapper.BootstrapInfo BOOTSTRAP_INFO =
       new Bootstrapper.BootstrapInfo(
           Arrays.asList(
-              new Bootstrapper.ServerInfo(SERVER_URI, InsecureChannelCredentials.create(), false)),
+              new Bootstrapper.ServerInfo(SERVER_URI, InsecureChannelCredentials.create(), true)),
           BOOTSTRAP_NODE,
           null,
           "grpc/server?udpa.resource.listening_address=%s");


### PR DESCRIPTION
Fix the NPE caused when server-listener-resource-name-template is not set in the bootstrap file. Fixes #8373