### PR TITLE
xds: BootstrapperImpl should not be public (1.45.x backport)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/BootstrapperImpl.java
+++ b/xds/src/main/java/io/grpc/xds/BootstrapperImpl.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.grpc.ChannelCredentials;
 import io.grpc.InsecureChannelCredentials;
-import io.grpc.Internal;
 import io.grpc.InternalLogId;
 import io.grpc.TlsChannelCredentials;
 import io.grpc.alts.GoogleDefaultChannelCredentials;
@@ -44,8 +43,7 @@ import javax.annotation.Nullable;
 /**
  * A {@link Bootstrapper} implementation that reads xDS configurations from local file system.
  */
-@Internal
-public class BootstrapperImpl extends Bootstrapper {
+class BootstrapperImpl extends Bootstrapper {
 
   private static final String BOOTSTRAP_PATH_SYS_ENV_VAR = "GRPC_XDS_BOOTSTRAP";
   @VisibleForTesting


### PR DESCRIPTION
It isn't used outside the package and is showing up in Javadoc. Instead
of excluding it from the Javadoc, just make it package-private.

Backport of #8962