### PR TITLE
xds: populate LRS ServerInfo to CdsUpdate

### DIFF
--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
@@ -157,12 +157,12 @@ final class CdsLoadBalancer2 extends LoadBalancer {
             if (clusterState.result.clusterType() ==  ClusterType.EDS) {
               instance = DiscoveryMechanism.forEds(
                   clusterState.name, clusterState.result.edsServiceName(),
-                  clusterState.result.lrsServerName(), clusterState.result.maxConcurrentRequests(),
+                  clusterState.result.lrsServerInfo(), clusterState.result.maxConcurrentRequests(),
                   clusterState.result.upstreamTlsContext());
             } else {  // logical DNS
               instance = DiscoveryMechanism.forLogicalDns(
                   clusterState.name, clusterState.result.dnsHostName(),
-                  clusterState.result.lrsServerName(), clusterState.result.maxConcurrentRequests(),
+                  clusterState.result.lrsServerInfo(), clusterState.result.maxConcurrentRequests(),
                   clusterState.result.upstreamTlsContext());
             }
             instances.add(instance);

--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -1471,7 +1471,7 @@ final class ClientXdsClient extends XdsClient implements XdsResponseHandler, Res
         if (getBootstrapInfo() != null && getBootstrapInfo().certProviders() != null) {
           certProviderInstances = getBootstrapInfo().certProviders().keySet();
         }
-        cdsUpdate = parseCluster(cluster, retainedEdsResources, certProviderInstances);
+        cdsUpdate = parseCluster(cluster, retainedEdsResources, certProviderInstances, serverInfo);
       } catch (ResourceInvalidException e) {
         errors.add(
             "CDS response Cluster '" + clusterName + "' validation error: " + e.getMessage());
@@ -1490,13 +1490,13 @@ final class ClientXdsClient extends XdsClient implements XdsResponseHandler, Res
 
   @VisibleForTesting
   static CdsUpdate parseCluster(Cluster cluster, Set<String> retainedEdsResources,
-      Set<String> certProviderInstances)
+      Set<String> certProviderInstances, ServerInfo serverInfo)
       throws ResourceInvalidException {
     StructOrError<CdsUpdate.Builder> structOrError;
     switch (cluster.getClusterDiscoveryTypeCase()) {
       case TYPE:
         structOrError = parseNonAggregateCluster(cluster, retainedEdsResources,
-            certProviderInstances);
+            certProviderInstances, serverInfo);
         break;
       case CLUSTER_TYPE:
         structOrError = parseAggregateCluster(cluster);
@@ -1559,9 +1559,10 @@ final class ClientXdsClient extends XdsClient implements XdsResponseHandler, Res
   }
 
   private static StructOrError<CdsUpdate.Builder> parseNonAggregateCluster(
-      Cluster cluster, Set<String> edsResources, Set<String> certProviderInstances) {
+      Cluster cluster, Set<String> edsResources, Set<String> certProviderInstances,
+      ServerInfo serverInfo) {
     String clusterName = cluster.getName();
-    String lrsServerName = null;
+    ServerInfo lrsServerInfo = null;
     Long maxConcurrentRequests = null;
     UpstreamTlsContext upstreamTlsContext = null;
     if (cluster.hasLrsServer()) {
@@ -1569,7 +1570,7 @@ final class ClientXdsClient extends XdsClient implements XdsResponseHandler, Res
         return StructOrError.fromError(
             "Cluster " + clusterName + ": only support LRS for the same management server");
       }
-      lrsServerName = "";
+      lrsServerInfo = serverInfo;
     }
     if (cluster.hasCircuitBreakers()) {
       List<Thresholds> thresholds = cluster.getCircuitBreakers().getThresholdsList();
@@ -1621,7 +1622,7 @@ final class ClientXdsClient extends XdsClient implements XdsResponseHandler, Res
         edsResources.add(clusterName);
       }
       return StructOrError.fromStruct(CdsUpdate.forEds(
-          clusterName, edsServiceName, lrsServerName, maxConcurrentRequests, upstreamTlsContext));
+          clusterName, edsServiceName, lrsServerInfo, maxConcurrentRequests, upstreamTlsContext));
     } else if (type.equals(DiscoveryType.LOGICAL_DNS)) {
       if (!cluster.hasLoadAssignment()) {
         return StructOrError.fromError(
@@ -1656,7 +1657,7 @@ final class ClientXdsClient extends XdsClient implements XdsResponseHandler, Res
       String dnsHostName =
           String.format("%s:%d", socketAddress.getAddress(), socketAddress.getPortValue());
       return StructOrError.fromStruct(CdsUpdate.forLogicalDns(
-          clusterName, dnsHostName, lrsServerName, maxConcurrentRequests, upstreamTlsContext));
+          clusterName, dnsHostName, lrsServerInfo, maxConcurrentRequests, upstreamTlsContext));
     }
     return StructOrError.fromError(
         "Cluster " + clusterName + ": unsupported built-in discovery type: " + type);
