### PR TITLE
Use new wrr_locality LB policy.

### DIFF
--- a/xds/src/main/java/io/grpc/xds/InternalXdsAttributes.java
+++ b/xds/src/main/java/io/grpc/xds/InternalXdsAttributes.java
@@ -24,6 +24,7 @@ import io.grpc.NameResolver;
 import io.grpc.internal.ObjectPool;
 import io.grpc.xds.XdsNameResolverProvider.CallCounterProvider;
 import io.grpc.xds.internal.sds.SslContextProviderSupplier;
+import java.util.Map;
 
 /**
  * Internal attributes used for xDS implementation. Do not use.
@@ -52,6 +53,13 @@ public final class InternalXdsAttributes {
   @NameResolver.ResolutionResultAttr
   static final Attributes.Key<CallCounterProvider> CALL_COUNTER_PROVIDER =
       Attributes.Key.create("io.grpc.xds.InternalXdsAttributes.callCounterProvider");
+
+  /**
+   * Map from localities to their weights.
+   */
+  @NameResolver.ResolutionResultAttr
+  static final Attributes.Key<Map<Locality, Integer>> ATTR_LOCALITY_WEIGHTS =
+      Attributes.Key.create("io.grpc.xds.InternalXdsAttributes.localityWeights");
 
   /**
    * Name of the cluster that provides this EquivalentAddressGroup.

--- a/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancer.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
+
+import com.google.common.base.MoreObjects;
+import io.grpc.InternalLogId;
+import io.grpc.LoadBalancer;
+import io.grpc.Status;
+import io.grpc.internal.ServiceConfigUtil.PolicySelection;
+import io.grpc.xds.WeightedTargetLoadBalancerProvider.WeightedPolicySelection;
+import io.grpc.xds.WeightedTargetLoadBalancerProvider.WeightedTargetConfig;
+import io.grpc.xds.XdsLogger.XdsLogLevel;
+import io.grpc.xds.XdsSubchannelPickers.ErrorPicker;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * This load balancer acts as a parent for the {@link WeightedTargetLoadBalancer} and configures
+ * it with a child policy in its configuration and locality weights it gets from an attribute in
+ * {@link io.grpc.LoadBalancer.ResolvedAddresses}.
+ */
+public class WrrLocalityLoadBalancer extends LoadBalancer {
+
+  private final XdsLogger logger;
+  private LoadBalancer childLb;
+  private final Helper helper;
+
+  WrrLocalityLoadBalancer(Helper helper) {
+    this.helper = checkNotNull(helper, "helper");
+    logger = XdsLogger.withLogId(
+        InternalLogId.allocate("xds-wrr-locality-lb", helper.getAuthority()));
+    logger.log(XdsLogLevel.INFO, "Created");
+  }
+
+  @Override
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
+
+    // The configuration with the child policy is combined with the locality weights
+    // to produce the weighted target LB config.
+    WrrLocalityConfig wrrLocalityConfig
+        = (WrrLocalityConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
+    Map<Locality, Integer> localityWeights = resolvedAddresses.getAttributes()
+        .get(InternalXdsAttributes.ATTR_LOCALITY_WEIGHTS);
+
+    // Weighted target LB expects a WeightedPolicySelection for each locality as it will create a
+    // child LB for each.
+    Map<String, WeightedPolicySelection> weightedPolicySelections = new HashMap<>();
+    for (Locality locality : localityWeights.keySet()) {
+      weightedPolicySelections.put(locality.toString(),
+          new WeightedPolicySelection(localityWeights.get(locality),
+              wrrLocalityConfig.childPolicy));
+    }
+
+    childLb = wrrLocalityConfig.childPolicy.getProvider().newLoadBalancer(helper);
+    childLb.handleResolvedAddresses(
+        resolvedAddresses.toBuilder()
+            .setLoadBalancingPolicyConfig(new WeightedTargetConfig(weightedPolicySelections))
+            .build());
+  }
+
+  @Override
+  public void handleNameResolutionError(Status error) {
+    logger.log(XdsLogLevel.WARNING, "Received name resolution error: {0}", error);
+    if (childLb != null) {
+      childLb.handleNameResolutionError(error);
+    } else {
+      helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(error));
+    }
+  }
+
+  @Override
+  public void shutdown() {
+    if (childLb != null) {
+      childLb.shutdown();
+    }
+  }
+
+  /**
+   * The LB config for {@link WrrLocalityLoadBalancer}.
+   */
+  static final class WrrLocalityConfig {
+
+    final PolicySelection childPolicy;
+
+    WrrLocalityConfig(PolicySelection childPolicy) {
+      this.childPolicy = childPolicy;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      WrrLocalityConfig that = (WrrLocalityConfig) o;
+      return Objects.equals(childPolicy, that.childPolicy);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(childPolicy);
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this).add("childPolicy", childPolicy).toString();
+    }
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancerProvider.java
@@ -30,7 +30,6 @@ import io.grpc.internal.ServiceConfigUtil.PolicySelection;
 import io.grpc.xds.WrrLocalityLoadBalancer.WrrLocalityConfig;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 
 /**
  * The provider for {@link WrrLocalityLoadBalancer}. An instance of this class should be acquired
@@ -38,10 +37,7 @@ import javax.annotation.Nullable;
  * "xds_wrr_locality_experimental".
  */
 @Internal
