### PR TITLE
core/netty: infinite local-only transparent retry for netty

### DIFF
--- a/core/src/main/java/io/grpc/internal/ClientStreamListener.java
+++ b/core/src/main/java/io/grpc/internal/ClientStreamListener.java
@@ -57,12 +57,16 @@ public interface ClientStreamListener extends StreamListener {
      */
     PROCESSED,
     /**
-     * The RPC is not processed by the server's application logic.
+     * The stream on the wire is created but not processed by the server's application logic.
      */
     REFUSED,
     /**
      * The RPC is dropped (by load balancer).
      */
-    DROPPED
+    DROPPED,
+    /**
+     * The stream is closed even before anything leaves the client.
+     */
+    MISCARRIED
   }
 }

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -851,8 +851,9 @@ abstract class RetriableStream<ReqT> implements ClientStream {
       }
 
       if (state.winningSubstream == null) {
-        if (rpcProgress == RpcProgress.REFUSED
-            && noMoreTransparentRetry.compareAndSet(false, true)) {
+        if (rpcProgress == RpcProgress.MISCARRIED
+            || (rpcProgress == RpcProgress.REFUSED
+                && noMoreTransparentRetry.compareAndSet(false, true))) {
           // transparent retry
           final Substream newSubstream = createSubstream(substream.previousAttemptCount, true);
           if (isHedging) {

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -101,7 +101,9 @@ abstract class RetriableStream<ReqT> implements ClientStream {
       false, 0);
 
   /**
-   * Either transparent retry happened or reached server's application logic.
+   * Either non-local transparent retry happened or reached server's application logic.
+   *
+   * <p>Note that local-only transparent retries are unlimited.
    */
   private final AtomicBoolean noMoreTransparentRetry = new AtomicBoolean();
 

--- a/core/src/main/java/io/grpc/internal/SubchannelChannel.java
+++ b/core/src/main/java/io/grpc/internal/SubchannelChannel.java
@@ -43,7 +43,7 @@ final class SubchannelChannel extends Channel {
       Status.UNAVAILABLE.withDescription(
           "wait-for-ready RPC is not supported on Subchannel.asChannel()");
   private static final FailingClientTransport notReadyTransport =
-      new FailingClientTransport(NOT_READY_ERROR, RpcProgress.REFUSED);
+      new FailingClientTransport(NOT_READY_ERROR, RpcProgress.MISCARRIED);
   private final InternalSubchannel subchannel;
   private final Executor executor;
   private final ScheduledExecutorService deadlineCancellationExecutor;

--- a/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
@@ -18,6 +18,7 @@ package io.grpc.internal;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.internal.ClientStreamListener.RpcProgress.DROPPED;
+import static io.grpc.internal.ClientStreamListener.RpcProgress.MISCARRIED;
 import static io.grpc.internal.ClientStreamListener.RpcProgress.PROCESSED;
 import static io.grpc.internal.ClientStreamListener.RpcProgress.REFUSED;
 import static io.grpc.internal.RetriableStream.GRPC_PREVIOUS_RPC_ATTEMPTS;
@@ -1611,7 +1612,7 @@ public class RetriableStreamTest {
   }
 
   @Test
-  public void transparentRetry() {
+  public void transparentRetry_onlyOnceOnRefused() {
     ClientStream mockStream1 = mock(ClientStream.class);
     ClientStream mockStream2 = mock(ClientStream.class);
     ClientStream mockStream3 = mock(ClientStream.class);
@@ -1652,6 +1653,55 @@ public class RetriableStreamTest {
     assertEquals(1, fakeClock.numPendingTasks());
     fakeClock.forwardTime((long) (INITIAL_BACKOFF_IN_SECONDS * FAKE_RANDOM), TimeUnit.SECONDS);
     inOrder.verify(retriableStreamRecorder).newSubstream(1);
+    ArgumentCaptor<ClientStreamListener> sublistenerCaptor3 =
+        ArgumentCaptor.forClass(ClientStreamListener.class);
+    inOrder.verify(mockStream3).start(sublistenerCaptor3.capture());
+    inOrder.verify(mockStream3).isReady();
+    inOrder.verifyNoMoreInteractions();
+    verify(retriableStreamRecorder, never()).postCommit();
+    assertEquals(0, fakeClock.numPendingTasks());
+  }
+
+  @Test
+  public void transparentRetry_unlimitedTimesOnMiscarried() {
+    ClientStream mockStream1 = mock(ClientStream.class);
+    ClientStream mockStream2 = mock(ClientStream.class);
+    ClientStream mockStream3 = mock(ClientStream.class);
+    InOrder inOrder = inOrder(
+        retriableStreamRecorder,
+        mockStream1, mockStream2, mockStream3);
+
+    // start
+    doReturn(mockStream1).when(retriableStreamRecorder).newSubstream(0);
+    retriableStream.start(masterListener);
+
+    inOrder.verify(retriableStreamRecorder).newSubstream(0);
+    ArgumentCaptor<ClientStreamListener> sublistenerCaptor1 =
+        ArgumentCaptor.forClass(ClientStreamListener.class);
+    inOrder.verify(mockStream1).start(sublistenerCaptor1.capture());
+    inOrder.verify(mockStream1).isReady();
+    inOrder.verifyNoMoreInteractions();
+
+    // transparent retry
+    doReturn(mockStream2).when(retriableStreamRecorder).newSubstream(0);
+    sublistenerCaptor1.getValue()
+        .closed(Status.fromCode(NON_RETRIABLE_STATUS_CODE), MISCARRIED, new Metadata());
+
+    inOrder.verify(retriableStreamRecorder).newSubstream(0);
+    ArgumentCaptor<ClientStreamListener> sublistenerCaptor2 =
+        ArgumentCaptor.forClass(ClientStreamListener.class);
+    inOrder.verify(mockStream2).start(sublistenerCaptor2.capture());
+    inOrder.verify(mockStream2).isReady();
+    inOrder.verifyNoMoreInteractions();
+    verify(retriableStreamRecorder, never()).postCommit();
+    assertEquals(0, fakeClock.numPendingTasks());
+
+    // more transparent retry
+    doReturn(mockStream3).when(retriableStreamRecorder).newSubstream(0);
+    sublistenerCaptor2.getValue()
+        .closed(Status.fromCode(NON_RETRIABLE_STATUS_CODE), MISCARRIED, new Metadata());
+
+    inOrder.verify(retriableStreamRecorder).newSubstream(0);
     ArgumentCaptor<ClientStreamListener> sublistenerCaptor3 =
         ArgumentCaptor.forClass(ClientStreamListener.class);
     inOrder.verify(mockStream3).start(sublistenerCaptor3.capture());

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -642,7 +642,6 @@ class NettyClientHandler extends AbstractNettyHandler {
                 Status status = statusFromH2Error(
                     Status.Code.UNAVAILABLE, "GOAWAY closed buffered stream",
                     e.errorCode(), e.debugData());
-                status = status.withCause(cause);
                 cause = status.asRuntimeException();
                 stream.transportReportStatus(status, RpcProgress.MISCARRIED, true, new Metadata());
               } else if (cause instanceof StreamBufferingEncoder.Http2ChannelClosedException) {

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -673,11 +673,7 @@ class NettyClientHandler extends AbstractNettyHandler {
     try {
       Status reason = cmd.reason();
       if (reason != null) {
-        if (cmd.stream().isNonExistent())  {
-          stream.transportReportStatus(reason, RpcProgress.MISCARRIED, true, new Metadata());
-        } else {
-          stream.transportReportStatus(reason, RpcProgress.PROCESSED, true, new Metadata());
-        }
+        stream.transportReportStatus(reason, true, new Metadata());
       }
       if (!cmd.stream().isNonExistent()) {
         encoder().writeRstStream(ctx, stream.id(), Http2Error.CANCEL.code(), promise);

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -645,16 +645,12 @@ class NettyClientHandler extends AbstractNettyHandler {
                 cause = status.asRuntimeException();
                 stream.transportReportStatus(status, RpcProgress.MISCARRIED, true, new Metadata());
               } else if (cause instanceof StreamBufferingEncoder.Http2ChannelClosedException) {
-                if (lifecycleManager.getShutdownStatus() == null) {
-                  Status status = Status.UNAVAILABLE.withCause(cause)
+                Status status = lifecycleManager.getShutdownStatus();
+                if (status == null) {
+                  status = Status.UNAVAILABLE.withCause(cause)
                       .withDescription("Connection closed while stream is buffered");
-                  stream.transportReportStatus(
-                      status, RpcProgress.MISCARRIED, true, new Metadata());
-                } else {
-                  stream.transportReportStatus(
-                      lifecycleManager.getShutdownStatus(), RpcProgress.MISCARRIED, true,
-                      new Metadata());
                 }
+                stream.transportReportStatus(status, RpcProgress.MISCARRIED, true, new Metadata());
               }
               promise.setFailure(cause);
             }

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -18,6 +18,7 @@ package io.grpc.netty;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.truth.Truth.assertThat;
+import static io.grpc.internal.ClientStreamListener.RpcProgress.MISCARRIED;
 import static io.grpc.internal.ClientStreamListener.RpcProgress.PROCESSED;
 import static io.grpc.internal.ClientStreamListener.RpcProgress.REFUSED;
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
@@ -378,7 +379,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
     channelRead(goAwayFrame(0, 8 /* Cancel */, Unpooled.copiedBuffer("this is a test", UTF_8)));
 
     ArgumentCaptor<Status> captor = ArgumentCaptor.forClass(Status.class);
-    verify(streamListener).closed(captor.capture(), same(REFUSED),
+    verify(streamListener).closed(captor.capture(), same(MISCARRIED),
         ArgumentMatchers.<Metadata>notNull());
     assertEquals(Status.UNAVAILABLE.getCode(), captor.getValue().getCode());
     assertEquals(


### PR DESCRIPTION
In core, add a new enum element to `RpcProgress` for the case that the stream is closed even before anything leaves the client. `RetriableStream` will do unlimited transparent retry for this type of `RpcProgress` since they are local-only.

In netty, call `tranportReportStatus()` for pending streams on failure.