### PR TITLE
googleapis: Stabilize google-c2p resolver

### DIFF
--- a/googleapis/src/main/java/io/grpc/googleapis/GoogleCloudToProdExperimentalNameResolverProvider.java
+++ b/googleapis/src/main/java/io/grpc/googleapis/GoogleCloudToProdExperimentalNameResolverProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.googleapis;
+
+import io.grpc.Internal;
+import io.grpc.NameResolver;
+import io.grpc.NameResolver.Args;
+import io.grpc.NameResolverProvider;
+import java.net.URI;
+
+/**
+ * A provider for {@link GoogleCloudToProdNameResolver}, with experimental scheme.
+ */
+@Internal
+public final class GoogleCloudToProdExperimentalNameResolverProvider extends NameResolverProvider {
+  private final GoogleCloudToProdNameResolverProvider delegate =
+      new GoogleCloudToProdNameResolverProvider("google-c2p-experimental");
+
+  @Override
+  public NameResolver newNameResolver(URI targetUri, Args args) {
+    return delegate.newNameResolver(targetUri, args);
+  }
+
+  @Override
+  public String getDefaultScheme() {
+    return delegate.getDefaultScheme();
+  }
+
+  @Override
+  protected boolean isAvailable() {
+    return delegate.isAvailable();
+  }
+
+  @Override
+  protected int priority() {
+    return delegate.priority();
+  }
+}

--- a/googleapis/src/main/java/io/grpc/googleapis/GoogleCloudToProdNameResolverProvider.java
+++ b/googleapis/src/main/java/io/grpc/googleapis/GoogleCloudToProdNameResolverProvider.java
@@ -16,6 +16,7 @@
 
 package io.grpc.googleapis;
 
+import com.google.common.base.Preconditions;
 import io.grpc.Internal;
 import io.grpc.NameResolver;
 import io.grpc.NameResolver.Args;
@@ -31,11 +32,21 @@ import java.util.Map;
 @Internal
 public final class GoogleCloudToProdNameResolverProvider extends NameResolverProvider {
 
-  private static final String SCHEME = "google-c2p-experimental";
+  private static final String SCHEME = "google-c2p";
+
+  private final String scheme;
+
+  public GoogleCloudToProdNameResolverProvider() {
+    this(SCHEME);
+  }
+
+  GoogleCloudToProdNameResolverProvider(String scheme) {
+    this.scheme = Preconditions.checkNotNull(scheme, "scheme");
+  }
 
   @Override
   public NameResolver newNameResolver(URI targetUri, Args args) {
-    if (SCHEME.equals(targetUri.getScheme())) {
+    if (scheme.equals(targetUri.getScheme())) {
       return new GoogleCloudToProdNameResolver(
           targetUri, args, GrpcUtil.SHARED_CHANNEL_EXECUTOR,
           new SharedXdsClientPoolProviderBootstrapSetter());
@@ -45,7 +56,7 @@ public final class GoogleCloudToProdNameResolverProvider extends NameResolverPro
 
   @Override
   public String getDefaultScheme() {
-    return SCHEME;
+    return scheme;
   }
 
   @Override

--- a/googleapis/src/main/resources/META-INF/services/io.grpc.NameResolverProvider
+++ b/googleapis/src/main/resources/META-INF/services/io.grpc.NameResolverProvider
@@ -1,1 +1,2 @@
+io.grpc.googleapis.GoogleCloudToProdExperimentalNameResolverProvider
 io.grpc.googleapis.GoogleCloudToProdNameResolverProvider

--- a/googleapis/src/test/java/io/grpc/googleapis/GoogleCloudToProdNameResolverProviderTest.java
+++ b/googleapis/src/test/java/io/grpc/googleapis/GoogleCloudToProdNameResolverProviderTest.java
@@ -72,8 +72,27 @@ public class GoogleCloudToProdNameResolverProviderTest {
   }
 
   @Test
+  public void experimentalProvided() {
+    for (NameResolverProvider current
+        : InternalServiceProviders.getCandidatesViaServiceLoader(
+        NameResolverProvider.class, getClass().getClassLoader())) {
+      if (current instanceof GoogleCloudToProdExperimentalNameResolverProvider) {
+        return;
+      }
+    }
+    fail("GoogleCloudToProdExperimentalNameResolverProvider not registered");
+  }
+
+  @Test
   public void newNameResolver() {
     assertThat(provider
+        .newNameResolver(URI.create("google-c2p:///foo.googleapis.com"), args))
+        .isInstanceOf(GoogleCloudToProdNameResolver.class);
+  }
+
+  @Test
+  public void experimentalNewNameResolver() {
+    assertThat(new GoogleCloudToProdExperimentalNameResolverProvider()
         .newNameResolver(URI.create("google-c2p-experimental:///foo.googleapis.com"), args))
         .isInstanceOf(GoogleCloudToProdNameResolver.class);
   }


### PR DESCRIPTION
Preserve google-c2p-experimental support for the moment to ease testing
migration.