### PR TITLE
interop client: add --soak_min_time_ms_between_rpcs flag and log peer addresses

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -93,6 +93,7 @@ public class TestServiceClient {
   private int soakIterations = 10;
   private int soakMaxFailures = 0;
   private int soakPerIterationMaxAcceptableLatencyMs = 1000;
+  private int soakMinTimeMsBetweenRPCs = 0;
   private int soakOverallTimeoutSeconds =
       soakIterations * soakPerIterationMaxAcceptableLatencyMs / 1000;
   private static LoadBalancerProvider customBackendMetricsLoadBalancerProvider;
@@ -166,6 +167,8 @@ public class TestServiceClient {
         soakMaxFailures = Integer.parseInt(value);
       } else if ("soak_per_iteration_max_acceptable_latency_ms".equals(key)) {
         soakPerIterationMaxAcceptableLatencyMs = Integer.parseInt(value);
+      } else if ("soak_min_time_ms_between_rpcs".equals(key)) {
+        soakMinTimeMsBetweenRPCs = Integer.parseInt(value);
       } else if ("soak_overall_timeout_seconds".equals(key)) {
         soakOverallTimeoutSeconds = Integer.parseInt(value);
       } else {
@@ -226,6 +229,11 @@ public class TestServiceClient {
           + "\n                              two soak tests (rpc_soak and channel_soak) should "
           + "\n                              take. Default "
             + c.soakPerIterationMaxAcceptableLatencyMs
+          + "\n --soak_min_time_ms_between_rpcs "
+          + "\n                              The minimum time in milliseconds between consecutive "
+          + "\n                              RPCs in a soak test (rpc_soak or channel_soak), useful "
+          + "\n                              for limiting QPS. Default: "
+          + c.soakMinTimeMsBetweenRPCs
           + "\n --soak_overall_timeout_seconds "
           + "\n                              The overall number of seconds after which a soak test "
           + "\n                              should stop and fail, if the desired number of "
@@ -457,6 +465,7 @@ public class TestServiceClient {
             soakIterations,
             soakMaxFailures,
             soakPerIterationMaxAcceptableLatencyMs,
+            soakMinTimeMsBetweenRPCs,
             soakOverallTimeoutSeconds);
         break;
       }
@@ -467,6 +476,7 @@ public class TestServiceClient {
             soakIterations,
             soakMaxFailures,
             soakPerIterationMaxAcceptableLatencyMs,
+            soakMinTimeMsBetweenRPCs,
             soakOverallTimeoutSeconds);
         break;
 


### PR DESCRIPTION
This adjusts the interop soak test case to:

a) log results as per recent updates to https://github.com/apolcyn/grpc/blob/98593f75e0f1a045d6db20d802a1269bee9230cb/doc/interop-test-descriptions.md#rpc_soak (includes the peer address, in particular)

b) Add the `--soak_min_time_ms_between_rpcs` flag to control QPS (described in https://github.com/apolcyn/grpc/blob/98593f75e0f1a045d6db20d802a1269bee9230cb/doc/interop-test-descriptions.md#rpc_soak)

These changes are useful for a load balancing related test, where we run the client at some QPS and check RPC distribution across different backends.