### PR TITLE
backport fix v1.40.x: extend the xds_url_map job's timeout to 90 minutes

### DIFF
--- a/buildscripts/kokoro/xds_url_map.cfg
+++ b/buildscripts/kokoro/xds_url_map.cfg
@@ -2,7 +2,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-java/buildscripts/kokoro/xds_url_map.sh"
-timeout_mins: 60
+timeout_mins: 90
 
 action {
   define_artifacts {


### PR DESCRIPTION
Related https://github.com/grpc/grpc-java/pull/8429.

We recently had one flake caused by the Kokoro job timeout.

@dapengzhang0 