### PR TITLE
interop-testing: Support syncing protos from grpc-proto

### DIFF
--- a/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -18,27 +18,27 @@ public final class ReconnectServiceGrpc {
   public static final String SERVICE_NAME = "grpc.testing.ReconnectService";
 
   // Static method descriptors that strictly reflect the proto.
-  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.EmptyProtos.Empty,
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.ReconnectParams,
       io.grpc.testing.integration.EmptyProtos.Empty> getStartMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "Start",
-      requestType = io.grpc.testing.integration.EmptyProtos.Empty.class,
+      requestType = io.grpc.testing.integration.Messages.ReconnectParams.class,
       responseType = io.grpc.testing.integration.EmptyProtos.Empty.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.EmptyProtos.Empty,
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.ReconnectParams,
       io.grpc.testing.integration.EmptyProtos.Empty> getStartMethod() {
-    io.grpc.MethodDescriptor<io.grpc.testing.integration.EmptyProtos.Empty, io.grpc.testing.integration.EmptyProtos.Empty> getStartMethod;
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.ReconnectParams, io.grpc.testing.integration.EmptyProtos.Empty> getStartMethod;
     if ((getStartMethod = ReconnectServiceGrpc.getStartMethod) == null) {
       synchronized (ReconnectServiceGrpc.class) {
         if ((getStartMethod = ReconnectServiceGrpc.getStartMethod) == null) {
           ReconnectServiceGrpc.getStartMethod = getStartMethod =
-              io.grpc.MethodDescriptor.<io.grpc.testing.integration.EmptyProtos.Empty, io.grpc.testing.integration.EmptyProtos.Empty>newBuilder()
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.Messages.ReconnectParams, io.grpc.testing.integration.EmptyProtos.Empty>newBuilder()
               .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
               .setFullMethodName(generateFullMethodName(SERVICE_NAME, "Start"))
               .setSampledToLocalTracing(true)
               .setRequestMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
-                  io.grpc.testing.integration.EmptyProtos.Empty.getDefaultInstance()))
+                  io.grpc.testing.integration.Messages.ReconnectParams.getDefaultInstance()))
               .setResponseMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
                   io.grpc.testing.integration.EmptyProtos.Empty.getDefaultInstance()))
               .build();
