### PR TITLE
xds: remove filter chain uuid name generator [backport v1.41.x]

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -104,7 +104,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
@@ -376,14 +375,10 @@ final class ClientXdsClient extends AbstractXdsClient {
               validateDownstreamTlsContext(downstreamTlsContextProto, certProviderInstances));
     }
 
-    String name = proto.getName();
-    if (name.isEmpty()) {
-      name = UUID.randomUUID().toString();
-    }
     FilterChainMatch filterChainMatch = parseFilterChainMatch(proto.getFilterChainMatch());
     checkForUniqueness(uniqueSet, filterChainMatch);
     return new FilterChain(
-        name,
+        proto.getName(),
         filterChainMatch,
         httpConnectionManager,
         downstreamTlsContext,

--- a/xds/src/main/java/io/grpc/xds/EnvoyServerProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyServerProtoData.java
@@ -314,7 +314,7 @@ public final class EnvoyServerProtoData {
    * Corresponds to Envoy proto message {@link io.envoyproxy.envoy.api.v2.listener.FilterChain}.
    */
   static final class FilterChain {
-    // Unique name for the FilterChain.
+    // possibly empty
     private final String name;
     // TODO(sanjaypujare): flatten structure by moving FilterChainMatch class members here.
     private final FilterChainMatch filterChainMatch;

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
@@ -1588,7 +1588,7 @@ public class ClientXdsClientDataTest {
   }
 
   @Test
-  public void parseFilterChain_noName_generatedUuid() throws ResourceInvalidException {
+  public void parseFilterChain_noName() throws ResourceInvalidException {
     FilterChain filterChain1 =
         FilterChain.newBuilder()
             .setFilterChainMatch(FilterChainMatch.getDefaultInstance())
@@ -1616,7 +1616,7 @@ public class ClientXdsClientDataTest {
     EnvoyServerProtoData.FilterChain parsedFilterChain2 = ClientXdsClient.parseFilterChain(
         filterChain2, new HashSet<String>(), null, filterRegistry, null,
         null, true /* does not matter */);
-    assertThat(parsedFilterChain1.getName()).isNotEqualTo(parsedFilterChain2.getName());
+    assertThat(parsedFilterChain1.getName()).isEqualTo(parsedFilterChain2.getName());
   }
 
   @Test


### PR DESCRIPTION
backport of #8663

Generating a uuid in filterChain breaks the de-duplication detection which causes XdsServer to cycle connections, so removing it.
An empty name is now allowed. The name is currently only used for debug purpose.