### PR TITLE
kokoro: Enable xds authz_test (v1.42.x backport)

### DIFF
--- a/buildscripts/kokoro/xds-k8s.cfg
+++ b/buildscripts/kokoro/xds-k8s.cfg
@@ -2,7 +2,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-java/buildscripts/kokoro/xds-k8s.sh"
-timeout_mins: 120
+timeout_mins: 180
 
 action {
   define_artifacts {

--- a/buildscripts/kokoro/xds-k8s.sh
+++ b/buildscripts/kokoro/xds-k8s.sh
@@ -168,6 +168,7 @@ main() {
   cd "${TEST_DRIVER_FULL_DIR}"
   run_test baseline_test
   run_test security_test
+  run_test authz_test
 }
 
 main "$@"


### PR DESCRIPTION
This is a backport of #8664 and its fixup #8667