@@ -131,7 +131,7 @@ public final class ReconnectServiceGrpc {
 
     /**
      */
-    public void start(io.grpc.testing.integration.EmptyProtos.Empty request,
+    public void start(io.grpc.testing.integration.Messages.ReconnectParams request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.EmptyProtos.Empty> responseObserver) {
       io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getStartMethod(), responseObserver);
     }
@@ -149,7 +149,7 @@ public final class ReconnectServiceGrpc {
             getStartMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
               new MethodHandlers<
-                io.grpc.testing.integration.EmptyProtos.Empty,
+                io.grpc.testing.integration.Messages.ReconnectParams,
                 io.grpc.testing.integration.EmptyProtos.Empty>(
                   this, METHODID_START)))
           .addMethod(
@@ -182,7 +182,7 @@ public final class ReconnectServiceGrpc {
 
     /**
      */
-    public void start(io.grpc.testing.integration.EmptyProtos.Empty request,
+    public void start(io.grpc.testing.integration.Messages.ReconnectParams request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.EmptyProtos.Empty> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getStartMethod(), getCallOptions()), request, responseObserver);
@@ -216,7 +216,7 @@ public final class ReconnectServiceGrpc {
 
     /**
      */
-    public io.grpc.testing.integration.EmptyProtos.Empty start(io.grpc.testing.integration.EmptyProtos.Empty request) {
+    public io.grpc.testing.integration.EmptyProtos.Empty start(io.grpc.testing.integration.Messages.ReconnectParams request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getStartMethod(), getCallOptions(), request);
     }
@@ -249,7 +249,7 @@ public final class ReconnectServiceGrpc {
     /**
      */
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.EmptyProtos.Empty> start(
-        io.grpc.testing.integration.EmptyProtos.Empty request) {
+        io.grpc.testing.integration.Messages.ReconnectParams request) {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
           getChannel().newCall(getStartMethod(), getCallOptions()), request);
     }
@@ -284,7 +284,7 @@ public final class ReconnectServiceGrpc {
     public void invoke(Req request, io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
         case METHODID_START:
-          serviceImpl.start((io.grpc.testing.integration.EmptyProtos.Empty) request,
+          serviceImpl.start((io.grpc.testing.integration.Messages.ReconnectParams) request,
               (io.grpc.stub.StreamObserver<io.grpc.testing.integration.EmptyProtos.Empty>) responseObserver);
           break;
         case METHODID_STOP:

--- a/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -18,27 +18,27 @@ public final class ReconnectServiceGrpc {
   public static final String SERVICE_NAME = "grpc.testing.ReconnectService";
 
   // Static method descriptors that strictly reflect the proto.
-  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.EmptyProtos.Empty,
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.ReconnectParams,
       io.grpc.testing.integration.EmptyProtos.Empty> getStartMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "Start",
-      requestType = io.grpc.testing.integration.EmptyProtos.Empty.class,
+      requestType = io.grpc.testing.integration.Messages.ReconnectParams.class,
       responseType = io.grpc.testing.integration.EmptyProtos.Empty.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.EmptyProtos.Empty,
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.ReconnectParams,
       io.grpc.testing.integration.EmptyProtos.Empty> getStartMethod() {
-    io.grpc.MethodDescriptor<io.grpc.testing.integration.EmptyProtos.Empty, io.grpc.testing.integration.EmptyProtos.Empty> getStartMethod;
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.ReconnectParams, io.grpc.testing.integration.EmptyProtos.Empty> getStartMethod;
     if ((getStartMethod = ReconnectServiceGrpc.getStartMethod) == null) {
       synchronized (ReconnectServiceGrpc.class) {
         if ((getStartMethod = ReconnectServiceGrpc.getStartMethod) == null) {
           ReconnectServiceGrpc.getStartMethod = getStartMethod =
-              io.grpc.MethodDescriptor.<io.grpc.testing.integration.EmptyProtos.Empty, io.grpc.testing.integration.EmptyProtos.Empty>newBuilder()
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.Messages.ReconnectParams, io.grpc.testing.integration.EmptyProtos.Empty>newBuilder()
               .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
               .setFullMethodName(generateFullMethodName(SERVICE_NAME, "Start"))
               .setSampledToLocalTracing(true)
               .setRequestMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
-                  io.grpc.testing.integration.EmptyProtos.Empty.getDefaultInstance()))
+                  io.grpc.testing.integration.Messages.ReconnectParams.getDefaultInstance()))
               .setResponseMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
                   io.grpc.testing.integration.EmptyProtos.Empty.getDefaultInstance()))
               .build();
@@ -131,7 +131,7 @@ public final class ReconnectServiceGrpc {
 
     /**
      */
-    public void start(io.grpc.testing.integration.EmptyProtos.Empty request,
+    public void start(io.grpc.testing.integration.Messages.ReconnectParams request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.EmptyProtos.Empty> responseObserver) {
       io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getStartMethod(), responseObserver);
     }
@@ -149,7 +149,7 @@ public final class ReconnectServiceGrpc {
             getStartMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
               new MethodHandlers<
-                io.grpc.testing.integration.EmptyProtos.Empty,
+                io.grpc.testing.integration.Messages.ReconnectParams,
                 io.grpc.testing.integration.EmptyProtos.Empty>(
                   this, METHODID_START)))
           .addMethod(
@@ -182,7 +182,7 @@ public final class ReconnectServiceGrpc {
 
     /**
      */
-    public void start(io.grpc.testing.integration.EmptyProtos.Empty request,
+    public void start(io.grpc.testing.integration.Messages.ReconnectParams request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.EmptyProtos.Empty> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getStartMethod(), getCallOptions()), request, responseObserver);
@@ -216,7 +216,7 @@ public final class ReconnectServiceGrpc {
 
     /**
      */
-    public io.grpc.testing.integration.EmptyProtos.Empty start(io.grpc.testing.integration.EmptyProtos.Empty request) {
+    public io.grpc.testing.integration.EmptyProtos.Empty start(io.grpc.testing.integration.Messages.ReconnectParams request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getStartMethod(), getCallOptions(), request);
     }
@@ -249,7 +249,7 @@ public final class ReconnectServiceGrpc {
     /**
      */
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.EmptyProtos.Empty> start(
-        io.grpc.testing.integration.EmptyProtos.Empty request) {
+        io.grpc.testing.integration.Messages.ReconnectParams request) {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
           getChannel().newCall(getStartMethod(), getCallOptions()), request);
     }
@@ -284,7 +284,7 @@ public final class ReconnectServiceGrpc {
     public void invoke(Req request, io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
         case METHODID_START:
-          serviceImpl.start((io.grpc.testing.integration.EmptyProtos.Empty) request,
+          serviceImpl.start((io.grpc.testing.integration.Messages.ReconnectParams) request,
               (io.grpc.stub.StreamObserver<io.grpc.testing.integration.EmptyProtos.Empty>) responseObserver);
           break;
         case METHODID_STOP:

--- a/buildscripts/sync-protos.sh
+++ b/buildscripts/sync-protos.sh
@@ -8,7 +8,7 @@ curl -Ls https://github.com/grpc/grpc-proto/archive/master.tar.gz | tar xz -C "$
 base="$tmpdir/grpc-proto-master"
 
 # Copy protos in 'src/main/proto' from grpc-proto for these projects
-for project in alts grpclb services rls; do
+for project in alts grpclb services rls interop-testing; do
   while read -r proto; do
     [ -f "$base/$proto" ] && cp "$base/$proto" "$project/src/main/proto/$proto"
     echo "$proto"

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -18,27 +18,27 @@ public final class ReconnectServiceGrpc {
   public static final String SERVICE_NAME = "grpc.testing.ReconnectService";
 
   // Static method descriptors that strictly reflect the proto.
-  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.EmptyProtos.Empty,
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.ReconnectParams,
       io.grpc.testing.integration.EmptyProtos.Empty> getStartMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "Start",
-      requestType = io.grpc.testing.integration.EmptyProtos.Empty.class,
+      requestType = io.grpc.testing.integration.Messages.ReconnectParams.class,
       responseType = io.grpc.testing.integration.EmptyProtos.Empty.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.EmptyProtos.Empty,
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.ReconnectParams,
       io.grpc.testing.integration.EmptyProtos.Empty> getStartMethod() {
-    io.grpc.MethodDescriptor<io.grpc.testing.integration.EmptyProtos.Empty, io.grpc.testing.integration.EmptyProtos.Empty> getStartMethod;
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.ReconnectParams, io.grpc.testing.integration.EmptyProtos.Empty> getStartMethod;
     if ((getStartMethod = ReconnectServiceGrpc.getStartMethod) == null) {
       synchronized (ReconnectServiceGrpc.class) {
         if ((getStartMethod = ReconnectServiceGrpc.getStartMethod) == null) {
           ReconnectServiceGrpc.getStartMethod = getStartMethod =
-              io.grpc.MethodDescriptor.<io.grpc.testing.integration.EmptyProtos.Empty, io.grpc.testing.integration.EmptyProtos.Empty>newBuilder()
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.Messages.ReconnectParams, io.grpc.testing.integration.EmptyProtos.Empty>newBuilder()
               .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
               .setFullMethodName(generateFullMethodName(SERVICE_NAME, "Start"))
               .setSampledToLocalTracing(true)
               .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  io.grpc.testing.integration.EmptyProtos.Empty.getDefaultInstance()))
+                  io.grpc.testing.integration.Messages.ReconnectParams.getDefaultInstance()))
               .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
                   io.grpc.testing.integration.EmptyProtos.Empty.getDefaultInstance()))
               .setSchemaDescriptor(new ReconnectServiceMethodDescriptorSupplier("Start"))
@@ -133,7 +133,7 @@ public final class ReconnectServiceGrpc {
 
     /**
      */
-    public void start(io.grpc.testing.integration.EmptyProtos.Empty request,
+    public void start(io.grpc.testing.integration.Messages.ReconnectParams request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.EmptyProtos.Empty> responseObserver) {
       io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getStartMethod(), responseObserver);
     }
@@ -151,7 +151,7 @@ public final class ReconnectServiceGrpc {
             getStartMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
               new MethodHandlers<
-                io.grpc.testing.integration.EmptyProtos.Empty,
+                io.grpc.testing.integration.Messages.ReconnectParams,
                 io.grpc.testing.integration.EmptyProtos.Empty>(
                   this, METHODID_START)))
           .addMethod(
@@ -184,7 +184,7 @@ public final class ReconnectServiceGrpc {
 
     /**
      */
-    public void start(io.grpc.testing.integration.EmptyProtos.Empty request,
+    public void start(io.grpc.testing.integration.Messages.ReconnectParams request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.EmptyProtos.Empty> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getStartMethod(), getCallOptions()), request, responseObserver);
@@ -218,7 +218,7 @@ public final class ReconnectServiceGrpc {
 
     /**
      */
-    public io.grpc.testing.integration.EmptyProtos.Empty start(io.grpc.testing.integration.EmptyProtos.Empty request) {
+    public io.grpc.testing.integration.EmptyProtos.Empty start(io.grpc.testing.integration.Messages.ReconnectParams request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getStartMethod(), getCallOptions(), request);
     }
@@ -251,7 +251,7 @@ public final class ReconnectServiceGrpc {
     /**
      */
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.EmptyProtos.Empty> start(
-        io.grpc.testing.integration.EmptyProtos.Empty request) {
+        io.grpc.testing.integration.Messages.ReconnectParams request) {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
           getChannel().newCall(getStartMethod(), getCallOptions()), request);
     }
@@ -286,7 +286,7 @@ public final class ReconnectServiceGrpc {
     public void invoke(Req request, io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
         case METHODID_START:
-          serviceImpl.start((io.grpc.testing.integration.EmptyProtos.Empty) request,
+          serviceImpl.start((io.grpc.testing.integration.Messages.ReconnectParams) request,
               (io.grpc.stub.StreamObserver<io.grpc.testing.integration.EmptyProtos.Empty>) responseObserver);
           break;
         case METHODID_STOP:

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -40,6 +40,7 @@ import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.MessageLite;
+import com.google.protobuf.StringValue;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -1058,10 +1059,9 @@ public abstract class AbstractInteropTest {
   public void exchangeMetadataUnaryCall() throws Exception {
     // Capture the metadata exchange
     Metadata fixedHeaders = new Metadata();
-    // Send a context proto (as it's in the default extension registry)
-    Messages.SimpleContext contextValue =
-        Messages.SimpleContext.newBuilder().setValue("dog").build();
-    fixedHeaders.put(Util.METADATA_KEY, contextValue);
+    // Send a metadata proto
+    StringValue metadataValue = StringValue.newBuilder().setValue("dog").build();
+    fixedHeaders.put(Util.METADATA_KEY, metadataValue);
     // .. and expect it to be echoed back in trailers
     AtomicReference<Metadata> trailersCapture = new AtomicReference<>();
     AtomicReference<Metadata> headersCapture = new AtomicReference<>();
@@ -1072,18 +1072,17 @@ public abstract class AbstractInteropTest {
     assertNotNull(stub.emptyCall(EMPTY));
 
     // Assert that our side channel object is echoed back in both headers and trailers
-    Assert.assertEquals(contextValue, headersCapture.get().get(Util.METADATA_KEY));
-    Assert.assertEquals(contextValue, trailersCapture.get().get(Util.METADATA_KEY));
+    Assert.assertEquals(metadataValue, headersCapture.get().get(Util.METADATA_KEY));
+    Assert.assertEquals(metadataValue, trailersCapture.get().get(Util.METADATA_KEY));
   }
 
   @Test
   public void exchangeMetadataStreamingCall() throws Exception {
     // Capture the metadata exchange
     Metadata fixedHeaders = new Metadata();
-    // Send a context proto (as it's in the default extension registry)
-    Messages.SimpleContext contextValue =
-        Messages.SimpleContext.newBuilder().setValue("dog").build();
-    fixedHeaders.put(Util.METADATA_KEY, contextValue);
+    // Send a metadata proto
+    StringValue metadataValue = StringValue.newBuilder().setValue("dog").build();
+    fixedHeaders.put(Util.METADATA_KEY, metadataValue);
     // .. and expect it to be echoed back in trailers
     AtomicReference<Metadata> trailersCapture = new AtomicReference<>();
     AtomicReference<Metadata> headersCapture = new AtomicReference<>();
@@ -1114,8 +1113,8 @@ public abstract class AbstractInteropTest {
     org.junit.Assert.assertEquals(responseSizes.size() * numRequests, recorder.getValues().size());
 
     // Assert that our side channel object is echoed back in both headers and trailers
-    Assert.assertEquals(contextValue, headersCapture.get().get(Util.METADATA_KEY));
-    Assert.assertEquals(contextValue, trailersCapture.get().get(Util.METADATA_KEY));
+    Assert.assertEquals(metadataValue, headersCapture.get().get(Util.METADATA_KEY));
+    Assert.assertEquals(metadataValue, trailersCapture.get().get(Util.METADATA_KEY));
   }
 
   @Test

--- a/interop-testing/src/main/java/io/grpc/testing/integration/ReconnectTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/ReconnectTestClient.java
@@ -25,6 +25,7 @@ import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.okhttp.OkHttpChannelBuilder;
 import io.grpc.testing.integration.EmptyProtos.Empty;
 import io.grpc.testing.integration.Messages.ReconnectInfo;
+import io.grpc.testing.integration.Messages.ReconnectParams;
 
 /**
  * Verifies the client is reconnecting the server with correct backoffs
@@ -79,12 +80,12 @@ public class ReconnectTestClient {
             .negotiationType(NegotiationType.TLS).build();
       }
       retryStub = ReconnectServiceGrpc.newBlockingStub(retryChannel);
-      controlStub.start(Empty.getDefaultInstance());
+      controlStub.start(ReconnectParams.getDefaultInstance());
 
       long startTimeStamp = System.currentTimeMillis();
       while ((System.currentTimeMillis() - startTimeStamp) < TEST_TIME_MS) {
         try {
-          retryStub.start(Empty.getDefaultInstance());
+          retryStub.start(ReconnectParams.getDefaultInstance());
         } catch (StatusRuntimeException expected) {
           // Make CheckStyle happy.
         }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/Util.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/Util.java
@@ -17,6 +17,7 @@
 package io.grpc.testing.integration;
 
 import com.google.protobuf.MessageLite;
+import com.google.protobuf.StringValue;
 import io.grpc.Metadata;
 import io.grpc.protobuf.lite.ProtoLiteUtils;
 import java.util.List;
@@ -27,10 +28,10 @@ import org.junit.Assert;
  */
 public class Util {
 
-  public static final Metadata.Key<Messages.SimpleContext> METADATA_KEY =
+  public static final Metadata.Key<StringValue> METADATA_KEY =
       Metadata.Key.of(
-          "grpc.testing.SimpleContext" + Metadata.BINARY_HEADER_SUFFIX,
-          ProtoLiteUtils.metadataMarshaller(Messages.SimpleContext.getDefaultInstance()));
+          "google.protobuf.StringValue" + Metadata.BINARY_HEADER_SUFFIX,
+          ProtoLiteUtils.metadataMarshaller(StringValue.getDefaultInstance()));
   public static final Metadata.Key<String> ECHO_INITIAL_METADATA_KEY
       = Metadata.Key.of("x-grpc-test-echo-initial", Metadata.ASCII_STRING_MARSHALLER);
   public static final Metadata.Key<byte[]> ECHO_TRAILING_METADATA_KEY

--- a/interop-testing/src/main/proto/grpc/testing/empty.proto
+++ b/interop-testing/src/main/proto/grpc/testing/empty.proto
@@ -1,4 +1,5 @@
-// Copyright 2015 The gRPC Authors
+
+// Copyright 2015 gRPC authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-syntax = "proto2";
+
+syntax = "proto3";
 
 package grpc.testing;
 

--- a/interop-testing/src/main/proto/grpc/testing/messages.proto
+++ b/interop-testing/src/main/proto/grpc/testing/messages.proto
@@ -1,4 +1,5 @@
-// Copyright 2015 The gRPC Authors
+
+// Copyright 2015-2016 gRPC authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,16 +21,24 @@ package grpc.testing;
 
 option java_package = "io.grpc.testing.integration";
 
-// TODO(jihuncho): Use well-known types once all languages are synced.
+// TODO(dgq): Go back to using well-known types once
+// https://github.com/grpc/grpc/issues/6980 has been fixed.
+// import "google/protobuf/wrappers.proto";
 message BoolValue {
   // The bool value.
   bool value = 1;
 }
 
+// The type of payload that should be returned.
+enum PayloadType {
+  // Compressable text format.
+  COMPRESSABLE = 0;
+}
+
 // A block of data, to simply increase gRPC message size.
 message Payload {
-  reserved 1;
-
+  // The type of data in body.
+  PayloadType type = 1;
   // Primary contents of payload.
   bytes body = 2;
 }
@@ -58,7 +67,9 @@ enum GrpclbRouteType {
 
 // Unary request.
 message SimpleRequest {
-  reserved 1;
+  // Desired payload type in the response from the server.
+  // If response_type is RANDOM, server randomly chooses one from other formats.
+  PayloadType response_type = 1;
 
   // Desired payload size in the response from the server.
   int32 response_size = 2;
@@ -106,12 +117,9 @@ message SimpleResponse {
   string server_id = 4;
   // gRPCLB Path.
   GrpclbRouteType grpclb_route_type = 5;
+
   // Server hostname.
   string hostname = 6;
-}
-
-message SimpleContext {
-  string value = 1;
 }
 
 // Client-streaming request.
@@ -152,7 +160,11 @@ message ResponseParameters {
 
 // Server-streaming request.
 message StreamingOutputCallRequest {
-  reserved 1;
+  // Desired payload type in the response from the server.
+  // If response_type is RANDOM, the payload from each response in the stream
+  // might be of different types. This is to simulate a mixed type of payload
+  // stream.
+  PayloadType response_type = 1;
 
   // Configuration for each expected response message.
   repeated ResponseParameters response_parameters = 2;

--- a/interop-testing/src/main/proto/grpc/testing/test.proto
+++ b/interop-testing/src/main/proto/grpc/testing/test.proto
@@ -1,4 +1,5 @@
-// Copyright 2015 The gRPC Authors
+
+// Copyright 2015-2016 gRPC authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 // An integration test service that covers all the method signature permutations
 // of unary/streaming requests/responses.
+
 syntax = "proto3";
 
 import "grpc/testing/empty.proto";
@@ -73,7 +76,7 @@ service UnimplementedService {
 
 // A service used to control reconnect server.
 service ReconnectService {
-  rpc Start(grpc.testing.Empty) returns (grpc.testing.Empty);
+  rpc Start(grpc.testing.ReconnectParams) returns (grpc.testing.Empty);
   rpc Stop(grpc.testing.Empty) returns (grpc.testing.ReconnectInfo);
 }
 
@@ -81,11 +84,11 @@ service ReconnectService {
 service LoadBalancerStatsService {
   // Gets the backend distribution for RPCs sent by a test client.
   rpc GetClientStats(LoadBalancerStatsRequest)
-    returns (LoadBalancerStatsResponse) {}
+      returns (LoadBalancerStatsResponse) {}
 
   // Gets the accumulated stats for RPCs sent by a test client.
   rpc GetClientAccumulatedStats(LoadBalancerAccumulatedStatsRequest)
-    returns (LoadBalancerAccumulatedStatsResponse) {}
+      returns (LoadBalancerAccumulatedStatsResponse) {}
 }
 
 // A service to remotely control health status of an xDS test server.

--- a/services/src/main/proto/grpc/channelz/v1/channelz.proto
+++ b/services/src/main/proto/grpc/channelz/v1/channelz.proto
@@ -35,7 +35,7 @@ option java_outer_classname = "ChannelzProto";
 
 // Channel is a logical grouping of channels, subchannels, and sockets.
 message Channel {
-  // The identifier for this channel. This should bet set.
+  // The identifier for this channel. This should be set.
   ChannelRef ref = 1;
   // Data specific to this channel.
   ChannelData data = 2;


### PR DESCRIPTION
Two main incompatibilities existed in the copy of protos in grpc-proto:
no SimpleContext and an Empty method argument was replaced with a
message. "Context" is a very old word for "Metadata" back from the days
before the current gRPC protocol. We don't need that message in
particular, and well-known protos actually works in Protobuf Lite these
days, so we can swap to wrappers.proto's StringValue and don't need to
upstream a change to grpc-proto. The argument problem is fixed just by
changing the type in the Java code.

With the incompatibilities fixed, do a sync from grpc-proto and include
interop-testing.