### PR TITLE
Revert "kokoro: Enable xds authz_test"

### DIFF
--- a/buildscripts/kokoro/xds-k8s.sh
+++ b/buildscripts/kokoro/xds-k8s.sh
@@ -168,7 +168,6 @@ main() {
   cd "${TEST_DRIVER_FULL_DIR}"
   run_test baseline_test
   run_test security_test
-  run_test authz_test
 }
 
 main "$@"


### PR DESCRIPTION
This reverts commit 0d34572149b515c19130800bb593c8f3985c5e21.

The added test causes a 2 hour timeout to be exceeded.

CC @sergiitk 