### PR TITLE
rls: remove wrong empty address check for child lb

### DIFF
--- a/rls/src/main/java/io/grpc/rls/ChildLbResolvedAddressFactory.java
+++ b/rls/src/main/java/io/grpc/rls/ChildLbResolvedAddressFactory.java
@@ -16,7 +16,6 @@
 
 package io.grpc.rls;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.grpc.Attributes;
@@ -33,8 +32,7 @@ final class ChildLbResolvedAddressFactory implements ResolvedAddressFactory {
 
   ChildLbResolvedAddressFactory(
       List<EquivalentAddressGroup> addresses, Attributes attributes) {
-    checkArgument(addresses != null && !addresses.isEmpty(), "Address must be provided");
-    this.addresses = Collections.unmodifiableList(addresses);
+    this.addresses = Collections.unmodifiableList(checkNotNull(addresses, "addresses"));
     this.attributes = checkNotNull(attributes, "attributes");
   }
 


### PR DESCRIPTION
We shouldn't require addresses to be non-empty for the child lb of rls_lb. That might be a right requirement when the child lb is grpclb, but in our new usecase, the child lb will be cds lb and will only work if empty address is allowed.

Fixing b/223866089#comment24

