### PR TITLE
stub: Shutdown ThreadlessExecutor only if onClose() is called

### DIFF
--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -161,6 +161,7 @@ public final class ClientCalls {
           // Now wait for onClose() to be called, so interceptors can clean up
         }
       }
+      executor.shutdown();
       return getUnchecked(responseFuture);
     } catch (RuntimeException e) {
       // Something very bad happened. All bets are off; it may be dangerous to wait for onClose().
@@ -169,7 +170,6 @@ public final class ClientCalls {
       // Something very bad happened. All bets are off; it may be dangerous to wait for onClose().
       throw cancelThrow(call, e);
     } finally {
-      executor.shutdown();
       if (interrupt) {
         Thread.currentThread().interrupt();
       }


### PR DESCRIPTION
It is only safe to shutdown the executor if onClose() is called. Normal
RPC completions (both success and failure) will see the future complete,
so this only avoids shutting down in stranger cases like an interceptor
throwing an exception.