### PR TITLE
xds: use the new cert-provider instances if present

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -473,26 +473,24 @@ final class ClientXdsClient extends AbstractXdsClient {
     if (certInstanceName == null) {
       if (server) {
         throw new ResourceInvalidException(
-            "tls_certificate_certificate_provider_instance is required in downstream-tls-context");
+            "tls_certificate_provider_instance is required in downstream-tls-context");
       }
       if (commonTlsContext.getTlsCertificatesCount() > 0) {
         throw new ResourceInvalidException(
-            "common-tls-context with tls_certificates is not supported");
+            "tls_certificate_provider_instance is unset");
       }
       if (commonTlsContext.getTlsCertificateSdsSecretConfigsCount() > 0) {
         throw new ResourceInvalidException(
-            "common-tls-context with tls_certificate_sds_secret_configs is not supported");
+            "tls_certificate_provider_instance is unset");
       }
       if (commonTlsContext.hasTlsCertificateCertificateProvider()) {
         throw new ResourceInvalidException(
-            "common-tls-context with tls_certificate_certificate_provider is not supported");
+            "tls_certificate_provider_instance is unset");
       }
-    } else {
-      if (certProviderInstances == null || !certProviderInstances.contains(certInstanceName)) {
-        throw new ResourceInvalidException(
-            "CertificateProvider instance name '" + certInstanceName
-                + "' not defined in the bootstrap file.");
-      }
+    } else if (certProviderInstances == null || !certProviderInstances.contains(certInstanceName)) {
+      throw new ResourceInvalidException(
+          "CertificateProvider instance name '" + certInstanceName
+              + "' not defined in the bootstrap file.");
     }
     String rootCaInstanceName = getRootCertInstanceName(commonTlsContext);
     if (rootCaInstanceName == null) {

--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -456,10 +456,6 @@ final class ClientXdsClient extends AbstractXdsClient {
     if (commonTlsContext.hasTlsParams()) {
       throw new ResourceInvalidException("common-tls-context with tls_params is not supported");
     }
-    if (commonTlsContext.hasValidationContext()) {
-      throw new ResourceInvalidException(
-          "common-tls-context with validation_context is not supported");
-    }
     if (commonTlsContext.hasValidationContextSdsSecretConfig()) {
       throw new ResourceInvalidException(
           "common-tls-context with validation_context_sds_secret_config is not supported");
@@ -473,8 +469,8 @@ final class ClientXdsClient extends AbstractXdsClient {
           "common-tls-context with validation_context_certificate_provider_instance is not"
               + " supported");
     }
-    String certInstanceName = null;
-    if (!commonTlsContext.hasTlsCertificateCertificateProviderInstance()) {
+    String certInstanceName = getIdentityCertInstanceName(commonTlsContext);
+    if (certInstanceName == null) {
       if (server) {
         throw new ResourceInvalidException(
             "tls_certificate_certificate_provider_instance is required in downstream-tls-context");
@@ -492,35 +488,33 @@ final class ClientXdsClient extends AbstractXdsClient {
             "common-tls-context with tls_certificate_certificate_provider is not supported");
       }
     } else {
-      certInstanceName = commonTlsContext.getTlsCertificateCertificateProviderInstance()
-          .getInstanceName();
-    }
-    if (certInstanceName != null) {
       if (certProviderInstances == null || !certProviderInstances.contains(certInstanceName)) {
         throw new ResourceInvalidException(
             "CertificateProvider instance name '" + certInstanceName
                 + "' not defined in the bootstrap file.");
       }
     }
-    String rootCaInstanceName = null;
-    if (!commonTlsContext.hasCombinedValidationContext()) {
+    String rootCaInstanceName = getRootCertInstanceName(commonTlsContext);
+    if (rootCaInstanceName == null) {
       if (!server) {
         throw new ResourceInvalidException(
-            "combined_validation_context is required in upstream-tls-context");
+            "ca_certificate_provider_instance is required in upstream-tls-context");
       }
     } else {
-      CommonTlsContext.CombinedCertificateValidationContext combinedCertificateValidationContext
-          = commonTlsContext.getCombinedValidationContext();
-      if (!combinedCertificateValidationContext.hasValidationContextCertificateProviderInstance()) {
+      if (certProviderInstances == null || !certProviderInstances.contains(rootCaInstanceName)) {
         throw new ResourceInvalidException(
-            "validation_context_certificate_provider_instance is required in"
-                + " combined_validation_context");
+                "ca_certificate_provider_instance name '" + rootCaInstanceName
+                        + "' not defined in the bootstrap file.");
       }
-      rootCaInstanceName = combinedCertificateValidationContext
-          .getValidationContextCertificateProviderInstance().getInstanceName();
-      if (combinedCertificateValidationContext.hasDefaultValidationContext()) {
-        CertificateValidationContext certificateValidationContext
-            = combinedCertificateValidationContext.getDefaultValidationContext();
+      CertificateValidationContext certificateValidationContext = null;
+      if (commonTlsContext.hasValidationContext()) {
+        certificateValidationContext = commonTlsContext.getValidationContext();
+      } else if (commonTlsContext.hasCombinedValidationContext() && commonTlsContext
+          .getCombinedValidationContext().hasDefaultValidationContext()) {
+        certificateValidationContext = commonTlsContext.getCombinedValidationContext()
+            .getDefaultValidationContext();
+      }
+      if (certificateValidationContext != null) {
         if (certificateValidationContext.getMatchSubjectAltNamesCount() > 0 && server) {
           throw new ResourceInvalidException(
               "match_subject_alt_names only allowed in upstream_tls_context");
@@ -547,13 +541,38 @@ final class ClientXdsClient extends AbstractXdsClient {
         }
       }
     }
-    if (rootCaInstanceName != null) {
-      if (certProviderInstances == null || !certProviderInstances.contains(rootCaInstanceName)) {
-        throw new ResourceInvalidException(
-            "ValidationContextProvider instance name '" + rootCaInstanceName
-                + "' not defined in the bootstrap file.");
+  }
+
+  private static String getIdentityCertInstanceName(CommonTlsContext commonTlsContext) {
+    if (commonTlsContext.hasTlsCertificateProviderInstance()) {
+      return commonTlsContext.getTlsCertificateProviderInstance().getInstanceName();
+    } else if (commonTlsContext.hasTlsCertificateCertificateProviderInstance()) {
+      return commonTlsContext.getTlsCertificateCertificateProviderInstance().getInstanceName();
+    }
+    return null;
+  }
+
+  private static String getRootCertInstanceName(CommonTlsContext commonTlsContext) {
+    if (commonTlsContext.hasValidationContext()) {
+      if (commonTlsContext.getValidationContext().hasCaCertificateProviderInstance()) {
+        return commonTlsContext.getValidationContext().getCaCertificateProviderInstance()
+            .getInstanceName();
+      }
+    } else if (commonTlsContext.hasCombinedValidationContext()) {
+      CommonTlsContext.CombinedCertificateValidationContext combinedCertificateValidationContext
+          = commonTlsContext.getCombinedValidationContext();
+      if (combinedCertificateValidationContext.hasDefaultValidationContext()
+          && combinedCertificateValidationContext.getDefaultValidationContext()
+          .hasCaCertificateProviderInstance()) {
+        return combinedCertificateValidationContext.getDefaultValidationContext()
+            .getCaCertificateProviderInstance().getInstanceName();
+      } else if (combinedCertificateValidationContext
+          .hasValidationContextCertificateProviderInstance()) {
+        return combinedCertificateValidationContext
+            .getValidationContextCertificateProviderInstance().getInstanceName();
       }
     }
+    return null;
   }
 
   private static void checkForUniqueness(Set<FilterChainMatch> uniqueSet,

--- a/xds/src/main/java/io/grpc/xds/internal/certprovider/CertProviderClientSslContextProvider.java
+++ b/xds/src/main/java/io/grpc/xds/internal/certprovider/CertProviderClientSslContextProvider.java
@@ -22,7 +22,6 @@ import com.google.common.annotations.VisibleForTesting;
 import io.envoyproxy.envoy.config.core.v3.Node;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateValidationContext;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext;
-import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext.CombinedCertificateValidationContext;
 import io.grpc.Internal;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.xds.Bootstrapper.CertificateProviderInfo;
@@ -94,27 +93,12 @@ public final class CertProviderClientSslContextProvider extends CertProviderSslC
         @Nullable Map<String, CertificateProviderInfo> certProviders) {
       checkNotNull(upstreamTlsContext, "upstreamTlsContext");
       CommonTlsContext commonTlsContext = upstreamTlsContext.getCommonTlsContext();
-      CommonTlsContext.CertificateProviderInstance rootCertInstance = null;
-      CertificateValidationContext staticCertValidationContext = null;
-      if (commonTlsContext.hasCombinedValidationContext()) {
-        CombinedCertificateValidationContext combinedValidationContext =
-            commonTlsContext.getCombinedValidationContext();
-        if (combinedValidationContext.hasValidationContextCertificateProviderInstance()) {
-          rootCertInstance =
-              combinedValidationContext.getValidationContextCertificateProviderInstance();
-        }
-        if (combinedValidationContext.hasDefaultValidationContext()) {
-          staticCertValidationContext = combinedValidationContext.getDefaultValidationContext();
-        }
-      } else if (commonTlsContext.hasValidationContextCertificateProviderInstance()) {
-        rootCertInstance = commonTlsContext.getValidationContextCertificateProviderInstance();
-      } else if (commonTlsContext.hasValidationContext()) {
-        staticCertValidationContext = commonTlsContext.getValidationContext();
-      }
-      CommonTlsContext.CertificateProviderInstance certInstance = null;
-      if (commonTlsContext.hasTlsCertificateCertificateProviderInstance()) {
-        certInstance = commonTlsContext.getTlsCertificateCertificateProviderInstance();
-      }
+      CertificateValidationContext staticCertValidationContext = getStaticValidationContext(
+          commonTlsContext);
+      CommonTlsContext.CertificateProviderInstance rootCertInstance = getRootCertProviderInstance(
+          commonTlsContext);
+      CommonTlsContext.CertificateProviderInstance certInstance = getCertProviderInstance(
+          commonTlsContext);
       return new CertProviderClientSslContextProvider(
           node,
           certProviders,

--- a/xds/src/main/java/io/grpc/xds/internal/certprovider/CertProviderSslContextProvider.java
+++ b/xds/src/main/java/io/grpc/xds/internal/certprovider/CertProviderSslContextProvider.java
@@ -18,9 +18,11 @@ package io.grpc.xds.internal.certprovider;
 
 import io.envoyproxy.envoy.config.core.v3.Node;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateValidationContext;
+import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext.CertificateProviderInstance;
 import io.grpc.xds.Bootstrapper.CertificateProviderInfo;
 import io.grpc.xds.EnvoyServerProtoData.BaseTlsContext;
+import io.grpc.xds.internal.sds.CommonTlsContextUtil;
 import io.grpc.xds.internal.sds.DynamicSslContextProvider;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
@@ -86,6 +88,50 @@ abstract class CertProviderSslContextProvider extends DynamicSslContextProvider 
   private static CertificateProviderInfo getCertProviderConfig(
       @Nullable Map<String, CertificateProviderInfo> certProviders, String pluginInstanceName) {
     return certProviders != null ? certProviders.get(pluginInstanceName) : null;
+  }
+
+  protected static CertificateProviderInstance getCertProviderInstance(
+      CommonTlsContext commonTlsContext) {
+    CertificateProviderInstance certInstance = null;
+    if (commonTlsContext.hasTlsCertificateProviderInstance()) {
+      return CommonTlsContextUtil.convert(commonTlsContext.getTlsCertificateProviderInstance());
+    } else if (commonTlsContext.hasTlsCertificateCertificateProviderInstance()) {
+      certInstance = commonTlsContext.getTlsCertificateCertificateProviderInstance();
+    }
+    return certInstance;
+  }
+
+  protected static CertificateValidationContext getStaticValidationContext(
+      CommonTlsContext commonTlsContext) {
+    if (commonTlsContext.hasValidationContext()) {
+      return commonTlsContext.getValidationContext();
+    } else if (commonTlsContext.hasCombinedValidationContext()) {
+      CommonTlsContext.CombinedCertificateValidationContext combinedValidationContext =
+          commonTlsContext.getCombinedValidationContext();
+      if (combinedValidationContext.hasDefaultValidationContext()) {
+        return combinedValidationContext.getDefaultValidationContext();
+      }
+    }
+    return null;
+  }
+
+  protected static CommonTlsContext.CertificateProviderInstance getRootCertProviderInstance(
+      CommonTlsContext commonTlsContext) {
+    CertificateValidationContext certValidationContext = getStaticValidationContext(
+        commonTlsContext);
+    if (certValidationContext != null && certValidationContext.hasCaCertificateProviderInstance()) {
+      return CommonTlsContextUtil.convert(certValidationContext.getCaCertificateProviderInstance());
+    }
+    if (commonTlsContext.hasCombinedValidationContext()) {
+      CommonTlsContext.CombinedCertificateValidationContext combinedValidationContext =
+          commonTlsContext.getCombinedValidationContext();
+      if (combinedValidationContext.hasValidationContextCertificateProviderInstance()) {
+        return combinedValidationContext.getValidationContextCertificateProviderInstance();
+      }
+    } else if (commonTlsContext.hasValidationContextCertificateProviderInstance()) {
+      return commonTlsContext.getValidationContextCertificateProviderInstance();
+    }
+    return null;
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/internal/certprovider/CertProviderSslContextProvider.java
+++ b/xds/src/main/java/io/grpc/xds/internal/certprovider/CertProviderSslContextProvider.java
@@ -90,17 +90,18 @@ abstract class CertProviderSslContextProvider extends DynamicSslContextProvider 
     return certProviders != null ? certProviders.get(pluginInstanceName) : null;
   }
 
+  @Nullable
   protected static CertificateProviderInstance getCertProviderInstance(
       CommonTlsContext commonTlsContext) {
-    CertificateProviderInstance certInstance = null;
     if (commonTlsContext.hasTlsCertificateProviderInstance()) {
       return CommonTlsContextUtil.convert(commonTlsContext.getTlsCertificateProviderInstance());
     } else if (commonTlsContext.hasTlsCertificateCertificateProviderInstance()) {
-      certInstance = commonTlsContext.getTlsCertificateCertificateProviderInstance();
+      return commonTlsContext.getTlsCertificateCertificateProviderInstance();
     }
-    return certInstance;
+    return null;
   }
 
+  @Nullable
   protected static CertificateValidationContext getStaticValidationContext(
       CommonTlsContext commonTlsContext) {
     if (commonTlsContext.hasValidationContext()) {
@@ -115,6 +116,7 @@ abstract class CertProviderSslContextProvider extends DynamicSslContextProvider 
     return null;
   }
 
+  @Nullable
   protected static CommonTlsContext.CertificateProviderInstance getRootCertProviderInstance(
       CommonTlsContext commonTlsContext) {
     CertificateValidationContext certValidationContext = getStaticValidationContext(

--- a/xds/src/main/java/io/grpc/xds/internal/sds/CommonTlsContextUtil.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/CommonTlsContextUtil.java
@@ -16,11 +16,12 @@
 
 package io.grpc.xds.internal.sds;
 
+import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateProviderPluginInstance;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext.CombinedCertificateValidationContext;
 
 /** Class for utility functions for {@link CommonTlsContext}. */
-final class CommonTlsContextUtil {
+public final class CommonTlsContextUtil {
 
   private CommonTlsContextUtil() {}
 
@@ -37,5 +38,16 @@ final class CommonTlsContextUtil {
       return combinedCertificateValidationContext.hasValidationContextCertificateProviderInstance();
     }
     return commonTlsContext.hasValidationContextCertificateProviderInstance();
+  }
+
+  /**
+   * Converts {@link CertificateProviderPluginInstance} to
+   * {@link CommonTlsContext.CertificateProviderInstance}.
+   */
+  public static CommonTlsContext.CertificateProviderInstance convert(
+      CertificateProviderPluginInstance pluginInstance) {
+    return CommonTlsContext.CertificateProviderInstance.newBuilder()
+        .setInstanceName(pluginInstance.getInstanceName())
+        .setCertificateName(pluginInstance.getCertificateName()).build();
   }
 }

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
@@ -77,6 +77,7 @@ import io.envoyproxy.envoy.extensions.filters.http.router.v3.Router;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.Rds;
+import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateProviderPluginInstance;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateValidationContext;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext.CertificateProviderInstance;
@@ -1551,7 +1552,7 @@ public class ClientXdsClientDataTest {
             .setValidationContext(CertificateValidationContext.getDefaultInstance())
             .build();
     thrown.expect(ResourceInvalidException.class);
-    thrown.expectMessage("common-tls-context with validation_context is not supported");
+    thrown.expectMessage("ca_certificate_provider_instance is required in upstream-tls-context");
     ClientXdsClient.validateCommonTlsContext(commonTlsContext, null, false);
   }
 
@@ -1609,8 +1610,20 @@ public class ClientXdsClientDataTest {
 
   @Test
   @SuppressWarnings("deprecation")
+  public void validateCommonTlsContext_tlsNewCertificateProviderInstance()
+      throws ResourceInvalidException {
+    CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
+        .setTlsCertificateProviderInstance(
+            CertificateProviderPluginInstance.newBuilder().setInstanceName("name1").build())
+        .build();
+    ClientXdsClient
+        .validateCommonTlsContext(commonTlsContext, ImmutableSet.of("name1", "name2"), true);
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_tlsCertificateProviderInstance()
-          throws ResourceInvalidException {
+      throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
         .setTlsCertificateCertificateProviderInstance(
             CertificateProviderInstance.newBuilder().setInstanceName("name1").build())
@@ -1662,7 +1675,7 @@ public class ClientXdsClientDataTest {
         .build();
     thrown.expect(ResourceInvalidException.class);
     thrown.expectMessage(
-        "ValidationContextProvider instance name 'bad-name' not defined in the bootstrap file.");
+        "ca_certificate_provider_instance name 'bad-name' not defined in the bootstrap file.");
     ClientXdsClient
         .validateCommonTlsContext(commonTlsContext, ImmutableSet.of("name1", "name2"), false);
   }
@@ -1710,7 +1723,7 @@ public class ClientXdsClientDataTest {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
         .build();
     thrown.expect(ResourceInvalidException.class);
-    thrown.expectMessage("combined_validation_context is required in upstream-tls-context");
+    thrown.expectMessage("ca_certificate_provider_instance is required in upstream-tls-context");
     ClientXdsClient.validateCommonTlsContext(commonTlsContext, null, false);
   }
 
@@ -1723,8 +1736,7 @@ public class ClientXdsClientDataTest {
         .build();
     thrown.expect(ResourceInvalidException.class);
     thrown.expectMessage(
-        "validation_context_certificate_provider_instance is required in "
-            + "combined_validation_context");
+        "ca_certificate_provider_instance is required in upstream-tls-context");
     ClientXdsClient.validateCommonTlsContext(commonTlsContext, null, false);
   }
 

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
@@ -1604,7 +1604,7 @@ public class ClientXdsClientDataTest {
         .build();
     thrown.expect(ResourceInvalidException.class);
     thrown.expectMessage(
-        "tls_certificate_certificate_provider_instance is required in downstream-tls-context");
+        "tls_certificate_provider_instance is required in downstream-tls-context");
     ClientXdsClient.validateCommonTlsContext(commonTlsContext, null, true);
   }
 
@@ -1687,7 +1687,7 @@ public class ClientXdsClientDataTest {
             .addTlsCertificates(TlsCertificate.getDefaultInstance())
             .build();
     thrown.expect(ResourceInvalidException.class);
-    thrown.expectMessage("common-tls-context with tls_certificates is not supported");
+    thrown.expectMessage("tls_certificate_provider_instance is unset");
     ClientXdsClient.validateCommonTlsContext(commonTlsContext, null, false);
   }
 
@@ -1699,7 +1699,7 @@ public class ClientXdsClientDataTest {
         .build();
     thrown.expect(ResourceInvalidException.class);
     thrown.expectMessage(
-        "common-tls-context with tls_certificate_sds_secret_configs is not supported");
+        "tls_certificate_provider_instance is unset");
     ClientXdsClient.validateCommonTlsContext(commonTlsContext, null, false);
   }
 
@@ -1713,7 +1713,7 @@ public class ClientXdsClientDataTest {
         .build();
     thrown.expect(ResourceInvalidException.class);
     thrown.expectMessage(
-        "common-tls-context with tls_certificate_certificate_provider is not supported");
+        "tls_certificate_provider_instance is unset");
     ClientXdsClient.validateCommonTlsContext(commonTlsContext, null, false);
   }
 

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientV2Test.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientV2Test.java
@@ -516,6 +516,12 @@ public class ClientXdsClientV2Test extends ClientXdsClientTestBase {
     }
 
     @Override
+    protected Message buildNewUpstreamTlsContext(String instanceName, String certName) {
+      return buildUpstreamTlsContext(instanceName, certName);
+    }
+
+
+    @Override
     protected Message buildCircuitBreakers(int highPriorityMaxRequests,
         int defaultPriorityMaxRequests) {
       return CircuitBreakers.newBuilder()

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientV3Test.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientV3Test.java
@@ -77,6 +77,8 @@ import io.envoyproxy.envoy.extensions.filters.http.fault.v3.HTTPFault;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.Rds;
+import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateProviderPluginInstance;
+import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateValidationContext;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext;
 import io.envoyproxy.envoy.service.discovery.v3.AggregatedDiscoveryServiceGrpc.AggregatedDiscoveryServiceImplBase;
@@ -549,6 +551,20 @@ public class ClientXdsClientV3Test extends ClientXdsClientTestBase {
                 .setValidationContextCertificateProviderInstance(providerInstance)
                 .build();
         commonTlsContextBuilder.setCombinedValidationContext(combined);
+      }
+      return UpstreamTlsContext.newBuilder()
+          .setCommonTlsContext(commonTlsContextBuilder)
+          .build();
+    }
+
+    @Override
+    protected Message buildNewUpstreamTlsContext(String instanceName, String certName) {
+      CommonTlsContext.Builder commonTlsContextBuilder = CommonTlsContext.newBuilder();
+      if (instanceName != null && certName != null) {
+        commonTlsContextBuilder.setValidationContext(CertificateValidationContext.newBuilder()
+            .setCaCertificateProviderInstance(
+                CertificateProviderPluginInstance.newBuilder().setInstanceName(instanceName)
+                    .setCertificateName(certName).build()));
       }
       return UpstreamTlsContext.newBuilder()
           .setCommonTlsContext(commonTlsContextBuilder)

--- a/xds/src/test/java/io/grpc/xds/internal/certprovider/CertProviderClientSslContextProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/certprovider/CertProviderClientSslContextProviderTest.java
@@ -87,6 +87,27 @@ public class CertProviderClientSslContextProviderTest {
         bootstrapInfo.getCertProviders());
   }
 
+  /** Helper method to build CertProviderClientSslContextProvider. */
+  private CertProviderClientSslContextProvider getNewSslContextProvider(
+          String certInstanceName,
+          String rootInstanceName,
+          Bootstrapper.BootstrapInfo bootstrapInfo,
+          Iterable<String> alpnProtocols,
+          CertificateValidationContext staticCertValidationContext) {
+    EnvoyServerProtoData.UpstreamTlsContext upstreamTlsContext =
+            CommonTlsContextTestsUtil.buildNewUpstreamTlsContextForCertProviderInstance(
+                    certInstanceName,
+                    "cert-default",
+                    rootInstanceName,
+                    "root-default",
+                    alpnProtocols,
+                    staticCertValidationContext);
+    return certProviderClientSslContextProviderFactory.getProvider(
+            upstreamTlsContext,
+            bootstrapInfo.getNode().toEnvoyProtoNode(),
+            bootstrapInfo.getCertProviders());
+  }
+
   @Test
   public void testProviderForClient_mtls() throws Exception {
     final CertificateProvider.DistributorWatcher[] watcherCaptor =
@@ -142,6 +163,69 @@ public class CertProviderClientSslContextProviderTest {
     watcherCaptor[0].updateCertificate(
         CommonCertProviderTestUtils.getPrivateKey(SERVER_1_KEY_FILE),
         ImmutableList.of(getCertFromResourceName(SERVER_1_PEM_FILE)));
+    assertThat(provider.savedKey).isNull();
+    assertThat(provider.savedCertChain).isNull();
+    assertThat(provider.savedTrustedRoots).isNull();
+    assertThat(provider.getSslContext()).isNotNull();
+    testCallback1 = CommonTlsContextTestsUtil.getValueThruCallback(provider);
+    assertThat(testCallback1.updatedSslContext).isNotSameInstanceAs(testCallback.updatedSslContext);
+  }
+
+  @Test
+  public void testProviderForClient_mtls_newXds() throws Exception {
+    final CertificateProvider.DistributorWatcher[] watcherCaptor =
+            new CertificateProvider.DistributorWatcher[1];
+    TestCertificateProvider.createAndRegisterProviderProvider(
+            certificateProviderRegistry, watcherCaptor, "testca", 0);
+    CertProviderClientSslContextProvider provider =
+            getNewSslContextProvider(
+                    "gcp_id",
+                    "gcp_id",
+                    CommonBootstrapperTestUtils.getTestBootstrapInfo(),
+                    /* alpnProtocols= */ null,
+                    /* staticCertValidationContext= */ null);
+
+    assertThat(provider.savedKey).isNull();
+    assertThat(provider.savedCertChain).isNull();
+    assertThat(provider.savedTrustedRoots).isNull();
+    assertThat(provider.getSslContext()).isNull();
+
+    // now generate cert update
+    watcherCaptor[0].updateCertificate(
+            CommonCertProviderTestUtils.getPrivateKey(CLIENT_KEY_FILE),
+            ImmutableList.of(getCertFromResourceName(CLIENT_PEM_FILE)));
+    assertThat(provider.savedKey).isNotNull();
+    assertThat(provider.savedCertChain).isNotNull();
+    assertThat(provider.getSslContext()).isNull();
+
+    // now generate root cert update
+    watcherCaptor[0].updateTrustedRoots(ImmutableList.of(getCertFromResourceName(CA_PEM_FILE)));
+    assertThat(provider.getSslContext()).isNotNull();
+    assertThat(provider.savedKey).isNull();
+    assertThat(provider.savedCertChain).isNull();
+    assertThat(provider.savedTrustedRoots).isNull();
+
+    TestCallback testCallback =
+            CommonTlsContextTestsUtil.getValueThruCallback(provider);
+
+    doChecksOnSslContext(false, testCallback.updatedSslContext, /* expectedApnProtos= */ null);
+    TestCallback testCallback1 =
+            CommonTlsContextTestsUtil.getValueThruCallback(provider);
+    assertThat(testCallback1.updatedSslContext).isSameInstanceAs(testCallback.updatedSslContext);
+
+    // just do root cert update: sslContext should still be the same
+    watcherCaptor[0].updateTrustedRoots(
+            ImmutableList.of(getCertFromResourceName(SERVER_0_PEM_FILE)));
+    assertThat(provider.savedKey).isNull();
+    assertThat(provider.savedCertChain).isNull();
+    assertThat(provider.savedTrustedRoots).isNotNull();
+    testCallback1 = CommonTlsContextTestsUtil.getValueThruCallback(provider);
+    assertThat(testCallback1.updatedSslContext).isSameInstanceAs(testCallback.updatedSslContext);
+
+    // now update id cert: sslContext should be updated i.e.different from the previous one
+    watcherCaptor[0].updateCertificate(
+            CommonCertProviderTestUtils.getPrivateKey(SERVER_1_KEY_FILE),
+            ImmutableList.of(getCertFromResourceName(SERVER_1_PEM_FILE)));
     assertThat(provider.savedKey).isNull();
     assertThat(provider.savedCertChain).isNull();
     assertThat(provider.savedTrustedRoots).isNull();


### PR DESCRIPTION
After importing the new protos (definitions) in PR #8490 this PR uses the new fields as per the gRFC [A29](https://github.com/grpc/proposal/blob/master/A29-xds-tls-security.md#xds-protocol). Specifically:

- use [`tls_certificate_provider_instance`](https://github.com/envoyproxy/envoy/blob/main/api/envoy/extensions/transport_sockets/tls/v3/tls.proto#L247) if present
- use [`ca_certificate_provider_instance`](https://github.com/envoyproxy/envoy/blob/main/api/envoy/extensions/transport_sockets/tls/v3/common.proto#L315) if present in either [`validation_context`](https://github.com/envoyproxy/envoy/blob/main/api/envoy/extensions/transport_sockets/tls/v3/tls.proto#L261) or [`combined_validation_context.default_validation_context`](https://github.com/envoyproxy/envoy/blob/main/api/envoy/extensions/transport_sockets/tls/v3/tls.proto#L188)

Various validations and translations take into account the above.