### PR TITLE
Fix for ipv6 link local with scope

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpProtocolNegotiator.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpProtocolNegotiator.java
@@ -252,7 +252,7 @@ class OkHttpProtocolNegotiator {
             SET_SERVER_NAMES
                 .invoke(sslParams, Collections.singletonList(
                   SNI_HOST_NAME.newInstance((Object) hostname.getBytes(Charsets.UTF_8)))
-                );
+            );
           } else {
             SET_HOSTNAME.invokeOptionalWithoutCheckedException(sslSocket, hostname);
           }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpProtocolNegotiator.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpProtocolNegotiator.java
@@ -194,7 +194,7 @@ class OkHttpProtocolNegotiator {
       try {
         setServerNamesMethod = SSLParameters.class.getMethod("setServerNames", List.class);
         sniHostNameConstructor =
-            Class.forName("javax.net.ssl.SNIHostName").getConstructor(String.class);
+            Class.forName("javax.net.ssl.SNIHostName").getConstructor(byte[].class);
       } catch (ClassNotFoundException e) {
         logger.log(Level.FINER, "Failed to find Android 7.0+ APIs", e);
       } catch (NoSuchMethodException e) {
@@ -249,7 +249,7 @@ class OkHttpProtocolNegotiator {
           }
           if (SET_SERVER_NAMES != null && SNI_HOST_NAME != null) {
             SET_SERVER_NAMES
-                .invoke(sslParams, Collections.singletonList(SNI_HOST_NAME.newInstance(hostname)));
+                .invoke(sslParams, Collections.singletonList(SNI_HOST_NAME.newInstance((Object) hostname.getBytes())));
           } else {
             SET_HOSTNAME.invokeOptionalWithoutCheckedException(sslSocket, hostname);
           }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpProtocolNegotiator.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpProtocolNegotiator.java
@@ -30,6 +30,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -249,7 +250,7 @@ class OkHttpProtocolNegotiator {
           }
           if (SET_SERVER_NAMES != null && SNI_HOST_NAME != null) {
             SET_SERVER_NAMES
-                .invoke(sslParams, Collections.singletonList(SNI_HOST_NAME.newInstance((Object) hostname.getBytes())));
+                .invoke(sslParams, Collections.singletonList(SNI_HOST_NAME.newInstance((Object) hostname.getBytes(StandardCharsets.UTF_8))));
           } else {
             SET_HOSTNAME.invokeOptionalWithoutCheckedException(sslSocket, hostname);
           }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpProtocolNegotiator.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpProtocolNegotiator.java
@@ -30,7 +30,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.Socket;
-import java.nio.charset.StandardCharsets;
+import com.google.common.base.Charsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -250,7 +250,7 @@ class OkHttpProtocolNegotiator {
           }
           if (SET_SERVER_NAMES != null && SNI_HOST_NAME != null) {
             SET_SERVER_NAMES
-                .invoke(sslParams, Collections.singletonList(SNI_HOST_NAME.newInstance((Object) hostname.getBytes(StandardCharsets.UTF_8))));
+                .invoke(sslParams, Collections.singletonList(SNI_HOST_NAME.newInstance((Object) hostname.getBytes(Charsets.UTF_8))));
           } else {
             SET_HOSTNAME.invokeOptionalWithoutCheckedException(sslSocket, hostname);
           }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpProtocolNegotiator.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpProtocolNegotiator.java
@@ -19,6 +19,7 @@ package io.grpc.okhttp;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Charsets;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.okhttp.internal.OptionalMethod;
 import io.grpc.okhttp.internal.Platform;
@@ -30,7 +31,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.Socket;
-import com.google.common.base.Charsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -250,7 +250,9 @@ class OkHttpProtocolNegotiator {
           }
           if (SET_SERVER_NAMES != null && SNI_HOST_NAME != null) {
             SET_SERVER_NAMES
-                .invoke(sslParams, Collections.singletonList(SNI_HOST_NAME.newInstance((Object) hostname.getBytes(Charsets.UTF_8))));
+                .invoke(sslParams, Collections.singletonList(
+                  SNI_HOST_NAME.newInstance((Object) hostname.getBytes(Charsets.UTF_8)))
+                );
           } else {
             SET_HOSTNAME.invokeOptionalWithoutCheckedException(sslSocket, hostname);
           }


### PR DESCRIPTION
Fix for ipv6 link local with scope. If you try to connect passing address like "ipv6%wlan0" it will use 

```
public SNIHostName(String hostname) {
        super(0, (hostname = IDN.toASCII((String)Objects.requireNonNull(hostname, "Server name value of host_name cannot be null"), 2)).getBytes(StandardCharsets.US_ASCII));
        this.hostname = hostname;
        this.checkHostName();
    }
```

Which raises hostname is not valid because this method doesn't accept non ASCII characters. With the change it will use 

```
public SNIHostName(byte[] encoded) {
        super(0, encoded);

        try {
            CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder().onMalformedInput(CodingErrorAction.REPORT).onUnmappableCharacter(CodingErrorAction.REPORT);
            this.hostname = IDN.toASCII(decoder.decode(ByteBuffer.wrap(encoded)).toString());
        } catch (CharacterCodingException | RuntimeException var3) {
            throw new IllegalArgumentException("The encoded server name value is invalid", var3);
        }

        this.checkHostName();
    }
```
Now scoped ipv6 link is supported. 😄 
