### PR TITLE
interop-testing: skip empty orca updates for unary at the server 

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
@@ -130,6 +130,9 @@ public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
   }
 
   private static void echoCallMetricsFromPayload(TestOrcaReport report) {
+    if (TestOrcaReport.getDefaultInstance().equals(report)) {
+      return;
+    }
     CallMetricRecorder recorder = CallMetricRecorder.getCurrent()
         .recordCpuUtilizationMetric(report.getCpuUtilization())
         .recordMemoryUtilizationMetric(report.getMemoryUtilization());
@@ -142,6 +145,9 @@ public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
   }
 
   private void echoMetricsFromPayload(TestOrcaReport report) {
+    if (TestOrcaReport.getDefaultInstance().equals(report)) {
+      return;
+    }
     metricRecorder.setCpuUtilizationMetric(report.getCpuUtilization());
     metricRecorder.setMemoryUtilizationMetric(report.getMemoryUtilization());
     metricRecorder.setAllUtilizationMetrics(new HashMap<>());

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
@@ -123,16 +123,17 @@ public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
       return;
     }
 
-    echoCallMetricsFromPayload(req.getOrcaPerQueryReport());
-    echoMetricsFromPayload(req.getOrcaOobReport());
+    if (req.hasOrcaPerQueryReport()) {
+      echoCallMetricsFromPayload(req.getOrcaPerQueryReport());
+    }
+    if (req.hasOrcaOobReport()) {
+      echoMetricsFromPayload(req.getOrcaOobReport());
+    }
     responseObserver.onNext(responseBuilder.build());
     responseObserver.onCompleted();
   }
 
   private static void echoCallMetricsFromPayload(TestOrcaReport report) {
-    if (TestOrcaReport.getDefaultInstance().equals(report)) {
-      return;
-    }
     CallMetricRecorder recorder = CallMetricRecorder.getCurrent()
         .recordCpuUtilizationMetric(report.getCpuUtilization())
         .recordMemoryUtilizationMetric(report.getMemoryUtilization());
@@ -145,9 +146,6 @@ public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
   }
 
   private void echoMetricsFromPayload(TestOrcaReport report) {
-    if (TestOrcaReport.getDefaultInstance().equals(report)) {
-      return;
-    }
     metricRecorder.setCpuUtilizationMetric(report.getCpuUtilization());
     metricRecorder.setMemoryUtilizationMetric(report.getMemoryUtilization());
     metricRecorder.setAllUtilizationMetrics(new HashMap<>());


### PR DESCRIPTION
this fix the problem that multiple clients run other unary test cases in parallel against the same server:
see [successful run](https://source.cloud.google.com/results/invocations/e1e21c7c-3942-420b-9101-2adad9f52825/log) on interop test driver change: https://github.com/grpc/grpc/pull/29791