### PR TITLE
buildscripts: upload kokoro test reports to artifacts

### DIFF
--- a/buildscripts/kokoro/macos.cfg
+++ b/buildscripts/kokoro/macos.cfg
@@ -16,5 +16,6 @@ env_vars {
 action {
   define_artifacts {
     regex: "github/grpc-java/mvn-artifacts/**"
+    regex: "**/build/reports/tests/**"
   }
 }

--- a/buildscripts/kokoro/windows.cfg
+++ b/buildscripts/kokoro/windows.cfg
@@ -8,6 +8,7 @@ timeout_mins: 45
 action {
   define_artifacts {
     regex: "**/build/test-results/**/*.xml"
+    regex: "**/build/reports/tests/**"
     regex: "github/grpc-java/mvn-artifacts/**"
   }
 }


### PR DESCRIPTION
The current kokoro jobs only reports limited test result information (can not see full stacktrace, time consumed, or stderr from child threads).