### PR TITLE
xds: add RlsClusterSpecifierPlugin for RLS-in-xDS

### DIFF
--- a/rls/src/main/java/io/grpc/rls/RlsProtoData.java
+++ b/rls/src/main/java/io/grpc/rls/RlsProtoData.java
@@ -25,6 +25,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.grpc.Internal;
 import io.grpc.rls.RlsProtoData.GrpcKeyBuilder.Name;
 import java.util.HashSet;
 import java.util.List;
@@ -35,7 +36,10 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /** RlsProtoData is a collection of internal representation of RouteLookupService proto messages. */
-final class RlsProtoData {
+@Internal
+public final class RlsProtoData {
+
+  private RlsProtoData() {}
 
   /** A request object sent to route lookup service. */
   @Immutable
@@ -138,7 +142,7 @@ final class RlsProtoData {
 
   /** A config object for gRPC RouteLookupService. */
   @Immutable
-  static final class RouteLookupConfig {
+  public static final class RouteLookupConfig {
 
     private static final long MAX_AGE_MILLIS = TimeUnit.MINUTES.toMillis(5);
     private static final long MAX_CACHE_SIZE = 5 * 1024 * 1024;
@@ -160,7 +164,7 @@ final class RlsProtoData {
     @Nullable
     private final String defaultTarget;
 
-    RouteLookupConfig(
+    public RouteLookupConfig(
         List<GrpcKeyBuilder> grpcKeyBuilders,
         String lookupService,
         long lookupServiceTimeoutInMillis,
@@ -197,6 +201,9 @@ final class RlsProtoData {
       checkArgument(cacheSizeBytes > 0, "cacheSize must be positive");
       this.cacheSizeBytes = Math.min(cacheSizeBytes, MAX_CACHE_SIZE);
       this.validTargets = ImmutableList.copyOf(checkNotNull(validTargets, "validTargets"));
+      if (defaultTarget != null && defaultTarget.isEmpty()) {
+        defaultTarget = null;
+      }
       this.defaultTarget = defaultTarget;
     }
 
@@ -328,7 +335,7 @@ final class RlsProtoData {
    * is true, one of the specified names must be present for the keybuilder to match.
    */
   @Immutable
-  static final class NameMatcher {
+  public static final class NameMatcher {
 
     private final String key;
 
@@ -336,7 +343,7 @@ final class RlsProtoData {
 
     private final boolean optional;
 
-    NameMatcher(String key, List<String> names, @Nullable Boolean optional) {
+    public NameMatcher(String key, List<String> names, @Nullable Boolean optional) {
       this.key = checkNotNull(key, "key");
       this.names = ImmutableList.copyOf(checkNotNull(names, "names"));
       this.optional = optional != null ? optional : true;
@@ -389,7 +396,7 @@ final class RlsProtoData {
   }
 
   /** GrpcKeyBuilder is a configuration to construct headers consumed by route lookup service. */
-  static final class GrpcKeyBuilder {
+  public static final class GrpcKeyBuilder {
 
     private final ImmutableList<Name> names;
 
@@ -476,17 +483,17 @@ final class RlsProtoData {
      * required and includes the proto package name. The method name may be omitted, in which case
      * any method on the given service is matched.
      */
-    static final class Name {
+    public static final class Name {
 
       private final String service;
 
       private final String method;
 
-      Name(String service) {
+      public Name(String service) {
         this(service, "*");
       }
 
-      Name(String service, String method) {
+      public Name(String service, String method) {
         checkState(
             !checkNotNull(service, "service").isEmpty(),
             "service must not be empty or null");
@@ -531,7 +538,7 @@ final class RlsProtoData {
   }
 
   @AutoValue
-  abstract static class ExtraKeys {
+  public abstract static class ExtraKeys {
     static final ExtraKeys DEFAULT = create(null, null, null);
 
     @Nullable abstract String host();
@@ -540,7 +547,7 @@ final class RlsProtoData {
 
     @Nullable abstract String method();
 
-    static ExtraKeys create(
+    public static ExtraKeys create(
         @Nullable String host, @Nullable String service, @Nullable String method) {
       return new AutoValue_RlsProtoData_ExtraKeys(host, service, method);
     }

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -39,6 +39,7 @@ dependencies {
             libraries.autovalue_annotation,
             libraries.opencensus_proto,
             libraries.protobuf_util
+    implementation project(path: ':grpc-rls')
     def nettyDependency = implementation project(':grpc-netty')
 
     testImplementation project(':grpc-core').sourceSets.test.output

--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -73,7 +73,6 @@ import io.grpc.xds.EnvoyServerProtoData.FilterChain;
 import io.grpc.xds.EnvoyServerProtoData.FilterChainMatch;
 import io.grpc.xds.EnvoyServerProtoData.UpstreamTlsContext;
 import io.grpc.xds.Filter.ClientInterceptorBuilder;
-import io.grpc.xds.Filter.ConfigOrError;
 import io.grpc.xds.Filter.FilterConfig;
 import io.grpc.xds.Filter.NamedFilterConfig;
 import io.grpc.xds.Filter.ServerInterceptorBuilder;

--- a/xds/src/main/java/io/grpc/xds/ClusterSpecifierPlugin.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterSpecifierPlugin.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import com.google.protobuf.Message;
+
+/**
+ * Defines the parsing functionality of a ClusterSpecifierPlugin as defined in the Enovy proto
+ * api/envoy/config/route/v3/route.proto.
+ */
+interface ClusterSpecifierPlugin {
+  /**
+   * The proto message types supported by this plugin. A plugin will be registered by each of its
+   * supported message types.
+   */
+  String[] typeUrls();
+
+  ConfigOrError<? extends PluginConfig> parsePlugin(Message rawProtoMessage);
+
+  /** Represents an opaque data structure holding configuration for a ClusterSpecifierPlugin. */
+  interface PluginConfig {
+    String typeUrl();
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/ClusterSpecifierPluginRegistry.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterSpecifierPluginRegistry.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+final class ClusterSpecifierPluginRegistry {
+  private static ClusterSpecifierPluginRegistry instance;
+
+  private final Map<String, ClusterSpecifierPlugin> supportedPlugins = new HashMap<>();
+
+  private ClusterSpecifierPluginRegistry() {}
+
+  static synchronized ClusterSpecifierPluginRegistry getDefaultRegistry() {
+    if (instance == null) {
+      instance = newRegistry().register(RlsClusterSpecifierPlugin.INSTANCE);
+    }
+    return instance;
+  }
+
+  private static ClusterSpecifierPluginRegistry newRegistry() {
+    return new ClusterSpecifierPluginRegistry();
+  }
+
+  private ClusterSpecifierPluginRegistry register(ClusterSpecifierPlugin... plugins) {
+    for (ClusterSpecifierPlugin plugin : plugins) {
+      for (String typeUrl : plugin.typeUrls()) {
+        supportedPlugins.put(typeUrl, plugin);
+      }
+    }
+    return this;
+  }
+
+  @Nullable
+  ClusterSpecifierPlugin get(String typeUrl) {
+    return supportedPlugins.get(typeUrl);
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/ConfigOrError.java
+++ b/xds/src/main/java/io/grpc/xds/ConfigOrError.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+// TODO(zdapeng): Unify with ClientXdsClient.StructOrError, or just have parseFilterConfig() throw
+//     certain types of Exception.
+final class ConfigOrError<T> {
+
+  /**
+   * Returns a {@link ConfigOrError} for the successfully converted data object.
+   */
+  static <T> ConfigOrError<T> fromConfig(T config) {
+    return new ConfigOrError<>(config);
+  }
+
+  /**
+   * Returns a {@link ConfigOrError} for the failure to convert the data object.
+   */
+  static <T> ConfigOrError<T> fromError(String errorDetail) {
+    return new ConfigOrError<>(errorDetail);
+  }
+
+  final String errorDetail;
+  final T config;
+
+  private ConfigOrError(T config) {
+    this.config = checkNotNull(config, "config");
+    this.errorDetail = null;
+  }
+
+  private ConfigOrError(String errorDetail) {
+    this.config = null;
+    this.errorDetail = checkNotNull(errorDetail, "errorDetail");
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/Filter.java
+++ b/xds/src/main/java/io/grpc/xds/Filter.java
@@ -16,8 +16,6 @@
 
 package io.grpc.xds;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.base.MoreObjects;
 import com.google.protobuf.Message;
 import io.grpc.ClientInterceptor;
@@ -70,37 +68,6 @@ interface Filter {
     @Nullable
     ServerInterceptor buildServerInterceptor(
         FilterConfig config, @Nullable FilterConfig overrideConfig);
-  }
-
-  // TODO(zdapeng): Unify with ClientXdsClient.StructOrError, or just have parseFilterConfig() throw
-  //     certain types of Exception.
-  final class ConfigOrError<T> {
-    /**
-     * Returns a {@link ConfigOrError} for the successfully converted data object.
-     */
-    static <T> ConfigOrError<T> fromConfig(T config) {
-      return new ConfigOrError<>(config);
-    }
-
-    /**
-     * Returns a {@link ConfigOrError} for the failure to convert the data object.
-     */
-    static <T> ConfigOrError<T> fromError(String errorDetail) {
-      return new ConfigOrError<>(errorDetail);
-    }
-
-    final String errorDetail;
-    final T config;
-
-    private ConfigOrError(T config) {
-      this.config = checkNotNull(config, "config");
-      this.errorDetail = null;
-    }
-
-    private ConfigOrError(String errorDetail) {
-      this.config = null;
-      this.errorDetail = checkNotNull(errorDetail, "errorDetail");
-    }
   }
 
   /** Filter config with instance name. */

--- a/xds/src/main/java/io/grpc/xds/RlsClusterSpecifierPlugin.java
+++ b/xds/src/main/java/io/grpc/xds/RlsClusterSpecifierPlugin.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+import com.google.protobuf.util.Durations;
+import io.grpc.lookup.v1.GrpcKeyBuilder;
+import io.grpc.lookup.v1.GrpcKeyBuilder.ExtraKeys;
+import io.grpc.lookup.v1.GrpcKeyBuilder.Name;
+import io.grpc.lookup.v1.NameMatcher;
+import io.grpc.lookup.v1.RouteLookupConfig;
+import io.grpc.rls.RlsProtoData;
+import java.util.ArrayList;
+import java.util.List;
+
+/** The ClusterSpecifierPlugin for RouteLookup policy. */
+final class RlsClusterSpecifierPlugin implements ClusterSpecifierPlugin {
+
+  static final RlsClusterSpecifierPlugin INSTANCE = new RlsClusterSpecifierPlugin();
+
+  private static final String TYPE_URL =
+      "type.googleapis.com/grpc.lookup.v1.RouteLookupConfig";
+
+  private RlsClusterSpecifierPlugin() {}
+
+  @Override
+  public String[] typeUrls() {
+    return new String[] {
+        TYPE_URL
+    };
+  }
+
+  @Override
+  public ConfigOrError<RlsPluginConfig> parsePlugin(Message rawProtoMessage) {
+    if (!(rawProtoMessage instanceof Any)) {
+      return ConfigOrError.fromError("Invalid config type: " + rawProtoMessage.getClass());
+    }
+
+    Any anyMessage = (Any) rawProtoMessage;
+    RouteLookupConfig configProto;
+    try {
+      configProto = anyMessage.unpack(RouteLookupConfig.class);
+    } catch (InvalidProtocolBufferException e) {
+      return ConfigOrError.fromError("Invalid proto: " + e);
+    }
+    try {
+      List<GrpcKeyBuilder> keyBuildersProto = configProto.getGrpcKeybuildersList();
+      List<RlsProtoData.GrpcKeyBuilder> keyBuilders =
+          new ArrayList<>(keyBuildersProto.size());
+      for (GrpcKeyBuilder keyBuilderProto : keyBuildersProto) {
+        List<Name> namesProto = keyBuilderProto.getNamesList();
+        List<RlsProtoData.GrpcKeyBuilder.Name> names = new ArrayList<>(namesProto.size());
+        for (Name nameProto : namesProto) {
+          if (nameProto.getMethod().isEmpty()) {
+            names.add(new RlsProtoData.GrpcKeyBuilder.Name(nameProto.getService()));
+          } else {
+            names.add(
+                new RlsProtoData.GrpcKeyBuilder.Name(
+                    nameProto.getService(), nameProto.getMethod()));
+          }
+        }
+
+        List<NameMatcher> headersProto = keyBuilderProto.getHeadersList();
+        List<RlsProtoData.NameMatcher> headers = new ArrayList<>(headersProto.size());
+        for (NameMatcher headerProto : headersProto) {
+          headers.add(
+              new RlsProtoData.NameMatcher(
+                  headerProto.getKey(), headerProto.getNamesList(),
+                  headerProto.getRequiredMatch()));
+        }
+
+        String host = null;
+        String service = null;
+        String method = null;
+        if (keyBuilderProto.hasExtraKeys()) {
+          ExtraKeys extraKeysProto = keyBuilderProto.getExtraKeys();
+          host = extraKeysProto.getHost();
+          service = extraKeysProto.getService();
+          method = extraKeysProto.getMethod();
+        }
+        RlsProtoData.ExtraKeys extraKeys =
+            RlsProtoData.ExtraKeys.create(host, service, method);
+
+        RlsProtoData.GrpcKeyBuilder keyBuilder =
+            new RlsProtoData.GrpcKeyBuilder(
+                names, headers, extraKeys, keyBuilderProto.getConstantKeysMap());
+        keyBuilders.add(keyBuilder);
+      }
+      RlsProtoData.RouteLookupConfig config = new RlsProtoData.RouteLookupConfig(
+          keyBuilders,
+          configProto.getLookupService(),
+          Durations.toMillis(configProto.getLookupServiceTimeout()),
+          configProto.hasMaxAge() ? Durations.toMillis(configProto.getMaxAge()) : null,
+          configProto.hasStaleAge() ? Durations.toMillis(configProto.getStaleAge()) : null,
+          configProto.getCacheSizeBytes(),
+          configProto.getValidTargetsList(),
+          configProto.getDefaultTarget());
+      return ConfigOrError.fromConfig(new RlsPluginConfig(config));
+    } catch (RuntimeException e) {
+      return ConfigOrError.fromError(
+          "Error parsing RouteLookupConfig: \n" + configProto + "\n reason: " + e);
+    }
+  }
+
+  static class RlsPluginConfig implements PluginConfig {
+
+    final RlsProtoData.RouteLookupConfig config;
+
+    RlsPluginConfig(RlsProtoData.RouteLookupConfig config) {
+      this.config = config;
+    }
+
+    @Override
+    public String typeUrl() {
+      return TYPE_URL;
+    }
+  }
+}

--- a/xds/src/test/java/io/grpc/xds/ClusterSpecifierPluginRegistryTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterSpecifierPluginRegistryTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link ClusterSpecifierPluginRegistry}. */
+@RunWith(JUnit4.class)
+public class ClusterSpecifierPluginRegistryTest {
+  @Test
+  public void pluginsInGlobaalInstance() {
+    assertThat(ClusterSpecifierPluginRegistry.getDefaultRegistry()
+            .get("type.googleapis.com/grpc.lookup.v1.RouteLookupConfig"))
+        .isEqualTo(RlsClusterSpecifierPlugin.INSTANCE);
+  }
+}

--- a/xds/src/test/java/io/grpc/xds/RbacFilterTest.java
+++ b/xds/src/test/java/io/grpc/xds/RbacFilterTest.java
@@ -52,7 +52,6 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 import io.grpc.testing.TestMethodDescriptors;
-import io.grpc.xds.Filter.ConfigOrError;
 import io.grpc.xds.Filter.FilterConfig;
 import io.grpc.xds.internal.rbac.engine.GrpcAuthorizationEngine;
 import io.grpc.xds.internal.rbac.engine.GrpcAuthorizationEngine.AlwaysTrueMatcher;

--- a/xds/src/test/java/io/grpc/xds/RlsClusterSpecifierPluginTest.java
+++ b/xds/src/test/java/io/grpc/xds/RlsClusterSpecifierPluginTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.Any;
+import com.google.protobuf.util.Durations;
+import io.grpc.lookup.v1.GrpcKeyBuilder;
+import io.grpc.lookup.v1.GrpcKeyBuilder.ExtraKeys;
+import io.grpc.lookup.v1.GrpcKeyBuilder.Name;
+import io.grpc.lookup.v1.NameMatcher;
+import io.grpc.lookup.v1.RouteLookupConfig;
+import io.grpc.rls.RlsProtoData;
+import io.grpc.xds.RlsClusterSpecifierPlugin.RlsPluginConfig;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link RlsClusterSpecifierPlugin}. */
+@RunWith(JUnit4.class)
+public class RlsClusterSpecifierPluginTest {
+  @Test
+  public void parseConfigWithAllFieldsGiven() {
+    RouteLookupConfig routeLookupConfig = RouteLookupConfig.newBuilder()
+        .addGrpcKeybuilders(
+            GrpcKeyBuilder.newBuilder()
+                .addNames(Name.newBuilder().setService("service1").setMethod("method1"))
+                .addNames(Name.newBuilder().setService("service2").setMethod("method2"))
+                .addHeaders(
+                    NameMatcher.newBuilder().setKey("key1").addNames("v1").setRequiredMatch(true))
+                .setExtraKeys(
+                    ExtraKeys.newBuilder()
+                        .setHost("host1").setService("service1").setMethod("method1"))
+                .putConstantKeys("key2", "value2"))
+        .setLookupService("rls-cbt.googleapis.com")
+        .setLookupServiceTimeout(Durations.fromMillis(1234))
+        .setMaxAge(Durations.fromMillis(56789))
+        .setStaleAge(Durations.fromMillis(1000))
+        .setCacheSizeBytes(5000)
+        .addValidTargets("valid-target")
+        .setDefaultTarget("default-target")
+        .build();
+    RlsPluginConfig config =
+        RlsClusterSpecifierPlugin.INSTANCE.parsePlugin(Any.pack(routeLookupConfig)).config;
+    assertThat(config.typeUrl()).isEqualTo("type.googleapis.com/grpc.lookup.v1.RouteLookupConfig");
+    assertThat(config.config).isEqualTo(
+        new RlsProtoData.RouteLookupConfig(
+            ImmutableList.of(
+                new RlsProtoData.GrpcKeyBuilder(
+                    ImmutableList.of(
+                        new RlsProtoData.GrpcKeyBuilder.Name("service1", "method1"),
+                        new RlsProtoData.GrpcKeyBuilder.Name("service2", "method2")),
+                    ImmutableList.of(
+                        new RlsProtoData.NameMatcher("key1", ImmutableList.of("v1"), true)),
+                    RlsProtoData.ExtraKeys.create("host1", "service1", "method1"),
+                    ImmutableMap.of("key2", "value2")
+                )),
+            "rls-cbt.googleapis.com",
+            1234,
+            56789L,
+            1000L,
+            5000,
+            ImmutableList.of("valid-target"),
+            "default-target"));
+  }
+
+  @Test
+  public void parseConfigWithOptionalFieldsUnspecified() {
+    RouteLookupConfig routeLookupConfig = RouteLookupConfig.newBuilder()
+        .addGrpcKeybuilders(
+            GrpcKeyBuilder.newBuilder()
+                .addNames(Name.newBuilder().setService("service1"))
+                .addNames(Name.newBuilder().setService("service2"))
+                .addHeaders(
+                    NameMatcher.newBuilder().setKey("key1").addNames("v1").setRequiredMatch(true)))
+        .setLookupService("rls-cbt.googleapis.com")
+        .setLookupServiceTimeout(Durations.fromMillis(1234))
+        .setCacheSizeBytes(5000)
+        .addValidTargets("valid-target")
+        .build();
+    RlsPluginConfig config =
+        RlsClusterSpecifierPlugin.INSTANCE.parsePlugin(Any.pack(routeLookupConfig)).config;
+    assertThat(config.typeUrl()).isEqualTo("type.googleapis.com/grpc.lookup.v1.RouteLookupConfig");
+    assertThat(config.config).isEqualTo(
+        new RlsProtoData.RouteLookupConfig(
+            ImmutableList.of(
+                new RlsProtoData.GrpcKeyBuilder(
+                    ImmutableList.of(
+                        new RlsProtoData.GrpcKeyBuilder.Name("service1"),
+                        new RlsProtoData.GrpcKeyBuilder.Name("service2")),
+                    ImmutableList.of(
+                        new RlsProtoData.NameMatcher("key1", ImmutableList.of("v1"), true)),
+                    RlsProtoData.ExtraKeys.create(null, null, null),
+                    ImmutableMap.<String, String>of()
+                )),
+            "rls-cbt.googleapis.com",
+            1234,
+            null,
+            null,
+            5000,
+            ImmutableList.of("valid-target"),
+            null));
+  }
+}


### PR DESCRIPTION
Add RlsClusterSpecifierPlugin as per go/grpc-rls-in-xds#heading=h.dmyrvi6ohebx

The structure of `ClusterSpecifierPlugin` is very similar to `io.grpc.xds.Filter`.

The following changes to the existing code are made:

- move `ConfigOrError` class out of `Filter` class to be shared with `ClusterSpecifierPlugin`
- make `io.grpc.rls.RlsProtoData` public to be accessible by `io.grpc.xds`
- treat empty defaultTarget in `io.grpc.rls.RlsProtoData.RouteLookupConfig` as null to support both json and proto config without defaultTarget field specified.