### PR TITLE
rls: migrate deprecated server/path to extraKeys

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -16,6 +16,8 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "com.google.auth:google-auth-library-oauth2-http:0.22.0",
     "com.google.code.findbugs:jsr305:3.0.2",
     "com.google.code.gson:gson:jar:2.8.6",
+    "com.google.auto.value:auto-value:1.7.4",
+    "com.google.auto.value:auto-value-annotations:1.7.4",
     "com.google.errorprone:error_prone_annotations:2.9.0",
     "com.google.guava:failureaccess:1.0.1",
     "com.google.guava:guava:30.1-android",

--- a/rls/BUILD.bazel
+++ b/rls/BUILD.bazel
@@ -7,16 +7,37 @@ java_library(
     ]),
     visibility = ["//visibility:public"],
     deps = [
+        ":autovalue",
         ":rls_java_grpc",
         "//api",
         "//core",
         "//core:internal",
         "//core:util",
         "//stub",
+        "@com_google_auto_value_auto_value_annotations//jar",
         "@com_google_code_findbugs_jsr305//jar",
         "@com_google_guava_guava//jar",
         "@io_grpc_grpc_proto//:rls_java_proto",
         "@io_grpc_grpc_proto//:rls_config_java_proto",
+    ],
+)
+
+java_plugin(
+    name = "autovalue_plugin",
+    processor_class = "com.google.auto.value.processor.AutoValueProcessor",
+    deps = [
+        "@com_google_auto_value_auto_value//jar",
+    ],
+)
+
+java_library(
+    name = "autovalue",
+    exported_plugins = [
+        ":autovalue_plugin",
+    ],
+    neverlink = 1,
+    exports = [
+        "@com_google_auto_value_auto_value//jar",
     ],
 )
 

