### PR TITLE
Add TERMINATED state to allow notifying a caller when gRPC resources …

### DIFF
--- a/api/src/main/java/io/grpc/ConnectivityState.java
+++ b/api/src/main/java/io/grpc/ConnectivityState.java
@@ -67,6 +67,17 @@ public enum ConnectivityState {
    * happened during attempts to connect communicate . (As of 6/12/2015, there are no known errors
    * (while connecting or communicating) that are classified as non-recoverable) Channels that
    * enter this state never leave this state.
+   *
+   * @see ManagedChannel#isShutdown()
    */
-  SHUTDOWN
+  SHUTDOWN,
+
+  /**
+   * This channel has terminated. All pending RPCs have been completed and any new RPCs will fail
+   * immediately. The channel's resources (like TCP connections) have all been released and there
+   * will be no further network activity issued by this channel.
+   *
+   * @see ManagedChannel#isTerminated()
+   */
+  TERMINATED,
 }

--- a/core/src/main/java/io/grpc/internal/ConnectivityStateManager.java
+++ b/core/src/main/java/io/grpc/internal/ConnectivityStateManager.java
@@ -61,7 +61,8 @@ final class ConnectivityStateManager {
    */
   void gotoState(@Nonnull ConnectivityState newState) {
     checkNotNull(newState, "newState");
-    if (state != newState && state != ConnectivityState.SHUTDOWN) {
+    ConnectivityState currentState = state;
+    if (currentState != newState && currentState != ConnectivityState.TERMINATED) {
       state = newState;
       if (listeners.isEmpty()) {
         return;

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static io.grpc.ConnectivityState.IDLE;
 import static io.grpc.ConnectivityState.SHUTDOWN;
+import static io.grpc.ConnectivityState.TERMINATED;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 import static io.grpc.EquivalentAddressGroup.ATTR_AUTHORITY_OVERRIDE;
 
@@ -1276,6 +1277,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
       transportFactory.close();
 
       terminated = true;
+      channelStateManager.gotoState(TERMINATED);
       terminatedLatch.countDown();
     }
   }

--- a/core/src/test/java/io/grpc/internal/ConnectivityStateManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/ConnectivityStateManagerTest.java
@@ -19,7 +19,7 @@ package io.grpc.internal;
 import static io.grpc.ConnectivityState.CONNECTING;
 import static io.grpc.ConnectivityState.IDLE;
 import static io.grpc.ConnectivityState.READY;
-import static io.grpc.ConnectivityState.SHUTDOWN;
+import static io.grpc.ConnectivityState.TERMINATED;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 import static org.junit.Assert.assertEquals;
 
@@ -235,11 +235,11 @@ public class ConnectivityStateManagerTest {
   }
 
   @Test
-  public void shutdownThenReady() {
-    state.gotoState(SHUTDOWN);
-    assertEquals(SHUTDOWN, state.getState());
+  public void terminatedThenReady() {
+    state.gotoState(TERMINATED);
+    assertEquals(TERMINATED, state.getState());
 
     state.gotoState(READY);
-    assertEquals(SHUTDOWN, state.getState());
+    assertEquals(TERMINATED, state.getState());
   }
 }

--- a/rls/src/test/java/io/grpc/rls/SubchannelStateManagerImplTest.java
+++ b/rls/src/test/java/io/grpc/rls/SubchannelStateManagerImplTest.java
@@ -62,7 +62,7 @@ public class SubchannelStateManagerImplTest {
   @Test
   public void getAggregatedStatus_single() {
     for (ConnectivityState value : ConnectivityState.values()) {
-      if (value == ConnectivityState.SHUTDOWN) {
+      if (value == ConnectivityState.SHUTDOWN || value == ConnectivityState.TERMINATED) {
         continue;
       }
       SubchannelStateManager stateManager = new SubchannelStateManagerImpl();

--- a/services/src/main/proto/grpc/channelz/v1/channelz.proto
+++ b/services/src/main/proto/grpc/channelz/v1/channelz.proto
@@ -90,6 +90,7 @@ message ChannelConnectivityState {
     READY = 3;
     TRANSIENT_FAILURE = 4;
     SHUTDOWN = 5;
+    TERMINATED = 6;
   }
   State state = 1;
 }


### PR DESCRIPTION
…have been completely closed.

Leaving in draft since this may be complicated. The `channelz.proto` change tipped me off that the states are actually part of the gRPC spec itself

https://github.com/grpc/grpc/blob/master/doc/connectivity-semantics-and-api.md

So presumably before making a change like this one, that spec has to be updated. I imagine myself sending PRs to that spec would be far less productive than a gRPC team member doing so but am not sure. @sanjaypujare let me know how best to proceed with this.

Fixes #8432 