### PR TITLE
xds: fix RingHash LB null pointer issue [v1.39.x]

### DIFF
--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
@@ -188,7 +188,8 @@ final class CdsLoadBalancer2 extends LoadBalancer {
       if (root.result.lbPolicy() == LbPolicy.RING_HASH) {
         lbProvider = lbRegistry.getProvider("ring_hash");
         lbConfig = new RingHashConfig(root.result.minRingSize(), root.result.maxRingSize());
-      } else {
+      }
+      if (lbProvider == null) {
         lbProvider = lbRegistry.getProvider("round_robin");
       }
       ClusterResolverConfig config = new ClusterResolverConfig(


### PR DESCRIPTION
This is a minimum fix. Would have fixed to disable the logic in parsing RDS update (hashPolicies) and CDS update (ring_hash lb) by the protection flag, but they are scattered in main source and tests. The parsing logic seemed to work fine in tests in later release.