### PR TITLE
feat: add request validator

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -15,8 +15,6 @@ dependencies {
             libraries.jsr305,
             libraries.errorprone.annotations
     implementation libraries.guava
-    implementation "com.google.protobuf:protobuf-javalite:3.19.2"
-
 
     testImplementation project(':grpc-context').sourceSets.test.output,
             project(':grpc-testing'),

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -15,6 +15,8 @@ dependencies {
             libraries.jsr305,
             libraries.errorprone.annotations
     implementation libraries.guava
+    implementation "com.google.protobuf:protobuf-javalite:3.19.2"
+
 
     testImplementation project(':grpc-context').sourceSets.test.output,
             project(':grpc-testing'),

--- a/api/src/main/java/io/grpc/RequestValidationInterceptor.java
+++ b/api/src/main/java/io/grpc/RequestValidationInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The gRPC Authors
+ * Copyright 2022 The gRPC Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/grpc/RequestValidationInterceptor.java
+++ b/api/src/main/java/io/grpc/RequestValidationInterceptor.java
@@ -1,0 +1,21 @@
+package io.grpc;
+
+public class RequestValidationInterceptor implements ServerInterceptor {
+
+    private RequestValidatorResolver requestValidatorResolver;
+
+    public RequestValidationInterceptor(RequestValidatorResolver requestValidatorResolver) {
+        this.requestValidatorResolver = requestValidatorResolver;
+    }
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+            ServerCall<ReqT, RespT> call,
+            Metadata headers,
+            ServerCallHandler<ReqT, RespT> next
+    ) {
+        ServerCall.Listener<ReqT> delegate = next.startCall(call, headers);
+
+        return new RequestValidationListener<ReqT, RespT>(delegate, call, headers, requestValidatorResolver);
+    }
+}

--- a/api/src/main/java/io/grpc/RequestValidationInterceptor.java
+++ b/api/src/main/java/io/grpc/RequestValidationInterceptor.java
@@ -30,8 +30,11 @@ public class RequestValidationInterceptor implements ServerInterceptor {
             Metadata headers,
             ServerCallHandler<ReqT, RespT> next
     ) {
-        ServerCall.Listener<ReqT> delegate = next.startCall(call, headers);
+        ServerCallHandler<ReqT, RespT> handler = (call1, headers1) -> {
+            call1.request(1);
+            return new RequestValidationListener<>(call1, headers1, next, requestValidatorResolver);
+        };
 
-        return new RequestValidationListener<ReqT, RespT>(delegate, call, headers, requestValidatorResolver);
+        return handler.startCall(call, headers);
     }
 }

