### PR TITLE
okhttp: Pass TransportFactory directly to transport constructor

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -505,7 +505,7 @@ public final class OkHttpChannelBuilder extends
     return this;
   }
 
-  ClientTransportFactory buildTransportFactory() {
+  OkHttpTransportFactory buildTransportFactory() {
     boolean enableKeepAlive = keepAliveTimeNanos != KEEPALIVE_TIME_NANOS_DISABLED;
     return new OkHttpTransportFactory(
         transportExecutor,
@@ -712,25 +712,25 @@ public final class OkHttpChannelBuilder extends
    */
   @Internal
   static final class OkHttpTransportFactory implements ClientTransportFactory {
-    private final Executor executor;
+    final Executor executor;
     private final boolean usingSharedExecutor;
     private final boolean usingSharedScheduler;
-    private final TransportTracer.Factory transportTracerFactory;
-    private final SocketFactory socketFactory;
-    @Nullable private final SSLSocketFactory sslSocketFactory;
+    final TransportTracer.Factory transportTracerFactory;
+    final SocketFactory socketFactory;
+    @Nullable final SSLSocketFactory sslSocketFactory;
     @Nullable
-    private final HostnameVerifier hostnameVerifier;
-    private final ConnectionSpec connectionSpec;
-    private final int maxMessageSize;
+    final HostnameVerifier hostnameVerifier;
+    final ConnectionSpec connectionSpec;
+    final int maxMessageSize;
     private final boolean enableKeepAlive;
     private final long keepAliveTimeNanos;
     private final AtomicBackoff keepAliveBackoff;
     private final long keepAliveTimeoutNanos;
-    private final int flowControlWindow;
+    final int flowControlWindow;
     private final boolean keepAliveWithoutCalls;
-    private final int maxInboundMetadataSize;
+    final int maxInboundMetadataSize;
     private final ScheduledExecutorService timeoutService;
-    private final boolean useGetForSafeMethods;
+    final boolean useGetForSafeMethods;
     private boolean closed;
 
     private OkHttpTransportFactory(
@@ -793,22 +793,13 @@ public final class OkHttpChannelBuilder extends
       InetSocketAddress inetSocketAddr = (InetSocketAddress) addr;
       // TODO(carl-mastrangelo): Pass channelLogger in.
       OkHttpClientTransport transport = new OkHttpClientTransport(
+          this,
           inetSocketAddr,
           options.getAuthority(),
           options.getUserAgent(),
           options.getEagAttributes(),
-          executor,
-          socketFactory,
-          sslSocketFactory,
-          hostnameVerifier,
-          connectionSpec,
-          maxMessageSize,
-          flowControlWindow,
           options.getHttpConnectProxiedSocketAddress(),
-          tooManyPingsRunnable,
-          maxInboundMetadataSize,
-          transportTracerFactory.create(),
-          useGetForSafeMethods);
+          tooManyPingsRunnable);
       if (enableKeepAlive) {
         transport.enableKeepAlive(
             true, keepAliveTimeNanosState.get(), keepAliveTimeoutNanos, keepAliveWithoutCalls);

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -227,87 +227,62 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
   SettableFuture<Void> connectedFuture;
 
   public OkHttpClientTransport(
+      OkHttpChannelBuilder.OkHttpTransportFactory transportFactory,
       InetSocketAddress address,
       String authority,
       @Nullable String userAgent,
       Attributes eagAttrs,
-      Executor executor,
-      @Nullable SocketFactory socketFactory,
-      @Nullable SSLSocketFactory sslSocketFactory,
-      @Nullable HostnameVerifier hostnameVerifier,
-      ConnectionSpec connectionSpec,
-      int maxMessageSize,
-      int initialWindowSize,
       @Nullable HttpConnectProxiedSocketAddress proxiedAddr,
-      Runnable tooManyPingsRunnable,
-      int maxInboundMetadataSize,
-      TransportTracer transportTracer,
-      boolean useGetForSafeMethods) {
+      Runnable tooManyPingsRunnable) {
     this(
+        transportFactory,
         address,
         authority,
         userAgent,
         eagAttrs,
-        executor,
-        socketFactory,
-        sslSocketFactory,
-        hostnameVerifier,
-        connectionSpec,
         GrpcUtil.STOPWATCH_SUPPLIER,
         new Http2(),
-        maxMessageSize,
-        initialWindowSize,
         proxiedAddr,
-        tooManyPingsRunnable,
-        maxInboundMetadataSize,
-        transportTracer,
-        useGetForSafeMethods);
+        tooManyPingsRunnable);
   }
 
   private OkHttpClientTransport(
+      OkHttpChannelBuilder.OkHttpTransportFactory transportFactory,
       InetSocketAddress address,
       String authority,
       @Nullable String userAgent,
       Attributes eagAttrs,
-      Executor executor,
-      @Nullable SocketFactory socketFactory,
-      @Nullable SSLSocketFactory sslSocketFactory,
-      @Nullable HostnameVerifier hostnameVerifier,
-      ConnectionSpec connectionSpec,
       Supplier<Stopwatch> stopwatchFactory,
       Variant variant,
-      int maxMessageSize,
-      int initialWindowSize,
       @Nullable HttpConnectProxiedSocketAddress proxiedAddr,
-      Runnable tooManyPingsRunnable,
-      int maxInboundMetadataSize,
-      TransportTracer transportTracer,
-      boolean useGetForSafeMethods) {
+      Runnable tooManyPingsRunnable) {
     this.address = Preconditions.checkNotNull(address, "address");
     this.defaultAuthority = authority;
-    this.maxMessageSize = maxMessageSize;
-    this.initialWindowSize = initialWindowSize;
-    this.executor = Preconditions.checkNotNull(executor, "executor");
-    serializingExecutor = new SerializingExecutor(executor);
+    this.maxMessageSize = transportFactory.maxMessageSize;
+    this.initialWindowSize = transportFactory.flowControlWindow;
+    this.executor = Preconditions.checkNotNull(transportFactory.executor, "executor");
+    serializingExecutor = new SerializingExecutor(transportFactory.executor);
     // Client initiated streams are odd, server initiated ones are even. Server should not need to
     // use it. We start clients at 3 to avoid conflicting with HTTP negotiation.
     nextStreamId = 3;
-    this.socketFactory = socketFactory == null ? SocketFactory.getDefault() : socketFactory;
-    this.sslSocketFactory = sslSocketFactory;
-    this.hostnameVerifier = hostnameVerifier;
-    this.connectionSpec = Preconditions.checkNotNull(connectionSpec, "connectionSpec");
+    this.socketFactory = transportFactory.socketFactory == null
+        ? SocketFactory.getDefault() : transportFactory.socketFactory;
+    this.sslSocketFactory = transportFactory.sslSocketFactory;
+    this.hostnameVerifier = transportFactory.hostnameVerifier;
+    this.connectionSpec = Preconditions.checkNotNull(
+        transportFactory.connectionSpec, "connectionSpec");
     this.stopwatchFactory = Preconditions.checkNotNull(stopwatchFactory, "stopwatchFactory");
     this.variant = Preconditions.checkNotNull(variant, "variant");
     this.userAgent = GrpcUtil.getGrpcUserAgent("okhttp", userAgent);
     this.proxiedAddr = proxiedAddr;
     this.tooManyPingsRunnable =
         Preconditions.checkNotNull(tooManyPingsRunnable, "tooManyPingsRunnable");
-    this.maxInboundMetadataSize = maxInboundMetadataSize;
-    this.transportTracer = Preconditions.checkNotNull(transportTracer);
+    this.maxInboundMetadataSize = transportFactory.maxInboundMetadataSize;
+    this.transportTracer = transportFactory.transportTracerFactory.create();
     this.logId = InternalLogId.allocate(getClass(), address.toString());
     this.attributes = Attributes.newBuilder()
         .set(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS, eagAttrs).build();
-    this.useGetForSafeMethods = useGetForSafeMethods;
+    this.useGetForSafeMethods = transportFactory.useGetForSafeMethods;
     initTransportTracer();
   }
 
@@ -316,36 +291,23 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
    */
   @VisibleForTesting
   OkHttpClientTransport(
+      OkHttpChannelBuilder.OkHttpTransportFactory transportFactory,
       String userAgent,
-      Executor executor,
-      @Nullable SocketFactory socketFactory,
       Supplier<Stopwatch> stopwatchFactory,
       Variant variant,
       @Nullable Runnable connectingCallback,
       SettableFuture<Void> connectedFuture,
-      int maxMessageSize,
-      int initialWindowSize,
-      Runnable tooManyPingsRunnable,
-      TransportTracer transportTracer) {
+      Runnable tooManyPingsRunnable) {
     this(
+        transportFactory,
         new InetSocketAddress("127.0.0.1", 80),
         "notarealauthority:80",
         userAgent,
         Attributes.EMPTY,
-        executor,
-        socketFactory,
-        null,
-        null,
-        OkHttpChannelBuilder.INTERNAL_DEFAULT_CONNECTION_SPEC,
         stopwatchFactory,
         variant,
-        maxMessageSize,
-        initialWindowSize,
         null,
-        tooManyPingsRunnable,
-        Integer.MAX_VALUE,
-        transportTracer,
-        false);
+        tooManyPingsRunnable);
     this.connectingCallback = connectingCallback;
     this.connectedFuture = Preconditions.checkNotNull(connectedFuture, "connectedFuture");
   }

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -21,7 +21,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.internal.ClientStreamListener.RpcProgress.MISCARRIED;
 import static io.grpc.internal.ClientStreamListener.RpcProgress.PROCESSED;
 import static io.grpc.internal.ClientStreamListener.RpcProgress.REFUSED;
-import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 import static io.grpc.okhttp.Headers.CONTENT_TYPE_HEADER;
 import static io.grpc.okhttp.Headers.HTTP_SCHEME_HEADER;
 import static io.grpc.okhttp.Headers.METHOD_HEADER;
@@ -73,12 +72,11 @@ import io.grpc.StatusException;
 import io.grpc.internal.AbstractStream;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ClientTransport;
+import io.grpc.internal.FakeClock;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.ManagedClientTransport;
-import io.grpc.internal.TransportTracer;
 import io.grpc.okhttp.OkHttpClientTransport.ClientFrameHandler;
 import io.grpc.okhttp.OkHttpFrameLogger.Direction;
-import io.grpc.okhttp.internal.ConnectionSpec;
 import io.grpc.okhttp.internal.Protocol;
 import io.grpc.okhttp.internal.framed.ErrorCode;
 import io.grpc.okhttp.internal.framed.FrameReader;
@@ -119,8 +117,6 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import javax.net.SocketFactory;
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLSocketFactory;
 import okio.Buffer;
 import okio.BufferedSink;
 import okio.BufferedSource;
@@ -153,7 +149,6 @@ public class OkHttpClientTransportTest {
   private static final Status SHUTDOWN_REASON = Status.UNAVAILABLE.withDescription("for test");
   private static final HttpConnectProxiedSocketAddress NO_PROXY = null;
   private static final int DEFAULT_START_STREAM_ID = 3;
-  private static final int DEFAULT_MAX_INBOUND_METADATA_SIZE = Integer.MAX_VALUE;
   private static final Attributes EAG_ATTRS = Attributes.EMPTY;
   private static final Logger logger = Logger.getLogger(OkHttpClientTransport.class.getName());
   private static final ClientStreamTracer[] tracers = new ClientStreamTracer[] {
@@ -167,10 +162,6 @@ public class OkHttpClientTransportTest {
   @Mock
   private ManagedClientTransport.Listener transportListener;
 
-  private final SocketFactory socketFactory = null;
-  private final SSLSocketFactory sslSocketFactory = null;
-  private final HostnameVerifier hostnameVerifier = null;
-  private final TransportTracer transportTracer = new TransportTracer();
   private final Queue<Buffer> capturedBuffer = new ArrayDeque<>();
   private OkHttpClientTransport clientTransport;
   private final MockFrameReader frameReader = new MockFrameReader();
@@ -186,6 +177,12 @@ public class OkHttpClientTransportTest {
       throw new AssertionError();
     }
   };
+  private OkHttpChannelBuilder channelBuilder = OkHttpChannelBuilder.forAddress("127.0.0.1", 1234)
+      .usePlaintext()
+      .executor(new FakeClock().getScheduledExecutorService()) // Executor unused
+      .scheduledExecutorService(new FakeClock().getScheduledExecutorService()) // Executor unused
+      .transportExecutor(executor)
+      .flowControlWindow(INITIAL_WINDOW_SIZE);
 
   /** Set up for test. */
   @Before
@@ -200,11 +197,11 @@ public class OkHttpClientTransportTest {
 
   private void initTransport() throws Exception {
     startTransport(
-        DEFAULT_START_STREAM_ID, null, true, DEFAULT_MAX_MESSAGE_SIZE, INITIAL_WINDOW_SIZE, null);
+        DEFAULT_START_STREAM_ID, null, true, null);
   }
 
   private void initTransport(int startId) throws Exception {
-    startTransport(startId, null, true, DEFAULT_MAX_MESSAGE_SIZE, INITIAL_WINDOW_SIZE, null);
+    startTransport(startId, null, true, null);
   }
 
   private void initTransportAndDelayConnected() throws Exception {
@@ -213,13 +210,11 @@ public class OkHttpClientTransportTest {
         DEFAULT_START_STREAM_ID,
         delayConnectedCallback,
         false,
-        DEFAULT_MAX_MESSAGE_SIZE,
-        INITIAL_WINDOW_SIZE,
         null);
   }
 
   private void startTransport(int startId, @Nullable Runnable connectingCallback,
-      boolean waitingForConnected, int maxMessageSize, int initialWindowSize, String userAgent)
+      boolean waitingForConnected, String userAgent)
       throws Exception {
     connectedFuture = SettableFuture.create();
     final Ticker ticker = new Ticker() {
@@ -234,18 +229,15 @@ public class OkHttpClientTransportTest {
         return Stopwatch.createUnstarted(ticker);
       }
     };
+    channelBuilder.socketFactory(new FakeSocketFactory(socket));
     clientTransport = new OkHttpClientTransport(
+        channelBuilder.buildTransportFactory(),
         userAgent,
-        executor,
-        new FakeSocketFactory(socket),
         stopwatchSupplier,
         new FakeVariant(frameReader, frameWriter),
         connectingCallback,
         connectedFuture,
-        maxMessageSize,
-        initialWindowSize,
-        tooManyPingsRunnable,
-        new TransportTracer());
+        tooManyPingsRunnable);
     clientTransport.start(transportListener);
     if (waitingForConnected) {
       connectedFuture.get(TIME_OUT_MS, TimeUnit.MILLISECONDS);
@@ -259,22 +251,13 @@ public class OkHttpClientTransportTest {
   public void testToString() throws Exception {
     InetSocketAddress address = InetSocketAddress.createUnresolved("hostname", 31415);
     clientTransport = new OkHttpClientTransport(
+        channelBuilder.buildTransportFactory(),
         address,
         "hostname",
         /*agent=*/ null,
         EAG_ATTRS,
-        executor,
-        socketFactory,
-        sslSocketFactory,
-        hostnameVerifier,
-        OkHttpChannelBuilder.INTERNAL_DEFAULT_CONNECTION_SPEC,
-        DEFAULT_MAX_MESSAGE_SIZE,
-        INITIAL_WINDOW_SIZE,
         NO_PROXY,
-        tooManyPingsRunnable,
-        DEFAULT_MAX_INBOUND_METADATA_SIZE,
-        transportTracer,
-        false);
+        tooManyPingsRunnable);
     String s = clientTransport.toString();
     assertTrue("Unexpected: " + s, s.contains("OkHttpClientTransport"));
     assertTrue("Unexpected: " + s, s.contains(address.toString()));
@@ -395,8 +378,8 @@ public class OkHttpClientTransportTest {
 
   @Test
   public void maxMessageSizeShouldBeEnforced() throws Exception {
-    // Allow the response payloads of up to 1 byte.
-    startTransport(3, null, true, 1, INITIAL_WINDOW_SIZE, null);
+    channelBuilder.maxInboundMessageSize(1);
+    initTransport();
 
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
@@ -419,9 +402,8 @@ public class OkHttpClientTransportTest {
 
   @Test
   public void includeInitialWindowSizeInFirstSettings() throws Exception {
-    int initialWindowSize = 65535;
-    startTransport(
-            DEFAULT_START_STREAM_ID, null, true, DEFAULT_MAX_MESSAGE_SIZE, initialWindowSize, null);
+    channelBuilder.flowControlWindow(65535);
+    initTransport();
 
     ArgumentCaptor<Settings> settings = ArgumentCaptor.forClass(Settings.class);
     verify(frameWriter, timeout(TIME_OUT_MS)).settings(settings.capture());
@@ -434,9 +416,8 @@ public class OkHttpClientTransportTest {
    */
   @Test
   public void includeInitialWindowSizeInFirstSettings_largeWindowSize() throws Exception {
-    int initialWindowSize = 75535; // 65535 + 10000
-    startTransport(
-            DEFAULT_START_STREAM_ID, null, true, DEFAULT_MAX_MESSAGE_SIZE, initialWindowSize, null);
+    channelBuilder.flowControlWindow(75535); // 65535 + 10000
+    initTransport();
 
     ArgumentCaptor<Settings> settings = ArgumentCaptor.forClass(Settings.class);
     verify(frameWriter, timeout(TIME_OUT_MS)).settings(settings.capture());
@@ -703,7 +684,7 @@ public class OkHttpClientTransportTest {
 
   @Test
   public void overrideDefaultUserAgent() throws Exception {
-    startTransport(3, null, true, DEFAULT_MAX_MESSAGE_SIZE, INITIAL_WINDOW_SIZE, "fakeUserAgent");
+    startTransport(3, null, true, "fakeUserAgent");
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream =
         clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT, tracers);
@@ -1770,22 +1751,13 @@ public class OkHttpClientTransportTest {
   @Test
   public void invalidAuthorityPropagates() {
     clientTransport = new OkHttpClientTransport(
+        channelBuilder.buildTransportFactory(),
         new InetSocketAddress("host", 1234),
         "invalid_authority",
         "userAgent",
         EAG_ATTRS,
-        executor,
-        socketFactory,
-        sslSocketFactory,
-        hostnameVerifier,
-        ConnectionSpec.CLEARTEXT,
-        DEFAULT_MAX_MESSAGE_SIZE,
-        INITIAL_WINDOW_SIZE,
         NO_PROXY,
-        tooManyPingsRunnable,
-        DEFAULT_MAX_INBOUND_METADATA_SIZE,
-        transportTracer,
-        false);
+        tooManyPingsRunnable);
 
     String host = clientTransport.getOverridenHost();
     int port = clientTransport.getOverridenPort();
@@ -1797,22 +1769,13 @@ public class OkHttpClientTransportTest {
   @Test
   public void unreachableServer() throws Exception {
     clientTransport = new OkHttpClientTransport(
+        channelBuilder.buildTransportFactory(),
         new InetSocketAddress("localhost", 0),
         "authority",
         "userAgent",
         EAG_ATTRS,
-        executor,
-        socketFactory,
-        sslSocketFactory,
-        hostnameVerifier,
-        ConnectionSpec.CLEARTEXT,
-        DEFAULT_MAX_MESSAGE_SIZE,
-        INITIAL_WINDOW_SIZE,
         NO_PROXY,
-        tooManyPingsRunnable,
-        DEFAULT_MAX_INBOUND_METADATA_SIZE,
-        new TransportTracer(),
-        false);
+        tooManyPingsRunnable);
 
     ManagedClientTransport.Listener listener = mock(ManagedClientTransport.Listener.class);
     clientTransport.start(listener);
@@ -1836,22 +1799,13 @@ public class OkHttpClientTransportTest {
 
     clientTransport =
         new OkHttpClientTransport(
+            channelBuilder.socketFactory(socketFactory).buildTransportFactory(),
             new InetSocketAddress("localhost", 0),
             "authority",
             "userAgent",
             EAG_ATTRS,
-            executor,
-            socketFactory,
-            sslSocketFactory,
-            hostnameVerifier,
-            ConnectionSpec.CLEARTEXT,
-            DEFAULT_MAX_MESSAGE_SIZE,
-            INITIAL_WINDOW_SIZE,
             NO_PROXY,
-            tooManyPingsRunnable,
-            DEFAULT_MAX_INBOUND_METADATA_SIZE,
-            new TransportTracer(),
-            false);
+            tooManyPingsRunnable);
 
     ManagedClientTransport.Listener listener = mock(ManagedClientTransport.Listener.class);
     clientTransport.start(listener);
@@ -1867,25 +1821,16 @@ public class OkHttpClientTransportTest {
     ServerSocket serverSocket = new ServerSocket(0);
     InetSocketAddress targetAddress = InetSocketAddress.createUnresolved("theservice", 80);
     clientTransport = new OkHttpClientTransport(
+        channelBuilder.buildTransportFactory(),
         targetAddress,
         "authority",
         "userAgent",
         EAG_ATTRS,
-        executor,
-        socketFactory,
-        sslSocketFactory,
-        hostnameVerifier,
-        ConnectionSpec.CLEARTEXT,
-        DEFAULT_MAX_MESSAGE_SIZE,
-        INITIAL_WINDOW_SIZE,
         HttpConnectProxiedSocketAddress.newBuilder()
             .setTargetAddress(targetAddress)
             .setProxyAddress(new InetSocketAddress("localhost", serverSocket.getLocalPort()))
             .build(),
-        tooManyPingsRunnable,
-        DEFAULT_MAX_INBOUND_METADATA_SIZE,
-        transportTracer,
-        false);
+        tooManyPingsRunnable);
     clientTransport.start(transportListener);
 
     Socket sock = serverSocket.accept();
@@ -1925,25 +1870,16 @@ public class OkHttpClientTransportTest {
     ServerSocket serverSocket = new ServerSocket(0);
     InetSocketAddress targetAddress = InetSocketAddress.createUnresolved("theservice", 80);
     clientTransport = new OkHttpClientTransport(
+        channelBuilder.buildTransportFactory(),
         targetAddress,
         "authority",
         "userAgent",
         EAG_ATTRS,
-        executor,
-        socketFactory,
-        sslSocketFactory,
-        hostnameVerifier,
-        ConnectionSpec.CLEARTEXT,
-        DEFAULT_MAX_MESSAGE_SIZE,
-        INITIAL_WINDOW_SIZE,
         HttpConnectProxiedSocketAddress.newBuilder()
             .setTargetAddress(targetAddress)
             .setProxyAddress(new InetSocketAddress("localhost", serverSocket.getLocalPort()))
             .build(),
-        tooManyPingsRunnable,
-        DEFAULT_MAX_INBOUND_METADATA_SIZE,
-        transportTracer,
-        false);
+        tooManyPingsRunnable);
     clientTransport.start(transportListener);
 
     Socket sock = serverSocket.accept();
@@ -1982,25 +1918,16 @@ public class OkHttpClientTransportTest {
     ServerSocket serverSocket = new ServerSocket(0);
     InetSocketAddress targetAddress = InetSocketAddress.createUnresolved("theservice", 80);
     clientTransport = new OkHttpClientTransport(
+        channelBuilder.buildTransportFactory(),
         targetAddress,
         "authority",
         "userAgent",
         EAG_ATTRS,
-        executor,
-        socketFactory,
-        sslSocketFactory,
-        hostnameVerifier,
-        ConnectionSpec.CLEARTEXT,
-        DEFAULT_MAX_MESSAGE_SIZE,
-        INITIAL_WINDOW_SIZE,
         HttpConnectProxiedSocketAddress.newBuilder()
             .setTargetAddress(targetAddress)
             .setProxyAddress(new InetSocketAddress("localhost", serverSocket.getLocalPort()))
             .build(),
-        tooManyPingsRunnable,
-        DEFAULT_MAX_INBOUND_METADATA_SIZE,
-        transportTracer,
-        false);
+        tooManyPingsRunnable);
     clientTransport.start(transportListener);
 
     Socket sock = serverSocket.accept();


### PR DESCRIPTION
This greatly reduces the number of arguments passed to the constructor
and allows using the builder in tests to change specific arguments
without having to pass all the other arguments. It also makes it easier
to see where tests are doing something special.

While it is weird to expose fields as package-private for digging-into
in the constructor, it's actually very similar to the pattern of passing
the builder instance into the constuctor. In this case, the weirdness is
because the builder isn't a nested class of the transport and there is
an additional level of building going on (Builder and TransportFactory).
We do this pattern already in ManagedChannelImpl which only has the one
level of building.

----

@temawi, @YifeiZhuang, if you are doubtful of whether this is an improvement, we can discuss. I think the benefits are strong, but I do see some downfalls so do accept that others make feel differently. Also if you don't like it, now is a good time to consider, because we may want to copy the approach in other transports.

The fields of OkHttpTransportFactory are a bit weird in how they are a mix of exposed and unexposed. Just changing their order would improve things some, but I have plans for most of them. For example, `usingSharedExecutor` should be replaced with `ObjectPool`, like we do in Netty; it'd remain private, but it could be ordered more "naturally." And the keepalive fields can just be accessed directly instead of using [a setter on the transport](https://github.com/grpc/grpc-java/blob/18753b654f69ce2bfb4d54bb362479bd9f239c32/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java#L376). I'm pretty confident that [was only done that way](https://github.com/grpc/grpc-java/commit/d9001ca4488ba48cf8f732c5fbe59386f55833dc) to avoid updating tests; `OkHttpClientTransportTest` didn't need any change.

I didn't reorder the fields right now because it will cloud the blame and make the PR harder to review.