### PR TITLE
bom: Exclude grpc-observability (v1.45.x)

### DIFF
--- a/bom/build.gradle
+++ b/bom/build.gradle
@@ -17,6 +17,7 @@ publishing {
           'grpc-authz',
           'grpc-compiler',
           'grpc-gae-interop-testing-jdk8',
+          'grpc-observability',
         ]
 
         def dependencyManagement = asNode().appendNode('dependencyManagement')


### PR DESCRIPTION
grpc-observability has publishing to Maven Central disabled. As
discovered in GoogleCloudPlatform/cloud-opensource-java#2303

Related: f2348b0 (#9120)

CC @temawi 