### PR TITLE
Make binder instrumentation tests run on kokoro.

### DIFF
--- a/android-interop-testing/src/main/AndroidManifest.xml
+++ b/android-interop-testing/src/main/AndroidManifest.xml
@@ -19,6 +19,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <!-- To support tests under binder, which need Android services -->
+        <service android:name="io.grpc.binder.HostServices$HostService1"/>
+        <service android:name="io.grpc.binder.HostServices$HostService2"/>
     </application>
 
 </manifest>

--- a/buildscripts/kokoro/android-interop.sh
+++ b/buildscripts/kokoro/android-interop.sh
@@ -38,3 +38,18 @@ gcloud firebase test android run \
   --device model=Nexus6P,version=23,locale=en,orientation=portrait \
   --device model=Nexus6,version=22,locale=en,orientation=portrait \
   --device model=Nexus6,version=21,locale=en,orientation=portrait
+
+# Build and run binderchannel instrumentation tests on Firebase Test Lab
+cd binder
+../gradlew assembleDebugAndroidTest
+gcloud firebase test android run \
+  --type instrumentation \
+  --app ../android-interop-testing/build/outputs/apk/debug/grpc-android-interop-testing-debug.apk \
+  --test build/outputs/apk/androidTest/debug/grpc-binder-debug-androidTest.apk \
+  --device model=Nexus6P,version=27,locale=en,orientation=portrait \
+  --device model=Nexus6P,version=26,locale=en,orientation=portrait \
+  --device model=Nexus6P,version=25,locale=en,orientation=portrait \
+  --device model=Nexus6P,version=24,locale=en,orientation=portrait \
+  --device model=Nexus6P,version=23,locale=en,orientation=portrait \
+  --device model=Nexus6,version=22,locale=en,orientation=portrait \
+  --device model=Nexus6,version=21,locale=en,orientation=portrait

--- a/buildscripts/kokoro/android-interop.sh
+++ b/buildscripts/kokoro/android-interop.sh
@@ -40,7 +40,7 @@ gcloud firebase test android run \
   --device model=Nexus6,version=21,locale=en,orientation=portrait
 
 # Build and run binderchannel instrumentation tests on Firebase Test Lab
-cd binder
+cd ../binder
 ../gradlew assembleDebugAndroidTest
 gcloud firebase test android run \
   --type instrumentation \


### PR DESCRIPTION
The tests run as part of the existing android-interop-testing job, using the same "apk under test".
    
The manifest under android-interop-testing/src/main is modified to declare Android Services needed for the binder tests.
