### PR TITLE
core: Always pass offload executor to CallCredentials

### DIFF
--- a/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
@@ -144,8 +144,7 @@ final class CallCredentialsApplyingTransportFactory implements ClientTransportFa
             }
           };
         try {
-          creds.applyRequestMetadata(
-              requestInfo, firstNonNull(callOptions.getExecutor(), appExecutor), applier);
+          creds.applyRequestMetadata(requestInfo, appExecutor, applier);
         } catch (Throwable t) {
           applier.fail(Status.UNAUTHENTICATED
               .withDescription("Credentials should use fail() instead of throwing exceptions")

--- a/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
+++ b/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
@@ -168,7 +168,7 @@ public class CallCredentialsApplyingTest {
 
     ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(null);
     verify(mockCreds).applyRequestMetadata(infoCaptor.capture(),
-        same(anotherExecutor), any(CallCredentials.MetadataApplier.class));
+        same(mockExecutor), any(CallCredentials.MetadataApplier.class));
     RequestInfo info = infoCaptor.getValue();
     assertSame(transportAttrs, info.getTransportAttrs());
     assertSame(method, info.getMethodDescriptor());
@@ -212,7 +212,7 @@ public class CallCredentialsApplyingTest {
 
     ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(null);
     verify(mockCreds).applyRequestMetadata(
-            infoCaptor.capture(), same(anotherExecutor),
+            infoCaptor.capture(), same(mockExecutor),
             any(io.grpc.CallCredentials.MetadataApplier.class));
     RequestInfo info = infoCaptor.getValue();
     assertSame(method, info.getMethodDescriptor());


### PR DESCRIPTION
Previously would use the executor provided in CallOptions if it was present.  Now that executor is ignored.