-public class WrrLocalityLoadBalancerProvider extends LoadBalancerProvider {
-
-  @Nullable
-  private LoadBalancerRegistry lbRegistry;
+public final class WrrLocalityLoadBalancerProvider extends LoadBalancerProvider {
 
   @Override
   public LoadBalancer newLoadBalancer(Helper helper) {
@@ -70,13 +66,12 @@ public class WrrLocalityLoadBalancerProvider extends LoadBalancerProvider {
           JsonUtil.getListOfObjects(rawConfig, "childPolicy"));
       if (childConfigCandidates == null || childConfigCandidates.isEmpty()) {
         return ConfigOrError.fromError(Status.INTERNAL.withDescription(
-            "No child policy in wrr_locality LB policy:\n "
+            "No child policy in wrr_locality LB policy: "
                 + rawConfig));
       }
-      LoadBalancerRegistry lbRegistry =
-          this.lbRegistry == null ? LoadBalancerRegistry.getDefaultRegistry() : this.lbRegistry;
       ConfigOrError selectedConfig =
-          ServiceConfigUtil.selectLbPolicyFromList(childConfigCandidates, lbRegistry);
+          ServiceConfigUtil.selectLbPolicyFromList(childConfigCandidates,
+              LoadBalancerRegistry.getDefaultRegistry());
       if (selectedConfig.getError() != null) {
         return selectedConfig;
       }

--- a/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancerProvider.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import io.grpc.Internal;
+import io.grpc.LoadBalancer;
+import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancerProvider;
+import io.grpc.LoadBalancerRegistry;
+import io.grpc.NameResolver.ConfigOrError;
+import io.grpc.Status;
+import io.grpc.internal.JsonUtil;
+import io.grpc.internal.ServiceConfigUtil;
+import io.grpc.internal.ServiceConfigUtil.LbConfig;
+import io.grpc.internal.ServiceConfigUtil.PolicySelection;
+import io.grpc.xds.WrrLocalityLoadBalancer.WrrLocalityConfig;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * The provider for {@link WrrLocalityLoadBalancer}. An instance of this class should be acquired
+ * through {@link LoadBalancerRegistry#getProvider} by using the name
+ * "xds_wrr_locality_experimental".
+ */
+@Internal
+public class WrrLocalityLoadBalancerProvider extends LoadBalancerProvider {
+
+  @Nullable
+  private LoadBalancerRegistry lbRegistry;
+
+  @Override
+  public LoadBalancer newLoadBalancer(Helper helper) {
+    return new WrrLocalityLoadBalancer(helper);
+  }
+
+  @Override
+  public boolean isAvailable() {
+    return true;
+  }
+
+  @Override
+  public int getPriority() {
+    return 5;
+  }
+
+  @Override
+  public String getPolicyName() {
+    return XdsLbPolicies.WRR_LOCALITY_POLICY_NAME;
+  }
+
+  @Override
+  public ConfigOrError parseLoadBalancingPolicyConfig(Map<String, ?> rawConfig) {
+    try {
+      List<LbConfig> childConfigCandidates = ServiceConfigUtil.unwrapLoadBalancingConfigList(
+          JsonUtil.getListOfObjects(rawConfig, "childPolicy"));
+      if (childConfigCandidates == null || childConfigCandidates.isEmpty()) {
+        return ConfigOrError.fromError(Status.INTERNAL.withDescription(
+            "No child policy in wrr_locality LB policy:\n "
+                + rawConfig));
+      }
+      LoadBalancerRegistry lbRegistry =
+          this.lbRegistry == null ? LoadBalancerRegistry.getDefaultRegistry() : this.lbRegistry;
+      ConfigOrError selectedConfig =
+          ServiceConfigUtil.selectLbPolicyFromList(childConfigCandidates, lbRegistry);
+      if (selectedConfig.getError() != null) {
+        return selectedConfig;
+      }
+      PolicySelection policySelection = (PolicySelection) selectedConfig.getConfig();
+      return ConfigOrError.fromConfig(new WrrLocalityConfig(policySelection));
+    } catch (RuntimeException e) {
+      return ConfigOrError.fromError(Status.fromThrowable(e)
+          .withDescription("Failed to parse wrr_locality LB config: " + rawConfig));
+    }
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/XdsLbPolicies.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLbPolicies.java
@@ -23,6 +23,7 @@ final class XdsLbPolicies {
   static final String PRIORITY_POLICY_NAME = "priority_experimental";
   static final String CLUSTER_IMPL_POLICY_NAME = "cluster_impl_experimental";
   static final String WEIGHTED_TARGET_POLICY_NAME = "weighted_target_experimental";
+  static final String WRR_LOCALITY_POLICY_NAME = "wrr_locality_experimental";
 
   private XdsLbPolicies() {}
 }

--- a/xds/src/main/resources/META-INF/services/io.grpc.LoadBalancerProvider
+++ b/xds/src/main/resources/META-INF/services/io.grpc.LoadBalancerProvider
@@ -6,3 +6,4 @@ io.grpc.xds.ClusterResolverLoadBalancerProvider
 io.grpc.xds.ClusterImplLoadBalancerProvider
 io.grpc.xds.LeastRequestLoadBalancerProvider
 io.grpc.xds.RingHashLoadBalancerProvider
+io.grpc.xds.WrrLocalityLoadBalancerProvider

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientDataTest.java
@@ -1758,7 +1758,11 @@ public class ClientXdsClientDataTest {
         cluster, new HashSet<String>(), null, LRS_SERVER_INFO,
         LoadBalancerRegistry.getDefaultRegistry());
     LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(update.lbPolicyConfig());
-    assertThat(lbConfig.getPolicyName()).isEqualTo("least_request_experimental");
+    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
+    @SuppressWarnings("unchecked")
+    List<LbConfig> childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
+        (List<Map<String, ?>>) lbConfig.getRawConfigValue().get("childPolicy"));
+    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("least_request_experimental");
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientTestBase.java
@@ -1628,8 +1628,12 @@ public abstract class ClientXdsClientTestBase {
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.EDS);
     assertThat(cdsUpdate.edsServiceName()).isNull();
-    assertThat(ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig())
-        .getPolicyName()).isEqualTo("round_robin");
+    LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig());
+    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
+    @SuppressWarnings("unchecked")
+    List<LbConfig> childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
+        (List<Map<String, ?>>) lbConfig.getRawConfigValue().get("childPolicy"));
+    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("round_robin");
     assertThat(cdsUpdate.lrsServerInfo()).isNull();
     assertThat(cdsUpdate.maxConcurrentRequests()).isNull();
     assertThat(cdsUpdate.upstreamTlsContext()).isNull();
@@ -1651,8 +1655,12 @@ public abstract class ClientXdsClientTestBase {
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.EDS);
     assertThat(cdsUpdate.edsServiceName()).isNull();
-    assertThat(ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig())
-        .getPolicyName()).isEqualTo("round_robin");
+    LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig());
+    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
+    @SuppressWarnings("unchecked")
+    List<LbConfig> childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
+        (List<Map<String, ?>>) lbConfig.getRawConfigValue().get("childPolicy"));
+    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("round_robin");
     assertThat(cdsUpdate.lrsServerInfo()).isNull();
     assertThat(cdsUpdate.maxConcurrentRequests()).isNull();
     assertThat(cdsUpdate.upstreamTlsContext()).isNull();
