### PR TITLE
Change to a non-workload-identity GKE cluster

### DIFF
--- a/buildscripts/kokoro/xds_url_map.sh
+++ b/buildscripts/kokoro/xds_url_map.sh
@@ -4,8 +4,8 @@ set -eo pipefail
 # Constants
 readonly GITHUB_REPOSITORY_NAME="grpc-java"
 # GKE Cluster
-readonly GKE_CLUSTER_NAME="interop-test-psm-sec-v2-us-central1-a"
-readonly GKE_CLUSTER_ZONE="us-central1-a"
+readonly GKE_CLUSTER_NAME="interop-test-psm-basic"
+readonly GKE_CLUSTER_ZONE="us-central1-c"
 ## xDS test client Docker images
 readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/java-client"
 readonly FORCE_IMAGE_BUILD="${FORCE_IMAGE_BUILD:-0}"


### PR DESCRIPTION
Part of grpc/grpc#27189 and b/198291728.

By disabling the workload identity, we should be able to run tests faster and avoid future IAM policy size issue.

@dapengzhang0 PTAL.

Kokoro run: https://fusion2.corp.google.com/invocations/b52b1684-47de-406d-a9f6-644909755f34/targets