### PR TITLE
api: Explain security constraints of ATTR_AUTHORITY_OVERRIDE

### DIFF
--- a/api/src/main/java/io/grpc/EquivalentAddressGroup.java
+++ b/api/src/main/java/io/grpc/EquivalentAddressGroup.java
@@ -40,6 +40,11 @@ public final class EquivalentAddressGroup {
    * However, if the channel has overridden authority via
    * {@link ManagedChannelBuilder#overrideAuthority(String)}, the transport will use the channel's
    * authority override.
+   *
+   * <p>The authority <strong>must</strong> be from a trusted source, because if the authority is
+   * tampered with RPCs may be sent to attackers which may leak sensitive user data. If the
+   * authority was acquired by doing I/O, the communication must be authenticated (e.g., via TLS).
+   * Recognize that the server that provided the authority can trivially impersonate the service.
    */
   @Attr
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/6138")


### PR DESCRIPTION
Half of the text was copied from NameResolver.getServiceAuthority().
However, that method can't perform I/O (which would block) so more text
was appropriate here to mention the implications of having a remote
service provide the authority.

I noticed the text was lacking while discussing #9266.