### PR TITLE
api: Add GlobalInterceptors API

### DIFF
--- a/api/src/main/java/io/grpc/GlobalInterceptors.java
+++ b/api/src/main/java/io/grpc/GlobalInterceptors.java
@@ -34,7 +34,7 @@ public final class GlobalInterceptors {
   GlobalInterceptors() {}
 
   /** Returns the GlobalInterceptors instance. */
-  private static synchronized GlobalInterceptors getInstance() {
+  private static GlobalInterceptors getInstance() {
     if (instance == null) {
       instance = new GlobalInterceptors();
     }
@@ -59,7 +59,7 @@ public final class GlobalInterceptors {
    * @param serverStreamTracerFactoryList list of {@link ServerStreamTracer.Factory} that make up
    *     global ServerStreamTracer factories.
    */
-  public static void setInterceptorsTracers(
+  public static synchronized void setInterceptorsTracers(
       List<ClientInterceptor> clientInterceptorList,
       List<ServerInterceptor> serverInterceptorList,
       List<ServerStreamTracer.Factory> serverStreamTracerFactoryList) {
@@ -73,27 +73,27 @@ public final class GlobalInterceptors {
   }
 
   /** Returns the list of global {@link ClientInterceptor}. If not set, this returns null. */
-  public static List<ClientInterceptor> getClientInterceptors() {
+  public static synchronized List<ClientInterceptor> getClientInterceptors() {
     return GlobalInterceptors.getInstance().getGlobalClientInterceptors();
   }
 
   /** Returns list of global {@link ServerInterceptor}. If not set, this returns null. */
-  public static List<ServerInterceptor> getServerInterceptors() {
+  public static synchronized List<ServerInterceptor> getServerInterceptors() {
     return GlobalInterceptors.getInstance().getGlobalServerInterceptors();
   }
 
   /** Returns list of global {@link ServerStreamTracer.Factory}. If not set, this returns null. */
-  public static List<ServerStreamTracer.Factory> getServerStreamTracerFactories() {
+  public static synchronized List<ServerStreamTracer.Factory> getServerStreamTracerFactories() {
     return GlobalInterceptors.getInstance().getGlobalServerStreamTracerFactories();
   }
 
   @VisibleForTesting
-  synchronized void setGlobalInterceptorsTracers(
+  void setGlobalInterceptorsTracers(
       List<ClientInterceptor> clientInterceptorList,
       List<ServerInterceptor> serverInterceptorList,
       List<ServerStreamTracer.Factory> serverStreamTracerFactoryList) {
     if (isGlobalInterceptorsTracersGet) {
-      throw new IllegalStateException("Set cannot be called after any corresponding get call");
+      throw new IllegalStateException("Set cannot be called after any get call");
     }
     if (isGlobalInterceptorsTracersSet) {
       throw new IllegalStateException("Global interceptors and tracers are already set");
@@ -119,26 +119,20 @@ public final class GlobalInterceptors {
   }
 
   @VisibleForTesting
-  synchronized List<ClientInterceptor> getGlobalClientInterceptors() {
-    if (!isGlobalInterceptorsTracersGet) {
-      isGlobalInterceptorsTracersGet = true;
-    }
+  List<ClientInterceptor> getGlobalClientInterceptors() {
+    isGlobalInterceptorsTracersGet = true;
     return clientInterceptors;
   }
 
   @VisibleForTesting
-  synchronized List<ServerInterceptor> getGlobalServerInterceptors() {
-    if (!isGlobalInterceptorsTracersGet) {
-      isGlobalInterceptorsTracersGet = true;
-    }
+  List<ServerInterceptor> getGlobalServerInterceptors() {
+    isGlobalInterceptorsTracersGet = true;
     return serverInterceptors;
   }
 
   @VisibleForTesting
-  synchronized List<ServerStreamTracer.Factory> getGlobalServerStreamTracerFactories() {
-    if (!isGlobalInterceptorsTracersGet) {
-      isGlobalInterceptorsTracersGet = true;
-    }
+  List<ServerStreamTracer.Factory> getGlobalServerStreamTracerFactories() {
+    isGlobalInterceptorsTracersGet = true;
     return serverStreamTracerFactories;
   }
 }

--- a/api/src/main/java/io/grpc/GlobalInterceptors.java
+++ b/api/src/main/java/io/grpc/GlobalInterceptors.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The collection of default interceptors and stream tracers.
+ */
+@Internal
+public final class GlobalInterceptors {
+  private static volatile GlobalInterceptors instance = null;
+
+  /** Returns the default GlobalInterceptors instance. */
+  public static synchronized GlobalInterceptors getDefaultInterceptors() {
+    if (instance == null) {
+      synchronized (GlobalInterceptors.class) {
+        if (instance == null) {
+          instance = new GlobalInterceptors();
+        }
+      }
+    }
+    return instance;
+  }
+
+  /** Sets the list of global {@link ClientInterceptor}.
+   *
+   * @throws IllegalStateException if setClientInterceptors is called twice
+   */
+  public static void setClientInterceptors(List<ClientInterceptor> clientInterceptorList) {
+    try {
+      GlobalInterceptors.getDefaultInterceptors()
+          .setGlobalClientInterceptors(clientInterceptorList);
+    } catch (Exception e) {
+      throw e;
+    }
+  }
+
+  /** Sets the list of global {@link ServerInterceptor}.
+   *
+   * @throws IllegalStateException if setServerInterceptors is called twice
+   */
+  public static void setServerInterceptors(List<ServerInterceptor> serverInterceptorList) {
+    try {
+      GlobalInterceptors.getDefaultInterceptors()
+          .setGlobalServerInterceptors(serverInterceptorList);
+    } catch (Exception e) {
+      throw e;
+    }
+  }
+
+  /** Sets the list of global {@link ClientStreamTracer.Factory}.
+   *
+   * @throws IllegalStateException if setClientStreamTracerFactories is called twice
+   */
+  public static void setClientStreamTracerFactories(
+      List<ClientStreamTracer.Factory> clientStreamTracerFactoriesList) {
+    try {
+      GlobalInterceptors.getDefaultInterceptors()
+          .setGlobalClientStreamTracerFactories(clientStreamTracerFactoriesList);
+    } catch (Exception e) {
+      throw e;
+    }
+  }
+
+  /** Sets the list of global {@link ServerStreamTracer.Factory}.
+   *
+   * @throws IllegalStateException if setServerStreamTracerFactories is called twice
+   */
+  public static void setServerStreamTracerFactories(
+      List<ServerStreamTracer.Factory> serverStreamTracerFactoriesList) {
+    try {
+      GlobalInterceptors.getDefaultInterceptors()
+          .setGlobalServerStreamTracerFactories(serverStreamTracerFactoriesList);
+    } catch (Exception e) {
+      throw e;
+    }
+  }
+
+  /** Gets the list of global {@link ClientInterceptor}. If not set, returns an empty list. */
+  public static List<ClientInterceptor> getClientInterceptors() {
+    return GlobalInterceptors.getDefaultInterceptors().getGlobalClientInterceptors();
+  }
+
+  /** Gets list of global {@link ServerInterceptor}. If not set, returns an empty list. */
+  public static List<ServerInterceptor> getServerInterceptors() {
+    return GlobalInterceptors.getDefaultInterceptors().getGlobalServerInterceptors();
+  }
+
+  /** Gets list og global {@link ClientStreamTracer.Factory}. If not set, returns an empty list. */
+  public static List<ClientStreamTracer.Factory> getClientStreamTracerFactories() {
+    return GlobalInterceptors.getDefaultInterceptors().getGlobalClientStreamTracerFactories();
+  }
+
+  /** Gets list of global {@link ServerStreamTracer.Factory}. If not set, returns an empty list. */
+  public static List<ServerStreamTracer.Factory> getServerStreamTracerFactories() {
+    return GlobalInterceptors.getDefaultInterceptors().getGlobalServerStreamTracerFactories();
+  }
+
+  private List<ClientInterceptor> clientInterceptors = new ArrayList<>();
+  private List<ServerInterceptor> serverInterceptors = new ArrayList<>();
+  private List<ClientStreamTracer.Factory> clientStreamTracerFactories = new ArrayList<>();
+  private List<ServerStreamTracer.Factory> serverStreamTracerFactories = new ArrayList<>();
+  private boolean clientInterceptorsSet;
+  private boolean serverInterceptorsSet;
+  private boolean clientStreamTracersSet;
+  private boolean serverStreamTracersSet;
+  private boolean clientInterceptorsGet;
+  private boolean serverInterceptorsGet;
+  private boolean clientStreamTracersGet;
+  private boolean serverStreamTracersGet;
+
+  @VisibleForTesting
+  GlobalInterceptors() {}
+
+  @VisibleForTesting
+  synchronized void setGlobalClientInterceptors(List<ClientInterceptor> clientInterceptorList) {
+    checkNotNull(clientInterceptorList, "clientInterceptorList");
+    if (clientInterceptorsGet) {
+      throw new IllegalStateException("Set cannot be called after corresponding Get call");
+    }
+    if (clientInterceptorsSet) {
+      throw new IllegalStateException("Client interceptors are already set");
+    }
+    ImmutableList.Builder<ClientInterceptor> interceptorBuilder = new ImmutableList.Builder<>();
+    for (ClientInterceptor interceptor : clientInterceptorList) {
+      interceptorBuilder.add(interceptor);
+    }
+    clientInterceptors = interceptorBuilder.build();
+    clientInterceptorsSet = true;
+  }
+
+  @VisibleForTesting
+  synchronized void setGlobalServerInterceptors(List<ServerInterceptor> serverInterceptorList) {
+    checkNotNull(serverInterceptorList, "serverInterceptorList");
+    if (serverInterceptorsGet) {
+      throw new IllegalStateException("Set cannot be called after corresponding Get call");
+    }
+    if (serverInterceptorsSet) {
+      throw new IllegalStateException("Server interceptors are already set");
+    }
+    ImmutableList.Builder<ServerInterceptor> interceptorBuilder = new ImmutableList.Builder<>();
+    for (ServerInterceptor interceptor : serverInterceptorList) {
+      interceptorBuilder.add(interceptor);
+    }
+    serverInterceptors = interceptorBuilder.build();
+    serverInterceptorsSet = true;
+  }
+
+  @VisibleForTesting
+  synchronized void setGlobalClientStreamTracerFactories(
+      List<ClientStreamTracer.Factory> clientStreamTracerFactoriesList) {
+    checkNotNull(clientStreamTracerFactoriesList, "clientStreamTracerFactoriesList");
+    if (clientStreamTracersGet) {
+      throw new IllegalStateException("Set cannot be called after corresponding Get call");
+    }
+    if (clientStreamTracersSet) {
+      throw new IllegalStateException("ClientStreamTracer factories are already set");
+    }
+    ImmutableList.Builder<ClientStreamTracer.Factory> factoryBuilder =
+        new ImmutableList.Builder<>();
+    for (ClientStreamTracer.Factory factory : clientStreamTracerFactoriesList) {
+      factoryBuilder.add(factory);
+    }
+    clientStreamTracerFactories = factoryBuilder.build();
+    clientStreamTracersSet = true;
+  }
+
+  @VisibleForTesting
+  synchronized void setGlobalServerStreamTracerFactories(
+      List<ServerStreamTracer.Factory> serverStreamTracerFactoriesList) {
+    checkNotNull(serverStreamTracerFactoriesList, "serverStreamTracerFactoriesList");
+    if (serverStreamTracersGet) {
+      throw new IllegalStateException("Set cannot be called after corresponding Get call");
+    }
+    if (serverStreamTracersSet) {
+      throw new IllegalStateException("ServerStreamTracer factories are already set");
+    }
+    ImmutableList.Builder<ServerStreamTracer.Factory> factoryBuilder =
+        new ImmutableList.Builder<>();
+    for (ServerStreamTracer.Factory factory : serverStreamTracerFactoriesList) {
+      factoryBuilder.add(factory);
+    }
+    serverStreamTracerFactories = factoryBuilder.build();
+    serverStreamTracersSet = true;
+  }
+
+  @VisibleForTesting
+  synchronized List<ClientInterceptor> getGlobalClientInterceptors() {
+    if (!clientInterceptorsGet) {
+      clientInterceptorsGet = true;
+    }
+    return clientInterceptors;
+  }
+
+  @VisibleForTesting
+  synchronized List<ServerInterceptor> getGlobalServerInterceptors() {
+    if (!serverInterceptorsGet) {
+      serverInterceptorsGet = true;
+    }
+    return serverInterceptors;
+  }
+
+  @VisibleForTesting
+  synchronized List<ClientStreamTracer.Factory> getGlobalClientStreamTracerFactories() {
+    if (!clientStreamTracersGet) {
+      clientStreamTracersGet = true;
+    }
+    return clientStreamTracerFactories;
+  }
+
+  @VisibleForTesting
+  synchronized List<ServerStreamTracer.Factory> getGlobalServerStreamTracerFactories() {
+    if (!serverStreamTracersGet) {
+      serverStreamTracersGet = true;
+    }
+    return serverStreamTracerFactories;
+  }
+}

--- a/api/src/main/java/io/grpc/GlobalInterceptors.java
+++ b/api/src/main/java/io/grpc/GlobalInterceptors.java
@@ -16,30 +16,20 @@
 
 package io.grpc;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 /** The collection of global interceptors and global server stream tracers. */
 @Internal
-public final class GlobalInterceptors {
-  private static GlobalInterceptors instance = null;
-  private List<ClientInterceptor> clientInterceptors;
-  private List<ServerInterceptor> serverInterceptors;
-  private List<ServerStreamTracer.Factory> serverStreamTracerFactories;
-  private boolean isGlobalInterceptorsTracersSet;
-  private boolean isGlobalInterceptorsTracersGet;
+final class GlobalInterceptors {
+  private static List<ClientInterceptor> clientInterceptors;
+  private static List<ServerInterceptor> serverInterceptors;
+  private static List<ServerStreamTracer.Factory> serverStreamTracerFactories;
+  private static boolean isGlobalInterceptorsTracersSet;
+  private static boolean isGlobalInterceptorsTracersGet;
 
-  @VisibleForTesting
-  GlobalInterceptors() {}
-
-  /** Returns the GlobalInterceptors instance. */
-  private static GlobalInterceptors getInstance() {
-    if (instance == null) {
-      instance = new GlobalInterceptors();
-    }
-    return instance;
-  }
+  // Prevent instantiation
+  private GlobalInterceptors() {}
 
   /**
    * Sets the list of global interceptors and global server stream tracers.
@@ -59,36 +49,7 @@ public final class GlobalInterceptors {
    * @param serverStreamTracerFactoryList list of {@link ServerStreamTracer.Factory} that make up
    *     global ServerStreamTracer factories.
    */
-  public static synchronized void setInterceptorsTracers(
-      List<ClientInterceptor> clientInterceptorList,
-      List<ServerInterceptor> serverInterceptorList,
-      List<ServerStreamTracer.Factory> serverStreamTracerFactoryList) {
-    try {
-      GlobalInterceptors.getInstance()
-          .setGlobalInterceptorsTracers(
-              clientInterceptorList, serverInterceptorList, serverStreamTracerFactoryList);
-    } catch (Exception exception) {
-      throw exception;
-    }
-  }
-
-  /** Returns the list of global {@link ClientInterceptor}. If not set, this returns null. */
-  public static synchronized List<ClientInterceptor> getClientInterceptors() {
-    return GlobalInterceptors.getInstance().getGlobalClientInterceptors();
-  }
-
-  /** Returns list of global {@link ServerInterceptor}. If not set, this returns null. */
-  public static synchronized List<ServerInterceptor> getServerInterceptors() {
-    return GlobalInterceptors.getInstance().getGlobalServerInterceptors();
-  }
-
-  /** Returns list of global {@link ServerStreamTracer.Factory}. If not set, this returns null. */
-  public static synchronized List<ServerStreamTracer.Factory> getServerStreamTracerFactories() {
-    return GlobalInterceptors.getInstance().getGlobalServerStreamTracerFactories();
-  }
-
-  @VisibleForTesting
-  void setGlobalInterceptorsTracers(
+  static synchronized void setInterceptorsTracers(
       List<ClientInterceptor> clientInterceptorList,
       List<ServerInterceptor> serverInterceptorList,
       List<ServerStreamTracer.Factory> serverStreamTracerFactoryList) {
@@ -118,20 +79,20 @@ public final class GlobalInterceptors {
     isGlobalInterceptorsTracersSet = true;
   }
 
-  @VisibleForTesting
-  List<ClientInterceptor> getGlobalClientInterceptors() {
+  /** Returns the list of global {@link ClientInterceptor}. If not set, this returns null. */
+  static synchronized List<ClientInterceptor> getClientInterceptors() {
     isGlobalInterceptorsTracersGet = true;
     return clientInterceptors;
   }
 
-  @VisibleForTesting
-  List<ServerInterceptor> getGlobalServerInterceptors() {
+  /** Returns list of global {@link ServerInterceptor}. If not set, this returns null. */
+  static synchronized List<ServerInterceptor> getServerInterceptors() {
     isGlobalInterceptorsTracersGet = true;
     return serverInterceptors;
   }
 
-  @VisibleForTesting
-  List<ServerStreamTracer.Factory> getGlobalServerStreamTracerFactories() {
+  /** Returns list of global {@link ServerStreamTracer.Factory}. If not set, this returns null. */
+  static synchronized List<ServerStreamTracer.Factory> getServerStreamTracerFactories() {
     isGlobalInterceptorsTracersGet = true;
     return serverStreamTracerFactories;
   }

--- a/api/src/main/java/io/grpc/GlobalInterceptors.java
+++ b/api/src/main/java/io/grpc/GlobalInterceptors.java
@@ -16,15 +16,17 @@
 
 package io.grpc;
 
-import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /** The collection of global interceptors and global server stream tracers. */
 @Internal
 final class GlobalInterceptors {
-  private static List<ClientInterceptor> clientInterceptors;
-  private static List<ServerInterceptor> serverInterceptors;
-  private static List<ServerStreamTracer.Factory> serverStreamTracerFactories;
+  private static List<ClientInterceptor> clientInterceptors = Collections.emptyList();
+  private static List<ServerInterceptor> serverInterceptors = Collections.emptyList();
+  private static List<ServerStreamTracer.Factory> serverStreamTracerFactories =
+      Collections.emptyList();
   private static boolean isGlobalInterceptorsTracersSet;
   private static boolean isGlobalInterceptorsTracersGet;
 
@@ -61,37 +63,38 @@ final class GlobalInterceptors {
     }
 
     if (clientInterceptorList != null) {
-      clientInterceptors =
-          ImmutableList.<ClientInterceptor>builder().addAll(clientInterceptorList).build();
+      clientInterceptors = Collections.unmodifiableList(new ArrayList<>(clientInterceptorList));
     }
 
     if (serverInterceptorList != null) {
-      serverInterceptors =
-          ImmutableList.<ServerInterceptor>builder().addAll(serverInterceptorList).build();
+      serverInterceptors = Collections.unmodifiableList(new ArrayList<>(serverInterceptorList));
     }
 
     if (serverStreamTracerFactoryList != null) {
       serverStreamTracerFactories =
-          ImmutableList.<ServerStreamTracer.Factory>builder()
-              .addAll(serverStreamTracerFactoryList)
-              .build();
+          Collections.unmodifiableList(new ArrayList<>(serverStreamTracerFactoryList));
     }
     isGlobalInterceptorsTracersSet = true;
   }
 
-  /** Returns the list of global {@link ClientInterceptor}. If not set, this returns null. */
+  /**
+   * Returns the list of global {@link ClientInterceptor}. If not set, this returns am empty list.
+   */
   static synchronized List<ClientInterceptor> getClientInterceptors() {
     isGlobalInterceptorsTracersGet = true;
     return clientInterceptors;
   }
 
-  /** Returns list of global {@link ServerInterceptor}. If not set, this returns null. */
+  /** Returns list of global {@link ServerInterceptor}. If not set, this returns an empty list. */
   static synchronized List<ServerInterceptor> getServerInterceptors() {
     isGlobalInterceptorsTracersGet = true;
     return serverInterceptors;
   }
 
-  /** Returns list of global {@link ServerStreamTracer.Factory}. If not set, this returns null. */
+  /**
+   * Returns list of global {@link ServerStreamTracer.Factory}. If not set, this returns an empty
+   * list.
+   */
   static synchronized List<ServerStreamTracer.Factory> getServerStreamTracerFactories() {
     isGlobalInterceptorsTracersGet = true;
     return serverStreamTracerFactories;

--- a/api/src/main/java/io/grpc/GlobalInterceptors.java
+++ b/api/src/main/java/io/grpc/GlobalInterceptors.java
@@ -23,7 +23,7 @@ import java.util.List;
 /** The collection of global interceptors and global server stream tracers. */
 @Internal
 public final class GlobalInterceptors {
-  private static volatile GlobalInterceptors instance = null;
+  private static GlobalInterceptors instance = null;
   private List<ClientInterceptor> clientInterceptors;
   private List<ServerInterceptor> serverInterceptors;
   private List<ServerStreamTracer.Factory> serverStreamTracerFactories;
@@ -36,11 +36,7 @@ public final class GlobalInterceptors {
   /** Returns the GlobalInterceptors instance. */
   private static synchronized GlobalInterceptors getInstance() {
     if (instance == null) {
-      synchronized (GlobalInterceptors.class) {
-        if (instance == null) {
-          instance = new GlobalInterceptors();
-        }
-      }
+      instance = new GlobalInterceptors();
     }
     return instance;
   }
@@ -48,15 +44,20 @@ public final class GlobalInterceptors {
   /**
    * Sets the list of global interceptors and global server stream tracers.
    *
+   * <p>If {@code setInterceptorsTracers()} is called again, this method will throw {@link
+   * IllegalStateException}.
+   *
+   * <p>It is only safe to call early. This method throws {@link IllegalStateException} after any of
+   * the get calls [{@link #getClientInterceptors()}, {@link #getServerInterceptors()} or {@link
+   * #getServerStreamTracerFactories()}] has been called, in order to limit changes to the result of
+   * {@code setInterceptorsTracers()}.
+   *
    * @param clientInterceptorList list of {@link ClientInterceptor} that make up global Client
    *     Interceptors.
    * @param serverInterceptorList list of {@link ServerInterceptor} that make up global Server
    *     Interceptors.
    * @param serverStreamTracerFactoryList list of {@link ServerStreamTracer.Factory} that make up
    *     global ServerStreamTracer factories.
-   * @throws IllegalStateException if setInterceptorsTracers is called twice.
-   * @throws IllegalStateException if setInterceptorsTracers is called after any of the
-   *     corresponding get call.
    */
   public static void setInterceptorsTracers(
       List<ClientInterceptor> clientInterceptorList,
@@ -71,23 +72,17 @@ public final class GlobalInterceptors {
     }
   }
 
-  /**
-   * Returns the list of global {@link ClientInterceptor}. If not set, this returns null.
-   */
+  /** Returns the list of global {@link ClientInterceptor}. If not set, this returns null. */
   public static List<ClientInterceptor> getClientInterceptors() {
     return GlobalInterceptors.getInstance().getGlobalClientInterceptors();
   }
 
-  /**
-   * Returns list of global {@link ServerInterceptor}. If not set, this returns null.
-   */
+  /** Returns list of global {@link ServerInterceptor}. If not set, this returns null. */
   public static List<ServerInterceptor> getServerInterceptors() {
     return GlobalInterceptors.getInstance().getGlobalServerInterceptors();
   }
 
-  /**
-   * Returns list of global {@link ServerStreamTracer.Factory}. If not set, this returns null.
-   */
+  /** Returns list of global {@link ServerStreamTracer.Factory}. If not set, this returns null. */
   public static List<ServerStreamTracer.Factory> getServerStreamTracerFactories() {
     return GlobalInterceptors.getInstance().getGlobalServerStreamTracerFactories();
   }

--- a/api/src/main/java/io/grpc/InternalGlobalInterceptors.java
+++ b/api/src/main/java/io/grpc/InternalGlobalInterceptors.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import java.util.List;
+
+/** Accessor to internal methods of {@link GlobalInterceptors}. */
+@Internal
+public final class InternalGlobalInterceptors {
+
+  public static void setInterceptorsTracers(
+      List<ClientInterceptor> clientInterceptorList,
+      List<ServerInterceptor> serverInterceptorList,
+      List<ServerStreamTracer.Factory> serverStreamTracerFactoryList) {
+    GlobalInterceptors.setInterceptorsTracers(
+        clientInterceptorList, serverInterceptorList, serverStreamTracerFactoryList);
+  }
+
+  public static List<ClientInterceptor> getClientInterceptors() {
+    return GlobalInterceptors.getClientInterceptors();
+  }
+
+  public static List<ServerInterceptor> getServerInterceptors() {
+    return GlobalInterceptors.getServerInterceptors();
+  }
+
+  public static List<ServerStreamTracer.Factory> getServerStreamTracerFactories() {
+    return GlobalInterceptors.getServerStreamTracerFactories();
+  }
+
+  private InternalGlobalInterceptors() {}
+}

--- a/api/src/test/java/io/grpc/GlobalInterceptorsTest.java
+++ b/api/src/test/java/io/grpc/GlobalInterceptorsTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import io.grpc.ClientStreamTracer.StreamInfo;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+public class GlobalInterceptorsTest {
+
+  @Test
+  public void setClientInterceptors() {
+    GlobalInterceptors instance = new GlobalInterceptors();
+    List<ClientInterceptor> clientInterceptors = new ArrayList<>();
+    clientInterceptors.add(new NoopClientInterceptor());
+    clientInterceptors.add(new NoopClientInterceptor());
+
+    instance.setGlobalClientInterceptors(clientInterceptors);
+    assertThat(instance.getGlobalClientInterceptors()).hasSize(2);
+  }
+
+  @Test
+  public void setClientInterceptors_twice() {
+    GlobalInterceptors instance = new GlobalInterceptors();
+    List<ClientInterceptor> clientInterceptors = new ArrayList<>();
+    clientInterceptors.add(new NoopClientInterceptor());
+    clientInterceptors.add(new NoopClientInterceptor());
+
+    instance.setGlobalClientInterceptors(clientInterceptors);
+    try {
+      instance.setGlobalClientInterceptors(clientInterceptors);
+      fail("should have failed for calling setClientInterceptors() again");
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessageThat().isEqualTo("Client interceptors are already set");
+    }
+  }
+
+  @Test
+  public void getBeforeSet_clientInterceptors() {
+    GlobalInterceptors instance = new GlobalInterceptors();
+    List<ClientInterceptor> clientInterceptors = instance.getGlobalClientInterceptors();
+    assertThat(clientInterceptors).isEmpty();
+
+    try {
+      instance.setGlobalClientInterceptors(
+          new ArrayList<>(Arrays.asList(new NoopClientInterceptor())));
+      fail("should have failed for invoking set call after get is already called");
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessageThat().isEqualTo("Set cannot be called after corresponding Get call");
+    }
+  }
+
+  @Test
+  public void setServerInterceptors() {
+    GlobalInterceptors instance = new GlobalInterceptors();
+    List<ServerInterceptor> serverInterceptors = new ArrayList<>();
+    serverInterceptors.add(new NoopServerInterceptor());
+
+    instance.setGlobalServerInterceptors(serverInterceptors);
+    assertThat(instance.getGlobalServerInterceptors()).hasSize(1);
+  }
+
+  @Test
+  public void setServerInterceptors_twice() {
+    GlobalInterceptors instance = new GlobalInterceptors();
+    List<ServerInterceptor> serverInterceptors = new ArrayList<>();
+    serverInterceptors.add(new NoopServerInterceptor());
+    serverInterceptors.add(new NoopServerInterceptor());
+
+    instance.setGlobalServerInterceptors(serverInterceptors);
+    try {
+      instance.setGlobalServerInterceptors(serverInterceptors);
+      fail("should have failed for calling setClientInterceptors() again");
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessageThat().isEqualTo("Server interceptors are already set");
+    }
+  }
+
+  @Test
+  public void getBeforeSet_serverInterceptors() {
+    GlobalInterceptors instance = new GlobalInterceptors();
+    List<ServerInterceptor> serverInterceptors = instance.getGlobalServerInterceptors();
+    assertThat(serverInterceptors).isEmpty();
+
+    try {
+      instance.setGlobalServerInterceptors(
+          new ArrayList<>(Arrays.asList(new NoopServerInterceptor())));
+      fail("should have failed for invoking set call after get is already called");
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessageThat().isEqualTo("Set cannot be called after corresponding Get call");
+    }
+  }
+
+  @Test
+  public void setClientStreamTracerFactories() {
+    GlobalInterceptors instance = new GlobalInterceptors();
+    List<ClientStreamTracer.Factory> clientStreamTracerFactories = new ArrayList<>();
+    clientStreamTracerFactories.add(DUMMY_CLIENT_TRACER);
+
+    instance.setGlobalClientStreamTracerFactories(clientStreamTracerFactories);
+    assertThat(instance.getGlobalClientStreamTracerFactories()).hasSize(1);
+  }
+
+  @Test
+  public void setClientStreamTracerFactories_twice() {
+    GlobalInterceptors instance = new GlobalInterceptors();
+    List<ClientStreamTracer.Factory> clientStreamTracerFactories = new ArrayList<>();
+    clientStreamTracerFactories.add(DUMMY_CLIENT_TRACER);
+    clientStreamTracerFactories.add(DUMMY_CLIENT_TRACER);
+
+    instance.setGlobalClientStreamTracerFactories(clientStreamTracerFactories);
+    try {
+      instance.setGlobalClientStreamTracerFactories(clientStreamTracerFactories);
+      fail("should have failed for calling setClientInterceptors() again");
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessageThat().isEqualTo("ClientStreamTracer factories are already set");
+    }
+  }
+
+  @Test
+  public void getBeforeSet_clientStreamTracerFactories() {
+    GlobalInterceptors instance = new GlobalInterceptors();
+    List<ClientStreamTracer.Factory> clientStreamTracerFactories =
+        instance.getGlobalClientStreamTracerFactories();
+    assertThat(clientStreamTracerFactories).isEmpty();
+
+    try {
+      instance.setGlobalClientStreamTracerFactories(
+          new ArrayList<>(Arrays.asList(DUMMY_CLIENT_TRACER)));
+      fail("should have failed for invoking set call after get is already called");
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessageThat().isEqualTo("Set cannot be called after corresponding Get call");
+    }
+  }
+
+  @Test
+  public void setServerStreamTracerFactories() {
+    GlobalInterceptors instance = new GlobalInterceptors();
+    List<ServerStreamTracer.Factory> serverStreamTracerFactories = new ArrayList<>();
+    serverStreamTracerFactories.add(DUMMY_SERVER_TRACER);
+
+    instance.setGlobalServerStreamTracerFactories(serverStreamTracerFactories);
+    assertThat(instance.getGlobalServerStreamTracerFactories()).hasSize(1);
+  }
+
+  @Test
+  public void setServerStreamTracerFactories_twice() {
+    GlobalInterceptors instance = new GlobalInterceptors();
+    List<ServerStreamTracer.Factory> serverStreamTracerFactories = new ArrayList<>();
+    serverStreamTracerFactories.add(DUMMY_SERVER_TRACER);
+    serverStreamTracerFactories.add(DUMMY_SERVER_TRACER);
+
+    instance.setGlobalServerStreamTracerFactories(serverStreamTracerFactories);
+    try {
+      instance.setGlobalServerStreamTracerFactories(serverStreamTracerFactories);
+      fail("should have failed for calling setClientInterceptors() again");
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessageThat().isEqualTo("ServerStreamTracer factories are already set");
+    }
+  }
+
+  @Test
+  public void getBeforeSet_serverStreamTracerFactories() {
+    GlobalInterceptors instance = new GlobalInterceptors();
+    List<ServerStreamTracer.Factory> serverStreamTracerFactories =
+        instance.getGlobalServerStreamTracerFactories();
+    assertThat(serverStreamTracerFactories).isEmpty();
+
+    try {
+      instance.setGlobalServerStreamTracerFactories(
+          new ArrayList<>(Arrays.asList(DUMMY_SERVER_TRACER)));
+      fail("should have failed for invoking set call after get is already called");
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessageThat().isEqualTo("Set cannot be called after corresponding Get call");
+    }
+  }
+
+  private static class NoopClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+      return next.newCall(method, callOptions);
+    }
+  }
+
+  private static class NoopServerInterceptor implements ServerInterceptor {
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+        ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+      return next.startCall(call, headers);
+    }
+  }
+
+  private static final ClientStreamTracer.Factory DUMMY_CLIENT_TRACER =
+      new ClientStreamTracer.Factory() {
+        @Override
+        public ClientStreamTracer newClientStreamTracer(StreamInfo info, Metadata headers) {
+          throw new UnsupportedOperationException();
+        }
+      };
+
+  private static final ServerStreamTracer.Factory DUMMY_SERVER_TRACER =
+      new ServerStreamTracer.Factory() {
+        @Override
+        public ServerStreamTracer newServerStreamTracer(String fullMethodName, Metadata headers) {
+          throw new UnsupportedOperationException();
+        }
+      };
+}


### PR DESCRIPTION
GlobalInterceptors API will be used to set global interceptors and global stream tracers.  

The API is intended for `Internal` use only for time being. It currently supports 

- `ClientInterceptor`
- `ServerInterceptor`
- `ClientStreamTracer Factory`

Sample use case:
These interceptors and tracer factories can be set by grpc observability and be queried later by grpc to set into each builder created as well as by direct users of Netty channel/server builders (as required).

CC @sanjaypujare 
