### PR TITLE
okhttp: Fix AsyncSink.close() NPE

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/AsyncSink.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/AsyncSink.java
@@ -208,7 +208,7 @@ final class AsyncSink implements Sink {
       @Override
       public void run() {
         try {
-          if (buffer.size() > 0) {
+          if (sink != null && buffer.size() > 0) {
             sink.write(buffer, buffer.size());
           }
         } catch (IOException e) {


### PR DESCRIPTION
This fixes a regression introduced in e96d0477. The NullPointerException
only happens on client-side when some other error occurred during
handshaking.

I tried to add a test, but SerializingExecutor catches+logs the
exception and the expected behavior in the circumstance is that close()
is a noop. So the NPE was entirely benign other than annoying log
messages.

CC @temawi 