### PR TITLE
xds: Envoy proto sync to 2022-04-08

### DIFF
--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/discovery/v2/AggregatedDiscoveryServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/discovery/v2/AggregatedDiscoveryServiceGrpc.java
@@ -4,7 +4,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 
 /**
  * <pre>
- * See https://github.com/lyft/envoy-api#apis for a description of the role of
+ * See https://github.com/envoyproxy/envoy-api#apis for a description of the role of
  * ADS and how it is intended to be used by a management server. ADS requests
  * have the same structure as their singleton xDS counterparts, but can
  * multiplex many resource types on a single stream. The type_url in the
@@ -131,7 +131,7 @@ public final class AggregatedDiscoveryServiceGrpc {
 
   /**
    * <pre>
-   * See https://github.com/lyft/envoy-api#apis for a description of the role of
+   * See https://github.com/envoyproxy/envoy-api#apis for a description of the role of
    * ADS and how it is intended to be used by a management server. ADS requests
    * have the same structure as their singleton xDS counterparts, but can
    * multiplex many resource types on a single stream. The type_url in the
@@ -180,7 +180,7 @@ public final class AggregatedDiscoveryServiceGrpc {
 
   /**
    * <pre>
-   * See https://github.com/lyft/envoy-api#apis for a description of the role of
+   * See https://github.com/envoyproxy/envoy-api#apis for a description of the role of
    * ADS and how it is intended to be used by a management server. ADS requests
    * have the same structure as their singleton xDS counterparts, but can
    * multiplex many resource types on a single stream. The type_url in the
@@ -222,7 +222,7 @@ public final class AggregatedDiscoveryServiceGrpc {
 
   /**
    * <pre>
-   * See https://github.com/lyft/envoy-api#apis for a description of the role of
+   * See https://github.com/envoyproxy/envoy-api#apis for a description of the role of
    * ADS and how it is intended to be used by a management server. ADS requests
    * have the same structure as their singleton xDS counterparts, but can
    * multiplex many resource types on a single stream. The type_url in the
@@ -245,7 +245,7 @@ public final class AggregatedDiscoveryServiceGrpc {
 
   /**
    * <pre>
-   * See https://github.com/lyft/envoy-api#apis for a description of the role of
+   * See https://github.com/envoyproxy/envoy-api#apis for a description of the role of
    * ADS and how it is intended to be used by a management server. ADS requests
    * have the same structure as their singleton xDS counterparts, but can
    * multiplex many resource types on a single stream. The type_url in the

--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/discovery/v3/AggregatedDiscoveryServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/discovery/v3/AggregatedDiscoveryServiceGrpc.java
@@ -4,7 +4,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 
 /**
  * <pre>
- * See https://github.com/lyft/envoy-api#apis for a description of the role of
+ * See https://github.com/envoyproxy/envoy-api#apis for a description of the role of
  * ADS and how it is intended to be used by a management server. ADS requests
  * have the same structure as their singleton xDS counterparts, but can
  * multiplex many resource types on a single stream. The type_url in the
@@ -131,7 +131,7 @@ public final class AggregatedDiscoveryServiceGrpc {
 
   /**
    * <pre>
-   * See https://github.com/lyft/envoy-api#apis for a description of the role of
+   * See https://github.com/envoyproxy/envoy-api#apis for a description of the role of
    * ADS and how it is intended to be used by a management server. ADS requests
    * have the same structure as their singleton xDS counterparts, but can
    * multiplex many resource types on a single stream. The type_url in the
@@ -180,7 +180,7 @@ public final class AggregatedDiscoveryServiceGrpc {
 
   /**
    * <pre>
-   * See https://github.com/lyft/envoy-api#apis for a description of the role of
+   * See https://github.com/envoyproxy/envoy-api#apis for a description of the role of
    * ADS and how it is intended to be used by a management server. ADS requests
    * have the same structure as their singleton xDS counterparts, but can
    * multiplex many resource types on a single stream. The type_url in the
@@ -222,7 +222,7 @@ public final class AggregatedDiscoveryServiceGrpc {
 
   /**
    * <pre>
-   * See https://github.com/lyft/envoy-api#apis for a description of the role of
+   * See https://github.com/envoyproxy/envoy-api#apis for a description of the role of
    * ADS and how it is intended to be used by a management server. ADS requests
    * have the same structure as their singleton xDS counterparts, but can
    * multiplex many resource types on a single stream. The type_url in the
@@ -245,7 +245,7 @@ public final class AggregatedDiscoveryServiceGrpc {
 
   /**
    * <pre>
-   * See https://github.com/lyft/envoy-api#apis for a description of the role of
+   * See https://github.com/envoyproxy/envoy-api#apis for a description of the role of
    * ADS and how it is intended to be used by a management server. ADS requests
    * have the same structure as their singleton xDS counterparts, but can
    * multiplex many resource types on a single stream. The type_url in the

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
@@ -44,6 +44,7 @@ import io.envoyproxy.envoy.config.core.v3.ConfigSource;
 import io.envoyproxy.envoy.config.core.v3.DataSource;
 import io.envoyproxy.envoy.config.core.v3.HttpProtocolOptions;
 import io.envoyproxy.envoy.config.core.v3.Locality;
+import io.envoyproxy.envoy.config.core.v3.PathConfigSource;
 import io.envoyproxy.envoy.config.core.v3.RuntimeFractionalPercent;
 import io.envoyproxy.envoy.config.core.v3.SelfConfigSource;
 import io.envoyproxy.envoy.config.core.v3.SocketAddress;
@@ -1616,7 +1617,8 @@ public class ClientXdsClientDataTest {
             .setRds(Rds.newBuilder()
                 .setRouteConfigName("rds-config-foo")
                 .setConfigSource(
-                    ConfigSource.newBuilder().setPath("foo-path")))
+                    ConfigSource.newBuilder()
+                        .setPathConfigSource(PathConfigSource.newBuilder().setPath("foo-path"))))
             .build();
     thrown.expect(ResourceInvalidException.class);
     thrown.expectMessage(
@@ -1822,7 +1824,7 @@ public class ClientXdsClientDataTest {
             EdsClusterConfig.newBuilder()
                 .setEdsConfig(
                     ConfigSource.newBuilder()
-                        .setPath("foo-path"))
+                        .setPathConfigSource(PathConfigSource.newBuilder().setPath("foo-path")))
                 .setServiceName("service-foo.googleapis.com"))
         .setLbPolicy(LbPolicy.ROUND_ROBIN)
         .build();

--- a/xds/src/test/java/io/grpc/xds/internal/certprovider/CertProviderServerSslContextProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/certprovider/CertProviderServerSslContextProviderTest.java
@@ -177,6 +177,7 @@ public class CertProviderServerSslContextProviderTest {
             new CertificateProvider.DistributorWatcher[1];
     TestCertificateProvider.createAndRegisterProviderProvider(
             certificateProviderRegistry, watcherCaptor, "testca", 0);
+    @SuppressWarnings("deprecation")
     CertificateValidationContext staticCertValidationContext =
         CertificateValidationContext.newBuilder().addAllMatchSubjectAltNames(Arrays
             .asList(StringMatcher.newBuilder().setExact("foo.com").build(),

--- a/xds/src/test/java/io/grpc/xds/internal/sds/ClientSslContextProviderFactoryTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/sds/ClientSslContextProviderFactoryTest.java
@@ -152,6 +152,7 @@ public class ClientSslContextProviderFactoryTest {
     final CertificateProvider.DistributorWatcher[] watcherCaptor =
             new CertificateProvider.DistributorWatcher[1];
     createAndRegisterProviderProvider(certificateProviderRegistry, watcherCaptor, "testca", 0);
+    @SuppressWarnings("deprecation")
     CertificateValidationContext staticCertValidationContext =
         CertificateValidationContext.newBuilder()
             .addAllMatchSubjectAltNames(
@@ -216,6 +217,7 @@ public class ClientSslContextProviderFactoryTest {
     createAndRegisterProviderProvider(
         certificateProviderRegistry, watcherCaptor, "file_watcher", 1);
 
+    @SuppressWarnings("deprecation")
     CertificateValidationContext staticCertValidationContext =
         CertificateValidationContext.newBuilder()
             .addAllMatchSubjectAltNames(
@@ -248,6 +250,7 @@ public class ClientSslContextProviderFactoryTest {
     final CertificateProvider.DistributorWatcher[] watcherCaptor =
         new CertificateProvider.DistributorWatcher[1];
     createAndRegisterProviderProvider(certificateProviderRegistry, watcherCaptor, "testca", 0);
+    @SuppressWarnings("deprecation")
     CertificateValidationContext staticCertValidationContext =
         CertificateValidationContext.newBuilder()
             .addAllMatchSubjectAltNames(

--- a/xds/src/test/java/io/grpc/xds/internal/sds/ServerSslContextProviderFactoryTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/sds/ServerSslContextProviderFactoryTest.java
@@ -149,6 +149,7 @@ public class ServerSslContextProviderFactoryTest {
     final CertificateProvider.DistributorWatcher[] watcherCaptor =
             new CertificateProvider.DistributorWatcher[1];
     createAndRegisterProviderProvider(certificateProviderRegistry, watcherCaptor, "testca", 0);
+    @SuppressWarnings("deprecation")
     CertificateValidationContext staticCertValidationContext =
             CertificateValidationContext.newBuilder()
                     .addAllMatchSubjectAltNames(
@@ -215,6 +216,7 @@ public class ServerSslContextProviderFactoryTest {
     createAndRegisterProviderProvider(certificateProviderRegistry, watcherCaptor, "testca", 0);
     createAndRegisterProviderProvider(
         certificateProviderRegistry, watcherCaptor, "file_watcher", 1);
+    @SuppressWarnings("deprecation")
     CertificateValidationContext staticCertValidationContext =
         CertificateValidationContext.newBuilder()
             .addAllMatchSubjectAltNames(

--- a/xds/src/test/java/io/grpc/xds/internal/sds/trust/SdsTrustManagerFactoryTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/sds/trust/SdsTrustManagerFactoryTest.java
@@ -256,7 +256,9 @@ public class SdsTrustManagerFactoryTest {
           String... verifySans) {
     CertificateValidationContext.Builder builder = CertificateValidationContext.newBuilder();
     for (String san : verifySans) {
-      builder.addMatchSubjectAltNames(StringMatcher.newBuilder().setExact(san));
+      @SuppressWarnings("deprecation")
+      CertificateValidationContext.Builder unused =
+          builder.addMatchSubjectAltNames(StringMatcher.newBuilder().setExact(san));
     }
     return builder.build();
   }

--- a/xds/src/test/java/io/grpc/xds/internal/sds/trust/SdsX509TrustManagerTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/sds/trust/SdsX509TrustManagerTest.java
@@ -90,6 +90,7 @@ public class SdsX509TrustManagerTest {
   @Test
   public void missingPeerCerts() {
     StringMatcher stringMatcher = StringMatcher.newBuilder().setExact("foo.com").build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new SdsX509TrustManager(certContext, mockDelegate);
@@ -104,6 +105,7 @@ public class SdsX509TrustManagerTest {
   @Test
   public void emptyArrayPeerCerts() {
     StringMatcher stringMatcher = StringMatcher.newBuilder().setExact("foo.com").build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new SdsX509TrustManager(certContext, mockDelegate);
@@ -118,6 +120,7 @@ public class SdsX509TrustManagerTest {
   @Test
   public void noSansInPeerCerts() throws CertificateException, IOException {
     StringMatcher stringMatcher = StringMatcher.newBuilder().setExact("foo.com").build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new SdsX509TrustManager(certContext, mockDelegate);
@@ -138,6 +141,7 @@ public class SdsX509TrustManagerTest {
             .setExact("waterzooi.test.google.be")
             .setIgnoreCase(false)
             .build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new SdsX509TrustManager(certContext, mockDelegate);
@@ -154,6 +158,7 @@ public class SdsX509TrustManagerTest {
             .setExact("waterZooi.test.Google.be")
             .setIgnoreCase(false)
             .build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new SdsX509TrustManager(certContext, mockDelegate);
@@ -171,6 +176,7 @@ public class SdsX509TrustManagerTest {
   public void oneSanInPeerCertsVerifies_ignoreCase() throws CertificateException, IOException {
     StringMatcher stringMatcher =
         StringMatcher.newBuilder().setExact("Waterzooi.Test.google.be").setIgnoreCase(true).build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new SdsX509TrustManager(certContext, mockDelegate);
@@ -186,6 +192,7 @@ public class SdsX509TrustManagerTest {
             .setPrefix("waterzooi.") // test.google.be
             .setIgnoreCase(false)
             .build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new SdsX509TrustManager(certContext, mockDelegate);
@@ -199,6 +206,7 @@ public class SdsX509TrustManagerTest {
       throws CertificateException, IOException {
     StringMatcher stringMatcher =
         StringMatcher.newBuilder().setPrefix("waterZooi.").setIgnoreCase(false).build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new SdsX509TrustManager(certContext, mockDelegate);
@@ -219,6 +227,7 @@ public class SdsX509TrustManagerTest {
             .setPrefix("WaterZooi.") // test.google.be
             .setIgnoreCase(true)
             .build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new SdsX509TrustManager(certContext, mockDelegate);
@@ -231,6 +240,7 @@ public class SdsX509TrustManagerTest {
   public void oneSanInPeerCerts_suffix() throws CertificateException, IOException {
     StringMatcher stringMatcher =
         StringMatcher.newBuilder().setSuffix(".google.be").setIgnoreCase(false).build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new SdsX509TrustManager(certContext, mockDelegate);
@@ -244,6 +254,7 @@ public class SdsX509TrustManagerTest {
       throws CertificateException, IOException {
     StringMatcher stringMatcher =
         StringMatcher.newBuilder().setSuffix(".gooGle.bE").setIgnoreCase(false).build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new SdsX509TrustManager(certContext, mockDelegate);
@@ -261,6 +272,7 @@ public class SdsX509TrustManagerTest {
   public void oneSanInPeerCerts_suffixIgnoreCase() throws CertificateException, IOException {
     StringMatcher stringMatcher =
         StringMatcher.newBuilder().setSuffix(".GooGle.BE").setIgnoreCase(true).build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new SdsX509TrustManager(certContext, mockDelegate);
@@ -273,6 +285,7 @@ public class SdsX509TrustManagerTest {
   public void oneSanInPeerCerts_substring() throws CertificateException, IOException {
     StringMatcher stringMatcher =
         StringMatcher.newBuilder().setContains("zooi.test.google").setIgnoreCase(false).build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new SdsX509TrustManager(certContext, mockDelegate);
@@ -286,6 +299,7 @@ public class SdsX509TrustManagerTest {
       throws CertificateException, IOException {
     StringMatcher stringMatcher =
         StringMatcher.newBuilder().setContains("zooi.Test.gooGle").setIgnoreCase(false).build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new SdsX509TrustManager(certContext, mockDelegate);
@@ -303,6 +317,7 @@ public class SdsX509TrustManagerTest {
   public void oneSanInPeerCerts_substringIgnoreCase() throws CertificateException, IOException {
     StringMatcher stringMatcher =
         StringMatcher.newBuilder().setContains("zooI.Test.Google").setIgnoreCase(true).build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new SdsX509TrustManager(certContext, mockDelegate);
@@ -318,6 +333,7 @@ public class SdsX509TrustManagerTest {
             .setSafeRegex(
                 RegexMatcher.newBuilder().setRegex("water[[:alpha:]]{1}ooi\\.test\\.google\\.be"))
             .build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new SdsX509TrustManager(certContext, mockDelegate);
@@ -333,6 +349,7 @@ public class SdsX509TrustManagerTest {
             .setSafeRegex(
                 RegexMatcher.newBuilder().setRegex("no-match-string|\\*\\.test\\.youtube\\.com"))
             .build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new SdsX509TrustManager(certContext, mockDelegate);
@@ -348,6 +365,7 @@ public class SdsX509TrustManagerTest {
             .setSafeRegex(
                 RegexMatcher.newBuilder().setRegex("([[:digit:]]{1,3}\\.){3}[[:digit:]]{1,3}"))
             .build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new SdsX509TrustManager(certContext, mockDelegate);
@@ -363,6 +381,7 @@ public class SdsX509TrustManagerTest {
             .setSafeRegex(
                 RegexMatcher.newBuilder().setRegex("water[[:alpha:]]{2}ooi\\.test\\.google\\.be"))
             .build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new SdsX509TrustManager(certContext, mockDelegate);
@@ -382,6 +401,7 @@ public class SdsX509TrustManagerTest {
     StringMatcher stringMatcher = StringMatcher.newBuilder().setExact("x.foo.com").build();
     StringMatcher stringMatcher1 =
         StringMatcher.newBuilder().setExact("waterzooi.test.google.be").build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder()
             .addMatchSubjectAltNames(stringMatcher)
@@ -397,6 +417,7 @@ public class SdsX509TrustManagerTest {
   public void oneSanInPeerCertsNotFoundException()
           throws CertificateException, IOException {
     StringMatcher stringMatcher = StringMatcher.newBuilder().setExact("x.foo.com").build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new SdsX509TrustManager(certContext, mockDelegate);
@@ -416,6 +437,7 @@ public class SdsX509TrustManagerTest {
     StringMatcher stringMatcher = StringMatcher.newBuilder().setExact("x.foo.com").build();
     StringMatcher stringMatcher1 =
         StringMatcher.newBuilder().setSuffix("test.youTube.Com").setIgnoreCase(true).build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder()
             .addMatchSubjectAltNames(stringMatcher)
@@ -433,6 +455,7 @@ public class SdsX509TrustManagerTest {
     StringMatcher stringMatcher = StringMatcher.newBuilder().setExact("x.foo.com").build();
     StringMatcher stringMatcher1 =
         StringMatcher.newBuilder().setContains("est.Google.f").setIgnoreCase(true).build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder()
             .addMatchSubjectAltNames(stringMatcher)
@@ -452,6 +475,7 @@ public class SdsX509TrustManagerTest {
     //    sub.test.example.com.
     StringMatcher stringMatcher =
         StringMatcher.newBuilder().setExact("sub.abc.test.youtube.com").build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new SdsX509TrustManager(certContext, mockDelegate);
@@ -469,6 +493,7 @@ public class SdsX509TrustManagerTest {
   public void oneIpAddressInPeerCertsVerifies() throws CertificateException, IOException {
     StringMatcher stringMatcher = StringMatcher.newBuilder().setExact("x.foo.com").build();
     StringMatcher stringMatcher1 = StringMatcher.newBuilder().setExact("192.168.1.3").build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder()
             .addMatchSubjectAltNames(stringMatcher)
@@ -484,6 +509,7 @@ public class SdsX509TrustManagerTest {
   public void oneIpAddressInPeerCertsMismatch() throws CertificateException, IOException {
     StringMatcher stringMatcher = StringMatcher.newBuilder().setExact("x.foo.com").build();
     StringMatcher stringMatcher1 = StringMatcher.newBuilder().setExact("192.168.2.3").build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder()
             .addMatchSubjectAltNames(stringMatcher)
@@ -561,6 +587,7 @@ public class SdsX509TrustManagerTest {
             .setExact("waterzooi.test.google.be")
             .setIgnoreCase(false)
             .build();
+    @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new SdsX509TrustManager(certContext, mockDelegate);

--- a/xds/third_party/envoy/NOTICE
+++ b/xds/third_party/envoy/NOTICE
@@ -1,4 +1,4 @@
 Envoy
-Copyright 2016-2019 Envoy Project Authors
+Copyright The Envoy Project Authors
 
 Licensed under Apache License 2.0.  See LICENSE for terms.

--- a/xds/third_party/envoy/import.sh
+++ b/xds/third_party/envoy/import.sh
@@ -18,7 +18,7 @@
 set -e
 BRANCH=main
 # import VERSION from one of the google internal CLs
-VERSION=368650f7fe037a28cc2719065289ced036d67420
+VERSION=5d74719102f461bc57e85acdda706e0a8df9b12d
 GIT_REPO="https://github.com/envoyproxy/envoy.git"
 GIT_BASE_DIR=envoy
 SOURCE_PROTO_BASE_DIR=envoy/api

--- a/xds/third_party/envoy/import.sh
+++ b/xds/third_party/envoy/import.sh
@@ -18,7 +18,7 @@
 set -e
 BRANCH=main
 # import VERSION from one of the google internal CLs
-VERSION=c223756b0856f734a6a5cff2d0b95388cd2583d4
+VERSION=368650f7fe037a28cc2719065289ced036d67420
 GIT_REPO="https://github.com/envoyproxy/envoy.git"
 GIT_BASE_DIR=envoy
 SOURCE_PROTO_BASE_DIR=envoy/api

--- a/xds/third_party/envoy/src/main/proto/envoy/admin/v3/config_dump.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/admin/v3/config_dump.proto
@@ -13,6 +13,7 @@ import "udpa/annotations/versioning.proto";
 option java_package = "io.envoyproxy.envoy.admin.v3";
 option java_outer_classname = "ConfigDumpProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/admin/v3;adminv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: ConfigDump]

--- a/xds/third_party/envoy/src/main/proto/envoy/annotations/deprecation.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/annotations/deprecation.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package envoy.annotations;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/annotations";
 
 import "google/protobuf/descriptor.proto";
 

--- a/xds/third_party/envoy/src/main/proto/envoy/annotations/resource.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/annotations/resource.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package envoy.annotations;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/annotations";
 
 import "google/protobuf/descriptor.proto";
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/auth/cert.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/auth/cert.proto
@@ -11,5 +11,6 @@ import public "envoy/api/v2/auth/tls.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.auth";
 option java_outer_classname = "CertProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth";
 option (udpa.annotations.file_migrate).move_to_package =
     "envoy.extensions.transport_sockets.tls.v3";

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/auth/common.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/auth/common.proto
@@ -17,6 +17,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.auth";
 option java_outer_classname = "CommonProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth";
 option (udpa.annotations.file_migrate).move_to_package =
     "envoy.extensions.transport_sockets.tls.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
@@ -41,8 +42,7 @@ message TlsParameters {
     TLSv1_3 = 4;
   }
 
-  // Minimum TLS protocol version. By default, it's ``TLSv1_2`` for clients and ``TLSv1_0`` for
-  // servers.
+  // Minimum TLS protocol version. By default, it's ``TLSv1_2`` for both clients and servers.
   TlsProtocol tls_minimum_protocol_version = 1 [(validate.rules).enum = {defined_only: true}];
 
   // Maximum TLS protocol version. By default, it's ``TLSv1_2`` for clients and ``TLSv1_3`` for

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/auth/secret.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/auth/secret.proto
@@ -13,6 +13,7 @@ import "udpa/annotations/status.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.auth";
 option java_outer_classname = "SecretProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth";
 option (udpa.annotations.file_migrate).move_to_package =
     "envoy.extensions.transport_sockets.tls.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/auth/tls.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/auth/tls.proto
@@ -15,6 +15,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.auth";
 option java_outer_classname = "TlsProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth";
 option (udpa.annotations.file_migrate).move_to_package =
     "envoy.extensions.transport_sockets.tls.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
@@ -81,10 +82,9 @@ message DownstreamTlsContext {
     bool disable_stateless_session_resumption = 7;
   }
 
-  // If specified, session_timeout will change maximum lifetime (in seconds) of TLS session
-  // Currently this value is used as a hint to `TLS session ticket lifetime (for TLSv1.2)
-  // <https://tools.ietf.org/html/rfc5077#section-5.6>`
-  // only seconds could be specified (fractional seconds are going to be ignored).
+  // If specified, ``session_timeout`` will change the maximum lifetime (in seconds) of the TLS session.
+  // Currently this value is used as a hint for the `TLS session ticket lifetime (for TLSv1.2) <https://tools.ietf.org/html/rfc5077#section-5.6>`_.
+  // Only seconds can be specified (fractional seconds are ignored).
   google.protobuf.Duration session_timeout = 6 [(validate.rules).duration = {
     lt {seconds: 4294967296}
     gte {}

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/cds.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/cds.proto
@@ -15,6 +15,7 @@ import public "envoy/api/v2/cluster.proto";
 option java_package = "io.envoyproxy.envoy.api.v2";
 option java_outer_classname = "CdsProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2;apiv2";
 option java_generic_services = true;
 option (udpa.annotations.file_migrate).move_to_package = "envoy.service.cluster.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/cluster.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/cluster.proto
@@ -27,6 +27,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.api.v2";
 option java_outer_classname = "ClusterProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2;apiv2";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.cluster.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/cluster/circuit_breaker.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/cluster/circuit_breaker.proto
@@ -14,8 +14,9 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.cluster";
 option java_outer_classname = "CircuitBreakerProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster";
 option csharp_namespace = "Envoy.Api.V2.ClusterNS";
-option ruby_package = "Envoy.Api.V2.ClusterNS";
+option ruby_package = "Envoy::Api::V2::ClusterNS";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.cluster.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/cluster/filter.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/cluster/filter.proto
@@ -11,8 +11,9 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.cluster";
 option java_outer_classname = "FilterProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster";
 option csharp_namespace = "Envoy.Api.V2.ClusterNS";
-option ruby_package = "Envoy.Api.V2.ClusterNS";
+option ruby_package = "Envoy::Api::V2::ClusterNS";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.cluster.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/cluster/outlier_detection.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/cluster/outlier_detection.proto
@@ -12,8 +12,9 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.cluster";
 option java_outer_classname = "OutlierDetectionProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster";
 option csharp_namespace = "Envoy.Api.V2.ClusterNS";
-option ruby_package = "Envoy.Api.V2.ClusterNS";
+option ruby_package = "Envoy::Api::V2::ClusterNS";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.cluster.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/address.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/address.proto
@@ -13,6 +13,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.core";
 option java_outer_classname = "AddressProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/core";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.core.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/backoff.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/backoff.proto
@@ -11,6 +11,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.core";
 option java_outer_classname = "BackoffProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/core";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.core.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/base.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/base.proto
@@ -21,6 +21,7 @@ import public "envoy/api/v2/core/socket_option.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.core";
 option java_outer_classname = "BaseProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/core";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.core.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/config_source.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/config_source.proto
@@ -15,6 +15,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.core";
 option java_outer_classname = "ConfigSourceProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/core";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.core.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/event_service_config.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/event_service_config.proto
@@ -11,6 +11,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.core";
 option java_outer_classname = "EventServiceConfigProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/core";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.core.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/grpc_service.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/grpc_service.proto
@@ -17,6 +17,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.core";
 option java_outer_classname = "GrpcServiceProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/core";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.core.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/health_check.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/health_check.proto
@@ -21,6 +21,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.core";
 option java_outer_classname = "HealthCheckProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/core";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.core.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/http_uri.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/http_uri.proto
@@ -11,6 +11,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.core";
 option java_outer_classname = "HttpUriProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/core";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.core.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/protocol.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/protocol.proto
@@ -12,6 +12,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.core";
 option java_outer_classname = "ProtocolProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/core";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.core.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/socket_option.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/socket_option.proto
@@ -9,6 +9,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.core";
 option java_outer_classname = "SocketOptionProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/core";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.core.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/discovery.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/discovery.proto
@@ -13,6 +13,7 @@ import "udpa/annotations/status.proto";
 option java_package = "io.envoyproxy.envoy.api.v2";
 option java_outer_classname = "DiscoveryProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2;apiv2";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.service.discovery.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/eds.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/eds.proto
@@ -15,6 +15,7 @@ import public "envoy/api/v2/endpoint.proto";
 option java_package = "io.envoyproxy.envoy.api.v2";
 option java_outer_classname = "EdsProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2;apiv2";
 option java_generic_services = true;
 option (udpa.annotations.file_migrate).move_to_package = "envoy.service.endpoint.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/endpoint.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/endpoint.proto
@@ -15,6 +15,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.api.v2";
 option java_outer_classname = "EndpointProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2;apiv2";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.endpoint.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/endpoint/endpoint.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/endpoint/endpoint.proto
@@ -7,3 +7,4 @@ import public "envoy/api/v2/endpoint/endpoint_components.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.endpoint";
 option java_outer_classname = "EndpointProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint";

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/endpoint/endpoint_components.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/endpoint/endpoint_components.proto
@@ -15,6 +15,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.endpoint";
 option java_outer_classname = "EndpointComponentsProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.endpoint.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/endpoint/load_report.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/endpoint/load_report.proto
@@ -15,6 +15,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.endpoint";
 option java_outer_classname = "LoadReportProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.endpoint.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/lds.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/lds.proto
@@ -15,6 +15,7 @@ import public "envoy/api/v2/listener.proto";
 option java_package = "io.envoyproxy.envoy.api.v2";
 option java_outer_classname = "LdsProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2;apiv2";
 option java_generic_services = true;
 option (udpa.annotations.file_migrate).move_to_package = "envoy.service.listener.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/listener.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/listener.proto
@@ -20,6 +20,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.api.v2";
 option java_outer_classname = "ListenerProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2;apiv2";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.listener.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/listener/listener.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/listener/listener.proto
@@ -7,5 +7,6 @@ import public "envoy/api/v2/listener/listener_components.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.listener";
 option java_outer_classname = "ListenerProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener";
 option csharp_namespace = "Envoy.Api.V2.ListenerNS";
-option ruby_package = "Envoy.Api.V2.ListenerNS";
+option ruby_package = "Envoy::Api::V2::ListenerNS";

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/listener/listener_components.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/listener/listener_components.proto
@@ -18,8 +18,9 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.listener";
 option java_outer_classname = "ListenerComponentsProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener";
 option csharp_namespace = "Envoy.Api.V2.ListenerNS";
-option ruby_package = "Envoy.Api.V2.ListenerNS";
+option ruby_package = "Envoy::Api::V2::ListenerNS";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.listener.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/listener/udp_listener_config.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/listener/udp_listener_config.proto
@@ -11,8 +11,9 @@ import "udpa/annotations/status.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.listener";
 option java_outer_classname = "UdpListenerConfigProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener";
 option csharp_namespace = "Envoy.Api.V2.ListenerNS";
-option ruby_package = "Envoy.Api.V2.ListenerNS";
+option ruby_package = "Envoy::Api::V2::ListenerNS";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.listener.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/rds.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/rds.proto
@@ -15,6 +15,7 @@ import public "envoy/api/v2/route.proto";
 option java_package = "io.envoyproxy.envoy.api.v2";
 option java_outer_classname = "RdsProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2;apiv2";
 option java_generic_services = true;
 option (udpa.annotations.file_migrate).move_to_package = "envoy.service.route.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/route.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/route.proto
@@ -15,6 +15,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.api.v2";
 option java_outer_classname = "RouteProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2;apiv2";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.route.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/route/route.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/route/route.proto
@@ -7,3 +7,4 @@ import public "envoy/api/v2/route/route_components.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.route";
 option java_outer_classname = "RouteProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/route";

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/route/route_components.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/route/route_components.proto
@@ -22,6 +22,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.api.v2.route";
 option java_outer_classname = "RouteComponentsProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/route";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.route.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
@@ -675,8 +676,8 @@ message RouteAction {
 
     message FilterState {
       // The name of the Object in the per-request filterState, which is an
-      // Envoy::Http::Hashable object. If there is no data associated with the key,
-      // or the stored object is not Envoy::Http::Hashable, no hash will be produced.
+      // Envoy::Hashable object. If there is no data associated with the key,
+      // or the stored object is not Envoy::Hashable, no hash will be produced.
       string key = 1 [(validate.rules).string = {min_bytes: 1}];
     }
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/scoped_route.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/scoped_route.proto
@@ -9,6 +9,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.api.v2";
 option java_outer_classname = "ScopedRouteProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2;apiv2";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.route.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/srds.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/srds.proto
@@ -15,6 +15,7 @@ import public "envoy/api/v2/scoped_route.proto";
 option java_package = "io.envoyproxy.envoy.api.v2";
 option java_outer_classname = "SrdsProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2;apiv2";
 option java_generic_services = true;
 option (udpa.annotations.file_migrate).move_to_package = "envoy.service.route.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;

--- a/xds/third_party/envoy/src/main/proto/envoy/config/accesslog/v3/accesslog.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/accesslog/v3/accesslog.proto
@@ -30,9 +30,7 @@ message AccessLog {
 
   reserved "config";
 
-  // The name of the access log extension to instantiate.
-  // The name must match one of the compiled in loggers.
-  // See the :ref:`extensions listed in typed_config below <extension_category_envoy.access_loggers>` for the default list of available loggers.
+  // The name of the access log extension configuration.
   string name = 1;
 
   // Filter which is used to determine if the access log needs to be written.

--- a/xds/third_party/envoy/src/main/proto/envoy/config/accesslog/v3/accesslog.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/accesslog/v3/accesslog.proto
@@ -17,6 +17,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.accesslog.v3";
 option java_outer_classname = "AccesslogProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3;accesslogv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Common access log types]
@@ -83,6 +84,7 @@ message AccessLogFilter {
     GrpcStatusFilter grpc_status_filter = 10;
 
     // Extension filter.
+    // [#extension-category: envoy.access_loggers.extension_filters]
     ExtensionFilter extension_filter = 11;
 
     // Metadata Filter

--- a/xds/third_party/envoy/src/main/proto/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/bootstrap/v3/bootstrap.proto
@@ -32,6 +32,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.bootstrap.v3";
 option java_outer_classname = "BootstrapProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3;bootstrapv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Bootstrap]
@@ -40,7 +41,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // <config_overview_bootstrap>` for more detail.
 
 // Bootstrap :ref:`configuration overview <config_overview_bootstrap>`.
-// [#next-free-field: 33]
+// [#next-free-field: 34]
 message Bootstrap {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.bootstrap.v2.Bootstrap";
@@ -248,9 +249,6 @@ message Bootstrap {
   // when :ref:`dns_resolvers <envoy_v3_api_field_config.cluster.v3.Cluster.dns_resolvers>` and
   // :ref:`use_tcp_for_dns_lookups <envoy_v3_api_field_config.cluster.v3.Cluster.use_tcp_for_dns_lookups>` are
   // specified.
-  // Setting this value causes failure if the
-  // ``envoy.restart_features.use_apple_api_for_dns_lookups`` runtime value is true during
-  // server startup. Apple' API only uses UDP for DNS resolution.
   // This field is deprecated in favor of *dns_resolution_config*
   // which aggregates all of the DNS resolver configuration in a single message.
   bool use_tcp_for_dns_lookups = 20
@@ -260,23 +258,22 @@ message Bootstrap {
   // This may be overridden on a per-cluster basis in cds_config, when
   // :ref:`dns_resolution_config <envoy_v3_api_field_config.cluster.v3.Cluster.dns_resolution_config>`
   // is specified.
-  // *dns_resolution_config* will be deprecated once
-  // :ref:'typed_dns_resolver_config <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.typed_dns_resolver_config>'
-  // is fully supported.
-  core.v3.DnsResolutionConfig dns_resolution_config = 30;
+  // This field is deprecated in favor of
+  // :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.typed_dns_resolver_config>`.
+  core.v3.DnsResolutionConfig dns_resolution_config = 30
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // DNS resolver type configuration extension. This extension can be used to configure c-ares, apple,
   // or any other DNS resolver types and the related parameters.
-  // For example, an object of :ref:`DnsResolutionConfig <envoy_v3_api_msg_config.core.v3.DnsResolutionConfig>`
-  // can be packed into this *typed_dns_resolver_config*. This configuration will replace the
-  // :ref:'dns_resolution_config <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.dns_resolution_config>'
-  // configuration eventually.
-  // TODO(yanjunxiang): Investigate the deprecation plan for *dns_resolution_config*.
+  // For example, an object of
+  // :ref:`CaresDnsResolverConfig <envoy_v3_api_msg_extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig>`
+  // can be packed into this *typed_dns_resolver_config*. This configuration replaces the
+  // :ref:`dns_resolution_config <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.dns_resolution_config>`
+  // configuration.
   // During the transition period when both *dns_resolution_config* and *typed_dns_resolver_config* exists,
-  // this configuration is optional.
-  // When *typed_dns_resolver_config* is in place, Envoy will use it and ignore *dns_resolution_config*.
+  // when *typed_dns_resolver_config* is in place, Envoy will use it and ignore *dns_resolution_config*.
   // When *typed_dns_resolver_config* is missing, the default behavior is in place.
-  // [#not-implemented-hide:]
+  // [#extension-category: envoy.network.dns_resolver]
   core.v3.TypedExtensionConfig typed_dns_resolver_config = 31;
 
   // Specifies optional bootstrap extensions to be instantiated at startup time.
@@ -329,11 +326,15 @@ message Bootstrap {
   //
   // Note that the 'set-cookie' header cannot be registered as inline header.
   repeated CustomInlineHeader inline_headers = 32;
+
+  // Optional path to a file with performance tracing data created by "Perfetto" SDK in binary
+  // ProtoBuf format. The default value is "envoy.pftrace".
+  string perf_tracing_file_path = 33;
 }
 
 // Administration interface :ref:`operations documentation
 // <operations_admin_interface>`.
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message Admin {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.bootstrap.v2.Admin";
 
@@ -359,6 +360,10 @@ message Admin {
   // Additional socket options that may not be present in Envoy source code or
   // precompiled binaries.
   repeated core.v3.SocketOption socket_options = 4;
+
+  // Indicates whether :ref:`global_downstream_max_connections <config_overload_manager_limiting_connections>`
+  // should apply to the admin interface or not.
+  bool ignore_global_conn_limit = 6;
 }
 
 // Cluster manager :ref:`architecture overview <arch_overview_cluster_manager>`.

--- a/xds/third_party/envoy/src/main/proto/envoy/config/cluster/aggregate/v2alpha/cluster.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/cluster/aggregate/v2alpha/cluster.proto
@@ -9,6 +9,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.cluster.aggregate.v2alpha";
 option java_outer_classname = "ClusterProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/cluster/aggregate/v2alpha";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.clusters.aggregate.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/circuit_breaker.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/circuit_breaker.proto
@@ -14,6 +14,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.cluster.v3";
 option java_outer_classname = "CircuitBreakerProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3;clusterv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Circuit breakers]
@@ -59,10 +60,12 @@ message CircuitBreakers {
 
     // The maximum number of pending requests that Envoy will allow to the
     // upstream cluster. If not specified, the default is 1024.
+    // This limit is applied as a connection limit for non-HTTP traffic.
     google.protobuf.UInt32Value max_pending_requests = 3;
 
     // The maximum number of parallel requests that Envoy will make to the
     // upstream cluster. If not specified, the default is 1024.
+    // This limit does not apply to non-HTTP traffic.
     google.protobuf.UInt32Value max_requests = 4;
 
     // The maximum number of parallel retries that Envoy will allow to the
@@ -102,4 +105,17 @@ message CircuitBreakers {
   // :ref:`RoutingPriority<envoy_v3_api_enum_config.core.v3.RoutingPriority>`, the default values
   // are used.
   repeated Thresholds thresholds = 1;
+
+  // Optional per-host limits which apply to each individual host in a cluster.
+  //
+  // .. note::
+  //  currently only the :ref:`max_connections
+  //  <envoy_v3_api_field_config.cluster.v3.CircuitBreakers.Thresholds.max_connections>` field is supported for per-host limits.
+  //
+  // If multiple per-host :ref:`Thresholds<envoy_v3_api_msg_config.cluster.v3.CircuitBreakers.Thresholds>`
+  // are defined with the same :ref:`RoutingPriority<envoy_v3_api_enum_config.core.v3.RoutingPriority>`,
+  // the first one in the list is used. If no per-host Thresholds are defined for a given
+  // :ref:`RoutingPriority<envoy_v3_api_enum_config.core.v3.RoutingPriority>`,
+  // the cluster will not have per-host limits.
+  repeated Thresholds per_host_thresholds = 2;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/cluster.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/cluster.proto
@@ -474,9 +474,8 @@ message Cluster {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.Cluster.OriginalDstLbConfig";
 
-    // When true, :ref:`x-envoy-original-dst-host
-    // <config_http_conn_man_headers_x-envoy-original-dst-host>` can be used to override destination
-    // address.
+    // When true, a HTTP header can be used to override the original dst address. The default header is
+    // :ref:`x-envoy-original-dst-host <config_http_conn_man_headers_x-envoy-original-dst-host>`.
     //
     // .. attention::
     //
@@ -488,6 +487,10 @@ message Cluster {
     //
     //   If the header appears multiple times only the first value is used.
     bool use_http_header = 1;
+
+    // The http header to override destination address if :ref:`use_http_header <envoy_v3_api_field_config.cluster.v3.Cluster.OriginalDstLbConfig.use_http_header>`.
+    // is set to true. If the value is empty, :ref:`x-envoy-original-dst-host <config_http_conn_man_headers_x-envoy-original-dst-host>` will be used.
+    string http_header_name = 2;
   }
 
   // Common configuration for all load balancer implementations.

--- a/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/cluster.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/cluster.proto
@@ -32,6 +32,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.cluster.v3";
 option java_outer_classname = "ClusterProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3;clusterv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Cluster configuration]
@@ -43,7 +44,7 @@ message ClusterCollection {
 }
 
 // Configuration for a single upstream cluster.
-// [#next-free-field: 56]
+// [#next-free-field: 57]
 message Cluster {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Cluster";
 
@@ -112,9 +113,9 @@ message Cluster {
 
     // Use the new :ref:`load_balancing_policy
     // <envoy_v3_api_field_config.cluster.v3.Cluster.load_balancing_policy>` field to determine the LB policy.
-    // [#next-major-version: In the v3 API, we should consider deprecating the lb_policy field
-    // and instead using the new load_balancing_policy field as the one and only mechanism for
-    // configuring this.]
+    // This has been deprecated in favor of using the :ref:`load_balancing_policy
+    // <envoy_v3_api_field_config.cluster.v3.Cluster.load_balancing_policy>` field without
+    // setting any value in :ref:`lb_policy<envoy_v3_api_field_config.cluster.v3.Cluster.lb_policy>`.
     LOAD_BALANCING_POLICY_CONFIG = 7;
   }
 
@@ -123,15 +124,26 @@ message Cluster {
   // only perform a lookup for addresses in the IPv6 family. If AUTO is
   // specified, the DNS resolver will first perform a lookup for addresses in
   // the IPv6 family and fallback to a lookup for addresses in the IPv4 family.
+  // This is semantically equivalent to a non-existent V6_PREFERRED option.
+  // AUTO is a legacy name that is more opaque than
+  // necessary and will be deprecated in favor of V6_PREFERRED in a future major version of the API.
+  // If V4_PREFERRED is specified, the DNS resolver will first perform a lookup for addresses in the
+  // IPv4 family and fallback to a lookup for addresses in the IPv6 family. i.e., the callback
+  // target will only get v6 addresses if there were NO v4 addresses to return.
+  // If ALL is specified, the DNS resolver will perform a lookup for both IPv4 and IPv6 families,
+  // and return all resolved addresses.
   // For cluster types other than
   // :ref:`STRICT_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.STRICT_DNS>` and
   // :ref:`LOGICAL_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.LOGICAL_DNS>`,
   // this setting is
   // ignored.
+  // [#next-major-version: deprecate AUTO in favor of a V6_PREFERRED option.]
   enum DnsLookupFamily {
     AUTO = 0;
     V4_ONLY = 1;
     V6_ONLY = 2;
+    V4_PREFERRED = 3;
+    ALL = 4;
   }
 
   enum ClusterProtocolSelection {
@@ -337,6 +349,40 @@ message Cluster {
     bool list_as_any = 7;
   }
 
+  // Configuration for :ref:`slow start mode <arch_overview_load_balancing_slow_start>`.
+  message SlowStartConfig {
+    // Represents the size of slow start window.
+    // If set, the newly created host remains in slow start mode starting from its creation time
+    // for the duration of slow start window.
+    google.protobuf.Duration slow_start_window = 1;
+
+    // This parameter controls the speed of traffic increase over the slow start window. Defaults to 1.0,
+    // so that endpoint would get linearly increasing amount of traffic.
+    // When increasing the value for this parameter, the speed of traffic ramp-up increases non-linearly.
+    // The value of aggression parameter should be greater than 0.0.
+    // By tuning the parameter, is possible to achieve polynomial or exponential shape of ramp-up curve.
+    //
+    // During slow start window, effective weight of an endpoint would be scaled with time factor and aggression:
+    // `new_weight = weight * max(min_weight_percent, time_factor ^ (1 / aggression))`,
+    // where `time_factor=(time_since_start_seconds / slow_start_time_seconds)`.
+    //
+    // As time progresses, more and more traffic would be sent to endpoint, which is in slow start window.
+    // Once host exits slow start, time_factor and aggression no longer affect its weight.
+    core.v3.RuntimeDouble aggression = 2;
+
+    // Configures the minimum percentage of origin weight that avoids too small new weight,
+    // which may cause endpoints in slow start mode receive no traffic in slow start window.
+    // If not specified, the default is 10%.
+    type.v3.Percent min_weight_percent = 3;
+  }
+
+  // Specific configuration for the RoundRobin load balancing policy.
+  message RoundRobinLbConfig {
+    // Configuration for slow start mode.
+    // If this configuration is not set, slow start will not be not enabled.
+    SlowStartConfig slow_start_config = 1;
+  }
+
   // Specific configuration for the LeastRequest load balancing policy.
   message LeastRequestLbConfig {
     option (udpa.annotations.versioning).previous_message_type =
@@ -370,6 +416,10 @@ message Cluster {
     // .. note::
     //   This setting only takes effect if all host weights are not equal.
     core.v3.RuntimeDouble active_request_bias = 2;
+
+    // Configuration for slow start mode.
+    // If this configuration is not set, slow start will not be not enabled.
+    SlowStartConfig slow_start_config = 3;
   }
 
   // Specific configuration for the :ref:`RingHash<arch_overview_load_balancing_types_ring_hash>`
@@ -441,7 +491,7 @@ message Cluster {
   }
 
   // Common configuration for all load balancer implementations.
-  // [#next-free-field: 8]
+  // [#next-free-field: 9]
   message CommonLbConfig {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.Cluster.CommonLbConfig";
@@ -550,6 +600,14 @@ message Cluster {
 
     // Common Configuration for all consistent hashing load balancers (MaglevLb, RingHashLb, etc.)
     ConsistentHashingLbConfig consistent_hashing_lb_config = 7;
+
+    // This controls what hosts are considered valid when using
+    // :ref:`host overrides <arch_overview_load_balancing_override_host>`, which is used by some
+    // filters to modify the load balancing decision.
+    //
+    // If this is unset then [UNKNOWN, HEALTHY, DEGRADED] will be applied by default. If this is
+    // set with an empty set of statuses then host overrides will be ignored by the load balancing.
+    core.v3.HealthStatusSet override_host_status = 8;
   }
 
   message RefreshRate {
@@ -690,11 +748,9 @@ message Cluster {
   // emitting stats for the cluster and access logging the cluster name. This will appear as
   // additional information in configuration dumps of a cluster's current status as
   // :ref:`observability_name <envoy_v3_api_field_admin.v3.ClusterStatus.observability_name>`
-  // and as an additional tag "upstream_cluster.name" while tracing. Note: access logging using
-  // this field is presently enabled with runtime feature
-  // `envoy.reloadable_features.use_observable_cluster_name`. Any ``:`` in the name will be
-  // converted to ``_`` when emitting statistics. This should not be confused with :ref:`Router
-  // Filter Header <config_http_filters_router_x-envoy-upstream-alt-stat-name>`.
+  // and as an additional tag "upstream_cluster.name" while tracing. Note: Any ``:`` in the name
+  // will be converted to ``_`` when emitting statistics. This should not be confused with
+  // :ref:`Router Filter Header <config_http_filters_router_x-envoy-upstream-alt-stat-name>`.
   string alt_stat_name = 28 [(udpa.annotations.field_migrate).rename = "observability_name"];
 
   oneof cluster_discovery_type {
@@ -859,41 +915,34 @@ message Cluster {
   // :ref:`STRICT_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.STRICT_DNS>`
   // and :ref:`LOGICAL_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.LOGICAL_DNS>`
   // this setting is ignored.
-  // Setting this value causes failure if the
-  // ``envoy.restart_features.use_apple_api_for_dns_lookups`` runtime value is true during
-  // server startup. Apple's API only allows overriding DNS resolvers via system settings.
   // This field is deprecated in favor of *dns_resolution_config*
   // which aggregates all of the DNS resolver configuration in a single message.
   repeated core.v3.Address dns_resolvers = 18
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // Always use TCP queries instead of UDP queries for DNS lookups.
-  // Setting this value causes failure if the
-  // ``envoy.restart_features.use_apple_api_for_dns_lookups`` runtime value is true during
-  // server startup. Apple' API only uses UDP for DNS resolution.
   // This field is deprecated in favor of *dns_resolution_config*
   // which aggregates all of the DNS resolver configuration in a single message.
   bool use_tcp_for_dns_lookups = 45
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // DNS resolution configuration which includes the underlying dns resolver addresses and options.
-  // *dns_resolution_config* will be deprecated once
-  // :ref:'typed_dns_resolver_config <envoy_v3_api_field_config.cluster.v3.Cluster.typed_dns_resolver_config>'
-  // is fully supported.
-  core.v3.DnsResolutionConfig dns_resolution_config = 53;
+  // This field is deprecated in favor of
+  // :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.cluster.v3.Cluster.typed_dns_resolver_config>`.
+  core.v3.DnsResolutionConfig dns_resolution_config = 53
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // DNS resolver type configuration extension. This extension can be used to configure c-ares, apple,
   // or any other DNS resolver types and the related parameters.
-  // For example, an object of :ref:`DnsResolutionConfig <envoy_v3_api_msg_config.core.v3.DnsResolutionConfig>`
-  // can be packed into this *typed_dns_resolver_config*. This configuration will replace the
-  // :ref:'dns_resolution_config <envoy_v3_api_field_config.cluster.v3.Cluster.dns_resolution_config>'
-  // configuration eventually.
-  // TODO(yanjunxiang): Investigate the deprecation plan for *dns_resolution_config*.
+  // For example, an object of
+  // :ref:`CaresDnsResolverConfig <envoy_v3_api_msg_extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig>`
+  // can be packed into this *typed_dns_resolver_config*. This configuration replaces the
+  // :ref:`dns_resolution_config <envoy_v3_api_field_config.cluster.v3.Cluster.dns_resolution_config>`
+  // configuration.
   // During the transition period when both *dns_resolution_config* and *typed_dns_resolver_config* exists,
-  // this configuration is optional.
-  // When *typed_dns_resolver_config* is in place, Envoy will use it and ignore *dns_resolution_config*.
+  // when *typed_dns_resolver_config* is in place, Envoy will use it and ignore *dns_resolution_config*.
   // When *typed_dns_resolver_config* is missing, the default behavior is in place.
-  // [#not-implemented-hide:]
+  // [#extension-category: envoy.network.dns_resolver]
   core.v3.TypedExtensionConfig typed_dns_resolver_config = 55;
 
   // Optional configuration for having cluster readiness block on warm-up. Currently, only applicable for
@@ -951,6 +1000,9 @@ message Cluster {
 
     // Optional configuration for the LeastRequest load balancing policy.
     LeastRequestLbConfig least_request_lb_config = 37;
+
+    // Optional configuration for the RoundRobin load balancing policy.
+    RoundRobinLbConfig round_robin_lb_config = 56;
   }
 
   // Common configuration for all load balancer implementations.
@@ -1007,9 +1059,8 @@ message Cluster {
   // servers of this cluster.
   repeated Filter filters = 40;
 
-  // New mechanism for LB policy configuration. Used only if the
-  // :ref:`lb_policy<envoy_v3_api_field_config.cluster.v3.Cluster.lb_policy>` field has the value
-  // :ref:`LOAD_BALANCING_POLICY_CONFIG<envoy_v3_api_enum_value_config.cluster.v3.Cluster.LbPolicy.LOAD_BALANCING_POLICY_CONFIG>`.
+  // If this field is set and is supported by the client, it will supersede the value of
+  // :ref:`lb_policy<envoy_v3_api_field_config.cluster.v3.Cluster.lb_policy>`.
   LoadBalancingPolicy load_balancing_policy = 41;
 
   // [#not-implemented-hide:]
@@ -1126,6 +1177,11 @@ message UpstreamConnectionOptions {
 
   // If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
   core.v3.TcpKeepalive tcp_keepalive = 1;
+
+  // If enabled, associates the interface name of the local address with the upstream connection.
+  // This can be used by extensions during processing of requests. The association mechanism is
+  // implementation specific. Defaults to false due to performance concerns.
+  bool set_local_interface_name_on_upstream_connections = 2;
 }
 
 message TrackClusterStats {

--- a/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/filter.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/filter.proto
@@ -20,12 +20,12 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 message Filter {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.cluster.Filter";
 
-  // The name of the filter to instantiate. The name must match a
-  // supported upstream filter. Note that Envoy's :ref:`downstream network
-  // filters <config_network_filters>` are not valid upstream filters.
+  // The name of the filter configuration.
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
   // Filter specific configuration which depends on the filter being
   // instantiated. See the supported filters for further documentation.
+  // Note that Envoy's :ref:`downstream network
+  // filters <config_network_filters>` are not valid upstream filters.
   google.protobuf.Any typed_config = 2;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/filter.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/filter.proto
@@ -11,6 +11,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.cluster.v3";
 option java_outer_classname = "FilterProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3;clusterv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Upstream filters]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/outlier_detection.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/outlier_detection.proto
@@ -12,13 +12,14 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.cluster.v3";
 option java_outer_classname = "OutlierDetectionProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3;clusterv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Outlier detection]
 
 // See the :ref:`architecture overview <arch_overview_outlier_detection>` for
 // more information on outlier detection.
-// [#next-free-field: 22]
+// [#next-free-field: 23]
 message OutlierDetection {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.cluster.OutlierDetection";
@@ -154,4 +155,10 @@ message OutlierDetection {
   // for more information. If not specified, the default value (300000ms or 300s) or
   // :ref:`base_ejection_time<envoy_v3_api_field_config.cluster.v3.OutlierDetection.base_ejection_time>` value is applied, whatever is larger.
   google.protobuf.Duration max_ejection_time = 21 [(validate.rules).duration = {gt {}}];
+
+  // The maximum amount of jitter to add to the ejection time, in order to prevent
+  // a 'thundering herd' effect where all proxies try to reconnect to host at the same time.
+  // See :ref:`max_ejection_time_jitter<envoy_v3_api_field_config.cluster.v3.OutlierDetection.base_ejection_time>`
+  // Defaults to 0s.
+  google.protobuf.Duration max_ejection_time_jitter = 22;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/address.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/address.proto
@@ -13,6 +13,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.core.v3";
 option java_outer_classname = "AddressProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/core/v3;corev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Network addresses]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/address.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/address.proto
@@ -31,9 +31,9 @@ message Pipe {
   uint32 mode = 2 [(validate.rules).uint32 = {lte: 511}];
 }
 
-// [#not-implemented-hide:] The address represents an envoy internal listener.
-// TODO(lambdai): Make this address available for listener and endpoint.
-// TODO(asraa): When address available, remove workaround from test/server/server_fuzz_test.cc:30.
+// The address represents an envoy internal listener.
+// [#comment: TODO(lambdai): Make this address available for listener and endpoint.
+// TODO(asraa): When address available, remove workaround from test/server/server_fuzz_test.cc:30.]
 message EnvoyInternalAddress {
   oneof address_name_specifier {
     option (validate.required) = true;

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/backoff.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/backoff.proto
@@ -11,6 +11,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.core.v3";
 option java_outer_classname = "BackoffProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/core/v3;corev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Backoff Strategy]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/base.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/base.proto
@@ -23,6 +23,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.core.v3";
 option java_outer_classname = "BaseProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/core/v3;corev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Common types]
@@ -296,6 +297,15 @@ message RuntimeFeatureFlag {
   string runtime_key = 2 [(validate.rules).string = {min_len: 1}];
 }
 
+// Query parameter name/value pair.
+message QueryParameter {
+  // The key of the query parameter. Case sensitive.
+  string key = 1 [(validate.rules).string = {min_len: 1}];
+
+  // The value of the query parameter.
+  string value = 2;
+}
+
 // Header name/value pair.
 message HeaderValue {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.core.HeaderValue";
@@ -320,12 +330,33 @@ message HeaderValueOption {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.core.HeaderValueOption";
 
+  // Describes the supported actions types for header append action.
+  enum HeaderAppendAction {
+    // This action will append the specified value to the existing values if the header
+    // already exists. If the header doesn't exist then this will add the header with
+    // specified key and value.
+    APPEND_IF_EXISTS_OR_ADD = 0;
+
+    // This action will add the header if it doesn't already exist. If the header
+    // already exists then this will be a no-op.
+    ADD_IF_ABSENT = 1;
+
+    // This action will overwrite the specified value by discarding any existing values if
+    // the header already exists. If the header doesn't exist then this will add the header
+    // with specified key and value.
+    OVERWRITE_IF_EXISTS_OR_ADD = 2;
+  }
+
   // Header name/value pair that this option applies to.
   HeaderValue header = 1 [(validate.rules).message = {required: true}];
 
   // Should the value be appended? If true (default), the value is appended to
   // existing values. Otherwise it replaces any existing values.
   google.protobuf.BoolValue append = 2;
+
+  // [#not-implemented-hide:] Describes the action taken to append/overwrite the given value for an existing header
+  // or to only add this header if it's absent. Value defaults to :ref:`APPEND_IF_EXISTS_OR_ADD<envoy_v3_api_enum_value_config.core.v3.HeaderValueOption.HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD>`.
+  HeaderAppendAction append_action = 3 [(validate.rules).enum = {defined_only: true}];
 }
 
 // Wrapper for a set of headers.
@@ -342,7 +373,7 @@ message WatchedDirectory {
   string path = 1 [(validate.rules).string = {min_len: 1}];
 }
 
-// Data source consisting of either a file or an inline value.
+// Data source consisting of a file, an inline value, or an environment variable.
 message DataSource {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.core.DataSource";
 
@@ -357,6 +388,9 @@ message DataSource {
 
     // String inlined in the configuration.
     string inline_string = 3;
+
+    // Environment variable data source.
+    string environment_variable = 4 [(validate.rules).string = {min_len: 1}];
   }
 }
 

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/config_source.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/config_source.proto
@@ -2,8 +2,11 @@ syntax = "proto3";
 
 package envoy.config.core.v3;
 
+import "envoy/config/core/v3/base.proto";
+import "envoy/config/core/v3/extension.proto";
 import "envoy/config/core/v3/grpc_service.proto";
 
+import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
@@ -17,6 +20,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.core.v3";
 option java_outer_classname = "ConfigSourceProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/core/v3;corev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Configuration sources]
@@ -38,7 +42,7 @@ enum ApiVersion {
 
 // API configuration source. This identifies the API type and cluster that Envoy
 // will use to fetch an xDS API.
-// [#next-free-field: 9]
+// [#next-free-field: 10]
 message ApiConfigSource {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.core.ApiConfigSource";
 
@@ -106,6 +110,16 @@ message ApiConfigSource {
 
   // Skip the node identifier in subsequent discovery requests for streaming gRPC config types.
   bool set_node_on_first_message_only = 7;
+
+  // A list of config validators that will be executed when a new update is
+  // received from the ApiConfigSource. Note that each validator handles a
+  // specific xDS service type, and only the validators corresponding to the
+  // type url (in `:ref: DiscoveryResponse` or `:ref: DeltaDiscoveryResponse`)
+  // will be invoked.
+  // If the validator returns false or throws an exception, the config will be rejected by
+  // the client, and a NACK will be sent.
+  // [#extension-category: envoy.config.validators]
+  repeated TypedExtensionConfig config_validators = 9;
 }
 
 // Aggregated Discovery Service (ADS) options. This is currently empty, but when
@@ -142,13 +156,49 @@ message RateLimitSettings {
   google.protobuf.DoubleValue fill_rate = 2 [(validate.rules).double = {gt: 0.0}];
 }
 
+// Local filesystem path configuration source.
+message PathConfigSource {
+  // Path on the filesystem to source and watch for configuration updates.
+  // When sourcing configuration for a :ref:`secret <envoy_v3_api_msg_extensions.transport_sockets.tls.v3.Secret>`,
+  // the certificate and key files are also watched for updates.
+  //
+  // .. note::
+  //
+  //  The path to the source must exist at config load time.
+  //
+  // .. note::
+  //
+  //   If `watched_directory` is *not* configured, Envoy will watch the file path for *moves.*
+  //   This is because in general only moves are atomic. The same method of swapping files as is
+  //   demonstrated in the :ref:`runtime documentation <config_runtime_symbolic_link_swap>` can be
+  //   used here also. If `watched_directory` is configured, no watch will be placed directly on
+  //   this path. Instead, the configured `watched_directory` will be used to trigger reloads of
+  //   this path. This is required in certain deployment scenarios. See below for more information.
+  string path = 1 [(validate.rules).string = {min_len: 1}];
+
+  // If configured, this directory will be watched for *moves.* When an entry in this directory is
+  // moved to, the `path` will be reloaded. This is required in certain deployment scenarios.
+  //
+  // Specifically, if trying to load an xDS resource using a
+  // `Kubernetes ConfigMap <https://kubernetes.io/docs/concepts/configuration/configmap/>`_, the
+  // following configuration might be used:
+  // 1. Store xds.yaml inside a ConfigMap.
+  // 2. Mount the ConfigMap to `/config_map/xds`
+  // 3. Configure path `/config_map/xds/xds.yaml`
+  // 4. Configure watched directory `/config_map/xds`
+  //
+  // The above configuration will ensure that Envoy watches the owning directory for moves which is
+  // required due to how Kubernetes manages ConfigMap symbolic links during atomic updates.
+  WatchedDirectory watched_directory = 2;
+}
+
 // Configuration for :ref:`listeners <config_listeners>`, :ref:`clusters
 // <config_cluster_manager>`, :ref:`routes
 // <envoy_v3_api_msg_config.route.v3.RouteConfiguration>`, :ref:`endpoints
 // <arch_overview_service_discovery>` etc. may either be sourced from the
 // filesystem or from an xDS API source. Filesystem configs are watched with
 // inotify for updates.
-// [#next-free-field: 8]
+// [#next-free-field: 9]
 message ConfigSource {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.core.ConfigSource";
 
@@ -161,20 +211,11 @@ message ConfigSource {
   oneof config_source_specifier {
     option (validate.required) = true;
 
-    // Path on the filesystem to source and watch for configuration updates.
-    // When sourcing configuration for :ref:`secret <envoy_v3_api_msg_extensions.transport_sockets.tls.v3.Secret>`,
-    // the certificate and key files are also watched for updates.
-    //
-    // .. note::
-    //
-    //  The path to the source must exist at config load time.
-    //
-    // .. note::
-    //
-    //   Envoy will only watch the file path for *moves.* This is because in general only moves
-    //   are atomic. The same method of swapping files as is demonstrated in the
-    //   :ref:`runtime documentation <config_runtime_symbolic_link_swap>` can be used here also.
-    string path = 1;
+    // Deprecated in favor of `path_config_source`. Use that field instead.
+    string path = 1 [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+
+    // Local filesystem path configuration source.
+    PathConfigSource path_config_source = 8;
 
     // API configuration source.
     ApiConfigSource api_config_source = 2;
@@ -210,4 +251,33 @@ message ConfigSource {
   // will request for resources and the resource type that the client will in
   // turn expect to be delivered.
   ApiVersion resource_api_version = 6 [(validate.rules).enum = {defined_only: true}];
+}
+
+// Configuration source specifier for a late-bound extension configuration. The
+// parent resource is warmed until all the initial extension configurations are
+// received, unless the flag to apply the default configuration is set.
+// Subsequent extension updates are atomic on a per-worker basis. Once an
+// extension configuration is applied to a request or a connection, it remains
+// constant for the duration of processing. If the initial delivery of the
+// extension configuration fails, due to a timeout for example, the optional
+// default configuration is applied. Without a default configuration, the
+// extension is disabled, until an extension configuration is received. The
+// behavior of a disabled extension depends on the context. For example, a
+// filter chain with a disabled extension filter rejects all incoming streams.
+message ExtensionConfigSource {
+  ConfigSource config_source = 1 [(validate.rules).any = {required: true}];
+
+  // Optional default configuration to use as the initial configuration if
+  // there is a failure to receive the initial extension configuration or if
+  // `apply_default_config_without_warming` flag is set.
+  google.protobuf.Any default_config = 2;
+
+  // Use the default config as the initial configuration without warming and
+  // waiting for the first discovery response. Requires the default configuration
+  // to be supplied.
+  bool apply_default_config_without_warming = 3;
+
+  // A set of permitted extension type URLs. Extension configuration updates are rejected
+  // if they do not match any type URL in the set.
+  repeated string type_urls = 4 [(validate.rules).repeated = {min_items: 1}];
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/event_service_config.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/event_service_config.proto
@@ -11,6 +11,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.core.v3";
 option java_outer_classname = "EventServiceConfigProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/core/v3;corev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#not-implemented-hide:]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/extension.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/extension.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package envoy.config.core.v3;
 
-import "envoy/config/core/v3/config_source.proto";
-
 import "google/protobuf/any.proto";
 
 import "udpa/annotations/status.proto";
@@ -12,6 +10,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.core.v3";
 option java_outer_classname = "ExtensionProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/core/v3;corev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Extension configuration]
@@ -24,38 +23,10 @@ message TypedExtensionConfig {
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
   // The typed config for the extension. The type URL will be used to identify
-  // the extension. In the case that the type URL is *udpa.type.v1.TypedStruct*,
-  // the inner type URL of *TypedStruct* will be utilized. See the
+  // the extension. In the case that the type URL is *xds.type.v3.TypedStruct*
+  // (or, for historical reasons, *udpa.type.v1.TypedStruct*), the inner type
+  // URL of *TypedStruct* will be utilized. See the
   // :ref:`extension configuration overview
   // <config_overview_extension_configuration>` for further details.
   google.protobuf.Any typed_config = 2 [(validate.rules).any = {required: true}];
-}
-
-// Configuration source specifier for a late-bound extension configuration. The
-// parent resource is warmed until all the initial extension configurations are
-// received, unless the flag to apply the default configuration is set.
-// Subsequent extension updates are atomic on a per-worker basis. Once an
-// extension configuration is applied to a request or a connection, it remains
-// constant for the duration of processing. If the initial delivery of the
-// extension configuration fails, due to a timeout for example, the optional
-// default configuration is applied. Without a default configuration, the
-// extension is disabled, until an extension configuration is received. The
-// behavior of a disabled extension depends on the context. For example, a
-// filter chain with a disabled extension filter rejects all incoming streams.
-message ExtensionConfigSource {
-  ConfigSource config_source = 1 [(validate.rules).any = {required: true}];
-
-  // Optional default configuration to use as the initial configuration if
-  // there is a failure to receive the initial extension configuration or if
-  // `apply_default_config_without_warming` flag is set.
-  google.protobuf.Any default_config = 2;
-
-  // Use the default config as the initial configuration without warming and
-  // waiting for the first discovery response. Requires the default configuration
-  // to be supplied.
-  bool apply_default_config_without_warming = 3;
-
-  // A set of permitted extension type URLs. Extension configuration updates are rejected
-  // if they do not match any type URL in the set.
-  repeated string type_urls = 4 [(validate.rules).repeated = {min_items: 1}];
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/grpc_service.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/grpc_service.proto
@@ -18,6 +18,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.core.v3";
 option java_outer_classname = "GrpcServiceProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/core/v3;corev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: gRPC services]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/health_check.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/health_check.proto
@@ -20,6 +20,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.core.v3";
 option java_outer_classname = "HealthCheckProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/core/v3;corev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Health check]
@@ -53,6 +54,12 @@ enum HealthStatus {
   DEGRADED = 5;
 }
 
+message HealthStatusSet {
+  // An order-independent set of health status.
+  repeated HealthStatus statuses = 1
+      [(validate.rules).repeated = {items {enum {defined_only: true}}}];
+}
+
 // [#next-free-field: 25]
 message HealthCheck {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.core.HealthCheck";
@@ -73,7 +80,7 @@ message HealthCheck {
     }
   }
 
-  // [#next-free-field: 12]
+  // [#next-free-field: 13]
   message HttpHealthCheck {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.core.HealthCheck.HttpHealthCheck";
@@ -117,6 +124,18 @@ message HealthCheck {
     // semantics of :ref:`Int64Range <envoy_v3_api_msg_type.v3.Int64Range>`. The start and end of each
     // range are required. Only statuses in the range [100, 600) are allowed.
     repeated type.v3.Int64Range expected_statuses = 9;
+
+    // Specifies a list of HTTP response statuses considered retriable. If provided, responses in this range
+    // will count towards the configured :ref:`unhealthy_threshold <envoy_v3_api_field_config.core.v3.HealthCheck.unhealthy_threshold>`,
+    // but will not result in the host being considered immediately unhealthy. Ranges follow half-open semantics of
+    // :ref:`Int64Range <envoy_v3_api_msg_type.v3.Int64Range>`. The start and end of each range are required.
+    // Only statuses in the range [100, 600) are allowed. The :ref:`expected_statuses <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.expected_statuses>`
+    // field takes precedence for any range overlaps with this field i.e. if status code 200 is both retriable and expected, a 200 response will
+    // be considered a successful health check. By default all responses not in
+    // :ref:`expected_statuses <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.expected_statuses>` will result in
+    // the host being considered immediately unhealthy i.e. if status code 200 is expected and there are no configured retriable statuses, any
+    // non-200 response will result in the host being marked unhealthy.
+    repeated type.v3.Int64Range retriable_statuses = 12;
 
     // Use specified application protocol for health checks.
     type.v3.CodecClientType codec_client_type = 10 [(validate.rules).enum = {defined_only: true}];
@@ -173,6 +192,12 @@ message HealthCheck {
     // the :ref:`hostname <envoy_v3_api_field_config.endpoint.v3.Endpoint.HealthCheckConfig.hostname>` field.
     string authority = 2
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
+
+    // Specifies a list of key-value pairs that should be added to the metadata of each GRPC call
+    // that is sent to the health checked cluster. For more information, including details on header value syntax,
+    // see the documentation on :ref:`custom request headers
+    // <config_http_conn_man_headers_custom_request_headers>`.
+    repeated HeaderValueOption initial_metadata = 3 [(validate.rules).repeated = {max_items: 1000}];
   }
 
   // Custom health check.
@@ -243,8 +268,10 @@ message HealthCheck {
   uint32 interval_jitter_percent = 18;
 
   // The number of unhealthy health checks required before a host is marked
-  // unhealthy. Note that for *http* health checking if a host responds with 503
-  // this threshold is ignored and the host is considered unhealthy immediately.
+  // unhealthy. Note that for *http* health checking if a host responds with a code not in
+  // :ref:`expected_statuses <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.expected_statuses>`
+  // or :ref:`retriable_statuses <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.retriable_statuses>`,
+  // this threshold is ignored and the host is considered immediately unhealthy.
   google.protobuf.UInt32Value unhealthy_threshold = 4 [(validate.rules).message = {required: true}];
 
   // The number of healthy health checks required before a host is marked

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/http_uri.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/http_uri.proto
@@ -11,6 +11,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.core.v3";
 option java_outer_classname = "HttpUriProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/core/v3;corev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: HTTP Service URI ]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/protocol.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/protocol.proto
@@ -8,6 +8,8 @@ import "envoy/type/v3/percent.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
+import "xds/annotations/v3/status.proto";
+
 import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -16,6 +18,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.core.v3";
 option java_outer_classname = "ProtocolProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/core/v3;corev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Protocol options]
@@ -26,11 +29,38 @@ message TcpProtocolOptions {
       "envoy.api.v2.core.TcpProtocolOptions";
 }
 
+// Config for keepalive probes in a QUIC connection.
+// Note that QUIC keep-alive probing packets work differently from HTTP/2 keep-alive PINGs in a sense that the probing packet
+// itself doesn't timeout waiting for a probing response. Quic has a shorter idle timeout than TCP, so it doesn't rely on such probing to discover dead connections. If the peer fails to respond, the connection will idle timeout eventually. Thus, they are configured differently from :ref:`connection_keepalive <envoy_v3_api_field_config.core.v3.Http2ProtocolOptions.connection_keepalive>`.
+message QuicKeepAliveSettings {
+  // The max interval for a connection to send keep-alive probing packets (with PING or PATH_RESPONSE). The value should be smaller than :ref:`connection idle_timeout <envoy_v3_api_field_config.listener.v3.QuicProtocolOptions.idle_timeout>` to prevent idle timeout while not less than 1s to avoid throttling the connection or flooding the peer with probes.
+  //
+  // If :ref:`initial_interval <envoy_v3_api_field_config.core.v3.QuicKeepAliveSettings.initial_interval>` is absent or zero, a client connection will use this value to start probing.
+  //
+  // If zero, disable keepalive probing.
+  // If absent, use the QUICHE default interval to probe.
+  google.protobuf.Duration max_interval = 1 [(validate.rules).duration = {
+    lte {}
+    gte {seconds: 1}
+  }];
+
+  // The interval to send the first few keep-alive probing packets to prevent connection from hitting the idle timeout. Subsequent probes will be sent, each one with an interval exponentially longer than previous one, till it reaches :ref:`max_interval <envoy_v3_api_field_config.core.v3.QuicKeepAliveSettings.max_interval>`. And the probes afterwards will always use :ref:`max_interval <envoy_v3_api_field_config.core.v3.QuicKeepAliveSettings.max_interval>`.
+  //
+  // The value should be smaller than :ref:`connection idle_timeout <envoy_v3_api_field_config.listener.v3.QuicProtocolOptions.idle_timeout>` to prevent idle timeout and smaller than max_interval to take effect.
+  //
+  // If absent or zero, disable keepalive probing for a server connection. For a client connection, if :ref:`max_interval <envoy_v3_api_field_config.core.v3.QuicKeepAliveSettings.max_interval>`  is also zero, do not keepalive, otherwise use max_interval or QUICHE default to probe all the time.
+  google.protobuf.Duration initial_interval = 2 [(validate.rules).duration = {
+    lte {}
+    gte {seconds: 1}
+  }];
+}
+
 // QUIC protocol options which apply to both downstream and upstream connections.
+// [#next-free-field: 6]
 message QuicProtocolOptions {
   // Maximum number of streams that the client can negotiate per connection. 100
   // if not specified.
-  google.protobuf.UInt32Value max_concurrent_streams = 1;
+  google.protobuf.UInt32Value max_concurrent_streams = 1 [(validate.rules).uint32 = {gte: 1}];
 
   // `Initial stream-level flow-control receive window
   // <https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-4.1>`_ size. Valid values range from
@@ -53,6 +83,17 @@ message QuicProtocolOptions {
   // window size now, so it's also the minimum.
   google.protobuf.UInt32Value initial_connection_window_size = 3
       [(validate.rules).uint32 = {lte: 25165824 gte: 1}];
+
+  // The number of timeouts that can occur before port migration is triggered for QUIC clients.
+  // This defaults to 1. If set to 0, port migration will not occur on path degrading.
+  // Timeout here refers to QUIC internal path degrading timeout mechanism, such as PTO.
+  // This has no effect on server sessions.
+  google.protobuf.UInt32Value num_timeouts_to_trigger_port_migration = 4
+      [(validate.rules).uint32 = {lte: 5 gte: 0}];
+
+  // Probes the peer at the configured interval to solicit traffic, i.e. ACK or PATH_RESPONSE, from the peer to push back connection idle timeout.
+  // If absent, use the default keepalive behavior of which a client connection sends PINGs every 15s, and a server connection doesn't do anything.
+  QuicKeepAliveSettings connection_keepalive = 5;
 }
 
 message UpstreamHttpProtocolOptions {
@@ -60,15 +101,26 @@ message UpstreamHttpProtocolOptions {
       "envoy.api.v2.core.UpstreamHttpProtocolOptions";
 
   // Set transport socket `SNI <https://en.wikipedia.org/wiki/Server_Name_Indication>`_ for new
-  // upstream connections based on the downstream HTTP host/authority header, as seen by the
-  // :ref:`router filter <config_http_filters_router>`.
+  // upstream connections based on the downstream HTTP host/authority header or any other arbitrary
+  // header when :ref:`override_auto_sni_header <envoy_v3_api_field_config.core.v3.UpstreamHttpProtocolOptions.override_auto_sni_header>`
+  // is set, as seen by the :ref:`router filter <config_http_filters_router>`.
   bool auto_sni = 1;
 
   // Automatic validate upstream presented certificate for new upstream connections based on the
-  // downstream HTTP host/authority header, as seen by the
-  // :ref:`router filter <config_http_filters_router>`.
-  // This field is intended to set with `auto_sni` field.
+  // downstream HTTP host/authority header or any other arbitrary header when :ref:`override_auto_sni_header <envoy_v3_api_field_config.core.v3.UpstreamHttpProtocolOptions.override_auto_sni_header>`
+  // is set, as seen by the :ref:`router filter <config_http_filters_router>`.
+  // This field is intended to be set with `auto_sni` field.
   bool auto_san_validation = 2;
+
+  // An optional alternative to the host/authority header to be used for setting the SNI value.
+  // It should be a valid downstream HTTP header, as seen by the
+  // :ref:`router filter <config_http_filters_router>`.
+  // If unset, host/authority header will be used for populating the SNI. If the specified header
+  // is not found or the value is empty, host/authority header will be used instead.
+  // This field is intended to be set with `auto_sni` and/or `auto_san_validation` fields.
+  // If none of these fields are set then setting this would be a no-op.
+  string override_auto_sni_header = 3
+      [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME ignore_empty: true}];
 }
 
 // Configures the alternate protocols cache which tracks alternate protocols that can be used to
@@ -76,6 +128,24 @@ message UpstreamHttpProtocolOptions {
 // HTTP Alternative Services and https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-04
 // for the "HTTPS" DNS resource record.
 message AlternateProtocolsCacheOptions {
+  // Allows pre-populating the cache with HTTP/3 alternate protocols entries with a 7 day lifetime.
+  // This will cause Envoy to attempt HTTP/3 to those upstreams, even if the upstreams have not
+  // advertised HTTP/3 support. These entries will be overwritten by alt-svc
+  // response headers or cached values.
+  // As with regular cached entries, if the origin response would result in clearing an existing
+  // alternate protocol cache entry, pre-populated entries will also be cleared.
+  // Adding a cache entry with hostname=foo.com port=123 is the equivalent of getting
+  // response headers
+  // alt-svc: h3=:"123"; ma=86400" in a response to a request to foo.com:123
+  message AlternateProtocolsCacheEntry {
+    // The host name for the alternate protocol entry.
+    string hostname = 1
+        [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME ignore_empty: true}];
+
+    // The port for the alternate protocol entry.
+    uint32 port = 2 [(validate.rules).uint32 = {lt: 65535 gt: 0}];
+  }
+
   // The name of the cache. Multiple named caches allow independent alternate protocols cache
   // configurations to operate within a single Envoy process using different configurations. All
   // alternate protocols cache options with the same name *must* be equal in all fields when
@@ -91,6 +161,16 @@ message AlternateProtocolsCacheOptions {
   //   it is possible for the maximum entries in the cache to go slightly above the configured
   //   value depending on timing. This is similar to how other circuit breakers work.
   google.protobuf.UInt32Value max_entries = 2 [(validate.rules).uint32 = {gt: 0}];
+
+  // Allows configuring a persistent
+  // :ref:`key value store <envoy_v3_api_msg_config.common.key_value.v3.KeyValueStoreConfig>` to flush
+  // alternate protocols entries to disk.
+  // This function is currently only supported if concurrency is 1
+  // Cached entries will take precedence over pre-populated entries below.
+  TypedExtensionConfig key_value_store_config = 3;
+
+  // Allows pre-populating the cache with entries, as described above.
+  repeated AlternateProtocolsCacheEntry prepopulated_entries = 4;
 }
 
 // [#next-free-field: 7]
@@ -112,7 +192,7 @@ message HttpProtocolOptions {
     // is incremented for each rejected request.
     REJECT_REQUEST = 1;
 
-    // Drop the header with name containing underscores. The header is dropped before the filter chain is
+    // Drop the client header with name containing underscores. The header is dropped before the filter chain is
     // invoked and as such filters will not see dropped headers. The
     // "httpN.dropped_headers_with_underscores" is incremented for each dropped header.
     DROP_HEADER = 2;
@@ -138,10 +218,10 @@ message HttpProtocolOptions {
 
   // The maximum duration of a connection. The duration is defined as a period since a connection
   // was established. If not set, there is no max duration. When max_connection_duration is reached
-  // the connection will be closed. Drain sequence will occur prior to closing the connection if
-  // if's applicable. See :ref:`drain_timeout
+  // and if there are no active streams, the connection will be closed. If the connection is a
+  // downstream connection and there are any active streams, the drain sequence will kick-in,
+  // and the connection will be force-closed after the drain period. See :ref:`drain_timeout
   // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.drain_timeout>`.
-  // Note: not implemented for upstream connections.
   google.protobuf.Duration max_connection_duration = 3;
 
   // The maximum number of headers. If unconfigured, the default
@@ -156,6 +236,8 @@ message HttpProtocolOptions {
   // Action to take when a client request with a header name containing underscore characters is received.
   // If this setting is not specified, the value defaults to ALLOW.
   // Note: upstream responses are not affected by this setting.
+  // Note: this only affects client headers. It does not affect headers added
+  // by Envoy filters and does not have any impact if added to cluster config.
   HeadersWithUnderscoresAction headers_with_underscores_action = 5;
 
   // Optional maximum requests for both upstream and downstream connections.
@@ -232,7 +314,7 @@ message Http1ProtocolOptions {
   // Allows Envoy to process requests/responses with both `Content-Length` and `Transfer-Encoding`
   // headers set. By default such messages are rejected, but if option is enabled - Envoy will
   // remove Content-Length header and process message.
-  // See `RFC7230, sec. 3.3.3 <https://tools.ietf.org/html/rfc7230#section-3.3.3>` for details.
+  // See `RFC7230, sec. 3.3.3 <https://tools.ietf.org/html/rfc7230#section-3.3.3>`_ for details.
   //
   // .. attention::
   //   Enabling this option might lead to request smuggling vulnerability, especially if traffic
@@ -270,6 +352,8 @@ message KeepaliveSettings {
   // If this is zero, this type of PING will not be sent.
   // If an interval ping is outstanding, a second ping will not be sent as the
   // interval ping will determine if the connection is dead.
+  //
+  // The same feature for HTTP/3 is given by inheritance from QUICHE which uses :ref:`connection idle_timeout <envoy_v3_api_field_config.listener.v3.QuicProtocolOptions.idle_timeout>` and the current PTO of the connection to decide whether to probe before sending a new request.
   google.protobuf.Duration connection_idle_interval = 4
       [(validate.rules).duration = {gte {nanos: 1000000}}];
 }
@@ -349,8 +433,6 @@ message Http2ProtocolOptions {
   // be written into the socket). Exceeding this limit triggers flood mitigation and connection is
   // terminated. The ``http2.outbound_flood`` stat tracks the number of terminated connections due
   // to flood mitigation. The default limit is 10000.
-  // NOTE: flood and abuse mitigation for upstream connections is presently enabled by the
-  // `envoy.reloadable_features.upstream_http2_flood_checks` flag.
   google.protobuf.UInt32Value max_outbound_frames = 7 [(validate.rules).uint32 = {gte: 1}];
 
   // Limit the number of pending outbound downstream frames of types PING, SETTINGS and RST_STREAM,
@@ -358,8 +440,6 @@ message Http2ProtocolOptions {
   // this limit triggers flood mitigation and connection is terminated. The
   // ``http2.outbound_control_flood`` stat tracks the number of terminated connections due to flood
   // mitigation. The default limit is 1000.
-  // NOTE: flood and abuse mitigation for upstream connections is presently enabled by the
-  // `envoy.reloadable_features.upstream_http2_flood_checks` flag.
   google.protobuf.UInt32Value max_outbound_control_frames = 8 [(validate.rules).uint32 = {gte: 1}];
 
   // Limit the number of consecutive inbound frames of types HEADERS, CONTINUATION and DATA with an
@@ -368,8 +448,6 @@ message Http2ProtocolOptions {
   // stat tracks the number of connections terminated due to flood mitigation.
   // Setting this to 0 will terminate connection upon receiving first frame with an empty payload
   // and no end stream flag. The default limit is 1.
-  // NOTE: flood and abuse mitigation for upstream connections is presently enabled by the
-  // `envoy.reloadable_features.upstream_http2_flood_checks` flag.
   google.protobuf.UInt32Value max_consecutive_inbound_frames_with_empty_payload = 9;
 
   // Limit the number of inbound PRIORITY frames allowed per each opened stream. If the number
@@ -383,8 +461,6 @@ message Http2ProtocolOptions {
   // `opened_streams` is incremented when Envoy send the HEADERS frame for a new stream. The
   // ``http2.inbound_priority_frames_flood`` stat tracks
   // the number of connections terminated due to flood mitigation. The default limit is 100.
-  // NOTE: flood and abuse mitigation for upstream connections is presently enabled by the
-  // `envoy.reloadable_features.upstream_http2_flood_checks` flag.
   google.protobuf.UInt32Value max_inbound_priority_frames_per_stream = 10;
 
   // Limit the number of inbound WINDOW_UPDATE frames allowed per DATA frame sent. If the number
@@ -401,8 +477,6 @@ message Http2ProtocolOptions {
   // flood mitigation. The default max_inbound_window_update_frames_per_data_frame_sent value is 10.
   // Setting this to 1 should be enough to support HTTP/2 implementations with basic flow control,
   // but more complex implementations that try to estimate available bandwidth require at least 2.
-  // NOTE: flood and abuse mitigation for upstream connections is presently enabled by the
-  // `envoy.reloadable_features.upstream_http2_flood_checks` flag.
   google.protobuf.UInt32Value max_inbound_window_update_frames_per_data_frame_sent = 11
       [(validate.rules).uint32 = {gte: 1}];
 
@@ -473,6 +547,7 @@ message GrpcProtocolOptions {
 }
 
 // A message which allows using HTTP/3.
+// [#next-free-field: 6]
 message Http3ProtocolOptions {
   QuicProtocolOptions quic_protocol_options = 1;
 
@@ -483,6 +558,14 @@ message Http3ProtocolOptions {
   // If set, this overrides any HCM :ref:`stream_error_on_invalid_http_messaging
   // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.stream_error_on_invalid_http_message>`.
   google.protobuf.BoolValue override_stream_error_on_invalid_http_message = 2;
+
+  // Allows proxying Websocket and other upgrades over HTTP/3 CONNECT using
+  // the header mechanisms from the `HTTP/2 extended connect RFC
+  // <https://datatracker.ietf.org/doc/html/rfc8441>`_
+  // and settings `proposed for HTTP/3
+  // <https://datatracker.ietf.org/doc/draft-ietf-httpbis-h3-websockets/>`_
+  // Note that HTTP/3 CONNECT is not yet an RFC.
+  bool allow_extended_connect = 5 [(xds.annotations.v3.field_status).work_in_progress = true];
 }
 
 // A message to control transformations to the :scheme header

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/proxy_protocol.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/proxy_protocol.proto
@@ -7,6 +7,7 @@ import "udpa/annotations/status.proto";
 option java_package = "io.envoyproxy.envoy.config.core.v3";
 option java_outer_classname = "ProxyProtocolProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/core/v3;corev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Proxy Protocol]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/resolver.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/resolver.proto
@@ -10,6 +10,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.core.v3";
 option java_outer_classname = "ResolverProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/core/v3;corev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Resolver]
@@ -17,9 +18,6 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Configuration of DNS resolver option flags which control the behavior of the DNS resolver.
 message DnsResolverOptions {
   // Use TCP for all DNS queries instead of the default protocol UDP.
-  // Setting this value causes failure if the
-  // ``envoy.restart_features.use_apple_api_for_dns_lookups`` runtime value is true during
-  // server startup. Apple's API only uses UDP for DNS resolution.
   bool use_tcp_for_dns_lookups = 1;
 
   // Do not use the default search domains; only query hostnames as-is or as aliases.
@@ -31,9 +29,6 @@ message DnsResolutionConfig {
   // A list of dns resolver addresses. If specified, the DNS client library will perform resolution
   // via the underlying DNS resolvers. Otherwise, the default system resolvers
   // (e.g., /etc/resolv.conf) will be used.
-  // Setting this value causes failure if the
-  // ``envoy.restart_features.use_apple_api_for_dns_lookups`` runtime value is true during
-  // server startup. Apple's API only allows overriding DNS resolvers via system settings.
   repeated Address resolvers = 1 [(validate.rules).repeated = {min_items: 1}];
 
   // Configuration of DNS resolver option flags which control the behavior of the DNS resolver.

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/socket_option.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/socket_option.proto
@@ -9,6 +9,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.core.v3";
 option java_outer_classname = "SocketOptionProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/core/v3;corev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Socket Option ]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/substitution_format_string.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/substitution_format_string.proto
@@ -14,6 +14,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.core.v3";
 option java_outer_classname = "SubstitutionFormatStringProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/core/v3;corev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Substitution format string]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/udp_socket_config.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/udp_socket_config.proto
@@ -10,6 +10,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.core.v3";
 option java_outer_classname = "UdpSocketConfigProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/core/v3;corev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: UDP socket config]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/endpoint/v3/endpoint.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/endpoint/v3/endpoint.proto
@@ -15,6 +15,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.endpoint.v3";
 option java_outer_classname = "EndpointProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3;endpointv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Endpoint configuration]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/endpoint/v3/endpoint_components.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/endpoint/v3/endpoint_components.proto
@@ -9,7 +9,6 @@ import "envoy/config/core/v3/health_check.proto";
 
 import "google/protobuf/wrappers.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -17,6 +16,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.endpoint.v3";
 option java_outer_classname = "EndpointComponentsProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3;endpointv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Endpoints]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/endpoint/v3/load_report.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/endpoint/v3/load_report.proto
@@ -15,6 +15,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.endpoint.v3";
 option java_outer_classname = "LoadReportProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3;endpointv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Load Report]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/filter/accesslog/v2/accesslog.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/filter/accesslog/v2/accesslog.proto
@@ -16,6 +16,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.filter.accesslog.v2";
 option java_outer_classname = "AccesslogProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2;accesslogv2";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.accesslog.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/config/filter/fault/v2/fault.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/filter/fault/v2/fault.proto
@@ -14,6 +14,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.filter.fault.v2";
 option java_outer_classname = "FaultProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/filter/fault/v2;faultv2";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.filters.common.fault.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/config/filter/http/fault/v2/fault.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/filter/http/fault/v2/fault.proto
@@ -15,6 +15,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.filter.http.fault.v2";
 option java_outer_classname = "FaultProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/fault/v2;faultv2";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.filters.http.fault.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/config/filter/http/router/v2/router.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/filter/http/router/v2/router.proto
@@ -13,6 +13,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.filter.http.router.v2";
 option java_outer_classname = "RouterProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/router/v2;routerv2";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.filters.http.router.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -24,6 +24,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.filter.network.http_connection_manager.v2";
 option java_outer_classname = "HttpConnectionManagerProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2;http_connection_managerv2";
 option (udpa.annotations.file_migrate).move_to_package =
     "envoy.extensions.filters.network.http_connection_manager.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;

--- a/xds/third_party/envoy/src/main/proto/envoy/config/listener/v2/api_listener.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/listener/v2/api_listener.proto
@@ -10,6 +10,7 @@ import "udpa/annotations/status.proto";
 option java_package = "io.envoyproxy.envoy.config.listener.v2";
 option java_outer_classname = "ApiListenerProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/listener/v2;listenerv2";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.listener.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/api_listener.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/api_listener.proto
@@ -10,6 +10,7 @@ import "udpa/annotations/versioning.proto";
 option java_package = "io.envoyproxy.envoy.config.listener.v3";
 option java_outer_classname = "ApiListenerProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3;listenerv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: API listener]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/listener.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/listener.proto
@@ -24,6 +24,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.listener.v3";
 option java_outer_classname = "ListenerProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3;listenerv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Listener configuration]
@@ -35,7 +36,7 @@ message ListenerCollection {
   repeated xds.core.v3.CollectionEntry entries = 1;
 }
 
-// [#next-free-field: 30]
+// [#next-free-field: 32]
 message Listener {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Listener";
 
@@ -153,7 +154,6 @@ message Listener {
   // UDP Listener filters can be specified when the protocol in the listener socket address in
   // :ref:`protocol <envoy_v3_api_field_config.core.v3.SocketAddress.protocol>` is :ref:`UDP
   // <envoy_v3_api_enum_value_config.core.v3.SocketAddress.Protocol.UDP>`.
-  // UDP listeners currently support a single filter.
   repeated ListenerFilter listener_filters = 9;
 
   // The timeout to wait for all listener filters to complete operation. If the timeout is reached,
@@ -315,4 +315,12 @@ message Listener {
     // [#not-implemented-hide:]
     InternalListenerConfig internal_listener = 27;
   }
+
+  // Enable MPTCP (multi-path TCP) on this listener. Clients will be allowed to establish
+  // MPTCP connections. Non-MPTCP clients will fall back to regular TCP.
+  bool enable_mptcp = 30;
+
+  // Whether the listener should limit connections based upon the value of
+  // :ref:`global_downstream_max_connections <config_overload_manager_limiting_connections>`.
+  bool ignore_global_conn_limit = 31;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/listener_components.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/listener_components.proto
@@ -33,8 +33,7 @@ message Filter {
 
   reserved "config";
 
-  // The name of the filter to instantiate. The name must match a
-  // :ref:`supported filter <config_network_filters>`.
+  // The name of the filter configuration.
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
   oneof config_type {
@@ -343,8 +342,7 @@ message ListenerFilter {
 
   reserved "config";
 
-  // The name of the filter to instantiate. The name must match a
-  // :ref:`supported filter <config_listener_filters>`.
+  // The name of the filter configuration.
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
   oneof config_type {

--- a/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/listener_components.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/listener_components.proto
@@ -4,7 +4,7 @@ package envoy.config.listener.v3;
 
 import "envoy/config/core/v3/address.proto";
 import "envoy/config/core/v3/base.proto";
-import "envoy/config/core/v3/extension.proto";
+import "envoy/config/core/v3/config_source.proto";
 import "envoy/type/v3/range.proto";
 
 import "google/protobuf/any.proto";
@@ -19,6 +19,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.listener.v3";
 option java_outer_classname = "ListenerComponentsProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3;listenerv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Listener components]
@@ -333,6 +334,7 @@ message ListenerFilterChainMatchPredicate {
   }
 }
 
+// [#next-free-field: 6]
 message ListenerFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.listener.ListenerFilter";
@@ -350,6 +352,12 @@ message ListenerFilter {
     // instantiated. See the supported filters for further documentation.
     // [#extension-category: envoy.filters.listener,envoy.filters.udp_listener]
     google.protobuf.Any typed_config = 3;
+
+    // Configuration source specifier for an extension configuration discovery
+    // service. In case of a failure and without the default configuration, the
+    // listener closes the connections.
+    // [#not-implemented-hide:]
+    core.v3.ExtensionConfigSource config_discovery = 5;
   }
 
   // Optional match predicate used to disable the filter. The filter is enabled when this field is empty.

--- a/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/quic_config.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/quic_config.proto
@@ -16,6 +16,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.listener.v3";
 option java_outer_classname = "QuicConfigProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3;listenerv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: QUIC listener config]
@@ -29,11 +30,14 @@ message QuicProtocolOptions {
   core.v3.QuicProtocolOptions quic_protocol_options = 1;
 
   // Maximum number of milliseconds that connection will be alive when there is
-  // no network activity. 300000ms if not specified.
+  // no network activity.
+  //
+  // If it is less than 1ms, Envoy will use 1ms. 300000ms if not specified.
   google.protobuf.Duration idle_timeout = 2;
 
   // Connection timeout in milliseconds before the crypto handshake is finished.
-  // 20000ms if not specified.
+  //
+  // If it is less than 5000ms, Envoy will use 5000ms. 20000ms if not specified.
   google.protobuf.Duration crypto_handshake_timeout = 3;
 
   // Runtime flag that controls whether the listener is enabled or not. If not specified, defaults

--- a/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/udp_listener_config.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/udp_listener_config.proto
@@ -11,6 +11,7 @@ import "udpa/annotations/versioning.proto";
 option java_package = "io.envoyproxy.envoy.config.listener.v3";
 option java_outer_classname = "UdpListenerConfigProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3;listenerv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: UDP listener config]
@@ -33,10 +34,6 @@ message UdpListenerConfig {
 
   // Configuration for QUIC protocol. If empty, QUIC will not be enabled on this listener. Set
   // to the default object to enable QUIC without modifying any additional options.
-  //
-  // .. warning::
-  //   QUIC support is currently alpha and should be used with caution. Please
-  //   see :ref:`here <arch_overview_http3>` for details.
   QuicProtocolOptions quic_options = 7;
 }
 

--- a/xds/third_party/envoy/src/main/proto/envoy/config/metrics/v3/stats.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/metrics/v3/stats.proto
@@ -15,6 +15,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.metrics.v3";
 option java_outer_classname = "StatsProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/metrics/v3;metricsv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Stats]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/overload/v3/overload.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/overload/v3/overload.proto
@@ -14,6 +14,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.overload.v3";
 option java_outer_classname = "OverloadProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/overload/v3;overloadv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Overload Manager]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/rbac/v2/rbac.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/rbac/v2/rbac.proto
@@ -16,6 +16,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.rbac.v2";
 option java_outer_classname = "RbacProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v2;rbacv2";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Role Based Access Control (RBAC)]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/rbac/v3/rbac.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/rbac/v3/rbac.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.config.rbac.v3;
 
 import "envoy/config/core/v3/address.proto";
+import "envoy/config/core/v3/extension.proto";
 import "envoy/config/route/v3/route_components.proto";
 import "envoy/type/matcher/v3/metadata.proto";
 import "envoy/type/matcher/v3/path.proto";
@@ -21,6 +22,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.rbac.v3";
 option java_outer_classname = "RbacProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3;rbacv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Role Based Access Control (RBAC)]
@@ -146,7 +148,7 @@ message Policy {
 }
 
 // Permission defines an action (or actions) that a principal can take.
-// [#next-free-field: 12]
+// [#next-free-field: 13]
 message Permission {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.rbac.v2.Permission";
 
@@ -218,6 +220,10 @@ message Permission {
     // Please refer to :ref:`this FAQ entry <faq_how_to_setup_sni>` to learn to
     // setup SNI.
     type.matcher.v3.StringMatcher requested_server_name = 9;
+
+    // Extension for configuring custom matchers for RBAC.
+    // [#extension-category: envoy.rbac.matchers]
+    core.v3.TypedExtensionConfig matcher = 12;
   }
 }
 

--- a/xds/third_party/envoy/src/main/proto/envoy/config/route/v3/route.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/route/v3/route.proto
@@ -16,13 +16,14 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.route.v3";
 option java_outer_classname = "RouteProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/route/v3;routev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: HTTP route configuration]
 // * Routing :ref:`architecture overview <arch_overview_http_routing>`
 // * HTTP :ref:`router filter <config_http_filters_router>`
 
-// [#next-free-field: 13]
+// [#next-free-field: 14]
 message RouteConfiguration {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.RouteConfiguration";
 
@@ -126,12 +127,23 @@ message RouteConfiguration {
   // :ref:`envoy_v3_api_field_config.route.v3.RouteAction.cluster_specifier_plugin`
   // within the route. All *extension.name* fields in this list must be unique.
   repeated ClusterSpecifierPlugin cluster_specifier_plugins = 12;
+
+  // Specify a set of default request mirroring policies which apply to all routes under its virtual hosts.
+  // Note that policies are not merged, the most specific non-empty one becomes the mirror policies.
+  repeated RouteAction.RequestMirrorPolicy request_mirror_policies = 13;
 }
 
 // Configuration for a cluster specifier plugin.
 message ClusterSpecifierPlugin {
   // The name of the plugin and its opaque configuration.
   core.v3.TypedExtensionConfig extension = 1;
+
+  // If is_optional is not set and the plugin defined by this message is not
+  // a supported type, the containing resource is NACKed. If is_optional is
+  // set, the resource would not be NACKed for this reason. In this case,
+  // routes referencing this plugin's name would not be treated as an illegal
+  // configuration, but would result in a failure if the route is selected.
+  bool is_optional = 2;
 }
 
 message Vhds {

--- a/xds/third_party/envoy/src/main/proto/envoy/config/route/v3/route_components.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/route/v3/route_components.proto
@@ -453,7 +453,7 @@ message WeightedCluster {
   }
 }
 
-// [#next-free-field: 14]
+// [#next-free-field: 15]
 message RouteMatch {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.RouteMatch";
 
@@ -518,6 +518,17 @@ message RouteMatch {
     // Note that CONNECT support is currently considered alpha in Envoy.
     // [#comment: TODO(htuch): Replace the above comment with an alpha tag.]
     ConnectMatcher connect_matcher = 12;
+
+    // If specified, the route is a path-separated prefix rule meaning that the
+    // ``:path`` header (without the query string) must either exactly match the
+    // ``path_separated_prefix`` or have it as a prefix, followed by ``/``
+    //
+    // For example, ``/api/dev`` would match
+    // ``/api/dev``, ``/api/dev/``, ``/api/dev/v1``, and ``/api/dev?param=true``
+    // but would not match ``/api/developer``
+    //
+    // Expect the value to not contain ``?`` or ``#`` and not to end in ``/``
+    string path_separated_prefix = 14 [(validate.rules).string = {pattern: "^[^?#]+[^?#/]$"}];
   }
 
   // Indicates that prefix/path matching should be case sensitive. The default

--- a/xds/third_party/envoy/src/main/proto/envoy/config/route/v3/route_components.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/route/v3/route_components.proto
@@ -5,6 +5,7 @@ package envoy.config.route.v3;
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/extension.proto";
 import "envoy/config/core/v3/proxy_protocol.proto";
+import "envoy/type/matcher/v3/metadata.proto";
 import "envoy/type/matcher/v3/regex.proto";
 import "envoy/type/matcher/v3/string.proto";
 import "envoy/type/metadata/v3/metadata.proto";
@@ -16,6 +17,9 @@ import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
+import "xds/annotations/v3/status.proto";
+import "xds/type/matcher/v3/matcher.proto";
+
 import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
@@ -25,6 +29,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.route.v3";
 option java_outer_classname = "RouteComponentsProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/route/v3;routev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: HTTP route components]
@@ -36,7 +41,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // host header. This allows a single listener to service multiple top level domain path trees. Once
 // a virtual host is selected based on the domain, the routes are processed in order to see which
 // upstream cluster to route to or whether to perform a redirect.
-// [#next-free-field: 21]
+// [#next-free-field: 23]
 message VirtualHost {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.VirtualHost";
 
@@ -86,7 +91,14 @@ message VirtualHost {
 
   // The list of routes that will be matched, in order, for incoming requests.
   // The first route that matches will be used.
+  // Only one of this and `matcher` can be specified.
   repeated Route routes = 3;
+
+  // [#next-major-version: This should be included in a oneof with routes wrapped in a message.]
+  // The match tree to use when resolving route actions for incoming requests. Only one of this and `routes`
+  // can be specified.
+  xds.type.matcher.v3.Matcher matcher = 21
+      [(xds.annotations.v3.field_status).work_in_progress = true];
 
   // Specifies the type of TLS enforcement the virtual host expects. If this option is not
   // specified, there is no TLS requirement for the virtual host.
@@ -186,6 +198,11 @@ message VirtualHost {
   // If set and a route-specific limit is not set, the bytes actually buffered will be the minimum
   // value of this and the listener per_connection_buffer_limit_bytes.
   google.protobuf.UInt32Value per_request_buffer_limit_bytes = 18;
+
+  // Specify a set of default request mirroring policies for every route under this virtual host.
+  // It takes precedence over the route config mirror policy entirely.
+  // That is, policies are not merged, the most specific non-empty one becomes the mirror policies.
+  repeated RouteAction.RequestMirrorPolicy request_mirror_policies = 22;
 }
 
 // A filter-defined action type.
@@ -311,7 +328,7 @@ message Route {
 message WeightedCluster {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.WeightedCluster";
 
-  // [#next-free-field: 12]
+  // [#next-free-field: 13]
   message ClusterWeight {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.route.WeightedCluster.ClusterWeight";
@@ -320,9 +337,31 @@ message WeightedCluster {
 
     reserved "per_filter_config";
 
+    // Only one of *name* and *cluster_header* may be specified.
+    // [#next-major-version: Need to add back the validation rule: (validate.rules).string = {min_len: 1}]
     // Name of the upstream cluster. The cluster must exist in the
     // :ref:`cluster manager configuration <config_cluster_manager>`.
-    string name = 1 [(validate.rules).string = {min_len: 1}];
+    string name = 1 [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
+
+    // Only one of *name* and *cluster_header* may be specified.
+    // [#next-major-version: Need to add back the validation rule: (validate.rules).string = {min_len: 1 }]
+    // Envoy will determine the cluster to route to by reading the value of the
+    // HTTP header named by cluster_header from the request headers. If the
+    // header is not found or the referenced cluster does not exist, Envoy will
+    // return a 404 response.
+    //
+    // .. attention::
+    //
+    //   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1
+    //   *Host* header. Thus, if attempting to match on *Host*, match on *:authority* instead.
+    //
+    // .. note::
+    //
+    //   If the header appears multiple times only the first value is used.
+    string cluster_header = 12 [
+      (validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false},
+      (udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"
+    ];
 
     // An integer between 0 and :ref:`total_weight
     // <envoy_v3_api_field_config.route.v3.WeightedCluster.total_weight>`. When a request matches the route,
@@ -403,9 +442,18 @@ message WeightedCluster {
   // configuration file will be used as the default weight. See the :ref:`runtime documentation
   // <operations_runtime>` for how key names map to the underlying implementation.
   string runtime_key_prefix = 2;
+
+  oneof random_value_specifier {
+    // Specifies the header name that is used to look up the random value passed in the request header.
+    // This is used to ensure consistent cluster picking across multiple proxy levels for weighted traffic.
+    // If header is not present or invalid, Envoy will fall back to use the internally generated random value.
+    // This header is expected to be single-valued header as we only want to have one selected value throughout
+    // the process for the consistency. And the value is a unsigned number between 0 and UINT64_MAX.
+    string header_name = 4;
+  }
 }
 
-// [#next-free-field: 13]
+// [#next-free-field: 14]
 message RouteMatch {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.RouteMatch";
 
@@ -506,6 +554,14 @@ message RouteMatch {
   // against all the specified query parameters. If the number of specified
   // query parameters is nonzero, they all must match the *path* header's
   // query string for a match to occur.
+  //
+  // .. note::
+  //
+  //    If query parameters are used to pass request message fields when
+  //    `grpc_json_transcoder <https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/grpc_json_transcoder_filter>`_
+  //    is used, the transcoded message fields maybe different. The query parameters are
+  //    url encoded, but the message fields are not. For example, if a query
+  //    parameter is "foo%20bar", the message field will be "foo bar".
   repeated QueryParameterMatcher query_parameters = 7;
 
   // If specified, only gRPC requests will be matched. The router will check
@@ -518,6 +574,12 @@ message RouteMatch {
   //
   // [#next-major-version: unify with RBAC]
   TlsContextMatchOptions tls_context = 11;
+
+  // Specifies a set of dynamic metadata matchers on which the route should match.
+  // The router will check the dynamic metadata against all the specified dynamic metadata matchers.
+  // If the number of specified dynamic metadata matchers is nonzero, they all must match the
+  // dynamic metadata for a match to occur.
+  repeated type.matcher.v3.MetadataMatcher dynamic_metadata = 13;
 }
 
 // [#next-free-field: 12]
@@ -570,7 +632,7 @@ message CorsPolicy {
   core.v3.RuntimeFractionalPercent shadow_enabled = 10;
 }
 
-// [#next-free-field: 38]
+// [#next-free-field: 39]
 message RouteAction {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.RouteAction";
 
@@ -705,8 +767,8 @@ message RouteAction {
           "envoy.api.v2.route.RouteAction.HashPolicy.FilterState";
 
       // The name of the Object in the per-request filterState, which is an
-      // Envoy::Http::Hashable object. If there is no data associated with the key,
-      // or the stored object is not Envoy::Http::Hashable, no hash will be produced.
+      // Envoy::Hashable object. If there is no data associated with the key,
+      // or the stored object is not Envoy::Hashable, no hash will be produced.
       string key = 1 [(validate.rules).string = {min_len: 1}];
     }
 
@@ -934,20 +996,29 @@ message RouteAction {
 
   oneof host_rewrite_specifier {
     // Indicates that during forwarding, the host header will be swapped with
-    // this value.
+    // this value. Using this option will append the
+    // :ref:`config_http_conn_man_headers_x-forwarded-host` header if
+    // :ref:`append_x_forwarded_host <envoy_v3_api_field_config.route.v3.RouteAction.append_x_forwarded_host>`
+    // is set.
     string host_rewrite_literal = 6
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
     // Indicates that during forwarding, the host header will be swapped with
     // the hostname of the upstream host chosen by the cluster manager. This
     // option is applicable only when the destination cluster for a route is of
-    // type *strict_dns* or *logical_dns*. Setting this to true with other cluster
-    // types has no effect.
+    // type *strict_dns* or *logical_dns*. Setting this to true with other cluster types
+    // has no effect. Using this option will append the
+    // :ref:`config_http_conn_man_headers_x-forwarded-host` header if
+    // :ref:`append_x_forwarded_host <envoy_v3_api_field_config.route.v3.RouteAction.append_x_forwarded_host>`
+    // is set.
     google.protobuf.BoolValue auto_host_rewrite = 7;
 
     // Indicates that during forwarding, the host header will be swapped with the content of given
     // downstream or :ref:`custom <config_http_conn_man_headers_custom_request_headers>` header.
-    // If header value is empty, host header is left intact.
+    // If header value is empty, host header is left intact. Using this option will append the
+    // :ref:`config_http_conn_man_headers_x-forwarded-host` header if
+    // :ref:`append_x_forwarded_host <envoy_v3_api_field_config.route.v3.RouteAction.append_x_forwarded_host>`
+    // is set.
     //
     // .. attention::
     //
@@ -963,6 +1034,10 @@ message RouteAction {
     // Indicates that during forwarding, the host header will be swapped with
     // the result of the regex substitution executed on path value with query and fragment removed.
     // This is useful for transitioning variable content between path segment and subdomain.
+    // Using this option will append the
+    // :ref:`config_http_conn_man_headers_x-forwarded-host` header if
+    // :ref:`append_x_forwarded_host <envoy_v3_api_field_config.route.v3.RouteAction.append_x_forwarded_host>`
+    // is set.
     //
     // For example with the following config:
     //
@@ -977,6 +1052,15 @@ message RouteAction {
     // Would rewrite the host header to `envoyproxy.io` given the path `/envoyproxy.io/some/path`.
     type.matcher.v3.RegexMatchAndSubstitute host_rewrite_path_regex = 35;
   }
+
+  // If set, then a host rewrite action (one of
+  // :ref:`host_rewrite_literal <envoy_v3_api_field_config.route.v3.RouteAction.host_rewrite_literal>`,
+  // :ref:`auto_host_rewrite <envoy_v3_api_field_config.route.v3.RouteAction.auto_host_rewrite>`,
+  // :ref:`host_rewrite_header <envoy_v3_api_field_config.route.v3.RouteAction.host_rewrite_header>`, or
+  // :ref:`host_rewrite_path_regex <envoy_v3_api_field_config.route.v3.RouteAction.host_rewrite_path_regex>`)
+  // causes the original value of the host header, if any, to be appended to the
+  // :ref:`config_http_conn_man_headers_x-forwarded-host` HTTP header.
+  bool append_x_forwarded_host = 38;
 
   // Specifies the upstream timeout for the route. If not specified, the default is 15s. This
   // spans between the point at which the entire downstream request (i.e. end-of-stream) has been
@@ -1027,7 +1111,9 @@ message RouteAction {
   // should not be set if this field is used.
   google.protobuf.Any retry_policy_typed_config = 33;
 
-  // Indicates that the route has request mirroring policies.
+  // Specify a set of route request mirroring policies.
+  // It takes precedence over the virtual host and route config mirror policy entirely.
+  // That is, policies are not merged, the most specific non-empty one becomes the mirror policies.
   repeated RequestMirrorPolicy request_mirror_policies = 30;
 
   // Optionally specifies the :ref:`routing priority <arch_overview_http_routing_priority>`.
@@ -1135,7 +1221,7 @@ message RouteAction {
 }
 
 // HTTP retry :ref:`architecture overview <arch_overview_http_routing_retry>`.
-// [#next-free-field: 12]
+// [#next-free-field: 14]
 message RetryPolicy {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.RetryPolicy";
 
@@ -1276,8 +1362,8 @@ message RetryPolicy {
   google.protobuf.UInt32Value num_retries = 2
       [(udpa.annotations.field_migrate).rename = "max_retries"];
 
-  // Specifies a non-zero upstream timeout per retry attempt. This parameter is optional. The
-  // same conditions documented for
+  // Specifies a non-zero upstream timeout per retry attempt (including the initial attempt). This
+  // parameter is optional. The same conditions documented for
   // :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms` apply.
   //
   // .. note::
@@ -1289,6 +1375,27 @@ message RetryPolicy {
   //   would have been exhausted.
   google.protobuf.Duration per_try_timeout = 3;
 
+  // Specifies an upstream idle timeout per retry attempt (including the initial attempt). This
+  // parameter is optional and if absent there is no per try idle timeout. The semantics of the per
+  // try idle timeout are similar to the
+  // :ref:`route idle timeout <envoy_v3_api_field_config.route.v3.RouteAction.timeout>` and
+  // :ref:`stream idle timeout
+  // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.stream_idle_timeout>`
+  // both enforced by the HTTP connection manager. The difference is that this idle timeout
+  // is enforced by the router for each individual attempt and thus after all previous filters have
+  // run, as opposed to *before* all previous filters run for the other idle timeouts. This timeout
+  // is useful in cases in which total request timeout is bounded by a number of retries and a
+  // :ref:`per_try_timeout <envoy_v3_api_field_config.route.v3.RetryPolicy.per_try_timeout>`, but
+  // there is a desire to ensure each try is making incremental progress. Note also that similar
+  // to :ref:`per_try_timeout <envoy_v3_api_field_config.route.v3.RetryPolicy.per_try_timeout>`,
+  // this idle timeout does not start until after both the entire request has been received by the
+  // router *and* a connection pool connection has been obtained. Unlike
+  // :ref:`per_try_timeout <envoy_v3_api_field_config.route.v3.RetryPolicy.per_try_timeout>`,
+  // the idle timer continues once the response starts streaming back to the downstream client.
+  // This ensures that response data continues to make progress without using one of the HTTP
+  // connection manager idle timeouts.
+  google.protobuf.Duration per_try_idle_timeout = 13;
+
   // Specifies an implementation of a RetryPriority which is used to determine the
   // distribution of load across priorities used for retries. Refer to
   // :ref:`retry plugin configuration <arch_overview_http_retry_plugins>` for more details.
@@ -1299,6 +1406,11 @@ message RetryPolicy {
   // Refer to :ref:`retry plugin configuration <arch_overview_http_retry_plugins>` for more
   // details.
   repeated RetryHostPredicate retry_host_predicate = 5;
+
+  // Retry options predicates that will be applied prior to retrying a request. These predicates
+  // allow customizing request behavior between retries.
+  // [#comment: add [#extension-category: envoy.retry_options_predicates] when there are built-in extensions]
+  repeated core.v3.TypedExtensionConfig retry_options_predicates = 12;
 
   // The maximum number of times host selection will be reattempted before giving up, at which
   // point the host that was last selected will be routed to. If unspecified, this will default to
@@ -1477,7 +1589,7 @@ message DirectResponseAction {
       "envoy.api.v2.route.DirectResponseAction";
 
   // Specifies the HTTP response status to be returned.
-  uint32 status = 1 [(validate.rules).uint32 = {lt: 600 gte: 100}];
+  uint32 status = 1 [(validate.rules).uint32 = {lt: 600 gte: 200}];
 
   // Specifies the content of the response body. If this setting is omitted,
   // no body is included in the generated response.
@@ -1687,6 +1799,9 @@ message RateLimit {
     message HeaderValueMatch {
       option (udpa.annotations.versioning).previous_message_type =
           "envoy.api.v2.route.RateLimit.Action.HeaderValueMatch";
+
+      // The key to use in the descriptor entry. Defaults to `header_match`.
+      string descriptor_key = 4;
 
       // The value to use in the descriptor entry.
       string descriptor_value = 1 [(validate.rules).string = {min_len: 1}];

--- a/xds/third_party/envoy/src/main/proto/envoy/config/route/v3/scoped_route.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/route/v3/scoped_route.proto
@@ -2,6 +2,9 @@ syntax = "proto3";
 
 package envoy.config.route.v3;
 
+import "envoy/config/route/v3/route.proto";
+
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -9,6 +12,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.route.v3";
 option java_outer_classname = "ScopedRouteProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/route/v3;routev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: HTTP scoped routing configuration]
@@ -16,7 +20,10 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // Specifies a routing scope, which associates a
 // :ref:`Key<envoy_v3_api_msg_config.route.v3.ScopedRouteConfiguration.Key>` to a
-// :ref:`envoy_v3_api_msg_config.route.v3.RouteConfiguration` (identified by its resource name).
+// :ref:`envoy_v3_api_msg_config.route.v3.RouteConfiguration`.
+// The :ref:`envoy_v3_api_msg_config.route.v3.RouteConfiguration` can be obtained dynamically
+// via RDS (:ref:`route_configuration_name<envoy_v3_api_field_config.route.v3.ScopedRouteConfiguration.route_configuration_name>`)
+// or specified inline (:ref:`route_configuration<envoy_v3_api_field_config.route.v3.ScopedRouteConfiguration.route_configuration>`).
 //
 // The HTTP connection manager builds up a table consisting of these Key to
 // RouteConfiguration mappings, and looks up the RouteConfiguration to use per
@@ -73,6 +80,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // would result in the routing table defined by the `route-config1`
 // RouteConfiguration being assigned to the HTTP request/stream.
 //
+// [#next-free-field: 6]
 message ScopedRouteConfiguration {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.ScopedRouteConfiguration";
@@ -113,7 +121,12 @@ message ScopedRouteConfiguration {
   // The resource name to use for a :ref:`envoy_v3_api_msg_service.discovery.v3.DiscoveryRequest` to an
   // RDS server to fetch the :ref:`envoy_v3_api_msg_config.route.v3.RouteConfiguration` associated
   // with this scope.
-  string route_configuration_name = 2 [(validate.rules).string = {min_len: 1}];
+  string route_configuration_name = 2
+      [(udpa.annotations.field_migrate).oneof_promotion = "route_config"];
+
+  // The :ref:`envoy_v3_api_msg_config.route.v3.RouteConfiguration` associated with the scope.
+  RouteConfiguration route_configuration = 5
+      [(udpa.annotations.field_migrate).oneof_promotion = "route_config"];
 
   // The key to match against.
   Key key = 3 [(validate.rules).message = {required: true}];

--- a/xds/third_party/envoy/src/main/proto/envoy/config/trace/v2/datadog.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/trace/v2/datadog.proto
@@ -8,6 +8,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.trace.v2";
 option java_outer_classname = "DatadogProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/trace/v2;tracev2";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Datadog tracer]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/trace/v2/dynamic_ot.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/trace/v2/dynamic_ot.proto
@@ -10,6 +10,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.trace.v2";
 option java_outer_classname = "DynamicOtProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/trace/v2;tracev2";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Dynamically loadable OpenTracing tracer]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/trace/v2/http_tracer.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/trace/v2/http_tracer.proto
@@ -11,6 +11,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.trace.v2";
 option java_outer_classname = "HttpTracerProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/trace/v2;tracev2";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Tracing]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/trace/v2/lightstep.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/trace/v2/lightstep.proto
@@ -8,6 +8,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.trace.v2";
 option java_outer_classname = "LightstepProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/trace/v2;tracev2";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: LightStep tracer]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/trace/v2/opencensus.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/trace/v2/opencensus.proto
@@ -11,6 +11,7 @@ import "udpa/annotations/status.proto";
 option java_package = "io.envoyproxy.envoy.config.trace.v2";
 option java_outer_classname = "OpencensusProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/trace/v2;tracev2";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: OpenCensus tracer]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/trace/v2/service.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/trace/v2/service.proto
@@ -10,6 +10,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.trace.v2";
 option java_outer_classname = "ServiceProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/trace/v2;tracev2";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Trace Service]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/trace/v2/trace.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/trace/v2/trace.proto
@@ -13,3 +13,4 @@ import public "envoy/config/trace/v2/zipkin.proto";
 option java_package = "io.envoyproxy.envoy.config.trace.v2";
 option java_outer_classname = "TraceProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/trace/v2;tracev2";

--- a/xds/third_party/envoy/src/main/proto/envoy/config/trace/v2/zipkin.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/trace/v2/zipkin.proto
@@ -11,6 +11,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.trace.v2";
 option java_outer_classname = "ZipkinProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/trace/v2;tracev2";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Zipkin tracer]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/datadog.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/datadog.proto
@@ -10,6 +10,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.trace.v3";
 option java_outer_classname = "DatadogProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3;tracev3";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.tracers.datadog.v4alpha";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/dynamic_ot.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/dynamic_ot.proto
@@ -12,6 +12,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.trace.v3";
 option java_outer_classname = "DynamicOtProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3;tracev3";
 option (udpa.annotations.file_migrate).move_to_package =
     "envoy.extensions.tracers.dynamic_ot.v4alpha";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;

--- a/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/http_tracer.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/http_tracer.proto
@@ -11,6 +11,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.trace.v3";
 option java_outer_classname = "HttpTracerProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3;tracev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Tracing]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/lightstep.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/lightstep.proto
@@ -13,6 +13,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.trace.v3";
 option java_outer_classname = "LightstepProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3;tracev3";
 option (udpa.annotations.file_migrate).move_to_package =
     "envoy.extensions.tracers.lightstep.v4alpha";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;

--- a/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/opencensus.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/opencensus.proto
@@ -14,6 +14,7 @@ import "udpa/annotations/versioning.proto";
 option java_package = "io.envoyproxy.envoy.config.trace.v3";
 option java_outer_classname = "OpencensusProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3;tracev3";
 option (udpa.annotations.file_migrate).move_to_package =
     "envoy.extensions.tracers.opencensus.v4alpha";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;

--- a/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/service.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/service.proto
@@ -11,6 +11,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.trace.v3";
 option java_outer_classname = "ServiceProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3;tracev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Trace Service]

--- a/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/trace.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/trace.proto
@@ -13,3 +13,4 @@ import public "envoy/config/trace/v3/zipkin.proto";
 option java_package = "io.envoyproxy.envoy.config.trace.v3";
 option java_outer_classname = "TraceProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3;tracev3";

--- a/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/zipkin.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/zipkin.proto
@@ -13,6 +13,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.config.trace.v3";
 option java_outer_classname = "ZipkinProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3;tracev3";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.tracers.zipkin.v4alpha";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
@@ -50,8 +51,7 @@ message ZipkinConfig {
   string collector_cluster = 1 [(validate.rules).string = {min_len: 1}];
 
   // The API endpoint of the Zipkin service where the spans will be sent. When
-  // using a standard Zipkin installation, the API endpoint is typically
-  // /api/v1/spans, which is the default value.
+  // using a standard Zipkin installation.
   string collector_endpoint = 2 [(validate.rules).string = {min_len: 1}];
 
   // Determines whether a 128bit trace id will be used when creating a new
@@ -62,8 +62,7 @@ message ZipkinConfig {
   // The default value is true.
   google.protobuf.BoolValue shared_span_context = 4;
 
-  // Determines the selected collector endpoint version. By default, the ``HTTP_JSON_V1`` will be
-  // used.
+  // Determines the selected collector endpoint version.
   CollectorEndpointVersion collector_endpoint_version = 5;
 
   // Optional hostname to use when sending spans to the collector_cluster. Useful for collectors

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/clusters/aggregate/v3/cluster.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/clusters/aggregate/v3/cluster.proto
@@ -9,6 +9,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.clusters.aggregate.v3";
 option java_outer_classname = "ClusterProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/aggregate/v3;aggregatev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Aggregate cluster configuration]

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/common/fault/v3/fault.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/common/fault/v3/fault.proto
@@ -13,6 +13,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.common.fault.v3";
 option java_outer_classname = "FaultProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/common/fault/v3;faultv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Common fault injection types]

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/http/fault/v3/fault.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/http/fault/v3/fault.proto
@@ -15,6 +15,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.fault.v3";
 option java_outer_classname = "FaultProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/fault/v3;faultv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Fault Injection]

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/http/rbac/v3/rbac.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/http/rbac/v3/rbac.proto
@@ -10,6 +10,7 @@ import "udpa/annotations/versioning.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.rbac.v3";
 option java_outer_classname = "RbacProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/rbac/v3;rbacv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: RBAC]

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/http/router/v3/router.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/http/router/v3/router.proto
@@ -13,6 +13,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.router.v3";
 option java_outer_classname = "RouterProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3;routerv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Router]

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -28,13 +28,14 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3";
 option java_outer_classname = "HttpConnectionManagerProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3;http_connection_managerv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: HTTP connection manager]
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 // [#extension: envoy.filters.network.http_connection_manager]
 
-// [#next-free-field: 49]
+// [#next-free-field: 50]
 message HttpConnectionManager {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager";
@@ -299,6 +300,54 @@ message HttpConnectionManager {
     // respond with 400 to paths that are malformed (e.g. for paths that fail RFC 3986
     // normalization due to disallowed characters.)
     type.http.v3.PathTransformation http_filter_transformation = 2;
+  }
+
+  // Configures the manner in which the Proxy-Status HTTP response header is
+  // populated.
+  //
+  // See the [Proxy-Status
+  // RFC](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-proxy-status-08).
+  // [#comment:TODO: Update this with the non-draft URL when finalized.]
+  //
+  // The Proxy-Status header is a string of the form:
+  //
+  //   "<server_name>; error=<error_type>; details=<details>"
+  // [#next-free-field: 7]
+  message ProxyStatusConfig {
+    // If true, the details field of the Proxy-Status header is not populated with stream_info.response_code_details.
+    // This value defaults to `false`, i.e. the `details` field is populated by default.
+    bool remove_details = 1;
+
+    // If true, the details field of the Proxy-Status header will not contain
+    // connection termination details. This value defaults to `false`, i.e. the
+    // `details` field will contain connection termination details by default.
+    bool remove_connection_termination_details = 2;
+
+    // If true, the details field of the Proxy-Status header will not contain an
+    // enumeration of the Envoy ResponseFlags. This value defaults to `false`,
+    // i.e. the `details` field will contain a list of ResponseFlags by default.
+    bool remove_response_flags = 3;
+
+    // If true, overwrites the existing Status header with the response code
+    // recommended by the Proxy-Status spec.
+    // This value defaults to `false`, i.e. the HTTP response code is not
+    // overwritten.
+    bool set_recommended_response_code = 4;
+
+    // The name of the proxy as it appears at the start of the Proxy-Status
+    // header.
+    //
+    // If neither of these values are set, this value defaults to `server_name`,
+    // which itself defaults to "envoy".
+    oneof proxy_name {
+      // If `use_node_id` is set, Proxy-Status headers will use the Envoy's node
+      // ID as the name of the proxy.
+      bool use_node_id = 5;
+
+      // If `literal_proxy_name` is set, Proxy-Status headers will use this
+      // value as the name of the proxy.
+      string literal_proxy_name = 6;
+    }
   }
 
   reserved 27, 11;
@@ -706,6 +755,11 @@ message HttpConnectionManager {
   // setting this option will strip a trailing dot, if present, from the host section,
   // leaving the port as is (e.g. host value `example.com.:443` will be updated to `example.com:443`).
   bool strip_trailing_host_dot = 47;
+
+  // Proxy-Status HTTP response header configuration.
+  // If this config is set, the Proxy-Status HTTP response header field is
+  // populated. By default, it is not.
+  ProxyStatusConfig proxy_status_config = 49;
 }
 
 // The configuration to customize local reply returned by Envoy.
@@ -911,7 +965,7 @@ message ScopedRoutes {
   // Configuration source specifier for RDS.
   // This config source is used to subscribe to RouteConfiguration resources specified in
   // ScopedRouteConfiguration messages.
-  config.core.v3.ConfigSource rds_config_source = 3 [(validate.rules).message = {required: true}];
+  config.core.v3.ConfigSource rds_config_source = 3;
 
   oneof config_specifier {
     option (validate.required) = true;

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.extensions.filters.network.http_connection_manager.v3;
 
 import "envoy/config/accesslog/v3/accesslog.proto";
+import "envoy/config/core/v3/address.proto";
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/config_source.proto";
 import "envoy/config/core/v3/extension.proto";
@@ -202,6 +203,10 @@ message HttpConnectionManager {
 
     // Whether unix socket addresses should be considered internal.
     bool unix_sockets = 1;
+
+    // List of CIDR ranges that are treated as internal. If unset, then RFC1918 / RFC4193
+    // IP addresses will be considered internal.
+    repeated config.core.v3.CidrRange cidr_ranges = 2;
   }
 
   // [#next-free-field: 7]
@@ -1008,9 +1013,7 @@ message HttpFilter {
 
   reserved "config";
 
-  // The name of the filter configuration. The name is used as a fallback to
-  // select an extension if the type of the configuration proto is not
-  // sufficient. It also serves as a resource name in ExtensionConfigDS.
+  // The name of the filter configuration. It also serves as a resource name in ExtensionConfigDS.
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
   oneof config_type {

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/cert.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/cert.proto
@@ -9,3 +9,4 @@ import public "envoy/extensions/transport_sockets/tls/v3/tls.proto";
 option java_package = "io.envoyproxy.envoy.extensions.transport_sockets.tls.v3";
 option java_outer_classname = "CertProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3;tlsv3";

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -288,7 +288,7 @@ message SubjectAltNameMatcher {
   type.matcher.v3.StringMatcher matcher = 2 [(validate.rules).message = {required: true}];
 }
 
-// [#next-free-field: 16]
+// [#next-free-field: 17]
 message CertificateValidationContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.auth.CertificateValidationContext";
@@ -486,4 +486,11 @@ message CertificateValidationContext {
   // If this option is set to true, only the certificate at the end of the
   // certificate chain will be subject to validation by :ref:`CRL <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.crl>`.
   bool only_verify_leaf_cert_crl = 14;
+
+  // Config for the max number of intermediate certificates in chain that are parsed during verification.
+  // This does not include the leaf certificate. If configured, and the certificate chain is longer than allowed, the certificates
+  // above the limit are ignored, and certificate validation will fail. The default limit is 100,
+  // though this can be system-dependent.
+  // https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_verify_depth.html
+  google.protobuf.UInt32Value max_verify_depth = 16 [(validate.rules).uint32 = {lte: 100}];
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -9,6 +9,7 @@ import "envoy/type/matcher/v3/string.proto";
 import "google/protobuf/any.proto";
 import "google/protobuf/wrappers.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";
@@ -18,6 +19,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.transport_sockets.tls.v3";
 option java_outer_classname = "CommonProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3;tlsv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Common TLS configuration]
@@ -42,8 +44,7 @@ message TlsParameters {
     TLSv1_3 = 4;
   }
 
-  // Minimum TLS protocol version. By default, it's ``TLSv1_2`` for clients and ``TLSv1_0`` for
-  // servers.
+  // Minimum TLS protocol version. By default, it's ``TLSv1_2`` for both clients and servers.
   TlsProtocol tls_minimum_protocol_version = 1 [(validate.rules).enum = {defined_only: true}];
 
   // Maximum TLS protocol version. By default, it's ``TLSv1_2`` for clients and ``TLSv1_3`` for
@@ -149,7 +150,7 @@ message PrivateKeyProvider {
   }
 }
 
-// [#next-free-field: 8]
+// [#next-free-field: 9]
 message TlsCertificate {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.auth.TlsCertificate";
 
@@ -167,6 +168,21 @@ message TlsCertificate {
   // directory for any file moves to support rotation. This currently only
   // applies to dynamic secrets, when the *TlsCertificate* is delivered via SDS.
   config.core.v3.DataSource private_key = 2 [(udpa.annotations.sensitive) = true];
+
+  // `Pkcs12` data containing TLS certificate, chain, and private key.
+  //
+  // If *pkcs12* is a filesystem path, the file will be read, but no watch will
+  // be added to the parent directory, since *pkcs12* isn't used by SDS.
+  // This field is mutually exclusive with *certificate_chain*, *private_key* and *private_key_provider*.
+  // This can't be marked as ``oneof`` due to API compatibility reasons. Setting
+  // both :ref:`private_key <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsCertificate.private_key>`,
+  // :ref:`certificate_chain <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsCertificate.certificate_chain>`,
+  // or :ref:`private_key_provider <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsCertificate.private_key_provider>`
+  // and :ref:`pkcs12 <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsCertificate.pkcs12>`
+  // fields will result in an error. Use :ref:`password
+  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsCertificate.password>`
+  // to specify the password to unprotect the `PKCS12` data, if necessary.
+  config.core.v3.DataSource pkcs12 = 8 [(udpa.annotations.sensitive) = true];
 
   // If specified, updates of file-based *certificate_chain* and *private_key*
   // sources will be triggered by this watch. The certificate/key pair will be
@@ -253,7 +269,26 @@ message CertificateProviderPluginInstance {
   string certificate_name = 2;
 }
 
-// [#next-free-field: 14]
+// Matcher for subject alternative names, to match both type and value of the SAN.
+message SubjectAltNameMatcher {
+  // Indicates the choice of GeneralName as defined in section 4.2.1.5 of RFC 5280 to match
+  // against.
+  enum SanType {
+    SAN_TYPE_UNSPECIFIED = 0;
+    EMAIL = 1;
+    DNS = 2;
+    URI = 3;
+    IP_ADDRESS = 4;
+  }
+
+  // Specification of type of SAN. Note that the default enum value is an invalid choice.
+  SanType san_type = 1 [(validate.rules).enum = {defined_only: true not_in: 0}];
+
+  // Matcher for SAN value.
+  type.matcher.v3.StringMatcher matcher = 2 [(validate.rules).message = {required: true}];
+}
+
+// [#next-free-field: 16]
 message CertificateValidationContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.auth.CertificateValidationContext";
@@ -283,8 +318,8 @@ message CertificateValidationContext {
   // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.verify_certificate_spki>`,
   // :ref:`verify_certificate_hash
   // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.verify_certificate_hash>`, or
-  // :ref:`match_subject_alt_names
-  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_subject_alt_names>`) is also
+  // :ref:`match_typed_subject_alt_names
+  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_typed_subject_alt_names>`) is also
   // specified.
   //
   // It can optionally contain certificate revocation lists, in which case Envoy will verify
@@ -292,6 +327,9 @@ message CertificateValidationContext {
   // that if a CRL is provided for any certificate authority in a trust chain, a CRL must be
   // provided for all certificate authorities in that chain. Failure to do so will result in
   // verification failure for both revoked and unrevoked certificates from that chain.
+  // The behavior of requiring all certificates to contain CRLs if any do can be altered by
+  // setting :ref:`only_verify_leaf_cert_crl <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.only_verify_leaf_cert_crl>`
+  // true. If set to true, only the final certificate in the chain undergoes CRL verification.
   //
   // See :ref:`the TLS overview <arch_overview_ssl_enabling_verification>` for a list of common
   // system CA locations.
@@ -388,6 +426,8 @@ message CertificateValidationContext {
 
   // An optional list of Subject Alternative name matchers. If specified, Envoy will verify that the
   // Subject Alternative Name of the presented certificate matches one of the specified matchers.
+  // The matching uses "any" semantics, that is to say, the SAN is verified if at least one matcher is
+  // matched.
   //
   // When a certificate has wildcard DNS SAN entries, to match a specific client, it should be
   // configured with exact match type in the :ref:`string matcher <envoy_v3_api_msg_type.matcher.v3.StringMatcher>`.
@@ -396,15 +436,22 @@ message CertificateValidationContext {
   //
   // .. code-block:: yaml
   //
-  //  match_subject_alt_names:
-  //    exact: "api.example.com"
+  //  match_typed_subject_alt_names:
+  //  - san_type: DNS
+  //    matcher:
+  //      exact: "api.example.com"
   //
   // .. attention::
   //
   //   Subject Alternative Names are easily spoofable and verifying only them is insecure,
   //   therefore this option must be used together with :ref:`trusted_ca
   //   <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
-  repeated type.matcher.v3.StringMatcher match_subject_alt_names = 9;
+  repeated SubjectAltNameMatcher match_typed_subject_alt_names = 15;
+
+  // This field is deprecated in favor of ref:`match_typed_subject_alt_names
+  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_typed_subject_alt_names>`
+  repeated type.matcher.v3.StringMatcher match_subject_alt_names = 9
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // [#not-implemented-hide:] Must present signed certificate time-stamp.
   google.protobuf.BoolValue require_signed_certificate_timestamp = 6;
@@ -417,7 +464,9 @@ message CertificateValidationContext {
   // for any certificate authority in a trust chain, a CRL must be provided
   // for all certificate authorities in that chain. Failure to do so will
   // result in verification failure for both revoked and unrevoked certificates
-  // from that chain.
+  // from that chain. This default behavior can be altered by setting
+  // :ref:`only_verify_leaf_cert_crl <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.only_verify_leaf_cert_crl>` to
+  // true.
   config.core.v3.DataSource crl = 7;
 
   // If specified, Envoy will not reject expired certificates.
@@ -433,4 +482,8 @@ message CertificateValidationContext {
   // Refer to the documentation for the specified validator. If you do not want a custom validation algorithm, do not set this field.
   // [#extension-category: envoy.tls.cert_validator]
   config.core.v3.TypedExtensionConfig custom_validator_config = 12;
+
+  // If this option is set to true, only the certificate at the end of the
+  // certificate chain will be subject to validation by :ref:`CRL <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.crl>`.
+  bool only_verify_leaf_cert_crl = 14;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/secret.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/secret.proto
@@ -14,6 +14,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.transport_sockets.tls.v3";
 option java_outer_classname = "SecretProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3;tlsv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Secrets configuration]

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -131,8 +131,6 @@ message TlsKeyLog {
   // The path to save the TLS key log.
   string path = 1 [(validate.rules).string = {min_len: 1}];
 
-  // At least one of src or dst must be specified, or the config will be rejected as invalid.
-
   // The local IP address that will be used to filter the connection which should save the TLS key log
   // If it is not set, any local IP address  will be matched.
   repeated config.core.v3.CidrRange local_address_range = 2;

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package envoy.extensions.transport_sockets.tls.v3;
 
+import "envoy/config/core/v3/address.proto";
 import "envoy/config/core/v3/extension.proto";
 import "envoy/extensions/transport_sockets/tls/v3/common.proto";
 import "envoy/extensions/transport_sockets/tls/v3/secret.proto";
@@ -17,6 +18,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.transport_sockets.tls.v3";
 option java_outer_classname = "TlsProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3;tlsv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: TLS transport socket]
@@ -109,10 +111,9 @@ message DownstreamTlsContext {
     bool disable_stateless_session_resumption = 7;
   }
 
-  // If specified, session_timeout will change maximum lifetime (in seconds) of TLS session
-  // Currently this value is used as a hint to `TLS session ticket lifetime (for TLSv1.2)
-  // <https://tools.ietf.org/html/rfc5077#section-5.6>`
-  // only seconds could be specified (fractional seconds are going to be ignored).
+  // If specified, ``session_timeout`` will change the maximum lifetime (in seconds) of the TLS session.
+  // Currently this value is used as a hint for the `TLS session ticket lifetime (for TLSv1.2) <https://tools.ietf.org/html/rfc5077#section-5.6>`_.
+  // Only seconds can be specified (fractional seconds are ignored).
   google.protobuf.Duration session_timeout = 6 [(validate.rules).duration = {
     lt {seconds: 4294967296}
     gte {}
@@ -124,8 +125,25 @@ message DownstreamTlsContext {
   OcspStaplePolicy ocsp_staple_policy = 8 [(validate.rules).enum = {defined_only: true}];
 }
 
+// TLS key log configuration.
+// The key log file format is "format used by NSS for its SSLKEYLOGFILE debugging output" (text taken from openssl man page)
+message TlsKeyLog {
+  // The path to save the TLS key log.
+  string path = 1 [(validate.rules).string = {min_len: 1}];
+
+  // At least one of src or dst must be specified, or the config will be rejected as invalid.
+
+  // The local IP address that will be used to filter the connection which should save the TLS key log
+  // If it is not set, any local IP address  will be matched.
+  repeated config.core.v3.CidrRange local_address_range = 2;
+
+  // The remote IP address that will be used to filter the connection which should save the TLS key log
+  // If it is not set, any remote IP address will be matched.
+  repeated config.core.v3.CidrRange remote_address_range = 3;
+}
+
 // TLS context shared by both client and server TLS contexts.
-// [#next-free-field: 15]
+// [#next-free-field: 16]
 message CommonTlsContext {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.auth.CommonTlsContext";
 
@@ -299,4 +317,7 @@ message CommonTlsContext {
   // Custom TLS handshaker. If empty, defaults to native TLS handshaking
   // behavior.
   config.core.v3.TypedExtensionConfig custom_handshaker = 13;
+
+  // TLS key log configuration
+  TlsKeyLog key_log = 15;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/service/discovery/v2/ads.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/service/discovery/v2/ads.proto
@@ -9,17 +9,18 @@ import "udpa/annotations/status.proto";
 option java_package = "io.envoyproxy.envoy.service.discovery.v2";
 option java_outer_classname = "AdsProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2;discoveryv2";
 option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Aggregated Discovery Service (ADS)]
 
-// [#not-implemented-hide:] Discovery services for endpoints, clusters, routes,
+// Discovery services for endpoints, clusters, routes,
 // and listeners are retained in the package `envoy.api.v2` for backwards
 // compatibility with existing management servers. New development in discovery
 // services should proceed in the package `envoy.service.discovery.v2`.
 
-// See https://github.com/lyft/envoy-api#apis for a description of the role of
+// See https://github.com/envoyproxy/envoy-api#apis for a description of the role of
 // ADS and how it is intended to be used by a management server. ADS requests
 // have the same structure as their singleton xDS counterparts, but can
 // multiplex many resource types on a single stream. The type_url in the

--- a/xds/third_party/envoy/src/main/proto/envoy/service/discovery/v2/sds.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/service/discovery/v2/sds.proto
@@ -13,6 +13,7 @@ import "udpa/annotations/status.proto";
 option java_package = "io.envoyproxy.envoy.service.discovery.v2";
 option java_outer_classname = "SdsProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2;discoveryv2";
 option java_generic_services = true;
 option (udpa.annotations.file_migrate).move_to_package = "envoy.service.secret.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;

--- a/xds/third_party/envoy/src/main/proto/envoy/service/discovery/v3/ads.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/service/discovery/v3/ads.proto
@@ -10,17 +10,18 @@ import "udpa/annotations/versioning.proto";
 option java_package = "io.envoyproxy.envoy.service.discovery.v3";
 option java_outer_classname = "AdsProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3;discoveryv3";
 option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Aggregated Discovery Service (ADS)]
 
-// [#not-implemented-hide:] Discovery services for endpoints, clusters, routes,
+// Discovery services for endpoints, clusters, routes,
 // and listeners are retained in the package `envoy.api.v2` for backwards
 // compatibility with existing management servers. New development in discovery
 // services should proceed in the package `envoy.service.discovery.v2`.
 
-// See https://github.com/lyft/envoy-api#apis for a description of the role of
+// See https://github.com/envoyproxy/envoy-api#apis for a description of the role of
 // ADS and how it is intended to be used by a management server. ADS requests
 // have the same structure as their singleton xDS counterparts, but can
 // multiplex many resource types on a single stream. The type_url in the

--- a/xds/third_party/envoy/src/main/proto/envoy/service/discovery/v3/discovery.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/service/discovery/v3/discovery.proto
@@ -14,6 +14,7 @@ import "udpa/annotations/versioning.proto";
 option java_package = "io.envoyproxy.envoy.service.discovery.v3";
 option java_outer_classname = "DiscoveryProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3;discoveryv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Common discovery API components]

--- a/xds/third_party/envoy/src/main/proto/envoy/service/load_stats/v2/lrs.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/service/load_stats/v2/lrs.proto
@@ -12,6 +12,7 @@ import "udpa/annotations/status.proto";
 option java_package = "io.envoyproxy.envoy.service.load_stats.v2";
 option java_outer_classname = "LrsProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v2;load_statsv2";
 option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/service/load_stats/v3/lrs.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/service/load_stats/v3/lrs.proto
@@ -13,6 +13,7 @@ import "udpa/annotations/versioning.proto";
 option java_package = "io.envoyproxy.envoy.service.load_stats.v3";
 option java_outer_classname = "LrsProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v3;load_statsv3";
 option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/service/status/v3/csds.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/service/status/v3/csds.proto
@@ -17,6 +17,7 @@ import "udpa/annotations/versioning.proto";
 option java_package = "io.envoyproxy.envoy.service.status.v3";
 option java_outer_classname = "CsdsProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/status/v3;statusv3";
 option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/type/http.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/http.proto
@@ -7,6 +7,7 @@ import "udpa/annotations/status.proto";
 option java_package = "io.envoyproxy.envoy.type";
 option java_outer_classname = "HttpProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: HTTP]

--- a/xds/third_party/envoy/src/main/proto/envoy/type/http/v3/path_transformation.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/http/v3/path_transformation.proto
@@ -8,6 +8,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.type.http.v3";
 option java_outer_classname = "PathTransformationProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/http/v3;httpv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Path Transformations API]

--- a/xds/third_party/envoy/src/main/proto/envoy/type/matcher/metadata.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/matcher/metadata.proto
@@ -10,6 +10,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.type.matcher";
 option java_outer_classname = "MetadataProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/matcher";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Metadata matcher]

--- a/xds/third_party/envoy/src/main/proto/envoy/type/matcher/number.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/matcher/number.proto
@@ -10,6 +10,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.type.matcher";
 option java_outer_classname = "NumberProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/matcher";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Number matcher]

--- a/xds/third_party/envoy/src/main/proto/envoy/type/matcher/path.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/matcher/path.proto
@@ -10,6 +10,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.type.matcher";
 option java_outer_classname = "PathProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/matcher";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Path matcher]

--- a/xds/third_party/envoy/src/main/proto/envoy/type/matcher/regex.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/matcher/regex.proto
@@ -10,6 +10,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.type.matcher";
 option java_outer_classname = "RegexProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/matcher";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Regex matcher]

--- a/xds/third_party/envoy/src/main/proto/envoy/type/matcher/string.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/matcher/string.proto
@@ -11,6 +11,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.type.matcher";
 option java_outer_classname = "StringProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/matcher";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: String matcher]

--- a/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/metadata.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/metadata.proto
@@ -11,6 +11,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.type.matcher.v3";
 option java_outer_classname = "MetadataProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3;matcherv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Metadata matcher]
@@ -101,4 +102,7 @@ message MetadataMatcher {
 
   // The MetadataMatcher is matched if the value retrieved by path is matched to this value.
   ValueMatcher value = 3 [(validate.rules).message = {required: true}];
+
+  // If true, the match result will be inverted.
+  bool invert = 4;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/node.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/node.proto
@@ -11,6 +11,7 @@ import "udpa/annotations/versioning.proto";
 option java_package = "io.envoyproxy.envoy.type.matcher.v3";
 option java_outer_classname = "NodeProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3;matcherv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Node matcher]

--- a/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/number.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/number.proto
@@ -11,6 +11,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.type.matcher.v3";
 option java_outer_classname = "NumberProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3;matcherv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Number matcher]

--- a/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/path.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/path.proto
@@ -11,6 +11,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.type.matcher.v3";
 option java_outer_classname = "PathProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3;matcherv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Path matcher]

--- a/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/regex.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/regex.proto
@@ -62,7 +62,8 @@ message RegexMatcher {
     GoogleRE2 google_re2 = 1 [(validate.rules).message = {required: true}];
   }
 
-  // The regex match string. The string must be supported by the configured engine.
+  // The regex match string. The string must be supported by the configured engine. The regex is matched
+  // against the full string, not as a partial match.
   string regex = 2 [(validate.rules).string = {min_len: 1}];
 }
 

--- a/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/regex.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/regex.proto
@@ -12,6 +12,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.type.matcher.v3";
 option java_outer_classname = "RegexProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3;matcherv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Regex matcher]
@@ -44,6 +45,12 @@ message RegexMatcher {
     //
     // This field is deprecated; regexp validation should be performed on the management server
     // instead of being done by each individual client.
+    //
+    // .. note::
+    //
+    //  Although this field is deprecated, the program size will still be checked against the
+    //  global ``re2.max_program_size.error_level`` runtime value.
+    //
     google.protobuf.UInt32Value max_program_size = 1
         [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
   }

--- a/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/string.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/string.proto
@@ -11,6 +11,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.type.matcher.v3";
 option java_outer_classname = "StringProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3;matcherv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: String matcher]

--- a/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/struct.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/struct.proto
@@ -11,6 +11,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.type.matcher.v3";
 option java_outer_classname = "StructProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3;matcherv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Struct matcher]

--- a/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/value.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/value.proto
@@ -12,6 +12,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.type.matcher.v3";
 option java_outer_classname = "ValueProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3;matcherv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Value matcher]

--- a/xds/third_party/envoy/src/main/proto/envoy/type/matcher/value.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/matcher/value.proto
@@ -11,6 +11,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.type.matcher";
 option java_outer_classname = "ValueProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/matcher";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Value matcher]

--- a/xds/third_party/envoy/src/main/proto/envoy/type/metadata/v2/metadata.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/metadata/v2/metadata.proto
@@ -9,6 +9,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.type.metadata.v2";
 option java_outer_classname = "MetadataProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/metadata/v2;metadatav2";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.type.metadata.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/type/metadata/v3/metadata.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/metadata/v3/metadata.proto
@@ -9,6 +9,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.type.metadata.v3";
 option java_outer_classname = "MetadataProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/metadata/v3;metadatav3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Metadata]

--- a/xds/third_party/envoy/src/main/proto/envoy/type/percent.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/percent.proto
@@ -8,6 +8,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.type";
 option java_outer_classname = "PercentProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Percent]

--- a/xds/third_party/envoy/src/main/proto/envoy/type/range.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/range.proto
@@ -7,6 +7,7 @@ import "udpa/annotations/status.proto";
 option java_package = "io.envoyproxy.envoy.type";
 option java_outer_classname = "RangeProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Range]

--- a/xds/third_party/envoy/src/main/proto/envoy/type/semantic_version.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/semantic_version.proto
@@ -7,6 +7,7 @@ import "udpa/annotations/status.proto";
 option java_package = "io.envoyproxy.envoy.type";
 option java_outer_classname = "SemanticVersionProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Semantic Version]

--- a/xds/third_party/envoy/src/main/proto/envoy/type/tracing/v2/custom_tag.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/tracing/v2/custom_tag.proto
@@ -10,6 +10,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.type.tracing.v2";
 option java_outer_classname = "CustomTagProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/tracing/v2;tracingv2";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Custom Tag]

--- a/xds/third_party/envoy/src/main/proto/envoy/type/tracing/v3/custom_tag.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/tracing/v3/custom_tag.proto
@@ -11,6 +11,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.type.tracing.v3";
 option java_outer_classname = "CustomTagProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/tracing/v3;tracingv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Custom Tag]

--- a/xds/third_party/envoy/src/main/proto/envoy/type/v3/http.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/v3/http.proto
@@ -7,6 +7,7 @@ import "udpa/annotations/status.proto";
 option java_package = "io.envoyproxy.envoy.type.v3";
 option java_outer_classname = "HttpProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/v3;typev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: HTTP]

--- a/xds/third_party/envoy/src/main/proto/envoy/type/v3/percent.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/v3/percent.proto
@@ -9,6 +9,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.type.v3";
 option java_outer_classname = "PercentProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/v3;typev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Percent]

--- a/xds/third_party/envoy/src/main/proto/envoy/type/v3/range.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/v3/range.proto
@@ -8,6 +8,7 @@ import "udpa/annotations/versioning.proto";
 option java_package = "io.envoyproxy.envoy.type.v3";
 option java_outer_classname = "RangeProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/v3;typev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Range]

--- a/xds/third_party/envoy/src/main/proto/envoy/type/v3/semantic_version.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/v3/semantic_version.proto
@@ -8,6 +8,7 @@ import "udpa/annotations/versioning.proto";
 option java_package = "io.envoyproxy.envoy.type.v3";
 option java_outer_classname = "SemanticVersionProto";
 option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/v3;typev3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Semantic Version]

--- a/xds/third_party/protoc-gen-validate/import.sh
+++ b/xds/third_party/protoc-gen-validate/import.sh
@@ -16,9 +16,9 @@
 # Update GIT_ORIGIN_REV_ID then in this directory run ./import.sh
 
 set -e
-BRANCH=master
+BRANCH=main
 # import GIT_ORIGIN_REV_ID from one of the google internal CLs
-GIT_ORIGIN_REV_ID=ab56c3dd1cf9b516b62c5087e1ec1471bd63631e
+GIT_ORIGIN_REV_ID=dfcdc5ea103dda467963fb7079e4df28debcfd28
 GIT_REPO="https://github.com/envoyproxy/protoc-gen-validate.git"
 GIT_BASE_DIR=protoc-gen-validate
 SOURCE_PROTO_BASE_DIR=protoc-gen-validate

--- a/xds/third_party/protoc-gen-validate/src/main/proto/validate/validate.proto
+++ b/xds/third_party/protoc-gen-validate/src/main/proto/validate/validate.proto
@@ -13,6 +13,8 @@ extend google.protobuf.MessageOptions {
     // Disabled nullifies any validation rules for this message, including any
     // message fields associated with it that do support validation.
     optional bool disabled = 1071;
+    // Ignore skips generation of validation methods for this message.
+    optional bool ignored = 1072;
 }
 
 // Validation rules applied at the oneof level
@@ -93,6 +95,10 @@ message FloatRules {
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
     repeated float not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
 }
 
 // DoubleRules describes the constraints applied to `double` values
@@ -125,6 +131,10 @@ message DoubleRules {
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
     repeated double not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
 }
 
 // Int32Rules describes the constraints applied to `int32` values
@@ -157,6 +167,10 @@ message Int32Rules {
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
     repeated int32 not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
 }
 
 // Int64Rules describes the constraints applied to `int64` values
@@ -189,6 +203,10 @@ message Int64Rules {
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
     repeated int64 not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
 }
 
 // UInt32Rules describes the constraints applied to `uint32` values
@@ -221,6 +239,10 @@ message UInt32Rules {
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
     repeated uint32 not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
 }
 
 // UInt64Rules describes the constraints applied to `uint64` values
@@ -253,6 +275,10 @@ message UInt64Rules {
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
     repeated uint64 not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
 }
 
 // SInt32Rules describes the constraints applied to `sint32` values
@@ -285,6 +311,10 @@ message SInt32Rules {
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
     repeated sint32 not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
 }
 
 // SInt64Rules describes the constraints applied to `sint64` values
@@ -317,6 +347,10 @@ message SInt64Rules {
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
     repeated sint64 not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
 }
 
 // Fixed32Rules describes the constraints applied to `fixed32` values
@@ -349,6 +383,10 @@ message Fixed32Rules {
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
     repeated fixed32 not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
 }
 
 // Fixed64Rules describes the constraints applied to `fixed64` values
@@ -381,6 +419,10 @@ message Fixed64Rules {
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
     repeated fixed64 not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
 }
 
 // SFixed32Rules describes the constraints applied to `sfixed32` values
@@ -413,6 +455,10 @@ message SFixed32Rules {
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
     repeated sfixed32 not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
 }
 
 // SFixed64Rules describes the constraints applied to `sfixed64` values
@@ -445,6 +491,10 @@ message SFixed64Rules {
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
     repeated sfixed64 not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
 }
 
 // BoolRules describes the constraints applied to `bool` values
@@ -474,7 +524,6 @@ message StringRules {
     optional uint64 max_len = 3;
 
     // LenBytes specifies that this field must be the specified number of bytes
-    // at a minimum
     optional uint64 len_bytes = 20;
 
     // MinBytes specifies that this field must be the specified number of bytes
@@ -564,6 +613,10 @@ message StringRules {
   // Setting to false will enable a looser validations that only disallows
   // \r\n\0 characters, which can be used to bypass header matching rules.
   optional bool strict = 25 [default = true];
+
+  // IgnoreEmpty specifies that the validation rules of this field should be
+  // evaluated only if the field is not empty
+  optional bool ignore_empty = 26;
 }
 
 // WellKnownRegex contain some well-known patterns.
@@ -633,6 +686,10 @@ message BytesRules {
         // format
         bool ipv6 = 12;
     }
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 14;
 }
 
 // EnumRules describe the constraints applied to enum values
@@ -683,6 +740,10 @@ message RepeatedRules {
     // Repeated message fields will still execute validation against each item
     // unless skip is specified here.
     optional FieldRules items = 4;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 5;
 }
 
 // MapRules describe the constraints applied to `map` values
@@ -706,6 +767,10 @@ message MapRules {
     // in the field. Message values will still have their validations evaluated
     // unless skip is specified here.
     optional FieldRules values = 5;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 6;
 }
 
 // AnyRules describe constraints applied exclusively to the

--- a/xds/third_party/xds/import.sh
+++ b/xds/third_party/xds/import.sh
@@ -26,26 +26,26 @@ TARGET_PROTO_BASE_DIR=src/main/proto
 # Sorted alphabetically.
 FILES=(
 udpa/annotations/migrate.proto
-xds/annotations/v3/migrate.proto
 udpa/annotations/security.proto
-xds/annotations/v3/security.proto
 udpa/annotations/security.proto
-xds/annotations/v3/security.proto
 udpa/annotations/sensitive.proto
-xds/annotations/v3/sensitive.proto
 udpa/annotations/status.proto
-xds/annotations/v3/status.proto
 udpa/annotations/versioning.proto
-xds/annotations/v3/versioning.proto
-xds/data/orca/v3/orca_load_report.proto
-xds/service/orca/v3/orca.proto
 udpa/type/v1/typed_struct.proto
-xds/type/v3/typed_struct.proto
+xds/annotations/v3/migrate.proto
+xds/annotations/v3/security.proto
+xds/annotations/v3/security.proto
+xds/annotations/v3/sensitive.proto
+xds/annotations/v3/status.proto
+xds/annotations/v3/versioning.proto
 xds/core/v3/authority.proto
 xds/core/v3/collection_entry.proto
 xds/core/v3/context_params.proto
 xds/core/v3/resource_locator.proto
 xds/core/v3/resource_name.proto
+xds/data/orca/v3/orca_load_report.proto
+xds/service/orca/v3/orca.proto
+xds/type/v3/typed_struct.proto
 )
 
 pushd `git rev-parse --show-toplevel`/xds/third_party/xds

--- a/xds/third_party/xds/import.sh
+++ b/xds/third_party/xds/import.sh
@@ -18,7 +18,7 @@
 set -e
 BRANCH=main
 # import VERSION from one of the google internal CLs
-VERSION=cb28da3451f158a947dfc45090fe92b07b243bc1
+VERSION=d92e9ce0af512a73a3a126b32fa4920bee12e180
 GIT_REPO="https://github.com/cncf/xds.git"
 GIT_BASE_DIR=xds
 SOURCE_PROTO_BASE_DIR=xds
@@ -41,10 +41,14 @@ xds/annotations/v3/versioning.proto
 xds/core/v3/authority.proto
 xds/core/v3/collection_entry.proto
 xds/core/v3/context_params.proto
+xds/core/v3/extension.proto
 xds/core/v3/resource_locator.proto
 xds/core/v3/resource_name.proto
 xds/data/orca/v3/orca_load_report.proto
 xds/service/orca/v3/orca.proto
+xds/type/matcher/v3/matcher.proto
+xds/type/matcher/v3/regex.proto
+xds/type/matcher/v3/string.proto
 xds/type/v3/typed_struct.proto
 )
 

--- a/xds/third_party/xds/src/main/proto/xds/core/v3/extension.proto
+++ b/xds/third_party/xds/src/main/proto/xds/core/v3/extension.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package xds.core.v3;
+
+option java_outer_classname = "ExtensionProto";
+option java_multiple_files = true;
+option java_package = "com.github.xds.core.v3";
+option go_package = "github.com/cncf/xds/go/xds/core/v3";
+
+import "validate/validate.proto";
+import "google/protobuf/any.proto";
+
+// Message type for extension configuration.
+message TypedExtensionConfig {
+  // The name of an extension. This is not used to select the extension, instead
+  // it serves the role of an opaque identifier.
+  string name = 1 [(validate.rules).string = {min_len: 1}];
+
+  // The typed config for the extension. The type URL will be used to identify
+  // the extension. In the case that the type URL is *xds.type.v3.TypedStruct*
+  // (or, for historical reasons, *udpa.type.v1.TypedStruct*), the inner type
+  // URL of *TypedStruct* will be utilized. See the
+  // :ref:`extension configuration overview
+  // <config_overview_extension_configuration>` for further details.
+  google.protobuf.Any typed_config = 2 [(validate.rules).any = {required: true}];
+}

--- a/xds/third_party/xds/src/main/proto/xds/type/matcher/v3/matcher.proto
+++ b/xds/third_party/xds/src/main/proto/xds/type/matcher/v3/matcher.proto
@@ -1,0 +1,139 @@
+syntax = "proto3";
+
+package xds.type.matcher.v3;
+
+import "xds/annotations/v3/status.proto";
+import "xds/core/v3/extension.proto";
+import "xds/type/matcher/v3/string.proto";
+
+import "validate/validate.proto";
+
+option java_package = "com.github.xds.type.matcher.v3";
+option java_outer_classname = "MatcherProto";
+option java_multiple_files = true;
+option go_package = "github.com/cncf/xds/go/xds/type/matcher/v3";
+
+// [#protodoc-title: Unified Matcher API]
+
+// A matcher, which may traverse a matching tree in order to result in a match action.
+// During matching, the tree will be traversed until a match is found, or if no match
+// is found the action specified by the most specific on_no_match will be evaluated.
+// As an on_no_match might result in another matching tree being evaluated, this process
+// might repeat several times until the final OnMatch (or no match) is decided.
+message Matcher {
+  option (xds.annotations.v3.message_status).work_in_progress = true;
+
+  // What to do if a match is successful.
+  message OnMatch {
+    oneof on_match {
+      option (validate.required) = true;
+
+      // Nested matcher to evaluate.
+      // If the nested matcher does not match and does not specify
+      // on_no_match, then this matcher is considered not to have
+      // matched, even if a predicate at this level or above returned
+      // true.
+      Matcher matcher = 1;
+
+      // Protocol-specific action to take.
+      core.v3.TypedExtensionConfig action = 2;
+    }
+  }
+
+  // A linear list of field matchers.
+  // The field matchers are evaluated in order, and the first match
+  // wins.
+  message MatcherList {
+    // Predicate to determine if a match is successful.
+    message Predicate {
+      // Predicate for a single input field.
+      message SinglePredicate {
+        // Protocol-specific specification of input field to match on.
+        // [#extension-category: envoy.matching.common_inputs]
+        core.v3.TypedExtensionConfig input = 1 [(validate.rules).message = {required: true}];
+
+        oneof matcher {
+          option (validate.required) = true;
+
+          // Built-in string matcher.
+          type.matcher.v3.StringMatcher value_match = 2;
+
+          // Extension for custom matching logic.
+          // [#extension-category: envoy.matching.input_matchers]
+          core.v3.TypedExtensionConfig custom_match = 3;
+        }
+      }
+
+      // A list of two or more matchers. Used to allow using a list within a oneof.
+      message PredicateList {
+        repeated Predicate predicate = 1 [(validate.rules).repeated = {min_items: 2}];
+      }
+
+      oneof match_type {
+        option (validate.required) = true;
+
+        // A single predicate to evaluate.
+        SinglePredicate single_predicate = 1;
+
+        // A list of predicates to be OR-ed together.
+        PredicateList or_matcher = 2;
+
+        // A list of predicates to be AND-ed together.
+        PredicateList and_matcher = 3;
+
+        // The invert of a predicate
+        Predicate not_matcher = 4;
+      }
+    }
+
+    // An individual matcher.
+    message FieldMatcher {
+      // Determines if the match succeeds.
+      Predicate predicate = 1 [(validate.rules).message = {required: true}];
+
+      // What to do if the match succeeds.
+      OnMatch on_match = 2 [(validate.rules).message = {required: true}];
+    }
+
+    // A list of matchers. First match wins.
+    repeated FieldMatcher matchers = 1 [(validate.rules).repeated = {min_items: 1}];
+  }
+
+  message MatcherTree {
+    // A map of configured matchers. Used to allow using a map within a oneof.
+    message MatchMap {
+      map<string, OnMatch> map = 1 [(validate.rules).map = {min_pairs: 1}];
+    }
+
+    // Protocol-specific specification of input field to match on.
+    core.v3.TypedExtensionConfig input = 1 [(validate.rules).message = {required: true}];
+
+    // Exact or prefix match maps in which to look up the input value.
+    // If the lookup succeeds, the match is considered successful, and
+    // the corresponding OnMatch is used.
+    oneof tree_type {
+      option (validate.required) = true;
+
+      MatchMap exact_match_map = 2;
+
+      // Longest matching prefix wins.
+      MatchMap prefix_match_map = 3;
+
+      // Extension for custom matching logic.
+      core.v3.TypedExtensionConfig custom_match = 4;
+    }
+  }
+
+  oneof matcher_type {
+    // A linear list of matchers to evaluate.
+    MatcherList matcher_list = 1;
+
+    // A match tree to evaluate.
+    MatcherTree matcher_tree = 2;
+  }
+
+  // Optional OnMatch to use if no matcher above matched (e.g., if there are no matchers specified
+  // above, or if none of the matches specified above succeeded).
+  // If no matcher above matched and this field is not populated, the match will be considered unsuccessful.
+  OnMatch on_no_match = 3;
+}

--- a/xds/third_party/xds/src/main/proto/xds/type/matcher/v3/regex.proto
+++ b/xds/third_party/xds/src/main/proto/xds/type/matcher/v3/regex.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+
+package xds.type.matcher.v3;
+
+import "validate/validate.proto";
+
+option java_package = "com.github.xds.type.matcher.v3";
+option java_outer_classname = "RegexProto";
+option java_multiple_files = true;
+option go_package = "github.com/cncf/xds/go/xds/type/matcher/v3";
+
+// [#protodoc-title: Regex matcher]
+
+// A regex matcher designed for safety when used with untrusted input.
+message RegexMatcher {
+  // Google's `RE2 <https://github.com/google/re2>`_ regex engine. The regex
+  // string must adhere to the documented `syntax
+  // <https://github.com/google/re2/wiki/Syntax>`_. The engine is designed to
+  // complete execution in linear time as well as limit the amount of memory
+  // used.
+  //
+  // Envoy supports program size checking via runtime. The runtime keys
+  // `re2.max_program_size.error_level` and `re2.max_program_size.warn_level`
+  // can be set to integers as the maximum program size or complexity that a
+  // compiled regex can have before an exception is thrown or a warning is
+  // logged, respectively. `re2.max_program_size.error_level` defaults to 100,
+  // and `re2.max_program_size.warn_level` has no default if unset (will not
+  // check/log a warning).
+  //
+  // Envoy emits two stats for tracking the program size of regexes: the
+  // histogram `re2.program_size`, which records the program size, and the
+  // counter `re2.exceeded_warn_level`, which is incremented each time the
+  // program size exceeds the warn level threshold.
+  message GoogleRE2 {}
+
+  oneof engine_type {
+    option (validate.required) = true;
+
+    // Google's RE2 regex engine.
+    GoogleRE2 google_re2 = 1 [ (validate.rules).message = {required : true} ];
+  }
+
+  // The regex match string. The string must be supported by the configured
+  // engine.
+  string regex = 2 [ (validate.rules).string = {min_len : 1} ];
+}

--- a/xds/third_party/xds/src/main/proto/xds/type/matcher/v3/string.proto
+++ b/xds/third_party/xds/src/main/proto/xds/type/matcher/v3/string.proto
@@ -1,0 +1,66 @@
+syntax = "proto3";
+
+package xds.type.matcher.v3;
+
+import "xds/type/matcher/v3/regex.proto";
+
+import "validate/validate.proto";
+
+option java_package = "com.github.xds.type.matcher.v3";
+option java_outer_classname = "StringProto";
+option java_multiple_files = true;
+option go_package = "github.com/cncf/xds/go/xds/type/matcher/v3";
+
+// [#protodoc-title: String matcher]
+
+// Specifies the way to match a string.
+// [#next-free-field: 8]
+message StringMatcher {
+  oneof match_pattern {
+    option (validate.required) = true;
+
+    // The input string must match exactly the string specified here.
+    //
+    // Examples:
+    //
+    // * *abc* only matches the value *abc*.
+    string exact = 1;
+
+    // The input string must have the prefix specified here.
+    // Note: empty prefix is not allowed, please use regex instead.
+    //
+    // Examples:
+    //
+    // * *abc* matches the value *abc.xyz*
+    string prefix = 2 [(validate.rules).string = {min_len: 1}];
+
+    // The input string must have the suffix specified here.
+    // Note: empty prefix is not allowed, please use regex instead.
+    //
+    // Examples:
+    //
+    // * *abc* matches the value *xyz.abc*
+    string suffix = 3 [(validate.rules).string = {min_len: 1}];
+
+    // The input string must match the regular expression specified here.
+    RegexMatcher safe_regex = 5 [(validate.rules).message = {required: true}];
+
+    // The input string must have the substring specified here.
+    // Note: empty contains match is not allowed, please use regex instead.
+    //
+    // Examples:
+    //
+    // * *abc* matches the value *xyz.abc.def*
+    string contains = 7 [(validate.rules).string = {min_len: 1}];
+  }
+
+  // If true, indicates the exact/prefix/suffix matching should be case insensitive. This has no
+  // effect for the safe_regex match.
+  // For example, the matcher *data* will match both input string *Data* and *data* if set to true.
+  bool ignore_case = 6;
+}
+
+// Specifies a list of ways to match a string.
+message ListStringMatcher {
+  repeated StringMatcher patterns = 1 [(validate.rules).repeated = {min_items: 1}];
+}


### PR DESCRIPTION
### Proto updates

1. `cncf/xds`: Sort xds/import.sh protos alphabetically
2. `cncf/xds`: Sync protos to https://github.com/cncf/xds/commit/d92e9ce0af512a73a3a126b32fa4920bee12e180 (commit 2021-12-16, corresponding to envoy cl/440193522). It's a no-op for used protos, but helpful to import the latest matcher.proto
3. `cncf/xds`: Import xds/type/matcher/v3/matcher.proto with dependencies
4. `envoyproxy/protoc-gen-validate`: Sync protos to https://github.com/envoyproxy/protoc-gen-validate/commit/dfcdc5ea103dda467963fb7079e4df28debcfd28 (commit 2022-03-10, corresponding to envoy cl/440193522) to pick up ignore_empty field required for the following envoy sync
5. `envoyproxy/envoy` Sync protos to https://github.com/envoyproxy/envoy/commit/e33f444b4c5ee783a8a1126f3186832f4a031a39 (commit 2022-04-07, cl/440193522). This is the minimal version needed to pick up `ClusterSpecifierPlugin.is_optional`.
   a. Generated code: `AggregatedDiscoveryServiceGrpc` was regenerated from the updated proto. This is a no-op, just a minor change to the docblocks.
   b. Deprecated fields had to be taken care of manually, see "Manual updates to the code" below.
6. `envoyproxy/envoy` Sync protos to the latest imported version https://github.com/envoyproxy/envoy/commit/5d74719102f461bc57e85acdda706e0a8df9b12d (commit 2022-04-08, cl/443359189). Not needed for anything specific, just the last version, and was easy to import.

### Manual updates to the code

As the result of https://github.com/envoyproxy/envoy/commit/e33f444b4c5ee783a8a1126f3186832f4a031a39 sync:

1. Deprecated `ConfigSource.path` replaced with the `ConfigSource.path_config_source` in test fake resources. The `ConfigSource.path` isn't in active code paths, so no prod code changes needed.
2. Suppress `CertificateValidationContext.match_subject_alt_names` deprecations in test files. Surprisingly, we don't report deprecations in prod files, despite the fact this field is used in prod code a few times.