### PR TITLE
interop-testing: add soak test cases to test service client

### DIFF
--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -27,6 +27,7 @@ dependencies {
             project(':grpc-stub'),
             project(':grpc-testing'),
             project(path: ':grpc-xds', configuration: 'shadow'),
+            libraries.hdrhistogram,
             libraries.junit,
             libraries.truth,
             libraries.opencensus_contrib_grpc_metrics,

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestCases.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestCases.java
@@ -54,7 +54,9 @@ public enum TestCases {
   CANCEL_AFTER_FIRST_RESPONSE("cancel on first response"),
   TIMEOUT_ON_SLEEPING_SERVER("timeout before receiving a response"),
   VERY_LARGE_REQUEST("very large request"),
-  PICK_FIRST_UNARY("all requests are sent to one server despite multiple servers are resolved");
+  PICK_FIRST_UNARY("all requests are sent to one server despite multiple servers are resolved"),
+  RPC_SOAK("sends 'soak_iterations' large_unary rpcs in a loop, each on the same channel"),
+  CHANNEL_SOAK("sends 'soak_iterations' large_unary rpcs in a loop, each on a new channel");
 
   private final String description;
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -86,6 +86,10 @@ public class TestServiceClient {
   private boolean fullStreamDecompression;
   private int localHandshakerPort = -1;
   private Map<String, ?> serviceConfig = null;
+  private int soakIterations = 0;
+  private int soakMaxFailures = 0;
+  private int soakPerIterationMaxAcceptableLatencyMs = 0;
+  private int soakOverallTimeoutSeconds = 0;
 
   private Tester tester = new Tester();
 
@@ -150,6 +154,14 @@ public class TestServiceClient {
         @SuppressWarnings("unchecked")
         Map<String, ?> map = (Map<String, ?>) JsonParser.parse(value);
         serviceConfig = map;
+      } else if ("soak_iterations".equals(key)) {
+        soakIterations = Integer.parseInt(value);
+      } else if ("soak_max_failures".equals(key)) {
+        soakMaxFailures = Integer.parseInt(value);
+      } else if ("soak_per_iteration_max_acceptable_latency_ms".equals(key)) {
+        soakPerIterationMaxAcceptableLatencyMs = Integer.parseInt(value);
+      } else if ("soak_overall_timeout_seconds".equals(key)) {
+        soakOverallTimeoutSeconds = Integer.parseInt(value);
       } else {
         System.err.println("Unknown argument: " + key);
         usage = true;
@@ -411,6 +423,28 @@ public class TestServiceClient {
         tester.pickFirstUnary();
         break;
       }
+
+      case RPC_SOAK:
+        {
+          tester.performSoakTest(
+              false /* resetChannelPerIteration */,
+              soakIterations,
+              soakMaxFailures,
+              soakPerIterationMaxAcceptableLatencyMs,
+              soakOverallTimeoutSeconds);
+          break;
+        }
+
+      case CHANNEL_SOAK:
+        {
+          tester.performSoakTest(
+              true /* resetChannelPerIteration */,
+              soakIterations,
+              soakMaxFailures,
+              soakPerIterationMaxAcceptableLatencyMs,
+              soakOverallTimeoutSeconds);
+          break;
+        }
 
       default:
         throw new IllegalArgumentException("Unknown test case: " + testCase);

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -208,6 +208,18 @@ public class TestServiceClient {
           + "\n --service_config_json=SERVICE_CONFIG_JSON"
           + "\n                              Disables service config lookups and sets the provided "
           + "\n                              string as the default service config."
+          + "\n --soak_iterations            The number of iterations to use for the two soak "
+          + "\n                              tests: rpc_soak and channel_soak."
+          + "\n --soak_max_failures          The number of iterations in soak tests that are "
+          + "\n                              allowed to fail (either due to non-OK status code or "
+          + "\n                              exceeding the per-iteration max acceptable latency)."
+          + "\n --soak_per_iteration_max_acceptable_latency_ms "
+          + "\n                              The number of milliseconds a single iteration in the "
+          + "\n                              two soak tests (rpc_soak and channel_soak) should take.
+          + "\n --soak_overall_timeout_seconds "
+          + "\n                              The overall number of seconds after which a soak test "
+          + "\n                              should stop and fail, if the desired number of "
+          + "\n                              iterations have not yet completed."
       );
       System.exit(1);
     }


### PR DESCRIPTION
This adds a java-analogue of the C++  [channel_soak](https://github.com/grpc/grpc/blob/3e34e3aac790a256943b4b7dada269209c60fe44/test/cpp/interop/client.cc#L55) and [rpc_soak](https://github.com/grpc/grpc/blob/3e34e3aac790a256943b4b7dada269209c60fe44/test/cpp/interop/client.cc#L72) (for which the code is mainly in https://github.com/grpc/grpc/blob/3e34e3aac790a256943b4b7dada269209c60fe44/test/cpp/interop/interop_client.cc#L1120).