### PR TITLE
xds: support xdstp scheme in resource URIs for federation

### DIFF
--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -33,6 +33,8 @@ import javax.annotation.Nullable;
 @Internal
 public abstract class Bootstrapper {
 
+  static final String XDSTP_SCHEME = "xdstp:";
+
   /**
    * Returns system-loaded bootstrap configuration.
    */

--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -16,6 +16,8 @@
 
 package io.grpc.xds;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -106,12 +108,13 @@ public abstract class Bootstrapper {
      * <p>If the same server is listed in multiple authorities, the entries will be de-duped (i.e.,
      * resources for both authorities will be fetched on the same ADS stream).
      *
-     * <p>If empty, the top-level server list {@link BootstrapInfo#servers()} will be used.
+     * <p>Defaults to the top-level server list {@link BootstrapInfo#servers()}. Must not be empty.
      */
     abstract ImmutableList<ServerInfo> xdsServers();
 
     static AuthorityInfo create(
         String clientListenerResourceNameTemplate, List<ServerInfo> xdsServers) {
+      checkArgument(!xdsServers.isEmpty(), "xdsServers must not be empty");
       return new AutoValue_Bootstrapper_AuthorityInfo(
           clientListenerResourceNameTemplate, ImmutableList.copyOf(xdsServers));
     }
@@ -123,7 +126,7 @@ public abstract class Bootstrapper {
   @AutoValue
   @Internal
   public abstract static class BootstrapInfo {
-    /** Returns the list of xDS servers to be connected to. */
+    /** Returns the list of xDS servers to be connected to. Must not be empty. */
     abstract ImmutableList<ServerInfo> servers();
 
     /** Returns the node identifier to be included in xDS requests. */

--- a/xds/src/main/java/io/grpc/xds/BootstrapperImpl.java
+++ b/xds/src/main/java/io/grpc/xds/BootstrapperImpl.java
@@ -229,7 +229,7 @@ public class BootstrapperImpl extends Bootstrapper {
             JsonUtil.getString(rawAuthority, "client_listener_resource_name_template");
         logger.log(
             XdsLogLevel.INFO, "client_listener_resource_name_template: {0}", clientListnerTemplate);
-        String prefix = "xdstp://" + authorityName + "/";
+        String prefix = XDSTP_SCHEME + "//" + authorityName + "/";
         if (clientListnerTemplate == null) {
           clientListnerTemplate = prefix + "envoy.config.listener.v3.Listener/%s";
         } else if (!clientListnerTemplate.startsWith(prefix)) {

--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -18,6 +18,7 @@ package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.grpc.xds.Bootstrapper.XDSTP_SCHEME;
 
 import com.github.udpa.udpa.type.v1.TypedStruct;
 import com.google.common.annotations.VisibleForTesting;
@@ -70,6 +71,7 @@ import io.grpc.SynchronizationContext.ScheduledHandle;
 import io.grpc.internal.BackoffPolicy;
 import io.grpc.internal.TimeProvider;
 import io.grpc.xds.AbstractXdsClient.ResourceType;
+import io.grpc.xds.Bootstrapper.AuthorityInfo;
 import io.grpc.xds.Bootstrapper.ServerInfo;
 import io.grpc.xds.Endpoints.DropOverload;
 import io.grpc.xds.Endpoints.LbEndpoint;
@@ -98,6 +100,7 @@ import io.grpc.xds.XdsLogger.XdsLogLevel;
 import io.grpc.xds.internal.Matchers.FractionMatcher;
 import io.grpc.xds.internal.Matchers.HeaderMatcher;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2256,8 +2259,12 @@ final class ClientXdsClient extends XdsClient implements XdsResponseHandler, Res
     ResourceSubscriber(ResourceType type, String resource) {
       syncContext.throwIfNotInThisSynchronizationContext();
       this.type = type;
+      // TODO(zdapeng): Validate authority in resource URI for new-style resource name
+      //   when parsing XDS response.
+      // TODO(zdapeng): Canonicalize the resource name by sorting the context params in normal
+      //   lexicographic order.
       this.resource = resource;
-      this.serverInfo = getServerInfo();
+      this.serverInfo = getServerInfo(resource);
       // Initialize metadata in UNKNOWN state to cover the case when resource subscriber,
       // is created but not yet requested because the client is in backoff.
       this.metadata = ResourceMetadata.newResourceMetadataUnknown();
@@ -2269,8 +2276,16 @@ final class ClientXdsClient extends XdsClient implements XdsResponseHandler, Res
       restartTimer();
     }
 
-    // TODO(zdapeng): add resourceName arg and support xdstp:// resources
-    private ServerInfo getServerInfo() {
+    private ServerInfo getServerInfo(String resource) {
+      if (resource.startsWith(XDSTP_SCHEME)) {
+        URI uri = URI.create(resource);
+        String authority = uri.getAuthority();
+        if (authority == null) {
+          authority = "";
+        }
+        AuthorityInfo authorityInfo = bootstrapInfo.authorities().get(authority);
+        return authorityInfo.xdsServers().get(0);
+      }
       return bootstrapInfo.servers().get(0); // use first server
     }
 

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -18,6 +18,7 @@ package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.grpc.xds.Bootstrapper.XDSTP_SCHEME;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
@@ -185,8 +186,8 @@ final class XdsNameResolver extends NameResolver {
       listenerNameTemplate = authorityInfo.clientListenerResourceNameTemplate();
     }
     String replacement = serviceAuthority;
-    if (listenerNameTemplate.startsWith("xdstp:")) {
-      replacement = percentEncode(serviceAuthority);
+    if (listenerNameTemplate.startsWith(XDSTP_SCHEME)) {
+      replacement = UrlEscapers.urlFragmentEscaper().escape(replacement);
     }
     String ldsResourceName = expandPercentS(listenerNameTemplate, replacement);
     callCounterProvider = SharedCallCounterMap.getInstance();
@@ -196,10 +197,6 @@ final class XdsNameResolver extends NameResolver {
 
   private static String expandPercentS(String template, String replacement) {
     return template.replace("%s", replacement);
-  }
-
-  private static String percentEncode(String input) {
-    return UrlEscapers.urlFragmentEscaper().escape(input);
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
@@ -74,9 +74,10 @@ public final class XdsNameResolverProvider extends NameResolverProvider {
           targetPath,
           targetUri);
       String name = targetPath.substring(1);
-      return new XdsNameResolver(name, args.getServiceConfigParser(),
-              args.getSynchronizationContext(), args.getScheduledExecutorService(),
-              bootstrapOverride);
+      return new XdsNameResolver(
+          targetUri.getAuthority(), name, args.getServiceConfigParser(),
+          args.getSynchronizationContext(), args.getScheduledExecutorService(),
+          bootstrapOverride);
     }
     return null;
   }

--- a/xds/src/main/java/io/grpc/xds/XdsServerWrapper.java
+++ b/xds/src/main/java/io/grpc/xds/XdsServerWrapper.java
@@ -18,11 +18,13 @@ package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static io.grpc.xds.Bootstrapper.XDSTP_SCHEME;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.net.UrlEscapers;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.InternalServerInterceptors;
@@ -192,7 +194,11 @@ final class XdsServerWrapper extends Server {
       xdsClient = xdsClientPool.returnObject(xdsClient);
       return;
     }
-    discoveryState = new DiscoveryState(listenerTemplate.replaceAll("%s", listenerAddress));
+    String replacement = listenerAddress;
+    if (listenerTemplate.startsWith(XDSTP_SCHEME)) {
+      replacement = UrlEscapers.urlFragmentEscaper().escape(replacement);
+    }
+    discoveryState = new DiscoveryState(listenerTemplate.replaceAll("%s", replacement));
   }
 
   @Override

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -45,6 +46,7 @@ import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
 import io.grpc.Deadline;
+import io.grpc.InsecureChannelCredentials;
 import io.grpc.InternalConfigSelector;
 import io.grpc.InternalConfigSelector.Result;
 import io.grpc.Metadata;
@@ -67,6 +69,10 @@ import io.grpc.internal.ObjectPool;
 import io.grpc.internal.PickSubchannelArgsImpl;
 import io.grpc.internal.ScParser;
 import io.grpc.testing.TestMethodDescriptors;
+import io.grpc.xds.Bootstrapper.AuthorityInfo;
+import io.grpc.xds.Bootstrapper.BootstrapInfo;
+import io.grpc.xds.Bootstrapper.ServerInfo;
+import io.grpc.xds.EnvoyProtoData.Node;
 import io.grpc.xds.FaultConfig.FaultAbort;
 import io.grpc.xds.FaultConfig.FaultDelay;
 import io.grpc.xds.Filter.FilterConfig;
@@ -132,6 +138,12 @@ public class XdsNameResolverTest {
   private final CallInfo call1 = new CallInfo("HelloService", "hi");
   private final CallInfo call2 = new CallInfo("GreetService", "bye");
   private final TestChannel channel = new TestChannel();
+  private BootstrapInfo bootstrapInfo = BootstrapInfo.builder()
+      .servers(ImmutableList.of(ServerInfo.create(
+          "td.googleapis.com", InsecureChannelCredentials.create(), true)))
+      .node(Node.newBuilder().build())
+      .build();
+  private String expectedLdsResourceName = AUTHORITY;
 
   @Mock
   private ThreadSafeRandom mockRandom;
@@ -152,7 +164,7 @@ public class XdsNameResolverTest {
     FilterRegistry filterRegistry = FilterRegistry.newRegistry().register(
         new FaultFilter(mockRandom, new AtomicLong()),
         RouterFilter.INSTANCE);
-    resolver = new XdsNameResolver(AUTHORITY, serviceConfigParser, syncContext, scheduler,
+    resolver = new XdsNameResolver(null, AUTHORITY, serviceConfigParser, syncContext, scheduler,
         xdsClientPoolFactory, mockRandom, filterRegistry, null);
   }
 
@@ -185,7 +197,7 @@ public class XdsNameResolverTest {
         throw new XdsInitializationException("Fail to read bootstrap file");
       }
     };
-    resolver = new XdsNameResolver(AUTHORITY, serviceConfigParser, syncContext, scheduler,
+    resolver = new XdsNameResolver(null, AUTHORITY, serviceConfigParser, syncContext, scheduler,
         xdsClientPoolFactory, mockRandom, FilterRegistry.getDefaultRegistry(), null);
     resolver.start(mockListener);
     verify(mockListener).onError(errorCaptor.capture());
@@ -193,6 +205,78 @@ public class XdsNameResolverTest {
     assertThat(error.getCode()).isEqualTo(Code.UNAVAILABLE);
     assertThat(error.getDescription()).isEqualTo("Failed to initialize xDS");
     assertThat(error.getCause()).hasMessageThat().isEqualTo("Fail to read bootstrap file");
+  }
+
+  @Test
+  public void resolving_withTargetAuthorityNotFound() {
+    resolver = new XdsNameResolver(
+        "notfound.google.com", AUTHORITY, serviceConfigParser, syncContext, scheduler,
+        xdsClientPoolFactory, mockRandom, FilterRegistry.getDefaultRegistry(), null);
+    resolver.start(mockListener);
+    verify(mockListener).onError(errorCaptor.capture());
+    Status error = errorCaptor.getValue();
+    assertThat(error.getCode()).isEqualTo(Code.INVALID_ARGUMENT);
+    assertThat(error.getDescription()).isEqualTo(
+        "invalid target URI: target authority not found in the bootstrap");
+  }
+
+  @Test
+  public void resolving_noTargetAuthority_templateWithoutXdstp() {
+    bootstrapInfo = BootstrapInfo.builder()
+        .servers(ImmutableList.of(ServerInfo.create(
+            "td.googleapis.com", InsecureChannelCredentials.create(), true)))
+        .node(Node.newBuilder().build())
+        .clientDefaultListenerResourceNameTemplate("%s/id=1")
+        .build();
+    String serviceAuthority = "[::FFFF:129.144.52.38]:80";
+    expectedLdsResourceName = "[::FFFF:129.144.52.38]:80/id=1";
+    resolver = new XdsNameResolver(
+        null, serviceAuthority, serviceConfigParser, syncContext, scheduler, xdsClientPoolFactory,
+        mockRandom, FilterRegistry.getDefaultRegistry(), null);
+    resolver.start(mockListener);
+    verify(mockListener, never()).onError(any(Status.class));
+  }
+
+  @Test
+  public void resolving_noTargetAuthority_templateWithXdstp() {
+    bootstrapInfo = BootstrapInfo.builder()
+        .servers(ImmutableList.of(ServerInfo.create(
+            "td.googleapis.com", InsecureChannelCredentials.create(), true)))
+        .node(Node.newBuilder().build())
+        .clientDefaultListenerResourceNameTemplate(
+            "xdstp://xds.authority.com/envoy.config.listener.v3.Listener/%s?id=1")
+        .build();
+    String serviceAuthority = "[::FFFF:129.144.52.38]:80";
+    expectedLdsResourceName =
+        "xdstp://xds.authority.com/envoy.config.listener.v3.Listener/"
+            + "%5B::FFFF:129.144.52.38%5D:80?id=1";
+    resolver = new XdsNameResolver(
+        null, serviceAuthority, serviceConfigParser, syncContext, scheduler,
+        xdsClientPoolFactory, mockRandom, FilterRegistry.getDefaultRegistry(), null);
+    resolver.start(mockListener);
+    verify(mockListener, never()).onError(any(Status.class));
+  }
+
+  @Test
+  public void resolving_targetAuthorityInAuthoritiesMap() {
+    String targetAuthority = "xds.authority.com";
+    String serviceAuthority = "[::FFFF:129.144.52.38]:80";
+    bootstrapInfo = BootstrapInfo.builder()
+        .servers(ImmutableList.of(ServerInfo.create(
+            "td.googleapis.com", InsecureChannelCredentials.create(), true)))
+        .node(Node.newBuilder().build())
+        .authorities(
+            ImmutableMap.of(targetAuthority, AuthorityInfo.create(
+                "xdstp://" + targetAuthority + "/envoy.config.listener.v3.Listener/%s",
+                ImmutableList.<ServerInfo>of())))
+        .build();
+    expectedLdsResourceName =
+        "xdstp://xds.authority.com/envoy.config.listener.v3.Listener/%5B::FFFF:129.144.52.38%5D:80";
+    resolver = new XdsNameResolver(
+        "xds.authority.com", serviceAuthority, serviceConfigParser, syncContext, scheduler,
+        xdsClientPoolFactory, mockRandom, FilterRegistry.getDefaultRegistry(), null);
+    resolver.start(mockListener);
+    verify(mockListener, never()).onError(any(Status.class));
   }
 
   @Test
@@ -435,7 +519,7 @@ public class XdsNameResolverTest {
   public void retryPolicyInPerMethodConfigGeneratedByResolverIsValid() {
     ServiceConfigParser realParser = new ScParser(
         true, 5, 5, new AutoConfiguredLoadBalancerFactory("pick-first"));
-    resolver = new XdsNameResolver(AUTHORITY, realParser, syncContext, scheduler,
+    resolver = new XdsNameResolver(null, AUTHORITY, realParser, syncContext, scheduler,
         xdsClientPoolFactory, mockRandom, FilterRegistry.getDefaultRegistry(), null);
     resolver.start(mockListener);
     FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();
@@ -638,7 +722,7 @@ public class XdsNameResolverTest {
     // A different resolver/Channel.
     resolver.shutdown();
     reset(mockListener);
-    resolver = new XdsNameResolver(AUTHORITY, serviceConfigParser, syncContext, scheduler,
+    resolver = new XdsNameResolver(null, AUTHORITY, serviceConfigParser, syncContext, scheduler,
         xdsClientPoolFactory, mockRandom, FilterRegistry.getDefaultRegistry(), null);
     resolver.start(mockListener);
     xdsClient = (FakeXdsClient) resolver.getXdsClient();
@@ -1698,8 +1782,11 @@ public class XdsNameResolverTest {
   }
 
   private final class FakeXdsClientPoolFactory implements XdsClientPoolFactory {
+    Map<String, ?> bootstrap;
+
     @Override
     public void setBootstrapOverride(Map<String, ?> bootstrap) {
+      this.bootstrap = bootstrap;
     }
 
     @Override
@@ -1732,10 +1819,15 @@ public class XdsNameResolverTest {
     private RdsResourceWatcher rdsWatcher;
 
     @Override
+    BootstrapInfo getBootstrapInfo() {
+      return bootstrapInfo;
+    }
+
+    @Override
     void watchLdsResource(String resourceName, LdsResourceWatcher watcher) {
       assertThat(ldsResource).isNull();
       assertThat(ldsWatcher).isNull();
-      assertThat(resourceName).isEqualTo(AUTHORITY);
+      assertThat(resourceName).isEqualTo(expectedLdsResourceName);
       ldsResource = resourceName;
       ldsWatcher = watcher;
     }
@@ -1744,7 +1836,7 @@ public class XdsNameResolverTest {
     void cancelLdsResourceWatch(String resourceName, LdsResourceWatcher watcher) {
       assertThat(ldsResource).isNotNull();
       assertThat(ldsWatcher).isNotNull();
-      assertThat(resourceName).isEqualTo(AUTHORITY);
+      assertThat(resourceName).isEqualTo(expectedLdsResourceName);
       ldsResource = null;
       ldsWatcher = null;
     }
@@ -1773,7 +1865,7 @@ public class XdsNameResolverTest {
     void deliverLdsUpdate(final List<Route> routes) {
       VirtualHost virtualHost =
           VirtualHost.create(
-              "virtual-host", Collections.singletonList(AUTHORITY), routes,
+              "virtual-host", Collections.singletonList(expectedLdsResourceName), routes,
               ImmutableMap.<String, FilterConfig>of());
       ldsWatcher.onChanged(LdsUpdate.forApiListener(HttpConnectionManager.forVirtualHosts(
           0L, Collections.singletonList(virtualHost), null)));
@@ -1817,7 +1909,7 @@ public class XdsNameResolverTest {
               FAULT_FILTER_INSTANCE_NAME, virtualHostFaultConfig);
       VirtualHost virtualHost = VirtualHost.create(
           "virtual-host",
-          Collections.singletonList(AUTHORITY),
+          Collections.singletonList(expectedLdsResourceName),
           Collections.singletonList(route),
           overrideConfig);
       ldsWatcher.onChanged(LdsUpdate.forApiListener(HttpConnectionManager.forVirtualHosts(
@@ -1843,7 +1935,7 @@ public class XdsNameResolverTest {
     }
 
     void deliverLdsResourceNotFound() {
-      ldsWatcher.onResourceDoesNotExist(AUTHORITY);
+      ldsWatcher.onResourceDoesNotExist(expectedLdsResourceName);
     }
 
     void deliverRdsUpdateWithFaultInjection(
@@ -1876,7 +1968,7 @@ public class XdsNameResolverTest {
               FAULT_FILTER_INSTANCE_NAME, virtualHostFaultConfig);
       VirtualHost virtualHost = VirtualHost.create(
           "virtual-host",
-          Collections.singletonList(AUTHORITY),
+          Collections.singletonList(expectedLdsResourceName),
           Collections.singletonList(route),
           overrideConfig);
       rdsWatcher.onChanged(new RdsUpdate(Collections.singletonList(virtualHost)));

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -268,7 +268,8 @@ public class XdsNameResolverTest {
         .authorities(
             ImmutableMap.of(targetAuthority, AuthorityInfo.create(
                 "xdstp://" + targetAuthority + "/envoy.config.listener.v3.Listener/%s",
-                ImmutableList.<ServerInfo>of())))
+                ImmutableList.<ServerInfo>of(ServerInfo.create(
+                    "td.googleapis.com", InsecureChannelCredentials.create(), true)))))
         .build();
     expectedLdsResourceName =
         "xdstp://xds.authority.com/envoy.config.listener.v3.Listener/%5B::FFFF:129.144.52.38%5D:80";

--- a/xds/src/test/java/io/grpc/xds/XdsServerWrapperTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerWrapperTest.java
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -55,6 +56,7 @@ import io.grpc.xds.FilterChainMatchingProtocolNegotiators.FilterChainMatchingHan
 import io.grpc.xds.VirtualHost.Route;
 import io.grpc.xds.VirtualHost.Route.RouteMatch;
 import io.grpc.xds.VirtualHost.Route.RouteMatch.PathMatcher;
+import io.grpc.xds.XdsClient.LdsResourceWatcher;
 import io.grpc.xds.XdsClient.RdsResourceWatcher;
 import io.grpc.xds.XdsClient.RdsUpdate;
 import io.grpc.xds.XdsServerBuilder.XdsServingStatusListener;
@@ -165,6 +167,36 @@ public class XdsServerWrapperTest {
       assertThat(((StatusException)cause).getStatus().getCode())
               .isEqualTo(Status.UNAVAILABLE.getCode());
     }
+  }
+
+  @Test
+  public void testBootstrap_templateWithXdstp() throws Exception {
+    Bootstrapper.BootstrapInfo b = Bootstrapper.BootstrapInfo.builder()
+        .servers(Arrays.asList(
+            Bootstrapper.ServerInfo.create(
+                "uri", InsecureChannelCredentials.create(), true)))
+        .node(EnvoyProtoData.Node.newBuilder().setId("id").build())
+        .serverListenerResourceNameTemplate(
+            "xdstp://xds.authority.com/envoy.config.listener.v3.Listener/grpc/server/%s")
+        .build();
+    XdsClient xdsClient = mock(XdsClient.class);
+    when(xdsClient.getBootstrapInfo()).thenReturn(b);
+    xdsServerWrapper = new XdsServerWrapper("[::FFFF:129.144.52.38]:80", mockBuilder, listener,
+        selectorManager, new FakeXdsClientPoolFactory(xdsClient), filterRegistry);
+    Executors.newSingleThreadExecutor().execute(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          xdsServerWrapper.start();
+        } catch (IOException ex) {
+          // ignore
+        }
+      }
+    });
+    verify(xdsClient, timeout(5000)).watchLdsResource(
+        eq("xdstp://xds.authority.com/envoy.config.listener.v3.Listener/grpc/server/"
+            + "%5B::FFFF:129.144.52.38%5D:80"),
+        any(LdsResourceWatcher.class));
   }
 
   @Test


### PR DESCRIPTION
Implement applying `server_listener_resource_name_template` and `client_listener_resource_name_template` with xdstp scheme, extracting authorities from xdstp resource URI and lookup authorities map in bootstrap.