### PR TITLE
xds: Drain old server connections on Listener updates

### DIFF
--- a/netty/src/main/java/io/grpc/netty/GracefulServerCloseCommand.java
+++ b/netty/src/main/java/io/grpc/netty/GracefulServerCloseCommand.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.netty;
+
+import com.google.common.base.Preconditions;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A command to trigger close and allow streams naturally close.
+ */
+class GracefulServerCloseCommand extends WriteQueue.AbstractQueuedCommand {
+  private final String goAwayDebugString;
+  private final long graceTime;
+  private final TimeUnit graceTimeUnit;
+
+  public GracefulServerCloseCommand(String goAwayDebugString) {
+    this(goAwayDebugString, -1, null);
+  }
+
+  public GracefulServerCloseCommand(
+      String goAwayDebugString, long graceTime, TimeUnit graceTimeUnit) {
+    this.goAwayDebugString = Preconditions.checkNotNull(goAwayDebugString, "goAwayDebugString");
+    this.graceTime = graceTime;
+    this.graceTimeUnit = graceTimeUnit;
+  }
+
+  public String getGoAwayDebugString() {
+    return goAwayDebugString;
+  }
+
+  /** Has no meaning if {@code getGraceTimeUnit() == null}. */
+  public long getGraceTime() {
+    return graceTime;
+  }
+
+  public TimeUnit getGraceTimeUnit() {
+    return graceTimeUnit;
+  }
+}

