### PR TITLE
interop-test: Remove duplicated GCE tests (v1.47.x backport)

### DIFF
--- a/buildscripts/kokoro/xds.sh
+++ b/buildscripts/kokoro/xds.sh
@@ -22,7 +22,7 @@ grpc/tools/run_tests/helper_scripts/prep_xds.sh
 # --test_case after they are added into "all".
 JAVA_OPTS=-Djava.util.logging.config.file=grpc-java/buildscripts/xds_logging.properties \
   python3 grpc/tools/run_tests/run_xds_tests.py \
-    --test_case="all,circuit_breaking,timeout,fault_injection,csds" \
+    --test_case="ping_pong,circuit_breaking" \
     --project_id=grpc-testing \
     --project_num=830293263384 \
     --source_image=projects/grpc-testing/global/images/xds-test-server-5 \


### PR DESCRIPTION
Backports https://github.com/grpc/grpc-java/pull/9199.

* [xds](http://sponge/77084ffc-bf00-47c9-a026-e06f88052952)
* [xds_v3](http://sponge/0ae23634-ecc7-41da-b89d-eb2942bcde9d)
* [xds_k8s_lb](http://sponge/d14f79bb-0adb-4400-abe5-dda40fee3dd0)
* [xds_url_map](http://sponge/a07a5248-03b5-4fc1-b319-e59c743aafee)