### PR TITLE
Add more xds_lb test cases

### DIFF
--- a/buildscripts/kokoro/xds_k8s_lb.sh
+++ b/buildscripts/kokoro/xds_k8s_lb.sh
@@ -166,7 +166,15 @@ main() {
   build_docker_images_if_needed
   # Run tests
   cd "${TEST_DRIVER_FULL_DIR}"
-  run_test api_listener_test
+  local failed_tests=0
+  test_suites=("api_listener_test" "change_backend_service_test" "failover_test" "remove_neg_test" "round_robin_test" "affinity_test")
+  for test in "${test_suites[@]}"; do
+    run_test $test || (( failed_tests++ ))
+  done
+  echo "Failed test suites: ${failed_tests}"
+  if (( failed_tests > 0 )); then
+    exit 1
+  fi
 }
 
 main "$@"


### PR DESCRIPTION
This test suite is only fully enabled for C++ and Python at this moment: https://github.com/grpc/grpc/blob/master/tools/internal_ci/linux/grpc_xds_k8s_lb.sh

This PR enables the rest of the test suite for grpc-java:

* change_backend_service_test
* failover_test
* remove_neg_test
* round_robin_test
* affinity_test

(CC @YifeiZhuang you mentioned that the tests were failing when deployed to Kokoro, it might be caused by using the wrong GKE clusters. You were using the "basic" cluster, which don't have workload-identity turned on.)

Tested: [prod:grpc/java/master/branch/xds_k8s_lb](https://fusion2.corp.google.com/invocations/66db2c32-2cbc-4a14-94e8-c7c49e9b25a0/targets)