### PR TITLE
observability: implement server interceptor for logging

### DIFF
--- a/observability/src/main/java/io/grpc/observability/Observability.java
+++ b/observability/src/main/java/io/grpc/observability/Observability.java
@@ -41,7 +41,7 @@ public final class Observability {
     // TODO(dnvindhya): PROJECT_ID to be replaced with configured destinationProjectId
     Sink sink = new GcpLogSink(PROJECT_ID);
     LoggingChannelProvider.init(new InternalLoggingChannelInterceptor.FactoryImpl(sink));
-    LoggingServerProvider.init(new InternalLoggingServerInterceptor.FactoryImpl());
+    LoggingServerProvider.init(new InternalLoggingServerInterceptor.FactoryImpl(sink));
     // TODO(sanjaypujare): initialize customTags map
     initialized = true;
   }

--- a/observability/src/main/java/io/grpc/observability/interceptors/InternalLoggingServerInterceptor.java
+++ b/observability/src/main/java/io/grpc/observability/interceptors/InternalLoggingServerInterceptor.java
@@ -86,7 +86,6 @@ public final class InternalLoggingServerInterceptor implements ServerInterceptor
   @Override
   public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
       Metadata headers, ServerCallHandler<ReqT, RespT> next) {
-    // TODO(dnvindhya) implement the interceptor
     final AtomicLong seq = new AtomicLong(1);
     final String rpcId = UUID.randomUUID().toString();
     final String authority = call.getAuthority();
@@ -128,24 +127,6 @@ public final class InternalLoggingServerInterceptor implements ServerInterceptor
     ServerCall<ReqT, RespT> wrapperCall =
         new SimpleForwardingServerCall<ReqT, RespT>(call) {
           @Override
-          public void sendMessage(RespT message) {
-            // Event: EventType.GRPC_CALL_RESPONSE_MESSAGE
-            try {
-              helper.logRpcMessage(
-                  seq.getAndIncrement(),
-                  serviceName,
-                  methodName,
-                  EventType.GRPC_CALL_RESPONSE_MESSAGE,
-                  message,
-                  EventLogger.LOGGER_SERVER,
-                  rpcId);
-            } catch (Exception e) {
-              logger.log(Level.SEVERE, "Unable to log response message", e);
-            }
-            super.sendMessage(message);
-          }
-
-          @Override
           public void sendHeaders(Metadata headers) {
             // Event: EventType.GRPC_CALL_RESPONSE_HEADER
             try {
@@ -161,6 +142,24 @@ public final class InternalLoggingServerInterceptor implements ServerInterceptor
               logger.log(Level.SEVERE, "Unable to log response header", e);
             }
             super.sendHeaders(headers);
+          }
+
+          @Override
+          public void sendMessage(RespT message) {
+            // Event: EventType.GRPC_CALL_RESPONSE_MESSAGE
+            try {
+              helper.logRpcMessage(
+                  seq.getAndIncrement(),
+                  serviceName,
+                  methodName,
+                  EventType.GRPC_CALL_RESPONSE_MESSAGE,
+                  message,
+                  EventLogger.LOGGER_SERVER,
+                  rpcId);
+            } catch (Exception e) {
+              logger.log(Level.SEVERE, "Unable to log response message", e);
+            }
+            super.sendMessage(message);
           }
 
           @Override

--- a/observability/src/main/java/io/grpc/observability/interceptors/InternalLoggingServerInterceptor.java
+++ b/observability/src/main/java/io/grpc/observability/interceptors/InternalLoggingServerInterceptor.java
@@ -16,32 +16,165 @@
 
 package io.grpc.observability.interceptors;
 
+import com.google.protobuf.Duration;
+import com.google.protobuf.util.Durations;
+import io.grpc.Context;
+import io.grpc.Deadline;
+import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
+import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener;
 import io.grpc.Internal;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import io.grpc.internal.TimeProvider;
+import io.grpc.observability.interceptors.LogHelper.LogSinkWriter;
+import io.grpc.observability.logging.Sink;
+import io.grpc.observabilitylog.v1.GrpcLogRecord.EventLogger;
+import io.grpc.observabilitylog.v1.GrpcLogRecord.EventType;
+import java.net.SocketAddress;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 /** A logging interceptor for {@code LoggingServerProvider}. */
 @Internal
 public final class InternalLoggingServerInterceptor implements ServerInterceptor {
+  private final LogSinkWriter writer;
 
   public interface Factory {
     ServerInterceptor create();
   }
 
   public static class FactoryImpl implements Factory {
+    Sink sink;
+
+    public FactoryImpl(Sink sink) {
+      this.sink = sink;
+    }
 
     @Override
     public ServerInterceptor create() {
-      return new InternalLoggingServerInterceptor();
+      return new InternalLoggingServerInterceptor(sink);
     }
+  }
+
+  private InternalLoggingServerInterceptor(Sink sink) {
+    this.writer = new LogSinkWriter(sink, TimeProvider.SYSTEM_TIME_PROVIDER);
   }
 
   @Override
   public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
       Metadata headers, ServerCallHandler<ReqT, RespT> next) {
     // TODO(dnvindhya) implement the interceptor
-    return null;
+    final AtomicLong seq = new AtomicLong(1);
+    final String rpcId = UUID.randomUUID().toString();
+    final String authority = call.getAuthority();
+    final String serviceName = call.getMethodDescriptor().getServiceName();
+    final String methodName = call.getMethodDescriptor().getBareMethodName();
+    final SocketAddress peerAddress = LogHelper.getPeerAddress(call.getAttributes());
+    Deadline deadline = Context.current().getDeadline();
+    final Duration timeout = deadline == null ? null
+        : Durations.fromNanos(deadline.timeRemaining(TimeUnit.NANOSECONDS));
+
+    // Event: EventType.GRPC_CALL_REQUEST_HEADER
+    writer.logRequestHeader(
+        seq.getAndIncrement(),
+        serviceName,
+        methodName,
+        authority,
+        timeout,
+        headers,
+        EventLogger.LOGGER_SERVER,
+        rpcId,
+        peerAddress);
+
+    ServerCall<ReqT, RespT> wrapperCall =
+        new SimpleForwardingServerCall<ReqT, RespT>(call) {
+          @Override
+          public void sendMessage(RespT message) {
+            // Event: EventType.GRPC_CALL_RESPONSE_MESSAGE
+            writer.logRpcMessage(
+                seq.getAndIncrement(),
+                serviceName,
+                methodName,
+                EventType.GRPC_CALL_RESPONSE_MESSAGE,
+                message,
+                EventLogger.LOGGER_SERVER,
+                rpcId);
+            super.sendMessage(message);
+          }
+
+          @Override
+          public void sendHeaders(Metadata headers) {
+            // Event: EventType.GRPC_CALL_RESPONSE_HEADER
+            writer.logResponseHeader(
+                seq.getAndIncrement(),
+                serviceName,
+                methodName,
+                headers,
+                EventLogger.LOGGER_SERVER,
+                rpcId,
+                null);
+            super.sendHeaders(headers);
+          }
+
+          @Override
+          public void close(Status status, Metadata trailers) {
+            // Event: EventType.GRPC_CALL_TRAILER
+            writer.logTrailer(
+                seq.getAndIncrement(),
+                serviceName,
+                methodName,
+                status,
+                trailers,
+                EventLogger.LOGGER_SERVER,
+                rpcId,
+                null);
+            super.close(status, trailers);
+          }
+        };
+
+    ServerCall.Listener<ReqT> listener = next.startCall(wrapperCall, headers);
+    return new SimpleForwardingServerCallListener<ReqT>(listener) {
+      @Override
+      public void onMessage(ReqT message) {
+        // Event: EventType.GRPC_CALL_REQUEST_MESSAGE
+        writer.logRpcMessage(
+            seq.getAndIncrement(),
+            serviceName,
+            methodName,
+            EventType.GRPC_CALL_REQUEST_MESSAGE,
+            message,
+            EventLogger.LOGGER_SERVER,
+            rpcId);
+        super.onMessage(message);
+      }
+
+      @Override
+      public void onHalfClose() {
+        // Event: EventType.GRPC_CALL_HALF_CLOSE
+        writer.logHalfClose(
+            seq.getAndIncrement(),
+            serviceName,
+            methodName,
+            EventLogger.LOGGER_SERVER,
+            rpcId);
+        super.onHalfClose();
+      }
+
+      @Override
+      public void onCancel() {
+        // Event: EventType.GRPC_CALL_CANCEL
+        writer.logCancel(
+            seq.getAndIncrement(),
+            serviceName,
+            methodName,
+            EventLogger.LOGGER_SERVER,
+            rpcId);
+        super.onCancel();
+      }
+    };
   }
 }

--- a/observability/src/main/java/io/grpc/observability/interceptors/LogHelper.java
+++ b/observability/src/main/java/io/grpc/observability/interceptors/LogHelper.java
@@ -33,6 +33,7 @@ import io.grpc.internal.TimeProvider;
 import io.grpc.observability.logging.Sink;
 import io.grpc.observabilitylog.v1.GrpcLogRecord;
 import io.grpc.observabilitylog.v1.GrpcLogRecord.Address;
+import io.grpc.observabilitylog.v1.GrpcLogRecord.EventLogger;
 import io.grpc.observabilitylog.v1.GrpcLogRecord.EventType;
 import io.grpc.observabilitylog.v1.GrpcLogRecord.LogLevel;
 import java.net.Inet4Address;
@@ -65,8 +66,7 @@ class LogHelper {
   }
 
   /**
-   * Logs the request header.
-   * Binary logging equivalent of logClientHeader.
+   * Logs the request header. Binary logging equivalent of logClientHeader.
    */
   void logRequestHeader(
       long seqId,
@@ -95,7 +95,7 @@ class LogHelper {
         .setEventType(EventType.GRPC_CALL_REQUEST_HEADER)
         .setEventLogger(eventLogger)
         .setLogLevel(LogLevel.LOG_LEVEL_DEBUG)
-        .setMetadata(pair.proto)
+        .setMetadata(pair.payload)
         .setPayloadSize(pair.size)
         .setRpcId(rpcId);
     if (timeout != null) {
@@ -108,8 +108,7 @@ class LogHelper {
   }
 
   /**
-   * Logs the reponse header.
-   * Binary logging equivalent of logServerHeader.
+   * Logs the reponse header. Binary logging equivalent of logServerHeader.
    */
   void logResponseHeader(
       long seqId,
@@ -136,7 +135,7 @@ class LogHelper {
         .setEventType(EventType.GRPC_CALL_RESPONSE_HEADER)
         .setEventLogger(eventLogger)
         .setLogLevel(LogLevel.LOG_LEVEL_DEBUG)
-        .setMetadata(pair.proto)
+        .setMetadata(pair.payload)
         .setPayloadSize(pair.size)
         .setRpcId(rpcId);
     if (peerAddress != null) {
@@ -173,7 +172,7 @@ class LogHelper {
         .setEventType(EventType.GRPC_CALL_TRAILER)
         .setEventLogger(eventLogger)
         .setLogLevel(LogLevel.LOG_LEVEL_DEBUG)
-        .setMetadata(pair.proto)
+        .setMetadata(pair.payload)
         .setPayloadSize(pair.size)
         .setStatusCode(status.getCode().value())
         .setRpcId(rpcId);
@@ -198,9 +197,9 @@ class LogHelper {
       long seqId,
       String serviceName,
       String methodName,
-      GrpcLogRecord.EventType eventType,
+      EventType eventType,
       T message,
-      GrpcLogRecord.EventLogger eventLogger,
+      EventLogger eventLogger,
       String rpcId) {
     checkNotNull(serviceName, "serviceName");
     checkNotNull(methodName, "methodName");
@@ -211,11 +210,23 @@ class LogHelper {
         "event type must correspond to client message or server message");
     checkNotNull(message, "message");
 
-    // TODO(dnvindhya): Convert message to bystestring and also log the message
-    // byte[] messageArray = (byte[])message;
-    // int messageLength = messageArray.length;
-    // ByteString messageData =
-    // ByteString.copyFrom((byte[]) message, 0, ((byte[]) message).length);
+    // TODO(dnvindhya): Implement conversion of generics to ByteString
+    // Following is a temporary workaround to log if message is of following types :
+    // 1. com.google.protobuf.Message
+    // 2. byte[]
+    byte[] messageBytesArray = null;
+    if (message instanceof com.google.protobuf.Message) {
+      messageBytesArray = ((com.google.protobuf.Message)message).toByteArray();
+    } else if (message instanceof byte[]) {
+      messageBytesArray = (byte[]) message;
+    } else {
+      logger.log(Level.WARNING, "message is of UNKNOWN type, message and payload_size fields"
+          + "of GrpcLogRecord proto will not be logged");
+    }
+    PayloadBuilder<ByteString> pair = null;
+    if (messageBytesArray != null) {
+      pair = createMesageProto(messageBytesArray);
+    }
 
     GrpcLogRecord.Builder logEntryBuilder = createTimestamp()
         .setSequenceId(seqId)
@@ -225,6 +236,12 @@ class LogHelper {
         .setEventLogger(eventLogger)
         .setLogLevel(LogLevel.LOG_LEVEL_DEBUG)
         .setRpcId(rpcId);
+    if ((pair != null) && (pair.size != 0)) {
+      logEntryBuilder.setPayloadSize(pair.size);
+    }
+    if ((pair != null) && (pair.payload != null)) {
+      logEntryBuilder.setMessage(pair.payload);
+    }
     sink.write(logEntryBuilder.build());
   }
 
@@ -282,11 +299,11 @@ class LogHelper {
   }
 
   static final class PayloadBuilder<T> {
-    T proto;
+    T payload;
     int size;
 
-    private PayloadBuilder(T proto, int size) {
-      this.proto = proto;
+    private PayloadBuilder(T payload, int size) {
+      this.payload = payload;
       this.size = size;
     }
   }
@@ -313,6 +330,13 @@ class LogHelper {
       }
     }
     return new PayloadBuilder<>(metadataBuilder, totalMetadataBytes);
+  }
+
+  static PayloadBuilder<ByteString> createMesageProto(byte[] message) {
+    int messageLength = message.length;
+    ByteString messageData =
+        ByteString.copyFrom(message, 0, messageLength);
+    return new PayloadBuilder<ByteString>(messageData, messageLength);
   }
 
   static Address socketAddressToProto(SocketAddress address) {
@@ -343,7 +367,7 @@ class LogHelper {
   }
 
   /**
-   *  Retrieves socket address.
+   * Retrieves socket address.
    */
   static SocketAddress getPeerAddress(Attributes streamAttributes) {
     return streamAttributes.get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
@@ -367,5 +391,4 @@ class LogHelper {
   boolean isMethodToBeLogged(String fullMethodName) {
     return true;
   }
-
 }

--- a/observability/src/main/java/io/grpc/observability/interceptors/LogHelper.java
+++ b/observability/src/main/java/io/grpc/observability/interceptors/LogHelper.java
@@ -236,10 +236,10 @@ class LogHelper {
         .setEventLogger(eventLogger)
         .setLogLevel(LogLevel.LOG_LEVEL_DEBUG)
         .setRpcId(rpcId);
-    if ((pair != null) && (pair.size != 0)) {
+    if (pair != null && pair.size != 0) {
       logEntryBuilder.setPayloadSize(pair.size);
     }
-    if ((pair != null) && (pair.payload != null)) {
+    if (pair != null && pair.payload != null) {
       logEntryBuilder.setMessage(pair.payload);
     }
     sink.write(logEntryBuilder.build());

--- a/observability/src/test/java/io/grpc/observability/LoggingServerProviderTest.java
+++ b/observability/src/test/java/io/grpc/observability/LoggingServerProviderTest.java
@@ -36,6 +36,8 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.ServerProvider;
 import io.grpc.observability.interceptors.InternalLoggingServerInterceptor;
+import io.grpc.observability.logging.GcpLogSink;
+import io.grpc.observability.logging.Sink;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
 import io.grpc.testing.protobuf.SimpleRequest;
@@ -57,10 +59,11 @@ public class LoggingServerProviderTest {
   public void initTwiceCausesException() {
     ServerProvider prevProvider = ServerProvider.provider();
     assertThat(prevProvider).isNotInstanceOf(LoggingServerProvider.class);
-    LoggingServerProvider.init(new InternalLoggingServerInterceptor.FactoryImpl());
+    Sink mockSink = mock(GcpLogSink.class);
+    LoggingServerProvider.init(new InternalLoggingServerInterceptor.FactoryImpl(mockSink));
     assertThat(ServerProvider.provider()).isInstanceOf(ServerProvider.class);
     try {
-      LoggingServerProvider.init(new InternalLoggingServerInterceptor.FactoryImpl());
+      LoggingServerProvider.init(new InternalLoggingServerInterceptor.FactoryImpl(mockSink));
       fail("should have failed for calling init() again");
     } catch (IllegalStateException e) {
       assertThat(e).hasMessageThat().contains("LoggingServerProvider already initialized!");

--- a/observability/src/test/java/io/grpc/observability/LoggingTest.java
+++ b/observability/src/test/java/io/grpc/observability/LoggingTest.java
@@ -62,7 +62,7 @@ public class LoggingTest {
         .usePlaintext().build();
     SimpleServiceGrpc.SimpleServiceBlockingStub stub = SimpleServiceGrpc.newBlockingStub(
         cleanupRule.register(channel));
-    assertThat(LoggingTestHelper.unaryRpc("buddy", stub))
+    assertThat(LoggingTestHelper.makeUnaryRpcViaClientStub("buddy", stub))
         .isEqualTo("Hello buddy");
     sink.close();
     LoggingChannelProvider.finish();

--- a/observability/src/test/java/io/grpc/observability/LoggingTest.java
+++ b/observability/src/test/java/io/grpc/observability/LoggingTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.observability;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.observability.interceptors.InternalLoggingChannelInterceptor;
+import io.grpc.observability.interceptors.InternalLoggingServerInterceptor;
+import io.grpc.observability.logging.GcpLogSink;
+import io.grpc.observability.logging.Sink;
+import io.grpc.testing.GrpcCleanupRule;
+import io.grpc.testing.protobuf.SimpleServiceGrpc;
+import java.io.IOException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class LoggingTest {
+
+  @Rule
+  public final GrpcCleanupRule cleanupRule = new GrpcCleanupRule();
+
+  private static final String PROJECT_ID = "project-id";
+
+  public void clientServer_interceptorCalled()
+      throws IOException {
+    Sink sink = GcpLogSink.getInstance(PROJECT_ID);
+    LoggingServerProvider.init(
+        new InternalLoggingServerInterceptor.FactoryImpl(sink));
+    Server server = ServerBuilder.forPort(0).addService(new LoggingTestHelper.SimpleServiceImpl())
+        .build().start();
+    int port = cleanupRule.register(server).getPort();
+    LoggingChannelProvider.init(
+        new InternalLoggingChannelInterceptor.FactoryImpl(sink));
+    ManagedChannel channel = ManagedChannelBuilder.forAddress("localhost", port)
+        .usePlaintext().build();
+    SimpleServiceGrpc.SimpleServiceBlockingStub stub = SimpleServiceGrpc.newBlockingStub(
+        cleanupRule.register(channel));
+    assertThat(LoggingTestHelper.unaryRpc("buddy", stub))
+        .isEqualTo("Hello buddy");
+    GcpLogSink.getInstance(PROJECT_ID).close();
+    LoggingChannelProvider.finish();
+    LoggingServerProvider.finish();
+  }
+}

--- a/observability/src/test/java/io/grpc/observability/LoggingTest.java
+++ b/observability/src/test/java/io/grpc/observability/LoggingTest.java
@@ -29,6 +29,7 @@ import io.grpc.observability.logging.Sink;
 import io.grpc.testing.GrpcCleanupRule;
 import io.grpc.testing.protobuf.SimpleServiceGrpc;
 import java.io.IOException;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,9 +43,14 @@ public class LoggingTest {
 
   private static final String PROJECT_ID = "project-id";
 
+  /**
+   * Cloud logging test using LoggingChannelProvider and LoggingServerProvider.
+   */
+  @Ignore
+  @Test
   public void clientServer_interceptorCalled()
       throws IOException {
-    Sink sink = GcpLogSink.getInstance(PROJECT_ID);
+    Sink sink = new GcpLogSink(PROJECT_ID);
     LoggingServerProvider.init(
         new InternalLoggingServerInterceptor.FactoryImpl(sink));
     Server server = ServerBuilder.forPort(0).addService(new LoggingTestHelper.SimpleServiceImpl())
@@ -58,7 +64,7 @@ public class LoggingTest {
         cleanupRule.register(channel));
     assertThat(LoggingTestHelper.unaryRpc("buddy", stub))
         .isEqualTo("Hello buddy");
-    GcpLogSink.getInstance(PROJECT_ID).close();
+    sink.close();
     LoggingChannelProvider.finish();
     LoggingServerProvider.finish();
   }

--- a/observability/src/test/java/io/grpc/observability/LoggingTestHelper.java
+++ b/observability/src/test/java/io/grpc/observability/LoggingTestHelper.java
@@ -16,20 +16,14 @@
 
 package io.grpc.observability;
 
-import io.grpc.ServerCallHandler;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.protobuf.SimpleRequest;
 import io.grpc.testing.protobuf.SimpleResponse;
 import io.grpc.testing.protobuf.SimpleServiceGrpc;
-import org.mockito.ArgumentMatchers;
 
 public class LoggingTestHelper {
 
-  static ServerCallHandler<String, Integer> anyCallHandler() {
-    return ArgumentMatchers.any();
-  }
-
-  static String unaryRpc(
+  static String makeUnaryRpcViaClientStub(
       String requestMessage, SimpleServiceGrpc.SimpleServiceBlockingStub blockingStub) {
     SimpleRequest request = SimpleRequest.newBuilder().setRequestMessage(requestMessage).build();
     SimpleResponse response = blockingStub.unaryRpc(request);

--- a/observability/src/test/java/io/grpc/observability/LoggingTestHelper.java
+++ b/observability/src/test/java/io/grpc/observability/LoggingTestHelper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.observability;
+
+import io.grpc.ServerCallHandler;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.protobuf.SimpleRequest;
+import io.grpc.testing.protobuf.SimpleResponse;
+import io.grpc.testing.protobuf.SimpleServiceGrpc;
+import org.mockito.ArgumentMatchers;
+
+public class LoggingTestHelper {
+
+  static ServerCallHandler<String, Integer> anyCallHandler() {
+    return ArgumentMatchers.any();
+  }
+
+  static String unaryRpc(
+      String requestMessage, SimpleServiceGrpc.SimpleServiceBlockingStub blockingStub) {
+    SimpleRequest request = SimpleRequest.newBuilder().setRequestMessage(requestMessage).build();
+    SimpleResponse response = blockingStub.unaryRpc(request);
+    return response.getResponseMessage();
+  }
+
+  static class SimpleServiceImpl extends SimpleServiceGrpc.SimpleServiceImplBase {
+
+    @Override
+    public void unaryRpc(SimpleRequest req, StreamObserver<SimpleResponse> responseObserver) {
+      SimpleResponse response =
+          SimpleResponse.newBuilder()
+              .setResponseMessage("Hello " + req.getRequestMessage())
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    }
+  }
+}

--- a/observability/src/test/java/io/grpc/observability/interceptors/InternalLoggingServerInterceptorTest.java
+++ b/observability/src/test/java/io/grpc/observability/interceptors/InternalLoggingServerInterceptorTest.java
@@ -17,6 +17,7 @@
 package io.grpc.observability.interceptors;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.grpc.observability.interceptors.LogHelperTest.BYTEARRAY_MARSHALLER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.mockito.ArgumentMatchers.same;
@@ -32,13 +33,11 @@ import io.grpc.Context;
 import io.grpc.Grpc;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
-import io.grpc.MethodDescriptor.Marshaller;
 import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.Status;
 import io.grpc.internal.NoopServerCall;
-import io.grpc.observability.interceptors.LogHelper.ByteArrayMarshaller;
 import io.grpc.observability.logging.GcpLogSink;
 import io.grpc.observability.logging.Sink;
 import io.grpc.observabilitylog.v1.GrpcLogRecord;
@@ -68,7 +67,6 @@ public class InternalLoggingServerInterceptorTest {
   @Rule
   public final MockitoRule mockito = MockitoJUnit.rule();
 
-  public static final Marshaller<byte[]> BYTEARRAY_MARSHALLER = new ByteArrayMarshaller();
   private static final Charset US_ASCII = Charset.forName("US-ASCII");
 
   private InternalLoggingServerInterceptor.Factory factory;

--- a/observability/src/test/java/io/grpc/observability/interceptors/InternalLoggingServerInterceptorTest.java
+++ b/observability/src/test/java/io/grpc/observability/interceptors/InternalLoggingServerInterceptorTest.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.observability.interceptors;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.google.protobuf.Duration;
+import com.google.protobuf.util.Durations;
+import io.grpc.Attributes;
+import io.grpc.Context;
+import io.grpc.Grpc;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.Marshaller;
+import io.grpc.MethodDescriptor.MethodType;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.Status;
+import io.grpc.internal.NoopServerCall;
+import io.grpc.observability.interceptors.LogHelper.ByteArrayMarshaller;
+import io.grpc.observability.logging.GcpLogSink;
+import io.grpc.observability.logging.Sink;
+import io.grpc.observabilitylog.v1.GrpcLogRecord;
+import io.grpc.observabilitylog.v1.GrpcLogRecord.EventType;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.charset.Charset;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+/**
+ * Tests for {@link InternalLoggingServerInterceptor}.
+ */
+@RunWith(JUnit4.class)
+public class InternalLoggingServerInterceptorTest {
+
+  @Rule
+  public final MockitoRule mockito = MockitoJUnit.rule();
+
+  public static final Marshaller<byte[]> BYTEARRAY_MARSHALLER = new ByteArrayMarshaller();
+  private static final Charset US_ASCII = Charset.forName("US-ASCII");
+
+  private InternalLoggingServerInterceptor.Factory factory;
+  private AtomicReference<ServerCall<byte[], byte[]>> interceptedLoggingCall;
+  ServerCall.Listener<byte[]> capturedListener;
+  private ServerCall.Listener<byte[]> mockListener;
+  // capture these manually because ServerCall can not be mocked
+  private AtomicReference<Metadata> actualServerInitial;
+  private AtomicReference<byte[]> actualResponse;
+  private AtomicReference<Status> actualStatus;
+  private AtomicReference<Metadata> actualTrailers;
+  private final Sink mockSink = mock(GcpLogSink.class);
+  private SocketAddress peer;
+
+  @Before
+  @SuppressWarnings("unchecked")
+  public void setup() throws Exception {
+    factory = new InternalLoggingServerInterceptor.FactoryImpl(mockSink);
+    interceptedLoggingCall = new AtomicReference<>();
+    mockListener = mock(ServerCall.Listener.class);
+    actualServerInitial = new AtomicReference<>();
+    actualResponse = new AtomicReference<>();
+    actualStatus = new AtomicReference<>();
+    actualTrailers = new AtomicReference<>();
+    peer = new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 1234);
+  }
+
+  @Test
+  public void internalLoggingServerInterceptor() {
+    Metadata clientInitial = new Metadata();
+    final MethodDescriptor<byte[], byte[]> method =
+        MethodDescriptor.<byte[], byte[]>newBuilder()
+            .setType(MethodType.UNKNOWN)
+            .setFullMethodName("service/method")
+            .setRequestMarshaller(BYTEARRAY_MARSHALLER)
+            .setResponseMarshaller(BYTEARRAY_MARSHALLER)
+            .build();
+    capturedListener =
+        factory.create()
+            .interceptCall(
+                new NoopServerCall<byte[], byte[]>() {
+                  @Override
+                  public void sendHeaders(Metadata headers) {
+                    actualServerInitial.set(headers);
+                  }
+
+                  @Override
+                  public void sendMessage(byte[] message) {
+                    actualResponse.set(message);
+                  }
+
+                  @Override
+                  public void close(Status status, Metadata trailers) {
+                    actualStatus.set(status);
+                    actualTrailers.set(trailers);
+                  }
+
+                  @Override
+                  public MethodDescriptor<byte[], byte[]> getMethodDescriptor() {
+                    return method;
+                  }
+
+                  @Override
+                  public Attributes getAttributes() {
+                    return Attributes
+                        .newBuilder()
+                        .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, peer)
+                        .build();
+                  }
+
+                  @Override
+                  public String getAuthority() {
+                    return "the-authority";
+                  }
+                },
+                clientInitial,
+                new ServerCallHandler<byte[], byte[]>() {
+                  @Override
+                  public ServerCall.Listener<byte[]> startCall(
+                      ServerCall<byte[], byte[]> call,
+                      Metadata headers) {
+                    interceptedLoggingCall.set(call);
+                    return mockListener;
+                  }
+                });
+    // receive request header
+    {
+      EventType expectedRequestHeaderEvent = EventType.GRPC_CALL_REQUEST_HEADER;
+      ArgumentCaptor<GrpcLogRecord> captor = ArgumentCaptor.forClass(GrpcLogRecord.class);
+      verify(mockSink).write(captor.capture());
+      assertEquals(captor.getValue().getEventType(),
+          expectedRequestHeaderEvent);
+      verifyNoMoreInteractions(mockSink);
+    }
+
+    // send response header
+    {
+      EventType expectedResponseHeaderEvent = EventType.GRPC_CALL_RESPONSE_HEADER;
+      ArgumentCaptor<GrpcLogRecord> captor = ArgumentCaptor.forClass(GrpcLogRecord.class);
+      Metadata serverInital = new Metadata();
+      interceptedLoggingCall.get().sendHeaders(serverInital);
+      verify(mockSink, times(2)).write(captor.capture());
+      assertEquals(captor.getValue().getEventType(),
+          expectedResponseHeaderEvent);
+      verifyNoMoreInteractions(mockSink);
+      assertSame(serverInital, actualServerInitial.get());
+    }
+
+    // receive request message
+    {
+      EventType expectedRequestMessageEvent = EventType.GRPC_CALL_REQUEST_MESSAGE;
+      ArgumentCaptor<GrpcLogRecord> captor = ArgumentCaptor.forClass(GrpcLogRecord.class);
+      byte[] request = "this is a request".getBytes(US_ASCII);
+      capturedListener.onMessage(request);
+      verify(mockSink, times(3)).write(captor.capture());
+      assertEquals(captor.getValue().getEventType(),
+          expectedRequestMessageEvent);
+      verifyNoMoreInteractions(mockSink);
+      verify(mockListener).onMessage(same(request));
+    }
+
+    // client half close
+    {
+      EventType expectedHalfCloseEvent = EventType.GRPC_CALL_HALF_CLOSE;
+      ArgumentCaptor<GrpcLogRecord> captor = ArgumentCaptor.forClass(GrpcLogRecord.class);
+      capturedListener.onHalfClose();
+      verify(mockSink, times(4)).write(captor.capture());
+      assertEquals(captor.getValue().getEventType(),
+          expectedHalfCloseEvent);
+      verifyNoMoreInteractions(mockSink);
+      verify(mockListener).onHalfClose();
+    }
+
+    // send response message
+    {
+      EventType expectedResponseMessageEvent = EventType.GRPC_CALL_RESPONSE_MESSAGE;
+      ArgumentCaptor<GrpcLogRecord> captor = ArgumentCaptor.forClass(GrpcLogRecord.class);
+      byte[] response = "this is a response".getBytes(US_ASCII);
+      interceptedLoggingCall.get().sendMessage(response);
+      verify(mockSink, times(5)).write(captor.capture());
+      assertEquals(captor.getValue().getEventType(),
+          expectedResponseMessageEvent);
+      verifyNoMoreInteractions(mockSink);
+      assertSame(response, actualResponse.get());
+    }
+
+    // send trailer
+    {
+      EventType expectedTrailerEvent = EventType.GRPC_CALL_TRAILER;
+      ArgumentCaptor<GrpcLogRecord> captor = ArgumentCaptor.forClass(GrpcLogRecord.class);
+      Status status = Status.INTERNAL.withDescription("trailer description");
+      Metadata trailers = new Metadata();
+
+      interceptedLoggingCall.get().close(status, trailers);
+      verify(mockSink, times(6)).write(captor.capture());
+      assertEquals(captor.getValue().getEventType(),
+          expectedTrailerEvent);
+      verifyNoMoreInteractions(mockSink);
+      assertSame(status, actualStatus.get());
+      assertSame(trailers, actualTrailers.get());
+    }
+
+    // cancel
+    {
+      EventType expectedCancelEvent = EventType.GRPC_CALL_CANCEL;
+      ArgumentCaptor<GrpcLogRecord> captor = ArgumentCaptor.forClass(GrpcLogRecord.class);
+      capturedListener.onCancel();
+      verify(mockSink, times(7)).write(captor.capture());
+      assertEquals(captor.getValue().getEventType(),
+          expectedCancelEvent);
+      verify(mockListener).onCancel();
+    }
+  }
+
+  @Test
+  public void serverDeadlineLogged() {
+    final MethodDescriptor<byte[], byte[]> method =
+        MethodDescriptor.<byte[], byte[]>newBuilder()
+            .setType(MethodType.UNKNOWN)
+            .setFullMethodName("service/method")
+            .setRequestMarshaller(BYTEARRAY_MARSHALLER)
+            .setResponseMarshaller(BYTEARRAY_MARSHALLER)
+            .build();
+    final ServerCall<byte[], byte[]> noopServerCall = new NoopServerCall<byte[], byte[]>() {
+      @Override
+      public MethodDescriptor<byte[], byte[]> getMethodDescriptor() {
+        return method;
+      }
+
+      @Override
+      public String getAuthority() {
+        return "the-authority";
+      }
+    };
+    final ServerCallHandler<byte[], byte[]> noopHandler = new ServerCallHandler<byte[], byte[]>() {
+      @Override
+      public ServerCall.Listener<byte[]> startCall(
+          ServerCall<byte[], byte[]> call,
+          Metadata headers) {
+        return new ServerCall.Listener<byte[]>() {};
+      }
+    };
+
+    // We expect the contents of the "grpc-timeout" header to be installed the context
+    Context.current()
+        .withDeadlineAfter(1, TimeUnit.SECONDS, Executors.newSingleThreadScheduledExecutor())
+        .run(new Runnable() {
+          @Override
+          public void run() {
+            ServerCall.Listener<byte[]> unused =
+                factory.create()
+                    .interceptCall(noopServerCall, new Metadata(), noopHandler);
+          }
+        });
+    ArgumentCaptor<GrpcLogRecord> captor = ArgumentCaptor.forClass(GrpcLogRecord.class);
+    verify(mockSink, times(1)).write(captor.capture());
+    verifyNoMoreInteractions(mockSink);
+    Duration timeout = captor.getValue().getTimeout();
+    assertThat(TimeUnit.SECONDS.toNanos(1) - Durations.toNanos(timeout))
+        .isAtMost(TimeUnit.MILLISECONDS.toNanos(250));
+  }
+}

--- a/observability/src/test/java/io/grpc/observability/interceptors/LogHelperTest.java
+++ b/observability/src/test/java/io/grpc/observability/interceptors/LogHelperTest.java
@@ -111,8 +111,6 @@ public class LogHelperTest {
       new LogHelper(
           sink,
           timeProvider);
-  private final byte[] message = new byte[100];
-
 
   @Before
   public void setUp() throws Exception {
@@ -466,8 +464,10 @@ public class LogHelperTest {
     String serviceName = "service";
     String methodName = "method";
     String rpcId = "d155e885-9587-4e77-81f7-3aa5a443d47f";
+    byte[] message = new byte[100];
 
-    GrpcLogRecord.Builder builder = GrpcLogRecord.newBuilder()
+    GrpcLogRecord.Builder builder = messageTestHelper(message)
+        .toBuilder()
         .setTimestamp(timestamp)
         .setSequenceId(seqId)
         .setServiceName(serviceName)
@@ -552,9 +552,18 @@ public class LogHelperTest {
     GrpcLogRecord.Builder builder = GrpcLogRecord.newBuilder();
     PayloadBuilder<GrpcLogRecord.Metadata.Builder> pair
         = LogHelper.createMetadataProto(metadata);
-    builder.setMetadata(pair.proto);
+    builder.setMetadata(pair.payload);
     builder.setPayloadSize(pair.size);
     builder.setEventType(type);
+    return builder.build();
+  }
+
+  private static GrpcLogRecord messageTestHelper(byte[] message) {
+    GrpcLogRecord.Builder builder = GrpcLogRecord.newBuilder();
+    PayloadBuilder<ByteString> pair
+        = LogHelper.createMesageProto(message);
+    builder.setMessage(pair.payload);
+    builder.setPayloadSize(pair.size);
     return builder.build();
   }
 
@@ -614,5 +623,4 @@ public class LogHelperTest {
       return total;
     }
   }
-
 }


### PR DESCRIPTION
This PR implements Server Interceptor for logging i.e InternalLoggingServerInterceptor. Events are intercepted and a log record is written to logging as part of intercepting methods.

RPC messages will be logged if they are of following types:
- `com.google.protobuf.Message`
- `byte[]`