### PR TITLE
Change the gRPC o11y logName when sending logs to GCP.

### DIFF
--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/GcpLogSink.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/GcpLogSink.java
@@ -47,7 +47,8 @@ public class GcpLogSink implements Sink {
 
   // TODO(DNVindhya): Make cloud logging service a configurable value
   private static final String SERVICE_TO_EXCLUDE = "google.logging.v2.LoggingServiceV2";
-  private static final String DEFAULT_LOG_NAME = "microservices.googleapis.com%2Fobservability%2Fgrpc";
+  private static final String DEFAULT_LOG_NAME =
+      "microservices.googleapis.com%2Fobservability%2Fgrpc";
   private static final String K8S_MONITORED_RESOURCE_TYPE = "k8s_container";
   private static final Set<String> kubernetesResourceLabelSet
       = ImmutableSet.of("project_id", "location", "cluster_name", "namespace_name",

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/GcpLogSink.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/GcpLogSink.java
@@ -38,9 +38,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * Sink for Google Cloud Logging.
- */
+/** Sink for Google Cloud Logging. */
 @Internal
 public class GcpLogSink implements Sink {
   private final Logger logger = Logger.getLogger(GcpLogSink.class.getName());
@@ -50,9 +48,9 @@ public class GcpLogSink implements Sink {
   private static final String DEFAULT_LOG_NAME =
       "microservices.googleapis.com%2Fobservability%2Fgrpc";
   private static final String K8S_MONITORED_RESOURCE_TYPE = "k8s_container";
-  private static final Set<String> kubernetesResourceLabelSet
-      = ImmutableSet.of("project_id", "location", "cluster_name", "namespace_name",
-      "pod_name", "container_name");
+  private static final Set<String> kubernetesResourceLabelSet =
+      ImmutableSet.of(
+          "project_id", "location", "cluster_name", "namespace_name", "pod_name", "container_name");
   private static final long FALLBACK_FLUSH_LIMIT = 100L;
   private final Map<String, String> customTags;
   private final Logging gcpLoggingClient;
@@ -73,16 +71,26 @@ public class GcpLogSink implements Sink {
    *
    * @param destinationProjectId cloud project id to write logs
    */
-  public GcpLogSink(String destinationProjectId, Map<String, String> locationTags,
-      Map<String, String> customTags, Long flushLimit) {
-    this(createLoggingClient(destinationProjectId), destinationProjectId, locationTags,
-        customTags, flushLimit);
-
+  public GcpLogSink(
+      String destinationProjectId,
+      Map<String, String> locationTags,
+      Map<String, String> customTags,
+      Long flushLimit) {
+    this(
+        createLoggingClient(destinationProjectId),
+        destinationProjectId,
+        locationTags,
+        customTags,
+        flushLimit);
   }
 
   @VisibleForTesting
-  GcpLogSink(Logging client, String destinationProjectId, Map<String, String> locationTags,
-      Map<String, String> customTags, Long flushLimit) {
+  GcpLogSink(
+      Logging client,
+      String destinationProjectId,
+      Map<String, String> locationTags,
+      Map<String, String> customTags,
+      Long flushLimit) {
     this.gcpLoggingClient = client;
     this.customTags = getCustomTags(customTags, locationTags, destinationProjectId);
     this.kubernetesResource = getResource(locationTags);
@@ -134,8 +142,10 @@ public class GcpLogSink implements Sink {
   }
 
   @VisibleForTesting
-  static Map<String, String> getCustomTags(Map<String, String> customTags,
-      Map<String, String> locationTags, String destinationProjectId) {
+  static Map<String, String> getCustomTags(
+      Map<String, String> customTags,
+      Map<String, String> locationTags,
+      String destinationProjectId) {
     ImmutableMap.Builder<String, String> tagsBuilder = ImmutableMap.builder();
     String sourceProjectId = locationTags.get("project_id");
     if (!Strings.isNullOrEmpty(destinationProjectId)
@@ -163,8 +173,7 @@ public class GcpLogSink implements Sink {
   }
 
   @SuppressWarnings("unchecked")
-  private Map<String, Object> protoToMapConverter(GrpcLogRecord logProto)
-      throws IOException {
+  private Map<String, Object> protoToMapConverter(GrpcLogRecord logProto) throws IOException {
     JsonFormat.Printer printer = JsonFormat.printer().preservingProtoFieldNames();
     String recordJson = printer.print(logProto);
     return (Map<String, Object>) JsonParser.parse(recordJson);
@@ -188,9 +197,7 @@ public class GcpLogSink implements Sink {
     }
   }
 
-  /**
-   * Closes Cloud Logging Client.
-   */
+  /** Closes Cloud Logging Client. */
   @Override
   public synchronized void close() {
     if (gcpLoggingClient == null) {

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/GcpLogSink.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/GcpLogSink.java
@@ -47,7 +47,7 @@ public class GcpLogSink implements Sink {
 
   // TODO(DNVindhya): Make cloud logging service a configurable value
   private static final String SERVICE_TO_EXCLUDE = "google.logging.v2.LoggingServiceV2";
-  private static final String DEFAULT_LOG_NAME = "grpc";
+  private static final String DEFAULT_LOG_NAME = "microservices.googleapis.com%2Fobservability%2Fgrpc";
   private static final String K8S_MONITORED_RESOURCE_TYPE = "k8s_container";
   private static final Set<String> kubernetesResourceLabelSet
       = ImmutableSet.of("project_id", "location", "cluster_name", "namespace_name",

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/GcpLogSink.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/GcpLogSink.java
@@ -38,7 +38,9 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/** Sink for Google Cloud Logging. */
+/**
+ * Sink for Google Cloud Logging.
+ */
 @Internal
 public class GcpLogSink implements Sink {
   private final Logger logger = Logger.getLogger(GcpLogSink.class.getName());
@@ -48,9 +50,9 @@ public class GcpLogSink implements Sink {
   private static final String DEFAULT_LOG_NAME =
       "microservices.googleapis.com%2Fobservability%2Fgrpc";
   private static final String K8S_MONITORED_RESOURCE_TYPE = "k8s_container";
-  private static final Set<String> kubernetesResourceLabelSet =
-      ImmutableSet.of(
-          "project_id", "location", "cluster_name", "namespace_name", "pod_name", "container_name");
+  private static final Set<String> kubernetesResourceLabelSet
+      = ImmutableSet.of("project_id", "location", "cluster_name", "namespace_name",
+      "pod_name", "container_name");
   private static final long FALLBACK_FLUSH_LIMIT = 100L;
   private final Map<String, String> customTags;
   private final Logging gcpLoggingClient;
@@ -71,26 +73,16 @@ public class GcpLogSink implements Sink {
    *
    * @param destinationProjectId cloud project id to write logs
    */
-  public GcpLogSink(
-      String destinationProjectId,
-      Map<String, String> locationTags,
-      Map<String, String> customTags,
-      Long flushLimit) {
-    this(
-        createLoggingClient(destinationProjectId),
-        destinationProjectId,
-        locationTags,
-        customTags,
-        flushLimit);
+  public GcpLogSink(String destinationProjectId, Map<String, String> locationTags,
+      Map<String, String> customTags, Long flushLimit) {
+    this(createLoggingClient(destinationProjectId), destinationProjectId, locationTags,
+        customTags, flushLimit);
+
   }
 
   @VisibleForTesting
-  GcpLogSink(
-      Logging client,
-      String destinationProjectId,
-      Map<String, String> locationTags,
-      Map<String, String> customTags,
-      Long flushLimit) {
+  GcpLogSink(Logging client, String destinationProjectId, Map<String, String> locationTags,
+      Map<String, String> customTags, Long flushLimit) {
     this.gcpLoggingClient = client;
     this.customTags = getCustomTags(customTags, locationTags, destinationProjectId);
     this.kubernetesResource = getResource(locationTags);
@@ -142,10 +134,8 @@ public class GcpLogSink implements Sink {
   }
 
   @VisibleForTesting
-  static Map<String, String> getCustomTags(
-      Map<String, String> customTags,
-      Map<String, String> locationTags,
-      String destinationProjectId) {
+  static Map<String, String> getCustomTags(Map<String, String> customTags,
+      Map<String, String> locationTags, String destinationProjectId) {
     ImmutableMap.Builder<String, String> tagsBuilder = ImmutableMap.builder();
     String sourceProjectId = locationTags.get("project_id");
     if (!Strings.isNullOrEmpty(destinationProjectId)
@@ -173,7 +163,8 @@ public class GcpLogSink implements Sink {
   }
 
   @SuppressWarnings("unchecked")
-  private Map<String, Object> protoToMapConverter(GrpcLogRecord logProto) throws IOException {
+  private Map<String, Object> protoToMapConverter(GrpcLogRecord logProto)
+      throws IOException {
     JsonFormat.Printer printer = JsonFormat.printer().preservingProtoFieldNames();
     String recordJson = printer.print(logProto);
     return (Map<String, Object>) JsonParser.parse(recordJson);
@@ -197,7 +188,9 @@ public class GcpLogSink implements Sink {
     }
   }
 
-  /** Closes Cloud Logging Client. */
+  /**
+   * Closes Cloud Logging Client.
+   */
   @Override
   public synchronized void close() {
     if (gcpLoggingClient == null) {

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/logging/GcpLogSinkTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/logging/GcpLogSinkTest.java
@@ -65,6 +65,9 @@ public class GcpLogSinkTest {
   private static final Map<String, String> customTags = ImmutableMap.of("KEY1", "Value1",
       "KEY2", "VALUE2");
   private static final long flushLimit = 10L;
+  // gRPC is expected to alway use this log name when reporting to GCP cloud logging.
+  private static final String expectedLogName =
+      "microservices.googleapis.com%2Fobservability%2Fgrpc";
   private final long seqId = 1;
   private final String destProjectName = "PROJECT";
   private final String serviceName = "service";
@@ -122,6 +125,7 @@ public class GcpLogSinkTest {
       LogEntry entry = it.next();
       System.out.println(entry);
       assertThat(entry.getPayload().getData()).isEqualTo(expectedStructLogProto);
+      assertThat(entry.getLogName()).isEqualTo(expectedLogName);
     }
     verifyNoMoreInteractions(mockLogging);
   }
@@ -143,6 +147,7 @@ public class GcpLogSinkTest {
       assertThat(entry.getResource()).isEqualTo(expectedMonitoredResource);
       assertThat(entry.getLabels()).isEqualTo(customTags);
       assertThat(entry.getPayload().getData()).isEqualTo(expectedStructLogProto);
+      assertThat(entry.getLogName()).isEqualTo(expectedLogName);
     }
     verifyNoMoreInteractions(mockLogging);
   }


### PR DESCRIPTION
Change the gRPC o11y logName when sending logs to GCP.
From: grpc
To: microservices.googelapis.com%2Fobservability%2Fgrpc