### PR TITLE
api: Stabilize the Status.asException() call.

### DIFF
--- a/api/src/main/java/io/grpc/Status.java
+++ b/api/src/main/java/io/grpc/Status.java
@@ -546,7 +546,6 @@ public final class Status {
   /**
    * Same as {@link #asException()} but includes the provided trailers in the returned exception.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4683")
   public StatusException asException(@Nullable Metadata trailers) {
     return new StatusException(this, trailers);
   }


### PR DESCRIPTION
Removes the ExperimentalApi annotation from this call.

Contributes to: #4683