### PR TITLE
interop-testing: assign server as soon as it is built instead of after start

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
@@ -180,16 +180,16 @@ public final class XdsTestServer {
               .addService(
                   ServerInterceptors.intercept(
                       new TestServiceImpl(serverId, host), new TestInfoInterceptor(host)))
-              .build()
-              .start();
+              .build();
+      server.start();
       maintenanceServer =
           NettyServerBuilder.forPort(maintenancePort)
               .addService(new XdsUpdateHealthServiceImpl(health))
               .addService(health.getHealthService())
               .addService(ProtoReflectionService.newInstance())
               .addServices(AdminInterface.getStandardServices())
-              .build()
-              .start();
+              .build();
+      maintenanceServer.start();
     } else {
       server =
           NettyServerBuilder.forPort(port)
@@ -200,8 +200,8 @@ public final class XdsTestServer {
               .addService(health.getHealthService())
               .addService(ProtoReflectionService.newInstance())
               .addServices(AdminInterface.getStandardServices())
-              .build()
-              .start();
+              .build();
+      server.start();
       maintenanceServer = null;
     }
     health.setStatus("", ServingStatus.SERVING);


### PR DESCRIPTION
fixes the issue about XdsTestServer mentioned in #8657. Make sure server is still assigned even if `start()` throws