### PR TITLE
[Backport v1.37.x] Redirect xDS tests to use grpc/grpc's master branch

### DIFF
--- a/buildscripts/kokoro/xds.sh
+++ b/buildscripts/kokoro/xds.sh
@@ -8,16 +8,10 @@ fi
 cd github
 
 pushd grpc-java/interop-testing
-branch=$(git branch --all --no-color --contains "${KOKORO_GITHUB_COMMIT}" \
-      | grep -v HEAD | head -1)
-shopt -s extglob
-branch="${branch//[[:space:]]}"
-branch="${branch##remotes/origin/}"
-shopt -u extglob
 ../gradlew installDist -x test -PskipCodegen=true -PskipAndroid=true
 popd
 
-git clone -b "${branch}" --single-branch --depth=1 https://github.com/grpc/grpc.git
+git clone -b master --single-branch --depth=1 https://github.com/grpc/grpc.git
 
 grpc/tools/run_tests/helper_scripts/prep_xds.sh
 


### PR DESCRIPTION
[prod:grpc/java/v1.37.x/branch/xds](https://fusion2.corp.google.com/invocations/8e9756db-fd4a-45c8-9808-938a2943fab9/targets)