### PR TITLE
xds: Use weighted_target LB provider in wrr_locality

### DIFF
--- a/xds/src/test/java/io/grpc/xds/FakeControlPlaneXdsIntegrationTest.java
+++ b/xds/src/test/java/io/grpc/xds/FakeControlPlaneXdsIntegrationTest.java
@@ -17,23 +17,30 @@
 
 package io.grpc.xds;
 
+import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.xds.XdsTestControlPlaneService.ADS_TYPE_URL_CDS;
 import static io.grpc.xds.XdsTestControlPlaneService.ADS_TYPE_URL_EDS;
 import static io.grpc.xds.XdsTestControlPlaneService.ADS_TYPE_URL_LDS;
 import static io.grpc.xds.XdsTestControlPlaneService.ADS_TYPE_URL_RDS;
 import static org.junit.Assert.assertEquals;
 
+import com.github.xds.type.v3.TypedStruct;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Any;
 import com.google.protobuf.Message;
+import com.google.protobuf.Struct;
 import com.google.protobuf.UInt32Value;
+import com.google.protobuf.Value;
 import io.envoyproxy.envoy.config.cluster.v3.Cluster;
+import io.envoyproxy.envoy.config.cluster.v3.LoadBalancingPolicy;
+import io.envoyproxy.envoy.config.cluster.v3.LoadBalancingPolicy.Policy;
 import io.envoyproxy.envoy.config.core.v3.Address;
 import io.envoyproxy.envoy.config.core.v3.AggregatedConfigSource;
 import io.envoyproxy.envoy.config.core.v3.ConfigSource;
 import io.envoyproxy.envoy.config.core.v3.HealthStatus;
 import io.envoyproxy.envoy.config.core.v3.SocketAddress;
 import io.envoyproxy.envoy.config.core.v3.TrafficDirection;
+import io.envoyproxy.envoy.config.core.v3.TypedExtensionConfig;
 import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
 import io.envoyproxy.envoy.config.endpoint.v3.Endpoint;
 import io.envoyproxy.envoy.config.endpoint.v3.LbEndpoint;
@@ -53,12 +60,27 @@ import io.envoyproxy.envoy.extensions.filters.http.router.v3.Router;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.Rds;
+import io.envoyproxy.envoy.extensions.load_balancing_policies.wrr_locality.v3.WrrLocality;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import io.grpc.ForwardingClientCallListener;
+import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
 import io.grpc.Grpc;
 import io.grpc.InsecureChannelCredentials;
 import io.grpc.InsecureServerCredentials;
+import io.grpc.LoadBalancerRegistry;
 import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
 import io.grpc.NameResolverRegistry;
 import io.grpc.Server;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.protobuf.SimpleRequest;
@@ -100,6 +122,7 @@ public class FakeControlPlaneXdsIntegrationTest {
   private Server controlPlane;
   private XdsTestControlPlaneService controlPlaneService;
   private XdsNameResolverProvider nameResolverProvider;
+  private MetadataLoadBalancerProvider metadataLoadBalancerProvider;
 
   protected int testServerPort = 0;
   protected int controlPlaneServicePort;
@@ -135,10 +158,13 @@ public class FakeControlPlaneXdsIntegrationTest {
    */
   @Before
   public void setUp() throws Exception {
+    ClientXdsClient.enableCustomLbConfig = true;
     startControlPlane();
     nameResolverProvider = XdsNameResolverProvider.createForTest(SCHEME,
         defaultBootstrapOverride());
     NameResolverRegistry.getDefaultRegistry().register(nameResolverProvider);
+    metadataLoadBalancerProvider = new MetadataLoadBalancerProvider();
+    LoadBalancerRegistry.getDefaultRegistry().register(metadataLoadBalancerProvider);
   }
 
   @After
@@ -156,6 +182,7 @@ public class FakeControlPlaneXdsIntegrationTest {
       }
     }
     NameResolverRegistry.getDefaultRegistry().deregister(nameResolverProvider);
+    LoadBalancerRegistry.getDefaultRegistry().deregister(metadataLoadBalancerProvider);
   }
 
   @Test
