### PR TITLE
android-interop-testing: add the linter error message ignore annotation in the source xml file

### DIFF
--- a/android-interop-testing/src/main/res/layout/activity_tester.xml
+++ b/android-interop-testing/src/main/res/layout/activity_tester.xml
@@ -46,6 +46,7 @@
       android:layout_height="wrap_content"
       android:onClick="startEmptyUnary"
       android:text="Empty Unary"
+      tools:ignore="OnClick"
       />
 
   <Button
@@ -54,6 +55,7 @@
       android:layout_height="wrap_content"
       android:onClick="startLargeUnary"
       android:text="Large Unary"
+      tools:ignore="OnClick"
       />
 
   <Button
@@ -62,6 +64,7 @@
       android:layout_height="wrap_content"
       android:onClick="startClientStreaming"
       android:text="Client Streaming"
+      tools:ignore="OnClick"
       />
 
   <Button
@@ -70,6 +73,7 @@
       android:layout_height="wrap_content"
       android:onClick="startServerStreaming"
       android:text="Server Streaming"
+      tools:ignore="OnClick"
       />
 
   <Button
@@ -78,6 +82,7 @@
       android:layout_height="wrap_content"
       android:onClick="startPingPong"
       android:text="Ping Pong"
+      tools:ignore="OnClick"
       />
 
   <TextView


### PR DESCRIPTION
As per https://developer.android.com/studio/write/lint.html#configuring-lint-checking-in-xml

(this replaces the internal android-interop-testing/android_lint_baseline.xml file and works for generated files as described in an internal article).