### PR TITLE
buildscripts: add config for building grpc-binder artifact

### DIFF
--- a/buildscripts/kokoro/linux_artifacts.sh
+++ b/buildscripts/kokoro/linux_artifacts.sh
@@ -10,7 +10,7 @@ readonly GRPC_JAVA_DIR="$(cd "$(dirname "$0")"/../.. && pwd)"
 "$GRPC_JAVA_DIR"/buildscripts/build_docker.sh
 "$GRPC_JAVA_DIR"/buildscripts/run_in_docker.sh /grpc-java/buildscripts/build_artifacts_in_docker.sh
 
-# grpc-android and grpc-cronet require the Android SDK, so build outside of Docker and
+# grpc-android, grpc-cronet and grpc-binder require the Android SDK, so build outside of Docker and
 # use --include-build for its grpc-core dependency
 echo y | ${ANDROID_HOME}/tools/bin/sdkmanager "build-tools;28.0.3"
 LOCAL_MVN_TEMP=$(mktemp -d)
@@ -22,6 +22,13 @@ pushd "$GRPC_JAVA_DIR/android"
 popd
 
 pushd "$GRPC_JAVA_DIR/cronet"
+../gradlew publish \
+  -Dorg.gradle.parallel=false \
+  -PskipCodegen=true \
+  -PrepositoryDir="$LOCAL_MVN_TEMP"
+popd
+
+pushd "$GRPC_JAVA_DIR/binder"
 ../gradlew publish \
   -Dorg.gradle.parallel=false \
   -PskipCodegen=true \

--- a/buildscripts/kokoro/upload_artifacts.sh
+++ b/buildscripts/kokoro/upload_artifacts.sh
@@ -24,6 +24,9 @@ LOCAL_OTHER_ARTIFACTS="$KOKORO_GFILE_DIR"/github/grpc-java/artifacts/
 # cronet artifact from linux job:
 [[ "$(find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'grpc-cronet-*.aar' | wc -l)" != '0' ]]
 
+# binder artifact from linux job:
+[[ "$(find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'grpc-binder-*.aar' | wc -l)" != '0' ]]
+
 # from linux job:
 [[ "$(find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'protoc-gen-grpc-java-*-linux-x86_64.exe' | wc -l)" != '0' ]]
 [[ "$(find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'protoc-gen-grpc-java-*-linux-x86_32.exe' | wc -l)" != '0' ]]


### PR DESCRIPTION
Without this, grpc-binder isn't published to maven.