### PR TITLE
Revert android api level check to 14

### DIFF
--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -77,6 +77,7 @@ dependencies {
     compileOnly libraries.javax_annotation
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.3',
+            'androidx.test:rules:1.4.0',
             'androidx.test:runner:1.4.0'
 }
 

--- a/android-interop-testing/src/androidTest/java/io/grpc/android/integrationtest/InteropInstrumentationTest.java
+++ b/android-interop-testing/src/androidTest/java/io/grpc/android/integrationtest/InteropInstrumentationTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 
 import android.util.Log;
 import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
@@ -30,6 +31,7 @@ import io.grpc.android.integrationtest.InteropTask.Listener;
 import java.io.InputStream;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -44,6 +46,12 @@ public class InteropInstrumentationTest {
   private String serverHostOverride;
   private boolean useTestCa;
   private String testCase;
+
+  // Ensures Looper is initialized for tests running on API level 15. Otherwise instantiating an
+  // AsyncTask throws an exception.
+  @Rule
+  public ActivityScenarioRule<TesterActivity> activityRule =
+      new ActivityScenarioRule<TesterActivity>(TesterActivity.class);
 
   @Before
   public void setUp() throws Exception {

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     jmh project(':grpc-core')
 
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
-    signature "net.sf.androidscents.signature:android-api-level-19:4.4.2_r4@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }
 
 javadoc {

--- a/api/src/jmh/java/io/grpc/StatusBenchmark.java
+++ b/api/src/jmh/java/io/grpc/StatusBenchmark.java
@@ -16,7 +16,7 @@
 
 package io.grpc;
 
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -57,7 +57,7 @@ public class StatusBenchmark {
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public String messageDecodePlain() {
     return Status.MESSAGE_KEY.parseBytes(
-        "Unexpected RST in stream".getBytes(StandardCharsets.US_ASCII));
+        "Unexpected RST in stream".getBytes(Charset.forName("US-ASCII")));
   }
 
   /**
@@ -68,7 +68,7 @@ public class StatusBenchmark {
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public String messageDecodeEscape() {
     return Status.MESSAGE_KEY.parseBytes(
-        "Some Error%10Wasabi and Horseradish are the same".getBytes(StandardCharsets.US_ASCII));
+        "Some Error%10Wasabi and Horseradish are the same".getBytes(Charset.forName("US-ASCII")));
   }
 
   /**
@@ -88,7 +88,7 @@ public class StatusBenchmark {
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public Status codeDecode() {
-    return Status.CODE_KEY.parseBytes("15".getBytes(StandardCharsets.US_ASCII));
+    return Status.CODE_KEY.parseBytes("15".getBytes(Charset.forName("US-ASCII")));
   }
 }
 

--- a/api/src/main/java/io/grpc/DecompressorRegistry.java
+++ b/api/src/main/java/io/grpc/DecompressorRegistry.java
@@ -20,7 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Joiner;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -85,7 +85,7 @@ public final class DecompressorRegistry {
 
     decompressors = Collections.unmodifiableMap(newDecompressors);
     advertisedDecompressors = ACCEPT_ENCODING_JOINER.join(getAdvertisedMessageEncodings())
-        .getBytes(StandardCharsets.US_ASCII);
+        .getBytes(Charset.forName("US-ASCII"));
   }
 
   private DecompressorRegistry() {

--- a/api/src/main/java/io/grpc/InternalMetadata.java
+++ b/api/src/main/java/io/grpc/InternalMetadata.java
@@ -20,7 +20,6 @@ import com.google.common.io.BaseEncoding;
 import io.grpc.Metadata.AsciiMarshaller;
 import io.grpc.Metadata.BinaryStreamMarshaller;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 
 /**
  * Internal {@link Metadata} accessor. This is intended for use by io.grpc.internal, and the
@@ -43,7 +42,7 @@ public final class InternalMetadata {
    * Copy of StandardCharsets, which is only available on Java 1.7 and above.
    */
   @Internal
-  public static final Charset US_ASCII = StandardCharsets.US_ASCII;
+  public static final Charset US_ASCII = Charset.forName("US-ASCII");
 
   /**
    * An instance of base64 encoder that omits padding.

--- a/api/src/test/java/io/grpc/StatusTest.java
+++ b/api/src/test/java/io/grpc/StatusTest.java
@@ -21,8 +21,6 @@ import static org.junit.Assert.assertSame;
 
 import io.grpc.Status.Code;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -30,7 +28,7 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link Status}. */
 @RunWith(JUnit4.class)
 public class StatusTest {
-  private final Charset ascii = StandardCharsets.US_ASCII;
+  private final Charset ascii = Charset.forName("US-ASCII");
 
   @Test
   public void verifyExceptionMessage() {

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -14,5 +14,5 @@ dependencies {
     testImplementation project(':grpc-testing'),
             libraries.google_auth_oauth2_http
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
-    signature "net.sf.androidscents.signature:android-api-level-19:4.4.2_r4@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/context/build.gradle
+++ b/context/build.gradle
@@ -15,5 +15,5 @@ dependencies {
         exclude group: 'junit', module: 'junit'
     }
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
-    signature "net.sf.androidscents.signature:android-api-level-19:4.4.2_r4@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     jmh project(':grpc-testing')
 
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
-    signature "net.sf.androidscents.signature:android-api-level-19:4.4.2_r4@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }
 
 javadoc {

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -53,7 +53,7 @@ import io.perfmark.Link;
 import io.perfmark.PerfMark;
 import io.perfmark.Tag;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.util.Locale;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.Executor;
@@ -71,7 +71,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
 
   private static final Logger log = Logger.getLogger(ClientCallImpl.class.getName());
   private static final byte[] FULL_STREAM_DECOMPRESSION_ENCODINGS
-      = "gzip".getBytes(StandardCharsets.US_ASCII);
+      = "gzip".getBytes(Charset.forName("US-ASCII"));
 
   private final MethodDescriptor<ReqT, RespT> method;
   private final Tag tag;

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -55,7 +55,6 @@ import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -76,7 +75,7 @@ public final class GrpcUtil {
 
   private static final Logger log = Logger.getLogger(GrpcUtil.class.getName());
 
-  public static final Charset US_ASCII = StandardCharsets.US_ASCII;
+  public static final Charset US_ASCII = Charset.forName("US-ASCII");
 
   /**
    * {@link io.grpc.Metadata.Key} for the timeout header.

--- a/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
+++ b/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
@@ -202,7 +202,14 @@ class ProxyDetectorImpl implements ProxyDetector {
 
   private ProxiedSocketAddress detectProxy(InetSocketAddress targetAddr) throws IOException {
     URI uri;
-    String host = GrpcUtil.getHost(targetAddr);
+    String host;
+    try {
+      host = GrpcUtil.getHost(targetAddr);
+    } catch (Throwable t) {
+      // Workaround for Android API levels < 19 if getHostName causes a NetworkOnMainThreadException
+      log.log(Level.WARNING, "Failed to get host for proxy lookup, proceeding without proxy", t);
+      return null;
+    }
     try {
       uri =
           new URI(

--- a/cronet/src/main/java/io/grpc/cronet/CronetClientStream.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetClientStream.java
@@ -44,7 +44,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -408,10 +408,10 @@ class CronetClientStream extends AbstractClientStream {
     // String and byte array.
     byte[][] serializedHeaders = TransportFrameUtil.toHttp2Headers(headers);
     for (int i = 0; i < serializedHeaders.length; i += 2) {
-      String key = new String(serializedHeaders[i], StandardCharsets.UTF_8);
+      String key = new String(serializedHeaders[i], Charset.forName("UTF-8"));
       // TODO(ericgribkoff): log an error or throw an exception
       if (isApplicationHeader(key)) {
-        String value = new String(serializedHeaders[i + 1],  StandardCharsets.UTF_8);
+        String value = new String(serializedHeaders[i + 1], Charset.forName("UTF-8"));
         builder.addHeader(key, value);
       }
     }
@@ -588,8 +588,8 @@ class CronetClientStream extends AbstractClientStream {
 
       byte[][] headerValues = new byte[headerList.size()][];
       for (int i = 0; i < headerList.size(); i += 2) {
-        headerValues[i] = headerList.get(i).getBytes(StandardCharsets.UTF_8);
-        headerValues[i + 1] = headerList.get(i + 1).getBytes(StandardCharsets.UTF_8);
+        headerValues[i] = headerList.get(i).getBytes(Charset.forName("UTF-8"));
+        headerValues[i + 1] = headerList.get(i + 1).getBytes(Charset.forName("UTF-8"));
       }
       Metadata metadata =
           InternalMetadata.newMetadata(TransportFrameUtil.toRawSerializedHeaders(headerValues));

--- a/cronet/src/test/java/io/grpc/cronet/CronetClientStreamTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientStreamTest.java
@@ -46,7 +46,7 @@ import io.grpc.testing.TestMethodDescriptors;
 import java.io.ByteArrayInputStream;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -168,7 +168,7 @@ public final class CronetClientStreamTest {
     for (int i = 0; i < 5; ++i) {
       requests[i] = new String("request" + String.valueOf(i));
       buffers[i] = allocator.allocate(requests[i].length());
-      buffers[i].write(requests[i].getBytes(StandardCharsets.UTF_8), 0, requests[i].length());
+      buffers[i].write(requests[i].getBytes(Charset.forName("UTF-8")), 0, requests[i].length());
       // The 3rd and 5th writeFrame calls have flush=true.
       clientStream.abstractClientStreamSink().writeFrame(buffers[i], false, i == 2 || i == 4, 1);
     }
@@ -261,7 +261,7 @@ public final class CronetClientStreamTest {
     callback.onReadCompleted(
         cronetStream,
         info,
-        createMessageFrame(new String("response1").getBytes(StandardCharsets.UTF_8)),
+        createMessageFrame(new String("response1").getBytes(Charset.forName("UTF-8"))),
         false);
     // Haven't request any message, so no callback is called here.
     verify(clientListener, times(0)).messagesAvailable(isA(MessageProducer.class));
@@ -293,7 +293,7 @@ public final class CronetClientStreamTest {
     CronetWritableBufferAllocator allocator = new CronetWritableBufferAllocator();
     String request = new String("request");
     WritableBuffer writableBuffer = allocator.allocate(request.length());
-    writableBuffer.write(request.getBytes(StandardCharsets.UTF_8), 0, request.length());
+    writableBuffer.write(request.getBytes(Charset.forName("UTF-8")), 0, request.length());
     clientStream.abstractClientStreamSink().writeFrame(writableBuffer, false, true, 1);
     ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
     verify(cronetStream, times(1)).write(bufferCaptor.capture(), isA(Boolean.class));
@@ -312,7 +312,7 @@ public final class CronetClientStreamTest {
     callback.onReadCompleted(
         cronetStream,
         info,
-        createMessageFrame(new String("response").getBytes(StandardCharsets.UTF_8)),
+        createMessageFrame(new String("response").getBytes(Charset.forName("UTF-8"))),
         false);
     verify(clientListener, times(1)).messagesAvailable(isA(MessageProducer.class));
     verify(cronetStream, times(2)).read(isA(ByteBuffer.class));
@@ -688,7 +688,7 @@ public final class CronetClientStreamTest {
         .newBidirectionalStreamBuilder(
             isA(String.class), isA(BidirectionalStream.Callback.class), isA(Executor.class));
 
-    byte[] msg = "request".getBytes(StandardCharsets.UTF_8);
+    byte[] msg = "request".getBytes(Charset.forName("UTF-8"));
     stream.writeMessage(new ByteArrayInputStream(msg));
     // We still haven't built the stream or sent anything.
     verify(cronetStream, times(0)).write(isA(ByteBuffer.class), isA(Boolean.class));

--- a/examples/src/main/java/io/grpc/examples/advanced/JsonMarshaller.java
+++ b/examples/src/main/java/io/grpc/examples/advanced/JsonMarshaller.java
@@ -30,7 +30,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 
 /**
  * A {@link Marshaller} for JSON.  This marshals in the Protobuf 3 format described here:
@@ -59,7 +58,7 @@ final class JsonMarshaller {
   public static <T extends Message> Marshaller<T> jsonMarshaller(
       final T defaultInstance, final Parser parser, final Printer printer) {
 
-    final Charset charset = StandardCharsets.UTF_8;
+    final Charset charset = Charset.forName("UTF-8");
 
     return new Marshaller<T>() {
       @Override

--- a/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideUtil.java
+++ b/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideUtil.java
@@ -22,7 +22,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.util.List;
 
 /**
@@ -58,7 +58,7 @@ public class RouteGuideUtil {
   public static List<Feature> parseFeatures(URL file) throws IOException {
     InputStream input = file.openStream();
     try {
-      Reader reader = new InputStreamReader(input, StandardCharsets.UTF_8);
+      Reader reader = new InputStreamReader(input, Charset.forName("UTF-8"));
       try {
         FeatureDatabase.Builder database = FeatureDatabase.newBuilder();
         JsonFormat.parser().merge(reader, database);

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -40,7 +40,6 @@ import io.grpc.okhttp.OkHttpChannelBuilder;
 import java.io.File;
 import java.io.FileInputStream;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
@@ -51,7 +50,7 @@ import javax.annotation.Nullable;
  */
 public class TestServiceClient {
 
-  private static final Charset UTF_8 = StandardCharsets.UTF_8;
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
 
   /**
    * The main application allowing this client to be launched from the command line.

--- a/interop-testing/src/test/java/io/grpc/testing/integration/CompressionTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/CompressionTest.java
@@ -52,7 +52,7 @@ import io.grpc.testing.integration.Messages.SimpleRequest;
 import io.grpc.testing.integration.Messages.SimpleResponse;
 import io.grpc.testing.integration.TestServiceGrpc.TestServiceBlockingStub;
 import io.grpc.testing.integration.TransportCompressionTest.Fzip;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -312,6 +312,6 @@ public class CompressionTest {
   }
 
   private static void assertEqualsString(String expected, byte[] actual) {
-    assertEquals(expected, new String(actual, StandardCharsets.US_ASCII));
+    assertEquals(expected, new String(actual, Charset.forName("US-ASCII")));
   }
 }

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -22,7 +22,7 @@ dependencies {
             project(':grpc-testing'),
             project(':grpc-netty')
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
-    signature "net.sf.androidscents.signature:android-api-level-19:4.4.2_r4@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }
 
 project.sourceSets {

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
@@ -42,7 +42,7 @@ import io.grpc.okhttp.internal.framed.FrameWriter;
 import io.grpc.okhttp.internal.framed.Header;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
@@ -243,7 +243,7 @@ public class OkHttpClientStreamTest {
         eq(false), eq(false), eq(3), eq(0), headersCaptor.capture());
     verify(transport, times(0)).streamReadyToStart(isA(OkHttpClientStream.class));
 
-    byte[] msg = "request".getBytes(StandardCharsets.UTF_8);
+    byte[] msg = "request".getBytes(Charset.forName("UTF-8"));
     stream.writeMessage(new ByteArrayInputStream(msg));
     stream.halfClose();
     verify(transport).streamReadyToStart(eq(stream));

--- a/okhttp/third_party/okhttp/main/java/io/grpc/okhttp/internal/Util.java
+++ b/okhttp/third_party/okhttp/main/java/io/grpc/okhttp/internal/Util.java
@@ -27,7 +27,6 @@ import java.lang.reflect.Array;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -48,7 +47,7 @@ public final class Util {
   public static final String[] EMPTY_STRING_ARRAY = new String[0];
 
   /** A cheap and type-safe constant for the UTF-8 Charset. */
-  public static final Charset UTF_8 = StandardCharsets.UTF_8;
+  public static final Charset UTF_8 = Charset.forName("UTF-8");
 
   private Util() {
   }

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testImplementation project(':grpc-core')
 
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
-    signature "net.sf.androidscents.signature:android-api-level-19:4.4.2_r4@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }
 
 compileTestJava {

--- a/services/src/test/java/io/grpc/protobuf/services/BinlogHelperTest.java
+++ b/services/src/test/java/io/grpc/protobuf/services/BinlogHelperTest.java
@@ -80,7 +80,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -95,7 +94,7 @@ import org.mockito.ArgumentMatchers;
 /** Tests for {@link BinlogHelper}. */
 @RunWith(JUnit4.class)
 public final class BinlogHelperTest {
-  private static final Charset US_ASCII = StandardCharsets.US_ASCII;
+  private static final Charset US_ASCII = Charset.forName("US-ASCII");
   private static final BinlogHelper HEADER_FULL = new Builder().header(Integer.MAX_VALUE).build();
   private static final BinlogHelper HEADER_256 = new Builder().header(256).build();
   private static final BinlogHelper MSG_FULL = new Builder().msg(Integer.MAX_VALUE).build();

--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation libraries.truth,
             project(':grpc-testing')
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
-    signature "net.sf.androidscents.signature:android-api-level-19:4.4.2_r4@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }
 
 javadoc {


### PR DESCRIPTION
There are internal integration tests running on devices with Android API level lower than 19. Revert #8327 and #8814 