### PR TITLE
api: Ignore ClassCastExceptions for hard-coded providers

### DIFF
--- a/api/src/test/java/io/grpc/ServiceProvidersTest.java
+++ b/api/src/test/java/io/grpc/ServiceProvidersTest.java
@@ -215,17 +215,33 @@ public class ServiceProvidersTest {
   }
 
   @Test
-  public void create_throwsErrorOnMisconfiguration() throws Exception {
-    class PrivateClass {}
+  public void getCandidatesViaHardCoded_throwsErrorOnMisconfiguration() throws Exception {
+    class PrivateClass extends BaseProvider {
+      private PrivateClass() {
+        super(true, 5);
+      }
+    }
 
     try {
-      ServiceProviders.create(
-          ServiceProvidersTestAbstractProvider.class, PrivateClass.class);
+      ServiceProviders.getCandidatesViaHardCoded(
+          ServiceProvidersTestAbstractProvider.class,
+          Collections.<Class<?>>singletonList(PrivateClass.class));
       fail("Expected exception");
     } catch (ServiceConfigurationError expected) {
-      assertTrue("Expected ClassCastException cause: " + expected.getCause(),
-          expected.getCause() instanceof ClassCastException);
+      assertTrue("Expected NoSuchMethodException cause: " + expected.getCause(),
+          expected.getCause() instanceof NoSuchMethodException);
     }
+  }
+
+  @Test
+  public void getCandidatesViaHardCoded_skipsWrongClassType() throws Exception {
+    class RandomClass {}
+
+    Iterable<ServiceProvidersTestAbstractProvider> candidates =
+        ServiceProviders.getCandidatesViaHardCoded(
+            ServiceProvidersTestAbstractProvider.class,
+            Collections.<Class<?>>singletonList(RandomClass.class));
+    assertFalse(candidates.iterator().hasNext());
   }
 
   private static class BaseProvider extends ServiceProvidersTestAbstractProvider {


### PR DESCRIPTION
This was observed in the Bazel/Blaze build where io.grpc.util is a
separate target from the rest of core. During the build of a library
SecretRoundRobinLoadBalancerProvider was not on the classpath, and the
library was later included into a binary using grpc-core from Maven
Central which includes SecretRoundRobinLoadBalancerProvider.

```
java.util.ServiceConfigurationError: Provider io.grpc.util.SecretRoundRobinLoadBalancerProvider$Provider could not be instantiated java.lang.ClassCastException: class io.grpc.util.SecretRoundRobinLoadBalancerProvider$Provider cannot be cast to some.app.aaa.aab
```

CC @YifeiZhuang 