### PR TITLE
Use Gradle's task configuration avoidance APIs

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     api subprojects.minus([project(':grpc-protobuf-lite')])
 }
 
-javadoc {
+tasks.named("javadoc").configure {
     classpath = files(subprojects.collect { subproject ->
         subproject.javadoc.classpath
     })
@@ -49,7 +49,7 @@ javadoc {
     }
 }
 
-task jacocoMerge(type: JacocoMerge) {
+tasks.register("jacocoMerge", JacocoMerge) {
     dependsOn(subprojects.jacocoTestReport.dependsOn)
     dependsOn(project(':grpc-interop-testing').jacocoTestReport.dependsOn)
     mustRunAfter(subprojects.jacocoTestReport.mustRunAfter)
@@ -60,7 +60,7 @@ task jacocoMerge(type: JacocoMerge) {
             .filter { f -> f.exists() }
 }
 
-jacocoTestReport {
+tasks.named("jacocoTestReport").configure {
     dependsOn(jacocoMerge)
     reports {
         xml.required = true
@@ -78,4 +78,4 @@ coveralls {
     sourceDirs = subprojects.sourceSets.main.allSource.srcDirs.flatten()
 }
 
-tasks.coveralls { dependsOn(jacocoTestReport) }
+tasks.named("coveralls").configure { dependsOn tasks.named("jacocoTestReport") }

--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -52,28 +52,28 @@ configureProtoCompilation()
 
 import net.ltgt.gradle.errorprone.CheckSeverity
 
-[compileJava, compileTestJava].each() {
+[tasks.named("compileJava"), tasks.named("compileTestJava")]*.configure {
     // protobuf calls valueof. Will be fixed in next release (google/protobuf#4046)
-    it.options.compilerArgs += [
+    options.compilerArgs += [
         "-Xlint:-deprecation"
     ]
     // ALTS returns a lot of futures that we mostly don't care about.
-    it.options.errorprone.check("FutureReturnValueIgnored", CheckSeverity.OFF)
+    options.errorprone.check("FutureReturnValueIgnored", CheckSeverity.OFF)
 }
 
-javadoc {
+tasks.named("javadoc").configure {
     exclude 'io/grpc/alts/internal/**'
     exclude 'io/grpc/alts/Internal*'
 }
 
-jar {
+tasks.named("jar").configure {
     // Must use a different archiveClassifier to avoid conflicting with shadowJar
     archiveClassifier = 'original'
 }
 
 // We want to use grpc-netty-shaded instead of grpc-netty. But we also want our
 // source to work with Bazel, so we rewrite the code as part of the build.
-shadowJar {
+tasks.named("shadowJar").configure {
     archiveClassifier = null
     dependencies {
         exclude(dependency {true})

--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -101,7 +101,7 @@ project.tasks['check'].dependsOn checkStyleMain, checkStyleTest
 
 import net.ltgt.gradle.errorprone.CheckSeverity
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     options.compilerArgs += [
             "-Xlint:-cast"
     ]

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     testImplementation libraries.truth
 }
 
-task javadocs(type: Javadoc) {
+tasks.register("javadocs", Javadoc) {
     source = android.sourceSets.main.java.srcDirs
     classpath += files(android.getBootClasspath())
     classpath += files({
@@ -58,12 +58,13 @@ task javadocs(type: Javadoc) {
     }
 }
 
-task javadocJar(type: Jar, dependsOn: javadocs) {
+tasks.register("javadocJar", Jar) {
+    dependsOn javadocs
     archiveClassifier = 'javadoc'
     from javadocs.destinationDir
 }
 
-task sourcesJar(type: Jar) {
+tasks.register("sourcesJar", Jar) {
     archiveClassifier = 'sources'
     from android.sourceSets.main.java.srcDirs
 }

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }
 
-javadoc {
+tasks.named("javadoc").configure {
     // We want io.grpc.Internal, but not io.grpc.Internal*
     exclude 'io/grpc/Internal?*.java'
 }

--- a/authz/build.gradle
+++ b/authz/build.gradle
@@ -29,17 +29,17 @@ dependencies {
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
 }
 
-jar {
+tasks.named("jar").configure {
     classifier = 'original'
 }
 
 // TODO(ashithasantosh): Remove javadoc exclusion on adding authorization
 // interceptor implementations.
-javadoc {
+tasks.named("javadoc").configure {
     exclude "io/grpc/authz/*"
 }
 
-shadowJar {
+tasks.named("shadowJar").configure {
     classifier = null
     dependencies {
         exclude(dependency {true})
@@ -74,4 +74,6 @@ publishing {
     }
 }
 
-publishMavenPublicationToMavenRepository.enabled = false
+tasks.named("publishMavenPublicationToMavenRepository").configure {
+    enabled = false
+}

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -9,10 +9,7 @@ plugins {
 
 description = "grpc Benchmarks"
 
-startScripts.enabled = false
-run.enabled = false
-
-jmh {
+tasks.named("jmh").configure {
     jvmArgs = ["-server", "-Xms2g", "-Xmx2g"]
 }
 
@@ -46,7 +43,7 @@ dependencies {
 
 import net.ltgt.gradle.errorprone.CheckSeverity
 
-compileJava {
+tasks.named("compileJava").configure {
     // The Control.Void protobuf clashes
     options.errorprone.check("JavaLangClash", CheckSeverity.OFF)
 }
@@ -60,7 +57,15 @@ def vmArgs = [
     "-XX:+PrintGCDetails"
 ]
 
-task qps_client(type: CreateStartScripts) {
+tasks.named("startScripts").configure {
+    enabled = false
+}
+
+tasks.named("run").configure {
+    enabled = false
+}
+
+def qps_client = tasks.register("qps_client", CreateStartScripts) {
     mainClass = "io.grpc.benchmarks.qps.AsyncClient"
     applicationName = "qps_client"
     defaultJvmOpts = vmArgs
@@ -68,7 +73,7 @@ task qps_client(type: CreateStartScripts) {
     classpath = startScripts.classpath
 }
 
-task openloop_client(type: CreateStartScripts) {
+def openloop_client = tasks.register("openloop_client", CreateStartScripts) {
     mainClass = "io.grpc.benchmarks.qps.OpenLoopClient"
     applicationName = "openloop_client"
     defaultJvmOpts = vmArgs
@@ -76,14 +81,14 @@ task openloop_client(type: CreateStartScripts) {
     classpath = startScripts.classpath
 }
 
-task qps_server(type: CreateStartScripts) {
+def qps_server = tasks.register("qps_server", CreateStartScripts) {
     mainClass = "io.grpc.benchmarks.qps.AsyncServer"
     applicationName = "qps_server"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
 }
 
-task benchmark_worker(type: CreateStartScripts) {
+def benchmark_worker = tasks.register("benchmark_worker", CreateStartScripts) {
     mainClass = "io.grpc.benchmarks.driver.LoadWorker"
     applicationName = "benchmark_worker"
     defaultJvmOpts = vmArgs

--- a/binder/build.gradle
+++ b/binder/build.gradle
@@ -85,7 +85,7 @@ dependencies {
 
 import net.ltgt.gradle.errorprone.CheckSeverity
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     options.compilerArgs += [
             "-Xlint:-cast"
     ]
@@ -94,7 +94,7 @@ tasks.withType(JavaCompile) {
     options.errorprone.check("UnnecessaryAnonymousClass", CheckSeverity.OFF)
 }
 
-task javadocs(type: Javadoc) {
+tasks.register("javadocs", Javadoc) {
     source = android.sourceSets.main.java.srcDirs
     classpath += files(android.getBootClasspath())
     classpath += files({
@@ -110,12 +110,13 @@ task javadocs(type: Javadoc) {
     }
 }
 
-task javadocJar(type: Jar, dependsOn: javadocs) {
+tasks.register("javadocJar", Jar) {
+    dependsOn javadocs
     archiveClassifier = 'javadoc'
     from javadocs.destinationDir
 }
 
-task sourcesJar(type: Jar) {
+tasks.register("sourcesJar", Jar) {
     archiveClassifier = 'sources'
     from android.sourceSets.main.java.srcDirs
 }

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ subprojects {
         mavenLocal()
     }
 
-    tasks.withType(JavaCompile) {
+    tasks.withType(JavaCompile).configureEach {
         it.options.compilerArgs += [
             "-Xlint:all",
             "-Xlint:-options",
@@ -42,7 +42,7 @@ subprojects {
         }
     }
 
-    tasks.withType(GenerateModuleMetadata) {
+    tasks.withType(GenerateModuleMetadata).configureEach {
         // Module metadata, introduced in Gradle 6.0, conflicts with our publishing task for
         // grpc-alts and grpc-compiler.
         enabled = false
@@ -82,7 +82,7 @@ subprojects {
             if (rootProject.childProjects.containsKey('grpc-compiler')) {
                 // Only when the codegen is built along with the project, will we be able to run
                 // the grpc code generator.
-                task syncGeneratedSources { }
+                def syncGeneratedSources = tasks.register("syncGeneratedSources") { }
                 project.protobuf {
                     plugins { grpc { path = javaPluginPath } }
                     generateProtoTasks {
@@ -97,16 +97,20 @@ subprojects {
                                 }
                                 dependsOn "generate${source}Proto"
                             }
-                            syncGeneratedSources.dependsOn syncTask
+                            syncGeneratedSources.configure {
+                                dependsOn syncTask
+                            }
 
-                            task.dependsOn ':grpc-compiler:java_pluginExecutable'
-                            // Recompile protos when the codegen has been changed
-                            task.inputs.file javaPluginPath
-                            task.plugins { grpc { option 'noversion' } }
-                            if (isAndroid) {
-                                task.plugins {
-                                    grpc {
-                                        option 'lite'
+                            task.configure {
+                                dependsOn ':grpc-compiler:java_pluginExecutable'
+                                // Recompile protos when the codegen has been changed
+                                inputs.file javaPluginPath
+                                plugins { grpc { option 'noversion' } }
+                                if (isAndroid) {
+                                    plugins {
+                                        grpc {
+                                            option 'lite'
+                                        }
                                     }
                                 }
                             }
@@ -114,7 +118,9 @@ subprojects {
                     }
                 }
                 // Re-sync as part of a normal build, to avoid forgetting to run the sync
-                assemble.dependsOn syncGeneratedSources
+                tasks.named("assemble").configure {
+                    dependsOn syncGeneratedSources
+                }
             } else {
                 // Otherwise, we just use the checked-in generated code.
                 if (isAndroid) {
@@ -129,7 +135,7 @@ subprojects {
                 }
             }
 
-            tasks.withType(JavaCompile) {
+            tasks.withType(JavaCompile).configureEach {
                 appendToProperty(
                     it.options.errorprone.excludedPaths,
                     ".*/src/generated/[^/]+/java/.*" +
@@ -152,7 +158,7 @@ subprojects {
     // Disable JavaDoc doclint on Java 8. It's annoying.
     if (JavaVersion.current().isJava8Compatible()) {
         allprojects {
-            tasks.withType(Javadoc) {
+            tasks.withType(Javadoc).configureEach {
                 options.addStringOption('Xdoclint:none', '-quiet')
             }
         }
@@ -174,7 +180,7 @@ subprojects {
         }
     } else {
         // Disable Error Prone
-        tasks.withType(JavaCompile) {
+        tasks.withType(JavaCompile).configureEach {
             options.errorprone.enabled = false
         }
     }
@@ -189,36 +195,40 @@ subprojects {
                     libraries.truth
         }
 
-        compileTestJava {
+        tasks.named("compileTestJava").configure {
             // serialVersionUID is basically guaranteed to be useless in our tests
             options.compilerArgs += [
                 "-Xlint:-serial"
             ]
         }
 
-        jar.manifest {
-            attributes('Implementation-Title': name,
-            'Implementation-Version': version)
+        tasks.named("jar").configure {
+            manifest {
+                attributes('Implementation-Title': name,
+                        'Implementation-Version': project.version)
+            }
         }
 
-        javadoc.options {
-            encoding = 'UTF-8'
-            use = true
-            links 'https://docs.oracle.com/javase/8/docs/api/'
-            source = "8"
+        tasks.named("javadoc").configure {
+            options {
+                encoding = 'UTF-8'
+                use = true
+                links 'https://docs.oracle.com/javase/8/docs/api/'
+                source = "8"
+            }
         }
 
-        checkstyleMain {
+        tasks.named("checkstyleMain").configure {
             source = fileTree(dir: "$projectDir/src/main", include: "**/*.java")
         }
 
-        checkstyleTest {
+        tasks.named("checkstyleTest").configure {
             source = fileTree(dir: "$projectDir/src/test", include: "**/*.java")
         }
 
         // At a test failure, log the stack trace to the console so that we don't
         // have to open the HTML in a browser.
-        test {
+        tasks.named("test").configure {
             testLogging {
                 exceptionFormat = 'full'
                 showExceptions true
@@ -234,7 +244,7 @@ subprojects {
             }
         }
 
-        compileJava {
+        tasks.named("compileJava").configure {
             // This project targets Java 7 (no method references)
             options.errorprone.check("UnnecessaryAnonymousClass", CheckSeverity.OFF)
             // This project targets Java 7 (no time.Duration class)
@@ -243,7 +253,7 @@ subprojects {
             // The warning fails to provide a source location
             options.errorprone.check("MissingSummary", CheckSeverity.OFF)
         }
-        compileTestJava {
+        tasks.named("compileTestJava").configure {
             // LinkedList doesn't hurt much in tests and has lots of usages
             options.errorprone.check("JdkObsolete", CheckSeverity.OFF)
             options.errorprone.check("UnnecessaryAnonymousClass", CheckSeverity.OFF)
@@ -267,7 +277,7 @@ subprojects {
                 requireUpperBoundDepsMatch(configurations.runtimeClasspath, project)
             }
         }
-        tasks.named('compileJava') {
+        tasks.named('compileJava').configure {
             dependsOn checkUpperBoundDeps
         }
     }
@@ -275,11 +285,11 @@ subprojects {
     plugins.withId("me.champeau.jmh") {
         // invoke jmh on a single benchmark class like so:
         //   ./gradlew -PjmhIncludeSingleClass=StatsTraceContextBenchmark clean :grpc-core:jmh
-	compileJmhJava {
+	tasks.named("compileJmhJava").configure {
 	    sourceCompatibility = 1.8
 	    targetCompatibility = 1.8
 	}
-        jmh {
+        tasks.named("jmh").configure {
             warmupIterations = 10
             iterations = 10
             fork = 1
@@ -296,7 +306,7 @@ subprojects {
     }
 
     plugins.withId("com.github.johnrengelman.shadow") {
-        tasks.named("shadowJar") {
+        tasks.named("shadowJar").configure {
             // Do a dance to remove Class-Path. This needs to run after the doFirst() from the
             // shadow plugin that adds Class-Path and before the core jar action. Using doFirst will
             // have this run before the shadow plugin, and doLast will run after the core jar
@@ -442,7 +452,8 @@ subprojects {
         }
 
         // Add a japicmp task that compares the current .jar with baseline .jar
-        task japicmp(type: me.champeau.gradle.japicmp.JapicmpTask, dependsOn: jar) {
+        tasks.register("japicmp", me.champeau.gradle.japicmp.JapicmpTask) {
+            dependsOn jar
             oldClasspath = files(baselineArtifact)
             newClasspath = files(jar.archivePath)
             onlyBinaryIncompatibleModified = false

--- a/census/build.gradle
+++ b/census/build.gradle
@@ -20,7 +20,7 @@ dependencies {
             libraries.opencensus.impl
 }
 
-javadoc {
+tasks.named("javadoc").configure {
     failOnError false  // no public or protected classes found to document
     exclude 'io/grpc/census/internal/**'
     exclude 'io/grpc/census/Internal*'

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -152,11 +152,11 @@ sourceSets {
     }
 }
 
-compileTestJava {
+tasks.named("compileTestJava").configure {
     options.errorprone.excludedPaths = ".*/build/generated/source/proto/.*"
 }
 
-compileTestLiteJava {
+tasks.named("compileTestLiteJava").configure {
     options.compilerArgs = compileTestJava.options.compilerArgs
     options.compilerArgs += [
         "-Xlint:-cast"
@@ -177,16 +177,24 @@ protobuf {
     }
     generateProtoTasks {
         all().each { task ->
-            task.dependsOn 'java_pluginExecutable'
-            task.inputs.file javaPluginPath
-        }
-        ofSourceSet('test')*.plugins { grpc {} }
-        ofSourceSet('testLite')*.each { task ->
-            task.builtins {
-                java { option 'lite' }
+            task.configure {
+                dependsOn 'java_pluginExecutable'
+                inputs.file javaPluginPath
             }
-            task.plugins {
-                grpc { option 'lite' }
+        }
+        ofSourceSet('test').each { task ->
+            task.configure {
+                plugins { grpc {} }
+            }
+        }
+        ofSourceSet('testLite').each { task ->
+            task.configure {
+                builtins {
+                    java { option 'lite' }
+                }
+                plugins {
+                    grpc { option 'lite' }
+                }
             }
         }
     }
@@ -195,7 +203,7 @@ protobuf {
 println "*** Building codegen requires Protobuf version ${libs.versions.protobuf.get()}"
 println "*** Please refer to https://github.com/grpc/grpc-java/blob/master/COMPILING.md#how-to-build-code-generation-plugin"
 
-task buildArtifacts(type: Copy) {
+tasks.register("buildArtifacts", Copy) {
     dependsOn 'java_pluginExecutable'
     from("$buildDir/exe") {
         if (osdetector.os != 'windows') {
@@ -207,7 +215,7 @@ task buildArtifacts(type: Copy) {
 
 archivesBaseName = "$protocPluginBaseName"
 
-task checkArtifacts {
+def checkArtifacts = tasks.register("checkArtifacts") {
     dependsOn buildArtifacts
     doLast {
         if (!usingVisualCpp) {
@@ -290,11 +298,15 @@ def configureTestTask(Task task, String dep, String extraPackage, String service
             "$projectDir/src/test${dep}/golden/${serviceName}.java.txt"
 }
 
-task testGolden(type: Exec)
-task testLiteGolden(type: Exec)
-task testDeprecatedGolden(type: Exec)
-task testDeprecatedLiteGolden(type: Exec)
-configureTestTask(testGolden, '', '', 'TestService')
-configureTestTask(testLiteGolden, 'Lite', '', 'TestService')
-configureTestTask(testDeprecatedGolden, '', '', 'TestDeprecatedService')
-configureTestTask(testDeprecatedLiteGolden, 'Lite', '', 'TestDeprecatedService')
+tasks.register("testGolden", Exec) {
+    configureTestTask(it, '', '', 'TestService')
+}
+tasks.register("testLiteGolden", Exec) {
+    configureTestTask(it, 'Lite', '', 'TestService')
+}
+tasks.register("testDeprecatedGolden", Exec) {
+    configureTestTask(it, '', '', 'TestDeprecatedService')
+}
+tasks.register("testDeprecatedLiteGolden", Exec) {
+    configureTestTask(it, 'Lite', '', 'TestDeprecatedService')
+}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }
 
-javadoc {
+tasks.named("javadoc").configure {
     exclude 'io/grpc/internal/**'
     exclude 'io/grpc/inprocess/Internal*'
     // Disabled until kinda stable.
@@ -87,7 +87,7 @@ def replaceConstant(File file, String needle, String replacement) {
 }
 
 plugins.withId("java") {
-    compileJava {
+    tasks.named("compileJava").configure {
         doLast {
             // Replace value of Signature Attribute.
             // https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.7.9
@@ -109,13 +109,13 @@ plugins.withId("java") {
         }
     }
 
-    compileJmhJava {
+    tasks.named("compileJmhJava").configure {
         // This project targets Java 7 (no method references)
         options.errorprone.check("UnnecessaryAnonymousClass", CheckSeverity.OFF)
     }
 }
 
-task versionFile() {
+tasks.register("versionFile") {
     doLast {
         new File(buildDir, "version").write("${project.version}\n")
     }

--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     runtimeOnly libraries.netty.tcnative, libraries.netty.tcnative.classes
 }
 
-compileJava {
+tasks.named("compileJava").configure {
     // Disable "No processor claimed any of these annotations: org.junit.Ignore"
     options.compilerArgs += ["-Xlint:-processing"]
 }
@@ -118,7 +118,8 @@ String getAppUrl(String project, String service, String version) {
     return "http://${version}.${service}.${project}.appspot.com"
 }
 
-task runInteropTestRemote(dependsOn: 'appengineDeploy') {
+tasks.register("runInteropTestRemote") {
+    dependsOn appengineDeploy
     doLast {
         // give remote app some time to settle down
         sleep(20000)

--- a/gcp-observability/build.gradle
+++ b/gcp-observability/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 description = "gRPC: Google Cloud Platform Observability"
 
-[compileJava].each() {
+tasks.named("compileJava").configure {
     it.options.compilerArgs += [
             // only has AutoValue annotation processor
             "-Xlint:-processing"

--- a/grpclb/build.gradle
+++ b/grpclb/build.gradle
@@ -25,11 +25,11 @@ dependencies {
 
 configureProtoCompilation()
 
-javadoc {
+tasks.named("javadoc").configure {
     exclude 'io/grpc/grpclb/Internal*'
 }
 
-jacocoTestReport {
+tasks.named("jacocoTestReport").configure {
     classDirectories.from = sourceSets.main.output.collect {
         fileTree(dir: it,
         exclude: [

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -8,9 +8,6 @@ plugins {
 }
 
 description = "gRPC: Integration Testing"
-startShadowScripts.enabled = false
-installDist.dependsOn(installShadowDist)
-installDist.enabled = false
 
 configurations {
     alpnagent
@@ -63,17 +60,17 @@ configureProtoCompilation()
 
 import net.ltgt.gradle.errorprone.CheckSeverity
 
-compileJava {
+tasks.named("compileJava").configure {
     // This isn't a library; it can use beta APIs
     options.errorprone.check("BetaApi", CheckSeverity.OFF)
 }
-jar {
+tasks.named("jar").configure {
     // Must use a different archiveClassifier to avoid conflicting with shadowJar
     archiveClassifier = 'original'
 }
 
 def xdsPrefixName = 'io.grpc.xds'
-shadowJar {
+tasks.named("shadowJar").configure {
     archiveClassifier = null
     dependencies {
         exclude(dependency {true})
@@ -81,94 +78,104 @@ shadowJar {
     relocate 'com.github.xds', "${xdsPrefixName}.shaded.com.github.xds"
 }
 
-test {
+tasks.named("test").configure {
     // For the automated tests, use Jetty ALPN.
     jvmArgs "-javaagent:" + configurations.alpnagent.asPath
+}
+
+tasks.named("startShadowScripts").configure {
+    enabled = false
+}
+tasks.named("installDist").configure {
+    dependsOn installShadowDist
+    enabled = false
 }
 
 // For the generated scripts, use Netty tcnative (i.e. OpenSSL).
 // Note that OkHttp currently only supports ALPN, so OpenSSL version >= 1.0.2 is required.
 
-var startScriptsClasspath = shadowJar.outputs.files + configurations.shadow
+def startScriptsClasspath = provider {
+    shadowJar.outputs.files + configurations.shadow
+}
 
-task test_client(type: CreateStartScripts) {
+def test_client = tasks.register("test_client", CreateStartScripts) {
     mainClass = "io.grpc.testing.integration.TestServiceClient"
     applicationName = "test-client"
     defaultJvmOpts = [
         "-javaagent:JAVAAGENT_APP_HOME" + configurations.alpnagent.singleFile.name
     ]
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
-    classpath = startScriptsClasspath
+    classpath = startScriptsClasspath.get()
     doLast {
         unixScript.text = unixScript.text.replace('JAVAAGENT_APP_HOME', '\'"\$APP_HOME"\'/lib/')
         windowsScript.text = windowsScript.text.replace('JAVAAGENT_APP_HOME', '%APP_HOME%\\lib\\')
     }
 }
 
-task test_server(type: CreateStartScripts) {
+def test_server = tasks.register("test_server", CreateStartScripts) {
     mainClass = "io.grpc.testing.integration.TestServiceServer"
     applicationName = "test-server"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
-    classpath = startScriptsClasspath
+    classpath = startScriptsClasspath.get()
 }
 
-task reconnect_test_client(type: CreateStartScripts) {
+def reconnect_test_client = tasks.register("reconnect_test_client", CreateStartScripts) {
     mainClass = "io.grpc.testing.integration.ReconnectTestClient"
     applicationName = "reconnect-test-client"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
-    classpath = startScriptsClasspath
+    classpath = startScriptsClasspath.get()
 }
 
-task stresstest_client(type: CreateStartScripts) {
+def stresstest_client = tasks.register("stresstest_client", CreateStartScripts) {
     mainClass = "io.grpc.testing.integration.StressTestClient"
     applicationName = "stresstest-client"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
-    classpath = startScriptsClasspath
+    classpath = startScriptsClasspath.get()
     defaultJvmOpts = [
         "-verbose:gc",
         "-XX:+PrintFlagsFinal"
     ]
 }
 
-task http2_client(type: CreateStartScripts) {
+def http2_client = tasks.register("http2_client", CreateStartScripts) {
     mainClass = "io.grpc.testing.integration.Http2Client"
     applicationName = "http2-client"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
-    classpath = startScriptsClasspath
+    classpath = startScriptsClasspath.get()
 }
 
-task grpclb_long_lived_affinity_test_client(type: CreateStartScripts) {
+def grpclb_long_lived_affinity_test_client = tasks.register("grpclb_long_lived_affinity_test_client", CreateStartScripts) {
     mainClass = "io.grpc.testing.integration.GrpclbLongLivedAffinityTestClient"
     applicationName = "grpclb-long-lived-affinity-test-client"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
-    classpath = startScriptsClasspath
+    classpath = startScriptsClasspath.get()
     defaultJvmOpts = [
         "-Dio.grpc.internal.DnsNameResolverProvider.enable_service_config=true"
     ]
 }
 
-task grpclb_fallback_test_client (type: CreateStartScripts) {
+def grpclb_fallback_test_client = tasks.register("grpclb_fallback_test_client", CreateStartScripts) {
     mainClass = "io.grpc.testing.integration.GrpclbFallbackTestClient"
     applicationName = "grpclb-fallback-test-client"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
-    classpath = startScriptsClasspath
+    classpath = startScriptsClasspath.get()
     defaultJvmOpts = [
         "-Dio.grpc.internal.DnsNameResolverProvider.enable_service_config=true"
     ]
 }
 
-task xds_test_client(type: CreateStartScripts) {
+def xds_test_client = tasks.register("xds_test_client", CreateStartScripts) {
     mainClass = "io.grpc.testing.integration.XdsTestClient"
     applicationName = "xds-test-client"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
-    classpath = startScriptsClasspath
+    classpath = startScriptsClasspath.get()
 }
 
-task xds_test_server(type: CreateStartScripts) {
+def xds_test_server = tasks.register("xds_test_server", CreateStartScripts) {
     mainClass = "io.grpc.testing.integration.XdsTestServer"
     applicationName = "xds-test-server"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
-    classpath = startScriptsClasspath
+    classpath = startScriptsClasspath.get()
 }
 
 distributions.shadow.contents.into("bin") {

--- a/istio-interop-testing/build.gradle
+++ b/istio-interop-testing/build.gradle
@@ -47,7 +47,7 @@ configureProtoCompilation()
 
 import net.ltgt.gradle.errorprone.CheckSeverity
 
-compileJava {
+tasks.named("compileJava").configure {
     // This isn't a library; it can use beta APIs
     options.errorprone.check("BetaApi", CheckSeverity.OFF)
 }

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -69,12 +69,12 @@ dependencies {
 
 import net.ltgt.gradle.errorprone.CheckSeverity
 
-[compileJava, compileTestJava].each() {
+[tasks.named("compileJava"), tasks.named("compileTestJava")]*.configure {
     // Netty retuns a lot of futures that we mostly don't care about.
-    it.options.errorprone.check("FutureReturnValueIgnored", CheckSeverity.OFF)
+    options.errorprone.check("FutureReturnValueIgnored", CheckSeverity.OFF)
 }
 
-javadoc {
+tasks.named("javadoc").configure {
     options.links 'http://netty.io/4.1/api/'
     exclude 'io/grpc/netty/Internal*'
 }
@@ -83,17 +83,17 @@ project.sourceSets {
     main { java { srcDir "${projectDir}/third_party/netty/java" } }
 }
 
-test {
+tasks.named("test").configure {
     // Allow testing Jetty ALPN in TlsTest
     jvmArgs "-javaagent:" + configurations.alpnagent.asPath
 }
 
-jmh {
+tasks.named("jmh").configure {
     // Workaround
     // https://github.com/melix/jmh-gradle-plugin/issues/97#issuecomment-316664026
     includeTests = true
 }
 
-checkstyleMain {
+tasks.named("checkstyleMain").configure {
     source = source.minus(fileTree(dir: "src/main", include: "**/Http2ControlFrameLimitEncoder.java"))
 }

--- a/netty/shaded/build.gradle
+++ b/netty/shaded/build.gradle
@@ -63,12 +63,12 @@ dependencies {
     }
 }
 
-jar {
+tasks.named("jar").configure {
     // Must use a different archiveClassifier to avoid conflicting with shadowJar
     archiveClassifier = 'original'
 }
 
-shadowJar {
+tasks.named("shadowJar").configure {
     archiveClassifier = null
     dependencies {
         include(project(':grpc-netty'))
@@ -120,14 +120,18 @@ publishing {
     }
 }
 
-task testShadow(type: Test) {
+tasks.register("testShadow", Test) {
     testClassesDirs = sourceSets.testShadow.output.classesDirs
     classpath = sourceSets.testShadow.runtimeClasspath
 }
-compileTestShadowJava.options.compilerArgs = compileTestJava.options.compilerArgs
-compileTestShadowJava.options.encoding = compileTestJava.options.encoding
+tasks.named("compileTestShadowJava").configure {
+    options.compilerArgs = compileTestJava.options.compilerArgs
+    options.encoding = compileTestJava.options.encoding
+}
 
-test.dependsOn testShadow
+tasks.named("test").configure {
+    dependsOn tasks.named("testShadow")
+}
 
 /**
  * A Transformer which updates the Netty JAR META-INF/ resources to accurately

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -32,15 +32,17 @@ project.sourceSets {
     test { java { srcDir "${projectDir}/third_party/okhttp/test/java" } }
 }
 
-checkstyleMain.exclude '**/io/grpc/okhttp/internal/**'
+tasks.named("checkstyleMain").configure {
+    exclude '**/io/grpc/okhttp/internal/**'
+}
 
-javadoc {
+tasks.named("javadoc").configure {
     options.links 'http://square.github.io/okhttp/2.x/okhttp/'
     exclude 'io/grpc/okhttp/Internal*'
     exclude 'io/grpc/okhttp/internal/**'
 }
 
-jacocoTestReport {
+tasks.named("jacocoTestReport").configure {
     classDirectories.from = sourceSets.main.output.collect {
         fileTree(dir: it,
         exclude: [

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }
 
-compileTestJava {
+tasks.named("compileTestJava").configure {
     options.compilerArgs += [
         "-Xlint:-cast"
     ]

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -28,4 +28,6 @@ dependencies {
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
 }
 
-javadoc.options.links 'https://developers.google.com/protocol-buffers/docs/reference/java/'
+tasks.named("javadoc").configure {
+    options.links 'https://developers.google.com/protocol-buffers/docs/reference/java/'
+}

--- a/rls/build.gradle
+++ b/rls/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
 }
 
-[compileJava].each() {
+tasks.named("compileJava").configure {
     it.options.compilerArgs += [
             // only has AutoValue annotation processor
             "-Xlint:-processing",
@@ -37,7 +37,7 @@ dependencies {
             "|")
 }
 
-javadoc {
+tasks.named("javadoc").configure {
     // Do not publish javadoc since currently there is no public API.
     failOnError false  // no public or protected classes found to document
     exclude 'io/grpc/lookup/v1/**'
@@ -45,7 +45,7 @@ javadoc {
     exclude 'io/grpc/rls/Internal*'
 }
 
-jacocoTestReport {
+tasks.named("jacocoTestReport").configure {
     classDirectories.from = sourceSets.main.output.collect {
         fileTree(dir: it, exclude: ['**/io/grpc/lookup/**'])
     }

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 description = "gRPC: Services"
 
-[compileJava].each() {
+tasks.named("compileJava").configure {
     // v1alpha of reflection.proto is deprecated at the file level.
     // Without this workaround, the project can not compile.
     it.options.compilerArgs += [
@@ -37,12 +37,12 @@ dependencies {
 
 configureProtoCompilation()
 
-javadoc {
+tasks.named("javadoc").configure {
     exclude 'io/grpc/services/Internal*.java'
     exclude 'io/grpc/services/internal/*'
 }
 
-jacocoTestReport {
+tasks.named("jacocoTestReport").configure {
     classDirectories.from = sourceSets.main.output.collect {
         fileTree(dir: it,
         exclude: [

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
         id "com.github.kt3k.coveralls" version "2.12.0"
         id "com.google.cloud.tools.jib" version "3.2.1"
         id "com.google.osdetector" version "1.7.0"
-        id "com.google.protobuf" version "0.8.18"
+        id "com.google.protobuf" version "0.8.19"
         id "digital.wup.android-maven-publish" version "3.6.3"
         id "me.champeau.gradle.japicmp" version "0.3.0"
         id "me.champeau.jmh" version "0.6.6"

--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -17,6 +17,6 @@ dependencies {
     signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }
 
-javadoc {
+tasks.named("javadoc").configure {
     exclude 'io/grpc/stub/Internal*'
 }

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -26,9 +26,9 @@ dependencies {
             project(':grpc-core').sourceSets.test.output
 }
 
-javadoc { exclude 'io/grpc/internal/**' }
+tasks.named("javadoc").configure { exclude 'io/grpc/internal/**' }
 
-jacocoTestReport {
+tasks.named("jacocoTestReport").configure {
     classDirectories.from = sourceSets.main.output.collect {
         fileTree(dir: it,
         exclude: [

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -109,7 +109,7 @@ dependencies {
 
 configureProtoCompilation()
 
-compileThirdpartyJava {
+tasks.named("compileThirdpartyJava").configure {
     options.errorprone.enabled = false
     options.compilerArgs += [
         // valueOf(int) in RoutingPriority has been deprecated
@@ -117,11 +117,11 @@ compileThirdpartyJava {
     ]
 }
 
-checkstyleThirdparty {
+tasks.named("checkstyleThirdparty").configure {
     enabled = false
 }
 
-[compileJava].each() {
+tasks.named("compileJava").configure {
     it.options.compilerArgs += [
         // TODO: remove
         "-Xlint:-deprecation",
@@ -134,12 +134,12 @@ checkstyleThirdparty {
             "|")
 }
 
-jar {
+tasks.named("jar").configure {
     archiveClassifier = 'original'
     from sourceSets.thirdparty.output
 }
 
-javadoc {
+tasks.named("javadoc").configure {
     // Exclusions here should generally also be relocated
     exclude 'com/github/udpa/**'
     exclude 'com/github/xds/**'
@@ -159,7 +159,7 @@ javadoc {
 }
 
 def prefixName = 'io.grpc.xds'
-shadowJar {
+tasks.named("shadowJar").configure {
     archiveClassifier = null
     dependencies {
         include(project(':grpc-xds'))
@@ -180,7 +180,8 @@ shadowJar {
     exclude "**/*.proto"
 }
 
-task checkPackageLeakage(dependsOn: shadowJar) {
+def checkPackageLeakage = tasks.register("checkPackageLeakage") {
+    dependsOn shadowJar
     doLast {
         def jarEntryPrefixName = prefixName.replaceAll('\\.', '/')
         shadowJar.outputs.getFiles().each { jar ->
@@ -203,11 +204,11 @@ task checkPackageLeakage(dependsOn: shadowJar) {
     }
 }
 
-test {
+tasks.named("test").configure {
     dependsOn checkPackageLeakage
 }
 
-jacocoTestReport {
+tasks.named("jacocoTestReport").configure {
     classDirectories.from = sourceSets.main.output.collect {
         fileTree(dir: it,
         exclude: [ // Exclusions here should generally also be relocated


### PR DESCRIPTION
This can avoid creating an additional 736 tasks (previously 502 out of
1591 were not created). That's not all that important as the build time
is essentially the same, but this lets us see the poor behavior of the
protobuf plugin in our own project and increase our understanding of how
to avoid task creation when developing the plugin. Of the tasks still
being created, protobuf is the highest contributor with 165 tasks,
followed by maven-publish with 76 and appengine with 53. The remaining
59 are from our own build, but indirectly caused by maven-publish.

----

Before: https://scans.gradle.com/s/xqzdk3gmmm7vs/performance/configuration
After: https://scans.gradle.com/s/2agmuounbbzfa/performance/configuration