### PR TITLE
Update README etc to reference 1.44.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ For a guided tour, take a look at the [quick start
 guide](https://grpc.io/docs/languages/java/quickstart) or the more explanatory [gRPC
 basics](https://grpc.io/docs/languages/java/basics).
 
-The [examples](https://github.com/grpc/grpc-java/tree/v1.44.0/examples) and the
-[Android example](https://github.com/grpc/grpc-java/tree/v1.44.0/examples/android)
+The [examples](https://github.com/grpc/grpc-java/tree/v1.44.1/examples) and the
+[Android example](https://github.com/grpc/grpc-java/tree/v1.44.1/examples/android)
 are standalone projects that showcase the usage of gRPC.
 
 Download
@@ -43,18 +43,18 @@ Download [the JARs][]. Or for Maven with non-Android, add to your `pom.xml`:
 <dependency>
   <groupId>io.grpc</groupId>
   <artifactId>grpc-netty-shaded</artifactId>
-  <version>1.44.0</version>
+  <version>1.44.1</version>
   <scope>runtime</scope>
 </dependency>
 <dependency>
   <groupId>io.grpc</groupId>
   <artifactId>grpc-protobuf</artifactId>
-  <version>1.44.0</version>
+  <version>1.44.1</version>
 </dependency>
 <dependency>
   <groupId>io.grpc</groupId>
   <artifactId>grpc-stub</artifactId>
-  <version>1.44.0</version>
+  <version>1.44.1</version>
 </dependency>
 <dependency> <!-- necessary for Java 9+ -->
   <groupId>org.apache.tomcat</groupId>
@@ -66,23 +66,23 @@ Download [the JARs][]. Or for Maven with non-Android, add to your `pom.xml`:
 
 Or for Gradle with non-Android, add to your dependencies:
 ```gradle
-runtimeOnly 'io.grpc:grpc-netty-shaded:1.44.0'
-implementation 'io.grpc:grpc-protobuf:1.44.0'
-implementation 'io.grpc:grpc-stub:1.44.0'
+runtimeOnly 'io.grpc:grpc-netty-shaded:1.44.1'
+implementation 'io.grpc:grpc-protobuf:1.44.1'
+implementation 'io.grpc:grpc-stub:1.44.1'
 compileOnly 'org.apache.tomcat:annotations-api:6.0.53' // necessary for Java 9+
 ```
 
 For Android client, use `grpc-okhttp` instead of `grpc-netty-shaded` and
 `grpc-protobuf-lite` instead of `grpc-protobuf`:
 ```gradle
-implementation 'io.grpc:grpc-okhttp:1.44.0'
-implementation 'io.grpc:grpc-protobuf-lite:1.44.0'
-implementation 'io.grpc:grpc-stub:1.44.0'
+implementation 'io.grpc:grpc-okhttp:1.44.1'
+implementation 'io.grpc:grpc-protobuf-lite:1.44.1'
+implementation 'io.grpc:grpc-stub:1.44.1'
 compileOnly 'org.apache.tomcat:annotations-api:6.0.53' // necessary for Java 9+
 ```
 
 [the JARs]:
-https://search.maven.org/search?q=g:io.grpc%20AND%20v:1.44.0
+https://search.maven.org/search?q=g:io.grpc%20AND%20v:1.44.1
 
 Development snapshots are available in [Sonatypes's snapshot
 repository](https://oss.sonatype.org/content/repositories/snapshots/).
@@ -114,7 +114,7 @@ For protobuf-based codegen integrated with the Maven build system, you can use
       <configuration>
         <protocArtifact>com.google.protobuf:protoc:3.19.2:exe:${os.detected.classifier}</protocArtifact>
         <pluginId>grpc-java</pluginId>
-        <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.44.0:exe:${os.detected.classifier}</pluginArtifact>
+        <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.44.1:exe:${os.detected.classifier}</pluginArtifact>
       </configuration>
       <executions>
         <execution>
@@ -144,7 +144,7 @@ protobuf {
   }
   plugins {
     grpc {
-      artifact = 'io.grpc:protoc-gen-grpc-java:1.44.0'
+      artifact = 'io.grpc:protoc-gen-grpc-java:1.44.1'
     }
   }
   generateProtoTasks {
@@ -177,7 +177,7 @@ protobuf {
   }
   plugins {
     grpc {
-      artifact = 'io.grpc:protoc-gen-grpc-java:1.44.0'
+      artifact = 'io.grpc:protoc-gen-grpc-java:1.44.1'
     }
   }
   generateProtoTasks {

--- a/cronet/README.md
+++ b/cronet/README.md
@@ -26,7 +26,7 @@ In your app module's `build.gradle` file, include a dependency on both `grpc-cro
 Google Play Services Client Library for Cronet
 
 ```
-implementation 'io.grpc:grpc-cronet:1.44.0'
+implementation 'io.grpc:grpc-cronet:1.44.1'
 implementation 'com.google.android.gms:play-services-cronet:16.0.0'
 ```
 

--- a/documentation/android-channel-builder.md
+++ b/documentation/android-channel-builder.md
@@ -36,8 +36,8 @@ In your `build.gradle` file, include a dependency on both `grpc-android` and
 `grpc-okhttp`:
 
 ```
-implementation 'io.grpc:grpc-android:1.44.0'
-implementation 'io.grpc:grpc-okhttp:1.44.0'
+implementation 'io.grpc:grpc-android:1.44.1'
+implementation 'io.grpc:grpc-okhttp:1.44.1'
 ```
 
 You also need permission to access the device's network state in your


### PR DESCRIPTION
The release doesn't appear in the top/search results but is present e.g. https://repo1.maven.org/maven2/io/grpc/grpc-core/1.44.1/ 