### PR TITLE
Add a configurable warmup phase to fallback test client

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/GrpclbFallbackTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/GrpclbFallbackTestClient.java
@@ -204,7 +204,8 @@ public final class GrpclbFallbackTestClient {
     assertEquals(0, exitCode);
   }
 
-  private GrpclbRouteType doRpcAndGetPath(TestServiceGrpc.TestServiceBlockingStub stub, Deadline deadline) {
+  private GrpclbRouteType doRpcAndGetPath(
+      TestServiceGrpc.TestServiceBlockingStub stub, Deadline deadline) {
     logger.info("doRpcAndGetPath deadline: " + deadline);
     final SimpleRequest request = SimpleRequest.newBuilder()
         .setFillGrpclbRouteType(true)

--- a/interop-testing/src/main/java/io/grpc/testing/integration/GrpclbFallbackTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/GrpclbFallbackTestClient.java
@@ -75,7 +75,7 @@ public final class GrpclbFallbackTestClient {
   private String customCredentialsType;
   private String testCase;
   private Boolean skipNetCmd = false;
-  private Integer numWarmupRpcs;
+  private int numWarmupRpcs;
 
   private ManagedChannel channel;
   private TestServiceGrpc.TestServiceBlockingStub blockingStub;


### PR DESCRIPTION
We currently use a 5 second fallback timeout with this client in certain cases where we expect fallback to happen ~immediately.

However, we frequently surpass that 5 second timeout in automated runs. Repro'ing manually, I can see the test client consistently spend its first few seconds burning 100% CPU - so I suspect there is some expensive stuff that happens the first time we make an RPC, loading dependencies etc.

Adding a warmup phase to the test should get the initialization things out of the way (which is not relevant for the test), and let us keep the 5 second timeout.

b/213963877