### PR TITLE
xds: add hashCode and equals back to SslContextProviderSupplier [backport to 1.41.x] (#8528)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/internal/sds/SslContextProviderSupplier.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/SslContextProviderSupplier.java
@@ -25,6 +25,7 @@ import io.grpc.xds.EnvoyServerProtoData.DownstreamTlsContext;
 import io.grpc.xds.EnvoyServerProtoData.UpstreamTlsContext;
 import io.grpc.xds.TlsContextManager;
 import io.netty.handler.ssl.SslContext;
+import java.util.Objects;
 
 /**
  * Enables Client or server side to initialize this object with the received {@link BaseTlsContext}
@@ -116,6 +117,24 @@ public final class SslContextProviderSupplier implements Closeable {
     }
     sslContextProvider = null;
     shutdown = true;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SslContextProviderSupplier that = (SslContextProviderSupplier) o;
+    return Objects.equals(tlsContext, that.tlsContext)
+        && Objects.equals(tlsContextManager, that.tlsContextManager);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(tlsContext, tlsContextManager);
   }
 
   @Override


### PR DESCRIPTION
backport of #8528

The xdsClient uses equals() for duplicate detection/suppression so a proper equals() (and also hashCode()) is needed. sslContextProvider and shutdown are excluded because these are implementation instances instead of pure data. This will be replaced by a more permanent solution later (such as removing the construction of implementation instances by XdsClient)