### PR TITLE
readme: grpc-netty-shaded runtime scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Download [the JARs][]. Or for Maven with non-Android, add to your `pom.xml`:
   <groupId>io.grpc</groupId>
   <artifactId>grpc-netty-shaded</artifactId>
   <version>1.43.1</version>
+  <scope>runtime</scope>
 </dependency>
 <dependency>
   <groupId>io.grpc</groupId>

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Download [the JARs][]. Or for Maven with non-Android, add to your `pom.xml`:
 
 Or for Gradle with non-Android, add to your dependencies:
 ```gradle
-implementation 'io.grpc:grpc-netty-shaded:1.43.1'
+runtimeOnly 'io.grpc:grpc-netty-shaded:1.43.1'
 implementation 'io.grpc:grpc-protobuf:1.43.1'
 implementation 'io.grpc:grpc-stub:1.43.1'
 compileOnly 'org.apache.tomcat:annotations-api:6.0.53' // necessary for Java 9+


### PR DESCRIPTION
We should recommend runtime scope for grpc-netty-shaded.

https://github.com/grpc/grpc-java/issues/8606#issuecomment-1004504316