### PR TITLE
xds: Allow unsupported cluster specifiers

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -1340,12 +1340,11 @@ final class ClientXdsClient extends XdsClient implements XdsResponseHandler, Res
           return StructOrError.fromStruct(RouteAction.forClusterSpecifierPlugin(
               namedPluginConfig, hashPolicies, timeoutNano, retryPolicy));
         } else {
-          return StructOrError.fromError("Support for ClusterSpecifierPlugin not enabled");
+          return null;
         }
       case CLUSTERSPECIFIER_NOT_SET:
       default:
-        return StructOrError.fromError(
-            "Unknown cluster specifier: " + proto.getClusterSpecifierCase());
+        return null;
     }
   }
 

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
@@ -17,6 +17,7 @@
 package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.envoyproxy.envoy.config.route.v3.RouteAction.ClusterSpecifierCase.CLUSTER_SPECIFIER_PLUGIN;
 
 import com.github.udpa.udpa.type.v1.TypedStruct;
 import com.google.common.collect.ImmutableMap;
@@ -799,6 +800,30 @@ public class ClientXdsClientDataTest {
 
     assertThat(policies.get(1).type()).isEqualTo(HashPolicy.Type.CHANNEL_ID);
     assertThat(policies.get(1).isTerminal()).isFalse();
+  }
+
+  @Test
+  public void parseRouteAction_clusterSpecifier_routeLookupDisabled() {
+    ClientXdsClient.enableRouteLookup = false;
+    io.envoyproxy.envoy.config.route.v3.RouteAction proto =
+        io.envoyproxy.envoy.config.route.v3.RouteAction.newBuilder()
+            .setClusterSpecifierPlugin(CLUSTER_SPECIFIER_PLUGIN.name())
+            .build();
+    StructOrError<RouteAction> struct =
+        ClientXdsClient.parseRouteAction(proto, filterRegistry, false,
+            ImmutableMap.<String, PluginConfig>of());
+    assertThat(struct).isNull();
+  }
+
+  @Test
+  public void parseRouteAction_custerSpecifierNotSet() {
+    io.envoyproxy.envoy.config.route.v3.RouteAction proto =
+        io.envoyproxy.envoy.config.route.v3.RouteAction.newBuilder()
+            .build();
+    StructOrError<RouteAction> struct =
+        ClientXdsClient.parseRouteAction(proto, filterRegistry, false,
+            ImmutableMap.<String, PluginConfig>of());
+    assertThat(struct).isNull();
   }
 
   @Test


### PR DESCRIPTION
Return a null RouteAction when cluster has no cluster_specifier or route lookup is not enabled with a cluster_specifier_plugin.

We want to ignore the route in these situations, which is achieved by returning a null. The current behavior of returning an error triggers a NACK to the update.

cc: @ejona86 @sergiitk 