### PR TITLE
Redirect xDS tests to use grpc/grpc's master branch

### DIFF
--- a/buildscripts/kokoro/xds.sh
+++ b/buildscripts/kokoro/xds.sh
@@ -8,16 +8,10 @@ fi
 cd github
 
 pushd grpc-java/interop-testing
-branch=$(git branch --all --no-color --contains "${KOKORO_GITHUB_COMMIT}" \
-      | grep -v HEAD | head -1)
-shopt -s extglob
-branch="${branch//[[:space:]]}"
-branch="${branch##remotes/origin/}"
-shopt -u extglob
 ../gradlew installDist -x test -PskipCodegen=true -PskipAndroid=true
 popd
 
-git clone -b "${branch}" --single-branch --depth=1 https://github.com/grpc/grpc.git
+git clone -b master --single-branch --depth=1 https://github.com/grpc/grpc.git
 
 grpc/tools/run_tests/helper_scripts/prep_xds.sh
 


### PR DESCRIPTION
Giving this task another thought, we don't need to redirect older branches, as they are working fine. We are solving the issue of grpc/grpc delaying the release, causing GCE tests to fail. Updating the master branch prevents similar cases from happening.

Tested: [prod:grpc/java/master/branch/xds_v3](http://sponge/010f5353-e65e-4b1a-b6d3-f5a84e31546b )

Attempted: https://github.com/grpc/grpc-java/pull/8979