### PR TITLE
xds: change ring_hash LB aggregation rule to handle transient_failure (1.46.x backport)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -40,8 +40,10 @@ import io.grpc.xds.XdsSubchannelPickers.ErrorPicker;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 
 /**
@@ -67,6 +69,8 @@ final class RingHashLoadBalancer extends LoadBalancer {
 
   private List<RingEntry> ring;
   private ConnectivityState currentState;
+  private Iterator<Subchannel> connectionAttemptIterator = subchannels.values().iterator();
+  private final Random random = new Random();
 
   RingHashLoadBalancer(Helper helper) {
     this.helper = checkNotNull(helper, "helper");
@@ -142,6 +146,14 @@ final class RingHashLoadBalancer extends LoadBalancer {
     for (EquivalentAddressGroup addr : removedAddrs) {
       removedSubchannels.add(subchannels.remove(addr));
     }
+    // If we need to proactively start connecting, iterate through all the subchannels, starting
+    // at a random position.
+    // Alternatively, we should better start at the same position.
+    connectionAttemptIterator = subchannels.values().iterator();
+    int randomAdvance = random.nextInt(subchannels.size());
+    while (randomAdvance-- > 0) {
+      connectionAttemptIterator.next();
+    }
 
     // Update the picker before shutting down the subchannels, to reduce the chance of race
     // between picking a subchannel and shutting it down.
@@ -203,53 +215,77 @@ final class RingHashLoadBalancer extends LoadBalancer {
    *   TRANSIENT_FAILURE</li>
    *   <li>If there is at least one subchannel in CONNECTING state, overall state is
    *   CONNECTING</li>
+   *   <li> If there is one subchannel in TRANSIENT_FAILURE state and there is
+   *    more than one subchannel, report CONNECTING </li>
    *   <li>If there is at least one subchannel in IDLE state, overall state is IDLE</li>
    *   <li>Otherwise, overall state is TRANSIENT_FAILURE</li>
    * </ol>
    */
   private void updateBalancingState() {
     checkState(!subchannels.isEmpty(), "no subchannel has been created");
-    int failureCount = 0;
-    boolean hasConnecting = false;
-    Subchannel idleSubchannel = null;
-    ConnectivityState overallState = null;
+    boolean start_connection_attempt = false;
+    int num_idle_ = 0;
+    int num_ready_ = 0;
+    int num_connecting_ = 0;
+    int num_transient_failure_ = 0;
     for (Subchannel subchannel : subchannels.values()) {
       ConnectivityState state = getSubchannelStateInfoRef(subchannel).value.getState();
       if (state == READY) {
-        overallState = READY;
+        num_ready_++;
         break;
-      }
-      if (state == TRANSIENT_FAILURE) {
-        failureCount++;
-      } else if (state == CONNECTING) {
-        hasConnecting = true;
+      } else if (state == TRANSIENT_FAILURE) {
+        num_transient_failure_++;
+      } else if (state == CONNECTING ) {
+        num_connecting_++;
       } else if (state == IDLE) {
-        if (idleSubchannel == null) {
-          idleSubchannel = subchannel;
-        }
+        num_idle_++;
       }
     }
-    if (overallState == null) {
-      if (failureCount >= 2) {
-        // This load balancer may not get any pick requests from the upstream if it's reporting
-        // TRANSIENT_FAILURE. It needs to recover by itself by attempting to connect to at least
-        // one subchannel that has not failed at any given time.
-        if (!hasConnecting && idleSubchannel != null) {
-          idleSubchannel.requestConnection();
-        }
-        overallState = TRANSIENT_FAILURE;
-      } else if (hasConnecting) {
-        overallState = CONNECTING;
-      } else if (idleSubchannel != null) {
-        overallState = IDLE;
-      } else {
-        overallState = TRANSIENT_FAILURE;
-      }
+    ConnectivityState overallState;
+    if (num_ready_ > 0) {
+      overallState = READY;
+    } else if (num_transient_failure_ >= 2) {
+      overallState = TRANSIENT_FAILURE;
+      start_connection_attempt = true;
+    } else if (num_connecting_ > 0) {
+      overallState = CONNECTING;
+    } else if (num_transient_failure_ == 1 && subchannels.size() > 1) {
+      overallState = CONNECTING;
+      start_connection_attempt = true;
+    } else if (num_idle_ > 0) {
+      overallState = IDLE;
+    } else {
+      overallState = TRANSIENT_FAILURE;
+      start_connection_attempt = true;
     }
     RingHashPicker picker = new RingHashPicker(syncContext, ring, subchannels);
     // TODO(chengyuanzhang): avoid unnecessary reprocess caused by duplicated server addr updates
     helper.updateBalancingState(overallState, picker);
     currentState = overallState;
+    // While the ring_hash policy is reporting TRANSIENT_FAILURE, it will
+    // not be getting any pick requests from the priority policy.
+    // However, because the ring_hash policy does not attempt to
+    // reconnect to subchannels unless it is getting pick requests,
+    // it will need special handling to ensure that it will eventually
+    // recover from TRANSIENT_FAILURE state once the problem is resolved.
+    // Specifically, it will make sure that it is attempting to connect to
+    // at least one subchannel at any given time.  After a given subchannel
+    // fails a connection attempt, it will move on to the next subchannel
+    // in the ring.  It will keep doing this until one of the subchannels
+    // successfully connects, at which point it will report READY and stop
+    // proactively trying to connect.  The policy will remain in
+    // TRANSIENT_FAILURE until at least one subchannel becomes connected,
+    // even if subchannels are in state CONNECTING during that time.
+    //
+    // Note that we do the same thing when the policy is in state
+    // CONNECTING, just to ensure that we don't remain in CONNECTING state
+    // indefinitely if there are no new picks coming in.
+    if (start_connection_attempt) {
+      if (!connectionAttemptIterator.hasNext()) {
+        connectionAttemptIterator = subchannels.values().iterator();
+      }
+      connectionAttemptIterator.next().requestConnection();
+    }
   }
 
   private void processSubchannelState(Subchannel subchannel, ConnectivityStateInfo stateInfo) {
@@ -259,18 +295,22 @@ final class RingHashLoadBalancer extends LoadBalancer {
     if (stateInfo.getState() == TRANSIENT_FAILURE || stateInfo.getState() == IDLE) {
       helper.refreshNameResolution();
     }
-    Ref<ConnectivityStateInfo> subchannelStateRef = getSubchannelStateInfoRef(subchannel);
+    updateConnectivityState(subchannel, stateInfo);
+    updateBalancingState();
+  }
 
+  private void updateConnectivityState(Subchannel subchannel, ConnectivityStateInfo stateInfo) {
+    Ref<ConnectivityStateInfo> subchannelStateRef = getSubchannelStateInfoRef(subchannel);
+    ConnectivityState previousConnectivityState = subchannelStateRef.value.getState();
     // Don't proactively reconnect if the subchannel enters IDLE, even if previously was connected.
     // If the subchannel was previously in TRANSIENT_FAILURE, it is considered to stay in
     // TRANSIENT_FAILURE until it becomes READY.
-    if (subchannelStateRef.value.getState() == TRANSIENT_FAILURE) {
+    if (previousConnectivityState == TRANSIENT_FAILURE) {
       if (stateInfo.getState() == CONNECTING || stateInfo.getState() == IDLE) {
         return;
       }
     }
     subchannelStateRef.value = stateInfo;
-    updateBalancingState();
   }
 
   private static void shutdownSubchannel(Subchannel subchannel) {

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
@@ -25,6 +25,7 @@ import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -56,8 +57,10 @@ import io.grpc.testing.TestMethodDescriptors;
 import io.grpc.xds.RingHashLoadBalancer.RingHashConfig;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.net.SocketAddress;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -95,6 +98,7 @@ public class RingHashLoadBalancerTest {
   private final Map<List<EquivalentAddressGroup>, Subchannel> subchannels = new HashMap<>();
   private final Map<Subchannel, SubchannelStateListener> subchannelStateListeners =
       new HashMap<>();
+  private final Deque<Subchannel> connectionRequestedQueue = new ArrayDeque<>();
   private final XxHash64 hashFunc = XxHash64.INSTANCE;
   @Mock
   private Helper helper;
@@ -123,6 +127,13 @@ public class RingHashLoadBalancerTest {
                 return null;
               }
             }).when(subchannel).start(any(SubchannelStateListener.class));
+            doAnswer(new Answer<Void>() {
+              @Override
+              public Void answer(InvocationOnMock invocation) throws Throwable {
+                connectionRequestedQueue.offer(subchannel);
+                return null;
+              }
+            }).when(subchannel).requestConnection();
             return subchannel;
           }
         });
