### PR TITLE
xds: fix RingHash LB null pointer issue [v1.37.x]

### DIFF
--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
@@ -186,6 +186,9 @@ final class CdsLoadBalancer2 extends LoadBalancer {
           lbRegistry.getProvider(XdsLbPolicies.WEIGHTED_TARGET_POLICY_NAME);  // hardcoded
       LoadBalancerProvider endpointPickingLbProvider =
           lbRegistry.getProvider(endpointPickingPolicy);
+      if (endpointPickingLbProvider == null) {
+        endpointPickingLbProvider = lbRegistry.getProvider("round_robin");
+      }
       ClusterResolverConfig config = new ClusterResolverConfig(
           Collections.unmodifiableList(instances),
           new PolicySelection(localityPickingLbProvider, null /* by cluster_resolver LB policy */),


### PR DESCRIPTION
This is a minimum fix. Would have fixed to disable the logic in parsing RDS update (hashPolicies) and CDS update (ring_hash lb) by the protection flag, but they are scattered in main source and tests. The parsing logic seemed to work fine in tests in later release.