### PR TITLE
gcp-observability: making classes in Observability Internal

### DIFF
--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/ObservabilityConfig.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/ObservabilityConfig.java
@@ -16,9 +16,11 @@
 
 package io.grpc.gcp.observability;
 
+import io.grpc.Internal;
 import io.grpc.observabilitylog.v1.GrpcLogRecord.EventType;
 import java.util.List;
 
+@Internal
 public interface ObservabilityConfig {
   /** Is Cloud Logging enabled. */
   boolean isEnableCloudLogging();

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/interceptors/LogHelper.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/interceptors/LogHelper.java
@@ -26,6 +26,7 @@ import com.google.protobuf.util.Timestamps;
 import io.grpc.Attributes;
 import io.grpc.Deadline;
 import io.grpc.Grpc;
+import io.grpc.Internal;
 import io.grpc.InternalMetadata;
 import io.grpc.Metadata;
 import io.grpc.Status;
@@ -51,6 +52,7 @@ import javax.annotation.Nullable;
 /**
  * Helper class for GCP observability logging.
  */
+@Internal
 public class LogHelper {
   private static final Logger logger = Logger.getLogger(LogHelper.class.getName());
 

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/GcpLogSink.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/GcpLogSink.java
@@ -27,6 +27,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.util.JsonFormat;
+import io.grpc.Internal;
 import io.grpc.internal.JsonParser;
 import io.grpc.observabilitylog.v1.GrpcLogRecord;
 import java.io.IOException;
@@ -40,6 +41,7 @@ import java.util.logging.Logger;
 /**
  * Sink for Google Cloud Logging.
  */
+@Internal
 public class GcpLogSink implements Sink {
   private final Logger logger = Logger.getLogger(GcpLogSink.class.getName());
 

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/Sink.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/Sink.java
@@ -16,13 +16,13 @@
 
 package io.grpc.gcp.observability.logging;
 
-import io.grpc.ExperimentalApi;
+import io.grpc.Internal;
 import io.grpc.observabilitylog.v1.GrpcLogRecord;
 
 /**
  * Sink for GCP observability.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/8869")
+@Internal
 public interface Sink {
   /**
    * Writes the {@code message} to the destination.


### PR DESCRIPTION
Making classes which are only used by gcp-observability internal.

CC @sanjaypujare 