### PR TITLE
stub,examples: fix comments related to ServerCallStreamObserver.isReady() to clarify it applies to sending side readiness

### DIFF
--- a/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlServer.java
+++ b/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlServer.java
@@ -42,11 +42,11 @@ public class ManualFlowControlServer {
         serverCallStreamObserver.disableAutoRequest();
 
         // Set up a back-pressure-aware consumer for the request stream. The onReadyHandler will be invoked
-        // when the sending side has enough buffer space to store more responses.
+        // when there is available buffer space to store more responses.
         //
         // Note: the onReadyHandler's invocation is serialized on the same thread pool as the incoming StreamObserver's
         // onNext(), onError(), and onComplete() handlers. Blocking the onReadyHandler will prevent additional messages
-        // from being processed by the sending StreamObserver. The onReadyHandler must return in a timely manner or
+        // from being processed by the incoming StreamObserver. The onReadyHandler must return in a timely manner or
         // else message processing throughput will suffer.
         class OnReadyHandler implements Runnable {
           // Guard against spurious onReady() calls caused by a race between onNext() and onReady(). If the transport

--- a/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
@@ -98,7 +98,7 @@ public abstract class ServerCallStreamObserver<RespT> extends CallStreamObserver
 
 
   /**
-   * If {@code true}, indicates that the observer is capable of sending additional messages
+   * If {@code true}, indicates that the observer is capable of sending additional responses
    * without requiring excessive buffering internally. This value is just a suggestion and the
    * application is free to ignore it, however doing so may result in excessive buffering within the
    * observer.


### PR DESCRIPTION
fixed examples/manualflowcontrol/ManualFlowControlServer.java
fixed stub/ServerCallStreamObserver.java

to clarify the wording

@ejona86 as discussed.