### PR TITLE
core: enable retry by default

### DIFF
--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -467,7 +467,6 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * @return this
    * @since 1.11.0
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/3982")
   public T disableRetry() {
     throw new UnsupportedOperationException();
   }
@@ -482,7 +481,6 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * @return this
    * @since 1.11.0
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/3982")
   public T enableRetry() {
     throw new UnsupportedOperationException();
   }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -142,7 +142,7 @@ public final class ManagedChannelImplBuilder
   int maxHedgedAttempts = 5;
   long retryBufferSize = DEFAULT_RETRY_BUFFER_SIZE_IN_BYTES;
   long perRpcBufferLimit = DEFAULT_PER_RPC_BUFFER_LIMIT_IN_BYTES;
-  boolean retryEnabled = false; // TODO(zdapeng): default to true
+  boolean retryEnabled = true;
 
   InternalChannelz channelz = InternalChannelz.instance();
   int maxTraceEvents;

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -355,6 +355,7 @@ public class ManagedChannelImplTest {
 
     channelBuilder = new ManagedChannelImplBuilder(TARGET,
         new UnsupportedClientTransportFactoryBuilder(), new FixedPortProvider(DEFAULT_PORT));
+    channelBuilder.disableRetry();
     configureBuilder(channelBuilder);
   }
 
@@ -1881,6 +1882,7 @@ public class ManagedChannelImplTest {
         TARGET, InsecureChannelCredentials.create(),
         new FakeCallCredentials(metadataKey, channelCredValue),
         new UnsupportedClientTransportFactoryBuilder(), new FixedPortProvider(DEFAULT_PORT));
+    channelBuilder.disableRetry();
     configureBuilder(channelBuilder);
     createChannel();
 
@@ -1933,6 +1935,7 @@ public class ManagedChannelImplTest {
             new FakeNameResolverFactory.Builder(URI.create("oobauthority")).build())
         .defaultLoadBalancingPolicy(MOCK_POLICY_NAME)
         .idleTimeout(ManagedChannelImplBuilder.IDLE_MODE_MAX_TIMEOUT_DAYS, TimeUnit.DAYS)
+        .disableRetry() // irrelevant to what we test, disable retry to make verification easy
         .build();
     oob.getState(true);
     ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
@@ -1980,6 +1983,7 @@ public class ManagedChannelImplTest {
         TARGET, InsecureChannelCredentials.create(),
         new FakeCallCredentials(metadataKey, channelCredValue),
         new UnsupportedClientTransportFactoryBuilder(), new FixedPortProvider(DEFAULT_PORT));
+    channelBuilder.disableRetry();
     configureBuilder(channelBuilder);
     createChannel();
 
@@ -2017,6 +2021,7 @@ public class ManagedChannelImplTest {
             new FakeNameResolverFactory.Builder(URI.create("fake://oobauthority/")).build())
         .defaultLoadBalancingPolicy(MOCK_POLICY_NAME)
         .idleTimeout(ManagedChannelImplBuilder.IDLE_MODE_MAX_TIMEOUT_DAYS, TimeUnit.DAYS)
+        .disableRetry() // irrelevant to what we test, disable retry to make verification easy
         .build();
     oob.getState(true);
     ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -37,13 +37,11 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -154,7 +152,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatcher;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.InOrder;
