### PR TITLE
api: add support for SocketAddress types in ManagedChannelProvider

### DIFF
--- a/api/src/main/java/io/grpc/ManagedChannelProvider.java
+++ b/api/src/main/java/io/grpc/ManagedChannelProvider.java
@@ -17,6 +17,8 @@
 package io.grpc;
 
 import com.google.common.base.Preconditions;
+import java.net.SocketAddress;
+import java.util.Collection;
 
 /**
  * Provider of managed channels for transport agnostic consumption.
@@ -78,6 +80,11 @@ public abstract class ManagedChannelProvider {
   protected NewChannelBuilderResult newChannelBuilder(String target, ChannelCredentials creds) {
     return NewChannelBuilderResult.error("ChannelCredentials are unsupported");
   }
+
+  /**
+   * Returns the {@link SocketAddress} types this ManagedChannelProvider supports.
+   */
+  protected abstract Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes();
 
   public static final class NewChannelBuilderResult {
     private final ManagedChannelBuilder<?> channelBuilder;

--- a/api/src/main/java/io/grpc/NameResolverProvider.java
+++ b/api/src/main/java/io/grpc/NameResolverProvider.java
@@ -17,6 +17,7 @@
 package io.grpc;
 
 import io.grpc.NameResolver.Factory;
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Collection;
 import java.util.Collections;
@@ -67,12 +68,12 @@ public abstract class NameResolverProvider extends NameResolver.Factory {
   }
 
   /**
-   * Returns the {@link SocketAddress} types this provider's name-resolver is capable of providing.
+   * Returns the {@link SocketAddress} types this provider's name-resolver is capable of producing.
    * This enables selection of the appropriate {@link ManagedChannelProvider} for a channel.
    *
-   * @return the {@link SocketAddress} types this provider's name-resolver is capable of providing.
+   * @return the {@link SocketAddress} types this provider's name-resolver is capable of producing.
    */
-  protected Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
-    return Collections.emptySet();
+  protected Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
+    return Collections.singleton(InetSocketAddress.class);
   }
 }

--- a/api/src/main/java/io/grpc/NameResolverProvider.java
+++ b/api/src/main/java/io/grpc/NameResolverProvider.java
@@ -17,6 +17,9 @@
 package io.grpc;
 
 import io.grpc.NameResolver.Factory;
+import java.net.SocketAddress;
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Provider of name resolvers for name agnostic consumption.
@@ -61,5 +64,15 @@ public abstract class NameResolverProvider extends NameResolver.Factory {
    * */
   protected String getScheme() {
     return getDefaultScheme();
+  }
+
+  /**
+   * Returns the {@link SocketAddress} types this provider's name-resolver is capable of providing.
+   * This enables selection of the appropriate {@link ManagedChannelProvider} for a channel.
+   *
+   * @return the {@link SocketAddress} types this provider's name-resolver is capable of providing.
+   */
+  protected Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
+    return Collections.emptySet();
   }
 }

