### PR TITLE
RELEASING.md: Bump protobuf version to match build.gradle

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -117,7 +117,8 @@ Tagging the Release
    $ git checkout v$MAJOR.$MINOR.x
    $ git pull upstream v$MAJOR.$MINOR.x
    $ git checkout -b release
-   # Bump documented versions. Don't forget protobuf version
+   # Bump documented gRPC versions.
+   # Also update protoc version to match protocVersion in build.gradle.
    $ ${EDITOR:-nano -w} README.md
    $ ${EDITOR:-nano -w} documentation/android-channel-builder.md
    $ ${EDITOR:-nano -w} cronet/README.md


### PR DESCRIPTION
For 1.40.0 the protobuf version was bumped to the latest version, which
we hadn't tested at all. We want to bump to the version used in the
release.