@@ -138,6 +149,7 @@ public class RingHashLoadBalancerTest {
     for (Subchannel subchannel : subchannels.values()) {
       verify(subchannel).shutdown();
     }
+    connectionRequestedQueue.clear();
   }
 
   @Test
@@ -216,18 +228,21 @@ public class RingHashLoadBalancerTest {
         subchannels.get(Collections.singletonList(servers.get(0))),
         ConnectivityStateInfo.forNonError(CONNECTING));
     inOrder.verify(helper).updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
+    verifyConnection(0);
 
     // two in CONNECTING
     deliverSubchannelState(
         subchannels.get(Collections.singletonList(servers.get(1))),
         ConnectivityStateInfo.forNonError(CONNECTING));
     inOrder.verify(helper).updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
+    verifyConnection(0);
 
     // one in CONNECTING, one in READY
     deliverSubchannelState(
         subchannels.get(Collections.singletonList(servers.get(1))),
         ConnectivityStateInfo.forNonError(READY));
     inOrder.verify(helper).updateBalancingState(eq(READY), any(SubchannelPicker.class));
+    verifyConnection(0);
 
     // one in TRANSIENT_FAILURE, one in READY
     deliverSubchannelState(
@@ -236,15 +251,26 @@ public class RingHashLoadBalancerTest {
             Status.UNKNOWN.withDescription("unknown failure")));
     inOrder.verify(helper).refreshNameResolution();
     inOrder.verify(helper).updateBalancingState(eq(READY), any(SubchannelPicker.class));
