### PR TITLE
rls: migrate data types to AutoValue

### DIFF
--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -115,14 +115,14 @@ final class CachingRlsLbClient {
     synchronizationContext = helper.getSynchronizationContext();
     lbPolicyConfig = checkNotNull(builder.lbPolicyConfig, "lbPolicyConfig");
     RouteLookupConfig rlsConfig = lbPolicyConfig.getRouteLookupConfig();
-    maxAgeNanos = rlsConfig.getMaxAgeInNanos();
-    staleAgeNanos = rlsConfig.getStaleAgeInNanos();
-    callTimeoutNanos = rlsConfig.getLookupServiceTimeoutInNanos();
+    maxAgeNanos = rlsConfig.maxAgeInNanos();
+    staleAgeNanos = rlsConfig.staleAgeInNanos();
+    callTimeoutNanos = rlsConfig.lookupServiceTimeoutInNanos();
     timeProvider = checkNotNull(builder.timeProvider, "timeProvider");
     throttler = checkNotNull(builder.throttler, "throttler");
     linkedHashLruCache =
         new RlsAsyncLruCache(
-            rlsConfig.getCacheSizeBytes(),
+            rlsConfig.cacheSizeBytes(),
             builder.evictionListener,
             scheduledExecutorService,
             timeProvider,
@@ -147,7 +147,7 @@ final class CachingRlsLbClient {
     // will be looked up differently than the backends; overrideAuthority(helper.getAuthority()) is
     // called to impose the authority security restrictions.
     ManagedChannelBuilder<?> rlsChannelBuilder = helper.createResolvingOobChannelBuilder(
-        rlsConfig.getLookupService(), helper.getUnsafeChannelCredentials());
+        rlsConfig.lookupService(), helper.getUnsafeChannelCredentials());
     rlsChannelBuilder.overrideAuthority(helper.getAuthority());
     Map<String, ?> routeLookupChannelServiceConfig =
         lbPolicyConfig.getRouteLookupChannelServiceConfig();
@@ -893,7 +893,7 @@ final class CachingRlsLbClient {
         headers.discardAll(RLS_DATA_KEY);
         headers.put(RLS_DATA_KEY, response.getHeaderData());
       }
-      String defaultTarget = lbPolicyConfig.getRouteLookupConfig().getDefaultTarget();
+      String defaultTarget = lbPolicyConfig.getRouteLookupConfig().defaultTarget();
       boolean hasFallback = defaultTarget != null && !defaultTarget.isEmpty();
       if (response.hasData()) {
         ChildPolicyWrapper childPolicyWrapper = response.getChildPolicyWrapper();
@@ -933,7 +933,7 @@ final class CachingRlsLbClient {
     }
 
     private void startFallbackChildPolicy() {
-      String defaultTarget = lbPolicyConfig.getRouteLookupConfig().getDefaultTarget();
+      String defaultTarget = lbPolicyConfig.getRouteLookupConfig().defaultTarget();
       logger.log(ChannelLogLevel.DEBUG, "starting fallback to {0}", defaultTarget);
       synchronized (lock) {
         if (fallbackChildPolicyWrapper != null) {
@@ -953,7 +953,7 @@ final class CachingRlsLbClient {
     @Override
     public String toString() {
       return MoreObjects.toStringHelper(this)
-          .add("target", lbPolicyConfig.getRouteLookupConfig().getLookupService())
+          .add("target", lbPolicyConfig.getRouteLookupConfig().lookupService())
           .toString();
     }
   }

--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -518,7 +518,7 @@ final class CachingRlsLbClient {
       // TODO(creamsoup) fallback to other targets if first one is not available
       childPolicyWrapper =
           refCountedChildPolicyWrapperFactory
-              .createOrGet(response.getTargets().get(0));
+              .createOrGet(response.targets().get(0));
       long now = timeProvider.currentTimeNanos();
       expireTime = now + maxAgeNanos;
       staleTime = now + staleAgeNanos;
@@ -576,7 +576,7 @@ final class CachingRlsLbClient {
     int getSizeBytes() {
       // size of strings and java object overhead, actual memory usage is more than this.
       return
-          (response.getTargets().get(0).length() + response.getHeaderData().length()) * 2 + 38 * 2;
+          (response.targets().get(0).length() + response.getHeaderData().length()) * 2 + 38 * 2;
     }
 
     @Override

--- a/rls/src/main/java/io/grpc/rls/RlsLoadBalancer.java
+++ b/rls/src/main/java/io/grpc/rls/RlsLoadBalancer.java
@@ -56,8 +56,8 @@ final class RlsLoadBalancer extends LoadBalancer {
     checkNotNull(lbPolicyConfiguration, "Missing rls lb config");
     if (!lbPolicyConfiguration.equals(this.lbPolicyConfiguration)) {
       boolean needToConnect = this.lbPolicyConfiguration == null
-          || !this.lbPolicyConfiguration.getRouteLookupConfig().getLookupService().equals(
-          lbPolicyConfiguration.getRouteLookupConfig().getLookupService());
+          || !this.lbPolicyConfiguration.getRouteLookupConfig().lookupService().equals(
+          lbPolicyConfiguration.getRouteLookupConfig().lookupService());
       if (needToConnect) {
         if (routeLookupClient != null) {
           routeLookupClient.close();

--- a/rls/src/main/java/io/grpc/rls/RlsProtoConverters.java
+++ b/rls/src/main/java/io/grpc/rls/RlsProtoConverters.java
@@ -201,8 +201,9 @@ final class RlsProtoConverters {
         checkArgument(
             requiredMatch == null || !requiredMatch,
             "requiredMatch shouldn't be specified for gRPC");
-        NameMatcher matcher = new NameMatcher(
-            JsonUtil.getString(rawHeader, "key"), (List<String>) rawHeader.get("names"));
+        NameMatcher matcher = NameMatcher.create(
+            JsonUtil.getString(rawHeader, "key"),
+            ImmutableList.copyOf((List<String>) rawHeader.get("names")));
         nameMatchersBuilder.add(matcher);
       }
       ExtraKeys extraKeys = ExtraKeys.DEFAULT;
@@ -228,7 +229,7 @@ final class RlsProtoConverters {
     Set<String> keys = new HashSet<>(constantKeys);
     keys.addAll(EXTRA_KEY_NAMES);
     for (NameMatcher nameMatcher :  nameMatchers) {
-      keys.add(nameMatcher.getKey());
+      keys.add(nameMatcher.key());
     }
     if (keys.size() != nameMatchers.size() + constantKeys.size() + EXTRA_KEY_NAMES.size()) {
       throw new IllegalArgumentException("keys in KeyBuilder must be unique");

--- a/rls/src/main/java/io/grpc/rls/RlsProtoConverters.java
+++ b/rls/src/main/java/io/grpc/rls/RlsProtoConverters.java
@@ -189,7 +189,7 @@ final class RlsProtoConverters {
       for (Map<String, ?> rawName : rawNames) {
         String serviceName = JsonUtil.getString(rawName, "service");
         checkArgument(!Strings.isNullOrEmpty(serviceName), "service must not be empty or null");
-        namesBuilder.add(new Name(serviceName, JsonUtil.getString(rawName, "method")));
+        namesBuilder.add(Name.create(serviceName, JsonUtil.getString(rawName, "method")));
       }
       List<?> rawRawHeaders = JsonUtil.getList(keyBuilder, "headers");
       List<Map<String, ?>> rawHeaders =

--- a/rls/src/main/java/io/grpc/rls/RlsProtoConverters.java
+++ b/rls/src/main/java/io/grpc/rls/RlsProtoConverters.java
@@ -63,7 +63,8 @@ final class RlsProtoConverters {
 
     @Override
     protected RlsProtoData.RouteLookupRequest doForward(RouteLookupRequest routeLookupRequest) {
-      return new RlsProtoData.RouteLookupRequest(routeLookupRequest.getKeyMapMap());
+      return RlsProtoData.RouteLookupRequest.create(
+          ImmutableMap.copyOf(routeLookupRequest.getKeyMapMap()));
     }
 
     @Override
@@ -71,7 +72,7 @@ final class RlsProtoConverters {
       return
           RouteLookupRequest.newBuilder()
               .setTargetType("grpc")
-              .putAllKeyMap(routeLookupRequest.getKeyMap())
+              .putAllKeyMap(routeLookupRequest.keyMap())
               .build();
     }
   }
@@ -86,15 +87,15 @@ final class RlsProtoConverters {
     @Override
     protected RlsProtoData.RouteLookupResponse doForward(RouteLookupResponse routeLookupResponse) {
       return
-          new RlsProtoData.RouteLookupResponse(
-              routeLookupResponse.getTargetsList(),
+          RlsProtoData.RouteLookupResponse.create(
+              ImmutableList.copyOf(routeLookupResponse.getTargetsList()),
               routeLookupResponse.getHeaderData());
     }
 
     @Override
     protected RouteLookupResponse doBackward(RlsProtoData.RouteLookupResponse routeLookupResponse) {
       return RouteLookupResponse.newBuilder()
-          .addAllTargets(routeLookupResponse.getTargets())
+          .addAllTargets(routeLookupResponse.targets())
           .setHeaderData(routeLookupResponse.getHeaderData())
           .build();
     }

--- a/rls/src/main/java/io/grpc/rls/RlsProtoConverters.java
+++ b/rls/src/main/java/io/grpc/rls/RlsProtoConverters.java
@@ -108,7 +108,7 @@ final class RlsProtoConverters {
 
     @Override
     protected RouteLookupConfig doForward(Map<String, ?> json) {
-      List<GrpcKeyBuilder> grpcKeyBuilders =
+      ImmutableList<GrpcKeyBuilder> grpcKeyBuilders =
           GrpcKeyBuilderConverter.covertAll(
               checkNotNull(JsonUtil.getListOfObjects(json, "grpcKeyBuilders"), "grpcKeyBuilders"));
       checkArgument(!grpcKeyBuilders.isEmpty(), "must have at least one GrpcKeyBuilder");
@@ -145,14 +145,15 @@ final class RlsProtoConverters {
       checkArgument(cacheSize > 0, "cacheSize must be positive");
       cacheSize = Math.min(cacheSize, MAX_CACHE_SIZE);
       String defaultTarget = Strings.emptyToNull(JsonUtil.getString(json, "defaultTarget"));
-      return new RouteLookupConfig(
-          grpcKeyBuilders,
-          lookupService,
-          /* lookupServiceTimeoutInNanos= */ timeout,
-          /* maxAgeInNanos= */ maxAge,
-          /* staleAgeInNanos= */ staleAge,
-          /* cacheSizeBytes= */ cacheSize,
-          defaultTarget);
+      return RouteLookupConfig.builder()
+          .grpcKeyBuilders(grpcKeyBuilders)
+          .lookupService(lookupService)
+          .lookupServiceTimeoutInNanos(timeout)
+          .maxAgeInNanos(maxAge)
+          .staleAgeInNanos(staleAge)
+          .cacheSizeBytes(cacheSize)
+          .defaultTarget(defaultTarget)
+          .build();
     }
 
     private static <T> T orDefault(@Nullable T value, T defaultValue) {
@@ -169,12 +170,12 @@ final class RlsProtoConverters {
   }
 
   private static final class GrpcKeyBuilderConverter {
-    public static List<GrpcKeyBuilder> covertAll(List<Map<String, ?>> keyBuilders) {
-      List<GrpcKeyBuilder> keyBuilderList = new ArrayList<>();
+    public static ImmutableList<GrpcKeyBuilder> covertAll(List<Map<String, ?>> keyBuilders) {
+      ImmutableList.Builder<GrpcKeyBuilder> keyBuilderList = ImmutableList.builder();
       for (Map<String, ?> keyBuilder : keyBuilders) {
         keyBuilderList.add(convert(keyBuilder));
       }
-      return keyBuilderList;
+      return keyBuilderList.build();
     }
 
     @SuppressWarnings("unchecked")

--- a/rls/src/main/java/io/grpc/rls/RlsProtoData.java
+++ b/rls/src/main/java/io/grpc/rls/RlsProtoData.java
@@ -134,41 +134,8 @@ final class RlsProtoData {
   }
 
   /** A config object for gRPC RouteLookupService. */
-  @Immutable
-  static final class RouteLookupConfig {
-
-    private final ImmutableList<GrpcKeyBuilder> grpcKeyBuilders;
-
-    private final String lookupService;
-
-    private final long lookupServiceTimeoutInNanos;
-
-    private final long maxAgeInNanos;
-
-    private final long staleAgeInNanos;
-
-    private final long cacheSizeBytes;
-
-    @Nullable
-    private final String defaultTarget;
-
-    RouteLookupConfig(
-        List<GrpcKeyBuilder> grpcKeyBuilders,
-        String lookupService,
-        long lookupServiceTimeoutInNanos,
-        long maxAgeInNanos,
-        long staleAgeInNanos,
-        long cacheSizeBytes,
-        @Nullable
-        String defaultTarget) {
-      this.grpcKeyBuilders = ImmutableList.copyOf(grpcKeyBuilders);
-      this.lookupService = lookupService;
-      this.lookupServiceTimeoutInNanos = lookupServiceTimeoutInNanos;
-      this.maxAgeInNanos = maxAgeInNanos;
-      this.staleAgeInNanos = staleAgeInNanos;
-      this.cacheSizeBytes = cacheSizeBytes;
-      this.defaultTarget = defaultTarget;
-    }
+  @AutoValue
+  abstract static class RouteLookupConfig {
 
     /**
      * Returns unordered specifications for constructing keys for gRPC requests. All GrpcKeyBuilders
@@ -176,36 +143,25 @@ final class RlsProtoData {
      * keyed by name. If no GrpcKeyBuilder matches, an empty key_map will be sent to the lookup
      * service; it should likely reply with a global default route and raise an alert.
      */
-    ImmutableList<GrpcKeyBuilder> getGrpcKeyBuilders() {
-      return grpcKeyBuilders;
-    }
+    abstract ImmutableList<GrpcKeyBuilder> grpcKeyBuilders();
 
     /**
      * Returns the name of the lookup service as a gRPC URI. Typically, this will be a subdomain of
      * the target, such as "lookup.datastore.googleapis.com".
      */
-    String getLookupService() {
-      return lookupService;
-    }
+    abstract String lookupService();
 
     /** Returns the timeout value for lookup service requests. */
-    long getLookupServiceTimeoutInNanos() {
-      return lookupServiceTimeoutInNanos;
-    }
-
+    abstract long lookupServiceTimeoutInNanos();
 
     /** Returns the maximum age the result will be cached. */
-    long getMaxAgeInNanos() {
-      return maxAgeInNanos;
-    }
+    abstract long maxAgeInNanos();
 
     /**
      * Returns the time when an entry will be in a staled status. When cache is accessed whgen the
      * entry is in staled status, it will
      */
-    long getStaleAgeInNanos() {
-      return staleAgeInNanos;
-    }
+    abstract long staleAgeInNanos();
 
     /**
      * Returns a rough indicator of amount of memory to use for the client cache. Some of the data
@@ -213,9 +169,7 @@ final class RlsProtoData {
      * than this value.  If this field is omitted or set to zero, a client default will be used.
      * The value may be capped to a lower amount based on client configuration.
      */
-    long getCacheSizeBytes() {
-      return cacheSizeBytes;
-    }
+    abstract long cacheSizeBytes();
 
     /**
      * Returns the default target to use if needed.  If nonempty (implies request processing
@@ -224,51 +178,30 @@ final class RlsProtoData {
      * {@literal e.g.} "us_east_1.cloudbigtable.googleapis.com".
      */
     @Nullable
-    String getDefaultTarget() {
-      return defaultTarget;
+    abstract String defaultTarget();
+
+    static Builder builder() {
+      return new AutoValue_RlsProtoData_RouteLookupConfig.Builder();
     }
 
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      RouteLookupConfig that = (RouteLookupConfig) o;
-      return lookupServiceTimeoutInNanos == that.lookupServiceTimeoutInNanos
-          && maxAgeInNanos == that.maxAgeInNanos
-          && staleAgeInNanos == that.staleAgeInNanos
-          && cacheSizeBytes == that.cacheSizeBytes
-          && Objects.equal(grpcKeyBuilders, that.grpcKeyBuilders)
-          && Objects.equal(lookupService, that.lookupService)
-          && Objects.equal(defaultTarget, that.defaultTarget);
-    }
+    @AutoValue.Builder
+    abstract static class Builder {
 
-    @Override
-    public int hashCode() {
-      return Objects.hashCode(
-          grpcKeyBuilders,
-          lookupService,
-          lookupServiceTimeoutInNanos,
-          maxAgeInNanos,
-          staleAgeInNanos,
-          cacheSizeBytes,
-          defaultTarget);
-    }
+      abstract Builder grpcKeyBuilders(ImmutableList<GrpcKeyBuilder> grpcKeyBuilders);
 
-    @Override
-    public String toString() {
-      return MoreObjects.toStringHelper(this)
-          .add("grpcKeyBuilders", grpcKeyBuilders)
-          .add("lookupService", lookupService)
-          .add("lookupServiceTimeoutInNanos", lookupServiceTimeoutInNanos)
-          .add("maxAgeInNanos", maxAgeInNanos)
-          .add("staleAgeInNanos", staleAgeInNanos)
-          .add("cacheSize", cacheSizeBytes)
-          .add("defaultTarget", defaultTarget)
-          .toString();
+      abstract Builder lookupService(String lookupService);
+
+      abstract Builder lookupServiceTimeoutInNanos(long lookupServiceTimeoutInNanos);
+
+      abstract Builder maxAgeInNanos(long maxAgeInNanos);
+
+      abstract Builder staleAgeInNanos(long staleAgeInNanos);
+
+      abstract Builder cacheSizeBytes(long cacheSizeBytes);
+
+      abstract Builder defaultTarget(@Nullable String defaultTarget);
+
+      abstract RouteLookupConfig build();
     }
   }
 

--- a/rls/src/main/java/io/grpc/rls/RlsProtoData.java
+++ b/rls/src/main/java/io/grpc/rls/RlsProtoData.java
@@ -211,52 +211,18 @@ final class RlsProtoData {
    * The name must match one of the names listed in the "name" field. If the "required_match" field
    * is true, one of the specified names must be present for the keybuilder to match.
    */
+  @AutoValue
   @Immutable
-  static final class NameMatcher {
-
-    private final String key;
-
-    private final ImmutableList<String> names;
-
-    NameMatcher(String key, List<String> names) {
-      this.key = checkNotNull(key, "key");
-      this.names = ImmutableList.copyOf(checkNotNull(names, "names"));
-    }
+  abstract static class NameMatcher {
 
     /** The name that will be used in the RLS key_map to refer to this value. */
-    String getKey() {
-      return key;
-    }
+    abstract String key();
 
     /** Returns ordered list of names; the first non-empty value will be used. */
-    ImmutableList<String> names() {
-      return names;
-    }
+    abstract ImmutableList<String> names();
 
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      NameMatcher matcher = (NameMatcher) o;
-      return java.util.Objects.equals(key, matcher.key)
-          && java.util.Objects.equals(names, matcher.names);
-    }
-
-    @Override
-    public int hashCode() {
-      return java.util.Objects.hash(key, names);
-    }
-
-    @Override
-    public String toString() {
-      return MoreObjects.toStringHelper(this)
-          .add("key", key)
-          .add("names", names)
-          .toString();
+    static NameMatcher create(String key, ImmutableList<String> names) {
+      return new AutoValue_RlsProtoData_NameMatcher(key, names);
     }
   }
 

--- a/rls/src/main/java/io/grpc/rls/RlsProtoData.java
+++ b/rls/src/main/java/io/grpc/rls/RlsProtoData.java
@@ -202,7 +202,7 @@ final class RlsProtoData {
       @Nullable
       abstract String method();
 
-      static Name create(String service, String method) {
+      static Name create(String service, @Nullable String method) {
         return new AutoValue_RlsProtoData_GrpcKeyBuilder_Name(service, method);
       }
     }

--- a/rls/src/main/java/io/grpc/rls/RlsProtoData.java
+++ b/rls/src/main/java/io/grpc/rls/RlsProtoData.java
@@ -262,52 +262,17 @@ final class RlsProtoData {
      * required and includes the proto package name. The method name may be omitted, in which case
      * any method on the given service is matched.
      */
-    static final class Name {
+    @AutoValue
+    @Immutable
+    abstract static class Name {
 
-      private final String service;
-
-      @Nullable
-      private final String method;
-
-      /** The primary constructor. */
-      Name(String service, @Nullable String method) {
-        this.service = service;
-        this.method = method;
-      }
-
-      String getService() {
-        return service;
-      }
+      abstract String service();
 
       @Nullable
-      String getMethod() {
-        return method;
-      }
+      abstract String method();
 
-      @Override
-      public boolean equals(Object o) {
-        if (this == o) {
-          return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-          return false;
-        }
-        Name name = (Name) o;
-        return Objects.equal(service, name.service)
-            && Objects.equal(method, name.method);
-      }
-
-      @Override
-      public int hashCode() {
-        return Objects.hashCode(service, method);
-      }
-
-      @Override
-      public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("service", service)
-            .add("method", method)
-            .toString();
+      static Name create(String service, String method) {
+        return new AutoValue_RlsProtoData_GrpcKeyBuilder_Name(service, method);
       }
     }
   }

--- a/rls/src/main/java/io/grpc/rls/RlsProtoData.java
+++ b/rls/src/main/java/io/grpc/rls/RlsProtoData.java
@@ -135,6 +135,7 @@ final class RlsProtoData {
 
   /** A config object for gRPC RouteLookupService. */
   @AutoValue
+  @Immutable
   abstract static class RouteLookupConfig {
 
     /**
@@ -260,24 +261,9 @@ final class RlsProtoData {
   }
 
   /** GrpcKeyBuilder is a configuration to construct headers consumed by route lookup service. */
-  static final class GrpcKeyBuilder {
-
-    private final ImmutableList<Name> names;
-
-    private final ImmutableList<NameMatcher> headers;
-    private final ExtraKeys extraKeys;
-    private final ImmutableMap<String, String> constantKeys;
-
-    /** Constructor. All args should be nonnull. Headers should head unique keys. */
-    GrpcKeyBuilder(
-        List<Name> names, List<NameMatcher> headers, ExtraKeys extraKeys,
-        Map<String, String> constantKeys) {
-      checkState(names != null && !names.isEmpty(), "names cannot be empty");
-      this.names = ImmutableList.copyOf(names);
-      this.headers = ImmutableList.copyOf(headers);
-      this.extraKeys = checkNotNull(extraKeys, "extraKeys");
-      this.constantKeys = ImmutableMap.copyOf(checkNotNull(constantKeys, "constantKeys"));
-    }
+  @AutoValue
+  @Immutable
+  abstract static class GrpcKeyBuilder {
 
     /**
      * Returns names. To match, one of the given Name fields must match; the service and method
@@ -285,53 +271,23 @@ final class RlsProtoData {
      * package name. The method name may be omitted, in which case any method on the given service
      * is matched.
      */
-    ImmutableList<Name> getNames() {
-      return names;
-    }
+    abstract ImmutableList<Name> names();
 
     /**
      * Returns a list of NameMatchers for header. Extract keys from all listed headers. For gRPC, it
      * is an error to specify "required_match" on the NameMatcher protos, and we ignore it if set.
      */
-    ImmutableList<NameMatcher> getHeaders() {
-      return headers;
-    }
+    abstract ImmutableList<NameMatcher> headers();
 
-    ExtraKeys getExtraKeys() {
-      return extraKeys;
-    }
+    abstract ExtraKeys extraKeys();
 
-    ImmutableMap<String, String> getConstantKeys() {
-      return constantKeys;
-    }
+    abstract ImmutableMap<String, String> constantKeys();
 
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      GrpcKeyBuilder that = (GrpcKeyBuilder) o;
-      return Objects.equal(names, that.names) && Objects.equal(headers, that.headers)
-          && Objects.equal(extraKeys, that.extraKeys)
-          && Objects.equal(constantKeys, that.constantKeys);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hashCode(names, headers, extraKeys, constantKeys);
-    }
-
-    @Override
-    public String toString() {
-      return MoreObjects.toStringHelper(this)
-          .add("names", names)
-          .add("headers", headers)
-          .add("extraKeys", extraKeys)
-          .add("constantKeys", constantKeys)
-          .toString();
+    static GrpcKeyBuilder create(
+        ImmutableList<Name> names,
+        ImmutableList<NameMatcher> headers,
+        ExtraKeys extraKeys, ImmutableMap<String, String> constantKeys) {
+      return new AutoValue_RlsProtoData_GrpcKeyBuilder(names, headers, extraKeys, constantKeys);
     }
 
     /**

--- a/rls/src/main/java/io/grpc/rls/RlsProtoData.java
+++ b/rls/src/main/java/io/grpc/rls/RlsProtoData.java
@@ -16,16 +16,9 @@
 
 package io.grpc.rls;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
-
 import com.google.auto.value.AutoValue;
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import java.util.List;
-import java.util.Map;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -35,101 +28,39 @@ final class RlsProtoData {
   private RlsProtoData() {}
 
   /** A request object sent to route lookup service. */
+  @AutoValue
   @Immutable
-  static final class RouteLookupRequest {
-
-    private final ImmutableMap<String, String> keyMap;
-
-    RouteLookupRequest(Map<String, String> keyMap) {
-      this.keyMap = ImmutableMap.copyOf(checkNotNull(keyMap, "keyMap"));
-    }
+  abstract static class RouteLookupRequest {
 
     /** Returns a map of key values extracted via key builders for the gRPC or HTTP request. */
-    ImmutableMap<String, String> getKeyMap() {
-      return keyMap;
-    }
+    abstract ImmutableMap<String, String> keyMap();
 
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      RouteLookupRequest that = (RouteLookupRequest) o;
-      return Objects.equal(keyMap, that.keyMap);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hashCode(keyMap);
-    }
-
-    @Override
-    public String toString() {
-      return MoreObjects.toStringHelper(this)
-          .add("keyMap", keyMap)
-          .toString();
+    static RouteLookupRequest create(ImmutableMap<String, String> keyMap) {
+      return new AutoValue_RlsProtoData_RouteLookupRequest(keyMap);
     }
   }
 
   /** A response from route lookup service. */
+  @AutoValue
   @Immutable
-  static final class RouteLookupResponse {
-
-    private final ImmutableList<String> targets;
-
-    private final String headerData;
-
-    RouteLookupResponse(List<String> targets, String headerData) {
-      checkState(targets != null && !targets.isEmpty(), "targets cannot be empty or null");
-      this.targets = ImmutableList.copyOf(targets);
-      this.headerData = checkNotNull(headerData, "headerData");
-    }
+  abstract static class RouteLookupResponse {
 
     /**
      * Returns list of targets. Prioritized list (best one first) of addressable entities to use for
      * routing, using syntax requested by the request target_type. The targets will be tried in
      * order until a healthy one is found.
      */
-    ImmutableList<String> getTargets() {
-      return targets;
-    }
+    abstract ImmutableList<String> targets();
 
     /**
      * Returns optional header data to pass along to AFE in the X-Google-RLS-Data header. Cached
      * with "target" and sent with all requests that match the request key. Allows the RLS to pass
      * its work product to the eventual target.
      */
-    String getHeaderData() {
-      return headerData;
-    }
+    abstract String getHeaderData();
 
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      RouteLookupResponse that = (RouteLookupResponse) o;
-      return java.util.Objects.equals(targets, that.targets)
-          && java.util.Objects.equals(headerData, that.headerData);
-    }
-
-    @Override
-    public int hashCode() {
-      return java.util.Objects.hash(targets, headerData);
-    }
-
-    @Override
-    public String toString() {
-      return MoreObjects.toStringHelper(this)
-          .add("targets", targets)
-          .add("headerData", headerData)
-          .toString();
+    static RouteLookupResponse create(ImmutableList<String> targets, String getHeaderData) {
+      return new AutoValue_RlsProtoData_RouteLookupResponse(targets, getHeaderData);
     }
   }
 
@@ -278,6 +209,7 @@ final class RlsProtoData {
   }
 
   @AutoValue
+  @Immutable
   abstract static class ExtraKeys {
     static final ExtraKeys DEFAULT = create(null, null, null);
 

--- a/rls/src/main/java/io/grpc/rls/RlsRequestFactory.java
+++ b/rls/src/main/java/io/grpc/rls/RlsRequestFactory.java
@@ -52,9 +52,9 @@ final class RlsRequestFactory {
     Map<String, GrpcKeyBuilder> table = new HashMap<>();
     for (GrpcKeyBuilder grpcKeyBuilder : config.grpcKeyBuilders()) {
       for (Name name : grpcKeyBuilder.names()) {
-        boolean hasMethod = name.getMethod() == null || name.getMethod().isEmpty();
-        String method = hasMethod ? "*" : name.getMethod();
-        String path = "/" + name.getService() + "/" + method;
+        boolean hasMethod = name.method() == null || name.method().isEmpty();
+        String method = hasMethod ? "*" : name.method();
+        String path = "/" + name.service() + "/" + method;
         table.put(path, grpcKeyBuilder);
       }
     }

--- a/rls/src/main/java/io/grpc/rls/RlsRequestFactory.java
+++ b/rls/src/main/java/io/grpc/rls/RlsRequestFactory.java
@@ -50,7 +50,7 @@ final class RlsRequestFactory {
   private static Map<String, GrpcKeyBuilder> createKeyBuilderTable(
       RouteLookupConfig config) {
     Map<String, GrpcKeyBuilder> table = new HashMap<>();
-    for (GrpcKeyBuilder grpcKeyBuilder : config.getGrpcKeyBuilders()) {
+    for (GrpcKeyBuilder grpcKeyBuilder : config.grpcKeyBuilders()) {
       for (Name name : grpcKeyBuilder.getNames()) {
         boolean hasMethod = name.getMethod() == null || name.getMethod().isEmpty();
         String method = hasMethod ? "*" : name.getMethod();

--- a/rls/src/main/java/io/grpc/rls/RlsRequestFactory.java
+++ b/rls/src/main/java/io/grpc/rls/RlsRequestFactory.java
@@ -104,7 +104,7 @@ final class RlsRequestFactory {
         }
       }
       if (value != null) {
-        rlsRequestHeaders.put(nameMatcher.getKey(), value);
+        rlsRequestHeaders.put(nameMatcher.key(), value);
       }
     }
     return rlsRequestHeaders;

--- a/rls/src/main/java/io/grpc/rls/RlsRequestFactory.java
+++ b/rls/src/main/java/io/grpc/rls/RlsRequestFactory.java
@@ -73,9 +73,9 @@ final class RlsRequestFactory {
       grpcKeyBuilder = keyBuilderTable.get("/" + service + "/*");
     }
     if (grpcKeyBuilder == null) {
-      return new RouteLookupRequest(ImmutableMap.<String, String>of());
+      return RouteLookupRequest.create(ImmutableMap.<String, String>of());
     }
-    Map<String, String> rlsRequestHeaders =
+    ImmutableMap.Builder<String, String> rlsRequestHeaders =
         createRequestHeaders(metadata, grpcKeyBuilder.headers());
     ExtraKeys extraKeys = grpcKeyBuilder.extraKeys();
     Map<String, String> constantKeys = grpcKeyBuilder.constantKeys();
@@ -89,12 +89,12 @@ final class RlsRequestFactory {
       rlsRequestHeaders.put(extraKeys.method(), method);
     }
     rlsRequestHeaders.putAll(constantKeys);
-    return new RouteLookupRequest(rlsRequestHeaders);
+    return RouteLookupRequest.create(rlsRequestHeaders.build());
   }
 
-  private Map<String, String> createRequestHeaders(
+  private ImmutableMap.Builder<String, String> createRequestHeaders(
       Metadata metadata, List<NameMatcher> keyBuilder) {
-    Map<String, String> rlsRequestHeaders = new HashMap<>();
+    ImmutableMap.Builder<String, String> rlsRequestHeaders = ImmutableMap.builder();
     for (NameMatcher nameMatcher : keyBuilder) {
       String value = null;
       for (String requestHeaderName : nameMatcher.names()) {

--- a/rls/src/main/java/io/grpc/rls/RlsRequestFactory.java
+++ b/rls/src/main/java/io/grpc/rls/RlsRequestFactory.java
@@ -51,7 +51,7 @@ final class RlsRequestFactory {
       RouteLookupConfig config) {
     Map<String, GrpcKeyBuilder> table = new HashMap<>();
     for (GrpcKeyBuilder grpcKeyBuilder : config.grpcKeyBuilders()) {
-      for (Name name : grpcKeyBuilder.getNames()) {
+      for (Name name : grpcKeyBuilder.names()) {
         boolean hasMethod = name.getMethod() == null || name.getMethod().isEmpty();
         String method = hasMethod ? "*" : name.getMethod();
         String path = "/" + name.getService() + "/" + method;
@@ -76,9 +76,9 @@ final class RlsRequestFactory {
       return new RouteLookupRequest(ImmutableMap.<String, String>of());
     }
     Map<String, String> rlsRequestHeaders =
-        createRequestHeaders(metadata, grpcKeyBuilder.getHeaders());
-    ExtraKeys extraKeys = grpcKeyBuilder.getExtraKeys();
-    Map<String, String> constantKeys = grpcKeyBuilder.getConstantKeys();
+        createRequestHeaders(metadata, grpcKeyBuilder.headers());
+    ExtraKeys extraKeys = grpcKeyBuilder.extraKeys();
+    Map<String, String> constantKeys = grpcKeyBuilder.constantKeys();
     if (extraKeys.host() != null) {
       rlsRequestHeaders.put(extraKeys.host(), target);
     }

--- a/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
+++ b/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
@@ -188,12 +188,12 @@ public class CachingRlsLbClientTest {
   public void get_noError_lifeCycle() throws Exception {
     setUpRlsLbClient();
     InOrder inOrder = inOrder(evictionListener);
-    RouteLookupRequest routeLookupRequest = new RouteLookupRequest(ImmutableMap.of(
+    RouteLookupRequest routeLookupRequest = RouteLookupRequest.create(ImmutableMap.of(
         "server", "bigtable.googleapis.com", "service-key", "foo", "method-key", "bar"));
     rlsServerImpl.setLookupTable(
         ImmutableMap.of(
             routeLookupRequest,
-            new RouteLookupResponse(ImmutableList.of("target"), "header")));
+            RouteLookupResponse.create(ImmutableList.of("target"), "header")));
 
     // initial request
     CachedRouteLookupResponse resp = getInSyncContext(routeLookupRequest);
@@ -258,12 +258,12 @@ public class CachingRlsLbClientTest {
             .setThrottler(fakeThrottler)
             .setTimeProvider(fakeTimeProvider)
             .build();
-    RouteLookupRequest routeLookupRequest = new RouteLookupRequest(ImmutableMap.of(
+    RouteLookupRequest routeLookupRequest = RouteLookupRequest.create(ImmutableMap.of(
         "server", "bigtable.googleapis.com", "service-key", "foo", "method-key", "bar"));
     rlsServerImpl.setLookupTable(
         ImmutableMap.of(
             routeLookupRequest,
-            new RouteLookupResponse(ImmutableList.of("target"), "header")));
+            RouteLookupResponse.create(ImmutableList.of("target"), "header")));
 
     // initial request
     CachedRouteLookupResponse resp = getInSyncContext(routeLookupRequest);
@@ -282,12 +282,12 @@ public class CachingRlsLbClientTest {
   @Test
   public void get_throttledAndRecover() throws Exception {
     setUpRlsLbClient();
-    RouteLookupRequest routeLookupRequest = new RouteLookupRequest(ImmutableMap.of(
+    RouteLookupRequest routeLookupRequest = RouteLookupRequest.create(ImmutableMap.of(
         "server", "bigtable.googleapis.com", "service-key", "foo", "method-key", "bar"));
     rlsServerImpl.setLookupTable(
         ImmutableMap.of(
             routeLookupRequest,
-            new RouteLookupResponse(ImmutableList.of("target"), "header")));
+            RouteLookupResponse.create(ImmutableList.of("target"), "header")));
 
     fakeThrottler.nextResult = true;
     fakeBackoffProvider.nextPolicy = createBackoffPolicy(10, TimeUnit.MILLISECONDS);
@@ -325,12 +325,12 @@ public class CachingRlsLbClientTest {
   public void get_updatesLbState() throws Exception {
     setUpRlsLbClient();
     InOrder inOrder = inOrder(helper);
-    RouteLookupRequest routeLookupRequest = new RouteLookupRequest(ImmutableMap.of(
+    RouteLookupRequest routeLookupRequest = RouteLookupRequest.create(ImmutableMap.of(
         "server", "bigtable.googleapis.com", "service-key", "service1", "method-key", "create"));
     rlsServerImpl.setLookupTable(
         ImmutableMap.of(
             routeLookupRequest,
-            new RouteLookupResponse(
+            RouteLookupResponse.create(
                 ImmutableList.of("primary.cloudbigtable.googleapis.com"),
                 "header-rls-data-value")));
 
@@ -366,7 +366,7 @@ public class CachingRlsLbClientTest {
     fakeBackoffProvider.nextPolicy = createBackoffPolicy(100, TimeUnit.MILLISECONDS);
     // try to get invalid
     RouteLookupRequest invalidRouteLookupRequest =
-        new RouteLookupRequest(ImmutableMap.<String, String>of());
+        RouteLookupRequest.create(ImmutableMap.<String, String>of());
     CachedRouteLookupResponse errorResp = getInSyncContext(invalidRouteLookupRequest);
     assertThat(errorResp.isPending()).isTrue();
     fakeTimeProvider.forwardTime(SERVER_LATENCY_MILLIS, TimeUnit.MILLISECONDS);
@@ -392,14 +392,16 @@ public class CachingRlsLbClientTest {
   @Test
   public void get_childPolicyWrapper_reusedForSameTarget() throws Exception {
     setUpRlsLbClient();
-    RouteLookupRequest routeLookupRequest = new RouteLookupRequest(ImmutableMap.of(
+    RouteLookupRequest routeLookupRequest = RouteLookupRequest.create(ImmutableMap.of(
         "server", "bigtable.googleapis.com", "service-key", "foo", "method-key", "bar"));
-    RouteLookupRequest routeLookupRequest2 = new RouteLookupRequest(ImmutableMap.of(
+    RouteLookupRequest routeLookupRequest2 = RouteLookupRequest.create(ImmutableMap.of(
         "server", "bigtable.googleapis.com", "service-key", "foo", "method-key", "baz"));
     rlsServerImpl.setLookupTable(
         ImmutableMap.of(
-            routeLookupRequest, new RouteLookupResponse(ImmutableList.of("target"), "header"),
-            routeLookupRequest2, new RouteLookupResponse(ImmutableList.of("target"), "header2")));
+            routeLookupRequest,
+            RouteLookupResponse.create(ImmutableList.of("target"), "header"),
+            routeLookupRequest2,
+            RouteLookupResponse.create(ImmutableList.of("target"), "header2")));
 
     CachedRouteLookupResponse resp = getInSyncContext(routeLookupRequest);
     assertThat(resp.isPending()).isTrue();

--- a/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
+++ b/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
@@ -428,7 +428,7 @@ public class CachingRlsLbClientTest {
     return RouteLookupConfig.builder()
         .grpcKeyBuilders(ImmutableList.of(
             GrpcKeyBuilder.create(
-                ImmutableList.of(new Name("service1", "create")),
+                ImmutableList.of(Name.create("service1", "create")),
                 ImmutableList.of(
                     NameMatcher.create("user", ImmutableList.of("User", "Parent")),
                     NameMatcher.create("id", ImmutableList.of("X-Google-Id"))),

--- a/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
+++ b/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
@@ -430,8 +430,8 @@ public class CachingRlsLbClientTest {
             GrpcKeyBuilder.create(
                 ImmutableList.of(new Name("service1", "create")),
                 ImmutableList.of(
-                    new NameMatcher("user", ImmutableList.of("User", "Parent")),
-                    new NameMatcher("id", ImmutableList.of("X-Google-Id"))),
+                    NameMatcher.create("user", ImmutableList.of("User", "Parent")),
+                    NameMatcher.create("id", ImmutableList.of("X-Google-Id"))),
                 ExtraKeys.create("server", "service-key", "method-key"),
                 ImmutableMap.<String, String>of())))
         .lookupService("service1")

--- a/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
+++ b/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
@@ -206,7 +206,7 @@ public class CachingRlsLbClientTest {
     assertThat(resp.hasData()).isTrue();
 
     // cache hit for staled entry
-    fakeTimeProvider.forwardTime(ROUTE_LOOKUP_CONFIG.getStaleAgeInNanos(), TimeUnit.NANOSECONDS);
+    fakeTimeProvider.forwardTime(ROUTE_LOOKUP_CONFIG.staleAgeInNanos(), TimeUnit.NANOSECONDS);
 
     resp = getInSyncContext(routeLookupRequest);
     assertThat(resp.hasData()).isTrue();
@@ -222,7 +222,7 @@ public class CachingRlsLbClientTest {
     assertThat(resp.hasData()).isTrue();
 
     // existing cache expired
-    fakeTimeProvider.forwardTime(ROUTE_LOOKUP_CONFIG.getMaxAgeInNanos(), TimeUnit.NANOSECONDS);
+    fakeTimeProvider.forwardTime(ROUTE_LOOKUP_CONFIG.maxAgeInNanos(), TimeUnit.NANOSECONDS);
 
     resp = getInSyncContext(routeLookupRequest);
 
@@ -425,21 +425,22 @@ public class CachingRlsLbClientTest {
   }
 
   private static RouteLookupConfig getRouteLookupConfig() {
-    return new RouteLookupConfig(
-        ImmutableList.of(
+    return RouteLookupConfig.builder()
+        .grpcKeyBuilders(ImmutableList.of(
             new GrpcKeyBuilder(
                 ImmutableList.of(new Name("service1", "create")),
                 ImmutableList.of(
                     new NameMatcher("user", ImmutableList.of("User", "Parent")),
                     new NameMatcher("id", ImmutableList.of("X-Google-Id"))),
                 ExtraKeys.create("server", "service-key", "method-key"),
-                ImmutableMap.<String, String>of())),
-        /* lookupService= */ "service1",
-        /* lookupServiceTimeoutInNanos= */ TimeUnit.SECONDS.toNanos(2),
-        /* maxAgeInNanos= */ TimeUnit.SECONDS.toNanos(300),
-        /* staleAgeInNanos= */ TimeUnit.SECONDS.toNanos(240),
-        /* cacheSizeBytes= */ 1000,
-        DEFAULT_TARGET);
+                ImmutableMap.<String, String>of())))
+        .lookupService("service1")
+        .lookupServiceTimeoutInNanos(TimeUnit.SECONDS.toNanos(2))
+        .maxAgeInNanos(TimeUnit.SECONDS.toNanos(300))
+        .staleAgeInNanos(TimeUnit.SECONDS.toNanos(240))
+        .cacheSizeBytes(1000)
+        .defaultTarget(DEFAULT_TARGET)
+        .build();
   }
 
   private static BackoffPolicy createBackoffPolicy(final long delay, final TimeUnit unit) {

--- a/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
+++ b/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
@@ -427,7 +427,7 @@ public class CachingRlsLbClientTest {
   private static RouteLookupConfig getRouteLookupConfig() {
     return RouteLookupConfig.builder()
         .grpcKeyBuilders(ImmutableList.of(
-            new GrpcKeyBuilder(
+            GrpcKeyBuilder.create(
                 ImmutableList.of(new Name("service1", "create")),
                 ImmutableList.of(
                     new NameMatcher("user", ImmutableList.of("User", "Parent")),

--- a/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
@@ -140,16 +140,16 @@ public class RlsLoadBalancerTest {
             .build();
     fakeRlsServerImpl.setLookupTable(
         ImmutableMap.of(
-            new RouteLookupRequest(ImmutableMap.of(
+            RouteLookupRequest.create(ImmutableMap.of(
                 "server", "fake-bigtable.googleapis.com",
                 "service-key", "com.google",
                 "method-key", "Search")),
-            new RouteLookupResponse(ImmutableList.of("wilderness"), "where are you?"),
-            new RouteLookupRequest(ImmutableMap.of(
+            RouteLookupResponse.create(ImmutableList.of("wilderness"), "where are you?"),
+            RouteLookupRequest.create(ImmutableMap.of(
                 "server", "fake-bigtable.googleapis.com",
                 "service-key", "com.google",
                 "method-key", "Rescue")),
-            new RouteLookupResponse(ImmutableList.of("civilization"), "you are safe")));
+            RouteLookupResponse.create(ImmutableList.of("civilization"), "you are safe")));
 
     rlsLb = (RlsLoadBalancer) provider.newLoadBalancer(helper);
     rlsLb.cachingRlsLbClientBuilderProvider = new CachingRlsLbClientBuilderProvider() {

--- a/rls/src/test/java/io/grpc/rls/RlsProtoConvertersTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsProtoConvertersTest.java
@@ -181,21 +181,21 @@ public class RlsProtoConvertersTest {
                 GrpcKeyBuilder.create(
                     ImmutableList.of(new Name("service1", "create")),
                     ImmutableList.of(
-                        new NameMatcher("user", ImmutableList.of("User", "Parent")),
-                        new NameMatcher("id", ImmutableList.of("X-Google-Id"))),
+                        NameMatcher.create("user", ImmutableList.of("User", "Parent")),
+                        NameMatcher.create("id", ImmutableList.of("X-Google-Id"))),
                     ExtraKeys.DEFAULT,
                     ImmutableMap.<String, String>of()),
                 GrpcKeyBuilder.create(
                     ImmutableList.of(new Name("service1", "*")),
                     ImmutableList.of(
-                        new NameMatcher("user", ImmutableList.of("User", "Parent")),
-                        new NameMatcher("password", ImmutableList.of("Password"))),
+                        NameMatcher.create("user", ImmutableList.of("User", "Parent")),
+                        NameMatcher.create("password", ImmutableList.of("Password"))),
                     ExtraKeys.DEFAULT,
                     ImmutableMap.<String, String>of()),
                 GrpcKeyBuilder.create(
                     ImmutableList.of(new Name("service3", "*")),
                     ImmutableList.of(
-                        new NameMatcher("user", ImmutableList.of("User", "Parent"))),
+                        NameMatcher.create("user", ImmutableList.of("User", "Parent"))),
                     ExtraKeys.create("host-key", "service-key", "method-key"),
                     ImmutableMap.of("constKey1", "value1"))))
             .lookupService("service1")
@@ -406,8 +406,8 @@ public class RlsProtoConvertersTest {
                 GrpcKeyBuilder.create(
                     ImmutableList.of(new Name("service1", "create")),
                     ImmutableList.of(
-                        new NameMatcher("user", ImmutableList.of("User", "Parent")),
-                        new NameMatcher("id", ImmutableList.of("X-Google-Id"))),
+                        NameMatcher.create("user", ImmutableList.of("User", "Parent")),
+                        NameMatcher.create("id", ImmutableList.of("X-Google-Id"))),
                     ExtraKeys.DEFAULT,
                     ImmutableMap.<String, String>of())))
             .lookupService("service1")

--- a/rls/src/test/java/io/grpc/rls/RlsProtoConvertersTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsProtoConvertersTest.java
@@ -176,8 +176,8 @@ public class RlsProtoConvertersTest {
         + "}";
 
     RouteLookupConfig expectedConfig =
-        new RouteLookupConfig(
-            ImmutableList.of(
+        RouteLookupConfig.builder()
+            .grpcKeyBuilders(ImmutableList.of(
                 new GrpcKeyBuilder(
                     ImmutableList.of(new Name("service1", "create")),
                     ImmutableList.of(
@@ -197,13 +197,14 @@ public class RlsProtoConvertersTest {
                     ImmutableList.of(
                         new NameMatcher("user", ImmutableList.of("User", "Parent"))),
                     ExtraKeys.create("host-key", "service-key", "method-key"),
-                    ImmutableMap.of("constKey1", "value1"))),
-            /* lookupService= */ "service1",
-            /* lookupServiceTimeoutInNanos= */ TimeUnit.SECONDS.toNanos(2),
-            /* maxAgeInNanos= */ TimeUnit.SECONDS.toNanos(300),
-            /* staleAgeInNanos= */ TimeUnit.SECONDS.toNanos(240),
-            /* cacheSizeBytes= */ 1000,
-            /* defaultTarget= */ "us_east_1.cloudbigtable.googleapis.com");
+                    ImmutableMap.of("constKey1", "value1"))))
+            .lookupService("service1")
+            .lookupServiceTimeoutInNanos(TimeUnit.SECONDS.toNanos(2))
+            .maxAgeInNanos(TimeUnit.SECONDS.toNanos(300))
+            .staleAgeInNanos(TimeUnit.SECONDS.toNanos(240))
+            .cacheSizeBytes(1000)
+            .defaultTarget("us_east_1.cloudbigtable.googleapis.com")
+            .build();
 
     RouteLookupConfigConverter converter = new RouteLookupConfigConverter();
     @SuppressWarnings("unchecked")
@@ -343,19 +344,20 @@ public class RlsProtoConvertersTest {
         + "}";
 
     RouteLookupConfig expectedConfig =
-        new RouteLookupConfig(
-            ImmutableList.of(
+        RouteLookupConfig.builder()
+            .grpcKeyBuilders(ImmutableList.of(
                 new GrpcKeyBuilder(
                     ImmutableList.of(new Name("service1", null)),
                     ImmutableList.<NameMatcher>of(),
                     ExtraKeys.DEFAULT,
-                    ImmutableMap.<String, String>of())),
-            /* lookupService= */ "service1",
-            /* lookupServiceTimeoutInNanos= */ TimeUnit.SECONDS.toNanos(10),
-            /* maxAgeInNanos= */ TimeUnit.MINUTES.toNanos(5),
-            /* staleAgeInNanos= */ TimeUnit.MINUTES.toNanos(5),
-            /* cacheSizeBytes= */ 5 * 1024 * 1024,
-            /* defaultTarget= */ "us_east_1.cloudbigtable.googleapis.com");
+                    ImmutableMap.<String, String>of())))
+            .lookupService("service1")
+            .lookupServiceTimeoutInNanos(TimeUnit.SECONDS.toNanos(10))
+            .maxAgeInNanos(TimeUnit.MINUTES.toNanos(5))
+            .staleAgeInNanos(TimeUnit.MINUTES.toNanos(5))
+            .cacheSizeBytes(5 * 1024 * 1024)
+            .defaultTarget("us_east_1.cloudbigtable.googleapis.com")
+            .build();
 
     RouteLookupConfigConverter converter = new RouteLookupConfigConverter();
     @SuppressWarnings("unchecked")
@@ -399,21 +401,22 @@ public class RlsProtoConvertersTest {
         + "}";
 
     RouteLookupConfig expectedConfig =
-        new RouteLookupConfig(
-            ImmutableList.of(
+        RouteLookupConfig.builder()
+            .grpcKeyBuilders(ImmutableList.of(
                 new GrpcKeyBuilder(
                     ImmutableList.of(new Name("service1", "create")),
                     ImmutableList.of(
                         new NameMatcher("user", ImmutableList.of("User", "Parent")),
                         new NameMatcher("id", ImmutableList.of("X-Google-Id"))),
                     ExtraKeys.DEFAULT,
-                    ImmutableMap.<String, String>of())),
-            /* lookupService= */ "service1",
-            /* lookupServiceTimeoutInNanos= */ TimeUnit.SECONDS.toNanos(2),
-            /* maxAgeInNanos= */ TimeUnit.SECONDS.toNanos(300),
-            /* staleAgeInNanos= */ TimeUnit.SECONDS.toNanos(300),
-            /* cacheSizeBytes= */ 1000,
-            /* defaultTarget= */ "us_east_1.cloudbigtable.googleapis.com");
+                    ImmutableMap.<String, String>of())))
+            .lookupService("service1")
+            .lookupServiceTimeoutInNanos(TimeUnit.SECONDS.toNanos(2))
+            .maxAgeInNanos(TimeUnit.SECONDS.toNanos(300))
+            .staleAgeInNanos(TimeUnit.SECONDS.toNanos(300))
+            .cacheSizeBytes(1000)
+            .defaultTarget("us_east_1.cloudbigtable.googleapis.com")
+            .build();
 
     RouteLookupConfigConverter converter = new RouteLookupConfigConverter();
     @SuppressWarnings("unchecked")

--- a/rls/src/test/java/io/grpc/rls/RlsProtoConvertersTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsProtoConvertersTest.java
@@ -178,21 +178,21 @@ public class RlsProtoConvertersTest {
     RouteLookupConfig expectedConfig =
         RouteLookupConfig.builder()
             .grpcKeyBuilders(ImmutableList.of(
-                new GrpcKeyBuilder(
+                GrpcKeyBuilder.create(
                     ImmutableList.of(new Name("service1", "create")),
                     ImmutableList.of(
                         new NameMatcher("user", ImmutableList.of("User", "Parent")),
                         new NameMatcher("id", ImmutableList.of("X-Google-Id"))),
                     ExtraKeys.DEFAULT,
                     ImmutableMap.<String, String>of()),
-                new GrpcKeyBuilder(
+                GrpcKeyBuilder.create(
                     ImmutableList.of(new Name("service1", "*")),
                     ImmutableList.of(
                         new NameMatcher("user", ImmutableList.of("User", "Parent")),
                         new NameMatcher("password", ImmutableList.of("Password"))),
                     ExtraKeys.DEFAULT,
                     ImmutableMap.<String, String>of()),
-                new GrpcKeyBuilder(
+                GrpcKeyBuilder.create(
                     ImmutableList.of(new Name("service3", "*")),
                     ImmutableList.of(
                         new NameMatcher("user", ImmutableList.of("User", "Parent"))),
@@ -346,7 +346,7 @@ public class RlsProtoConvertersTest {
     RouteLookupConfig expectedConfig =
         RouteLookupConfig.builder()
             .grpcKeyBuilders(ImmutableList.of(
-                new GrpcKeyBuilder(
+                GrpcKeyBuilder.create(
                     ImmutableList.of(new Name("service1", null)),
                     ImmutableList.<NameMatcher>of(),
                     ExtraKeys.DEFAULT,
@@ -403,7 +403,7 @@ public class RlsProtoConvertersTest {
     RouteLookupConfig expectedConfig =
         RouteLookupConfig.builder()
             .grpcKeyBuilders(ImmutableList.of(
-                new GrpcKeyBuilder(
+                GrpcKeyBuilder.create(
                     ImmutableList.of(new Name("service1", "create")),
                     ImmutableList.of(
                         new NameMatcher("user", ImmutableList.of("User", "Parent")),

--- a/rls/src/test/java/io/grpc/rls/RlsProtoConvertersTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsProtoConvertersTest.java
@@ -179,21 +179,21 @@ public class RlsProtoConvertersTest {
         RouteLookupConfig.builder()
             .grpcKeyBuilders(ImmutableList.of(
                 GrpcKeyBuilder.create(
-                    ImmutableList.of(new Name("service1", "create")),
+                    ImmutableList.of(Name.create("service1", "create")),
                     ImmutableList.of(
                         NameMatcher.create("user", ImmutableList.of("User", "Parent")),
                         NameMatcher.create("id", ImmutableList.of("X-Google-Id"))),
                     ExtraKeys.DEFAULT,
                     ImmutableMap.<String, String>of()),
                 GrpcKeyBuilder.create(
-                    ImmutableList.of(new Name("service1", "*")),
+                    ImmutableList.of(Name.create("service1", "*")),
                     ImmutableList.of(
                         NameMatcher.create("user", ImmutableList.of("User", "Parent")),
                         NameMatcher.create("password", ImmutableList.of("Password"))),
                     ExtraKeys.DEFAULT,
                     ImmutableMap.<String, String>of()),
                 GrpcKeyBuilder.create(
-                    ImmutableList.of(new Name("service3", "*")),
+                    ImmutableList.of(Name.create("service3", "*")),
                     ImmutableList.of(
                         NameMatcher.create("user", ImmutableList.of("User", "Parent"))),
                     ExtraKeys.create("host-key", "service-key", "method-key"),
@@ -347,7 +347,7 @@ public class RlsProtoConvertersTest {
         RouteLookupConfig.builder()
             .grpcKeyBuilders(ImmutableList.of(
                 GrpcKeyBuilder.create(
-                    ImmutableList.of(new Name("service1", null)),
+                    ImmutableList.of(Name.create("service1", null)),
                     ImmutableList.<NameMatcher>of(),
                     ExtraKeys.DEFAULT,
                     ImmutableMap.<String, String>of())))
@@ -404,7 +404,7 @@ public class RlsProtoConvertersTest {
         RouteLookupConfig.builder()
             .grpcKeyBuilders(ImmutableList.of(
                 GrpcKeyBuilder.create(
-                    ImmutableList.of(new Name("service1", "create")),
+                    ImmutableList.of(Name.create("service1", "create")),
                     ImmutableList.of(
                         NameMatcher.create("user", ImmutableList.of("User", "Parent")),
                         NameMatcher.create("id", ImmutableList.of("X-Google-Id"))),

--- a/rls/src/test/java/io/grpc/rls/RlsProtoConvertersTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsProtoConvertersTest.java
@@ -53,7 +53,7 @@ public class RlsProtoConvertersTest {
 
     RlsProtoData.RouteLookupRequest object = converter.convert(proto);
 
-    assertThat(object.getKeyMap()).containsExactly("key1", "val1");
+    assertThat(object.keyMap()).containsExactly("key1", "val1");
   }
 
   @Test
@@ -61,7 +61,7 @@ public class RlsProtoConvertersTest {
     Converter<RlsProtoData.RouteLookupRequest, RouteLookupRequest> converter =
         new RouteLookupRequestConverter().reverse();
     RlsProtoData.RouteLookupRequest requestObject =
-        new RlsProtoData.RouteLookupRequest(ImmutableMap.of("key1", "val1"));
+        RlsProtoData.RouteLookupRequest.create(ImmutableMap.of("key1", "val1"));
 
     RouteLookupRequest proto = converter.convert(requestObject);
 
@@ -80,7 +80,7 @@ public class RlsProtoConvertersTest {
 
     RlsProtoData.RouteLookupResponse object = converter.convert(proto);
 
-    assertThat(object.getTargets()).containsExactly("target");
+    assertThat(object.targets()).containsExactly("target");
     assertThat(object.getHeaderData()).isEqualTo("some header data");
   }
 
@@ -90,7 +90,7 @@ public class RlsProtoConvertersTest {
         new RouteLookupResponseConverter().reverse();
 
     RlsProtoData.RouteLookupResponse object =
-        new RlsProtoData.RouteLookupResponse(ImmutableList.of("target"), "some header data");
+        RlsProtoData.RouteLookupResponse.create(ImmutableList.of("target"), "some header data");
 
     RouteLookupResponse proto = converter.convert(object);
 

--- a/rls/src/test/java/io/grpc/rls/RlsRequestFactoryTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsRequestFactoryTest.java
@@ -39,27 +39,27 @@ public class RlsRequestFactoryTest {
       RouteLookupConfig.builder()
           .grpcKeyBuilders(ImmutableList.of(
               GrpcKeyBuilder.create(
-                  ImmutableList.of(new Name("com.google.service1", "Create")),
+                  ImmutableList.of(Name.create("com.google.service1", "Create")),
                   ImmutableList.of(
                       NameMatcher.create("user", ImmutableList.of("User", "Parent")),
                       NameMatcher.create("id", ImmutableList.of("X-Google-Id"))),
                   ExtraKeys.create("server-1", null, null),
                   ImmutableMap.of("const-key-1", "const-value-1")),
               GrpcKeyBuilder.create(
-                  ImmutableList.of(new Name("com.google.service1", "*")),
+                  ImmutableList.of(Name.create("com.google.service1", "*")),
                   ImmutableList.of(
                       NameMatcher.create("user", ImmutableList.of("User", "Parent")),
                       NameMatcher.create("password", ImmutableList.of("Password"))),
                   ExtraKeys.create(null, "service-2", null),
                   ImmutableMap.of("const-key-2", "const-value-2")),
               GrpcKeyBuilder.create(
-                  ImmutableList.of(new Name("com.google.service2", "*")),
+                  ImmutableList.of(Name.create("com.google.service2", "*")),
                   ImmutableList.of(
                       NameMatcher.create("password", ImmutableList.of("Password"))),
                   ExtraKeys.create(null, "service-3", "method-3"),
                   ImmutableMap.<String, String>of()),
               GrpcKeyBuilder.create(
-                  ImmutableList.of(new Name("com.google.service3", "*")),
+                  ImmutableList.of(Name.create("com.google.service3", "*")),
                   ImmutableList.of(
                       NameMatcher.create("user", ImmutableList.of("User", "Parent"))),
                   ExtraKeys.create(null, null, null),

--- a/rls/src/test/java/io/grpc/rls/RlsRequestFactoryTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsRequestFactoryTest.java
@@ -83,7 +83,7 @@ public class RlsRequestFactoryTest {
     metadata.put(Metadata.Key.of("foo", Metadata.ASCII_STRING_MARSHALLER), "bar");
 
     RouteLookupRequest request = factory.create("com.google.service1", "Create", metadata);
-    assertThat(request.getKeyMap()).containsExactly(
+    assertThat(request.keyMap()).containsExactly(
         "user", "test",
         "id", "123",
         "server-1", "bigtable.googleapis.com",
@@ -99,7 +99,7 @@ public class RlsRequestFactoryTest {
 
     RouteLookupRequest request = factory.create("com.google.service1" , "Update", metadata);
 
-    assertThat(request.getKeyMap()).containsExactly(
+    assertThat(request.keyMap()).containsExactly(
         "user", "test",
         "password", "hunter2",
         "service-2", "com.google.service1",
@@ -115,7 +115,7 @@ public class RlsRequestFactoryTest {
 
     RouteLookupRequest request = factory.create("com.google.service1", "Update", metadata);
 
-    assertThat(request.getKeyMap()).containsExactly(
+    assertThat(request.keyMap()).containsExactly(
         "user", "test",
         "service-2", "com.google.service1",
         "const-key-2", "const-value-2");
@@ -129,7 +129,7 @@ public class RlsRequestFactoryTest {
     metadata.put(Metadata.Key.of("foo", Metadata.ASCII_STRING_MARSHALLER), "bar");
 
     RouteLookupRequest request = factory.create("abc.def.service999", "Update", metadata);
-    assertThat(request.getKeyMap()).isEmpty();
+    assertThat(request.keyMap()).isEmpty();
   }
 
   @Test
@@ -141,7 +141,7 @@ public class RlsRequestFactoryTest {
 
     RouteLookupRequest request = factory.create("com.google.service3", "Update", metadata);
 
-    assertThat(request.getKeyMap()).containsExactly(
+    assertThat(request.keyMap()).containsExactly(
         "user", "test", "const-key-4", "const-value-4");
   }
 }

--- a/rls/src/test/java/io/grpc/rls/RlsRequestFactoryTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsRequestFactoryTest.java
@@ -38,27 +38,27 @@ public class RlsRequestFactoryTest {
   private static final RouteLookupConfig RLS_CONFIG =
       RouteLookupConfig.builder()
           .grpcKeyBuilders(ImmutableList.of(
-              new GrpcKeyBuilder(
+              GrpcKeyBuilder.create(
                   ImmutableList.of(new Name("com.google.service1", "Create")),
                   ImmutableList.of(
                       new NameMatcher("user", ImmutableList.of("User", "Parent")),
                       new NameMatcher("id", ImmutableList.of("X-Google-Id"))),
                   ExtraKeys.create("server-1", null, null),
                   ImmutableMap.of("const-key-1", "const-value-1")),
-              new GrpcKeyBuilder(
+              GrpcKeyBuilder.create(
                   ImmutableList.of(new Name("com.google.service1", "*")),
                   ImmutableList.of(
                       new NameMatcher("user", ImmutableList.of("User", "Parent")),
                       new NameMatcher("password", ImmutableList.of("Password"))),
                   ExtraKeys.create(null, "service-2", null),
                   ImmutableMap.of("const-key-2", "const-value-2")),
-              new GrpcKeyBuilder(
+              GrpcKeyBuilder.create(
                   ImmutableList.of(new Name("com.google.service2", "*")),
                   ImmutableList.of(
                       new NameMatcher("password", ImmutableList.of("Password"))),
                   ExtraKeys.create(null, "service-3", "method-3"),
                   ImmutableMap.<String, String>of()),
-              new GrpcKeyBuilder(
+              GrpcKeyBuilder.create(
                   ImmutableList.of(new Name("com.google.service3", "*")),
                   ImmutableList.of(
                       new NameMatcher("user", ImmutableList.of("User", "Parent"))),

--- a/rls/src/test/java/io/grpc/rls/RlsRequestFactoryTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsRequestFactoryTest.java
@@ -41,27 +41,27 @@ public class RlsRequestFactoryTest {
               GrpcKeyBuilder.create(
                   ImmutableList.of(new Name("com.google.service1", "Create")),
                   ImmutableList.of(
-                      new NameMatcher("user", ImmutableList.of("User", "Parent")),
-                      new NameMatcher("id", ImmutableList.of("X-Google-Id"))),
+                      NameMatcher.create("user", ImmutableList.of("User", "Parent")),
+                      NameMatcher.create("id", ImmutableList.of("X-Google-Id"))),
                   ExtraKeys.create("server-1", null, null),
                   ImmutableMap.of("const-key-1", "const-value-1")),
               GrpcKeyBuilder.create(
                   ImmutableList.of(new Name("com.google.service1", "*")),
                   ImmutableList.of(
-                      new NameMatcher("user", ImmutableList.of("User", "Parent")),
-                      new NameMatcher("password", ImmutableList.of("Password"))),
+                      NameMatcher.create("user", ImmutableList.of("User", "Parent")),
+                      NameMatcher.create("password", ImmutableList.of("Password"))),
                   ExtraKeys.create(null, "service-2", null),
                   ImmutableMap.of("const-key-2", "const-value-2")),
               GrpcKeyBuilder.create(
                   ImmutableList.of(new Name("com.google.service2", "*")),
                   ImmutableList.of(
-                      new NameMatcher("password", ImmutableList.of("Password"))),
+                      NameMatcher.create("password", ImmutableList.of("Password"))),
                   ExtraKeys.create(null, "service-3", "method-3"),
                   ImmutableMap.<String, String>of()),
               GrpcKeyBuilder.create(
                   ImmutableList.of(new Name("com.google.service3", "*")),
                   ImmutableList.of(
-                      new NameMatcher("user", ImmutableList.of("User", "Parent"))),
+                      NameMatcher.create("user", ImmutableList.of("User", "Parent"))),
                   ExtraKeys.create(null, null, null),
                   ImmutableMap.of("const-key-4", "const-value-4"))))
           .lookupService("bigtable-rls.googleapis.com")

--- a/rls/src/test/java/io/grpc/rls/RlsRequestFactoryTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsRequestFactoryTest.java
@@ -36,8 +36,8 @@ import org.junit.runners.JUnit4;
 public class RlsRequestFactoryTest {
 
   private static final RouteLookupConfig RLS_CONFIG =
-      new RouteLookupConfig(
-          ImmutableList.of(
+      RouteLookupConfig.builder()
+          .grpcKeyBuilders(ImmutableList.of(
               new GrpcKeyBuilder(
                   ImmutableList.of(new Name("com.google.service1", "Create")),
                   ImmutableList.of(
@@ -63,13 +63,14 @@ public class RlsRequestFactoryTest {
                   ImmutableList.of(
                       new NameMatcher("user", ImmutableList.of("User", "Parent"))),
                   ExtraKeys.create(null, null, null),
-                  ImmutableMap.of("const-key-4", "const-value-4"))),
-          /* lookupService= */ "bigtable-rls.googleapis.com",
-          /* lookupServiceTimeoutInNanos= */ TimeUnit.SECONDS.toNanos(2),
-          /* maxAgeInNanos= */ TimeUnit.SECONDS.toNanos(300),
-          /* staleAgeInNanos= */ TimeUnit.SECONDS.toNanos(240),
-          /* cacheSizeBytes= */ 1000,
-          /* defaultTarget= */ "us_east_1.cloudbigtable.googleapis.com");
+                  ImmutableMap.of("const-key-4", "const-value-4"))))
+          .lookupService("bigtable-rls.googleapis.com")
+          .lookupServiceTimeoutInNanos(TimeUnit.SECONDS.toNanos(2))
+          .maxAgeInNanos(TimeUnit.SECONDS.toNanos(300))
+          .staleAgeInNanos(TimeUnit.SECONDS.toNanos(240))
+          .cacheSizeBytes(1000)
+          .defaultTarget("us_east_1.cloudbigtable.googleapis.com")
+          .build();
 
   private final RlsRequestFactory factory = new RlsRequestFactory(
       RLS_CONFIG, "bigtable.googleapis.com");


### PR DESCRIPTION
Refactor to use `@AutoValue` for data types. This reduces human mistakes on `equals()`, `hashCode()`, and `toString()` while we are constantly adding and changing member fields of the data type.