### PR TITLE
rls: support routeLookupChannelServiceConfig in RLS lb config

### DIFF
--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -23,8 +23,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Converter;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.ChannelLogger;
@@ -82,13 +80,6 @@ final class CachingRlsLbClient {
       REQUEST_CONVERTER = new RlsProtoConverters.RouteLookupRequestConverter().reverse();
   private static final Converter<RouteLookupResponse, io.grpc.lookup.v1.RouteLookupResponse>
       RESPONSE_CONVERTER = new RouteLookupResponseConverter().reverse();
-
-  // System property to use direct path enabled OobChannel, by default direct path is enabled.
-  private static final String RLS_ENABLE_OOB_CHANNEL_DIRECTPATH_PROPERTY =
-      "io.grpc.rls.CachingRlsLbClient.enable_oobchannel_directpath";
-  @VisibleForTesting
-  static boolean enableOobChannelDirectPath =
-      Boolean.parseBoolean(System.getProperty(RLS_ENABLE_OOB_CHANNEL_DIRECTPATH_PROPERTY, "false"));
 
   // All cache status changes (pending, backoff, success) must be under this lock
   private final Object lock = new Object();
@@ -158,9 +149,8 @@ final class CachingRlsLbClient {
     ManagedChannelBuilder<?> rlsChannelBuilder = helper.createResolvingOobChannelBuilder(
         rlsConfig.getLookupService(), helper.getUnsafeChannelCredentials());
     rlsChannelBuilder.overrideAuthority(helper.getAuthority());
-    if (enableOobChannelDirectPath) {
-      Map<String, ?> directPathServiceConfig =
-          getDirectPathServiceConfig(rlsConfig.getLookupService());
+    Map<String, ?> directPathServiceConfig = lbPolicyConfig.getRouteLookupChannelServiceConfig();
+    if (directPathServiceConfig != null) {
       logger.log(
           ChannelLogLevel.DEBUG,
           "RLS channel direct path enabled. RLS channel service config: {0}",
@@ -182,21 +172,6 @@ final class CachingRlsLbClient {
             childLbHelperProvider,
             new BackoffRefreshListener());
     logger.log(ChannelLogLevel.DEBUG, "CachingRlsLbClient created");
-  }
-
-  private static ImmutableMap<String, Object> getDirectPathServiceConfig(String serviceName) {
-    ImmutableMap<String, Object> pickFirstStrategy =
-        ImmutableMap.<String, Object>of("pick_first", ImmutableMap.of());
-
-    ImmutableMap<String, Object> childPolicy =
-        ImmutableMap.<String, Object>of(
-            "childPolicy", ImmutableList.of(pickFirstStrategy),
-            "serviceName", serviceName);
-
-    ImmutableMap<String, Object> grpcLbPolicy =
-        ImmutableMap.<String, Object>of("grpclb", childPolicy);
-
-    return ImmutableMap.<String, Object>of("loadBalancingConfig", ImmutableList.of(grpcLbPolicy));
   }
 
   @CheckReturnValue

--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -154,7 +154,7 @@ final class CachingRlsLbClient {
     if (routeLookupChannelServiceConfig != null) {
       logger.log(
           ChannelLogLevel.DEBUG,
-          "RLS channel direct path enabled. RLS channel service config: {0}",
+          "RLS channel service config: {0}",
           routeLookupChannelServiceConfig);
       rlsChannelBuilder.defaultServiceConfig(routeLookupChannelServiceConfig);
       rlsChannelBuilder.disableServiceConfigLookUp();

--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -149,13 +149,14 @@ final class CachingRlsLbClient {
     ManagedChannelBuilder<?> rlsChannelBuilder = helper.createResolvingOobChannelBuilder(
         rlsConfig.getLookupService(), helper.getUnsafeChannelCredentials());
     rlsChannelBuilder.overrideAuthority(helper.getAuthority());
-    Map<String, ?> directPathServiceConfig = lbPolicyConfig.getRouteLookupChannelServiceConfig();
-    if (directPathServiceConfig != null) {
+    Map<String, ?> routeLookupChannelServiceConfig =
+        lbPolicyConfig.getRouteLookupChannelServiceConfig();
+    if (routeLookupChannelServiceConfig != null) {
       logger.log(
           ChannelLogLevel.DEBUG,
           "RLS channel direct path enabled. RLS channel service config: {0}",
-          directPathServiceConfig);
-      rlsChannelBuilder.defaultServiceConfig(directPathServiceConfig);
+          routeLookupChannelServiceConfig);
+      rlsChannelBuilder.defaultServiceConfig(routeLookupChannelServiceConfig);
       rlsChannelBuilder.disableServiceConfigLookUp();
     }
     rlsChannel = rlsChannelBuilder.build();

--- a/rls/src/main/java/io/grpc/rls/LbPolicyConfiguration.java
+++ b/rls/src/main/java/io/grpc/rls/LbPolicyConfiguration.java
@@ -42,22 +42,32 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /** Configuration for RLS load balancing policy. */
 final class LbPolicyConfiguration {
 
   private final RouteLookupConfig routeLookupConfig;
+  @Nullable
+  private final Map<String, ?> routeLookupChannelServiceConfig;
   private final ChildLoadBalancingPolicy policy;
 
   LbPolicyConfiguration(
-      RouteLookupConfig routeLookupConfig, ChildLoadBalancingPolicy policy) {
+      RouteLookupConfig routeLookupConfig, @Nullable Map<String, ?> routeLookupChannelServiceConfig,
+      ChildLoadBalancingPolicy policy) {
     this.routeLookupConfig = checkNotNull(routeLookupConfig, "routeLookupConfig");
+    this.routeLookupChannelServiceConfig = routeLookupChannelServiceConfig;
     this.policy = checkNotNull(policy, "policy");
   }
 
   RouteLookupConfig getRouteLookupConfig() {
     return routeLookupConfig;
+  }
+
+  @Nonnull
+  Map<String, ?> getRouteLookupChannelServiceConfig() {
+    return routeLookupChannelServiceConfig;
   }
 
   ChildLoadBalancingPolicy getLoadBalancingPolicy() {
@@ -74,18 +84,20 @@ final class LbPolicyConfiguration {
     }
     LbPolicyConfiguration that = (LbPolicyConfiguration) o;
     return Objects.equals(routeLookupConfig, that.routeLookupConfig)
+        && Objects.equals(routeLookupChannelServiceConfig, that.routeLookupChannelServiceConfig)
         && Objects.equals(policy, that.policy);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(routeLookupConfig, policy);
+    return Objects.hash(routeLookupConfig, routeLookupChannelServiceConfig, policy);
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("routeLookupConfig", routeLookupConfig)
+        .add("routeLookupChannelServiceConfig", routeLookupChannelServiceConfig)
         .add("policy", policy)
         .toString();
   }

--- a/rls/src/main/java/io/grpc/rls/LbPolicyConfiguration.java
+++ b/rls/src/main/java/io/grpc/rls/LbPolicyConfiguration.java
@@ -42,7 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /** Configuration for RLS load balancing policy. */
@@ -65,7 +64,7 @@ final class LbPolicyConfiguration {
     return routeLookupConfig;
   }
 
-  @Nonnull
+  @Nullable
   Map<String, ?> getRouteLookupChannelServiceConfig() {
     return routeLookupChannelServiceConfig;
   }

--- a/rls/src/main/java/io/grpc/rls/RlsLoadBalancerProvider.java
+++ b/rls/src/main/java/io/grpc/rls/RlsLoadBalancerProvider.java
@@ -62,12 +62,15 @@ public final class RlsLoadBalancerProvider extends LoadBalancerProvider {
     try {
       RouteLookupConfig routeLookupConfig = new RouteLookupConfigConverter()
           .convert(JsonUtil.getObject(rawLoadBalancingConfigPolicy, "routeLookupConfig"));
+      Map<String, ?> routeLookupChannelServiceConfig =
+          JsonUtil.getObject(rawLoadBalancingConfigPolicy, "routeLookupChannelServiceConfig");
       ChildLoadBalancingPolicy lbPolicy = ChildLoadBalancingPolicy
           .create(
               JsonUtil.getString(rawLoadBalancingConfigPolicy, "childPolicyConfigTargetFieldName"),
               JsonUtil.checkObjectList(
                   checkNotNull(JsonUtil.getList(rawLoadBalancingConfigPolicy, "childPolicy"))));
-      return ConfigOrError.fromConfig(new LbPolicyConfiguration(routeLookupConfig, lbPolicy));
+      return ConfigOrError.fromConfig(
+          new LbPolicyConfiguration(routeLookupConfig, routeLookupChannelServiceConfig, lbPolicy));
     } catch (Exception e) {
       return ConfigOrError.fromError(
           Status.INVALID_ARGUMENT

--- a/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
+++ b/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
@@ -235,7 +235,7 @@ public class CachingRlsLbClientTest {
   }
 
   @Test
-  public void rls_overDirectPath() throws Exception {
+  public void rls_withCustomRlsChannelServiceConfig() throws Exception {
     Map<String, ?> routeLookupChannelServiceConfig =
         ImmutableMap.of(
             "loadBalancingConfig",

--- a/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
@@ -118,15 +118,11 @@ public class RlsLoadBalancerTest {
   private MethodDescriptor<Object, Object> fakeSearchMethod;
   private MethodDescriptor<Object, Object> fakeRescueMethod;
   private RlsLoadBalancer rlsLb;
-  private boolean existingEnableOobChannelDirectPath;
   private String defaultTarget = "defaultTarget";
 
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
-
-    existingEnableOobChannelDirectPath = CachingRlsLbClient.enableOobChannelDirectPath;
-    CachingRlsLbClient.enableOobChannelDirectPath = false;
 
     fakeSearchMethod =
         MethodDescriptor.newBuilder()
@@ -168,7 +164,6 @@ public class RlsLoadBalancerTest {
   @After
   public void tearDown() throws Exception {
     rlsLb.shutdown();
-    CachingRlsLbClient.enableOobChannelDirectPath = existingEnableOobChannelDirectPath;
   }
 
   @Test


### PR DESCRIPTION
Implementing the latest change for RLS lb config.

```
The configuration for the LB policy will be of the following form:

{
  "routeLookupConfig": <JSON form of RouteLookupConfig proto>,
  "routeLookupChannelServiceConfig": {...service config JSON...},
  "childPolicy": [
    {"<policy name>": {...child policy config...}}
  ],
  "childPolicyConfigTargetFieldName": "<name of field>"
}
```

>If the routeLookupChannelServiceConfig field is present, we will pass the specified service config to the RLS control plane channel, and we will disable fetching service config via that channel's resolver.
