### PR TITLE
Update ensureAlpnAndH2Enabled to reflect NPN protocol

### DIFF
--- a/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
@@ -271,17 +271,17 @@ public class GrpcSslContexts {
     return null;
   }
 
-  @SuppressWarnings("deprecation")
-  static void ensureAlpnAndH2Enabled(
-      io.netty.handler.ssl.ApplicationProtocolNegotiator alpnNegotiator) {
-    checkArgument(alpnNegotiator != null, "ALPN must be configured");
-    checkArgument(alpnNegotiator.protocols() != null && !alpnNegotiator.protocols().isEmpty(),
-        "ALPN must be enabled and list HTTP/2 as a supported protocol.");
+  static void ensureProtocolNegotiationAndH2Enabled(
+      io.netty.handler.ssl.ApplicationProtocolNegotiator protocolNegotiator) {
+    checkArgument(protocolNegotiator != null, "ALPN or NPN must be configured");
+    List<String> protocols = protocolNegotiator.protocols();
+    checkArgument(protocols != null && !protocols.isEmpty(),
+        "ALPN or NPN must be enabled and list HTTP/2 as a supported protocol.");
     checkArgument(
-        alpnNegotiator.protocols().contains(HTTP2_VERSION),
-        "This ALPN config does not support HTTP/2. Expected %s, but got %s'.",
+        protocols.contains(HTTP2_VERSION),
+        "This ApplicationProtocolConfig does not support HTTP/2. Expected %s, but got %s'.",
         HTTP2_VERSION,
-        alpnNegotiator.protocols());
+        protocols);
   }
 
   private static class ConscryptHolder {

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -349,7 +349,7 @@ public final class NettyChannelBuilder extends
     if (sslContext != null) {
       checkArgument(sslContext.isClient(),
           "Server SSL context can not be used for client channel");
-      GrpcSslContexts.ensureAlpnAndH2Enabled(sslContext.applicationProtocolNegotiator());
+      GrpcSslContexts.ensureProtocolNegotiationAndH2Enabled(sslContext.applicationProtocolNegotiator());
     }
     if (!(protocolNegotiatorFactory instanceof DefaultProtocolNegotiator)) {
       // Do nothing for compatibility

--- a/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
@@ -355,7 +355,7 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
     if (sslContext != null) {
       checkArgument(sslContext.isServer(),
           "Client SSL context can not be used for server");
-      GrpcSslContexts.ensureAlpnAndH2Enabled(sslContext.applicationProtocolNegotiator());
+      GrpcSslContexts.ensureProtocolNegotiationAndH2Enabled(sslContext.applicationProtocolNegotiator());
       protocolNegotiatorFactory = ProtocolNegotiators.serverTlsFactory(sslContext);
     } else {
       protocolNegotiatorFactory = ProtocolNegotiators.serverPlaintextFactory();

--- a/netty/src/main/java/io/grpc/netty/NettySslContextChannelCredentials.java
+++ b/netty/src/main/java/io/grpc/netty/NettySslContextChannelCredentials.java
@@ -33,7 +33,7 @@ public final class NettySslContextChannelCredentials {
   public static ChannelCredentials create(SslContext sslContext) {
     Preconditions.checkArgument(sslContext.isClient(),
         "Server SSL context can not be used for client channel");
-    GrpcSslContexts.ensureAlpnAndH2Enabled(sslContext.applicationProtocolNegotiator());
+    GrpcSslContexts.ensureProtocolNegotiationAndH2Enabled(sslContext.applicationProtocolNegotiator());
     return NettyChannelCredentials.create(ProtocolNegotiators.tlsClientFactory(sslContext));
   }
 }

--- a/netty/src/main/java/io/grpc/netty/NettySslContextServerCredentials.java
+++ b/netty/src/main/java/io/grpc/netty/NettySslContextServerCredentials.java
@@ -33,7 +33,7 @@ public final class NettySslContextServerCredentials {
   public static ServerCredentials create(SslContext sslContext) {
     Preconditions.checkArgument(sslContext.isServer(),
         "Client SSL context can not be used for server");
-    GrpcSslContexts.ensureAlpnAndH2Enabled(sslContext.applicationProtocolNegotiator());
+    GrpcSslContexts.ensureProtocolNegotiationAndH2Enabled(sslContext.applicationProtocolNegotiator());
     return NettyServerCredentials.create(ProtocolNegotiators.serverTlsFactory(sslContext));
   }
 }


### PR DESCRIPTION
Currently `#ensureAlpnAndH2Enabled` is functionally correct, but the method name and error messages make it look like only ALPN is allowed by this method and it doesn't allow NPN protocol, which is not the case.
This method likely wasn't updated when NPN was added in addition to NPN and now the naming and the error messages are misleading for the reader.

This PR updates the method name and error messages to reflect that there are currently two Protocol Negotiators
