### PR TITLE
xds: Rename ring_hash LB Policy to ring_hash_experimental

### DIFF
--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
@@ -187,7 +187,7 @@ final class CdsLoadBalancer2 extends LoadBalancer {
       LoadBalancerProvider lbProvider = null;
       Object lbConfig = null;
       if (root.result.lbPolicy() == LbPolicy.RING_HASH) {
-        lbProvider = lbRegistry.getProvider("ring_hash");
+        lbProvider = lbRegistry.getProvider("ring_hash_experimental");
         lbConfig = new RingHashConfig(root.result.minRingSize(), root.result.maxRingSize());
       }
       if (lbProvider == null) {

--- a/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
@@ -672,7 +672,7 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
    * Generates configs to be used in the priority LB policy for priorities in an EDS cluster.
    *
    * <p>priority LB -> cluster_impl LB (one per priority) -> (weighted_target LB
-   * -> round_robin (one per locality)) / ring_hash
+   * -> round_robin (one per locality)) / ring_hash_experimental
    */
   private static Map<String, PriorityChildConfig> generateEdsBasedPriorityChildConfigs(
       String cluster, @Nullable String edsServiceName, @Nullable ServerInfo lrsServerInfo,
@@ -687,9 +687,9 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
       // created. If the endpoint-level LB policy is round_robin, it creates a two-level LB
       // hierarchy: a locality-level LB policy that balances load according to locality weights
       // followed by an endpoint-level LB policy that simply rounds robin the endpoints within
-      // the locality. If the endpoint-level LB policy is ring_hash, it creates a unified LB
-      // policy that balances load by weighing the product of each endpoint's weight and the
-      // weight of the locality it belongs to.
+      // the locality. If the endpoint-level LB policy is ring_hash_experimental, it creates
+      // a unified LB policy that balances load by weighing the product of each endpoint's weight
+      // and the weight of the locality it belongs to.
       if (endpointLbPolicy.getProvider().getPolicyName().equals("round_robin")) {
         Map<Locality, Integer> localityWeights = prioritizedLocalityWeights.get(priority);
         Map<String, WeightedPolicySelection> targets = new HashMap<>();

--- a/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancerProvider.java
@@ -68,7 +68,7 @@ public final class ClusterResolverLoadBalancerProvider extends LoadBalancerProvi
   static final class ClusterResolverConfig {
     // Ordered list of clusters to be resolved.
     final List<DiscoveryMechanism> discoveryMechanisms;
-    // Endpoint-level load balancing policy with config (round_robin or ring_hash).
+    // Endpoint-level load balancing policy with config (round_robin or ring_hash_experimental).
     final PolicySelection lbPolicy;
 
     ClusterResolverConfig(List<DiscoveryMechanism> discoveryMechanisms, PolicySelection lbPolicy) {

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancerProvider.java
@@ -29,7 +29,7 @@ import io.grpc.xds.RingHashLoadBalancer.RingHashConfig;
 import java.util.Map;
 
 /**
- * The provider for the "ring_hash" balancing policy.
+ * The provider for the "ring_hash_experimental" balancing policy.
  */
 @Internal
 public final class RingHashLoadBalancerProvider extends LoadBalancerProvider {
@@ -66,7 +66,7 @@ public final class RingHashLoadBalancerProvider extends LoadBalancerProvider {
 
   @Override
   public String getPolicyName() {
-    return "ring_hash";
+    return "ring_hash_experimental";
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -113,10 +113,10 @@ abstract class XdsClient {
     // Endpoint-level load balancing policy.
     abstract LbPolicy lbPolicy();
 
-    // Only valid if lbPolicy is "ring_hash".
+    // Only valid if lbPolicy is "ring_hash_experimental".
     abstract long minRingSize();
 
-    // Only valid if lbPolicy is "ring_hash".
+    // Only valid if lbPolicy is "ring_hash_experimental".
     abstract long maxRingSize();
 
     // Alternative resource name to be used in EDS requests.

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
@@ -120,7 +120,7 @@ public class CdsLoadBalancer2Test {
     when(helper.getSynchronizationContext()).thenReturn(syncContext);
     lbRegistry.register(new FakeLoadBalancerProvider(CLUSTER_RESOLVER_POLICY_NAME));
     lbRegistry.register(new FakeLoadBalancerProvider("round_robin"));
-    lbRegistry.register(new FakeLoadBalancerProvider("ring_hash"));
+    lbRegistry.register(new FakeLoadBalancerProvider("ring_hash_experimental"));
     loadBalancer = new CdsLoadBalancer2(helper, lbRegistry);
     loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
@@ -283,7 +283,7 @@ public class CdsLoadBalancer2Test {
     assertDiscoveryMechanism(childLbConfig.discoveryMechanisms.get(2), cluster4,
         DiscoveryMechanism.Type.EDS, null, null, LRS_SERVER_INFO, 300L, null);
     assertThat(childLbConfig.lbPolicy.getProvider().getPolicyName())
-        .isEqualTo("ring_hash");  // dominated by top-level cluster's config
+        .isEqualTo("ring_hash_experimental");  // dominated by top-level cluster's config
     assertThat(((RingHashConfig) childLbConfig.lbPolicy.getConfig()).minRingSize).isEqualTo(100L);
     assertThat(((RingHashConfig) childLbConfig.lbPolicy.getConfig()).maxRingSize).isEqualTo(1000L);
   }

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
@@ -1483,8 +1483,8 @@ public abstract class ClientXdsClientTestBase {
     DiscoveryRpcCall call = startResourceWatcher(CDS, CDS_RESOURCE, cdsResourceWatcher);
     Message ringHashConfig = mf.buildRingHashLbConfig("xx_hash", 10L, 100L);
     Any clusterRingHash = Any.pack(
-        mf.buildEdsCluster(CDS_RESOURCE, null, "ring_hash", ringHashConfig, false, null,
-            "envoy.transport_sockets.tls", null
+        mf.buildEdsCluster(CDS_RESOURCE, null, "ring_hash_experimental", ringHashConfig, false,
+            null, "envoy.transport_sockets.tls", null
         ));
     call.sendResponse(ResourceType.CDS, clusterRingHash, VERSION_1, "0000");
 

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientV2Test.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientV2Test.java
@@ -438,7 +438,7 @@ public class ClientXdsClientV2Test extends ClientXdsClientTestBase {
       Cluster.Builder builder = Cluster.newBuilder().setName(clusterName).setClusterType(type);
       if (lbPolicy.equals("round_robin")) {
         builder.setLbPolicy(LbPolicy.ROUND_ROBIN);
-      } else if (lbPolicy.equals("ring_hash")) {
+      } else if (lbPolicy.equals("ring_hash_experimental")) {
         builder.setLbPolicy(LbPolicy.RING_HASH);
         builder.setRingHashLbConfig((RingHashLbConfig) ringHashLbConfig);
       } else {
@@ -454,7 +454,7 @@ public class ClientXdsClientV2Test extends ClientXdsClientTestBase {
       builder.setName(clusterName);
       if (lbPolicy.equals("round_robin")) {
         builder.setLbPolicy(LbPolicy.ROUND_ROBIN);
-      } else if (lbPolicy.equals("ring_hash")) {
+      } else if (lbPolicy.equals("ring_hash_experimental")) {
         builder.setLbPolicy(LbPolicy.RING_HASH);
         builder.setRingHashLbConfig((RingHashLbConfig) ringHashLbConfig);
       } else {

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientV3Test.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientV3Test.java
@@ -494,7 +494,7 @@ public class ClientXdsClientV3Test extends ClientXdsClientTestBase {
       Cluster.Builder builder = Cluster.newBuilder().setName(clusterName).setClusterType(type);
       if (lbPolicy.equals("round_robin")) {
         builder.setLbPolicy(LbPolicy.ROUND_ROBIN);
-      } else if (lbPolicy.equals("ring_hash")) {
+      } else if (lbPolicy.equals("ring_hash_experimental")) {
         builder.setLbPolicy(LbPolicy.RING_HASH);
         builder.setRingHashLbConfig((RingHashLbConfig) ringHashLbConfig);
       } else {
@@ -511,7 +511,7 @@ public class ClientXdsClientV3Test extends ClientXdsClientTestBase {
       builder.setName(clusterName);
       if (lbPolicy.equals("round_robin")) {
         builder.setLbPolicy(LbPolicy.ROUND_ROBIN);
-      } else if (lbPolicy.equals("ring_hash")) {
+      } else if (lbPolicy.equals("ring_hash_experimental")) {
         builder.setLbPolicy(LbPolicy.RING_HASH);
         builder.setRingHashLbConfig((RingHashLbConfig) ringHashLbConfig);
       } else {

--- a/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
@@ -135,7 +135,7 @@ public class ClusterResolverLoadBalancerTest {
   private final PolicySelection roundRobin =
       new PolicySelection(new FakeLoadBalancerProvider("round_robin"), null);
   private final PolicySelection ringHash = new PolicySelection(
-      new FakeLoadBalancerProvider("ring_hash"), new RingHashConfig(10L, 100L));
+      new FakeLoadBalancerProvider("ring_hash_experimental"), new RingHashConfig(10L, 100L));
   private final List<FakeLoadBalancer> childBalancers = new ArrayList<>();
   private final List<FakeNameResolver> resolvers = new ArrayList<>();
   private final FakeXdsClient xdsClient = new FakeXdsClient();
@@ -260,7 +260,7 @@ public class ClusterResolverLoadBalancerTest {
     ClusterImplConfig clusterImplConfig =
         (ClusterImplConfig) priorityChildConfig.policySelection.getConfig();
     assertClusterImplConfig(clusterImplConfig, CLUSTER1, EDS_SERVICE_NAME1, LRS_SERVER_INFO, 100L,
-        tlsContext, Collections.<DropOverload>emptyList(), "ring_hash");
+        tlsContext, Collections.<DropOverload>emptyList(), "ring_hash_experimental");
     RingHashConfig ringHashConfig =
         (RingHashConfig) clusterImplConfig.childPolicy.getConfig();
     assertThat(ringHashConfig.minRingSize).isEqualTo(10L);


### PR DESCRIPTION
Ring hash can only be used from within xds currently, because that's
the only way to get a hash assigned to RPCs which is required for it
to function. So it should be using the _experimental suffix like the
other only-used-from-xds policies.

Fixes #8756