### PR TITLE
xds: Support least_request LB in LoadBalancingPolicy

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -135,10 +135,10 @@ def grpc_java_repositories():
     if not native.existing_rule("envoy_api"):
         http_archive(
             name = "envoy_api",
-            sha256 = "621577591d48cee20b61d4e71466bf4019791f9991da4813ccf75f3b9898de5f",
-            strip_prefix = "data-plane-api-bb6d6abe8b4d035c2f4ba3acf924cec0cbec5f70",
+            sha256 = "a0c58442cc2038ccccad9616dd1bab5ff1e65da2bbc0ae41020ef6010119eb0e",
+            strip_prefix = "data-plane-api-869b00336913138cad96a653458aab650c4e70ea",
             urls = [
-                "https://github.com/envoyproxy/data-plane-api/archive/bb6d6abe8b4d035c2f4ba3acf924cec0cbec5f70.tar.gz",
+                "https://github.com/envoyproxy/data-plane-api/archive/869b00336913138cad96a653458aab650c4e70ea.tar.gz",
             ],
         )
 

--- a/xds/BUILD.bazel
+++ b/xds/BUILD.bazel
@@ -83,6 +83,7 @@ java_proto_library(
         "@envoy_api//envoy/extensions/filters/http/rbac/v3:pkg",
         "@envoy_api//envoy/extensions/filters/http/router/v3:pkg",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg",
+        "@envoy_api//envoy/extensions/load_balancing_policies/least_request/v3:pkg",
         "@envoy_api//envoy/extensions/load_balancing_policies/ring_hash/v3:pkg",
         "@envoy_api//envoy/extensions/load_balancing_policies/round_robin/v3:pkg",
         "@envoy_api//envoy/extensions/load_balancing_policies/wrr_locality/v3:pkg",

--- a/xds/src/main/java/io/grpc/xds/LoadBalancerConfigFactory.java
+++ b/xds/src/main/java/io/grpc/xds/LoadBalancerConfigFactory.java
@@ -28,6 +28,7 @@ import io.envoyproxy.envoy.config.cluster.v3.Cluster.LeastRequestLbConfig;
 import io.envoyproxy.envoy.config.cluster.v3.Cluster.RingHashLbConfig;
 import io.envoyproxy.envoy.config.cluster.v3.LoadBalancingPolicy;
 import io.envoyproxy.envoy.config.cluster.v3.LoadBalancingPolicy.Policy;
+import io.envoyproxy.envoy.extensions.load_balancing_policies.least_request.v3.LeastRequest;
 import io.envoyproxy.envoy.extensions.load_balancing_policies.ring_hash.v3.RingHash;
 import io.envoyproxy.envoy.extensions.load_balancing_policies.round_robin.v3.RoundRobin;
 import io.envoyproxy.envoy.extensions.load_balancing_policies.wrr_locality.v3.WrrLocality;
@@ -167,6 +168,8 @@ class LoadBalancerConfigFactory {
                 recursionDepth);
           } else if (typedConfig.is(RoundRobin.class)) {
             serviceConfig = convertRoundRobinConfig();
+          } else if (typedConfig.is(LeastRequest.class)) {
+            serviceConfig = convertLeastRequestConfig(typedConfig.unpack(LeastRequest.class));
           } else if (typedConfig.is(com.github.xds.type.v3.TypedStruct.class)) {
             serviceConfig = convertCustomConfig(
                 typedConfig.unpack(com.github.xds.type.v3.TypedStruct.class));
@@ -229,6 +232,15 @@ class LoadBalancerConfigFactory {
      */
     private static ImmutableMap<String, ?> convertRoundRobinConfig() {
       return buildRoundRobinConfig();
+    }
+
+    /**
+     * Converts a least_request {@link Any} configuration to service config format.
+     */
+    private static ImmutableMap<String, ?> convertLeastRequestConfig(LeastRequest leastRequest)
+        throws ResourceInvalidException {
+      return buildLeastRequestConfig(
+          leastRequest.hasChoiceCount() ? leastRequest.getChoiceCount().getValue() : null);
     }
 
     /**


### PR DESCRIPTION
Allows the least_request load balancer to be configured via the control plane using the new LoadBalancingPolicy message in Cluster.