### PR TITLE
core: test JsonUtil.getObject with a map containing a null value

### DIFF
--- a/core/src/test/java/io/grpc/internal/JsonUtilTest.java
+++ b/core/src/test/java/io/grpc/internal/JsonUtilTest.java
@@ -19,6 +19,7 @@ package io.grpc.internal;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
@@ -129,5 +130,17 @@ public class JsonUtilTest {
     assertThat(JsonUtil.getNumberAsDouble(map, "key_nonexistent")).isNull();
     assertThat(JsonUtil.getNumberAsInteger(map, "key_nonexistent")).isNull();
     assertThat(JsonUtil.getNumberAsLong(map, "key_nonexistent")).isNull();
+  }
+
+  @Test
+  public void getObject_mapExplicitNullValue() {
+    Map<String, ?> mapWithNullValue = Collections.singletonMap("key", null);
+    try {
+      JsonUtil.getObject(mapWithNullValue, "key");
+      fail("ClassCastException expected");
+    } catch (ClassCastException e) {
+      assertThat(e).hasMessageThat()
+          .isEqualTo("value 'null' for key 'key' in '{key=null}' is not object");
+    }
   }
 }


### PR DESCRIPTION
Verifies the behavior of `JsonUtil.getObject` when the map contains a null value for a given key.

Context: https://github.com/grpc/grpc-java/pull/8871#discussion_r796191392