--- a/netty/src/main/java/io/grpc/netty/InternalGracefulServerCloseCommand.java
+++ b/netty/src/main/java/io/grpc/netty/InternalGracefulServerCloseCommand.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.netty;
+
+import io.grpc.Internal;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Internal accessor for {@link GracefulServerCloseCommand}.
+ */
+@Internal
+public final class InternalGracefulServerCloseCommand {
+  private InternalGracefulServerCloseCommand() {}
+
+  public static Object create(String goAwayDebugString) {
+    return new GracefulServerCloseCommand(goAwayDebugString);
+  }
+
+  public static Object create(String goAwayDebugString, long graceTime, TimeUnit graceTimeUnit) {
+    return new GracefulServerCloseCommand(goAwayDebugString, graceTime, graceTimeUnit);
+  }
+}

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -625,6 +625,8 @@ class NettyServerHandler extends AbstractNettyHandler {
       sendResponseHeaders(ctx, (SendResponseHeadersCommand) msg, promise);
     } else if (msg instanceof CancelServerStreamCommand) {
       cancelStream(ctx, (CancelServerStreamCommand) msg, promise);
+    } else if (msg instanceof GracefulServerCloseCommand) {
+      gracefulClose(ctx, (GracefulServerCloseCommand) msg, promise);
     } else if (msg instanceof ForcefulCloseCommand) {
       forcefulClose(ctx, (ForcefulCloseCommand) msg, promise);
     } else {
@@ -638,11 +640,8 @@ class NettyServerHandler extends AbstractNettyHandler {
 
   @Override
   public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
-    if (gracefulShutdown == null) {
-      gracefulShutdown = new GracefulShutdown("app_requested", null);
-      gracefulShutdown.start(ctx);
-      ctx.flush();
-    }
+    gracefulClose(ctx, new GracefulServerCloseCommand("app_requested"), promise);
+    ctx.flush();
   }
 
   /**
@@ -721,6 +720,21 @@ class NettyServerHandler extends AbstractNettyHandler {
     } finally {
       PerfMark.stopTask("NettyServerHandler.cancelStream", cmd.stream().tag());
     }
+  }
+
+  private void gracefulClose(final ChannelHandlerContext ctx, final GracefulServerCloseCommand msg,
+      ChannelPromise promise) throws Exception {
+    // Ideally we'd adjust a pre-existing graceful shutdown's grace period to at least what is
+    // requested here. But that's an edge case and seems bug-prone.
+    if (gracefulShutdown == null) {
+      Long graceTimeInNanos = null;
+      if (msg.getGraceTimeUnit() != null) {
+        graceTimeInNanos = msg.getGraceTimeUnit().toNanos(msg.getGraceTime());
+      }
+      gracefulShutdown = new GracefulShutdown(msg.getGoAwayDebugString(), graceTimeInNanos);
+      gracefulShutdown.start(ctx);
+    }
+    promise.setSuccess();
   }
 
   private void forcefulClose(final ChannelHandlerContext ctx, final ForcefulCloseCommand msg,

--- a/netty/src/main/java/io/grpc/netty/WriteBufferingAndExceptionHandler.java
+++ b/netty/src/main/java/io/grpc/netty/WriteBufferingAndExceptionHandler.java
@@ -124,6 +124,8 @@ final class WriteBufferingAndExceptionHandler extends ChannelDuplexHandler {
       promise.setFailure(failCause);
       ReferenceCountUtil.release(msg);
     } else {
+      // Do not special case GracefulServerCloseCommand, as we don't want to cause handshake
+      // failures.
       if (msg instanceof GracefulCloseCommand || msg instanceof ForcefulCloseCommand) {
         // No point in continuing negotiation
         ctx.close();

--- a/xds/src/main/java/io/grpc/xds/FilterChainSelectorManager.java
+++ b/xds/src/main/java/io/grpc/xds/FilterChainSelectorManager.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import io.grpc.xds.FilterChainMatchingProtocolNegotiators.FilterChainMatchingHandler.FilterChainSelector;
+import java.util.Comparator;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.concurrent.GuardedBy;
+
+/**
+ * Maintains the current xDS selector and any resources using that selector. When the selector
+ * changes, old resources are closed to avoid old config usages.
+ */
+final class FilterChainSelectorManager {
+  private static final AtomicLong closerId = new AtomicLong();
+
+  private final Object lock = new Object();
+  @GuardedBy("lock")
+  private FilterChainSelector selector;
+  // Avoid HashSet since it does not decrease in size, forming a high water mark.
+  @GuardedBy("lock")
+  private TreeSet<Closer> closers = new TreeSet<Closer>(new CloserComparator());
+
+  public FilterChainSelector register(Closer closer) {
+    synchronized (lock) {
+      Preconditions.checkState(closers.add(closer), "closer already registered");
+      return selector;
+    }
+  }
+
+  public void deregister(Closer closer) {
+    synchronized (lock) {
+      closers.remove(closer);
+    }
+  }
+
+  /** Only safe to be called by code that is responsible for updating the selector.  */
+  public FilterChainSelector getSelectorToUpdateSelector() {
+    synchronized (lock) {
+      return selector;
+    }
+  }
+
+  public void updateSelector(FilterChainSelector newSelector) {
+    TreeSet<Closer> oldClosers;
+    synchronized (lock) {
+      oldClosers = closers;
+      closers = new TreeSet<Closer>(closers.comparator());
+      selector = newSelector;
+    }
+    for (Closer closer : oldClosers) {
+      closer.closer.run();
+    }
+  }
+
+  @VisibleForTesting
+  int getRegisterCount() {
+    synchronized (lock) {
+      return closers.size();
+    }
+  }
+
+  public static final class Closer {
+    private final long id = closerId.getAndIncrement();
+    private final Runnable closer;
+
+    /** {@code closer} may be run multiple times. */
+    public Closer(Runnable closer) {
+      this.closer = Preconditions.checkNotNull(closer, "closer");
+    }
+  }
+
+  private static class CloserComparator implements Comparator<Closer> {
+    @Override public int compare(Closer c1, Closer c2) {
+      return Long.compare(c1.id, c2.id);
+    }
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/InternalXdsAttributes.java
+++ b/xds/src/main/java/io/grpc/xds/InternalXdsAttributes.java
@@ -22,10 +22,8 @@ import io.grpc.Grpc;
 import io.grpc.Internal;
 import io.grpc.NameResolver;
 import io.grpc.internal.ObjectPool;
-import io.grpc.xds.FilterChainMatchingProtocolNegotiators.FilterChainMatchingHandler.FilterChainSelector;
 import io.grpc.xds.XdsNameResolverProvider.CallCounterProvider;
 import io.grpc.xds.internal.sds.SslContextProviderSupplier;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Internal attributes used for xDS implementation. Do not use.
@@ -81,9 +79,14 @@ public final class InternalXdsAttributes {
    * Filter chain match for network filters.
    */
   @Grpc.TransportAttr
-  static final Attributes.Key<AtomicReference<FilterChainSelector>>
-          ATTR_FILTER_CHAIN_SELECTOR_REF = Attributes.Key.create(
-          "io.grpc.xds.InternalXdsAttributes.filterChainSelectorRef");
+  static final Attributes.Key<FilterChainSelectorManager>
+          ATTR_FILTER_CHAIN_SELECTOR_MANAGER = Attributes.Key.create(
+          "io.grpc.xds.InternalXdsAttributes.filterChainSelectorManager");
+
+  /** Grace time to use when draining. Null for an infinite grace time. */
+  @Grpc.TransportAttr
+  static final Attributes.Key<Long> ATTR_DRAIN_GRACE_NANOS =
+      Attributes.Key.create("io.grpc.xds.InternalXdsAttributes.drainGraceTime");
 
   private InternalXdsAttributes() {}
 }

--- a/xds/src/main/java/io/grpc/xds/XdsServerWrapper.java
+++ b/xds/src/main/java/io/grpc/xds/XdsServerWrapper.java
@@ -100,7 +100,7 @@ final class XdsServerWrapper extends Server {
   private final ThreadSafeRandom random = ThreadSafeRandomImpl.instance;
   private final XdsClientPoolFactory xdsClientPoolFactory;
   private final XdsServingStatusListener listener;
-  private final AtomicReference<FilterChainSelector> filterChainSelectorRef;
+  private final FilterChainSelectorManager filterChainSelectorManager;
   private final AtomicBoolean started = new AtomicBoolean(false);
   private final AtomicBoolean shutdown = new AtomicBoolean(false);
   private boolean isServing;
@@ -117,11 +117,11 @@ final class XdsServerWrapper extends Server {
       String listenerAddress,
       ServerBuilder<?> delegateBuilder,
       XdsServingStatusListener listener,
-      AtomicReference<FilterChainSelector> filterChainSelectorRef,
+      FilterChainSelectorManager filterChainSelectorManager,
       XdsClientPoolFactory xdsClientPoolFactory,
       FilterRegistry filterRegistry) {
-    this(listenerAddress, delegateBuilder, listener, filterChainSelectorRef, xdsClientPoolFactory,
-            filterRegistry, SharedResourceHolder.get(GrpcUtil.TIMER_SERVICE));
+    this(listenerAddress, delegateBuilder, listener, filterChainSelectorManager,
+        xdsClientPoolFactory, filterRegistry, SharedResourceHolder.get(GrpcUtil.TIMER_SERVICE));
     sharedTimeService = true;
   }
 
@@ -130,7 +130,7 @@ final class XdsServerWrapper extends Server {
           String listenerAddress,
           ServerBuilder<?> delegateBuilder,
           XdsServingStatusListener listener,
-          AtomicReference<FilterChainSelector> filterChainSelectorRef,
+          FilterChainSelectorManager filterChainSelectorManager,
           XdsClientPoolFactory xdsClientPoolFactory,
           FilterRegistry filterRegistry,
           ScheduledExecutorService timeService) {
@@ -138,7 +138,8 @@ final class XdsServerWrapper extends Server {
     this.delegateBuilder = checkNotNull(delegateBuilder, "delegateBuilder");
     this.delegateBuilder.intercept(new ConfigApplyingInterceptor());
     this.listener = checkNotNull(listener, "listener");
-    this.filterChainSelectorRef = checkNotNull(filterChainSelectorRef, "filterChainSelectorRef");
+    this.filterChainSelectorManager
+        = checkNotNull(filterChainSelectorManager, "filterChainSelectorManager");
     this.xdsClientPoolFactory = checkNotNull(xdsClientPoolFactory, "xdsClientPoolFactory");
     this.timeService = checkNotNull(timeService, "timeService");
     this.filterRegistry = checkNotNull(filterRegistry,"filterRegistry");
@@ -361,8 +362,8 @@ final class XdsServerWrapper extends Server {
           }
           checkNotNull(update.listener(), "update");
           if (!pendingRds.isEmpty()) {
-            // filter chain state has not yet been applied to filterChainSelectorRef and there are
-            // two sets of sslContextProviderSuppliers, so we release the old ones.
+            // filter chain state has not yet been applied to filterChainSelectorManager and there
+            // are two sets of sslContextProviderSuppliers, so we release the old ones.
             releaseSuppliersInFlight();
             pendingRds.clear();
           }
@@ -443,7 +444,7 @@ final class XdsServerWrapper extends Server {
       logger.log(Level.FINE, "Stop watching LDS resource {0}", resourceName);
       xdsClient.cancelLdsResourceWatch(resourceName, this);
       List<SslContextProviderSupplier> toRelease = getSuppliersInUse();
-      filterChainSelectorRef.set(FilterChainSelector.NO_FILTER_CHAIN);
+      filterChainSelectorManager.updateSelector(FilterChainSelector.NO_FILTER_CHAIN);
       for (SslContextProviderSupplier s: toRelease) {
         s.close();
       }
@@ -460,7 +461,7 @@ final class XdsServerWrapper extends Server {
           defaultFilterChain == null ? null : defaultFilterChain.getSslContextProviderSupplier(),
           defaultFilterChain == null ? null : generateRoutingConfig(defaultFilterChain));
       List<SslContextProviderSupplier> toRelease = getSuppliersInUse();
-      filterChainSelectorRef.set(selector);
+      filterChainSelectorManager.updateSelector(selector);
       for (SslContextProviderSupplier e: toRelease) {
         e.close();
       }
@@ -482,7 +483,7 @@ final class XdsServerWrapper extends Server {
     private void handleConfigNotFound(StatusException exception) {
       cleanUpRouteDiscoveryStates();
       List<SslContextProviderSupplier> toRelease = getSuppliersInUse();
-      filterChainSelectorRef.set(FilterChainSelector.NO_FILTER_CHAIN);
+      filterChainSelectorManager.updateSelector(FilterChainSelector.NO_FILTER_CHAIN);
       for (SslContextProviderSupplier s: toRelease) {
         s.close();
       }
@@ -511,7 +512,7 @@ final class XdsServerWrapper extends Server {
 
     private List<SslContextProviderSupplier> getSuppliersInUse() {
       List<SslContextProviderSupplier> toRelease = new ArrayList<>();
-      FilterChainSelector selector = filterChainSelectorRef.get();
+      FilterChainSelector selector = filterChainSelectorManager.getSelectorToUpdateSelector();
       if (selector != null) {
         for (FilterChain f: selector.getRoutingConfigs().keySet()) {
           if (f.getSslContextProviderSupplier() != null) {

--- a/xds/src/test/java/io/grpc/xds/FilterChainSelectorManagerTest.java
+++ b/xds/src/test/java/io/grpc/xds/FilterChainSelectorManagerTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import io.grpc.xds.EnvoyServerProtoData.FilterChain;
+import io.grpc.xds.Filter.NamedFilterConfig;
+import io.grpc.xds.FilterChainMatchingProtocolNegotiators.FilterChainMatchingHandler.FilterChainSelector;
+import io.grpc.xds.FilterChainSelectorManager.Closer;
+import io.grpc.xds.XdsServerWrapper.ServerRoutingConfig;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class FilterChainSelectorManagerTest {
+  private FilterChainSelectorManager manager = new FilterChainSelectorManager();
+  private ServerRoutingConfig noopConfig = ServerRoutingConfig.create(
+          Collections.<NamedFilterConfig>emptyList(),
+          new AtomicReference<ImmutableList<VirtualHost>>());
+  private FilterChainSelector selector1 = new FilterChainSelector(
+            Collections.<FilterChain,ServerRoutingConfig>emptyMap(), null, null);
+  private FilterChainSelector selector2 = new FilterChainSelector(
+            Collections.<FilterChain,ServerRoutingConfig>emptyMap(), null, noopConfig);
+  private CounterRunnable runnable1 = new CounterRunnable();
+  private CounterRunnable runnable2 = new CounterRunnable();
+
+  @Test
+  public void updateSelector_changesSelector() {
+    assertThat(manager.getSelectorToUpdateSelector()).isNull();
+    assertThat(manager.register(new Closer(runnable1))).isNull();
+
+    manager.updateSelector(selector1);
+
+    assertThat(runnable1.counter).isEqualTo(1);
+    assertThat(manager.getSelectorToUpdateSelector()).isSameInstanceAs(selector1);
+    assertThat(manager.register(new Closer(runnable2))).isSameInstanceAs(selector1);
+    assertThat(runnable2.counter).isEqualTo(0);
+  }
+
+  @Test
+  public void updateSelector_callsCloserOnce() {
+    assertThat(manager.register(new Closer(runnable1))).isNull();
+
+    manager.updateSelector(selector1);
+    manager.updateSelector(selector2);
+
+    assertThat(runnable1.counter).isEqualTo(1);
+  }
+
+  @Test
+  public void deregister_removesCloser() {
+    Closer closer1 = new Closer(runnable1);
+    manager.updateSelector(selector1);
+    assertThat(manager.register(closer1)).isSameInstanceAs(selector1);
+    assertThat(manager.getRegisterCount()).isEqualTo(1);
+
+    manager.deregister(closer1);
+
+    assertThat(manager.getRegisterCount()).isEqualTo(0);
+    manager.updateSelector(selector2);
+    assertThat(runnable1.counter).isEqualTo(0);
+  }
+
+  @Test
+  public void deregister_removesCorrectCloser() {
+    Closer closer1 = new Closer(runnable1);
+    Closer closer2 = new Closer(runnable2);
+    manager.updateSelector(selector1);
+    assertThat(manager.register(closer1)).isSameInstanceAs(selector1);
+    assertThat(manager.register(closer2)).isSameInstanceAs(selector1);
+    assertThat(manager.getRegisterCount()).isEqualTo(2);
+
+    manager.deregister(closer1);
+
+    assertThat(manager.getRegisterCount()).isEqualTo(1);
+    manager.updateSelector(selector2);
+    assertThat(runnable1.counter).isEqualTo(0);
+    assertThat(runnable2.counter).isEqualTo(1);
+  }
+
+  private static class CounterRunnable implements Runnable {
+    int counter;
+
+    @Override public void run() {
+      counter++;
+    }
+  }
+}

--- a/xds/src/test/java/io/grpc/xds/XdsServerBuilderTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerBuilderTest.java
@@ -281,4 +281,15 @@ public class XdsServerBuilderTest {
       assertThat(expected).hasMessageThat().contains("Server already built!");
     }
   }
+
+  @Test
+  public void drainGraceTime_negativeThrows() throws IOException {
+    buildBuilder(null);
+    try {
+      builder.drainGraceTime(-1, TimeUnit.SECONDS);
+      fail("exception expected");
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessageThat().contains("drain grace time");
+    }
+  }
 }


### PR DESCRIPTION
This is necessary to make sure all connections are using the new
configuration.

CC @dapengzhang0, if you want to take a glance at the Netty changes