### PR TITLE
core: Decrease transparent retry limit to 1000

### DIFF
--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -853,7 +853,7 @@ abstract class RetriableStream<ReqT> implements ClientStream {
         return;
       }
       if (rpcProgress == RpcProgress.MISCARRIED
-          && localOnlyTransparentRetries.incrementAndGet() > 10_000) {
+          && localOnlyTransparentRetries.incrementAndGet() > 1_000) {
         commitAndRun(substream);
         if (state.winningSubstream == substream) {
           Status tooManyTransparentRetries = Status.INTERNAL

--- a/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
@@ -1711,12 +1711,12 @@ public class RetriableStreamTest {
     assertEquals(0, fakeClock.numPendingTasks());
 
     ArgumentCaptor<ClientStreamListener> sublistenerCaptor = sublistenerCaptor3;
-    for (int i = 0; i < 9999; i++) {
+    for (int i = 0; i < 999; i++) {
       ClientStream mockStream = mock(ClientStream.class);
       doReturn(mockStream).when(retriableStreamRecorder).newSubstream(0);
       sublistenerCaptor.getValue()
           .closed(Status.fromCode(NON_RETRIABLE_STATUS_CODE), MISCARRIED, new Metadata());
-      if (i == 9998) {
+      if (i == 998) {
         verify(retriableStreamRecorder).postCommit();
         verify(masterListener)
             .closed(any(Status.class), any(RpcProgress.class), any(Metadata.class));


### PR DESCRIPTION
The test for 10,000 took 10s to run and would time out when using other
tools like TSAN. "10000" was just a "very large number less than
infinity" and 1000 serves the same purpose and should similarly never
trigger. Using 1000 has the test run in 1s and TSAN completes in 17s.

The limit was originally added in dc6eaccc.