### PR TITLE
Fix flake in security policy tests.

### DIFF
--- a/binder/build.gradle
+++ b/binder/build.gradle
@@ -13,8 +13,6 @@ android {
                 srcDirs += "${projectDir}/../core/src/test/java/"
                 setIncludes(["io/grpc/internal/FakeClock.java",
                              "io/grpc/binder/**"])
-                exclude 'io/grpc/binder/ServerSecurityPolicyTest.java'
-                exclude 'io/grpc/binder/SecurityPoliciesTest.java'
             }
         }
         androidTest {

--- a/binder/src/test/java/io/grpc/binder/SecurityPoliciesTest.java
+++ b/binder/src/test/java/io/grpc/binder/SecurityPoliciesTest.java
@@ -18,26 +18,20 @@ package io.grpc.binder;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import android.os.Process;
 import io.grpc.Status;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.shadows.ShadowProcess;
 
 @RunWith(RobolectricTestRunner.class)
 public final class SecurityPoliciesTest {
-  private static final int MY_UID = 1234;
+  private static final int MY_UID = Process.myUid();
   private static final int OTHER_UID = MY_UID + 1;
 
   private static final String PERMISSION_DENIED_REASONS = "some reasons";
 
   private SecurityPolicy policy;
-
-  @Before
-  public void setUp() {
-    ShadowProcess.setUid(MY_UID);
-  }
 
   @Test
   public void testInternalOnly() throws Exception {

--- a/binder/src/test/java/io/grpc/binder/ServerSecurityPolicyTest.java
+++ b/binder/src/test/java/io/grpc/binder/ServerSecurityPolicyTest.java
@@ -18,13 +18,12 @@ package io.grpc.binder;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import android.os.Process;
 import com.google.common.base.Function;
 import io.grpc.Status;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.shadows.ShadowProcess;
 
 @RunWith(RobolectricTestRunner.class)
 public final class ServerSecurityPolicyTest {
@@ -33,15 +32,10 @@ public final class ServerSecurityPolicyTest {
   private static final String SERVICE2 = "service_two";
   private static final String SERVICE3 = "service_three";
 
-  private static final int MY_UID = 1234;
+  private static final int MY_UID = Process.myUid();
   private static final int OTHER_UID = MY_UID + 1;
 
   ServerSecurityPolicy policy;
-
-  @Before
-  public void setUp() {
-    ShadowProcess.setUid(MY_UID);
-  }
 
   @Test
   public void testDefaultInternalOnly() {


### PR DESCRIPTION
Using ShadowProcess to set the processes uID doesn't help since SecurityPolicies class fetches the ID in a static initializer, and it may have already been loaded.

Instead, just rely on whatever the uID is already, and ensure the other UIDs we test with are offset from that first value.