### PR TITLE
Fix Channelz window reporting

### DIFF
--- a/netty/src/main/java/io/grpc/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/netty/Utils.java
@@ -466,8 +466,11 @@ class Utils {
     private final Http2FlowController remote;
 
     FlowControlReader(Http2Connection connection) {
-      local = connection.local().flowController();
-      remote = connection.remote().flowController();
+      // 'local' in Netty is the _controller_ that controls inbound data. 'local' in Channelz is
+      // the _present window_ provided by the remote that allows data to be sent. They are
+      // opposites.
+      local = connection.remote().flowController();
+      remote = connection.local().flowController();
       connectionStream = connection.connectionStream();
     }
 

--- a/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
+++ b/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
@@ -456,8 +456,8 @@ public abstract class NettyHandlerTestBase<T extends Http2ConnectionHandler> {
   public void transportTracer_windowSizeDefault() throws Exception {
     manualSetUp();
     TransportStats transportStats = transportTracer.getStats();
-    assertEquals(Http2CodecUtil.DEFAULT_WINDOW_SIZE, transportStats.remoteFlowControlWindow);
-    assertEquals(flowControlWindow, transportStats.localFlowControlWindow);
+    assertEquals(Http2CodecUtil.DEFAULT_WINDOW_SIZE, transportStats.localFlowControlWindow);
+    assertEquals(flowControlWindow, transportStats.remoteFlowControlWindow);
   }
 
   @Test
@@ -465,31 +465,31 @@ public abstract class NettyHandlerTestBase<T extends Http2ConnectionHandler> {
     flowControlWindow = 1024 * 1024;
     manualSetUp();
     TransportStats transportStats = transportTracer.getStats();
-    assertEquals(Http2CodecUtil.DEFAULT_WINDOW_SIZE, transportStats.remoteFlowControlWindow);
-    assertEquals(flowControlWindow, transportStats.localFlowControlWindow);
+    assertEquals(Http2CodecUtil.DEFAULT_WINDOW_SIZE, transportStats.localFlowControlWindow);
+    assertEquals(flowControlWindow, transportStats.remoteFlowControlWindow);
   }
 
   @Test
   public void transportTracer_windowUpdate_remote() throws Exception {
     manualSetUp();
     TransportStats before = transportTracer.getStats();
-    assertEquals(Http2CodecUtil.DEFAULT_WINDOW_SIZE, before.remoteFlowControlWindow);
     assertEquals(Http2CodecUtil.DEFAULT_WINDOW_SIZE, before.localFlowControlWindow);
+    assertEquals(Http2CodecUtil.DEFAULT_WINDOW_SIZE, before.remoteFlowControlWindow);
 
     ByteBuf serializedSettings = windowUpdate(0, 1000);
     channelRead(serializedSettings);
     TransportStats after = transportTracer.getStats();
     assertEquals(Http2CodecUtil.DEFAULT_WINDOW_SIZE + 1000,
-        after.remoteFlowControlWindow);
-    assertEquals(flowControlWindow, after.localFlowControlWindow);
+        after.localFlowControlWindow);
+    assertEquals(flowControlWindow, after.remoteFlowControlWindow);
   }
 
   @Test
   public void transportTracer_windowUpdate_local() throws Exception {
     manualSetUp();
     TransportStats before = transportTracer.getStats();
-    assertEquals(Http2CodecUtil.DEFAULT_WINDOW_SIZE, before.remoteFlowControlWindow);
-    assertEquals(flowControlWindow, before.localFlowControlWindow);
+    assertEquals(Http2CodecUtil.DEFAULT_WINDOW_SIZE, before.localFlowControlWindow);
+    assertEquals(flowControlWindow, before.remoteFlowControlWindow);
 
     // If the window size is below a certain threshold, netty will wait to apply the update.
     // Use a large increment to be sure that it exceeds the threshold.
@@ -497,7 +497,7 @@ public abstract class NettyHandlerTestBase<T extends Http2ConnectionHandler> {
         connection().connectionStream(), 8 * Http2CodecUtil.DEFAULT_WINDOW_SIZE);
 
     TransportStats after = transportTracer.getStats();
-    assertEquals(Http2CodecUtil.DEFAULT_WINDOW_SIZE, after.remoteFlowControlWindow);
+    assertEquals(Http2CodecUtil.DEFAULT_WINDOW_SIZE, after.localFlowControlWindow);
     assertEquals(flowControlWindow + 8 * Http2CodecUtil.DEFAULT_WINDOW_SIZE,
         connection().local().flowController().windowSize(connection().connectionStream()));
   }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -323,8 +323,10 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
         @Override
         public TransportTracer.FlowControlWindows read() {
           synchronized (lock) {
-            long local = -1; // okhttp does not track the local window size
-            long remote = outboundFlow == null ? -1 : outboundFlow.windowUpdate(null, 0);
+            long local = outboundFlow == null ? -1 : outboundFlow.windowUpdate(null, 0);
+            // connectionUnacknowledgedBytesRead is only readable by ClientFrameHandler, so we
+            // provide a lower bound.
+            long remote = (long) (initialWindowSize * DEFAULT_WINDOW_UPDATE_RATIO);
             return new TransportTracer.FlowControlWindows(local, remote);
           }
         }

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -727,24 +727,21 @@ public class OkHttpClientTransportTest {
   public void transportTracer_windowSizeDefault() throws Exception {
     initTransport();
     TransportStats stats = getTransportStats(clientTransport);
-    assertEquals(INITIAL_WINDOW_SIZE, stats.remoteFlowControlWindow);
-    // okhttp does not track local window sizes
-    assertEquals(-1, stats.localFlowControlWindow);
+    assertEquals(INITIAL_WINDOW_SIZE / 2, stats.remoteFlowControlWindow); // Lower bound
+    assertEquals(INITIAL_WINDOW_SIZE, stats.localFlowControlWindow);
   }
 
   @Test
   public void transportTracer_windowSize_remote() throws Exception {
     initTransport();
     TransportStats before = getTransportStats(clientTransport);
-    assertEquals(INITIAL_WINDOW_SIZE, before.remoteFlowControlWindow);
-    // okhttp does not track local window sizes
-    assertEquals(-1, before.localFlowControlWindow);
+    assertEquals(INITIAL_WINDOW_SIZE / 2, before.remoteFlowControlWindow); // Lower bound
+    assertEquals(INITIAL_WINDOW_SIZE, before.localFlowControlWindow);
 
     frameHandler().windowUpdate(0, 1000);
     TransportStats after = getTransportStats(clientTransport);
-    assertEquals(INITIAL_WINDOW_SIZE + 1000, after.remoteFlowControlWindow);
-    // okhttp does not track local window sizes
-    assertEquals(-1, after.localFlowControlWindow);
+    assertEquals(INITIAL_WINDOW_SIZE / 2, after.remoteFlowControlWindow);
+    assertEquals(INITIAL_WINDOW_SIZE + 1000, after.localFlowControlWindow);
   }
 
   @Test


### PR DESCRIPTION
Both Netty and OkHttp had local and remote windows flipped. Also, the
comment in OkHttp about "not tracked" wasn't true, so make it more
accurate and provide a _hint_ of what the window may be instead of just
-1.

----

For reference:
https://github.com/grpc/grpc-proto/blob/99b9845f1df4313b87e878d0ad94ba994c1e06ca/grpc/channelz/v1/channelz.proto#L282
https://netty.io/4.1/api/io/netty/handler/codec/http2/Http2LocalFlowController.html