+    verifyConnection(0);
 
     // one in TRANSIENT_FAILURE, one in IDLE
     deliverSubchannelState(
         subchannels.get(Collections.singletonList(servers.get(1))),
         ConnectivityStateInfo.forNonError(IDLE));
     inOrder.verify(helper).refreshNameResolution();
-    inOrder.verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
+    inOrder.verify(helper).updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
+    verifyConnection(1);
 
     verifyNoMoreInteractions(helper);
+  }
+
+  private void verifyConnection(int times) {
+    for (int i = 0; i < times; i++) {
+      Subchannel connectOnce = connectionRequestedQueue.poll();
+      assertThat(connectOnce).isNotNull();
+      clearInvocations(connectOnce);
+    }
+    assertThat(connectionRequestedQueue.poll()).isNull();
   }
 
   @Test
@@ -264,7 +290,8 @@ public class RingHashLoadBalancerTest {
         ConnectivityStateInfo.forTransientFailure(
             Status.UNAVAILABLE.withDescription("not found")));
     inOrder.verify(helper).refreshNameResolution();
-    inOrder.verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
+    inOrder.verify(helper).updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
+    verifyConnection(1);
 
     // two in TRANSIENT_FAILURE, two in IDLE
     deliverSubchannelState(
@@ -274,6 +301,7 @@ public class RingHashLoadBalancerTest {
     inOrder.verify(helper).refreshNameResolution();
     inOrder.verify(helper)
         .updateBalancingState(eq(TRANSIENT_FAILURE), any(SubchannelPicker.class));
+    verifyConnection(1);
 
     // two in TRANSIENT_FAILURE, one in CONNECTING, one in IDLE
     // The overall state is dominated by the two in TRANSIENT_FAILURE.
@@ -282,6 +310,7 @@ public class RingHashLoadBalancerTest {
         ConnectivityStateInfo.forNonError(CONNECTING));
     inOrder.verify(helper)
         .updateBalancingState(eq(TRANSIENT_FAILURE), any(SubchannelPicker.class));
+    verifyConnection(1);
 
     // three in TRANSIENT_FAILURE, one in CONNECTING
     deliverSubchannelState(
@@ -291,12 +320,14 @@ public class RingHashLoadBalancerTest {
     inOrder.verify(helper).refreshNameResolution();
     inOrder.verify(helper)
         .updateBalancingState(eq(TRANSIENT_FAILURE), any(SubchannelPicker.class));
+    verifyConnection(1);
 
     // three in TRANSIENT_FAILURE, one in READY
     deliverSubchannelState(
         subchannels.get(Collections.singletonList(servers.get(2))),
         ConnectivityStateInfo.forNonError(READY));
     inOrder.verify(helper).updateBalancingState(eq(READY), any(SubchannelPicker.class));
+    verifyConnection(0);
 
     verifyNoMoreInteractions(helper);
   }
@@ -320,21 +351,71 @@ public class RingHashLoadBalancerTest {
     verify(helper, times(3)).refreshNameResolution();
 
     // Stays in IDLE when until there are two or more subchannels in TRANSIENT_FAILURE.
-    verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
+    verify(helper).updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
     verify(helper, times(2))
         .updateBalancingState(eq(TRANSIENT_FAILURE), any(SubchannelPicker.class));
+    verifyConnection(3);
 
     verifyNoMoreInteractions(helper);
+    reset(helper);
     // Simulate underlying subchannel auto reconnect after backoff.
     for (Subchannel subchannel : subchannels.values()) {
       deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(CONNECTING));
     }
+    verify(helper, times(3))
+        .updateBalancingState(eq(TRANSIENT_FAILURE), any(SubchannelPicker.class));
+    verifyConnection(3);
     verifyNoMoreInteractions(helper);
 
     // Simulate one subchannel enters READY.
     deliverSubchannelState(
         subchannels.values().iterator().next(), ConnectivityStateInfo.forNonError(READY));
     verify(helper).updateBalancingState(eq(READY), any(SubchannelPicker.class));
+  }
+
+  @Test
+  public void updateConnectionIterator() {
+    RingHashConfig config = new RingHashConfig(10, 100);
+    List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
+    InOrder inOrder = Mockito.inOrder(helper);
+    loadBalancer.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
+    verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
+    verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
+
+    deliverSubchannelState(
+        subchannels.get(Collections.singletonList(servers.get(0))),
+        ConnectivityStateInfo.forTransientFailure(
+            Status.UNAVAILABLE.withDescription("connection lost")));
+    inOrder.verify(helper).refreshNameResolution();
+    inOrder.verify(helper)
+        .updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
+    verifyConnection(1);
+
+    servers = createWeightedServerAddrs(1,1);
+    loadBalancer.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
+    inOrder.verify(helper)
+        .updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
+    verifyConnection(1);
+
+    deliverSubchannelState(
+        subchannels.get(Collections.singletonList(servers.get(1))),
+        ConnectivityStateInfo.forTransientFailure(
+            Status.UNAVAILABLE.withDescription("connection lost")));
+    inOrder.verify(helper).refreshNameResolution();
+    inOrder.verify(helper)
+        .updateBalancingState(eq(TRANSIENT_FAILURE), any(SubchannelPicker.class));
+    verifyConnection(1);
+
+    deliverSubchannelState(
+        subchannels.get(Collections.singletonList(servers.get(0))),
+        ConnectivityStateInfo.forNonError(CONNECTING));
+    inOrder.verify(helper)
+        .updateBalancingState(eq(TRANSIENT_FAILURE), any(SubchannelPicker.class));
+    verifyConnection(1);
   }
 
   @Test
@@ -466,7 +547,8 @@ public class RingHashLoadBalancerTest {
         subchannels.get(Collections.singletonList(servers.get(0))),
         ConnectivityStateInfo.forTransientFailure(
             Status.UNAVAILABLE.withDescription("unreachable")));
-    verify(helper).updateBalancingState(eq(IDLE), pickerCaptor.capture());
+    verify(helper).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
+    verifyConnection(1);
 
     PickResult result = pickerCaptor.getValue().pickSubchannel(args);
     assertThat(result.getStatus().isOk()).isTrue();
@@ -476,6 +558,7 @@ public class RingHashLoadBalancerTest {
     verify(subchannels.get(Collections.singletonList(servers.get(1))), never())
         .requestConnection();  // no excessive connection
 
+    reset(helper);
     deliverSubchannelState(
         subchannels.get(Collections.singletonList(servers.get(2))),
         ConnectivityStateInfo.forNonError(CONNECTING));
@@ -526,16 +609,18 @@ public class RingHashLoadBalancerTest {
         ConnectivityStateInfo.forTransientFailure(
             Status.PERMISSION_DENIED.withDescription("permission denied")));
     verify(helper).updateBalancingState(eq(TRANSIENT_FAILURE), pickerCaptor.capture());
-    verify(subchannels.get(Collections.singletonList(servers.get(1))))
-        .requestConnection();  // LB attempts to recover by itself
+    verifyConnection(2); // LB attempts to recover by itself
 
     PickResult result = pickerCaptor.getValue().pickSubchannel(args);
     assertThat(result.getStatus().isOk()).isFalse();  // fail the RPC
     assertThat(result.getStatus().getCode())
         .isEqualTo(Code.UNAVAILABLE);  // with error status for the original server hit by hash
     assertThat(result.getStatus().getDescription()).isEqualTo("unreachable");
-    verify(subchannels.get(Collections.singletonList(servers.get(1))), times(2))
-        .requestConnection();  // kickoff connection to server3 (next first non-failing)
+    verify(subchannels.get(Collections.singletonList(servers.get(1))))
+        .requestConnection(); // kickoff connection to server3 (next first non-failing)
+    // TODO: zivy@
+    //verify(subchannels.get(Collections.singletonList(servers.get(0)))).requestConnection();
+    //verify(subchannels.get(Collections.singletonList(servers.get(2)))).requestConnection();
 
     // Now connecting to server1.
     deliverSubchannelState(
@@ -589,6 +674,43 @@ public class RingHashLoadBalancerTest {
     assertThat(result.getStatus().getCode()).isEqualTo(Code.UNAVAILABLE);
     assertThat(result.getStatus().getDescription())
         .isEqualTo("[FakeSocketAddress-server0] unreachable");
+  }
+
+  @Test
+  public void stickyTransientFailure() {
+    // Map each server address to exactly one ring entry.
+    RingHashConfig config = new RingHashConfig(3, 3);
+    List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
+    loadBalancer.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
+    verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
+    verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
+
+    // Bring one subchannel to TRANSIENT_FAILURE.
+    Subchannel firstSubchannel = subchannels.get(Collections.singletonList(servers.get(0)));
+    deliverSubchannelState(firstSubchannel,
+        ConnectivityStateInfo.forTransientFailure(
+        Status.UNAVAILABLE.withDescription(
+            firstSubchannel.getAddresses().getAddresses() + " unreachable")));
+
+    verify(helper).updateBalancingState(eq(CONNECTING), any());
+    verifyConnection(1);
+    deliverSubchannelState(firstSubchannel, ConnectivityStateInfo.forNonError(IDLE));
+    verify(helper, times(2)).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
+    verifyConnection(1);
+
+    // Picking subchannel triggers connection. RPC hash hits server0.
+    PickSubchannelArgs args = new PickSubchannelArgsImpl(
+        TestMethodDescriptors.voidMethod(), new Metadata(),
+        CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, hashFunc.hashVoid()));
+    PickResult result = pickerCaptor.getValue().pickSubchannel(args);
+    assertThat(result.getStatus().isOk()).isTrue();
+    // enabled me. there is a bug in picker behavior
+    // verify(subchannels.get(Collections.singletonList(servers.get(0)))).requestConnection();
+    verify(subchannels.get(Collections.singletonList(servers.get(2)))).requestConnection();
+    verify(subchannels.get(Collections.singletonList(servers.get(1))), never())
+        .requestConnection();
   }
 
   @Test


### PR DESCRIPTION
per gRFC change https://github.com/grpc/grpc/pull/29332:
Apply new aggregation rule: If there is at least one subchannel in state TRANSIENT_FAILURE and there are more than one subchannel, report state CONNECTING. If we hit this rule, proactively start a subchannel connection attempt.

backport of https://github.com/grpc/grpc-java/pull/9084