### PR TITLE
xds: remove hashCode() and equals() for SslContextProviderSupplier [backport v1.41.x] 

### DIFF
--- a/xds/src/main/java/io/grpc/xds/internal/sds/SslContextProviderSupplier.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/SslContextProviderSupplier.java
@@ -25,7 +25,6 @@ import io.grpc.xds.EnvoyServerProtoData.DownstreamTlsContext;
 import io.grpc.xds.EnvoyServerProtoData.UpstreamTlsContext;
 import io.grpc.xds.TlsContextManager;
 import io.netty.handler.ssl.SslContext;
-import java.util.Objects;
 
 /**
  * Enables Client or server side to initialize this object with the received {@link BaseTlsContext}
@@ -117,26 +116,6 @@ public final class SslContextProviderSupplier implements Closeable {
     }
     sslContextProvider = null;
     shutdown = true;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    SslContextProviderSupplier that = (SslContextProviderSupplier) o;
-    return shutdown == that.shutdown
-        && Objects.equals(tlsContext, that.tlsContext)
-        && Objects.equals(tlsContextManager, that.tlsContextManager)
-        && Objects.equals(sslContextProvider, that.sslContextProvider);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(tlsContext, tlsContextManager, sslContextProvider, shutdown);
   }
 
   @Override


### PR DESCRIPTION
Backport of #8496 

hashCode and equals() based on members of SslContextProviderSupplier is brittle because of mutation of the members. Leave them as Object's impls.