### PR TITLE
android: bump min Android SDK version to 19

### DIFF
--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -33,7 +33,7 @@ android {
 
     defaultConfig {
         applicationId "io.grpc.android.integrationtest"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,7 +15,7 @@ android {
     compileSdkVersion 29
     defaultConfig {
         consumerProguardFiles "proguard-rules.txt"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"

--- a/binder/build.gradle
+++ b/binder/build.gradle
@@ -29,7 +29,7 @@ android {
         targetCompatibility 1.8
     }
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -15,7 +15,7 @@ repositories {
 android {
     compileSdkVersion 29
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId "io.grpc.helloworldexample"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId "io.grpc.routeguideexample"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
As Google Play Service [discontinued updates for Jelly Bean (API levels 16, 17 & 18)](https://android-developers.googleblog.com/2021/07/google-play-services-discontinuing-jelly-bean.html).