### PR TITLE
all: bump PerfMark to 0.25.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,7 +169,7 @@ subprojects {
             opencensus_impl_lite: "io.opencensus:opencensus-impl-lite:${opencensusVersion}",
             opencensus_proto: "io.opencensus:opencensus-proto:0.2.0",
             instrumentation_api: 'com.google.instrumentation:instrumentation-api:0.4.3',
-            perfmark: 'io.perfmark:perfmark-api:0.23.0',
+            perfmark: 'io.perfmark:perfmark-api:0.25.0',
             protobuf: "com.google.protobuf:protobuf-java:${protobufVersion}",
             protobuf_lite: "com.google.protobuf:protobuf-javalite:${protobufVersion}",
             protobuf_util: "com.google.protobuf:protobuf-java-util:${protobufVersion}",

--- a/observability/build.gradle
+++ b/observability/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 
     implementation project(':grpc-protobuf'),
             project(':grpc-stub'),
+            libraries.perfmark,
             ('com.google.guava:guava:31.0.1-jre'),
             ('com.google.errorprone:error_prone_annotations:2.11.0'),
             ('com.google.auth:google-auth-library-credentials:1.4.0'),

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -39,7 +39,7 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "io.netty:netty-transport:4.1.72.Final",
     "io.opencensus:opencensus-api:0.24.0",
     "io.opencensus:opencensus-contrib-grpc-metrics:0.24.0",
-    "io.perfmark:perfmark-api:0.23.0",
+    "io.perfmark:perfmark-api:0.25.0",
     "junit:junit:4.12",
     "org.apache.tomcat:annotations-api:6.0.53",
     "org.codehaus.mojo:animal-sniffer-annotations:1.19",


### PR DESCRIPTION
Perfmark 0.24.0 is much more defensive about class initialization failures, and speeds up class load time by a few millis.   
