### PR TITLE
interop-testing: Improve ConcurrencyTest error reporting

### DIFF
--- a/interop-testing/src/test/java/io/grpc/testing/integration/ConcurrencyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/ConcurrencyTest.java
@@ -120,6 +120,9 @@ public class ConcurrencyTest {
         // all clients send their requests at approximately the same time.
         startBarrier.await();
         clientStub.streamingOutputCall(request, new SignalingResponseObserver(completionFuture));
+      } catch (InterruptedException ex) {
+        Thread.currentThread().interrupt();
+        completionFuture.setException(ex);
       } catch (Throwable t) {
         completionFuture.setException(t);
       }


### PR DESCRIPTION
When a problem happens, it will now report back quickly instead of
waiting until the timeout expires. The timeout exception will also
report each RPC's state.

This is to help diagnose aarch64 test failures.