### PR TITLE
.github/workflows: Bump codecov-action to v2

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -60,4 +60,4 @@ jobs:
       if: matrix.jre == 8 # Upload once, instead of for each job in the matrix
       run: ./gradlew :grpc-all:coveralls -x compileJava
     - name: Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2


### PR DESCRIPTION
The codecov bash uploader is being replaced (supposedly partially for
security reasons, but it seems maintenance reasons are the real goal).
https://about.codecov.io/blog/codecov-uploader-deprecation-plan/

v1 uses the bash uploader. v2 uses the new uploader. The bash uploader
will begin seeing brownouts soon.