### PR TITLE
Extend the xDS interop tests timeout to 360 mins [backport v1.34.x]

### DIFF
--- a/buildscripts/kokoro/xds.cfg
+++ b/buildscripts/kokoro/xds.cfg
@@ -2,7 +2,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-java/buildscripts/kokoro/xds.sh"
-timeout_mins: 120
+timeout_mins: 360
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
backport of #8133