### PR TITLE
android: Use InternalManagedChannelProvider instead of reflection

### DIFF
--- a/api/src/main/java/io/grpc/InternalManagedChannelProvider.java
+++ b/api/src/main/java/io/grpc/InternalManagedChannelProvider.java
@@ -25,6 +25,10 @@ public final class InternalManagedChannelProvider {
   private InternalManagedChannelProvider() {
   }
 
+  public static boolean isAvailable(ManagedChannelProvider provider) {
+    return provider.isAvailable();
+  }
+
   public static ManagedChannelBuilder<?> builderForAddress(ManagedChannelProvider provider,
       String name, int port) {
     return provider.builderForAddress(name, port);


### PR DESCRIPTION
This fixes up cda0e9d to be compatible with Proguard without
configuration. Since the methods are now accessed directly there is no
need for manual -keep configuration.

CC @YifeiZhuang, @beatrausch 