### PR TITLE
fix artifact name in IO_GRPC_GRPC_JAVA_ARTIFACTS

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -15,7 +15,7 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "com.google.auth:google-auth-library-credentials:0.22.0",
     "com.google.auth:google-auth-library-oauth2-http:0.22.0",
     "com.google.code.findbugs:jsr305:3.0.2",
-    "com.google.code.gson:gson:jar:2.8.9",
+    "com.google.code.gson:gson:2.8.9",
     "com.google.auto.value:auto-value:1.7.4",
     "com.google.auto.value:auto-value-annotations:1.7.4",
     "com.google.errorprone:error_prone_annotations:2.9.0",


### PR DESCRIPTION
~~When I try to use `IO_GRPC_GRPC_JAVA_ARTIFACTS`, it can't parse `com.google.code.gson:gson:jar`~~

> `Error in fail: Error while fetching artifact with coursier: Resolution error: Error downloading com.google.code.gson:gson:jar
  not found: not a valid blob`