@@ -186,7 +213,108 @@ public class FakeControlPlaneXdsIntegrationTest {
     assertEquals(goldenResponse, blockingStub.unaryRpc(request));
   }
 
+  @Test
+  public void pingPong_metadataLoadBalancer() throws Exception {
+    String tcpListenerName = SERVER_LISTENER_TEMPLATE_NO_REPLACEMENT;
+    String serverHostName = "test-server";
+    controlPlaneService.setXdsConfig(ADS_TYPE_URL_LDS, ImmutableMap.of(
+        tcpListenerName, serverListener(tcpListenerName),
+        serverHostName, clientListener(serverHostName)
+    ));
+    startServer(defaultBootstrapOverride());
+    controlPlaneService.setXdsConfig(ADS_TYPE_URL_RDS,
+        ImmutableMap.of(RDS_NAME, rds(serverHostName)));
+
+    // Use the LoadBalancingPolicy to configure a custom LB that adds a header to server calls.
+    Policy metadataLbPolicy = Policy.newBuilder().setTypedExtensionConfig(
+        TypedExtensionConfig.newBuilder().setTypedConfig(Any.pack(
+            TypedStruct.newBuilder().setTypeUrl("type.googleapis.com/test.MetadataLoadBalancer")
+                .setValue(Struct.newBuilder()
+                    .putFields("metadataKey", Value.newBuilder().setStringValue("foo").build())
+                    .putFields("metadataValue", Value.newBuilder().setStringValue("bar").build()))
+                .build()))).build();
+    Policy wrrLocalityPolicy = Policy.newBuilder()
+        .setTypedExtensionConfig(TypedExtensionConfig.newBuilder().setTypedConfig(
+            Any.pack(WrrLocality.newBuilder().setEndpointPickingPolicy(
+                LoadBalancingPolicy.newBuilder().addPolicies(metadataLbPolicy)).build()))).build();
+    controlPlaneService.setXdsConfig(ADS_TYPE_URL_CDS,
+        ImmutableMap.<String, Message>of(CLUSTER_NAME, cds().toBuilder().setLoadBalancingPolicy(
+            LoadBalancingPolicy.newBuilder()
+                .addPolicies(wrrLocalityPolicy)).build()));
+
+    InetSocketAddress edsInetSocketAddress = (InetSocketAddress) server.getListenSockets().get(0);
+    controlPlaneService.setXdsConfig(ADS_TYPE_URL_EDS,
+        ImmutableMap.<String, Message>of(EDS_NAME, eds(edsInetSocketAddress.getHostName(),
+            edsInetSocketAddress.getPort())));
+    ManagedChannel channel = Grpc.newChannelBuilder(SCHEME + ":///" + serverHostName,
+        InsecureChannelCredentials.create()).build();
+    ResponseHeaderClientInterceptor responseHeaderInterceptor
+        = new ResponseHeaderClientInterceptor();
+
+    // We add an interceptor to catch the response headers from the server.
+    blockingStub = SimpleServiceGrpc.newBlockingStub(channel)
+        .withInterceptors(responseHeaderInterceptor);
+    SimpleRequest request = SimpleRequest.newBuilder()
+        .build();
+    SimpleResponse goldenResponse = SimpleResponse.newBuilder()
+        .setResponseMessage("Hi, xDS!")
+        .build();
+    assertEquals(goldenResponse, blockingStub.unaryRpc(request));
+
+    // Make sure we got back the header we configured the LB with.
+    assertThat(responseHeaderInterceptor.reponseHeaders.get(
+        Metadata.Key.of("foo", Metadata.ASCII_STRING_MARSHALLER))).isEqualTo("bar");
+  }
+
+  // Captures response headers from the server.
+  private class ResponseHeaderClientInterceptor implements ClientInterceptor {
+    Metadata reponseHeaders;
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
+        CallOptions callOptions, Channel next) {
+
+      return new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(ClientCall.Listener<RespT> responseListener, Metadata headers) {
+          super.start(new ForwardingClientCallListener<RespT>() {
+            @Override
+            protected ClientCall.Listener<RespT> delegate() {
+              return responseListener;
+            }
+
+            @Override
+            public void onHeaders(Metadata headers) {
+              reponseHeaders = headers;
+            }
+          }, headers);
+        }
+      };
+    }
+  }
+
   private void startServer(Map<String, ?> bootstrapOverride) throws Exception {
+    ServerInterceptor metadataInterceptor = new ServerInterceptor() {
+      @Override
+      public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
+          Metadata requestHeaders, ServerCallHandler<ReqT, RespT> next) {
+        logger.fine("Received following metadata: " + requestHeaders);
+
+        return next.startCall(new SimpleForwardingServerCall<ReqT, RespT>(call) {
+          @Override
+          public void sendHeaders(Metadata responseHeaders) {
+            responseHeaders.merge(requestHeaders);
+            super.sendHeaders(responseHeaders);
+          }
+
+          @Override
+          public void close(Status status, Metadata trailers) {
+            super.close(status, trailers);
+          }
+        }, requestHeaders);
+      }
+    };
+
     SimpleServiceGrpc.SimpleServiceImplBase simpleServiceImpl =
         new SimpleServiceGrpc.SimpleServiceImplBase() {
           @Override
@@ -202,6 +330,7 @@ public class FakeControlPlaneXdsIntegrationTest {
     XdsServerBuilder serverBuilder = XdsServerBuilder.forPort(
             0, InsecureServerCredentials.create())
         .addService(simpleServiceImpl)
+        .intercept(metadataInterceptor)
         .overrideBootstrapForTest(bootstrapOverride);
     server = serverBuilder.build().start();
     testServerPort = server.getPort();

--- a/xds/src/test/java/io/grpc/xds/MetadataLoadBalancerProvider.java
+++ b/xds/src/test/java/io/grpc/xds/MetadataLoadBalancerProvider.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import io.grpc.ConnectivityState;
+import io.grpc.LoadBalancer;
+import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancer.PickResult;
+import io.grpc.LoadBalancer.PickSubchannelArgs;
+import io.grpc.LoadBalancer.SubchannelPicker;
+import io.grpc.LoadBalancerProvider;
+import io.grpc.LoadBalancerRegistry;
+import io.grpc.Metadata;
+import io.grpc.NameResolver;
+import io.grpc.Status;
+import io.grpc.internal.JsonUtil;
+import io.grpc.util.ForwardingLoadBalancer;
+import io.grpc.util.ForwardingLoadBalancerHelper;
+import java.util.Map;
+import javax.annotation.Nonnull;
+
+/**
+ * A custom LB for testing purposes that simply delegates to round_robin and adds a metadata entry
+ * to each request.
+ */
+public class MetadataLoadBalancerProvider extends LoadBalancerProvider {
+
+  @Override
+  public NameResolver.ConfigOrError parseLoadBalancingPolicyConfig(
+      Map<String, ?> rawLoadBalancingPolicyConfig) {
+    String metadataKey = JsonUtil.getString(rawLoadBalancingPolicyConfig, "metadataKey");
+    if (metadataKey == null) {
+      return NameResolver.ConfigOrError.fromError(
+          Status.INVALID_ARGUMENT.withDescription("no 'metadataKey' defined"));
+    }
+
+    String metadataValue = JsonUtil.getString(rawLoadBalancingPolicyConfig, "metadataValue");
+    if (metadataValue == null) {
+      return NameResolver.ConfigOrError.fromError(
+          Status.INVALID_ARGUMENT.withDescription("no 'metadataValue' defined"));
+    }
+
+    return NameResolver.ConfigOrError.fromConfig(
+        new MetadataLoadBalancerConfig(metadataKey, metadataValue));
+  }
+
+  @Override
+  public LoadBalancer newLoadBalancer(Helper helper) {
+    MetadataHelper metadataHelper = new MetadataHelper(helper);
+    return new MetadataLoadBalancer(metadataHelper,
+        LoadBalancerRegistry.getDefaultRegistry().getProvider("round_robin")
+            .newLoadBalancer(metadataHelper));
+  }
+
+  @Override
+  public boolean isAvailable() {
+    return true;
+  }
+
+  @Override
+  public int getPriority() {
+    return 5;
+  }
+
+  @Override
+  public String getPolicyName() {
+    return "test.MetadataLoadBalancer";
+  }
+
+  static class MetadataLoadBalancerConfig {
+
+    final String metadataKey;
+    final String metadataValue;
+
+    MetadataLoadBalancerConfig(String metadataKey, String metadataValue) {
+      this.metadataKey = metadataKey;
+      this.metadataValue = metadataValue;
+    }
+  }
+
+  static class MetadataLoadBalancer extends ForwardingLoadBalancer {
+
+    private final MetadataHelper helper;
+    private final LoadBalancer delegateLb;
+
+    MetadataLoadBalancer(MetadataHelper helper, LoadBalancer delegateLb) {
+      this.helper = helper;
+      this.delegateLb = delegateLb;
+    }
+
+    @Override
+    protected LoadBalancer delegate() {
+      return delegateLb;
+    }
+
+    @Override
+    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+      MetadataLoadBalancerConfig config
+          = (MetadataLoadBalancerConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
+      helper.setMetadata(config.metadataKey, config.metadataValue);
+      delegateLb.handleResolvedAddresses(resolvedAddresses);
+    }
+  }
+
+  /**
+   * Wraps the picker that is provided when the balancing change updates with the {@link
+   * MetadataPicker} that injects the metadata entry.
+   */
+  static class MetadataHelper extends ForwardingLoadBalancerHelper {
+
+    private final Helper delegateHelper;
+    private String metadataKey;
+    private String metadataValue;
+
+    MetadataHelper(Helper delegateHelper) {
+      this.delegateHelper = delegateHelper;
+    }
+
+    void setMetadata(String metadataKey, String metadataValue) {
+      this.metadataKey = metadataKey;
+      this.metadataValue = metadataValue;
+    }
+
+    @Override
+    protected Helper delegate() {
+      return delegateHelper;
+    }
+
+    @Override
+    public void updateBalancingState(@Nonnull ConnectivityState newState,
+        @Nonnull SubchannelPicker newPicker) {
+      delegateHelper.updateBalancingState(newState,
+          new MetadataPicker(newPicker, metadataKey, metadataValue));
+    }
+  }
+
+  /**
+   * Includes the rpc-behavior metadata entry on each subchannel pick.
+   */
+  static class MetadataPicker extends SubchannelPicker {
+
+    private final SubchannelPicker delegatePicker;
+    private final String metadataKey;
+    private final String metadataValue;
+
+    MetadataPicker(SubchannelPicker delegatePicker, String metadataKey, String metadataValue) {
+      this.delegatePicker = delegatePicker;
+      this.metadataKey = metadataKey;
+      this.metadataValue = metadataValue;
+    }
+
+    @Override
+    public PickResult pickSubchannel(PickSubchannelArgs args) {
+      args.getHeaders()
+          .put(Metadata.Key.of(metadataKey, Metadata.ASCII_STRING_MARSHALLER), metadataValue);
+      return delegatePicker.pickSubchannel(args);
+    }
+  }
+}


### PR DESCRIPTION
Fixes a bug where WrrLocalityLoadBalancer would use the endpoint picking policy provider instead of WeightedTargetLoadBalancerProvider.

Also adds a test to fake control plane integration test that caught this bug. The test scaffolding is also updated to have the test server echo all client headers back in the response.

The test load balancer in the test is an almost straight copy of: https://github.com/grpc/grpc-java/blob/master/interop-testing/src/test/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProviderTest.java