@@ -1680,8 +1688,12 @@ public abstract class ClientXdsClientTestBase {
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.EDS);
     assertThat(cdsUpdate.edsServiceName()).isNull();
     LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig());
-    assertThat(lbConfig.getPolicyName()).isEqualTo("least_request_experimental");
-    assertThat(lbConfig.getRawConfigValue().get("choiceCount")).isEqualTo(3);
+    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
+    @SuppressWarnings("unchecked")
+    List<LbConfig> childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
+        (List<Map<String, ?>>) lbConfig.getRawConfigValue().get("childPolicy"));
+    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("least_request_experimental");
+    assertThat(childConfigs.get(0).getRawConfigValue().get("choiceCount")).isEqualTo(3);
     assertThat(cdsUpdate.lrsServerInfo()).isNull();
     assertThat(cdsUpdate.maxConcurrentRequests()).isNull();
     assertThat(cdsUpdate.upstreamTlsContext()).isNull();
@@ -1736,8 +1748,12 @@ public abstract class ClientXdsClientTestBase {
     CdsUpdate cdsUpdate = cdsUpdateCaptor.getValue();
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.AGGREGATE);
-    assertThat(ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig())
-        .getPolicyName()).isEqualTo("round_robin");
+    LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig());
+    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
+    @SuppressWarnings("unchecked")
+    List<LbConfig> childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
+        (List<Map<String, ?>>) lbConfig.getRawConfigValue().get("childPolicy"));
+    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("round_robin");
     assertThat(cdsUpdate.prioritizedClusterNames()).containsExactlyElementsIn(candidates).inOrder();
     verifyResourceMetadataAcked(CDS, CDS_RESOURCE, clusterAggregate, VERSION_1, TIME_INCREMENT);
     verifySubscribedResourcesMetadataSizes(0, 1, 0, 0);
