### PR TITLE
Add LoadBalancer.acceptResolvedAddresses()

### DIFF
--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -125,10 +125,8 @@ public abstract class LoadBalancer {
    * <p>Implementations should not modify the given {@code servers}.
    *
    * @param resolvedAddresses the resolved server addresses, attributes, and config.
-   * @deprecated override {@link #acceptResolvedAddresses(ResolvedAddresses) instead}
    * @since 1.21.0
    */
-  @Deprecated
   public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     if (recursionCount++ == 0) {
       // Note that the information about the addresses actually being accepted will be lost
@@ -151,7 +149,6 @@ public abstract class LoadBalancer {
    * @return {@code true} if the resolved addresses were accepted. {@code false} if rejected.
    * @since 1.49.0
    */
-  @SuppressWarnings("deprecation")
   public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     if (resolvedAddresses.getAddresses().isEmpty()
         && !canHandleEmptyAddressListFromNameResolution()) {

--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -126,18 +126,20 @@ public abstract class LoadBalancer {
    *
    * @param servers the resolved server addresses, never empty.
    * @param attributes extra information from naming system.
+   * @return {@code true} if the resolved addresses were accepted. {@code false} if rejected.
    * @deprecated override {@link #handleResolvedAddresses(ResolvedAddresses) instead}
    * @since 1.2.0
    */
   @Deprecated
-  public void handleResolvedAddressGroups(
+  public boolean handleResolvedAddressGroups(
       List<EquivalentAddressGroup> servers,
       @NameResolver.ResolutionResultAttr Attributes attributes) {
     if (recursionCount++ == 0) {
-      handleResolvedAddresses(
+      return handleResolvedAddresses(
           ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(attributes).build());
     }
     recursionCount = 0;
+    return true;
   }
 
   /**
@@ -148,15 +150,17 @@ public abstract class LoadBalancer {
    * <p>Implementations should not modify the given {@code servers}.
    *
    * @param resolvedAddresses the resolved server addresses, attributes, and config.
+   * @return {@code true} if the resolved addresses were accepted. {@code false} if rejected.
    * @since 1.21.0
    */
   @SuppressWarnings("deprecation")
-  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     if (recursionCount++ == 0) {
-      handleResolvedAddressGroups(
+      return handleResolvedAddressGroups(
           resolvedAddresses.getAddresses(), resolvedAddresses.getAttributes());
     }
     recursionCount = 0;
+    return true;
   }
 
   /**

--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -153,13 +153,20 @@ public abstract class LoadBalancer {
    */
   @SuppressWarnings("deprecation")
   public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-    if (recursionCount++ == 0) {
-      handleResolvedAddresses(resolvedAddresses);
-    }
-    recursionCount = 0;
+    if (resolvedAddresses.getAddresses().isEmpty()
+        && !canHandleEmptyAddressListFromNameResolution()) {
+      handleNameResolutionError(Status.UNAVAILABLE.withDescription(
+          "NameResolver returned no usable address. addrs=" + resolvedAddresses.getAddresses()
+              + ", attrs=" + resolvedAddresses.getAttributes()));
+      return false;
+    } else {
+      if (recursionCount++ == 0) {
+        handleResolvedAddresses(resolvedAddresses);
+      }
+      recursionCount = 0;
 
-    // The legacy method does not tell us if the addresses were accepted, so we default to true.
-    return true;
+      return true;
+    }
   }
 
   /**
@@ -365,6 +372,20 @@ public abstract class LoadBalancer {
    * @since 1.2.0
    */
   public abstract void shutdown();
+
+  /**
+   * Whether this LoadBalancer can handle empty address group list to be passed to {@link
+   * #handleResolvedAddresses(ResolvedAddresses)}.  The default implementation returns
+   * {@code false}, meaning that if the NameResolver returns an empty list, the Channel will turn
+   * that into an error and call {@link #handleNameResolutionError}.  LoadBalancers that want to
+   * accept empty lists should override this method and return {@code true}.
+   *
+   * <p>This method should always return a constant value.  It's not specified when this will be
+   * called.
+   */
+  public boolean canHandleEmptyAddressListFromNameResolution() {
+    return false;
+  }
 
   /**
    * The channel asks the LoadBalancer to establish connections now (if applicable) so that the

--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -124,42 +124,41 @@ public abstract class LoadBalancer {
    *
    * <p>Implementations should not modify the given {@code servers}.
    *
-   * @param servers the resolved server addresses, never empty.
-   * @param attributes extra information from naming system.
-   * @return {@code true} if the resolved addresses were accepted. {@code false} if rejected.
-   * @deprecated override {@link #handleResolvedAddresses(ResolvedAddresses) instead}
-   * @since 1.2.0
+   * @param resolvedAddresses the resolved server addresses, attributes, and config.
+   * @deprecated override {@link #acceptResolvedAddresses(ResolvedAddresses) instead}
+   * @since 1.21.0
    */
   @Deprecated
-  public boolean handleResolvedAddressGroups(
-      List<EquivalentAddressGroup> servers,
-      @NameResolver.ResolutionResultAttr Attributes attributes) {
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     if (recursionCount++ == 0) {
-      return handleResolvedAddresses(
-          ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(attributes).build());
+      // Note that the information about the addresses actually being accepted will be lost
+      // if you rely on this method for backward compatibility.
+      acceptResolvedAddresses(resolvedAddresses);
     }
     recursionCount = 0;
-    return true;
   }
 
   /**
-   * Handles newly resolved server groups and metadata attributes from name resolution system.
-   * {@code servers} contained in {@link EquivalentAddressGroup} should be considered equivalent
-   * but may be flattened into a single list if needed.
+   * Accepts newly resolved addresses from the name resolution system. The {@link
+   * EquivalentAddressGroup} addresses should be considered equivalent but may be flattened into a
+   * single list if needed.
    *
-   * <p>Implementations should not modify the given {@code servers}.
+   * <p>Implementations can choose to reject the given addresses by returning {@code false}.
+   *
+   * <p>Implementations should not modify the given {@code addresses}.
    *
    * @param resolvedAddresses the resolved server addresses, attributes, and config.
    * @return {@code true} if the resolved addresses were accepted. {@code false} if rejected.
-   * @since 1.21.0
+   * @since 1.49.0
    */
   @SuppressWarnings("deprecation")
-  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     if (recursionCount++ == 0) {
-      return handleResolvedAddressGroups(
-          resolvedAddresses.getAddresses(), resolvedAddresses.getAttributes());
+      handleResolvedAddresses(resolvedAddresses);
     }
     recursionCount = 0;
+
+    // The legacy method does not tell us if the addresses were accepted, so we default to true.
     return true;
   }
 

--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -368,20 +368,6 @@ public abstract class LoadBalancer {
   public abstract void shutdown();
 
   /**
-   * Whether this LoadBalancer can handle empty address group list to be passed to {@link
-   * #handleResolvedAddresses(ResolvedAddresses)}.  The default implementation returns
-   * {@code false}, meaning that if the NameResolver returns an empty list, the Channel will turn
-   * that into an error and call {@link #handleNameResolutionError}.  LoadBalancers that want to
-   * accept empty lists should override this method and return {@code true}.
-   *
-   * <p>This method should always return a constant value.  It's not specified when this will be
-   * called.
-   */
-  public boolean canHandleEmptyAddressListFromNameResolution() {
-    return false;
-  }
-
-  /**
    * The channel asks the LoadBalancer to establish connections now (if applicable) so that the
    * upcoming RPC may then just pick a ready connection without waiting for connections.  This
    * is triggered by {@link ManagedChannel#getState ManagedChannel.getState(true)}.

--- a/api/src/test/java/io/grpc/LoadBalancerTest.java
+++ b/api/src/test/java/io/grpc/LoadBalancerTest.java
@@ -235,12 +235,12 @@ public class LoadBalancerTest {
 
   @Deprecated
   @Test
-  public void handleResolvedAddressGroups_delegatesToHandleResolvedAddresses() {
+  public void handleResolvedAddresses_delegatesToAcceptResolvedAddresses() {
     final AtomicReference<ResolvedAddresses> resultCapture = new AtomicReference<>();
 
     LoadBalancer balancer = new LoadBalancer() {
         @Override
-        public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+        public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
           resultCapture.set(resolvedAddresses);
           return true;
         }
@@ -261,24 +261,22 @@ public class LoadBalancerTest {
     List<EquivalentAddressGroup> servers = Arrays.asList(
         new EquivalentAddressGroup(new SocketAddress(){}),
         new EquivalentAddressGroup(new SocketAddress(){}));
-    balancer.handleResolvedAddressGroups(servers, attrs);
+    ResolvedAddresses addresses = ResolvedAddresses.newBuilder().setAddresses(servers)
+        .setAttributes(attrs).build();
+    balancer.handleResolvedAddresses(addresses);
     assertThat(resultCapture.get()).isEqualTo(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(attrs).build());
   }
 
   @Deprecated
   @Test
-  public void handleResolvedAddresses_delegatesToHandleResolvedAddressGroups() {
-    final AtomicReference<List<EquivalentAddressGroup>> serversCapture = new AtomicReference<>();
-    final AtomicReference<Attributes> attrsCapture = new AtomicReference<>();
+  public void acceptResolvedAddresses_delegatesToHandleResolvedAddressGroups() {
+    final AtomicReference<ResolvedAddresses> addressesCapture = new AtomicReference<>();
 
     LoadBalancer balancer = new LoadBalancer() {
         @Override
-        public boolean handleResolvedAddressGroups(
-            List<EquivalentAddressGroup> servers, Attributes attrs) {
-          serversCapture.set(servers);
-          attrsCapture.set(attrs);
-          return true;
+        public void handleResolvedAddresses(ResolvedAddresses addresses) {
+          addressesCapture.set(addresses);
         }
 
         @Override
@@ -297,26 +295,23 @@ public class LoadBalancerTest {
     List<EquivalentAddressGroup> servers = Arrays.asList(
         new EquivalentAddressGroup(new SocketAddress(){}),
         new EquivalentAddressGroup(new SocketAddress(){}));
-    balancer.handleResolvedAddresses(
-        ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(attrs).build());
-    assertThat(serversCapture.get()).isEqualTo(servers);
-    assertThat(attrsCapture.get()).isEqualTo(attrs);
+    ResolvedAddresses addresses = ResolvedAddresses.newBuilder().setAddresses(servers)
+        .setAttributes(attrs).build();
+    balancer.handleResolvedAddresses(addresses);
+    assertThat(addressesCapture.get().getAddresses()).isEqualTo(servers);
+    assertThat(addressesCapture.get().getAttributes()).isEqualTo(attrs);
   }
 
   @Deprecated
   @Test
-  public void handleResolvedAddresses_noInfiniteLoop() {
-    final List<List<EquivalentAddressGroup>> serversCapture = new ArrayList<>();
-    final List<Attributes> attrsCapture = new ArrayList<>();
+  public void acceptResolvedAddresses_noInfiniteLoop() {
+    final List<ResolvedAddresses> addressesCapture = new ArrayList<>();
 
     LoadBalancer balancer = new LoadBalancer() {
       @Override
-      public boolean handleResolvedAddressGroups(
-          List<EquivalentAddressGroup> servers, Attributes attrs) {
-        serversCapture.add(servers);
-        attrsCapture.add(attrs);
-        super.handleResolvedAddressGroups(servers, attrs);
-        return true;
+      public void handleResolvedAddresses(ResolvedAddresses addresses) {
+        addressesCapture.add(addresses);
+        super.handleResolvedAddresses(addresses);
       }
 
       @Override
@@ -331,12 +326,12 @@ public class LoadBalancerTest {
     List<EquivalentAddressGroup> servers = Arrays.asList(
         new EquivalentAddressGroup(new SocketAddress(){}),
         new EquivalentAddressGroup(new SocketAddress(){}));
-    balancer.handleResolvedAddresses(
-        ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(attrs).build());
-    assertThat(serversCapture).hasSize(1);
-    assertThat(attrsCapture).hasSize(1);
-    assertThat(serversCapture.get(0)).isEqualTo(servers);
-    assertThat(attrsCapture.get(0)).isEqualTo(attrs);
+    ResolvedAddresses addresses = ResolvedAddresses.newBuilder().setAddresses(servers)
+        .setAttributes(attrs).build();
+    balancer.handleResolvedAddresses(addresses);
+    assertThat(addressesCapture).hasSize(1);
+    assertThat(addressesCapture.get(0).getAddresses()).isEqualTo(servers);
+    assertThat(addressesCapture.get(0).getAttributes()).isEqualTo(attrs);
   }
 
   private static class NoopHelper extends LoadBalancer.Helper {

--- a/api/src/test/java/io/grpc/LoadBalancerTest.java
+++ b/api/src/test/java/io/grpc/LoadBalancerTest.java
@@ -240,8 +240,9 @@ public class LoadBalancerTest {
 
     LoadBalancer balancer = new LoadBalancer() {
         @Override
-        public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+        public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
           resultCapture.set(resolvedAddresses);
+          return true;
         }
 
         @Override
@@ -273,10 +274,11 @@ public class LoadBalancerTest {
 
     LoadBalancer balancer = new LoadBalancer() {
         @Override
-        public void handleResolvedAddressGroups(
+        public boolean handleResolvedAddressGroups(
             List<EquivalentAddressGroup> servers, Attributes attrs) {
           serversCapture.set(servers);
           attrsCapture.set(attrs);
+          return true;
         }
 
         @Override
@@ -309,11 +311,12 @@ public class LoadBalancerTest {
 
     LoadBalancer balancer = new LoadBalancer() {
       @Override
-      public void handleResolvedAddressGroups(
+      public boolean handleResolvedAddressGroups(
           List<EquivalentAddressGroup> servers, Attributes attrs) {
         serversCapture.add(servers);
         attrsCapture.add(attrs);
         super.handleResolvedAddressGroups(servers, attrs);
+        return true;
       }
 
       @Override

--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
@@ -104,7 +104,7 @@ public final class AutoConfiguredLoadBalancerFactory {
      * Returns non-OK status if the delegate rejects the resolvedAddresses (e.g. if it does not
      * support an empty list).
      */
-    Status tryAcceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    boolean tryAcceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       List<EquivalentAddressGroup> servers = resolvedAddresses.getAddresses();
       Attributes attributes = resolvedAddresses.getAttributes();
       PolicySelection policySelection =
@@ -120,7 +120,7 @@ public final class AutoConfiguredLoadBalancerFactory {
           delegate.shutdown();
           delegateProvider = null;
           delegate = new NoopLoadBalancer();
-          return Status.OK;
+          return true;
         }
         policySelection =
             new PolicySelection(defaultProvider, /* config= */ null);
@@ -150,11 +150,9 @@ public final class AutoConfiguredLoadBalancerFactory {
               .setAttributes(attributes)
               .setLoadBalancingPolicyConfig(lbConfig)
               .build())) {
-        return Status.OK;
+        return true;
       } else {
-        return Status.UNAVAILABLE.withDescription(
-            "The load balancer did not accept the addresses returned from the NameResolver. addrs="
-                + servers + ", attrs=" + attributes);
+        return false;
       }
     }
 

--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
@@ -68,12 +68,11 @@ public final class AutoConfiguredLoadBalancerFactory {
     @Override
     @Deprecated
     @SuppressWarnings("InlineMeSuggester")
-    public boolean handleResolvedAddressGroups(List<EquivalentAddressGroup> s, Attributes a) {
-      return true;
+    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     }
 
     @Override
-    public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       return true;
     }
 
@@ -105,7 +104,7 @@ public final class AutoConfiguredLoadBalancerFactory {
      * Returns non-OK status if the delegate rejects the resolvedAddresses (e.g. if it does not
      * support an empty list).
      */
-    Status tryHandleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    Status tryAcceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       List<EquivalentAddressGroup> servers = resolvedAddresses.getAddresses();
       Attributes attributes = resolvedAddresses.getAttributes();
       PolicySelection policySelection =
@@ -145,7 +144,7 @@ public final class AutoConfiguredLoadBalancerFactory {
       }
 
       LoadBalancer delegate = getDelegate();
-      if (delegate.handleResolvedAddresses(
+      if (delegate.acceptResolvedAddresses(
           ResolvedAddresses.newBuilder()
               .setAddresses(resolvedAddresses.getAddresses())
               .setAttributes(attributes)
@@ -154,7 +153,8 @@ public final class AutoConfiguredLoadBalancerFactory {
         return Status.OK;
       } else {
         return Status.UNAVAILABLE.withDescription(
-            "NameResolver returned no usable address. addrs=" + servers + ", attrs=" + attributes);
+            "The load balancer did not accept the addresses returned from the NameResolver. addrs="
+                + servers + ", attrs=" + attributes);
       }
     }
 

--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
@@ -20,11 +20,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
-import io.grpc.Attributes;
 import io.grpc.ChannelLogger.ChannelLogLevel;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
-import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.PickResult;
@@ -105,8 +103,6 @@ public final class AutoConfiguredLoadBalancerFactory {
      * support an empty list).
      */
     boolean tryAcceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-      List<EquivalentAddressGroup> servers = resolvedAddresses.getAddresses();
-      Attributes attributes = resolvedAddresses.getAttributes();
       PolicySelection policySelection =
           (PolicySelection) resolvedAddresses.getLoadBalancingPolicyConfig();
 
@@ -143,17 +139,12 @@ public final class AutoConfiguredLoadBalancerFactory {
             ChannelLogLevel.DEBUG, "Load-balancing config: {0}", policySelection.config);
       }
 
-      LoadBalancer delegate = getDelegate();
-      if (delegate.acceptResolvedAddresses(
+      return getDelegate().acceptResolvedAddresses(
           ResolvedAddresses.newBuilder()
               .setAddresses(resolvedAddresses.getAddresses())
-              .setAttributes(attributes)
+              .setAttributes(resolvedAddresses.getAttributes())
               .setLoadBalancingPolicyConfig(lbConfig)
-              .build())) {
-        return true;
-      } else {
-        return false;
-      }
+              .build());
     }
 
     void handleNameResolutionError(Status error) {

--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
@@ -67,10 +67,14 @@ public final class AutoConfiguredLoadBalancerFactory {
 
     @Override
     @Deprecated
-    public void handleResolvedAddressGroups(List<EquivalentAddressGroup> s, Attributes a) {}
+    public boolean handleResolvedAddressGroups(List<EquivalentAddressGroup> s, Attributes a) {
+      return true;
+    }
 
     @Override
-    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {}
+    public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+      return true;
+    }
 
     @Override
     public void handleNameResolutionError(Status error) {}

--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
@@ -67,6 +67,7 @@ public final class AutoConfiguredLoadBalancerFactory {
 
     @Override
     @Deprecated
+    @SuppressWarnings("InlineMeSuggester")
     public boolean handleResolvedAddressGroups(List<EquivalentAddressGroup> s, Attributes a) {
       return true;
     }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1870,10 +1870,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
                     .build());
 
             if (!addressesAccepted) {
-              handleErrorInSyncContext(Status.UNAVAILABLE.withDescription(
-                  "The load balancer did not accept the addresses returned from the NameResolver. "
-                      + "addrs=" + servers + ", attrs=" + attributes + "\n" + resolver
-                      + " was used"));
+              scheduleExponentialBackOffInSyncContext();
             }
           }
         }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1861,7 +1861,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
                   .build();
             }
 
-            Status handleResult = helper.lb.tryHandleResolvedAddresses(
+            Status handleResult = helper.lb.tryAcceptResolvedAddresses(
                 ResolvedAddresses.newBuilder()
                     .setAddresses(servers)
                     .setAttributes(attrBuilder.build())

--- a/core/src/main/java/io/grpc/internal/PickFirstLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLoadBalancer.java
@@ -45,7 +45,7 @@ final class PickFirstLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     List<EquivalentAddressGroup> servers = resolvedAddresses.getAddresses();
     if (subchannel == null) {
       final Subchannel subchannel = helper.createSubchannel(

--- a/core/src/main/java/io/grpc/internal/PickFirstLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLoadBalancer.java
@@ -45,7 +45,7 @@ final class PickFirstLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     List<EquivalentAddressGroup> servers = resolvedAddresses.getAddresses();
     if (subchannel == null) {
       final Subchannel subchannel = helper.createSubchannel(
@@ -67,6 +67,8 @@ final class PickFirstLoadBalancer extends LoadBalancer {
     } else {
       subchannel.updateAddresses(servers);
     }
+
+    return true;
   }
 
   @Override

--- a/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
@@ -64,11 +64,6 @@ public abstract class ForwardingLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean canHandleEmptyAddressListFromNameResolution() {
-    return delegate().canHandleEmptyAddressListFromNameResolution();
-  }
-
-  @Override
   public void requestConnection() {
     delegate().requestConnection();
   }

--- a/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
@@ -35,15 +35,15 @@ public abstract class ForwardingLoadBalancer extends LoadBalancer {
 
   @Override
   @Deprecated
-  public void handleResolvedAddressGroups(
+  public boolean handleResolvedAddressGroups(
         List<EquivalentAddressGroup> servers,
         @NameResolver.ResolutionResultAttr Attributes attributes) {
-    delegate().handleResolvedAddressGroups(servers, attributes);
+    return delegate().handleResolvedAddressGroups(servers, attributes);
   }
 
   @Override
-  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-    delegate().handleResolvedAddresses(resolvedAddresses);
+  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    return delegate().handleResolvedAddresses(resolvedAddresses);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
@@ -17,14 +17,10 @@
 package io.grpc.util;
 
 import com.google.common.base.MoreObjects;
-import io.grpc.Attributes;
 import io.grpc.ConnectivityStateInfo;
-import io.grpc.EquivalentAddressGroup;
 import io.grpc.ExperimentalApi;
 import io.grpc.LoadBalancer;
-import io.grpc.NameResolver;
 import io.grpc.Status;
-import java.util.List;
 
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
 public abstract class ForwardingLoadBalancer extends LoadBalancer {
@@ -35,15 +31,13 @@ public abstract class ForwardingLoadBalancer extends LoadBalancer {
 
   @Override
   @Deprecated
-  public boolean handleResolvedAddressGroups(
-        List<EquivalentAddressGroup> servers,
-        @NameResolver.ResolutionResultAttr Attributes attributes) {
-    return delegate().handleResolvedAddressGroups(servers, attributes);
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    delegate().handleResolvedAddresses(resolvedAddresses);
   }
 
   @Override
-  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-    return delegate().handleResolvedAddresses(resolvedAddresses);
+  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    return delegate().acceptResolvedAddresses(resolvedAddresses);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
@@ -58,6 +58,11 @@ public abstract class ForwardingLoadBalancer extends LoadBalancer {
   }
 
   @Override
+  public boolean canHandleEmptyAddressListFromNameResolution() {
+    return delegate().canHandleEmptyAddressListFromNameResolution();
+  }
+
+  @Override
   public void requestConnection() {
     delegate().requestConnection();
   }

--- a/core/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
@@ -35,7 +35,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  * will keep using the old policy until the new policy reports READY or the old policy exits READY.
  *
  * <p>The balancer must {@link #switchTo(LoadBalancer.Factory) switch to} a policy prior to {@link
- * LoadBalancer#handleResolvedAddresses(ResolvedAddresses) handling resolved addresses} for the
+ * LoadBalancer#acceptResolvedAddresses(ResolvedAddresses) handling resolved addresses} for the
  * first time.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/5999")
@@ -43,7 +43,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 public final class GracefulSwitchLoadBalancer extends ForwardingLoadBalancer {
   private final LoadBalancer defaultBalancer = new LoadBalancer() {
     @Override
-    public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       //  Most LB policies using this class will receive child policy configuration within the
       //  service config, so they are naturally calling switchTo() just before
       //  handleResolvedAddresses(), within their own handleResolvedAddresses(). If switchTo() is

--- a/core/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
@@ -43,7 +43,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 public final class GracefulSwitchLoadBalancer extends ForwardingLoadBalancer {
   private final LoadBalancer defaultBalancer = new LoadBalancer() {
     @Override
-    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       //  Most LB policies using this class will receive child policy configuration within the
       //  service config, so they are naturally calling switchTo() just before
       //  handleResolvedAddresses(), within their own handleResolvedAddresses(). If switchTo() is

--- a/core/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
@@ -69,7 +69,7 @@ final class RoundRobinLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     List<EquivalentAddressGroup> servers = resolvedAddresses.getAddresses();
     Set<EquivalentAddressGroup> currentAddrs = subchannels.keySet();
     Map<EquivalentAddressGroup, EquivalentAddressGroup> latestAddrs = stripAttrs(servers);

--- a/core/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
@@ -69,7 +69,7 @@ final class RoundRobinLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     List<EquivalentAddressGroup> servers = resolvedAddresses.getAddresses();
     Set<EquivalentAddressGroup> currentAddrs = subchannels.keySet();
     Map<EquivalentAddressGroup, EquivalentAddressGroup> latestAddrs = stripAttrs(servers);
@@ -126,6 +126,8 @@ final class RoundRobinLoadBalancer extends LoadBalancer {
     for (Subchannel removedSubchannel : removedSubchannels) {
       shutdownSubchannel(removedSubchannel);
     }
+
+    return !resolvedAddresses.getAddresses().isEmpty();
   }
 
   @Override

--- a/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
+++ b/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
@@ -170,7 +170,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   }
 
   @Test
-  public void handleResolvedAddressGroups_keepOldBalancer() {
+  public void acceptResolvedAddresses_keepOldBalancer() {
     final List<EquivalentAddressGroup> servers =
         Collections.singletonList(new EquivalentAddressGroup(new SocketAddress(){}));
     Helper helper = new TestHelper() {
@@ -195,7 +195,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   }
 
   @Test
-  public void handleResolvedAddressGroups_shutsDownOldBalancer() throws Exception {
+  public void acceptResolvedAddresses_shutsDownOldBalancer() throws Exception {
     Map<String, ?> serviceConfig =
         parseConfig("{\"loadBalancingConfig\": [ {\"round_robin\": { } } ] }");
     ConfigOrError lbConfigs = lbf.parseLoadBalancerPolicy(serviceConfig);
@@ -239,7 +239,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void handleResolvedAddressGroups_propagateLbConfigToDelegate() throws Exception {
+  public void acceptResolvedAddresses_propagateLbConfigToDelegate() throws Exception {
     Map<String, ?> rawServiceConfig =
         parseConfig("{\"loadBalancingConfig\": [ {\"test_lb\": { \"setting1\": \"high\" } } ] }");
     ConfigOrError lbConfigs = lbf.parseLoadBalancerPolicy(rawServiceConfig);
@@ -292,7 +292,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   }
 
   @Test
-  public void handleResolvedAddressGroups_propagateAddrsToDelegate() throws Exception {
+  public void acceptResolvedAddresses_propagateAddrsToDelegate() throws Exception {
     Map<String, ?> rawServiceConfig =
         parseConfig("{\"loadBalancingConfig\": [ {\"test_lb\": { \"setting1\": \"high\" } } ] }");
     ConfigOrError lbConfigs = lbf.parseLoadBalancerPolicy(rawServiceConfig);
@@ -331,7 +331,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   }
 
   @Test
-  public void handleResolvedAddressGroups_delegateDoNotAcceptEmptyAddressList_nothing()
+  public void acceptResolvedAddresses_delegateDoNotAcceptEmptyAddressList_nothing()
       throws Exception {
 
     // The test LB will NOT accept the addresses we give them.
@@ -356,7 +356,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   }
 
   @Test
-  public void handleResolvedAddressGroups_delegateAcceptsEmptyAddressList()
+  public void acceptResolvedAddresses_delegateAcceptsEmptyAddressList()
       throws Exception {
     Helper helper = new TestHelper();
     AutoConfiguredLoadBalancer lb = lbf.newLoadBalancer(helper);
@@ -382,7 +382,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   }
 
   @Test
-  public void handleResolvedAddressGroups_useSelectedLbPolicy() throws Exception {
+  public void acceptResolvedAddresses_useSelectedLbPolicy() throws Exception {
     Map<String, ?> rawServiceConfig =
         parseConfig("{\"loadBalancingConfig\": [{\"round_robin\": {}}]}");
     ConfigOrError lbConfigs = lbf.parseLoadBalancerPolicy(rawServiceConfig);
@@ -411,7 +411,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   }
 
   @Test
-  public void handleResolvedAddressGroups_noLbPolicySelected_defaultToPickFirst() {
+  public void acceptResolvedAddresses_noLbPolicySelected_defaultToPickFirst() {
     final List<EquivalentAddressGroup> servers =
         Collections.singletonList(new EquivalentAddressGroup(new SocketAddress(){}));
     Helper helper = new TestHelper() {
@@ -432,7 +432,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   }
 
   @Test
-  public void handleResolvedAddressGroups_noLbPolicySelected_defaultToCustomDefault() {
+  public void acceptResolvedAddresses_noLbPolicySelected_defaultToCustomDefault() {
     AutoConfiguredLoadBalancer lb = new AutoConfiguredLoadBalancerFactory("test_lb")
         .newLoadBalancer(new TestHelper());
     List<EquivalentAddressGroup> servers =

--- a/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
+++ b/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
@@ -643,14 +643,14 @@ public class AutoConfiguredLoadBalancerFactoryTest {
 
     @Override
     @Deprecated
-    public void handleResolvedAddressGroups(
+    public boolean handleResolvedAddressGroups(
         List<EquivalentAddressGroup> servers, Attributes attributes) {
-      delegate().handleResolvedAddressGroups(servers, attributes);
+      return delegate().handleResolvedAddressGroups(servers, attributes);
     }
 
     @Override
-    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-      delegate().handleResolvedAddresses(resolvedAddresses);
+    public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+      return delegate().handleResolvedAddresses(resolvedAddresses);
     }
 
     @Override

--- a/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
+++ b/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
@@ -97,8 +98,10 @@ public class AutoConfiguredLoadBalancerFactoryTest {
 
   @Before
   public void setUp() {
+    when(testLbBalancer.handleResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(true);
     when(testLbBalancer.canHandleEmptyAddressListFromNameResolution()).thenCallRealMethod();
     assertThat(testLbBalancer.canHandleEmptyAddressListFromNameResolution()).isFalse();
+    when(testLbBalancer2.handleResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(true);
     when(testLbBalancer2.canHandleEmptyAddressListFromNameResolution()).thenReturn(true);
     defaultRegistry.register(testLbBalancerProvider);
     defaultRegistry.register(testLbBalancerProvider2);
@@ -335,6 +338,10 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   @Test
   public void handleResolvedAddressGroups_delegateDoNotAcceptEmptyAddressList_nothing()
       throws Exception {
+
+    // The test LB will NOT accept the addresses we give them.
+    when(testLbBalancer.handleResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(false);
+
     Helper helper = new TestHelper();
     AutoConfiguredLoadBalancer lb = lbf.newLoadBalancer(helper);
 

--- a/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
+++ b/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
@@ -23,7 +23,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.ArgumentMatchers.same;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -99,10 +98,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   @Before
   public void setUp() {
     when(testLbBalancer.handleResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(true);
-    when(testLbBalancer.canHandleEmptyAddressListFromNameResolution()).thenCallRealMethod();
-    assertThat(testLbBalancer.canHandleEmptyAddressListFromNameResolution()).isFalse();
     when(testLbBalancer2.handleResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(true);
-    when(testLbBalancer2.canHandleEmptyAddressListFromNameResolution()).thenReturn(true);
     defaultRegistry.register(testLbBalancerProvider);
     defaultRegistry.register(testLbBalancerProvider2);
   }
@@ -267,7 +263,6 @@ public class AutoConfiguredLoadBalancerFactoryTest {
         ArgumentCaptor.forClass(ResolvedAddresses.class);
     verify(testLbBalancer).handleResolvedAddresses(resultCaptor.capture());
     assertThat(resultCaptor.getValue().getAddresses()).containsExactlyElementsIn(servers).inOrder();
-    verify(testLbBalancer, atLeast(0)).canHandleEmptyAddressListFromNameResolution();
     ArgumentCaptor<Map<String, ?>> lbConfigCaptor = ArgumentCaptor.forClass(Map.class);
     verify(testLbBalancerProvider).parseLoadBalancingPolicyConfig(lbConfigCaptor.capture());
     assertThat(lbConfigCaptor.getValue()).containsExactly("setting1", "high");
@@ -354,7 +349,6 @@ public class AutoConfiguredLoadBalancerFactoryTest {
             .setLoadBalancingPolicyConfig(lbConfig.getConfig())
             .build());
 
-    assertThat(testLbBalancer.canHandleEmptyAddressListFromNameResolution()).isFalse();
     assertThat(handleResult.getCode()).isEqualTo(Status.Code.UNAVAILABLE);
     assertThat(handleResult.getDescription()).startsWith("NameResolver returned no usable address");
     assertThat(lb.getDelegate()).isSameInstanceAs(testLbBalancer);
@@ -378,7 +372,6 @@ public class AutoConfiguredLoadBalancerFactoryTest {
 
     assertThat(handleResult.getCode()).isEqualTo(Status.Code.OK);
     assertThat(lb.getDelegate()).isSameInstanceAs(testLbBalancer2);
-    assertThat(testLbBalancer2.canHandleEmptyAddressListFromNameResolution()).isTrue();
     ArgumentCaptor<ResolvedAddresses> resultCaptor =
         ArgumentCaptor.forClass(ResolvedAddresses.class);
     verify(testLbBalancer2).handleResolvedAddresses(resultCaptor.capture());

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -154,7 +154,7 @@ public class ManagedChannelImplIdlenessTest {
   @Before
   @SuppressWarnings("deprecation") // For NameResolver.Listener
   public void setUp() {
-    when(mockLoadBalancer.handleResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(true);
+    when(mockLoadBalancer.acceptResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(true);
     LoadBalancerRegistry.getDefaultRegistry().register(mockLoadBalancerProvider);
     when(mockNameResolver.getServiceAuthority()).thenReturn(AUTHORITY);
     when(mockNameResolverFactory
@@ -221,7 +221,7 @@ public class ManagedChannelImplIdlenessTest {
 
     ArgumentCaptor<ResolvedAddresses> resolvedAddressCaptor =
         ArgumentCaptor.forClass(ResolvedAddresses.class);
-    verify(mockLoadBalancer).handleResolvedAddresses(resolvedAddressCaptor.capture());
+    verify(mockLoadBalancer).acceptResolvedAddresses(resolvedAddressCaptor.capture());
     assertThat(resolvedAddressCaptor.getValue().getAddresses())
         .containsExactlyElementsIn(servers);
   }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -154,6 +154,7 @@ public class ManagedChannelImplIdlenessTest {
   @Before
   @SuppressWarnings("deprecation") // For NameResolver.Listener
   public void setUp() {
+    when(mockLoadBalancer.handleResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(true);
     LoadBalancerRegistry.getDefaultRegistry().register(mockLoadBalancerProvider);
     when(mockNameResolver.getServiceAuthority()).thenReturn(AUTHORITY);
     when(mockNameResolverFactory

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -327,6 +327,7 @@ public class ManagedChannelImplTest {
 
   @Before
   public void setUp() throws Exception {
+    when(mockLoadBalancer.handleResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(true);
     when(mockLoadBalancer.canHandleEmptyAddressListFromNameResolution()).thenCallRealMethod();
     LoadBalancerRegistry.getDefaultRegistry().register(mockLoadBalancerProvider);
     expectedUri = new URI(TARGET);
@@ -1165,6 +1166,9 @@ public class ManagedChannelImplTest {
   @Test
   public void nameResolverReturnsEmptySubLists_becomeErrorByDefault() throws Exception {
     String errorDescription = "NameResolver returned no usable address";
+
+    // The mock LB is set to reject the addresses.
+    when(mockLoadBalancer.handleResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(false);
 
     // Pass a FakeNameResolverFactory with an empty list and LB config
     FakeNameResolverFactory nameResolverFactory =

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -1163,10 +1163,7 @@ public class ManagedChannelImplTest {
   }
 
   @Test
-  public void nameResolverReturnsEmptySubLists_becomeErrorByDefault() throws Exception {
-    String errorDescription
-        = "The load balancer did not accept the addresses returned from the NameResolver";
-
+  public void nameResolverReturnsEmptySubLists_resolutionRetry() throws Exception {
     // The mock LB is set to reject the addresses.
     when(mockLoadBalancer.acceptResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(false);
 
@@ -1180,13 +1177,6 @@ public class ManagedChannelImplTest {
     nameResolverFactory.nextConfigOrError.set(ConfigOrError.fromConfig(parsedServiceConfig));
     channelBuilder.nameResolverFactory(nameResolverFactory);
     createChannel();
-
-    // LoadBalancer received the error
-    verify(mockLoadBalancerProvider).newLoadBalancer(any(Helper.class));
-    verify(mockLoadBalancer).handleNameResolutionError(statusCaptor.capture());
-    Status status = statusCaptor.getValue();
-    assertSame(Status.Code.UNAVAILABLE, status.getCode());
-    assertThat(status.getDescription()).startsWith(errorDescription);
 
     // A resolution retry has been scheduled
     assertEquals(1, timer.numPendingTasks(NAME_RESOLVER_REFRESH_TASK_FILTER));

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -327,7 +327,7 @@ public class ManagedChannelImplTest {
 
   @Before
   public void setUp() throws Exception {
-    when(mockLoadBalancer.handleResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(true);
+    when(mockLoadBalancer.acceptResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(true);
     LoadBalancerRegistry.getDefaultRegistry().register(mockLoadBalancerProvider);
     expectedUri = new URI(TARGET);
     transports = TestUtils.captureTransports(mockTransportFactory);
@@ -948,7 +948,7 @@ public class ManagedChannelImplTest {
 
     FakeNameResolverFactory.FakeNameResolver resolver = nameResolverFactory.resolvers.get(0);
     verify(mockLoadBalancerProvider).newLoadBalancer(any(Helper.class));
-    verify(mockLoadBalancer).handleResolvedAddresses(resolvedAddressCaptor.capture());
+    verify(mockLoadBalancer).acceptResolvedAddresses(resolvedAddressCaptor.capture());
     assertThat(resolvedAddressCaptor.getValue().getAddresses()).containsExactly(addressGroup);
 
     SubchannelStateListener stateListener1 = mock(SubchannelStateListener.class);
@@ -1164,10 +1164,11 @@ public class ManagedChannelImplTest {
 
   @Test
   public void nameResolverReturnsEmptySubLists_becomeErrorByDefault() throws Exception {
-    String errorDescription = "NameResolver returned no usable address";
+    String errorDescription
+        = "The load balancer did not accept the addresses returned from the NameResolver";
 
     // The mock LB is set to reject the addresses.
-    when(mockLoadBalancer.handleResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(false);
+    when(mockLoadBalancer.acceptResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(false);
 
     // Pass a FakeNameResolverFactory with an empty list and LB config
     FakeNameResolverFactory nameResolverFactory =
@@ -1214,7 +1215,7 @@ public class ManagedChannelImplTest {
     verify(mockLoadBalancerProvider).newLoadBalancer(any(Helper.class));
     ArgumentCaptor<ResolvedAddresses> resultCaptor =
         ArgumentCaptor.forClass(ResolvedAddresses.class);
-    verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+    verify(mockLoadBalancer).acceptResolvedAddresses(resultCaptor.capture());
     assertThat(resultCaptor.getValue().getAddresses()).isEmpty();
     assertThat(resultCaptor.getValue().getLoadBalancingPolicyConfig()).isEqualTo(parsedLbConfig);
 
@@ -1235,7 +1236,7 @@ public class ManagedChannelImplTest {
     createChannel();
 
     verify(mockLoadBalancerProvider).newLoadBalancer(any(Helper.class));
-    doThrow(ex).when(mockLoadBalancer).handleResolvedAddresses(any(ResolvedAddresses.class));
+    doThrow(ex).when(mockLoadBalancer).acceptResolvedAddresses(any(ResolvedAddresses.class));
 
     // NameResolver returns addresses.
     nameResolverFactory.allResolved();
@@ -1297,7 +1298,7 @@ public class ManagedChannelImplTest {
 
     // Simulate name resolution results
     EquivalentAddressGroup addressGroup = new EquivalentAddressGroup(resolvedAddrs);
-    inOrder.verify(mockLoadBalancer).handleResolvedAddresses(resolvedAddressCaptor.capture());
+    inOrder.verify(mockLoadBalancer).acceptResolvedAddresses(resolvedAddressCaptor.capture());
     assertThat(resolvedAddressCaptor.getValue().getAddresses()).containsExactly(addressGroup);
     Subchannel subchannel =
         createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
@@ -1447,7 +1448,7 @@ public class ManagedChannelImplTest {
 
     // Simulate name resolution results
     EquivalentAddressGroup addressGroup = new EquivalentAddressGroup(resolvedAddrs);
-    inOrder.verify(mockLoadBalancer).handleResolvedAddresses(resolvedAddressCaptor.capture());
+    inOrder.verify(mockLoadBalancer).acceptResolvedAddresses(resolvedAddressCaptor.capture());
     assertThat(resolvedAddressCaptor.getValue().getAddresses()).containsExactly(addressGroup);
 
     Subchannel subchannel =
@@ -3773,7 +3774,7 @@ public class ManagedChannelImplTest {
     ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
     verify(mockLoadBalancerProvider).newLoadBalancer(helperCaptor.capture());
     helper = helperCaptor.getValue();
-    verify(mockLoadBalancer).handleResolvedAddresses(
+    verify(mockLoadBalancer).acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(nameResolverFactory.servers)
             .build());
@@ -3879,7 +3880,7 @@ public class ManagedChannelImplTest {
     ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
     verify(mockLoadBalancerProvider).newLoadBalancer(helperCaptor.capture());
     helper = helperCaptor.getValue();
-    verify(mockLoadBalancer).handleResolvedAddresses(
+    verify(mockLoadBalancer).acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(nameResolverFactory.servers)
             .build());
@@ -4206,7 +4207,7 @@ public class ManagedChannelImplTest {
 
       ArgumentCaptor<ResolvedAddresses> resultCaptor =
           ArgumentCaptor.forClass(ResolvedAddresses.class);
-      verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+      verify(mockLoadBalancer).acceptResolvedAddresses(resultCaptor.capture());
       assertThat(resultCaptor.getValue().getAddresses()).containsExactly(addressGroup);
       assertThat(resultCaptor.getValue().getAttributes().get(InternalConfigSelector.KEY)).isNull();
       verify(mockLoadBalancer, never()).handleNameResolutionError(any(Status.class));
@@ -4244,7 +4245,7 @@ public class ManagedChannelImplTest {
 
       ArgumentCaptor<ResolvedAddresses> resultCaptor =
           ArgumentCaptor.forClass(ResolvedAddresses.class);
-      verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+      verify(mockLoadBalancer).acceptResolvedAddresses(resultCaptor.capture());
       assertThat(resultCaptor.getValue().getAddresses()).containsExactly(addressGroup);
       assertThat(resultCaptor.getValue().getAttributes().get(InternalConfigSelector.KEY)).isNull();
       verify(mockLoadBalancer, never()).handleNameResolutionError(any(Status.class));
@@ -4274,7 +4275,7 @@ public class ManagedChannelImplTest {
       createChannel();
       ArgumentCaptor<ResolvedAddresses> resultCaptor =
           ArgumentCaptor.forClass(ResolvedAddresses.class);
-      verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+      verify(mockLoadBalancer).acceptResolvedAddresses(resultCaptor.capture());
       assertThat(resultCaptor.getValue().getAddresses()).containsExactly(addressGroup);
       verify(mockLoadBalancer, never()).handleNameResolutionError(any(Status.class));
 
@@ -4290,7 +4291,7 @@ public class ManagedChannelImplTest {
       nameResolverFactory.allResolved();
 
       resultCaptor = ArgumentCaptor.forClass(ResolvedAddresses.class);
-      verify(mockLoadBalancer, times(2)).handleResolvedAddresses(resultCaptor.capture());
+      verify(mockLoadBalancer, times(2)).acceptResolvedAddresses(resultCaptor.capture());
       assertThat(resultCaptor.getValue().getAddresses()).containsExactly(addressGroup);
       verify(mockLoadBalancer, never()).handleNameResolutionError(any(Status.class));
     } finally {
@@ -4324,7 +4325,7 @@ public class ManagedChannelImplTest {
       createChannel();
       ArgumentCaptor<ResolvedAddresses> resultCaptor =
           ArgumentCaptor.forClass(ResolvedAddresses.class);
-      verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+      verify(mockLoadBalancer).acceptResolvedAddresses(resultCaptor.capture());
       assertThat(resultCaptor.getValue().getAddresses()).containsExactly(addressGroup);
       verify(mockLoadBalancer, never()).handleNameResolutionError(any(Status.class));
     } finally {
@@ -4352,7 +4353,7 @@ public class ManagedChannelImplTest {
       createChannel();
       ArgumentCaptor<ResolvedAddresses> resultCaptor =
           ArgumentCaptor.forClass(ResolvedAddresses.class);
-      verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+      verify(mockLoadBalancer).acceptResolvedAddresses(resultCaptor.capture());
       assertThat(resultCaptor.getValue().getAddresses()).containsExactly(addressGroup);
       verify(mockLoadBalancer, never()).handleNameResolutionError(any(Status.class));
     } finally {
@@ -4378,7 +4379,7 @@ public class ManagedChannelImplTest {
       createChannel();
       ArgumentCaptor<ResolvedAddresses> resultCaptor =
           ArgumentCaptor.forClass(ResolvedAddresses.class);
-      verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+      verify(mockLoadBalancer).acceptResolvedAddresses(resultCaptor.capture());
       assertThat(resultCaptor.getValue().getAddresses()).containsExactly(addressGroup);
       verify(mockLoadBalancer, never()).handleNameResolutionError(any(Status.class));
     } finally {
@@ -4458,7 +4459,7 @@ public class ManagedChannelImplTest {
 
       ArgumentCaptor<ResolvedAddresses> resultCaptor =
           ArgumentCaptor.forClass(ResolvedAddresses.class);
-      verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+      verify(mockLoadBalancer).acceptResolvedAddresses(resultCaptor.capture());
       assertThat(resultCaptor.getValue().getAttributes()
           .get(LoadBalancer.ATTR_HEALTH_CHECKING_CONFIG))
           .containsExactly("serviceName", "service1");

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -328,7 +328,6 @@ public class ManagedChannelImplTest {
   @Before
   public void setUp() throws Exception {
     when(mockLoadBalancer.handleResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(true);
-    when(mockLoadBalancer.canHandleEmptyAddressListFromNameResolution()).thenCallRealMethod();
     LoadBalancerRegistry.getDefaultRegistry().register(mockLoadBalancerProvider);
     expectedUri = new URI(TARGET);
     transports = TestUtils.captureTransports(mockTransportFactory);
@@ -1194,8 +1193,6 @@ public class ManagedChannelImplTest {
 
   @Test
   public void nameResolverReturnsEmptySubLists_optionallyAllowed() throws Exception {
-    when(mockLoadBalancer.canHandleEmptyAddressListFromNameResolution()).thenReturn(true);
-
     // Pass a FakeNameResolverFactory with an empty list and LB config
     FakeNameResolverFactory nameResolverFactory =
         new FakeNameResolverFactory.Builder(expectedUri).build();

--- a/core/src/test/java/io/grpc/internal/PickFirstLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/internal/PickFirstLoadBalancerTest.java
@@ -121,7 +121,7 @@ public class PickFirstLoadBalancerTest {
 
   @Test
   public void pickAfterResolved() throws Exception {
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
 
     verify(mockHelper).createSubchannel(createArgsCaptor.capture());
@@ -139,7 +139,7 @@ public class PickFirstLoadBalancerTest {
 
   @Test
   public void requestConnectionPicker() throws Exception {
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
 
     InOrder inOrder = inOrder(mockHelper, mockSubchannel);
@@ -164,7 +164,7 @@ public class PickFirstLoadBalancerTest {
 
   @Test
   public void refreshNameResolutionAfterSubchannelConnectionBroken() {
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     verify(mockHelper).createSubchannel(any(CreateSubchannelArgs.class));
 
@@ -196,11 +196,11 @@ public class PickFirstLoadBalancerTest {
 
   @Test
   public void pickAfterResolvedAndUnchanged() throws Exception {
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     verify(mockSubchannel).start(any(SubchannelStateListener.class));
     verify(mockSubchannel).requestConnection();
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     verify(mockSubchannel).updateAddresses(eq(servers));
     verifyNoMoreInteractions(mockSubchannel);
@@ -223,7 +223,7 @@ public class PickFirstLoadBalancerTest {
 
     InOrder inOrder = inOrder(mockHelper, mockSubchannel);
 
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     inOrder.verify(mockHelper).createSubchannel(createArgsCaptor.capture());
     verify(mockSubchannel).start(any(SubchannelStateListener.class));
@@ -233,7 +233,7 @@ public class PickFirstLoadBalancerTest {
     verify(mockSubchannel).requestConnection();
     assertEquals(mockSubchannel, pickerCaptor.getValue().pickSubchannel(mockArgs).getSubchannel());
 
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(newServers).setAttributes(affinity).build());
     inOrder.verify(mockSubchannel).updateAddresses(eq(newServers));
 
@@ -245,7 +245,7 @@ public class PickFirstLoadBalancerTest {
   public void pickAfterStateChangeAfterResolution() throws Exception {
     InOrder inOrder = inOrder(mockHelper);
 
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     inOrder.verify(mockHelper).createSubchannel(createArgsCaptor.capture());
     CreateSubchannelArgs args = createArgsCaptor.getValue();
@@ -297,7 +297,7 @@ public class PickFirstLoadBalancerTest {
         .updateBalancingState(any(ConnectivityState.class), any(SubchannelPicker.class));
     verify(mockSubchannel, never()).requestConnection();
 
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     inOrder.verify(mockHelper).createSubchannel(createArgsCaptor.capture());
     CreateSubchannelArgs args = createArgsCaptor.getValue();
@@ -318,7 +318,7 @@ public class PickFirstLoadBalancerTest {
   @Test
   public void nameResolutionErrorWithStateChanges() throws Exception {
     InOrder inOrder = inOrder(mockHelper);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     inOrder.verify(mockHelper).createSubchannel(createArgsCaptor.capture());
     verify(mockSubchannel).start(stateListenerCaptor.capture());
@@ -358,7 +358,7 @@ public class PickFirstLoadBalancerTest {
     loadBalancer.requestConnection();
 
     verify(mockSubchannel, never()).requestConnection();
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     verify(mockSubchannel).requestConnection();
 

--- a/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
+++ b/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
@@ -284,16 +284,10 @@ public class ServiceConfigErrorHandlingTest {
     nameResolverFactory.allResolved();
 
     // 2nd service config without addresses
-    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
     verify(mockLoadBalancer).acceptResolvedAddresses(any(ResolvedAddresses.class));
-    verify(mockLoadBalancer).handleNameResolutionError(statusCaptor.capture());
-    assertThat(statusCaptor.getValue().getCode()).isEqualTo(Status.Code.UNAVAILABLE);
-    assertThat(statusCaptor.getValue().getDescription())
-        .contains("The load balancer did not accept the addresses returned from the NameResolver.");
-    assertThat(channel.getState(true)).isEqualTo(ConnectivityState.TRANSIENT_FAILURE);
-    assertWithMessage("Empty address should schedule NameResolver retry")
-        .that(getNameResolverRefresh())
-        .isNotNull();
+
+    // A resolution retry has been scheduled
+    assertEquals(1, timer.numPendingTasks(NAME_RESOLVER_REFRESH_TASK_FILTER));
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
+++ b/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
@@ -193,7 +193,6 @@ public class ServiceConfigErrorHandlingTest {
   @Before
   public void setUp() throws Exception {
     mockLoadBalancer.setAcceptAddresses(true);
-    when(mockLoadBalancer.canHandleEmptyAddressListFromNameResolution()).thenCallRealMethod();
     LoadBalancerRegistry.getDefaultRegistry().register(mockLoadBalancerProvider);
     expectedUri = new URI(TARGET);
     when(mockTransportFactory.getScheduledExecutorService())
@@ -304,7 +303,6 @@ public class ServiceConfigErrorHandlingTest {
             .setServers(Collections.<EquivalentAddressGroup>emptyList())
             .build();
     channelBuilder.nameResolverFactory(nameResolverFactory);
-    when(mockLoadBalancer.canHandleEmptyAddressListFromNameResolution()).thenReturn(true);
 
     Map<String, Object> rawServiceConfig =
         parseJson("{\"loadBalancingConfig\": [{\"mock_lb\": {\"check\": \"val\"}}]}");

--- a/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
+++ b/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
@@ -268,7 +268,7 @@ public class ServiceConfigErrorHandlingTest {
 
     ArgumentCaptor<ResolvedAddresses> resultCaptor =
         ArgumentCaptor.forClass(ResolvedAddresses.class);
-    verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+    verify(mockLoadBalancer).acceptResolvedAddresses(resultCaptor.capture());
     ResolvedAddresses resolvedAddresses = resultCaptor.getValue();
     assertThat(resolvedAddresses.getAddresses()).containsExactly(addressGroup);
     assertThat(resolvedAddresses.getLoadBalancingPolicyConfig()).isEqualTo("12");
@@ -285,11 +285,11 @@ public class ServiceConfigErrorHandlingTest {
 
     // 2nd service config without addresses
     ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
-    verify(mockLoadBalancer).handleResolvedAddresses(any(ResolvedAddresses.class));
+    verify(mockLoadBalancer).acceptResolvedAddresses(any(ResolvedAddresses.class));
     verify(mockLoadBalancer).handleNameResolutionError(statusCaptor.capture());
     assertThat(statusCaptor.getValue().getCode()).isEqualTo(Status.Code.UNAVAILABLE);
     assertThat(statusCaptor.getValue().getDescription())
-        .contains("NameResolver returned no usable address.");
+        .contains("The load balancer did not accept the addresses returned from the NameResolver.");
     assertThat(channel.getState(true)).isEqualTo(ConnectivityState.TRANSIENT_FAILURE);
     assertWithMessage("Empty address should schedule NameResolver retry")
         .that(getNameResolverRefresh())
@@ -312,7 +312,7 @@ public class ServiceConfigErrorHandlingTest {
 
     ArgumentCaptor<ResolvedAddresses> resultCaptor =
         ArgumentCaptor.forClass(ResolvedAddresses.class);
-    verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+    verify(mockLoadBalancer).acceptResolvedAddresses(resultCaptor.capture());
 
     ResolvedAddresses resolvedAddresses = resultCaptor.getValue();
     assertThat(resolvedAddresses.getAddresses()).isEmpty();
@@ -338,7 +338,7 @@ public class ServiceConfigErrorHandlingTest {
 
     ArgumentCaptor<ResolvedAddresses> resultCaptor =
         ArgumentCaptor.forClass(ResolvedAddresses.class);
-    verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+    verify(mockLoadBalancer).acceptResolvedAddresses(resultCaptor.capture());
     ResolvedAddresses resolvedAddresses = resultCaptor.getValue();
     assertThat(resolvedAddresses.getAddresses()).containsExactly(addressGroup);
     assertThat(resolvedAddresses.getLoadBalancingPolicyConfig()).isEqualTo("foo");
@@ -360,7 +360,7 @@ public class ServiceConfigErrorHandlingTest {
 
     ArgumentCaptor<ResolvedAddresses> resultCaptor =
         ArgumentCaptor.forClass(ResolvedAddresses.class);
-    verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+    verify(mockLoadBalancer).acceptResolvedAddresses(resultCaptor.capture());
     ResolvedAddresses resolvedAddresses = resultCaptor.getValue();
     assertThat(resolvedAddresses.getAddresses()).containsExactly(addressGroup);
     assertThat(resolvedAddresses.getLoadBalancingPolicyConfig()).isNull();
@@ -386,7 +386,7 @@ public class ServiceConfigErrorHandlingTest {
 
     ArgumentCaptor<ResolvedAddresses> resultCaptor =
         ArgumentCaptor.forClass(ResolvedAddresses.class);
-    verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+    verify(mockLoadBalancer).acceptResolvedAddresses(resultCaptor.capture());
     ResolvedAddresses resolvedAddresses = resultCaptor.getValue();
     assertThat(resolvedAddresses.getAddresses()).containsExactly(addressGroup);
     assertThat(resolvedAddresses.getLoadBalancingPolicyConfig()).isEqualTo("foo");
@@ -431,7 +431,7 @@ public class ServiceConfigErrorHandlingTest {
 
     ArgumentCaptor<ResolvedAddresses> resultCaptor =
         ArgumentCaptor.forClass(ResolvedAddresses.class);
-    verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+    verify(mockLoadBalancer).acceptResolvedAddresses(resultCaptor.capture());
 
     ResolvedAddresses resolvedAddresses = resultCaptor.getValue();
     assertThat(resolvedAddresses.getAddresses()).containsExactly(addressGroup);
@@ -462,7 +462,7 @@ public class ServiceConfigErrorHandlingTest {
 
     ArgumentCaptor<ResolvedAddresses> resultCaptor =
         ArgumentCaptor.forClass(ResolvedAddresses.class);
-    verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+    verify(mockLoadBalancer).acceptResolvedAddresses(resultCaptor.capture());
     ResolvedAddresses resolvedAddresses = resultCaptor.getValue();
     assertThat(resolvedAddresses.getAddresses()).containsExactly(addressGroup);
     assertThat(resolvedAddresses.getLoadBalancingPolicyConfig()).isEqualTo("1st raw config");
@@ -477,7 +477,7 @@ public class ServiceConfigErrorHandlingTest {
     nextLbPolicyConfigError.set(Status.UNKNOWN);
     nameResolverFactory.allResolved();
 
-    verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+    verify(mockLoadBalancer).acceptResolvedAddresses(resultCaptor.capture());
     ResolvedAddresses newResolvedAddress = resultCaptor.getValue();
     // should use previous service config because new service config is invalid.
     assertThat(newResolvedAddress.getLoadBalancingPolicyConfig()).isEqualTo("1st raw config");
@@ -510,7 +510,7 @@ public class ServiceConfigErrorHandlingTest {
 
     ArgumentCaptor<ResolvedAddresses> resultCaptor =
         ArgumentCaptor.forClass(ResolvedAddresses.class);
-    verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+    verify(mockLoadBalancer).acceptResolvedAddresses(resultCaptor.capture());
     ResolvedAddresses resolvedAddresses = resultCaptor.getValue();
     assertThat(resolvedAddresses.getAddresses()).containsExactly(addressGroup);
     // should use previous service config because new resolution result is no config.
@@ -522,7 +522,7 @@ public class ServiceConfigErrorHandlingTest {
     nameResolverFactory.nextRawServiceConfig.set(null);
     nameResolverFactory.allResolved();
 
-    verify(mockLoadBalancer, times(2)).handleResolvedAddresses(resultCaptor.capture());
+    verify(mockLoadBalancer, times(2)).acceptResolvedAddresses(resultCaptor.capture());
     ResolvedAddresses newResolvedAddress = resultCaptor.getValue();
     assertThat(newResolvedAddress.getLoadBalancingPolicyConfig()).isEqualTo("mate");
     assertThat(newResolvedAddress.getAttributes().get(InternalConfigSelector.KEY))
@@ -668,7 +668,7 @@ public class ServiceConfigErrorHandlingTest {
     }
 
     @Override
-    public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       return acceptAddresses;
     }
 

--- a/core/src/test/java/io/grpc/util/GracefulSwitchLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/util/GracefulSwitchLoadBalancerTest.java
@@ -94,17 +94,17 @@ public class GracefulSwitchLoadBalancerTest {
     helper0.updateBalancingState(READY, picker);
 
     ResolvedAddresses addresses = newFakeAddresses();
-    gracefulSwitchLb.handleResolvedAddresses(addresses);
-    verify(lb0).handleResolvedAddresses(addresses);
+    gracefulSwitchLb.acceptResolvedAddresses(addresses);
+    verify(lb0).acceptResolvedAddresses(addresses);
     gracefulSwitchLb.handleNameResolutionError(Status.DATA_LOSS);
     verify(lb0).handleNameResolutionError(Status.DATA_LOSS);
 
     gracefulSwitchLb.switchTo(lbProviders.get(lbPolicies[1]));
     LoadBalancer lb1 = balancers.get(lbPolicies[1]);
     addresses = newFakeAddresses();
-    gracefulSwitchLb.handleResolvedAddresses(addresses);
-    verify(lb0, never()).handleResolvedAddresses(addresses);
-    verify(lb1).handleResolvedAddresses(addresses);
+    gracefulSwitchLb.acceptResolvedAddresses(addresses);
+    verify(lb0, never()).acceptResolvedAddresses(addresses);
+    verify(lb1).acceptResolvedAddresses(addresses);
     gracefulSwitchLb.handleNameResolutionError(Status.ALREADY_EXISTS);
     verify(lb0, never()).handleNameResolutionError(Status.ALREADY_EXISTS);
     verify(lb1).handleNameResolutionError(Status.ALREADY_EXISTS);
@@ -113,10 +113,10 @@ public class GracefulSwitchLoadBalancerTest {
     verify(lb1).shutdown();
     LoadBalancer lb2 = balancers.get(lbPolicies[2]);
     addresses = newFakeAddresses();
-    gracefulSwitchLb.handleResolvedAddresses(addresses);
-    verify(lb0, never()).handleResolvedAddresses(addresses);
-    verify(lb1, never()).handleResolvedAddresses(addresses);
-    verify(lb2).handleResolvedAddresses(addresses);
+    gracefulSwitchLb.acceptResolvedAddresses(addresses);
+    verify(lb0, never()).acceptResolvedAddresses(addresses);
+    verify(lb1, never()).acceptResolvedAddresses(addresses);
+    verify(lb2).acceptResolvedAddresses(addresses);
     gracefulSwitchLb.handleNameResolutionError(Status.CANCELLED);
     verify(lb0, never()).handleNameResolutionError(Status.CANCELLED);
     verify(lb1, never()).handleNameResolutionError(Status.CANCELLED);

--- a/core/src/test/java/io/grpc/util/GracefulSwitchLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/util/GracefulSwitchLoadBalancerTest.java
@@ -22,7 +22,6 @@ import static io.grpc.ConnectivityState.READY;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 import static io.grpc.util.GracefulSwitchLoadBalancer.BUFFER_PICKER;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -84,35 +83,6 @@ public class GracefulSwitchLoadBalancerTest {
       lbProviders.put(lbPolicy, lbProvider);
       lbRegistry.register(lbProvider);
     }
-  }
-
-  @Test
-  public void canHandleEmptyAddressListFromNameResolutionForwardedToLatestPolicy() {
-    gracefulSwitchLb.switchTo(lbProviders.get(lbPolicies[0]));
-    LoadBalancer lb0 = balancers.get(lbPolicies[0]);
-    Helper helper0 = helpers.get(lb0);
-    SubchannelPicker picker = mock(SubchannelPicker.class);
-    helper0.updateBalancingState(READY, picker);
-
-    assertThat(gracefulSwitchLb.canHandleEmptyAddressListFromNameResolution()).isFalse();
-    doReturn(true).when(lb0).canHandleEmptyAddressListFromNameResolution();
-    assertThat(gracefulSwitchLb.canHandleEmptyAddressListFromNameResolution()).isTrue();
-
-    gracefulSwitchLb.switchTo(lbProviders.get(lbPolicies[1]));
-    LoadBalancer lb1 = balancers.get(lbPolicies[1]);
-
-    assertThat(gracefulSwitchLb.canHandleEmptyAddressListFromNameResolution()).isFalse();
-
-    doReturn(true).when(lb1).canHandleEmptyAddressListFromNameResolution();
-    assertThat(gracefulSwitchLb.canHandleEmptyAddressListFromNameResolution()).isTrue();
-
-    gracefulSwitchLb.switchTo(lbProviders.get(lbPolicies[2]));
-    LoadBalancer lb2 = balancers.get(lbPolicies[2]);
-
-    assertThat(gracefulSwitchLb.canHandleEmptyAddressListFromNameResolution()).isFalse();
-
-    doReturn(true).when(lb2).canHandleEmptyAddressListFromNameResolution();
-    assertThat(gracefulSwitchLb.canHandleEmptyAddressListFromNameResolution()).isTrue();
   }
 
   @Test

--- a/core/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
@@ -148,7 +148,7 @@ public class RoundRobinLoadBalancerTest {
   @Test
   public void pickAfterResolved() throws Exception {
     final Subchannel readySubchannel = subchannels.values().iterator().next();
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     deliverSubchannelState(readySubchannel, ConnectivityStateInfo.forNonError(READY));
 
@@ -199,7 +199,7 @@ public class RoundRobinLoadBalancerTest {
 
     InOrder inOrder = inOrder(mockHelper);
 
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(currentServers).setAttributes(affinity)
             .build());
 
@@ -221,7 +221,7 @@ public class RoundRobinLoadBalancerTest {
     // This time with Attributes
     List<EquivalentAddressGroup> latestServers = Lists.newArrayList(oldEag2, newEag);
 
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(latestServers).setAttributes(affinity).build());
 
     verify(newSubchannel, times(1)).requestConnection();
@@ -241,7 +241,7 @@ public class RoundRobinLoadBalancerTest {
     assertThat(getList(picker)).containsExactly(oldSubchannel, newSubchannel);
 
     // test going from non-empty to empty
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(Collections.<EquivalentAddressGroup>emptyList())
             .setAttributes(affinity)
@@ -256,7 +256,7 @@ public class RoundRobinLoadBalancerTest {
   @Test
   public void pickAfterStateChange() throws Exception {
     InOrder inOrder = inOrder(mockHelper);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(Attributes.EMPTY)
             .build());
     Subchannel subchannel = loadBalancer.getSubchannels().iterator().next();
@@ -296,7 +296,7 @@ public class RoundRobinLoadBalancerTest {
   @Test
   public void ignoreShutdownSubchannelStateChange() {
     InOrder inOrder = inOrder(mockHelper);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(Attributes.EMPTY)
             .build());
     inOrder.verify(mockHelper).updateBalancingState(eq(CONNECTING), isA(EmptyPicker.class));
@@ -315,7 +315,7 @@ public class RoundRobinLoadBalancerTest {
   @Test
   public void stayTransientFailureUntilReady() {
     InOrder inOrder = inOrder(mockHelper);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(Attributes.EMPTY)
             .build());
 
@@ -353,7 +353,7 @@ public class RoundRobinLoadBalancerTest {
   @Test
   public void refreshNameResolutionWhenSubchannelConnectionBroken() {
     InOrder inOrder = inOrder(mockHelper);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(Attributes.EMPTY)
             .build());
 
@@ -420,7 +420,7 @@ public class RoundRobinLoadBalancerTest {
   @Test
   public void nameResolutionErrorWithActiveChannels() throws Exception {
     final Subchannel readySubchannel = subchannels.values().iterator().next();
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     deliverSubchannelState(readySubchannel, ConnectivityStateInfo.forNonError(READY));
     loadBalancer.handleNameResolutionError(Status.NOT_FOUND.withDescription("nameResolutionError"));
@@ -449,7 +449,7 @@ public class RoundRobinLoadBalancerTest {
     Subchannel sc2 = subchannelIterator.next();
     Subchannel sc3 = subchannelIterator.next();
 
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(Attributes.EMPTY)
             .build());
     verify(sc1, times(1)).requestConnection();

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -76,7 +76,7 @@ class GrpclbLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     Attributes attributes = resolvedAddresses.getAttributes();
     List<EquivalentAddressGroup> newLbAddresses = attributes.get(GrpclbConstants.ATTR_LB_ADDRS);
     if (newLbAddresses == null) {

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -152,11 +152,6 @@ class GrpclbLoadBalancer extends LoadBalancer {
     }
   }
 
-  @Override
-  public boolean canHandleEmptyAddressListFromNameResolution() {
-    return true;
-  }
-
   @VisibleForTesting
   @Nullable
   GrpclbState getGrpclbState() {

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -76,7 +76,7 @@ class GrpclbLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     Attributes attributes = resolvedAddresses.getAttributes();
     List<EquivalentAddressGroup> newLbAddresses = attributes.get(GrpclbConstants.ATTR_LB_ADDRS);
     if (newLbAddresses == null) {
@@ -85,7 +85,7 @@ class GrpclbLoadBalancer extends LoadBalancer {
     if (newLbAddresses.isEmpty() && resolvedAddresses.getAddresses().isEmpty()) {
       handleNameResolutionError(
           Status.UNAVAILABLE.withDescription("No backend or balancer addresses found"));
-      return;
+      return false;
     }
     List<EquivalentAddressGroup> overrideAuthorityLbAddresses =
         new ArrayList<>(newLbAddresses.size());
@@ -114,6 +114,8 @@ class GrpclbLoadBalancer extends LoadBalancer {
     }
     grpclbState.handleAddresses(Collections.unmodifiableList(overrideAuthorityLbAddresses),
         newBackendServers);
+
+    return true;
   }
 
   @Override

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -2735,7 +2735,7 @@ public class GrpclbLoadBalancerTest {
     syncContext.execute(new Runnable() {
       @Override
       public void run() {
-        balancer.handleResolvedAddresses(
+        balancer.acceptResolvedAddresses(
             ResolvedAddresses.newBuilder()
                 .setAddresses(backendAddrs)
                 .setAttributes(attrs)

--- a/interop-testing/src/main/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProvider.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProvider.java
@@ -111,10 +111,10 @@ public class RpcBehaviorLoadBalancerProvider extends LoadBalancerProvider {
     }
 
     @Override
-    public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       helper.setRpcBehavior(
           ((RpcBehaviorConfig) resolvedAddresses.getLoadBalancingPolicyConfig()).rpcBehavior);
-      delegateLb.handleResolvedAddresses(resolvedAddresses);
+      delegateLb.acceptResolvedAddresses(resolvedAddresses);
 
       return true;
     }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProvider.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProvider.java
@@ -111,10 +111,12 @@ public class RpcBehaviorLoadBalancerProvider extends LoadBalancerProvider {
     }
 
     @Override
-    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       helper.setRpcBehavior(
           ((RpcBehaviorConfig) resolvedAddresses.getLoadBalancingPolicyConfig()).rpcBehavior);
       delegateLb.handleResolvedAddresses(resolvedAddresses);
+
+      return true;
     }
   }
 

--- a/interop-testing/src/test/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProviderTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProviderTest.java
@@ -83,8 +83,8 @@ public class RpcBehaviorLoadBalancerProviderTest {
     RpcBehaviorLoadBalancer lb = new RpcBehaviorLoadBalancer(new RpcBehaviorHelper(mockHelper),
         mockDelegateLb);
     ResolvedAddresses resolvedAddresses = buildResolvedAddresses(buildConfig());
-    lb.handleResolvedAddresses(resolvedAddresses);
-    verify(mockDelegateLb).handleResolvedAddresses(resolvedAddresses);
+    lb.acceptResolvedAddresses(resolvedAddresses);
+    verify(mockDelegateLb).acceptResolvedAddresses(resolvedAddresses);
   }
 
   @Test

--- a/rls/src/main/java/io/grpc/rls/LbPolicyConfiguration.java
+++ b/rls/src/main/java/io/grpc/rls/LbPolicyConfiguration.java
@@ -302,7 +302,8 @@ final class LbPolicyConfiguration {
           new Runnable() {
             @Override
             public void run() {
-              lb.handleResolvedAddresses(
+              // TODO: How should a false response be handled?
+              lb.acceptResolvedAddresses(
                   childLbResolvedAddressFactory.create(lbConfig.getConfig()));
               lb.requestConnection();
             }

--- a/rls/src/main/java/io/grpc/rls/LbPolicyConfiguration.java
+++ b/rls/src/main/java/io/grpc/rls/LbPolicyConfiguration.java
@@ -302,7 +302,6 @@ final class LbPolicyConfiguration {
           new Runnable() {
             @Override
             public void run() {
-              // TODO: How should a false response be handled?
               lb.acceptResolvedAddresses(
                   childLbResolvedAddressFactory.create(lbConfig.getConfig()));
               lb.requestConnection();

--- a/rls/src/main/java/io/grpc/rls/RlsLoadBalancer.java
+++ b/rls/src/main/java/io/grpc/rls/RlsLoadBalancer.java
@@ -49,7 +49,7 @@ final class RlsLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(ChannelLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     LbPolicyConfiguration lbPolicyConfiguration =
         (LbPolicyConfiguration) resolvedAddresses.getLoadBalancingPolicyConfig();
@@ -78,6 +78,8 @@ final class RlsLoadBalancer extends LoadBalancer {
       //  not required.
       this.lbPolicyConfiguration = lbPolicyConfiguration;
     }
+
+    return true;
   }
 
   @Override

--- a/rls/src/main/java/io/grpc/rls/RlsLoadBalancer.java
+++ b/rls/src/main/java/io/grpc/rls/RlsLoadBalancer.java
@@ -49,7 +49,7 @@ final class RlsLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(ChannelLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     LbPolicyConfiguration lbPolicyConfiguration =
         (LbPolicyConfiguration) resolvedAddresses.getLoadBalancingPolicyConfig();

--- a/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
+++ b/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
@@ -566,7 +566,7 @@ public class CachingRlsLbClientTest {
       LoadBalancer loadBalancer = new LoadBalancer() {
 
         @Override
-        public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+        public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
           Map<?, ?> config = (Map<?, ?>) resolvedAddresses.getLoadBalancingPolicyConfig();
           if (DEFAULT_TARGET.equals(config.get("target"))) {
             helper.updateBalancingState(

--- a/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
+++ b/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
@@ -566,7 +566,7 @@ public class CachingRlsLbClientTest {
       LoadBalancer loadBalancer = new LoadBalancer() {
 
         @Override
-        public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+        public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
           Map<?, ?> config = (Map<?, ?>) resolvedAddresses.getLoadBalancingPolicyConfig();
           if (DEFAULT_TARGET.equals(config.get("target"))) {
             helper.updateBalancingState(
@@ -588,6 +588,8 @@ public class CachingRlsLbClientTest {
                   }
                 });
           }
+
+          return true;
         }
 
         @Override

--- a/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
@@ -412,7 +412,8 @@ public class RlsLoadBalancerTest {
     ConfigOrError parsedConfigOrError =
         provider.parseLoadBalancingPolicyConfig(getServiceConfig());
     assertThat(parsedConfigOrError.getConfig()).isNotNull();
-    rlsLb.handleResolvedAddresses(ResolvedAddresses.newBuilder()
+    // TODO: Do something with acceptance status
+    rlsLb.acceptResolvedAddresses(ResolvedAddresses.newBuilder()
         .setAddresses(ImmutableList.of(new EquivalentAddressGroup(mock(SocketAddress.class))))
         .setLoadBalancingPolicyConfig(parsedConfigOrError.getConfig())
         .build());

--- a/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
@@ -412,7 +412,6 @@ public class RlsLoadBalancerTest {
     ConfigOrError parsedConfigOrError =
         provider.parseLoadBalancingPolicyConfig(getServiceConfig());
     assertThat(parsedConfigOrError.getConfig()).isNotNull();
-    // TODO: Do something with acceptance status
     rlsLb.acceptResolvedAddresses(ResolvedAddresses.newBuilder()
         .setAddresses(ImmutableList.of(new EquivalentAddressGroup(mock(SocketAddress.class))))
         .setLoadBalancingPolicyConfig(parsedConfigOrError.getConfig())

--- a/services/src/main/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactory.java
+++ b/services/src/main/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactory.java
@@ -179,14 +179,14 @@ final class HealthCheckingLoadBalancerFactory extends LoadBalancer.Factory {
     }
 
     @Override
-    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       Map<String, ?> healthCheckingConfig =
           resolvedAddresses
               .getAttributes()
               .get(LoadBalancer.ATTR_HEALTH_CHECKING_CONFIG);
       String serviceName = ServiceConfigUtil.getHealthCheckedServiceName(healthCheckingConfig);
       helper.setHealthCheckedService(serviceName);
-      super.handleResolvedAddresses(resolvedAddresses);
+      return super.handleResolvedAddresses(resolvedAddresses);
     }
 
     @Override

--- a/services/src/main/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactory.java
+++ b/services/src/main/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactory.java
@@ -179,14 +179,14 @@ final class HealthCheckingLoadBalancerFactory extends LoadBalancer.Factory {
     }
 
     @Override
-    public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       Map<String, ?> healthCheckingConfig =
           resolvedAddresses
               .getAttributes()
               .get(LoadBalancer.ATTR_HEALTH_CHECKING_CONFIG);
       String serviceName = ServiceConfigUtil.getHealthCheckedServiceName(healthCheckingConfig);
       helper.setHealthCheckedService(serviceName);
-      return super.handleResolvedAddresses(resolvedAddresses);
+      return super.acceptResolvedAddresses(resolvedAddresses);
     }
 
     @Override

--- a/services/src/test/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactoryTest.java
+++ b/services/src/test/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactoryTest.java
@@ -193,12 +193,12 @@ public class HealthCheckingLoadBalancerFactoryTest {
         boolean shutdown;
 
         @Override
-        public boolean handleResolvedAddresses(final ResolvedAddresses resolvedAddresses) {
+        public boolean acceptResolvedAddresses(final ResolvedAddresses resolvedAddresses) {
           syncContext.execute(new Runnable() {
               @Override
               public void run() {
                 if (!shutdown) {
-                  hcLb.handleResolvedAddresses(resolvedAddresses);
+                  hcLb.acceptResolvedAddresses(resolvedAddresses);
                 }
               }
             });
@@ -252,9 +252,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result);
+    hcLbEventDelivery.acceptResolvedAddresses(result);
 
-    verify(origLb).handleResolvedAddresses(result);
+    verify(origLb).acceptResolvedAddresses(result);
     verify(origHelper, atLeast(0)).getSynchronizationContext();
     verify(origHelper, atLeast(0)).getScheduledExecutorService();
     verifyNoMoreInteractions(origHelper);
@@ -373,9 +373,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result);
+    hcLbEventDelivery.acceptResolvedAddresses(result);
 
-    verify(origLb).handleResolvedAddresses(result);
+    verify(origLb).acceptResolvedAddresses(result);
     verifyNoMoreInteractions(origLb);
 
     // We create 2 Subchannels. One of them connects to a server that doesn't implement health check
@@ -442,9 +442,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result);
+    hcLbEventDelivery.acceptResolvedAddresses(result);
 
-    verify(origLb).handleResolvedAddresses(result);
+    verify(origLb).acceptResolvedAddresses(result);
     verifyNoMoreInteractions(origLb);
 
     FakeSubchannel subchannel = unwrap(createSubchannel(0, Attributes.EMPTY));
@@ -513,9 +513,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result);
+    hcLbEventDelivery.acceptResolvedAddresses(result);
 
-    verify(origLb).handleResolvedAddresses(result);
+    verify(origLb).acceptResolvedAddresses(result);
     verifyNoMoreInteractions(origLb);
 
     SubchannelStateListener mockStateListener = mockStateListeners[0];
@@ -606,9 +606,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(Attributes.EMPTY)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result1);
+    hcLbEventDelivery.acceptResolvedAddresses(result1);
 
-    verify(origLb).handleResolvedAddresses(result1);
+    verify(origLb).acceptResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     // First, create Subchannels 0
@@ -627,8 +627,8 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result2);
-    verify(origLb).handleResolvedAddresses(result2);
+    hcLbEventDelivery.acceptResolvedAddresses(result2);
+    verify(origLb).acceptResolvedAddresses(result2);
 
     // Health check started on existing Subchannel
     assertThat(healthImpls[0].calls).hasSize(1);
@@ -650,9 +650,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result1);
+    hcLbEventDelivery.acceptResolvedAddresses(result1);
 
-    verify(origLb).handleResolvedAddresses(result1);
+    verify(origLb).acceptResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     Subchannel subchannel = createSubchannel(0, Attributes.EMPTY);
@@ -673,7 +673,7 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(Attributes.EMPTY)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result2);
+    hcLbEventDelivery.acceptResolvedAddresses(result2);
 
     // Health check RPC cancelled.
     assertThat(serverCall.cancelled).isTrue();
@@ -681,7 +681,7 @@ public class HealthCheckingLoadBalancerFactoryTest {
     inOrder.verify(mockStateListeners[0]).onSubchannelState(
         eq(ConnectivityStateInfo.forNonError(READY)));
 
-    inOrder.verify(origLb).handleResolvedAddresses(result2);
+    inOrder.verify(origLb).acceptResolvedAddresses(result2);
 
     verifyNoMoreInteractions(origLb, mockStateListeners[0]);
     assertThat(healthImpl.calls).isEmpty();
@@ -694,9 +694,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result);
+    hcLbEventDelivery.acceptResolvedAddresses(result);
 
-    verify(origLb).handleResolvedAddresses(result);
+    verify(origLb).acceptResolvedAddresses(result);
     verifyNoMoreInteractions(origLb);
 
     Subchannel subchannel = createSubchannel(0, Attributes.EMPTY);
@@ -723,7 +723,7 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(Attributes.EMPTY)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result2);
+    hcLbEventDelivery.acceptResolvedAddresses(result2);
 
     // Retry timer is cancelled
     assertThat(clock.getPendingTasks()).isEmpty();
@@ -735,7 +735,7 @@ public class HealthCheckingLoadBalancerFactoryTest {
     inOrder.verify(mockStateListeners[0]).onSubchannelState(
         eq(ConnectivityStateInfo.forNonError(READY)));
 
-    inOrder.verify(origLb).handleResolvedAddresses(result2);
+    inOrder.verify(origLb).acceptResolvedAddresses(result2);
 
     verifyNoMoreInteractions(origLb, mockStateListeners[0]);
   }
@@ -747,9 +747,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result1);
+    hcLbEventDelivery.acceptResolvedAddresses(result1);
 
-    verify(origLb).handleResolvedAddresses(result1);
+    verify(origLb).acceptResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     Subchannel subchannel = createSubchannel(0, Attributes.EMPTY);
@@ -769,9 +769,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(Attributes.EMPTY)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result2);
+    hcLbEventDelivery.acceptResolvedAddresses(result2);
 
-    inOrder.verify(origLb).handleResolvedAddresses(result2);
+    inOrder.verify(origLb).acceptResolvedAddresses(result2);
 
     // Underlying subchannel is now ready
     deliverSubchannelState(0, ConnectivityStateInfo.forNonError(READY));
@@ -793,9 +793,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result1);
+    hcLbEventDelivery.acceptResolvedAddresses(result1);
 
-    verify(origLb).handleResolvedAddresses(result1);
+    verify(origLb).acceptResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     Subchannel subchannel = createSubchannel(0, Attributes.EMPTY);
@@ -819,9 +819,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         eq(ConnectivityStateInfo.forNonError(READY)));
 
     // Service config returns with the same health check name.
-    hcLbEventDelivery.handleResolvedAddresses(result1);
+    hcLbEventDelivery.acceptResolvedAddresses(result1);
     // It's delivered to origLb, but nothing else happens
-    inOrder.verify(origLb).handleResolvedAddresses(result1);
+    inOrder.verify(origLb).acceptResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb, mockListener);
 
     // Service config returns a different health check name.
@@ -830,8 +830,8 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result2);
-    inOrder.verify(origLb).handleResolvedAddresses(result2);
+    hcLbEventDelivery.acceptResolvedAddresses(result2);
+    inOrder.verify(origLb).acceptResolvedAddresses(result2);
 
     // Current health check RPC cancelled.
     assertThat(serverCall.cancelled).isTrue();
@@ -853,9 +853,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result1);
+    hcLbEventDelivery.acceptResolvedAddresses(result1);
 
-    verify(origLb).handleResolvedAddresses(result1);
+    verify(origLb).acceptResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     Subchannel subchannel = createSubchannel(0, Attributes.EMPTY);
@@ -884,9 +884,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
 
     // Service config returns with the same health check name.
 
-    hcLbEventDelivery.handleResolvedAddresses(result1);
+    hcLbEventDelivery.acceptResolvedAddresses(result1);
     // It's delivered to origLb, but nothing else happens
-    inOrder.verify(origLb).handleResolvedAddresses(result1);
+    inOrder.verify(origLb).acceptResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb, mockListener);
     assertThat(clock.getPendingTasks()).hasSize(1);
     assertThat(healthImpl.calls).isEmpty();
@@ -897,13 +897,13 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result2);
+    hcLbEventDelivery.acceptResolvedAddresses(result2);
 
     // Concluded CONNECTING state
     inOrder.verify(mockListener).onSubchannelState(
         eq(ConnectivityStateInfo.forNonError(CONNECTING)));
 
-    inOrder.verify(origLb).handleResolvedAddresses(result2);
+    inOrder.verify(origLb).acceptResolvedAddresses(result2);
 
     // Current retry timer cancelled
     assertThat(clock.getPendingTasks()).isEmpty();
@@ -924,9 +924,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result1);
+    hcLbEventDelivery.acceptResolvedAddresses(result1);
 
-    verify(origLb).handleResolvedAddresses(result1);
+    verify(origLb).acceptResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     Subchannel subchannel = createSubchannel(0, Attributes.EMPTY);
@@ -944,9 +944,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
     inOrder.verifyNoMoreInteractions();
 
     // Service config returns with the same health check name.
-    hcLbEventDelivery.handleResolvedAddresses(result1);
+    hcLbEventDelivery.acceptResolvedAddresses(result1);
     // It's delivered to origLb, but nothing else happens
-    inOrder.verify(origLb).handleResolvedAddresses(result1);
+    inOrder.verify(origLb).acceptResolvedAddresses(result1);
     assertThat(healthImpl.calls).isEmpty();
     verifyNoMoreInteractions(origLb);
 
@@ -956,9 +956,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result2);
+    hcLbEventDelivery.acceptResolvedAddresses(result2);
 
-    inOrder.verify(origLb).handleResolvedAddresses(result2);
+    inOrder.verify(origLb).acceptResolvedAddresses(result2);
 
     // Underlying subchannel is now ready
     deliverSubchannelState(0, ConnectivityStateInfo.forNonError(READY));
@@ -1001,9 +1001,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result);
+    hcLbEventDelivery.acceptResolvedAddresses(result);
 
-    verify(origLb).handleResolvedAddresses(result);
+    verify(origLb).acceptResolvedAddresses(result);
     verifyNoMoreInteractions(origLb);
     ServerSideCall[] serverCalls = new ServerSideCall[NUM_SUBCHANNELS];
 
@@ -1075,8 +1075,8 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result);
-    verify(origLb).handleResolvedAddresses(result);
+    hcLbEventDelivery.acceptResolvedAddresses(result);
+    verify(origLb).acceptResolvedAddresses(result);
     createSubchannel(0, Attributes.EMPTY);
     assertThat(healthImpls[0].calls).isEmpty();
     deliverSubchannelState(0, ConnectivityStateInfo.forNonError(READY));

--- a/services/src/test/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactoryTest.java
+++ b/services/src/test/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactoryTest.java
@@ -193,7 +193,7 @@ public class HealthCheckingLoadBalancerFactoryTest {
         boolean shutdown;
 
         @Override
-        public void handleResolvedAddresses(final ResolvedAddresses resolvedAddresses) {
+        public boolean handleResolvedAddresses(final ResolvedAddresses resolvedAddresses) {
           syncContext.execute(new Runnable() {
               @Override
               public void run() {
@@ -202,6 +202,7 @@ public class HealthCheckingLoadBalancerFactoryTest {
                 }
               }
             });
+          return true;
         }
 
         @Override

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
@@ -79,7 +79,7 @@ final class CdsLoadBalancer2 extends LoadBalancer {
   }
 
   @Override
-  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     if (this.resolvedAddresses != null) {
       return true;
     }
@@ -210,7 +210,7 @@ final class CdsLoadBalancer2 extends LoadBalancer {
       if (childLb == null) {
         childLb = lbRegistry.getProvider(CLUSTER_RESOLVER_POLICY_NAME).newLoadBalancer(helper);
       }
-      childLb.handleResolvedAddresses(
+      childLb.acceptResolvedAddresses(
           resolvedAddresses.toBuilder().setLoadBalancingPolicyConfig(config).build());
     }
 

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
@@ -79,9 +79,9 @@ final class CdsLoadBalancer2 extends LoadBalancer {
   }
 
   @Override
-  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     if (this.resolvedAddresses != null) {
-      return;
+      return true;
     }
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     this.resolvedAddresses = resolvedAddresses;
@@ -91,6 +91,7 @@ final class CdsLoadBalancer2 extends LoadBalancer {
     logger.log(XdsLogLevel.INFO, "Config: {0}", config);
     cdsLbState = new CdsLbState(config.name);
     cdsLbState.start();
+    return true;
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -102,7 +102,7 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     Attributes attributes = resolvedAddresses.getAttributes();
     if (xdsClientPool == null) {
@@ -129,13 +129,11 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
     childLbHelper.updateDropPolicies(config.dropCategories);
     childLbHelper.updateMaxConcurrentRequests(config.maxConcurrentRequests);
     childLbHelper.updateSslContextProviderSupplier(config.tlsContext);
-    childLb.handleResolvedAddresses(
+    return childLb.acceptResolvedAddresses(
         resolvedAddresses.toBuilder()
             .setAttributes(attributes)
             .setLoadBalancingPolicyConfig(config.childPolicy.getConfig())
             .build());
-
-    return true;
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -164,11 +164,6 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
     }
   }
 
-  @Override
-  public boolean canHandleEmptyAddressListFromNameResolution() {
-    return true;
-  }
-
   /**
    * A decorated {@link LoadBalancer.Helper} that applies configurations for connections
    * or requests to endpoints in the cluster.

--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -102,7 +102,7 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     Attributes attributes = resolvedAddresses.getAttributes();
     if (xdsClientPool == null) {
@@ -134,6 +134,8 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
             .setAttributes(attributes)
             .setLoadBalancingPolicyConfig(config.childPolicy.getConfig())
             .build());
+
+    return true;
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
@@ -73,13 +73,13 @@ class ClusterManagerLoadBalancer extends LoadBalancer {
   public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     try {
       resolvingAddresses = true;
-      handleResolvedAddressesInternal(resolvedAddresses);
+      return handleResolvedAddressesInternal(resolvedAddresses);
     } finally {
       resolvingAddresses = false;
     }
   }
 
-  public void handleResolvedAddressesInternal(ResolvedAddresses resolvedAddresses) {
+  public boolean handleResolvedAddressesInternal(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     ClusterManagerConfig config = (ClusterManagerConfig)
         resolvedAddresses.getLoadBalancingPolicyConfig();

--- a/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
@@ -70,7 +70,7 @@ class ClusterManagerLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     try {
       resolvingAddresses = true;
       return handleResolvedAddressesInternal(resolvedAddresses);
@@ -99,7 +99,7 @@ class ClusterManagerLoadBalancer extends LoadBalancer {
       LoadBalancer childLb = childLbStates.get(name).lb;
       ResolvedAddresses childAddresses =
           resolvedAddresses.toBuilder().setLoadBalancingPolicyConfig(childConfig).build();
-      childLb.handleResolvedAddresses(childAddresses);
+      childLb.acceptResolvedAddresses(childAddresses);
     }
     for (String name : childLbStates.keySet()) {
       if (!newChildPolicies.containsKey(name)) {

--- a/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
@@ -70,7 +70,7 @@ class ClusterManagerLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     try {
       resolvingAddresses = true;
       handleResolvedAddressesInternal(resolvedAddresses);
@@ -109,6 +109,8 @@ class ClusterManagerLoadBalancer extends LoadBalancer {
     // Must update channel picker before return so that new RPCs will not be routed to deleted
     // clusters and resolver can remove them in service config.
     updateOverallBalancingState();
+
+    return true;
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
@@ -129,11 +129,6 @@ class ClusterManagerLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean canHandleEmptyAddressListFromNameResolution() {
-    return true;
-  }
-
-  @Override
   public void shutdown() {
     logger.log(XdsLogLevel.INFO, "Shutdown");
     for (ChildLbState state : childLbStates.values()) {

--- a/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
@@ -109,7 +109,7 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     if (xdsClientPool == null) {
       xdsClientPool = resolvedAddresses.getAttributes().get(InternalXdsAttributes.XDS_CLIENT_POOL);
@@ -123,6 +123,8 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
       this.config = config;
       delegate.handleResolvedAddresses(resolvedAddresses);
     }
+
+    return true;
   }
 
   @Override
@@ -166,7 +168,7 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
     }
 
     @Override
-    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       this.resolvedAddresses = resolvedAddresses;
       ClusterResolverConfig config =
           (ClusterResolverConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
@@ -184,6 +186,8 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
         clusterStates.put(instance.cluster, state);
         state.start();
       }
+
+      return true;
     }
 
     @Override

--- a/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
@@ -109,7 +109,7 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     if (xdsClientPool == null) {
       xdsClientPool = resolvedAddresses.getAttributes().get(InternalXdsAttributes.XDS_CLIENT_POOL);
@@ -121,7 +121,7 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
       logger.log(XdsLogLevel.DEBUG, "Config: {0}", config);
       delegate.switchTo(new ClusterResolverLbStateFactory());
       this.config = config;
-      delegate.handleResolvedAddresses(resolvedAddresses);
+      return delegate.acceptResolvedAddresses(resolvedAddresses);
     }
 
     return true;
@@ -168,7 +168,7 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
     }
 
     @Override
-    public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       this.resolvedAddresses = resolvedAddresses;
       ClusterResolverConfig config =
           (ClusterResolverConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
@@ -253,7 +253,7 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
       if (childLb == null) {
         childLb = lbRegistry.getProvider(PRIORITY_POLICY_NAME).newLoadBalancer(helper);
       }
-      childLb.handleResolvedAddresses(
+      childLb.acceptResolvedAddresses(
           resolvedAddresses.toBuilder()
               .setLoadBalancingPolicyConfig(childConfig)
               .setAddresses(Collections.unmodifiableList(addresses))

--- a/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancer.java
@@ -88,7 +88,7 @@ final class LeastRequestLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     LeastRequestConfig config =
         (LeastRequestConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
     // Config may be null if least_request is used outside xDS

--- a/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancer.java
@@ -88,7 +88,7 @@ final class LeastRequestLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     LeastRequestConfig config =
         (LeastRequestConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
     // Config may be null if least_request is used outside xDS
@@ -146,6 +146,8 @@ final class LeastRequestLoadBalancer extends LoadBalancer {
     for (Subchannel removedSubchannel : removedSubchannels) {
       shutdownSubchannel(removedSubchannel);
     }
+
+    return true;
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/PriorityLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/PriorityLoadBalancer.java
@@ -81,7 +81,7 @@ final class PriorityLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     this.resolvedAddresses = resolvedAddresses;
     PriorityLbConfig config = (PriorityLbConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
@@ -279,7 +279,7 @@ final class PriorityLoadBalancer extends LoadBalancer {
         policy = newPolicy;
         lb.switchTo(lbProvider);
       }
-      lb.handleResolvedAddresses(
+      lb.acceptResolvedAddresses(
           resolvedAddresses.toBuilder()
               .setAddresses(AddressFilter.filter(resolvedAddresses.getAddresses(), priority))
               .setLoadBalancingPolicyConfig(childPolicySelection.getConfig())

--- a/xds/src/main/java/io/grpc/xds/PriorityLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/PriorityLoadBalancer.java
@@ -81,7 +81,7 @@ final class PriorityLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     this.resolvedAddresses = resolvedAddresses;
     PriorityLbConfig config = (PriorityLbConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
@@ -102,6 +102,8 @@ final class PriorityLoadBalancer extends LoadBalancer {
     // Not to report connecting in case a pending priority bumps up on top of the current READY
     // priority.
     tryNextPriority(false);
+
+    return true;
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -81,13 +81,13 @@ final class RingHashLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     List<EquivalentAddressGroup> addrList = resolvedAddresses.getAddresses();
     if (addrList.isEmpty()) {
       handleNameResolutionError(Status.UNAVAILABLE.withDescription("Ring hash lb error: EDS "
           + "resolution was successful, but returned server addresses are empty."));
-      return;
+      return false;
     }
     Map<EquivalentAddressGroup, EquivalentAddressGroup> latestAddrs = stripAttrs(addrList);
     Set<EquivalentAddressGroup> removedAddrs =
@@ -162,6 +162,8 @@ final class RingHashLoadBalancer extends LoadBalancer {
     for (Subchannel subchann : removedSubchannels) {
       shutdownSubchannel(subchann);
     }
+
+    return true;
   }
 
   private static List<RingEntry> buildRing(

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -81,7 +81,7 @@ final class RingHashLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     List<EquivalentAddressGroup> addrList = resolvedAddresses.getAddresses();
     if (addrList.isEmpty()) {

--- a/xds/src/main/java/io/grpc/xds/WeightedTargetLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedTargetLoadBalancer.java
@@ -61,7 +61,7 @@ final class WeightedTargetLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     try {
       resolvingAddresses = true;
       return handleResolvedAddressesInternal(resolvedAddresses);
@@ -92,7 +92,7 @@ final class WeightedTargetLoadBalancer extends LoadBalancer {
     }
     targets = newTargets;
     for (String targetName : targets.keySet()) {
-      childBalancers.get(targetName).handleResolvedAddresses(
+      childBalancers.get(targetName).acceptResolvedAddresses(
           resolvedAddresses.toBuilder()
               .setAddresses(AddressFilter.filter(resolvedAddresses.getAddresses(), targetName))
               .setLoadBalancingPolicyConfig(targets.get(targetName).policySelection.getConfig())

--- a/xds/src/main/java/io/grpc/xds/WeightedTargetLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedTargetLoadBalancer.java
@@ -125,11 +125,6 @@ final class WeightedTargetLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean canHandleEmptyAddressListFromNameResolution() {
-    return true;
-  }
-
-  @Override
   public void shutdown() {
     logger.log(XdsLogLevel.INFO, "Shutdown");
     for (LoadBalancer childBalancer : childBalancers.values()) {

--- a/xds/src/main/java/io/grpc/xds/WeightedTargetLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedTargetLoadBalancer.java
@@ -61,16 +61,16 @@ final class WeightedTargetLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     try {
       resolvingAddresses = true;
-      handleResolvedAddressesInternal(resolvedAddresses);
+      return handleResolvedAddressesInternal(resolvedAddresses);
     } finally {
       resolvingAddresses = false;
     }
   }
 
-  public void handleResolvedAddressesInternal(ResolvedAddresses resolvedAddresses) {
+  public boolean handleResolvedAddressesInternal(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     Object lbConfig = resolvedAddresses.getLoadBalancingPolicyConfig();
     checkNotNull(lbConfig, "missing weighted_target lb config");
@@ -109,6 +109,8 @@ final class WeightedTargetLoadBalancer extends LoadBalancer {
     childBalancers.keySet().retainAll(targets.keySet());
     childHelpers.keySet().retainAll(targets.keySet());
     updateOverallBalancingState();
+
+    return true;
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancer.java
@@ -61,7 +61,7 @@ final class WrrLocalityLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
 
     // The configuration with the child policy is combined with the locality weights
@@ -97,12 +97,10 @@ final class WrrLocalityLoadBalancer extends LoadBalancer {
             .discard(InternalXdsAttributes.ATTR_LOCALITY_WEIGHTS).build()).build();
 
     switchLb.switchTo(lbRegistry.getProvider(WEIGHTED_TARGET_POLICY_NAME));
-    switchLb.handleResolvedAddresses(
+    return switchLb.acceptResolvedAddresses(
         resolvedAddresses.toBuilder()
             .setLoadBalancingPolicyConfig(new WeightedTargetConfig(weightedPolicySelections))
             .build());
-
-    return true;
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancer.java
@@ -61,7 +61,7 @@ final class WrrLocalityLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
 
     // The configuration with the child policy is combined with the locality weights
@@ -76,7 +76,7 @@ final class WrrLocalityLoadBalancer extends LoadBalancer {
       Status unavailable =
           Status.UNAVAILABLE.withDescription("wrr_locality error: no locality weights provided");
       helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(unavailable));
-      return;
+      return false;
     }
 
     // Weighted target LB expects a WeightedPolicySelection for each locality as it will create a
@@ -101,6 +101,8 @@ final class WrrLocalityLoadBalancer extends LoadBalancer {
         resolvedAddresses.toBuilder()
             .setLoadBalancingPolicyConfig(new WeightedTargetConfig(weightedPolicySelections))
             .build());
+
+    return true;
   }
 
   @Override

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
@@ -627,8 +627,9 @@ public class CdsLoadBalancer2Test {
     }
 
     @Override
-    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       config = resolvedAddresses.getLoadBalancingPolicyConfig();
+      return true;
     }
 
     @Override

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
@@ -130,7 +130,7 @@ public class CdsLoadBalancer2Test {
     lbRegistry.register(new FakeLoadBalancerProvider("least_request_experimental",
         new LeastRequestLoadBalancerProvider()));
     loadBalancer = new CdsLoadBalancer2(helper, lbRegistry);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(Collections.<EquivalentAddressGroup>emptyList())
             .setAttributes(
@@ -627,7 +627,7 @@ public class CdsLoadBalancer2Test {
     }
 
     @Override
-    public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       config = resolvedAddresses.getLoadBalancingPolicyConfig();
       return true;
     }

--- a/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
@@ -282,7 +282,7 @@ public class ClusterImplLoadBalancerTest {
     config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO, null,
         Collections.singletonList(DropOverload.create("lb", 1_000_000)),
         new PolicySelection(weightedTargetProvider, weightedTargetConfig), null);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(Collections.singletonList(endpoint))
             .setAttributes(
@@ -571,7 +571,7 @@ public class ClusterImplLoadBalancerTest {
 
   private void deliverAddressesAndConfig(List<EquivalentAddressGroup> addresses,
       ClusterImplConfig config) {
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(addresses)
             .setAttributes(
@@ -677,7 +677,7 @@ public class ClusterImplLoadBalancerTest {
     }
 
     @Override
-    public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       addresses = resolvedAddresses.getAddresses();
       config = resolvedAddresses.getLoadBalancingPolicyConfig();
       attributes = resolvedAddresses.getAttributes();

--- a/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
@@ -677,10 +677,11 @@ public class ClusterImplLoadBalancerTest {
     }
 
     @Override
-    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       addresses = resolvedAddresses.getAddresses();
       config = resolvedAddresses.getLoadBalancingPolicyConfig();
       attributes = resolvedAddresses.getAttributes();
+      return true;
     }
 
     @Override

--- a/xds/src/test/java/io/grpc/xds/ClusterManagerLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterManagerLoadBalancerTest.java
@@ -20,7 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.clearInvocations;

--- a/xds/src/test/java/io/grpc/xds/ClusterManagerLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterManagerLoadBalancerTest.java
@@ -266,7 +266,7 @@ public class ClusterManagerLoadBalancerTest {
   }
 
   private void deliverResolvedAddresses(final Map<String, String> childPolicies, boolean failing) {
-    clusterManagerLoadBalancer.handleResolvedAddresses(
+    clusterManagerLoadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(Collections.<EquivalentAddressGroup>emptyList())
             .setLoadBalancingPolicyConfig(buildConfig(childPolicies, failing))
@@ -347,7 +347,7 @@ public class ClusterManagerLoadBalancerTest {
     }
 
     @Override
-    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       config = resolvedAddresses.getLoadBalancingPolicyConfig();
 
       if (failing) {

--- a/xds/src/test/java/io/grpc/xds/ClusterManagerLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterManagerLoadBalancerTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.clearInvocations;
@@ -353,6 +354,8 @@ public class ClusterManagerLoadBalancerTest {
       if (failing) {
         helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(Status.INTERNAL));
       }
+
+      return !failing;
     }
 
     @Override

--- a/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
@@ -985,7 +985,7 @@ public class ClusterResolverLoadBalancerTest {
   }
 
   private void deliverLbConfig(ClusterResolverConfig config) {
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(Collections.<EquivalentAddressGroup>emptyList())
             .setAttributes(
@@ -1221,7 +1221,7 @@ public class ClusterResolverLoadBalancerTest {
     }
 
     @Override
-    public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       addresses = resolvedAddresses.getAddresses();
       config = resolvedAddresses.getLoadBalancingPolicyConfig();
       attributes = resolvedAddresses.getAttributes();

--- a/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
@@ -1221,10 +1221,11 @@ public class ClusterResolverLoadBalancerTest {
     }
 
     @Override
-    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       addresses = resolvedAddresses.getAddresses();
       config = resolvedAddresses.getLoadBalancingPolicyConfig();
       attributes = resolvedAddresses.getAttributes();
+      return true;
     }
 
     @Override

--- a/xds/src/test/java/io/grpc/xds/LeastRequestLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/LeastRequestLoadBalancerTest.java
@@ -155,7 +155,7 @@ public class LeastRequestLoadBalancerTest {
   @Test
   public void pickAfterResolved() throws Exception {
     final Subchannel readySubchannel = subchannels.values().iterator().next();
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     deliverSubchannelState(readySubchannel, ConnectivityStateInfo.forNonError(READY));
 
@@ -206,7 +206,7 @@ public class LeastRequestLoadBalancerTest {
 
     InOrder inOrder = inOrder(mockHelper);
 
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(currentServers).setAttributes(affinity)
             .build());
 
@@ -228,7 +228,7 @@ public class LeastRequestLoadBalancerTest {
     // This time with Attributes
     List<EquivalentAddressGroup> latestServers = Lists.newArrayList(oldEag2, newEag);
 
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(latestServers).setAttributes(affinity).build());
 
     verify(newSubchannel, times(1)).requestConnection();
@@ -248,7 +248,7 @@ public class LeastRequestLoadBalancerTest {
     assertThat(getList(picker)).containsExactly(oldSubchannel, newSubchannel);
 
     // test going from non-empty to empty
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(Collections.<EquivalentAddressGroup>emptyList())
             .setAttributes(affinity)
@@ -263,7 +263,7 @@ public class LeastRequestLoadBalancerTest {
   @Test
   public void pickAfterStateChange() throws Exception {
     InOrder inOrder = inOrder(mockHelper);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(Attributes.EMPTY)
             .build());
     Subchannel subchannel = loadBalancer.getSubchannels().iterator().next();
@@ -305,7 +305,7 @@ public class LeastRequestLoadBalancerTest {
     final LeastRequestConfig oldConfig = new LeastRequestConfig(4);
     final LeastRequestConfig newConfig = new LeastRequestConfig(6);
     final Subchannel readySubchannel = subchannels.values().iterator().next();
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity)
             .setLoadBalancingPolicyConfig(oldConfig).build());
     deliverSubchannelState(readySubchannel, ConnectivityStateInfo.forNonError(READY));
@@ -317,7 +317,7 @@ public class LeastRequestLoadBalancerTest {
     pickerCaptor.getValue().pickSubchannel(mockArgs);
     verify(mockRandom, times(oldConfig.choiceCount)).nextInt(1);
 
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity)
             .setLoadBalancingPolicyConfig(newConfig).build());
     verify(mockHelper, times(3))
@@ -332,7 +332,7 @@ public class LeastRequestLoadBalancerTest {
   @Test
   public void ignoreShutdownSubchannelStateChange() {
     InOrder inOrder = inOrder(mockHelper);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(Attributes.EMPTY)
             .build());
     inOrder.verify(mockHelper).updateBalancingState(eq(CONNECTING), isA(EmptyPicker.class));
@@ -351,7 +351,7 @@ public class LeastRequestLoadBalancerTest {
   @Test
   public void stayTransientFailureUntilReady() {
     InOrder inOrder = inOrder(mockHelper);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(Attributes.EMPTY)
             .build());
 
@@ -389,7 +389,7 @@ public class LeastRequestLoadBalancerTest {
   @Test
   public void refreshNameResolutionWhenSubchannelConnectionBroken() {
     InOrder inOrder = inOrder(mockHelper);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(Attributes.EMPTY)
             .build());
 
@@ -419,7 +419,7 @@ public class LeastRequestLoadBalancerTest {
   public void pickerLeastRequest() throws Exception {
     int choiceCount = 2;
     // This should add inFlight counters to all subchannels.
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(Attributes.EMPTY)
             .setLoadBalancingPolicyConfig(new LeastRequestConfig(choiceCount))
             .build());
@@ -505,7 +505,7 @@ public class LeastRequestLoadBalancerTest {
   public void nameResolutionErrorWithActiveChannels() throws Exception {
     int choiceCount = 8;
     final Subchannel readySubchannel = subchannels.values().iterator().next();
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setLoadBalancingPolicyConfig(new LeastRequestConfig(choiceCount))
             .setAddresses(servers).setAttributes(affinity).build());
@@ -538,7 +538,7 @@ public class LeastRequestLoadBalancerTest {
     Subchannel sc2 = subchannelIterator.next();
     Subchannel sc3 = subchannelIterator.next();
 
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(Attributes.EMPTY)
             .build());
     verify(sc1, times(1)).requestConnection();

--- a/xds/src/test/java/io/grpc/xds/MetadataLoadBalancerProvider.java
+++ b/xds/src/test/java/io/grpc/xds/MetadataLoadBalancerProvider.java
@@ -108,11 +108,11 @@ public class MetadataLoadBalancerProvider extends LoadBalancerProvider {
     }
 
     @Override
-    public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       MetadataLoadBalancerConfig config
           = (MetadataLoadBalancerConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
       helper.setMetadata(config.metadataKey, config.metadataValue);
-      delegateLb.handleResolvedAddresses(resolvedAddresses);
+      delegateLb.acceptResolvedAddresses(resolvedAddresses);
 
       return true;
     }

--- a/xds/src/test/java/io/grpc/xds/MetadataLoadBalancerProvider.java
+++ b/xds/src/test/java/io/grpc/xds/MetadataLoadBalancerProvider.java
@@ -108,11 +108,13 @@ public class MetadataLoadBalancerProvider extends LoadBalancerProvider {
     }
 
     @Override
-    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       MetadataLoadBalancerConfig config
           = (MetadataLoadBalancerConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
       helper.setMetadata(config.metadataKey, config.metadataValue);
       delegateLb.handleResolvedAddresses(resolvedAddresses);
+
+      return true;
     }
   }
 

--- a/xds/src/test/java/io/grpc/xds/PriorityLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/PriorityLoadBalancerTest.java
@@ -157,7 +157,7 @@ public class PriorityLoadBalancerTest {
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1,
                 "p2", priorityChildConfig2),
             ImmutableList.of("p0", "p1", "p2"));
-    priorityLb.handleResolvedAddresses(
+    priorityLb.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(addresses)
             .setAttributes(attributes)
@@ -166,7 +166,7 @@ public class PriorityLoadBalancerTest {
     assertThat(fooBalancers).hasSize(1);
     assertThat(barBalancers).isEmpty();
     LoadBalancer fooBalancer0 = Iterables.getOnlyElement(fooBalancers);
-    verify(fooBalancer0).handleResolvedAddresses(resolvedAddressesCaptor.capture());
+    verify(fooBalancer0).acceptResolvedAddresses(resolvedAddressesCaptor.capture());
     ResolvedAddresses addressesReceived = resolvedAddressesCaptor.getValue();
     assertThat(addressesReceived.getAddresses()).isEmpty();
     assertThat(addressesReceived.getAttributes()).isEqualTo(attributes);
@@ -177,7 +177,7 @@ public class PriorityLoadBalancerTest {
     assertThat(fooBalancers).hasSize(1);
     assertThat(barBalancers).hasSize(1);
     LoadBalancer barBalancer0 = Iterables.getOnlyElement(barBalancers);
-    verify(barBalancer0).handleResolvedAddresses(resolvedAddressesCaptor.capture());
+    verify(barBalancer0).acceptResolvedAddresses(resolvedAddressesCaptor.capture());
     addressesReceived = resolvedAddressesCaptor.getValue();
     assertThat(Iterables.getOnlyElement(addressesReceived.getAddresses()).getAddresses())
         .containsExactly(socketAddress);
@@ -189,7 +189,7 @@ public class PriorityLoadBalancerTest {
     assertThat(fooBalancers).hasSize(2);
     assertThat(barBalancers).hasSize(1);
     LoadBalancer fooBalancer1 = Iterables.getLast(fooBalancers);
-    verify(fooBalancer1).handleResolvedAddresses(resolvedAddressesCaptor.capture());
+    verify(fooBalancer1).acceptResolvedAddresses(resolvedAddressesCaptor.capture());
     addressesReceived = resolvedAddressesCaptor.getValue();
     assertThat(addressesReceived.getAddresses()).isEmpty();
     assertThat(addressesReceived.getAttributes()).isEqualTo(attributes);
@@ -206,14 +206,14 @@ public class PriorityLoadBalancerTest {
             ImmutableMap.of("p1",
                 new PriorityChildConfig(new PolicySelection(barLbProvider, newBarConfig), true)),
             ImmutableList.of("p1"));
-    priorityLb.handleResolvedAddresses(
+    priorityLb.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(newAddresses)
             .setLoadBalancingPolicyConfig(newPriorityLbConfig)
             .build());
     assertThat(fooBalancers).hasSize(2);
     assertThat(barBalancers).hasSize(1);
-    verify(barBalancer0, times(2)).handleResolvedAddresses(resolvedAddressesCaptor.capture());
+    verify(barBalancer0, times(2)).acceptResolvedAddresses(resolvedAddressesCaptor.capture());
     addressesReceived = resolvedAddressesCaptor.getValue();
     assertThat(Iterables.getOnlyElement(addressesReceived.getAddresses()).getAddresses())
         .containsExactly(newSocketAddress);
@@ -238,7 +238,7 @@ public class PriorityLoadBalancerTest {
 
     PriorityLbConfig priorityLbConfig =
         new PriorityLbConfig(ImmutableMap.of("p0", priorityChildConfig0), ImmutableList.of("p0"));
-    priorityLb.handleResolvedAddresses(
+    priorityLb.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(priorityLbConfig)
@@ -250,7 +250,7 @@ public class PriorityLoadBalancerTest {
 
     priorityLbConfig =
         new PriorityLbConfig(ImmutableMap.of("p1", priorityChildConfig1), ImmutableList.of("p1"));
-    priorityLb.handleResolvedAddresses(
+    priorityLb.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(priorityLbConfig)
@@ -281,7 +281,7 @@ public class PriorityLoadBalancerTest {
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1,
                 "p2", priorityChildConfig2, "p3", priorityChildConfig3),
             ImmutableList.of("p0", "p1", "p2", "p3"));
-    priorityLb.handleResolvedAddresses(
+    priorityLb.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(priorityLbConfig)
@@ -409,7 +409,7 @@ public class PriorityLoadBalancerTest {
         new PriorityLbConfig(
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1),
             ImmutableList.of("p0", "p1"));
-    priorityLb.handleResolvedAddresses(
+    priorityLb.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(priorityLbConfig)
@@ -445,7 +445,7 @@ public class PriorityLoadBalancerTest {
         new PriorityLbConfig(
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1),
             ImmutableList.of("p0", "p1"));
-    priorityLb.handleResolvedAddresses(
+    priorityLb.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(priorityLbConfig)
@@ -483,7 +483,7 @@ public class PriorityLoadBalancerTest {
         new PriorityLbConfig(
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1),
             ImmutableList.of("p0", "p1"));
-    priorityLb.handleResolvedAddresses(
+    priorityLb.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(priorityLbConfig)
@@ -516,7 +516,7 @@ public class PriorityLoadBalancerTest {
 
     // resolution update without priority change does not trigger failover
     Attributes.Key<String> fooKey = Attributes.Key.create("fooKey");
-    priorityLb.handleResolvedAddresses(
+    priorityLb.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(priorityLbConfig)
@@ -545,7 +545,7 @@ public class PriorityLoadBalancerTest {
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1,
                 "p2", priorityChildConfig2, "p3", priorityChildConfig3),
             ImmutableList.of("p0", "p1", "p2", "p3"));
-    priorityLb.handleResolvedAddresses(
+    priorityLb.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(priorityLbConfig)
@@ -643,7 +643,7 @@ public class PriorityLoadBalancerTest {
         new PriorityLbConfig(
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1),
             ImmutableList.of("p0", "p1"));
-    priorityLb.handleResolvedAddresses(
+    priorityLb.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(priorityLbConfig)
@@ -670,7 +670,7 @@ public class PriorityLoadBalancerTest {
         new PriorityLbConfig(
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1),
             ImmutableList.of("p0", "p1"));
-    priorityLb.handleResolvedAddresses(
+    priorityLb.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(priorityLbConfig)

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
@@ -156,7 +156,7 @@ public class RingHashLoadBalancerTest {
   public void subchannelLazyConnectUntilPicked() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1);  // one server
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper).createSubchannel(any(CreateSubchannelArgs.class));
@@ -187,7 +187,7 @@ public class RingHashLoadBalancerTest {
   public void subchannelNotAutoReconnectAfterReenteringIdle() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1);  // one server
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     Subchannel subchannel = Iterables.getOnlyElement(subchannels.values());
@@ -217,7 +217,7 @@ public class RingHashLoadBalancerTest {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1);
     InOrder inOrder = Mockito.inOrder(helper);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     inOrder.verify(helper, times(2)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -278,7 +278,7 @@ public class RingHashLoadBalancerTest {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1, 1);
     InOrder inOrder = Mockito.inOrder(helper);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     inOrder.verify(helper, times(4)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -336,7 +336,7 @@ public class RingHashLoadBalancerTest {
   public void subchannelStayInTransientFailureUntilBecomeReady() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -378,7 +378,7 @@ public class RingHashLoadBalancerTest {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
     InOrder inOrder = Mockito.inOrder(helper);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -394,7 +394,7 @@ public class RingHashLoadBalancerTest {
     verifyConnection(1);
 
     servers = createWeightedServerAddrs(1,1);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     inOrder.verify(helper)
@@ -422,7 +422,7 @@ public class RingHashLoadBalancerTest {
   public void ignoreShutdownSubchannelStateChange() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -442,7 +442,7 @@ public class RingHashLoadBalancerTest {
   public void deterministicPickWithHostsPartiallyRemoved() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1, 1, 1);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     InOrder inOrder = Mockito.inOrder(helper);
@@ -470,7 +470,7 @@ public class RingHashLoadBalancerTest {
       Attributes attr = addr.getAttributes().toBuilder().set(CUSTOM_KEY, "custom value").build();
       updatedServers.add(new EquivalentAddressGroup(addr.getAddresses(), attr));
     }
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(updatedServers).setLoadBalancingPolicyConfig(config).build());
     verify(subchannels.get(Collections.singletonList(servers.get(0))))
@@ -487,7 +487,7 @@ public class RingHashLoadBalancerTest {
   public void deterministicPickWithNewHostsAdded() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1);  // server0 and server1
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     InOrder inOrder = Mockito.inOrder(helper);
@@ -511,7 +511,7 @@ public class RingHashLoadBalancerTest {
     assertThat(subchannel.getAddresses()).isEqualTo(servers.get(1));
 
     servers = createWeightedServerAddrs(1, 1, 1, 1, 1);  // server2, server3, server4 added
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     inOrder.verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -526,7 +526,7 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -583,7 +583,7 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -649,7 +649,7 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -687,7 +687,7 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -718,7 +718,7 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -749,7 +749,7 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -784,7 +784,7 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -822,7 +822,7 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -864,7 +864,7 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -908,7 +908,7 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -943,7 +943,7 @@ public class RingHashLoadBalancerTest {
   public void hostSelectionProportionalToWeights() {
     RingHashConfig config = new RingHashConfig(10000, 100000);  // large ring
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 10, 100); // 1:10:100
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -979,7 +979,7 @@ public class RingHashLoadBalancerTest {
   public void hostSelectionProportionalToRepeatedAddressCount() {
     RingHashConfig config = new RingHashConfig(10000, 100000);
     List<EquivalentAddressGroup> servers = createRepeatedServerAddrs(1, 10, 100);  // 1:10:100
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -1027,7 +1027,7 @@ public class RingHashLoadBalancerTest {
   public void nameResolutionErrorWithActiveSubchannels() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper).createSubchannel(any(CreateSubchannelArgs.class));

--- a/xds/src/test/java/io/grpc/xds/WeightedTargetLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedTargetLoadBalancerTest.java
@@ -200,7 +200,7 @@ public class WeightedTargetLoadBalancerTest {
     eag2 = AddressFilter.setPathFilter(eag2, ImmutableList.of("target2"));
     EquivalentAddressGroup eag3 = new EquivalentAddressGroup(socketAddresses[3]);
     eag3 = AddressFilter.setPathFilter(eag3, ImmutableList.of("target3"));
-    weightedTargetLb.handleResolvedAddresses(
+    weightedTargetLb.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.of(eag0, eag1, eag2, eag3))
             .setAttributes(Attributes.newBuilder().set(fakeKey, fakeValue).build())
@@ -213,7 +213,7 @@ public class WeightedTargetLoadBalancerTest {
     assertThat(barLbCreated).isEqualTo(2);
 
     for (int i = 0; i < childBalancers.size(); i++) {
-      verify(childBalancers.get(i)).handleResolvedAddresses(resolvedAddressesCaptor.capture());
+      verify(childBalancers.get(i)).acceptResolvedAddresses(resolvedAddressesCaptor.capture());
       ResolvedAddresses resolvedAddresses = resolvedAddressesCaptor.getValue();
       assertThat(resolvedAddresses.getLoadBalancingPolicyConfig()).isEqualTo(configs[i]);
       assertThat(resolvedAddresses.getAttributes().get(fakeKey)).isEqualTo(fakeValue);
@@ -238,7 +238,7 @@ public class WeightedTargetLoadBalancerTest {
         "target4",
         new WeightedPolicySelection(
             newWeights[3], new PolicySelection(fooLbProvider, newConfigs[3])));
-    weightedTargetLb.handleResolvedAddresses(
+    weightedTargetLb.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(new WeightedTargetConfig(newTargets))
@@ -252,7 +252,7 @@ public class WeightedTargetLoadBalancerTest {
     verify(childBalancers.get(0)).shutdown();
     for (int i = 1; i < childBalancers.size(); i++) {
       verify(childBalancers.get(i), atLeastOnce())
-          .handleResolvedAddresses(resolvedAddressesCaptor.capture());
+          .acceptResolvedAddresses(resolvedAddressesCaptor.capture());
       assertThat(resolvedAddressesCaptor.getValue().getLoadBalancingPolicyConfig())
           .isEqualTo(newConfigs[i - 1]);
     }
@@ -280,7 +280,7 @@ public class WeightedTargetLoadBalancerTest {
         "target2", weightedLbConfig2,
         // {foo, 40, config3}
         "target3", weightedLbConfig3);
-    weightedTargetLb.handleResolvedAddresses(
+    weightedTargetLb.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(new WeightedTargetConfig(targets))
@@ -307,7 +307,7 @@ public class WeightedTargetLoadBalancerTest {
         "target2", weightedLbConfig2,
         // {foo, 40, config3}
         "target3", weightedLbConfig3);
-    weightedTargetLb.handleResolvedAddresses(
+    weightedTargetLb.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(new WeightedTargetConfig(targets))
@@ -388,7 +388,7 @@ public class WeightedTargetLoadBalancerTest {
     Map<String, WeightedPolicySelection> targets = ImmutableMap.of(
         "target0", weightedLbConfig0,
         "target1", weightedLbConfig1);
-    weightedTargetLb.handleResolvedAddresses(
+    weightedTargetLb.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(new WeightedTargetConfig(targets))
@@ -414,7 +414,7 @@ public class WeightedTargetLoadBalancerTest {
             weights[0], new PolicySelection(fakeLbProvider, configs[0])),
         "target3", new WeightedPolicySelection(
             weights[3], new PolicySelection(fakeLbProvider, configs[3])));
-    weightedTargetLb.handleResolvedAddresses(
+    weightedTargetLb.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(new WeightedTargetConfig(targets))
@@ -459,7 +459,7 @@ public class WeightedTargetLoadBalancerTest {
     }
 
     @Override
-    public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(Status.INTERNAL));
       return true;
     }

--- a/xds/src/test/java/io/grpc/xds/WeightedTargetLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedTargetLoadBalancerTest.java
@@ -459,8 +459,9 @@ public class WeightedTargetLoadBalancerTest {
     }
 
     @Override
-    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public boolean handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(Status.INTERNAL));
+      return true;
     }
 
     @Override

--- a/xds/src/test/java/io/grpc/xds/WrrLocalityLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WrrLocalityLoadBalancerTest.java
@@ -129,7 +129,7 @@ public class WrrLocalityLoadBalancerTest {
 
     // Assert that the child policy and the locality weights were correctly mapped to a
     // WeightedTargetConfig.
-    verify(mockWeightedTargetLb).handleResolvedAddresses(resolvedAddressesCaptor.capture());
+    verify(mockWeightedTargetLb).acceptResolvedAddresses(resolvedAddressesCaptor.capture());
     Object config = resolvedAddressesCaptor.getValue().getLoadBalancingPolicyConfig();
     assertThat(config).isInstanceOf(WeightedTargetConfig.class);
     WeightedTargetConfig wtConfig = (WeightedTargetConfig) config;
@@ -190,7 +190,7 @@ public class WrrLocalityLoadBalancerTest {
 
     // Assert that the child policy and the locality weights were correctly mapped to a
     // WeightedTargetConfig.
-    verify(mockWeightedTargetLb).handleResolvedAddresses(resolvedAddressesCaptor.capture());
+    verify(mockWeightedTargetLb).acceptResolvedAddresses(resolvedAddressesCaptor.capture());
     assertThat(resolvedAddressesCaptor.getValue().getAttributes()
         .get(InternalXdsAttributes.ATTR_LOCALITY_WEIGHTS)).isNull();
   }
@@ -219,7 +219,7 @@ public class WrrLocalityLoadBalancerTest {
   }
 
   private void deliverAddresses(WrrLocalityConfig config, Map<Locality, Integer> localityWeights) {
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(ImmutableList.of(eag)).setAttributes(
                 Attributes.newBuilder()
                     .set(InternalXdsAttributes.ATTR_LOCALITY_WEIGHTS, localityWeights).build())


### PR DESCRIPTION
Introduces a new `acceptResolvedAddresses()` to the `LoadBalancer` that is now the preferred way to handle addresses from the `NameResolver`. The existing `handleResolvedAddresses()` will eventually be deprecated.

The new method returns a boolean based on the `LoadBalancer`s ability to use the provided addresses. If it does not accept them, `false` is returned. `LoadBalancer` implementations using the new method should no longer implement the `canHandleEmptyAddressListFromNameResolution()`, which will eventually be removed, along with `handleResolvedAddresses()`.

Backward compatibility will be maintained so existing load balancers using `handleResolvedAddresses()` will continue to work.

Additionally the previously deprecated `handleResolvedAddressGroups()` method is removed.