### PR TITLE
rls: fix child lb leak when client channel is shutdown [backport v1.44.x]

### DIFF
--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -30,17 +30,14 @@ import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.ChannelLogger;
 import io.grpc.ChannelLogger.ChannelLogLevel;
 import io.grpc.ConnectivityState;
-import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
 import io.grpc.LoadBalancer.ResolvedAddresses;
 import io.grpc.LoadBalancer.SubchannelPicker;
-import io.grpc.LoadBalancerProvider;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
-import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.Status;
 import io.grpc.SynchronizationContext;
 import io.grpc.SynchronizationContext.ScheduledHandle;
@@ -51,7 +48,6 @@ import io.grpc.lookup.v1.RouteLookupServiceGrpc;
 import io.grpc.lookup.v1.RouteLookupServiceGrpc.RouteLookupServiceStub;
 import io.grpc.rls.ChildLoadBalancerHelper.ChildLoadBalancerHelperProvider;
 import io.grpc.rls.LbPolicyConfiguration.ChildLbStatusListener;
-import io.grpc.rls.LbPolicyConfiguration.ChildLoadBalancingPolicy;
 import io.grpc.rls.LbPolicyConfiguration.ChildPolicyWrapper;
 import io.grpc.rls.LbPolicyConfiguration.RefCountedChildPolicyWrapperFactory;
 import io.grpc.rls.LruCache.EvictionListener;
@@ -138,7 +134,8 @@ final class CachingRlsLbClient {
             rlsConfig.getCacheSizeBytes(),
             builder.evictionListener,
             scheduledExecutorService,
-            timeProvider);
+            timeProvider,
+            lock);
     logger = helper.getChannelLogger();
     String serverHost = null;
     try {
@@ -181,7 +178,9 @@ final class CachingRlsLbClient {
         new ChildLoadBalancerHelperProvider(helper, new SubchannelStateManagerImpl(), rlsPicker);
     refCountedChildPolicyWrapperFactory =
         new RefCountedChildPolicyWrapperFactory(
-            childLbHelperProvider, new BackoffRefreshListener());
+            lbPolicyConfig.getLoadBalancingPolicy(), childLbResolvedAddressFactory,
+            childLbHelperProvider,
+            new BackoffRefreshListener());
     logger.log(ChannelLogLevel.DEBUG, "CachingRlsLbClient created");
   }
 
