### PR TITLE
Revert Provider use in AndroidChannelBuilder and okhttp compileOnly

### DIFF
--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -11,18 +11,17 @@ description = "gRPC: OkHttp"
 evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
-    api project(':grpc-core')
+    api project(':grpc-core'),
+            libraries.okhttp
     implementation libraries.okio,
             libraries.guava,
             libraries.perfmark
     // Make okhttp dependencies compile only
-    compileOnly libraries.okhttp
     // Tests depend on base class defined by core module.
     testImplementation project(':grpc-core').sourceSets.test.output,
             project(':grpc-api').sourceSets.test.output,
             project(':grpc-testing'),
-            project(':grpc-netty'),
-            libraries.okhttp
+            project(':grpc-netty')
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }


### PR DESCRIPTION
Revert #9003 and partly revert #8971. The two commits will be kept separate when merging. There are details in the two commits, but essentially #9003 is incompatible with Proguard and we don't want users to need Proguard configuration.

CC @beatrausch

There's a few options to roll forward, but it'll need to be discussed.