### PR TITLE
xds: fix the validation code to accept new-style CertificateProviderPluginInstance wherever used

### DIFF
--- a/xds/src/main/java/io/grpc/xds/internal/sds/CommonTlsContextUtil.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/CommonTlsContextUtil.java
@@ -27,8 +27,8 @@ public final class CommonTlsContextUtil {
 
   static boolean hasCertProviderInstance(CommonTlsContext commonTlsContext) {
     return commonTlsContext != null
-        && (commonTlsContext.hasTlsCertificateCertificateProviderInstance()
-            || hasCertProviderValidationContext(commonTlsContext));
+        && (hasIdentityCertificateProviderInstance(commonTlsContext)
+        || hasCertProviderValidationContext(commonTlsContext));
   }
 
   private static boolean hasCertProviderValidationContext(CommonTlsContext commonTlsContext) {
@@ -37,7 +37,18 @@ public final class CommonTlsContextUtil {
           commonTlsContext.getCombinedValidationContext();
       return combinedCertificateValidationContext.hasValidationContextCertificateProviderInstance();
     }
-    return commonTlsContext.hasValidationContextCertificateProviderInstance();
+    return hasValidationProviderInstance(commonTlsContext);
+  }
+
+  private static boolean hasIdentityCertificateProviderInstance(CommonTlsContext commonTlsContext) {
+    return commonTlsContext.hasTlsCertificateProviderInstance()
+        || commonTlsContext.hasTlsCertificateCertificateProviderInstance();
+  }
+
+  private static boolean hasValidationProviderInstance(CommonTlsContext commonTlsContext) {
+    return (commonTlsContext.hasValidationContext() && commonTlsContext.getValidationContext()
+        .hasCaCertificateProviderInstance())
+        || commonTlsContext.hasValidationContextCertificateProviderInstance();
   }
 
   /**

--- a/xds/src/main/java/io/grpc/xds/internal/sds/CommonTlsContextUtil.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/CommonTlsContextUtil.java
@@ -26,9 +26,11 @@ public final class CommonTlsContextUtil {
   private CommonTlsContextUtil() {}
 
   static boolean hasCertProviderInstance(CommonTlsContext commonTlsContext) {
-    return commonTlsContext != null
-        && (hasIdentityCertificateProviderInstance(commonTlsContext)
-        || hasCertProviderValidationContext(commonTlsContext));
+    if (commonTlsContext == null) {
+      return false;
+    }
+    return hasIdentityCertificateProviderInstance(commonTlsContext)
+        || hasCertProviderValidationContext(commonTlsContext);
   }
 
   private static boolean hasCertProviderValidationContext(CommonTlsContext commonTlsContext) {
@@ -46,9 +48,11 @@ public final class CommonTlsContextUtil {
   }
 
   private static boolean hasValidationProviderInstance(CommonTlsContext commonTlsContext) {
-    return (commonTlsContext.hasValidationContext() && commonTlsContext.getValidationContext()
-        .hasCaCertificateProviderInstance())
-        || commonTlsContext.hasValidationContextCertificateProviderInstance();
+    if (commonTlsContext.hasValidationContext() && commonTlsContext.getValidationContext()
+        .hasCaCertificateProviderInstance()) {
+      return true;
+    }
+    return commonTlsContext.hasValidationContextCertificateProviderInstance();
   }
 
   /**


### PR DESCRIPTION
Update `CommonTlsContextUtil` validation functions to accept new-style `CertificateProviderPluginInstance`

fixes #8885
