### PR TITLE
gcp-observability: Populate global interceptors from observability

### DIFF
--- a/api/src/main/java/io/grpc/GlobalInterceptors.java
+++ b/api/src/main/java/io/grpc/GlobalInterceptors.java
@@ -73,24 +73,19 @@ final class GlobalInterceptors {
     isGlobalInterceptorsTracersSet = true;
   }
 
-  /**
-   * Returns the list of global {@link ClientInterceptor}. If not set, this returns am empty list.
-   */
+  /** Returns the list of global {@link ClientInterceptor}. If not set, this returns null. */
   static synchronized List<ClientInterceptor> getClientInterceptors() {
     isGlobalInterceptorsTracersGet = true;
     return clientInterceptors;
   }
 
-  /** Returns list of global {@link ServerInterceptor}. If not set, this returns an empty list. */
+  /** Returns list of global {@link ServerInterceptor}. If not set, this returns null. */
   static synchronized List<ServerInterceptor> getServerInterceptors() {
     isGlobalInterceptorsTracersGet = true;
     return serverInterceptors;
   }
 
-  /**
-   * Returns list of global {@link ServerStreamTracer.Factory}. If not set, this returns an empty
-   * list.
-   */
+  /** Returns list of global {@link ServerStreamTracer.Factory}. If not set, this returns null. */
   static synchronized List<ServerStreamTracer.Factory> getServerStreamTracerFactories() {
     isGlobalInterceptorsTracersGet = true;
     return serverStreamTracerFactories;

--- a/gcp-observability/build.gradle
+++ b/gcp-observability/build.gradle
@@ -30,6 +30,7 @@ dependencies {
             project(':grpc-alts'),
             project(':grpc-census'),
             ("com.google.cloud:google-cloud-logging:${cloudLoggingVersion}"),
+            libraries.opencensus.contrib.grpc.metrics,
             libraries.opencensus.exporter.stats.stackdriver,
             libraries.opencensus.exporter.trace.stackdriver,
             libraries.animalsniffer.annotations, // Prefer our version

--- a/gcp-observability/build.gradle
+++ b/gcp-observability/build.gradle
@@ -41,7 +41,8 @@ dependencies {
 
     runtimeOnly libraries.opencensus.impl
 
-    testImplementation project(':grpc-testing'),
+    testImplementation project(':grpc-context').sourceSets.test.output,
+            project(':grpc-testing'),
             project(':grpc-testing-proto'),
             project(':grpc-netty-shaded')
     testImplementation (libraries.guava.testlib) {

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/GcpObservability.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/GcpObservability.java
@@ -19,8 +19,14 @@ package io.grpc.gcp.observability;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.grpc.ClientInterceptor;
 import io.grpc.ExperimentalApi;
+import io.grpc.InternalGlobalInterceptors;
 import io.grpc.ManagedChannelProvider.ProviderNotFoundException;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerStreamTracer;
+import io.grpc.census.InternalCensusStatsAccessor;
+import io.grpc.census.InternalCensusTracingAccessor;
 import io.grpc.gcp.observability.interceptors.ConfigFilterHelper;
 import io.grpc.gcp.observability.interceptors.InternalLoggingChannelInterceptor;
 import io.grpc.gcp.observability.interceptors.InternalLoggingServerInterceptor;
@@ -28,13 +34,25 @@ import io.grpc.gcp.observability.interceptors.LogHelper;
 import io.grpc.gcp.observability.logging.GcpLogSink;
 import io.grpc.gcp.observability.logging.Sink;
 import io.grpc.internal.TimeProvider;
+import io.opencensus.contrib.grpc.metrics.RpcViews;
+import io.opencensus.exporter.stats.stackdriver.StackdriverStatsConfiguration;
+import io.opencensus.exporter.stats.stackdriver.StackdriverStatsExporter;
+import io.opencensus.exporter.trace.stackdriver.StackdriverTraceConfiguration;
+import io.opencensus.exporter.trace.stackdriver.StackdriverTraceExporter;
+import io.opencensus.trace.Tracing;
+import io.opencensus.trace.config.TraceConfig;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** The main class for gRPC Google Cloud Platform Observability features. */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8869")
 public final class GcpObservability implements AutoCloseable {
+  private static final Logger logger = Logger.getLogger(GcpObservability.class.getName());
   private static GcpObservability instance = null;
   private final Sink sink;
+  private final ObservabilityConfig config;
 
   /**
    * Initialize grpc-observability.
@@ -45,23 +63,33 @@ public final class GcpObservability implements AutoCloseable {
     if (instance == null) {
       GlobalLoggingTags globalLoggingTags = new GlobalLoggingTags();
       ObservabilityConfigImpl observabilityConfig = ObservabilityConfigImpl.getInstance();
-      Sink sink = new GcpLogSink(observabilityConfig.getDestinationProjectId(),
-          globalLoggingTags.getLocationTags(), globalLoggingTags.getCustomTags(),
-          observabilityConfig.getFlushMessageCount());
+      Sink sink =
+          new GcpLogSink(
+              observabilityConfig.getDestinationProjectId(),
+              globalLoggingTags.getLocationTags(),
+              globalLoggingTags.getCustomTags(),
+              observabilityConfig.getFlushMessageCount());
       LogHelper helper = new LogHelper(sink, TimeProvider.SYSTEM_TIME_PROVIDER);
       ConfigFilterHelper configFilterHelper = ConfigFilterHelper.factory(observabilityConfig);
-      instance = grpcInit(sink,
-          new InternalLoggingChannelInterceptor.FactoryImpl(helper, configFilterHelper),
-          new InternalLoggingServerInterceptor.FactoryImpl(helper, configFilterHelper));
+      instance =
+          grpcInit(
+              sink,
+              observabilityConfig,
+              new InternalLoggingChannelInterceptor.FactoryImpl(helper, configFilterHelper),
+              new InternalLoggingServerInterceptor.FactoryImpl(helper, configFilterHelper));
     }
     return instance;
   }
 
-  @VisibleForTesting static GcpObservability grpcInit(Sink sink,
+  @VisibleForTesting
+  static GcpObservability grpcInit(
+      Sink sink,
+      ObservabilityConfig config,
       InternalLoggingChannelInterceptor.Factory channelInterceptorFactory,
       InternalLoggingServerInterceptor.Factory serverInterceptorFactory) {
     if (instance == null) {
-      instance = new GcpObservability(sink, channelInterceptorFactory, serverInterceptorFactory);
+      instance =
+          new GcpObservability(sink, config, channelInterceptorFactory, serverInterceptorFactory);
     }
     return instance;
   }
@@ -76,15 +104,106 @@ public final class GcpObservability implements AutoCloseable {
       LoggingChannelProvider.shutdown();
       LoggingServerProvider.shutdown();
       sink.close();
+      unRegisterStackDriverExporter();
       instance = null;
     }
   }
 
-  private GcpObservability(Sink sink,
+  private GcpObservability(
+      Sink sink,
+      ObservabilityConfig config,
       InternalLoggingChannelInterceptor.Factory channelInterceptorFactory,
       InternalLoggingServerInterceptor.Factory serverInterceptorFactory) {
     this.sink = checkNotNull(sink);
+    this.config = checkNotNull(config);
+
+    ArrayList<ClientInterceptor> clientInterceptors = new ArrayList<>();
+    ArrayList<ServerInterceptor> serverInterceptors = new ArrayList<>();
+    ArrayList<ServerStreamTracer.Factory> tracerFactories = new ArrayList<>();
+    String projectId = config.getDestinationProjectId();
+    LogHelper logHelper = new LogHelper(sink, TimeProvider.SYSTEM_TIME_PROVIDER);
+    ConfigFilterHelper logFilterHelper = ConfigFilterHelper.factory(config);
+
+    if (config.isEnableCloudLogging()) {
+      clientInterceptors.add(
+          new InternalLoggingChannelInterceptor.FactoryImpl(logHelper, logFilterHelper).create());
+      serverInterceptors.add(
+          new InternalLoggingServerInterceptor.FactoryImpl(logHelper, logFilterHelper).create());
+    }
+
+    if (config.isEnableCloudMonitoring()) {
+      clientInterceptors.add(
+          InternalCensusStatsAccessor.getClientInterceptor(true, true, true, true));
+      tracerFactories.add(
+          InternalCensusStatsAccessor.getServerStreamTracerFactory(true, true, true));
+    }
+
+    if (config.isEnableCloudTracing()) {
+      clientInterceptors.add(InternalCensusTracingAccessor.getClientInterceptor());
+      tracerFactories.add(InternalCensusTracingAccessor.getServerStreamTracerFactory());
+    }
+    if (!clientInterceptors.isEmpty()
+        || !serverInterceptors.isEmpty()
+        || !tracerFactories.isEmpty()) {
+      InternalGlobalInterceptors.setInterceptorsTracers(
+          clientInterceptors, serverInterceptors, tracerFactories);
+    }
+
+    registerStackDriverExporter(projectId);
+
     LoggingChannelProvider.init(checkNotNull(channelInterceptorFactory));
     LoggingServerProvider.init(checkNotNull(serverInterceptorFactory));
+  }
+
+  private void registerStackDriverExporter(String projectId) {
+    if (config.isEnableCloudMonitoring()) {
+      RpcViews.registerAllGrpcViews();
+      StackdriverStatsConfiguration.Builder statsConfigurationBuilder =
+          StackdriverStatsConfiguration.builder();
+      if (projectId != null) {
+        statsConfigurationBuilder.setProjectId(projectId);
+      }
+      try {
+        StackdriverStatsExporter.createAndRegister(statsConfigurationBuilder.build());
+      } catch (Exception ex) {
+        throw new IllegalStateException(
+            "Could not register Cloud Stats exporter:" + ex.getMessage());
+      }
+    }
+
+    if (config.isEnableCloudTracing()) {
+      TraceConfig traceConfig = Tracing.getTraceConfig();
+      traceConfig.updateActiveTraceParams(
+          traceConfig.getActiveTraceParams().toBuilder().setSampler(config.getSampler()).build());
+      StackdriverTraceConfiguration.Builder traceConfigurationBuilder =
+          StackdriverTraceConfiguration.builder();
+      if (projectId != null) {
+        traceConfigurationBuilder.setProjectId(projectId);
+      }
+      try {
+        StackdriverTraceExporter.createAndRegister(traceConfigurationBuilder.build());
+      } catch (Exception ex) {
+        throw new IllegalStateException(
+            "Could not register Cloud Trace exporter:" + ex.getMessage());
+      }
+    }
+  }
+
+  private void unRegisterStackDriverExporter() {
+    if (config.isEnableCloudMonitoring()) {
+      try {
+        StackdriverStatsExporter.unregister();
+      } catch (IllegalStateException ex) {
+        logger.log(Level.WARNING, "Could not unregister Cloud Stats exporter");
+      }
+    }
+
+    if (config.isEnableCloudTracing()) {
+      try {
+        StackdriverTraceExporter.unregister();
+      } catch (IllegalStateException ex) {
+        logger.log(Level.WARNING, "Could not unregister Cloud Trace exporter");
+      }
+    }
   }
 }

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/GcpObservability.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/GcpObservability.java
@@ -42,6 +42,7 @@ import io.opencensus.exporter.trace.stackdriver.StackdriverTraceConfiguration;
 import io.opencensus.exporter.trace.stackdriver.StackdriverTraceExporter;
 import io.opencensus.trace.Tracing;
 import io.opencensus.trace.config.TraceConfig;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -64,7 +65,7 @@ public final class GcpObservability implements AutoCloseable {
    *
    * @throws ProviderNotFoundException if no underlying channel/server provider is available.
    */
-  public static synchronized GcpObservability grpcInit() throws Exception {
+  public static synchronized GcpObservability grpcInit() throws IOException {
     if (instance == null) {
       GlobalLoggingTags globalLoggingTags = new GlobalLoggingTags();
       ObservabilityConfigImpl observabilityConfig = ObservabilityConfigImpl.getInstance();
@@ -95,7 +96,7 @@ public final class GcpObservability implements AutoCloseable {
       ObservabilityConfig config,
       InternalLoggingChannelInterceptor.Factory channelInterceptorFactory,
       InternalLoggingServerInterceptor.Factory serverInterceptorFactory)
-      throws Exception {
+      throws IOException {
     if (instance == null) {
       instance =
           new GcpObservability(sink, config, channelInterceptorFactory, serverInterceptorFactory);
@@ -149,7 +150,7 @@ public final class GcpObservability implements AutoCloseable {
     }
   }
 
-  private void registerStackDriverExporter(String projectId) throws Exception {
+  private void registerStackDriverExporter(String projectId) throws IOException {
     if (config.isEnableCloudMonitoring()) {
       RpcViews.registerAllGrpcViews();
       StackdriverStatsConfiguration.Builder statsConfigurationBuilder =
@@ -159,8 +160,8 @@ public final class GcpObservability implements AutoCloseable {
       }
       try {
         StackdriverStatsExporter.createAndRegister(statsConfigurationBuilder.build());
-      } catch (Exception e) {
-        throw new Exception("Failed to register Stackdriver stats exporter, " + e.getMessage());
+      } catch (IOException e) {
+        throw new IOException("Failed to register Stackdriver stats exporter, " + e.getMessage());
       }
       metricsEnabled = true;
     }
@@ -176,8 +177,8 @@ public final class GcpObservability implements AutoCloseable {
       }
       try {
         StackdriverTraceExporter.createAndRegister(traceConfigurationBuilder.build());
-      } catch (Exception e) {
-        throw new Exception("Failed to register Stackdriver trace exporter, " + e.getMessage());
+      } catch (IOException e) {
+        throw new IOException("Failed to register Stackdriver trace exporter, " + e.getMessage());
       }
       tracesEnabled = true;
     }

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/ObservabilityConfig.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/ObservabilityConfig.java
@@ -44,6 +44,7 @@ public interface ObservabilityConfig {
   /** Get event types to log. */
   List<EventType> getEventTypes();
 
+  /** Get sampler for TraceConfig - when Cloud Tracing is enabled. */
   Sampler getSampler();
 
   /**

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/ObservabilityConfig.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/ObservabilityConfig.java
@@ -18,6 +18,7 @@ package io.grpc.gcp.observability;
 
 import io.grpc.Internal;
 import io.grpc.observabilitylog.v1.GrpcLogRecord.EventType;
+import io.opencensus.trace.Sampler;
 import java.util.List;
 
 @Internal
@@ -69,36 +70,6 @@ public interface ObservabilityConfig {
       this.pattern = pattern;
       this.headerBytes = headerBytes;
       this.messageBytes = messageBytes;
-    }
-  }
-
-  /** Corresponds to a {@link io.opencensus.trace.Sampler} type. */
-  enum SamplerType {
-    ALWAYS,
-    NEVER,
-    PROBABILISTIC;
-  }
-
-  /** Represents a trace {@link io.opencensus.trace.Sampler} configuration. */
-  class Sampler {
-    private SamplerType type;
-    private double probability;
-
-    Sampler(double probability) {
-      this.probability = probability;
-      this.type = SamplerType.PROBABILISTIC;
-    }
-
-    Sampler(SamplerType type) {
-      this.type = type;
-    }
-
-    double getProbability() {
-      return probability;
-    }
-
-    SamplerType getType() {
-      return type;
     }
   }
 }

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/ObservabilityConfigImpl.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/ObservabilityConfigImpl.java
@@ -106,11 +106,15 @@ final class ObservabilityConfigImpl implements ObservabilityConfig {
       if (enableCloudTracing && samplingRate == null) {
         this.sampler = Samplers.probabilitySampler(0.0);
       }
+      double epsilon = 1e-6;
       if (samplingRate != null) {
         checkArgument(
             samplingRate >= 0.0 && samplingRate <= 1.0,
             "'global_trace_sampling_rate' needs to be between [0.0, 1.0]");
-        if (samplingRate == 1.0) {
+        // Using alwaysSample() instead of probabilitySampler() because according to
+        // {@link io.opencensus.trace.samplers.ProbabilitySampler#shouldSample}
+        // there is a (very) small chance of *not* sampling if probability = 1.00.
+        if (Math.abs(1 - samplingRate) < epsilon) {
           this.sampler = Samplers.alwaysSample();
         } else {
           this.sampler = Samplers.probabilitySampler(samplingRate);

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/ObservabilityConfigImpl.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/ObservabilityConfigImpl.java
@@ -103,13 +103,14 @@ final class ObservabilityConfigImpl implements ObservabilityConfig {
         this.eventTypes = eventTypesBuilder.build();
       }
       Double samplingRate = JsonUtil.getNumberAsDouble(config, "global_trace_sampling_rate");
+      if (enableCloudTracing && samplingRate == null) {
+        this.sampler = Samplers.probabilitySampler(0.0);
+      }
       if (samplingRate != null) {
         checkArgument(
             samplingRate >= 0.0 && samplingRate <= 1.0,
             "'global_trace_sampling_rate' needs to be between [0.0, 1.0]");
-        if (samplingRate == 0) {
-          this.sampler = Samplers.neverSample();
-        } else if (samplingRate == 1) {
+        if (samplingRate == 1.0) {
           this.sampler = Samplers.alwaysSample();
         } else {
           this.sampler = Samplers.probabilitySampler(samplingRate);

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
@@ -48,6 +48,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class GcpObservabilityTest {
 
+  private static final String PROJECT_ID = "project";
+
   @Test
   public void initFinish() throws Exception {
     ManagedChannelProvider prevChannelProvider = ManagedChannelProvider.provider();
@@ -100,6 +102,7 @@ public class GcpObservabilityTest {
       when(config.isEnableCloudMonitoring()).thenReturn(true);
       when(config.isEnableCloudTracing()).thenReturn(true);
       when(config.getSampler()).thenReturn(Samplers.neverSample());
+      when(config.getDestinationProjectId()).thenReturn(PROJECT_ID);
 
       ClientInterceptor clientInterceptor =
           mock(ClientInterceptor.class, delegatesTo(new NoopClientInterceptor()));

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
@@ -18,14 +18,29 @@ package io.grpc.gcp.observability;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.InternalGlobalInterceptors;
 import io.grpc.ManagedChannelProvider;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
 import io.grpc.ServerProvider;
+import io.grpc.StaticTestingClassLoader;
 import io.grpc.gcp.observability.interceptors.InternalLoggingChannelInterceptor;
 import io.grpc.gcp.observability.interceptors.InternalLoggingServerInterceptor;
 import io.grpc.gcp.observability.logging.Sink;
+import io.opencensus.trace.samplers.Samplers;
+import java.util.regex.Pattern;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -34,7 +49,7 @@ import org.junit.runners.JUnit4;
 public class GcpObservabilityTest {
 
   @Test
-  public void initFinish() {
+  public void initFinish() throws Exception {
     ManagedChannelProvider prevChannelProvider = ManagedChannelProvider.provider();
     ServerProvider prevServerProvider = ServerProvider.provider();
     Sink sink = mock(Sink.class);
@@ -62,6 +77,67 @@ public class GcpObservabilityTest {
       fail("should have failed for calling close() second time");
     } catch (IllegalStateException e) {
       assertThat(e).hasMessageThat().contains("GcpObservability already closed!");
+    }
+  }
+
+  @Test
+  public void enableObservability() throws Exception {
+    StaticTestingClassLoader classLoader =
+        new StaticTestingClassLoader(
+            getClass().getClassLoader(), Pattern.compile("io\\.grpc\\.[^.]+"));
+    Class<?> runnable = classLoader.loadClass(StaticTestingClassLoaderSet.class.getName());
+    ((Runnable) runnable.getDeclaredConstructor().newInstance()).run();
+  }
+
+  // UsedReflectively
+  public static final class StaticTestingClassLoaderSet implements Runnable {
+
+    @Override
+    public void run() {
+      Sink sink = mock(Sink.class);
+      ObservabilityConfig config = mock(ObservabilityConfig.class);
+      when(config.isEnableCloudLogging()).thenReturn(true);
+      when(config.isEnableCloudMonitoring()).thenReturn(true);
+      when(config.isEnableCloudTracing()).thenReturn(true);
+      when(config.getSampler()).thenReturn(Samplers.neverSample());
+
+      ClientInterceptor clientInterceptor =
+          mock(ClientInterceptor.class, delegatesTo(new NoopClientInterceptor()));
+      InternalLoggingChannelInterceptor.Factory channelInterceptorFactory =
+          mock(InternalLoggingChannelInterceptor.Factory.class);
+      when(channelInterceptorFactory.create()).thenReturn(clientInterceptor);
+
+      ServerInterceptor serverInterceptor =
+          mock(ServerInterceptor.class, delegatesTo(new NoopServerInterceptor()));
+      InternalLoggingServerInterceptor.Factory serverInterceptorFactory =
+          mock(InternalLoggingServerInterceptor.Factory.class);
+      when(serverInterceptorFactory.create()).thenReturn(serverInterceptor);
+
+      try (GcpObservability observability =
+          GcpObservability.grpcInit(
+              sink, config, channelInterceptorFactory, serverInterceptorFactory)) {
+        assertThat(InternalGlobalInterceptors.getClientInterceptors()).hasSize(3);
+        assertThat(InternalGlobalInterceptors.getServerInterceptors()).hasSize(1);
+        assertThat(InternalGlobalInterceptors.getServerStreamTracerFactories()).hasSize(2);
+      } catch (Exception e) {
+        fail("Encountered exception: " + e);
+      }
+    }
+  }
+
+  private static class NoopClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+      return next.newCall(method, callOptions);
+    }
+  }
+
+  private static class NoopServerInterceptor implements ServerInterceptor {
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+        ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+      return next.startCall(call, headers);
     }
   }
 }

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
@@ -28,14 +28,12 @@ import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
 import io.grpc.InternalGlobalInterceptors;
-// import io.grpc.ManagedChannelProvider;
 import io.grpc.ManagedChannelProvider;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
-// import io.grpc.ServerProvider;
 import io.grpc.ServerProvider;
 import io.grpc.StaticTestingClassLoader;
 import io.grpc.gcp.observability.interceptors.InternalLoggingChannelInterceptor;
@@ -86,6 +84,7 @@ public class GcpObservabilityTest {
 
     @Override
     public void run() {
+      // TODO(dnvindhya) : Remove usage of Providers on cleaning up Logging*Provider
       ManagedChannelProvider prevChannelProvider = ManagedChannelProvider.provider();
       ServerProvider prevServerProvider = ServerProvider.provider();
       Sink sink = mock(Sink.class);
@@ -144,7 +143,7 @@ public class GcpObservabilityTest {
           mock(InternalLoggingServerInterceptor.Factory.class);
       when(serverInterceptorFactory.create()).thenReturn(serverInterceptor);
 
-      try (GcpObservability observability =
+      try (GcpObservability unused =
           GcpObservability.grpcInit(
               sink, config, channelInterceptorFactory, serverInterceptorFactory)) {
         assertThat(InternalGlobalInterceptors.getClientInterceptors()).hasSize(3);
@@ -172,7 +171,7 @@ public class GcpObservabilityTest {
       InternalLoggingServerInterceptor.Factory serverInterceptorFactory =
           mock(InternalLoggingServerInterceptor.Factory.class);;
 
-      try (GcpObservability observability =
+      try (GcpObservability unused =
           GcpObservability.grpcInit(
               sink, config, channelInterceptorFactory, serverInterceptorFactory)) {
         assertThat(InternalGlobalInterceptors.getClientInterceptors()).isEmpty();

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
@@ -32,25 +32,27 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class GcpObservabilityTest {
-  
+
   @Test
   public void initFinish() {
     ManagedChannelProvider prevChannelProvider = ManagedChannelProvider.provider();
     ServerProvider prevServerProvider = ServerProvider.provider();
     Sink sink = mock(Sink.class);
-    InternalLoggingChannelInterceptor.Factory channelInterceptorFactory = mock(
-        InternalLoggingChannelInterceptor.Factory.class);
-    InternalLoggingServerInterceptor.Factory serverInterceptorFactory = mock(
-        InternalLoggingServerInterceptor.Factory.class);
+    ObservabilityConfig config = mock(ObservabilityConfig.class);
+    InternalLoggingChannelInterceptor.Factory channelInterceptorFactory =
+        mock(InternalLoggingChannelInterceptor.Factory.class);
+    InternalLoggingServerInterceptor.Factory serverInterceptorFactory =
+        mock(InternalLoggingServerInterceptor.Factory.class);
     GcpObservability observability1;
-    try (GcpObservability observability = GcpObservability.grpcInit(sink, channelInterceptorFactory,
-        serverInterceptorFactory)) {
+    try (GcpObservability observability =
+        GcpObservability.grpcInit(
+            sink, config, channelInterceptorFactory, serverInterceptorFactory)) {
       assertThat(ManagedChannelProvider.provider()).isInstanceOf(LoggingChannelProvider.class);
       assertThat(ServerProvider.provider()).isInstanceOf(ServerProvider.class);
-      observability1 = GcpObservability.grpcInit(sink, channelInterceptorFactory,
-              serverInterceptorFactory);
+      observability1 =
+          GcpObservability.grpcInit(
+              sink, config, channelInterceptorFactory, serverInterceptorFactory);
       assertThat(observability1).isSameInstanceAs(observability);
-
     }
     verify(sink).close();
     assertThat(ManagedChannelProvider.provider()).isSameInstanceAs(prevChannelProvider);

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/ObservabilityConfigImplTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/ObservabilityConfigImplTest.java
@@ -81,27 +81,6 @@ public class ObservabilityConfigImplTest {
           + "    \"enable_cloud_tracing\": true\n"
           + "}";
 
-  private static final String GLOBAL_TRACING_ALWAYS_SAMPLER = "{\n"
-          + "    \"enable_cloud_tracing\": true,\n"
-          + "    \"global_trace_sampler\": \"always\"\n"
-          + "}";
-
-  private static final String GLOBAL_TRACING_NEVER_SAMPLER = "{\n"
-          + "    \"enable_cloud_tracing\": true,\n"
-          + "    \"global_trace_sampler\": \"never\"\n"
-          + "}";
-
-  private static final String GLOBAL_TRACING_PROBABILISTIC_SAMPLER = "{\n"
-          + "    \"enable_cloud_tracing\": true,\n"
-          + "    \"global_trace_sampling_rate\": 0.75\n"
-          + "}";
-
-  private static final String GLOBAL_TRACING_BOTH_SAMPLER_ERROR = "{\n"
-          + "    \"enable_cloud_tracing\": true,\n"
-          + "    \"global_trace_sampler\": \"never\",\n"
-          + "    \"global_trace_sampling_rate\": 0.75\n"
-          + "}";
-
   private static final String GLOBAL_TRACING_BADPROBABILISTIC_SAMPLER = "{\n"
           + "    \"enable_cloud_tracing\": true,\n"
           + "    \"global_trace_sampling_rate\": -0.75\n"
@@ -195,54 +174,13 @@ public class ObservabilityConfigImplTest {
   }
 
   @Test
-  public void alwaysSampler() throws IOException {
-    observabilityConfig.parse(GLOBAL_TRACING_ALWAYS_SAMPLER);
-    assertTrue(observabilityConfig.isEnableCloudTracing());
-    ObservabilityConfig.Sampler sampler = observabilityConfig.getSampler();
-    assertThat(sampler).isNotNull();
-    assertThat(sampler.getType()).isEqualTo(ObservabilityConfig.SamplerType.ALWAYS);
-  }
-
-  @Test
-  public void neverSampler() throws IOException {
-    observabilityConfig.parse(GLOBAL_TRACING_NEVER_SAMPLER);
-    assertTrue(observabilityConfig.isEnableCloudTracing());
-    ObservabilityConfig.Sampler sampler = observabilityConfig.getSampler();
-    assertThat(sampler).isNotNull();
-    assertThat(sampler.getType()).isEqualTo(ObservabilityConfig.SamplerType.NEVER);
-  }
-
-  @Test
-  public void probabilisticSampler() throws IOException {
-    observabilityConfig.parse(GLOBAL_TRACING_PROBABILISTIC_SAMPLER);
-    assertTrue(observabilityConfig.isEnableCloudTracing());
-    ObservabilityConfig.Sampler sampler = observabilityConfig.getSampler();
-    assertThat(sampler).isNotNull();
-    assertThat(sampler.getType()).isEqualTo(ObservabilityConfig.SamplerType.PROBABILISTIC);
-    assertThat(sampler.getProbability()).isEqualTo(0.75);
-  }
-
-  @Test
-  public void bothSamplerAndSamplingRate_error() throws IOException {
-    try {
-      observabilityConfig.parse(GLOBAL_TRACING_BOTH_SAMPLER_ERROR);
-      fail("exception expected!");
-    } catch (IllegalArgumentException iae) {
-      assertThat(iae.getMessage())
-          .isEqualTo(
-              "only one of 'global_trace_sampler' or 'global_trace_sampling_rate' can be"
-                  + " specified");
-    }
-  }
-
-  @Test
   public void badProbabilisticSampler_error() throws IOException {
     try {
       observabilityConfig.parse(GLOBAL_TRACING_BADPROBABILISTIC_SAMPLER);
       fail("exception expected!");
     } catch (IllegalArgumentException iae) {
       assertThat(iae.getMessage()).isEqualTo(
-              "'global_trace_sampling_rate' needs to be between 0.0 and 1.0");
+              "'global_trace_sampling_rate' needs to be between [0.0, 1.0]");
     }
   }
 


### PR DESCRIPTION
This PR populates Global Interceptors and Stream Tracers based on observability configuration. 
Also, adds stackdriver exporter required for exporting metric and trace to Google cloud.

CC @sanjaypujare 