### PR TITLE
Bump GSON to 2.9.0 (1.47.x backport)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,7 @@ subprojects {
             errorprone: "com.google.errorprone:error_prone_annotations:2.10.0",
             cronet_api: 'org.chromium.net:cronet-api:92.4515.131',
             cronet_embedded: 'org.chromium.net:cronet-embedded:92.4515.131',
-            gson: "com.google.code.gson:gson:2.8.9",
+            gson: "com.google.code.gson:gson:2.9.0",
             guava: "com.google.guava:guava:${guavaVersion}",
             javax_annotation: 'org.apache.tomcat:annotations-api:6.0.53',
             jsr305: 'com.google.code.findbugs:jsr305:3.0.2',

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.9</version> <!-- prevent downgrade via protobuf-java-util -->
+      <version>2.9.0</version> <!-- prevent downgrade via protobuf-java-util -->
     </dependency>
     <dependency>
       <groupId>org.apache.tomcat</groupId>

--- a/gcp-observability/build.gradle
+++ b/gcp-observability/build.gradle
@@ -34,6 +34,7 @@ dependencies {
             libraries.autovalue_annotation,
             libraries.perfmark,
             libraries.opencensus_contrib_grpc_metrics,
+            libraries.gson,
             ('com.google.guava:guava:31.0.1-jre'),
             ('com.google.errorprone:error_prone_annotations:2.11.0'),
             ('com.google.auth:google-auth-library-credentials:1.4.0'),

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -17,7 +17,7 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "com.google.auto.value:auto-value-annotations:1.9",
     "com.google.auto.value:auto-value:1.9",
     "com.google.code.findbugs:jsr305:3.0.2",
-    "com.google.code.gson:gson:2.8.9",
+    "com.google.code.gson:gson:2.9.0",
     "com.google.errorprone:error_prone_annotations:2.9.0",
     "com.google.guava:failureaccess:1.0.1",
     "com.google.guava:guava:31.0.1-android",


### PR DESCRIPTION
Justification for the update: `gson` 2.8.9 and older has a security [vulnerability issue](https://nvd.nist.gov/vuln/detail/CVE-2022-25647). 

That also required updating `google-http-client` from 1.41.0 to 1.41.8.

`gradle test` passes.

Backport of #9215. CC @mirlord 