### PR TITLE
xds: migrate Bootstrapper data classes to use AutoValue

### DIFF
--- a/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
@@ -303,7 +303,7 @@ abstract class AbstractXdsClient extends XdsClient {
   // Must be synchronized.
   private void startRpcStream() {
     checkState(adsStream == null, "Previous adsStream has not been cleared yet");
-    if (bootstrapInfo.getServers().get(0).isUseProtocolV3()) {
+    if (bootstrapInfo.servers().get(0).useProtocolV3()) {
       adsStream = new AdsStreamV3();
     } else {
       adsStream = new AdsStreamV2();
@@ -619,7 +619,7 @@ abstract class AbstractXdsClient extends XdsClient {
       io.envoyproxy.envoy.api.v2.DiscoveryRequest.Builder builder =
           io.envoyproxy.envoy.api.v2.DiscoveryRequest.newBuilder()
               .setVersionInfo(versionInfo)
-              .setNode(bootstrapInfo.getNode().toEnvoyProtoNodeV2())
+              .setNode(bootstrapInfo.node().toEnvoyProtoNodeV2())
               .addAllResourceNames(resources)
               .setTypeUrl(type.typeUrlV2())
               .setResponseNonce(nonce);
@@ -696,7 +696,7 @@ abstract class AbstractXdsClient extends XdsClient {
       DiscoveryRequest.Builder builder =
           DiscoveryRequest.newBuilder()
               .setVersionInfo(versionInfo)
-              .setNode(bootstrapInfo.getNode().toEnvoyProtoNode())
+              .setNode(bootstrapInfo.node().toEnvoyProtoNode())
               .addAllResourceNames(resources)
               .setTypeUrl(type.typeUrl())
               .setResponseNonce(nonce);

--- a/xds/src/main/java/io/grpc/xds/BootstrapperImpl.java
+++ b/xds/src/main/java/io/grpc/xds/BootstrapperImpl.java
@@ -154,7 +154,7 @@ public class BootstrapperImpl extends Bootstrapper {
         logger.log(XdsLogLevel.INFO, "Server features: {0}", serverFeatures);
         useProtocolV3 = serverFeatures.contains(XDS_V3_SERVER_FEATURE);
       }
-      servers.add(new ServerInfo(serverUri, channelCredentials, useProtocolV3));
+      servers.add(ServerInfo.create(serverUri, channelCredentials, useProtocolV3));
     }
 
     Node.Builder nodeBuilder = Node.newBuilder();
@@ -211,13 +211,18 @@ public class BootstrapperImpl extends Bootstrapper {
             checkForNull(JsonUtil.getString(valueMap, "plugin_name"), "plugin_name");
         Map<String, ?> config = checkForNull(JsonUtil.getObject(valueMap, "config"), "config");
         CertificateProviderInfo certificateProviderInfo =
-            new CertificateProviderInfo(pluginName, config);
+            CertificateProviderInfo.create(pluginName, config);
         certProviders.put(name, certificateProviderInfo);
       }
     }
     String grpcServerResourceId =
         JsonUtil.getString(rawData, "server_listener_resource_name_template");
-    return new BootstrapInfo(servers, nodeBuilder.build(), certProviders, grpcServerResourceId);
+    return BootstrapInfo.builder()
+        .servers(servers)
+        .node(nodeBuilder.build())
+        .certProviders(certProviders)
+        .serverListenerResourceNameTemplate(grpcServerResourceId)
+        .build();
   }
 
   @VisibleForTesting

--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -186,7 +186,7 @@ final class ClientXdsClient extends AbstractXdsClient {
     this.timeProvider = timeProvider;
     this.tlsContextManager = checkNotNull(tlsContextManager, "tlsContextManager");
     lrsClient = new LoadReportClient(loadStatsManager, channel, context,
-        bootstrapInfo.getServers().get(0).isUseProtocolV3(), bootstrapInfo.getNode(),
+        bootstrapInfo.servers().get(0).useProtocolV3(), bootstrapInfo.node(),
         getSyncContext(), timeService, backoffPolicyProvider, stopwatchSupplier);
   }
 
@@ -263,8 +263,8 @@ final class ClientXdsClient extends AbstractXdsClient {
       Listener proto, Set<String> rdsResources, boolean parseHttpFilter)
       throws ResourceInvalidException {
     Set<String> certProviderInstances = null;
-    if (getBootstrapInfo() != null && getBootstrapInfo().getCertProviders() != null) {
-      certProviderInstances = getBootstrapInfo().getCertProviders().keySet();
+    if (getBootstrapInfo() != null && getBootstrapInfo().certProviders() != null) {
+      certProviderInstances = getBootstrapInfo().certProviders().keySet();
     }
     return LdsUpdate.forTcpListener(parseServerSideListener(
         proto, rdsResources, tlsContextManager, filterRegistry, certProviderInstances,
@@ -1404,8 +1404,8 @@ final class ClientXdsClient extends AbstractXdsClient {
       CdsUpdate cdsUpdate;
       try {
         Set<String> certProviderInstances = null;
-        if (getBootstrapInfo() != null && getBootstrapInfo().getCertProviders() != null) {
-          certProviderInstances = getBootstrapInfo().getCertProviders().keySet();
+        if (getBootstrapInfo() != null && getBootstrapInfo().certProviders() != null) {
+          certProviderInstances = getBootstrapInfo().certProviders().keySet();
         }
         cdsUpdate = parseCluster(cluster, retainedEdsResources, certProviderInstances);
       } catch (ResourceInvalidException e) {

--- a/xds/src/main/java/io/grpc/xds/CsdsService.java
+++ b/xds/src/main/java/io/grpc/xds/CsdsService.java
@@ -162,7 +162,7 @@ public final class CsdsService extends
         xdsClient.getSubscribedResourcesMetadata(ResourceType.EDS));
 
     return ClientConfig.newBuilder()
-        .setNode(xdsClient.getBootstrapInfo().getNode().toEnvoyProtoNode())
+        .setNode(xdsClient.getBootstrapInfo().node().toEnvoyProtoNode())
         .addXdsConfig(PerXdsConfig.newBuilder().setListenerConfig(ldsConfig))
         .addXdsConfig(PerXdsConfig.newBuilder().setRouteConfig(rdsConfig))
         .addXdsConfig(PerXdsConfig.newBuilder().setClusterConfig(cdsConfig))

--- a/xds/src/main/java/io/grpc/xds/SharedXdsClientPoolProvider.java
+++ b/xds/src/main/java/io/grpc/xds/SharedXdsClientPoolProvider.java
@@ -90,7 +90,7 @@ final class SharedXdsClientPoolProvider implements XdsClientPoolFactory {
           } else {
             bootstrapInfo = bootstrapper.bootstrap();
           }
-          if (bootstrapInfo.getServers().isEmpty()) {
+          if (bootstrapInfo.servers().isEmpty()) {
             throw new XdsInitializationException("No xDS server provided");
           }
           ref = xdsClientPool = new RefCountedXdsClientObjectPool(bootstrapInfo);
@@ -128,9 +128,9 @@ final class SharedXdsClientPoolProvider implements XdsClientPoolFactory {
     public XdsClient getObject() {
       synchronized (lock) {
         if (refCount == 0) {
-          ServerInfo serverInfo = bootstrapInfo.getServers().get(0);  // use first server
-          String target = serverInfo.getTarget();
-          ChannelCredentials channelCredentials = serverInfo.getChannelCredentials();
+          ServerInfo serverInfo = bootstrapInfo.servers().get(0);  // use first server
+          String target = serverInfo.target();
+          ChannelCredentials channelCredentials = serverInfo.channelCredentials();
           channel = Grpc.newChannelBuilder(target, channelCredentials)
               .keepAliveTime(5, TimeUnit.MINUTES)
               .build();

--- a/xds/src/main/java/io/grpc/xds/XdsServerWrapper.java
+++ b/xds/src/main/java/io/grpc/xds/XdsServerWrapper.java
@@ -181,8 +181,8 @@ final class XdsServerWrapper extends Server {
       return;
     }
     xdsClient = xdsClientPool.getObject();
-    boolean useProtocolV3 = xdsClient.getBootstrapInfo().getServers().get(0).isUseProtocolV3();
-    String listenerTemplate = xdsClient.getBootstrapInfo().getServerListenerResourceNameTemplate();
+    boolean useProtocolV3 = xdsClient.getBootstrapInfo().servers().get(0).useProtocolV3();
+    String listenerTemplate = xdsClient.getBootstrapInfo().serverListenerResourceNameTemplate();
     if (!useProtocolV3 || listenerTemplate == null) {
       StatusException statusException =
           Status.UNAVAILABLE.withDescription(

--- a/xds/src/main/java/io/grpc/xds/internal/certprovider/CertProviderSslContextProvider.java
+++ b/xds/src/main/java/io/grpc/xds/internal/certprovider/CertProviderSslContextProvider.java
@@ -61,8 +61,8 @@ abstract class CertProviderSslContextProvider extends DynamicSslContextProvider 
       certHandle = certProviderInstanceConfig == null ? null
           : certificateProviderStore.createOrGetProvider(
               certInstance.getCertificateName(),
-              certProviderInstanceConfig.getPluginName(),
-              certProviderInstanceConfig.getConfig(),
+              certProviderInstanceConfig.pluginName(),
+              certProviderInstanceConfig.config(),
               this,
               true);
     } else {
@@ -76,8 +76,8 @@ abstract class CertProviderSslContextProvider extends DynamicSslContextProvider 
       rootCertHandle = certProviderInstanceConfig == null ? null
           : certificateProviderStore.createOrGetProvider(
               rootCertInstance.getCertificateName(),
-              certProviderInstanceConfig.getPluginName(),
-              certProviderInstanceConfig.getConfig(),
+              certProviderInstanceConfig.pluginName(),
+              certProviderInstanceConfig.config(),
               this,
               true);
     } else {

--- a/xds/src/main/java/io/grpc/xds/internal/sds/ClientSslContextProviderFactory.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/ClientSslContextProviderFactory.java
@@ -52,8 +52,8 @@ final class ClientSslContextProviderFactory
         upstreamTlsContext.getCommonTlsContext())) {
       return certProviderClientSslContextProviderFactory.getProvider(
           upstreamTlsContext,
-          bootstrapInfo.getNode().toEnvoyProtoNode(),
-          bootstrapInfo.getCertProviders());
+          bootstrapInfo.node().toEnvoyProtoNode(),
+          bootstrapInfo.certProviders());
     }
     throw new UnsupportedOperationException("Unsupported configurations in UpstreamTlsContext!");
   }

--- a/xds/src/main/java/io/grpc/xds/internal/sds/ServerSslContextProviderFactory.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/ServerSslContextProviderFactory.java
@@ -53,8 +53,8 @@ final class ServerSslContextProviderFactory
         downstreamTlsContext.getCommonTlsContext())) {
       return certProviderServerSslContextProviderFactory.getProvider(
           downstreamTlsContext,
-          bootstrapInfo.getNode().toEnvoyProtoNode(),
-          bootstrapInfo.getCertProviders());
+          bootstrapInfo.node().toEnvoyProtoNode(),
+          bootstrapInfo.certProviders());
     }
     throw new UnsupportedOperationException("Unsupported configurations in DownstreamTlsContext!");
   }

--- a/xds/src/test/java/io/grpc/xds/BootstrapperImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/BootstrapperImplTest.java
@@ -106,11 +106,11 @@ public class BootstrapperImplTest {
 
     bootstrapper.setFileReader(createFileReader(BOOTSTRAP_FILE_PATH, rawData));
     BootstrapInfo info = bootstrapper.bootstrap();
-    assertThat(info.getServers()).hasSize(1);
-    ServerInfo serverInfo = Iterables.getOnlyElement(info.getServers());
-    assertThat(serverInfo.getTarget()).isEqualTo(SERVER_URI);
-    assertThat(serverInfo.getChannelCredentials()).isInstanceOf(InsecureChannelCredentials.class);
-    assertThat(info.getNode()).isEqualTo(
+    assertThat(info.servers()).hasSize(1);
+    ServerInfo serverInfo = Iterables.getOnlyElement(info.servers());
+    assertThat(serverInfo.target()).isEqualTo(SERVER_URI);
+    assertThat(serverInfo.channelCredentials()).isInstanceOf(InsecureChannelCredentials.class);
+    assertThat(info.node()).isEqualTo(
         getNodeBuilder()
             .setId("ENVOY_NODE_ID")
             .setCluster("ENVOY_CLUSTER")
@@ -158,17 +158,17 @@ public class BootstrapperImplTest {
 
     bootstrapper.setFileReader(createFileReader(BOOTSTRAP_FILE_PATH, rawData));
     BootstrapInfo info = bootstrapper.bootstrap();
-    assertThat(info.getServers()).hasSize(2);
-    List<ServerInfo> serverInfoList = info.getServers();
-    assertThat(serverInfoList.get(0).getTarget())
+    assertThat(info.servers()).hasSize(2);
+    List<ServerInfo> serverInfoList = info.servers();
+    assertThat(serverInfoList.get(0).target())
         .isEqualTo("trafficdirector-foo.googleapis.com:443");
-    assertThat(serverInfoList.get(0).getChannelCredentials())
+    assertThat(serverInfoList.get(0).channelCredentials())
         .isInstanceOf(TlsChannelCredentials.class);
-    assertThat(serverInfoList.get(1).getTarget())
+    assertThat(serverInfoList.get(1).target())
         .isEqualTo("trafficdirector-bar.googleapis.com:443");
-    assertThat(serverInfoList.get(1).getChannelCredentials())
+    assertThat(serverInfoList.get(1).channelCredentials())
         .isInstanceOf(InsecureChannelCredentials.class);
-    assertThat(info.getNode()).isEqualTo(
+    assertThat(info.node()).isEqualTo(
         getNodeBuilder()
             .setId("ENVOY_NODE_ID")
             .setCluster("ENVOY_CLUSTER")
@@ -208,11 +208,11 @@ public class BootstrapperImplTest {
 
     bootstrapper.setFileReader(createFileReader(BOOTSTRAP_FILE_PATH, rawData));
     BootstrapInfo info = bootstrapper.bootstrap();
-    assertThat(info.getServers()).hasSize(1);
-    ServerInfo serverInfo = Iterables.getOnlyElement(info.getServers());
-    assertThat(serverInfo.getTarget()).isEqualTo(SERVER_URI);
-    assertThat(serverInfo.getChannelCredentials()).isInstanceOf(InsecureChannelCredentials.class);
-    assertThat(info.getNode()).isEqualTo(
+    assertThat(info.servers()).hasSize(1);
+    ServerInfo serverInfo = Iterables.getOnlyElement(info.servers());
+    assertThat(serverInfo.target()).isEqualTo(SERVER_URI);
+    assertThat(serverInfo.channelCredentials()).isInstanceOf(InsecureChannelCredentials.class);
+    assertThat(info.node()).isEqualTo(
         getNodeBuilder()
             .setId("ENVOY_NODE_ID")
             .setCluster("ENVOY_CLUSTER")
@@ -277,11 +277,11 @@ public class BootstrapperImplTest {
 
     bootstrapper.setFileReader(createFileReader(BOOTSTRAP_FILE_PATH, rawData));
     BootstrapInfo info = bootstrapper.bootstrap();
-    assertThat(info.getServers()).hasSize(1);
-    ServerInfo serverInfo = Iterables.getOnlyElement(info.getServers());
-    assertThat(serverInfo.getTarget()).isEqualTo(SERVER_URI);
-    assertThat(serverInfo.getChannelCredentials()).isInstanceOf(InsecureChannelCredentials.class);
-    assertThat(info.getNode()).isEqualTo(getNodeBuilder().build());
+    assertThat(info.servers()).hasSize(1);
+    ServerInfo serverInfo = Iterables.getOnlyElement(info.servers());
+    assertThat(serverInfo.target()).isEqualTo(SERVER_URI);
+    assertThat(serverInfo.channelCredentials()).isInstanceOf(InsecureChannelCredentials.class);
+    assertThat(info.node()).isEqualTo(getNodeBuilder().build());
   }
 
   @Test
@@ -379,17 +379,17 @@ public class BootstrapperImplTest {
 
     bootstrapper.setFileReader(createFileReader(BOOTSTRAP_FILE_PATH, rawData));
     BootstrapInfo info = bootstrapper.bootstrap();
-    assertThat(info.getServers()).isEmpty();
-    assertThat(info.getNode()).isEqualTo(getNodeBuilder().build());
-    Map<String, Bootstrapper.CertificateProviderInfo> certProviders = info.getCertProviders();
+    assertThat(info.servers()).isEmpty();
+    assertThat(info.node()).isEqualTo(getNodeBuilder().build());
+    Map<String, Bootstrapper.CertificateProviderInfo> certProviders = info.certProviders();
     assertThat(certProviders).isNotNull();
     Bootstrapper.CertificateProviderInfo gcpId = certProviders.get("gcp_id");
     Bootstrapper.CertificateProviderInfo fileProvider = certProviders.get("file_provider");
-    assertThat(gcpId.getPluginName()).isEqualTo("meshca");
-    assertThat(gcpId.getConfig()).isInstanceOf(Map.class);
-    assertThat(fileProvider.getPluginName()).isEqualTo("file_watcher");
-    assertThat(fileProvider.getConfig()).isInstanceOf(Map.class);
-    Map<String, ?> meshCaConfig = (Map<String, ?>)gcpId.getConfig();
+    assertThat(gcpId.pluginName()).isEqualTo("meshca");
+    assertThat(gcpId.config()).isInstanceOf(Map.class);
+    assertThat(fileProvider.pluginName()).isEqualTo("file_watcher");
+    assertThat(fileProvider.config()).isInstanceOf(Map.class);
+    Map<String, ?> meshCaConfig = gcpId.config();
     assertThat(meshCaConfig.get("key_size")).isEqualTo(2048);
   }
 
@@ -552,7 +552,7 @@ public class BootstrapperImplTest {
 
     bootstrapper.setFileReader(createFileReader(BOOTSTRAP_FILE_PATH, rawData));
     BootstrapInfo info = bootstrapper.bootstrap();
-    assertThat(info.getServerListenerResourceNameTemplate()).isEqualTo("grpc/serverx=%s");
+    assertThat(info.serverListenerResourceNameTemplate()).isEqualTo("grpc/serverx=%s");
   }
 
   @Test
@@ -571,10 +571,10 @@ public class BootstrapperImplTest {
 
     bootstrapper.setFileReader(createFileReader(BOOTSTRAP_FILE_PATH, rawData));
     BootstrapInfo info = bootstrapper.bootstrap();
-    ServerInfo serverInfo = Iterables.getOnlyElement(info.getServers());
-    assertThat(serverInfo.getTarget()).isEqualTo(SERVER_URI);
-    assertThat(serverInfo.getChannelCredentials()).isInstanceOf(InsecureChannelCredentials.class);
-    assertThat(serverInfo.isUseProtocolV3()).isFalse();
+    ServerInfo serverInfo = Iterables.getOnlyElement(info.servers());
+    assertThat(serverInfo.target()).isEqualTo(SERVER_URI);
+    assertThat(serverInfo.channelCredentials()).isInstanceOf(InsecureChannelCredentials.class);
+    assertThat(serverInfo.useProtocolV3()).isFalse();
   }
 
   @Test
@@ -593,10 +593,10 @@ public class BootstrapperImplTest {
 
     bootstrapper.setFileReader(createFileReader(BOOTSTRAP_FILE_PATH, rawData));
     BootstrapInfo info = bootstrapper.bootstrap();
-    ServerInfo serverInfo = Iterables.getOnlyElement(info.getServers());
-    assertThat(serverInfo.getTarget()).isEqualTo(SERVER_URI);
-    assertThat(serverInfo.getChannelCredentials()).isInstanceOf(InsecureChannelCredentials.class);
-    assertThat(serverInfo.isUseProtocolV3()).isTrue();
+    ServerInfo serverInfo = Iterables.getOnlyElement(info.servers());
+    assertThat(serverInfo.target()).isEqualTo(SERVER_URI);
+    assertThat(serverInfo.channelCredentials()).isInstanceOf(InsecureChannelCredentials.class);
+    assertThat(serverInfo.useProtocolV3()).isTrue();
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
@@ -275,14 +275,14 @@ public abstract class ClientXdsClientTestBase {
         cleanupRule.register(InProcessChannelBuilder.forName(serverName).directExecutor().build());
 
     Bootstrapper.BootstrapInfo bootstrapInfo =
-        new Bootstrapper.BootstrapInfo(
-            Arrays.asList(
-                new Bootstrapper.ServerInfo(
-                    SERVER_URI, InsecureChannelCredentials.create(), useProtocolV3())),
-            EnvoyProtoData.Node.newBuilder().build(),
-            ImmutableMap.of("cert-instance-name",
-                new CertificateProviderInfo("file-watcher", ImmutableMap.<String, Object>of())),
-            null);
+        Bootstrapper.BootstrapInfo.builder()
+            .servers(Arrays.asList(
+                Bootstrapper.ServerInfo.create(
+                    SERVER_URI, InsecureChannelCredentials.create(), useProtocolV3())))
+            .node(EnvoyProtoData.Node.newBuilder().build())
+            .certProviders(ImmutableMap.of("cert-instance-name",
+                CertificateProviderInfo.create("file-watcher", ImmutableMap.<String, Object>of())))
+            .build();
     xdsClient =
         new ClientXdsClient(
             channel,

--- a/xds/src/test/java/io/grpc/xds/CommonBootstrapperTestUtils.java
+++ b/xds/src/test/java/io/grpc/xds/CommonBootstrapperTestUtils.java
@@ -19,6 +19,7 @@ package io.grpc.xds;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.grpc.internal.JsonParser;
+import io.grpc.xds.Bootstrapper.ServerInfo;
 import io.grpc.xds.internal.sds.CommonTlsContextTestsUtil;
 import java.io.IOException;
 import java.util.HashMap;
@@ -57,19 +58,20 @@ public class CommonBootstrapperTestUtils {
   public static Bootstrapper.BootstrapInfo getTestBootstrapInfo() {
     try {
       Bootstrapper.CertificateProviderInfo gcpId =
-          new Bootstrapper.CertificateProviderInfo(
+          Bootstrapper.CertificateProviderInfo.create(
               "testca", (Map<String, ?>) JsonParser.parse(MESHCA_CONFIG));
       Bootstrapper.CertificateProviderInfo fileProvider =
-          new Bootstrapper.CertificateProviderInfo(
+          Bootstrapper.CertificateProviderInfo.create(
               "file_watcher", (Map<String, ?>) JsonParser.parse(FILE_WATCHER_CONFIG));
       Map<String, Bootstrapper.CertificateProviderInfo> certProviders =
           ImmutableMap.of("gcp_id", gcpId, "file_provider", fileProvider);
       Bootstrapper.BootstrapInfo bootstrapInfo =
-          new Bootstrapper.BootstrapInfo(
-              ImmutableList.<Bootstrapper.ServerInfo>of(),
-              EnvoyProtoData.Node.newBuilder().build(),
-              certProviders,
-              "grpc/server");
+          Bootstrapper.BootstrapInfo.builder()
+              .servers(ImmutableList.<Bootstrapper.ServerInfo>of())
+              .node(EnvoyProtoData.Node.newBuilder().build())
+              .certProviders(certProviders)
+              .serverListenerResourceNameTemplate("grpc/server")
+              .build();
       return bootstrapInfo;
     } catch (IOException e) {
       throw new AssertionError(e);
@@ -113,7 +115,7 @@ public class CommonBootstrapperTestUtils {
     config.put("private_key_file", privateKey1);
     config.put("ca_certificate_file", trustCa1);
     Bootstrapper.CertificateProviderInfo certificateProviderInfo =
-        new Bootstrapper.CertificateProviderInfo("file_watcher", config);
+        Bootstrapper.CertificateProviderInfo.create("file_watcher", config);
     HashMap<String, Bootstrapper.CertificateProviderInfo> certProviders =
         new HashMap<>();
     certProviders.put(certInstanceName1, certificateProviderInfo);
@@ -123,10 +125,13 @@ public class CommonBootstrapperTestUtils {
       config.put("private_key_file", privateKey2);
       config.put("ca_certificate_file", trustCa2);
       certificateProviderInfo =
-          new Bootstrapper.CertificateProviderInfo("file_watcher", config);
+          Bootstrapper.CertificateProviderInfo.create("file_watcher", config);
       certProviders.put(certInstanceName2, certificateProviderInfo);
     }
-    return new Bootstrapper.BootstrapInfo(null, EnvoyProtoData.Node.newBuilder().build(),
-        certProviders, null);
+    return Bootstrapper.BootstrapInfo.builder()
+        .servers(ImmutableList.<ServerInfo>of())
+        .node(EnvoyProtoData.Node.newBuilder().build())
+        .certProviders(certProviders)
+        .build();
   }
 }

--- a/xds/src/test/java/io/grpc/xds/CsdsServiceTest.java
+++ b/xds/src/test/java/io/grpc/xds/CsdsServiceTest.java
@@ -84,12 +84,12 @@ public class CsdsServiceTest {
   private static final XdsClient XDS_CLIENT_NO_RESOURCES = new XdsClient() {
     @Override
     Bootstrapper.BootstrapInfo getBootstrapInfo() {
-      return new Bootstrapper.BootstrapInfo(
-          Arrays.asList(
-             new Bootstrapper.ServerInfo(SERVER_URI, InsecureChannelCredentials.create(), false)),
-          BOOTSTRAP_NODE,
-          null,
-          null);
+      return Bootstrapper.BootstrapInfo.builder()
+          .servers(Arrays.asList(
+              Bootstrapper.ServerInfo.create(
+                  SERVER_URI, InsecureChannelCredentials.create(), false)))
+          .node(BOOTSTRAP_NODE)
+          .build();
     }
 
     @Override
@@ -695,10 +695,12 @@ public class CsdsServiceTest {
       ClientConfig clientConfig = CsdsService.getClientConfigForXdsClient(new XdsClient() {
         @Override
         Bootstrapper.BootstrapInfo getBootstrapInfo() {
-          return new Bootstrapper.BootstrapInfo(Arrays.asList(
-                  new Bootstrapper.ServerInfo(
-                          SERVER_URI, InsecureChannelCredentials.create(), false)),
-                  BOOTSTRAP_NODE, null,null);
+          return Bootstrapper.BootstrapInfo.builder()
+              .servers(Arrays.asList(
+                  Bootstrapper.ServerInfo.create(
+                          SERVER_URI, InsecureChannelCredentials.create(), false)))
+              .node(BOOTSTRAP_NODE)
+              .build();
         }
 
         @Override

--- a/xds/src/test/java/io/grpc/xds/SharedXdsClientPoolProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/SharedXdsClientPoolProviderTest.java
@@ -57,7 +57,7 @@ public class SharedXdsClientPoolProviderTest {
   @Test
   public void noServer() throws XdsInitializationException {
     BootstrapInfo bootstrapInfo =
-        new BootstrapInfo(Collections.<ServerInfo>emptyList(), node, null, null);
+        BootstrapInfo.builder().servers(Collections.<ServerInfo>emptyList()).node(node).build();
     when(bootstrapper.bootstrap()).thenReturn(bootstrapInfo);
     SharedXdsClientPoolProvider provider = new SharedXdsClientPoolProvider(bootstrapper);
     thrown.expect(XdsInitializationException.class);
@@ -68,9 +68,9 @@ public class SharedXdsClientPoolProviderTest {
 
   @Test
   public void sharedXdsClientObjectPool() throws XdsInitializationException {
-    ServerInfo server = new ServerInfo(SERVER_URI, InsecureChannelCredentials.create(), false);
+    ServerInfo server = ServerInfo.create(SERVER_URI, InsecureChannelCredentials.create(), false);
     BootstrapInfo bootstrapInfo =
-        new BootstrapInfo(Collections.singletonList(server), node, null, null);
+        BootstrapInfo.builder().servers(Collections.singletonList(server)).node(node).build();
     when(bootstrapper.bootstrap()).thenReturn(bootstrapInfo);
 
     SharedXdsClientPoolProvider provider = new SharedXdsClientPoolProvider(bootstrapper);
@@ -85,9 +85,9 @@ public class SharedXdsClientPoolProviderTest {
 
   @Test
   public void refCountedXdsClientObjectPool_delayedCreation() {
-    ServerInfo server = new ServerInfo(SERVER_URI, InsecureChannelCredentials.create(), false);
+    ServerInfo server = ServerInfo.create(SERVER_URI, InsecureChannelCredentials.create(), false);
     BootstrapInfo bootstrapInfo =
-        new BootstrapInfo(Collections.singletonList(server), node, null, null);
+        BootstrapInfo.builder().servers(Collections.singletonList(server)).node(node).build();
     RefCountedXdsClientObjectPool xdsClientPool = new RefCountedXdsClientObjectPool(bootstrapInfo);
     assertThat(xdsClientPool.getXdsClientForTest()).isNull();
     assertThat(xdsClientPool.getChannelForTest()).isNull();
@@ -98,9 +98,9 @@ public class SharedXdsClientPoolProviderTest {
 
   @Test
   public void refCountedXdsClientObjectPool_refCounted() {
-    ServerInfo server = new ServerInfo(SERVER_URI, InsecureChannelCredentials.create(), false);
+    ServerInfo server = ServerInfo.create(SERVER_URI, InsecureChannelCredentials.create(), false);
     BootstrapInfo bootstrapInfo =
-        new BootstrapInfo(Collections.singletonList(server), node, null, null);
+        BootstrapInfo.builder().servers(Collections.singletonList(server)).node(node).build();
     RefCountedXdsClientObjectPool xdsClientPool = new RefCountedXdsClientObjectPool(bootstrapInfo);
     // getObject once
     XdsClient xdsClient = xdsClientPool.getObject();
@@ -118,9 +118,9 @@ public class SharedXdsClientPoolProviderTest {
 
   @Test
   public void refCountedXdsClientObjectPool_getObjectCreatesNewInstanceIfAlreadyShutdown() {
-    ServerInfo server = new ServerInfo(SERVER_URI, InsecureChannelCredentials.create(), false);
+    ServerInfo server = ServerInfo.create(SERVER_URI, InsecureChannelCredentials.create(), false);
     BootstrapInfo bootstrapInfo =
-        new BootstrapInfo(Collections.singletonList(server), node, null, null);
+        BootstrapInfo.builder().servers(Collections.singletonList(server)).node(node).build();
     RefCountedXdsClientObjectPool xdsClientPool = new RefCountedXdsClientObjectPool(bootstrapInfo);
     XdsClient xdsClient1 = xdsClientPool.getObject();
     ManagedChannel channel1 = xdsClientPool.getChannelForTest();

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverProviderTest.java
@@ -164,7 +164,7 @@ public class XdsNameResolverProviderTest {
             .newNameResolver(URI.create("no-scheme:///localhost"), args);
     resolver.start(mock(NameResolver.Listener2.class));
     assertThat(resolver).isInstanceOf(XdsNameResolver.class);
-    assertThat(((XdsNameResolver)resolver).getXdsClient().getBootstrapInfo().getNode().getId())
+    assertThat(((XdsNameResolver)resolver).getXdsClient().getBootstrapInfo().node().getId())
             .isEqualTo("ENVOY_NODE_ID");
     resolver.shutdown();
     registry.deregister(provider);

--- a/xds/src/test/java/io/grpc/xds/XdsServerTestHelper.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerTestHelper.java
@@ -49,12 +49,13 @@ public class XdsServerTestHelper {
   private static final EnvoyProtoData.Node BOOTSTRAP_NODE =
       EnvoyProtoData.Node.newBuilder().setId(NODE_ID).build();
   static final Bootstrapper.BootstrapInfo BOOTSTRAP_INFO =
-      new Bootstrapper.BootstrapInfo(
-          Arrays.asList(
-              new Bootstrapper.ServerInfo(SERVER_URI, InsecureChannelCredentials.create(), true)),
-          BOOTSTRAP_NODE,
-          null,
-          "grpc/server?udpa.resource.listening_address=%s");
+      Bootstrapper.BootstrapInfo.builder()
+          .servers(Arrays.asList(
+              Bootstrapper.ServerInfo.create(
+                  SERVER_URI, InsecureChannelCredentials.create(), true)))
+          .node(BOOTSTRAP_NODE)
+          .serverListenerResourceNameTemplate("grpc/server?udpa.resource.listening_address=%s")
+          .build();
 
   static void generateListenerUpdate(FakeXdsClient xdsClient,
                                      EnvoyServerProtoData.DownstreamTlsContext tlsContext,

--- a/xds/src/test/java/io/grpc/xds/XdsServerWrapperTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerWrapperTest.java
@@ -118,24 +118,23 @@ public class XdsServerWrapperTest {
   @Test
   public void testBootstrap_notV3() throws Exception {
     Bootstrapper.BootstrapInfo b =
-        new Bootstrapper.BootstrapInfo(
-          Arrays.asList(
-                  new Bootstrapper.ServerInfo("uri", InsecureChannelCredentials.create(), false)),
-          EnvoyProtoData.Node.newBuilder().setId("id").build(),
-          null,
-                "grpc/server?udpa.resource.listening_address=%s");
+        Bootstrapper.BootstrapInfo.builder()
+            .servers(Arrays.asList(
+                Bootstrapper.ServerInfo.create("uri", InsecureChannelCredentials.create(), false)))
+            .node(EnvoyProtoData.Node.newBuilder().setId("id").build())
+            .serverListenerResourceNameTemplate("grpc/server?udpa.resource.listening_address=%s")
+            .build();
     verifyBootstrapFail(b);
   }
 
   @Test
   public void testBootstrap_noTemplate() throws Exception {
     Bootstrapper.BootstrapInfo b =
-        new Bootstrapper.BootstrapInfo(
-            Arrays.asList(
-                    new Bootstrapper.ServerInfo("uri", InsecureChannelCredentials.create(), true)),
-            EnvoyProtoData.Node.newBuilder().setId("id").build(),
-            null,
-            null);
+        Bootstrapper.BootstrapInfo.builder()
+            .servers(Arrays.asList(
+                Bootstrapper.ServerInfo.create("uri", InsecureChannelCredentials.create(), true)))
+            .node(EnvoyProtoData.Node.newBuilder().setId("id").build())
+            .build();
     verifyBootstrapFail(b);
   }
 

--- a/xds/src/test/java/io/grpc/xds/internal/certprovider/CertProviderClientSslContextProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/certprovider/CertProviderClientSslContextProviderTest.java
@@ -83,8 +83,8 @@ public class CertProviderClientSslContextProviderTest {
             staticCertValidationContext);
     return certProviderClientSslContextProviderFactory.getProvider(
         upstreamTlsContext,
-        bootstrapInfo.getNode().toEnvoyProtoNode(),
-        bootstrapInfo.getCertProviders());
+        bootstrapInfo.node().toEnvoyProtoNode(),
+        bootstrapInfo.certProviders());
   }
 
   /** Helper method to build CertProviderClientSslContextProvider. */
@@ -104,8 +104,8 @@ public class CertProviderClientSslContextProviderTest {
                     staticCertValidationContext);
     return certProviderClientSslContextProviderFactory.getProvider(
             upstreamTlsContext,
-            bootstrapInfo.getNode().toEnvoyProtoNode(),
-            bootstrapInfo.getCertProviders());
+            bootstrapInfo.node().toEnvoyProtoNode(),
+            bootstrapInfo.certProviders());
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/internal/certprovider/CertProviderServerSslContextProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/certprovider/CertProviderServerSslContextProviderTest.java
@@ -79,8 +79,8 @@ public class CertProviderServerSslContextProviderTest {
             requireClientCert);
     return certProviderServerSslContextProviderFactory.getProvider(
         downstreamTlsContext,
-        bootstrapInfo.getNode().toEnvoyProtoNode(),
-        bootstrapInfo.getCertProviders());
+        bootstrapInfo.node().toEnvoyProtoNode(),
+        bootstrapInfo.certProviders());
   }
 
   /** Helper method to build CertProviderServerSslContextProvider. */
@@ -102,8 +102,8 @@ public class CertProviderServerSslContextProviderTest {
                     requireClientCert);
     return certProviderServerSslContextProviderFactory.getProvider(
             downstreamTlsContext,
-            bootstrapInfo.getNode().toEnvoyProtoNode(),
-            bootstrapInfo.getCertProviders());
+            bootstrapInfo.node().toEnvoyProtoNode(),
+            bootstrapInfo.certProviders());
   }
 
 


### PR DESCRIPTION
As many new fields will be added to `BootstrapInfo` for xds federation support, refactor `Bootstrapper.java` to use `AutoValue`. All the other files are just mechanical changes due to the refactoring.