### PR TITLE
all: clean up code related to android api level less than 19

### DIFF
--- a/android-interop-testing/src/androidTest/java/io/grpc/android/integrationtest/InteropInstrumentationTest.java
+++ b/android-interop-testing/src/androidTest/java/io/grpc/android/integrationtest/InteropInstrumentationTest.java
@@ -20,7 +20,6 @@ import static junit.framework.Assert.assertEquals;
 
 import android.util.Log;
 import androidx.test.InstrumentationRegistry;
-import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.AndroidJUnit4;
 import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
 import com.google.android.gms.common.GooglePlayServicesRepairableException;
@@ -30,7 +29,6 @@ import io.grpc.android.integrationtest.InteropTask.Listener;
 import java.io.InputStream;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -45,12 +43,6 @@ public class InteropInstrumentationTest {
   private String serverHostOverride;
   private boolean useTestCa;
   private String testCase;
-
-  // Ensures Looper is initialized for tests running on API level 15. Otherwise instantiating an
-  // AsyncTask throws an exception.
-  @Rule
-  public ActivityTestRule<TesterActivity> activityRule =
-      new ActivityTestRule<TesterActivity>(TesterActivity.class);
 
   @Before
   public void setUp() throws Exception {

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     jmh project(':grpc-core')
 
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
+    signature "net.sf.androidscents.signature:android-api-level-19:4.4.2_r4@signature"
 }
 
 javadoc {

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -14,5 +14,5 @@ dependencies {
     testImplementation project(':grpc-testing'),
             libraries.google_auth_oauth2_http
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
+    signature "net.sf.androidscents.signature:android-api-level-19:4.4.2_r4@signature"
 }

--- a/context/build.gradle
+++ b/context/build.gradle
@@ -15,5 +15,5 @@ dependencies {
         exclude group: 'junit', module: 'junit'
     }
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
+    signature "net.sf.androidscents.signature:android-api-level-19:4.4.2_r4@signature"
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     jmh project(':grpc-testing')
 
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
+    signature "net.sf.androidscents.signature:android-api-level-19:4.4.2_r4@signature"
 }
 
 javadoc {

--- a/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
+++ b/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
@@ -202,14 +202,7 @@ class ProxyDetectorImpl implements ProxyDetector {
 
   private ProxiedSocketAddress detectProxy(InetSocketAddress targetAddr) throws IOException {
     URI uri;
-    String host;
-    try {
-      host = GrpcUtil.getHost(targetAddr);
-    } catch (Throwable t) {
-      // Workaround for Android API levels < 19 if getHostName causes a NetworkOnMainThreadException
-      log.log(Level.WARNING, "Failed to get host for proxy lookup, proceeding without proxy", t);
-      return null;
-    }
+    String host = GrpcUtil.getHost(targetAddr);
     try {
       uri =
           new URI(

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -22,7 +22,7 @@ dependencies {
             project(':grpc-testing'),
             project(':grpc-netty')
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
+    signature "net.sf.androidscents.signature:android-api-level-19:4.4.2_r4@signature"
 }
 
 project.sourceSets {

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testImplementation project(':grpc-core')
 
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
+    signature "net.sf.androidscents.signature:android-api-level-19:4.4.2_r4@signature"
 }
 
 compileTestJava {

--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation libraries.truth,
             project(':grpc-testing')
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
+    signature "net.sf.androidscents.signature:android-api-level-19:4.4.2_r4@signature"
 }
 
 javadoc {


### PR DESCRIPTION
This cleanup could have been done right after #8583

Manual android-interop run:
https://fusion2.corp.google.com/invocations/09ea8ade-e7a4-4dd4-9212-5f417fd05f0a