### PR TITLE
build.gradle: Add missing dependsOn for generated code sync

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
 }
 
 import net.ltgt.gradle.errorprone.CheckSeverity
+import org.gradle.util.GUtil
 
 subprojects {
     apply plugin: "checkstyle"
@@ -97,6 +98,11 @@ subprojects {
                             def syncTask = project.tasks.register("syncGeneratedSources${variantOrSourceSet}", Sync) {
                                 from "$buildDir/generated/source/proto/${variantOrSourceSet}/grpc"
                                 into "$generatedSourcePath/${variantOrSourceSet}/grpc"
+                                String source = GUtil.toCamelCase(variantOrSourceSet)
+                                if (source == "Main") {
+                                    source = ""
+                                }
+                                dependsOn "generate${source}Proto"
                             }
                             syncGeneratedSources.dependsOn syncTask
 


### PR DESCRIPTION
When messing with error prone for another commit, Gradle started
producing a clear warning the dependsOn was missing. But the warning
was not reliable. However, even when no warning was printed it is clear
the task was broken.

CC @dapengzhang0 