### PR TITLE
Fix code & javadoc warnings in the binder package.

### DIFF
--- a/binder/src/main/java/io/grpc/binder/SecurityPolicy.java
+++ b/binder/src/main/java/io/grpc/binder/SecurityPolicy.java
@@ -35,7 +35,7 @@ import javax.annotation.CheckReturnValue;
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
 public abstract class SecurityPolicy {
 
-  public SecurityPolicy() {}
+  protected SecurityPolicy() {}
 
   /**
    * Decides whether the given Android UID is authorized. (Validity is implementation dependent).

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -87,7 +87,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * need to call into this class to send a transaction (possibly waiting for the transport to become
  * ready).
  *
- * <p>The split between Outbound & Inbound helps reduce this risk, but not entirely remove it.
+ * <p>The split between Outbound &amp; Inbound helps reduce this risk, but not entirely remove it.
  *
  * <p>For this reason, while most state within this class is guarded by this instance, methods
  * exposed to individual stream instances need to use atomic or volatile types, since those calls

--- a/binder/src/main/java/io/grpc/binder/internal/MetadataHelper.java
+++ b/binder/src/main/java/io/grpc/binder/internal/MetadataHelper.java
@@ -31,7 +31,7 @@ import java.io.InputStream;
 import javax.annotation.Nullable;
 
 /**
- * Helper class for reading & writing metadata to parcels.
+ * Helper class for reading &amp; writing metadata to parcels.
  *
  * <p>Metadata is written to a parcel as a single int for the number of name/value pairs, followed
  * by the following pattern for each pair.

--- a/binder/src/main/java/io/grpc/binder/internal/Outbound.java
+++ b/binder/src/main/java/io/grpc/binder/internal/Outbound.java
@@ -219,6 +219,7 @@ abstract class Outbound {
   }
 
   @GuardedBy("this")
+  @SuppressWarnings("fallthrough")
   protected final void sendInternal() throws StatusException {
     Parcel parcel = Parcel.obtain();
     int flags = 0;


### PR DESCRIPTION
Note: I didn't fix all javadoc warnings mentioned in #8585, since
they're not generated with a modern java version, and the fix feels
worse than the warning.

Specifically, {@link X.Y} generates a warning if only X is imported,
and {@link Z} generates a warning if Z is declared later in the class.

In particular, attempting to fix the first issue by importing X.Y results
in a code-readability warning suggesting I shouldn't do that.