### PR TITLE
core: change the mapping from ChannelLogLevel to java.util.logging.Level

### DIFF
--- a/api/src/main/java/io/grpc/ChannelLogger.java
+++ b/api/src/main/java/io/grpc/ChannelLogger.java
@@ -36,8 +36,8 @@ public abstract class ChannelLogger {
    * | ChannelLogger Level | Channelz Severity | Java Logger Level |
    * +---------------------+-------------------+-------------------+
    * | DEBUG               | N/A               | FINEST            |
-   * | INFO                | CT_INFO           | FINEST            |
-   * | WARNING             | CT_WARNING        | FINER             |
+   * | INFO                | CT_INFO           | FINER             |
+   * | WARNING             | CT_WARNING        | FINE             |
    * | ERROR               | CT_ERROR          | FINE              |
    * +---------------------+-------------------+-------------------+
    * </pre>

--- a/core/src/main/java/io/grpc/internal/ChannelLoggerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ChannelLoggerImpl.java
@@ -97,8 +97,9 @@ final class ChannelLoggerImpl extends ChannelLogger {
   private static Level toJavaLogLevel(ChannelLogLevel level) {
     switch (level) {
       case ERROR:
-        return Level.FINE;
       case WARNING:
+        return Level.FINE;
+      case INFO:
         return Level.FINER;
       default:
         return Level.FINEST;

--- a/core/src/test/java/io/grpc/internal/ChannelLoggerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ChannelLoggerImplTest.java
@@ -100,7 +100,7 @@ public class ChannelLoggerImplTest {
         .setTimestampNanos(200)
         .build();
     assertThat(stats.channelTrace.events).containsExactly(event);
-    assertThat(logs).contains("FINER: " + logPrefix + "Warning message");
+    assertThat(logs).contains("FINE: " + logPrefix + "Warning message");
 
     clock.forwardNanos(100);
     logger.log(ChannelLogLevel.INFO, "Info message");
@@ -112,7 +112,7 @@ public class ChannelLoggerImplTest {
         .setTimestampNanos(300)
         .build();
     assertThat(stats.channelTrace.events).containsExactly(event);
-    assertThat(logs).contains("FINEST: " + logPrefix + "Info message");
+    assertThat(logs).contains("FINER: " + logPrefix + "Info message");
 
     clock.forwardNanos(100);
     logger.log(ChannelLogLevel.DEBUG, "Debug message");
@@ -154,7 +154,7 @@ public class ChannelLoggerImplTest {
         .setTimestampNanos(200)
         .build();
     assertThat(stats.channelTrace.events).containsExactly(event);
-    assertThat(logs).contains("FINER: " + logPrefix + "Warning message foo, bar");
+    assertThat(logs).contains("FINE: " + logPrefix + "Warning message foo, bar");
 
     clock.forwardNanos(100);
     logger.log(ChannelLogLevel.INFO, "Info message {0}", "bar");
@@ -166,7 +166,7 @@ public class ChannelLoggerImplTest {
         .setTimestampNanos(300)
         .build();
     assertThat(stats.channelTrace.events).containsExactly(event);
-    assertThat(logs).contains("FINEST: " + logPrefix + "Info message bar");
+    assertThat(logs).contains("FINER: " + logPrefix + "Info message bar");
 
     clock.forwardNanos(100);
     logger.log(ChannelLogLevel.DEBUG, "Debug message {0}", "foo");


### PR DESCRIPTION
Instead of `ChannelLogLevel.{DEBUG,INFO}` mapping to the same java level, `ChannelLogLevel.{WARNING,ERROR}` will shame the same java level. This allows us to be able to independently control the visibility of `ChannelLogLevel.DEBUG` logs which are the most verbose.