### PR TITLE
all: remove deprecated StreamInfo.transportAttrs

### DIFF
--- a/api/src/main/java/io/grpc/ClientStreamTracer.java
+++ b/api/src/main/java/io/grpc/ClientStreamTracer.java
@@ -81,10 +81,6 @@ public abstract class ClientStreamTracer extends StreamTracer {
     }
   }
 
-  /** An abstract class for internal use only. */
-  @Internal
-  public abstract static class InternalLimitedInfoFactory extends Factory {}
-
   /**
    * Information about a stream.
    *
@@ -95,30 +91,15 @@ public abstract class ClientStreamTracer extends StreamTracer {
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2861")
   public static final class StreamInfo {
-    private final Attributes transportAttrs;
     private final CallOptions callOptions;
     private final int previousAttempts;
     private final boolean isTransparentRetry;
 
     StreamInfo(
-        Attributes transportAttrs, CallOptions callOptions, int previousAttempts,
-        boolean isTransparentRetry) {
-      this.transportAttrs = checkNotNull(transportAttrs, "transportAttrs");
+        CallOptions callOptions, int previousAttempts, boolean isTransparentRetry) {
       this.callOptions = checkNotNull(callOptions, "callOptions");
       this.previousAttempts = previousAttempts;
       this.isTransparentRetry = isTransparentRetry;
-    }
-
-    /**
-     * Returns the attributes of the transport that this stream was created on.
-     *
-     * @deprecated Use {@link ClientStreamTracer#streamCreated(Attributes, Metadata)} to handle
-     *             the transport Attributes instead.
-     */
-    @Deprecated
-    @Grpc.TransportAttr
-    public Attributes getTransportAttrs() {
-      return transportAttrs;
     }
 
     /**
@@ -154,7 +135,6 @@ public abstract class ClientStreamTracer extends StreamTracer {
     public Builder toBuilder() {
       return new Builder()
           .setCallOptions(callOptions)
-          .setTransportAttrs(transportAttrs)
           .setPreviousAttempts(previousAttempts)
           .setIsTransparentRetry(isTransparentRetry);
     }
@@ -171,7 +151,6 @@ public abstract class ClientStreamTracer extends StreamTracer {
     @Override
     public String toString() {
       return MoreObjects.toStringHelper(this)
-          .add("transportAttrs", transportAttrs)
           .add("callOptions", callOptions)
           .add("previousAttempts", previousAttempts)
           .add("isTransparentRetry", isTransparentRetry)
@@ -184,25 +163,11 @@ public abstract class ClientStreamTracer extends StreamTracer {
      * @since 1.21.0
      */
     public static final class Builder {
-      private Attributes transportAttrs = Attributes.EMPTY;
       private CallOptions callOptions = CallOptions.DEFAULT;
       private int previousAttempts;
       private boolean isTransparentRetry;
 
       Builder() {
-      }
-
-      /**
-       * Sets the attributes of the transport that this stream was created on.  This field is
-       * optional.
-       *
-       * @deprecated Use {@link ClientStreamTracer#streamCreated(Attributes, Metadata)} to handle
-       *             the transport Attributes instead.
-       */
-      @Deprecated
-      public Builder setTransportAttrs(@Grpc.TransportAttr Attributes transportAttrs) {
-        this.transportAttrs = checkNotNull(transportAttrs, "transportAttrs cannot be null");
-        return this;
       }
 
       /**
@@ -237,7 +202,7 @@ public abstract class ClientStreamTracer extends StreamTracer {
        * Builds a new StreamInfo.
        */
       public StreamInfo build() {
-        return new StreamInfo(transportAttrs, callOptions, previousAttempts, isTransparentRetry);
+        return new StreamInfo(callOptions, previousAttempts, isTransparentRetry);
       }
     }
   }

--- a/api/src/test/java/io/grpc/CallOptionsTest.java
+++ b/api/src/test/java/io/grpc/CallOptionsTest.java
@@ -272,7 +272,7 @@ public class CallOptionsTest {
     }
   }
 
