### PR TITLE
xds: Don't end status with '.' in XdsNameResolver

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -723,7 +723,7 @@ final class XdsNameResolver extends NameResolver {
             return;
           }
           listener.onError(Status.UNAVAILABLE.withCause(error.getCause()).withDescription(
-              String.format("Unable to load LDS %s. xDS server returned: %s: %s.",
+              String.format("Unable to load LDS %s. xDS server returned: %s: %s",
               ldsResourceName, error.getCode(), error.getDescription())));
         }
       });
@@ -923,7 +923,7 @@ final class XdsNameResolver extends NameResolver {
               return;
             }
             listener.onError(Status.UNAVAILABLE.withCause(error.getCause()).withDescription(
-                String.format("Unable to load RDS %s. xDS server returned: %s: %s.",
+                String.format("Unable to load RDS %s. xDS server returned: %s: %s",
                 resourceName, error.getCode(), error.getDescription())));
           }
         });

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -432,7 +432,7 @@ public class XdsNameResolverTest {
     Status error = errorCaptor.getValue();
     assertThat(error.getCode()).isEqualTo(Code.UNAVAILABLE);
     assertThat(error.getDescription()).isEqualTo("Unable to load LDS " + AUTHORITY
-        + ". xDS server returned: UNAVAILABLE: server unreachable.");
+        + ". xDS server returned: UNAVAILABLE: server unreachable");
   }
 
   @Test
@@ -444,7 +444,7 @@ public class XdsNameResolverTest {
     Status error = errorCaptor.getValue();
     assertThat(error.getCode()).isEqualTo(Code.UNAVAILABLE);
     assertThat(error.getDescription()).isEqualTo("Unable to load LDS " + AUTHORITY
-        + ". xDS server returned: NOT_FOUND: server unreachable.");
+        + ". xDS server returned: NOT_FOUND: server unreachable");
     assertThat(error.getCause()).isNull();
   }
 
@@ -458,11 +458,11 @@ public class XdsNameResolverTest {
     Status error = errorCaptor.getAllValues().get(0);
     assertThat(error.getCode()).isEqualTo(Code.UNAVAILABLE);
     assertThat(error.getDescription()).isEqualTo("Unable to load LDS " + AUTHORITY
-        + ". xDS server returned: UNAVAILABLE: server unreachable.");
+        + ". xDS server returned: UNAVAILABLE: server unreachable");
     error = errorCaptor.getAllValues().get(1);
     assertThat(error.getCode()).isEqualTo(Code.UNAVAILABLE);
     assertThat(error.getDescription()).isEqualTo("Unable to load RDS " + RDS_RESOURCE_NAME
-        + ". xDS server returned: UNAVAILABLE: server unreachable.");
+        + ". xDS server returned: UNAVAILABLE: server unreachable");
   }
 
   @Test


### PR DESCRIPTION
2a45524 introduced '.' to the end of some status descriptions. We
typically don't end status descriptiosn in periods, but that's minor. In
this case though if the causal status ends in period then the new status
will end in two periods, which could easily be confusing to users.