@@ -536,6 +535,7 @@ final class CachingRlsLbClient {
     private final long staleTime;
     private final ChildPolicyWrapper childPolicyWrapper;
 
+    // GuardedBy CachingRlsLbClient.lock
     DataCacheEntry(RouteLookupRequest request, final RouteLookupResponse response) {
       super(request);
       this.response = checkNotNull(response, "response");
@@ -546,29 +546,6 @@ final class CachingRlsLbClient {
       long now = timeProvider.currentTimeNanos();
       expireTime = now + maxAgeNanos;
       staleTime = now + staleAgeNanos;
-
-      if (childPolicyWrapper.getPicker() != null) {
-        childPolicyWrapper.refreshState();
-      } else {
-        createChildLbPolicy();
-      }
-    }
-
-    private void createChildLbPolicy() {
-      ChildLoadBalancingPolicy childPolicy = lbPolicyConfig.getLoadBalancingPolicy();
-      LoadBalancerProvider lbProvider = childPolicy.getEffectiveLbProvider();
-      ConfigOrError lbConfig =
-          lbProvider
-              .parseLoadBalancingPolicyConfig(
-                  childPolicy.getEffectiveChildPolicy(childPolicyWrapper.getTarget()));
-
-      LoadBalancer lb = lbProvider.newLoadBalancer(childPolicyWrapper.getHelper());
-      logger.log(
-          ChannelLogLevel.DEBUG,
-          "RLS child lb created. config: {0}",
-          lbConfig.getConfig());
-      lb.handleResolvedAddresses(childLbResolvedAddressFactory.create(lbConfig.getConfig()));
-      lb.requestConnection();
     }
 
     /**
@@ -637,7 +614,9 @@ final class CachingRlsLbClient {
 
     @Override
     void cleanup() {
-      refCountedChildPolicyWrapperFactory.release(childPolicyWrapper);
+      synchronized (lock) {
+        refCountedChildPolicyWrapperFactory.release(childPolicyWrapper);
+      }
     }
 
     @Override
@@ -856,14 +835,15 @@ final class CachingRlsLbClient {
 
     RlsAsyncLruCache(long maxEstimatedSizeBytes,
         @Nullable EvictionListener<RouteLookupRequest, CacheEntry> evictionListener,
-        ScheduledExecutorService ses, TimeProvider timeProvider) {
+        ScheduledExecutorService ses, TimeProvider timeProvider, Object lock) {
       super(
           maxEstimatedSizeBytes,
           new AutoCleaningEvictionListener(evictionListener),
           1,
           TimeUnit.MINUTES,
           ses,
-          timeProvider);
+          timeProvider,
+          lock);
     }
 
     @Override
@@ -985,27 +965,9 @@ final class CachingRlsLbClient {
         }
         fallbackChildPolicyWrapper = refCountedChildPolicyWrapperFactory.createOrGet(defaultTarget);
       }
-      LoadBalancerProvider lbProvider =
-          lbPolicyConfig.getLoadBalancingPolicy().getEffectiveLbProvider();
-      final LoadBalancer lb =
-          lbProvider.newLoadBalancer(fallbackChildPolicyWrapper.getHelper());
-      final ConfigOrError lbConfig =
-          lbProvider
-              .parseLoadBalancingPolicyConfig(
-                  lbPolicyConfig
-                      .getLoadBalancingPolicy()
-                      .getEffectiveChildPolicy(defaultTarget));
-      helper.getSynchronizationContext().execute(
-          new Runnable() {
-            @Override
-            public void run() {
-              lb.handleResolvedAddresses(
-                  childLbResolvedAddressFactory.create(lbConfig.getConfig()));
-              lb.requestConnection();
-            }
-          });
     }
 
+    // GuardedBy CachingRlsLbClient.lock
     void close() {
       if (fallbackChildPolicyWrapper != null) {
         refCountedChildPolicyWrapperFactory.release(fallbackChildPolicyWrapper);

--- a/rls/src/main/java/io/grpc/rls/LbPolicyConfiguration.java
+++ b/rls/src/main/java/io/grpc/rls/LbPolicyConfiguration.java
@@ -22,12 +22,15 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
+import io.grpc.ChannelLogger.ChannelLogLevel;
 import io.grpc.ConnectivityState;
+import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
+import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.internal.ObjectPool;
 import io.grpc.rls.ChildLoadBalancerHelper.ChildLoadBalancerHelperProvider;
 import io.grpc.rls.RlsProtoData.RouteLookupConfig;
@@ -191,33 +194,49 @@ final class LbPolicyConfiguration {
 
   /** Factory for {@link ChildPolicyWrapper}. */
   static final class RefCountedChildPolicyWrapperFactory {
+    // GuardedBy CachingRlsLbClient.lock
     @VisibleForTesting
     final Map<String /* target */, RefCountedChildPolicyWrapper> childPolicyMap =
         new HashMap<>();
 
     private final ChildLoadBalancerHelperProvider childLbHelperProvider;
     private final ChildLbStatusListener childLbStatusListener;
+    private final ChildLoadBalancingPolicy childPolicy;
+    private final ResolvedAddressFactory childLbResolvedAddressFactory;
 
     public RefCountedChildPolicyWrapperFactory(
+        ChildLoadBalancingPolicy childPolicy,
+        ResolvedAddressFactory childLbResolvedAddressFactory,
         ChildLoadBalancerHelperProvider childLbHelperProvider,
         ChildLbStatusListener childLbStatusListener) {
+      this.childPolicy = checkNotNull(childPolicy, "childPolicy");
+      this.childLbResolvedAddressFactory =
+          checkNotNull(childLbResolvedAddressFactory, "childLbResolvedAddressFactory");
       this.childLbHelperProvider = checkNotNull(childLbHelperProvider, "childLbHelperProvider");
       this.childLbStatusListener = checkNotNull(childLbStatusListener, "childLbStatusListener");
     }
 
+    // GuardedBy CachingRlsLbClient.lock
     ChildPolicyWrapper createOrGet(String target) {
       // TODO(creamsoup) check if the target is valid or not
       RefCountedChildPolicyWrapper pooledChildPolicyWrapper = childPolicyMap.get(target);
       if (pooledChildPolicyWrapper == null) {
-        ChildPolicyWrapper childPolicyWrapper =
-            new ChildPolicyWrapper(target, childLbHelperProvider, childLbStatusListener);
+        ChildPolicyWrapper childPolicyWrapper = new ChildPolicyWrapper(
+            target, childPolicy, childLbResolvedAddressFactory, childLbHelperProvider,
+            childLbStatusListener);
         pooledChildPolicyWrapper = RefCountedChildPolicyWrapper.of(childPolicyWrapper);
         childPolicyMap.put(target, pooledChildPolicyWrapper);
+        return pooledChildPolicyWrapper.getObject();
+      } else {
+        ChildPolicyWrapper childPolicyWrapper = pooledChildPolicyWrapper.getObject();
+        if (childPolicyWrapper.getPicker() != null) {
+          childPolicyWrapper.refreshState();
+        }
+        return childPolicyWrapper;
       }
-
-      return pooledChildPolicyWrapper.getObject();
     }
 
+    // GuardedBy CachingRlsLbClient.lock
     void release(ChildPolicyWrapper childPolicyWrapper) {
       checkNotNull(childPolicyWrapper, "childPolicyWrapper");
       String target = childPolicyWrapper.getTarget();
@@ -238,16 +257,36 @@ final class LbPolicyConfiguration {
 
     private final String target;
     private final ChildPolicyReportingHelper helper;
+    private final LoadBalancer lb;
     private volatile SubchannelPicker picker;
     private ConnectivityState state;
 
     public ChildPolicyWrapper(
         String target,
+        ChildLoadBalancingPolicy childPolicy,
+        final ResolvedAddressFactory childLbResolvedAddressFactory,
         ChildLoadBalancerHelperProvider childLbHelperProvider,
         ChildLbStatusListener childLbStatusListener) {
       this.target = target;
       this.helper =
           new ChildPolicyReportingHelper(childLbHelperProvider, childLbStatusListener);
+      LoadBalancerProvider lbProvider = childPolicy.getEffectiveLbProvider();
+      final ConfigOrError lbConfig =
+          lbProvider
+              .parseLoadBalancingPolicyConfig(
+                  childPolicy.getEffectiveChildPolicy(target));
+      this.lb = lbProvider.newLoadBalancer(helper);
+      helper.getChannelLogger().log(
+          ChannelLogLevel.DEBUG, "RLS child lb created. config: {0}", lbConfig.getConfig());
+      helper.getSynchronizationContext().execute(
+          new Runnable() {
+            @Override
+            public void run() {
+              lb.handleResolvedAddresses(
+                  childLbResolvedAddressFactory.create(lbConfig.getConfig()));
+              lb.requestConnection();
+            }
+          });
     }
 
     String getTarget() {
@@ -263,7 +302,25 @@ final class LbPolicyConfiguration {
     }
 
     void refreshState() {
-      helper.updateBalancingState(state, picker);
+      helper.getSynchronizationContext().execute(
+          new Runnable() {
+            @Override
+            public void run() {
+              helper.updateBalancingState(state, picker);
+            }
+          }
+      );
+    }
+
+    void shutdown() {
+      helper.getSynchronizationContext().execute(
+          new Runnable() {
+            @Override
+            public void run() {
+              lb.shutdown();
+            }
+          }
+      );
     }
 
     @Override
@@ -346,6 +403,7 @@ final class LbPolicyConfiguration {
       long newCnt = refCnt.decrementAndGet();
       checkState(newCnt != -1, "Cannot return never pooled childPolicyWrapper");
       if (newCnt == 0) {
+        childPolicyWrapper.shutdown();
         childPolicyWrapper = null;
       }
       return null;

--- a/rls/src/main/java/io/grpc/rls/LruCache.java
+++ b/rls/src/main/java/io/grpc/rls/LruCache.java
@@ -49,10 +49,10 @@ interface LruCache<K, V> {
   V invalidate(K key);
 
   /**
-   * Invalidates cache entries for given keys. This operation will trigger {@link EvictionListener}
+   * Invalidates cache entries for all keys. This operation will trigger {@link EvictionListener}
    * with {@link EvictionType#EXPLICIT}.
    */
-  void invalidateAll(Iterable<K> keys);
+  void invalidateAll();
 
   /** Returns {@code true} if given key is cached. */
   @CheckReturnValue

--- a/rls/src/test/java/io/grpc/rls/LinkedHashLruCacheTest.java
+++ b/rls/src/test/java/io/grpc/rls/LinkedHashLruCacheTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import com.google.common.collect.ImmutableList;
 import io.grpc.rls.DoNotUseDirectScheduledExecutorService.FakeTimeProvider;
 import io.grpc.rls.LruCache.EvictionListener;
 import io.grpc.rls.LruCache.EvictionType;
@@ -62,7 +61,8 @@ public class LinkedHashLruCacheTest {
         10,
         TimeUnit.NANOSECONDS,
         fakeScheduledService,
-        timeProvider) {
+        timeProvider,
+        new Object()) {
       @Override
       protected boolean isExpired(Integer key, Entry value, long nowNanos) {
         return value.expireTime <= nowNanos;
@@ -210,7 +210,7 @@ public class LinkedHashLruCacheTest {
 
     assertThat(cache.estimatedSize()).isEqualTo(2);
 
-    cache.invalidateAll(ImmutableList.of(1, 2));
+    cache.invalidateAll();
 
     assertThat(cache.estimatedSize()).isEqualTo(0);
   }


### PR DESCRIPTION
Backport of #8750 

When client channel is shutting down, the RlsLoadBalancer is shutting down. However, the child loadbalancers of RlsLoadBalancer are not shut down. This is causing the issue b/209831670