### PR TITLE
core: Clear ConfigSelector in panic mode

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -887,6 +887,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
     }
 
     updateSubchannelPicker(new PanicSubchannelPicker());
+    realChannel.updateConfigSelector(null);
     channelLogger.log(ChannelLogLevel.ERROR, "PANIC! Entering TRANSIENT_FAILURE");
     channelStateManager.gotoState(TRANSIENT_FAILURE);
   }
@@ -1755,6 +1756,9 @@ final class ManagedChannelImpl extends ManagedChannel implements
         @SuppressWarnings("ReferenceEquality")
         @Override
         public void run() {
+          if (ManagedChannelImpl.this.nameResolver != resolver) {
+            return;
+          }
 
           List<EquivalentAddressGroup> servers = resolutionResult.getAddresses();
           channelLogger.log(


### PR DESCRIPTION
If the failure is before the NameResolver has returned the first time,
RPCs would be queued waiting for service config. We don't want to use
the ConfigSelector, as we are trying to circumvent the NameResolver and
LoadBalancer.

Fixes #9257

CC @hikoma 