--- a/api/src/test/java/io/grpc/ManagedChannelRegistryTest.java
+++ b/api/src/test/java/io/grpc/ManagedChannelRegistryTest.java
@@ -173,13 +173,13 @@ public class ManagedChannelRegistryTest {
 
     nameResolverRegistry.register(new BaseNameResolverProvider(true, 5, "sc1") {
       @Override
-      protected Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
+      protected Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
         return Collections.singleton(SocketAddress1.class);
       }
     });
     nameResolverRegistry.register(new BaseNameResolverProvider(true, 6, "sc2") {
       @Override
-      protected Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
+      protected Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
         fail("Should not be called");
         throw new AssertionError();
       }
@@ -234,7 +234,7 @@ public class ManagedChannelRegistryTest {
 
     nameResolverRegistry.register(new BaseNameResolverProvider(true, 5, "sc1") {
       @Override
-      protected Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
+      protected Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
         return ImmutableSet.of(SocketAddress1.class, SocketAddress2.class);
       }
     });
@@ -283,7 +283,7 @@ public class ManagedChannelRegistryTest {
   }
 
   @Test
-  public void newChannelBuilder_inetSocketAddress_asDefault() {
+  public void newChannelBuilder_emptySet_asDefault() {
     NameResolverRegistry nameResolverRegistry = new NameResolverRegistry();
 
     ManagedChannelRegistry registry = new ManagedChannelRegistry();
@@ -297,7 +297,7 @@ public class ManagedChannelRegistryTest {
     registry.register(new BaseProvider(true, 4) {
       @Override
       protected Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
-        return Collections.singleton(InetSocketAddress.class);
+        return Collections.emptySet();
       }
 
       @Override
@@ -319,7 +319,7 @@ public class ManagedChannelRegistryTest {
 
     nameResolverRegistry.register(new BaseNameResolverProvider(true, 5, "sc1") {
       @Override
-      protected Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
+      protected Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
         return Collections.singleton(SocketAddress1.class);
       }
     });

--- a/core/src/main/java/io/grpc/internal/DnsNameResolverProvider.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolverProvider.java
@@ -21,7 +21,11 @@ import com.google.common.base.Stopwatch;
 import io.grpc.InternalServiceProviders;
 import io.grpc.NameResolver;
 import io.grpc.NameResolverProvider;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * A provider for {@link DnsNameResolver}.
@@ -74,5 +78,10 @@ public final class DnsNameResolverProvider extends NameResolverProvider {
   @Override
   public int priority() {
     return 5;
+  }
+
+  @Override
+  protected Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
+    return Collections.singleton(InetSocketAddress.class);
   }
 }

--- a/core/src/main/java/io/grpc/internal/DnsNameResolverProvider.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolverProvider.java
@@ -81,7 +81,7 @@ public final class DnsNameResolverProvider extends NameResolverProvider {
   }
 
   @Override
-  protected Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
+  protected Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
     return Collections.singleton(InetSocketAddress.class);
   }
 }

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/LoggingChannelProvider.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/LoggingChannelProvider.java
@@ -24,6 +24,10 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.ManagedChannelProvider;
 import io.grpc.ManagedChannelRegistry;
 import io.grpc.gcp.observability.interceptors.InternalLoggingChannelInterceptor;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.Collection;
+import java.util.Collections;
 
 /** A channel provider that injects logging interceptor. */
 final class LoggingChannelProvider extends ManagedChannelProvider {
@@ -89,5 +93,10 @@ final class LoggingChannelProvider extends ManagedChannelProvider {
     }
     checkNotNull(result.getError(), "Expected error to be set!");
     return result;
+  }
+
+  @Override
+  protected Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
+    return Collections.singleton(InetSocketAddress.class);
   }
 }

--- a/googleapis/src/main/java/io/grpc/googleapis/GoogleCloudToProdNameResolverProvider.java
+++ b/googleapis/src/main/java/io/grpc/googleapis/GoogleCloudToProdNameResolverProvider.java
@@ -63,7 +63,7 @@ public final class GoogleCloudToProdNameResolverProvider extends NameResolverPro
   }
 
   @Override
-  protected Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
+  protected Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
     return Collections.singleton(InetSocketAddress.class);
   }
 

--- a/googleapis/src/main/java/io/grpc/googleapis/GoogleCloudToProdNameResolverProvider.java
+++ b/googleapis/src/main/java/io/grpc/googleapis/GoogleCloudToProdNameResolverProvider.java
@@ -22,7 +22,11 @@ import io.grpc.NameResolver.Args;
 import io.grpc.NameResolverProvider;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.xds.InternalSharedXdsClientPoolProvider;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -56,6 +60,11 @@ public final class GoogleCloudToProdNameResolverProvider extends NameResolverPro
   @Override
   protected int priority() {
     return 4;
+  }
+
+  @Override
+  protected Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
+    return Collections.singleton(InetSocketAddress.class);
   }
 
   private static final class SharedXdsClientPoolProviderBootstrapSetter

