### PR TITLE
.github/workflows: publish test results for failed job

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,6 +53,13 @@ jobs:
 
     - name: Build
       run: buildscripts/kokoro/unix.sh
+    - name: Post Failure Upload Test Reports to Artifacts
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: Test Reports (JRE ${{ matrix.jre }})
+        path: ./*/build/reports/tests/**
+        retention-days: 14
     - name: Check for modified codegen
       run: test -z "$(git status --porcelain)" || (git status && echo Error Working directory is not clean. Forget to commit generated files? && false)
 


### PR DESCRIPTION
The GitHub Actions Linux Testing only reports limited information (can not see full stacktrace, time consumed, or stderr from child threads) when unit tests fail. Adding a step to upload the test report to Artifacts if the test fails. If the test is successful, no artifacts will be uploaded.

![Screen Shot Artifacts](https://user-images.githubusercontent.com/4779759/148261905-d183c842-e281-4605-9e79-9a2aa006b143.jpeg)

Also considered using the 'Publish Unit Test Results' github action. However, when [matrix strategy is used](https://github.com/marketplace/actions/publish-unit-test-results#use-with-matrix-strategy), the config will be more complex than this PR, it still will use the upload-artifact anyway, and there's a bug displaying the name of the check item like "Validate Gradle Wrapper / Publish Unit Test Results". So I chose to just use the upload-artifact action.