### PR TITLE
xsd: wrr_locality to not propagate locality weight attribute

### DIFF
--- a/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancer.java
@@ -80,6 +80,14 @@ final class WrrLocalityLoadBalancer extends LoadBalancer {
               wrrLocalityConfig.childPolicy));
     }
 
+    // Remove the locality weights attribute now that we have consumed it. This is done simply for
+    // ease of debugging for the unsupported (and unlikely) scenario where WrrLocalityConfig has
+    // another wrr_locality as the child policy. The missing locality weight attribute would make
+    // the child wrr_locality fail early.
+    resolvedAddresses = resolvedAddresses.toBuilder()
+        .setAttributes(resolvedAddresses.getAttributes().toBuilder()
+            .discard(InternalXdsAttributes.ATTR_LOCALITY_WEIGHTS).build()).build();
+
     switchLb.switchTo(wrrLocalityConfig.childPolicy.getProvider());
     switchLb.handleResolvedAddresses(
         resolvedAddresses.toBuilder()


### PR DESCRIPTION
WrrLocalityLoadBalancer should remove the locality weights attribute from Resolved addresses after using the information. Not propagating this attribute will make it impossible for another child wrr_locality from working. This is not a supported situation and this change make the failure happen earlier and to be more obvious as to the cause.