### PR TITLE
interop-testing: fix literal "{0}" in log message

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
@@ -369,7 +369,7 @@ public final class XdsTestClient {
                 @Override
                 public void onError(Throwable t) {
                   if (printResponse) {
-                    logger.log(Level.WARNING, "Rpc failed: {0}", t);
+                    logger.log(Level.WARNING, "Rpc failed", t);
                   }
                   handleRpcError(requestId, config.rpcType, Status.fromThrowable(t),
                       savedWatchers);


### PR DESCRIPTION
`logger.log(Level.WARNING, "Rpc failed: {0}", t)` will just print a literal "Rpc failed: {0}" followed by exception details.