### PR TITLE
bom: Automatically exclude unpublished projects

### DIFF
--- a/authz/build.gradle
+++ b/authz/build.gradle
@@ -74,4 +74,4 @@ publishing {
     }
 }
 
-[publishMavenPublicationToMavenRepository]*.onlyIf {false}
+publishMavenPublicationToMavenRepository.enabled = false

--- a/bom/build.gradle
+++ b/bom/build.gradle
@@ -14,15 +14,19 @@ publishing {
         // Generate bom using subprojects
         def internalProjects = [
           project.name,
-          'grpc-authz',
           'grpc-compiler',
-          'grpc-gae-interop-testing-jdk8',
         ]
 
         def dependencyManagement = asNode().appendNode('dependencyManagement')
         def dependencies = dependencyManagement.appendNode('dependencies')
         rootProject.subprojects.each { subproject ->
           if (internalProjects.contains(subproject.name)) {
+            return
+          }
+          if (!subproject.hasProperty('publishMavenPublicationToMavenRepository')) {
+            return
+          }
+          if (!subproject.publishMavenPublicationToMavenRepository.enabled) {
             return
           }
           def dependencyNode = dependencies.appendNode('dependency')


### PR DESCRIPTION
grpc-observability was accidentally included in grpc-bom in 1.45
even though it was not published to Maven Central. This
is intended to reduce the likelihood of such things reoccurring. We only
include a project in the bom if it is using maven-publish and if the
publishing task is enabled.

onlyIf is very similar to enabled, except it is processed just before
the task is run. We need a more static property here, so swap to
enabled. If a project uses onlyIf in the future, grpc-bom won't be able
to automatically exclude it.