### PR TITLE
xds: update Envoy protos to a later revision for the new CertificateProvider definitions

### DIFF
--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
@@ -256,6 +256,7 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void parseRouteMatch_withHeaderMatcher() {
     io.envoyproxy.envoy.config.route.v3.RouteMatch proto =
         io.envoyproxy.envoy.config.route.v3.RouteMatch.newBuilder()
@@ -336,6 +337,7 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void parseHeaderMatcher_withExactMatch() {
     io.envoyproxy.envoy.config.route.v3.HeaderMatcher proto =
         io.envoyproxy.envoy.config.route.v3.HeaderMatcher.newBuilder()
@@ -349,6 +351,7 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void parseHeaderMatcher_withSafeRegExMatch() {
     io.envoyproxy.envoy.config.route.v3.HeaderMatcher proto =
         io.envoyproxy.envoy.config.route.v3.HeaderMatcher.newBuilder()
@@ -388,6 +391,7 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void parseHeaderMatcher_withPrefixMatch() {
     io.envoyproxy.envoy.config.route.v3.HeaderMatcher proto =
         io.envoyproxy.envoy.config.route.v3.HeaderMatcher.newBuilder()
@@ -401,6 +405,7 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void parseHeaderMatcher_withSuffixMatch() {
     io.envoyproxy.envoy.config.route.v3.HeaderMatcher proto =
         io.envoyproxy.envoy.config.route.v3.HeaderMatcher.newBuilder()
@@ -414,6 +419,7 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void parseHeaderMatcher_malformedRegExPattern() {
     io.envoyproxy.envoy.config.route.v3.HeaderMatcher proto =
         io.envoyproxy.envoy.config.route.v3.HeaderMatcher.newBuilder()
@@ -1562,6 +1568,7 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_validationContextCertificateProvider()
       throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
@@ -1575,6 +1582,7 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_validationContextCertificateProviderInstance()
       throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
@@ -1600,6 +1608,7 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_tlsCertificateProviderInstance()
           throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
@@ -1611,6 +1620,7 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_tlsCertificateProviderInstance_absentInBootstrapFile()
           throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
@@ -1625,6 +1635,7 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_validationContextProviderInstance()
           throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
@@ -1639,6 +1650,7 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_validationContextProviderInstance_absentInBootstrapFile()
           throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
@@ -1679,6 +1691,7 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_tlsCertificateCertificateProvider()
       throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
@@ -1716,6 +1729,7 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_combinedValContextWithDefaultValContextForServer()
       throws ResourceInvalidException, InvalidProtocolBufferException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
@@ -1735,6 +1749,7 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_combinedValContextWithDefaultValContextVerifyCertSpki()
       throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
@@ -1754,6 +1769,7 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_combinedValContextWithDefaultValContextVerifyCertHash()
       throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
@@ -1773,6 +1789,7 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_combinedValContextDfltValContextRequireSignedCertTimestamp()
       throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
@@ -1793,6 +1810,7 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_combinedValidationContextWithDefaultValidationContextCrl()
       throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
@@ -1811,6 +1829,7 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_combinedValContextWithDfltValContextCustomValidatorConfig()
       throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
@@ -1838,6 +1857,7 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void validateDownstreamTlsContext_hasRequireSni() throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
         .setCombinedValidationContext(
@@ -1857,6 +1877,7 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void validateDownstreamTlsContext_hasOcspStaplePolicy() throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
         .setCombinedValidationContext(

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
@@ -1321,6 +1321,7 @@ public abstract class ClientXdsClientTestBase {
    * CDS response containing UpstreamTlsContext for a cluster.
    */
   @Test
+  @SuppressWarnings("deprecation")
   public void cdsResponseWithUpstreamTlsContext() {
     Assume.assumeTrue(useProtocolV3());
     DiscoveryRpcCall call = startResourceWatcher(CDS, CDS_RESOURCE, cdsResourceWatcher);

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientV3Test.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientV3Test.java
@@ -535,6 +535,7 @@ public class ClientXdsClientV3Test extends ClientXdsClientTestBase {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     protected Message buildUpstreamTlsContext(String instanceName, String certName) {
       CommonTlsContext.Builder commonTlsContextBuilder = CommonTlsContext.newBuilder();
       if (instanceName != null && certName != null) {

--- a/xds/src/test/java/io/grpc/xds/FilterChainMatchingProtocolNegotiatorsTest.java
+++ b/xds/src/test/java/io/grpc/xds/FilterChainMatchingProtocolNegotiatorsTest.java
@@ -1087,6 +1087,7 @@ public class FilterChainMatchingProtocolNegotiatorsTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void filterChainMatch_unsupportedMatchers() throws Exception {
     EnvoyServerProtoData.DownstreamTlsContext tlsContext1 =
             CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT1", "ROOTCA");

--- a/xds/src/test/java/io/grpc/xds/RbacFilterTest.java
+++ b/xds/src/test/java/io/grpc/xds/RbacFilterTest.java
@@ -155,7 +155,7 @@ public class RbacFilterTest {
   }
 
   @Test
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "deprecation"})
   public void headerParser() {
     HeaderMatcher headerMatcher = HeaderMatcher.newBuilder()
             .setName("party").setExactMatch("win").build();

--- a/xds/src/test/java/io/grpc/xds/internal/sds/ClientSslContextProviderFactoryTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/sds/ClientSslContextProviderFactoryTest.java
@@ -258,6 +258,7 @@ public class ClientSslContextProviderFactoryTest {
         .isSameInstanceAs(sslContextProvider);
   }
 
+  @SuppressWarnings("deprecation")
   static CommonTlsContext.Builder addFilenames(
       CommonTlsContext.Builder builder, String certChain, String privateKey, String trustCa) {
     TlsCertificate tlsCert =

--- a/xds/src/test/java/io/grpc/xds/internal/sds/CommonTlsContextTestsUtil.java
+++ b/xds/src/test/java/io/grpc/xds/internal/sds/CommonTlsContextTestsUtil.java
@@ -62,6 +62,7 @@ public class CommonTlsContextTestsUtil {
   public static final String BAD_CLIENT_KEY_FILE = "badclient.key";
 
   /** takes additional values and creates CombinedCertificateValidationContext as needed. */
+  @SuppressWarnings("deprecation")
   static CommonTlsContext buildCommonTlsContextWithAdditionalValues(
       String certInstanceName, String certName,
       String validationContextCertInstanceName, String validationContextCertName,
@@ -208,6 +209,7 @@ public class CommonTlsContextTestsUtil {
     return text;
   }
 
+  @SuppressWarnings("deprecation")
   private static CommonTlsContext buildCommonTlsContextForCertProviderInstance(
       String certInstanceName,
       String certName,
@@ -232,6 +234,7 @@ public class CommonTlsContextTestsUtil {
     return builder.build();
   }
 
+  @SuppressWarnings("deprecation")
   private static CommonTlsContext.Builder addCertificateValidationContext(
       CommonTlsContext.Builder builder,
       String rootInstanceName,

--- a/xds/third_party/envoy/import.sh
+++ b/xds/third_party/envoy/import.sh
@@ -18,7 +18,7 @@
 set -e
 BRANCH=main
 # import VERSION from one of the google internal CLs
-VERSION=62ca8bd2b5960ed1c6ce2be97d3120cee719ecab
+VERSION=c223756b0856f734a6a5cff2d0b95388cd2583d4
 GIT_REPO="https://github.com/envoyproxy/envoy.git"
 GIT_BASE_DIR=envoy
 SOURCE_PROTO_BASE_DIR=envoy/api

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/listener/listener_components.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/listener/listener_components.proto
@@ -230,7 +230,7 @@ message FilterChain {
 //    rules:
 //      - destination_port_range:
 //          start: 3306
-//          end: 3306
+//          end: 3307
 //      - destination_port_range:
 //          start: 15000
 //          end: 15001

--- a/xds/third_party/envoy/src/main/proto/envoy/config/accesslog/v3/accesslog.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/accesslog/v3/accesslog.proto
@@ -246,6 +246,7 @@ message ResponseFlagFilter {
         in: "DT"
         in: "UPE"
         in: "NC"
+        in: "OM"
       }
     }
   }];

--- a/xds/third_party/envoy/src/main/proto/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/bootstrap/v3/bootstrap.proto
@@ -40,7 +40,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // <config_overview_bootstrap>` for more detail.
 
 // Bootstrap :ref:`configuration overview <config_overview_bootstrap>`.
-// [#next-free-field: 31]
+// [#next-free-field: 33]
 message Bootstrap {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.bootstrap.v2.Bootstrap";
@@ -260,7 +260,24 @@ message Bootstrap {
   // This may be overridden on a per-cluster basis in cds_config, when
   // :ref:`dns_resolution_config <envoy_v3_api_field_config.cluster.v3.Cluster.dns_resolution_config>`
   // is specified.
+  // *dns_resolution_config* will be deprecated once
+  // :ref:'typed_dns_resolver_config <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.typed_dns_resolver_config>'
+  // is fully supported.
   core.v3.DnsResolutionConfig dns_resolution_config = 30;
+
+  // DNS resolver type configuration extension. This extension can be used to configure c-ares, apple,
+  // or any other DNS resolver types and the related parameters.
+  // For example, an object of :ref:`DnsResolutionConfig <envoy_v3_api_msg_config.core.v3.DnsResolutionConfig>`
+  // can be packed into this *typed_dns_resolver_config*. This configuration will replace the
+  // :ref:'dns_resolution_config <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.dns_resolution_config>'
+  // configuration eventually.
+  // TODO(yanjunxiang): Investigate the deprecation plan for *dns_resolution_config*.
+  // During the transition period when both *dns_resolution_config* and *typed_dns_resolver_config* exists,
+  // this configuration is optional.
+  // When *typed_dns_resolver_config* is in place, Envoy will use it and ignore *dns_resolution_config*.
+  // When *typed_dns_resolver_config* is missing, the default behavior is in place.
+  // [#not-implemented-hide:]
+  core.v3.TypedExtensionConfig typed_dns_resolver_config = 31;
 
   // Specifies optional bootstrap extensions to be instantiated at startup time.
   // Each item contains extension specific configuration.
@@ -305,6 +322,13 @@ message Bootstrap {
   // field.
   // [#not-implemented-hide:]
   map<string, core.v3.TypedExtensionConfig> certificate_provider_instances = 25;
+
+  // Specifies a set of headers that need to be registered as inline header. This configuration
+  // allows users to customize the inline headers on-demand at Envoy startup without modifying
+  // Envoy's source code.
+  //
+  // Note that the 'set-cookie' header cannot be registered as inline header.
+  repeated CustomInlineHeader inline_headers = 32;
 }
 
 // Administration interface :ref:`operations documentation
@@ -577,4 +601,44 @@ message LayeredRuntime {
   // The :ref:`layers <config_runtime_layering>` of the runtime. This is ordered
   // such that later layers in the list overlay earlier entries.
   repeated RuntimeLayer layers = 1;
+}
+
+// Used to specify the header that needs to be registered as an inline header.
+//
+// If request or response contain multiple headers with the same name and the header
+// name is registered as an inline header. Then multiple headers will be folded
+// into one, and multiple header values will be concatenated by a suitable delimiter.
+// The delimiter is generally a comma.
+//
+// For example, if 'foo' is registered as an inline header, and the headers contains
+// the following two headers:
+//
+// .. code-block:: text
+//
+//   foo: bar
+//   foo: eep
+//
+// Then they will eventually be folded into:
+//
+// .. code-block:: text
+//
+//   foo: bar, eep
+//
+// Inline headers provide O(1) search performance, but each inline header imposes
+// an additional memory overhead on all instances of the corresponding type of
+// HeaderMap or TrailerMap.
+message CustomInlineHeader {
+  enum InlineHeaderType {
+    REQUEST_HEADER = 0;
+    REQUEST_TRAILER = 1;
+    RESPONSE_HEADER = 2;
+    RESPONSE_TRAILER = 3;
+  }
+
+  // The name of the header that is expected to be set as the inline header.
+  string inline_header_name = 1
+      [(validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+
+  // The type of the header that is expected to be set as the inline header.
+  InlineHeaderType inline_header_type = 2 [(validate.rules).enum = {defined_only: true}];
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/cluster.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/cluster.proto
@@ -43,7 +43,7 @@ message ClusterCollection {
 }
 
 // Configuration for a single upstream cluster.
-// [#next-free-field: 54]
+// [#next-free-field: 56]
 message Cluster {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Cluster";
 
@@ -110,7 +110,7 @@ message Cluster {
     // this option or not.
     CLUSTER_PROVIDED = 6;
 
-    // [#not-implemented-hide:] Use the new :ref:`load_balancing_policy
+    // Use the new :ref:`load_balancing_policy
     // <envoy_v3_api_field_config.cluster.v3.Cluster.load_balancing_policy>` field to determine the LB policy.
     // [#next-major-version: In the v3 API, we should consider deprecating the lb_policy field
     // and instead using the new load_balancing_policy field as the one and only mechanism for
@@ -413,8 +413,8 @@ message Cluster {
     // The table size for Maglev hashing. The Maglev aims for ‘minimal disruption’ rather than an absolute guarantee.
     // Minimal disruption means that when the set of upstreams changes, a connection will likely be sent to the same
     // upstream as it was before. Increasing the table size reduces the amount of disruption.
-    // The table size must be prime number. If it is not specified, the default is 65537.
-    google.protobuf.UInt64Value table_size = 1;
+    // The table size must be prime number limited to 5000011. If it is not specified, the default is 65537.
+    google.protobuf.UInt64Value table_size = 1 [(validate.rules).uint64 = {lte: 5000011}];
   }
 
   // Specific configuration for the
@@ -720,8 +720,7 @@ message Cluster {
 
   // The :ref:`load balancer type <arch_overview_load_balancing_types>` to use
   // when picking a host in the cluster.
-  // [#comment:TODO: Remove enum constraint :ref:`LOAD_BALANCING_POLICY_CONFIG<envoy_v3_api_enum_value_config.cluster.v3.Cluster.LbPolicy.LOAD_BALANCING_POLICY_CONFIG>` when implemented.]
-  LbPolicy lb_policy = 6 [(validate.rules).enum = {defined_only: true not_in: 7}];
+  LbPolicy lb_policy = 6 [(validate.rules).enum = {defined_only: true}];
 
   // Setting this is required for specifying members of
   // :ref:`STATIC<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.STATIC>`,
@@ -746,7 +745,11 @@ message Cluster {
   // is respected by both the HTTP/1.1 and HTTP/2 connection pool
   // implementations. If not specified, there is no limit. Setting this
   // parameter to 1 will effectively disable keep alive.
-  google.protobuf.UInt32Value max_requests_per_connection = 9;
+  //
+  // .. attention::
+  //   This field has been deprecated in favor of the :ref:`max_requests_per_connection <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.max_requests_per_connection>` field.
+  google.protobuf.UInt32Value max_requests_per_connection = 9
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // Optional :ref:`circuit breaking <arch_overview_circuit_break>` for the cluster.
   CircuitBreakers circuit_breakers = 10;
@@ -778,7 +781,7 @@ message Cluster {
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // Additional options when handling HTTP1 requests.
-  // This has been deprecated in favor of http_protocol_options fields in the in the
+  // This has been deprecated in favor of http_protocol_options fields in the
   // :ref:`http_protocol_options <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` message.
   // http_protocol_options can be set via the cluster's
   // :ref:`extension_protocol_options<envoy_v3_api_field_config.cluster.v3.Cluster.typed_extension_protocol_options>`.
@@ -794,7 +797,7 @@ message Cluster {
   // supports prior knowledge for upstream connections. Even if TLS is used
   // with ALPN, `http2_protocol_options` must be specified. As an aside this allows HTTP/2
   // connections to happen over plain text.
-  // This has been deprecated in favor of http2_protocol_options fields in the in the
+  // This has been deprecated in favor of http2_protocol_options fields in the
   // :ref:`http_protocol_options <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>`
   // message. http2_protocol_options can be set via the cluster's
   // :ref:`extension_protocol_options<envoy_v3_api_field_config.cluster.v3.Cluster.typed_extension_protocol_options>`.
@@ -874,7 +877,31 @@ message Cluster {
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // DNS resolution configuration which includes the underlying dns resolver addresses and options.
+  // *dns_resolution_config* will be deprecated once
+  // :ref:'typed_dns_resolver_config <envoy_v3_api_field_config.cluster.v3.Cluster.typed_dns_resolver_config>'
+  // is fully supported.
   core.v3.DnsResolutionConfig dns_resolution_config = 53;
+
+  // DNS resolver type configuration extension. This extension can be used to configure c-ares, apple,
+  // or any other DNS resolver types and the related parameters.
+  // For example, an object of :ref:`DnsResolutionConfig <envoy_v3_api_msg_config.core.v3.DnsResolutionConfig>`
+  // can be packed into this *typed_dns_resolver_config*. This configuration will replace the
+  // :ref:'dns_resolution_config <envoy_v3_api_field_config.cluster.v3.Cluster.dns_resolution_config>'
+  // configuration eventually.
+  // TODO(yanjunxiang): Investigate the deprecation plan for *dns_resolution_config*.
+  // During the transition period when both *dns_resolution_config* and *typed_dns_resolver_config* exists,
+  // this configuration is optional.
+  // When *typed_dns_resolver_config* is in place, Envoy will use it and ignore *dns_resolution_config*.
+  // When *typed_dns_resolver_config* is missing, the default behavior is in place.
+  // [#not-implemented-hide:]
+  core.v3.TypedExtensionConfig typed_dns_resolver_config = 55;
+
+  // Optional configuration for having cluster readiness block on warm-up. Currently, only applicable for
+  // :ref:`STRICT_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.STRICT_DNS>`,
+  // or :ref:`LOGICAL_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.LOGICAL_DNS>`.
+  // If true, cluster readiness blocks on warm-up. If false, the cluster will complete
+  // initialization whether or not warm-up has completed. Defaults to true.
+  google.protobuf.BoolValue wait_for_warm_on_init = 54;
 
   // If specified, outlier detection will be enabled for this upstream cluster.
   // Each of the configuration values can be overridden via
@@ -930,7 +957,7 @@ message Cluster {
   CommonLbConfig common_lb_config = 27;
 
   // Optional custom transport socket implementation to use for upstream connections.
-  // To setup TLS, set a transport socket with name `tls` and
+  // To setup TLS, set a transport socket with name `envoy.transport_sockets.tls` and
   // :ref:`UpstreamTlsContexts <envoy_v3_api_msg_extensions.transport_sockets.tls.v3.UpstreamTlsContext>` in the `typed_config`.
   // If no transport socket configuration is specified, new connections
   // will be set up with plaintext.
@@ -980,7 +1007,7 @@ message Cluster {
   // servers of this cluster.
   repeated Filter filters = 40;
 
-  // [#not-implemented-hide:] New mechanism for LB policy configuration. Used only if the
+  // New mechanism for LB policy configuration. Used only if the
   // :ref:`lb_policy<envoy_v3_api_field_config.cluster.v3.Cluster.lb_policy>` field has the value
   // :ref:`LOAD_BALANCING_POLICY_CONFIG<envoy_v3_api_enum_value_config.cluster.v3.Cluster.LbPolicy.LOAD_BALANCING_POLICY_CONFIG>`.
   LoadBalancingPolicy load_balancing_policy = 41;
@@ -1045,7 +1072,7 @@ message Cluster {
   bool connection_pool_per_downstream_connection = 51;
 }
 
-// [#not-implemented-hide:] Extensible load balancing policy configuration.
+// Extensible load balancing policy configuration.
 //
 // Every LB policy defined via this mechanism will be identified via a unique name using reverse
 // DNS notation. If the policy needs configuration parameters, it must define a message for its
@@ -1071,14 +1098,11 @@ message LoadBalancingPolicy {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.LoadBalancingPolicy.Policy";
 
-    reserved 2;
+    reserved 2, 1, 3;
 
-    reserved "config";
+    reserved "config", "name", "typed_config";
 
-    // Required. The name of the LB policy.
-    string name = 1;
-
-    google.protobuf.Any typed_config = 3;
+    core.v3.TypedExtensionConfig typed_extension_config = 4;
   }
 
   // Each client will iterate over the list in order and stop at the first policy that it

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/protocol.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/protocol.proto
@@ -73,7 +73,7 @@ message UpstreamHttpProtocolOptions {
 
 // Configures the alternate protocols cache which tracks alternate protocols that can be used to
 // make an HTTP connection to an origin server. See https://tools.ietf.org/html/rfc7838 for
-// HTTP Alternate Services and https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-04
+// HTTP Alternative Services and https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-04
 // for the "HTTPS" DNS resource record.
 message AlternateProtocolsCacheOptions {
   // The name of the cache. Multiple named caches allow independent alternate protocols cache
@@ -93,7 +93,7 @@ message AlternateProtocolsCacheOptions {
   google.protobuf.UInt32Value max_entries = 2 [(validate.rules).uint32 = {gt: 0}];
 }
 
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message HttpProtocolOptions {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.core.HttpProtocolOptions";
@@ -157,6 +157,12 @@ message HttpProtocolOptions {
   // If this setting is not specified, the value defaults to ALLOW.
   // Note: upstream responses are not affected by this setting.
   HeadersWithUnderscoresAction headers_with_underscores_action = 5;
+
+  // Optional maximum requests for both upstream and downstream connections.
+  // If not specified, there is no limit.
+  // Setting this parameter to 1 will effectively disable keep alive.
+  // For HTTP/2 and HTTP/3, due to concurrent stream processing, the limit is approximate.
+  google.protobuf.UInt32Value max_requests_per_connection = 6;
 }
 
 // [#next-free-field: 8]
@@ -477,4 +483,12 @@ message Http3ProtocolOptions {
   // If set, this overrides any HCM :ref:`stream_error_on_invalid_http_messaging
   // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.stream_error_on_invalid_http_message>`.
   google.protobuf.BoolValue override_stream_error_on_invalid_http_message = 2;
+}
+
+// A message to control transformations to the :scheme header
+message SchemeHeaderTransformation {
+  oneof transformation {
+    // Overwrite any Scheme header with the contents of this string.
+    string scheme_to_overwrite = 1 [(validate.rules).string = {in: "http" in: "https"}];
+  }
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/config/endpoint/v3/endpoint_components.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/endpoint/v3/endpoint_components.proto
@@ -4,10 +4,12 @@ package envoy.config.endpoint.v3;
 
 import "envoy/config/core/v3/address.proto";
 import "envoy/config/core/v3/base.proto";
+import "envoy/config/core/v3/config_source.proto";
 import "envoy/config/core/v3/health_check.proto";
 
 import "google/protobuf/wrappers.proto";
 
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -108,20 +110,50 @@ message LbEndpoint {
   google.protobuf.UInt32Value load_balancing_weight = 4 [(validate.rules).uint32 = {gte: 1}];
 }
 
+// [#not-implemented-hide:]
+// A configuration for a LEDS collection.
+message LedsClusterLocalityConfig {
+  // Configuration for the source of LEDS updates for a Locality.
+  core.v3.ConfigSource leds_config = 1;
+
+  // The xDS transport protocol glob collection resource name.
+  // The service is only supported in delta xDS (incremental) mode.
+  string leds_collection_name = 2;
+}
+
 // A group of endpoints belonging to a Locality.
 // One can have multiple LocalityLbEndpoints for a locality, but this is
 // generally only done if the different groups need to have different load
 // balancing weights or different priorities.
-// [#next-free-field: 7]
+// [#next-free-field: 9]
 message LocalityLbEndpoints {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.endpoint.LocalityLbEndpoints";
+
+  // [#not-implemented-hide:]
+  // A list of endpoints of a specific locality.
+  message LbEndpointList {
+    repeated LbEndpoint lb_endpoints = 1;
+  }
 
   // Identifies location of where the upstream hosts run.
   core.v3.Locality locality = 1;
 
   // The group of endpoints belonging to the locality specified.
+  // [#comment:TODO(adisuissa): Once LEDS is implemented this field needs to be
+  // deprecated and replaced by *load_balancer_endpoints*.]
   repeated LbEndpoint lb_endpoints = 2;
+
+  // [#not-implemented-hide:]
+  oneof lb_config {
+    // The group of endpoints belonging to the locality.
+    // [#comment:TODO(adisuissa): Once LEDS is implemented the *lb_endpoints* field
+    // needs to be deprecated.]
+    LbEndpointList load_balancer_endpoints = 7;
+
+    // LEDS Configuration for the current locality.
+    LedsClusterLocalityConfig leds_cluster_locality_config = 8;
+  }
 
   // Optional: Per priority/region/zone/sub_zone weight; at least 1. The load
   // balancing weight for a locality is divided by the sum of the weights of all

--- a/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/api_listener.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/api_listener.proto
@@ -23,6 +23,7 @@ message ApiListener {
   // The type in this field determines the type of API listener. At present, the following
   // types are supported:
   // envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager (HTTP)
+  // envoy.extensions.filters.network.http_connection_manager.v3.EnvoyMobileHttpConnectionManager (HTTP)
   // [#next-major-version: In the v3 API, replace this Any field with a oneof containing the
   // specific config message for each type of API listener. We could not do this in v2 because
   // it would have caused circular dependencies for go protos: lds.proto depends on this file,

--- a/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/listener.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/listener.proto
@@ -35,7 +35,7 @@ message ListenerCollection {
   repeated xds.core.v3.CollectionEntry entries = 1;
 }
 
-// [#next-free-field: 29]
+// [#next-free-field: 30]
 message Listener {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Listener";
 
@@ -255,17 +255,30 @@ message Listener {
   // enable the balance config in Y1 and Y2 to balance the connections among the workers.
   ConnectionBalanceConfig connection_balance_config = 20;
 
+  // Deprecated. Use `enable_reuse_port` instead.
+  bool reuse_port = 21 [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+
   // When this flag is set to true, listeners set the *SO_REUSEPORT* socket option and
   // create one socket for each worker thread. This makes inbound connections
   // distribute among worker threads roughly evenly in cases where there are a high number
-  // of connections. When this flag is set to false, all worker threads share one socket.
+  // of connections. When this flag is set to false, all worker threads share one socket. This field
+  // defaults to true.
   //
-  // Before Linux v4.19-rc1, new TCP connections may be rejected during hot restart
-  // (see `3rd paragraph in 'soreuseport' commit message
-  // <https://github.com/torvalds/linux/commit/c617f398edd4db2b8567a28e89>`_).
-  // This issue was fixed by `tcp: Avoid TCP syncookie rejected by SO_REUSEPORT socket
-  // <https://github.com/torvalds/linux/commit/40a1227ea845a37ab197dd1caffb60b047fa36b1>`_.
-  bool reuse_port = 21;
+  // .. attention::
+  //
+  //   Although this field defaults to true, it has different behavior on different platforms. See
+  //   the following text for more information.
+  //
+  // * On Linux, reuse_port is respected for both TCP and UDP listeners. It also works correctly
+  //   with hot restart.
+  // * On macOS, reuse_port for TCP does not do what it does on Linux. Instead of load balancing,
+  //   the last socket wins and receives all connections/packets. For TCP, reuse_port is force
+  //   disabled and the user is warned. For UDP, it is enabled, but only one worker will receive
+  //   packets. For QUIC/H3, SW routing will send packets to other workers. For "raw" UDP, only
+  //   a single worker will currently receive packets.
+  // * On Windows, reuse_port for TCP has undefined behavior. It is force disabled and the user
+  //   is warned similar to macOS. It is left enabled for UDP with undefined behavior currently.
+  google.protobuf.BoolValue enable_reuse_port = 29;
 
   // Configuration for :ref:`access logs <arch_overview_access_logs>`
   // emitted by this listener.

--- a/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/listener_components.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/listener_components.proto
@@ -64,9 +64,12 @@ message Filter {
 // 3. Server name (e.g. SNI for TLS protocol),
 // 4. Transport protocol.
 // 5. Application protocols (e.g. ALPN for TLS protocol).
-// 6. Source type (e.g. any, local or external network).
-// 7. Source IP address.
-// 8. Source port.
+// 6. Directly connected source IP address (this will only be different from the source IP address
+//    when using a listener filter that overrides the source address, such as the :ref:`Proxy Protocol
+//    listener filter <config_listener_filters_proxy_protocol>`).
+// 7. Source type (e.g. any, local or external network).
+// 8. Source IP address.
+// 9. Source port.
 //
 // For criteria that allow ranges or wildcards, the most specific value in any
 // of the configured filter chains that matches the incoming connection is going
@@ -90,7 +93,7 @@ message Filter {
 // listed at the end, because that's how we want to list them in the docs.
 //
 // [#comment:TODO(PiotrSikora): Add support for configurable precedence of the rules]
-// [#next-free-field: 13]
+// [#next-free-field: 14]
 message FilterChainMatch {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.listener.FilterChainMatch";
@@ -123,6 +126,11 @@ message FilterChainMatch {
 
   // [#not-implemented-hide:]
   google.protobuf.UInt32Value suffix_len = 5;
+
+  // The criteria is satisfied if the directly connected source IP address of the downstream
+  // connection is contained in at least one of the specified subnets. If the parameter is not
+  // specified or the list is empty, the directly connected source IP address is ignored.
+  repeated core.v3.CidrRange direct_source_prefix_ranges = 13;
 
   // Specifies the connection source IP match type. Can be any, local or external network.
   ConnectionSourceType source_type = 12 [(validate.rules).enum = {defined_only: true}];
@@ -238,7 +246,7 @@ message FilterChain {
   core.v3.Metadata metadata = 5;
 
   // Optional custom transport socket implementation to use for downstream connections.
-  // To setup TLS, set a transport socket with name `tls` and
+  // To setup TLS, set a transport socket with name `envoy.transport_sockets.tls` and
   // :ref:`DownstreamTlsContext <envoy_v3_api_msg_extensions.transport_sockets.tls.v3.DownstreamTlsContext>` in the `typed_config`.
   // If no transport socket configuration is specified, new connections
   // will be set up with plaintext.
@@ -282,7 +290,7 @@ message FilterChain {
 //    rules:
 //      - destination_port_range:
 //          start: 3306
-//          end: 3306
+//          end: 3307
 //      - destination_port_range:
 //          start: 15000
 //          end: 15001

--- a/xds/third_party/envoy/src/main/proto/envoy/config/overload/v3/overload.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/overload/v3/overload.proto
@@ -141,6 +141,26 @@ message OverloadAction {
   google.protobuf.Any typed_config = 3;
 }
 
+// Configuration for which accounts the WatermarkBuffer Factories should
+// track.
+message BufferFactoryConfig {
+  // The minimum power of two at which Envoy starts tracking an account.
+  //
+  // Envoy has 8 power of two buckets starting with the provided exponent below.
+  // Concretely the 1st bucket contains accounts for streams that use
+  // [2^minimum_account_to_track_power_of_two,
+  // 2^(minimum_account_to_track_power_of_two + 1)) bytes.
+  // With the 8th bucket tracking accounts
+  // >= 128 * 2^minimum_account_to_track_power_of_two.
+  //
+  // The maximum value is 56, since we're using uint64_t for bytes counting,
+  // and that's the last value that would use the 8 buckets. In practice,
+  // we don't expect the proxy to be holding 2^56 bytes.
+  //
+  // If omitted, Envoy should not do any tracking.
+  uint32 minimum_account_to_track_power_of_two = 1 [(validate.rules).uint32 = {lte: 56 gte: 10}];
+}
+
 message OverloadManager {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.overload.v2alpha.OverloadManager";
@@ -153,4 +173,7 @@ message OverloadManager {
 
   // The set of overload actions.
   repeated OverloadAction actions = 3;
+
+  // Configuration for buffer factory.
+  BufferFactoryConfig buffer_factory_config = 4;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/config/rbac/v3/rbac.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/rbac/v3/rbac.proto
@@ -7,6 +7,7 @@ import "envoy/config/route/v3/route_components.proto";
 import "envoy/type/matcher/v3/metadata.proto";
 import "envoy/type/matcher/v3/path.proto";
 import "envoy/type/matcher/v3/string.proto";
+import "envoy/type/v3/range.proto";
 
 import "google/api/expr/v1alpha1/checked.proto";
 import "google/api/expr/v1alpha1/syntax.proto";
@@ -60,7 +61,10 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //       permissions:
 //           - and_rules:
 //               rules:
-//                 - header: { name: ":method", exact_match: "GET" }
+//                 - header:
+//                     name: ":method"
+//                     string_match:
+//                       exact: "GET"
 //                 - url_path:
 //                     path: { prefix: "/products" }
 //                 - or_rules:
@@ -142,7 +146,7 @@ message Policy {
 }
 
 // Permission defines an action (or actions) that a principal can take.
-// [#next-free-field: 11]
+// [#next-free-field: 12]
 message Permission {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.rbac.v2.Permission";
 
@@ -181,6 +185,9 @@ message Permission {
 
     // A port number that describes the destination port connecting to.
     uint32 destination_port = 6 [(validate.rules).uint32 = {lte: 65535}];
+
+    // A port number range that describes a range of destination ports connecting to.
+    type.v3.Int32Range destination_port_range = 11;
 
     // Metadata that describes additional information about the action.
     type.matcher.v3.MetadataMatcher metadata = 7;

--- a/xds/third_party/envoy/src/main/proto/envoy/config/route/v3/route.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/route/v3/route.proto
@@ -4,6 +4,7 @@ package envoy.config.route.v3;
 
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/config_source.proto";
+import "envoy/config/core/v3/extension.proto";
 import "envoy/config/route/v3/route_components.proto";
 
 import "google/protobuf/wrappers.proto";
@@ -21,7 +22,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // * Routing :ref:`architecture overview <arch_overview_http_routing>`
 // * HTTP :ref:`router filter <config_http_filters_router>`
 
-// [#next-free-field: 12]
+// [#next-free-field: 13]
 message RouteConfiguration {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.RouteConfiguration";
 
@@ -119,6 +120,18 @@ message RouteConfiguration {
   //   is not subject to data plane buffering controls.
   //
   google.protobuf.UInt32Value max_direct_response_body_size_bytes = 11;
+
+  // [#not-implemented-hide:]
+  // A list of plugins and their configurations which may be used by a
+  // :ref:`envoy_v3_api_field_config.route.v3.RouteAction.cluster_specifier_plugin`
+  // within the route. All *extension.name* fields in this list must be unique.
+  repeated ClusterSpecifierPlugin cluster_specifier_plugins = 12;
+}
+
+// Configuration for a cluster specifier plugin.
+message ClusterSpecifierPlugin {
+  // The name of the plugin and its opaque configuration.
+  core.v3.TypedExtensionConfig extension = 1;
 }
 
 message Vhds {

--- a/xds/third_party/envoy/src/main/proto/envoy/config/route/v3/route_components.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/route/v3/route_components.proto
@@ -311,7 +311,7 @@ message Route {
 message WeightedCluster {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.WeightedCluster";
 
-  // [#next-free-field: 11]
+  // [#next-free-field: 12]
   message ClusterWeight {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.route.WeightedCluster.ClusterWeight";
@@ -378,6 +378,13 @@ message WeightedCluster {
     // :ref:`FilterConfig<envoy_v3_api_msg_config.route.v3.FilterConfig>`
     // message to specify additional options.]
     map<string, google.protobuf.Any> typed_per_filter_config = 10;
+
+    oneof host_rewrite_specifier {
+      // Indicates that during forwarding, the host header will be swapped with
+      // this value.
+      string host_rewrite_literal = 11
+          [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
+    }
   }
 
   // Specifies one or more upstream clusters associated with the route.
@@ -466,7 +473,7 @@ message RouteMatch {
   }
 
   // Indicates that prefix/path matching should be case sensitive. The default
-  // is true.
+  // is true. Ignored for safe_regex matching.
   google.protobuf.BoolValue case_sensitive = 4;
 
   // Indicates that the route should additionally match on a runtime key. Every time the route
@@ -563,7 +570,7 @@ message CorsPolicy {
   core.v3.RuntimeFractionalPercent shadow_enabled = 10;
 }
 
-// [#next-free-field: 37]
+// [#next-free-field: 38]
 message RouteAction {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.RouteAction";
 
@@ -839,6 +846,14 @@ message RouteAction {
     // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
     // for additional documentation.
     WeightedCluster weighted_clusters = 3;
+
+    // [#not-implemented-hide:]
+    // Name of the cluster specifier plugin to use to determine the cluster for
+    // requests on this route. The plugin name must be defined in the associated
+    // :ref:`envoy_v3_api_field_config.route.v3.RouteConfiguration.cluster_specifier_plugins`
+    // in the
+    // :ref:`envoy_v3_api_field_config.core.v3.TypedExtensionConfig.name` field.
+    string cluster_specifier_plugin = 37;
   }
 
   // The HTTP status code to use when configured cluster is not found.
@@ -1850,7 +1865,7 @@ message RateLimit {
 //   value.
 //
 //  [#next-major-version: HeaderMatcher should be refactored to use StringMatcher.]
-// [#next-free-field: 13]
+// [#next-free-field: 14]
 message HeaderMatcher {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.HeaderMatcher";
 
@@ -1865,12 +1880,16 @@ message HeaderMatcher {
   // Specifies how the header match will be performed to route the request.
   oneof header_match_specifier {
     // If specified, header match will be performed based on the value of the header.
-    string exact_match = 4;
+    // This field is deprecated. Please use :ref:`string_match <envoy_v3_api_field_config.route.v3.HeaderMatcher.string_match>`.
+    string exact_match = 4
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
     // If specified, this regex string is a regular expression rule which implies the entire request
     // header value must match the regex. The rule will not match if only a subsequence of the
     // request header value matches the regex.
-    type.matcher.v3.RegexMatcher safe_regex_match = 11;
+    // This field is deprecated. Please use :ref:`string_match <envoy_v3_api_field_config.route.v3.HeaderMatcher.string_match>`.
+    type.matcher.v3.RegexMatcher safe_regex_match = 11
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
     // If specified, header match will be performed based on range.
     // The rule will match if the request header value is within this range.
@@ -1891,28 +1910,46 @@ message HeaderMatcher {
 
     // If specified, header match will be performed based on the prefix of the header value.
     // Note: empty prefix is not allowed, please use present_match instead.
+    // This field is deprecated. Please use :ref:`string_match <envoy_v3_api_field_config.route.v3.HeaderMatcher.string_match>`.
     //
     // Examples:
     //
     // * The prefix *abcd* matches the value *abcdxyz*, but not for *abcxyz*.
-    string prefix_match = 9 [(validate.rules).string = {min_len: 1}];
+    string prefix_match = 9 [
+      deprecated = true,
+      (validate.rules).string = {min_len: 1},
+      (envoy.annotations.deprecated_at_minor_version) = "3.0"
+    ];
 
     // If specified, header match will be performed based on the suffix of the header value.
     // Note: empty suffix is not allowed, please use present_match instead.
+    // This field is deprecated. Please use :ref:`string_match <envoy_v3_api_field_config.route.v3.HeaderMatcher.string_match>`.
     //
     // Examples:
     //
     // * The suffix *abcd* matches the value *xyzabcd*, but not for *xyzbcd*.
-    string suffix_match = 10 [(validate.rules).string = {min_len: 1}];
+    string suffix_match = 10 [
+      deprecated = true,
+      (validate.rules).string = {min_len: 1},
+      (envoy.annotations.deprecated_at_minor_version) = "3.0"
+    ];
 
     // If specified, header match will be performed based on whether the header value contains
     // the given value or not.
     // Note: empty contains match is not allowed, please use present_match instead.
+    // This field is deprecated. Please use :ref:`string_match <envoy_v3_api_field_config.route.v3.HeaderMatcher.string_match>`.
     //
     // Examples:
     //
     // * The value *abcd* matches the value *xyzabcdpqr*, but not for *xyzbcdpqr*.
-    string contains_match = 12 [(validate.rules).string = {min_len: 1}];
+    string contains_match = 12 [
+      deprecated = true,
+      (validate.rules).string = {min_len: 1},
+      (envoy.annotations.deprecated_at_minor_version) = "3.0"
+    ];
+
+    // If specified, header match will be performed based on the string match of the header value.
+    type.matcher.v3.StringMatcher string_match = 13;
   }
 
   // If specified, the match result will be inverted before checking. Defaults to false.

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/common/fault/v3/fault.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/common/fault/v3/fault.proto
@@ -18,7 +18,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#protodoc-title: Common fault injection types]
 
 // Delay specification is used to inject latency into the
-// HTTP/gRPC/Mongo/Redis operation or delay proxying of TCP connections.
+// HTTP/Mongo operation.
 // [#next-free-field: 6]
 message FaultDelay {
   option (udpa.annotations.versioning).previous_message_type =
@@ -46,10 +46,9 @@ message FaultDelay {
 
     // Add a fixed delay before forwarding the operation upstream. See
     // https://developers.google.com/protocol-buffers/docs/proto3#json for
-    // the JSON/YAML Duration mapping. For HTTP/Mongo/Redis, the specified
-    // delay will be injected before a new request/operation. For TCP
-    // connections, the proxying of the connection upstream will be delayed
-    // for the specified period. This is required if type is FIXED.
+    // the JSON/YAML Duration mapping. For HTTP/Mongo, the specified
+    // delay will be injected before a new request/operation.
+    // This is required if type is FIXED.
     google.protobuf.Duration fixed_delay = 3 [(validate.rules).duration = {gt {}}];
 
     // Fault delays are controlled via an HTTP header (if applicable).

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -19,7 +19,6 @@ import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
@@ -35,7 +34,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 // [#extension: envoy.filters.network.http_connection_manager]
 
-// [#next-free-field: 48]
+// [#next-free-field: 49]
 message HttpConnectionManager {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager";
@@ -371,6 +370,11 @@ message HttpConnectionManager {
   ServerHeaderTransformation server_header_transformation = 34
       [(validate.rules).enum = {defined_only: true}];
 
+  // Allows for explicit transformation of the :scheme header on the request path.
+  // If not set, Envoy's default :ref:`scheme  <config_http_conn_man_headers_scheme>`
+  // handling applies.
+  config.core.v3.SchemeHeaderTransformation scheme_header_transformation = 48;
+
   // The maximum request headers size for incoming connections.
   // If unconfigured, the default max request headers allowed is 60 KiB.
   // Requests that exceed this limit will receive a 431 response.
@@ -496,23 +500,7 @@ message HttpConnectionManager {
   // determining the origin client's IP address. The default is zero if this option
   // is not specified. See the documentation for
   // :ref:`config_http_conn_man_headers_x-forwarded-for` for more information.
-  //
-  // .. note::
-  //    This field is deprecated and instead :ref:`original_ip_detection_extensions
-  //    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.original_ip_detection_extensions>`
-  //    should be used to configure the :ref:`xff extension <envoy_v3_api_msg_extensions.http.original_ip_detection.xff.v3.XffConfig>`
-  //    to configure IP detection using the :ref:`config_http_conn_man_headers_x-forwarded-for` header. To replace
-  //    this field use a config like the following:
-  //
-  // .. code-block:: yaml
-  //
-  //    original_ip_detection_extensions:
-  //      typed_config:
-  //        "@type": type.googleapis.com/envoy.extensions.http.original_ip_detection.xff.v3.XffConfig
-  //        xff_num_trusted_hops: 1
-  //
-  uint32 xff_num_trusted_hops = 19
-      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+  uint32 xff_num_trusted_hops = 19;
 
   // The configuration for the original IP detection extensions.
   //
@@ -523,6 +511,12 @@ message HttpConnectionManager {
   // the request, the HCM will try the remaining extensions until one succeeds or rejects
   // the request. If the request isn't rejected nor any extension succeeds, the HCM will
   // fallback to using the remote address.
+  //
+  // .. WARNING::
+  //    Extensions cannot be used in conjunction with :ref:`use_remote_address
+  //    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.use_remote_address>`
+  //    nor :ref:`xff_num_trusted_hops
+  //    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.xff_num_trusted_hops>`.
   //
   // [#extension-category: envoy.http.original_ip_detection]
   repeated config.core.v3.TypedExtensionConfig original_ip_detection_extensions = 46;
@@ -999,4 +993,13 @@ message RequestIDExtension {
 
   // Request ID extension specific configuration.
   google.protobuf.Any typed_config = 1;
+}
+
+// [#protodoc-title: Envoy Mobile HTTP connection manager]
+// HTTP connection manager for use in Envoy mobile.
+// [#extension: envoy.filters.network.envoy_mobile_http_connection_manager]
+message EnvoyMobileHttpConnectionManager {
+  // The configuration for the underlying HttpConnectionManager which will be
+  // instantiated for Envoy mobile.
+  HttpConnectionManager config = 1;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -9,6 +9,7 @@ import "envoy/type/matcher/v3/string.proto";
 import "google/protobuf/any.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -232,7 +233,27 @@ message TlsSessionTicketKeys {
       [(validate.rules).repeated = {min_items: 1}, (udpa.annotations.sensitive) = true];
 }
 
-// [#next-free-field: 13]
+// Indicates a certificate to be obtained from a named CertificateProvider plugin instance.
+// The plugin instances are defined in the client's bootstrap file.
+// The plugin allows certificates to be fetched/refreshed over the network asynchronously with
+// respect to the TLS handshake.
+// [#not-implemented-hide:]
+message CertificateProviderPluginInstance {
+  // Provider instance name. If not present, defaults to "default".
+  //
+  // Instance names should generally be defined not in terms of the underlying provider
+  // implementation (e.g., "file_watcher") but rather in terms of the function of the
+  // certificates (e.g., "foo_deployment_identity").
+  string instance_name = 1;
+
+  // Opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
+  // a root-certificate (validation context) or "example.com" to specify a certificate for a
+  // particular domain. Not all provider instances will actually use this field, so the value
+  // defaults to the empty string.
+  string certificate_name = 2;
+}
+
+// [#next-free-field: 14]
 message CertificateValidationContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.auth.CertificateValidationContext";
@@ -279,7 +300,20 @@ message CertificateValidationContext {
   // directory for any file moves to support rotation. This currently only
   // applies to dynamic secrets, when the *CertificateValidationContext* is
   // delivered via SDS.
-  config.core.v3.DataSource trusted_ca = 1;
+  //
+  // Only one of *trusted_ca* and *ca_certificate_provider_instance* may be specified.
+  //
+  // [#next-major-version: This field and watched_directory below should ideally be moved into a
+  // separate sub-message, since there's no point in specifying the latter field without this one.]
+  config.core.v3.DataSource trusted_ca = 1
+      [(udpa.annotations.field_migrate).oneof_promotion = "ca_cert_source"];
+
+  // Certificate provider instance for fetching TLS certificates.
+  //
+  // Only one of *trusted_ca* and *ca_certificate_provider_instance* may be specified.
+  // [#not-implemented-hide:]
+  CertificateProviderPluginInstance ca_certificate_provider_instance = 13
+      [(udpa.annotations.field_migrate).oneof_promotion = "ca_cert_source"];
 
   // If specified, updates of a file-based *trusted_ca* source will be triggered
   // by this watch. This allows explicit control over the path watched, by

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -9,7 +9,7 @@ import "envoy/extensions/transport_sockets/tls/v3/secret.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
-import "udpa/annotations/migrate.proto";
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -125,12 +125,18 @@ message DownstreamTlsContext {
 }
 
 // TLS context shared by both client and server TLS contexts.
-// [#next-free-field: 14]
+// [#next-free-field: 15]
 message CommonTlsContext {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.auth.CommonTlsContext";
 
   // Config for Certificate provider to get certificates. This provider should allow certificates to be
   // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
+  //
+  // DEPRECATED: This message is not currently used, but if we ever do need it, we will want to
+  // move it out of CommonTlsContext and into common.proto, similar to the existing
+  // CertificateProviderPluginInstance message.
+  //
+  // [#not-implemented-hide:]
   message CertificateProvider {
     // opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
     // a root-certificate (validation context) or "TLS" to specify a new tls-certificate.
@@ -151,6 +157,11 @@ message CommonTlsContext {
 
   // Similar to CertificateProvider above, but allows the provider instances to be configured on
   // the client side instead of being sent from the control plane.
+  //
+  // DEPRECATED: This message was moved outside of CommonTlsContext
+  // and now lives in common.proto.
+  //
+  // [#not-implemented-hide:]
   message CertificateProviderInstance {
     // Provider instance name. This name must be defined in the client's configuration (e.g., a
     // bootstrap file) to correspond to a provider instance (i.e., the same data in the typed_config
@@ -179,26 +190,20 @@ message CommonTlsContext {
 
     // Config for fetching validation context via SDS API. Note SDS API allows certificates to be
     // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
-    // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
-    // or validation_context_certificate_provider_instance may be used.
-    SdsSecretConfig validation_context_sds_secret_config = 2 [
-      (validate.rules).message = {required: true},
-      (udpa.annotations.field_migrate).oneof_promotion = "dynamic_validation_context"
-    ];
+    SdsSecretConfig validation_context_sds_secret_config = 2
+        [(validate.rules).message = {required: true}];
 
-    // Certificate provider for fetching validation context.
-    // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
-    // or validation_context_certificate_provider_instance may be used.
+    // Certificate provider for fetching CA certs. This will populate the
+    // *default_validation_context.trusted_ca* field.
     // [#not-implemented-hide:]
     CertificateProvider validation_context_certificate_provider = 3
-        [(udpa.annotations.field_migrate).oneof_promotion = "dynamic_validation_context"];
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
-    // Certificate provider instance for fetching validation context.
-    // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
-    // or validation_context_certificate_provider_instance may be used.
+    // Certificate provider instance for fetching CA certs. This will populate the
+    // *default_validation_context.trusted_ca* field.
     // [#not-implemented-hide:]
     CertificateProviderInstance validation_context_certificate_provider_instance = 4
-        [(udpa.annotations.field_migrate).oneof_promotion = "dynamic_validation_context"];
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
   }
 
   reserved 5;
@@ -212,6 +217,12 @@ message CommonTlsContext {
   // Only a single TLS certificate is supported in client contexts. In server contexts, the first
   // RSA certificate is used for clients that only support RSA and the first ECDSA certificate is
   // used for clients that support ECDSA.
+  //
+  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
+  // and *tls_certificate_provider_instance* may be used.
+  // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
+  // not legal to put a repeated field in a oneof. In the next major version, we should rework
+  // this to avoid this problem.]
   repeated TlsCertificate tls_certificates = 2;
 
   // Configs for fetching TLS certificates via SDS API. Note SDS API allows certificates to be
@@ -220,18 +231,30 @@ message CommonTlsContext {
   // The same number and types of certificates as :ref:`tls_certificates <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CommonTlsContext.tls_certificates>`
   // are valid in the the certificates fetched through this setting.
   //
-  // If :ref:`tls_certificates <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CommonTlsContext.tls_certificates>`
-  // is non-empty, this field is ignored.
+  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
+  // and *tls_certificate_provider_instance* may be used.
+  // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
+  // not legal to put a repeated field in a oneof. In the next major version, we should rework
+  // this to avoid this problem.]
   repeated SdsSecretConfig tls_certificate_sds_secret_configs = 6
       [(validate.rules).repeated = {max_items: 2}];
 
+  // Certificate provider instance for fetching TLS certs.
+  //
+  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
+  // and *tls_certificate_provider_instance* may be used.
+  // [#not-implemented-hide:]
+  CertificateProviderPluginInstance tls_certificate_provider_instance = 14;
+
   // Certificate provider for fetching TLS certificates.
   // [#not-implemented-hide:]
-  CertificateProvider tls_certificate_certificate_provider = 9;
+  CertificateProvider tls_certificate_certificate_provider = 9
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // Certificate provider instance for fetching TLS certificates.
   // [#not-implemented-hide:]
-  CertificateProviderInstance tls_certificate_certificate_provider_instance = 11;
+  CertificateProviderInstance tls_certificate_certificate_provider_instance = 11
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   oneof validation_context_type {
     // How to validate peer certificates.
@@ -252,11 +275,13 @@ message CommonTlsContext {
 
     // Certificate provider for fetching validation context.
     // [#not-implemented-hide:]
-    CertificateProvider validation_context_certificate_provider = 10;
+    CertificateProvider validation_context_certificate_provider = 10
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
     // Certificate provider instance for fetching validation context.
     // [#not-implemented-hide:]
-    CertificateProviderInstance validation_context_certificate_provider_instance = 12;
+    CertificateProviderInstance validation_context_certificate_provider_instance = 12
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
   }
 
   // Supplies the list of ALPN protocols that the listener should expose. In

--- a/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/string.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/string.proto
@@ -62,8 +62,8 @@ message StringMatcher {
     string contains = 7 [(validate.rules).string = {min_len: 1}];
   }
 
-  // If true, indicates the exact/prefix/suffix matching should be case insensitive. This has no
-  // effect for the safe_regex match.
+  // If true, indicates the exact/prefix/suffix/contains matching should be case insensitive. This
+  // has no effect for the safe_regex match.
   // For example, the matcher *data* will match both input string *Data* and *data* if set to true.
   bool ignore_case = 6;
 }


### PR DESCRIPTION
Update the envoy protos import to rev to c223756b0856f734a6a5cff2d0b95388cd2583d4 to get the latest definitions in envoy/extensions/transport_sockets/tls/v3/tls.proto and envoy/extensions/transport_sockets/tls/v3/common.proto related to new certProviderPluginInstance definitions. This corresponds to the latest internal import cl/394493931