### PR TITLE
dep: bump protobuf, google-auth, google-http-client and google-cloud-…

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -44,11 +44,11 @@ This section is only necessary if you are making changes to the code
 generation. Most users only need to use `skipCodegen=true` as discussed above.
 
 ### Build Protobuf
-The codegen plugin is C++ code and requires protobuf 3.19.2 or later.
+The codegen plugin is C++ code and requires protobuf 3.19.4 or later.
 
 For Linux, Mac and MinGW:
 ```
-$ PROTOBUF_VERSION=3.19.2
+$ PROTOBUF_VERSION=3.19.4
 $ curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protobuf-all-$PROTOBUF_VERSION.tar.gz
 $ tar xzf protobuf-all-$PROTOBUF_VERSION.tar.gz
 $ cd protobuf-$PROTOBUF_VERSION

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ For protobuf-based codegen integrated with the Maven build system, you can use
       <artifactId>protobuf-maven-plugin</artifactId>
       <version>0.6.1</version>
       <configuration>
-        <protocArtifact>com.google.protobuf:protoc:3.19.2:exe:${os.detected.classifier}</protocArtifact>
+        <protocArtifact>com.google.protobuf:protoc:3.19.4:exe:${os.detected.classifier}</protocArtifact>
         <pluginId>grpc-java</pluginId>
         <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.45.0:exe:${os.detected.classifier}</pluginArtifact>
       </configuration>
@@ -140,7 +140,7 @@ plugins {
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:3.19.2"
+    artifact = "com.google.protobuf:protoc:3.19.4"
   }
   plugins {
     grpc {
@@ -173,7 +173,7 @@ plugins {
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:3.19.2"
+    artifact = "com.google.protobuf:protoc:3.19.4"
   }
   plugins {
     grpc {

--- a/build.gradle
+++ b/build.gradle
@@ -57,8 +57,8 @@ subprojects {
 
         nettyVersion = '4.1.72.Final'
         guavaVersion = '31.0.1-android'
-        googleauthVersion = '1.4.0'
-        protobufVersion = '3.19.2'
+        googleauthVersion = '1.5.3'
+        protobufVersion = '3.19.4'
         protocVersion = protobufVersion
         opencensusVersion = '0.28.0'
         autovalueVersion = '1.9'

--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -1,4 +1,4 @@
-set PROTOBUF_VER=3.19.2
+set PROTOBUF_VER=3.19.4
 set CMAKE_NAME=cmake-3.3.2-win32-x86
 
 if not exist "protobuf-%PROTOBUF_VER%\cmake\build\Release\" (

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -3,7 +3,7 @@
 # Build protoc
 set -evux -o pipefail
 
-PROTOBUF_VERSION=3.19.2
+PROTOBUF_VERSION=3.19.4
 
 # ARCH is x86_64 bit unless otherwise specified.
 ARCH="${ARCH:-x86_64}"

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -32,7 +32,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.19.2' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.19.4' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.46.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -30,7 +30,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.19.2' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.19.4' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.46.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -30,7 +30,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.19.2' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.19.4' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.46.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/android/strictmode/app/build.gradle
+++ b/examples/android/strictmode/app/build.gradle
@@ -31,7 +31,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.19.2' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.19.4' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.46.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -23,7 +23,7 @@ targetCompatibility = 1.8
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.46.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.19.2'
+def protobufVersion = '3.19.4'
 def protocVersion = protobufVersion
 
 dependencies {

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.8
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.46.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.19.2'
+def protocVersion = '3.19.4'
 
 dependencies {
     // grpc-alts transitively depends on grpc-netty-shaded, grpc-protobuf, and grpc-stub

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.8
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.46.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.19.2'
+def protobufVersion = '3.19.4'
 def protocVersion = protobufVersion
 
 

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.46.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.19.2</protobuf.version>
+    <protobuf.version>3.19.4</protobuf.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.8
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.46.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.19.2'
+def protobufVersion = '3.19.4'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-hostname/pom.xml
+++ b/examples/example-hostname/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.46.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protoc.version>3.19.2</protoc.version>
+    <protoc.version>3.19.4</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -23,7 +23,7 @@ targetCompatibility = 1.8
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.46.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.19.2'
+def protobufVersion = '3.19.4'
 def protocVersion = protobufVersion
 
 dependencies {

--- a/examples/example-jwt-auth/pom.xml
+++ b/examples/example-jwt-auth/pom.xml
@@ -14,8 +14,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.46.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.19.2</protobuf.version>
-    <protoc.version>3.19.2</protoc.version>
+    <protobuf.version>3.19.4</protobuf.version>
+    <protoc.version>3.19.4</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.8
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.46.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.19.2'
+def protocVersion = '3.19.4'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.46.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protoc.version>3.19.2</protoc.version>
+    <protoc.version>3.19.4</protoc.version>
     <netty.tcnative.version>2.0.34.Final</netty.tcnative.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>

--- a/examples/example-xds/build.gradle
+++ b/examples/example-xds/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.8
 // updating the version in our release process.
 def grpcVersion = '1.46.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 def nettyTcNativeVersion = '2.0.31.Final'
-def protocVersion = '3.19.2'
+def protocVersion = '3.19.4'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.46.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.19.2</protobuf.version>
-    <protoc.version>3.19.2</protoc.version>
+    <protobuf.version>3.19.4</protobuf.version>
+    <protoc.version>3.19.4</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -55,6 +55,10 @@ configureProtoCompilation()
 import net.ltgt.gradle.errorprone.CheckSeverity
 
 compileJava {
+    // opencensus ContextUtils in AbstractInteropTest has been deprecated
+    it.options.compilerArgs += [
+            "-Xlint:-deprecation"
+    ]
     // This isn't a library; it can use beta APIs
     options.errorprone.check("BetaApi", CheckSeverity.OFF)
 }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1548,6 +1548,7 @@ public abstract class AbstractInteropTest {
   }
 
   @Test(timeout = 10000)
+  @SuppressWarnings("deprecation")
   public void censusContextsPropagated() {
     Assume.assumeTrue("Skip the test because server is not in the same process.", server != null);
     Assume.assumeTrue(customCensusModulePresent());

--- a/observability/build.gradle
+++ b/observability/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 description = "gRPC: Observability"
 dependencies {
-    def cloudLoggingVersion = '3.6.1'
+    def cloudLoggingVersion = '3.7.1'
 
     api project(':grpc-api')
 
@@ -16,14 +16,14 @@ dependencies {
             project(':grpc-stub'),
             project(':grpc-alts'),
             libraries.google_auth_oauth2_http,
+            libraries.google_auth_credentials,
             ('com.google.guava:guava:31.0.1-jre'),
             ('com.google.errorprone:error_prone_annotations:2.11.0'),
-            ('com.google.auth:google-auth-library-credentials:1.4.0'),
-            ('org.checkerframework:checker-qual:3.20.0'),
+            ('org.checkerframework:checker-qual:3.21.3'),
             ('com.google.auto.value:auto-value-annotations:1.9'),
-            ('com.google.http-client:google-http-client:1.41.0'),
-            ('com.google.http-client:google-http-client-gson:1.41.0'),
-            ('com.google.api.grpc:proto-google-common-protos:2.7.1'),
+            ('com.google.http-client:google-http-client:1.41.4'),
+            ('com.google.http-client:google-http-client-gson:1.41.4'),
+            ('com.google.api.grpc:proto-google-common-protos:2.7.4'),
             ("com.google.cloud:google-cloud-logging:${cloudLoggingVersion}")
 
     testImplementation project(':grpc-testing'),

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -98,18 +98,18 @@ def com_google_protobuf():
     # This statement defines the @com_google_protobuf repo.
     http_archive(
         name = "com_google_protobuf",
-        sha256 = "9ceef0daf7e8be16cd99ac759271eb08021b53b1c7b6edd399953a76390234cd",
-        strip_prefix = "protobuf-3.19.2",
-        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.19.2.zip"],
+        sha256 = "57e3feb08995c9757421755cc6f3625483e22c1371967da3873fbe41b57f713e",
+        strip_prefix = "protobuf-3.19.4",
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.19.4.zip"],
     )
 
 def com_google_protobuf_javalite():
     # java_lite_proto_library rules implicitly depend on @com_google_protobuf_javalite
     http_archive(
         name = "com_google_protobuf_javalite",
-        sha256 = "9ceef0daf7e8be16cd99ac759271eb08021b53b1c7b6edd399953a76390234cd",
-        strip_prefix = "protobuf-3.19.2",
-        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.19.2.zip"],
+        sha256 = "57e3feb08995c9757421755cc6f3625483e22c1371967da3873fbe41b57f713e",
+        strip_prefix = "protobuf-3.19.4",
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.19.4.zip"],
     )
 
 def io_grpc_grpc_proto():

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -98,7 +98,7 @@ def com_google_protobuf():
     # This statement defines the @com_google_protobuf repo.
     http_archive(
         name = "com_google_protobuf",
-        sha256 = "57e3feb08995c9757421755cc6f3625483e22c1371967da3873fbe41b57f713e",
+        sha256 = "25680843adf0c3302648d35f744e38cc3b6b05a6c77a927de5aea3e1c2e36106",
         strip_prefix = "protobuf-3.19.4",
         urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.19.4.zip"],
     )
@@ -107,7 +107,7 @@ def com_google_protobuf_javalite():
     # java_lite_proto_library rules implicitly depend on @com_google_protobuf_javalite
     http_archive(
         name = "com_google_protobuf_javalite",
-        sha256 = "57e3feb08995c9757421755cc6f3625483e22c1371967da3873fbe41b57f713e",
+        sha256 = "25680843adf0c3302648d35f744e38cc3b6b05a6c77a927de5aea3e1c2e36106",
         strip_prefix = "protobuf-3.19.4",
         urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.19.4.zip"],
     )


### PR DESCRIPTION
…logging versions.

The current cloud-logging version is blocking #8948 and new cloud-logging requires the other upgrades.