### PR TITLE
gcp-observability: trim strings to remove newline for hostname and namespace name from files

### DIFF
--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/GlobalLoggingTags.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/GlobalLoggingTags.java
@@ -71,10 +71,10 @@ final class GlobalLoggingTags {
       String hostnameFile, String cgroupFile) {
     // namespace name: contents of file /var/run/secrets/kubernetes.io/serviceaccount/namespace
     populateFromFileContents(customTags, "namespace_name",
-        namespaceFile, (value) -> value);
+        namespaceFile, (value) -> value.trim());
 
     // pod_name: hostname i.e. contents of /etc/hostname
-    populateFromFileContents(customTags, "pod_name", hostnameFile, (value) -> value);
+    populateFromFileContents(customTags, "pod_name", hostnameFile, (value) -> value.trim());
 
     // container_id: parsed from /proc/self/cgroup . Note: only works for Linux-based containers
     populateFromFileContents(customTags, "container_id", cgroupFile,

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/GlobalLoggingTagsTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/GlobalLoggingTagsTest.java
@@ -89,7 +89,7 @@ public class GlobalLoggingTagsTest {
     File cgroupFile = cgroupFolder.newFile();
 
     Files.write("test-namespace1".getBytes(StandardCharsets.UTF_8), namespaceFile);
-    Files.write("test-hostname2".getBytes(StandardCharsets.UTF_8), hostnameFile);
+    Files.write("test-hostname2\n".getBytes(StandardCharsets.UTF_8), hostnameFile);
     Files.write(FILE_CONTENTS.getBytes(StandardCharsets.UTF_8), cgroupFile);
 
     ImmutableMap.Builder<String, String> customTags = ImmutableMap.builder();


### PR DESCRIPTION
CC @DNVindhya 