### PR TITLE
observability: add support for global tags using env vars and MDS

### DIFF
--- a/observability/build.gradle
+++ b/observability/build.gradle
@@ -11,7 +11,8 @@ dependencies {
     def cloudLoggingVersion = '3.6.1'
 
     api project(':grpc-api'),
-            project(':grpc-alts')
+            project(':grpc-alts'),
+            libraries.google_auth_oauth2_http
 
     implementation project(':grpc-protobuf'),
             project(':grpc-stub'),

--- a/observability/src/main/java/io/grpc/observability/GlobalLoggingTags.java
+++ b/observability/src/main/java/io/grpc/observability/GlobalLoggingTags.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.observability;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.auth.http.HttpTransportFactory;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableMap;
+import io.grpc.observability.metadata.MetadataConfig;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/** A container of all global custom tags used for logging (for now). */
+final class GlobalLoggingTags {
+  private static final Logger logger = Logger.getLogger(GlobalLoggingTags.class.getName());
+
+  private static final String ENV_KEY_PREFIX = "GRPC_OBSERVABILITY_";
+  private final Map<String, String> tags;
+
+  GlobalLoggingTags() {
+    HashMap<String, String> temp = new HashMap<>();
+    populate(temp);
+    tags = ImmutableMap.copyOf(temp);
+  }
+
+  Map<String, String> getTags() {
+    return tags;
+  }
+
+  @VisibleForTesting static void populateFromMetadataServer(HashMap<String, String> customTags) {
+    MetadataConfig metadataConfig = new MetadataConfig(new DefaultHttpTransportFactory());
+    customTags.putAll(metadataConfig.getAllValues());
+  }
+
+  @VisibleForTesting
+  static void populateKubernetesValues(HashMap<String, String> customTags, String namespaceFile,
+      String hostnameFile, String cgroupFile) {
+    // namespace name: contents of file /var/run/secrets/kubernetes.io/serviceaccount/namespace
+    populateFromFileContents(customTags, "namespace_name",
+        namespaceFile, (value) -> value);
+
+    // pod_name: hostname i.e. contents of /etc/hostname
+    populateFromFileContents(customTags, "pod_name", hostnameFile, (value) -> value);
+
+    // container_id: parsed from /proc/self/cgroup
+    populateFromFileContents(customTags, "container_id", cgroupFile,
+        (value) -> getContainerIdFromFileContents(value));
+  }
+
+  @VisibleForTesting
+  static void populateFromFileContents(HashMap<String, String> customTags, String key,
+      String filePath, Function<String, String> parser) {
+    String value = parser.apply(readFileContents(filePath));
+    if (value != null) {
+      customTags.put(key, value);
+    }
+  }
+
+  @VisibleForTesting static String getContainerIdFromFileContents(String value) {
+    if (value != null) {
+      try (Scanner scanner = new Scanner(value)) {
+        while (scanner.hasNextLine()) {
+          String line = scanner.nextLine();
+          String[] tokens = line.split(":");
+          if (tokens.length == 3 && tokens[2].startsWith("/kubepods/burstable/")) {
+            tokens = tokens[2].split("/");
+            if (tokens.length == 5) {
+              return tokens[4];
+            }
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  private static String readFileContents(String file) {
+    Path fileName = Paths.get(file);
+    if (Files.isReadable(fileName)) {
+      try {
+        byte[] bytes = Files.readAllBytes(fileName);
+        return new String(bytes, Charsets.US_ASCII);
+      } catch (IOException e) {
+        logger.log(Level.FINE, "Reading file:" + file, e);
+      }
+    } else {
+      logger.log(Level.FINE, "File:" + file + " is not readable (or missing?)");
+    }
+    return null;
+  }
+
+  private static void populateFromEnvironmentVars(HashMap<String, String> customTags) {
+    populateFromMap(System.getenv(), customTags);
+  }
+
+  @VisibleForTesting
+  static void populateFromMap(Map<String, String> map, final HashMap<String, String> customTags) {
+    checkNotNull(map);
+    map.forEach((k, v) -> {
+      if (k.startsWith(ENV_KEY_PREFIX)) {
+        String customTagKey = k.substring(ENV_KEY_PREFIX.length());
+        customTags.put(customTagKey, v);
+      }
+    });
+  }
+
+  static void populate(HashMap<String, String> customTags) {
+    populateFromEnvironmentVars(customTags);
+    populateFromMetadataServer(customTags);
+    populateKubernetesValues(customTags, "/var/run/secrets/kubernetes.io/serviceaccount/namespace",
+        "/etc/hostname", "/proc/self/cgroup");
+  }
+
+  private static class DefaultHttpTransportFactory implements HttpTransportFactory {
+
+    private static final HttpTransport netHttpTransport = new NetHttpTransport();
+
+    @Override
+    public HttpTransport create() {
+      return netHttpTransport;
+    }
+  }
+}

--- a/observability/src/main/java/io/grpc/observability/metadata/MetadataConfig.java
+++ b/observability/src/main/java/io/grpc/observability/metadata/MetadataConfig.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.observability.metadata;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.client.http.HttpTransport;
+import com.google.auth.http.HttpTransportFactory;
+import com.google.common.annotations.VisibleForTesting;
+import io.grpc.Internal;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/** Class to read Google Metadata Server values. */
+@Internal
+public final class MetadataConfig {
+  private static final Logger logger = Logger.getLogger(MetadataConfig.class.getName());
+
+  private static final int TIMEOUT_MS = 5000;
+  private static final String METADATA_URL = "http://metadata.google.internal/computeMetadata/v1/";
+  HttpRequestFactory requestFactory;
+
+  @VisibleForTesting public MetadataConfig(HttpTransportFactory transportFactory) {
+    HttpTransport httpTransport = transportFactory.create();
+    requestFactory = httpTransport.createRequestFactory();
+  }
+
+  /** gets all the values from the MDS we need to set in our logging tags. */
+  public Map<String, String> getAllValues() {
+    HashMap<String, String> map = new HashMap<>();
+    //addValueFor(map, "instance/hostname", "GCE_INSTANCE_HOSTNAME");
+    addValueFor(map, "instance/id", "gke_node_id");
+    //addValueFor(map, "instance/zone", "GCE_INSTANCE_ZONE");
+    addValueFor(map, "project/project-id", "project_id");
+    addValueFor(map, "project/numeric-project-id", "project_numeric_id");
+    addValueFor(map, "instance/attributes/cluster-name", "cluster_name");
+    addValueFor(map, "instance/attributes/cluster-uid", "cluster_uid");
+    addValueFor(map, "instance/attributes/cluster-location", "location");
+    try {
+      requestFactory.getTransport().shutdown();
+    } catch (IOException e) {
+      logger.log(Level.FINE, "Calling HttpTransport.shutdown()", e);
+    }
+    return map;
+  }
+
+  void addValueFor(Map<String, String> map, String attribute, String key) {
+    try {
+      String value = getAttribute(attribute);
+      if (value != null) {
+        map.put(key, value);
+      }
+    } catch (IOException e) {
+      logger.log(Level.FINE, "Calling getAttribute('" + attribute +  "')", e);
+    }
+  }
+
+  String getAttribute(String attributeName) throws IOException {
+    GenericUrl url = new GenericUrl(METADATA_URL + attributeName);
+    HttpRequest request = requestFactory.buildGetRequest(url);
+    request = request.setReadTimeout(TIMEOUT_MS);
+    request = request.setConnectTimeout(TIMEOUT_MS);
+    request = request.setHeaders(new HttpHeaders().set("Metadata-Flavor", "Google"));
+    HttpResponse response = null;
+    try {
+      response = request.execute();
+      if (response.getStatusCode() == HttpStatusCodes.STATUS_CODE_OK) {
+        InputStream stream = response.getContent();
+        if (stream != null) {
+          byte[] bytes = new byte[stream.available()];
+          stream.read(bytes);
+          return new String(bytes, response.getContentCharset());
+        }
+      }
+    } finally {
+      if (response != null) {
+        response.disconnect();
+      }
+    }
+    return null;
+  }
+}

--- a/observability/src/test/java/io/grpc/observability/GlobalLoggingTagsTest.java
+++ b/observability/src/test/java/io/grpc/observability/GlobalLoggingTagsTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.observability;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Files;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class GlobalLoggingTagsTest {
+
+  @Rule public TemporaryFolder namespaceFolder = new TemporaryFolder();
+  @Rule public TemporaryFolder hostnameFolder = new TemporaryFolder();
+  @Rule public TemporaryFolder cgroupFolder = new TemporaryFolder();
+
+  @Test
+  public void testPopulateFromMap() {
+    HashMap<String, String> customTags = new HashMap<>();
+    GlobalLoggingTags.populateFromMap(
+        ImmutableMap.of("GRPC_OBSERVABILITY_KEY1", "VALUE1", "ANOTHER_KEY2", "VALUE2",
+            "GRPC_OBSERVABILITY_KEY3", "VALUE3"), customTags);
+    assertThat(customTags).containsExactly("KEY1", "VALUE1", "KEY3", "VALUE3");
+  }
+
+  @Test
+  public void testContainerIdParsing_lastLine() {
+    String containerId = GlobalLoggingTags.getContainerIdFromFileContents(FILE_CONTENTS_LAST_LINE);
+    assertThat(containerId).isEqualTo("e19a54df");
+  }
+
+  @Test
+  public void testContainerIdParsing_fewerFields_notFound() {
+    String containerId = GlobalLoggingTags.getContainerIdFromFileContents(
+        "12:/kubepods/burstable/podc43b6442-0725-4fb8-bb1c-d17f5122155c/"
+            + "fe61ca6482b58f4a9831d08d6ea15db25f9fd19b4be19a54df8c6c0eab8742b7\n");
+    assertThat(containerId).isNull();
+  }
+
+  @Test
+  public void testContainerIdParsing_fewerPaths_notFound() {
+    String containerId = GlobalLoggingTags.getContainerIdFromFileContents(
+        "12:xdf:/kubepods/podc43b6442-0725-4fb8-bb1c-d17f5122155c/"
+            + "fe61ca6482b58f4a9831d08d6ea15db25f9fd19b4be19a54df8c6c0eab8742b7\n");
+    assertThat(containerId).isNull();
+  }
+
+  @Test
+  public void testPopulateKubernetesValues() throws IOException {
+    File namespaceFile = namespaceFolder.newFile();
+    File hostnameFile = hostnameFolder.newFile();
+    File cgroupFile = cgroupFolder.newFile();
+
+    Files.write("test-namespace1".getBytes(StandardCharsets.UTF_8), namespaceFile);
+    Files.write("test-hostname2".getBytes(StandardCharsets.UTF_8), hostnameFile);
+    Files.write(FILE_CONTENTS.getBytes(StandardCharsets.UTF_8), cgroupFile);
+
+    HashMap<String, String> customTags = new HashMap<>();
+    GlobalLoggingTags.populateKubernetesValues(customTags, namespaceFile.getAbsolutePath(),
+        hostnameFile.getAbsolutePath(), cgroupFile.getAbsolutePath());
+    assertThat(customTags).containsExactly("container_id",
+        "fe61ca6482b58f4a9831d08d6ea15db25f9fd19b4be19a54df8c6c0eab8742b7", "namespace_name",
+        "test-namespace1", "pod_name", "test-hostname2");
+  }
+
+  private static String FILE_CONTENTS =
+      "12:perf_event:/kubepods/burstable/podc43b6442-0725-4fb8-bb1c-d17f5122155c/"
+          + "fe61ca6482b58f4a9831d08d6ea15db25f9fd19b4be19a54df8c6c0eab8742b7\n"
+          + "11:freezer:/kubepods/burstable/podc43b6442-0725-4fb8-bb1c-d17f5122155c/"
+          + "fe61ca6482b58f4a9831d08d6ea15db25f9fd19b4be19a54df8c6c0eab8742b7\n"
+          + "2:rdma:/\n"
+          + "1:name=systemd:/kubepods/burstable/podc43b6442-0725-4fb8-bb1c-d17f5122155c/"
+          + "fe61ca6482b58f4a9831d08d6ea15db25f9fd19b4be19a54df8c6c0eab8742b7\n"
+          + "0::/system.slice/containerd.service\n";
+
+  private static String FILE_CONTENTS_LAST_LINE =
+      "0::/system.slice/containerd.service\n"
+          + "6442-0725-4fb8-bb1c-d17f5122155cslslsl/fe61ca6482b58f4a9831d08d6ea15db25f\n"
+          + "\n"
+          + "12:perf_event:/kubepods/burstable/podc43b6442-0725-4fb8-bb1c-d17f5122155c/e19a54df\n";
+}

--- a/observability/src/test/java/io/grpc/observability/metadata/MetadataConfigTest.java
+++ b/observability/src/test/java/io/grpc/observability/metadata/MetadataConfigTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.observability.metadata;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.google.api.client.testing.http.MockHttpTransport;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+import com.google.auth.http.HttpTransportFactory;
+import java.io.IOException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@RunWith(JUnit4.class)
+public class MetadataConfigTest {
+
+  @Mock HttpTransportFactory httpTransportFactory;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void testGetAllValues() throws IOException {
+    MockHttpTransport.Builder builder = new MockHttpTransport.Builder();
+    MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+    response.setContent("foo");
+    builder.setLowLevelHttpResponse(response);
+    MockHttpTransport httpTransport = builder.build();
+    when(httpTransportFactory.create()).thenReturn(httpTransport);
+    MetadataConfig metadataConfig = new MetadataConfig(httpTransportFactory);
+    String val = metadataConfig.getAttribute("instance/attributes/cluster-name");
+    assertThat(val).isEqualTo("foo");
+  }
+}


### PR DESCRIPTION
This adds support for global tags for logging which includes: custom tags from env vars, Google cloud metadata-server, and Kubernetes values

@DNVindhya pls take a look. CC @ejona86 