### PR TITLE
interop-test: sync grpc-proto and fix typo

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1750,7 +1750,7 @@ public abstract class AbstractInteropTest {
         .putUtilization("util", 0.30499)
         .build();
     blockingStub.withOption(ORCA_RPC_REPORT_KEY, reportHolder).unaryCall(
-        SimpleRequest.newBuilder().setOrcaPerRpcReport(answer).build());
+        SimpleRequest.newBuilder().setOrcaPerQueryReport(answer).build());
     assertThat(reportHolder.get()).isEqualTo(answer);
   }
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
@@ -123,7 +123,7 @@ public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
       return;
     }
 
-    echoCallMetricsFromPayload(req.getOrcaPerRpcReport());
+    echoCallMetricsFromPayload(req.getOrcaPerQueryReport());
     echoMetricsFromPayload(req.getOrcaOobReport());
     responseObserver.onNext(responseBuilder.build());
     responseObserver.onCompleted();

--- a/interop-testing/src/main/proto/grpc/testing/messages.proto
+++ b/interop-testing/src/main/proto/grpc/testing/messages.proto
@@ -101,18 +101,11 @@ message SimpleRequest {
   // Whether SimpleResponse should include grpclb_route_type.
   bool fill_grpclb_route_type = 10;
 
-  // Whether server should update per-rpc metrics.
-  TestOrcaReport orca_per_rpc_report = 11;
+  // If set the server should record this metrics report data for the current RPC.
+  TestOrcaReport orca_per_query_report = 11;
 
-  // Whether server should update OOB metrics.
+  // If set the server should update this metrics report data at the OOB server.
   TestOrcaReport orca_oob_report = 12;
-}
-
-message TestOrcaReport {
-  double cpu_utilization = 1;
-  double memory_utilization = 2;
-  map<string, double> request_cost = 3;
-  map<string, double> utilization = 4;
 }
 
 // Unary response, as configured by the request.
@@ -283,3 +276,13 @@ message ClientConfigureRequest {
 
 // Response for updating a test client's configuration.
 message ClientConfigureResponse {}
+
+// Metrics data the server will update and send to the client. It mirrors orca load report
+// https://github.com/cncf/xds/blob/eded343319d09f30032952beda9840bbd3dcf7ac/xds/data/orca/v3/orca_load_report.proto#L15,
+// but avoids orca dependency. Used by both per-query and out-of-band reporting tests.
+message TestOrcaReport {
+  double cpu_utilization = 1;
+  double memory_utilization = 2;
+  map<string, double> request_cost = 3;
+  map<string, double> utilization = 4;
+}


### PR DESCRIPTION
discovered during import, used : `../buildscripts/sync-protos.sh ` to sync proto
