### PR TITLE
binder: Use Ticker for durations

### DIFF
--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -29,6 +29,7 @@ import android.os.Process;
 import android.os.RemoteException;
 import android.os.TransactionTooLargeException;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Ticker;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
@@ -58,7 +59,6 @@ import io.grpc.internal.ServerStream;
 import io.grpc.internal.ServerTransport;
 import io.grpc.internal.ServerTransportListener;
 import io.grpc.internal.StatsTraceContext;
-import io.grpc.internal.TimeProvider;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -567,7 +567,7 @@ public abstract class BinderTransport
       this.securityPolicy = securityPolicy;
       this.offloadExecutor = offloadExecutorPool.getObject();
       numInUseStreams = new AtomicInteger();
-      pingTracker = new PingTracker(TimeProvider.SYSTEM_TIME_PROVIDER, (id) -> sendPing(id));
+      pingTracker = new PingTracker(Ticker.systemTicker(), (id) -> sendPing(id));
 
       serviceBinding =
           new ServiceBinding(

--- a/binder/src/test/java/io/grpc/binder/internal/PingTrackerTest.java
+++ b/binder/src/test/java/io/grpc/binder/internal/PingTrackerTest.java
@@ -50,7 +50,7 @@ public final class PingTrackerTest {
     callback = new TestCallback();
     pingTracker =
         new PingTracker(
-            clock.getTimeProvider(),
+            clock.getTicker(),
             (id) -> {
               sentPings.add(id);
               if (pingFailureStatus != null) {


### PR DESCRIPTION
Ticker is powered by System.nanoTime() which is CLOCK_MONOTONIC.
TimeProvider is powered by System.currentTimeMillis() which is
CLOCK_REALTIME. For durations, the monotonic clock is appropriate, not
the wall time which can jump around.

-----

I just happened to notice this, because of fallout from https://github.com/grpc/grpc-java/pull/8968#discussion_r819975613 . Got me poking around a bit more and noticed this and an rls/ usage were inappropriate.