### PR TITLE
rls: Increase RPC timeout for flaky rls_withCustomRlsChannelServiceConfig

### DIFF
--- a/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
+++ b/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
@@ -434,7 +434,7 @@ public class CachingRlsLbClientTest {
                 ExtraKeys.create("server", "service-key", "method-key"),
                 ImmutableMap.<String, String>of())))
         .lookupService("service1")
-        .lookupServiceTimeoutInNanos(TimeUnit.SECONDS.toNanos(2))
+        .lookupServiceTimeoutInNanos(TimeUnit.SECONDS.toNanos(10))
         .maxAgeInNanos(TimeUnit.SECONDS.toNanos(300))
         .staleAgeInNanos(TimeUnit.SECONDS.toNanos(240))
         .cacheSizeBytes(1000)


### PR DESCRIPTION
The test appears to be slow because of classloading. The failure cases
were very slow at 14-16 seconds, but looking at other logs it succeeds
after 12 seconds. It is the first test in the class, and the other tests
run much faster. This could be solved with warmup code, but increasing
the RPC deadline is easier.

Two back-to-back failures on aarch64:
https://source.cloud.google.com/results/invocations/c4612a28-d594-42e9-b8ab-12c999690b40/targets
https://source.cloud.google.com/results/invocations/3d5d1dc2-6b47-493d-b15c-e99458067d73/targets

```
expected to be true
	at app//io.grpc.rls.CachingRlsLbClientTest.rls_withCustomRlsChannelServiceConfig(CachingRlsLbClientTest.java:267)
```

And the next run failed on a different line but seems the same cause:
https://source.cloud.google.com/results/invocations/546b83d1-cd26-4b87-8871-a7a06a60dc06/targets

```
expected to be true
	at app//io.grpc.rls.CachingRlsLbClientTest.rls_withCustomRlsChannelServiceConfig(CachingRlsLbClientTest.java:273)
```

Reproduced with:
```diff
diff --git a/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java b/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
index 9fac852fa..631d632eb 100644
--- a/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
+++ b/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
@@ -264,6 +264,11 @@ public class CachingRlsLbClientTest {

     // initial request
     CachedRouteLookupResponse resp = getInSyncContext(routeLookupRequest);
+    try {
+      Thread.sleep(2000);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
     assertThat(resp.isPending()).isTrue();

     // server response
```