### PR TITLE
bom: Remove protoc-gen-grpc-java

### DIFF
--- a/bom/build.gradle
+++ b/bom/build.gradle
@@ -30,12 +30,6 @@ publishing {
           dependencyNode.appendNode('artifactId', subproject.name)
           dependencyNode.appendNode('version', subproject.version)
         }
-        // add protoc gen (produced by grpc-compiler with different artifact name)
-        def dependencyNode = dependencies.appendNode('dependency')
-        dependencyNode.appendNode('groupId', project.group)
-        dependencyNode.appendNode('artifactId', 'protoc-gen-grpc-java')
-        dependencyNode.appendNode('version', project.version)
-        dependencyNode.appendNode('type', 'pom')
       }
     }
   }


### PR DESCRIPTION
protoc-gen-grpc-java isn't useful in a BOM because the Gradle plugin
doesn't support BOMs (google/protobuf-gradle-plugin#412) and it seems
unlikely the Maven plugin would as well.

Right now the type is pom, which is useless; nobody cares about the pom
itself. We'd need to use a type of exe and repeat it for each platform
(classifier). Given that it is a strange case and we can't actually test
the results and having it in the bom might lead a user to trying to make
it work, let's just remove it for now until it provides value.

Fixes #8936