### PR TITLE
usage of ErrorProne CheckReturnValue

### DIFF
--- a/binder/src/main/java/io/grpc/binder/SecurityPolicies.java
+++ b/binder/src/main/java/io/grpc/binder/SecurityPolicies.java
@@ -25,12 +25,12 @@ import android.os.Build;
 import android.os.Process;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.errorprone.annotations.CheckReturnValue;
 import io.grpc.ExperimentalApi;
 import io.grpc.Status;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import javax.annotation.CheckReturnValue;
 
 /** Static factory methods for creating standard security policies. */
 @CheckReturnValue


### PR DESCRIPTION
Prefer ErrorProne's CheckReturnValue over JSR305's based on go/bugpattern/UsingJsr305CheckReturnValue