### PR TITLE
android-interop-test: add JetifyAndroidManifest.xml

### DIFF
--- a/android-interop-testing/src/main/AndroidManifest.xml
+++ b/android-interop-testing/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/Base.V7.Theme.AppCompat.Light"
-        android:name="androidx.multidex.MultiDexApplication" >
+        android:name="android.support.multidex.MultiDexApplication" >
         <activity
             android:name=".TesterActivity"
             android:label="@string/app_name" >

--- a/android-interop-testing/src/main/JetifyAndroidManifest.xml
+++ b/android-interop-testing/src/main/JetifyAndroidManifest.xml
@@ -9,7 +9,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/Base.V7.Theme.AppCompat.Light"
-        android:name="androidx.multidex.MultiDexApplication" >
+        android:name="android.support.multidex.MultiDexApplication" >
         <activity
             android:name=".TesterActivity"
             android:label="@string/app_name" >

--- a/android-interop-testing/src/main/JetifyAndroidManifest.xml
+++ b/android-interop-testing/src/main/JetifyAndroidManifest.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Only needed internally while Google's migration to Jetpack(Androidx) is still in progress. -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="io.grpc.android.integrationtest" >
 

--- a/android-interop-testing/src/main/JetifyAndroidManifest.xml
+++ b/android-interop-testing/src/main/JetifyAndroidManifest.xml
@@ -1,27 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.grpc.android.integrationtest" >
+  package="io.grpc.android.integrationtest" >
 
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
-        android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:theme="@style/Base.V7.Theme.AppCompat.Light"
-        android:name="android.support.multidex.MultiDexApplication" >
+      android:allowBackup="true"
+      android:icon="@mipmap/ic_launcher"
+      android:label="@string/app_name"
+      android:theme="@style/Base.V7.Theme.AppCompat.Light"
+      android:name="android.support.multidex.MultiDexApplication" >
         <activity
-            android:name=".TesterActivity"
-            android:label="@string/app_name" >
+          android:name=".TesterActivity"
+          android:label="@string/app_name"
+          android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <!-- To support tests under binder, which need Android services -->
-        <service android:name="io.grpc.binder.HostServices$HostService1"/>
-        <service android:name="io.grpc.binder.HostServices$HostService2"/>
     </application>
 
 </manifest>

--- a/android-interop-testing/src/main/JetifyAndroidManifest.xml
+++ b/android-interop-testing/src/main/JetifyAndroidManifest.xml
@@ -21,6 +21,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <!-- To support tests under binder, which need Android services -->
+        <service android:name="io.grpc.binder.HostServices$HostService1"/>
+        <service android:name="io.grpc.binder.HostServices$HostService2"/>
     </application>
 
 </manifest>


### PR DESCRIPTION
Fix internal tests failure introduced in #8808. It was (manually) fixed internally during the last import but somehow I must have missed the step to upstream the fix first. 