-  private static class FakeTracerFactory extends ClientStreamTracer.InternalLimitedInfoFactory {
+  private static class FakeTracerFactory extends ClientStreamTracer.Factory {
     final String name;
 
     FakeTracerFactory(String name) {

--- a/census/src/main/java/io/grpc/census/CensusStatsModule.java
+++ b/census/src/main/java/io/grpc/census/CensusStatsModule.java
@@ -397,7 +397,7 @@ final class CensusStatsModule {
 
   @VisibleForTesting
   static final class CallAttemptsTracerFactory extends
-      ClientStreamTracer.InternalLimitedInfoFactory {
+      ClientStreamTracer.Factory {
     static final MeasureLong RETRIES_PER_CALL =
         Measure.MeasureLong.create(
             "grpc.io/client/retries_per_call", "Number of retries per call", "1");

--- a/census/src/main/java/io/grpc/census/CensusTracingModule.java
+++ b/census/src/main/java/io/grpc/census/CensusTracingModule.java
@@ -226,7 +226,7 @@ final class CensusTracingModule {
   }
 
   @VisibleForTesting
-  final class CallAttemptsTracerFactory extends ClientStreamTracer.InternalLimitedInfoFactory {
+  final class CallAttemptsTracerFactory extends ClientStreamTracer.Factory {
     volatile int callEnded;
 
     private final boolean isSampledToLocalTracing;

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -27,10 +27,8 @@ import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ClientStreamTracer;
-import io.grpc.ClientStreamTracer.InternalLimitedInfoFactory;
 import io.grpc.ClientStreamTracer.StreamInfo;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalLogId;
@@ -725,7 +723,7 @@ public final class GrpcUtil {
             ClientStreamTracer[] tracers) {
           StreamInfo info = StreamInfo.newBuilder().setCallOptions(callOptions).build();
           ClientStreamTracer streamTracer =
-              newClientStreamTracer(streamTracerFactory, info, headers);
+              streamTracerFactory.newClientStreamTracer(info, headers);
           checkState(tracers[tracers.length - 1] == NOOP_TRACER, "lb tracer already assigned");
           tracers[tracers.length - 1] = streamTracer;
           return transport.newStream(method, headers, callOptions, tracers);
@@ -769,59 +767,12 @@ public final class GrpcUtil {
         .setIsTransparentRetry(isTransparentRetry)
         .build();
     for (int i = 0; i < factories.size(); i++) {
-      tracers[i] = newClientStreamTracer(factories.get(i), streamInfo, headers);
+      tracers[i] = factories.get(i).newClientStreamTracer(streamInfo, headers);
     }
     // Reserved to be set later by the lb as per the API contract of ClientTransport.newStream().
     // See also GrpcUtil.getTransportFromPickResult()
     tracers[tracers.length - 1] = NOOP_TRACER;
     return tracers;
-  }
-
-  // A util function for backward compatibility to support deprecated StreamInfo.getAttributes().
-  @VisibleForTesting
-  static ClientStreamTracer newClientStreamTracer(
-      final ClientStreamTracer.Factory streamTracerFactory, final StreamInfo info,
-      final Metadata headers) {
-    ClientStreamTracer streamTracer;
-    if (streamTracerFactory instanceof InternalLimitedInfoFactory) {
-      streamTracer = streamTracerFactory.newClientStreamTracer(info, headers);
-    } else {
-      streamTracer = new ForwardingClientStreamTracer() {
-        final ClientStreamTracer noop = new ClientStreamTracer() {};
-        volatile ClientStreamTracer delegate = noop;
-
-        void maybeInit(StreamInfo info, Metadata headers) {
-          if (delegate != noop) {
-            return;
-          }
-          synchronized (this) {
-            if (delegate == noop) {
-              delegate = streamTracerFactory.newClientStreamTracer(info, headers);
-            }
-          }
-        }
-
-        @Override
-        protected ClientStreamTracer delegate() {
-          return delegate;
-        }
-
-        @SuppressWarnings("deprecation")
-        @Override
-        public void streamCreated(Attributes transportAttrs, Metadata headers) {
-          StreamInfo streamInfo = info.toBuilder().setTransportAttrs(transportAttrs).build();
-          maybeInit(streamInfo, headers);
-          delegate().streamCreated(transportAttrs, headers);
-        }
-
-        @Override
-        public void streamClosed(Status status) {
-          maybeInit(info, headers);
-          delegate().streamClosed(status);
-        }
-      };
-    }
-    return streamTracer;
   }
 
   /** Quietly closes all messages in MessageProducer. */

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -221,7 +221,7 @@ abstract class RetriableStream<ReqT> implements ClientStream {
     Substream sub = new Substream(previousAttemptCount);
     // one tracer per substream
     final ClientStreamTracer bufferSizeTracer = new BufferSizeTracer(sub);
-    ClientStreamTracer.Factory tracerFactory = new ClientStreamTracer.InternalLimitedInfoFactory() {
+    ClientStreamTracer.Factory tracerFactory = new ClientStreamTracer.Factory() {
       @Override
       public ClientStreamTracer newClientStreamTracer(
           ClientStreamTracer.StreamInfo info, Metadata headers) {

--- a/core/src/test/java/io/grpc/ClientStreamTracerTest.java
+++ b/core/src/test/java/io/grpc/ClientStreamTracerTest.java
@@ -27,48 +27,34 @@ import org.junit.runners.JUnit4;
 /** Unit tests for the embedded classes in {@link ClientStreamTracer}. */
 @RunWith(JUnit4.class)
 public class ClientStreamTracerTest {
-  private static final Attributes.Key<String> TRANSPORT_ATTR_KEY =
-      Attributes.Key.create("transport-attr-key");
   private final CallOptions callOptions = CallOptions.DEFAULT.withDeadlineAfter(1, MINUTES);
-  private final Attributes transportAttrs =
-      Attributes.newBuilder().set(TRANSPORT_ATTR_KEY, "value").build();
 
   @Test
-  @SuppressWarnings("deprecation") // info.getTransportAttrs()
   public void streamInfo_empty() {
     StreamInfo info = StreamInfo.newBuilder().build();
     assertThat(info.getCallOptions()).isSameInstanceAs(CallOptions.DEFAULT);
-    assertThat(info.getTransportAttrs()).isSameInstanceAs(Attributes.EMPTY);
   }
 
   @Test
-  @SuppressWarnings("deprecation") // info.getTransportAttrs()
   public void streamInfo_withInfo() {
-    StreamInfo info = StreamInfo.newBuilder()
-        .setCallOptions(callOptions).setTransportAttrs(transportAttrs).build();
+    StreamInfo info = StreamInfo.newBuilder().setCallOptions(callOptions).build();
     assertThat(info.getCallOptions()).isSameInstanceAs(callOptions);
-    assertThat(info.getTransportAttrs()).isSameInstanceAs(transportAttrs);
   }
 
   @Test
-  @SuppressWarnings("deprecation") // info.setTransportAttrs()
   public void streamInfo_noEquality() {
-    StreamInfo info1 = StreamInfo.newBuilder()
-        .setCallOptions(callOptions).setTransportAttrs(transportAttrs).build();
-    StreamInfo info2 = StreamInfo.newBuilder()
-        .setCallOptions(callOptions).setTransportAttrs(transportAttrs).build();
+    StreamInfo info1 = StreamInfo.newBuilder().setCallOptions(callOptions).build();
+    StreamInfo info2 = StreamInfo.newBuilder().setCallOptions(callOptions).build();
 
     assertThat(info1).isNotSameInstanceAs(info2);
     assertThat(info1).isNotEqualTo(info2);
   }
 
   @Test
-  @SuppressWarnings("deprecation") // info.getTransportAttrs()
   public void streamInfo_toBuilder() {
     StreamInfo info1 = StreamInfo.newBuilder()
-        .setCallOptions(callOptions).setTransportAttrs(transportAttrs).build();
+        .setCallOptions(callOptions).build();
     StreamInfo info2 = info1.toBuilder().build();
     assertThat(info2.getCallOptions()).isSameInstanceAs(callOptions);
-    assertThat(info2.getTransportAttrs()).isSameInstanceAs(transportAttrs);
   }
 }

--- a/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
+++ b/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
@@ -16,7 +16,6 @@
 
 package io.grpc.internal;
 
-import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -28,18 +27,14 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ClientStreamTracer;
-import io.grpc.ClientStreamTracer.StreamInfo;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.ClientStreamListener.RpcProgress;
 import io.grpc.internal.GrpcUtil.Http2Error;
 import io.grpc.testing.TestMethodDescriptors;
-import java.util.ArrayDeque;
-import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -295,38 +290,5 @@ public class GrpcUtilTest {
     stream.start(listener);
 
     verify(listener).closed(eq(status), eq(RpcProgress.DROPPED), any(Metadata.class));
-  }
-
-  @Test
-  public void clientStreamTracerFactoryBackwardCompatibility() {
-    final AtomicReference<Attributes> transportAttrsRef = new AtomicReference<>();
-    final ClientStreamTracer mockTracer = mock(ClientStreamTracer.class);
-    final Metadata.Key<String> key = Metadata.Key.of("fake-key", Metadata.ASCII_STRING_MARSHALLER);
-    final ArrayDeque<ClientStreamTracer> tracers = new ArrayDeque<>();
-    ClientStreamTracer.Factory oldFactoryImpl = new ClientStreamTracer.Factory() {
-      @SuppressWarnings("deprecation")
-      @Override
-      public ClientStreamTracer newClientStreamTracer(StreamInfo info, Metadata headers) {
-        transportAttrsRef.set(info.getTransportAttrs());
-        headers.put(key, "fake-value");
-        tracers.offer(mockTracer);
-        return mockTracer;
-      }
-    };
-
-    StreamInfo info =
-        StreamInfo.newBuilder().setCallOptions(CallOptions.DEFAULT.withWaitForReady()).build();
-    Metadata metadata = new Metadata();
-    Attributes transAttrs =
-        Attributes.newBuilder().set(Attributes.Key.<String>create("foo"), "bar").build();
-    ClientStreamTracer tracer = GrpcUtil.newClientStreamTracer(oldFactoryImpl, info, metadata);
-    tracer.streamCreated(transAttrs, metadata);
-    assertThat(tracers.poll()).isSameInstanceAs(mockTracer);
-    assertThat(transportAttrsRef.get()).isEqualTo(transAttrs);
-    assertThat(metadata.get(key)).isEqualTo("fake-value");
-
-    tracer.streamClosed(Status.UNAVAILABLE);
-    // verify that newClientStreamTracer() is called no more than once
-    assertThat(tracers).isEmpty();
   }
 }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -2447,13 +2447,13 @@ public class ManagedChannelImplTest {
     ClientStream mockStream = mock(ClientStream.class);
     final ClientStreamTracer tracer1 = new ClientStreamTracer() {};
     final ClientStreamTracer tracer2 = new ClientStreamTracer() {};
-    ClientStreamTracer.Factory factory1 = new ClientStreamTracer.InternalLimitedInfoFactory() {
+    ClientStreamTracer.Factory factory1 = new ClientStreamTracer.Factory() {
       @Override
       public ClientStreamTracer newClientStreamTracer(StreamInfo info, Metadata headers) {
         return tracer1;
       }
     };
-    ClientStreamTracer.Factory factory2 = new ClientStreamTracer.InternalLimitedInfoFactory() {
+    ClientStreamTracer.Factory factory2 = new ClientStreamTracer.Factory() {
       @Override
       public ClientStreamTracer newClientStreamTracer(StreamInfo info, Metadata headers) {
         return tracer2;
@@ -2491,13 +2491,13 @@ public class ManagedChannelImplTest {
     ClientStream mockStream = mock(ClientStream.class);
     final ClientStreamTracer tracer1 = new ClientStreamTracer() {};
     final ClientStreamTracer tracer2 = new ClientStreamTracer() {};
-    ClientStreamTracer.Factory factory1 = new ClientStreamTracer.InternalLimitedInfoFactory() {
+    ClientStreamTracer.Factory factory1 = new ClientStreamTracer.Factory() {
       @Override
       public ClientStreamTracer newClientStreamTracer(StreamInfo info, Metadata headers) {
         return tracer1;
       }
     };
-    ClientStreamTracer.Factory factory2 = new ClientStreamTracer.InternalLimitedInfoFactory() {
+    ClientStreamTracer.Factory factory2 = new ClientStreamTracer.Factory() {
       @Override
       public ClientStreamTracer newClientStreamTracer(StreamInfo info, Metadata headers) {
         return tracer2;

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbClientLoadRecorder.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbClientLoadRecorder.java
@@ -37,7 +37,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * span of an LB stream with the remote load-balancer.
  */
 @ThreadSafe
-final class GrpclbClientLoadRecorder extends ClientStreamTracer.InternalLimitedInfoFactory {
+final class GrpclbClientLoadRecorder extends ClientStreamTracer.Factory {
 
   private static final AtomicLongFieldUpdater<GrpclbClientLoadRecorder> callsStartedUpdater =
       AtomicLongFieldUpdater.newUpdater(GrpclbClientLoadRecorder.class, "callsStarted");

--- a/grpclb/src/main/java/io/grpc/grpclb/TokenAttachingTracerFactory.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/TokenAttachingTracerFactory.java
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
  * Wraps a {@link ClientStreamTracer.Factory}, retrieves tokens from transport attributes and
  * attaches them to headers.  This is only used in the PICK_FIRST mode.
  */
-final class TokenAttachingTracerFactory extends ClientStreamTracer.InternalLimitedInfoFactory {
+final class TokenAttachingTracerFactory extends ClientStreamTracer.Factory {
   private static final ClientStreamTracer NOOP_TRACER = new ClientStreamTracer() {};
 
   @Nullable

--- a/grpclb/src/test/java/io/grpc/grpclb/TokenAttachingTracerFactoryTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/TokenAttachingTracerFactoryTest.java
@@ -49,7 +49,7 @@ public class TokenAttachingTracerFactoryTest {
   private final ClientStreamTracer.Factory delegate = mock(
       ClientStreamTracer.Factory.class,
       delegatesTo(
-          new ClientStreamTracer.InternalLimitedInfoFactory() {
+          new ClientStreamTracer.Factory() {
             @Override
             public ClientStreamTracer newClientStreamTracer(
                 ClientStreamTracer.StreamInfo info, Metadata headers) {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -302,7 +302,7 @@ public abstract class AbstractInteropTest {
       new LinkedBlockingQueue<>();
 
   private final ClientStreamTracer.Factory clientStreamTracerFactory =
-      new ClientStreamTracer.InternalLimitedInfoFactory() {
+      new ClientStreamTracer.Factory() {
         @Override
         public ClientStreamTracer newClientStreamTracer(
             ClientStreamTracer.StreamInfo info, Metadata headers) {

--- a/interop-testing/src/test/java/io/grpc/testing/integration/RetryTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/RetryTest.java
@@ -432,7 +432,7 @@ public class RetryTest {
       }
     }
 
-    class CloseDelayedTracerFactory extends ClientStreamTracer.InternalLimitedInfoFactory {
+    class CloseDelayedTracerFactory extends ClientStreamTracer.Factory {
       @Override
       public ClientStreamTracer newClientStreamTracer(StreamInfo info, Metadata headers) {
         return new CloseDelayedTracer();
@@ -492,7 +492,7 @@ public class RetryTest {
       }
     }
 
-    class TransparentRetryTracerFactory extends ClientStreamTracer.InternalLimitedInfoFactory {
+    class TransparentRetryTracerFactory extends ClientStreamTracer.Factory {
       @Override
       public ClientStreamTracer newClientStreamTracer(StreamInfo info, Metadata headers) {
         return new TransparentRetryTriggeringTracer();

--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -336,7 +336,7 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
   }
 
   private static final class CountingStreamTracerFactory extends
-      ClientStreamTracer.InternalLimitedInfoFactory {
+      ClientStreamTracer.Factory {
     private ClusterLocalityStats stats;
     private final AtomicLong inFlights;
     @Nullable

--- a/xds/src/main/java/io/grpc/xds/OrcaPerRequestUtil.java
+++ b/xds/src/main/java/io/grpc/xds/OrcaPerRequestUtil.java
@@ -37,7 +37,7 @@ import java.util.List;
 abstract class OrcaPerRequestUtil {
   private static final ClientStreamTracer NOOP_CLIENT_STREAM_TRACER = new ClientStreamTracer() {};
   private static final ClientStreamTracer.Factory NOOP_CLIENT_STREAM_TRACER_FACTORY =
-      new ClientStreamTracer.InternalLimitedInfoFactory() {
+      new ClientStreamTracer.Factory() {
         @Override
         public ClientStreamTracer newClientStreamTracer(StreamInfo info, Metadata headers) {
           return NOOP_CLIENT_STREAM_TRACER;
@@ -190,7 +190,7 @@ abstract class OrcaPerRequestUtil {
    */
   @VisibleForTesting
   static final class OrcaReportingTracerFactory extends
-      ClientStreamTracer.InternalLimitedInfoFactory {
+      ClientStreamTracer.Factory {
 
     @VisibleForTesting
     static final Metadata.Key<OrcaLoadReport> ORCA_ENDPOINT_LOAD_METRICS_KEY =


### PR DESCRIPTION
APIs such as `StreamInfo.getTransportAttrs()` were [deprecated](https://github.com/grpc/grpc-java/commit/860e97d12ab46e184ac4448eeca8a45671de6462#diff-aa4049f54d6d5d462700e9221344184a37d2068b3ba7d715abd417b1df5bf883R114) since 1.41.0. Removing now.