### PR TITLE
xds: Fix test compilation for confused javac

### DIFF
--- a/xds/src/test/java/io/grpc/xds/FilterChainMatchingProtocolNegotiatorsTest.java
+++ b/xds/src/test/java/io/grpc/xds/FilterChainMatchingProtocolNegotiatorsTest.java
@@ -170,7 +170,9 @@ public class FilterChainMatchingProtocolNegotiatorsTest {
     channel.runPendingTasks();
     channelHandlerCtx = pipeline.context(next);
     assertThat(channelHandlerCtx).isNotNull();
-    assertThat((Object) channel.readOutbound()).isNull();
+    // Force return value to Object, to avoid confusing javac of the type passed to assertThat()
+    Object msg = channel.readOutbound();
+    assertThat(msg).isNull();
 
     selectorManager.updateSelector(new FilterChainSelector(
             new HashMap<FilterChain, ServerRoutingConfig>(), null, noopConfig));

--- a/xds/src/test/java/io/grpc/xds/FilterChainMatchingProtocolNegotiatorsTest.java
+++ b/xds/src/test/java/io/grpc/xds/FilterChainMatchingProtocolNegotiatorsTest.java
@@ -170,7 +170,7 @@ public class FilterChainMatchingProtocolNegotiatorsTest {
     channel.runPendingTasks();
     channelHandlerCtx = pipeline.context(next);
     assertThat(channelHandlerCtx).isNotNull();
-    assertThat(channel.readOutbound()).isNull();
+    assertThat((Object) channel.readOutbound()).isNull();
 
     selectorManager.updateSelector(new FilterChainSelector(
             new HashMap<FilterChain, ServerRoutingConfig>(), null, noopConfig));


### PR DESCRIPTION
The internal build fails with "reference to assertThat is ambiguous". It
isn't clear why the internal build fails while the external one is okay,
but it is clear that the wildcard T return of readOutbound() is probably
confusing things as javac is considering assertThat(BigDecimal) as a
possible match.

The T return type is a hidden, convenience cast. We force the type
passed to assertThat() to be Object to avoid any ambiguity.