### PR TITLE
xds: fix XdsNameResolver blindly propagates XdsClient errors (1.44.x backport)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -701,7 +701,9 @@ final class XdsNameResolver extends NameResolver {
           if (stopped) {
             return;
           }
-          listener.onError(error);
+          listener.onError(Status.UNAVAILABLE.withCause(error.getCause()).withDescription(
+              String.format("Unable to load LDS %s. xDS server returned: %s: %s.",
+              ldsResourceName, error.getCode(), error.getDescription())));
         }
       });
     }
@@ -861,7 +863,9 @@ final class XdsNameResolver extends NameResolver {
             if (RouteDiscoveryState.this != routeDiscoveryState) {
               return;
             }
-            listener.onError(error);
+            listener.onError(Status.UNAVAILABLE.withCause(error.getCause()).withDescription(
+                String.format("Unable to load RDS %s. xDS server returned: %s: %s.",
+                resourceName, error.getCode(), error.getDescription())));
           }
         });
       }

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -428,7 +428,21 @@ public class XdsNameResolverTest {
     verify(mockListener).onError(errorCaptor.capture());
     Status error = errorCaptor.getValue();
     assertThat(error.getCode()).isEqualTo(Code.UNAVAILABLE);
-    assertThat(error.getDescription()).isEqualTo("server unreachable");
+    assertThat(error.getDescription()).isEqualTo("Unable to load LDS " + AUTHORITY
+        + ". xDS server returned: UNAVAILABLE: server unreachable.");
+  }
+
+  @Test
+  public void resolving_translateErrorLds() {
+    resolver.start(mockListener);
+    FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();
+    xdsClient.deliverError(Status.NOT_FOUND.withDescription("server unreachable"));
+    verify(mockListener).onError(errorCaptor.capture());
+    Status error = errorCaptor.getValue();
+    assertThat(error.getCode()).isEqualTo(Code.UNAVAILABLE);
+    assertThat(error.getDescription()).isEqualTo("Unable to load LDS " + AUTHORITY
+        + ". xDS server returned: NOT_FOUND: server unreachable.");
+    assertThat(error.getCause()).isNull();
   }
 
   @Test
@@ -438,10 +452,14 @@ public class XdsNameResolverTest {
     xdsClient.deliverLdsUpdateForRdsName(RDS_RESOURCE_NAME);
     xdsClient.deliverError(Status.UNAVAILABLE.withDescription("server unreachable"));
     verify(mockListener, times(2)).onError(errorCaptor.capture());
-    for (Status error : errorCaptor.getAllValues()) {
-      assertThat(error.getCode()).isEqualTo(Code.UNAVAILABLE);
-      assertThat(error.getDescription()).isEqualTo("server unreachable");
-    }
+    Status error = errorCaptor.getAllValues().get(0);
+    assertThat(error.getCode()).isEqualTo(Code.UNAVAILABLE);
+    assertThat(error.getDescription()).isEqualTo("Unable to load LDS " + AUTHORITY
+        + ". xDS server returned: UNAVAILABLE: server unreachable.");
+    error = errorCaptor.getAllValues().get(1);
+    assertThat(error.getCode()).isEqualTo(Code.UNAVAILABLE);
+    assertThat(error.getDescription()).isEqualTo("Unable to load RDS " + RDS_RESOURCE_NAME
+        + ". xDS server returned: UNAVAILABLE: server unreachable.");
   }
 
   @Test


### PR DESCRIPTION
fix https://github.com/grpc/grpc-java/issues/8950

Backport of #8953