### PR TITLE
Pass use_default_shell_env = True for protoc

### DIFF
--- a/java_grpc_library.bzl
+++ b/java_grpc_library.bzl
@@ -93,6 +93,7 @@ def _java_rpc_library_impl(ctx):
         outputs = [srcjar],
         executable = toolchain.protoc,
         arguments = [args],
+        use_default_shell_env = True,
     )
 
     deps_java_info = java_common.merge([dep[JavaInfo] for dep in ctx.attr.deps])


### PR DESCRIPTION
If protoc is compiled with MinGW it will depend on libstdc++-6.dll which is found in C:\msys64\mingw64\bin and can only be found by inheriting PATH from the environment.

Fixes #8983 