### PR TITLE
benchmarks: Modernize client to use target and credentials

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -27,7 +27,7 @@ dependencies {
             project(':grpc-stub'),
             project(':grpc-protobuf'),
             project(':grpc-testing'),
-            project(':grpc-xds'),
+            project(path: ':grpc-xds', configuration: 'shadow'),
             libraries.hdrhistogram,
             libraries.netty_tcnative,
             libraries.netty_epoll,

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -27,6 +27,7 @@ dependencies {
             project(':grpc-stub'),
             project(':grpc-protobuf'),
             project(':grpc-testing'),
+            project(':grpc-xds'),
             libraries.hdrhistogram,
             libraries.netty_tcnative,
             libraries.netty_epoll,

--- a/benchmarks/src/main/java/io/grpc/benchmarks/SocketAddressValidator.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/SocketAddressValidator.java
@@ -33,6 +33,11 @@ public interface SocketAddressValidator {
     public boolean isValidSocketAddress(SocketAddress address) {
       return address instanceof InetSocketAddress;
     }
+
+    @Override
+    public boolean isValidSocketAddress(String address) {
+      return !address.startsWith("unix://");
+    }
   };
 
   /**
@@ -43,10 +48,20 @@ public interface SocketAddressValidator {
     public boolean isValidSocketAddress(SocketAddress address) {
       return "DomainSocketAddress".equals(address.getClass().getSimpleName());
     }
+
+    @Override
+    public boolean isValidSocketAddress(String address) {
+      return address.startsWith("unix://");
+    }
   };
 
   /**
    * Returns {@code true} if the given address is valid.
    */
   boolean isValidSocketAddress(SocketAddress address);
+
+  /**
+   * Returns {@code true} if the given address is valid.
+   */
+  boolean isValidSocketAddress(String address);
 }

--- a/benchmarks/src/main/java/io/grpc/benchmarks/Transport.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/Transport.java
@@ -16,8 +16,6 @@
 
 package io.grpc.benchmarks;
 
-import java.net.SocketAddress;
-
 /**
  * All of the supported transports.
  */
@@ -49,7 +47,7 @@ public enum Transport {
    *
    * @throws IllegalArgumentException if the given address is invalid for this transport.
    */
-  public void validateSocketAddress(SocketAddress address) {
+  public void validateSocketAddress(String address) {
     if (!socketAddressValidator.isValidSocketAddress(address)) {
       throw new IllegalArgumentException(
           "Invalid address " + address + " for transport " + this);

--- a/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadClient.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadClient.java
@@ -82,7 +82,7 @@ class LoadClient {
       channels[i] =
           Utils.newClientChannel(
               Epoll.isAvailable() ?  Transport.NETTY_EPOLL : Transport.NETTY_NIO,
-              Utils.parseSocketAddress(config.getServerTargets(i % config.getServerTargetsCount())),
+              config.getServerTargets(i % config.getServerTargetsCount()),
               config.hasSecurityParams(),
               config.hasSecurityParams() && config.getSecurityParams().getUseTestCa(),
               config.hasSecurityParams()

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/ServerConfiguration.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/ServerConfiguration.java
@@ -142,7 +142,7 @@ class ServerConfiguration implements Configuration {
         + "(unix:///path/to/file), depending on the transport selected.", null, true) {
       @Override
       protected void setServerValue(ServerConfiguration config, String value) {
-        SocketAddress address = Utils.parseSocketAddress(value);
+        SocketAddress address = Utils.parseServerSocketAddress(value);
         if (address instanceof InetSocketAddress) {
           InetSocketAddress addr = (InetSocketAddress) address;
           int port = addr.getPort() == 0 ? Utils.pickUnusedPort() : addr.getPort();


### PR DESCRIPTION
This allows using LoadClient with xDS.

The changes to SocketAddressValidator are a bit hacky, but we really
don't care about cleanliness there. Eventually on client-side, we should
be deleting the unix special case entirely, as we'll have a unix name
resolver.

Fixes #8877

----

I manually tested the QPS client, but not LoadClient. The change is small there, so I assume/hope it works; I find it really annoying to set up.