### PR TITLE
xds: Properly assign picker.

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProvider.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProvider.java
@@ -38,7 +38,7 @@ import javax.annotation.Nonnull;
  * looks for an "rpc_behavior" field in its configuration and includes the value in the
  * "rpc-behavior" metadata entry that is sent to the server. This will cause the test server to
  * behave in a predefined way. Endpoint picking logic is delegated to the
- * {@link PickFirstLoadBalancer}.
+ * {@link RoundRobinLoadBalancer}.
  *
  * <p>Initial use case is to prove that a custom load balancer can be configured by the control
  * plane via xDS. An interop test will configure this LB and then verify it has been correctly
@@ -61,9 +61,10 @@ public class RpcBehaviorLoadBalancerProvider extends LoadBalancerProvider {
 
   @Override
   public LoadBalancer newLoadBalancer(Helper helper) {
-    return new RpcBehaviorLoadBalancer(helper,
+    RpcBehaviorHelper rpcBehaviorHelper = new RpcBehaviorHelper(helper);
+    return new RpcBehaviorLoadBalancer(rpcBehaviorHelper,
         LoadBalancerRegistry.getDefaultRegistry().getProvider("round_robin")
-            .newLoadBalancer(helper));
+            .newLoadBalancer(rpcBehaviorHelper));
   }
 
   @Override
@@ -99,8 +100,8 @@ public class RpcBehaviorLoadBalancerProvider extends LoadBalancerProvider {
     private final RpcBehaviorHelper helper;
     private final LoadBalancer delegateLb;
 
-    RpcBehaviorLoadBalancer(Helper helper, LoadBalancer delegateLb) {
-      this.helper = new RpcBehaviorHelper(helper);
+    RpcBehaviorLoadBalancer(RpcBehaviorHelper helper, LoadBalancer delegateLb) {
+      this.helper = helper;
       this.delegateLb = delegateLb;
     }
 

--- a/interop-testing/src/test/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProviderTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProviderTest.java
@@ -28,6 +28,7 @@ import io.grpc.CallOptions;
 import io.grpc.ConnectivityState;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
+import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.ResolvedAddresses;
 import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.Metadata;
@@ -60,7 +61,7 @@ public class RpcBehaviorLoadBalancerProviderTest {
   private LoadBalancer mockDelegateLb;
 
   @Mock
-  private RpcBehaviorHelper mockHelper;
+  private Helper mockHelper;
 
   @Mock
   private SubchannelPicker mockPicker;
@@ -79,7 +80,8 @@ public class RpcBehaviorLoadBalancerProviderTest {
 
   @Test
   public void handleResolvedAddressesDelegated() {
-    RpcBehaviorLoadBalancer lb = new RpcBehaviorLoadBalancer(mockHelper, mockDelegateLb);
+    RpcBehaviorLoadBalancer lb = new RpcBehaviorLoadBalancer(new RpcBehaviorHelper(mockHelper),
+        mockDelegateLb);
     ResolvedAddresses resolvedAddresses = buildResolvedAddresses(buildConfig());
     lb.handleResolvedAddresses(resolvedAddresses);
     verify(mockDelegateLb).handleResolvedAddresses(resolvedAddresses);

--- a/interop-testing/src/test/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProviderTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProviderTest.java
@@ -28,7 +28,6 @@ import io.grpc.CallOptions;
 import io.grpc.ConnectivityState;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
-import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.ResolvedAddresses;
 import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.Metadata;
@@ -61,7 +60,7 @@ public class RpcBehaviorLoadBalancerProviderTest {
   private LoadBalancer mockDelegateLb;
 
   @Mock
-  private Helper mockHelper;
+  private RpcBehaviorHelper mockHelper;
 
   @Mock
   private SubchannelPicker mockPicker;


### PR DESCRIPTION
Fixes a bug where the picker was not getting used in RpcBehaviorLoadBalancer.