### PR TITLE
core: reorder pick update and ChannelState listener event

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1473,7 +1473,6 @@ final class ManagedChannelImpl extends ManagedChannel implements
           if (LbHelperImpl.this != lbHelper) {
             return;
           }
-          updateSubchannelPicker(newPicker);
           // It's not appropriate to report SHUTDOWN state from lb.
           // Ignore the case of newState == SHUTDOWN for now.
           if (newState != SHUTDOWN) {
@@ -1481,6 +1480,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
                 ChannelLogLevel.INFO, "Entering {0} state with picker: {1}", newState, newPicker);
             channelStateManager.gotoState(newState);
           }
+          updateSubchannelPicker(newPicker);
         }
       }
 


### PR DESCRIPTION
Let the callback of ChannelState change fire before the picker update, so that the user can notice the channel state change via ChannelState callback before it is reflected by the pending RPC.