### PR TITLE
examples/xds: Remove unnecessary includeBuild ..

### DIFF
--- a/examples/example-xds/settings.gradle
+++ b/examples/example-xds/settings.gradle
@@ -1,3 +1,1 @@
 rootProject.name = 'example-xds'
-
-includeBuild '..'


### PR DESCRIPTION
Previously examples-xds depended on the normal hello-world, as it used
the same classes. But since b6601ba273f it has had its own classes and
not had a dependency on `:examples.