### PR TITLE
Upgrade Protobuf to 3.19.1 and Guava to 30.1.1

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -43,11 +43,11 @@ This section is only necessary if you are making changes to the code
 generation. Most users only need to use `skipCodegen=true` as discussed above.
 
 ### Build Protobuf
-The codegen plugin is C++ code and requires protobuf 3.17.2 or later.
+The codegen plugin is C++ code and requires protobuf 3.19.1 or later.
 
 For Linux, Mac and MinGW:
 ```
-$ PROTOBUF_VERSION=3.17.2
+$ PROTOBUF_VERSION=3.19.1
 $ curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protobuf-all-$PROTOBUF_VERSION.tar.gz
 $ tar xzf protobuf-all-$PROTOBUF_VERSION.tar.gz
 $ cd protobuf-$PROTOBUF_VERSION

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,17 +4,25 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_jvm_external",
-    sha256 = "62133c125bf4109dfd9d2af64830208356ce4ef8b165a6ef15bbff7460b35c3a",
-    strip_prefix = "rules_jvm_external-3.0",
-    url = "https://github.com/bazelbuild/rules_jvm_external/archive/3.0.zip",
+    sha256 = "cd1a77b7b02e8e008439ca76fd34f5b07aecb8c752961f9640dea15e9e5ba1ca",
+    strip_prefix = "rules_jvm_external-4.2",
+    url = "https://github.com/bazelbuild/rules_jvm_external/archive/4.2.zip",
 )
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 load("//:repositories.bzl", "IO_GRPC_GRPC_JAVA_ARTIFACTS")
 load("//:repositories.bzl", "IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS")
+load("//:repositories.bzl", "grpc_java_repositories")
+
+grpc_java_repositories()
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "PROTOBUF_MAVEN_ARTIFACTS")
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
 
 maven_install(
-    artifacts = IO_GRPC_GRPC_JAVA_ARTIFACTS,
+    artifacts = IO_GRPC_GRPC_JAVA_ARTIFACTS + PROTOBUF_MAVEN_ARTIFACTS,
     generate_compat_repositories = True,
     override_targets = IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS,
     repositories = [
@@ -25,11 +33,3 @@ maven_install(
 load("@maven//:compat.bzl", "compat_repositories")
 
 compat_repositories()
-
-load("//:repositories.bzl", "grpc_java_repositories")
-
-grpc_java_repositories()
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()

--- a/build.gradle
+++ b/build.gradle
@@ -55,9 +55,9 @@ subprojects {
         javaPluginPath = "$rootDir/compiler/build/exe/java_plugin/$protocPluginBaseName$exeSuffix"
 
         nettyVersion = '4.1.63.Final'
-        guavaVersion = '30.1-android'
+        guavaVersion = '30.1.1-android'
         googleauthVersion = '0.22.2'
-        protobufVersion = '3.17.2'
+        protobufVersion = '3.19.1'
         protocVersion = protobufVersion
         opencensusVersion = '0.28.0'
         autovalueVersion = '1.7.4'

--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -1,4 +1,4 @@
-set PROTOBUF_VER=3.17.2
+set PROTOBUF_VER=3.19.1
 set CMAKE_NAME=cmake-3.3.2-win32-x86
 
 if not exist "protobuf-%PROTOBUF_VER%\cmake\build\Release\" (

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -3,7 +3,7 @@
 # Build protoc
 set -evux -o pipefail
 
-PROTOBUF_VERSION=3.17.2
+PROTOBUF_VERSION=3.19.1
 
 # ARCH is x86_64 bit unless otherwise specified.
 ARCH="${ARCH:-x86_64}"

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -1,7 +1,9 @@
 workspace(name = "examples")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 # For released versions, use release tag:
-# http_repository(
+# http_archive(
 #     name = "io_grpc_grpc_java",
 #     sha256 = "<SHA>",
 #     strip_prefix = "grpc-java-<TAG>",
@@ -12,24 +14,30 @@ local_repository(
     path = "..",
 )
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 http_archive(
     name = "rules_jvm_external",
-    sha256 = "62133c125bf4109dfd9d2af64830208356ce4ef8b165a6ef15bbff7460b35c3a",
-    strip_prefix = "rules_jvm_external-3.0",
-    url = "https://github.com/bazelbuild/rules_jvm_external/archive/3.0.zip",
+    sha256 = "cd1a77b7b02e8e008439ca76fd34f5b07aecb8c752961f9640dea15e9e5ba1ca",
+    strip_prefix = "rules_jvm_external-4.2",
+    url = "https://github.com/bazelbuild/rules_jvm_external/archive/4.2.zip",
 )
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 load("@io_grpc_grpc_java//:repositories.bzl", "IO_GRPC_GRPC_JAVA_ARTIFACTS")
 load("@io_grpc_grpc_java//:repositories.bzl", "IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS")
+load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")
+
+grpc_java_repositories()
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "PROTOBUF_MAVEN_ARTIFACTS")
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
 
 maven_install(
     artifacts = [
         "com.google.api.grpc:grpc-google-cloud-pubsub-v1:0.1.24",
         "com.google.api.grpc:proto-google-cloud-pubsub-v1:0.1.24",
-    ] + IO_GRPC_GRPC_JAVA_ARTIFACTS,
+    ] + IO_GRPC_GRPC_JAVA_ARTIFACTS + PROTOBUF_MAVEN_ARTIFACTS,
     generate_compat_repositories = True,
     override_targets = IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS,
     repositories = [
@@ -40,11 +48,3 @@ maven_install(
 load("@maven//:compat.bzl", "compat_repositories")
 
 compat_repositories()
-
-load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")
-
-grpc_java_repositories()
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -32,7 +32,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.17.2' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.19.1' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.44.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -30,7 +30,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.17.2' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.19.1' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.44.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -30,7 +30,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.17.2' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.19.1' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.44.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/android/strictmode/app/build.gradle
+++ b/examples/android/strictmode/app/build.gradle
@@ -31,7 +31,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.17.2' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.19.1' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.44.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -23,7 +23,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.44.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.17.2'
+def protobufVersion = '3.19.1'
 def protocVersion = protobufVersion
 
 dependencies {

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.44.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.17.2'
+def protocVersion = '3.19.1'
 
 dependencies {
     // grpc-alts transitively depends on grpc-netty-shaded, grpc-protobuf, and grpc-stub

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.44.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.17.2'
+def protobufVersion = '3.19.1'
 def protocVersion = protobufVersion
 
 

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.44.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.17.2</protobuf.version>
+    <protobuf.version>3.19.1</protobuf.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.44.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.17.2'
+def protobufVersion = '3.19.1'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-hostname/pom.xml
+++ b/examples/example-hostname/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.44.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protoc.version>3.17.2</protoc.version>
+    <protoc.version>3.19.1</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -23,7 +23,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.44.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.17.2'
+def protobufVersion = '3.19.1'
 def protocVersion = protobufVersion
 
 dependencies {

--- a/examples/example-jwt-auth/pom.xml
+++ b/examples/example-jwt-auth/pom.xml
@@ -14,8 +14,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.44.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.17.2</protobuf.version>
-    <protoc.version>3.17.2</protoc.version>
+    <protobuf.version>3.19.1</protobuf.version>
+    <protoc.version>3.19.1</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.44.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.17.2'
+def protocVersion = '3.19.1'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.44.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protoc.version>3.17.2</protoc.version>
+    <protoc.version>3.19.1</protoc.version>
     <netty.tcnative.version>2.0.34.Final</netty.tcnative.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>

--- a/examples/example-xds/build.gradle
+++ b/examples/example-xds/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.7
 // updating the version in our release process.
 def grpcVersion = '1.44.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 def nettyTcNativeVersion = '2.0.31.Final'
-def protocVersion = '3.17.2'
+def protocVersion = '3.19.1'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.44.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.17.2</protobuf.version>
-    <protoc.version>3.17.2</protoc.version>
+    <protobuf.version>3.19.1</protobuf.version>
+    <protoc.version>3.19.1</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -20,7 +20,7 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "com.google.auto.value:auto-value-annotations:1.7.4",
     "com.google.errorprone:error_prone_annotations:2.9.0",
     "com.google.guava:failureaccess:1.0.1",
-    "com.google.guava:guava:30.1-android",
+    "com.google.guava:guava:30.1.1-android",
     "com.google.j2objc:j2objc-annotations:1.3",
     "com.google.truth:truth:1.0.1",
     "com.squareup.okhttp:okhttp:2.7.4",
@@ -92,37 +92,24 @@ def grpc_java_repositories():
     if not native.existing_rule("io_grpc_grpc_proto"):
         io_grpc_grpc_proto()
 
-    native.bind(
-        name = "guava",
-        actual = "@com_google_guava_guava//jar",
-    )
-    native.bind(
-        name = "gson",
-        actual = "@com_google_code_gson_gson//jar",
-    )
-    native.bind(
-        name = "error_prone_annotations",
-        actual = "@com_google_errorprone_error_prone_annotations//jar",
-    )
-
 def com_google_protobuf():
     # proto_library rules implicitly depend on @com_google_protobuf//:protoc,
     # which is the proto-compiler.
     # This statement defines the @com_google_protobuf repo.
     http_archive(
         name = "com_google_protobuf",
-        sha256 = "f6042eef01551cee4c663a11c3f429c06360a1f51daa9f4772bf3f13d24cde1f",
-        strip_prefix = "protobuf-3.17.2",
-        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.17.2.zip"],
+        sha256 = "25f1292d4ea6666f460a2a30038eef121e6c3937ae0f61d610611dfb14b0bd32",
+        strip_prefix = "protobuf-3.19.1",
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.19.1.zip"],
     )
 
 def com_google_protobuf_javalite():
     # java_lite_proto_library rules implicitly depend on @com_google_protobuf_javalite
     http_archive(
         name = "com_google_protobuf_javalite",
-        sha256 = "f6042eef01551cee4c663a11c3f429c06360a1f51daa9f4772bf3f13d24cde1f",
-        strip_prefix = "protobuf-3.17.2",
-        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.17.2.zip"],
+        sha256 = "25f1292d4ea6666f460a2a30038eef121e6c3937ae0f61d610611dfb14b0bd32",
+        strip_prefix = "protobuf-3.19.1",
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.19.1.zip"],
     )
 
 def io_grpc_grpc_proto():


### PR DESCRIPTION
Protobuf uses Guava 30.1.1, so I upgrade it at the same time. It also
caused an update to rules_jvm_external and reworking the Bazel build.
Protobuf no longer requires bind() so they were dropped. Although
Protobuf's protobuf_deps() brings in rules_jvm_external, and so we don't
need to define it ourselves, it seems better to define it directly and
not depend on transitive deps since we use it directly.

Protobuf now has support for maven_install() by exposing
PROTOBUF_MAVEN_ARTIFACTS, which required reorganizing the WORKSPACE to
use maven_install() after loading protobuf. Protobuf still doesn't
define target overrides for itself so we still maintain those. When
reorganizing the WORKSPACE I noticed http_archive should ideally be
above io_grpc_grpc_java as most users will need it there, so I fixed
that since there were lots of other load()-reordering already.