### PR TITLE
xds: Fix WeakReference bug in SharedCallCounterMap

### DIFF
--- a/xds/src/main/java/io/grpc/xds/SharedCallCounterMap.java
+++ b/xds/src/main/java/io/grpc/xds/SharedCallCounterMap.java
@@ -58,8 +58,14 @@ final class SharedCallCounterMap implements CallCounterProvider {
       counters.put(cluster, clusterCounters);
     }
     CounterReference ref = clusterCounters.get(edsServiceName);
-    AtomicLong counter;
-    if (ref == null || (counter = ref.get()) == null) {
+    AtomicLong counter = null;
+    if (ref != null) {
+      counter = ref.get();
+      if (counter == null) {
+        ref.enqueue();
+      }
+    }
+    if (counter == null) {
       counter = new AtomicLong();
       ref = new CounterReference(counter, refQueue, cluster, edsServiceName);
       clusterCounters.put(edsServiceName, ref);

--- a/xds/src/main/java/io/grpc/xds/SharedCallCounterMap.java
+++ b/xds/src/main/java/io/grpc/xds/SharedCallCounterMap.java
@@ -61,7 +61,7 @@ final class SharedCallCounterMap implements CallCounterProvider {
       }
     }
     // In the case of ref.get() == null, must call cleanQueue() prior to creating a new map entry,
-    // otherwise the new entry will be deleted be any cleanQueue().
+    // otherwise the new entry will be deleted by any later cleanQueue().
     cleanQueue();
     if (counter != null) {
       return counter;

--- a/xds/src/main/java/io/grpc/xds/SharedCallCounterMap.java
+++ b/xds/src/main/java/io/grpc/xds/SharedCallCounterMap.java
@@ -52,6 +52,7 @@ final class SharedCallCounterMap implements CallCounterProvider {
 
   @Override
   public synchronized AtomicLong getOrCreate(String cluster, @Nullable String edsServiceName) {
+    cleanQueue();
     Map<String, CounterReference> clusterCounters = counters.get(cluster);
     if (clusterCounters == null) {
       clusterCounters = new HashMap<>();
@@ -64,7 +65,6 @@ final class SharedCallCounterMap implements CallCounterProvider {
       ref = new CounterReference(counter, refQueue, cluster, edsServiceName);
       clusterCounters.put(edsServiceName, ref);
     }
-    cleanQueue();
     return counter;
   }
 


### PR DESCRIPTION
Fixes #8397.
#8397 is caused by mistakenly clearing up a map entry right after the entry is recreated after gc. Reproduced in regression test.

(`SharedCallCounterMap` is hard to read and can easily be a source of bugs. It's impossible to sufficiently test the class with unit test because GC can happen anytime concurrently with the method being tested. I'm not 100% confident about the correctness of the fix. If possible I would avoid using WeakReference in the first place.)