### PR TITLE
Emulate AbstractManagedChannelImplBuilder maxInboundMessageSize(int)

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -707,6 +707,28 @@ public final class ManagedChannelImplBuilder
     return channelBuilderDefaultPortProvider.getDefaultPort();
   }
 
+  // Remove this emulation when we delete AbstractManagedChannelImplBuilder
+  private AbstractManagedChannelImplBuilderEmulator abstractManagedChannelImplBuilderEmulator;
+
+  public interface AbstractManagedChannelImplBuilderEmulator {
+    void maxInboundMessageSize(int max);
+  }
+
+  public void emulateAbstractManagedChannelImplBuilder(
+      AbstractManagedChannelImplBuilderEmulator abstractManagedChannelImplBuilderEmulator) {
+    this.abstractManagedChannelImplBuilderEmulator = abstractManagedChannelImplBuilderEmulator;
+  }
+
+  @Override
+  public ManagedChannelImplBuilder maxInboundMessageSize(int max) {
+    if (abstractManagedChannelImplBuilderEmulator != null) {
+      abstractManagedChannelImplBuilderEmulator.maxInboundMessageSize(max);
+      return this;
+    } else {
+      return super.maxInboundMessageSize(max); // noop
+    }
+  }
+
   private static class DirectAddressNameResolverFactory extends NameResolver.Factory {
     final SocketAddress address;
     final String authority;

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -201,6 +201,7 @@ public final class NettyChannelBuilder extends
     managedChannelImplBuilder = new ManagedChannelImplBuilder(target,
         new NettyChannelTransportFactoryBuilder(),
         new NettyChannelDefaultPortProvider());
+    managedChannelImplBuilder.emulateAbstractManagedChannelImplBuilder(new OldBuilderEmulator());
     this.freezeProtocolNegotiatorFactory = false;
   }
 
@@ -211,6 +212,7 @@ public final class NettyChannelBuilder extends
         target, channelCreds, callCreds,
         new NettyChannelTransportFactoryBuilder(),
         new NettyChannelDefaultPortProvider());
+    managedChannelImplBuilder.emulateAbstractManagedChannelImplBuilder(new OldBuilderEmulator());
     this.protocolNegotiatorFactory = checkNotNull(negotiator, "negotiator");
     this.freezeProtocolNegotiatorFactory = true;
   }
@@ -221,6 +223,7 @@ public final class NettyChannelBuilder extends
         getAuthorityFromAddress(address),
         new NettyChannelTransportFactoryBuilder(),
         new NettyChannelDefaultPortProvider());
+    managedChannelImplBuilder.emulateAbstractManagedChannelImplBuilder(new OldBuilderEmulator());
     this.freezeProtocolNegotiatorFactory = false;
   }
 
@@ -232,6 +235,7 @@ public final class NettyChannelBuilder extends
         channelCreds, callCreds,
         new NettyChannelTransportFactoryBuilder(),
         new NettyChannelDefaultPortProvider());
+    managedChannelImplBuilder.emulateAbstractManagedChannelImplBuilder(new OldBuilderEmulator());
     this.protocolNegotiatorFactory = checkNotNull(negotiator, "negotiator");
     this.freezeProtocolNegotiatorFactory = true;
   }
@@ -762,6 +766,13 @@ public final class NettyChannelBuilder extends
 
       protocolNegotiator.close();
       groupPool.returnObject(group);
+    }
+  }
+
+  private final class OldBuilderEmulator implements
+      ManagedChannelImplBuilder.AbstractManagedChannelImplBuilderEmulator {
+    @Override public void maxInboundMessageSize(int max) {
+      NettyChannelBuilder.this.maxInboundMessageSize(max);
     }
   }
 }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -191,6 +191,7 @@ public final class OkHttpChannelBuilder extends
     managedChannelImplBuilder = new ManagedChannelImplBuilder(target,
         new OkHttpChannelTransportFactoryBuilder(),
         new OkHttpChannelDefaultPortProvider());
+    managedChannelImplBuilder.emulateAbstractManagedChannelImplBuilder(new OldBuilderEmulator());
     this.freezeSecurityConfiguration = false;
   }
 
@@ -201,6 +202,7 @@ public final class OkHttpChannelBuilder extends
         target, channelCreds, callCreds,
         new OkHttpChannelTransportFactoryBuilder(),
         new OkHttpChannelDefaultPortProvider());
+    managedChannelImplBuilder.emulateAbstractManagedChannelImplBuilder(new OldBuilderEmulator());
     this.sslSocketFactory = factory;
     this.negotiationType = factory == null ? NegotiationType.PLAINTEXT : NegotiationType.TLS;
     this.freezeSecurityConfiguration = true;
@@ -828,6 +830,13 @@ public final class OkHttpChannelBuilder extends
       if (usingSharedExecutor) {
         SharedResourceHolder.release(SHARED_EXECUTOR, executor);
       }
+    }
+  }
+
+  private final class OldBuilderEmulator implements
+      ManagedChannelImplBuilder.AbstractManagedChannelImplBuilderEmulator {
+    @Override public void maxInboundMessageSize(int max) {
+      OkHttpChannelBuilder.this.maxInboundMessageSize(max);
     }
   }
 }


### PR DESCRIPTION
In dbd903c0 we started generatating AbstractManagedChannelImplBuilder
methods in a way that they are present for ABI but on recompilation only
public ManagedChannelBuilder-returning methods would be used. However,
this sorta missed maxInboundMessageSize which is now being handled by
the concrete classes (e.g, NettyChannelBuilder) instead of
ManagedChannelImplBuilder. Users on the old ABI will end up getting
ManagedChannelImplBuilder.maxInboundMessageSize() which does nothing.

So, let's just implement the method and have it jump back up to the
concrete class. Hacky, but easy and predictable and will go away once we
remove the rest of the AbstractManagedChannelImplBuilder compatibility
hacks.

Fixes #8313