### PR TITLE
googleapis: Move GoogleCloudToProdNameResolver from xds (1.45.x backport)

### DIFF
--- a/googleapis/build.gradle
+++ b/googleapis/build.gradle
@@ -1,0 +1,36 @@
+plugins {
+    id "java-library"
+    id "maven-publish"
+
+    id "ru.vyarus.animalsniffer"
+}
+
+description = 'gRPC: googleapis'
+
+dependencies {
+    api project(':grpc-api')
+    implementation project(':grpc-alts'),
+                   project(':grpc-core'),
+                   project(':grpc-xds'),
+                   libraries.guava
+    testImplementation project(':grpc-core').sourceSets.test.output
+
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            pom {
+                withXml {
+                    // Since internal APIs are used, pin the version.
+                    asNode().dependencies.'*'.findAll() { dep ->
+                        dep.artifactId.text() in ['grpc-alts', 'grpc-xds']
+                    }.each() { core ->
+                        core.version*.value = "[" + core.version.text() + "]"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/googleapis/src/main/java/io/grpc/googleapis/GoogleCloudToProdNameResolverProvider.java
+++ b/googleapis/src/main/java/io/grpc/googleapis/GoogleCloudToProdNameResolverProvider.java
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-package io.grpc.xds;
+package io.grpc.googleapis;
 
 import io.grpc.Internal;
 import io.grpc.NameResolver;
 import io.grpc.NameResolver.Args;
 import io.grpc.NameResolverProvider;
 import io.grpc.internal.GrpcUtil;
+import io.grpc.xds.InternalSharedXdsClientPoolProvider;
 import java.net.URI;
+import java.util.Map;
 
 /**
  * A provider for {@link GoogleCloudToProdNameResolver}.
@@ -36,7 +38,7 @@ public final class GoogleCloudToProdNameResolverProvider extends NameResolverPro
     if (SCHEME.equals(targetUri.getScheme())) {
       return new GoogleCloudToProdNameResolver(
           targetUri, args, GrpcUtil.SHARED_CHANNEL_EXECUTOR,
-          SharedXdsClientPoolProvider.getDefaultProvider());
+          new SharedXdsClientPoolProviderBootstrapSetter());
     }
     return null;
   }
@@ -54,5 +56,13 @@ public final class GoogleCloudToProdNameResolverProvider extends NameResolverPro
   @Override
   protected int priority() {
     return 4;
+  }
+
+  private static final class SharedXdsClientPoolProviderBootstrapSetter
+      implements GoogleCloudToProdNameResolver.BootstrapSetter {
+    @Override
+    public void setBootstrap(Map<String, ?> bootstrap) {
+      InternalSharedXdsClientPoolProvider.setDefaultProviderBootstrapOverride(bootstrap);
+    }
   }
 }

--- a/googleapis/src/main/resources/META-INF/services/io.grpc.NameResolverProvider
+++ b/googleapis/src/main/resources/META-INF/services/io.grpc.NameResolverProvider
@@ -1,0 +1,1 @@
+io.grpc.googleapis.GoogleCloudToProdNameResolverProvider

--- a/googleapis/src/test/java/io/grpc/googleapis/GoogleCloudToProdNameResolverProviderTest.java
+++ b/googleapis/src/test/java/io/grpc/googleapis/GoogleCloudToProdNameResolverProviderTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.grpc.xds;
+package io.grpc.googleapis;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;

--- a/settings.gradle
+++ b/settings.gradle
@@ -37,6 +37,7 @@ include ":grpc-protobuf"
 include ":grpc-protobuf-lite"
 include ":grpc-netty"
 include ":grpc-netty-shaded"
+include ":grpc-googleapis"
 include ":grpc-grpclb"
 include ":grpc-testing"
 include ":grpc-testing-proto"
@@ -63,6 +64,7 @@ project(':grpc-protobuf').projectDir = "$rootDir/protobuf" as File
 project(':grpc-protobuf-lite').projectDir = "$rootDir/protobuf-lite" as File
 project(':grpc-netty').projectDir = "$rootDir/netty" as File
 project(':grpc-netty-shaded').projectDir = "$rootDir/netty/shaded" as File
+project(':grpc-googleapis').projectDir = "$rootDir/googleapis" as File
 project(':grpc-grpclb').projectDir = "$rootDir/grpclb" as File
 project(':grpc-testing').projectDir = "$rootDir/testing" as File
 project(':grpc-testing-proto').projectDir = "$rootDir/testing-proto" as File

--- a/xds/src/main/java/io/grpc/xds/InternalSharedXdsClientPoolProvider.java
+++ b/xds/src/main/java/io/grpc/xds/InternalSharedXdsClientPoolProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import io.grpc.Internal;
+import java.util.Map;
+
+/**
+ * Accessor for global factory for managing XdsClient instance.
+ */
+@Internal
+public final class InternalSharedXdsClientPoolProvider {
+  // Prevent instantiation
+  private InternalSharedXdsClientPoolProvider() {}
+
+  public static void setDefaultProviderBootstrapOverride(Map<String, ?> bootstrap) {
+    SharedXdsClientPoolProvider.getDefaultProvider().setBootstrapOverride(bootstrap);
+  }
+}

--- a/xds/src/main/resources/META-INF/services/io.grpc.NameResolverProvider
+++ b/xds/src/main/resources/META-INF/services/io.grpc.NameResolverProvider
@@ -1,2 +1,1 @@
 io.grpc.xds.XdsNameResolverProvider
-io.grpc.xds.GoogleCloudToProdNameResolverProvider


### PR DESCRIPTION
GoogleCloudToProdNameResolver has a hard dependency on alts whereas xds
only has a weak dependency on alts that can be solved by a
ChannelCredentialsRegistry. So split out the code to a separate
artifact.

CC @apolcyn 

Backport of #8961