### PR TITLE
core: synchronize delayedClientCall setCall and start, return drainPendingCalls runnable

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1099,22 +1099,18 @@ final class ManagedChannelImpl extends ManagedChannel implements
 
       /** Called when it's ready to create a real call and reprocess the pending call. */
       void reprocess() {
-        getCallExecutor(callOptions).execute(
-            new Runnable() {
-              @Override
-              public void run() {
-                ClientCall<ReqT, RespT> realCall;
-                Context previous = context.attach();
-                try {
-                  realCall = newClientCall(method, callOptions);
-                } finally {
-                  context.detach(previous);
-                }
-                setCall(realCall);
-                syncContext.execute(new PendingCallRemoval());
-              }
-            }
-        );
+        ClientCall<ReqT, RespT> realCall;
+        Context previous = context.attach();
+        try {
+          realCall = newClientCall(method, callOptions);
+        } finally {
+          context.detach(previous);
+        }
+        Runnable toRun = setCall(realCall);
+        if (toRun != null) {
+          getCallExecutor(callOptions).execute(toRun);
+        }
+        syncContext.execute(new PendingCallRemoval());
       }
 
       @Override

--- a/core/src/test/java/io/grpc/internal/DelayedClientCallTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientCallTest.java
@@ -64,11 +64,13 @@ public class DelayedClientCallTest {
     DelayedClientCall<String, Integer> delayedClientCall =
         new DelayedClientCall<>(callExecutor, fakeClock.getScheduledExecutorService(), null);
     delayedClientCall.setCall(mockRealCall);
+    delayedClientCall.start(listener, new Metadata());
     ForwardingTestUtil.testMethodsForwarded(
         ClientCall.class,
         mockRealCall,
         delayedClientCall,
-        Arrays.asList(ClientCall.class.getMethod("toString")),
+        Arrays.asList(ClientCall.class.getMethod("toString"),
+            ClientCall.class.getMethod("start", Listener.class, Metadata.class)),
         new ForwardingTestUtil.ArgumentProvider() {
           @Override
           public Object get(Method method, int argPos, Class<?> clazz) {


### PR DESCRIPTION
changes:
1. return runnable for `setCall()` only when there are calls to drain, otherwise return null. Synchronize between `setCall()` and `start()`. To faciliatate this, methods on `DelayedClientCall` should all be after `start()`
2. `ManagedChannelImpl` only use `getCallOptionsExecutor()` when call is not closed yet, so this should fix https://github.com/grpc/grpc-java/issues/8928
3. enable by default `GRPC_CLIENT_CALL_REJECT_RUNNABLE`

to fix https://github.com/grpc/grpc-java/issues/8928, verified in [issue reproduction](https://paste.googleplex.com/5816902191415296)