### PR TITLE
xds: fix implementation to comply with gRFC for security

### DIFF
--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -136,6 +136,7 @@ public abstract class Bootstrapper {
     }
 
     /** Returns the cert-providers config map. */
+    @Nullable
     public Map<String, CertificateProviderInfo> getCertProviders() {
       return certProviders == null ? null : Collections.unmodifiableMap(certProviders);
     }

--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -84,7 +84,8 @@ public abstract class Bootstrapper {
     private final String pluginName;
     private final Map<String, ?> config;
 
-    CertificateProviderInfo(String pluginName, Map<String, ?> config) {
+    @VisibleForTesting
+    public CertificateProviderInfo(String pluginName, Map<String, ?> config) {
       this.pluginName = checkNotNull(pluginName, "pluginName");
       this.config = checkNotNull(config, "config");
     }
@@ -136,7 +137,7 @@ public abstract class Bootstrapper {
 
     /** Returns the cert-providers config map. */
     public Map<String, CertificateProviderInfo> getCertProviders() {
-      return Collections.unmodifiableMap(certProviders);
+      return certProviders == null ? null : Collections.unmodifiableMap(certProviders);
     }
 
     @Nullable

--- a/xds/src/main/java/io/grpc/xds/internal/certprovider/CertProviderClientSslContextProvider.java
+++ b/xds/src/main/java/io/grpc/xds/internal/certprovider/CertProviderClientSslContextProvider.java
@@ -32,6 +32,7 @@ import io.netty.handler.ssl.SslContextBuilder;
 import java.security.cert.CertStoreException;
 import java.security.cert.X509Certificate;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /** A client SslContext provider using CertificateProviderInstance to fetch secrets. */
 @Internal
@@ -39,7 +40,7 @@ public final class CertProviderClientSslContextProvider extends CertProviderSslC
 
   private CertProviderClientSslContextProvider(
       Node node,
-      Map<String, CertificateProviderInfo> certProviders,
+      @Nullable Map<String, CertificateProviderInfo> certProviders,
       CommonTlsContext.CertificateProviderInstance certInstance,
       CommonTlsContext.CertificateProviderInstance rootCertInstance,
       CertificateValidationContext staticCertValidationContext,
@@ -90,7 +91,7 @@ public final class CertProviderClientSslContextProvider extends CertProviderSslC
     public CertProviderClientSslContextProvider getProvider(
         UpstreamTlsContext upstreamTlsContext,
         Node node,
-        Map<String, CertificateProviderInfo> certProviders) {
+        @Nullable Map<String, CertificateProviderInfo> certProviders) {
       checkNotNull(upstreamTlsContext, "upstreamTlsContext");
       CommonTlsContext commonTlsContext = upstreamTlsContext.getCommonTlsContext();
       CommonTlsContext.CertificateProviderInstance rootCertInstance = null;

--- a/xds/src/main/java/io/grpc/xds/internal/certprovider/CertProviderServerSslContextProvider.java
+++ b/xds/src/main/java/io/grpc/xds/internal/certprovider/CertProviderServerSslContextProvider.java
@@ -35,6 +35,7 @@ import java.security.cert.CertStoreException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /** A server SslContext provider using CertificateProviderInstance to fetch secrets. */
 @Internal
@@ -42,7 +43,7 @@ public final class CertProviderServerSslContextProvider extends CertProviderSslC
 
   private CertProviderServerSslContextProvider(
           Node node,
-          Map<String, CertificateProviderInfo> certProviders,
+          @Nullable Map<String, CertificateProviderInfo> certProviders,
           CommonTlsContext.CertificateProviderInstance certInstance,
           CommonTlsContext.CertificateProviderInstance rootCertInstance,
           CertificateValidationContext staticCertValidationContext,
@@ -93,7 +94,7 @@ public final class CertProviderServerSslContextProvider extends CertProviderSslC
     public CertProviderServerSslContextProvider getProvider(
         DownstreamTlsContext downstreamTlsContext,
         Node node,
-        Map<String, CertificateProviderInfo> certProviders) {
+        @Nullable Map<String, CertificateProviderInfo> certProviders) {
       checkNotNull(downstreamTlsContext, "downstreamTlsContext");
       CommonTlsContext commonTlsContext = downstreamTlsContext.getCommonTlsContext();
       CommonTlsContext.CertificateProviderInstance rootCertInstance = null;

--- a/xds/src/main/java/io/grpc/xds/internal/certprovider/CertProviderSslContextProvider.java
+++ b/xds/src/main/java/io/grpc/xds/internal/certprovider/CertProviderSslContextProvider.java
@@ -42,7 +42,7 @@ abstract class CertProviderSslContextProvider extends DynamicSslContextProvider 
 
   protected CertProviderSslContextProvider(
       Node node,
-      Map<String, CertificateProviderInfo> certProviders,
+      @Nullable Map<String, CertificateProviderInfo> certProviders,
       CertificateProviderInstance certInstance,
       CertificateProviderInstance rootCertInstance,
       CertificateValidationContext staticCertValidationContext,
@@ -56,8 +56,8 @@ abstract class CertProviderSslContextProvider extends DynamicSslContextProvider 
       certInstanceName = certInstance.getInstanceName();
       CertificateProviderInfo certProviderInstanceConfig =
           getCertProviderConfig(certProviders, certInstanceName);
-      certHandle =
-          certificateProviderStore.createOrGetProvider(
+      certHandle = certProviderInstanceConfig == null ? null
+          : certificateProviderStore.createOrGetProvider(
               certInstance.getCertificateName(),
               certProviderInstanceConfig.getPluginName(),
               certProviderInstanceConfig.getConfig(),
@@ -71,8 +71,8 @@ abstract class CertProviderSslContextProvider extends DynamicSslContextProvider 
         && !rootCertInstance.getInstanceName().equals(certInstanceName)) {
       CertificateProviderInfo certProviderInstanceConfig =
           getCertProviderConfig(certProviders, rootCertInstance.getInstanceName());
-      rootCertHandle =
-          certificateProviderStore.createOrGetProvider(
+      rootCertHandle = certProviderInstanceConfig == null ? null
+          : certificateProviderStore.createOrGetProvider(
               rootCertInstance.getCertificateName(),
               certProviderInstanceConfig.getPluginName(),
               certProviderInstanceConfig.getConfig(),
@@ -84,8 +84,8 @@ abstract class CertProviderSslContextProvider extends DynamicSslContextProvider 
   }
 
   private static CertificateProviderInfo getCertProviderConfig(
-      Map<String, CertificateProviderInfo> certProviders, String pluginInstanceName) {
-    return certProviders.get(pluginInstanceName);
+      @Nullable Map<String, CertificateProviderInfo> certProviders, String pluginInstanceName) {
+    return certProviders != null ? certProviders.get(pluginInstanceName) : null;
   }
 
   @Override

--- a/xds/src/test/java/io/grpc/xds/internal/sds/CommonTlsContextTestsUtil.java
+++ b/xds/src/test/java/io/grpc/xds/internal/sds/CommonTlsContextTestsUtil.java
@@ -146,7 +146,7 @@ public class CommonTlsContextTestsUtil {
     if (certName != null || validationContextCertName != null || useSans) {
       commonTlsContext = buildCommonTlsContextWithAdditionalValues(
           "cert-instance-name", certName,
-          "val-cert-instance-name", validationContextCertName,
+          "cert-instance-name", validationContextCertName,
           useSans ? Arrays.asList(
               StringMatcher.newBuilder()
                   .setExact("spiffe://grpc-sds-testing.svc.id.goog/ns/default/sa/bob")


### PR DESCRIPTION
Changes to comply with https://github.com/grpc/proposal/blob/master/A29-xds-tls-security.md . Specifically:

- check that cert-instance-name in CDS/LDS are defined in bootstrap file
- a number of fields are now ignored instead of NACKed (as per https://github.com/grpc/proposal/blob/master/A29-xds-tls-security.md#xds-protocol - look for "are ignored")
- additional check for transport-socket-matches - NACK if present