### PR TITLE
fix a flaky test in advanced TLS

### DIFF
--- a/core/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
+++ b/core/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
@@ -23,12 +23,11 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.Socket;
-import java.security.NoSuchAlgorithmException;
+import java.security.GeneralSecurityException;
 import java.security.Principal;
 import java.security.PrivateKey;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.security.spec.InvalidKeySpecException;
 import java.util.Arrays;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -107,8 +106,7 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
    * @param key  the private key that is going to be used
    * @param certs  the certificate chain that is going to be used
    */
-  public void updateIdentityCredentials(PrivateKey key, X509Certificate[] certs)
-      throws CertificateException {
+  public void updateIdentityCredentials(PrivateKey key, X509Certificate[] certs) {
     // TODO(ZhenLian): explore possibilities to do a crypto check here.
     this.keyInfo = new KeyInfo(checkNotNull(key, "key"), checkNotNull(certs, "certs"));
   }
@@ -126,10 +124,15 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
    * @return an object that caller should close when the file refreshes are not needed
    */
   public Closeable updateIdentityCredentialsFromFile(File keyFile, File certFile,
-      long period, TimeUnit unit, ScheduledExecutorService executor) {
+      long period, TimeUnit unit, ScheduledExecutorService executor) throws IOException,
+      GeneralSecurityException {
+    UpdateResult newResult = readAndUpdate(keyFile, certFile, 0, 0);
+    if (!newResult.success) {
+      throw new GeneralSecurityException("The initial update was not successful");
+    }
     final ScheduledFuture<?> future =
         executor.scheduleWithFixedDelay(
-            new LoadFilePathExecution(keyFile, certFile), 0, period, unit);
+            new LoadFilePathExecution(keyFile, certFile), period, period, unit);
     return new Closeable() {
       @Override public void close() {
         future.cancel(false);
@@ -170,8 +173,7 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
           this.currentKeyTime = newResult.keyTime;
           this.currentCertTime = newResult.certTime;
         }
-      } catch (CertificateException | IOException | NoSuchAlgorithmException
-          | InvalidKeySpecException e) {
+      } catch (IOException | GeneralSecurityException e) {
         log.log(Level.SEVERE, "Failed refreshing private key and certificate chain from files. "
             + "Using previous ones", e);
       }
@@ -201,7 +203,7 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
    * @return the result of this update execution
    */
   private UpdateResult readAndUpdate(File keyFile, File certFile, long oldKeyTime, long oldCertTime)
-      throws IOException, CertificateException, NoSuchAlgorithmException, InvalidKeySpecException {
+      throws IOException, GeneralSecurityException {
     long newKeyTime = keyFile.lastModified();
     long newCertTime = certFile.lastModified();
     // We only update when both the key and the certs are updated.

--- a/core/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
+++ b/core/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
@@ -128,7 +128,8 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
       GeneralSecurityException {
     UpdateResult newResult = readAndUpdate(keyFile, certFile, 0, 0);
     if (!newResult.success) {
-      throw new GeneralSecurityException("The initial update was not successful");
+      throw new GeneralSecurityException(
+          "Files were unmodified before their initial update. Probably a bug.");
     }
     final ScheduledFuture<?> future =
         executor.scheduleWithFixedDelay(

--- a/core/src/main/java/io/grpc/util/AdvancedTlsX509TrustManager.java
+++ b/core/src/main/java/io/grpc/util/AdvancedTlsX509TrustManager.java
@@ -223,7 +223,8 @@ public final class AdvancedTlsX509TrustManager extends X509ExtendedTrustManager 
       ScheduledExecutorService executor) throws IOException, GeneralSecurityException {
     long updatedTime = readAndUpdate(trustCertFile, 0);
     if (updatedTime == 0) {
-      throw new GeneralSecurityException("The initial update was not successful");
+      throw new GeneralSecurityException(
+          "Files were unmodified before their initial update. Probably a bug.");
     }
     final ScheduledFuture<?> future =
         executor.scheduleWithFixedDelay(

--- a/core/src/main/java/io/grpc/util/AdvancedTlsX509TrustManager.java
+++ b/core/src/main/java/io/grpc/util/AdvancedTlsX509TrustManager.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.Socket;
+import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -124,8 +125,8 @@ public final class AdvancedTlsX509TrustManager extends X509ExtendedTrustManager 
    *
    * @param trustCerts the trust certificates that are going to be used
    */
-  public void updateTrustCredentials(X509Certificate[] trustCerts) throws CertificateException,
-      KeyStoreException, NoSuchAlgorithmException, IOException {
+  public void updateTrustCredentials(X509Certificate[] trustCerts) throws IOException,
+      GeneralSecurityException {
     KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
     keyStore.load(null, null);
     int i = 1;
@@ -219,10 +220,14 @@ public final class AdvancedTlsX509TrustManager extends X509ExtendedTrustManager 
    * @return an object that caller should close when the file refreshes are not needed
    */
   public Closeable updateTrustCredentialsFromFile(File trustCertFile, long period, TimeUnit unit,
-      ScheduledExecutorService executor) {
+      ScheduledExecutorService executor) throws IOException, GeneralSecurityException {
+    long updatedTime = readAndUpdate(trustCertFile, 0);
+    if (updatedTime == 0) {
+      throw new GeneralSecurityException("The initial update was not successful");
+    }
     final ScheduledFuture<?> future =
         executor.scheduleWithFixedDelay(
-            new LoadFilePathExecution(trustCertFile), 0, period, unit);
+            new LoadFilePathExecution(trustCertFile), period, period, unit);
     return new Closeable() {
       @Override public void close() {
         future.cancel(false);
@@ -243,8 +248,7 @@ public final class AdvancedTlsX509TrustManager extends X509ExtendedTrustManager 
     public void run() {
       try {
         this.currentTime = readAndUpdate(this.file, this.currentTime);
-      } catch (CertificateException | IOException | KeyStoreException
-          | NoSuchAlgorithmException e) {
+      } catch (IOException | GeneralSecurityException e) {
         log.log(Level.SEVERE, "Failed refreshing trust CAs from file. Using previous CAs", e);
       }
     }
@@ -259,7 +263,7 @@ public final class AdvancedTlsX509TrustManager extends X509ExtendedTrustManager 
    * @return oldTime if failed or the modified time is not changed, otherwise the new modified time
    */
   private long readAndUpdate(File trustCertFile, long oldTime)
-      throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
+      throws IOException, GeneralSecurityException {
     long newTime = trustCertFile.lastModified();
     if (newTime == oldTime) {
       return oldTime;

--- a/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
+++ b/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
@@ -169,7 +169,6 @@ public class AdvancedTlsTest {
         .clientAuth(ClientAuth.REQUIRE).build();
     server = Grpc.newServerBuilderForPort(0, serverCredentials).addService(
         new SimpleServiceImpl()).build().start();
-    TimeUnit.SECONDS.sleep(5);
     // Create a client with the key manager and trust manager.
     AdvancedTlsX509KeyManager clientKeyManager = new AdvancedTlsX509KeyManager();
     clientKeyManager.updateIdentityCredentials(clientKey0, clientCert0);
@@ -181,6 +180,8 @@ public class AdvancedTlsTest {
         .keyManager(clientKeyManager).trustManager(clientTrustManager).build();
     channel = Grpc.newChannelBuilderForAddress("localhost", server.getPort(), channelCredentials)
         .overrideAuthority("foo.test.google.com.au").build();
+    // Wait 5 seconds for the client and server to load their credentials.
+    TimeUnit.SECONDS.sleep(5);
     // Start the connection.
     try {
       SimpleServiceGrpc.SimpleServiceBlockingStub client =

--- a/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
+++ b/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
@@ -180,8 +180,6 @@ public class AdvancedTlsTest {
         .keyManager(clientKeyManager).trustManager(clientTrustManager).build();
     channel = Grpc.newChannelBuilderForAddress("localhost", server.getPort(), channelCredentials)
         .overrideAuthority("foo.test.google.com.au").build();
-    // Wait 5 seconds for the client and server to load their credentials.
-    TimeUnit.SECONDS.sleep(5);
     // Start the connection.
     try {
       SimpleServiceGrpc.SimpleServiceBlockingStub client =
@@ -233,7 +231,6 @@ public class AdvancedTlsTest {
         .clientAuth(ClientAuth.REQUIRE).build();
     server = Grpc.newServerBuilderForPort(0, serverCredentials).addService(
         new SimpleServiceImpl()).build().start();
-    TimeUnit.SECONDS.sleep(5);
 
     AdvancedTlsX509KeyManager clientKeyManager = new AdvancedTlsX509KeyManager();
     clientKeyManager.updateIdentityCredentials(clientKey0, clientCert0);
@@ -308,7 +305,6 @@ public class AdvancedTlsTest {
         .clientAuth(ClientAuth.REQUIRE).build();
     server = Grpc.newServerBuilderForPort(0, serverCredentials).addService(
         new SimpleServiceImpl()).build().start();
-    TimeUnit.SECONDS.sleep(5);
 
     AdvancedTlsX509KeyManager clientKeyManager = new AdvancedTlsX509KeyManager();
     clientKeyManager.updateIdentityCredentials(clientKey0, clientCert0);
@@ -360,7 +356,6 @@ public class AdvancedTlsTest {
         .clientAuth(ClientAuth.REQUIRE).build();
     server = Grpc.newServerBuilderForPort(0, serverCredentials).addService(
         new SimpleServiceImpl()).build().start();
-    TimeUnit.SECONDS.sleep(5);
     // Create a client to connect.
     AdvancedTlsX509KeyManager clientKeyManager = new AdvancedTlsX509KeyManager();
     Closeable clientKeyShutdown = clientKeyManager.updateIdentityCredentialsFromFile(clientKey0File,

--- a/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
+++ b/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
@@ -45,6 +45,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.net.Socket;
+import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.cert.CertificateException;
@@ -385,6 +386,28 @@ public class AdvancedTlsTest {
     serverTrustShutdown.close();
     clientKeyShutdown.close();
     clientTrustShutdown.close();
+  }
+
+  @Test
+  public void onFileReloadingKeyManagerBadInitialContentTest() throws Exception {
+    exceptionRule.expect(GeneralSecurityException.class);
+    AdvancedTlsX509KeyManager keyManager = new AdvancedTlsX509KeyManager();
+    // We swap the order of key and certificates to intentionally create an exception.
+    Closeable keyShutdown = keyManager.updateIdentityCredentialsFromFile(serverCert0File,
+        serverKey0File, 100, TimeUnit.MILLISECONDS, executor);
+    keyShutdown.close();
+  }
+
+  @Test
+  public void onFileReloadingTrustManagerBadInitialContentTest() throws Exception {
+    exceptionRule.expect(GeneralSecurityException.class);
+    AdvancedTlsX509TrustManager trustManager = AdvancedTlsX509TrustManager.newBuilder()
+        .setVerification(Verification.CERTIFICATE_ONLY_VERIFICATION)
+        .build();
+    // We pass in a key as the trust certificates to intentionally create an exception.
+    Closeable trustShutdown = trustManager.updateTrustCredentialsFromFile(serverKey0File,
+        100, TimeUnit.MILLISECONDS, executor);
+    trustShutdown.close();
   }
 
   @Test


### PR DESCRIPTION
This is intended to fix https://github.com/grpc/grpc-java/issues/8454.
The problem was because at the time we scheduled the thread for the client, we didn't reserve enough time before starting the connection, so there could be a situation where the handshake has established, while the client hasn't finished its first read/reload yet. 
I added the code to sleep for 5 seconds and then begin our connection. Ideally, to fully remove the race condition, we might need some ways for the reloading thread telling us that the first read has been completed in the main test. But I can't think of any way that won't introduce any changes to the main code(I assume it is a bad practice to change code under "src" to better fit code under "test").
I've verified internally that this changes worked fine by running it for 1000 times(it failed previously).