### PR TITLE
gcp-observability: add null check before trim() for non-GKE instances

### DIFF
--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/GlobalLoggingTags.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/GlobalLoggingTags.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.util.Strings;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
@@ -50,6 +51,13 @@ final class GlobalLoggingTags {
     customTags = customTagsBuilder.build();
   }
 
+  private static String applyTrim(String value) {
+    if (!Strings.isNullOrEmpty(value)) {
+      value = value.trim();
+    }
+    return value;
+  }
+
   Map<String, String> getLocationTags() {
     return locationTags;
   }
@@ -71,10 +79,11 @@ final class GlobalLoggingTags {
       String hostnameFile, String cgroupFile) {
     // namespace name: contents of file /var/run/secrets/kubernetes.io/serviceaccount/namespace
     populateFromFileContents(customTags, "namespace_name",
-        namespaceFile, (value) -> value.trim());
+        namespaceFile, GlobalLoggingTags::applyTrim);
 
     // pod_name: hostname i.e. contents of /etc/hostname
-    populateFromFileContents(customTags, "pod_name", hostnameFile, (value) -> value.trim());
+    populateFromFileContents(customTags, "pod_name", hostnameFile,
+        GlobalLoggingTags::applyTrim);
 
     // container_id: parsed from /proc/self/cgroup . Note: only works for Linux-based containers
     populateFromFileContents(customTags, "container_id", cgroupFile,

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/GlobalLoggingTagsTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/GlobalLoggingTagsTest.java
@@ -99,4 +99,21 @@ public class GlobalLoggingTagsTest {
         "fe61ca6482b58f4a9831d08d6ea15db25f9fd19b4be19a54df8c6c0eab8742b7", "namespace_name",
         "test-namespace1", "pod_name", "test-hostname2");
   }
+
+  @Test
+  public void testNonKubernetesInstanceValues() throws IOException {
+    String namespaceFilePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
+    File hostnameFile = hostnameFolder.newFile();
+    File cgroupFile = cgroupFolder.newFile();
+
+    Files.write("test-hostname2\n".getBytes(StandardCharsets.UTF_8), hostnameFile);
+    Files.write(FILE_CONTENTS.getBytes(StandardCharsets.UTF_8), cgroupFile);
+
+    ImmutableMap.Builder<String, String> customTags = ImmutableMap.builder();
+    GlobalLoggingTags.populateFromKubernetesValues(customTags,
+        namespaceFilePath, hostnameFile.getAbsolutePath(), cgroupFile.getAbsolutePath());
+    assertThat(customTags.build()).containsExactly("container_id",
+        "fe61ca6482b58f4a9831d08d6ea15db25f9fd19b4be19a54df8c6c0eab8742b7",
+        "pod_name", "test-hostname2");
+  }
 }


### PR DESCRIPTION
Reading Config in non-GKE instances throws NPE, when kubernetes specific files does not exist. 
Fix: Added null check before doing `trim()`.

CC @sanjaypujare 