### PR TITLE
stub: Document that noop onCancelHandler is useful

### DIFF
--- a/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
@@ -53,7 +53,9 @@ public abstract class ServerCallStreamObserver<V> extends CallStreamObserver<V> 
    * service returns its {@code StreamObserver}.
    *
    * <p>Setting the onCancelHandler will suppress the on-cancel exception thrown by
-   * {@link #onNext}.
+   * {@link #onNext}. If the caller is already handling cancellation via polling or cannot
+   * substantially benefit from observing cancellation, using a no-op {@code onCancelHandler} is
+   * useful just to suppress the {@code onNext()} exception.
    *
    * @param onCancelHandler to call when client has cancelled the call.
    */


### PR DESCRIPTION
setOnCancelHandler tells gRPC that the application is handling
cancellation. But it's fine to have noop behavior within the handler
itself if the application doesn't need it. It is just a way to opt-in to
the more recent no-exception-from-onNext behavior. Let's mention this
use-case in the docs to make it more obvious it is a possibility.

Came up as part of #8409.

CC @morgwai 