### PR TITLE
rls: fix routeLookupClient may be null in RlsLoadBalancer.requestConnection()

### DIFF
--- a/rls/src/main/java/io/grpc/rls/RlsLoadBalancer.java
+++ b/rls/src/main/java/io/grpc/rls/RlsLoadBalancer.java
@@ -82,7 +82,9 @@ final class RlsLoadBalancer extends LoadBalancer {
 
   @Override
   public void requestConnection() {
-    routeLookupClient.requestConnection();
+    if(routeLookupClient != null) {
+      routeLookupClient.requestConnection();
+    }
   }
 
   @Override

--- a/rls/src/main/java/io/grpc/rls/RlsLoadBalancer.java
+++ b/rls/src/main/java/io/grpc/rls/RlsLoadBalancer.java
@@ -82,7 +82,7 @@ final class RlsLoadBalancer extends LoadBalancer {
 
   @Override
   public void requestConnection() {
-    if(routeLookupClient != null) {
+    if (routeLookupClient != null) {
       routeLookupClient.requestConnection();
     }
   }


### PR DESCRIPTION
~ClusterState.result may be null in `CdsLoadBalancer2`,can add not-null check to result to avoid NullPointerException, thanks~

`routeLookupClient` may be null in `RlsLoadBalancer.requestConnection()`