### PR TITLE
api: Add missing RunWith annotation to GlobalInterceptorsTest

### DIFF
--- a/api/src/test/java/io/grpc/GlobalInterceptorsTest.java
+++ b/api/src/test/java/io/grpc/GlobalInterceptorsTest.java
@@ -24,7 +24,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class GlobalInterceptorsTest {
 
   private final StaticTestingClassLoader classLoader =


### PR DESCRIPTION
Internal build failed with 

```
grpc/api/src/test/java/io/grpc/GlobalInterceptorsTest.java:28: error: 
[JUnit4RunWithMissing] Test class may not be run because it is missing a @RunWith annotation
public class GlobalInterceptorsTest {
       ^
  Did you mean '@RunWith(JUnit4.class)' or 'public abstract class GlobalInterceptorsTest {'?
```

Ref:
- https://github.com/grpc/grpc-java/pull/9235
- cl/454182049

cc @DNVindhya