### PR TITLE
kokoro: Pretty test results

### DIFF
--- a/buildscripts/kokoro/kokoro.sh
+++ b/buildscripts/kokoro/kokoro.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+spongify_logs() {
+  local f
+  for f in $(find "${KOKORO_ARTIFACTS_DIR:-.}" -name 'TEST-*.xml'); do
+    mkdir "${f%.xml}"
+    cp "$f" "${f%.xml}/sponge_log.xml"
+  done
+}

--- a/buildscripts/kokoro/kokoro.sh
+++ b/buildscripts/kokoro/kokoro.sh
@@ -2,8 +2,8 @@
 
 spongify_logs() {
   local f
-  for f in $(find "${KOKORO_ARTIFACTS_DIR:-.}" -name 'TEST-*.xml'); do
+  while read -r f; do
     mkdir "${f%.xml}"
     cp "$f" "${f%.xml}/sponge_log.xml"
-  done
+  done < <(find "${KOKORO_ARTIFACTS_DIR:-.}" -name 'TEST-*.xml')
 }

--- a/buildscripts/kokoro/linux_aarch64.cfg
+++ b/buildscripts/kokoro/linux_aarch64.cfg
@@ -6,6 +6,7 @@ timeout_mins: 60
 
 action {
   define_artifacts {
+    regex: "github/grpc-java/**/build/test-results/**/sponge_log.xml"
     regex: "github/grpc-java/mvn-artifacts/**"
     regex: "github/grpc-java/artifacts/**"
   }

--- a/buildscripts/kokoro/linux_artifacts.cfg
+++ b/buildscripts/kokoro/linux_artifacts.cfg
@@ -6,6 +6,7 @@ timeout_mins: 60
 
 action {
   define_artifacts {
+    regex: "github/grpc-java/**/build/test-results/**/sponge_log.xml"
     regex: "github/grpc-java/mvn-artifacts/**"
     regex: "github/grpc-java/artifacts/**"
   }

--- a/buildscripts/kokoro/linux_artifacts.sh
+++ b/buildscripts/kokoro/linux_artifacts.sh
@@ -7,6 +7,9 @@ fi
 
 readonly GRPC_JAVA_DIR="$(cd "$(dirname "$0")"/../.. && pwd)"
 
+. "$GRPC_JAVA_DIR"/buildscripts/kokoro/kokoro.sh
+trap spongify_logs EXIT
+
 "$GRPC_JAVA_DIR"/buildscripts/build_docker.sh
 "$GRPC_JAVA_DIR"/buildscripts/run_in_docker.sh /grpc-java/buildscripts/build_artifacts_in_docker.sh
 

--- a/buildscripts/kokoro/macos.cfg
+++ b/buildscripts/kokoro/macos.cfg
@@ -1,7 +1,7 @@
 # Config file for internal CI
 
 # Location of the continuous shell script in repository.
-build_file: "grpc-java/buildscripts/kokoro/unix.sh"
+build_file: "grpc-java/buildscripts/kokoro/macos.sh"
 timeout_mins: 45
 
 # We had problems with random tests timing out because it took seconds to do
@@ -15,7 +15,7 @@ env_vars {
 # We always build mvn artifacts.
 action {
   define_artifacts {
-    regex: "github/grpc-java/**/build/reports/**"
+    regex: "github/grpc-java/**/build/test-results/**/sponge_log.xml"
     regex: "github/grpc-java/mvn-artifacts/**"
   }
 }

--- a/buildscripts/kokoro/macos.sh
+++ b/buildscripts/kokoro/macos.sh
@@ -10,8 +10,4 @@ readonly GRPC_JAVA_DIR="$(cd "$(dirname "$0")"/../.. && pwd)"
 . "$GRPC_JAVA_DIR"/buildscripts/kokoro/kokoro.sh
 trap spongify_logs EXIT
 
-cd github/grpc-java
-
-buildscripts/qemu_helpers/prepare_qemu.sh
-
-buildscripts/run_arm64_tests_in_docker.sh
+"$GRPC_JAVA_DIR"/buildscripts/kokoro/unix.sh

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -44,7 +44,7 @@ export LD_LIBRARY_PATH=/tmp/protobuf/lib
 export LDFLAGS=-L/tmp/protobuf/lib
 export CXXFLAGS="-I/tmp/protobuf/include"
 
-./gradlew clean $GRADLE_FLAGS
+./gradlew grpc-compiler:clean $GRADLE_FLAGS
 
 if [[ -z "${SKIP_TESTS:-}" ]]; then
   # Ensure all *.proto changes include *.java generated code
@@ -58,7 +58,6 @@ if [[ -z "${SKIP_TESTS:-}" ]]; then
   # Run tests
   ./gradlew build :grpc-all:jacocoTestReport $GRADLE_FLAGS
   pushd examples
-  ./gradlew clean $GRADLE_FLAGS
   ./gradlew build $GRADLE_FLAGS
   # --batch-mode reduces log spam
   mvn verify --batch-mode

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -16,10 +16,6 @@ set -exu -o pipefail
 # It would be nicer to use 'readlink -f' here but osx does not support it.
 readonly GRPC_JAVA_DIR="$(cd "$(dirname "$0")"/../.. && pwd)"
 
-if [[ -f /VERSION ]]; then
-  cat /VERSION
-fi
-
 # cd to the root dir of grpc-java
 cd $(dirname $0)/../..
 

--- a/buildscripts/kokoro/windows.cfg
+++ b/buildscripts/kokoro/windows.cfg
@@ -7,7 +7,7 @@ timeout_mins: 45
 # We always build mvn artifacts.
 action {
   define_artifacts {
-    regex: "**/build/test-results/**/*.xml"
+    regex: "github/grpc-java/**/build/test-results/**/sponge_log.xml"
     regex: "github/grpc-java/mvn-artifacts/**"
   }
 }

--- a/buildscripts/kokoro/windows64.bat
+++ b/buildscripts/kokoro/windows64.bat
@@ -32,4 +32,4 @@ SET GRADLE_FLAGS=-PtargetArch=%TARGET_ARCH% -PfailOnWarnings=%FAIL_ON_WARNINGS% 
 @rem make sure no daemons have any files open
 cmd.exe /C "%WORKSPACE%\gradlew.bat --stop"
 
-cmd.exe /C "%WORKSPACE%\gradlew.bat  %GRADLE_FLAGS% -Dorg.gradle.parallel=false -PrepositoryDir=%WORKSPACE%\artifacts clean grpc-compiler:build grpc-compiler:publish" || exit /b 1
+cmd.exe /C "%WORKSPACE%\gradlew.bat  %GRADLE_FLAGS% -Dorg.gradle.parallel=false -PrepositoryDir=%WORKSPACE%\artifacts grpc-compiler:clean grpc-compiler:build grpc-compiler:publish" || exit /b 1


### PR DESCRIPTION
Previously, only Windows had the plumbing to rename test results for
the Kokoro result viewers to pretty-print.

macos.cfg was the only CI that lacked a corresponding .sh, which maked
unix.sh harder to reason about. Created macos.sh so that unix.sh is now
just a helper script and will not be called directly by Kokoro.