### PR TITLE
api: Add ManagedChannel method overloads to ClientInterceptors

### DIFF
--- a/api/src/test/java/io/grpc/ClientInterceptorsTest.java
+++ b/api/src/test/java/io/grpc/ClientInterceptorsTest.java
@@ -433,6 +433,7 @@ public class ClientInterceptorsTest {
 
           @Override
           public String authority() {
+            managedChannelMethods.add("authority");
             return null;
           }
 
@@ -499,10 +500,12 @@ public class ClientInterceptorsTest {
     ManagedChannel intercepted = ClientInterceptors.intercept(channel, interceptor);
     assertSame(call, intercepted.newCall(method, CallOptions.DEFAULT));
 
+    intercepted.authority();
     intercepted.awaitTermination(123, SECONDS);
     intercepted.enterIdle();
     intercepted.getState(true);
     intercepted.isShutdown();
+    intercepted.isTerminated();
     intercepted.notifyWhenStateChanged(
         ConnectivityState.CONNECTING,
         new Runnable() {
@@ -516,10 +519,12 @@ public class ClientInterceptorsTest {
     assertThat(order).containsExactly("interceptor", "channel").inOrder();
     assertThat(managedChannelMethods)
         .containsExactly(
+            "authority",
             "awaitTermination",
             "enterIdle",
             "getState",
             "isShutdown",
+            "isTerminated",
             "notifyWhenStateChanged",
             "resetConnectBackoff",
             "shutdown",

--- a/api/src/test/java/io/grpc/ClientInterceptorsTest.java
+++ b/api/src/test/java/io/grpc/ClientInterceptorsTest.java
@@ -503,7 +503,12 @@ public class ClientInterceptorsTest {
     intercepted.enterIdle();
     intercepted.getState(true);
     intercepted.isShutdown();
-    intercepted.notifyWhenStateChanged(ConnectivityState.CONNECTING, () -> {});
+    intercepted.notifyWhenStateChanged(
+        ConnectivityState.CONNECTING,
+        new Runnable() {
+          @Override
+          public void run() {}
+        });
     intercepted.resetConnectBackoff();
     intercepted.shutdown();
     intercepted.shutdownNow();


### PR DESCRIPTION
The current set of ClientInterceptors methods accept a ManagedChannel,
but return a regular Channel. This effetively erases the ability
to manage the channel after these methods are used to add interceptors.

This adds 1:1 overloads of ClientInterceptors methods that both accept
and return a ManagedChannel.

This did not causes breakages interally in google3, so assumed to be
safe externally as well.