### PR TITLE
Bump to Gradle 6.9 and update plugins

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -63,8 +63,8 @@ task jacocoMerge(type: JacocoMerge) {
 jacocoTestReport {
     dependsOn(jacocoMerge)
     reports {
-        xml.enabled = true
-        html.enabled = true
+        xml.required = true
+        html.required = true
     }
 
     subprojects.each { subproject ->

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "java-library"
     id "maven-publish"
 
-    id "me.champeau.gradle.jmh"
+    id "me.champeau.jmh"
     id "ru.vyarus.animalsniffer"
 }
 

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "maven-publish"
 
     id "com.google.protobuf"
-    id "me.champeau.gradle.jmh"
+    id "me.champeau.jmh"
 }
 
 description = "grpc Benchmarks"
@@ -13,7 +13,7 @@ startScripts.enabled = false
 run.enabled = false
 
 jmh {
-    jvmArgs = "-server -Xms2g -Xmx2g"
+    jvmArgs = ["-server", "-Xms2g", "-Xmx2g"]
 }
 
 configurations {
@@ -55,7 +55,7 @@ def vmArgs = [
 ]
 
 task qps_client(type: CreateStartScripts) {
-    mainClassName = "io.grpc.benchmarks.qps.AsyncClient"
+    mainClass = "io.grpc.benchmarks.qps.AsyncClient"
     applicationName = "qps_client"
     defaultJvmOpts = vmArgs
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
@@ -63,7 +63,7 @@ task qps_client(type: CreateStartScripts) {
 }
 
 task openloop_client(type: CreateStartScripts) {
-    mainClassName = "io.grpc.benchmarks.qps.OpenLoopClient"
+    mainClass = "io.grpc.benchmarks.qps.OpenLoopClient"
     applicationName = "openloop_client"
     defaultJvmOpts = vmArgs
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
@@ -71,14 +71,14 @@ task openloop_client(type: CreateStartScripts) {
 }
 
 task qps_server(type: CreateStartScripts) {
-    mainClassName = "io.grpc.benchmarks.qps.AsyncServer"
+    mainClass = "io.grpc.benchmarks.qps.AsyncServer"
     applicationName = "qps_server"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 
 task benchmark_worker(type: CreateStartScripts) {
-    mainClassName = "io.grpc.benchmarks.driver.LoadWorker"
+    mainClass = "io.grpc.benchmarks.driver.LoadWorker"
     applicationName = "benchmark_worker"
     defaultJvmOpts = vmArgs
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)

--- a/binder/build.gradle
+++ b/binder/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "maven-publish"
     id "com.android.library"
-    id "ru.vyarus.animalsniffer"
     id "digital.wup.android-maven-publish"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -224,8 +224,6 @@ subprojects {
         }
     }
 
-    jacoco { toolVersion = "0.8.2" }
-
     checkstyle {
         configDirectory = file("$rootDir/buildscripts")
         toolVersion = "6.17"
@@ -320,6 +318,14 @@ subprojects {
             options.errorprone.check("UnnecessaryAnonymousClass", CheckSeverity.OFF)
             options.errorprone.check("PreferJavaTimeOverload", CheckSeverity.OFF)
         }
+
+        plugins.withId("ru.vyarus.animalsniffer") {
+	    // Only available after java plugin has loaded
+            animalsniffer {
+                // Breaks on upgrade: https://github.com/mojohaus/animal-sniffer/issues/131
+                toolVersion = '1.18'
+            }
+        }
     }
 
     plugins.withId("java-library") {
@@ -335,13 +341,13 @@ subprojects {
         }
     }
 
-    plugins.withId("me.champeau.gradle.jmh") {
-        dependencies {
-            jmh 'org.openjdk.jmh:jmh-core:1.19',
-                    'org.openjdk.jmh:jmh-generator-bytecode:1.19'
-        }
+    plugins.withId("me.champeau.jmh") {
         // invoke jmh on a single benchmark class like so:
         //   ./gradlew -PjmhIncludeSingleClass=StatsTraceContextBenchmark clean :grpc-core:jmh
+	compileJmhJava {
+	    sourceCompatibility = 1.8
+	    targetCompatibility = 1.8
+	}
         jmh {
             warmupIterations = 10
             iterations = 10

--- a/context/build.gradle
+++ b/context/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"
-    id "me.champeau.gradle.jmh"
+    id "me.champeau.jmh"
     id "ru.vyarus.animalsniffer"
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"
-    id "me.champeau.gradle.jmh"
+    id "me.champeau.jmh"
     id "ru.vyarus.animalsniffer"
 }
 

--- a/examples/android/clientcache/build.gradle
+++ b/examples/android/clientcache/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.17"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.18"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/android/helloworld/build.gradle
+++ b/examples/android/helloworld/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.17"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.18"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/android/routeguide/build.gradle
+++ b/examples/android/routeguide/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.17"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.18"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/android/strictmode/build.gradle
+++ b/examples/android/strictmode/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.17"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.18"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -2,7 +2,7 @@ plugins {
     // Provide convenience executables for trying out the examples.
     id 'application'
     // ASSUMES GRADLE 5.6 OR HIGHER. Use plugin version 0.8.10 with earlier gradle versions
-    id 'com.google.protobuf' version '0.8.17'
+    id 'com.google.protobuf' version '0.8.18'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
 }
@@ -64,79 +64,79 @@ sourceSets {
 startScripts.enabled = false
 
 task routeGuideServer(type: CreateStartScripts) {
-    mainClassName = 'io.grpc.examples.routeguide.RouteGuideServer'
+    mainClass = 'io.grpc.examples.routeguide.RouteGuideServer'
     applicationName = 'route-guide-server'
-    outputDir = new File(project.buildDir, 'tmp')
+    outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 
 task routeGuideClient(type: CreateStartScripts) {
-    mainClassName = 'io.grpc.examples.routeguide.RouteGuideClient'
+    mainClass = 'io.grpc.examples.routeguide.RouteGuideClient'
     applicationName = 'route-guide-client'
-    outputDir = new File(project.buildDir, 'tmp')
+    outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 
 task helloWorldServer(type: CreateStartScripts) {
-    mainClassName = 'io.grpc.examples.helloworld.HelloWorldServer'
+    mainClass = 'io.grpc.examples.helloworld.HelloWorldServer'
     applicationName = 'hello-world-server'
-    outputDir = new File(project.buildDir, 'tmp')
+    outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 
 task helloWorldClient(type: CreateStartScripts) {
-    mainClassName = 'io.grpc.examples.helloworld.HelloWorldClient'
+    mainClass = 'io.grpc.examples.helloworld.HelloWorldClient'
     applicationName = 'hello-world-client'
-    outputDir = new File(project.buildDir, 'tmp')
+    outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 
 task retryingHelloWorldServer(type: CreateStartScripts) {
-    mainClassName = 'io.grpc.examples.retrying.RetryingHelloWorldServer'
+    mainClass = 'io.grpc.examples.retrying.RetryingHelloWorldServer'
     applicationName = 'retrying-hello-world-server'
-    outputDir = new File(project.buildDir, 'tmp')
+    outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 
 task retryingHelloWorldClient(type: CreateStartScripts) {
-    mainClassName = 'io.grpc.examples.retrying.RetryingHelloWorldClient'
+    mainClass = 'io.grpc.examples.retrying.RetryingHelloWorldClient'
     applicationName = 'retrying-hello-world-client'
-    outputDir = new File(project.buildDir, 'tmp')
+    outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 
 task hedgingHelloWorldServer(type: CreateStartScripts) {
-    mainClassName = 'io.grpc.examples.hedging.HedgingHelloWorldServer'
+    mainClass = 'io.grpc.examples.hedging.HedgingHelloWorldServer'
     applicationName = 'hedging-hello-world-server'
-    outputDir = new File(project.buildDir, 'tmp')
+    outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 
 task hedgingHelloWorldClient(type: CreateStartScripts) {
-    mainClassName = 'io.grpc.examples.hedging.HedgingHelloWorldClient'
+    mainClass = 'io.grpc.examples.hedging.HedgingHelloWorldClient'
     applicationName = 'hedging-hello-world-client'
-    outputDir = new File(project.buildDir, 'tmp')
+    outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 
 task compressingHelloWorldClient(type: CreateStartScripts) {
-    mainClassName = 'io.grpc.examples.experimental.CompressingHelloWorldClient'
+    mainClass = 'io.grpc.examples.experimental.CompressingHelloWorldClient'
     applicationName = 'compressing-hello-world-client'
-    outputDir = new File(project.buildDir, 'tmp')
+    outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 
 task manualFlowControlClient(type: CreateStartScripts) {
-    mainClassName = 'io.grpc.examples.manualflowcontrol.ManualFlowControlClient'
+    mainClass = 'io.grpc.examples.manualflowcontrol.ManualFlowControlClient'
     applicationName = 'manual-flow-control-client'
-    outputDir = new File(project.buildDir, 'tmp')
+    outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 
 task manualFlowControlServer(type: CreateStartScripts) {
-    mainClassName = 'io.grpc.examples.manualflowcontrol.ManualFlowControlServer'
+    mainClass = 'io.grpc.examples.manualflowcontrol.ManualFlowControlServer'
     applicationName = 'manual-flow-control-server'
-    outputDir = new File(project.buildDir, 'tmp')
+    outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -56,16 +56,16 @@ startScripts.enabled = false
 
 
 task helloWorldAltsServer(type: CreateStartScripts) {
-    mainClassName = 'io.grpc.examples.alts.HelloWorldAltsServer'
+    mainClass = 'io.grpc.examples.alts.HelloWorldAltsServer'
     applicationName = 'hello-world-alts-server'
-    outputDir = new File(project.buildDir, 'tmp')
+    outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 
 task helloWorldAltsClient(type: CreateStartScripts) {
-    mainClassName = 'io.grpc.examples.alts.HelloWorldAltsClient'
+    mainClass = 'io.grpc.examples.alts.HelloWorldAltsClient'
     applicationName = 'hello-world-alts-client'
-    outputDir = new File(project.buildDir, 'tmp')
+    outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -61,9 +61,9 @@ sourceSets {
 startScripts.enabled = false
 
 task googleAuthClient(type: CreateStartScripts) {
-    mainClassName = 'io.grpc.examples.googleAuth.GoogleAuthClient'
+    mainClass = 'io.grpc.examples.googleAuth.GoogleAuthClient'
     applicationName = 'google-auth-client'
-    outputDir = new File(project.buildDir, 'tmp')
+    outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -64,16 +64,16 @@ sourceSets {
 startScripts.enabled = false
 
 task hellowWorldJwtAuthServer(type: CreateStartScripts) {
-    mainClassName = 'io.grpc.examples.jwtauth.AuthServer'
+    mainClass = 'io.grpc.examples.jwtauth.AuthServer'
     applicationName = 'auth-server'
-    outputDir = new File(project.buildDir, 'tmp')
+    outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 
 task hellowWorldJwtAuthClient(type: CreateStartScripts) {
-    mainClassName = 'io.grpc.examples.jwtauth.AuthClient'
+    mainClass = 'io.grpc.examples.jwtauth.AuthClient'
     applicationName = 'auth-client'
-    outputDir = new File(project.buildDir, 'tmp')
+    outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -56,16 +56,16 @@ sourceSets {
 startScripts.enabled = false
 
 task helloWorldTlsServer(type: CreateStartScripts) {
-    mainClassName = 'io.grpc.examples.helloworldtls.HelloWorldServerTls'
+    mainClass = 'io.grpc.examples.helloworldtls.HelloWorldServerTls'
     applicationName = 'hello-world-tls-server'
-    outputDir = new File(project.buildDir, 'tmp')
+    outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 
 task helloWorldTlsClient(type: CreateStartScripts) {
-    mainClassName = 'io.grpc.examples.helloworldtls.HelloWorldClientTls'
+    mainClass = 'io.grpc.examples.helloworldtls.HelloWorldClientTls'
     applicationName = 'hello-world-tls-client'
-    outputDir = new File(project.buildDir, 'tmp')
+    outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 

--- a/examples/example-xds/build.gradle
+++ b/examples/example-xds/build.gradle
@@ -49,16 +49,16 @@ protobuf {
 startScripts.enabled = false
 
 task xdsHelloWorldClient(type: CreateStartScripts) {
-    mainClassName = 'io.grpc.examples.helloworldxds.XdsHelloWorldClient'
+    mainClass = 'io.grpc.examples.helloworldxds.XdsHelloWorldClient'
     applicationName = 'xds-hello-world-client'
-    outputDir = new File(project.buildDir, 'tmp')
+    outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 
 task xdsHelloWorldServer(type: CreateStartScripts) {
-    mainClassName = 'io.grpc.examples.helloworldxds.XdsHelloWorldServer'
+    mainClass = 'io.grpc.examples.helloworldxds.XdsHelloWorldServer'
     applicationName = 'xds-hello-world-server'
-    outputDir = new File(project.buildDir, 'tmp')
+    outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 

--- a/examples/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -68,7 +68,7 @@ test {
 // Note that OkHttp currently only supports ALPN, so OpenSSL version >= 1.0.2 is required.
 
 task test_client(type: CreateStartScripts) {
-    mainClassName = "io.grpc.testing.integration.TestServiceClient"
+    mainClass = "io.grpc.testing.integration.TestServiceClient"
     applicationName = "test-client"
     defaultJvmOpts = [
         "-javaagent:JAVAAGENT_APP_HOME" + configurations.alpnagent.singleFile.name
@@ -82,21 +82,21 @@ task test_client(type: CreateStartScripts) {
 }
 
 task test_server(type: CreateStartScripts) {
-    mainClassName = "io.grpc.testing.integration.TestServiceServer"
+    mainClass = "io.grpc.testing.integration.TestServiceServer"
     applicationName = "test-server"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 
 task reconnect_test_client(type: CreateStartScripts) {
-    mainClassName = "io.grpc.testing.integration.ReconnectTestClient"
+    mainClass = "io.grpc.testing.integration.ReconnectTestClient"
     applicationName = "reconnect-test-client"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 
 task stresstest_client(type: CreateStartScripts) {
-    mainClassName = "io.grpc.testing.integration.StressTestClient"
+    mainClass = "io.grpc.testing.integration.StressTestClient"
     applicationName = "stresstest-client"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
@@ -107,14 +107,14 @@ task stresstest_client(type: CreateStartScripts) {
 }
 
 task http2_client(type: CreateStartScripts) {
-    mainClassName = "io.grpc.testing.integration.Http2Client"
+    mainClass = "io.grpc.testing.integration.Http2Client"
     applicationName = "http2-client"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 
 task grpclb_long_lived_affinity_test_client(type: CreateStartScripts) {
-    mainClassName = "io.grpc.testing.integration.GrpclbLongLivedAffinityTestClient"
+    mainClass = "io.grpc.testing.integration.GrpclbLongLivedAffinityTestClient"
     applicationName = "grpclb-long-lived-affinity-test-client"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
@@ -124,7 +124,7 @@ task grpclb_long_lived_affinity_test_client(type: CreateStartScripts) {
 }
 
 task grpclb_fallback_test_client (type: CreateStartScripts) {
-    mainClassName = "io.grpc.testing.integration.GrpclbFallbackTestClient"
+    mainClass = "io.grpc.testing.integration.GrpclbFallbackTestClient"
     applicationName = "grpclb-fallback-test-client"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
@@ -134,14 +134,14 @@ task grpclb_fallback_test_client (type: CreateStartScripts) {
 }
 
 task xds_test_client(type: CreateStartScripts) {
-    mainClassName = "io.grpc.testing.integration.XdsTestClient"
+    mainClass = "io.grpc.testing.integration.XdsTestClient"
     applicationName = "xds-test-client"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 
 task xds_test_server(type: CreateStartScripts) {
-    mainClassName = "io.grpc.testing.integration.XdsTestServer"
+    mainClass = "io.grpc.testing.integration.XdsTestServer"
     applicationName = "xds-test-server"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id "maven-publish"
 
     id "me.champeau.gradle.japicmp"
-    id "me.champeau.gradle.jmh"
+    id "me.champeau.jmh"
     id "ru.vyarus.animalsniffer"
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,14 +3,14 @@ pluginManagement {
         id "com.android.application" version "3.5.0"
         id "com.android.library" version "3.5.0"
         id "com.github.johnrengelman.shadow" version "6.1.0"
-        id "com.github.kt3k.coveralls" version "2.10.2"
-        id "com.google.osdetector" version "1.6.2"
-        id "com.google.protobuf" version "0.8.17"
-        id "digital.wup.android-maven-publish" version "3.6.2"
-        id "me.champeau.gradle.japicmp" version "0.2.5"
-        id "me.champeau.gradle.jmh" version "0.5.2"
-        id "net.ltgt.errorprone" version "1.3.0"
-        id "ru.vyarus.animalsniffer" version "1.5.2"
+        id "com.github.kt3k.coveralls" version "2.12.0"
+        id "com.google.osdetector" version "1.7.0"
+        id "com.google.protobuf" version "0.8.18"
+        id "digital.wup.android-maven-publish" version "3.6.3"
+        id "me.champeau.gradle.japicmp" version "0.3.0"
+        id "me.champeau.jmh" version "0.6.6"
+        id "net.ltgt.errorprone" version "2.0.2"
+        id "ru.vyarus.animalsniffer" version "1.5.4"
     }
     resolutionStrategy {
         eachPlugin {


### PR DESCRIPTION
These changes make the build compatible with Gradle 7, except for
Android which requires plugin updates.

I removed animalsniffer from binder because it did nothing (as there
were no signatures) and it was failing after setting toolVersion. It
failed because animalsniffer is only compatible with java plugin. After
this change I put the withId(animalsniffer) loading inside the
withId(java) to avoid a plugin ordering failure. That made it safe again
for binder to load animalsniffer, but it is still best to remove the
plugin from binder as it is misleading.

I did not upgrade Android plugin versions as newer versions (even 3.6)
require dealing with androidx (#8421).