### PR TITLE
census: Fix retry stats data race (v2)

### DIFF
--- a/census/src/main/java/io/grpc/census/CensusStatsModule.java
+++ b/census/src/main/java/io/grpc/census/CensusStatsModule.java
@@ -492,6 +492,8 @@ final class CensusStatsModule {
       boolean shouldRecordFinishedCall = false;
       synchronized (lock) {
         if (callEnded) {
+          // FIXME(https://github.com/grpc/grpc-java/issues/7921)
+          logger.warning("callEnded() already called. This is a bug.");
           return;
         }
         callEnded = true;

--- a/census/src/main/java/io/grpc/census/CensusStatsModule.java
+++ b/census/src/main/java/io/grpc/census/CensusStatsModule.java
@@ -498,8 +498,7 @@ final class CensusStatsModule {
       boolean shouldRecordFinishedCall = false;
       synchronized (lock) {
         if (callEnded) {
-          // FIXME(https://github.com/grpc/grpc-java/issues/7921)
-          logger.warning("callEnded() already called. This is a bug.");
+          // FIXME(https://github.com/grpc/grpc-java/issues/7921): this shouldn't happen
           return;
         }
         callEnded = true;


### PR DESCRIPTION
(This is a modified version of #8422 using a lock for synchronization.)

There is data race in `CensusStatsModule. CallAttemptsTracerFactory`:

If client call is cancelled while an active stream on the transport is not committed, then a [noop substream](https://github.com/grpc/grpc-java/blob/v1.40.0/core/src/main/java/io/grpc/internal/RetriableStream.java#L486) will be committed and the active stream will be cancelled. Because the active stream cancellation triggers the stream listener closed() on the _transport_ thread, the closed() method can be invoked concurrently with the call listener onClose(). Therefore, one `CallAttemptsTracerFactory.attemptEnded()` can be called concurrently with `CallAttemptsTracerFactory.callEnded()`, and there could be data race on RETRY_DELAY_PER_CALL. See also the regression test added.

The same data race can happen in hedging case when one of hedges is committed and completes the call, other uncommitted hedges would cancel themselves and trigger their stream listeners closed() on the transport_thread concurrently. 

Fixing the race by recording RETRY_DELAY_PER_CALL once both the conditions are met: 
- callEnded is true 
- number of active streams is 0.