### PR TITLE
netty: Assign the result of a @CheckReturnValue'ed constructor to an unused variable

### DIFF
--- a/netty/src/test/java/io/grpc/netty/KeepAliveEnforcerTest.java
+++ b/netty/src/test/java/io/grpc/netty/KeepAliveEnforcerTest.java
@@ -32,12 +32,12 @@ public class KeepAliveEnforcerTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void negativeTime() {
-    new KeepAliveEnforcer(true, -1, TimeUnit.NANOSECONDS);
+    KeepAliveEnforcer unused = new KeepAliveEnforcer(true, -1, TimeUnit.NANOSECONDS);
   }
 
   @Test(expected = NullPointerException.class)
   public void nullTimeUnit() {
-    new KeepAliveEnforcer(true, 1, null);
+    KeepAliveEnforcer unused = new KeepAliveEnforcer(true, 1, null);
   }
 
   @Test


### PR DESCRIPTION
This fixes a soon-to-be compile error via ErrorProne.

Alternatively, we could use assertThrows() instead of
@Test(expected = ...), but grpc doesn't yet require Java 8.

CC @kluever 