### PR TITLE
stub: mark CallStreamObserver stable

### DIFF
--- a/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
@@ -16,33 +16,27 @@
 
 package io.grpc.stub;
 
-import io.grpc.ExperimentalApi;
-
 /**
- * A refinement of StreamObserver provided by the GRPC runtime to the application (the client or
- * the server) that allows for more complex interactions with call behavior.
+ * A refinement of StreamObserver provided by the GRPC runtime to the application (the client or the
+ * server) that allows for more complex interactions with call behavior.
  *
  * <p>In any call there are logically four {@link StreamObserver} implementations:
+ *
  * <ul>
- *   <li>'inbound', client-side - which the GRPC runtime calls when it receives messages from
- *   the server. This is implemented by the client application and passed into a service method
- *   on a stub object.
- *   </li>
+ *   <li>'inbound', client-side - which the GRPC runtime calls when it receives messages from the
+ *       server. This is implemented by the client application and passed into a service method on a
+ *       stub object.
  *   <li>'outbound', client-side - which the GRPC runtime provides to the client application and the
- *   client uses this {@code StreamObserver} to send messages to the server.
- *   </li>
- *   <li>'inbound', server-side - which the GRPC runtime calls when it receives messages from
- *   the client. This is implemented by the server application and returned from service
- *   implementations of client-side streaming and bidirectional streaming methods.
- *   </li>
- *   <li>'outbound', server-side - which the GRPC runtime provides to the server application and
- *   the server uses this {@code StreamObserver} to send messages (responses) to the client.
- *   </li>
+ *       client uses this {@code StreamObserver} to send messages to the server.
+ *   <li>'inbound', server-side - which the GRPC runtime calls when it receives messages from the
+ *       client. This is implemented by the server application and returned from service
+ *       implementations of client-side streaming and bidirectional streaming methods.
+ *   <li>'outbound', server-side - which the GRPC runtime provides to the server application and the
+ *       server uses this {@code StreamObserver} to send messages (responses) to the client.
  * </ul>
  *
- * <p>Implementations of this class represent the 'outbound' message streams. The client-side
- * one is {@link ClientCallStreamObserver} and the service-side one is
- * {@link ServerCallStreamObserver}.
+ * <p>Implementations of this class represent the 'outbound' message streams. The client-side one is
+ * {@link ClientCallStreamObserver} and the service-side one is {@link ServerCallStreamObserver}.
  *
  * <p>Like {@code StreamObserver}, implementations are not required to be thread-safe; if multiple
  * threads will be writing to an instance concurrently, the application must synchronize its calls.
@@ -50,7 +44,6 @@ import io.grpc.ExperimentalApi;
  * <p>DO NOT MOCK: The API is too complex to reliably mock. Use InProcessChannelBuilder to create
  * "real" RPCs suitable for testing.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1788")
 public abstract class CallStreamObserver<V> implements StreamObserver<V> {
 
   /**


### PR DESCRIPTION
I believe this was overlooked in #7938's work to fix #1788.
