### PR TITLE
Revert "netty: Requests with Connection header are malformed"

### DIFF
--- a/api/src/main/java/io/grpc/Metadata.java
+++ b/api/src/main/java/io/grpc/Metadata.java
@@ -40,8 +40,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -56,7 +54,6 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class Metadata {
-  private static final Logger logger = Logger.getLogger(Metadata.class.getName());
 
   /**
    * All binary headers should have this suffix in their names. Vice versa.
@@ -736,15 +733,6 @@ public final class Metadata {
     private static String validateName(String n, boolean pseudo) {
       checkNotNull(n, "name");
       checkArgument(!n.isEmpty(), "token must have at least 1 tchar");
-      if (n.equals("connection")) {
-        logger.log(
-            Level.WARNING,
-            "Metadata key is 'Connection', which should not be used. That is used by HTTP/1 for "
-            + "connection-specific headers which are not to be forwarded. There is probably an "
-            + "HTTP/1 conversion bug. Simply removing the Connection header is not enough; you "
-            + "should remove all headers it references as well. See RFC 7230 section 6.1",
-            new RuntimeException("exception to show backtrace"));
-      }
       for (int i = 0; i < n.length(); i++) {
         char tChar = n.charAt(i);
         if (pseudo && tChar == ':' && i == 0) {

--- a/netty/src/main/java/io/grpc/netty/GrpcHttp2HeadersUtils.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcHttp2HeadersUtils.java
@@ -146,11 +146,6 @@ class GrpcHttp2HeadersUtils {
     }
 
     @Override
-    public boolean contains(CharSequence name) {
-      return get(name) != null;
-    }
-
-    @Override
     public CharSequence status() {
       return get(Http2Headers.PseudoHeaderName.STATUS.value());
     }

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -26,7 +26,6 @@ import static io.grpc.netty.Utils.CONTENT_TYPE_HEADER;
 import static io.grpc.netty.Utils.HTTP_METHOD;
 import static io.grpc.netty.Utils.TE_HEADER;
 import static io.grpc.netty.Utils.TE_TRAILERS;
-import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
 import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
 import static io.netty.handler.codec.http2.DefaultHttp2LocalFlowController.DEFAULT_WINDOW_UPDATE_RATIO;
 import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.AUTHORITY;
@@ -378,12 +377,6 @@ class NettyServerHandler extends AbstractNettyHandler {
   private void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers)
       throws Http2Exception {
     try {
-      // Connection-specific header fields makes a request malformed. Ideally this would be handled
-      // by Netty. RFC 7540 section 8.1.2.2
-      if (headers.contains(CONNECTION)) {
-        resetStream(ctx, streamId, Http2Error.PROTOCOL_ERROR.code(), ctx.newPromise());
-        return;
-      }
 
       if (headers.authority() == null) {
         List<CharSequence> hosts = headers.getAll(HOST);

--- a/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
@@ -588,25 +588,6 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
   }
 
   @Test
-  public void headersWithConnectionHeaderShouldFail() throws Exception {
-    manualSetUp();
-    Http2Headers headers = new DefaultHttp2Headers()
-        .method(HTTP_METHOD)
-        .set(CONTENT_TYPE_HEADER, CONTENT_TYPE_GRPC)
-        .set(AsciiString.of("connection"), CONTENT_TYPE_GRPC)
-        .path(new AsciiString("/foo/bar"));
-    ByteBuf headersFrame = headersFrame(STREAM_ID, headers);
-    channelRead(headersFrame);
-
-    verifyWrite()
-        .writeRstStream(
-            eq(ctx()),
-            eq(STREAM_ID),
-            eq(Http2Error.PROTOCOL_ERROR.code()),
-            any(ChannelPromise.class));
-  }
-
-  @Test
   public void headersWithMultipleHostsShouldFail() throws Exception {
     manualSetUp();
     Http2Headers headers = new DefaultHttp2Headers()


### PR DESCRIPTION
This reverts commit 6e89919e3265eadd33dc7e154ba291d46563f286.

This was found to break a test proxy. We'll work on fixing the proxy and
then roll this forward again.

#8514 CC @dapengzhang0 