### PR TITLE
grpclb: include META-INF/services to bazel //grpclb:grpclb

### DIFF
--- a/grpclb/BUILD.bazel
+++ b/grpclb/BUILD.bazel
@@ -5,6 +5,9 @@ java_library(
     srcs = glob([
         "src/main/java/io/grpc/grpclb/*.java",
     ]),
+    resources = glob([
+        "src/main/resources/**",
+    ]),
     visibility = ["//visibility:public"],
     deps = [
         ":load_balancer_java_grpc",


### PR DESCRIPTION
Adds missing providers to `libgrpclb.jar` produced by bazel's target `//grpclb:grpclb`.

```
❯ jar tf bazel-bin/grpclb/libgrpclb.jar | grep services
META-INF/services/
META-INF/services/io.grpc.LoadBalancerProvider
META-INF/services/io.grpc.NameResolverProvider
```

Fixes #9149
cc @SanjayVas 
