### PR TITLE
Add Bazel build support for xds, googleapis to flesh out maven_install

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -51,3 +51,18 @@ java_library(
         "@com_google_guava_guava//jar",
     ],
 )
+
+java_plugin(
+    name = "auto_value",
+    generates_api = 1,
+    processor_class = "com.google.auto.value.processor.AutoValueProcessor",
+    deps = ["@com_google_auto_value_auto_value//jar"],
+)
+
+java_library(
+    name = "auto_value_annotations",
+    exported_plugins = [":auto_value"],
+    neverlink = 1,
+    visibility = ["//:__subpackages__"],
+    exports = ["@com_google_auto_value_auto_value_annotations//jar"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,6 +21,17 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
+load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
+
+api_dependencies()
+
+load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+
+switched_rules_by_language(
+    name = "com_google_googleapis_imports",
+    java = True,
+)
+
 maven_install(
     artifacts = IO_GRPC_GRPC_JAVA_ARTIFACTS + PROTOBUF_MAVEN_ARTIFACTS,
     generate_compat_repositories = True,

--- a/googleapis/BUILD.bazel
+++ b/googleapis/BUILD.bazel
@@ -1,0 +1,14 @@
+java_library(
+    name = "googleapis",
+    srcs = glob([
+        "src/main/java/**/*.java",
+    ]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//alts",
+        "//api",
+        "//core:internal",
+        "//xds",
+        "@com_google_guava_guava//jar",
+    ],
+)

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -14,14 +14,15 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "com.google.api.grpc:proto-google-common-protos:2.0.1",
     "com.google.auth:google-auth-library-credentials:0.22.0",
     "com.google.auth:google-auth-library-oauth2-http:0.22.0",
+    "com.google.auto.value:auto-value-annotations:1.9",
+    "com.google.auto.value:auto-value:1.9",
     "com.google.code.findbugs:jsr305:3.0.2",
     "com.google.code.gson:gson:2.8.9",
-    "com.google.auto.value:auto-value:1.7.4",
-    "com.google.auto.value:auto-value-annotations:1.7.4",
     "com.google.errorprone:error_prone_annotations:2.9.0",
     "com.google.guava:failureaccess:1.0.1",
     "com.google.guava:guava:31.0.1-android",
     "com.google.j2objc:j2objc-annotations:1.3",
+    "com.google.re2j:re2j:1.5",
     "com.google.truth:truth:1.0.1",
     "com.squareup.okhttp:okhttp:2.7.4",
     "com.squareup.okio:okio:1.17.5",
@@ -73,24 +74,73 @@ IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS = {
     "io.grpc:grpc-census": "@io_grpc_grpc_java//census",
     "io.grpc:grpc-context": "@io_grpc_grpc_java//context",
     "io.grpc:grpc-core": "@io_grpc_grpc_java//core:core_maven",
+    "io.grpc:grpc-googleapis": "@io_grpc_grpc_java//googleapis",
     "io.grpc:grpc-grpclb": "@io_grpc_grpc_java//grpclb",
     "io.grpc:grpc-netty": "@io_grpc_grpc_java//netty",
     "io.grpc:grpc-netty-shaded": "@io_grpc_grpc_java//netty:shaded_maven",
     "io.grpc:grpc-okhttp": "@io_grpc_grpc_java//okhttp",
     "io.grpc:grpc-protobuf": "@io_grpc_grpc_java//protobuf",
     "io.grpc:grpc-protobuf-lite": "@io_grpc_grpc_java//protobuf-lite",
+    "io.grpc:grpc-rls": "@io_grpc_grpc_java//rls",
+    "io.grpc:grpc-services": "@io_grpc_grpc_java//services",
     "io.grpc:grpc-stub": "@io_grpc_grpc_java//stub",
     "io.grpc:grpc-testing": "@io_grpc_grpc_java//testing",
+    "io.grpc:grpc-xds": "@io_grpc_grpc_java//xds",
 }
 
 def grpc_java_repositories():
     """Imports dependencies for grpc-java."""
+    if not native.existing_rule("com_github_cncf_xds"):
+        http_archive(
+            name = "com_github_cncf_xds",
+            strip_prefix = "xds-d92e9ce0af512a73a3a126b32fa4920bee12e180",
+            sha256 = "27be88b1ff2844885d3b2d0d579546f3a8b3f26b4871eed89082c9709e49a4bd",
+            urls = [
+                "https://github.com/cncf/xds/archive/d92e9ce0af512a73a3a126b32fa4920bee12e180.tar.gz",
+            ],
+        )
+    if not native.existing_rule("com_github_grpc_grpc"):
+        http_archive(
+            name = "com_github_grpc_grpc",
+            strip_prefix = "grpc-1.46.0",
+            sha256 = "67423a4cd706ce16a88d1549297023f0f9f0d695a96dd684adc21e67b021f9bc",
+            urls = [
+                "https://github.com/grpc/grpc/archive/v1.46.0.tar.gz",
+            ],
+        )
     if not native.existing_rule("com_google_protobuf"):
         com_google_protobuf()
     if not native.existing_rule("com_google_protobuf_javalite"):
         com_google_protobuf_javalite()
+    if not native.existing_rule("com_google_googleapis"):
+        http_archive(
+            name = "com_google_googleapis",
+            sha256 = "49930468563dd48283e8301e8d4e71436bf6d27ac27c235224cc1a098710835d",
+            strip_prefix = "googleapis-ca1372c6d7bcb199638ebfdb40d2b2660bab7b88",
+            urls = [
+                "https://github.com/googleapis/googleapis/archive/ca1372c6d7bcb199638ebfdb40d2b2660bab7b88.tar.gz",
+            ],
+        )
+    if not native.existing_rule("io_bazel_rules_go"):
+        http_archive(
+            name = "io_bazel_rules_go",
+            sha256 = "ab21448cef298740765f33a7f5acee0607203e4ea321219f2a4c85a6e0fb0a27",
+            urls = [
+                "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.32.0/rules_go-v0.32.0.zip",
+                "https://github.com/bazelbuild/rules_go/releases/download/v0.32.0/rules_go-v0.32.0.zip",
+            ],
+        )
     if not native.existing_rule("io_grpc_grpc_proto"):
         io_grpc_grpc_proto()
+    if not native.existing_rule("envoy_api"):
+        http_archive(
+            name = "envoy_api",
+            sha256 = "621577591d48cee20b61d4e71466bf4019791f9991da4813ccf75f3b9898de5f",
+            strip_prefix = "data-plane-api-bb6d6abe8b4d035c2f4ba3acf924cec0cbec5f70",
+            urls = [
+                "https://github.com/envoyproxy/data-plane-api/archive/bb6d6abe8b4d035c2f4ba3acf924cec0cbec5f70.tar.gz",
+            ],
+        )
 
 def com_google_protobuf():
     # proto_library rules implicitly depend on @com_google_protobuf//:protoc,

--- a/rls/BUILD.bazel
+++ b/rls/BUILD.bazel
@@ -7,8 +7,8 @@ java_library(
     ]),
     visibility = ["//visibility:public"],
     deps = [
-        ":autovalue",
         ":rls_java_grpc",
+        "//:auto_value_annotations",
         "//api",
         "//core",
         "//core:internal",
@@ -17,27 +17,8 @@ java_library(
         "@com_google_auto_value_auto_value_annotations//jar",
         "@com_google_code_findbugs_jsr305//jar",
         "@com_google_guava_guava//jar",
-        "@io_grpc_grpc_proto//:rls_java_proto",
         "@io_grpc_grpc_proto//:rls_config_java_proto",
-    ],
-)
-
-java_plugin(
-    name = "autovalue_plugin",
-    processor_class = "com.google.auto.value.processor.AutoValueProcessor",
-    deps = [
-        "@com_google_auto_value_auto_value//jar",
-    ],
-)
-
-java_library(
-    name = "autovalue",
-    exported_plugins = [
-        ":autovalue_plugin",
-    ],
-    neverlink = 1,
-    exports = [
-        "@com_google_auto_value_auto_value//jar",
+        "@io_grpc_grpc_proto//:rls_java_proto",
     ],
 )
 

--- a/services/BUILD.bazel
+++ b/services/BUILD.bazel
@@ -2,15 +2,75 @@ load("//:java_grpc_library.bzl", "java_grpc_library")
 
 package(default_visibility = ["//visibility:public"])
 
+# Mirrors the dependencies included in the artifact on Maven Central for usage
+# with maven_install's override_targets. Purposefully does not export any
+# symbols, as it should only be used as a dep for pre-compiled binaries on
+# Maven Central.
+java_library(
+    name = "services_maven",
+    runtime_deps = [
+        ":admin",
+        ":binarylog",
+        ":channelz",
+        ":health",
+        ":healthlb",
+        ":metrics",
+        ":metrics_internal",
+        ":reflection",
+    ],
+)
+
+java_library(
+    name = "admin",
+    srcs = [
+        "src/main/java/io/grpc/services/AdminInterface.java",
+    ],
+    deps = [
+        ":channelz",
+        "//api",
+        "@com_google_code_findbugs_jsr305//jar",
+    ],
+)
+
+java_library(
+    name = "metrics",
+    srcs = [
+        "src/main/java/io/grpc/services/CallMetricRecorder.java",
+        "src/main/java/io/grpc/services/MetricRecorder.java",
+    ],
+    deps = [
+        "//api",
+        "//context",
+        "@com_google_code_findbugs_jsr305//jar",
+        "@com_google_guava_guava//jar",
+    ],
+)
+
+java_library(
+    name = "metrics_internal",
+    srcs = [
+        "src/main/java/io/grpc/services/InternalCallMetricRecorder.java",
+        "src/main/java/io/grpc/services/InternalMetricRecorder.java",
+    ],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":metrics",
+        "//api",
+        "//context",
+    ],
+)
+
 java_library(
     name = "binarylog",
     srcs = [
         "src/main/java/io/grpc/protobuf/services/BinaryLogProvider.java",
         "src/main/java/io/grpc/protobuf/services/BinaryLogProviderImpl.java",
         "src/main/java/io/grpc/protobuf/services/BinaryLogSink.java",
+        "src/main/java/io/grpc/protobuf/services/BinaryLogs.java",
         "src/main/java/io/grpc/protobuf/services/BinlogHelper.java",
         "src/main/java/io/grpc/protobuf/services/InetAddressUtil.java",
         "src/main/java/io/grpc/protobuf/services/TempFileSink.java",
+        "src/main/java/io/grpc/services/BinaryLogs.java",
     ],
     deps = [
         "//api",
@@ -33,7 +93,6 @@ java_library(
     deps = [
         ":_channelz_java_grpc",
         "//api",
-        "//context",
         "//stub",
         "@com_google_code_findbugs_jsr305//jar",
         "@com_google_guava_guava//jar",
@@ -51,9 +110,6 @@ java_library(
     deps = [
         ":_reflection_java_grpc",
         "//api",
-        "//context",
-        "//core:internal",
-        "//core:util",
         "//protobuf",
         "//stub",
         "@com_google_code_findbugs_jsr305//jar",
@@ -76,6 +132,27 @@ java_library(
         "//api",
         "//context",
         "//stub",
+        "@com_google_code_findbugs_jsr305//jar",
+        "@com_google_guava_guava//jar",
+        "@io_grpc_grpc_proto//:health_java_proto",
+    ],
+)
+
+java_library(
+    name = "healthlb",
+    srcs = [
+        "src/main/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactory.java",
+        "src/main/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerUtil.java",
+        "src/main/java/io/grpc/protobuf/services/internal/HealthCheckingRoundRobinLoadBalancerProvider.java",
+    ],
+    resources = [
+        "src/main/resources/META-INF/services/io.grpc.LoadBalancerProvider",
+    ],
+    deps = [
+        ":_health_java_grpc",
+        "//api",
+        "//core:internal",
+        "//core:util",
         "@com_google_code_findbugs_jsr305//jar",
         "@com_google_guava_guava//jar",
         "@io_grpc_grpc_proto//:health_java_proto",

--- a/xds/BUILD.bazel
+++ b/xds/BUILD.bazel
@@ -1,0 +1,165 @@
+load("//:java_grpc_library.bzl", "java_grpc_library")
+
+# Mirrors the dependencies included in the artifact on Maven Central for usage
+# with maven_install's override_targets. Purposefully does not export any
+# symbols, as it should only be used as a dep for pre-compiled binaries on
+# Maven Central.
+java_library(
+    name = "xds_maven",
+    runtime_deps = [
+        ":orca",
+        ":xds",
+    ],
+)
+
+java_library(
+    name = "xds",
+    srcs = glob(
+        [
+            "src/main/java/**/*.java",
+            "third_party/zero-allocation-hashing/main/java/**/*.java",
+        ],
+        exclude = ["src/main/java/io/grpc/xds/orca/**"],
+    ),
+    resources = glob([
+        "src/main/resources/**",
+    ]),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":envoy_service_discovery_v2_java_grpc",
+        ":envoy_service_discovery_v3_java_grpc",
+        ":envoy_service_load_stats_v2_java_grpc",
+        ":envoy_service_load_stats_v3_java_grpc",
+        ":envoy_service_status_v3_java_grpc",
+        ":xds_protos_java",
+        "//:auto_value_annotations",
+        "//alts",
+        "//api",
+        "//context",
+        "//core:internal",
+        "//core:util",
+        "//netty",
+        "//stub",
+        "@com_google_code_findbugs_jsr305//jar",
+        "@com_google_code_gson_gson//jar",
+        "@com_google_errorprone_error_prone_annotations//jar",
+        "@com_google_googleapis//google/rpc:rpc_java_proto",
+        "@com_google_guava_guava//jar",
+        "@com_google_protobuf//:protobuf_java",
+        "@com_google_protobuf//:protobuf_java_util",
+        "@com_google_re2j_re2j//jar",
+        "@io_netty_netty_buffer//jar",
+        "@io_netty_netty_codec//jar",
+        "@io_netty_netty_common//jar",
+        "@io_netty_netty_handler//jar",
+        "@io_netty_netty_transport//jar",
+    ],
+)
+
+java_proto_library(
+    name = "xds_protos_java",
+    deps = [
+        "@com_github_cncf_udpa//udpa/type/v1:pkg",
+        "@com_github_cncf_xds//xds/data/orca/v3:pkg",
+        "@com_github_cncf_xds//xds/service/orca/v3:pkg",
+        "@com_github_cncf_xds//xds/type/v3:pkg",
+        "@envoy_api//envoy/admin/v3:pkg",
+        "@envoy_api//envoy/api/v2:pkg",
+        "@envoy_api//envoy/api/v2/core:pkg",
+        "@envoy_api//envoy/api/v2/endpoint:pkg",
+        "@envoy_api//envoy/config/cluster/aggregate/v2alpha:pkg",
+        "@envoy_api//envoy/config/cluster/v3:pkg",
+        "@envoy_api//envoy/config/core/v3:pkg",
+        "@envoy_api//envoy/config/endpoint/v3:pkg",
+        "@envoy_api//envoy/config/filter/http/fault/v2:pkg",
+        "@envoy_api//envoy/config/filter/http/router/v2:pkg",
+        "@envoy_api//envoy/config/filter/network/http_connection_manager/v2:pkg",
+        "@envoy_api//envoy/config/listener/v3:pkg",
+        "@envoy_api//envoy/config/rbac/v3:pkg",
+        "@envoy_api//envoy/config/route/v3:pkg",
+        "@envoy_api//envoy/extensions/clusters/aggregate/v3:pkg",
+        "@envoy_api//envoy/extensions/filters/common/fault/v3:pkg",
+        "@envoy_api//envoy/extensions/filters/http/fault/v3:pkg",
+        "@envoy_api//envoy/extensions/filters/http/rbac/v3:pkg",
+        "@envoy_api//envoy/extensions/filters/http/router/v3:pkg",
+        "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg",
+        "@envoy_api//envoy/extensions/load_balancing_policies/ring_hash/v3:pkg",
+        "@envoy_api//envoy/extensions/load_balancing_policies/round_robin/v3:pkg",
+        "@envoy_api//envoy/extensions/load_balancing_policies/wrr_locality/v3:pkg",
+        "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg",
+        "@envoy_api//envoy/service/discovery/v2:pkg",
+        "@envoy_api//envoy/service/discovery/v3:pkg",
+        "@envoy_api//envoy/service/load_stats/v2:pkg",
+        "@envoy_api//envoy/service/load_stats/v3:pkg",
+        "@envoy_api//envoy/service/status/v3:pkg",
+        "@envoy_api//envoy/type/matcher/v3:pkg",
+        "@envoy_api//envoy/type/v3:pkg",
+    ],
+)
+
+java_grpc_library(
+    name = "envoy_service_discovery_v2_java_grpc",
+    srcs = ["@envoy_api//envoy/service/discovery/v2:pkg"],
+    deps = [":xds_protos_java"],
+)
+
+java_grpc_library(
+    name = "envoy_service_discovery_v3_java_grpc",
+    srcs = ["@envoy_api//envoy/service/discovery/v3:pkg"],
+    deps = [":xds_protos_java"],
+)
+
+java_grpc_library(
+    name = "envoy_service_load_stats_v2_java_grpc",
+    srcs = ["@envoy_api//envoy/service/load_stats/v2:pkg"],
+    deps = [":xds_protos_java"],
+)
+
+java_grpc_library(
+    name = "envoy_service_load_stats_v3_java_grpc",
+    srcs = ["@envoy_api//envoy/service/load_stats/v3:pkg"],
+    deps = [":xds_protos_java"],
+)
+
+java_grpc_library(
+    name = "envoy_service_status_v3_java_grpc",
+    srcs = ["@envoy_api//envoy/service/status/v3:pkg"],
+    deps = [":xds_protos_java"],
+)
+
+java_library(
+    name = "orca",
+    srcs = glob([
+        "src/main/java/io/grpc/xds/orca/*.java",
+    ]),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":orca_protos_java",
+        ":xds_service_orca_v3_java_grpc",
+        "//api",
+        "//context",
+        "//core:internal",
+        "//core:util",
+        "//protobuf",
+        "//services:metrics",
+        "//services:metrics_internal",
+        "//stub",
+        "@com_google_code_findbugs_jsr305//jar",
+        "@com_google_guava_guava//jar",
+        "@com_google_protobuf//:protobuf_java_util",
+    ],
+)
+
+java_proto_library(
+    name = "orca_protos_java",
+    deps = [
+        "@com_github_cncf_xds//xds/data/orca/v3:pkg",
+        "@com_github_cncf_xds//xds/service/orca/v3:pkg",
+    ],
+)
+
+java_grpc_library(
+    name = "xds_service_orca_v3_java_grpc",
+    srcs = ["@com_github_cncf_xds//xds/service/orca/v3:pkg"],
+    deps = [":orca_protos_java"],
+)


### PR DESCRIPTION
Not updating the example WORKSPACE because it doesn't have any
Bazel-enabled build that depends on xds and so doesn't need the
additional repository dependencies.

Fixes #9162

CC @SanjayVas 