### PR TITLE
buildscripts: double Java memory allocation pool

### DIFF
--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -39,7 +39,7 @@ GRADLE_FLAGS+=" -PfailOnWarnings=true"
 GRADLE_FLAGS+=" -PerrorProne=true"
 GRADLE_FLAGS+=" -PskipAndroid=true"
 GRADLE_FLAGS+=" -Dorg.gradle.parallel=true"
-export GRADLE_OPTS="-Xmx512m"
+export GRADLE_OPTS="-Xmx1g"
 
 # Make protobuf discoverable by :grpc-compiler
 export LD_LIBRARY_PATH=/tmp/protobuf/lib


### PR DESCRIPTION
To reduce periodic OOMs of the "GitHub Actions Linux Testing / tests (11) (pull_request)" job.