### PR TITLE
core: Add missed internal comment about idle mode workaround

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -351,7 +351,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
     public void run() {
       // Workaround timer scheduled while in idle mode. This can happen from handleNotInUse() after
       // an explicit enterIdleMode() by the user. Protecting here as other locations are a bit too
-      // subtle to change rapidly to resolve the channel panic.
+      // subtle to change rapidly to resolve the channel panic. See #8714
       if (lbHelper == null) {
         return;
       }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -349,6 +349,9 @@ final class ManagedChannelImpl extends ManagedChannel implements
 
     @Override
     public void run() {
+      // Workaround timer scheduled while in idle mode. This can happen from handleNotInUse() after
+      // an explicit enterIdleMode() by the user. Protecting here as other locations are a bit too
+      // subtle to change rapidly to resolve the channel panic.
       if (lbHelper == null) {
         return;
       }


### PR DESCRIPTION
This should have been included in #8746 but wasn't.