### PR TITLE
benchmarks: Increase timeout of LoadWorkerTest

### DIFF
--- a/benchmarks/src/test/java/io/grpc/benchmarks/driver/LoadWorkerTest.java
+++ b/benchmarks/src/test/java/io/grpc/benchmarks/driver/LoadWorkerTest.java
@@ -181,7 +181,7 @@ public class LoadWorkerTest {
       throws InterruptedException {
 
     Stats.ClientStats stat = null;
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < 30; i++) {
       // Poll until we get some stats
       Thread.sleep(300);
       clientObserver.onNext(MARK);
@@ -197,7 +197,7 @@ public class LoadWorkerTest {
     assertThat(stat.hasLatencies()).isTrue();
     assertThat(stat.getLatencies().getCount()).isLessThan(stat.getLatencies().getSum());
     double mean = stat.getLatencies().getSum() / stat.getLatencies().getCount();
-    System.out.println("Mean " + mean + " us");
+    System.out.println("Mean " + mean + " ns");
     assertThat(stat.getLatencies().getMinSeen()).isLessThan(mean);
     assertThat(stat.getLatencies().getMaxSeen()).isGreaterThan(mean);
   }


### PR DESCRIPTION
This should fix test failures on aarch64.
```
expected to be less than: 0.0
but was                 : 0.0
	at app//io.grpc.benchmarks.driver.LoadWorkerTest.assertWorkOccurred(LoadWorkerTest.java:198)
	at app//io.grpc.benchmarks.driver.LoadWorkerTest.runUnaryBlockingClosedLoop(LoadWorkerTest.java:90)
```

runUnaryBlockingClosedLoop() has been failing but the other tests
suceeding. The failure is complaining that getCount() == 0, which means
no RPCs completed. The slowest successful test has a mean RPC time of
226 ms (the unit was logged incorrectly) and comparing to x86 tests
runUnaryBlockingClosedLoop() is ~2x as slow because it executes first.
So this is probably _barely_ failing and 4 attempts instead of 3 would
be sufficient. While the test tries to wait for 10 RPCs to complete, it
seems likely it is stopping early even for the successful runs on
aarch64. There are 4 concurrent RPCs, so to get 10 RPCs we need to wait
for 3 batches of RPCs to complete which would be 1346 ms (5 loops)
assuming a 452 ms mean latency. Bumping timeout by 10x to give lots of
headroom.