### PR TITLE
Drop Java 7 support

### DIFF
--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -9,9 +9,6 @@ plugins {
 
 description = "gRPC: ALTS"
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
-
 evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -252,8 +252,8 @@ subprojects {
     }
 
     plugins.withId("java") {
-        sourceCompatibility = 1.7
-        targetCompatibility = 1.7
+        sourceCompatibility = 1.8
+        targetCompatibility = 1.8
 
         dependencies {
             testImplementation libraries.junit,

--- a/context/build.gradle
+++ b/context/build.gradle
@@ -9,6 +9,9 @@ plugins {
 
 description = 'gRPC: Context'
 
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
 dependencies {
     testImplementation libraries.jsr305
     testImplementation (libraries.guava_testlib) {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -14,8 +14,8 @@ repositories {
     mavenLocal()
 }
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 // IMPORTANT: You probably want the non-SNAPSHOT version of gRPC. Make sure you
 // are looking at a tagged version of the example and not "master"!

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -15,8 +15,8 @@ repositories {
     mavenLocal()
 }
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 // IMPORTANT: You probably want the non-SNAPSHOT version of gRPC. Make sure you
 // are looking at a tagged version of the example and not "master"!

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -15,8 +15,8 @@ repositories {
     mavenLocal()
 }
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 // IMPORTANT: You probably want the non-SNAPSHOT version of gRPC. Make sure you
 // are looking at a tagged version of the example and not "master"!

--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -13,8 +13,8 @@ repositories {
     mavenLocal()
 }
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 // IMPORTANT: You probably want the non-SNAPSHOT version of gRPC. Make sure you
 // are looking at a tagged version of the example and not "master"!

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -14,8 +14,8 @@ repositories {
     mavenLocal()
 }
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 // IMPORTANT: You probably want the non-SNAPSHOT version of gRPC. Make sure you
 // are looking at a tagged version of the example and not "master"!

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -15,8 +15,8 @@ repositories {
     mavenLocal()
 }
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 // IMPORTANT: You probably want the non-SNAPSHOT version of gRPC. Make sure you
 // are looking at a tagged version of the example and not "master"!

--- a/examples/example-xds/build.gradle
+++ b/examples/example-xds/build.gradle
@@ -14,8 +14,8 @@ repositories {
     mavenLocal()
 }
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 // IMPORTANT: You probably want the non-SNAPSHOT version of gRPC. Make sure you
 // are looking at a tagged version of the example and not "master"!


### PR DESCRIPTION
Oracle's Premier Support for Java 7 ended in July 2019. Per gRFC P5,
dropping support for the only release. Android is able to desugar many
Java 8 language features.

Context left on Java 7 just to be super-conservative.

Draft PR because the gRFC has not yet merged (giving a bit more time for people to comment).