### PR TITLE
binder: Work around an Android Intent bug

### DIFF
--- a/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
+++ b/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
@@ -128,7 +128,14 @@ public class AndroidComponentAddress extends SocketAddress { // NOTE: Only tempo
 
   @Override
   public int hashCode() {
-    return bindIntent.filterHashCode();
+    Intent intentForHashCode = bindIntent;
+    // Clear a (usually redundant) package filter to work around an Android >= 31 bug where certain
+    // Intents compare filterEquals() but have different filterHashCode() values. It's always safe
+    // to include fewer fields in the hashCode() computation.
+    if (intentForHashCode.getPackage() != null) {
+      intentForHashCode = intentForHashCode.cloneFilter().setPackage(null);
+    }
+    return intentForHashCode.filterHashCode();
   }
 
   @Override

--- a/binder/src/test/java/io/grpc/binder/AndroidComponentAddressTest.java
+++ b/binder/src/test/java/io/grpc/binder/AndroidComponentAddressTest.java
@@ -27,6 +27,7 @@ import com.google.common.testing.EqualsTester;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
 public final class AndroidComponentAddressTest {
@@ -83,6 +84,37 @@ public final class AndroidComponentAddressTest {
                     .setAction("custom-action")
                     .setType("some-type")
                     .setComponent(hostComponent)))
+        .testEquals();
+  }
+
+  @Test
+  @Config(sdk = 30)
+  public void testPackageFilterEquality30AndUp() {
+    new EqualsTester()
+        .addEqualityGroup(
+            AndroidComponentAddress.forBindIntent(
+                new Intent().setAction("action").setComponent(new ComponentName("pkg", "cls"))),
+            AndroidComponentAddress.forBindIntent(
+                new Intent()
+                    .setAction("action")
+                    .setPackage("pkg")
+                    .setComponent(new ComponentName("pkg", "cls"))))
+        .testEquals();
+  }
+
+  @Test
+  @Config(sdk = 29)
+  public void testPackageFilterEqualityPre30() {
+    new EqualsTester()
+        .addEqualityGroup(
+            AndroidComponentAddress.forBindIntent(
+                new Intent().setAction("action").setComponent(new ComponentName("pkg", "cls"))))
+        .addEqualityGroup(
+            AndroidComponentAddress.forBindIntent(
+                new Intent()
+                    .setAction("action")
+                    .setPackage("pkg")
+                    .setComponent(new ComponentName("pkg", "cls"))))
         .testEquals();
   }
 }


### PR DESCRIPTION
... where a package filter can make filterEquals() inconsistent with filterHashCode() on SDK>=30

Fixes #9045