### PR TITLE
AdvancedTls: add functions to load credentials from static files

### DIFF
--- a/core/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
+++ b/core/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
@@ -141,6 +141,22 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
     };
   }
 
+  /**
+   * Loads the private key and certificate chains from the local file paths. The contents are only
+   * read at the construction time and won't be updated afterwards.
+   *
+   * @param keyFile  the file on disk holding the private key
+   * @param certFile  the file on disk holding the certificate chain
+   */
+  public void loadIdentityCredentialsFromFile(File keyFile, File certFile) throws IOException,
+      GeneralSecurityException {
+    UpdateResult newResult = readAndUpdate(keyFile, certFile, 0, 0);
+    if (!newResult.success) {
+      throw new GeneralSecurityException(
+          "Files were unmodified before their initial update. Probably a bug.");
+    }
+  }
+
   private static class KeyInfo {
     // The private key and the cert chain we will use to send to peers to prove our identity.
     final PrivateKey key;

--- a/core/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
+++ b/core/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
@@ -142,13 +142,12 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
   }
 
   /**
-   * Loads the private key and certificate chains from the local file paths. The contents are only
-   * read at the construction time and won't be updated afterwards.
+   * Updates the private key and certificate chains from the local file paths.
    *
    * @param keyFile  the file on disk holding the private key
    * @param certFile  the file on disk holding the certificate chain
    */
