### PR TITLE
testing: remove opencensus dependency from grpc-testing

### DIFF
--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -13,7 +13,8 @@ dependencies {
     api project(':grpc-core'),
             project(':grpc-stub'),
             libraries.junit
-    implementation libraries.opencensus_api
+    // Only io.grpc.internal.testing.StatsTestUtils depends on opencensus_api, for internal use.
+    compileOnly libraries.opencensus_api
     runtimeOnly project(":grpc-context") // Pull in newer version than census-api
 
     testImplementation (libraries.mockito) {


### PR DESCRIPTION
`io.grpc.internal.testing.StatsTestUtils` in `grpc-testing` is only used internally by `grpc-interop-testing` and unit tests. The opencensus dependency does not need to be exposed to `grpc-interop-testing` maven artifact.