### PR TITLE
netty: Support pseudo headers in all GrpcHttp2RequestHeaders methods

### DIFF
--- a/netty/src/test/java/io/grpc/netty/GrpcHttp2HeadersUtilsTest.java
+++ b/netty/src/test/java/io/grpc/netty/GrpcHttp2HeadersUtilsTest.java
@@ -137,7 +137,7 @@ public class GrpcHttp2HeadersUtilsTest {
   // contains() is used by Netty 4.1.75+. https://github.com/grpc/grpc-java/issues/8981
   // Just implement everything pseudo headers for all methods; too many recent breakages.
   @Test
-  public void GrpcHttp2RequestHeaders_pseudoHeaders_notPresent() {
+  public void grpcHttp2RequestHeaders_pseudoHeaders_notPresent() {
     Http2Headers http2Headers = new GrpcHttp2RequestHeaders(2);
     assertThat(http2Headers.get(AsciiString.of(":path"))).isNull();
     assertThat(http2Headers.get(AsciiString.of(":authority"))).isNull();
@@ -165,7 +165,7 @@ public class GrpcHttp2HeadersUtilsTest {
   }
 
   @Test
-  public void GrpcHttp2RequestHeaders_pseudoHeaders_present() {
+  public void grpcHttp2RequestHeaders_pseudoHeaders_present() {
     Http2Headers http2Headers = new GrpcHttp2RequestHeaders(2);
     http2Headers.add(AsciiString.of(":path"), AsciiString.of("mypath"));
     http2Headers.add(AsciiString.of(":authority"), AsciiString.of("myauthority"));
@@ -204,7 +204,7 @@ public class GrpcHttp2HeadersUtilsTest {
   }
 
   @Test
-  public void GrpcHttp2RequestHeaders_pseudoHeaders_set() {
+  public void grpcHttp2RequestHeaders_pseudoHeaders_set() {
     Http2Headers http2Headers = new GrpcHttp2RequestHeaders(2);
     http2Headers.set(AsciiString.of(":path"), AsciiString.of("mypath"));
     http2Headers.set(AsciiString.of(":authority"), AsciiString.of("myauthority"));
@@ -236,7 +236,7 @@ public class GrpcHttp2HeadersUtilsTest {
   }
 
   @Test
-  public void GrpcHttp2RequestHeaders_pseudoHeaders_addWhenPresent_throws() {
+  public void grpcHttp2RequestHeaders_pseudoHeaders_addWhenPresent_throws() {
     Http2Headers http2Headers = new GrpcHttp2RequestHeaders(2);
     http2Headers.add(AsciiString.of(":path"), AsciiString.of("mypath"));
     try {
@@ -248,7 +248,7 @@ public class GrpcHttp2HeadersUtilsTest {
   }
 
   @Test
-  public void GrpcHttp2RequestHeaders_pseudoHeaders_addInvalid_throws() {
+  public void grpcHttp2RequestHeaders_pseudoHeaders_addInvalid_throws() {
     Http2Headers http2Headers = new GrpcHttp2RequestHeaders(2);
     try {
       http2Headers.add(AsciiString.of(":status"), AsciiString.of("mystatus"));

--- a/netty/src/test/java/io/grpc/netty/GrpcHttp2HeadersUtilsTest.java
+++ b/netty/src/test/java/io/grpc/netty/GrpcHttp2HeadersUtilsTest.java
@@ -210,22 +210,28 @@ public class GrpcHttp2HeadersUtilsTest {
     http2Headers.set(AsciiString.of(":method"), AsciiString.of("mymethod"));
     http2Headers.set(AsciiString.of(":scheme"), AsciiString.of("myscheme"));
 
-    assertThat(http2Headers.get(AsciiString.of(":path"))).isEqualTo(AsciiString.of("mypath"));
-    assertThat(http2Headers.get(AsciiString.of(":authority")))
-        .isEqualTo(AsciiString.of("myauthority"));
-    assertThat(http2Headers.get(AsciiString.of(":method"))).isEqualTo(AsciiString.of("mymethod"));
-    assertThat(http2Headers.get(AsciiString.of(":scheme"))).isEqualTo(AsciiString.of("myscheme"));
+    assertThat(http2Headers.getAll(AsciiString.of(":path")))
+        .containsExactly(AsciiString.of("mypath"));
+    assertThat(http2Headers.getAll(AsciiString.of(":authority")))
+        .containsExactly(AsciiString.of("myauthority"));
+    assertThat(http2Headers.getAll(AsciiString.of(":method")))
+        .containsExactly(AsciiString.of("mymethod"));
+    assertThat(http2Headers.getAll(AsciiString.of(":scheme")))
+        .containsExactly(AsciiString.of("myscheme"));
 
     http2Headers.set(AsciiString.of(":path"), AsciiString.of("mypath2"));
     http2Headers.set(AsciiString.of(":authority"), AsciiString.of("myauthority2"));
     http2Headers.set(AsciiString.of(":method"), AsciiString.of("mymethod2"));
     http2Headers.set(AsciiString.of(":scheme"), AsciiString.of("myscheme2"));
 
-    assertThat(http2Headers.get(AsciiString.of(":path"))).isEqualTo(AsciiString.of("mypath2"));
-    assertThat(http2Headers.get(AsciiString.of(":authority")))
-        .isEqualTo(AsciiString.of("myauthority2"));
-    assertThat(http2Headers.get(AsciiString.of(":method"))).isEqualTo(AsciiString.of("mymethod2"));
-    assertThat(http2Headers.get(AsciiString.of(":scheme"))).isEqualTo(AsciiString.of("myscheme2"));
+    assertThat(http2Headers.getAll(AsciiString.of(":path")))
+        .containsExactly(AsciiString.of("mypath2"));
+    assertThat(http2Headers.getAll(AsciiString.of(":authority")))
+        .containsExactly(AsciiString.of("myauthority2"));
+    assertThat(http2Headers.getAll(AsciiString.of(":method")))
+        .containsExactly(AsciiString.of("mymethod2"));
+    assertThat(http2Headers.getAll(AsciiString.of(":scheme")))
+        .containsExactly(AsciiString.of("myscheme2"));
   }
 
   @Test

--- a/netty/src/test/java/io/grpc/netty/GrpcHttp2HeadersUtilsTest.java
+++ b/netty/src/test/java/io/grpc/netty/GrpcHttp2HeadersUtilsTest.java
@@ -133,7 +133,7 @@ public class GrpcHttp2HeadersUtilsTest {
     assertThat(decodedHeaders.toString()).contains("[]");
   }
 
-  // contains is used by Netty 4.1.75+. https://github.com/grpc/grpc-java/issues/8981
+  // contains() is used by Netty 4.1.75+. https://github.com/grpc/grpc-java/issues/8981
   // Just implement everything pseudo headers for all methods; too many recent breakages.
   @Test
   public void GrpcHttp2RequestHeaders_pseudoHeaders_notPresent() {

--- a/netty/src/test/java/io/grpc/netty/GrpcHttp2HeadersUtilsTest.java
+++ b/netty/src/test/java/io/grpc/netty/GrpcHttp2HeadersUtilsTest.java
@@ -22,6 +22,7 @@ import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE;
 import static io.netty.util.AsciiString.of;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.google.common.collect.Iterables;
 import com.google.common.io.BaseEncoding;
@@ -232,6 +233,29 @@ public class GrpcHttp2HeadersUtilsTest {
         .containsExactly(AsciiString.of("mymethod2"));
     assertThat(http2Headers.getAll(AsciiString.of(":scheme")))
         .containsExactly(AsciiString.of("myscheme2"));
+  }
+
+  @Test
+  public void GrpcHttp2RequestHeaders_pseudoHeaders_addWhenPresent_throws() {
+    Http2Headers http2Headers = new GrpcHttp2RequestHeaders(2);
+    http2Headers.add(AsciiString.of(":path"), AsciiString.of("mypath"));
+    try {
+      http2Headers.add(AsciiString.of(":path"), AsciiString.of("mypath2"));
+      fail("Expected exception");
+    } catch (Exception ex) {
+      // expected
+    }
+  }
+
+  @Test
+  public void GrpcHttp2RequestHeaders_pseudoHeaders_addInvalid_throws() {
+    Http2Headers http2Headers = new GrpcHttp2RequestHeaders(2);
+    try {
+      http2Headers.add(AsciiString.of(":status"), AsciiString.of("mystatus"));
+      fail("Expected exception");
+    } catch (Exception ex) {
+      // expected
+    }
   }
 
   @Test

--- a/netty/src/test/java/io/grpc/netty/GrpcHttp2HeadersUtilsTest.java
+++ b/netty/src/test/java/io/grpc/netty/GrpcHttp2HeadersUtilsTest.java
@@ -133,6 +133,101 @@ public class GrpcHttp2HeadersUtilsTest {
     assertThat(decodedHeaders.toString()).contains("[]");
   }
 
+  // contains is used by Netty 4.1.75+. https://github.com/grpc/grpc-java/issues/8981
+  // Just implement everything pseudo headers for all methods; too many recent breakages.
+  @Test
+  public void GrpcHttp2RequestHeaders_pseudoHeaders_notPresent() {
+    Http2Headers http2Headers = new GrpcHttp2RequestHeaders(2);
+    assertThat(http2Headers.get(AsciiString.of(":path"))).isNull();
+    assertThat(http2Headers.get(AsciiString.of(":authority"))).isNull();
+    assertThat(http2Headers.get(AsciiString.of(":method"))).isNull();
+    assertThat(http2Headers.get(AsciiString.of(":scheme"))).isNull();
+    assertThat(http2Headers.get(AsciiString.of(":status"))).isNull();
+
+    assertThat(http2Headers.getAll(AsciiString.of(":path"))).isEmpty();
+    assertThat(http2Headers.getAll(AsciiString.of(":authority"))).isEmpty();
+    assertThat(http2Headers.getAll(AsciiString.of(":method"))).isEmpty();
+    assertThat(http2Headers.getAll(AsciiString.of(":scheme"))).isEmpty();
+    assertThat(http2Headers.getAll(AsciiString.of(":status"))).isEmpty();
+
+    assertThat(http2Headers.contains(AsciiString.of(":path"))).isFalse();
+    assertThat(http2Headers.contains(AsciiString.of(":authority"))).isFalse();
+    assertThat(http2Headers.contains(AsciiString.of(":method"))).isFalse();
+    assertThat(http2Headers.contains(AsciiString.of(":scheme"))).isFalse();
+    assertThat(http2Headers.contains(AsciiString.of(":status"))).isFalse();
+
+    assertThat(http2Headers.remove(AsciiString.of(":path"))).isFalse();
+    assertThat(http2Headers.remove(AsciiString.of(":authority"))).isFalse();
+    assertThat(http2Headers.remove(AsciiString.of(":method"))).isFalse();
+    assertThat(http2Headers.remove(AsciiString.of(":scheme"))).isFalse();
+    assertThat(http2Headers.remove(AsciiString.of(":status"))).isFalse();
+  }
+
+  @Test
+  public void GrpcHttp2RequestHeaders_pseudoHeaders_present() {
+    Http2Headers http2Headers = new GrpcHttp2RequestHeaders(2);
+    http2Headers.add(AsciiString.of(":path"), AsciiString.of("mypath"));
+    http2Headers.add(AsciiString.of(":authority"), AsciiString.of("myauthority"));
+    http2Headers.add(AsciiString.of(":method"), AsciiString.of("mymethod"));
+    http2Headers.add(AsciiString.of(":scheme"), AsciiString.of("myscheme"));
+
+    assertThat(http2Headers.get(AsciiString.of(":path"))).isEqualTo(AsciiString.of("mypath"));
+    assertThat(http2Headers.get(AsciiString.of(":authority")))
+        .isEqualTo(AsciiString.of("myauthority"));
+    assertThat(http2Headers.get(AsciiString.of(":method"))).isEqualTo(AsciiString.of("mymethod"));
+    assertThat(http2Headers.get(AsciiString.of(":scheme"))).isEqualTo(AsciiString.of("myscheme"));
+
+    assertThat(http2Headers.getAll(AsciiString.of(":path")))
+        .containsExactly(AsciiString.of("mypath"));
+    assertThat(http2Headers.getAll(AsciiString.of(":authority")))
+        .containsExactly(AsciiString.of("myauthority"));
+    assertThat(http2Headers.getAll(AsciiString.of(":method")))
+        .containsExactly(AsciiString.of("mymethod"));
+    assertThat(http2Headers.getAll(AsciiString.of(":scheme")))
+        .containsExactly(AsciiString.of("myscheme"));
+
+    assertThat(http2Headers.contains(AsciiString.of(":path"))).isTrue();
+    assertThat(http2Headers.contains(AsciiString.of(":authority"))).isTrue();
+    assertThat(http2Headers.contains(AsciiString.of(":method"))).isTrue();
+    assertThat(http2Headers.contains(AsciiString.of(":scheme"))).isTrue();
+
+    assertThat(http2Headers.remove(AsciiString.of(":path"))).isTrue();
+    assertThat(http2Headers.remove(AsciiString.of(":authority"))).isTrue();
+    assertThat(http2Headers.remove(AsciiString.of(":method"))).isTrue();
+    assertThat(http2Headers.remove(AsciiString.of(":scheme"))).isTrue();
+
+    assertThat(http2Headers.contains(AsciiString.of(":path"))).isFalse();
+    assertThat(http2Headers.contains(AsciiString.of(":authority"))).isFalse();
+    assertThat(http2Headers.contains(AsciiString.of(":method"))).isFalse();
+    assertThat(http2Headers.contains(AsciiString.of(":scheme"))).isFalse();
+  }
+
+  @Test
+  public void GrpcHttp2RequestHeaders_pseudoHeaders_set() {
+    Http2Headers http2Headers = new GrpcHttp2RequestHeaders(2);
+    http2Headers.set(AsciiString.of(":path"), AsciiString.of("mypath"));
+    http2Headers.set(AsciiString.of(":authority"), AsciiString.of("myauthority"));
+    http2Headers.set(AsciiString.of(":method"), AsciiString.of("mymethod"));
+    http2Headers.set(AsciiString.of(":scheme"), AsciiString.of("myscheme"));
+
+    assertThat(http2Headers.get(AsciiString.of(":path"))).isEqualTo(AsciiString.of("mypath"));
+    assertThat(http2Headers.get(AsciiString.of(":authority")))
+        .isEqualTo(AsciiString.of("myauthority"));
+    assertThat(http2Headers.get(AsciiString.of(":method"))).isEqualTo(AsciiString.of("mymethod"));
+    assertThat(http2Headers.get(AsciiString.of(":scheme"))).isEqualTo(AsciiString.of("myscheme"));
+
+    http2Headers.set(AsciiString.of(":path"), AsciiString.of("mypath2"));
+    http2Headers.set(AsciiString.of(":authority"), AsciiString.of("myauthority2"));
+    http2Headers.set(AsciiString.of(":method"), AsciiString.of("mymethod2"));
+    http2Headers.set(AsciiString.of(":scheme"), AsciiString.of("myscheme2"));
+
+    assertThat(http2Headers.get(AsciiString.of(":path"))).isEqualTo(AsciiString.of("mypath2"));
+    assertThat(http2Headers.get(AsciiString.of(":authority")))
+        .isEqualTo(AsciiString.of("myauthority2"));
+    assertThat(http2Headers.get(AsciiString.of(":method"))).isEqualTo(AsciiString.of("mymethod2"));
+    assertThat(http2Headers.get(AsciiString.of(":scheme"))).isEqualTo(AsciiString.of("myscheme2"));
+  }
+
   @Test
   public void dupBinHeadersWithComma() {
     Key<byte[]> key = Key.of("bytes-bin", BINARY_BYTE_MARSHALLER);


### PR DESCRIPTION
The previous code assumed that only gRPC would be using these methods.
But twice now Netty has made a change (generally relating to security)
that used a method for pseudo headers that previously wasn't supported.
Let's stop the whack-a-mole and just implement them all.

This restores compatibility with Netty 4.1.75.Final. Fixes #8981

CC @njhill
Alternative to #9001