### PR TITLE
Simplify fallback test client and parameterize fallback deadline

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/GrpclbFallbackTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/GrpclbFallbackTestClient.java
@@ -145,7 +145,7 @@ public final class GrpclbFallbackTestClient {
           + c.fallbackDeadlineSeconds
           + "\n  --test_case=TEST_CASE        Test case to run. Valid options are:"
           + "\n      fallback_before_startup : fallback before startup e.g. due to "
-          + "LB/backend addresses being unreachable
+          + "LB/backend addresses being unreachable"
           + "\n      fallback_after_startup : fallback after startup e.g. due to "
           + "LB/backend addresses becoming unreachable"
           + "\n      Default: " + c.testCase


### PR DESCRIPTION
For one test where we happen to be using the ring hash LB policy and packets towards backend addresses are dropped, we need to increase the fallback deadline to > 60 seconds, since the ring hash LB policy needs two connections to time out (and it looks like each has a 30 second initial/default timeout).

This parameterizes the fallback deadline, allowing us to do this, and also since it seems useful to have a flag for this for experimentation anyways.