@@ -1758,8 +1774,12 @@ public abstract class ClientXdsClientTestBase {
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.EDS);
     assertThat(cdsUpdate.edsServiceName()).isNull();
-    assertThat(ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig())
-        .getPolicyName()).isEqualTo("round_robin");
+    LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig());
+    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
+    @SuppressWarnings("unchecked")
+    List<LbConfig> childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
+        (List<Map<String, ?>>) lbConfig.getRawConfigValue().get("childPolicy"));
+    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("round_robin");
     assertThat(cdsUpdate.lrsServerInfo()).isNull();
     assertThat(cdsUpdate.maxConcurrentRequests()).isEqualTo(200L);
     assertThat(cdsUpdate.upstreamTlsContext()).isNull();
@@ -1903,8 +1923,12 @@ public abstract class ClientXdsClientTestBase {
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.EDS);
     assertThat(cdsUpdate.edsServiceName()).isNull();
-    assertThat(ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig())
-        .getPolicyName()).isEqualTo("round_robin");
+    LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig());
+    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
+    @SuppressWarnings("unchecked")
+    List<LbConfig> childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
+        (List<Map<String, ?>>) lbConfig.getRawConfigValue().get("childPolicy"));
+    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("round_robin");
     assertThat(cdsUpdate.lrsServerInfo()).isNull();
     assertThat(cdsUpdate.maxConcurrentRequests()).isNull();
     assertThat(cdsUpdate.upstreamTlsContext()).isNull();
@@ -1929,6 +1953,7 @@ public abstract class ClientXdsClientTestBase {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void cdsResourceUpdated() {
     DiscoveryRpcCall call = startResourceWatcher(CDS, CDS_RESOURCE, cdsResourceWatcher);
     verifyResourceMetadataRequested(CDS, CDS_RESOURCE);
@@ -1946,8 +1971,11 @@ public abstract class ClientXdsClientTestBase {
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.LOGICAL_DNS);
     assertThat(cdsUpdate.dnsHostName()).isEqualTo(dnsHostAddr + ":" + dnsHostPort);
-    assertThat(ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig())
-        .getPolicyName()).isEqualTo("round_robin");
+    LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig());
+    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
+    List<LbConfig> childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
+        (List<Map<String, ?>>) lbConfig.getRawConfigValue().get("childPolicy"));
+    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("round_robin");
     assertThat(cdsUpdate.lrsServerInfo()).isNull();
     assertThat(cdsUpdate.maxConcurrentRequests()).isNull();
     assertThat(cdsUpdate.upstreamTlsContext()).isNull();
