### PR TITLE
netty: implement UdsNameResolver and UdsNettyChannelProvider

### DIFF
--- a/api/src/main/java/io/grpc/ManagedChannelRegistry.java
+++ b/api/src/main/java/io/grpc/ManagedChannelRegistry.java
@@ -145,6 +145,11 @@ public final class ManagedChannelRegistry {
     } catch (ClassNotFoundException e) {
       logger.log(Level.FINE, "Unable to find NettyChannelProvider", e);
     }
+    try {
+      list.add(Class.forName("io.grpc.netty.UdsNettyChannelProvider"));
+    } catch (ClassNotFoundException e) {
+      logger.log(Level.FINE, "Unable to find UdsNettyChannelProvider", e);
+    }
     return Collections.unmodifiableList(list);
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -176,6 +176,7 @@ subprojects {
 
             netty: "io.netty:netty-codec-http2:[${nettyVersion}]",
             netty_epoll: "io.netty:netty-transport-native-epoll:${nettyVersion}:linux-x86_64",
+            netty_epoll_common: "io.netty:netty-transport-native-epoll:${nettyVersion}",
             netty_unix_common: "io.netty:netty-transport-native-unix-common:${nettyVersion}",
             netty_epoll_arm64: "io.netty:netty-transport-native-epoll:${nettyVersion}:linux-aarch_64",
             netty_proxy_handler: "io.netty:netty-handler-proxy:${nettyVersion}",

--- a/build.gradle
+++ b/build.gradle
@@ -176,6 +176,7 @@ subprojects {
 
             netty: "io.netty:netty-codec-http2:[${nettyVersion}]",
             netty_epoll: "io.netty:netty-transport-native-epoll:${nettyVersion}:linux-x86_64",
+            netty_unix_common: "io.netty:netty-transport-native-unix-common:${nettyVersion}",
             netty_epoll_arm64: "io.netty:netty-transport-native-epoll:${nettyVersion}:linux-aarch_64",
             netty_proxy_handler: "io.netty:netty-handler-proxy:${nettyVersion}",
 

--- a/netty/BUILD.bazel
+++ b/netty/BUILD.bazel
@@ -20,6 +20,7 @@ java_library(
         "@io_netty_netty_codec_http2//jar",
         "@io_netty_netty_codec_socks//jar",
         "@io_netty_netty_common//jar",
+        "@io_netty_netty_transport_native_unix_common//jar",
         "@io_netty_netty_handler//jar",
         "@io_netty_netty_handler_proxy//jar",
         "@io_netty_netty_resolver//jar",

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -22,7 +22,7 @@ dependencies {
             libraries.guava,
             libraries.errorprone,
             libraries.perfmark,
-            ("io.netty:netty-transport-native-unix-common:${nettyVersion}")
+            libraries.netty_unix_common
 
     // Tests depend on base class defined by core module.
     testImplementation project(':grpc-core').sourceSets.test.output,

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -17,7 +17,8 @@ evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
     api project(':grpc-core'),
-            libraries.netty
+            libraries.netty,
+            libraries.netty_epoll
     implementation libraries.netty_proxy_handler,
             libraries.guava,
             libraries.errorprone,
@@ -29,8 +30,7 @@ dependencies {
             project(':grpc-testing'),
             project(':grpc-testing-proto')
     testRuntimeOnly libraries.netty_tcnative,
-            libraries.conscrypt,
-            libraries.netty_epoll
+            libraries.conscrypt
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     alpnagent libraries.jetty_alpn_agent
 }

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -17,12 +17,12 @@ evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
     api project(':grpc-core'),
-            libraries.netty,
-            libraries.netty_epoll
+            libraries.netty
     implementation libraries.netty_proxy_handler,
             libraries.guava,
             libraries.errorprone,
-            libraries.perfmark
+            libraries.perfmark,
+            ("io.netty:netty-transport-native-epoll:${nettyVersion}")
 
     // Tests depend on base class defined by core module.
     testImplementation project(':grpc-core').sourceSets.test.output,
@@ -30,7 +30,8 @@ dependencies {
             project(':grpc-testing'),
             project(':grpc-testing-proto')
     testRuntimeOnly libraries.netty_tcnative,
-            libraries.conscrypt
+            libraries.conscrypt,
+            libraries.netty_epoll
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     alpnagent libraries.jetty_alpn_agent
 }

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -29,7 +29,7 @@ dependencies {
             project(':grpc-api').sourceSets.test.output,
             project(':grpc-testing'),
             project(':grpc-testing-proto'),
-            ("io.netty:netty-transport-native-epoll:${nettyVersion}")
+            libraries.netty_epoll_common
     testRuntimeOnly libraries.netty_tcnative,
             libraries.conscrypt,
             libraries.netty_epoll

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -22,13 +22,14 @@ dependencies {
             libraries.guava,
             libraries.errorprone,
             libraries.perfmark,
-            ("io.netty:netty-transport-native-epoll:${nettyVersion}")
+            ("io.netty:netty-transport-native-unix-common:${nettyVersion}")
 
     // Tests depend on base class defined by core module.
     testImplementation project(':grpc-core').sourceSets.test.output,
             project(':grpc-api').sourceSets.test.output,
             project(':grpc-testing'),
-            project(':grpc-testing-proto')
+            project(':grpc-testing-proto'),
+            ("io.netty:netty-transport-native-epoll:${nettyVersion}")
     testRuntimeOnly libraries.netty_tcnative,
             libraries.conscrypt,
             libraries.netty_epoll

--- a/netty/src/main/java/io/grpc/netty/UdsNameResolver.java
+++ b/netty/src/main/java/io/grpc/netty/UdsNameResolver.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.netty;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Preconditions;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.NameResolver;
+import io.netty.channel.unix.DomainSocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class UdsNameResolver extends NameResolver {
+  private NameResolver.Listener2 listener;
+  private final String authority;
+
+  UdsNameResolver(String authority, String targetPath) {
+    checkArgument(authority == null, "non-null authority not supported");
+    this.authority = targetPath;
+  }
+
+  @Override
+  public String getServiceAuthority() {
+    return this.authority;
+  }
+
+  @Override
+  public void start(Listener2 listener) {
+    Preconditions.checkState(this.listener == null, "already started");
+    this.listener = checkNotNull(listener, "listener");
+    resolve();
+  }
+
+  @Override
+  public void refresh() {
+    resolve();
+  }
+
+  private void resolve() {
+    ResolutionResult.Builder resolutionResultBuilder = ResolutionResult.newBuilder();
+    List<EquivalentAddressGroup> servers = new ArrayList<>(1);
+    servers.add(new EquivalentAddressGroup(new DomainSocketAddress(authority)));
+    resolutionResultBuilder.setAddresses(Collections.unmodifiableList(servers));
+    listener.onResult(resolutionResultBuilder.build());
+  }
+
+  @Override
+  public void shutdown() {}
+}

--- a/netty/src/main/java/io/grpc/netty/UdsNameResolver.java
+++ b/netty/src/main/java/io/grpc/netty/UdsNameResolver.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public final class UdsNameResolver extends NameResolver {
+final class UdsNameResolver extends NameResolver {
   private NameResolver.Listener2 listener;
   private final String authority;
 

--- a/netty/src/main/java/io/grpc/netty/UdsNameResolverProvider.java
+++ b/netty/src/main/java/io/grpc/netty/UdsNameResolverProvider.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.netty;
+
+import com.google.common.base.Preconditions;
+import io.grpc.NameResolver;
+import io.grpc.NameResolverProvider;
+import java.net.URI;
+
+public class UdsNameResolverProvider extends NameResolverProvider {
+
+  private static final String SCHEME = "unix";
+
+  @Override
+  public UdsNameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
+    if (SCHEME.equals(targetUri.getScheme())) {
+      return new UdsNameResolver(targetUri.getAuthority(), getTargetPathFromUri(targetUri));
+    } else {
+      return null;
+    }
+  }
+
+  static String getTargetPathFromUri(URI targetUri) {
+    Preconditions.checkArgument(SCHEME.equals(targetUri.getScheme()), "scheme must be " + SCHEME);
+    String targetPath = targetUri.getPath();
+    if (targetPath == null) {
+      targetPath = Preconditions.checkNotNull(targetUri.getSchemeSpecificPart(), "targetPath");
+    }
+    return targetPath;
+  }
+
+  @Override
+  public String getDefaultScheme() {
+    return SCHEME;
+  }
+
+  @Override
+  protected boolean isAvailable() {
+    return true;
+  }
+
+  @Override
+  protected int priority() {
+    return 3;
+  }
+}

--- a/netty/src/main/java/io/grpc/netty/UdsNameResolverProvider.java
+++ b/netty/src/main/java/io/grpc/netty/UdsNameResolverProvider.java
@@ -17,11 +17,17 @@
 package io.grpc.netty;
 
 import com.google.common.base.Preconditions;
+import io.grpc.Internal;
 import io.grpc.NameResolver;
 import io.grpc.NameResolverProvider;
+import io.netty.channel.unix.DomainSocketAddress;
+import java.net.SocketAddress;
 import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
 
-public class UdsNameResolverProvider extends NameResolverProvider {
+@Internal
+public final class UdsNameResolverProvider extends NameResolverProvider {
 
   private static final String SCHEME = "unix";
 
@@ -56,5 +62,10 @@ public class UdsNameResolverProvider extends NameResolverProvider {
   @Override
   protected int priority() {
     return 3;
+  }
+
+  @Override
+  protected Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
+    return Collections.singleton(DomainSocketAddress.class);
   }
 }

--- a/netty/src/main/java/io/grpc/netty/UdsNettyChannelProvider.java
+++ b/netty/src/main/java/io/grpc/netty/UdsNettyChannelProvider.java
@@ -34,7 +34,7 @@ public final class UdsNettyChannelProvider extends ManagedChannelProvider {
 
   @Override
   public boolean isAvailable() {
-    return true;
+    return (Utils.EPOLL_DOMAIN_CLIENT_CHANNEL_TYPE != null);
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/netty/UdsNettyChannelProvider.java
+++ b/netty/src/main/java/io/grpc/netty/UdsNettyChannelProvider.java
@@ -22,7 +22,6 @@ import io.grpc.InsecureChannelCredentials;
 import io.grpc.Internal;
 import io.grpc.ManagedChannelProvider;
 import io.grpc.internal.SharedResourcePool;
-import io.netty.channel.epoll.EpollDomainSocketChannel;
 import io.netty.channel.unix.DomainSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
@@ -80,7 +79,7 @@ public final class UdsNettyChannelProvider extends ManagedChannelProvider {
     builder =
         builder
             .eventLoopGroupPool(SharedResourcePool.forResource(Utils.UDS_CHANNELS_EVENT_LOOP_GROUP))
-            .channelType(EpollDomainSocketChannel.class);
+            .channelType(Utils.EPOLL_DOMAIN_CLIENT_CHANNEL_TYPE);
     return builder;
   }
 

--- a/netty/src/main/java/io/grpc/netty/UdsNettyChannelProvider.java
+++ b/netty/src/main/java/io/grpc/netty/UdsNettyChannelProvider.java
@@ -72,13 +72,17 @@ public final class UdsNettyChannelProvider extends ManagedChannelProvider {
       ChannelCredentials creds,
       CallCredentials callCredentials,
       ProtocolNegotiator.ClientFactory negotiator) {
+    if (Utils.EPOLL_DOMAIN_CLIENT_CHANNEL_TYPE == null) {
+      throw new IllegalStateException("Epoll is not available");
+    }
     String targetPath = UdsNameResolverProvider.getTargetPathFromUri(URI.create(target));
     NettyChannelBuilder builder =
         new NettyChannelBuilder(
             new DomainSocketAddress(targetPath), creds, callCredentials, negotiator);
     builder =
         builder
-            .eventLoopGroupPool(SharedResourcePool.forResource(Utils.UDS_CHANNELS_EVENT_LOOP_GROUP))
+            .eventLoopGroupPool(
+                SharedResourcePool.forResource(Utils.DEFAULT_WORKER_EVENT_LOOP_GROUP))
             .channelType(Utils.EPOLL_DOMAIN_CLIENT_CHANNEL_TYPE);
     return builder;
   }

--- a/netty/src/main/java/io/grpc/netty/UdsNettyChannelProvider.java
+++ b/netty/src/main/java/io/grpc/netty/UdsNettyChannelProvider.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2015 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.netty;
+
+import io.grpc.CallCredentials;
+import io.grpc.ChannelCredentials;
+import io.grpc.InsecureChannelCredentials;
+import io.grpc.Internal;
+import io.grpc.ManagedChannelProvider;
+import io.grpc.internal.SharedResourcePool;
+import io.netty.channel.epoll.EpollDomainSocketChannel;
+import io.netty.channel.unix.DomainSocketAddress;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
+
+/** Provider for {@link NettyChannelBuilder} instances for UDS channels. */
+@Internal
+public final class UdsNettyChannelProvider extends ManagedChannelProvider {
+
+  @Override
+  public boolean isAvailable() {
+    return true;
+  }
+
+  @Override
+  public int priority() {
+    return 3;
+  }
+
+  @Override
+  public NettyChannelBuilder builderForAddress(String name, int port) {
+    throw new UnsupportedOperationException("host:port not supported");
+  }
+
+  @Override
+  public NettyChannelBuilder builderForTarget(String target) {
+    ChannelCredentials creds = InsecureChannelCredentials.create();
+    ProtocolNegotiators.FromChannelCredentialsResult result = ProtocolNegotiators.from(creds);
+    if (result.error != null) {
+      throw new RuntimeException(result.error);
+    }
+    return getNettyChannelBuilder(target, creds, null, result.negotiator);
+  }
+
+  @Override
+  public NewChannelBuilderResult newChannelBuilder(String target, ChannelCredentials creds) {
+    ProtocolNegotiators.FromChannelCredentialsResult result = ProtocolNegotiators.from(creds);
+    if (result.error != null) {
+      return NewChannelBuilderResult.error(result.error);
+    }
+    return NewChannelBuilderResult.channelBuilder(
+        getNettyChannelBuilder(target, creds, result.callCredentials, result.negotiator));
+  }
+
+  private static NettyChannelBuilder getNettyChannelBuilder(
+      String target,
+      ChannelCredentials creds,
+      CallCredentials callCredentials,
+      ProtocolNegotiator.ClientFactory negotiator) {
+    String targetPath = UdsNameResolverProvider.getTargetPathFromUri(URI.create(target));
+    NettyChannelBuilder builder =
+        new NettyChannelBuilder(
+            new DomainSocketAddress(targetPath), creds, callCredentials, negotiator);
+    builder =
+        builder
+            .eventLoopGroupPool(SharedResourcePool.forResource(Utils.UDS_CHANNELS_EVENT_LOOP_GROUP))
+            .channelType(EpollDomainSocketChannel.class);
+    return builder;
+  }
+
+  @Override
+  protected Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
+    return Collections.singleton(DomainSocketAddress.class);
+  }
+}

--- a/netty/src/main/java/io/grpc/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/netty/Utils.java
@@ -44,7 +44,6 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ReflectiveChannelFactory;
 import io.netty.channel.ServerChannel;
-import io.netty.channel.epoll.Epoll;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
@@ -91,7 +90,7 @@ class Utils {
   public static final Resource<EventLoopGroup> NIO_WORKER_EVENT_LOOP_GROUP
       = new DefaultEventLoopGroupResource(0, "grpc-nio-worker-ELG", EventLoopGroupType.NIO);
   public static final Resource<EventLoopGroup> UDS_CHANNELS_EVENT_LOOP_GROUP =
-      Epoll.isAvailable() ? new DefaultEventLoopGroupResource(1, "UdsChannels",
+      isEpollAvailable() ? new DefaultEventLoopGroupResource(1, "UdsChannels",
           EventLoopGroupType.EPOLL) : null;
 
   public static final Resource<EventLoopGroup> DEFAULT_BOSS_EVENT_LOOP_GROUP;
@@ -109,6 +108,7 @@ class Utils {
 
   public static final ChannelFactory<? extends ServerChannel> DEFAULT_SERVER_CHANNEL_FACTORY;
   public static final Class<? extends Channel> DEFAULT_CLIENT_CHANNEL_TYPE;
+  public static final Class<? extends Channel> EPOLL_DOMAIN_CLIENT_CHANNEL_TYPE;
 
   @Nullable
   private static final Constructor<? extends EventLoopGroup> EPOLL_EVENT_LOOP_GROUP_CONSTRUCTOR;
@@ -117,6 +117,7 @@ class Utils {
     // Decide default channel types and EventLoopGroup based on Epoll availability
     if (isEpollAvailable()) {
       DEFAULT_CLIENT_CHANNEL_TYPE = epollChannelType();
+      EPOLL_DOMAIN_CLIENT_CHANNEL_TYPE = epollDomainSocketChannelType();
       DEFAULT_SERVER_CHANNEL_FACTORY = new ReflectiveChannelFactory<>(epollServerChannelType());
       EPOLL_EVENT_LOOP_GROUP_CONSTRUCTOR = epollEventLoopGroupConstructor();
       DEFAULT_BOSS_EVENT_LOOP_GROUP
@@ -127,6 +128,7 @@ class Utils {
       logger.log(Level.FINE, "Epoll is not available, using Nio.", getEpollUnavailabilityCause());
       DEFAULT_SERVER_CHANNEL_FACTORY = nioServerChannelFactory();
       DEFAULT_CLIENT_CHANNEL_TYPE = NioSocketChannel.class;
+      EPOLL_DOMAIN_CLIENT_CHANNEL_TYPE = null;
       DEFAULT_BOSS_EVENT_LOOP_GROUP = NIO_BOSS_EVENT_LOOP_GROUP;
       DEFAULT_WORKER_EVENT_LOOP_GROUP = NIO_WORKER_EVENT_LOOP_GROUP;
       EPOLL_EVENT_LOOP_GROUP_CONSTRUCTOR = null;
@@ -328,6 +330,17 @@ class Utils {
       return channelType;
     } catch (ClassNotFoundException e) {
       throw new RuntimeException("Cannot load EpollSocketChannel", e);
+    }
+  }
+
+  // Must call when epoll is available
+  private static Class<? extends Channel> epollDomainSocketChannelType() {
+    try {
+      Class<? extends Channel> channelType = Class
+          .forName("io.netty.channel.epoll.EpollDomainSocketChannel").asSubclass(Channel.class);
+      return channelType;
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException("Cannot load EpollDomainSocketChannel", e);
     }
   }
 

--- a/netty/src/main/java/io/grpc/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/netty/Utils.java
@@ -44,6 +44,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ReflectiveChannelFactory;
 import io.netty.channel.ServerChannel;
+import io.netty.channel.epoll.Epoll;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
@@ -89,6 +90,10 @@ class Utils {
       = new DefaultEventLoopGroupResource(1, "grpc-nio-boss-ELG", EventLoopGroupType.NIO);
   public static final Resource<EventLoopGroup> NIO_WORKER_EVENT_LOOP_GROUP
       = new DefaultEventLoopGroupResource(0, "grpc-nio-worker-ELG", EventLoopGroupType.NIO);
+  public static final Resource<EventLoopGroup> UDS_CHANNELS_EVENT_LOOP_GROUP =
+      Epoll.isAvailable() ? new DefaultEventLoopGroupResource(1, "UdsChannels",
+          EventLoopGroupType.EPOLL) : null;
+
   public static final Resource<EventLoopGroup> DEFAULT_BOSS_EVENT_LOOP_GROUP;
   public static final Resource<EventLoopGroup> DEFAULT_WORKER_EVENT_LOOP_GROUP;
 

--- a/netty/src/main/java/io/grpc/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/netty/Utils.java
@@ -89,9 +89,6 @@ class Utils {
       = new DefaultEventLoopGroupResource(1, "grpc-nio-boss-ELG", EventLoopGroupType.NIO);
   public static final Resource<EventLoopGroup> NIO_WORKER_EVENT_LOOP_GROUP
       = new DefaultEventLoopGroupResource(0, "grpc-nio-worker-ELG", EventLoopGroupType.NIO);
-  public static final Resource<EventLoopGroup> UDS_CHANNELS_EVENT_LOOP_GROUP =
-      isEpollAvailable() ? new DefaultEventLoopGroupResource(1, "UdsChannels",
-          EventLoopGroupType.EPOLL) : null;
 
   public static final Resource<EventLoopGroup> DEFAULT_BOSS_EVENT_LOOP_GROUP;
   public static final Resource<EventLoopGroup> DEFAULT_WORKER_EVENT_LOOP_GROUP;

--- a/netty/src/main/resources/META-INF/services/io.grpc.ManagedChannelProvider
+++ b/netty/src/main/resources/META-INF/services/io.grpc.ManagedChannelProvider
@@ -1,1 +1,2 @@
 io.grpc.netty.NettyChannelProvider
+io.grpc.netty.UdsNettyChannelProvider

--- a/netty/src/main/resources/META-INF/services/io.grpc.NameResolverProvider
+++ b/netty/src/main/resources/META-INF/services/io.grpc.NameResolverProvider
@@ -1,0 +1,1 @@
+io.grpc.netty.UdsNameResolverProvider

--- a/netty/src/test/java/io/grpc/netty/UdsNameResolverProviderTest.java
+++ b/netty/src/test/java/io/grpc/netty/UdsNameResolverProviderTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2015 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.netty;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.verify;
+
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.NameResolver;
+import io.netty.channel.unix.DomainSocketAddress;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+/** Unit tests for {@link UdsNameResolverProvider}. */
+@RunWith(JUnit4.class)
+public class UdsNameResolverProviderTest {
+
+  @Rule
+  public final MockitoRule mocks = MockitoJUnit.rule();
+
+  @Mock
+  private NameResolver.Listener2 mockListener;
+
+  @Captor
+  private ArgumentCaptor<NameResolver.ResolutionResult> resultCaptor;
+
+  UdsNameResolverProvider udsNameResolverProvider = new UdsNameResolverProvider();
+
+
+  @Test
+  public void testUnixRelativePath() {
+    UdsNameResolver udsNameResolver =
+        udsNameResolverProvider.newNameResolver(URI.create("unix:sock.sock"), null);
+    assertThat(udsNameResolver).isNotNull();
+    udsNameResolver.start(mockListener);
+    verify(mockListener).onResult(resultCaptor.capture());
+    NameResolver.ResolutionResult result = resultCaptor.getValue();
+    List<EquivalentAddressGroup> list = result.getAddresses();
+    assertThat(list).isNotNull();
+    assertThat(list).hasSize(1);
+    EquivalentAddressGroup eag = list.get(0);
+    assertThat(eag).isNotNull();
+    List<SocketAddress> addresses = eag.getAddresses();
+    assertThat(addresses).hasSize(1);
+    assertThat(addresses.get(0)).isInstanceOf(DomainSocketAddress.class);
+    DomainSocketAddress domainSocketAddress = (DomainSocketAddress) addresses.get(0);
+    assertThat(domainSocketAddress.path()).isEqualTo("sock.sock");
+  }
+
+  @Test
+  public void testUnixAbsolutePath() {
+    UdsNameResolver udsNameResolver =
+        udsNameResolverProvider.newNameResolver(URI.create("unix:/sock.sock"), null);
+    assertThat(udsNameResolver).isNotNull();
+    udsNameResolver.start(mockListener);
+    verify(mockListener).onResult(resultCaptor.capture());
+    NameResolver.ResolutionResult result = resultCaptor.getValue();
+    List<EquivalentAddressGroup> list = result.getAddresses();
+    assertThat(list).isNotNull();
+    assertThat(list).hasSize(1);
+    EquivalentAddressGroup eag = list.get(0);
+    assertThat(eag).isNotNull();
+    List<SocketAddress> addresses = eag.getAddresses();
+    assertThat(addresses).hasSize(1);
+    assertThat(addresses.get(0)).isInstanceOf(DomainSocketAddress.class);
+    DomainSocketAddress domainSocketAddress = (DomainSocketAddress) addresses.get(0);
+    assertThat(domainSocketAddress.path()).isEqualTo("/sock.sock");
+  }
+
+  @Test
+  public void testUnixAbsoluteAlternatePath() {
+    UdsNameResolver udsNameResolver =
+        udsNameResolverProvider.newNameResolver(URI.create("unix:///sock.sock"), null);
+    assertThat(udsNameResolver).isNotNull();
+    udsNameResolver.start(mockListener);
+    verify(mockListener).onResult(resultCaptor.capture());
+    NameResolver.ResolutionResult result = resultCaptor.getValue();
+    List<EquivalentAddressGroup> list = result.getAddresses();
+    assertThat(list).isNotNull();
+    assertThat(list).hasSize(1);
+    EquivalentAddressGroup eag = list.get(0);
+    assertThat(eag).isNotNull();
+    List<SocketAddress> addresses = eag.getAddresses();
+    assertThat(addresses).hasSize(1);
+    assertThat(addresses.get(0)).isInstanceOf(DomainSocketAddress.class);
+    DomainSocketAddress domainSocketAddress = (DomainSocketAddress) addresses.get(0);
+    assertThat(domainSocketAddress.path()).isEqualTo("/sock.sock");
+  }
+
+  @Test
+  public void testUnixPathWithAuthority() {
+    try {
+      udsNameResolverProvider.newNameResolver(URI.create("unix://localhost/sock.sock"), null);
+      fail("exception expected");
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessageThat().isEqualTo("non-null authority not supported");
+    }
+  }
+}

--- a/netty/src/test/java/io/grpc/netty/UdsNameResolverTest.java
+++ b/netty/src/test/java/io/grpc/netty/UdsNameResolverTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2015 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.netty;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.verify;
+
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.NameResolver;
+import io.netty.channel.unix.DomainSocketAddress;
+import java.net.SocketAddress;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+/** Unit tests for {@link UdsNameResolver}. */
+@RunWith(JUnit4.class)
+public class UdsNameResolverTest {
+
+  @Rule
+  public final MockitoRule mocks = MockitoJUnit.rule();
+
+  @Mock
+  private NameResolver.Listener2 mockListener;
+
+  @Captor
+  private ArgumentCaptor<NameResolver.ResolutionResult> resultCaptor;
+
+  private UdsNameResolver udsNameResolver;
+
+  @Test
+  public void testValidTargetPath() {
+    udsNameResolver = new UdsNameResolver(null, "sock.sock");
+    udsNameResolver.start(mockListener);
+    verify(mockListener).onResult(resultCaptor.capture());
+    NameResolver.ResolutionResult result = resultCaptor.getValue();
+    List<EquivalentAddressGroup> list = result.getAddresses();
+    assertThat(list).isNotNull();
+    assertThat(list).hasSize(1);
+    EquivalentAddressGroup eag = list.get(0);
+    assertThat(eag).isNotNull();
+    List<SocketAddress> addresses = eag.getAddresses();
+    assertThat(addresses).hasSize(1);
+    assertThat(addresses.get(0)).isInstanceOf(DomainSocketAddress.class);
+    DomainSocketAddress domainSocketAddress = (DomainSocketAddress) addresses.get(0);
+    assertThat(domainSocketAddress.path()).isEqualTo("sock.sock");
+    assertThat(udsNameResolver.getServiceAuthority()).isEqualTo("sock.sock");
+  }
+
+  @Test
+  public void testNonNullAuthority() {
+    try {
+      udsNameResolver = new UdsNameResolver("authority", "sock.sock");
+      fail("exception expected");
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessageThat().isEqualTo("non-null authority not supported");
+    }
+  }
+}

--- a/netty/src/test/java/io/grpc/netty/UdsNettyChannelProviderTest.java
+++ b/netty/src/test/java/io/grpc/netty/UdsNettyChannelProviderTest.java
@@ -54,7 +54,6 @@ public class UdsNettyChannelProviderTest {
 
   @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
 
-  private static final String TEST_SOCKET = "/test.socket";
   @Rule
   public final GrpcCleanupRule cleanupRule = new GrpcCleanupRule();
 
@@ -151,7 +150,7 @@ public class UdsNettyChannelProviderTest {
   @Test
   public void udsClientServerTestUsingProvider() throws IOException {
     Assume.assumeTrue(Utils.isEpollAvailable());
-    String socketPath = tempFolder.getRoot().getAbsolutePath() + TEST_SOCKET;
+    String socketPath = tempFolder.getRoot().getAbsolutePath() + "/test.socket";
     createUdsServer(socketPath);
     ManagedChannelBuilder<?> channelBuilder =
         Grpc.newChannelBuilder("unix://" + socketPath, InsecureChannelCredentials.create());

--- a/netty/src/test/java/io/grpc/netty/UdsNettyChannelProviderTest.java
+++ b/netty/src/test/java/io/grpc/netty/UdsNettyChannelProviderTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2015 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.netty;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import io.grpc.Grpc;
+import io.grpc.InsecureChannelCredentials;
+import io.grpc.InternalServiceProviders;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.ManagedChannelProvider;
+import io.grpc.ManagedChannelProvider.NewChannelBuilderResult;
+import io.grpc.ManagedChannelRegistryAccessor;
+import io.grpc.TlsChannelCredentials;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link UdsNettyChannelProvider}. */
+@RunWith(JUnit4.class)
+public class UdsNettyChannelProviderTest {
+  private UdsNettyChannelProvider provider = new UdsNettyChannelProvider();
+
+  @Test
+  public void provided() {
+    for (ManagedChannelProvider current
+        : InternalServiceProviders.getCandidatesViaServiceLoader(
+            ManagedChannelProvider.class, getClass().getClassLoader())) {
+      if (current instanceof UdsNettyChannelProvider) {
+        return;
+      }
+    }
+    fail("ServiceLoader unable to load UdsNettyChannelProvider");
+  }
+
+  @Test
+  public void providedHardCoded() {
+    for (Class<?> current : ManagedChannelRegistryAccessor.getHardCodedClasses()) {
+      if (current == UdsNettyChannelProvider.class) {
+        return;
+      }
+    }
+    fail("Hard coded unable to load UdsNettyChannelProvider");
+  }
+
+  @Test
+  public void basicMethods() {
+    assertTrue(provider.isAvailable());
+    assertEquals(3, provider.priority());
+  }
+
+  @Test
+  public void builderForTarget() {
+    assertThat(provider.builderForTarget("unix:sock.sock")).isInstanceOf(NettyChannelBuilder.class);
+  }
+
+  @Test
+  public void builderForTarget_badScheme() {
+    try {
+      provider.builderForTarget("dns:sock.sock");
+      fail("exception expected");
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessageThat().isEqualTo("scheme must be unix");
+    }
+  }
+
+  @Test
+  public void newChannelBuilder_success() {
+    NewChannelBuilderResult result =
+        provider.newChannelBuilder("unix:sock.sock", TlsChannelCredentials.create());
+    assertThat(result.getChannelBuilder()).isInstanceOf(NettyChannelBuilder.class);
+  }
+
+  @Test
+  public void newChannelBuilder_badScheme() {
+    try {
+      provider.newChannelBuilder("dns:sock.sock", InsecureChannelCredentials.create());
+      fail("exception expected");
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessageThat().isEqualTo("scheme must be unix");
+    }
+  }
+
+  @Test
+  public void managedChannelRegistry_newChannelBuilder() {
+    ManagedChannelBuilder<?> managedChannelBuilder
+            = Grpc.newChannelBuilder("unix:///sock.sock", InsecureChannelCredentials.create());
+    assertThat(managedChannelBuilder).isNotNull();
+    ManagedChannel channel = managedChannelBuilder.build();
+    assertThat(channel).isNotNull();
+    assertThat(channel.authority()).isEqualTo("/sock.sock");
+    channel.shutdownNow();
+  }
+}

--- a/netty/src/test/java/io/grpc/netty/UdsNettyChannelProviderTest.java
+++ b/netty/src/test/java/io/grpc/netty/UdsNettyChannelProviderTest.java
@@ -104,6 +104,7 @@ public class UdsNettyChannelProviderTest {
 
   @Test
   public void builderForTarget() {
+    Assume.assumeTrue(Utils.isEpollAvailable());
     assertThat(provider.builderForTarget("unix:sock.sock")).isInstanceOf(NettyChannelBuilder.class);
   }
 
@@ -119,6 +120,7 @@ public class UdsNettyChannelProviderTest {
 
   @Test
   public void newChannelBuilder_success() {
+    Assume.assumeTrue(Utils.isEpollAvailable());
     NewChannelBuilderResult result =
         provider.newChannelBuilder("unix:sock.sock", TlsChannelCredentials.create());
     assertThat(result.getChannelBuilder()).isInstanceOf(NettyChannelBuilder.class);

--- a/netty/src/test/java/io/grpc/netty/UdsNettyChannelProviderTest.java
+++ b/netty/src/test/java/io/grpc/netty/UdsNettyChannelProviderTest.java
@@ -29,7 +29,6 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.ManagedChannelProvider;
 import io.grpc.ManagedChannelProvider.NewChannelBuilderResult;
 import io.grpc.ManagedChannelRegistryAccessor;
-import io.grpc.Server;
 import io.grpc.TlsChannelCredentials;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
@@ -155,8 +154,8 @@ public class UdsNettyChannelProviderTest {
   private void createUdsServer(String name) throws IOException {
     elg = new EpollEventLoopGroup();
     boss = new EpollEventLoopGroup(1);
-    Server server =
-        cleanupRule.register(NettyServerBuilder.forAddress(new DomainSocketAddress(name))
+    cleanupRule.register(
+        NettyServerBuilder.forAddress(new DomainSocketAddress(name))
             .bossEventLoopGroup(boss)
             .workerEventLoopGroup(elg)
             .channelType(EpollServerDomainSocketChannel.class)

--- a/netty/src/test/java/io/grpc/netty/UdsNettyChannelProviderTest.java
+++ b/netty/src/test/java/io/grpc/netty/UdsNettyChannelProviderTest.java
@@ -18,7 +18,6 @@ package io.grpc.netty;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import io.grpc.Grpc;
@@ -97,7 +96,7 @@ public class UdsNettyChannelProviderTest {
 
   @Test
   public void basicMethods() {
-    assertTrue(provider.isAvailable());
+    Assume.assumeTrue(provider.isAvailable());
     assertEquals(3, provider.priority());
   }
 

--- a/netty/src/test/java/io/grpc/netty/UdsNettyChannelProviderTest.java
+++ b/netty/src/test/java/io/grpc/netty/UdsNettyChannelProviderTest.java
@@ -109,6 +109,7 @@ public class UdsNettyChannelProviderTest {
 
   @Test
   public void builderForTarget_badScheme() {
+    Assume.assumeTrue(Utils.isEpollAvailable());
     try {
       provider.builderForTarget("dns:sock.sock");
       fail("exception expected");
@@ -127,6 +128,7 @@ public class UdsNettyChannelProviderTest {
 
   @Test
   public void newChannelBuilder_badScheme() {
+    Assume.assumeTrue(Utils.isEpollAvailable());
     try {
       provider.newChannelBuilder("dns:sock.sock", InsecureChannelCredentials.create());
       fail("exception expected");


### PR DESCRIPTION
When the scheme is "unix:" we get the UdsNettyChannelProvider to
create a NettyChannelBuilder with DomainSocketAddress type and
other related params needed for UDS sockets

fixes #8884