### PR TITLE
gcp-observability:  add grpc-census as a dependency and update opencensus version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ subprojects {
         googleauthVersion = '1.4.0'
         protobufVersion = '3.19.2'
         protocVersion = protobufVersion
-        opencensusVersion = '0.28.0'
+        opencensusVersion = '0.31.0'
         autovalueVersion = '1.9'
 
         configureProtoCompilation = {

--- a/census/src/main/java/io/grpc/census/CensusTracingModule.java
+++ b/census/src/main/java/io/grpc/census/CensusTracingModule.java
@@ -365,6 +365,11 @@ final class CensusTracingModule {
       span.end(createEndSpanOptions(status, isSampledToLocalTracing));
     }
 
+    /*
+     TODO(dnvindhya): Replace deprecated ContextUtils usage with ContextHandleUtils to interact
+     with io.grpc.Context as described in {@link io.opencensus.trace.unsafeContextUtils} to remove
+     SuppressWarnings annotation.
+    */
     @SuppressWarnings("deprecation")
     @Override
     public Context filterContext(Context context) {
@@ -404,6 +409,7 @@ final class CensusTracingModule {
 
   @VisibleForTesting
   final class TracingClientInterceptor implements ClientInterceptor {
+
     @SuppressWarnings("deprecation")
     @Override
     public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(

--- a/census/src/test/java/io/grpc/census/CensusModulesTest.java
+++ b/census/src/test/java/io/grpc/census/CensusModulesTest.java
@@ -95,7 +95,6 @@ import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.propagation.BinaryFormat;
 import io.opencensus.trace.propagation.SpanContextParseException;
-import io.opencensus.trace.unsafe.ContextUtils;
 import java.io.InputStream;
 import java.util.HashSet;
 import java.util.List;
@@ -247,6 +246,7 @@ public class CensusModulesTest {
   // Test that Census ClientInterceptors uses the TagContext and Span out of the current Context
   // to create the ClientCallTracer, and that it intercepts ClientCall.Listener.onClose() to call
   // ClientCallTracer.callEnded().
+  @SuppressWarnings("deprecation")
   private void testClientInterceptors(boolean nonDefaultContext) {
     grpcServerRule.getServiceRegistry().addService(
         ServerServiceDefinition.builder("package1.service2").addMethod(
@@ -284,7 +284,7 @@ public class CensusModulesTest {
                   .emptyBuilder()
                   .putLocal(StatsTestUtils.EXTRA_TAG, TagValue.create("extra value"))
                   .build());
-      ctx = ContextUtils.withValue(ctx, fakeClientParentSpan);
+      ctx =  io.opencensus.trace.unsafe.ContextUtils.withValue(ctx, fakeClientParentSpan);
       Context origCtx = ctx.attach();
       try {
         call = interceptedChannel.newCall(method, CALL_OPTIONS);
@@ -295,7 +295,8 @@ public class CensusModulesTest {
       assertEquals(
           io.opencensus.tags.unsafe.ContextUtils.getValue(Context.ROOT),
           io.opencensus.tags.unsafe.ContextUtils.getValue(Context.current()));
-      assertEquals(ContextUtils.getValue(Context.current()), BlankSpan.INSTANCE);
+      assertEquals(io.opencensus.trace.unsafe.ContextUtils.getValue(Context.current()),
+          BlankSpan.INSTANCE);
       call = interceptedChannel.newCall(method, CALL_OPTIONS);
     }
 
@@ -1035,6 +1036,7 @@ public class CensusModulesTest {
     assertSame(tagger.empty(), headers.get(censusStats.statsHeader));
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void traceHeadersPropagateSpanContext() throws Exception {
     CallAttemptsTracerFactory callTracer =
@@ -1062,7 +1064,7 @@ public class CensusModulesTest {
     verify(spyServerSpanBuilder).setRecordEvents(eq(true));
 
     Context filteredContext = serverTracer.filterContext(Context.ROOT);
-    assertSame(spyServerSpan, ContextUtils.getValue(filteredContext));
+    assertSame(spyServerSpan, io.opencensus.trace.unsafe.ContextUtils.getValue(filteredContext));
   }
 
   @Test
@@ -1279,6 +1281,7 @@ public class CensusModulesTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void serverBasicTracingNoHeaders() {
     ServerStreamTracer.Factory tracerFactory = censusTracing.getServerTracerFactory();
@@ -1290,7 +1293,7 @@ public class CensusModulesTest {
     verify(spyServerSpanBuilder).setRecordEvents(eq(true));
 
     Context filteredContext = serverStreamTracer.filterContext(Context.ROOT);
-    assertSame(spyServerSpan, ContextUtils.getValue(filteredContext));
+    assertSame(spyServerSpan, io.opencensus.trace.unsafe.ContextUtils.getValue(filteredContext));
 
     serverStreamTracer.serverCallStarted(
         new CallInfo<>(method, Attributes.EMPTY, null));

--- a/gcp-observability/build.gradle
+++ b/gcp-observability/build.gradle
@@ -21,10 +21,10 @@ description = "gRPC: Google Cloud Platform Observability"
 
 dependencies {
     def cloudLoggingVersion = '3.6.1'
+    def opencensusVersion = '0.31.0'
 
     annotationProcessor libraries.autovalue
     api project(':grpc-api')
-
     implementation project(':grpc-protobuf'),
             project(':grpc-stub'),
             project(':grpc-alts'),
@@ -36,10 +36,17 @@ dependencies {
             ('com.google.auth:google-auth-library-credentials:1.4.0'),
             ('org.checkerframework:checker-qual:3.20.0'),
             ('com.google.auto.value:auto-value-annotations:1.9'),
-            ('com.google.http-client:google-http-client:1.41.0'),
-            ('com.google.http-client:google-http-client-gson:1.41.0'),
+            ('com.google.http-client:google-http-client:1.41.7'),
+            ('com.google.http-client:google-http-client-gson:1.41.7'),
             ('com.google.api.grpc:proto-google-common-protos:2.7.1'),
             ("com.google.cloud:google-cloud-logging:${cloudLoggingVersion}")
+
+    implementation project(':grpc-census'),
+            libraries.opencensus_contrib_grpc_metrics,
+            ("io.opencensus:opencensus-exporter-stats-stackdriver:${opencensusVersion}"),
+            ("io.opencensus:opencensus-exporter-trace-stackdriver:${opencensusVersion}")
+
+    runtimeOnly libraries.opencensus_impl
 
     testImplementation project(':grpc-testing'),
             project(':grpc-testing-proto'),

--- a/gcp-observability/build.gradle
+++ b/gcp-observability/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 
     annotationProcessor libraries.autovalue
     api project(':grpc-api')
+    
     implementation project(':grpc-protobuf'),
             project(':grpc-stub'),
             project(':grpc-alts'),

--- a/gcp-observability/build.gradle
+++ b/gcp-observability/build.gradle
@@ -21,30 +21,29 @@ description = "gRPC: Google Cloud Platform Observability"
 
 dependencies {
     def cloudLoggingVersion = '3.6.1'
-    def opencensusVersion = '0.31.0'
+    def opencensusExporterVersion = '0.31.0'
 
     annotationProcessor libraries.autovalue
     api project(':grpc-api')
     implementation project(':grpc-protobuf'),
             project(':grpc-stub'),
             project(':grpc-alts'),
+            project(':grpc-census'),
             libraries.google_auth_oauth2_http,
             libraries.autovalue_annotation,
             libraries.perfmark,
+            libraries.opencensus_contrib_grpc_metrics,
             ('com.google.guava:guava:31.0.1-jre'),
             ('com.google.errorprone:error_prone_annotations:2.11.0'),
             ('com.google.auth:google-auth-library-credentials:1.4.0'),
             ('org.checkerframework:checker-qual:3.20.0'),
             ('com.google.auto.value:auto-value-annotations:1.9'),
-            ('com.google.http-client:google-http-client:1.41.7'),
-            ('com.google.http-client:google-http-client-gson:1.41.7'),
+            ('com.google.http-client:google-http-client:1.41.0'),
+            ('com.google.http-client:google-http-client-gson:1.41.0'),
             ('com.google.api.grpc:proto-google-common-protos:2.7.1'),
-            ("com.google.cloud:google-cloud-logging:${cloudLoggingVersion}")
-
-    implementation project(':grpc-census'),
-            libraries.opencensus_contrib_grpc_metrics,
-            ("io.opencensus:opencensus-exporter-stats-stackdriver:${opencensusVersion}"),
-            ("io.opencensus:opencensus-exporter-trace-stackdriver:${opencensusVersion}")
+            ("com.google.cloud:google-cloud-logging:${cloudLoggingVersion}"),
+            ("io.opencensus:opencensus-exporter-stats-stackdriver:${opencensusExporterVersion}"),
+            ("io.opencensus:opencensus-exporter-trace-stackdriver:${opencensusExporterVersion}")
 
     runtimeOnly libraries.opencensus_impl
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -100,7 +100,6 @@ import io.opencensus.tags.TagValue;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.Tracing;
-import io.opencensus.trace.unsafe.ContextUtils;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -1547,6 +1546,7 @@ public abstract class AbstractInteropTest {
         Collections.singleton(streamingRequest), Collections.singleton(goldenStreamingResponse));
   }
 
+  @SuppressWarnings("deprecation")
   @Test(timeout = 10000)
   public void censusContextsPropagated() {
     Assume.assumeTrue("Skip the test because server is not in the same process.", server != null);
@@ -1561,7 +1561,7 @@ public abstract class AbstractInteropTest {
                 .emptyBuilder()
                 .putLocal(StatsTestUtils.EXTRA_TAG, TagValue.create("extra value"))
                 .build());
-    ctx = ContextUtils.withValue(ctx, clientParentSpan);
+    ctx = io.opencensus.trace.unsafe.ContextUtils.withValue(ctx, clientParentSpan);
     Context origCtx = ctx.attach();
     try {
       blockingStub.unaryCall(SimpleRequest.getDefaultInstance());
@@ -1581,7 +1581,7 @@ public abstract class AbstractInteropTest {
       }
       assertTrue("tag not found", tagFound);
 
-      Span span = ContextUtils.getValue(serverCtx);
+      Span span = io.opencensus.trace.unsafe.ContextUtils.getValue(serverCtx);
       assertNotNull(span);
       SpanContext spanContext = span.getContext();
       assertEquals(clientParentSpan.getContext().getTraceId(), spanContext.getTraceId());


### PR DESCRIPTION
This PR adds dependencies required to export metrics and traces data to stackdriver.

- Also, updates opencensus version to `0.31.0`.
- As part of version update, `io.opencensus.trace.unsafe.ContextUtils` has been deprecated, suppressing warnings for now.

CC @sanjaypujare 