### PR TITLE
RELEASING.md: Use git merge-base instead of cherry for backport summary

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -85,7 +85,7 @@ would be used to create all `v1.7` tags (e.g. `v1.7.0`, `v1.7.1`).
    $ echo "## gRPC Java $MAJOR.$MINOR.0 Release Notes" && echo && \
      git shortlog "$(git merge-base upstream/v$MAJOR.$((MINOR-1)).x upstream/v$MAJOR.$MINOR.x)"..upstream/v$MAJOR.$MINOR.x | cat && \
      echo && echo && echo "Backported commits in previous release:" && \
-     git cherry -v v$MAJOR.$((MINOR-1)).0 upstream/v$MAJOR.$MINOR.x | grep ^-
+     git log --oneline "$(git merge-base v$MAJOR.$((MINOR-1)).0 upstream/v$MAJOR.$MINOR.x)"..v$MAJOR.$((MINOR-1)).0^
    ```
 
 Tagging the Release


### PR DESCRIPTION
git cherry is too conservative in determining backports. Showing all
commits between the branch point and the release is more reliable.