### PR TITLE
stub: ClientCalls.ThreadlessExecutor throws rejectedExecutorException disable by default

### DIFF
--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -39,6 +39,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.locks.LockSupport;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -161,6 +162,7 @@ public final class ClientCalls {
       // Something very bad happened. All bets are off; it may be dangerous to wait for onClose().
       throw cancelThrow(call, e);
     } finally {
+      executor.shutdown();
       if (interrupt) {
         Thread.currentThread().interrupt();
       }
@@ -626,6 +628,9 @@ public final class ClientCalls {
               // Now wait for onClose() to be called, so interceptors can clean up
             }
           }
+          if (next == this || next instanceof StatusRuntimeException) {
+            threadless.shutdown();
+          }
           return next;
         }
       } finally {
@@ -712,7 +717,10 @@ public final class ClientCalls {
       implements Executor {
     private static final Logger log = Logger.getLogger(ThreadlessExecutor.class.getName());
 
-    private volatile Thread waiter;
+    private static final Object SHUTDOWN = new Object(); // sentinel
+
+    // Set to the calling thread while it's parked, SHUTDOWN on RPC completion
+    private volatile Object waiter;
 
     // Non private to avoid synthetic class
     ThreadlessExecutor() {}
@@ -736,12 +744,27 @@ public final class ClientCalls {
         }
       }
       do {
-        try {
-          runnable.run();
-        } catch (Throwable t) {
-          log.log(Level.WARNING, "Runnable threw exception", t);
-        }
+        runQuietly(runnable);
       } while ((runnable = poll()) != null);
+    }
+
+    /**
+     * Called after final call to {@link #waitAndDrain()}, from same thread.
+     */
+    public void shutdown() {
+      waiter = SHUTDOWN;
+      Runnable runnable;
+      while ((runnable = poll()) != null) {
+        runQuietly(runnable);
+      }
+    }
+
+    private static void runQuietly(Runnable runnable) {
+      try {
+        runnable.run();
+      } catch (Throwable t) {
+        log.log(Level.WARNING, "Runnable threw exception", t);
+      }
     }
 
     private static void throwIfInterrupted() throws InterruptedException {
@@ -753,7 +776,12 @@ public final class ClientCalls {
     @Override
     public void execute(Runnable runnable) {
       add(runnable);
-      LockSupport.unpark(waiter); // no-op if null
+      Object waiter = this.waiter;
+      if (waiter != SHUTDOWN) {
+        LockSupport.unpark((Thread) waiter); // no-op if null
+      } else if (remove(runnable)) {
+        throw new RejectedExecutionException();
+      }
     }
   }
 

--- a/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
+++ b/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
@@ -19,6 +19,7 @@ package io.grpc.stub;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -58,6 +59,8 @@ import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -97,10 +100,12 @@ public class ClientCallsTest {
   private ArgumentCaptor<MethodDescriptor<?, ?>> methodDescriptorCaptor;
   @Captor
   private ArgumentCaptor<CallOptions> callOptionsCaptor;
+  private boolean originalRejectRunnableOnExecutor;
 
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
+    originalRejectRunnableOnExecutor = ClientCalls.rejectRunnableOnExecutor;
   }
 
   @After
@@ -111,6 +116,7 @@ public class ClientCallsTest {
     if (channel != null) {
       channel.shutdownNow();
     }
+    ClientCalls.rejectRunnableOnExecutor = originalRejectRunnableOnExecutor;
   }
 
   @Test
@@ -215,6 +221,49 @@ public class ClientCallsTest {
     }
     assertTrue("onCloseCalled", interceptor.onCloseCalled);
     assertTrue("context not cancelled", methodImpl.observer.isCancelled());
+  }
+
+  @Test
+  public void blockingUnaryCall2_rejectExecutionOnClose() throws Exception {
+    Integer req = 2;
+
+    class NoopUnaryMethod implements UnaryMethod<Integer, Integer> {
+      ServerCallStreamObserver<Integer> observer;
+
+      @Override public void invoke(Integer request, StreamObserver<Integer> responseObserver) {
+        observer = (ServerCallStreamObserver<Integer>) responseObserver;
+      }
+    }
+
+    NoopUnaryMethod methodImpl = new NoopUnaryMethod();
+    server = InProcessServerBuilder.forName("noop").directExecutor()
+        .addService(ServerServiceDefinition.builder("some")
+            .addMethod(UNARY_METHOD, ServerCalls.asyncUnaryCall(methodImpl))
+            .build())
+        .build().start();
+
+    InterruptInterceptor interceptor = new InterruptInterceptor();
+    channel = InProcessChannelBuilder.forName("noop")
+        .directExecutor()
+        .intercept(interceptor)
+        .build();
+    try {
+      ClientCalls.blockingUnaryCall(channel, UNARY_METHOD, CallOptions.DEFAULT, req);
+      fail();
+    } catch (StatusRuntimeException ex) {
+      assertTrue(Thread.interrupted());
+      assertTrue("interrupted", ex.getCause() instanceof InterruptedException);
+    }
+    assertTrue("onCloseCalled", interceptor.onCloseCalled);
+    assertTrue("context not cancelled", methodImpl.observer.isCancelled());
+    assertNotNull("callOptionsExecutor should not be null", interceptor.savedExecutor);
+    ClientCalls.rejectRunnableOnExecutor = true;
+    try {
+      interceptor.savedExecutor.execute(() -> {});
+      fail();
+    } catch (Exception ex) {
+      assertTrue(ex instanceof RejectedExecutionException);
+    }
   }
 
   @Test
@@ -858,6 +907,7 @@ public class ClientCallsTest {
   // Used for blocking tests to check interrupt behavior and make sure onClose is still called.
   class InterruptInterceptor implements ClientInterceptor {
     boolean onCloseCalled;
+    Executor savedExecutor;
 
     @Override
     public <ReqT,RespT> ClientCall<ReqT, RespT> interceptCall(
@@ -867,6 +917,7 @@ public class ClientCallsTest {
           super.start(new SimpleForwardingClientCallListener<RespT>(listener) {
             @Override public void onClose(Status status, Metadata trailers) {
               onCloseCalled = true;
+              savedExecutor = callOptions.getExecutor();
               super.onClose(status, trailers);
             }
           }, headers);

--- a/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
+++ b/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
@@ -259,7 +259,7 @@ public class ClientCallsTest {
     assertNotNull("callOptionsExecutor should not be null", interceptor.savedExecutor);
     ClientCalls.rejectRunnableOnExecutor = true;
     try {
-      interceptor.savedExecutor.execute(() -> {});
+      interceptor.savedExecutor.execute(() -> { });
       fail();
     } catch (Exception ex) {
       assertTrue(ex instanceof RejectedExecutionException);


### PR DESCRIPTION
redo https://github.com/grpc/grpc-java/pull/8847 but disable by default, we will enable after we fix https://github.com/grpc/grpc-java/issues/8928