### PR TITLE
xds: separate orca APIs and implementations

### DIFF
--- a/services/src/main/java/io/grpc/services/InternalMetricRecorder.java
+++ b/services/src/main/java/io/grpc/services/InternalMetricRecorder.java
@@ -29,10 +29,6 @@ public final class InternalMetricRecorder {
   private InternalMetricRecorder() {
   }
 
-  public static MetricRecorder newMetricRecorder() {
-    return MetricRecorder.newInstance();
-  }
-
   public static CallMetricRecorder.CallMetricReport getMetricReport(MetricRecorder recorder) {
     return recorder.getMetricReport();
   }

--- a/services/src/main/java/io/grpc/services/InternalMetricRecorder.java
+++ b/services/src/main/java/io/grpc/services/InternalMetricRecorder.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.services;
+
+import io.grpc.Internal;
+
+/**
+ * Internal {@link CallMetricRecorder} accessor.  This is intended for usage internal to the gRPC
+ * team.  If you *really* think you need to use this, contact the gRPC team first.
+ */
+@Internal
+public final class InternalMetricRecorder {
+
+  // Prevent instantiation.
+  private InternalMetricRecorder() {
+  }
+
+  public static MetricRecorder newMetricRecorder() {
+    return MetricRecorder.newInstance();
+  }
+
+  public static CallMetricRecorder.CallMetricReport getMetricReport(MetricRecorder recorder) {
+    return recorder.getMetricReport();
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/orca/OrcaMetrics.java
+++ b/xds/src/main/java/io/grpc/xds/orca/OrcaMetrics.java
@@ -28,10 +28,9 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Implements the service/APIs for Out-of-Band metrics reporting, only for utilization metrics.
- * Register the returned service
- * {@link #createService(long, TimeUnit, ScheduledExecutorService)} ()} to the server, then a
- * client can request for periodic load reports. A user should use the public set-APIs to update the
- * server machine's utilization metrics data.
+ * Register the returned service {@link #createService} to the server, then a client can request for
+ * periodic load reports. A user should use the public set-APIs to update the server machine's
+ * utilization metrics data.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/9006")
 public final class OrcaMetrics {
@@ -45,7 +44,7 @@ public final class OrcaMetrics {
   private volatile double memoryUtilization;
 
   /**
-   * Construct an OOB metrics reporting service.
+   * Create an OOB metrics reporting service.
    *
    * @param minInterval configures the minimum metrics reporting interval for the service. Bad
    *        configuration (non-positive) will be overridden to service default (30s).

--- a/xds/src/main/java/io/grpc/xds/orca/OrcaMetrics.java
+++ b/xds/src/main/java/io/grpc/xds/orca/OrcaMetrics.java
@@ -18,27 +18,31 @@ package io.grpc.xds.orca;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.grpc.BindableService;
 import io.grpc.ExperimentalApi;
+import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
  * Implements the service/APIs for Out-of-Band metrics reporting, only for utilization metrics.
- * Register the returned service {@link #getService()} to the server, then a client can request
- * for periodic load reports. A user should use the public set-APIs to update the server machine's
- * utilization metrics data.
+ * Register the returned service
+ * {@link #createService(long, TimeUnit, ScheduledExecutorService)} ()} to the server, then a
+ * client can request for periodic load reports. A user should use the public set-APIs to update the
+ * server machine's utilization metrics data.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/9006")
-public final class OrcaOobService {
+public final class OrcaMetrics {
   /**
    * Empty or invalid (non-positive) minInterval config in will be treated to this default value.
    */
   public static final long DEFAULT_MIN_REPORT_INTERVAL_NANOS = TimeUnit.SECONDS.toNanos(30);
 
-  private final OrcaServiceImpl orcaService;
+  private volatile ConcurrentHashMap<String, Double> metricsData = new ConcurrentHashMap<>();
+  private volatile double cpuUtilization;
+  private volatile double memoryUtilization;
 
   /**
    * Construct an OOB metrics reporting service.
@@ -48,75 +52,79 @@ public final class OrcaOobService {
    *        Minimum metrics reporting interval means, if the setting in the client's
    *        request is invalid (non-positive) or below this value, they will be treated
    *        as this value.
+   *
+   * @return the service instance to be bound to the server for ORCA OOB functionality.
    */
-  public OrcaOobService(long minInterval, TimeUnit timeUnit,
-                        ScheduledExecutorService timeService) {
-    this.orcaService = new OrcaServiceImpl(minInterval > 0 ? timeUnit.toNanos(minInterval)
-        : DEFAULT_MIN_REPORT_INTERVAL_NANOS, checkNotNull(timeService));
+  public BindableService createService(long minInterval, TimeUnit timeUnit,
+                                       ScheduledExecutorService timeService) {
+    return new OrcaServiceImpl(minInterval > 0 ? timeUnit.toNanos(minInterval)
+        : DEFAULT_MIN_REPORT_INTERVAL_NANOS, checkNotNull(timeService), this);
   }
 
-  public OrcaOobService(ScheduledExecutorService timeService) {
-    this(DEFAULT_MIN_REPORT_INTERVAL_NANOS, TimeUnit.NANOSECONDS, timeService);
+  public BindableService createService(ScheduledExecutorService timeService) {
+    return createService(DEFAULT_MIN_REPORT_INTERVAL_NANOS, TimeUnit.NANOSECONDS, timeService);
   }
 
-  /**
-   * Returns the service instance to be bound to the server for ORCA OOB functionality.
-   */
-  public BindableService getService() {
-    return orcaService;
-  }
-
-  @VisibleForTesting
-  int getClientsCount() {
-    return orcaService.clientCount.get();
-  }
+  public OrcaMetrics() {}
 
   /**
    * Update the metrics value corresponding to the specified key.
    */
   public void setUtilizationMetric(String key, double value) {
-    orcaService.setUtilizationMetric(key, value);
+    metricsData.put(key, value);
   }
 
   /**
    * Replace the whole metrics data using the specified map.
    */
   public void setAllUtilizationMetrics(Map<String, Double> metrics) {
-    orcaService.setAllUtilizationMetrics(metrics);
+    metricsData = new ConcurrentHashMap<>(metrics);
   }
 
   /**
    * Remove the metrics data entry corresponding to the specified key.
    */
   public void deleteUtilizationMetric(String key) {
-    orcaService.deleteUtilizationMetric(key);
+    metricsData.remove(key);
   }
 
   /**
    * Update the CPU utilization metrics data.
    */
   public void setCpuUtilizationMetric(double value) {
-    orcaService.setCpuUtilizationMetric(value);
+    cpuUtilization = value;
   }
 
   /**
    * Clear the CPU utilization metrics data.
    */
   public void deleteCpuUtilizationMetric() {
-    orcaService.deleteCpuUtilizationMetric();
+    cpuUtilization = 0;
   }
 
   /**
    * Update the memory utilization metrics data.
    */
   public void setMemoryUtilizationMetric(double value) {
-    orcaService.setMemoryUtilizationMetric(value);
+    memoryUtilization = value;
   }
 
   /**
    * Clear the memory utilization metrics data.
    */
   public void deleteMemoryUtilizationMetric() {
-    orcaService.deleteMemoryUtilizationMetric();
+    memoryUtilization = 0;
+  }
+
+  Map<String, Double> getUtilizationMetrics() {
+    return Collections.unmodifiableMap(metricsData);
+  }
+
+  double getCpuUtilization() {
+    return cpuUtilization;
+  }
+
+  double getMemoryUtilization() {
+    return memoryUtilization;
   }
 }

--- a/xds/src/main/java/io/grpc/xds/orca/OrcaServiceImpl.java
+++ b/xds/src/main/java/io/grpc/xds/orca/OrcaServiceImpl.java
@@ -66,9 +66,9 @@ public final class OrcaServiceImpl implements BindableService {
    *        request is invalid (non-positive) or below this value, they will be treated
    *        as this value.
    */
-  public static BindableService createService(long minInterval, TimeUnit timeUnit,
-                                       ScheduledExecutorService timeService,
-                                       MetricRecorder metricsRecorder) {
+  public static BindableService createService(ScheduledExecutorService timeService,
+                                              MetricRecorder metricsRecorder,
+                                              long minInterval, TimeUnit timeUnit) {
     return new OrcaServiceImpl(minInterval, timeUnit, timeService,  metricsRecorder);
   }
 

--- a/xds/src/main/java/io/grpc/xds/orca/OrcaServiceImpl.java
+++ b/xds/src/main/java/io/grpc/xds/orca/OrcaServiceImpl.java
@@ -34,7 +34,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-final class OrcaServiceImpl implements BindableService {
+/**
+ * Implements a {@link BindableService} that generates Out-Of-Band server metrics.
+ */
+public final class OrcaServiceImpl implements BindableService {
   private static final Logger logger = Logger.getLogger(OrcaServiceImpl.class.getName());
 
   private final long minReportIntervalNanos;
@@ -42,8 +45,12 @@ final class OrcaServiceImpl implements BindableService {
   @VisibleForTesting
   final AtomicInteger clientCount = new AtomicInteger(0);
   private OrcaMetrics orcaMetrics;
-  RealOrcaServiceImpl delegate = new RealOrcaServiceImpl();
+  private final RealOrcaServiceImpl delegate = new RealOrcaServiceImpl();
 
+  /**
+   * Constructs a service to report server metrics. Config the report interval lower bound, the
+   * executor to run the timer, and a {@link OrcaMetrics} that contains metrics data.
+   */
   public OrcaServiceImpl(long minReportIntervalNanos, ScheduledExecutorService timeService,
                          OrcaMetrics orcaMetrics) {
     this.minReportIntervalNanos = minReportIntervalNanos;

--- a/xds/src/test/java/io/grpc/xds/orca/OrcaServiceImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/orca/OrcaServiceImplTest.java
@@ -39,7 +39,6 @@ import io.grpc.Status;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.internal.FakeClock;
-import io.grpc.services.InternalMetricRecorder;
 import io.grpc.services.MetricRecorder;
 import io.grpc.testing.GrpcCleanupRule;
 import java.util.Iterator;
@@ -74,9 +73,9 @@ public class OrcaServiceImplTest {
 
   @Before
   public void setup() throws Exception {
-    defaultTestService = InternalMetricRecorder.newMetricRecorder();
-    orcaServiceImpl = OrcaServiceImpl.createService(1, TimeUnit.SECONDS,
-        fakeClock.getScheduledExecutorService(), defaultTestService);
+    defaultTestService = MetricRecorder.newInstance();
+    orcaServiceImpl = OrcaServiceImpl.createService(fakeClock.getScheduledExecutorService(),
+        defaultTestService, 1, TimeUnit.SECONDS);
     startServerAndGetChannel(orcaServiceImpl);
   }
 
@@ -185,7 +184,7 @@ public class OrcaServiceImplTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testRequestIntervalDefault() throws Exception {
-    defaultTestService = InternalMetricRecorder.newMetricRecorder();
+    defaultTestService = MetricRecorder.newInstance();
     oobServer.shutdownNow();
     startServerAndGetChannel(OrcaServiceImpl.createService(
         fakeClock.getScheduledExecutorService(), defaultTestService));

--- a/xds/src/test/java/io/grpc/xds/orca/OrcaServiceImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/orca/OrcaServiceImplTest.java
@@ -64,16 +64,18 @@ public class OrcaServiceImplTest {
   private ManagedChannel channel;
   private Server oobServer;
   private final FakeClock fakeClock = new FakeClock();
-  private OrcaOobService defaultTestService;
+  private OrcaMetrics defaultTestService;
+  private BindableService orcaServiceImpl;
   private final Random random = new Random();
   @Mock
   ClientCall.Listener<OrcaLoadReport> listener;
 
   @Before
   public void setup() throws Exception {
-    defaultTestService = new OrcaOobService(1, TimeUnit.SECONDS,
+    defaultTestService = new OrcaMetrics();
+    orcaServiceImpl = defaultTestService.createService(1, TimeUnit.SECONDS,
         fakeClock.getScheduledExecutorService());
-    startServerAndGetChannel(defaultTestService.getService());
+    startServerAndGetChannel(orcaServiceImpl);
   }
 
   @After
@@ -100,14 +102,14 @@ public class OrcaServiceImplTest {
         .streamCoreMetrics(OrcaLoadReportRequest.newBuilder().build());
     assertThat(reports.next()).isEqualTo(
         OrcaLoadReport.newBuilder().setCpuUtilization(0.1).build());
-    assertThat(defaultTestService.getClientsCount()).isEqualTo(1);
+    assertThat(((OrcaServiceImpl)orcaServiceImpl).clientCount.get()).isEqualTo(1);
     assertThat(fakeClock.getPendingTasks().size()).isEqualTo(1);
     assertThat(fakeClock.forwardTime(1, TimeUnit.SECONDS)).isEqualTo(1);
     assertThat(reports.next()).isEqualTo(
         OrcaLoadReport.newBuilder().setCpuUtilization(0.1).build());
     assertThat(fakeClock.getPendingTasks().size()).isEqualTo(1);
     channel.shutdownNow();
-    assertThat(defaultTestService.getClientsCount()).isEqualTo(0);
+    assertThat(((OrcaServiceImpl)orcaServiceImpl).clientCount.get()).isEqualTo(0);
     assertThat(fakeClock.getPendingTasks().size()).isEqualTo(0);
   }
 
@@ -123,12 +125,12 @@ public class OrcaServiceImplTest {
     call.halfClose();
     call.request(1);
     OrcaLoadReport expect = OrcaLoadReport.newBuilder().putUtilization("buffer", 0.2).build();
-    assertThat(defaultTestService.getClientsCount()).isEqualTo(1);
+    assertThat(((OrcaServiceImpl)orcaServiceImpl).clientCount.get()).isEqualTo(1);
     verify(listener).onMessage(eq(expect));
     reset(listener);
     oobServer.shutdownNow();
     assertThat(fakeClock.forwardTime(1, TimeUnit.SECONDS)).isEqualTo(0);
-    assertThat(defaultTestService.getClientsCount()).isEqualTo(0);
+    assertThat(((OrcaServiceImpl)orcaServiceImpl).clientCount.get()).isEqualTo(0);
     ArgumentCaptor<Status> callCloseCaptor = ArgumentCaptor.forClass(null);
     verify(listener).onClose(callCloseCaptor.capture(), any());
     assertThat(callCloseCaptor.getValue().getCode()).isEqualTo(Status.Code.UNAVAILABLE);
@@ -181,9 +183,10 @@ public class OrcaServiceImplTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testRequestIntervalDefault() throws Exception {
-    defaultTestService = new OrcaOobService(fakeClock.getScheduledExecutorService());
+    defaultTestService = new OrcaMetrics();
     oobServer.shutdownNow();
-    startServerAndGetChannel(defaultTestService.getService());
+    startServerAndGetChannel(defaultTestService.createService(
+        fakeClock.getScheduledExecutorService()));
     ClientCall<OrcaLoadReportRequest, OrcaLoadReport> call = channel.newCall(
         OpenRcaServiceGrpc.getStreamCoreMetricsMethod(), CallOptions.DEFAULT);
     defaultTestService.setUtilizationMetric("buffer", 0.2);
@@ -223,11 +226,11 @@ public class OrcaServiceImplTest {
     call2.request(1);
     expect = OrcaLoadReport.newBuilder(expect).setMemUtilization(0.5).build();
     verify(listener).onMessage(eq(expect));
-    assertThat(defaultTestService.getClientsCount()).isEqualTo(2);
+    assertThat(((OrcaServiceImpl)orcaServiceImpl).clientCount.get()).isEqualTo(2);
     assertThat(fakeClock.getPendingTasks().size()).isEqualTo(2);
     channel.shutdownNow();
     assertThat(fakeClock.forwardTime(1, TimeUnit.SECONDS)).isEqualTo(0);
-    assertThat(defaultTestService.getClientsCount()).isEqualTo(0);
+    assertThat(((OrcaServiceImpl)orcaServiceImpl).clientCount.get()).isEqualTo(0);
     ArgumentCaptor<Status> callCloseCaptor = ArgumentCaptor.forClass(null);
     verify(listener, times(2)).onClose(callCloseCaptor.capture(), any());
     assertThat(callCloseCaptor.getValue().getCode()).isEqualTo(Status.Code.UNAVAILABLE);


### PR DESCRIPTION
* moved orcaMetrics to service project and renamed to `MetricRecorder`, added internal accessor. Maybe we can combine metricsRecorder and callMetricRecorder, they looks almost the same things.
* OrcaServiceImpl depends on metricRecorder, not visa versa.