### PR TITLE
xds: Log about fallback credentials, not supplier

### DIFF
--- a/xds/src/main/java/io/grpc/xds/internal/sds/SdsProtocolNegotiators.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/SdsProtocolNegotiators.java
@@ -288,8 +288,7 @@ public final class SdsProtocolNegotiators {
             ctx.fireExceptionCaught(new CertStoreException("No certificate source found!"));
             return;
           }
-          logger.log(Level.FINE, "Using fallback sslContextProviderSupplier for connection "
-              + "from {0} to {1}",
+          logger.log(Level.FINE, "Using fallback credentials for connection from {0} to {1}",
               new Object[]{ctx.channel().remoteAddress(), ctx.channel().localAddress()});
           ctx.pipeline()
               .replace(


### PR DESCRIPTION
The sslContextProviderSupplier is used by the xds creds themselves when
the control plane has security configured. But the fallback credentials
don't use such a supplier and may not even be using TLS.

Language tweak following #8554.

CC @sanjaypujare 