### PR TITLE
kokoro: Increase xds-k8s timeout to 3 hours

### DIFF
--- a/buildscripts/kokoro/xds-k8s.cfg
+++ b/buildscripts/kokoro/xds-k8s.cfg
@@ -2,7 +2,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-java/buildscripts/kokoro/xds-k8s.sh"
-timeout_mins: 120
+timeout_mins: 180
 
 action {
   define_artifacts {


### PR DESCRIPTION
The addition of the authz tests in 0d345721 is causing the tests to
exceed their timeout. By itself, the authz test takes about an hour in
this environment. Before the authz tests, xds-k8s was taking an hour
and a half.