@@ -1966,8 +1994,11 @@ public abstract class ClientXdsClientTestBase {
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.EDS);
     assertThat(cdsUpdate.edsServiceName()).isEqualTo(edsService);
-    assertThat(ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig())
-        .getPolicyName()).isEqualTo("round_robin");
+    lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig());
+    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
+    childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
+        (List<Map<String, ?>>) lbConfig.getRawConfigValue().get("childPolicy"));
+    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("round_robin");
     assertThat(cdsUpdate.lrsServerInfo()).isEqualTo(lrsServerInfo);
     assertThat(cdsUpdate.maxConcurrentRequests()).isNull();
     assertThat(cdsUpdate.upstreamTlsContext()).isNull();
@@ -2035,8 +2066,12 @@ public abstract class ClientXdsClientTestBase {
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.EDS);
     assertThat(cdsUpdate.edsServiceName()).isNull();
-    assertThat(ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig())
-        .getPolicyName()).isEqualTo("round_robin");
+    LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig());
+    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
+    @SuppressWarnings("unchecked")
+    List<LbConfig> childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
+        (List<Map<String, ?>>) lbConfig.getRawConfigValue().get("childPolicy"));
+    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("round_robin");
     assertThat(cdsUpdate.lrsServerInfo()).isNull();
     assertThat(cdsUpdate.maxConcurrentRequests()).isNull();
     assertThat(cdsUpdate.upstreamTlsContext()).isNull();
@@ -2053,6 +2088,7 @@ public abstract class ClientXdsClientTestBase {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void multipleCdsWatchers() {
     String cdsResourceTwo = "cluster-bar.googleapis.com";
     CdsResourceWatcher watcher1 = mock(CdsResourceWatcher.class);
@@ -2088,8 +2124,11 @@ public abstract class ClientXdsClientTestBase {
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.LOGICAL_DNS);
     assertThat(cdsUpdate.dnsHostName()).isEqualTo(dnsHostAddr + ":" + dnsHostPort);
-    assertThat(ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig())
-        .getPolicyName()).isEqualTo("round_robin");
+    LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig());
+    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
+    List<LbConfig> childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
+        (List<Map<String, ?>>) lbConfig.getRawConfigValue().get("childPolicy"));
+    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("round_robin");
     assertThat(cdsUpdate.lrsServerInfo()).isNull();
     assertThat(cdsUpdate.maxConcurrentRequests()).isNull();
     assertThat(cdsUpdate.upstreamTlsContext()).isNull();
@@ -2098,8 +2137,11 @@ public abstract class ClientXdsClientTestBase {
     assertThat(cdsUpdate.clusterName()).isEqualTo(cdsResourceTwo);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.EDS);
     assertThat(cdsUpdate.edsServiceName()).isEqualTo(edsService);
-    assertThat(ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig())
-        .getPolicyName()).isEqualTo("round_robin");
+    lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig());
+    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
+    childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
+        (List<Map<String, ?>>) lbConfig.getRawConfigValue().get("childPolicy"));
+    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("round_robin");
     assertThat(cdsUpdate.lrsServerInfo()).isEqualTo(lrsServerInfo);
     assertThat(cdsUpdate.maxConcurrentRequests()).isNull();
     assertThat(cdsUpdate.upstreamTlsContext()).isNull();
@@ -2108,8 +2150,11 @@ public abstract class ClientXdsClientTestBase {
     assertThat(cdsUpdate.clusterName()).isEqualTo(cdsResourceTwo);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.EDS);
     assertThat(cdsUpdate.edsServiceName()).isEqualTo(edsService);
