### PR TITLE
xds: fix a concurrency issue in CSDS ClientStatus responses

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -2040,7 +2040,7 @@ final class ClientXdsClient extends XdsClient implements XdsResponseHandler, Res
     syncContext.execute(new Runnable() {
       @Override
       public void run() {
-        // A map from ResourceType to a map (ResourceName: ResourceMetadata)
+        // A map from a "resource type" to a map ("resource name": "resource metadata")
         ImmutableMap.Builder<ResourceType, Map<String, ResourceMetadata>> metadataSnapshot =
             ImmutableMap.builder();
         for (ResourceType type : ResourceType.values()) {

--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -28,7 +28,10 @@ import com.google.common.base.Stopwatch;
 import com.google.common.base.Strings;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.protobuf.Any;
 import com.google.protobuf.Duration;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -119,8 +122,10 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
 
 /**
@@ -159,6 +164,7 @@ final class ClientXdsClient extends XdsClient implements XdsResponseHandler, Res
       !Strings.isNullOrEmpty(System.getenv("GRPC_EXPERIMENTAL_XDS_RLS_LB"))
           && Boolean.parseBoolean(System.getenv("GRPC_EXPERIMENTAL_XDS_RLS_LB"));
 
+  private static final long METADATA_SYNC_TIMEOUT_SEC = 1;
   private static final String TYPE_URL_HTTP_CONNECTION_MANAGER_V2 =
       "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2"
           + ".HttpConnectionManager";
@@ -2028,12 +2034,34 @@ final class ClientXdsClient extends XdsClient implements XdsResponseHandler, Res
   }
 
   @Override
-  Map<String, ResourceMetadata> getSubscribedResourcesMetadata(ResourceType type) {
-    Map<String, ResourceMetadata> metadataMap = new HashMap<>();
-    for (Map.Entry<String, ResourceSubscriber> entry : getSubscribedResourcesMap(type).entrySet()) {
-      metadataMap.put(entry.getKey(), entry.getValue().metadata);
+  Map<ResourceType, Map<String, ResourceMetadata>> getSubscribedResourcesMetadataSnapshot() {
+    final SettableFuture<Map<ResourceType, Map<String, ResourceMetadata>>> future =
+        SettableFuture.create();
+    syncContext.execute(new Runnable() {
+      @Override
+      public void run() {
+        // A map from ResourceType to a map (ResourceName: ResourceMetadata)
+        ImmutableMap.Builder<ResourceType, Map<String, ResourceMetadata>> metadataSnapshot =
+            ImmutableMap.builder();
+        for (ResourceType type : ResourceType.values()) {
+          if (type == ResourceType.UNKNOWN) {
+            continue;
+          }
+          ImmutableMap.Builder<String, ResourceMetadata> metadataMap = ImmutableMap.builder();
+          for (Map.Entry<String, ResourceSubscriber> resourceEntry
+              : getSubscribedResourcesMap(type).entrySet()) {
+            metadataMap.put(resourceEntry.getKey(), resourceEntry.getValue().metadata);
+          }
+          metadataSnapshot.put(type, metadataMap.build());
+        }
+        future.set(metadataSnapshot.build());
+      }
+    });
+    try {
+      return future.get(METADATA_SYNC_TIMEOUT_SEC, TimeUnit.SECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new UncheckedExecutionException(e);
     }
-    return metadataMap;
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/CsdsService.java
+++ b/xds/src/main/java/io/grpc/xds/CsdsService.java
@@ -106,9 +106,10 @@ public final class CsdsService extends
 
   private boolean handleRequest(
       ClientStatusRequest request, StreamObserver<ClientStatusResponse> responseObserver) {
-    StatusException error = null;
+    StatusException error;
     try {
       responseObserver.onNext(getConfigDumpForRequest(request));
+      return true;
     } catch (StatusException e) {
       error = e;
     } catch (InterruptedException e) {
@@ -121,12 +122,8 @@ public final class CsdsService extends
           Status.INTERNAL.withDescription("Unexpected internal error").withCause(e).asException();
     }
 
-    if (error == null) {
-      return true;
-    } else {
-      responseObserver.onError(error);
-      return false;
-    }
+    responseObserver.onError(error);
+    return false;
   }
 
   private ClientStatusResponse getConfigDumpForRequest(ClientStatusRequest request)
@@ -197,7 +194,7 @@ public final class CsdsService extends
       // Normally this shouldn't take long, but add some slack for cases like a cold JVM.
       return future.get(20, TimeUnit.SECONDS);
     } catch (ExecutionException | TimeoutException e) {
-      // Four CSDS' purposes, the exact reason why metadata not loaded isn't important.
+      // For CSDS' purposes, the exact reason why metadata not loaded isn't important.
       throw new RuntimeException(e);
     }
   }

--- a/xds/src/main/java/io/grpc/xds/CsdsService.java
+++ b/xds/src/main/java/io/grpc/xds/CsdsService.java
@@ -17,6 +17,7 @@
 package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Verify.verifyNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.util.Timestamps;
@@ -148,10 +149,11 @@ public final class CsdsService extends
       ResourceType type = metadataByTypeEntry.getKey();
       for (Map.Entry<String, ResourceMetadata> metadataEntry
           : metadataByTypeEntry.getValue().entrySet()) {
+        String resourceName = metadataEntry.getKey();
         ResourceMetadata metadata = metadataEntry.getValue();
         GenericXdsConfig.Builder genericXdsConfigBuilder = GenericXdsConfig.newBuilder()
             .setTypeUrl(type.typeUrl())
-            .setName(metadataEntry.getKey())
+            .setName(resourceName)
             .setClientStatus(metadataStatusToClientStatus(metadata.getStatus()));
         if (metadata.getRawResource() != null) {
           genericXdsConfigBuilder
@@ -160,7 +162,7 @@ public final class CsdsService extends
               .setXdsConfig(metadata.getRawResource());
         }
         if (metadata.getStatus() == ResourceMetadataStatus.NACKED) {
-          assert metadata.getErrorState() != null;
+          verifyNotNull(metadata.getErrorState(), "resource %s getErrorState", resourceName);
           genericXdsConfigBuilder
               .setErrorState(metadataUpdateFailureStateToProto(metadata.getErrorState()));
         }

--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -495,8 +495,8 @@ abstract class XdsClient {
   }
 
   /**
-   * Returns the map containing the {@link ResourceMetadata} of the subscribed resources for the
-   * given resource type, indexed by the resource name.
+   * Returns a map from the "resource type" to a map ("resource name": "resource metadata")
+   * containing the snapshot of the subscribed resources as they are at the moment of the call.
    */
   // Must be synchronized.
   Map<ResourceType, Map<String, ResourceMetadata>> getSubscribedResourcesMetadataSnapshot() {

--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -494,7 +494,12 @@ abstract class XdsClient {
     throw new UnsupportedOperationException();
   }
 
-  Map<String, ResourceMetadata> getSubscribedResourcesMetadata(ResourceType type) {
+  /**
+   * Returns the map containing the {@link ResourceMetadata} of the subscribed resources for the
+   * given resource type, indexed by the resource name.
+   */
+  // Must be synchronized.
+  Map<ResourceType, Map<String, ResourceMetadata>> getSubscribedResourcesMetadataSnapshot() {
     throw new UnsupportedOperationException();
   }
 

--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.Any;
 import io.grpc.Status;
 import io.grpc.xds.AbstractXdsClient.ResourceType;
@@ -495,18 +496,15 @@ abstract class XdsClient {
   }
 
   /**
-   * Returns a map from the "resource type" to a map ("resource name": "resource metadata")
-   * containing the snapshot of the subscribed resources as they are at the moment of the call.
+   * Returns a {@link ListenableFuture} to the snapshot of the subscribed resources as
+   * they are at the moment of the call.
    *
-   * @throws com.google.common.util.concurrent.UncheckedExecutionException
-   *     if couldn't retrieve the snapshot of the subscribed resources in a synchronous manner
-   *     because the task failed, cancelled, or timed out.
-   *     TODO(sergiitk): when migrated to Java 8, throw CompletionException instead.
-   * @throws InterruptedException if the current thread was interrupted while waiting.
+   * <p>The snapshot is a map from the "resource type" to
+   * a map ("resource name": "resource metadata").
    */
   // Must be synchronized.
-  Map<ResourceType, Map<String, ResourceMetadata>> getSubscribedResourcesMetadataSnapshot()
-      throws InterruptedException {
+  ListenableFuture<Map<ResourceType, Map<String, ResourceMetadata>>>
+      getSubscribedResourcesMetadataSnapshot() {
     throw new UnsupportedOperationException();
   }
 

--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -497,6 +497,12 @@ abstract class XdsClient {
   /**
    * Returns a map from the "resource type" to a map ("resource name": "resource metadata")
    * containing the snapshot of the subscribed resources as they are at the moment of the call.
+   *
+   * @throws com.google.common.util.concurrent.UncheckedExecutionException
+   *     if couldn't retrieve the snapshot of the subscribed resources in a synchronous manner
+   *     because the task failed, cancelled, or timed out.
+   *     TODO(sergiitk): when migrated to Java 8, throw CompletionException instead.
+   * @throws InterruptedException if the current thread was interrupted while waiting.
    */
   // Must be synchronized.
   Map<ResourceType, Map<String, ResourceMetadata>> getSubscribedResourcesMetadataSnapshot()

--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -499,7 +499,8 @@ abstract class XdsClient {
    * containing the snapshot of the subscribed resources as they are at the moment of the call.
    */
   // Must be synchronized.
-  Map<ResourceType, Map<String, ResourceMetadata>> getSubscribedResourcesMetadataSnapshot() {
+  Map<ResourceType, Map<String, ResourceMetadata>> getSubscribedResourcesMetadataSnapshot()
+      throws InterruptedException {
     throw new UnsupportedOperationException();
   }
 

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
@@ -379,8 +379,13 @@ public abstract class ClientXdsClientTestBase {
 
   private void verifySubscribedResourcesMetadataSizes(
       int ldsSize, int cdsSize, int rdsSize, int edsSize) {
-    Map<ResourceType, Map<String, ResourceMetadata>> subscribedResourcesMetadata =
-        xdsClient.getSubscribedResourcesMetadataSnapshot();
+    Map<ResourceType, Map<String, ResourceMetadata>> subscribedResourcesMetadata;
+    try {
+      subscribedResourcesMetadata = xdsClient.getSubscribedResourcesMetadataSnapshot();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError("Thread interrupted", e);
+    }
     assertThat(subscribedResourcesMetadata.get(LDS)).hasSize(ldsSize);
     assertThat(subscribedResourcesMetadata.get(CDS)).hasSize(cdsSize);
     assertThat(subscribedResourcesMetadata.get(RDS)).hasSize(rdsSize);
@@ -436,8 +441,14 @@ public abstract class ClientXdsClientTestBase {
   private ResourceMetadata verifyResourceMetadata(
       ResourceType type, String resourceName, Any rawResource, ResourceMetadataStatus status,
       String versionInfo, long updateTimeNanos, boolean hasErrorState) {
-    ResourceMetadata resourceMetadata =
-        xdsClient.getSubscribedResourcesMetadataSnapshot().get(type).get(resourceName);
+    ResourceMetadata resourceMetadata;
+    try {
+      resourceMetadata =
+          xdsClient.getSubscribedResourcesMetadataSnapshot().get(type).get(resourceName);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError("Thread interrupted", e);
+    }
     assertThat(resourceMetadata).isNotNull();
     String name = type.toString() + " resource '" + resourceName + "' metadata field ";
     assertWithMessage(name + "status").that(resourceMetadata.getStatus()).isEqualTo(status);

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
@@ -379,10 +379,12 @@ public abstract class ClientXdsClientTestBase {
 
   private void verifySubscribedResourcesMetadataSizes(
       int ldsSize, int cdsSize, int rdsSize, int edsSize) {
-    assertThat(xdsClient.getSubscribedResourcesMetadata(LDS)).hasSize(ldsSize);
-    assertThat(xdsClient.getSubscribedResourcesMetadata(CDS)).hasSize(cdsSize);
-    assertThat(xdsClient.getSubscribedResourcesMetadata(RDS)).hasSize(rdsSize);
-    assertThat(xdsClient.getSubscribedResourcesMetadata(EDS)).hasSize(edsSize);
+    Map<ResourceType, Map<String, ResourceMetadata>> subscribedResourcesMetadata =
+        xdsClient.getSubscribedResourcesMetadataSnapshot();
+    assertThat(subscribedResourcesMetadata.get(LDS)).hasSize(ldsSize);
+    assertThat(subscribedResourcesMetadata.get(CDS)).hasSize(cdsSize);
+    assertThat(subscribedResourcesMetadata.get(RDS)).hasSize(rdsSize);
+    assertThat(subscribedResourcesMetadata.get(EDS)).hasSize(edsSize);
   }
 
   /** Verify the resource requested, but not updated. */
@@ -435,7 +437,7 @@ public abstract class ClientXdsClientTestBase {
       ResourceType type, String resourceName, Any rawResource, ResourceMetadataStatus status,
       String versionInfo, long updateTimeNanos, boolean hasErrorState) {
     ResourceMetadata resourceMetadata =
-        xdsClient.getSubscribedResourcesMetadata(type).get(resourceName);
+        xdsClient.getSubscribedResourcesMetadataSnapshot().get(type).get(resourceName);
     assertThat(resourceMetadata).isNotNull();
     String name = type.toString() + " resource '" + resourceName + "' metadata field ";
     assertWithMessage(name + "status").that(resourceMetadata.getStatus()).isEqualTo(status);

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
@@ -379,17 +379,23 @@ public abstract class ClientXdsClientTestBase {
 
   private void verifySubscribedResourcesMetadataSizes(
       int ldsSize, int cdsSize, int rdsSize, int edsSize) {
-    Map<ResourceType, Map<String, ResourceMetadata>> subscribedResourcesMetadata;
-    try {
-      subscribedResourcesMetadata = xdsClient.getSubscribedResourcesMetadataSnapshot();
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new AssertionError("Thread interrupted", e);
-    }
+    Map<ResourceType, Map<String, ResourceMetadata>> subscribedResourcesMetadata =
+        awaitSubscribedResourcesMetadata();
     assertThat(subscribedResourcesMetadata.get(LDS)).hasSize(ldsSize);
     assertThat(subscribedResourcesMetadata.get(CDS)).hasSize(cdsSize);
     assertThat(subscribedResourcesMetadata.get(RDS)).hasSize(rdsSize);
     assertThat(subscribedResourcesMetadata.get(EDS)).hasSize(edsSize);
+  }
+
+  private Map<ResourceType, Map<String, ResourceMetadata>> awaitSubscribedResourcesMetadata() {
+    try {
+      return xdsClient.getSubscribedResourcesMetadataSnapshot().get(20, TimeUnit.SECONDS);
+    } catch (Exception e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
+      throw new AssertionError(e);
+    }
   }
 
   /** Verify the resource requested, but not updated. */
@@ -441,28 +447,20 @@ public abstract class ClientXdsClientTestBase {
   private ResourceMetadata verifyResourceMetadata(
       ResourceType type, String resourceName, Any rawResource, ResourceMetadataStatus status,
       String versionInfo, long updateTimeNanos, boolean hasErrorState) {
-    ResourceMetadata resourceMetadata;
-    try {
-      resourceMetadata =
-          xdsClient.getSubscribedResourcesMetadataSnapshot().get(type).get(resourceName);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new AssertionError("Thread interrupted", e);
-    }
-    assertThat(resourceMetadata).isNotNull();
+    ResourceMetadata metadata = awaitSubscribedResourcesMetadata().get(type).get(resourceName);
+    assertThat(metadata).isNotNull();
     String name = type.toString() + " resource '" + resourceName + "' metadata field ";
-    assertWithMessage(name + "status").that(resourceMetadata.getStatus()).isEqualTo(status);
-    assertWithMessage(name + "version").that(resourceMetadata.getVersion()).isEqualTo(versionInfo);
-    assertWithMessage(name + "rawResource").that(resourceMetadata.getRawResource())
-        .isEqualTo(rawResource);
-    assertWithMessage(name + "updateTimeNanos").that(resourceMetadata.getUpdateTimeNanos())
+    assertWithMessage(name + "status").that(metadata.getStatus()).isEqualTo(status);
+    assertWithMessage(name + "version").that(metadata.getVersion()).isEqualTo(versionInfo);
+    assertWithMessage(name + "rawResource").that(metadata.getRawResource()).isEqualTo(rawResource);
+    assertWithMessage(name + "updateTimeNanos").that(metadata.getUpdateTimeNanos())
         .isEqualTo(updateTimeNanos);
     if (hasErrorState) {
-      assertWithMessage(name + "errorState").that(resourceMetadata.getErrorState()).isNotNull();
+      assertWithMessage(name + "errorState").that(metadata.getErrorState()).isNotNull();
     } else {
-      assertWithMessage(name + "errorState").that(resourceMetadata.getErrorState()).isNull();
+      assertWithMessage(name + "errorState").that(metadata.getErrorState()).isNull();
     }
-    return resourceMetadata;
+    return metadata;
   }
 
   /**

--- a/xds/src/test/java/io/grpc/xds/CsdsServiceTest.java
+++ b/xds/src/test/java/io/grpc/xds/CsdsServiceTest.java
@@ -28,7 +28,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.google.common.util.concurrent.SettableFuture;
 import com.google.protobuf.Any;
 import io.envoyproxy.envoy.admin.v3.ClientResourceStatus;
 import io.envoyproxy.envoy.config.cluster.v3.Cluster;
@@ -129,7 +128,8 @@ public class CsdsServiceTest {
         @Override
         ListenableFuture<Map<ResourceType, Map<String, ResourceMetadata>>>
               getSubscribedResourcesMetadataSnapshot() {
-          throw new IllegalArgumentException("IllegalArgumentException");
+          return Futures.immediateFailedFuture(
+              new IllegalArgumentException("IllegalArgumentException"));
         }
       };
       grpcServerRule.getServiceRegistry()
@@ -418,10 +418,7 @@ public class CsdsServiceTest {
     @Override
     ListenableFuture<Map<ResourceType, Map<String, ResourceMetadata>>>
         getSubscribedResourcesMetadataSnapshot() {
-      SettableFuture<Map<ResourceType, Map<String, ResourceMetadata>>> future =
-          SettableFuture.create();
-      future.set(getSubscribedResourcesMetadata());
-      return future;
+      return Futures.immediateFuture(getSubscribedResourcesMetadata());
     }
 
     @Override

--- a/xds/src/test/java/io/grpc/xds/CsdsServiceTest.java
+++ b/xds/src/test/java/io/grpc/xds/CsdsServiceTest.java
@@ -81,7 +81,7 @@ public class CsdsServiceTest {
     }
 
     @Override
-    Map<String, ResourceMetadata> getSubscribedResourcesMetadata(ResourceType type) {
+    Map<ResourceType, Map<String, ResourceMetadata>> getSubscribedResourcesMetadataSnapshot() {
       return ImmutableMap.of();
     }
   };
@@ -130,7 +130,7 @@ public class CsdsServiceTest {
     public void fetchClientConfig_unexpectedException() {
       XdsClient throwingXdsClient = new XdsClient() {
         @Override
-        Map<String, ResourceMetadata> getSubscribedResourcesMetadata(ResourceType type) {
+        Map<ResourceType, Map<String, ResourceMetadata>> getSubscribedResourcesMetadataSnapshot() {
           throw new IllegalArgumentException("IllegalArgumentException");
         }
       };
@@ -302,20 +302,13 @@ public class CsdsServiceTest {
         }
 
         @Override
-        Map<String, ResourceMetadata> getSubscribedResourcesMetadata(ResourceType type) {
-          switch (type) {
-            case LDS:
-              return ImmutableMap.of("subscribedResourceName." + type.name(), METADATA_ACKED_LDS);
-            case RDS:
-              return ImmutableMap.of("subscribedResourceName." + type.name(), METADATA_ACKED_RDS);
-            case CDS:
-              return ImmutableMap.of("subscribedResourceName." + type.name(), METADATA_ACKED_CDS);
-            case EDS:
-              return ImmutableMap.of("subscribedResourceName." + type.name(), METADATA_ACKED_EDS);
-            case UNKNOWN:
-            default:
-              throw new AssertionError("Unexpected resource name");
-          }
+        Map<ResourceType, Map<String, ResourceMetadata>> getSubscribedResourcesMetadataSnapshot() {
+          return new ImmutableMap.Builder<ResourceType, Map<String, ResourceMetadata>>()
+            .put(LDS, ImmutableMap.of("subscribedResourceName.LDS", METADATA_ACKED_LDS))
+            .put(RDS, ImmutableMap.of("subscribedResourceName.RDS", METADATA_ACKED_RDS))
+            .put(CDS, ImmutableMap.of("subscribedResourceName.CDS", METADATA_ACKED_CDS))
+            .put(EDS, ImmutableMap.of("subscribedResourceName.EDS", METADATA_ACKED_EDS))
+            .build();
         }
       });
 


### PR DESCRIPTION
Fixes an issue with ClientXdsClient.getSubscribedResourcesMetadata()
executed out of shared synchronization context, and leading to:

- each individual config dump containing outdated data when
  an xDS resource is updated during CsdsService preparing the response
- config dumps for different services being out-of-sync with each
  other when any of the related xDS resources is updated during
  CsdsService preparing the response

The fix replaces getSubscribedResourcesMetadata(ResourceType type)
with atomic getSubscribedResourcesMetadataSnapshot() returning
a snapshot of all resources for each type as they are
at the moment of a CSDS request.

Fix false negative in fetchClientConfig_unexpectedException,
where expected exception  was actually caused by missing
bootstrap data, not by throwing error from the local 
class implementation.