@@ -230,8 +227,6 @@ public class ManagedChannelImplTest {
   private ArgumentCaptor<Status> statusCaptor;
   @Captor
   private ArgumentCaptor<CallOptions> callOptionsCaptor;
-  @Captor
-  private ArgumentCaptor<Metadata> headersCaptor;
   @Captor
   private ArgumentCaptor<ClientStreamTracer[]> tracersCaptor;
   @Mock
@@ -535,7 +530,7 @@ public class ManagedChannelImplTest {
     ConnectionClientTransport mockTransport = transportInfo.transport;
     ManagedClientTransport.Listener transportListener = transportInfo.listener;
     when(mockTransport.newStream(
-            same(method), any(Metadata.class), any(CallOptions.class),
+            same(method), same(headers), any(CallOptions.class),
             ArgumentMatchers.<ClientStreamTracer[]>any()))
         .thenReturn(mockStream);
     transportListener.transportReady();
@@ -546,7 +541,7 @@ public class ManagedChannelImplTest {
 
     ArgumentCaptor<CallOptions> callOptionsCaptor = ArgumentCaptor.forClass(null);
     verify(mockTransport).newStream(
-        same(method), any(Metadata.class), callOptionsCaptor.capture(),
+        same(method), same(headers), callOptionsCaptor.capture(),
         ArgumentMatchers.<ClientStreamTracer[]>any());
     assertThat(callOptionsCaptor.getValue().isWaitForReady()).isTrue();
     verify(mockStream).start(streamListenerCaptor.capture());
@@ -613,14 +608,8 @@ public class ManagedChannelImplTest {
     MockClientTransportInfo transportInfo = transports.poll();
     ConnectionClientTransport mockTransport = transportInfo.transport;
     ManagedClientTransport.Listener transportListener = transportInfo.listener;
-    ArgumentMatcher<Metadata> headersMatcher = new ArgumentMatcher<Metadata>() {
-      @Override
-      public boolean matches(Metadata argument) {
-        return argument.get(metadataKey).equals("fooValue");
-      }
-    };
     when(mockTransport.newStream(
-            same(method), argThat(headersMatcher), any(CallOptions.class),
+            same(method), same(headers), any(CallOptions.class),
             ArgumentMatchers.<ClientStreamTracer[]>any()))
         .thenReturn(mockStream);
     transportListener.transportReady();
@@ -631,7 +620,7 @@ public class ManagedChannelImplTest {
 
     ArgumentCaptor<CallOptions> callOptionsCaptor = ArgumentCaptor.forClass(null);
     verify(mockTransport).newStream(
-        same(method), argThat(headersMatcher), callOptionsCaptor.capture(),
+        same(method), same(headers), callOptionsCaptor.capture(),
         ArgumentMatchers.<ClientStreamTracer[]>any());
     assertThat(callOptionsCaptor.getValue().getOption(callOptionsKey)).isEqualTo("fooValue");
     verify(mockStream).start(streamListenerCaptor.capture());
@@ -790,12 +779,6 @@ public class ManagedChannelImplTest {
   }
 
   @Test
-  public void callsAndShutdown_disableRetry() {
-    channelBuilder.disableRetry();
-    subtestCallsAndShutdown(false, false);
-  }
-
-  @Test
   public void callsAndShutdownNow() {
     subtestCallsAndShutdown(true, false);
   }
@@ -814,24 +797,8 @@ public class ManagedChannelImplTest {
     verify(executorPool).getObject();
     ClientStream mockStream = mock(ClientStream.class);
     ClientStream mockStream2 = mock(ClientStream.class);
-    final Metadata.Key<String> key1 = Metadata.Key.of("key1", Metadata.ASCII_STRING_MARSHALLER);
-    final Metadata.Key<String> key2 = Metadata.Key.of("key2", Metadata.ASCII_STRING_MARSHALLER);
     Metadata headers = new Metadata();
-    headers.put(key1, "value1");
     Metadata headers2 = new Metadata();
-    headers2.put(key2, "value2");
-    ArgumentMatcher<Metadata> headerMatcher1 = new ArgumentMatcher<Metadata>() {
-      @Override
-      public boolean matches(Metadata argument) {
-        return argument.containsKey(key1);
-      }
-    };
-    ArgumentMatcher<Metadata> headerMatcher2 = new ArgumentMatcher<Metadata>() {
-      @Override
-      public boolean matches(Metadata argument) {
-        return argument.containsKey(key2);
-      }
-    };
 
     // Configure the picker so that first RPC goes to delayed transport, and second RPC goes to
     // real transport.
@@ -845,32 +812,21 @@ public class ManagedChannelImplTest {
     ConnectionClientTransport mockTransport = transportInfo.transport;
     verify(mockTransport).start(any(ManagedClientTransport.Listener.class));
     ManagedClientTransport.Listener transportListener = transportInfo.listener;
-    doReturn(mockStream).when(mockTransport).newStream(
-            same(method), argThat(headerMatcher1), any(CallOptions.class),
-            ArgumentMatchers.<ClientStreamTracer[]>any());
-    doReturn(mockStream2).when(mockTransport).newStream(
-            same(method), argThat(headerMatcher2), any(CallOptions.class),
-            ArgumentMatchers.<ClientStreamTracer[]>any());
+    when(mockTransport.newStream(
+            same(method), same(headers), same(CallOptions.DEFAULT),
+            ArgumentMatchers.<ClientStreamTracer[]>any()))
+        .thenReturn(mockStream);
+    when(mockTransport.newStream(
+            same(method), same(headers2), same(CallOptions.DEFAULT),
+            ArgumentMatchers.<ClientStreamTracer[]>any()))
+        .thenReturn(mockStream2);
     transportListener.transportReady();
-    ArgumentMatcher<PickSubchannelArgs> pickArgsMatcher1 =
-        new ArgumentMatcher<PickSubchannelArgs>() {
-          @Override
-          public boolean matches(PickSubchannelArgs argument) {
-            return argument.getMethodDescriptor().equals(method)
-                && argument.getHeaders().containsKey(key1);
-          }
-        };
-    ArgumentMatcher<PickSubchannelArgs> pickArgsMatcher2 =
-        new ArgumentMatcher<PickSubchannelArgs>() {
-          @Override
-          public boolean matches(PickSubchannelArgs argument) {
-            return argument.getMethodDescriptor().equals(method)
-                && argument.getHeaders().containsKey(key2);
-          }
-        };
-    doReturn(PickResult.withNoResult()).when(mockPicker).pickSubchannel(argThat(pickArgsMatcher1));
-    doReturn(PickResult.withSubchannel(subchannel))
-        .when(mockPicker).pickSubchannel(argThat(pickArgsMatcher2));
+    when(mockPicker.pickSubchannel(
+        new PickSubchannelArgsImpl(method, headers, CallOptions.DEFAULT))).thenReturn(
+        PickResult.withNoResult());
+    when(mockPicker.pickSubchannel(
+        new PickSubchannelArgsImpl(method, headers2, CallOptions.DEFAULT))).thenReturn(
+        PickResult.withSubchannel(subchannel));
     updateBalancingStateSafely(helper, READY, mockPicker);
 
     // First RPC, will be pending
@@ -881,21 +837,19 @@ public class ManagedChannelImplTest {
     call.start(mockCallListener, headers);
 
     verify(mockTransport, never()).newStream(
-        same(method), argThat(headerMatcher1), any(CallOptions.class),
+        same(method), same(headers), same(CallOptions.DEFAULT),
         ArgumentMatchers.<ClientStreamTracer[]>any());
 
     // Second RPC, will be assigned to the real transport
     ClientCall<String, Integer> call2 = channel.newCall(method, CallOptions.DEFAULT);
     call2.start(mockCallListener2, headers2);
     verify(mockTransport).newStream(
-        same(method), argThat(headerMatcher2), any(CallOptions.class),
+        same(method), same(headers2), same(CallOptions.DEFAULT),
         ArgumentMatchers.<ClientStreamTracer[]>any());
-    verify(mockStream2).start(streamListenerCaptor.capture());
-    if (channelBuilder.retryEnabled) {
-      // commit call2
-      streamListenerCaptor.getValue().headersRead(new Metadata());
-      executor.runDueTasks();
-    }
+    verify(mockTransport).newStream(
+        same(method), same(headers2), same(CallOptions.DEFAULT),
+        ArgumentMatchers.<ClientStreamTracer[]>any());
+    verify(mockStream2).start(any(ClientStreamListener.class));
 
     // Shutdown
     if (shutdownNow) {
@@ -935,19 +889,14 @@ public class ManagedChannelImplTest {
       assertFalse(nameResolverFactory.resolvers.get(0).shutdown);
       // call and call2 are still alive, and can still be assigned to a real transport
       SubchannelPicker picker2 = mock(SubchannelPicker.class);
-      doReturn(PickResult.withSubchannel(subchannel))
-          .when(picker2).pickSubchannel(argThat(pickArgsMatcher1));
+      when(picker2.pickSubchannel(new PickSubchannelArgsImpl(method, headers, CallOptions.DEFAULT)))
+          .thenReturn(PickResult.withSubchannel(subchannel));
       updateBalancingStateSafely(helper, READY, picker2);
       executor.runDueTasks();
       verify(mockTransport).newStream(
-          same(method), argThat(headerMatcher1), any(CallOptions.class),
+          same(method), same(headers), same(CallOptions.DEFAULT),
           ArgumentMatchers.<ClientStreamTracer[]>any());
-      verify(mockStream).start(streamListenerCaptor.capture());
-      if (channelBuilder.retryEnabled) {
-        // commit call
-        streamListenerCaptor.getValue().headersRead(new Metadata());
-        executor.runDueTasks();
-      }
+      verify(mockStream).start(any(ClientStreamListener.class));
     }
 
     // After call is moved out of delayed transport, LoadBalancer, NameResolver and the transports
@@ -1096,7 +1045,7 @@ public class ManagedChannelImplTest {
     ConnectionClientTransport mockTransport = transportInfo.transport;
     ManagedClientTransport.Listener transportListener = transportInfo.listener;
     when(mockTransport.newStream(
-            same(method), any(Metadata.class), any(CallOptions.class),
+            same(method), same(headers), any(CallOptions.class),
             ArgumentMatchers.<ClientStreamTracer[]>any()))
         .thenReturn(mockStream);
     transportListener.transportReady();
@@ -1108,9 +1057,7 @@ public class ManagedChannelImplTest {
     // Real streams are started in the call executor if they were previously buffered.
     assertEquals(1, callExecutor.runDueTasks());
     verify(mockTransport).newStream(
-        same(method), any(Metadata.class), callOptionsCaptor.capture(),
-        ArgumentMatchers.<ClientStreamTracer[]>any());
-    assertThat(callOptionsCaptor.getValue().getExecutor()).isSameInstanceAs(options.getExecutor());
+        same(method), same(headers), same(options), ArgumentMatchers.<ClientStreamTracer[]>any());
     verify(mockStream).start(streamListenerCaptor.capture());
 
     // Call listener callbacks are also run in the call executor
@@ -1391,7 +1338,7 @@ public class ManagedChannelImplTest {
     executor.runDueTasks();
 
     verify(goodTransportInfo.transport).newStream(
-        same(method), any(Metadata.class), any(CallOptions.class),
+        same(method), same(headers), same(CallOptions.DEFAULT),
         ArgumentMatchers.<ClientStreamTracer[]>any());
     // The bad transport was never used.
     verify(badTransportInfo.transport, times(0)).newStream(
@@ -1949,19 +1896,17 @@ public class ManagedChannelImplTest {
     updateBalancingStateSafely(helper, READY, mockPicker);
 
     String callCredValue = "per-RPC call cred";
-    CallCredentials callCredentials = new FakeCallCredentials(metadataKey, callCredValue);
     CallOptions callOptions = CallOptions.DEFAULT
-        .withCallCredentials(callCredentials);
+        .withCallCredentials(new FakeCallCredentials(metadataKey, callCredValue));
     Metadata headers = new Metadata();
     ClientCall<String, Integer> call = channel.newCall(method, callOptions);
     call.start(mockCallListener, headers);
 
     verify(transportInfo.transport).newStream(
-        same(method), headersCaptor.capture(), callOptionsCaptor.capture(),
+        same(method), same(headers), same(callOptions),
         ArgumentMatchers.<ClientStreamTracer[]>any());
-    assertThat(headersCaptor.getValue().getAll(metadataKey))
+    assertThat(headers.getAll(metadataKey))
         .containsExactly(channelCredValue, callCredValue).inOrder();
-    assertThat(callOptionsCaptor.getValue().getCredentials()).isSameInstanceAs(callCredentials);
 
     // Verify that the oob channel does not
     ManagedChannel oob = helper.createOobChannel(
@@ -1977,9 +1922,9 @@ public class ManagedChannelImplTest {
     balancerRpcExecutor.runDueTasks();
 
     verify(transportInfo.transport).newStream(
-        same(method), headersCaptor.capture(), any(CallOptions.class),
+        same(method), same(headers), same(callOptions),
         ArgumentMatchers.<ClientStreamTracer[]>any());
-    assertThat(headersCaptor.getValue().getAll(metadataKey)).containsExactly(callCredValue);
+    assertThat(headers.getAll(metadataKey)).containsExactly(callCredValue);
     oob.shutdownNow();
 
     // Verify that resolving oob channel does not
@@ -2011,11 +1956,10 @@ public class ManagedChannelImplTest {
 
     // CallOptions may contain StreamTracerFactory for census that is added by default.
     verify(transportInfo.transport).newStream(
-        same(method), headersCaptor.capture(), any(CallOptions.class),
+        same(method), same(headers), any(CallOptions.class),
         ArgumentMatchers.<ClientStreamTracer[]>any());
-    assertThat(headersCaptor.getValue().getAll(metadataKey)).containsExactly(callCredValue);
+    assertThat(headers.getAll(metadataKey)).containsExactly(callCredValue);
     oob.shutdownNow();
-    executor.runDueTasks();
   }
 
   @Test
@@ -2050,18 +1994,17 @@ public class ManagedChannelImplTest {
     updateBalancingStateSafely(helper, READY, mockPicker);
 
     String callCredValue = "per-RPC call cred";
-    CallCredentials callCredentials = new FakeCallCredentials(metadataKey, callCredValue);
-    CallOptions callOptions = CallOptions.DEFAULT.withCallCredentials(callCredentials);
+    CallOptions callOptions = CallOptions.DEFAULT
+        .withCallCredentials(new FakeCallCredentials(metadataKey, callCredValue));
     Metadata headers = new Metadata();
     ClientCall<String, Integer> call = channel.newCall(method, callOptions);
     call.start(mockCallListener, headers);
 
     verify(transportInfo.transport).newStream(
-        same(method), headersCaptor.capture(), callOptionsCaptor.capture(),
+        same(method), same(headers), same(callOptions),
         ArgumentMatchers.<ClientStreamTracer[]>any());
-    assertThat(headersCaptor.getValue().getAll(metadataKey))
+    assertThat(headers.getAll(metadataKey))
         .containsExactly(channelCredValue, callCredValue).inOrder();
-    assertThat(callOptionsCaptor.getValue().getCredentials()).isSameInstanceAs(callCredentials);
 
     // Verify that resolving oob channel with oob channel creds provides call creds
     String oobChannelCredValue = "oob-channel-provided call cred";
@@ -2096,12 +2039,11 @@ public class ManagedChannelImplTest {
 
     // CallOptions may contain StreamTracerFactory for census that is added by default.
     verify(transportInfo.transport).newStream(
-        same(method), headersCaptor.capture(), any(CallOptions.class),
+        same(method), same(headers), any(CallOptions.class),
         ArgumentMatchers.<ClientStreamTracer[]>any());
-    assertThat(headersCaptor.getValue().getAll(metadataKey))
+    assertThat(headers.getAll(metadataKey))
         .containsExactly(oobChannelCredValue, callCredValue).inOrder();
     oob.shutdownNow();
-    executor.runDueTasks();
   }
 
   @Test
@@ -2462,9 +2404,8 @@ public class ManagedChannelImplTest {
     // newStream() is called after apply() is called
     applierCaptor.getValue().apply(new Metadata());
     verify(transport).newStream(
-        same(method), any(Metadata.class), callOptionsCaptor.capture(),
+        same(method), any(Metadata.class), same(callOptions),
         ArgumentMatchers.<ClientStreamTracer[]>any());
-    assertThat(callOptionsCaptor.getValue().getCredentials()).isSameInstanceAs(creds);
     assertEquals("testValue", testKey.get(newStreamContexts.poll()));
     // The context should not live beyond the scope of newStream() and applyRequestMetadata()
     assertNull(testKey.get());
@@ -2489,7 +2430,7 @@ public class ManagedChannelImplTest {
     // Still, newStream() is called after apply() is called
     applierCaptor.getValue().apply(new Metadata());
     verify(transport, times(2)).newStream(
-        same(method), any(Metadata.class), any(CallOptions.class),
+        same(method), any(Metadata.class), same(callOptions),
         ArgumentMatchers.<ClientStreamTracer[]>any());
     assertEquals("testValue", testKey.get(newStreamContexts.poll()));
 
@@ -2537,7 +2478,7 @@ public class ManagedChannelImplTest {
     verify(mockTransport).newStream(
         same(method), any(Metadata.class), callOptionsCaptor.capture(),
         tracersCaptor.capture());
-    assertThat(tracersCaptor.getValue()).asList().containsAtLeast(tracer1, tracer2);
+    assertThat(tracersCaptor.getValue()).isEqualTo(new ClientStreamTracer[] {tracer1, tracer2});
   }
 
   @Test
@@ -2583,7 +2524,7 @@ public class ManagedChannelImplTest {
     verify(mockTransport).newStream(
         same(method), any(Metadata.class), callOptionsCaptor.capture(),
         tracersCaptor.capture());
-    assertThat(tracersCaptor.getValue()).asList().containsAtLeast(tracer1, tracer2);
+    assertThat(tracersCaptor.getValue()).isEqualTo(new ClientStreamTracer[] {tracer1, tracer2});
   }
 
   @Test


### PR DESCRIPTION
Stabilize `enableRetry()` and `disableRetry()`.

Disable retry in `ManagedChannelImplTest` because each call attempt will fork the headers to a new instance, and add a ClientStreamTracer.Factory for bufferSizeLimit in CallOptions, which makes verification not straightforward.