### PR TITLE
xds: build per route serverInterceptor for httpConfig (backport v1.41.x)

### DIFF
--- a/xds/src/test/java/io/grpc/xds/FilterChainSelectorManagerTest.java
+++ b/xds/src/test/java/io/grpc/xds/FilterChainSelectorManagerTest.java
@@ -19,8 +19,9 @@ package io.grpc.xds;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.grpc.ServerInterceptor;
 import io.grpc.xds.EnvoyServerProtoData.FilterChain;
-import io.grpc.xds.Filter.NamedFilterConfig;
 import io.grpc.xds.FilterChainMatchingProtocolNegotiators.FilterChainMatchingHandler.FilterChainSelector;
 import io.grpc.xds.FilterChainSelectorManager.Closer;
 import io.grpc.xds.XdsServerWrapper.ServerRoutingConfig;
@@ -33,13 +34,15 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public final class FilterChainSelectorManagerTest {
   private FilterChainSelectorManager manager = new FilterChainSelectorManager();
-  private ServerRoutingConfig noopConfig = ServerRoutingConfig.create(
-          Collections.<NamedFilterConfig>emptyList(),
-          new AtomicReference<ImmutableList<VirtualHost>>());
+  private AtomicReference<ServerRoutingConfig> noopConfig = new AtomicReference<>(
+      ServerRoutingConfig.create(ImmutableList.<VirtualHost>of(),
+      ImmutableMap.<VirtualHost.Route, ServerInterceptor>of()));
   private FilterChainSelector selector1 = new FilterChainSelector(
-            Collections.<FilterChain,ServerRoutingConfig>emptyMap(), null, null);
+            Collections.<FilterChain,AtomicReference<ServerRoutingConfig>>emptyMap(),
+      null, new AtomicReference<ServerRoutingConfig>());
   private FilterChainSelector selector2 = new FilterChainSelector(
-            Collections.<FilterChain,ServerRoutingConfig>emptyMap(), null, noopConfig);
+            Collections.<FilterChain,AtomicReference<ServerRoutingConfig>>emptyMap(),
+      null, noopConfig);
   private CounterRunnable runnable1 = new CounterRunnable();
   private CounterRunnable runnable2 = new CounterRunnable();
 