--- a/grpclb/src/main/java/io/grpc/grpclb/SecretGrpclbNameResolverProvider.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/SecretGrpclbNameResolverProvider.java
@@ -22,7 +22,11 @@ import io.grpc.InternalServiceProviders;
 import io.grpc.NameResolver.Args;
 import io.grpc.NameResolverProvider;
 import io.grpc.internal.GrpcUtil;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * A provider for {@code io.grpc.grpclb.GrpclbNameResolver}.
@@ -84,6 +88,11 @@ final class SecretGrpclbNameResolverProvider {
     public int priority() {
       // Must be higher than DnsNameResolverProvider#priority.
       return 6;
+    }
+
+    @Override
+    protected Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
+      return Collections.singleton(InetSocketAddress.class);
     }
   }
 }

--- a/grpclb/src/main/java/io/grpc/grpclb/SecretGrpclbNameResolverProvider.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/SecretGrpclbNameResolverProvider.java
@@ -91,7 +91,7 @@ final class SecretGrpclbNameResolverProvider {
     }
 
     @Override
-    protected Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
+    protected Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
       return Collections.singleton(InetSocketAddress.class);
     }
   }

--- a/netty/src/main/java/io/grpc/netty/NettyChannelProvider.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelProvider.java
@@ -19,6 +19,10 @@ package io.grpc.netty;
 import io.grpc.ChannelCredentials;
 import io.grpc.Internal;
 import io.grpc.ManagedChannelProvider;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.Collection;
+import java.util.Collections;
 
 /** Provider for {@link NettyChannelBuilder} instances. */
 @Internal
@@ -51,5 +55,10 @@ public final class NettyChannelProvider extends ManagedChannelProvider {
     }
     return NewChannelBuilderResult.channelBuilder(
         new NettyChannelBuilder(target, creds, result.callCredentials, result.negotiator));
+  }
+
+  @Override
+  protected Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
+    return Collections.singleton(InetSocketAddress.class);
   }
 }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelProvider.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelProvider.java
@@ -20,6 +20,10 @@ import io.grpc.ChannelCredentials;
 import io.grpc.Internal;
 import io.grpc.InternalServiceProviders;
 import io.grpc.ManagedChannelProvider;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Provider for {@link OkHttpChannelBuilder} instances.
@@ -56,5 +60,10 @@ public final class OkHttpChannelProvider extends ManagedChannelProvider {
     }
     return NewChannelBuilderResult.channelBuilder(new OkHttpChannelBuilder(
         target, creds, result.callCredentials, result.factory));
+  }
+
+  @Override
+  protected Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
+    return Collections.singleton(InetSocketAddress.class);
   }
 }

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
@@ -104,7 +104,7 @@ public final class XdsNameResolverProvider extends NameResolverProvider {
   }
 
   @Override
-  protected Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
+  protected Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
     return Collections.singleton(InetSocketAddress.class);
   }
 

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
@@ -23,7 +23,11 @@ import io.grpc.Internal;
 import io.grpc.NameResolver.Args;
 import io.grpc.NameResolverProvider;
 import io.grpc.internal.ObjectPool;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
@@ -97,6 +101,11 @@ public final class XdsNameResolverProvider extends NameResolverProvider {
     // Set priority value to be < 5 as we still want DNS resolver to be the primary default
     // resolver.
     return 4;
+  }
+
+  @Override
+  protected Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
+    return Collections.singleton(InetSocketAddress.class);
   }
 
   interface XdsClientPoolFactory {


### PR DESCRIPTION
also add support for SocketAddress types in NameResolverProvider
Use scheme in target URI to select a NameRseolverProvider and get
that provider's supported SocketAddress types.
implement selection in ManagedChannelRegistry of appropriate
ManagedChannelProvider based on NameResolver's SocketAddress types

fixes #3085
