### PR TITLE
core: optimize to reduce excessive onReady() in hedging

### DIFF
--- a/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
@@ -1922,7 +1922,6 @@ public class RetriableStreamTest {
     inOrder.verify(mockStream2, times(2)).flush();
     inOrder.verify(mockStream2).writeMessage(any(InputStream.class));
     inOrder.verify(mockStream2).request(456);
-    inOrder.verify(mockStream1).isReady();
     inOrder.verify(mockStream2).isReady();
     inOrder.verifyNoMoreInteractions();
 
@@ -1961,8 +1960,6 @@ public class RetriableStreamTest {
     inOrder.verify(mockStream3).writeMessage(any(InputStream.class));
     inOrder.verify(mockStream3).request(456);
     inOrder.verify(mockStream3, times(2)).writeMessage(any(InputStream.class));
-    inOrder.verify(mockStream1).isReady();
-    inOrder.verify(mockStream2).isReady();
     inOrder.verify(mockStream3).isReady();
     inOrder.verifyNoMoreInteractions();
 
@@ -2006,8 +2003,6 @@ public class RetriableStreamTest {
     inOrder.verify(mockStream4).writeMessage(any(InputStream.class));
     inOrder.verify(mockStream4).request(456);
     inOrder.verify(mockStream4, times(4)).writeMessage(any(InputStream.class));
-    inOrder.verify(mockStream1).isReady();
-    inOrder.verify(mockStream2).isReady();
     inOrder.verify(mockStream4).isReady();
     inOrder.verifyNoMoreInteractions();
 
@@ -2320,7 +2315,7 @@ public class RetriableStreamTest {
     ArgumentCaptor<ClientStreamListener> sublistenerCaptor1 =
         ArgumentCaptor.forClass(ClientStreamListener.class);
     inOrder.verify(mockStream1).start(sublistenerCaptor1.capture());
-    inOrder.verify(mockStream1).isReady();
+    inOrder.verify(mockStream1).isReady(); // called when substream drained
     inOrder.verifyNoMoreInteractions();
 
     fakeClock.forwardTime(HEDGING_DELAY_IN_SECONDS, TimeUnit.SECONDS);
@@ -2328,8 +2323,7 @@ public class RetriableStreamTest {
     ArgumentCaptor<ClientStreamListener> sublistenerCaptor2 =
         ArgumentCaptor.forClass(ClientStreamListener.class);
     inOrder.verify(mockStream2).start(sublistenerCaptor2.capture());
-    inOrder.verify(mockStream1).isReady();
-    inOrder.verify(mockStream2).isReady();
+    inOrder.verify(mockStream2).isReady(); // called when substream drained
     inOrder.verifyNoMoreInteractions();
 
     Status status = Status.CANCELLED.withDescription("cancelled");
@@ -2369,7 +2363,6 @@ public class RetriableStreamTest {
     ArgumentCaptor<ClientStreamListener> sublistenerCaptor2 =
         ArgumentCaptor.forClass(ClientStreamListener.class);
     verify(mockStream2).start(sublistenerCaptor2.capture());
-    verify(mockStream1, times(2)).isReady();
     verify(mockStream2).isReady();
 
     ClientStreamTracer bufferSizeTracer2 = bufferSizeTracer;
@@ -2402,7 +2395,7 @@ public class RetriableStreamTest {
     ArgumentCaptor<ClientStreamListener> sublistenerCaptor1 =
         ArgumentCaptor.forClass(ClientStreamListener.class);
     verify(mockStream1).start(sublistenerCaptor1.capture());
-    verify(mockStream1).isReady();
+    verify(mockStream1).isReady(); // called when substream drained
 
     ClientStreamTracer bufferSizeTracer1 = bufferSizeTracer;
     bufferSizeTracer1.outboundWireSize(100);
@@ -2411,8 +2404,7 @@ public class RetriableStreamTest {
     ArgumentCaptor<ClientStreamListener> sublistenerCaptor2 =
         ArgumentCaptor.forClass(ClientStreamListener.class);
     verify(mockStream2).start(sublistenerCaptor2.capture());
-    verify(mockStream1, times(2)).isReady();
-    verify(mockStream2).isReady();
+    verify(mockStream2).isReady(); // called when substream drained
 
     ClientStreamTracer bufferSizeTracer2 = bufferSizeTracer;
     bufferSizeTracer2.outboundWireSize(100);


### PR DESCRIPTION
In hedging, multiple `substreamListener.onReady()` may be invoked concurrently, that may result in excessive `masterListener.onReady()` calls (although synchronized). This PR reduces some obvious excessive `onReady()` calls, by checking individual substream's `isReady()` rather than the global `isReady()`. Excessive `onReady()` still exists even after this PR though.