### PR TITLE
gcp-observability: add source project id to labels when cross project logging is enabled

### DIFF
--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/GcpLogSink.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/GcpLogSink.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -71,15 +72,16 @@ public class GcpLogSink implements Sink {
    */
   public GcpLogSink(String destinationProjectId, Map<String, String> locationTags,
       Map<String, String> customTags, Long flushLimit) {
-    this(createLoggingClient(destinationProjectId), locationTags, customTags, flushLimit);
+    this(createLoggingClient(destinationProjectId), destinationProjectId, locationTags,
+        customTags, flushLimit);
 
   }
 
   @VisibleForTesting
-  GcpLogSink(Logging client, Map<String, String> locationTags, Map<String, String> customTags,
-      Long flushLimit) {
+  GcpLogSink(Logging client, String destinationProjectId, Map<String, String> locationTags,
+      Map<String, String> customTags, Long flushLimit) {
     this.gcpLoggingClient = client;
-    this.customTags = customTags != null ? customTags : new HashMap<>();
+    this.customTags = getCustomTags(customTags, locationTags, destinationProjectId);
     this.kubernetesResource = getResource(locationTags);
     this.flushLimit = flushLimit != null ? flushLimit : FALLBACK_FLUSH_LIMIT;
     this.flushCounter = 0L;
@@ -109,6 +111,7 @@ public class GcpLogSink implements Sink {
               .setSeverity(logEntrySeverity)
               .setLogName(DEFAULT_LOG_NAME)
               .setResource(kubernetesResource);
+
       if (!customTags.isEmpty()) {
         grpcLogEntryBuilder.setLabels(customTags);
       }
@@ -125,6 +128,21 @@ public class GcpLogSink implements Sink {
     } catch (Exception e) {
       logger.log(Level.SEVERE, "Caught exception while writing to Cloud Logging", e);
     }
+  }
+
+  @VisibleForTesting
+  static Map<String, String> getCustomTags(Map<String, String> customTags,
+      Map<String, String> locationTags, String destinationProjectId) {
+    Map<String, String> tags = new HashMap<>();
+    String sourceProjectId = locationTags.get("project_id");
+    if (!Objects.equals(sourceProjectId, destinationProjectId)
+        && !Strings.isNullOrEmpty(destinationProjectId)) {
+      tags.put("source_project_id", sourceProjectId);
+    }
+    if (customTags != null) {
+      tags.putAll(customTags);
+    }
+    return tags;
   }
 
   @VisibleForTesting

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/GcpLogSink.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/GcpLogSink.java
@@ -24,13 +24,13 @@ import com.google.cloud.logging.Payload.JsonPayload;
 import com.google.cloud.logging.Severity;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.util.JsonFormat;
 import io.grpc.internal.JsonParser;
 import io.grpc.observabilitylog.v1.GrpcLogRecord;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -133,16 +133,16 @@ public class GcpLogSink implements Sink {
   @VisibleForTesting
   static Map<String, String> getCustomTags(Map<String, String> customTags,
       Map<String, String> locationTags, String destinationProjectId) {
-    Map<String, String> tags = new HashMap<>();
+    ImmutableMap.Builder<String, String> tagsBuilder = ImmutableMap.builder();
     String sourceProjectId = locationTags.get("project_id");
-    if (!Objects.equals(sourceProjectId, destinationProjectId)
-        && !Strings.isNullOrEmpty(destinationProjectId)) {
-      tags.put("source_project_id", sourceProjectId);
+    if (!Strings.isNullOrEmpty(destinationProjectId)
+        && !Objects.equals(sourceProjectId, destinationProjectId)) {
+      tagsBuilder.put("source_project_id", sourceProjectId);
     }
     if (customTags != null) {
-      tags.putAll(customTags);
+      tagsBuilder.putAll(customTags);
     }
-    return tags;
+    return tagsBuilder.build();
   }
 
   @VisibleForTesting

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/interceptors/ConfigFilterHelperTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/interceptors/ConfigFilterHelperTest.java
@@ -17,7 +17,6 @@
 package io.grpc.gcp.observability.interceptors;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -107,15 +106,15 @@ public class ConfigFilterHelperTest {
         FilterParams.create(true, 128, 128));
     expectedServiceFilters.put("service2",
         FilterParams.create(true, 2048, 1024));
-    assertEquals(expectedServiceFilters, configFilterHelper.perServiceFilters);
+    assertThat(configFilterHelper.perServiceFilters).isEqualTo(expectedServiceFilters);
 
     Map<String, FilterParams> expectedMethodFilters = new HashMap<>();
     expectedMethodFilters.put("service1/Method2",
         FilterParams.create(true, 1024, 1024));
-    assertEquals(expectedMethodFilters, configFilterHelper.perMethodFilters);
+    assertThat(configFilterHelper.perMethodFilters).isEqualTo(expectedMethodFilters);
 
     Set<EventType> expectedLogEventTypeSet = ImmutableSet.copyOf(configEventTypes);
-    assertEquals(expectedLogEventTypeSet, configFilterHelper.logEventTypeSet);
+    assertThat(configFilterHelper.logEventTypeSet).isEqualTo(expectedLogEventTypeSet);
   }
 
   @Test
@@ -130,7 +129,7 @@ public class ConfigFilterHelperTest {
     method = builder.setFullMethodName("service1/Method6").build();
     FilterParams resultParams
         = configFilterHelper.isMethodToBeLogged(method);
-    assertEquals(expectedParams, resultParams);
+    assertThat(resultParams).isEqualTo(expectedParams);
   }
 
   @Test
@@ -146,7 +145,7 @@ public class ConfigFilterHelperTest {
     method = builder.setFullMethodName("service3/Method3").build();
     FilterParams resultParams
         = configFilterHelper.isMethodToBeLogged(method);
-    assertEquals(expectedParams, resultParams);
+    assertThat(resultParams).isEqualTo(expectedParams);
   }
 
   @Test
@@ -159,14 +158,14 @@ public class ConfigFilterHelperTest {
     method = builder.setFullMethodName("service1/Method2").build();
     FilterParams resultParams
         = configFilterHelper.isMethodToBeLogged(method);
-    assertEquals(expectedParams, resultParams);
+    assertThat(resultParams).isEqualTo(expectedParams);
 
     FilterParams expectedParamsWildCard =
         FilterParams.create(true, 2048, 1024);
     method = builder.setFullMethodName("service2/Method1").build();
     FilterParams resultParamsWildCard
         = configFilterHelper.isMethodToBeLogged(method);
-    assertEquals(expectedParamsWildCard, resultParamsWildCard);
+    assertThat(resultParamsWildCard).isEqualTo(expectedParamsWildCard);
   }
 
   @Test

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/interceptors/ConfigFilterHelperTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/interceptors/ConfigFilterHelperTest.java
@@ -107,15 +107,15 @@ public class ConfigFilterHelperTest {
         FilterParams.create(true, 128, 128));
     expectedServiceFilters.put("service2",
         FilterParams.create(true, 2048, 1024));
-    assertEquals(configFilterHelper.perServiceFilters, expectedServiceFilters);
+    assertEquals(expectedServiceFilters, configFilterHelper.perServiceFilters);
 
     Map<String, FilterParams> expectedMethodFilters = new HashMap<>();
     expectedMethodFilters.put("service1/Method2",
         FilterParams.create(true, 1024, 1024));
-    assertEquals(configFilterHelper.perMethodFilters, expectedMethodFilters);
+    assertEquals(expectedMethodFilters, configFilterHelper.perMethodFilters);
 
     Set<EventType> expectedLogEventTypeSet = ImmutableSet.copyOf(configEventTypes);
-    assertEquals(configFilterHelper.logEventTypeSet, expectedLogEventTypeSet);
+    assertEquals(expectedLogEventTypeSet, configFilterHelper.logEventTypeSet);
   }
 
   @Test
@@ -130,7 +130,7 @@ public class ConfigFilterHelperTest {
     method = builder.setFullMethodName("service1/Method6").build();
     FilterParams resultParams
         = configFilterHelper.isMethodToBeLogged(method);
-    assertEquals(resultParams, expectedParams);
+    assertEquals(expectedParams, resultParams);
   }
 
   @Test
@@ -146,7 +146,7 @@ public class ConfigFilterHelperTest {
     method = builder.setFullMethodName("service3/Method3").build();
     FilterParams resultParams
         = configFilterHelper.isMethodToBeLogged(method);
-    assertEquals(resultParams, expectedParams);
+    assertEquals(expectedParams, resultParams);
   }
 
   @Test
@@ -159,14 +159,14 @@ public class ConfigFilterHelperTest {
     method = builder.setFullMethodName("service1/Method2").build();
     FilterParams resultParams
         = configFilterHelper.isMethodToBeLogged(method);
-    assertEquals(resultParams, expectedParams);
+    assertEquals(expectedParams, resultParams);
 
     FilterParams expectedParamsWildCard =
         FilterParams.create(true, 2048, 1024);
     method = builder.setFullMethodName("service2/Method1").build();
     FilterParams resultParamsWildCard
         = configFilterHelper.isMethodToBeLogged(method);
-    assertEquals(resultParamsWildCard, expectedParamsWildCard);
+    assertEquals(expectedParamsWildCard, resultParamsWildCard);
   }
 
   @Test

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/logging/GcpLogSinkTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/logging/GcpLogSinkTest.java
@@ -17,7 +17,6 @@
 package io.grpc.gcp.observability.logging;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyIterable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -122,7 +121,7 @@ public class GcpLogSinkTest {
     for (Iterator<LogEntry> it = logEntrySetCaptor.getValue().iterator(); it.hasNext(); ) {
       LogEntry entry = it.next();
       System.out.println(entry);
-      assertEquals(expectedStructLogProto, entry.getPayload().getData());
+      assertThat(entry.getPayload().getData()).isEqualTo(expectedStructLogProto);
     }
     verifyNoMoreInteractions(mockLogging);
   }
@@ -141,9 +140,9 @@ public class GcpLogSinkTest {
     System.out.println(logEntrySetCaptor.getValue());
     for (Iterator<LogEntry> it = logEntrySetCaptor.getValue().iterator(); it.hasNext(); ) {
       LogEntry entry = it.next();
-      assertEquals( expectedMonitoredResource, entry.getResource());
-      assertEquals(customTags, entry.getLabels());
-      assertEquals(expectedStructLogProto, entry.getPayload().getData());
+      assertThat(entry.getResource()).isEqualTo(expectedMonitoredResource);
+      assertThat(entry.getLabels()).isEqualTo(customTags);
+      assertThat(entry.getPayload().getData()).isEqualTo(expectedStructLogProto);
     }
     verifyNoMoreInteractions(mockLogging);
   }
@@ -162,8 +161,8 @@ public class GcpLogSinkTest {
     verify(mockLogging, times(1)).write(logEntrySetCaptor.capture());
     for (Iterator<LogEntry> it = logEntrySetCaptor.getValue().iterator(); it.hasNext(); ) {
       LogEntry entry = it.next();
-      assertEquals(expectedEmptyLabels, entry.getLabels());
-      assertEquals(expectedStructLogProto, entry.getPayload().getData());
+      assertThat(entry.getLabels()).isEqualTo(expectedEmptyLabels);
+      assertThat(entry.getPayload().getData()).isEqualTo(expectedStructLogProto);
     }
   }
 
@@ -174,7 +173,6 @@ public class GcpLogSinkTest {
     String destinationProjectId = "DESTINATION_PROJECT";
     Map<String, String> expectedLabels = GcpLogSink.getCustomTags(emptyCustomTags, locationTags,
         destinationProjectId);
-    expectedLabels.put("source_project_id", "PROJECT");
     GcpLogSink mockSink = new GcpLogSink(mockLogging, destinationProjectId, locationTags,
         emptyCustomTags, flushLimit);
     mockSink.write(logProto);
@@ -184,10 +182,9 @@ public class GcpLogSinkTest {
     verify(mockLogging, times(1)).write(logEntrySetCaptor.capture());
     for (Iterator<LogEntry> it = logEntrySetCaptor.getValue().iterator(); it.hasNext(); ) {
       LogEntry entry = it.next();
-      assertEquals(expectedLabels, entry.getLabels());
-      assertEquals(expectedStructLogProto, entry.getPayload().getData());
+      assertThat(entry.getLabels()).isEqualTo(expectedLabels);
+      assertThat(entry.getPayload().getData()).isEqualTo(expectedStructLogProto);
     }
-
   }
 
   @Test

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/logging/GcpLogSinkTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/logging/GcpLogSinkTest.java
@@ -67,6 +67,7 @@ public class GcpLogSinkTest {
       "KEY2", "VALUE2");
   private static final long flushLimit = 10L;
   private final long seqId = 1;
+  private final String destProjectName = "PROJECT";
   private final String serviceName = "service";
   private final String methodName = "method";
   private final String authority = "authority";
@@ -103,14 +104,16 @@ public class GcpLogSinkTest {
 
   @Test
   public void createSink() {
-    Sink mockSink = new GcpLogSink(mockLogging, locationTags, customTags, flushLimit);
+    Sink mockSink = new GcpLogSink(mockLogging, destProjectName, locationTags,
+        customTags, flushLimit);
     assertThat(mockSink).isInstanceOf(GcpLogSink.class);
   }
 
   @Test
   @SuppressWarnings("unchecked")
   public void verifyWrite() throws Exception {
-    Sink mockSink = new GcpLogSink(mockLogging, locationTags, customTags, flushLimit);
+    Sink mockSink = new GcpLogSink(mockLogging, destProjectName, locationTags,
+        customTags, flushLimit);
     mockSink.write(logProto);
 
     ArgumentCaptor<Collection<LogEntry>> logEntrySetCaptor = ArgumentCaptor.forClass(
@@ -119,7 +122,7 @@ public class GcpLogSinkTest {
     for (Iterator<LogEntry> it = logEntrySetCaptor.getValue().iterator(); it.hasNext(); ) {
       LogEntry entry = it.next();
       System.out.println(entry);
-      assertEquals(entry.getPayload().getData(), expectedStructLogProto);
+      assertEquals(expectedStructLogProto, entry.getPayload().getData());
     }
     verifyNoMoreInteractions(mockLogging);
   }
@@ -127,7 +130,8 @@ public class GcpLogSinkTest {
   @Test
   @SuppressWarnings("unchecked")
   public void verifyWriteWithTags() {
-    GcpLogSink mockSink = new GcpLogSink(mockLogging, locationTags, customTags, flushLimit);
+    GcpLogSink mockSink = new GcpLogSink(mockLogging, destProjectName, locationTags,
+        customTags, flushLimit);
     MonitoredResource expectedMonitoredResource = GcpLogSink.getResource(locationTags);
     mockSink.write(logProto);
 
@@ -137,9 +141,9 @@ public class GcpLogSinkTest {
     System.out.println(logEntrySetCaptor.getValue());
     for (Iterator<LogEntry> it = logEntrySetCaptor.getValue().iterator(); it.hasNext(); ) {
       LogEntry entry = it.next();
-      assertEquals(entry.getResource(), expectedMonitoredResource);
-      assertEquals(entry.getLabels(), customTags);
-      assertEquals(entry.getPayload().getData(), expectedStructLogProto);
+      assertEquals( expectedMonitoredResource, entry.getResource());
+      assertEquals(customTags, entry.getLabels());
+      assertEquals(expectedStructLogProto, entry.getPayload().getData());
     }
     verifyNoMoreInteractions(mockLogging);
   }
@@ -149,7 +153,8 @@ public class GcpLogSinkTest {
   public void emptyCustomTags_labelsNotSet() {
     Map<String, String> emptyCustomTags = null;
     Map<String, String> expectedEmptyLabels = new HashMap<>();
-    GcpLogSink mockSink = new GcpLogSink(mockLogging, locationTags, emptyCustomTags, flushLimit);
+    GcpLogSink mockSink = new GcpLogSink(mockLogging, destProjectName, locationTags,
+        emptyCustomTags, flushLimit);
     mockSink.write(logProto);
 
     ArgumentCaptor<Collection<LogEntry>> logEntrySetCaptor = ArgumentCaptor.forClass(
@@ -157,15 +162,39 @@ public class GcpLogSinkTest {
     verify(mockLogging, times(1)).write(logEntrySetCaptor.capture());
     for (Iterator<LogEntry> it = logEntrySetCaptor.getValue().iterator(); it.hasNext(); ) {
       LogEntry entry = it.next();
-      assertEquals(entry.getLabels(), expectedEmptyLabels);
-      assertEquals(entry.getPayload().getData(), expectedStructLogProto);
+      assertEquals(expectedEmptyLabels, entry.getLabels());
+      assertEquals(expectedStructLogProto, entry.getPayload().getData());
     }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void emptyCustomTags_setSourceProject() {
+    Map<String, String> emptyCustomTags = null;
+    String destinationProjectId = "DESTINATION_PROJECT";
+    Map<String, String> expectedLabels = GcpLogSink.getCustomTags(emptyCustomTags, locationTags,
+        destinationProjectId);
+    expectedLabels.put("source_project_id", "PROJECT");
+    GcpLogSink mockSink = new GcpLogSink(mockLogging, destinationProjectId, locationTags,
+        emptyCustomTags, flushLimit);
+    mockSink.write(logProto);
+
+    ArgumentCaptor<Collection<LogEntry>> logEntrySetCaptor = ArgumentCaptor.forClass(
+        (Class) Collection.class);
+    verify(mockLogging, times(1)).write(logEntrySetCaptor.capture());
+    for (Iterator<LogEntry> it = logEntrySetCaptor.getValue().iterator(); it.hasNext(); ) {
+      LogEntry entry = it.next();
+      assertEquals(expectedLabels, entry.getLabels());
+      assertEquals(expectedStructLogProto, entry.getPayload().getData());
+    }
+
   }
 
   @Test
   public void verifyFlush() {
     long lowerFlushLimit = 2L;
-    GcpLogSink mockSink = new GcpLogSink(mockLogging, locationTags, customTags, lowerFlushLimit);
+    GcpLogSink mockSink = new GcpLogSink(mockLogging, destProjectName, locationTags,
+        customTags, lowerFlushLimit);
     mockSink.write(logProto);
     verify(mockLogging, never()).flush();
     mockSink.write(logProto);
@@ -177,7 +206,8 @@ public class GcpLogSinkTest {
 
   @Test
   public void verifyClose() throws Exception {
-    Sink mockSink = new GcpLogSink(mockLogging, locationTags, customTags, flushLimit);
+    Sink mockSink = new GcpLogSink(mockLogging, destProjectName, locationTags,
+        customTags, flushLimit);
     mockSink.write(logProto);
     verify(mockLogging, times(1)).write(anyIterable());
     mockSink.close();


### PR DESCRIPTION
When GCP logging is enabled for a project different from source_project, add `source_project_id : project-id` as a `<key:value>` pair entry to custom tags for each log entry.

Value for `project-id` is retrieved from `locationTags` map created in `GlobalLoggingTags` as part of `GcpObservability.grpcInit()`.

CC @sanjaypujare 