### PR TITLE
core: remove unused method in AutoConfiguredLoadBalancer

### DIFF
--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
@@ -96,10 +96,6 @@ public final class AutoConfiguredLoadBalancerFactory {
       delegate = delegateProvider.newLoadBalancer(helper);
     }
 
-    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-      tryHandleResolvedAddresses(resolvedAddresses);
-    }
-
     /**
      * Returns non-OK status if resolvedAddresses is empty and delegate lb requires address ({@link
      * LoadBalancer#canHandleEmptyAddressListFromNameResolution()} returns {@code false}). {@code


### PR DESCRIPTION
The method added in #5821 seems not used now.