-  public void loadIdentityCredentialsFromFile(File keyFile, File certFile) throws IOException,
+  public void updateIdentityCredentialsFromFile(File keyFile, File certFile) throws IOException,
       GeneralSecurityException {
     UpdateResult newResult = readAndUpdate(keyFile, certFile, 0, 0);
     if (!newResult.success) {

--- a/core/src/main/java/io/grpc/util/AdvancedTlsX509TrustManager.java
+++ b/core/src/main/java/io/grpc/util/AdvancedTlsX509TrustManager.java
@@ -256,12 +256,11 @@ public final class AdvancedTlsX509TrustManager extends X509ExtendedTrustManager 
   }
 
   /**
-   * Loads the trust certificates from a local file path. The contents are only read at the
-   * construction time and won't be updated afterwards.
+   * Updates the trust certificates from a local file path.
    *
    * @param trustCertFile  the file on disk holding the trust certificates
    */
-  public void loadTrustCredentialsFromFile(File trustCertFile) throws IOException,
+  public void updateTrustCredentialsFromFile(File trustCertFile) throws IOException,
       GeneralSecurityException {
     long updatedTime = readAndUpdate(trustCertFile, 0);
     if (updatedTime == 0) {

--- a/core/src/main/java/io/grpc/util/AdvancedTlsX509TrustManager.java
+++ b/core/src/main/java/io/grpc/util/AdvancedTlsX509TrustManager.java
@@ -256,6 +256,21 @@ public final class AdvancedTlsX509TrustManager extends X509ExtendedTrustManager 
   }
 
   /**
+   * Loads the trust certificates from a local file path. The contents are only read at the
+   * construction time and won't be updated afterwards.
+   *
+   * @param trustCertFile  the file on disk holding the trust certificates
+   */
+  public void loadTrustCredentialsFromFile(File trustCertFile) throws IOException,
+      GeneralSecurityException {
+    long updatedTime = readAndUpdate(trustCertFile, 0);
+    if (updatedTime == 0) {
+      throw new GeneralSecurityException(
+          "Files were unmodified before their initial update. Probably a bug.");
+    }
+  }
+
+  /**
    * Reads the trust certificates specified in the path location, and update the key store if the
    * modified time has changed since last read.
    *

--- a/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
+++ b/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
@@ -181,8 +181,6 @@ public class AdvancedTlsTest {
         .keyManager(clientKeyManager).trustManager(clientTrustManager).build();
     channel = Grpc.newChannelBuilderForAddress("localhost", server.getPort(), channelCredentials)
         .overrideAuthority("foo.test.google.com.au").build();
-    // Wait 5 seconds for the client and server to load their credentials.
-    TimeUnit.SECONDS.sleep(5);
     // Start the connection.
     try {
       SimpleServiceGrpc.SimpleServiceBlockingStub client =

--- a/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
+++ b/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
@@ -389,6 +389,44 @@ public class AdvancedTlsTest {
   }
 
   @Test
+  public void onFileLoadingKeyManagerTrustManagerTest() throws Exception {
+    // Create & start a server.
+    AdvancedTlsX509KeyManager serverKeyManager = new AdvancedTlsX509KeyManager();
+    serverKeyManager.loadIdentityCredentialsFromFile(serverKey0File, serverCert0File);
+    AdvancedTlsX509TrustManager serverTrustManager = AdvancedTlsX509TrustManager.newBuilder()
+        .setVerification(Verification.CERTIFICATE_ONLY_VERIFICATION)
+        .build();
+    serverTrustManager.loadTrustCredentialsFromFile(caCertFile);
+    ServerCredentials serverCredentials = TlsServerCredentials.newBuilder()
+        .keyManager(serverKeyManager).trustManager(serverTrustManager)
+        .clientAuth(ClientAuth.REQUIRE).build();
+    server = Grpc.newServerBuilderForPort(0, serverCredentials).addService(
+        new SimpleServiceImpl()).build().start();
+    // Create a client to connect.
+    AdvancedTlsX509KeyManager clientKeyManager = new AdvancedTlsX509KeyManager();
+    clientKeyManager.loadIdentityCredentialsFromFile(clientKey0File, clientCert0File);
+    AdvancedTlsX509TrustManager clientTrustManager = AdvancedTlsX509TrustManager.newBuilder()
+        .setVerification(Verification.CERTIFICATE_AND_HOST_NAME_VERIFICATION)
+        .build();
+    clientTrustManager.loadTrustCredentialsFromFile(caCertFile);
+    ChannelCredentials channelCredentials = TlsChannelCredentials.newBuilder()
+        .keyManager(clientKeyManager).trustManager(clientTrustManager).build();
+    channel = Grpc.newChannelBuilderForAddress("localhost", server.getPort(), channelCredentials)
+        .overrideAuthority("foo.test.google.com.au").build();
+    // Start the connection.
+    try {
+      SimpleServiceGrpc.SimpleServiceBlockingStub client =
+          SimpleServiceGrpc.newBlockingStub(channel);
+      // Send an actual request, via the full GRPC & network stack, and check that a proper
+      // response comes back.
+      client.unaryRpc(SimpleRequest.getDefaultInstance());
+    } catch (StatusRuntimeException e) {
+      e.printStackTrace();
+      fail("Find error: " + e.getMessage());
+    }
+  }
+
+  @Test
   public void onFileReloadingKeyManagerBadInitialContentTest() throws Exception {
     exceptionRule.expect(GeneralSecurityException.class);
     AdvancedTlsX509KeyManager keyManager = new AdvancedTlsX509KeyManager();

--- a/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
+++ b/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
@@ -392,11 +392,11 @@ public class AdvancedTlsTest {
   public void onFileLoadingKeyManagerTrustManagerTest() throws Exception {
     // Create & start a server.
     AdvancedTlsX509KeyManager serverKeyManager = new AdvancedTlsX509KeyManager();
-    serverKeyManager.loadIdentityCredentialsFromFile(serverKey0File, serverCert0File);
+    serverKeyManager.updateIdentityCredentialsFromFile(serverKey0File, serverCert0File);
     AdvancedTlsX509TrustManager serverTrustManager = AdvancedTlsX509TrustManager.newBuilder()
         .setVerification(Verification.CERTIFICATE_ONLY_VERIFICATION)
         .build();
-    serverTrustManager.loadTrustCredentialsFromFile(caCertFile);
+    serverTrustManager.updateTrustCredentialsFromFile(caCertFile);
     ServerCredentials serverCredentials = TlsServerCredentials.newBuilder()
         .keyManager(serverKeyManager).trustManager(serverTrustManager)
         .clientAuth(ClientAuth.REQUIRE).build();
@@ -404,11 +404,11 @@ public class AdvancedTlsTest {
         new SimpleServiceImpl()).build().start();
     // Create a client to connect.
     AdvancedTlsX509KeyManager clientKeyManager = new AdvancedTlsX509KeyManager();
-    clientKeyManager.loadIdentityCredentialsFromFile(clientKey0File, clientCert0File);
+    clientKeyManager.updateIdentityCredentialsFromFile(clientKey0File, clientCert0File);
     AdvancedTlsX509TrustManager clientTrustManager = AdvancedTlsX509TrustManager.newBuilder()
         .setVerification(Verification.CERTIFICATE_AND_HOST_NAME_VERIFICATION)
         .build();
-    clientTrustManager.loadTrustCredentialsFromFile(caCertFile);
+    clientTrustManager.updateTrustCredentialsFromFile(caCertFile);
     ChannelCredentials channelCredentials = TlsChannelCredentials.newBuilder()
         .keyManager(clientKeyManager).trustManager(clientTrustManager).build();
     channel = Grpc.newChannelBuilderForAddress("localhost", server.getPort(), channelCredentials)

--- a/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
+++ b/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
@@ -181,6 +181,8 @@ public class AdvancedTlsTest {
         .keyManager(clientKeyManager).trustManager(clientTrustManager).build();
     channel = Grpc.newChannelBuilderForAddress("localhost", server.getPort(), channelCredentials)
         .overrideAuthority("foo.test.google.com.au").build();
+    // Wait 5 seconds for the client and server to load their credentials.
+    TimeUnit.SECONDS.sleep(5);
     // Start the connection.
     try {
       SimpleServiceGrpc.SimpleServiceBlockingStub client =


### PR DESCRIPTION
Add two functions in AdvancedTls classes to load credentials from static files, making it easier to use for users who don't have the need to periodically refresh their credentials. 