### PR TITLE
interop-testing: add orca_oob lock to allow only one test client at a time to perform the test case

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1794,7 +1794,8 @@ public abstract class AbstractInteropTest {
         });
 
     streamObserver.onNext(StreamingOutputCallRequest.newBuilder()
-        .setOrcaOobReport(answer).build());
+        .setOrcaOobReport(answer)
+        .addResponseParameters(ResponseParameters.newBuilder().setSize(1).build()).build());
     assertThat(queue.take()).isInstanceOf(StreamingOutputCallResponse.class);
     int i = 0;
     for (; i < retryLimit; i++) {
@@ -1806,7 +1807,8 @@ public abstract class AbstractInteropTest {
     }
     assertThat(i).isLessThan(retryLimit);
     streamObserver.onNext(StreamingOutputCallRequest.newBuilder()
-        .setOrcaOobReport(answer2).build());
+        .setOrcaOobReport(answer2)
+        .addResponseParameters(ResponseParameters.newBuilder().setSize(1).build()).build());
     assertThat(queue.take()).isInstanceOf(StreamingOutputCallResponse.class);
 
     for (i = 0; i < retryLimit; i++) {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1764,7 +1764,9 @@ public abstract class AbstractInteropTest {
         .setMemoryUtilization(0.5847)
         .putUtilization("util", 0.30499)
         .build();
-    blockingStub.unaryCall(SimpleRequest.newBuilder().setOrcaOobReport(answer).build());
+    String lock = blockingStub.unaryCall(
+        SimpleRequest.newBuilder().setOobLock("").setOrcaOobReport(answer).build())
+        .getOobLock();
     int i;
     int retryLimit = 5;
     for (i = 0; i < retryLimit; i++) {
@@ -1781,7 +1783,8 @@ public abstract class AbstractInteropTest {
         .setMemoryUtilization(0.2)
         .putUtilization("util", 100.2039)
         .build();
-    blockingStub.unaryCall(SimpleRequest.newBuilder().setOrcaOobReport(answer).build());
+    blockingStub.unaryCall(
+        SimpleRequest.newBuilder().setOobLock(lock).setOrcaOobReport(answer).build());
     for (i = 0; i < retryLimit; i++) {
       Thread.sleep(1000);
       blockingStub.withOption(ORCA_OOB_REPORT_KEY, reportHolder).emptyCall(EMPTY);

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1790,6 +1790,7 @@ public abstract class AbstractInteropTest {
                 }
               }
               assertThat(i).isLessThan(retryLimit);
+              System.out.println("\n" + reportHolder.get());
               lock.set(value.getOobLock());
               barrier.await(10, TimeUnit.SECONDS);
               for (i = 0; i < retryLimit; i++) {
@@ -1800,6 +1801,7 @@ public abstract class AbstractInteropTest {
                 }
               }
               assertThat(i).isLessThan(retryLimit);
+              System.out.println("\n" + reportHolder.get());
               barrier.await(10, TimeUnit.SECONDS);
             } catch (Exception ex) {
               throw new RuntimeException(ex);

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -116,7 +116,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executors;
@@ -1761,20 +1760,19 @@ public abstract class AbstractInteropTest {
    */
   public void testOrcaOob() throws Exception {
     AtomicReference<TestOrcaReport> reportHolder = new AtomicReference<>();
-    Random r = new Random();
     final TestOrcaReport answer = TestOrcaReport.newBuilder()
-        .setCpuUtilization(r.nextDouble())
-        .setMemoryUtilization(r.nextDouble())
-        .putUtilization("util", r.nextDouble())
+        .setCpuUtilization(0.8210)
+        .setMemoryUtilization(0.5847)
+        .putUtilization("util", 0.30499)
         .build();
     final TestOrcaReport answer2 = TestOrcaReport.newBuilder()
-        .setCpuUtilization(r.nextDouble())
-        .setMemoryUtilization(r.nextDouble())
-        .putUtilization("util", r.nextDouble())
+        .setCpuUtilization(0.29309)
+        .setMemoryUtilization(0.2)
+        .putUtilization("util", 100.2039)
         .build();
 
     final int retryLimit = 5;
-    BlockingQueue<StreamingOutputCallResponse> queue = new LinkedBlockingQueue<>();
+    BlockingQueue<Integer> queue = new LinkedBlockingQueue<>();
     SettableFuture<Void> closeFuture = SettableFuture.create();
 
     StreamObserver<StreamingOutputCallRequest> streamObserver =
@@ -1782,16 +1780,18 @@ public abstract class AbstractInteropTest {
 
           @Override
           public void onNext(StreamingOutputCallResponse value) {
-            queue.add(value);
+            queue.add(0);
           }
 
           @Override
           public void onError(Throwable t) {
+            queue.add(1);
             closeFuture.setException(new IllegalStateException("unexpected stream error", t));
           }
 
           @Override
           public void onCompleted() {
+            queue.add(2);
             closeFuture.set(null);
           }
         });

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -116,8 +116,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
@@ -1760,18 +1760,18 @@ public abstract class AbstractInteropTest {
    */
   public void testOrcaOob() throws Exception {
     AtomicReference<TestOrcaReport> reportHolder = new AtomicReference<>();
+    Random r = new Random();
     final TestOrcaReport answer = TestOrcaReport.newBuilder()
-        .setCpuUtilization(0.8210)
-        .setMemoryUtilization(0.5847)
-        .putUtilization("util", 0.30499)
+        .setCpuUtilization(r.nextDouble())
+        .setMemoryUtilization(r.nextDouble())
+        .putUtilization("util", r.nextDouble())
         .build();
     final TestOrcaReport answer2 = TestOrcaReport.newBuilder()
-        .setCpuUtilization(0.29309)
-        .setMemoryUtilization(0.2)
-        .putUtilization("util", 100.2039)
+        .setCpuUtilization(r.nextDouble())
+        .setMemoryUtilization(r.nextDouble())
+        .putUtilization("util", r.nextDouble())
         .build();
 
-    CyclicBarrier barrier = new CyclicBarrier(2);
     final int retryLimit = 5;
     AtomicReference<String> lock = new AtomicReference<>("");
 
@@ -1780,32 +1780,7 @@ public abstract class AbstractInteropTest {
 
           @Override
           public void onNext(StreamingOutputCallResponse value) {
-            try {
-              int i = 0;
-              for (; i < retryLimit; i++) {
-                Thread.sleep(1000);
-                blockingStub.withOption(ORCA_OOB_REPORT_KEY, reportHolder).emptyCall(EMPTY);
-                if (reportHolder.get().equals(answer)) {
-                  break;
-                }
-              }
-              assertThat(i).isLessThan(retryLimit);
-              System.out.println("\n" + reportHolder.get());
-              lock.set(value.getOobLock());
-              barrier.await(10, TimeUnit.SECONDS);
-              for (i = 0; i < retryLimit; i++) {
-                Thread.sleep(1000);
-                blockingStub.withOption(ORCA_OOB_REPORT_KEY, reportHolder).emptyCall(EMPTY);
-                if (reportHolder.get().equals(answer2)) {
-                  break;
-                }
-              }
-              assertThat(i).isLessThan(retryLimit);
-              System.out.println("\n" + reportHolder.get());
-              barrier.await(10, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-              throw new RuntimeException(ex);
-            }
+            lock.set(value.getOobLock());
           }
 
           @Override
@@ -1818,18 +1793,29 @@ public abstract class AbstractInteropTest {
           }
         });
 
-    try {
-      streamObserver.onNext(StreamingOutputCallRequest.newBuilder()
-          .setOobLock("").setOrcaOobReport(answer).build());
-      barrier.await(10, TimeUnit.SECONDS);
-      streamObserver.onNext(StreamingOutputCallRequest.newBuilder()
-          .setOobLock(lock.get()).setOrcaOobReport(answer2).build());
-      barrier.await(10, TimeUnit.SECONDS);
-      streamObserver.onCompleted();
-    } catch (Exception ex) {
-      streamObserver.onError(ex);
-      throw ex;
+    streamObserver.onNext(StreamingOutputCallRequest.newBuilder()
+        .setOobLock("").setOrcaOobReport(answer).build());
+    int i = 0;
+    for (; i < retryLimit; i++) {
+      Thread.sleep(1000);
+      blockingStub.withOption(ORCA_OOB_REPORT_KEY, reportHolder).emptyCall(EMPTY);
+      if (answer.equals(reportHolder.get())) {
+        break;
+      }
     }
+    assertThat(i).isLessThan(retryLimit);
+    streamObserver.onNext(StreamingOutputCallRequest.newBuilder()
+        .setOobLock(lock.get()).setOrcaOobReport(answer2).build());
+
+    for (i = 0; i < retryLimit; i++) {
+      Thread.sleep(1000);
+      blockingStub.withOption(ORCA_OOB_REPORT_KEY, reportHolder).emptyCall(EMPTY);
+      if (reportHolder.get().equals(answer2)) {
+        break;
+      }
+    }
+    assertThat(i).isLessThan(retryLimit);
+    streamObserver.onCompleted();
   }
 
   /** Sends a large unary rpc with service account credentials. */

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1799,6 +1799,9 @@ public abstract class AbstractInteropTest {
     streamObserver.onNext(StreamingOutputCallRequest.newBuilder()
         .setOrcaOobReport(answer).build());
     queue.take();
+    if (closeFuture.isDone()) {
+      closeFuture.get();
+    }
     assertFalse(closeFuture.isDone());
     int i = 0;
     for (; i < retryLimit; i++) {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
@@ -219,11 +219,11 @@ public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
             } catch (InterruptedException ex) {
               autoUnlockResponseObserver.onError(new StatusRuntimeException(
                   Status.ABORTED.withDescription("server service interrupted").withCause(ex)));
+              return;
             }
             oobTestLocked = true;
           }
           echoMetricsFromPayload(request.getOrcaOobReport());
-          responseObserver.onNext(StreamingOutputCallResponse.getDefaultInstance());
         }
         if (request.hasResponseStatus()) {
           dispatcher.cancel();
@@ -251,7 +251,7 @@ public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
       void cleanup() {
         if (oobTestLocked) {
           lock.release();
-          oobTestLocked = true;
+          oobTestLocked = false;
         }
       }
     }

--- a/interop-testing/src/main/proto/grpc/testing/messages.proto
+++ b/interop-testing/src/main/proto/grpc/testing/messages.proto
@@ -103,12 +103,6 @@ message SimpleRequest {
 
   // If set the server should record this metrics report data for the current RPC.
   TestOrcaReport orca_per_query_report = 11;
-
-  // If set the server should update this metrics report data at the OOB server.
-  TestOrcaReport orca_oob_report = 12;
-
-  // Allow only one test client at a time to perform orca_oob test;
-  string oob_lock = 13;
 }
 
 // Unary response, as configured by the request.
@@ -129,10 +123,6 @@ message SimpleResponse {
 
   // Server hostname.
   string hostname = 6;
-
-  // Allow only one test client at a time to perform orca_oob test.
-  // Set this value to the next request oob_lock field to acquire lock.
-  string oob_lock = 7;
 }
 
 // Client-streaming request.
@@ -187,12 +177,22 @@ message StreamingOutputCallRequest {
 
   // Whether server should return a given status
   EchoStatus response_status = 7;
+
+  // If set the server should update this metrics report data at the OOB server.
+  TestOrcaReport orca_oob_report = 8;
+
+  // Allow only one test client at a time to perform orca_oob test;
+  string oob_lock = 9;
 }
 
 // Server-streaming response, as configured by the request and parameters.
 message StreamingOutputCallResponse {
   // Payload to increase response size.
   Payload payload = 1;
+
+  // Allow only one test client at a time to perform orca_oob test;
+  // Set this value to the next request oob_lock field to acquire lock.
+  string oob_lock = 2;
 }
 
 // For reconnect interop test only.

--- a/interop-testing/src/main/proto/grpc/testing/messages.proto
+++ b/interop-testing/src/main/proto/grpc/testing/messages.proto
@@ -106,6 +106,9 @@ message SimpleRequest {
 
   // If set the server should update this metrics report data at the OOB server.
   TestOrcaReport orca_oob_report = 12;
+
+  // Allow only one test client at a time to perform orca_oob test;
+  string oob_lock = 13;
 }
 
 // Unary response, as configured by the request.
@@ -126,6 +129,10 @@ message SimpleResponse {
 
   // Server hostname.
   string hostname = 6;
+
+  // Allow only one test client at a time to perform orca_oob test.
+  // Set this value to the next request oob_lock field to acquire lock.
+  string oob_lock = 7;
 }
 
 // Client-streaming request.


### PR DESCRIPTION
[successful kokoro run](https://source.cloud.google.com/results/invocations/f5564114-7b0a-45ae-8bd7-2fee233d9d1c/log)

[latest kokoro run](https://source.cloud.google.com/results/invocations/8118505b-1256-4ed9-bb92-e1df271edf7a/log)