### PR TITLE
xds: enable PSM security by default

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -69,7 +69,8 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
           || Boolean.parseBoolean(System.getenv("GRPC_XDS_EXPERIMENTAL_CIRCUIT_BREAKING"));
   @VisibleForTesting
   static boolean enableSecurity =
-      Boolean.parseBoolean(System.getenv("GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"));
+      Strings.isNullOrEmpty(System.getenv("GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"))
+          || Boolean.parseBoolean(System.getenv("GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"));
   private static final Attributes.Key<ClusterLocalityStats> ATTR_CLUSTER_LOCALITY_STATS =
       Attributes.Key.create("io.grpc.xds.ClusterImplLoadBalancer.clusterLocalityStats");
 

--- a/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
@@ -480,16 +480,16 @@ public class ClusterImplLoadBalancerTest {
   }
 
   @Test
-  public void endpointAddressesAttachedWithTlsConfig_enableSecurity() {
+  public void endpointAddressesAttachedWithTlsConfig_disableSecurity() {
     boolean originalEnableSecurity = ClusterImplLoadBalancer.enableSecurity;
-    ClusterImplLoadBalancer.enableSecurity = true;
-    subtest_endpointAddressesAttachedWithTlsConfig(true);
+    ClusterImplLoadBalancer.enableSecurity = false;
+    subtest_endpointAddressesAttachedWithTlsConfig(false);
     ClusterImplLoadBalancer.enableSecurity = originalEnableSecurity;
   }
 
   @Test
-  public void endpointAddressesAttachedWithTlsConfig_securityDisabledByDefault() {
-    subtest_endpointAddressesAttachedWithTlsConfig(false);
+  public void endpointAddressesAttachedWithTlsConfig_securityEnabledByDefault() {
+    subtest_endpointAddressesAttachedWithTlsConfig(true);
   }
 
   private void subtest_endpointAddressesAttachedWithTlsConfig(boolean enableSecurity) {


### PR DESCRIPTION
For v1.41.x PSM security needs to be enabled by default
CC @ejona86 