--- a/rls/build.gradle
+++ b/rls/build.gradle
@@ -14,7 +14,9 @@ dependencies {
     implementation project(':grpc-core'),
             project(':grpc-protobuf'),
             project(':grpc-stub'),
+            libraries.autovalue_annotation,
             libraries.guava
+    annotationProcessor libraries.autovalue
     compileOnly libraries.javax_annotation
     testImplementation libraries.truth,
             project(':grpc-grpclb'),
@@ -22,6 +24,17 @@ dependencies {
             project(':grpc-testing-proto'),
             project(':grpc-core').sourceSets.test.output  // for FakeClock
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
+}
+
+[compileJava].each() {
+    it.options.compilerArgs += [
+            // only has AutoValue annotation processor
+            "-Xlint:-processing",
+    ]
+    appendToProperty(
+            it.options.errorprone.excludedPaths,
+            ".*/build/generated/sources/annotationProcessor/java/.*",
+            "|")
 }
 
 javadoc {

--- a/rls/src/main/java/io/grpc/rls/RlsProtoConverters.java
+++ b/rls/src/main/java/io/grpc/rls/RlsProtoConverters.java
@@ -20,9 +20,11 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Converter;
+import com.google.common.collect.ImmutableMap;
 import io.grpc.internal.JsonUtil;
 import io.grpc.lookup.v1.RouteLookupRequest;
 import io.grpc.lookup.v1.RouteLookupResponse;
+import io.grpc.rls.RlsProtoData.ExtraKeys;
 import io.grpc.rls.RlsProtoData.GrpcKeyBuilder;
 import io.grpc.rls.RlsProtoData.GrpcKeyBuilder.Name;
 import io.grpc.rls.RlsProtoData.NameMatcher;
@@ -46,25 +48,16 @@ final class RlsProtoConverters {
   static final class RouteLookupRequestConverter
       extends Converter<RouteLookupRequest, RlsProtoData.RouteLookupRequest> {
 
-    @SuppressWarnings("deprecation")
     @Override
     protected RlsProtoData.RouteLookupRequest doForward(RouteLookupRequest routeLookupRequest) {
-      return
-          new RlsProtoData.RouteLookupRequest(
-              /* server= */ routeLookupRequest.getServer(),
-              /* path= */ routeLookupRequest.getPath(),
-              /* targetType= */ routeLookupRequest.getTargetType(),
-              routeLookupRequest.getKeyMapMap());
+      return new RlsProtoData.RouteLookupRequest(routeLookupRequest.getKeyMapMap());
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     protected RouteLookupRequest doBackward(RlsProtoData.RouteLookupRequest routeLookupRequest) {
       return
           RouteLookupRequest.newBuilder()
-              .setServer(routeLookupRequest.getServer())
-              .setPath(routeLookupRequest.getPath())
-              .setTargetType(routeLookupRequest.getTargetType())
+              .setTargetType("grpc")
               .putAllKeyMap(routeLookupRequest.getKeyMap())
               .build();
     }
@@ -183,7 +176,21 @@ final class RlsProtoConverters {
             matcher.isOptional(), "NameMatcher for GrpcKeyBuilders shouldn't be required");
         nameMatchers.add(matcher);
       }
-      return new GrpcKeyBuilder(names, nameMatchers);
+      ExtraKeys extraKeys = ExtraKeys.DEFAULT;
+      Map<String, String> rawExtraKeys =
+          (Map<String, String>) JsonUtil.getObject(keyBuilder,  "extraKeys");
+      if (rawExtraKeys != null) {
+        extraKeys = ExtraKeys.create(
+            /* host= */ rawExtraKeys.get("host"),
+            /* service= */ rawExtraKeys.get("service"),
+            /* method= */ rawExtraKeys.get("method"));
+      }
+      Map<String, String> constantKeys =
+          (Map<String, String>) JsonUtil.getObject(keyBuilder,  "constantKeys");
+      if (constantKeys == null) {
+        constantKeys = ImmutableMap.of();
+      }
+      return new GrpcKeyBuilder(names, nameMatchers, extraKeys, constantKeys);
     }
   }
 

--- a/rls/src/main/java/io/grpc/rls/RlsProtoConverters.java
+++ b/rls/src/main/java/io/grpc/rls/RlsProtoConverters.java
@@ -181,9 +181,7 @@ final class RlsProtoConverters {
           (Map<String, String>) JsonUtil.getObject(keyBuilder,  "extraKeys");
       if (rawExtraKeys != null) {
         extraKeys = ExtraKeys.create(
-            /* host= */ rawExtraKeys.get("host"),
-            /* service= */ rawExtraKeys.get("service"),
-            /* method= */ rawExtraKeys.get("method"));
+            rawExtraKeys.get("host"), rawExtraKeys.get("service"), rawExtraKeys.get("method"));
       }
       Map<String, String> constantKeys =
           (Map<String, String>) JsonUtil.getObject(keyBuilder,  "constantKeys");

--- a/rls/src/main/java/io/grpc/rls/RlsProtoData.java
+++ b/rls/src/main/java/io/grpc/rls/RlsProtoData.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
+import com.google.auto.value.AutoValue;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
@@ -40,44 +41,10 @@ final class RlsProtoData {
   @Immutable
   static final class RouteLookupRequest {
 
-    private final String server;
-
-    private final String path;
-
-    private final String targetType;
-
     private final ImmutableMap<String, String> keyMap;
 
-    RouteLookupRequest(
-        String server, String path, String targetType, Map<String, String> keyMap) {
-      this.server = checkNotNull(server, "server");
-      this.path = checkNotNull(path, "path");
-      this.targetType = checkNotNull(targetType, "targetName");
+    RouteLookupRequest(Map<String, String> keyMap) {
       this.keyMap = ImmutableMap.copyOf(checkNotNull(keyMap, "keyMap"));
-    }
-
-    /**
-     * Returns a full host name of the target server, {@literal e.g.} firestore.googleapis.com. Only
-     * set for gRPC requests; HTTP requests must use key_map explicitly.
-     */
-    String getServer() {
-      return server;
-    }
-
-    /**
-     * Returns a full path of the request, {@literal i.e.} "/service/method". Only set for gRPC
-     * requests; HTTP requests must use key_map explicitly.
-     */
-    String getPath() {
-      return path;
-    }
-
-    /**
-     * Returns the target type allows the client to specify what kind of target format it would like
-     * from RLS to allow it to find the regional server, {@literal e.g.} "grpc".
-     */
-    String getTargetType() {
-      return targetType;
     }
 
     /** Returns a map of key values extracted via key builders for the gRPC or HTTP request. */
@@ -94,23 +61,17 @@ final class RlsProtoData {
         return false;
       }
       RouteLookupRequest that = (RouteLookupRequest) o;
-      return Objects.equal(server, that.server)
-          && Objects.equal(path, that.path)
-          && Objects.equal(targetType, that.targetType)
-          && Objects.equal(keyMap, that.keyMap);
+      return Objects.equal(keyMap, that.keyMap);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(server, path, targetType, keyMap);
+      return Objects.hashCode(keyMap);
     }
 
     @Override
     public String toString() {
       return MoreObjects.toStringHelper(this)
-          .add("server", server)
-          .add("path", path)
-          .add("targetName", targetType)
           .add("keyMap", keyMap)
           .toString();
     }
@@ -300,6 +261,7 @@ final class RlsProtoData {
      * error.  Note that requests can be routed only to a subdomain of the original target,
      * {@literal e.g.} "us_east_1.cloudbigtable.googleapis.com".
      */
+    @Nullable
     String getDefaultTarget() {
       return defaultTarget;
     }
@@ -431,12 +393,18 @@ final class RlsProtoData {
     private final ImmutableList<Name> names;
 
     private final ImmutableList<NameMatcher> headers;
+    private final ExtraKeys extraKeys;
+    private final ImmutableMap<String, String> constantKeys;
 
-    public GrpcKeyBuilder(List<Name> names, List<NameMatcher> headers) {
+    public GrpcKeyBuilder(
+        List<Name> names, List<NameMatcher> headers, ExtraKeys extraKeys,
+        Map<String, String> constantKeys) {
       checkState(names != null && !names.isEmpty(), "names cannot be empty");
       this.names = ImmutableList.copyOf(names);
       checkUniqueKey(checkNotNull(headers, "headers"));
       this.headers = ImmutableList.copyOf(headers);
+      this.extraKeys = checkNotNull(extraKeys, "extraKeys");
+      this.constantKeys = ImmutableMap.copyOf(checkNotNull(constantKeys, "constantKeys"));
     }
 
     private static void checkUniqueKey(List<NameMatcher> headers) {
@@ -464,6 +432,14 @@ final class RlsProtoData {
       return headers;
     }
 
+    ExtraKeys getExtraKeys() {
+      return extraKeys;
+    }
+
+    ImmutableMap<String, String> getConstantKeys() {
+      return constantKeys;
+    }
+
     @Override
     public boolean equals(Object o) {
       if (this == o) {
@@ -473,12 +449,14 @@ final class RlsProtoData {
         return false;
       }
       GrpcKeyBuilder that = (GrpcKeyBuilder) o;
-      return Objects.equal(names, that.names) && Objects.equal(headers, that.headers);
+      return Objects.equal(names, that.names) && Objects.equal(headers, that.headers)
+          && Objects.equal(extraKeys, that.extraKeys)
+          && Objects.equal(constantKeys, that.constantKeys);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(names, headers);
+      return Objects.hashCode(names, headers, extraKeys, constantKeys);
     }
 
     @Override
@@ -486,6 +464,8 @@ final class RlsProtoData {
       return MoreObjects.toStringHelper(this)
           .add("names", names)
           .add("headers", headers)
+          .add("extraKeys", extraKeys)
+          .add("constantKeys", constantKeys)
           .toString();
     }
 
@@ -546,6 +526,21 @@ final class RlsProtoData {
             .add("method", method)
             .toString();
       }
+    }
+  }
+
+  @AutoValue
+  abstract static class ExtraKeys {
+    static final ExtraKeys DEFAULT = create(null, null, null);
+
+    @Nullable abstract String host();
+
+    @Nullable abstract String service();
+
+    @Nullable abstract String method();
+
+    static ExtraKeys create(String host, String service, String method) {
+      return new AutoValue_RlsProtoData_ExtraKeys(host, service, method);
     }
   }
 }

--- a/rls/src/main/java/io/grpc/rls/RlsProtoData.java
+++ b/rls/src/main/java/io/grpc/rls/RlsProtoData.java
@@ -539,7 +539,8 @@ final class RlsProtoData {
 
     @Nullable abstract String method();
 
-    static ExtraKeys create(String host, String service, String method) {
+    static ExtraKeys create(
+        @Nullable String host, @Nullable String service, @Nullable String method) {
       return new AutoValue_RlsProtoData_ExtraKeys(host, service, method);
     }
   }

--- a/rls/src/main/java/io/grpc/rls/RlsRequestFactory.java
+++ b/rls/src/main/java/io/grpc/rls/RlsRequestFactory.java
@@ -19,17 +19,18 @@ package io.grpc.rls;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.Table;
+import com.google.common.collect.ImmutableMap;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import io.grpc.rls.RlsProtoData.ExtraKeys;
 import io.grpc.rls.RlsProtoData.GrpcKeyBuilder;
 import io.grpc.rls.RlsProtoData.GrpcKeyBuilder.Name;
 import io.grpc.rls.RlsProtoData.NameMatcher;
 import io.grpc.rls.RlsProtoData.RouteLookupConfig;
 import io.grpc.rls.RlsProtoData.RouteLookupRequest;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.CheckReturnValue;
 
@@ -40,10 +41,7 @@ import javax.annotation.CheckReturnValue;
 final class RlsRequestFactory {
 
   private final String target;
-  /**
-   * schema: Path(/serviceName/methodName or /serviceName/*), rls request headerName, header fields.
-   */
-  private final Table<String, String, NameMatcher> keyBuilderTable;
+  private final Map<String, GrpcKeyBuilder> keyBuilderTable;
 
   RlsRequestFactory(RouteLookupConfig rlsConfig, String target) {
     checkNotNull(rlsConfig, "rlsConfig");
@@ -51,18 +49,16 @@ final class RlsRequestFactory {
     this.keyBuilderTable = createKeyBuilderTable(rlsConfig);
   }
 
-  private static Table<String, String, NameMatcher> createKeyBuilderTable(
+  private static Map<String, GrpcKeyBuilder> createKeyBuilderTable(
       RouteLookupConfig config) {
-    Table<String, String, NameMatcher> table = HashBasedTable.create();
+    Map<String, GrpcKeyBuilder> table = new HashMap<>();
     for (GrpcKeyBuilder grpcKeyBuilder : config.getGrpcKeyBuilders()) {
-      for (NameMatcher nameMatcher : grpcKeyBuilder.getHeaders()) {
-        for (Name name : grpcKeyBuilder.getNames()) {
-          String method =
-              name.getMethod() == null || name.getMethod().isEmpty()
-                  ? "*" : name.getMethod();
-          String path = "/" + name.getService() + "/" + method;
-          table.put(path, nameMatcher.getKey(), nameMatcher);
-        }
+      for (Name name : grpcKeyBuilder.getNames()) {
+        String method =
+            name.getMethod() == null || name.getMethod().isEmpty()
+                ? "*" : name.getMethod();
+        String path = "/" + name.getService() + "/" + method;
+        table.put(path, grpcKeyBuilder);
       }
     }
     return table;
@@ -74,20 +70,35 @@ final class RlsRequestFactory {
     checkNotNull(service, "service");
     checkNotNull(method, "method");
     String path = "/" + service + "/" + method;
-    Map<String, NameMatcher> keyBuilder = keyBuilderTable.row(path);
-    // if no matching keyBuilder found, fall back to wildcard match (ServiceName/*)
-    if (keyBuilder.isEmpty()) {
-      keyBuilder = keyBuilderTable.row("/" + service + "/*");
+    GrpcKeyBuilder grpcKeyBuilder = keyBuilderTable.get(path);
+    if (grpcKeyBuilder == null) {
+      // if no matching keyBuilder found, fall back to wildcard match (ServiceName/*)
+      grpcKeyBuilder = keyBuilderTable.get("/" + service + "/*");
     }
-    Map<String, String> rlsRequestHeaders = createRequestHeaders(metadata, keyBuilder);
-    return new RouteLookupRequest(target, path, "grpc", rlsRequestHeaders);
+    if (grpcKeyBuilder == null) {
+      return new RouteLookupRequest(ImmutableMap.<String, String>of());
+    }
+    Map<String, String> rlsRequestHeaders =
+        createRequestHeaders(metadata, grpcKeyBuilder.getHeaders());
+    ExtraKeys extraKeys = grpcKeyBuilder.getExtraKeys();
+    Map<String, String> constantKeys = grpcKeyBuilder.getConstantKeys();
+    if (extraKeys.host() != null) {
+      rlsRequestHeaders.put(extraKeys.host(), target);
+    }
+    if (extraKeys.service() != null) {
+      rlsRequestHeaders.put(extraKeys.service(), service);
+    }
+    if (extraKeys.method() != null) {
+      rlsRequestHeaders.put(extraKeys.method(), method);
+    }
+    rlsRequestHeaders.putAll(constantKeys);
+    return new RouteLookupRequest(rlsRequestHeaders);
   }
 
   private Map<String, String> createRequestHeaders(
-      Metadata metadata, Map<String, NameMatcher> keyBuilder) {
+      Metadata metadata, List<NameMatcher> keyBuilder) {
     Map<String, String> rlsRequestHeaders = new HashMap<>();
-    for (Map.Entry<String, NameMatcher> entry : keyBuilder.entrySet()) {
-      NameMatcher nameMatcher = entry.getValue();
+    for (NameMatcher nameMatcher : keyBuilder) {
       String value = null;
       for (String requestHeaderName : nameMatcher.names()) {
         value = metadata.get(Metadata.Key.of(requestHeaderName, Metadata.ASCII_STRING_MARSHALLER));
@@ -96,11 +107,11 @@ final class RlsRequestFactory {
         }
       }
       if (value != null) {
-        rlsRequestHeaders.put(entry.getKey(), value);
+        rlsRequestHeaders.put(nameMatcher.getKey(), value);
       } else if (!nameMatcher.isOptional()) {
         throw new StatusRuntimeException(
             Status.INVALID_ARGUMENT.withDescription(
-                String.format("Missing mandatory metadata(%s) not found", entry.getKey())));
+                String.format("Missing mandatory metadata(%s) not found", nameMatcher.getKey())));
       }
     }
     return rlsRequestHeaders;

--- a/rls/src/main/java/io/grpc/rls/RlsRequestFactory.java
+++ b/rls/src/main/java/io/grpc/rls/RlsRequestFactory.java
@@ -54,9 +54,8 @@ final class RlsRequestFactory {
     Map<String, GrpcKeyBuilder> table = new HashMap<>();
     for (GrpcKeyBuilder grpcKeyBuilder : config.getGrpcKeyBuilders()) {
       for (Name name : grpcKeyBuilder.getNames()) {
-        String method =
-            name.getMethod() == null || name.getMethod().isEmpty()
-                ? "*" : name.getMethod();
+        boolean hasMethod = name.getMethod() == null || name.getMethod().isEmpty();
+        String method = hasMethod ? "*" : name.getMethod();
         String path = "/" + name.getService() + "/" + method;
         table.put(path, grpcKeyBuilder);
       }

--- a/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
@@ -144,13 +144,15 @@ public class RlsLoadBalancerTest {
             .build();
     fakeRlsServerImpl.setLookupTable(
         ImmutableMap.of(
-            new RouteLookupRequest(
-                "fake-bigtable.googleapis.com", "/com.google/Search", "grpc",
-                ImmutableMap.<String, String>of()),
+            new RouteLookupRequest(ImmutableMap.of(
+                "server", "fake-bigtable.googleapis.com",
+                "service-key", "com.google",
+                "method-key", "Search")),
             new RouteLookupResponse(ImmutableList.of("wilderness"), "where are you?"),
-            new RouteLookupRequest(
-                "fake-bigtable.googleapis.com", "/com.google/Rescue", "grpc",
-                ImmutableMap.<String, String>of()),
+            new RouteLookupRequest(ImmutableMap.of(
+                "server", "fake-bigtable.googleapis.com",
+                "service-key", "com.google",
+                "method-key", "Rescue")),
             new RouteLookupResponse(ImmutableList.of("civilization"), "you are safe")));
 
     rlsLb = (RlsLoadBalancer) provider.newLoadBalancer(helper);
@@ -409,7 +411,12 @@ public class RlsLoadBalancerTest {
         + "          \"names\": [\"PermitId\"],\n"
         + "          \"optional\": true\n"
         + "        }\n"
-        + "      ]\n"
+        + "      ],\n"
+        + "      \"extraKeys\": {\n"
+        + "        \"host\": \"server\",\n"
+        + "        \"service\": \"service-key\",\n"
+        + "        \"method\": \"method-key\"\n"
+        + "      }\n"
         + "    }\n"
         + "  ],\n"
         + "  \"lookupService\": \"localhost:8972\",\n"


### PR DESCRIPTION
The [`server` and `path` fields](https://github.com/grpc/grpc-java/blob/v1.40.1/rls/src/main/proto/grpc/lookup/v1/rls.proto#L25-L32) in `RouteLookupRequest` are deprecated. Instead, we will send the server/path information in side of [`key_map`](https://github.com/grpc/grpc-java/blob/v1.40.1/rls/src/main/proto/grpc/lookup/v1/rls.proto#L45).

The keys for the server, service and method in the `key_map` will be the _values_ of `host`, `service`, `method` fields respectively in [`extraKeys`](https://github.com/grpc/grpc-java/blob/v1.40.1/rls/src/main/proto/grpc/lookup/v1/rls_config.proto#L69) in RlsConfig.

We will also include all entries in the [`constantKey`](https://github.com/grpc/grpc-java/blob/v1.40.1/rls/src/main/proto/grpc/lookup/v1/rls_config.proto#L80) in RlsConfig into `RouteLookupRequest`.


Other changes:

- Add AutoValue library for ExtraKeys class, just like data classes used in grpc-xds. Will migrate other data classes to AutoValue as well.
- Not to keep `targetType` field in the route lookup request data class, because we always use "grpc" as targetType.