### PR TITLE
.github/workflows: Swap from adoptopenjdk to temurin

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.jre }}
-        distribution: 'adopt'
+        distribution: 'temurin'
 
     - name: Gradle cache
       uses: actions/cache@v2


### PR DESCRIPTION
Adopt OpenJDK is longer seeing new releases, and instead has moved under
the Eclipse umbrella with Temurin releases.
https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/
https://github.com/actions/setup-java#supported-distributions

The adopt binaries still work, but won't see new versions.