### PR TITLE
xds: use the new cert-provider instances if present [backport v1.41.x]

### DIFF
--- a/xds/src/main/java/io/grpc/xds/internal/certprovider/CertProviderClientSslContextProvider.java
+++ b/xds/src/main/java/io/grpc/xds/internal/certprovider/CertProviderClientSslContextProvider.java
@@ -22,7 +22,6 @@ import com.google.common.annotations.VisibleForTesting;
 import io.envoyproxy.envoy.config.core.v3.Node;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateValidationContext;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext;
-import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext.CombinedCertificateValidationContext;
 import io.grpc.Internal;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.xds.Bootstrapper.CertificateProviderInfo;
@@ -94,27 +93,12 @@ public final class CertProviderClientSslContextProvider extends CertProviderSslC
         @Nullable Map<String, CertificateProviderInfo> certProviders) {
       checkNotNull(upstreamTlsContext, "upstreamTlsContext");
       CommonTlsContext commonTlsContext = upstreamTlsContext.getCommonTlsContext();
-      CommonTlsContext.CertificateProviderInstance rootCertInstance = null;
-      CertificateValidationContext staticCertValidationContext = null;
-      if (commonTlsContext.hasCombinedValidationContext()) {
-        CombinedCertificateValidationContext combinedValidationContext =
-            commonTlsContext.getCombinedValidationContext();
-        if (combinedValidationContext.hasValidationContextCertificateProviderInstance()) {
-          rootCertInstance =
-              combinedValidationContext.getValidationContextCertificateProviderInstance();
-        }
-        if (combinedValidationContext.hasDefaultValidationContext()) {
-          staticCertValidationContext = combinedValidationContext.getDefaultValidationContext();
-        }
-      } else if (commonTlsContext.hasValidationContextCertificateProviderInstance()) {
-        rootCertInstance = commonTlsContext.getValidationContextCertificateProviderInstance();
-      } else if (commonTlsContext.hasValidationContext()) {
-        staticCertValidationContext = commonTlsContext.getValidationContext();
-      }
-      CommonTlsContext.CertificateProviderInstance certInstance = null;
-      if (commonTlsContext.hasTlsCertificateCertificateProviderInstance()) {
-        certInstance = commonTlsContext.getTlsCertificateCertificateProviderInstance();
-      }
+      CertificateValidationContext staticCertValidationContext = getStaticValidationContext(
+          commonTlsContext);
+      CommonTlsContext.CertificateProviderInstance rootCertInstance = getRootCertProviderInstance(
+          commonTlsContext);
+      CommonTlsContext.CertificateProviderInstance certInstance = getCertProviderInstance(
+          commonTlsContext);
       return new CertProviderClientSslContextProvider(
           node,
           certProviders,

--- a/xds/src/main/java/io/grpc/xds/internal/certprovider/CertProviderSslContextProvider.java
+++ b/xds/src/main/java/io/grpc/xds/internal/certprovider/CertProviderSslContextProvider.java
@@ -18,9 +18,11 @@ package io.grpc.xds.internal.certprovider;
 
 import io.envoyproxy.envoy.config.core.v3.Node;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateValidationContext;
+import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext.CertificateProviderInstance;
 import io.grpc.xds.Bootstrapper.CertificateProviderInfo;
 import io.grpc.xds.EnvoyServerProtoData.BaseTlsContext;
+import io.grpc.xds.internal.sds.CommonTlsContextUtil;
 import io.grpc.xds.internal.sds.DynamicSslContextProvider;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
@@ -86,6 +88,52 @@ abstract class CertProviderSslContextProvider extends DynamicSslContextProvider 
   private static CertificateProviderInfo getCertProviderConfig(
       @Nullable Map<String, CertificateProviderInfo> certProviders, String pluginInstanceName) {
     return certProviders != null ? certProviders.get(pluginInstanceName) : null;
+  }
+
+  @Nullable
+  protected static CertificateProviderInstance getCertProviderInstance(
+      CommonTlsContext commonTlsContext) {
+    if (commonTlsContext.hasTlsCertificateProviderInstance()) {
+      return CommonTlsContextUtil.convert(commonTlsContext.getTlsCertificateProviderInstance());
+    } else if (commonTlsContext.hasTlsCertificateCertificateProviderInstance()) {
+      return commonTlsContext.getTlsCertificateCertificateProviderInstance();
+    }
+    return null;
+  }
+
+  @Nullable
+  protected static CertificateValidationContext getStaticValidationContext(
+      CommonTlsContext commonTlsContext) {
+    if (commonTlsContext.hasValidationContext()) {
+      return commonTlsContext.getValidationContext();
+    } else if (commonTlsContext.hasCombinedValidationContext()) {
+      CommonTlsContext.CombinedCertificateValidationContext combinedValidationContext =
+          commonTlsContext.getCombinedValidationContext();
+      if (combinedValidationContext.hasDefaultValidationContext()) {
+        return combinedValidationContext.getDefaultValidationContext();
+      }
+    }
+    return null;
+  }
+
+  @Nullable
+  protected static CommonTlsContext.CertificateProviderInstance getRootCertProviderInstance(
+      CommonTlsContext commonTlsContext) {
+    CertificateValidationContext certValidationContext = getStaticValidationContext(
+        commonTlsContext);
+    if (certValidationContext != null && certValidationContext.hasCaCertificateProviderInstance()) {
+      return CommonTlsContextUtil.convert(certValidationContext.getCaCertificateProviderInstance());
+    }
+    if (commonTlsContext.hasCombinedValidationContext()) {
+      CommonTlsContext.CombinedCertificateValidationContext combinedValidationContext =
+          commonTlsContext.getCombinedValidationContext();
+      if (combinedValidationContext.hasValidationContextCertificateProviderInstance()) {
+        return combinedValidationContext.getValidationContextCertificateProviderInstance();
+      }
+    } else if (commonTlsContext.hasValidationContextCertificateProviderInstance()) {
+      return commonTlsContext.getValidationContextCertificateProviderInstance();
+    }
+    return null;
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/internal/sds/CommonTlsContextUtil.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/CommonTlsContextUtil.java
@@ -16,11 +16,12 @@
 
 package io.grpc.xds.internal.sds;
 
+import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateProviderPluginInstance;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext.CombinedCertificateValidationContext;
 
 /** Class for utility functions for {@link CommonTlsContext}. */
-final class CommonTlsContextUtil {
+public final class CommonTlsContextUtil {
 
   private CommonTlsContextUtil() {}
 
@@ -37,5 +38,16 @@ final class CommonTlsContextUtil {
       return combinedCertificateValidationContext.hasValidationContextCertificateProviderInstance();
     }
     return commonTlsContext.hasValidationContextCertificateProviderInstance();
+  }
+
+  /**
+   * Converts {@link CertificateProviderPluginInstance} to
+   * {@link CommonTlsContext.CertificateProviderInstance}.
+   */
+  public static CommonTlsContext.CertificateProviderInstance convert(
+      CertificateProviderPluginInstance pluginInstance) {
+    return CommonTlsContext.CertificateProviderInstance.newBuilder()
+        .setInstanceName(pluginInstance.getInstanceName())
+        .setCertificateName(pluginInstance.getCertificateName()).build();
   }
 }

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientV2Test.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientV2Test.java
@@ -516,6 +516,12 @@ public class ClientXdsClientV2Test extends ClientXdsClientTestBase {
     }
 
     @Override
+    protected Message buildNewUpstreamTlsContext(String instanceName, String certName) {
+      return buildUpstreamTlsContext(instanceName, certName);
+    }
+
+
+    @Override
     protected Message buildCircuitBreakers(int highPriorityMaxRequests,
         int defaultPriorityMaxRequests) {
       return CircuitBreakers.newBuilder()

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientV3Test.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientV3Test.java
@@ -77,6 +77,8 @@ import io.envoyproxy.envoy.extensions.filters.http.fault.v3.HTTPFault;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.Rds;
+import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateProviderPluginInstance;
+import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateValidationContext;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext;
 import io.envoyproxy.envoy.service.discovery.v3.AggregatedDiscoveryServiceGrpc.AggregatedDiscoveryServiceImplBase;
@@ -549,6 +551,20 @@ public class ClientXdsClientV3Test extends ClientXdsClientTestBase {
                 .setValidationContextCertificateProviderInstance(providerInstance)
                 .build();
         commonTlsContextBuilder.setCombinedValidationContext(combined);
+      }
+      return UpstreamTlsContext.newBuilder()
+          .setCommonTlsContext(commonTlsContextBuilder)
+          .build();
+    }
+
+    @Override
+    protected Message buildNewUpstreamTlsContext(String instanceName, String certName) {
+      CommonTlsContext.Builder commonTlsContextBuilder = CommonTlsContext.newBuilder();
+      if (instanceName != null && certName != null) {
+        commonTlsContextBuilder.setValidationContext(CertificateValidationContext.newBuilder()
+            .setCaCertificateProviderInstance(
+                CertificateProviderPluginInstance.newBuilder().setInstanceName(instanceName)
+                    .setCertificateName(certName).build()));
       }
       return UpstreamTlsContext.newBuilder()
           .setCommonTlsContext(commonTlsContextBuilder)

--- a/xds/src/test/java/io/grpc/xds/internal/certprovider/CertProviderClientSslContextProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/certprovider/CertProviderClientSslContextProviderTest.java
@@ -87,6 +87,27 @@ public class CertProviderClientSslContextProviderTest {
         bootstrapInfo.getCertProviders());
   }
 
+  /** Helper method to build CertProviderClientSslContextProvider. */
+  private CertProviderClientSslContextProvider getNewSslContextProvider(
+          String certInstanceName,
+          String rootInstanceName,
+          Bootstrapper.BootstrapInfo bootstrapInfo,
+          Iterable<String> alpnProtocols,
+          CertificateValidationContext staticCertValidationContext) {
+    EnvoyServerProtoData.UpstreamTlsContext upstreamTlsContext =
+            CommonTlsContextTestsUtil.buildNewUpstreamTlsContextForCertProviderInstance(
+                    certInstanceName,
+                    "cert-default",
+                    rootInstanceName,
+                    "root-default",
+                    alpnProtocols,
+                    staticCertValidationContext);
+    return certProviderClientSslContextProviderFactory.getProvider(
+            upstreamTlsContext,
+            bootstrapInfo.getNode().toEnvoyProtoNode(),
+            bootstrapInfo.getCertProviders());
+  }
+
   @Test
   public void testProviderForClient_mtls() throws Exception {
     final CertificateProvider.DistributorWatcher[] watcherCaptor =
@@ -142,6 +163,69 @@ public class CertProviderClientSslContextProviderTest {
     watcherCaptor[0].updateCertificate(
         CommonCertProviderTestUtils.getPrivateKey(SERVER_1_KEY_FILE),
         ImmutableList.of(getCertFromResourceName(SERVER_1_PEM_FILE)));
+    assertThat(provider.savedKey).isNull();
+    assertThat(provider.savedCertChain).isNull();
+    assertThat(provider.savedTrustedRoots).isNull();
+    assertThat(provider.getSslContext()).isNotNull();
+    testCallback1 = CommonTlsContextTestsUtil.getValueThruCallback(provider);
+    assertThat(testCallback1.updatedSslContext).isNotSameInstanceAs(testCallback.updatedSslContext);
+  }
+
+  @Test
+  public void testProviderForClient_mtls_newXds() throws Exception {
+    final CertificateProvider.DistributorWatcher[] watcherCaptor =
+            new CertificateProvider.DistributorWatcher[1];
+    TestCertificateProvider.createAndRegisterProviderProvider(
+            certificateProviderRegistry, watcherCaptor, "testca", 0);
+    CertProviderClientSslContextProvider provider =
+            getNewSslContextProvider(
+                    "gcp_id",
+                    "gcp_id",
+                    CommonBootstrapperTestUtils.getTestBootstrapInfo(),
+                    /* alpnProtocols= */ null,
+                    /* staticCertValidationContext= */ null);
+
+    assertThat(provider.savedKey).isNull();
+    assertThat(provider.savedCertChain).isNull();
+    assertThat(provider.savedTrustedRoots).isNull();
+    assertThat(provider.getSslContext()).isNull();
+
+    // now generate cert update
+    watcherCaptor[0].updateCertificate(
+            CommonCertProviderTestUtils.getPrivateKey(CLIENT_KEY_FILE),
+            ImmutableList.of(getCertFromResourceName(CLIENT_PEM_FILE)));
+    assertThat(provider.savedKey).isNotNull();
+    assertThat(provider.savedCertChain).isNotNull();
+    assertThat(provider.getSslContext()).isNull();
+
+    // now generate root cert update
+    watcherCaptor[0].updateTrustedRoots(ImmutableList.of(getCertFromResourceName(CA_PEM_FILE)));
+    assertThat(provider.getSslContext()).isNotNull();
+    assertThat(provider.savedKey).isNull();
+    assertThat(provider.savedCertChain).isNull();
+    assertThat(provider.savedTrustedRoots).isNull();
+
+    TestCallback testCallback =
+            CommonTlsContextTestsUtil.getValueThruCallback(provider);
+
+    doChecksOnSslContext(false, testCallback.updatedSslContext, /* expectedApnProtos= */ null);
+    TestCallback testCallback1 =
+            CommonTlsContextTestsUtil.getValueThruCallback(provider);
+    assertThat(testCallback1.updatedSslContext).isSameInstanceAs(testCallback.updatedSslContext);
+
+    // just do root cert update: sslContext should still be the same
+    watcherCaptor[0].updateTrustedRoots(
+            ImmutableList.of(getCertFromResourceName(SERVER_0_PEM_FILE)));
+    assertThat(provider.savedKey).isNull();
+    assertThat(provider.savedCertChain).isNull();
+    assertThat(provider.savedTrustedRoots).isNotNull();
+    testCallback1 = CommonTlsContextTestsUtil.getValueThruCallback(provider);
+    assertThat(testCallback1.updatedSslContext).isSameInstanceAs(testCallback.updatedSslContext);
+
+    // now update id cert: sslContext should be updated i.e.different from the previous one
+    watcherCaptor[0].updateCertificate(
+            CommonCertProviderTestUtils.getPrivateKey(SERVER_1_KEY_FILE),
+            ImmutableList.of(getCertFromResourceName(SERVER_1_PEM_FILE)));
     assertThat(provider.savedKey).isNull();
     assertThat(provider.savedCertChain).isNull();
     assertThat(provider.savedTrustedRoots).isNull();


### PR DESCRIPTION
backport of #8494

After importing the new protos (definitions) in PR #8490 this PR uses the new fields as per the gRFC A29. Specifically:

use tls_certificate_provider_instance if present
use ca_certificate_provider_instance if present in either validation_context or combined_validation_context.default_validation_context
Various validations and translations take into account the above.