### PR TITLE
Build against fixed JDK versions, with the distro that support this

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.jre }}
-        distribution: 'adopt'
+        distribution: 'temurin'
 
     - name: Gradle cache
       uses: actions/cache@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.jre }}
-        distribution: 'temurin'
+        distribution: 'zulu'
 
     - name: Gradle cache
       uses: actions/cache@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        jre: [8, 11]
+        jre: [8, 8.0.192, 11, 11.0.3]
       fail-fast: false # Should swap to true if we grow a large matrix
 
     steps:


### PR DESCRIPTION
Doing builds against a fixed version, e.g., 11.0.3, as well as the latest version, e.g., 11, can be helpful in identifying the reason why a build breaks, when it breaks. For example, when the build against 11.0.3 is green while against 11 it is red, that tells you the problem is related to the latest version, rather than something in your code. Adopt is no more with us, the alternatives now available are Temurin and Zulu, while Zulu supports more versions, has existed much longer, while Temurin is new and does not have multiple versions.