### PR TITLE
interop-test: Remove duplicated GCE tests (v1.46.x backport)

### DIFF
--- a/buildscripts/kokoro/xds.sh
+++ b/buildscripts/kokoro/xds.sh
@@ -22,7 +22,7 @@ grpc/tools/run_tests/helper_scripts/prep_xds.sh
 # --test_case after they are added into "all".
 JAVA_OPTS=-Djava.util.logging.config.file=grpc-java/buildscripts/xds_logging.properties \
   python3 grpc/tools/run_tests/run_xds_tests.py \
-    --test_case="all,circuit_breaking,timeout,fault_injection,csds" \
+    --test_case="ping_pong,circuit_breaking" \
     --project_id=grpc-testing \
     --project_num=830293263384 \
     --source_image=projects/grpc-testing/global/images/xds-test-server-5 \


### PR DESCRIPTION
Backports https://github.com/grpc/grpc-java/pull/9199.

* [xds](http://sponge/3da3cf9c-1135-4c5a-9bca-a2b811796abd)
* [xds_v3](http://sponge/4e358c72-a984-461f-bb4c-caf8ce4dbd18)
* [xds_k8s_lb](http://sponge/b6ffb846-b515-4dd2-8220-24da2af9ab68)
* [xds_url_map](http://sponge/260e678f-f3a6-472b-8618-c392e923b927)