### PR TITLE
android-interop-testing: migrate AndroidJUnit4 runner and update AndroidManifest.xml

### DIFF
--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -76,8 +76,8 @@ dependencies {
 
     compileOnly libraries.javax_annotation
 
-    androidTestImplementation 'androidx.test:rules:1.1.0-alpha1'
-    androidTestImplementation 'androidx.test:runner:1.1.0-alpha1'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3',
+            'androidx.test:runner:1.4.0'
 }
 
 // Checkstyle doesn't run automatically with android

--- a/android-interop-testing/src/androidTest/AndroidManifest.xml
+++ b/android-interop-testing/src/androidTest/AndroidManifest.xml
@@ -6,8 +6,8 @@
         android:name="androidx.test.runner.AndroidJUnitRunner"
         android:targetPackage="io.grpc.android.integrationtest" />
 
-    <application android:debuggable="true" >
-        <uses-library android:name="android.test.runner" />
+    <application
+        android:name="android.support.multidex.MultiDexApplication" >
     </application>
 
 </manifest>

--- a/android-interop-testing/src/androidTest/java/io/grpc/android/integrationtest/InteropInstrumentationTest.java
+++ b/android-interop-testing/src/androidTest/java/io/grpc/android/integrationtest/InteropInstrumentationTest.java
@@ -16,11 +16,12 @@
 
 package io.grpc.android.integrationtest;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import android.util.Log;
-import androidx.test.InstrumentationRegistry;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
 import com.google.android.gms.common.GooglePlayServicesRepairableException;
 import com.google.android.gms.security.ProviderInstaller;
@@ -59,7 +60,7 @@ public class InteropInstrumentationTest {
 
     if (useTls) {
       try {
-        ProviderInstaller.installIfNeeded(InstrumentationRegistry.getTargetContext());
+        ProviderInstaller.installIfNeeded(ApplicationProvider.getApplicationContext());
       } catch (GooglePlayServicesRepairableException e) {
         // The provider is helpful, but it is possible to succeed without it.
         // Hope that the system-provided libraries are new enough.
@@ -110,7 +111,7 @@ public class InteropInstrumentationTest {
         };
     InputStream testCa;
     if (useTestCa) {
-      testCa = InstrumentationRegistry.getTargetContext().getResources().openRawResource(R.raw.ca);
+      testCa = ApplicationProvider.getApplicationContext().getResources().openRawResource(R.raw.ca);
     } else {
       testCa = null;
     }


### PR DESCRIPTION
- Importing to google failed with
  ```
  grpc/android/integrationtest/InteropInstrumentationTest.java:35: error: could not resolve AndroidJUnit4
  @RunWith(AndroidJUnit4.class)
  ```
  when using internal jetifier.

  Migrate deprecated `androidx.test.runner.AndroidJUnit4` to `androidx.test.ext.junit.runners.AndroidJUnit4`.

- It also failed with
  ```
  ClassNotFoundException: androidx.multidex.MultiDexApplication
  ```

  Updated androidTest/AndroidManifest.xml for multidex.

- Leave the `android:debuggable attribute` unset as suggested by go/tiktok-conformance-violations/MANIFEST_DEBUGGABLE

Tested manually:
https://fusion2.corp.google.com/invocations/b6b87d6c-c1d2-42e1-bffe-198efccb0f59