### PR TITLE
kokoro: Enable xds authz_test

### DIFF
--- a/buildscripts/kokoro/xds-k8s.sh
+++ b/buildscripts/kokoro/xds-k8s.sh
@@ -168,6 +168,7 @@ main() {
   cd "${TEST_DRIVER_FULL_DIR}"
   run_test baseline_test
   run_test security_test
+  run_test authz_test
 }
 
 main "$@"


### PR DESCRIPTION
It is successfully passing against prod:
https://source.cloud.google.com/results/invocations/e2be0996-ed4d-4a4c-90ad-20bc706f9f70/targets

CC @sergiitk 