### PR TITLE
[Backport v1.40.x] add Docker tagging logic to the xds_url_map job

### DIFF
--- a/buildscripts/kokoro/xds_url_map.sh
+++ b/buildscripts/kokoro/xds_url_map.sh
@@ -7,6 +7,7 @@ readonly GITHUB_REPOSITORY_NAME="grpc-java"
 readonly GKE_CLUSTER_NAME="interop-test-psm-basic"
 readonly GKE_CLUSTER_ZONE="us-central1-c"
 ## xDS test client Docker images
+readonly SERVER_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/java-server"
 readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/java-client"
 readonly FORCE_IMAGE_BUILD="${FORCE_IMAGE_BUILD:-0}"
 readonly BUILD_APP_PATH="interop-testing/build/install/grpc-interop-testing"
@@ -19,7 +20,7 @@ readonly BUILD_APP_PATH="interop-testing/build/install/grpc-interop-testing"
 # Arguments:
 #   None
 # Outputs:
-#   Writes the output of xds-test-client --help to stderr
+#   Writes the output of xds-test-client and xds-test-server --help to stderr
 #######################################
 build_java_test_app() {
   echo "Building Java test app"
@@ -29,12 +30,14 @@ build_java_test_app() {
 
   # Test-run binaries
   run_ignore_exit_code "${SRC_DIR}/${BUILD_APP_PATH}/bin/xds-test-client" --help
+  run_ignore_exit_code "${SRC_DIR}/${BUILD_APP_PATH}/bin/xds-test-server" --help
 }
 
 #######################################
 # Builds test app Docker images and pushes them to GCR
 # Globals:
 #   BUILD_APP_PATH
+#   SERVER_IMAGE_NAME: Test server Docker image name
 #   CLIENT_IMAGE_NAME: Test client Docker image name
 #   GIT_COMMIT: SHA-1 of git commit being built
 # Arguments:
@@ -51,10 +54,16 @@ build_test_app_docker_images() {
   cp -v "${docker_dir}/"*.Dockerfile "${build_dir}"
   cp -v "${docker_dir}/"*.properties "${build_dir}"
   cp -rv "${SRC_DIR}/${BUILD_APP_PATH}" "${build_dir}"
+  # Pick a branch name for the built image
+  if [[ -n $KOKORO_JOB_NAME ]]; then
+    branch_name="$(echo "$KOKORO_JOB_NAME" | sed -E 's|^grpc/java/([^/]+)/.*|\1|')"
+  else
+    branch_name='experimental'
+  fi
   # Run Google Cloud Build
   gcloud builds submit "${build_dir}" \
     --config "${docker_dir}/cloudbuild.yaml" \
-    --substitutions "_CLIENT_IMAGE_NAME=${CLIENT_IMAGE_NAME},COMMIT_SHA=${GIT_COMMIT}"
+    --substitutions "_SERVER_IMAGE_NAME=${SERVER_IMAGE_NAME},_CLIENT_IMAGE_NAME=${CLIENT_IMAGE_NAME},COMMIT_SHA=${GIT_COMMIT},BRANCH_NAME=${branch_name}"
   # TODO(sergiitk): extra "cosmetic" tags for versioned branches, e.g. v1.34.x
   # TODO(sergiitk): do this when adding support for custom configs per version
 }
@@ -62,6 +71,7 @@ build_test_app_docker_images() {
 #######################################
 # Builds test app and its docker images unless they already exist
 # Globals:
+#   SERVER_IMAGE_NAME: Test server Docker image name
 #   CLIENT_IMAGE_NAME: Test client Docker image name
 #   GIT_COMMIT: SHA-1 of git commit being built
 #   FORCE_IMAGE_BUILD
@@ -72,12 +82,16 @@ build_test_app_docker_images() {
 #######################################
 build_docker_images_if_needed() {
   # Check if images already exist
+  server_tags="$(gcloud_gcr_list_image_tags "${SERVER_IMAGE_NAME}" "${GIT_COMMIT}")"
+  printf "Server image: %s:%s\n" "${SERVER_IMAGE_NAME}" "${GIT_COMMIT}"
+  echo "${server_tags:-Server image not found}"
+
   client_tags="$(gcloud_gcr_list_image_tags "${CLIENT_IMAGE_NAME}" "${GIT_COMMIT}")"
   printf "Client image: %s:%s\n" "${CLIENT_IMAGE_NAME}" "${GIT_COMMIT}"
   echo "${client_tags:-Client image not found}"
 
   # Build if any of the images are missing, or FORCE_IMAGE_BUILD=1
-  if [[ "${FORCE_IMAGE_BUILD}" == "1" || -z "${client_tags}" ]]; then
+  if [[ "${FORCE_IMAGE_BUILD}" == "1" || -z "${server_tags}" || -z "${client_tags}" ]]; then
     build_java_test_app
     build_test_app_docker_images
   else

--- a/buildscripts/xds-k8s/cloudbuild.yaml
+++ b/buildscripts/xds-k8s/cloudbuild.yaml
@@ -3,6 +3,7 @@ steps:
   args:
     - 'build'
     - '--tag=${_SERVER_IMAGE_NAME}:${COMMIT_SHA}'
+    - '--tag=${_SERVER_IMAGE_NAME}:${BRANCH_NAME}'
     - '--file=test-server.Dockerfile'
     - '.'
 
@@ -10,6 +11,7 @@ steps:
   args:
     - 'build'
     - '--tag=${_CLIENT_IMAGE_NAME}:${COMMIT_SHA}'
+    - '--tag=${_CLIENT_IMAGE_NAME}:${BRANCH_NAME}'
     - '--file=test-client.Dockerfile'
     - '.'
 
@@ -19,4 +21,6 @@ substitutions:
 
 images:
   - '${_SERVER_IMAGE_NAME}:${COMMIT_SHA}'
+  - '${_SERVER_IMAGE_NAME}:${BRANCH_NAME}'
   - '${_CLIENT_IMAGE_NAME}:${COMMIT_SHA}'
+  - '${_CLIENT_IMAGE_NAME}:${BRANCH_NAME}'


### PR DESCRIPTION
This PR backports https://github.com/grpc/grpc-java/pull/8580 and adds support for tagging Docker image with branch name in Cloud Build. Before this PR, branch v1.40.x is manually tagged.

Test run: https://fusion2.corp.google.com/invocations/cba37e1d-ee5e-4da4-8b5a-42f4a87a2779/targets (ok)