-    assertThat(ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig())
-        .getPolicyName()).isEqualTo("round_robin");
+    lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig());
+    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
+    childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
+        (List<Map<String, ?>>) lbConfig.getRawConfigValue().get("childPolicy"));
+    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("round_robin");
     assertThat(cdsUpdate.lrsServerInfo()).isEqualTo(lrsServerInfo);
     assertThat(cdsUpdate.maxConcurrentRequests()).isNull();
     assertThat(cdsUpdate.upstreamTlsContext()).isNull();

--- a/xds/src/test/java/io/grpc/xds/LegacyLoadBalancerConfigFactoryTest.java
+++ b/xds/src/test/java/io/grpc/xds/LegacyLoadBalancerConfigFactoryTest.java
@@ -30,6 +30,8 @@ import io.grpc.internal.JsonUtil;
 import io.grpc.internal.ServiceConfigUtil;
 import io.grpc.internal.ServiceConfigUtil.LbConfig;
 import io.grpc.xds.ClientXdsClient.ResourceInvalidException;
+import java.util.List;
+import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -46,9 +48,14 @@ public class LegacyLoadBalancerConfigFactoryTest {
 
     LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(
         LegacyLoadBalancerConfigFactory.newConfig(cluster, true));
+    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
 
-    assertThat(lbConfig.getPolicyName()).isEqualTo("round_robin");
-    assertThat(lbConfig.getRawConfigValue()).isEmpty();
+    @SuppressWarnings("unchecked")
+    List<LbConfig> childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
+        (List<Map<String, ?>>) lbConfig.getRawConfigValue().get("childPolicy"));
+    assertThat(childConfigs).hasSize(1);
+    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("round_robin");
+    assertThat(childConfigs.get(0).getRawConfigValue()).isEmpty();
   }
 
   @Test
@@ -67,7 +74,7 @@ public class LegacyLoadBalancerConfigFactoryTest {
   }
 
   @Test
