### PR TITLE
Bump Google Auth, Guava, Auto Value

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,12 +56,12 @@ subprojects {
         javaPluginPath = "$rootDir/compiler/build/exe/java_plugin/$protocPluginBaseName$exeSuffix"
 
         nettyVersion = '4.1.72.Final'
-        guavaVersion = '30.1.1-android'
-        googleauthVersion = '0.22.2'
+        guavaVersion = '31.0.1-android'
+        googleauthVersion = '1.4.0'
         protobufVersion = '3.19.2'
         protocVersion = protobufVersion
         opencensusVersion = '0.28.0'
-        autovalueVersion = '1.7.4'
+        autovalueVersion = '1.9'
 
         configureProtoCompilation = {
             String generatedSourcePath = "${projectDir}/src/generated"

--- a/context/build.gradle
+++ b/context/build.gradle
@@ -14,7 +14,10 @@ targetCompatibility = 1.7
 
 dependencies {
     testImplementation libraries.jsr305
-    testImplementation (libraries.guava_testlib) {
+    // Explicitly choose the guava version to stay Java 7-compatible. The rest of gRPC can move
+    // forward to Java 8-requiring versions. This is also only used for testing, so is unlikely to
+    // cause problems.
+    testImplementation ('com.google.guava:guava-testlib:30.1.1-android') {
         exclude group: 'junit', module: 'junit'
     }
     signature "org.codehaus.mojo.signature:java17:1.0@signature"


### PR DESCRIPTION
The Google Auth version is getting quite old. The new version pulls in
newer Guava and Auto Value. Two require Java 8: Google Auth since 1.x,
Guava since 31.x. Google Auth only needs Auto Value 1.8.2, but this
bumps to the latest, so all three are at their latest versions.