### PR TITLE
rls: limit cache_size in rls config to 5M

### DIFF
--- a/rls/src/main/java/io/grpc/rls/RlsProtoData.java
+++ b/rls/src/main/java/io/grpc/rls/RlsProtoData.java
@@ -141,6 +141,7 @@ final class RlsProtoData {
   static final class RouteLookupConfig {
 
     private static final long MAX_AGE_MILLIS = TimeUnit.MINUTES.toMillis(5);
+    private static final long MAX_CACHE_SIZE = 5 * 1024 * 1024;
 
     private final ImmutableList<GrpcKeyBuilder> grpcKeyBuilders;
 
@@ -194,7 +195,7 @@ final class RlsProtoData {
       this.maxAgeInMillis = Math.min(maxAgeInMillis, MAX_AGE_MILLIS);
       this.staleAgeInMillis = Math.min(staleAgeInMillis, this.maxAgeInMillis);
       checkArgument(cacheSizeBytes > 0, "cacheSize must be positive");
-      this.cacheSizeBytes = cacheSizeBytes;
+      this.cacheSizeBytes = Math.min(cacheSizeBytes, MAX_CACHE_SIZE);
       this.validTargets = ImmutableList.copyOf(checkNotNull(validTargets, "validTargets"));
       this.defaultTarget = defaultTarget;
     }

--- a/rls/src/test/java/io/grpc/rls/RlsProtoDataTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsProtoDataTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.rls;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.grpc.rls.RlsProtoData.ExtraKeys;
+import io.grpc.rls.RlsProtoData.GrpcKeyBuilder;
+import io.grpc.rls.RlsProtoData.GrpcKeyBuilder.Name;
+import io.grpc.rls.RlsProtoData.NameMatcher;
+import io.grpc.rls.RlsProtoData.RouteLookupConfig;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link RlsProtoData}. */
+@RunWith(JUnit4.class)
+public class RlsProtoDataTest {
+  @Test
+  public void maxCacheSize() {
+    RouteLookupConfig config = new RouteLookupConfig(
+        ImmutableList.of(
+            new GrpcKeyBuilder(
+                ImmutableList.of(new Name("service1", "create")),
+                ImmutableList.of(
+                    new NameMatcher("user", ImmutableList.of("User", "Parent"), true),
+                    new NameMatcher("id", ImmutableList.of("X-Google-Id"), true)),
+                ExtraKeys.create("server", "service-key", "method-key"),
+                ImmutableMap.<String, String>of())),
+        "service1",
+        /* lookupServiceTimeoutInMillis= */ TimeUnit.SECONDS.toMillis(2),
+        /* maxAgeInMillis= */ TimeUnit.SECONDS.toMillis(300),
+        /* staleAgeInMillis= */ TimeUnit.SECONDS.toMillis(240),
+        /* cacheSizeBytes= */ 20 * 1000 * 1000,
+        ImmutableList.of("a-valid-target"),
+        "default-target");
+    assertThat(config.getCacheSizeBytes()).isEqualTo(5 * 1024 * 1024);
+  }
+}


### PR DESCRIPTION
In the latest grpc-rls-lb-policy-design, if the value of cache_size_bytes is greater than 5M, we cap it at 5M.