--- a/xds/src/test/java/io/grpc/xds/XdsServerWrapperTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerWrapperTest.java
@@ -104,6 +104,8 @@ public class XdsServerWrapperTest {
   private FakeXdsClient xdsClient = new FakeXdsClient();
   private FilterRegistry filterRegistry = FilterRegistry.getDefaultRegistry();
   private XdsServerWrapper xdsServerWrapper;
+  private ServerRoutingConfig noopConfig = ServerRoutingConfig.create(
+      ImmutableList.<VirtualHost>of(), ImmutableMap.<Route, ServerInterceptor>of());
 
   @Before
   public void setup() {
@@ -380,9 +382,9 @@ public class XdsServerWrapperTest {
     assertThat(selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().size())
         .isEqualTo(1);
     ServerRoutingConfig realConfig =
-        selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(filterChain);
-    assertThat(realConfig.virtualHosts().get()).isEqualTo(httpConnectionManager.virtualHosts());
-    assertThat(realConfig.httpFilterConfigs()).isEqualTo(httpConnectionManager.httpFilterConfigs());
+        selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(filterChain).get();
+    assertThat(realConfig.virtualHosts()).isEqualTo(httpConnectionManager.virtualHosts());
+    assertThat(realConfig.interceptors()).isEqualTo(ImmutableMap.of());
     verify(listener).onServing();
     verify(mockServer).start();
   }
@@ -429,26 +431,21 @@ public class XdsServerWrapperTest {
     start.get(5000, TimeUnit.MILLISECONDS);
     verify(mockServer).start();
     ServerRoutingConfig realConfig =
-        selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(f0);
-    assertThat(realConfig.virtualHosts().get()).isEqualTo(
+        selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(f0).get();
+    assertThat(realConfig.virtualHosts()).isEqualTo(
         Collections.singletonList(createVirtualHost("virtual-host-0")));
-    assertThat(realConfig.httpFilterConfigs()).isEqualTo(
-        f0.getHttpConnectionManager().httpFilterConfigs());
+    assertThat(realConfig.interceptors()).isEqualTo(ImmutableMap.of());
     assertThat(selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().size())
         .isEqualTo(2);
-    realConfig = selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(f2);
-    assertThat(realConfig.virtualHosts().get()).isEqualTo(
+    realConfig = selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(f2).get();
+    assertThat(realConfig.virtualHosts()).isEqualTo(
         Collections.singletonList(createVirtualHost("virtual-host-1")));
-    assertThat(realConfig.httpFilterConfigs()).isEqualTo(
-        f2.getHttpConnectionManager().httpFilterConfigs());
-    realConfig = selectorManager.getSelectorToUpdateSelector().getDefaultRoutingConfig();
-    assertThat(realConfig.virtualHosts().get()).isEqualTo(
+    assertThat(realConfig.interceptors()).isEqualTo(ImmutableMap.of());
+    realConfig = selectorManager.getSelectorToUpdateSelector().getDefaultRoutingConfig().get();
+    assertThat(realConfig.virtualHosts()).isEqualTo(
         Collections.singletonList(createVirtualHost("virtual-host-2")));
-    assertThat(realConfig.httpFilterConfigs()).isEqualTo(
-        f3.getHttpConnectionManager().httpFilterConfigs());
     assertThat(selectorManager.getSelectorToUpdateSelector().getDefaultSslContextProviderSupplier())
-        .isEqualTo(
-            f3.getSslContextProviderSupplier());
+        .isEqualTo(f3.getSslContextProviderSupplier());
   }
 
   @Test
@@ -481,22 +478,20 @@ public class XdsServerWrapperTest {
     start.get(5000, TimeUnit.MILLISECONDS);
     verify(mockServer, times(1)).start();
     ServerRoutingConfig realConfig =
-        selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(f0);
-    assertThat(realConfig.virtualHosts().get()).isEqualTo(
+        selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(f0).get();
+    assertThat(realConfig.virtualHosts()).isEqualTo(
         Collections.singletonList(createVirtualHost("virtual-host-0")));
-    assertThat(realConfig.httpFilterConfigs()).isEqualTo(
-        f0.getHttpConnectionManager().httpFilterConfigs());
-    realConfig = selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(f1);
-    assertThat(realConfig.virtualHosts().get()).isEqualTo(
-        Collections.singletonList(createVirtualHost("virtual-host-0")));
-    assertThat(realConfig.httpFilterConfigs()).isEqualTo(
-        f1.getHttpConnectionManager().httpFilterConfigs());
+    assertThat(realConfig.interceptors()).isEqualTo(ImmutableMap.of());
 
-    realConfig = selectorManager.getSelectorToUpdateSelector().getDefaultRoutingConfig();
-    assertThat(realConfig.virtualHosts().get()).isEqualTo(
+    realConfig = selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(f1).get();
+    assertThat(realConfig.virtualHosts()).isEqualTo(
         Collections.singletonList(createVirtualHost("virtual-host-0")));
-    assertThat(realConfig.httpFilterConfigs()).isEqualTo(
-        f2.getHttpConnectionManager().httpFilterConfigs());
+    assertThat(realConfig.interceptors()).isEqualTo(ImmutableMap.of());
+
+    realConfig = selectorManager.getSelectorToUpdateSelector().getDefaultRoutingConfig().get();
+    assertThat(realConfig.virtualHosts()).isEqualTo(
+        Collections.singletonList(createVirtualHost("virtual-host-0")));
+    assertThat(realConfig.interceptors()).isEqualTo(ImmutableMap.of());
     assertThat(selectorManager.getSelectorToUpdateSelector().getDefaultSslContextProviderSupplier())
         .isSameInstanceAs(f2.getSslContextProviderSupplier());
 
@@ -513,25 +508,22 @@ public class XdsServerWrapperTest {
 
     assertThat(selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().size())
         .isEqualTo(2);
-    realConfig = selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(f5);
-    assertThat(realConfig.virtualHosts().get()).isEqualTo(
+    realConfig = selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(f5).get();
+    assertThat(realConfig.virtualHosts()).isEqualTo(
         Collections.singletonList(createVirtualHost("virtual-host-1")));
-    assertThat(realConfig.httpFilterConfigs()).isEqualTo(
-        f5.getHttpConnectionManager().httpFilterConfigs());
-    realConfig = selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(f3);
-    assertThat(realConfig.virtualHosts().get()).isEqualTo(
+    assertThat(realConfig.interceptors()).isEqualTo(ImmutableMap.of());
+    realConfig = selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(f3).get();
+    assertThat(realConfig.virtualHosts()).isEqualTo(
         Collections.singletonList(createVirtualHost("virtual-host-0")));
-    assertThat(realConfig.httpFilterConfigs()).isEqualTo(
-        f3.getHttpConnectionManager().httpFilterConfigs());
+    assertThat(realConfig.interceptors()).isEqualTo(ImmutableMap.of());
 
-    realConfig = selectorManager.getSelectorToUpdateSelector().getDefaultRoutingConfig();
-    assertThat(realConfig.virtualHosts().get()).isEqualTo(
+    realConfig = selectorManager.getSelectorToUpdateSelector().getDefaultRoutingConfig().get();
+    assertThat(realConfig.virtualHosts()).isEqualTo(
         Collections.singletonList(createVirtualHost("virtual-host-1")));
-    assertThat(realConfig.httpFilterConfigs()).isEqualTo(
-        f4.getHttpConnectionManager().httpFilterConfigs());
+    assertThat(realConfig.interceptors()).isEqualTo(ImmutableMap.of());
+
     assertThat(selectorManager.getSelectorToUpdateSelector().getDefaultSslContextProviderSupplier())
-        .isSameInstanceAs(
-            f4.getSslContextProviderSupplier());
+        .isSameInstanceAs(f4.getSslContextProviderSupplier());
     verify(mockServer, times(1)).start();
     xdsServerWrapper.shutdown();
     verify(mockServer, times(1)).shutdown();
@@ -567,35 +559,31 @@ public class XdsServerWrapperTest {
     assertThat(selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().size())
         .isEqualTo(2);
     ServerRoutingConfig realConfig =
-        selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(f1);
-    assertThat(realConfig.virtualHosts().get()).isNull();
-    assertThat(realConfig.httpFilterConfigs()).isEqualTo(
-        f1.getHttpConnectionManager().httpFilterConfigs());
-    realConfig = selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(f0);
-    assertThat(realConfig.virtualHosts().get()).isEqualTo(hcmVirtual.virtualHosts());
-    assertThat(realConfig.httpFilterConfigs()).isEqualTo(
-        f0.getHttpConnectionManager().httpFilterConfigs());
+        selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(f1).get();
+    assertThat(realConfig.virtualHosts()).isEmpty();
+    assertThat(realConfig.interceptors()).isEmpty();
+
+    realConfig = selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(f0).get();
+    assertThat(realConfig.virtualHosts()).isEqualTo(hcmVirtual.virtualHosts());
+    assertThat(realConfig.interceptors()).isEqualTo(ImmutableMap.of());
 
     xdsClient.deliverRdsUpdate("r0",
             Collections.singletonList(createVirtualHost("virtual-host-1")));
-    realConfig = selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(f1);
-    assertThat(realConfig.virtualHosts().get()).isEqualTo(
+    realConfig = selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(f1).get();
+    assertThat(realConfig.virtualHosts()).isEqualTo(
         Collections.singletonList(createVirtualHost("virtual-host-1")));
-    assertThat(realConfig.httpFilterConfigs()).isEqualTo(
-        f1.getHttpConnectionManager().httpFilterConfigs());
+    assertThat(realConfig.interceptors()).isEqualTo(ImmutableMap.of());
 
     xdsClient.rdsWatchers.get("r0").onError(Status.CANCELLED);
-    realConfig = selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(f1);
-    assertThat(realConfig.virtualHosts().get()).isEqualTo(
+    realConfig = selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(f1).get();
+    assertThat(realConfig.virtualHosts()).isEqualTo(
         Collections.singletonList(createVirtualHost("virtual-host-1")));
-    assertThat(realConfig.httpFilterConfigs()).isEqualTo(
-        f1.getHttpConnectionManager().httpFilterConfigs());
+    assertThat(realConfig.interceptors()).isEqualTo(ImmutableMap.of());
 
     xdsClient.rdsWatchers.get("r0").onResourceDoesNotExist("r0");
-    realConfig = selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(f1);
-    assertThat(realConfig.virtualHosts().get()).isNull();
-    assertThat(realConfig.httpFilterConfigs()).isEqualTo(
-        f1.getHttpConnectionManager().httpFilterConfigs());
+    realConfig = selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(f1).get();
+    assertThat(realConfig.virtualHosts()).isEmpty();
+    assertThat(realConfig.interceptors()).isEmpty();
   }
 
   @Test
@@ -648,11 +636,11 @@ public class XdsServerWrapperTest {
     assertThat(selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().size())
         .isEqualTo(1);
     ServerRoutingConfig realConfig =
-        selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(filterChain1);
-    assertThat(realConfig.virtualHosts().get()).isEqualTo(
+        selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().get(filterChain1).get();
+    assertThat(realConfig.virtualHosts()).isEqualTo(
         Collections.singletonList(createVirtualHost("virtual-host-1")));
-    assertThat(realConfig.httpFilterConfigs()).isEqualTo(
-        filterChain1.getHttpConnectionManager().httpFilterConfigs());
+    assertThat(realConfig.interceptors()).isEqualTo(ImmutableMap.of());
+
     // xds update after start
     xdsClient.deliverRdsUpdate("rds",
             Collections.singletonList(createVirtualHost("virtual-host-2")));
@@ -664,11 +652,11 @@ public class XdsServerWrapperTest {
     assertThat(selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().size())
         .isEqualTo(1);
     realConfig = selectorManager.getSelectorToUpdateSelector().getRoutingConfigs()
-        .get(filterChain1);
-    assertThat(realConfig.virtualHosts().get()).isEqualTo(
+        .get(filterChain1).get();
+    assertThat(realConfig.virtualHosts()).isEqualTo(
         Collections.singletonList(createVirtualHost("virtual-host-2")));
-    assertThat(realConfig.httpFilterConfigs()).isEqualTo(
-        filterChain1.getHttpConnectionManager().httpFilterConfigs());
+    assertThat(realConfig.interceptors()).isEqualTo(ImmutableMap.of());
+
     assertThat(sslSupplier1.isShutdown()).isFalse();
 
     // not serving after serving
@@ -705,11 +693,11 @@ public class XdsServerWrapperTest {
     assertThat(selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().size())
         .isEqualTo(1);
     realConfig = selectorManager.getSelectorToUpdateSelector().getRoutingConfigs()
-        .get(filterChain2);
-    assertThat(realConfig.virtualHosts().get()).isEqualTo(
+        .get(filterChain2).get();
+    assertThat(realConfig.virtualHosts()).isEqualTo(
         Collections.singletonList(createVirtualHost("virtual-host-1")));
-    assertThat(realConfig.httpFilterConfigs()).isEqualTo(
-        filterChain2.getHttpConnectionManager().httpFilterConfigs());
+    assertThat(realConfig.interceptors()).isEqualTo(ImmutableMap.of());
+
     assertThat(executor.numPendingTasks()).isEqualTo(1);
     xdsClient.ldsWatcher.onResourceDoesNotExist(ldsResource);
     verify(mockServer, times(4)).shutdown();
@@ -733,11 +721,11 @@ public class XdsServerWrapperTest {
     assertThat(selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().size())
         .isEqualTo(1);
     realConfig = selectorManager.getSelectorToUpdateSelector().getRoutingConfigs()
-        .get(filterChain3);
-    assertThat(realConfig.virtualHosts().get()).isEqualTo(
+        .get(filterChain3).get();
+    assertThat(realConfig.virtualHosts()).isEqualTo(
         Collections.singletonList(createVirtualHost("virtual-host-1")));
-    assertThat(realConfig.httpFilterConfigs()).isEqualTo(
-        filterChain3.getHttpConnectionManager().httpFilterConfigs());
+    assertThat(realConfig.interceptors()).isEqualTo(ImmutableMap.of());
+
     xdsServerWrapper.shutdown();
     verify(mockServer, times(5)).shutdown();
     assertThat(sslSupplier3.isShutdown()).isTrue();
@@ -747,9 +735,9 @@ public class XdsServerWrapperTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void interceptor_notServerInterceptor() throws Exception {
+  public void interceptor_success() throws Exception {
     ArgumentCaptor<ConfigApplyingInterceptor> interceptorCaptor =
-            ArgumentCaptor.forClass(ConfigApplyingInterceptor.class);
+        ArgumentCaptor.forClass(ConfigApplyingInterceptor.class);
     final SettableFuture<Server> start = SettableFuture.create();
     Executors.newSingleThreadExecutor().execute(new Runnable() {
       @Override
@@ -764,26 +752,36 @@ public class XdsServerWrapperTest {
     xdsClient.ldsResource.get(5, TimeUnit.SECONDS);
     verify(mockBuilder).intercept(interceptorCaptor.capture());
     ConfigApplyingInterceptor interceptor = interceptorCaptor.getValue();
-    ServerRoutingConfig routingConfig = createRoutingConfig("/FooService/barMethod",
-            "foo.google.com", "filter-type-url");
+    RouteMatch routeMatch =
+        RouteMatch.create(
+            PathMatcher.fromPath("/FooService/barMethod", true),
+            Collections.<HeaderMatcher>emptyList(), null);
+    Route route = Route.forAction(routeMatch, null,
+        ImmutableMap.<String, FilterConfig>of());
+    VirtualHost virtualHost  = VirtualHost.create(
+        "v1", Collections.singletonList("foo.google.com"), Arrays.asList(route),
+        ImmutableMap.<String, FilterConfig>of());
+    final List<Integer> interceptorTrace = new ArrayList<>();
+    ServerInterceptor interceptor0 = new ServerInterceptor() {
+      @Override
+      public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
+          Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+        interceptorTrace.add(0);
+        return next.startCall(call, headers);
+      }
+    };
+    ServerRoutingConfig realConfig = ServerRoutingConfig.create(
+        ImmutableList.of(virtualHost), ImmutableMap.of(route, interceptor0));
     ServerCall<Void, Void> serverCall = mock(ServerCall.class);
-    when(serverCall.getAttributes()).thenReturn(
-            Attributes.newBuilder().set(ATTR_SERVER_ROUTING_CONFIG, routingConfig).build());
     when(serverCall.getMethodDescriptor()).thenReturn(createMethod("FooService/barMethod"));
+    when(serverCall.getAttributes()).thenReturn(
+        Attributes.newBuilder().set(ATTR_SERVER_ROUTING_CONFIG,
+            new AtomicReference<>(realConfig)).build());
     when(serverCall.getAuthority()).thenReturn("foo.google.com");
-
-    Filter filter = mock(Filter.class);
-    when(filter.typeUrls()).thenReturn(new String[]{"filter-type-url"});
-    filterRegistry.register(filter);
     ServerCallHandler<Void, Void> next = mock(ServerCallHandler.class);
     interceptor.interceptCall(serverCall, new Metadata(), next);
-    verify(next, never()).startCall(any(ServerCall.class), any(Metadata.class));
-    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
-    verify(serverCall).close(statusCaptor.capture(), any(Metadata.class));
-    Status status = statusCaptor.getValue();
-    assertThat(status.getCode()).isEqualTo(Status.UNAVAILABLE.getCode());
-    assertThat(status.getDescription()).isEqualTo(
-            "HttpFilterConfig(type URL: filter-type-url) is not supported on server-side.");
+    verify(next).startCall(eq(serverCall), any(Metadata.class));
+    assertThat(interceptorTrace).isEqualTo(Arrays.asList(0));
   }
 
   @Test
@@ -809,7 +807,8 @@ public class XdsServerWrapperTest {
             "foo.google.com", "filter-type-url");
     ServerCall<Void, Void> serverCall = mock(ServerCall.class);
     when(serverCall.getAttributes()).thenReturn(
-            Attributes.newBuilder().set(ATTR_SERVER_ROUTING_CONFIG, routingConfig).build());
+        Attributes.newBuilder().set(ATTR_SERVER_ROUTING_CONFIG,
+            new AtomicReference<>(routingConfig)).build());
     when(serverCall.getAuthority()).thenReturn("not-match.google.com");
 
     Filter filter = mock(Filter.class);
@@ -848,7 +847,8 @@ public class XdsServerWrapperTest {
             "foo.google.com", "filter-type-url");
     ServerCall<Void, Void> serverCall = mock(ServerCall.class);
     when(serverCall.getAttributes()).thenReturn(
-            Attributes.newBuilder().set(ATTR_SERVER_ROUTING_CONFIG, routingConfig).build());
+            Attributes.newBuilder()
+                .set(ATTR_SERVER_ROUTING_CONFIG, new AtomicReference<>(routingConfig)).build());
     when(serverCall.getMethodDescriptor()).thenReturn(createMethod("NotMatchMethod"));
     when(serverCall.getAuthority()).thenReturn("foo.google.com");
 
@@ -884,12 +884,11 @@ public class XdsServerWrapperTest {
     xdsClient.ldsResource.get(5, TimeUnit.SECONDS);
     verify(mockBuilder).intercept(interceptorCaptor.capture());
     ConfigApplyingInterceptor interceptor = interceptorCaptor.getValue();
-    ServerRoutingConfig failingConfig = ServerRoutingConfig.create(
-            ImmutableList.<NamedFilterConfig>of(), new AtomicReference<ImmutableList<VirtualHost>>()
-    );
     ServerCall<Void, Void> serverCall = mock(ServerCall.class);
+
     when(serverCall.getAttributes()).thenReturn(
-            Attributes.newBuilder().set(ATTR_SERVER_ROUTING_CONFIG, failingConfig).build());
+        Attributes.newBuilder().set(ATTR_SERVER_ROUTING_CONFIG,
+            new AtomicReference<>(ServerRoutingConfig.FAILING_ROUTING_CONFIG)).build());
 
     ServerCallHandler<Void, Void> next = mock(ServerCallHandler.class);
     interceptor.interceptCall(serverCall, new Metadata(), next);
@@ -899,14 +898,12 @@ public class XdsServerWrapperTest {
     Status status = statusCaptor.getValue();
     assertThat(status.getCode()).isEqualTo(Status.UNAVAILABLE.getCode());
     assertThat(status.getDescription()).isEqualTo(
-        "Missing xDS routing config VirtualHosts due to RDS config unavailable.");
+        "Missing or broken xDS routing config: RDS config unavailable.");
   }
 
   @Test
   @SuppressWarnings("unchecked")
-  public void interceptors() throws Exception {
-    ArgumentCaptor<ConfigApplyingInterceptor> interceptorCaptor =
-            ArgumentCaptor.forClass(ConfigApplyingInterceptor.class);
+  public void buildInterceptor_inline() throws Exception {
     final SettableFuture<Server> start = SettableFuture.create();
     Executors.newSingleThreadExecutor().execute(new Runnable() {
       @Override
@@ -919,14 +916,12 @@ public class XdsServerWrapperTest {
       }
     });
     xdsClient.ldsResource.get(5, TimeUnit.SECONDS);
-    verify(mockBuilder).intercept(interceptorCaptor.capture());
-    final ConfigApplyingInterceptor interceptor = interceptorCaptor.getValue();
     RouteMatch routeMatch =
-            RouteMatch.create(
-                    PathMatcher.fromPath("/FooService/barMethod", true),
-                    Collections.<HeaderMatcher>emptyList(), null);
+        RouteMatch.create(
+            PathMatcher.fromPath("/FooService/barMethod", true),
+            Collections.<HeaderMatcher>emptyList(), null);
     Filter filter = mock(Filter.class, withSettings()
-            .extraInterfaces(ServerInterceptorBuilder.class));
+        .extraInterfaces(ServerInterceptorBuilder.class));
     when(filter.typeUrls()).thenReturn(new String[]{"filter-type-url"});
     filterRegistry.register(filter);
     FilterConfig f0 = mock(FilterConfig.class);
@@ -936,7 +931,7 @@ public class XdsServerWrapperTest {
     ServerInterceptor interceptor0 = new ServerInterceptor() {
       @Override
       public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
-            Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+          Metadata headers, ServerCallHandler<ReqT, RespT> next) {
         interceptorTrace.add(0);
         return next.startCall(call, headers);
       }
@@ -949,55 +944,130 @@ public class XdsServerWrapperTest {
         return next.startCall(call, headers);
       }
     };
-
+    when(((ServerInterceptorBuilder)filter).buildServerInterceptor(f0, null))
+        .thenReturn(interceptor0);
+    when(((ServerInterceptorBuilder)filter).buildServerInterceptor(f0, f0Override))
+        .thenReturn(interceptor1);
+    Route route = Route.forAction(routeMatch, null,
+        ImmutableMap.<String, FilterConfig>of());
     VirtualHost virtualHost  = VirtualHost.create(
-            "v1", Collections.singletonList("foo.google.com"),
-            Arrays.asList(Route.forAction(routeMatch, null,
-                    ImmutableMap.<String, FilterConfig>of())),
-            ImmutableMap.of("filter-config-name-0", f0Override));
-    ServerRoutingConfig routingConfig = ServerRoutingConfig.create(
-            Arrays.asList(new NamedFilterConfig("filter-config-name-0", f0),
-                    new NamedFilterConfig("filter-config-name-1", f0)),
-        new AtomicReference<>(ImmutableList.<VirtualHost>of(virtualHost))
-    );
+        "v1", Collections.singletonList("foo.google.com"), Arrays.asList(route),
+        ImmutableMap.of("filter-config-name-0", f0Override));
+    HttpConnectionManager hcmVirtual = HttpConnectionManager.forVirtualHosts(
+        0L, Collections.singletonList(virtualHost),
+        Arrays.asList(new NamedFilterConfig("filter-config-name-0", f0),
+            new NamedFilterConfig("filter-config-name-1", f0)));
+    EnvoyServerProtoData.FilterChain filterChain = createFilterChain("filter-chain-0", hcmVirtual);
+    xdsClient.deliverLdsUpdate(Collections.singletonList(filterChain), null);
+    start.get(5000, TimeUnit.MILLISECONDS);
+    verify(mockServer).start();
+    assertThat(selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().size())
+        .isEqualTo(1);
+    ServerInterceptor realInterceptor = selectorManager.getSelectorToUpdateSelector()
+        .getRoutingConfigs().get(filterChain).get().interceptors().get(route);
+    assertThat(realInterceptor).isNotNull();
+
     ServerCall<Void, Void> serverCall = mock(ServerCall.class);
     ServerCallHandler<Void, Void> mockNext = mock(ServerCallHandler.class);
     final ServerCall.Listener<Void> listener = new ServerCall.Listener<Void>() {};
     when(mockNext.startCall(any(ServerCall.class), any(Metadata.class))).thenReturn(listener);
-    when(serverCall.getAttributes()).thenReturn(
-            Attributes.newBuilder().set(ATTR_SERVER_ROUTING_CONFIG, routingConfig).build());
-    when(serverCall.getMethodDescriptor()).thenReturn(createMethod("FooService/barMethod"));
-    when(serverCall.getAuthority()).thenReturn("foo.google.com");
-
-    when(((ServerInterceptorBuilder)filter).buildServerInterceptor(f0, f0Override))
-            .thenReturn(null);
-    when(((ServerInterceptorBuilder)filter).buildServerInterceptor(f0, null))
-            .thenReturn(null);
-    ServerCall.Listener<Void> configApplyingInterceptorListener =
-            interceptor.interceptCall(serverCall, new Metadata(), mockNext);
-    assertThat(configApplyingInterceptorListener).isSameInstanceAs(listener);
+    realInterceptor.interceptCall(serverCall, new Metadata(), mockNext);
+    assertThat(interceptorTrace).isEqualTo(Arrays.asList(1, 0));
     verify(mockNext).startCall(eq(serverCall), any(Metadata.class));
-    assertThat(interceptorTrace).isEqualTo(Arrays.asList());
+  }
 
-    when(((ServerInterceptorBuilder)filter).buildServerInterceptor(f0, f0Override))
-            .thenReturn(null);
+  @Test
+  @SuppressWarnings("unchecked")
+  public void buildInterceptor_rds() throws Exception {
+    final SettableFuture<Server> start = SettableFuture.create();
+    Executors.newSingleThreadExecutor().execute(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          start.set(xdsServerWrapper.start());
+        } catch (Exception ex) {
+          start.setException(ex);
+        }
+      }
+    });
+    xdsClient.ldsResource.get(5, TimeUnit.SECONDS);
+
+    Filter filter = mock(Filter.class, withSettings()
+        .extraInterfaces(ServerInterceptorBuilder.class));
+    when(filter.typeUrls()).thenReturn(new String[]{"filter-type-url"});
+    filterRegistry.register(filter);
+    FilterConfig f0 = mock(FilterConfig.class);
+    FilterConfig f0Override = mock(FilterConfig.class);
+    when(f0.typeUrl()).thenReturn("filter-type-url");
+    final List<Integer> interceptorTrace = new ArrayList<>();
+    ServerInterceptor interceptor0 = new ServerInterceptor() {
+      @Override
+      public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
+          Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+        interceptorTrace.add(0);
+        return next.startCall(call, headers);
+      }
+    };
+    ServerInterceptor interceptor1 = new ServerInterceptor() {
+      @Override
+      public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
+          Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+        interceptorTrace.add(1);
+        return next.startCall(call, headers);
+      }
+    };
     when(((ServerInterceptorBuilder)filter).buildServerInterceptor(f0, null))
-            .thenReturn(interceptor0);
-    configApplyingInterceptorListener = interceptor.interceptCall(
-            serverCall, new Metadata(), mockNext);
-    assertThat(configApplyingInterceptorListener).isSameInstanceAs(listener);
+        .thenReturn(interceptor0);
+    when(((ServerInterceptorBuilder)filter).buildServerInterceptor(f0, f0Override))
+        .thenReturn(interceptor1);
+    RouteMatch routeMatch =
+        RouteMatch.create(
+            PathMatcher.fromPath("/FooService/barMethod", true),
+            Collections.<HeaderMatcher>emptyList(), null);
+
+    HttpConnectionManager rdsHcm = HttpConnectionManager.forRdsName(0L, "r0",
+        Arrays.asList(new NamedFilterConfig("filter-config-name-0", f0),
+            new NamedFilterConfig("filter-config-name-1", f0)));
+    EnvoyServerProtoData.FilterChain filterChain = createFilterChain("filter-chain-0", rdsHcm);
+    xdsClient.deliverLdsUpdate(Collections.singletonList(filterChain), null);
+    Route route = Route.forAction(routeMatch, null,
+        ImmutableMap.<String, FilterConfig>of());
+    VirtualHost virtualHost  = VirtualHost.create(
+        "v1", Collections.singletonList("foo.google.com"), Arrays.asList(route),
+        ImmutableMap.of("filter-config-name-0", f0Override));
+    xdsClient.rdsCount.await(5, TimeUnit.SECONDS);
+    xdsClient.deliverRdsUpdate("r0", Collections.singletonList(virtualHost));
+    start.get(5000, TimeUnit.MILLISECONDS);
+    verify(mockServer).start();
+    assertThat(selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().size())
+        .isEqualTo(1);
+    ServerInterceptor realInterceptor = selectorManager.getSelectorToUpdateSelector()
+        .getRoutingConfigs().get(filterChain).get().interceptors().get(route);
+    assertThat(realInterceptor).isNotNull();
+
+    ServerCall<Void, Void> serverCall = mock(ServerCall.class);
+    ServerCallHandler<Void, Void> mockNext = mock(ServerCallHandler.class);
+    final ServerCall.Listener<Void> listener = new ServerCall.Listener<Void>() {};
+    when(mockNext.startCall(any(ServerCall.class), any(Metadata.class))).thenReturn(listener);
+    realInterceptor.interceptCall(serverCall, new Metadata(), mockNext);
+    assertThat(interceptorTrace).isEqualTo(Arrays.asList(1, 0));
+    verify(mockNext).startCall(eq(serverCall), any(Metadata.class));
+
+    virtualHost  = VirtualHost.create(
+        "v1", Collections.singletonList("foo.google.com"), Arrays.asList(route),
+         ImmutableMap.<String, FilterConfig>of());
+    xdsClient.deliverRdsUpdate("r0", Collections.singletonList(virtualHost));
+    realInterceptor = selectorManager.getSelectorToUpdateSelector().getRoutingConfigs()
+        .get(filterChain).get().interceptors().get(route);
+    assertThat(realInterceptor).isNotNull();
+    interceptorTrace.clear();
+    realInterceptor.interceptCall(serverCall, new Metadata(), mockNext);
+    assertThat(interceptorTrace).isEqualTo(Arrays.asList(0, 0));
     verify(mockNext, times(2)).startCall(eq(serverCall), any(Metadata.class));
-    assertThat(interceptorTrace).isEqualTo(Arrays.asList(0));
 
-    when(((ServerInterceptorBuilder)filter).buildServerInterceptor(f0, f0Override))
-            .thenReturn(interceptor0);
-    when(((ServerInterceptorBuilder)filter).buildServerInterceptor(f0, null))
-            .thenReturn(interceptor1);
-    configApplyingInterceptorListener = interceptor.interceptCall(
-            serverCall, new Metadata(), mockNext);
-    assertThat(configApplyingInterceptorListener).isSameInstanceAs(listener);
-    verify(mockNext, times(3)).startCall(eq(serverCall), any(Metadata.class));
-    assertThat(interceptorTrace).isEqualTo(Arrays.asList(0, 0, 1));
+    xdsClient.rdsWatchers.get("r0").onResourceDoesNotExist("r0");
+    assertThat(selectorManager.getSelectorToUpdateSelector().getRoutingConfigs()
+        .get(filterChain).get()).isEqualTo(noopConfig);
   }
 
   private static FilterChain createFilterChain(String name, HttpConnectionManager hcm) {
@@ -1012,8 +1082,12 @@ public class XdsServerWrapperTest {
   }
 
   private static HttpConnectionManager createRds(String name) {
+    return createRds(name, null);
+  }
+
+  private static HttpConnectionManager createRds(String name, FilterConfig filterConfig) {
     return HttpConnectionManager.forRdsName(0L, name,
-            Arrays.asList(new NamedFilterConfig("named-config-" + name, null)));
+        Arrays.asList(new NamedFilterConfig("named-config-" + name, filterConfig)));
   }
 
   private static EnvoyServerProtoData.FilterChainMatch createMatch() {
@@ -1041,9 +1115,8 @@ public class XdsServerWrapperTest {
             Collections.<String, FilterConfig>emptyMap());
     FilterConfig f0 = mock(FilterConfig.class);
     when(f0.typeUrl()).thenReturn(filterType);
-    return ServerRoutingConfig.create(
-        Arrays.asList(new NamedFilterConfig("filter-config-name-0", f0)),
-        new AtomicReference<>(ImmutableList.<VirtualHost>of(virtualHost))
+    return ServerRoutingConfig.create(ImmutableList.<VirtualHost>of(virtualHost),
+        ImmutableMap.<Route, ServerInterceptor>of()
     );
   }
 


### PR DESCRIPTION
Pre-build serverInterceptors to allow individual RPCs to reuse interceptors for one set of httpConfigs.

backport of https://github.com/grpc/grpc-java/pull/8524