### PR TITLE
buildscripts: Increase memory for Gradle in Android CI

### DIFF
--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -18,8 +18,9 @@ export OS_NAME=$(uname)
 cat <<EOF >> gradle.properties
 # defaults to -Xmx512m -XX:MaxMetaspaceSize=256m
 # https://docs.gradle.org/current/userguide/build_environment.html#sec:configuring_jvm_memory
-# Increased due to java.lang.OutOfMemoryError: Metaspace failures
-org.gradle.jvmargs=-Xmx512m -XX:MaxMetaspaceSize=512m
+# Increased due to java.lang.OutOfMemoryError: Metaspace failures, "JVM heap
+# space is exhausted", and to increase build speed
+org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
 EOF
 
 echo y | ${ANDROID_HOME}/tools/bin/sdkmanager "build-tools;28.0.3"


### PR DESCRIPTION
We've still been seeing random memory-related failures with the Android
CI, but it is nowhere near as severe as it was. But even when running
locally with "-Xmx512m -XX:MaxMetaspaceSize=512m" I get failures. Our CI
environment has lots of RAM; let's use it.

See also trouble in #8388

CC @nastra 