### PR TITLE
Expose SecurityLevel on server-side

### DIFF
--- a/api/src/main/java/io/grpc/ServerCall.java
+++ b/api/src/main/java/io/grpc/ServerCall.java
@@ -212,6 +212,21 @@ public abstract class ServerCall<ReqT, RespT> {
   }
 
   /**
+   * Returns the level of security guarantee in communications
+   *
+   * <p>Determining the level of security offered by the transport for RPCs on server-side.
+   * This can be approximated by looking for the SSLSession, but that doesn't work for ALTS and
+   * maybe some future TLS approaches. May return a lower security level when it cannot be
+   * determined precisely.
+   *
+   * @return non-{@code null} SecurityLevel enum
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4692")
+  public SecurityLevel getSecurityLevel() {
+    return SecurityLevel.NONE;
+  }
+
+  /**
    * Returns properties of a single call.
    *
    * <p>Attributes originate from the transport and can be altered by {@link ServerTransportFilter}.

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -19,6 +19,7 @@ package io.grpc.internal;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static io.grpc.internal.GrpcAttributes.ATTR_SECURITY_LEVEL;
 import static io.grpc.internal.GrpcUtil.ACCEPT_ENCODING_SPLITTER;
 import static io.grpc.internal.GrpcUtil.CONTENT_LENGTH_KEY;
 import static io.grpc.internal.GrpcUtil.MESSAGE_ACCEPT_ENCODING_KEY;
@@ -36,6 +37,7 @@ import io.grpc.DecompressorRegistry;
 import io.grpc.InternalDecompressorRegistry;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.SecurityLevel;
 import io.grpc.ServerCall;
 import io.grpc.Status;
 import io.perfmark.PerfMark;
@@ -248,6 +250,16 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
   @Override
   public MethodDescriptor<ReqT, RespT> getMethodDescriptor() {
     return method;
+  }
+
+  @Override
+  public SecurityLevel getSecurityLevel() {
+    final Attributes attributes = getAttributes();
+    if (attributes == null) {
+      return super.getSecurityLevel();
+    }
+    final SecurityLevel securityLevel = attributes.get(ATTR_SECURITY_LEVEL);
+    return securityLevel == null ? super.getSecurityLevel() : securityLevel;
   }
 
   /**

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.io.CharStreams;
+import io.grpc.Attributes;
 import io.grpc.CompressorRegistry;
 import io.grpc.Context;
 import io.grpc.DecompressorRegistry;
@@ -41,6 +42,7 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.Marshaller;
 import io.grpc.MethodDescriptor.MethodType;
+import io.grpc.SecurityLevel;
 import io.grpc.ServerCall;
 import io.grpc.Status;
 import io.grpc.internal.ServerCallImpl.ServerStreamListenerImpl;
@@ -351,6 +353,23 @@ public class ServerCallImplTest {
     assertNull(call.getAuthority());
     verify(stream).getAuthority();
   }
+
+  @Test
+  public void getSecurityLevel() {
+    Attributes attributes = Attributes.newBuilder()
+        .set(GrpcAttributes.ATTR_SECURITY_LEVEL, SecurityLevel.INTEGRITY).build();
+    when(stream.getAttributes()).thenReturn(attributes);
+    assertEquals(SecurityLevel.INTEGRITY, call.getSecurityLevel());
+    verify(stream).getAttributes();
+  }
+
+  @Test
+  public void getNullSecurityLevel() {
+    when(stream.getAttributes()).thenReturn(null);
+    assertEquals(SecurityLevel.NONE, call.getSecurityLevel());
+    verify(stream).getAttributes();
+  }
+
 
   @Test
   public void setMessageCompression() {


### PR DESCRIPTION
This is a shot to [#7719](https://github.com/grpc/grpc-java/issues/7719).
Added a new method to ServerCall which returns `SecurityLevel.NONE` and ServerCallImpl returns the security level `getAttributes().get(ATTR_SECURITY_LEVEL),` in the case of uncertainty will return a lower level of security.