### PR TITLE
Revert "bom: Remove protoc-gen-grpc-java" (1.46.x backport)

### DIFF
--- a/bom/build.gradle
+++ b/bom/build.gradle
@@ -30,6 +30,12 @@ publishing {
           dependencyNode.appendNode('artifactId', subproject.name)
           dependencyNode.appendNode('version', subproject.version)
         }
+        // add protoc gen (produced by grpc-compiler with different artifact name)
+        def dependencyNode = dependencies.appendNode('dependency')
+        dependencyNode.appendNode('groupId', project.group)
+        dependencyNode.appendNode('artifactId', 'protoc-gen-grpc-java')
+        dependencyNode.appendNode('version', project.version)
+        dependencyNode.appendNode('type', 'pom')
       }
     }
   }


### PR DESCRIPTION
This reverts commit 4a84c6fa96f11eababb32ab691e3bf9b62c3d374. The BOM
was usable for protoc-gen-grpc-java using dependencyManagement for the
buildscript. See conversation on #9020.

CC @ST-DDT 

Backport of #9154