### PR TITLE
bazel: Support maven_install's strict_visibility=True

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,6 +39,7 @@ maven_install(
     repositories = [
         "https://repo.maven.apache.org/maven2/",
     ],
+    strict_visibility = True,
 )
 
 load("@maven//:compat.bzl", "compat_repositories")

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -37,6 +37,7 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "io.netty:netty-resolver:4.1.72.Final",
     "io.netty:netty-tcnative-boringssl-static:2.0.46.Final",
     "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.72.Final",
+    "io.netty:netty-transport-native-unix-common:4.1.72.Final",
     "io.netty:netty-transport:4.1.72.Final",
     "io.opencensus:opencensus-api:0.24.0",
     "io.opencensus:opencensus-contrib-grpc-metrics:0.24.0",


### PR DESCRIPTION
This seems like a poorly thought-out feature for maven_install in a
world where the dependency list is being combined from multiple
repositories, as it means all Bazel-aware dependencies must subscribe to
the idea this is good and useful. It also loses effectiveness as
transitive dependencies are likely to be included directly in
maven_install; users of gRPC can use netty, guava, and other
dependencies without explicitly defining them even with
strict_visibility=True. Given maven_install still complains
about "Found duplicate artifact versions", it isn't too surprising it
doesn't make sense in a multi-repo world.

This isn't a bad feature for gRPC as we are pretty low-level and it can
be helpful when making bazel dependency versions match gradle dependency
versions. But it doesn't necessarily seem like something we need to be
too worried about making sure we use. Similarly, don't use it in the
example as it seems low-value for our users.

Fixes #9288

CC @BoleynSu