--- a/api/src/main/java/io/grpc/RequestValidationInterceptor.java
+++ b/api/src/main/java/io/grpc/RequestValidationInterceptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.grpc;
 
 public class RequestValidationInterceptor implements ServerInterceptor {

--- a/api/src/main/java/io/grpc/RequestValidationListener.java
+++ b/api/src/main/java/io/grpc/RequestValidationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The gRPC Authors
+ * Copyright 2022 The gRPC Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/grpc/RequestValidationListener.java
+++ b/api/src/main/java/io/grpc/RequestValidationListener.java
@@ -1,6 +1,20 @@
-package io.grpc;
+/*
+ * Copyright 2016 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import com.google.protobuf.MessageLiteOrBuilder;
+package io.grpc;
 
 public class RequestValidationListener<ReqT, ResT> extends ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT> {
 
@@ -22,33 +36,33 @@ public class RequestValidationListener<ReqT, ResT> extends ForwardingServerCallL
 
     @Override
     public void onMessage(ReqT message) {
-        MessageLiteOrBuilder convertMessage = (MessageLiteOrBuilder) message;
-        RequestValidator<MessageLiteOrBuilder> validator = requestValidatorResolver.find(convertMessage.getClass().getTypeName());
+        RequestValidator<ReqT> validator = (RequestValidator<ReqT>) requestValidatorResolver.find(message.getClass());
 
         if (validator == null) {
             super.onMessage(message);
-        } else {
-            try {
-                ValidationResult validationResult = validator.isValid(convertMessage);
+            return;
+        }
 
-                if (validationResult.isValid()) {
-                    super.onMessage(message);
-                } else {
-                    Status status = Status.INVALID_ARGUMENT
-                            .withDescription("invalid argument. " + validationResult.getMessage());
-                    handleInvalidRequest(status);
-                }
-            } catch (Exception e) {
-                Status status = Status.INTERNAL.withDescription(e.getMessage());
+        try {
+            ValidationResult validationResult = validator.isValid(message);
 
+            if (validationResult.isValid()) {
+                super.onMessage(message);
+            } else {
+                Status status = Status.INVALID_ARGUMENT
+                        .withDescription("invalid argument. " + validationResult.getMessage());
                 handleInvalidRequest(status);
             }
+        } catch (Exception e) {
+            Status status = Status.INTERNAL.withDescription(e.getMessage());
+
+            handleInvalidRequest(status);
         }
     }
 
     private void handleInvalidRequest(Status status) {
         if (!serverCall.isCancelled()) {
-            serverCall.close(status, headers);
+            serverCall.close(status, new Metadata());
         }
     }
 }

--- a/api/src/main/java/io/grpc/RequestValidationListener.java
+++ b/api/src/main/java/io/grpc/RequestValidationListener.java
@@ -1,0 +1,54 @@
+package io.grpc;
+
+import com.google.protobuf.MessageLiteOrBuilder;
+
+public class RequestValidationListener<ReqT, ResT> extends ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT> {
+
+    private ServerCall<ReqT, ResT> serverCall;
+    private Metadata headers;
+    private RequestValidatorResolver requestValidatorResolver;
+
+    public RequestValidationListener(
+            ServerCall.Listener<ReqT> delegate,
+            ServerCall<ReqT, ResT> serverCall,
+            Metadata headers,
+            RequestValidatorResolver requestValidatorResolver
+    ) {
+        super(delegate);
+        this.serverCall = serverCall;
+        this.headers = headers;
+        this.requestValidatorResolver = requestValidatorResolver;
+    }
+
+    @Override
+    public void onMessage(ReqT message) {
+        MessageLiteOrBuilder convertMessage = (MessageLiteOrBuilder) message;
+        RequestValidator<MessageLiteOrBuilder> validator = requestValidatorResolver.find(convertMessage.getClass().getTypeName());
+
+        if (validator == null) {
+            super.onMessage(message);
+        } else {
+            try {
+                ValidationResult validationResult = validator.isValid(convertMessage);
+
+                if (validationResult.isValid()) {
+                    super.onMessage(message);
+                } else {
+                    Status status = Status.INVALID_ARGUMENT
+                            .withDescription("invalid argument. " + validationResult.getMessage());
+                    handleInvalidRequest(status);
+                }
+            } catch (Exception e) {
+                Status status = Status.INTERNAL.withDescription(e.getMessage());
+
+                handleInvalidRequest(status);
+            }
+        }
+    }
+
+    private void handleInvalidRequest(Status status) {
+        if (!serverCall.isCancelled()) {
+            serverCall.close(status, headers);
+        }
+    }
+}

--- a/api/src/main/java/io/grpc/RequestValidator.java
+++ b/api/src/main/java/io/grpc/RequestValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The gRPC Authors
+ * Copyright 2022 The gRPC Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/grpc/RequestValidator.java
+++ b/api/src/main/java/io/grpc/RequestValidator.java
@@ -1,7 +1,32 @@
+/*
+ * Copyright 2016 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.grpc;
 
-import com.google.protobuf.MessageLiteOrBuilder;
+abstract class RequestValidator<T> {
 
-interface RequestValidator<T extends MessageLiteOrBuilder> {
-    ValidationResult isValid(T request);
+    private Class<T> targetClass;
+
+    public RequestValidator(Class<T> targetClass) {
+        this.targetClass = targetClass;
+    }
+
+    public Class<T> getTargetClass() {
+        return targetClass;
+    }
+
+    abstract ValidationResult isValid(T request);
 }

--- a/api/src/main/java/io/grpc/RequestValidator.java
+++ b/api/src/main/java/io/grpc/RequestValidator.java
@@ -1,0 +1,7 @@
+package io.grpc;
+
+import com.google.protobuf.MessageLiteOrBuilder;
+
+interface RequestValidator<T extends MessageLiteOrBuilder> {
+    ValidationResult isValid(T request);
+}

--- a/api/src/main/java/io/grpc/RequestValidatorResolver.java
+++ b/api/src/main/java/io/grpc/RequestValidatorResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The gRPC Authors
+ * Copyright 2022 The gRPC Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/grpc/RequestValidatorResolver.java
+++ b/api/src/main/java/io/grpc/RequestValidatorResolver.java
@@ -1,38 +1,36 @@
+/*
+ * Copyright 2016 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.grpc;
 
-import com.google.protobuf.MessageLiteOrBuilder;
-
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 public class RequestValidatorResolver {
 
-    private List<RequestValidator<MessageLiteOrBuilder>> validators;
+    private Map<Class<?>, RequestValidator<?>> validatorMap;
 
-    private Map<String, RequestValidator<MessageLiteOrBuilder>> validatorMap;
-
-    public RequestValidatorResolver(List<RequestValidator<MessageLiteOrBuilder>> validators) {
-        this.validators = validators;
-
+    public RequestValidatorResolver(List<RequestValidator<?>> validators) {
         validatorMap = validators.stream()
-                .collect(Collectors.toMap(this::getClassName, it -> it));
+                .collect(Collectors.toMap(RequestValidator::getTargetClass, it -> it));
     }
 
-    private String getClassName(RequestValidator<MessageLiteOrBuilder> it) {
-        Type[] genericInterfaces = it.getClass().getGenericInterfaces();
-
-        if (genericInterfaces.length == 0) {
-            return null;
-        }
-
-        return ((ParameterizedType) genericInterfaces[0]).getActualTypeArguments()[0].getTypeName();
-    }
-
-    public RequestValidator<MessageLiteOrBuilder> find(String typeName) {
-        return validatorMap.get(typeName);
+    public RequestValidator<?> find(Class<?> targetClass) {
+        return validatorMap.get(targetClass);
     }
 }
 

--- a/api/src/main/java/io/grpc/RequestValidatorResolver.java
+++ b/api/src/main/java/io/grpc/RequestValidatorResolver.java
@@ -1,0 +1,38 @@
+package io.grpc;
+
+import com.google.protobuf.MessageLiteOrBuilder;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class RequestValidatorResolver {
+
+    private List<RequestValidator<MessageLiteOrBuilder>> validators;
+
+    private Map<String, RequestValidator<MessageLiteOrBuilder>> validatorMap;
+
+    public RequestValidatorResolver(List<RequestValidator<MessageLiteOrBuilder>> validators) {
+        this.validators = validators;
+
+        validatorMap = validators.stream()
+                .collect(Collectors.toMap(this::getClassName, it -> it));
+    }
+
+    private String getClassName(RequestValidator<MessageLiteOrBuilder> it) {
+        Type[] genericInterfaces = it.getClass().getGenericInterfaces();
+
+        if (genericInterfaces.length == 0) {
+            return null;
+        }
+
+        return ((ParameterizedType) genericInterfaces[0]).getActualTypeArguments()[0].getTypeName();
+    }
+
+    public RequestValidator<MessageLiteOrBuilder> find(String typeName) {
+        return validatorMap.get(typeName);
+    }
+}
+

--- a/api/src/main/java/io/grpc/ValidationResult.java
+++ b/api/src/main/java/io/grpc/ValidationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The gRPC Authors
+ * Copyright 2022 The gRPC Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/grpc/ValidationResult.java
+++ b/api/src/main/java/io/grpc/ValidationResult.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.grpc;
 
 public class ValidationResult {

--- a/api/src/main/java/io/grpc/ValidationResult.java
+++ b/api/src/main/java/io/grpc/ValidationResult.java
@@ -1,0 +1,21 @@
+package io.grpc;
+
+public class ValidationResult {
+
+    private boolean isValid;
+
+    private String message;
+
+    public ValidationResult(boolean isValid, String message) {
+        this.isValid = isValid;
+        this.message = message;
+    }
+
+    public boolean isValid() {
+        return isValid;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}


### PR DESCRIPTION
## Motivation
validation of grpc requests is inconvenient

```kotlin
class HelloRequestGrpcService : HelloServiceGrpcKt.HelloServiceCoroutineImplBase() {
    override suspend fun hello(request: HelloRequest): HelloResponse {
        if(request.message != "valid request") {
            throw StatusRuntimeException…
        }
 
        return super.hello(request)
    }
}
// If implement a validator interceptor I think the source can be cleaned up.

class HelloRequestGrpcService : HelloServiceGrpcKt.HelloServiceCoroutineImplBase() {
    override suspend fun hello(request: HelloRequest): HelloResponse { 
        return super.hello(request)
    }
}
```
## Modifications
add grpc request validator
add grpc request validation interceptor
## Result
You just need to implement a validator suitable for the request type.

if you are thinking of approving this or, tell me add test code.
Any other suggestions are welcome.



## Question
why fail compileJava ?
It works file on my computer 