@@ -2094,15 +2095,14 @@ final class ClientXdsClient extends XdsClient implements XdsResponseHandler, Res
 
   @Override
   ClusterDropStats addClusterDropStats(
-      String clusterName, @Nullable String edsServiceName) {
+      final ServerInfo serverInfo, String clusterName, @Nullable String edsServiceName) {
     ClusterDropStats dropCounter =
         loadStatsManager.getClusterDropStats(clusterName, edsServiceName);
     syncContext.execute(new Runnable() {
       @Override
       public void run() {
         if (!reportingLoad) {
-          // TODO(https://github.com/grpc/grpc-java/issues/8628): consume ServerInfo arg.
-          serverLrsClientMap.values().iterator().next().startLoadReporting();
+          serverLrsClientMap.get(serverInfo).startLoadReporting();
           reportingLoad = true;
         }
       }
@@ -2112,7 +2112,7 @@ final class ClientXdsClient extends XdsClient implements XdsResponseHandler, Res
 
   @Override
   ClusterLocalityStats addClusterLocalityStats(
-      String clusterName, @Nullable String edsServiceName,
+      final ServerInfo serverInfo, String clusterName, @Nullable String edsServiceName,
       Locality locality) {
     ClusterLocalityStats loadCounter =
         loadStatsManager.getClusterLocalityStats(clusterName, edsServiceName, locality);
@@ -2120,8 +2120,7 @@ final class ClientXdsClient extends XdsClient implements XdsResponseHandler, Res
       @Override
       public void run() {
         if (!reportingLoad) {
-          // TODO(https://github.com/grpc/grpc-java/issues/8628): consume ServerInfo arg.
-          serverLrsClientMap.values().iterator().next().startLoadReporting();
+          serverLrsClientMap.get(serverInfo).startLoadReporting();
           reportingLoad = true;
         }
       }

--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancerProvider.java
@@ -26,6 +26,7 @@ import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.internal.ServiceConfigUtil.PolicySelection;
+import io.grpc.xds.Bootstrapper.ServerInfo;
 import io.grpc.xds.Endpoints.DropOverload;
 import io.grpc.xds.EnvoyServerProtoData.UpstreamTlsContext;
 import java.util.ArrayList;
@@ -73,9 +74,9 @@ public final class ClusterImplLoadBalancerProvider extends LoadBalancerProvider 
     // Resource name used in discovering endpoints via EDS. Only valid for EDS clusters.
     @Nullable
     final String edsServiceName;
-    // Load report server name. Null if load reporting is disabled.
+    // Load report server info. Null if load reporting is disabled.
     @Nullable
-    final String lrsServerName;
+    final ServerInfo lrsServerInfo;
     // Cluster-level max concurrent request threshold. Null if not specified.
     @Nullable
     final Long maxConcurrentRequests;
@@ -88,12 +89,12 @@ public final class ClusterImplLoadBalancerProvider extends LoadBalancerProvider 
     final PolicySelection childPolicy;
 
     ClusterImplConfig(String cluster, @Nullable String edsServiceName,
-        @Nullable String lrsServerName, @Nullable Long maxConcurrentRequests,
+        @Nullable ServerInfo lrsServerInfo, @Nullable Long maxConcurrentRequests,
         List<DropOverload> dropCategories, PolicySelection childPolicy,
         @Nullable UpstreamTlsContext tlsContext) {
       this.cluster = checkNotNull(cluster, "cluster");
       this.edsServiceName = edsServiceName;
-      this.lrsServerName = lrsServerName;
+      this.lrsServerInfo = lrsServerInfo;
       this.maxConcurrentRequests = maxConcurrentRequests;
       this.tlsContext = tlsContext;
       this.dropCategories = Collections.unmodifiableList(
@@ -106,7 +107,7 @@ public final class ClusterImplLoadBalancerProvider extends LoadBalancerProvider 
       return MoreObjects.toStringHelper(this)
           .add("cluster", cluster)
           .add("edsServiceName", edsServiceName)
-          .add("lrsServerName", lrsServerName)
+          .add("lrsServerInfo", lrsServerInfo)
           .add("maxConcurrentRequests", maxConcurrentRequests)
           // Exclude tlsContext as its string representation is cumbersome.
           .add("dropCategories", dropCategories)

--- a/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancerProvider.java
@@ -25,6 +25,7 @@ import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.internal.ServiceConfigUtil.PolicySelection;
+import io.grpc.xds.Bootstrapper.ServerInfo;
 import io.grpc.xds.EnvoyServerProtoData.UpstreamTlsContext;
 import java.util.List;
 import java.util.Map;
@@ -107,9 +108,9 @@ public final class ClusterResolverLoadBalancerProvider extends LoadBalancerProvi
       final String cluster;
       // Type of the cluster.
       final Type type;
-      // Load reporting server name. Null if not enabled.
+      // Load reporting server info. Null if not enabled.
       @Nullable
-      final String lrsServerName;
+      final ServerInfo lrsServerInfo;
       // Cluster-level max concurrent request threshold. Null if not specified.
       @Nullable
       final Long maxConcurrentRequests;
@@ -129,34 +130,34 @@ public final class ClusterResolverLoadBalancerProvider extends LoadBalancerProvi
       }
 
       private DiscoveryMechanism(String cluster, Type type, @Nullable String edsServiceName,
-          @Nullable String dnsHostName, @Nullable String lrsServerName,
+          @Nullable String dnsHostName, @Nullable ServerInfo lrsServerInfo,
           @Nullable Long maxConcurrentRequests, @Nullable UpstreamTlsContext tlsContext) {
         this.cluster = checkNotNull(cluster, "cluster");
         this.type = checkNotNull(type, "type");
         this.edsServiceName = edsServiceName;
         this.dnsHostName = dnsHostName;
-        this.lrsServerName = lrsServerName;
+        this.lrsServerInfo = lrsServerInfo;
         this.maxConcurrentRequests = maxConcurrentRequests;
         this.tlsContext = tlsContext;
       }
 
       static DiscoveryMechanism forEds(String cluster, @Nullable String edsServiceName,
-          @Nullable String lrsServerName, @Nullable Long maxConcurrentRequests,
+          @Nullable ServerInfo lrsServerInfo, @Nullable Long maxConcurrentRequests,
           @Nullable UpstreamTlsContext tlsContext) {
-        return new DiscoveryMechanism(cluster, Type.EDS, edsServiceName, null, lrsServerName,
+        return new DiscoveryMechanism(cluster, Type.EDS, edsServiceName, null, lrsServerInfo,
             maxConcurrentRequests, tlsContext);
       }
 
       static DiscoveryMechanism forLogicalDns(String cluster, String dnsHostName,
-          @Nullable String lrsServerName, @Nullable Long maxConcurrentRequests,
+          @Nullable ServerInfo lrsServerInfo, @Nullable Long maxConcurrentRequests,
           @Nullable UpstreamTlsContext tlsContext) {
         return new DiscoveryMechanism(cluster, Type.LOGICAL_DNS, null, dnsHostName,
-            lrsServerName, maxConcurrentRequests, tlsContext);
+            lrsServerInfo, maxConcurrentRequests, tlsContext);
       }
 
       @Override
       public int hashCode() {
-        return Objects.hash(cluster, type, lrsServerName, maxConcurrentRequests, tlsContext,
+        return Objects.hash(cluster, type, lrsServerInfo, maxConcurrentRequests, tlsContext,
             edsServiceName, dnsHostName);
       }
 
@@ -173,7 +174,7 @@ public final class ClusterResolverLoadBalancerProvider extends LoadBalancerProvi
             && type == that.type
             && Objects.equals(edsServiceName, that.edsServiceName)
             && Objects.equals(dnsHostName, that.dnsHostName)
-            && Objects.equals(lrsServerName, that.lrsServerName)
+            && Objects.equals(lrsServerInfo, that.lrsServerInfo)
             && Objects.equals(maxConcurrentRequests, that.maxConcurrentRequests)
             && Objects.equals(tlsContext, that.tlsContext);
       }
@@ -186,7 +187,7 @@ public final class ClusterResolverLoadBalancerProvider extends LoadBalancerProvi
                 .add("type", type)
                 .add("edsServiceName", edsServiceName)
                 .add("dnsHostName", dnsHostName)
-                .add("lrsServerName", lrsServerName)
+                .add("lrsServerInfo", lrsServerInfo)
                 // Exclude tlsContext as its string representation is cumbersome.
                 .add("maxConcurrentRequests", maxConcurrentRequests);
         return toStringHelper.toString();

--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -130,10 +130,10 @@ abstract class XdsClient {
     @Nullable
     abstract String dnsHostName();
 
-    // Load report server name for reporting loads via LRS.
+    // Load report server info for reporting loads via LRS.
     // Only valid for EDS or LOGICAL_DNS cluster.
     @Nullable
-    abstract String lrsServerName();
+    abstract ServerInfo lrsServerInfo();
 
     // Max number of concurrent requests can be sent to this cluster.
     // Only valid for EDS or LOGICAL_DNS cluster.
@@ -161,7 +161,7 @@ abstract class XdsClient {
     }
 
     static Builder forEds(String clusterName, @Nullable String edsServiceName,
-        @Nullable String lrsServerName, @Nullable Long maxConcurrentRequests,
+        @Nullable ServerInfo lrsServerInfo, @Nullable Long maxConcurrentRequests,
         @Nullable UpstreamTlsContext upstreamTlsContext) {
       return new AutoValue_XdsClient_CdsUpdate.Builder()
           .clusterName(clusterName)
@@ -169,13 +169,13 @@ abstract class XdsClient {
           .minRingSize(0)
           .maxRingSize(0)
           .edsServiceName(edsServiceName)
-          .lrsServerName(lrsServerName)
+          .lrsServerInfo(lrsServerInfo)
           .maxConcurrentRequests(maxConcurrentRequests)
           .upstreamTlsContext(upstreamTlsContext);
     }
 
     static Builder forLogicalDns(String clusterName, String dnsHostName,
-        @Nullable String lrsServerName, @Nullable Long maxConcurrentRequests,
+        @Nullable ServerInfo lrsServerInfo, @Nullable Long maxConcurrentRequests,
         @Nullable UpstreamTlsContext upstreamTlsContext) {
       return new AutoValue_XdsClient_CdsUpdate.Builder()
           .clusterName(clusterName)
@@ -183,7 +183,7 @@ abstract class XdsClient {
           .minRingSize(0)
           .maxRingSize(0)
           .dnsHostName(dnsHostName)
-          .lrsServerName(lrsServerName)
+          .lrsServerInfo(lrsServerInfo)
           .maxConcurrentRequests(maxConcurrentRequests)
           .upstreamTlsContext(upstreamTlsContext);
     }
@@ -207,7 +207,7 @@ abstract class XdsClient {
           .add("maxRingSize", maxRingSize())
           .add("edsServiceName", edsServiceName())
           .add("dnsHostName", dnsHostName())
-          .add("lrsServerName", lrsServerName())
+          .add("lrsServerInfo", lrsServerInfo())
           .add("maxConcurrentRequests", maxConcurrentRequests())
           // Exclude upstreamTlsContext as its string representation is cumbersome.
           .add("prioritizedClusterNames", prioritizedClusterNames())
@@ -246,7 +246,7 @@ abstract class XdsClient {
       protected abstract Builder dnsHostName(String dnsHostName);
 
       // Private, use one of the static factory methods instead.
-      protected abstract Builder lrsServerName(String lrsServerName);
+      protected abstract Builder lrsServerInfo(ServerInfo lrsServerInfo);
 
       // Private, use one of the static factory methods instead.
       protected abstract Builder maxConcurrentRequests(Long maxConcurrentRequests);
@@ -569,8 +569,8 @@ abstract class XdsClient {
    * use {@link ClusterDropStats#release} to release its <i>hard</i> reference when it is safe to
    * stop reporting dropped RPCs for the specified cluster in the future.
    */
-  // TODO(https://github.com/grpc/grpc-java/issues/8628): add ServerInfo arg
-  ClusterDropStats addClusterDropStats(String clusterName, @Nullable String edsServiceName) {
+  ClusterDropStats addClusterDropStats(
+      ServerInfo serverInfo, String clusterName, @Nullable String edsServiceName) {
     throw new UnsupportedOperationException();
   }
 
@@ -582,9 +582,9 @@ abstract class XdsClient {
    * reference when it is safe to stop reporting RPC loads for the specified locality in the
    * future.
    */
-  // TODO(https://github.com/grpc/grpc-java/issues/8628): add ServerInfo arg
   ClusterLocalityStats addClusterLocalityStats(
-      String clusterName, @Nullable String edsServiceName, Locality locality) {
+      ServerInfo serverInfo, String clusterName, @Nullable String edsServiceName,
+      Locality locality) {
     throw new UnsupportedOperationException();
   }
 

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
@@ -94,7 +94,9 @@ import io.envoyproxy.envoy.type.matcher.v3.StringMatcher;
 import io.envoyproxy.envoy.type.v3.FractionalPercent;
 import io.envoyproxy.envoy.type.v3.FractionalPercent.DenominatorType;
 import io.envoyproxy.envoy.type.v3.Int64Range;
+import io.grpc.InsecureChannelCredentials;
 import io.grpc.Status.Code;
+import io.grpc.xds.Bootstrapper.ServerInfo;
 import io.grpc.xds.ClientXdsClient.ResourceInvalidException;
 import io.grpc.xds.ClientXdsClient.StructOrError;
 import io.grpc.xds.Endpoints.LbEndpoint;
@@ -125,6 +127,9 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class ClientXdsClientDataTest {
+
+  private static final ServerInfo LRS_SERVER_INFO =
+      ServerInfo.create("lrs.googleapis.com", InsecureChannelCredentials.create(), true);
 
   @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule
@@ -1239,7 +1244,8 @@ public class ClientXdsClientDataTest {
         .setLbPolicy(LbPolicy.RING_HASH)
         .build();
 
-    CdsUpdate update = ClientXdsClient.parseCluster(cluster, new HashSet<String>(), null);
+    CdsUpdate update = ClientXdsClient.parseCluster(
+        cluster, new HashSet<String>(), null, LRS_SERVER_INFO);
     assertThat(update.lbPolicy()).isEqualTo(CdsUpdate.LbPolicy.RING_HASH);
     assertThat(update.minRingSize())
         .isEqualTo(ClientXdsClient.DEFAULT_RING_HASH_LB_POLICY_MIN_RING_SIZE);
@@ -1266,7 +1272,7 @@ public class ClientXdsClientDataTest {
     thrown.expect(ResourceInvalidException.class);
     thrown.expectMessage(
         "Cluster cluster-foo.googleapis.com: transport-socket-matches not supported.");
-    ClientXdsClient.parseCluster(cluster, new HashSet<String>(), null);
+    ClientXdsClient.parseCluster(cluster, new HashSet<String>(), null, LRS_SERVER_INFO);
   }
 
   @Test
@@ -1291,7 +1297,7 @@ public class ClientXdsClientDataTest {
 
     thrown.expect(ResourceInvalidException.class);
     thrown.expectMessage("Cluster cluster-foo.googleapis.com: invalid ring_hash_lb_config");
-    ClientXdsClient.parseCluster(cluster, new HashSet<String>(), null);
+    ClientXdsClient.parseCluster(cluster, new HashSet<String>(), null, LRS_SERVER_INFO);
   }
 
   @Test
@@ -1318,7 +1324,7 @@ public class ClientXdsClientDataTest {
 
     thrown.expect(ResourceInvalidException.class);
     thrown.expectMessage("Cluster cluster-foo.googleapis.com: invalid ring_hash_lb_config");
-    ClientXdsClient.parseCluster(cluster, new HashSet<String>(), null);
+    ClientXdsClient.parseCluster(cluster, new HashSet<String>(), null, LRS_SERVER_INFO);
   }
 
   @Test


### PR DESCRIPTION
Replace `String lrsServerName` with `ServerInfo lrsServerInfo` in `CdsUpdate`.

See http://go/grpc-xds-federation#heading=h.gh3gjftay27x for details.

This PR is only refactoring. Federation support is not implemented until the TODO [here](https://github.com/grpc/grpc-java/blob/a5c526c12f699af9a846d9faabc18038ef431675/xds/src/main/java/io/grpc/xds/ClientXdsClient.java#L2280) is addressed.

Resolves #8628 