### PR TITLE
netty: Don't use old-style classpath for shadow plugin

### DIFF
--- a/netty/shaded/build.gradle
+++ b/netty/shaded/build.gradle
@@ -4,16 +4,6 @@ import org.gradle.api.file.FileTreeElement
 import shadow.org.apache.tools.zip.ZipOutputStream
 import shadow.org.apache.tools.zip.ZipEntry
 
-
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
-    }
-}
-
 plugins {
     id "java"
     id "maven-publish"


### PR DESCRIPTION
Seems it was introduced unnecessarily in dc74a31b. This also removes the
jcenter reference which is a repository that no longer receives updates.

----

I noticed this when looking at upgrading the android plugin (because of the jcenter usage).

CC nastra