### PR TITLE
rls: fix connectivity state aggregation

### DIFF
--- a/rls/src/main/java/io/grpc/rls/SubchannelStateManager.java
+++ b/rls/src/main/java/io/grpc/rls/SubchannelStateManager.java
@@ -16,6 +16,7 @@
 
 package io.grpc.rls;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.grpc.ConnectivityState;
 import javax.annotation.Nullable;
 
@@ -35,6 +36,7 @@ interface SubchannelStateManager {
    * {@code null}.
    */
   @Nullable
+  @VisibleForTesting
   ConnectivityState getState(String name);
 
   /** Returns representative subchannel status from all registered subchannels. */

--- a/rls/src/test/java/io/grpc/rls/ChildLoadBalancerHelperTest.java
+++ b/rls/src/test/java/io/grpc/rls/ChildLoadBalancerHelperTest.java
@@ -57,7 +57,7 @@ public class ChildLoadBalancerHelperTest {
         .isEqualTo(ConnectivityState.TRANSIENT_FAILURE);
 
     childLbHelper2.updateBalancingState(ConnectivityState.CONNECTING, picker2);
-    inOrder.verify(helper).updateBalancingState(ConnectivityState.CONNECTING, picker);
+    inOrder.verify(helper).updateBalancingState(ConnectivityState.TRANSIENT_FAILURE, picker);
     assertThat(subchannelStateManager.getState(target2)).isEqualTo(ConnectivityState.CONNECTING);
 
     childLbHelper1.updateBalancingState(ConnectivityState.READY, picker1);

--- a/rls/src/test/java/io/grpc/rls/SubchannelStateManagerImplTest.java
+++ b/rls/src/test/java/io/grpc/rls/SubchannelStateManagerImplTest.java
@@ -90,5 +90,13 @@ public class SubchannelStateManagerImplTest {
 
     assertThat(subchannelStateManager.getAggregatedState())
         .isEqualTo(ConnectivityState.TRANSIENT_FAILURE);
+
+    subchannelStateManager.updateState("channel1", ConnectivityState.CONNECTING);
+    assertThat(subchannelStateManager.getAggregatedState())
+        .isEqualTo(ConnectivityState.TRANSIENT_FAILURE);
+
+    subchannelStateManager.updateState("channel1", ConnectivityState.READY);
+    assertThat(subchannelStateManager.getAggregatedState())
+        .isEqualTo(ConnectivityState.READY);
   }
 }


### PR DESCRIPTION
Fix connectivity state aggregation as per http://go/grpc-rls-lb-policy-design#heading=h.6e8tt7xcwcdn

> Note that, for the purposes of aggregation, when a child policy reports TRANSIENT_FAILURE, we consider it to continue to be in that state until it reports READY (i.e., we ignore CONNECTING in between the two, no matter how many times it bounces back and forth between TRANSIENT_FAILURE and CONNECTING).
