### PR TITLE
Respect requested message limits within a single MessageProducer in BinderTransport.

### DIFF
--- a/binder/src/main/java/io/grpc/binder/internal/Inbound.java
+++ b/binder/src/main/java/io/grpc/binder/internal/Inbound.java
@@ -468,7 +468,7 @@ abstract class Inbound<L extends StreamListener> implements StreamListener.Messa
     if (firstMessage != null) {
       stream = firstMessage;
       firstMessage = null;
-    } else if (messageAvailable()) {
+    } else if (numRequestedMessages > 0 && messageAvailable()) {
       stream = assembleNextMessage();
     }
     if (stream != null) {

--- a/core/src/test/java/io/grpc/internal/AbstractTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractTransportTest.java
@@ -1526,6 +1526,8 @@ public abstract class AbstractTransportTest {
     clientStream.writeMessage(methodDescriptor.streamRequest("MESSAGE"));
     clientStream.flush();
 
+    doPingPong(serverListener);
+
     // Verify server only receives one message if that's all it requests.
     serverStreamCreation.stream.request(1);
     verifyMessageCountAndClose(serverStreamCreation.listener.messageQueue, 1);


### PR DESCRIPTION
Add check for request message count in binder grpc inbound stream.

Without check if messages are available and requested, producer provides everything that is available ignoring the request count. It leads to call listener API violation - it's possible that more messages will be provided than requested.