### PR TITLE
xds: Squelch ADS reconnection error logs (1.45.x backport)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -129,6 +129,9 @@ final class XdsNameResolver extends NameResolver {
   private XdsClient xdsClient;
   private CallCounterProvider callCounterProvider;
   private ResolveState resolveState;
+  // Workaround for https://github.com/grpc/grpc-java/issues/8886 . This should be handled in
+  // XdsClient instead of here.
+  private boolean receivedConfig;
 
   XdsNameResolver(
       @Nullable String targetAuthority, String name, ServiceConfigParser serviceConfigParser,
@@ -293,6 +296,7 @@ final class XdsNameResolver extends NameResolver {
             .setServiceConfig(parsedServiceConfig)
             .build();
     listener.onResult(result);
+    receivedConfig = true;
   }
 
   @VisibleForTesting
@@ -715,7 +719,7 @@ final class XdsNameResolver extends NameResolver {
       syncContext.execute(new Runnable() {
         @Override
         public void run() {
-          if (stopped) {
+          if (stopped || receivedConfig) {
             return;
           }
           listener.onError(error);
@@ -865,6 +869,7 @@ final class XdsNameResolver extends NameResolver {
       }
       routingConfig = RoutingConfig.empty;
       listener.onResult(emptyResult);
+      receivedConfig = true;
     }
 
     private void cleanUpRouteDiscoveryState() {
@@ -912,7 +917,7 @@ final class XdsNameResolver extends NameResolver {
         syncContext.execute(new Runnable() {
           @Override
           public void run() {
-            if (RouteDiscoveryState.this != routeDiscoveryState) {
+            if (RouteDiscoveryState.this != routeDiscoveryState || receivedConfig) {
               return;
             }
             listener.onError(error);


### PR DESCRIPTION
Workaround for #8886, as we wait on a real fix. The regular load
balancing disconnections are confusing users and will train users to
start ignoring gRPC warnings. At present, it is better to have no log
than excessively log.

CC @YifeiZhuang, @erikjoh

----

Backport of #8941