### PR TITLE
interop-test: Opt-in GKE tests && Remove duplicated GCE tests (v1.45.x backport)

### DIFF
--- a/buildscripts/kokoro/xds.sh
+++ b/buildscripts/kokoro/xds.sh
@@ -8,16 +8,10 @@ fi
 cd github
 
 pushd grpc-java/interop-testing
-branch=$(git branch --all --no-color --contains "${KOKORO_GITHUB_COMMIT}" \
-      | grep -v HEAD | head -1)
-shopt -s extglob
-branch="${branch//[[:space:]]}"
-branch="${branch##remotes/origin/}"
-shopt -u extglob
 ../gradlew installDist -x test -PskipCodegen=true -PskipAndroid=true
 popd
 
-git clone -b "${branch}" --single-branch --depth=1 https://github.com/grpc/grpc.git
+git clone -b master --single-branch --depth=1 https://github.com/grpc/grpc.git
 
 grpc/tools/run_tests/helper_scripts/prep_xds.sh
 

--- a/buildscripts/kokoro/xds.sh
+++ b/buildscripts/kokoro/xds.sh
@@ -22,7 +22,7 @@ grpc/tools/run_tests/helper_scripts/prep_xds.sh
 # --test_case after they are added into "all".
 JAVA_OPTS=-Djava.util.logging.config.file=grpc-java/buildscripts/xds_logging.properties \
   python3 grpc/tools/run_tests/run_xds_tests.py \
-    --test_case="all,circuit_breaking,timeout,fault_injection,csds" \
+    --test_case="ping_pong,circuit_breaking" \
     --project_id=grpc-testing \
     --project_num=830293263384 \
     --source_image=projects/grpc-testing/global/images/xds-test-server-5 \

--- a/buildscripts/kokoro/xds_k8s_lb.sh
+++ b/buildscripts/kokoro/xds_k8s_lb.sh
@@ -166,7 +166,15 @@ main() {
   build_docker_images_if_needed
   # Run tests
   cd "${TEST_DRIVER_FULL_DIR}"
-  run_test api_listener_test
+  local failed_tests=0
+  test_suites=("api_listener_test" "change_backend_service_test" "failover_test" "remove_neg_test" "round_robin_test" "affinity_test")
+  for test in "${test_suites[@]}"; do
+    run_test $test || (( failed_tests++ ))
+  done
+  echo "Failed test suites: ${failed_tests}"
+  if (( failed_tests > 0 )); then
+    exit 1
+  fi
 }
 
 main "$@"


### PR DESCRIPTION
Backports https://github.com/grpc/grpc-java/pull/9199 https://github.com/grpc/grpc-java/pull/8998 https://github.com/grpc/grpc-java/pull/8982. The xds_k8s_lb and xds_url_map files were copied from master branch.

* [xds](http://sponge/df42d85b-d7d4-46c9-b878-6c847ba7647f)
* [xds_v3](http://sponge/20152816-b58b-4e49-8c6a-950e52a93197)
* [xds_k8s_lb](http://sponge/8a7f6bf8-29a7-4113-8f3c-9c755c1d2e2a)
* [xds_url_map](http://sponge/a34673de-279c-4811-861e-74aa516a90f9)