### PR TITLE
api: Add connection management APIs to ServerBuilder

### DIFF
--- a/api/src/main/java/io/grpc/ForwardingServerBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingServerBuilder.java
@@ -134,6 +134,48 @@ public abstract class ForwardingServerBuilder<T extends ServerBuilder<T>> extend
   }
 
   @Override
+  public T keepAliveTime(long keepAliveTime, TimeUnit timeUnit) {
+    delegate().keepAliveTime(keepAliveTime, timeUnit);
+    return thisT();
+  }
+
+  @Override
+  public T keepAliveTimeout(long keepAliveTimeout, TimeUnit timeUnit) {
+    delegate().keepAliveTimeout(keepAliveTimeout, timeUnit);
+    return thisT();
+  }
+
+  @Override
+  public T maxConnectionIdle(long maxConnectionIdle, TimeUnit timeUnit) {
+    delegate().maxConnectionIdle(maxConnectionIdle, timeUnit);
+    return thisT();
+  }
+
+  @Override
+  public T maxConnectionAge(long maxConnectionAge, TimeUnit timeUnit) {
+    delegate().maxConnectionAge(maxConnectionAge, timeUnit);
+    return thisT();
+  }
+
+  @Override
+  public T maxConnectionAgeGrace(long maxConnectionAgeGrace, TimeUnit timeUnit) {
+    delegate().maxConnectionAgeGrace(maxConnectionAgeGrace, timeUnit);
+    return thisT();
+  }
+
+  @Override
+  public T permitKeepAliveTime(long keepAliveTime, TimeUnit timeUnit) {
+    delegate().permitKeepAliveTime(keepAliveTime, timeUnit);
+    return thisT();
+  }
+
+  @Override
+  public T permitKeepAliveWithoutCalls(boolean permit) {
+    delegate().permitKeepAliveWithoutCalls(permit);
+    return thisT();
+  }
+
+  @Override
   public T maxInboundMessageSize(int bytes) {
     delegate().maxInboundMessageSize(bytes);
     return thisT();

--- a/api/src/main/java/io/grpc/ServerBuilder.java
+++ b/api/src/main/java/io/grpc/ServerBuilder.java
@@ -244,6 +244,111 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
   }
 
   /**
+   * Sets the time without read activity before sending a keepalive ping. An unreasonably small
+   * value might be increased, and {@code Long.MAX_VALUE} nano seconds or an unreasonably large
+   * value will disable keepalive. The typical default is infinite when supported.
+   *
+   * @throws UnsupportedOperationException if unsupported
+   * @since 1.47.0
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/9009")
+  public T keepAliveTime(long keepAliveTime, TimeUnit timeUnit) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Sets a time waiting for read activity after sending a keepalive ping. If the time expires
+   * without any read activity on the connection, the connection is considered dead. An unreasonably
+   * small value might be increased. Defaults to 20 seconds when supported.
+   *
+   * <p>This value should be at least multiple times the RTT to allow for lost packets.
+   *
+   * @throws UnsupportedOperationException if unsupported
+   * @since 1.47.0
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/9009")
+  public T keepAliveTimeout(long keepAliveTimeout, TimeUnit timeUnit) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Sets the maximum connection idle time, connections being idle for longer than which will be
+   * gracefully terminated. Idleness duration is defined since the most recent time the number of
+   * outstanding RPCs became zero or the connection establishment. An unreasonably small value might
+   * be increased. {@code Long.MAX_VALUE} nano seconds or an unreasonably large value will disable
+   * max connection idle.
+   *
+   * @throws UnsupportedOperationException if unsupported
+   * @since 1.47.0
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/9009")
+  public T maxConnectionIdle(long maxConnectionIdle, TimeUnit timeUnit) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Sets the maximum connection age, connections lasting longer than which will be gracefully
+   * terminated. An unreasonably small value might be increased. A random jitter of +/-10% will be
+   * added to it. {@code Long.MAX_VALUE} nano seconds or an unreasonably large value will disable
+   * max connection age.
+   *
+   * @throws UnsupportedOperationException if unsupported
+   * @since 1.47.0
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/9009")
+  public T maxConnectionAge(long maxConnectionAge, TimeUnit timeUnit) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Sets the grace time for the graceful connection termination. Once the max connection age
+   * is reached, RPCs have the grace time to complete. RPCs that do not complete in time will be
+   * cancelled, allowing the connection to terminate. {@code Long.MAX_VALUE} nano seconds or an
+   * unreasonably large value are considered infinite.
+   *
+   * @throws UnsupportedOperationException if unsupported
+   * @see #maxConnectionAge(long, TimeUnit)
+   * @since 1.47.0
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/9009")
+  public T maxConnectionAgeGrace(long maxConnectionAgeGrace, TimeUnit timeUnit) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Specify the most aggressive keep-alive time clients are permitted to configure. The server will
+   * try to detect clients exceeding this rate and when detected will forcefully close the
+   * connection. The typical default is 5 minutes when supported.
+   *
+   * <p>Even though a default is defined that allows some keep-alives, clients must not use
+   * keep-alive without approval from the service owner. Otherwise, they may experience failures in
+   * the future if the service becomes more restrictive. When unthrottled, keep-alives can cause a
+   * significant amount of traffic and CPU usage, so clients and servers should be conservative in
+   * what they use and accept.
+   *
+   * @throws UnsupportedOperationException if unsupported
+   * @see #permitKeepAliveWithoutCalls(boolean)
+   * @since 1.47.0
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/9009")
+  public T permitKeepAliveTime(long keepAliveTime, TimeUnit timeUnit) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Sets whether to allow clients to send keep-alive HTTP/2 PINGs even if there are no outstanding
+   * RPCs on the connection. Defaults to {@code false} when supported.
+   *
+   * @throws UnsupportedOperationException if unsupported
+   * @see #permitKeepAliveTime(long, TimeUnit)
+   * @since 1.47.0
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/9009")
+  public T permitKeepAliveWithoutCalls(boolean permit) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Sets the maximum message size allowed to be received on the server. If not called,
    * defaults to 4 MiB. The default provides protection to servers who haven't considered the
    * possibility of receiving large messages while trying to be large enough to not be hit in normal

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -149,6 +149,48 @@ public abstract class AbstractServerImplBuilder
   }
 
   @Override
+  public T keepAliveTime(long keepAliveTime, TimeUnit timeUnit) {
+    delegate().keepAliveTime(keepAliveTime, timeUnit);
+    return thisT();
+  }
+
+  @Override
+  public T keepAliveTimeout(long keepAliveTimeout, TimeUnit timeUnit) {
+    delegate().keepAliveTimeout(keepAliveTimeout, timeUnit);
+    return thisT();
+  }
+
+  @Override
+  public T maxConnectionIdle(long maxConnectionIdle, TimeUnit timeUnit) {
+    delegate().maxConnectionIdle(maxConnectionIdle, timeUnit);
+    return thisT();
+  }
+
+  @Override
+  public T maxConnectionAge(long maxConnectionAge, TimeUnit timeUnit) {
+    delegate().maxConnectionAge(maxConnectionAge, timeUnit);
+    return thisT();
+  }
+
+  @Override
+  public T maxConnectionAgeGrace(long maxConnectionAgeGrace, TimeUnit timeUnit) {
+    delegate().maxConnectionAgeGrace(maxConnectionAgeGrace, timeUnit);
+    return thisT();
+  }
+
+  @Override
+  public T permitKeepAliveTime(long keepAliveTime, TimeUnit timeUnit) {
+    delegate().permitKeepAliveTime(keepAliveTime, timeUnit);
+    return thisT();
+  }
+
+  @Override
+  public T permitKeepAliveWithoutCalls(boolean permit) {
+    delegate().permitKeepAliveWithoutCalls(permit);
+    return thisT();
+  }
+
+  @Override
   public T maxInboundMessageSize(int bytes) {
     delegate().maxInboundMessageSize(bytes);
     return thisT();

--- a/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
@@ -490,6 +490,7 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
    *
    * @since 1.3.0
    */
