### PR TITLE
New streams before transportReady() are not guaranteed to work

### DIFF
--- a/binder/src/androidTest/java/io/grpc/binder/internal/BinderClientTransportTest.java
+++ b/binder/src/androidTest/java/io/grpc/binder/internal/BinderClientTransportTest.java
@@ -167,8 +167,7 @@ public final class BinderClientTransportTest {
   @Test
   public void testShutdownBeforeStreamStart_b153326034() throws Exception {
     transport = new BinderClientTransportBuilder().build();
-    transport.start(transportListener).run();
-    transportListener.awaitReady();
+    startAndAwaitReady(transport, transportListener);
     ClientStream stream = transport.newStream(
         methodDesc, new Metadata(), CallOptions.DEFAULT, tracers);
     transport.shutdownNow(Status.UNKNOWN.withDescription("reasons"));
@@ -180,8 +179,7 @@ public final class BinderClientTransportTest {
   @Test
   public void testRequestWhileStreamIsWaitingOnCall_b154088869() throws Exception {
     transport = new BinderClientTransportBuilder().build();
-    transport.start(transportListener).run();
-    transportListener.awaitReady();
+    startAndAwaitReady(transport, transportListener);
     ClientStream stream =
         transport.newStream(streamingMethodDesc, new Metadata(), CallOptions.DEFAULT, tracers);
 
@@ -201,8 +199,7 @@ public final class BinderClientTransportTest {
   @Test
   public void testTransactionForDiscardedCall_b155244043() throws Exception {
     transport = new BinderClientTransportBuilder().build();
-    transport.start(transportListener).run();
-    transportListener.awaitReady();
+    startAndAwaitReady(transport, transportListener);
     ClientStream stream =
         transport.newStream(streamingMethodDesc, new Metadata(), CallOptions.DEFAULT, tracers);
 
@@ -222,8 +219,7 @@ public final class BinderClientTransportTest {
   @Test
   public void testBadTransactionStreamThroughput_b163053382() throws Exception {
     transport = new BinderClientTransportBuilder().build();
-    transport.start(transportListener).run();
-    transportListener.awaitReady();
+    startAndAwaitReady(transport, transportListener);
     ClientStream stream =
         transport.newStream(streamingMethodDesc, new Metadata(), CallOptions.DEFAULT, tracers);
 
@@ -244,8 +240,7 @@ public final class BinderClientTransportTest {
   @Test
   public void testMessageProducerClosedAfterStream_b169313545() {
     transport = new BinderClientTransportBuilder().build();
-    transport.start(transportListener).run();
-    transportListener.awaitReady();
+    startAndAwaitReady(transport, transportListener);
     ClientStream stream =
         transport.newStream(methodDesc, new Metadata(), CallOptions.DEFAULT, tracers);
 
@@ -288,6 +283,12 @@ public final class BinderClientTransportTest {
         throw new AssertionError("Interrupted waiting for servercalls");
       }
     }
+  }
+
+  private static void startAndAwaitReady(
+      BinderTransport.BinderClientTransport transport, TestTransportListener transportListener) {
+    transport.start(transportListener).run();
+    transportListener.awaitReady();
   }
 
   private static final class TestTransportListener implements ManagedClientTransport.Listener {
@@ -385,6 +386,9 @@ public final class BinderClientTransportTest {
     }
   }
 
+  /**
+   * A SecurityPolicy that blocks the transport authorization check until a test sets the outcome.
+   */
   static class BlockingSecurityPolicy extends SecurityPolicy {
     private final BlockingQueue<Status> results = new LinkedBlockingQueue<>();
 

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -637,6 +637,12 @@ public abstract class BinderTransport
         ClientStreamTracer[] tracers) {
       if (isShutdown()) {
         return newFailingClientStream(shutdownStatus, attributes, headers, tracers);
+      } else if (!inState(TransportState.READY)) {
+        return newFailingClientStream(
+            Status.INTERNAL.withDescription("newStream() before transportReady()"),
+            attributes,
+            headers,
+            tracers);
       } else {
         int callId = latestCallId++;
         if (latestCallId == LAST_CALL_ID) {

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -635,39 +635,39 @@ public abstract class BinderTransport
         final Metadata headers,
         final CallOptions callOptions,
         ClientStreamTracer[] tracers) {
-      if (isShutdown()) {
-        return newFailingClientStream(shutdownStatus, attributes, headers, tracers);
-      } else if (!inState(TransportState.READY)) {
+      if (!inState(TransportState.READY)) {
         return newFailingClientStream(
-            Status.INTERNAL.withDescription("newStream() before transportReady()"),
+            isShutdown()
+                ? shutdownStatus
+                : Status.INTERNAL.withDescription("newStream() before transportReady()"),
             attributes,
             headers,
             tracers);
+      }
+
+      int callId = latestCallId++;
+      if (latestCallId == LAST_CALL_ID) {
+        latestCallId = FIRST_CALL_ID;
+      }
+      StatsTraceContext statsTraceContext =
+          StatsTraceContext.newClientContext(tracers, attributes, headers);
+      Inbound.ClientInbound inbound =
+          new Inbound.ClientInbound(
+              this, attributes, callId, GrpcUtil.shouldBeCountedForInUse(callOptions));
+      if (ongoingCalls.putIfAbsent(callId, inbound) != null) {
+        Status failure = Status.INTERNAL.withDescription("Clashing call IDs");
+        shutdownInternal(failure, true);
+        return newFailingClientStream(failure, attributes, headers, tracers);
       } else {
-        int callId = latestCallId++;
-        if (latestCallId == LAST_CALL_ID) {
-          latestCallId = FIRST_CALL_ID;
+        if (inbound.countsForInUse() && numInUseStreams.getAndIncrement() == 0) {
+          clientTransportListener.transportInUse(true);
         }
-        StatsTraceContext statsTraceContext =
-            StatsTraceContext.newClientContext(tracers, attributes, headers);
-        Inbound.ClientInbound inbound =
-            new Inbound.ClientInbound(
-                this, attributes, callId, GrpcUtil.shouldBeCountedForInUse(callOptions));
-        if (ongoingCalls.putIfAbsent(callId, inbound) != null) {
-          Status failure = Status.INTERNAL.withDescription("Clashing call IDs");
-          shutdownInternal(failure, true);
-          return newFailingClientStream(failure, attributes, headers, tracers);
+        Outbound.ClientOutbound outbound =
+            new Outbound.ClientOutbound(this, callId, method, headers, statsTraceContext);
+        if (method.getType().clientSendsOneMessage()) {
+          return new SingleMessageClientStream(inbound, outbound, attributes);
         } else {
-          if (inbound.countsForInUse() && numInUseStreams.getAndIncrement() == 0) {
-            clientTransportListener.transportInUse(true);
-          }
-          Outbound.ClientOutbound outbound =
-              new Outbound.ClientOutbound(this, callId, method, headers, statsTraceContext);
-          if (method.getType().clientSendsOneMessage()) {
-            return new SingleMessageClientStream(inbound, outbound, attributes);
-          } else {
-            return new MultiMessageClientStream(inbound, outbound, attributes);
-          }
+          return new MultiMessageClientStream(inbound, outbound, attributes);
         }
       }
     }

--- a/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
@@ -94,6 +94,8 @@ public interface ManagedClientTransport extends ClientTransport {
     /**
      * The transport is ready to accept traffic, because the connection is established.  This is
      * called at most once.
+     *
+     * <p>Streams created before this milestone are not guaranteed to function.
      */
     void transportReady();
 

--- a/core/src/test/java/io/grpc/internal/AbstractTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractTransportTest.java
@@ -1145,7 +1145,7 @@ public abstract class AbstractTransportTest {
   public void earlyServerClose_serverFailure_withClientCancelOnListenerClosed() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;


### PR DESCRIPTION
Update javadoc to mention this previously-unwritten rule.

Update earlyServerClose_serverFailure_withClientCancelOnListenerClosed to obey it.

Update BinderTransport to fail sooner and with a better message if this rule is broken.