-  public void ringHash_invalidHash() throws ResourceInvalidException {
+  public void ringHash_invalidHash() {
     Cluster cluster = Cluster.newBuilder().setLbPolicy(LbPolicy.RING_HASH).setRingHashLbConfig(
         RingHashLbConfig.newBuilder().setHashFunction(HashFunction.MURMUR_HASH_2)).build();
 
@@ -91,14 +98,20 @@ public class LegacyLoadBalancerConfigFactoryTest {
 
     LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(
         LegacyLoadBalancerConfigFactory.newConfig(cluster, true));
+    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
 
-    assertThat(lbConfig.getPolicyName()).isEqualTo("least_request_experimental");
-    assertThat(JsonUtil.getNumberAsLong(lbConfig.getRawConfigValue(), "choiceCount")).isEqualTo(10);
+    @SuppressWarnings("unchecked")
+    List<LbConfig> childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
+        (List<Map<String, ?>>) lbConfig.getRawConfigValue().get("childPolicy"));
+    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("least_request_experimental");
+    assertThat(
+        JsonUtil.getNumberAsLong(childConfigs.get(0).getRawConfigValue(), "choiceCount")).isEqualTo(
+        10);
   }
 
 
   @Test
-  public void leastRequest_notEnabled() throws ResourceInvalidException {
+  public void leastRequest_notEnabled() {
     System.setProperty("io.grpc.xds.experimentalEnableLeastRequest", "false");
 
     Cluster cluster = Cluster.newBuilder().setLbPolicy(LbPolicy.LEAST_REQUEST).build();

--- a/xds/src/test/java/io/grpc/xds/WrrLocalityLoadBalancerProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/WrrLocalityLoadBalancerProviderTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.grpc.LoadBalancer;
+import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancerProvider;
+import io.grpc.LoadBalancerRegistry;
+import io.grpc.NameResolver;
+import io.grpc.xds.WrrLocalityLoadBalancer.WrrLocalityConfig;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link WrrLocalityLoadBalancerProvider}.
+ */
+@RunWith(JUnit4.class)
+public class WrrLocalityLoadBalancerProviderTest {
+
+  @Test
+  public void provided() {
+    LoadBalancerProvider provider =
+        LoadBalancerRegistry.getDefaultRegistry().getProvider(
+            XdsLbPolicies.WRR_LOCALITY_POLICY_NAME);
+    assertThat(provider).isInstanceOf(WrrLocalityLoadBalancerProvider.class);
+  }
+
+  @Test
+  public void providesLoadBalancer()  {
+    Helper helper = mock(Helper.class);
+    when(helper.getAuthority()).thenReturn("api.google.com");
+    LoadBalancerProvider provider = new WrrLocalityLoadBalancerProvider();
+    LoadBalancer loadBalancer = provider.newLoadBalancer(helper);
+    assertThat(loadBalancer).isInstanceOf(WrrLocalityLoadBalancer.class);
+  }
+
+  @Test
+  public void parseConfig() {
+    Map<String, ?> rawConfig = ImmutableMap.of("childPolicy",
+        ImmutableList.of(ImmutableMap.of("round_robin", ImmutableMap.of())));
+
+    WrrLocalityLoadBalancerProvider provider = new WrrLocalityLoadBalancerProvider();
+    NameResolver.ConfigOrError configOrError = provider.parseLoadBalancingPolicyConfig(rawConfig);
+    WrrLocalityConfig config = (WrrLocalityConfig) configOrError.getConfig();
+    assertThat(config.childPolicy.getProvider().getPolicyName()).isEqualTo("round_robin");
+  }
+}

--- a/xds/src/test/java/io/grpc/xds/WrrLocalityLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WrrLocalityLoadBalancerTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.testing.EqualsTester;
+import io.grpc.Attributes;
+import io.grpc.ConnectivityState;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancer;
+import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancer.ResolvedAddresses;
+import io.grpc.LoadBalancerProvider;
+import io.grpc.Status;
+import io.grpc.internal.ServiceConfigUtil.PolicySelection;
+import io.grpc.xds.WeightedTargetLoadBalancerProvider.WeightedPolicySelection;
+import io.grpc.xds.WeightedTargetLoadBalancerProvider.WeightedTargetConfig;
+import io.grpc.xds.WrrLocalityLoadBalancer.WrrLocalityConfig;
+import io.grpc.xds.XdsSubchannelPickers.ErrorPicker;
+import java.net.SocketAddress;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Tests for {@link WrrLocalityLoadBalancerProvider}.
+ */
+@RunWith(JUnit4.class)
+public class WrrLocalityLoadBalancerTest {
+
+  @Mock
+  private LoadBalancerProvider mockProvider;
+  @Mock
+  private LoadBalancer mockChildLb;
+  @Mock
+  private Helper mockHelper;
+  @Mock
+  private SocketAddress mockSocketAddress;
+
+  @Captor
+  private ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor;
+  @Captor
+  private ArgumentCaptor<ConnectivityState> connectivityStateCaptor;
+  @Captor
+  private ArgumentCaptor<ErrorPicker> errorPickerCaptor;
+
+  private EquivalentAddressGroup eag = new EquivalentAddressGroup(mockSocketAddress);
+
+  private WrrLocalityLoadBalancer loadBalancer;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    when(mockProvider.newLoadBalancer(isA(Helper.class))).thenReturn(mockChildLb);
+    loadBalancer = new WrrLocalityLoadBalancer(mockHelper);
+  }
+
+  @Test
+  public void handleResolvedAddresses() {
+    // A two locality cluster with a mock child LB policy.
+    Locality localityOne = Locality.create("region1", "zone1", "subzone1");
+    Locality localityTwo = Locality.create("region2", "zone2", "subzone2");
+    PolicySelection childPolicy = new PolicySelection(mockProvider, null);
+
+    // The child config is delivered wrapped in the wrr_locality config and the locality weights
+    // in a ResolvedAddresses attribute.
+    WrrLocalityConfig wlConfig = new WrrLocalityConfig(childPolicy);
+    Map<Locality, Integer> localityWeights = ImmutableMap.of(localityOne, 1, localityTwo, 2);
+    deliverAddresses(wlConfig, localityWeights);
+
+    // Assert that the child policy and the locality weights were correctly mapped to a
+    // WeightedTargetConfig.
+    verify(mockChildLb).handleResolvedAddresses(resolvedAddressesCaptor.capture());
+    Object config = resolvedAddressesCaptor.getValue().getLoadBalancingPolicyConfig();
+    assertThat(config).isInstanceOf(WeightedTargetConfig.class);
+    WeightedTargetConfig wtConfig = (WeightedTargetConfig) config;
+    assertThat(wtConfig.targets).hasSize(2);
+    assertThat(wtConfig.targets).containsEntry(localityOne.toString(),
+        new WeightedPolicySelection(1, childPolicy));
+    assertThat(wtConfig.targets).containsEntry(localityTwo.toString(),
+        new WeightedPolicySelection(2, childPolicy));
+
+  }
+
+  @Test
+  public void handleNameResolutionError_noChildLb() {
+    loadBalancer.handleNameResolutionError(Status.DEADLINE_EXCEEDED);
+
+    verify(mockHelper).updateBalancingState(connectivityStateCaptor.capture(),
+        errorPickerCaptor.capture());
+    assertThat(connectivityStateCaptor.getValue()).isEqualTo(ConnectivityState.TRANSIENT_FAILURE);
+    assertThat(errorPickerCaptor.getValue().toString()).isEqualTo(
+        new ErrorPicker(Status.DEADLINE_EXCEEDED).toString());
+  }
+
+  @Test
+  public void handleNameResolutionError_withChildLb() {
+    deliverAddresses(new WrrLocalityConfig(new PolicySelection(mockProvider, null)),
+        ImmutableMap.of(
+            Locality.create("region", "zone", "subzone"), 1));
+    loadBalancer.handleNameResolutionError(Status.DEADLINE_EXCEEDED);
+
+    verify(mockHelper, never()).updateBalancingState(isA(ConnectivityState.class),
+        isA(ErrorPicker.class));
+    verify(mockChildLb).handleNameResolutionError(Status.DEADLINE_EXCEEDED);
+  }
+
+  @Test
+  public void shutdown() {
+    deliverAddresses(new WrrLocalityConfig(new PolicySelection(mockProvider, null)),
+        ImmutableMap.of(
+            Locality.create("region", "zone", "subzone"), 1));
+    loadBalancer.shutdown();
+
+    verify(mockChildLb).shutdown();
+  }
+
+  @Test
+  public void configEquality() {
+    WrrLocalityConfig configOne = new WrrLocalityConfig(new PolicySelection(mockProvider, null));
+    WrrLocalityConfig configTwo = new WrrLocalityConfig(new PolicySelection(mockProvider, null));
+    WrrLocalityConfig differentConfig = new WrrLocalityConfig(
+        new PolicySelection(mockProvider, "config"));
+
+    new EqualsTester().addEqualityGroup(configOne, configTwo).addEqualityGroup(differentConfig)
+        .testEquals();
+  }
+
+  private void deliverAddresses(WrrLocalityConfig config, Map<Locality, Integer> localityWeights) {
+    loadBalancer.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder().setAddresses(ImmutableList.of(eag)).setAttributes(
+                Attributes.newBuilder()
+                    .set(InternalXdsAttributes.ATTR_LOCALITY_WEIGHTS, localityWeights).build())
+            .setLoadBalancingPolicyConfig(config).build());
+  }
+}

--- a/xds/src/test/java/io/grpc/xds/WrrLocalityLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WrrLocalityLoadBalancerTest.java
@@ -115,8 +115,6 @@ public class WrrLocalityLoadBalancerTest {
   @Test
   public void handleResolvedAddresses_noLocalityWeights() {
     // A two locality cluster with a mock child LB policy.
-    Locality localityOne = Locality.create("region1", "zone1", "subzone1");
-    Locality localityTwo = Locality.create("region2", "zone2", "subzone2");
     PolicySelection childPolicy = new PolicySelection(mockProvider, null);
 
     // The child config is delivered wrapped in the wrr_locality config and the locality weights


### PR DESCRIPTION
Instead of providing round robin or least request configurations directly, ClientXdsClient now wraps them in a WRR locality config. 

ClusterResolverLoadBalancer passes this configuration directly to PriorityLoadBalancer to use as the endpoint LB policy it provides to ClusterImplLoadBalancer. A new ResolvedAddresses attribute is also set that has all the locality weights. This is needed by WrrLocalityLoadBalancer when it configures WeightedTargetLoadBalancer.

This builds on this (still unmerged) PR: https://github.com/grpc/grpc-java/pull/9103