### PR TITLE
xds: Improve code clarity by removing Unnecessary fully qualified names and using Immutable interface types.

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsCredentialsRegistry.java
+++ b/xds/src/main/java/io/grpc/xds/XdsCredentialsRegistry.java
@@ -133,7 +133,7 @@ final class XdsCredentialsRegistry {
    * XdsCredsProvider of that scheme. 
    */
   @VisibleForTesting
-  synchronized ImmutableMap<String, XdsCredentialsProvider> providers() {
+  synchronized Map<String, XdsCredentialsProvider> providers() {
     return effectiveProviders;
   }
 

--- a/xds/src/main/java/io/grpc/xds/XdsCredentialsRegistry.java
+++ b/xds/src/main/java/io/grpc/xds/XdsCredentialsRegistry.java
@@ -133,7 +133,7 @@ final class XdsCredentialsRegistry {
    * XdsCredsProvider of that scheme. 
    */
   @VisibleForTesting
-  synchronized Map<String, XdsCredentialsProvider> providers() {
+  synchronized ImmutableMap<String, XdsCredentialsProvider> providers() {
     return effectiveProviders;
   }
 

--- a/xds/src/test/java/io/grpc/xds/XdsCredentialsRegistryTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsCredentialsRegistryTest.java
@@ -25,6 +25,9 @@ import com.google.common.collect.ImmutableMap;
 import io.grpc.ChannelCredentials;
 import io.grpc.xds.XdsCredentialsProvider;
 import io.grpc.xds.XdsCredentialsRegistry;
+import io.grpc.xds.internal.GoogleDefaultXdsCredentialsProvider;
+import io.grpc.xds.internal.InsecureXdsCredentialsProvider;
+import io.grpc.xds.internal.TlsXdsCredentialsProvider;
 import java.util.List;
 import java.util.Map;
 import org.junit.Test;
@@ -95,7 +98,7 @@ public class XdsCredentialsRegistryTest {
         }
       });
 
-    Map<String, String> sampleConfig = ImmutableMap.of("a", "b");
+    ImmutableMap<String, String> sampleConfig = ImmutableMap.of("a", "b");
     ChannelCredentials creds = registry.providers().get(credsName)
         .newChannelCredentials(sampleConfig);
     assertSame(SampleChannelCredentials.class, creds.getClass());
@@ -135,20 +138,20 @@ public class XdsCredentialsRegistryTest {
             XdsCredentialsRegistry.getDefaultRegistry().providers();
     assertThat(providers).hasSize(3);
     assertThat(providers.get("google_default").getClass())
-        .isEqualTo(io.grpc.xds.internal.GoogleDefaultXdsCredentialsProvider.class);
+        .isEqualTo(GoogleDefaultXdsCredentialsProvider.class);
     assertThat(providers.get("insecure").getClass())
-        .isEqualTo(io.grpc.xds.internal.InsecureXdsCredentialsProvider.class);
+        .isEqualTo(InsecureXdsCredentialsProvider.class);
     assertThat(providers.get("tls").getClass())
-        .isEqualTo(io.grpc.xds.internal.TlsXdsCredentialsProvider.class);
+        .isEqualTo(TlsXdsCredentialsProvider.class);
   }
 
   @Test
   public void getClassesViaHardcoded_classesPresent() throws Exception {
     List<Class<?>> classes = XdsCredentialsRegistry.getHardCodedClasses();
     assertThat(classes).containsExactly(
-        io.grpc.xds.internal.GoogleDefaultXdsCredentialsProvider.class,
-        io.grpc.xds.internal.InsecureXdsCredentialsProvider.class,
-        io.grpc.xds.internal.TlsXdsCredentialsProvider.class);
+        GoogleDefaultXdsCredentialsProvider.class,
+        InsecureXdsCredentialsProvider.class,
+        TlsXdsCredentialsProvider.class);
   }
 
   @Test


### PR DESCRIPTION
1. Unnecessary fully qualified names
Currently in XdsCredentialsRegistry, the child classes are referred by
their fully qualified names i.e.
'io.grpc.xds.internal.GoogleDefaultXdsCredentialsProvider' instead of
importing GoogleDefaultXdsCredentialsProvider and just using
GoogleDefaultXdsCredentialsProvider.class.

2. Use immutable interfaces instead of the generic collection interface
   i.e. ImmutableMap instead of just Map in the unit tests.

These improvements are related to changes made in #8924.

@ejona86 