### PR TITLE
Fix branch name missing error in xds_url_map

### DIFF
--- a/buildscripts/kokoro/xds_url_map.sh
+++ b/buildscripts/kokoro/xds_url_map.sh
@@ -54,7 +54,7 @@ build_test_app_docker_images() {
   # Run Google Cloud Build
   gcloud builds submit "${build_dir}" \
     --config "${docker_dir}/cloudbuild.yaml" \
-    --substitutions "_CLIENT_IMAGE_NAME=${CLIENT_IMAGE_NAME},COMMIT_SHA=${GIT_COMMIT}"
+    --substitutions "_CLIENT_IMAGE_NAME=${CLIENT_IMAGE_NAME},COMMIT_SHA=${GIT_COMMIT},BRANCH_NAME=experimental"
   # TODO(sergiitk): extra "cosmetic" tags for versioned branches, e.g. v1.34.x
   # TODO(sergiitk): do this when adding support for custom configs per version
 }


### PR DESCRIPTION
As title. Related b/196290351.

- xds_url_map: https://fusion2.corp.google.com/invocations/e43946b2-19fc-47b2-a045-02b6a87a8d7d/targets
- xds-k8s: https://fusion2.corp.google.com/invocations/c6dd2e77-551f-44f3-8a35-b150cc9f21fe/targets