### PR TITLE
benchmarks: Raise timeout for aarch64

### DIFF
--- a/benchmarks/src/test/java/io/grpc/benchmarks/driver/LoadWorkerTest.java
+++ b/benchmarks/src/test/java/io/grpc/benchmarks/driver/LoadWorkerTest.java
@@ -42,7 +42,7 @@ import org.junit.runners.JUnit4;
 public class LoadWorkerTest {
 
 
-  private static final int TIMEOUT = 5;
+  private static final int TIMEOUT = 10;
   private static final Control.ClientArgs MARK = Control.ClientArgs.newBuilder()
       .setMark(Control.Mark.newBuilder().setReset(true).build())
       .build();


### PR DESCRIPTION
runUnaryBlockingClosedLoop is failing after 10.3s, which means 5.3s was
probably spent loading the LoadWorker. That means things are likely
indeed slow enough that 5s isn't enough time to wait for the server to
start. A successful execution of runUnaryBlockingClosedLoop takes
12.1 seconds, which again points to general slow execution.