### PR TITLE
rls: fix RLS lb name

### DIFF
--- a/rls/src/main/java/io/grpc/rls/RlsLoadBalancerProvider.java
+++ b/rls/src/main/java/io/grpc/rls/RlsLoadBalancerProvider.java
@@ -30,9 +30,9 @@ import io.grpc.rls.RlsProtoData.RouteLookupConfig;
 import java.util.Map;
 
 /**
- * The provider for the "rls-experimental" balancing policy.  This class should not be directly
+ * The provider for the "rls_experimental" balancing policy.  This class should not be directly
  * referenced in code.  The policy should be accessed through {@link
- * io.grpc.LoadBalancerRegistry#getProvider} with the name "rls-experimental".
+ * io.grpc.LoadBalancerRegistry#getProvider} with the name "rls_experimental".
  */
 @Internal
 public final class RlsLoadBalancerProvider extends LoadBalancerProvider {
@@ -49,7 +49,7 @@ public final class RlsLoadBalancerProvider extends LoadBalancerProvider {
 
   @Override
   public String getPolicyName() {
-    return "rls-experimental";
+    return "rls_experimental";
   }
 
   @Override


### PR DESCRIPTION
As pointed out by @easwars , the lb name of RLS lb should be "rls_experimental" instead of "rls-experimental", using underscore like "round_robin".