### PR TITLE
remove DSA check in CertificateUtils

### DIFF
--- a/core/src/main/java/io/grpc/util/CertificateUtils.java
+++ b/core/src/main/java/io/grpc/util/CertificateUtils.java
@@ -56,8 +56,7 @@ public final class CertificateUtils {
 
   /**
    * Generates a {@link PrivateKey} from a PEM file.
-   * The key should be PKCS #8 formatted. The key algorithm should be "RSA", "DiffieHellman",
-   * "DSA", or "EC".
+   * The key should be PKCS #8 formatted. The key algorithm should be "RSA" or "EC".
    * The PEM file should contain one item in Base64 encoding, with plain-text headers and footers
    * (e.g. -----BEGIN PRIVATE KEY----- and -----END PRIVATE KEY-----).
    *
@@ -86,13 +85,9 @@ public final class CertificateUtils {
       return KeyFactory.getInstance("RSA").generatePrivate(keySpec);
     } catch (InvalidKeySpecException ignore) {
       try {
-        return KeyFactory.getInstance("DSA").generatePrivate(keySpec);
-      } catch (InvalidKeySpecException ignore2) {
-        try {
-          return KeyFactory.getInstance("EC").generatePrivate(keySpec);
-        } catch (InvalidKeySpecException e) {
-          throw new InvalidKeySpecException("Neither RSA, DSA nor EC worked", e);
-        }
+        return KeyFactory.getInstance("EC").generatePrivate(keySpec);
+      } catch (InvalidKeySpecException e) {
+        throw new InvalidKeySpecException("Neither RSA nor EC worked", e);
       }
     }
   }


### PR DESCRIPTION
Our Internal check says DSA is insecure and doesn't allow us to use DSA.
It's fine to remove it since we don't have users using it. We can discuss what to do next once we have users requesting for it.