### PR TITLE
core: Use SyncContext for InProcessTransport listener callbacks to avoid deadlocks

### DIFF
--- a/examples/src/test/java/io/grpc/examples/helloworld/HelloWorldClientTest.java
+++ b/examples/src/test/java/io/grpc/examples/helloworld/HelloWorldClientTest.java
@@ -40,8 +40,6 @@ import org.mockito.ArgumentMatchers;
  * Not intended to provide a high code coverage or to test every major usecase.
  *
  * directExecutor() makes it easier to have deterministic tests.
- * However, if your implementation uses another thread and uses streaming it is better to use
- * the default executor, to avoid hitting bug #3084.
  *
  * <p>For more unit test examples see {@link io.grpc.examples.routeguide.RouteGuideClientTest} and
  * {@link io.grpc.examples.routeguide.RouteGuideServerTest}.

--- a/examples/src/test/java/io/grpc/examples/helloworld/HelloWorldServerTest.java
+++ b/examples/src/test/java/io/grpc/examples/helloworld/HelloWorldServerTest.java
@@ -33,8 +33,6 @@ import org.junit.runners.JUnit4;
  * Not intended to provide a high code coverage or to test every major usecase.
  *
  * directExecutor() makes it easier to have deterministic tests.
- * However, if your implementation uses another thread and uses streaming it is better to use
- * the default executor, to avoid hitting bug #3084.
  *
  * <p>For more unit test examples see {@link io.grpc.examples.routeguide.RouteGuideClientTest} and
  * {@link io.grpc.examples.routeguide.RouteGuideServerTest}.

--- a/examples/src/test/java/io/grpc/examples/routeguide/RouteGuideClientTest.java
+++ b/examples/src/test/java/io/grpc/examples/routeguide/RouteGuideClientTest.java
@@ -53,8 +53,6 @@ import org.mockito.ArgumentCaptor;
  * Not intended to provide a high code coverage or to test every major usecase.
  *
  * directExecutor() makes it easier to have deterministic tests.
- * However, if your implementation uses another thread and uses streaming it is better to use
- * the default executor, to avoid hitting bug #3084.
  *
  * <p>For basic unit test examples see {@link io.grpc.examples.helloworld.HelloWorldClientTest} and
  * {@link io.grpc.examples.helloworld.HelloWorldServerTest}.

--- a/examples/src/test/java/io/grpc/examples/routeguide/RouteGuideServerTest.java
+++ b/examples/src/test/java/io/grpc/examples/routeguide/RouteGuideServerTest.java
@@ -50,8 +50,6 @@ import org.mockito.ArgumentCaptor;
  * Not intended to provide a high code coverage or to test every major usecase.
  *
  * directExecutor() makes it easier to have deterministic tests.
- * However, if your implementation uses another thread and uses streaming it is better to use
- * the default executor, to avoid hitting bug #3084.
  *
  * <p>For basic unit test examples see {@link io.grpc.examples.helloworld.HelloWorldClientTest} and
  * {@link io.grpc.examples.helloworld.HelloWorldServerTest}.


### PR DESCRIPTION
Fixes deadlocks caused by client and server listeners being called in a synchronized block  

Also support unary calls returning null values

Fixes #3084