### PR TITLE
kokoro: standard TESTING_VERSION in k8s framework build scripts (1.40.x backport)

### DIFF
--- a/buildscripts/kokoro/xds_k8s_lb.sh
+++ b/buildscripts/kokoro/xds_k8s_lb.sh
@@ -38,6 +38,7 @@ build_java_test_app() {
 #   SERVER_IMAGE_NAME: Test server Docker image name
 #   CLIENT_IMAGE_NAME: Test client Docker image name
 #   GIT_COMMIT: SHA-1 of git commit being built
+#   TESTING_VERSION: version branch under test, f.e. v1.42.x, master
 # Arguments:
 #   None
 # Outputs:
@@ -53,10 +54,9 @@ build_test_app_docker_images() {
   cp -v "${docker_dir}/"*.properties "${build_dir}"
   cp -rv "${SRC_DIR}/${BUILD_APP_PATH}" "${build_dir}"
   # Pick a branch name for the built image
-  if [[ -n $KOKORO_JOB_NAME ]]; then
-    branch_name=$(echo "$KOKORO_JOB_NAME" | sed -E 's|^grpc/java/([^/]+)/.*|\1|')
-  else
-    branch_name='experimental'
+  local branch_name='experimental'
+  if is_version_branch "${TESTING_VERSION}"; then
+    branch_name="${TESTING_VERSION}"
   fi
   # Run Google Cloud Build
   gcloud builds submit "${build_dir}" \
@@ -122,6 +122,7 @@ run_test() {
     --kube_context="${KUBE_CONTEXT}" \
     --server_image="${SERVER_IMAGE_NAME}:${GIT_COMMIT}" \
     --client_image="${CLIENT_IMAGE_NAME}:${GIT_COMMIT}" \
+    --testing_version="${TESTING_VERSION}" \
     --xml_output_file="${TEST_XML_OUTPUT_DIR}/${test_name}/sponge_log.xml" \
     --force_cleanup
   set +x

--- a/buildscripts/kokoro/xds_url_map.sh
+++ b/buildscripts/kokoro/xds_url_map.sh
@@ -38,6 +38,7 @@ build_java_test_app() {
 #   SERVER_IMAGE_NAME: Test server Docker image name
 #   CLIENT_IMAGE_NAME: Test client Docker image name
 #   GIT_COMMIT: SHA-1 of git commit being built
+#   TESTING_VERSION: version branch under test, f.e. v1.42.x, master
 # Arguments:
 #   None
 # Outputs:
@@ -53,10 +54,9 @@ build_test_app_docker_images() {
   cp -v "${docker_dir}/"*.properties "${build_dir}"
   cp -rv "${SRC_DIR}/${BUILD_APP_PATH}" "${build_dir}"
   # Pick a branch name for the built image
-  if [[ -n $KOKORO_JOB_NAME ]]; then
-    branch_name="$(echo "$KOKORO_JOB_NAME" | sed -E 's|^grpc/java/([^/]+)/.*|\1|')"
-  else
-    branch_name='experimental'
+  local branch_name='experimental'
+  if is_version_branch "${TESTING_VERSION}"; then
+    branch_name="${TESTING_VERSION}"
   fi
   # Run Google Cloud Build
   gcloud builds submit "${build_dir}" \
@@ -105,6 +105,8 @@ build_docker_images_if_needed() {
 #   TEST_XML_OUTPUT_DIR: Output directory for the test xUnit XML report
 #   CLIENT_IMAGE_NAME: Test client Docker image name
 #   GIT_COMMIT: SHA-1 of git commit being built
+#   TESTING_VERSION: version branch under test: used by the framework to
+#                     determine the supported PSM features.
 # Arguments:
 #   Test case name
 # Outputs:
@@ -120,7 +122,7 @@ run_test() {
     --flagfile="${TEST_DRIVER_FLAGFILE}" \
     --kube_context="${KUBE_CONTEXT}" \
     --client_image="${CLIENT_IMAGE_NAME}:${GIT_COMMIT}" \
-    --testing_version="$(echo "$KOKORO_JOB_NAME" | sed -E 's|^grpc/java/([^/]+)/.*|\1|')" \
+    --testing_version="${TESTING_VERSION}" \
     --xml_output_file="${TEST_XML_OUTPUT_DIR}/${test_name}/sponge_log.xml" \
     --flagfile="config/url-map.cfg"
   set +x


### PR DESCRIPTION
This Addresses the issue with skips not working due to the missing/inconsistent `--testing_version` flag, ref b/235688697.

1. Uses the new `TESTING_VERSION` variable populated in the shared grpc_xds_k8s_install_test_driver.sh - new approach for detecting versions applicable to all languages.
2. Use `TESTING_VERSION` in all build files in `--testing_version` and when tagging docker images. This will be backported to all active test branches. Build scripts in all other languages will be updated as well.

Corresponding grpc core change: https://github.com/grpc/grpc/pull/30027

Backport of #9286