### PR TITLE
xds: fix parsing retryOn values [backport v1.40.x]

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -1254,21 +1254,20 @@ final class ClientXdsClient extends AbstractXdsClient {
         maxBackoff = Durations.fromNanos(Durations.toNanos(initialBackoff) * 10);
       }
     }
-    Iterable<String> retryOns = Splitter.on(',').split(retryPolicyProto.getRetryOn());
+    Iterable<String> retryOns =
+        Splitter.on(',').omitEmptyStrings().trimResults().split(retryPolicyProto.getRetryOn());
     ImmutableList.Builder<Code> retryableStatusCodesBuilder = ImmutableList.builder();
     for (String retryOn : retryOns) {
       Code code;
       try {
         code = Code.valueOf(retryOn.toUpperCase(Locale.US).replace('-', '_'));
       } catch (IllegalArgumentException e) {
-        // TODO(zdapeng): TBD
         // unsupported value, such as "5xx"
-        return null;
+        continue;
       }
       if (!SUPPORTED_RETRYABLE_CODES.contains(code)) {
-        // TODO(zdapeng): TBD
         // unsupported value
-        return null;
+        continue;
       }
       retryableStatusCodesBuilder.add(code);
     }

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
@@ -646,7 +646,8 @@ public class ClientXdsClientDataTest {
         .setRetryPolicy(builder)
         .build();
     struct = ClientXdsClient.parseRouteAction(proto, filterRegistry, false);
-    assertThat(struct.getStruct().retryPolicy()).isNull();
+    assertThat(struct.getStruct().retryPolicy().retryableStatusCodes())
+        .containsExactly(Code.CANCELLED);
 
     // unsupported retry_on code
     builder = RetryPolicy.newBuilder()
@@ -662,7 +663,25 @@ public class ClientXdsClientDataTest {
         .setRetryPolicy(builder)
         .build();
     struct = ClientXdsClient.parseRouteAction(proto, filterRegistry, false);
-    assertThat(struct.getStruct().retryPolicy()).isNull();
+    assertThat(struct.getStruct().retryPolicy().retryableStatusCodes())
+        .containsExactly(Code.CANCELLED);
+
+    // whitespace in retry_on
+    builder = RetryPolicy.newBuilder()
+        .setNumRetries(UInt32Value.of(3))
+        .setRetryBackOff(
+            RetryBackOff.newBuilder()
+                .setBaseInterval(Durations.fromMillis(500))
+                .setMaxInterval(Durations.fromMillis(600)))
+        .setPerTryTimeout(Durations.fromMillis(300))
+        .setRetryOn("abort, , cancelled , ");
+    proto = io.envoyproxy.envoy.config.route.v3.RouteAction.newBuilder()
+        .setCluster("cluster-foo")
+        .setRetryPolicy(builder)
+        .build();
+    struct = ClientXdsClient.parseRouteAction(proto, filterRegistry, false);
+    assertThat(struct.getStruct().retryPolicy().retryableStatusCodes())
+        .containsExactly(Code.CANCELLED);
   }
 
   @Test


### PR DESCRIPTION
Backport of #8477 

- Envoy ignores white spaces in `retryOn` field
https://github.com/envoyproxy/envoy/blob/v1.19.1/source/common/router/retry_state_impl.cc#L166

  We should do the same.

- Envoy ignores unsupported values https://github.com/envoyproxy/envoy/blob/v1.19.1/source/common/router/config_impl.cc#L89-L90
  and we should do the same.