### PR TITLE
api: Document Attributes.Key uses reference equality

### DIFF
--- a/api/src/main/java/io/grpc/Attributes.java
+++ b/api/src/main/java/io/grpc/Attributes.java
@@ -110,7 +110,8 @@ public final class Attributes {
   }
 
   /**
-   * Key for an key-value pair.
+   * Key for an key-value pair. Uses reference equality.
+   *
    * @param <T> type of the value in the key-value pair
    */
   @Immutable


### PR DESCRIPTION
The text here should be expanded once `keys()` is removed. But for now
this at least can make it clearer that the current behavior is on
purpose. The text here is the same as that in CallOptions.Key.

See https://github.com/grpc/grpc-java/issues/1764#issuecomment-1144935608