### PR TITLE
Update to handle rename of java_names.h to names.h in protobuf upstream

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ subprojects {
         nettyVersion = '4.1.72.Final'
         guavaVersion = '31.0.1-android'
         googleauthVersion = '1.4.0'
-        protobufVersion = '3.21.0'
+        protobufVersion = '3.19.2'
         protocVersion = protobufVersion
         opencensusVersion = '0.31.0'
         autovalueVersion = '1.9'

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ subprojects {
         nettyVersion = '4.1.72.Final'
         guavaVersion = '31.0.1-android'
         googleauthVersion = '1.4.0'
-        protobufVersion = '3.19.2'
+        protobufVersion = '3.21.0'
         protocVersion = protobufVersion
         opencensusVersion = '0.31.0'
         autovalueVersion = '1.9'

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -22,7 +22,7 @@
 #include <map>
 #include <set>
 #include <vector>
-#include <google/protobuf/compiler/java/java_names.h>
+#include <google/protobuf/compiler/java/names.h>
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/descriptor.pb.h>
 #include <google/protobuf/io/printer.h>

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -22,11 +22,18 @@
 #include <map>
 #include <set>
 #include <vector>
-#include <google/protobuf/compiler/java/names.h>
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/descriptor.pb.h>
 #include <google/protobuf/io/printer.h>
 #include <google/protobuf/io/zero_copy_stream.h>
+#include <google/protobuf/stubs/common.h>
+
+// Protobuf 3.21 changed the name of this file.
+#if GOOGLE_PROTOBUF_VERSION >= 3021000
+  #include <google/protobuf/compiler/java/names.h>
+#else
+  #include <google/protobuf/compiler/java/java_names.h>
+#endif
 
 // Stringify helpers used solely to cast GRPC_VERSION
 #ifndef STR


### PR DESCRIPTION
Protobuf 3.21 [renamed](https://github.com/protocolbuffers/protobuf/commit/40db3dabf0fe72b572e89c1e176318b04d3e2408#diff-5f26c0a0569a037848b977aa23ab7107d6939e1d3886c6254aee00e19664fd06) `google/protobuf/compiler/java/java_names.h` to `google/protobuf/compiler/java/names.h`

Fixes #9220