### PR TITLE
testing: fix GrpcCleanupRule issue when retrying tests

### DIFF
--- a/testing/src/main/java/io/grpc/testing/GrpcCleanupRule.java
+++ b/testing/src/main/java/io/grpc/testing/GrpcCleanupRule.java
@@ -175,6 +175,7 @@ public final class GrpcCleanupRule implements TestRule {
    * Releases all the registered resources.
    */
   private void teardown() {
+    stopwatch.reset();
     stopwatch.start();
 
     if (firstException == null) {

--- a/testing/src/main/java/io/grpc/testing/GrpcCleanupRule.java
+++ b/testing/src/main/java/io/grpc/testing/GrpcCleanupRule.java
@@ -149,6 +149,7 @@ public final class GrpcCleanupRule implements TestRule {
     return new Statement() {
       @Override
       public void evaluate() throws Throwable {
+        firstException = null;
         try {
           base.evaluate();
         } catch (Throwable t) {


### PR DESCRIPTION
Fix an issue in GrpcCleanupRule when tests are retried and the
teardown() method is invoked multiple times, causing Stopwatch instance
to throw an IllegalStateException.

fixes grpc/grpc-java#8917.