+  @Override
   public NettyServerBuilder keepAliveTime(long keepAliveTime, TimeUnit timeUnit) {
     checkArgument(keepAliveTime > 0L, "keepalive time must be positive：%s", keepAliveTime);
     keepAliveTimeInNanos = timeUnit.toNanos(keepAliveTime);
@@ -511,6 +512,7 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
    *
    * @since 1.3.0
    */
+  @Override
   public NettyServerBuilder keepAliveTimeout(long keepAliveTimeout, TimeUnit timeUnit) {
     checkArgument(keepAliveTimeout > 0L, "keepalive timeout must be positive: %s",
         keepAliveTimeout);
@@ -533,6 +535,7 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
    *
    * @since 1.4.0
    */
+  @Override
   public NettyServerBuilder maxConnectionIdle(long maxConnectionIdle, TimeUnit timeUnit) {
     checkArgument(maxConnectionIdle > 0L, "max connection idle must be positive: %s",
         maxConnectionIdle);
@@ -554,6 +557,7 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
    *
    * @since 1.3.0
    */
+  @Override
   public NettyServerBuilder maxConnectionAge(long maxConnectionAge, TimeUnit timeUnit) {
     checkArgument(maxConnectionAge > 0L, "max connection age must be positive: %s",
         maxConnectionAge);
@@ -576,6 +580,7 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
    * @see #maxConnectionAge(long, TimeUnit)
    * @since 1.3.0
    */
+  @Override
   public NettyServerBuilder maxConnectionAgeGrace(long maxConnectionAgeGrace, TimeUnit timeUnit) {
     checkArgument(maxConnectionAgeGrace >= 0L, "max connection age grace must be non-negative: %s",
         maxConnectionAgeGrace);
@@ -600,6 +605,7 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
    * @see #permitKeepAliveWithoutCalls(boolean)
    * @since 1.3.0
    */
+  @Override
   public NettyServerBuilder permitKeepAliveTime(long keepAliveTime, TimeUnit timeUnit) {
     checkArgument(keepAliveTime >= 0, "permit keepalive time must be non-negative: %s",
         keepAliveTime);
@@ -614,6 +620,7 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
    * @see #permitKeepAliveTime(long, TimeUnit)
    * @since 1.3.0
    */
+  @Override
   public NettyServerBuilder permitKeepAliveWithoutCalls(boolean permit) {
     permitKeepAliveWithoutCalls = permit;
     return this;


### PR DESCRIPTION
These APIs were added to NettyServerBuilder for gRFC A8 and A9. They are
important enough that they shouldn't require using the perma-unstable
transport API to access. This change also allows using these methods
with grpc-netty-shaded.

Fixes #8991

----

We want them for the okhttp server as well.