### PR TITLE
xds: implement ignore_resource_deletion server feature

### DIFF
--- a/xds/src/main/java/io/grpc/xds/Bootstrapper.java
+++ b/xds/src/main/java/io/grpc/xds/Bootstrapper.java
@@ -62,10 +62,21 @@ public abstract class Bootstrapper {
 
     abstract boolean useProtocolV3();
 
+    abstract boolean ignoreResourceDeletion();
+
     @VisibleForTesting
     static ServerInfo create(
         String target, ChannelCredentials channelCredentials, boolean useProtocolV3) {
-      return new AutoValue_Bootstrapper_ServerInfo(target, channelCredentials, useProtocolV3);
+      return new AutoValue_Bootstrapper_ServerInfo(target, channelCredentials, useProtocolV3,
+          false);
+    }
+
+    @VisibleForTesting
+    static ServerInfo create(
+        String target, ChannelCredentials channelCredentials, boolean useProtocolV3,
+        boolean ignoreResourceDeletion) {
+      return new AutoValue_Bootstrapper_ServerInfo(target, channelCredentials, useProtocolV3,
+          ignoreResourceDeletion);
     }
   }
 

--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -2549,10 +2549,12 @@ final class ClientXdsClient extends XdsClient implements XdsResponseHandler, Res
       }
       stopTimer();
       String message = "Unsubscribing {0} resource {1} from server {2}";
+      XdsLogLevel logLevel = XdsLogLevel.INFO;
       if (resourceDeletionIgnored) {
         message += " for which we previously ignored a deletion";
+        logLevel = XdsLogLevel.FORCE_INFO;
       }
-      logger.log(XdsLogLevel.INFO, message, type, resource,
+      logger.log(logLevel, message, type, resource,
           serverInfo != null ? serverInfo.target() : "unknown");
     }
 
@@ -2571,8 +2573,8 @@ final class ClientXdsClient extends XdsClient implements XdsResponseHandler, Res
       this.data = parsedResource.getResourceUpdate();
       absent = false;
       if (resourceDeletionIgnored) {
-        logger.log(XdsLogLevel.INFO, "xds server {0}: server returned new version of resource "
-                + "for which we previously ignored a deletion: type {1} name {2}",
+        logger.log(XdsLogLevel.FORCE_INFO, "xds server {0}: server returned new version "
+                + "of resource for which we previously ignored a deletion: type {1} name {2}",
             serverInfo != null ? serverInfo.target() : "unknown", type, resource);
         resourceDeletionIgnored = false;
       }
@@ -2595,7 +2597,7 @@ final class ClientXdsClient extends XdsClient implements XdsResponseHandler, Res
       boolean isStateOfTheWorld = (type == ResourceType.LDS || type == ResourceType.CDS);
       if (ignoreResourceDeletionEnabled && isStateOfTheWorld && data != null) {
         if (!resourceDeletionIgnored) {
-          logger.log(XdsLogLevel.WARNING,
+          logger.log(XdsLogLevel.FORCE_WARNING,
               "xds server {0}: ignoring deletion for resource type {1} name {2}}",
               serverInfo.target(), type, resource);
           resourceDeletionIgnored = true;

--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -2587,8 +2587,12 @@ final class ClientXdsClient extends XdsClient implements XdsResponseHandler, Res
         return;
       }
 
-      // Ignore deletion when the server instructs to, and the resource is reusable.
-      if (data != null && serverInfo != null && serverInfo.ignoreResourceDeletion()) {
+      // Ignore deletion of State of the World resources when this feature is on,
+      // and the resource is reusable.
+      boolean ignoreResourceDeletionEnabled =
+          serverInfo != null && serverInfo.ignoreResourceDeletion();
+      boolean isStateOfTheWorld = (type == ResourceType.LDS || type == ResourceType.CDS);
+      if (ignoreResourceDeletionEnabled && isStateOfTheWorld && data != null) {
         if (!resourceDeletionIgnored) {
           logger.log(XdsLogLevel.WARNING,
               "xds server {0}: ignoring deletion for resource type {1} name {2}}",

--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -2373,7 +2373,8 @@ final class ClientXdsClient extends XdsClient implements XdsResponseHandler, Res
           // For State of the World services, notify watchers when their watched resource is missing
           // from the ADS update.
           subscriber.onAbsent();
-          // Retain any dependent resources if the resource deletion is ignored per server setting.
+          // Retain any dependent resources if the resource deletion is ignored
+          // per bootstrap ignore_resource_deletion server feature.
           if (!subscriber.absent) {
             retainDependentResource(subscriber, retainedResources);
           }
@@ -2444,7 +2445,7 @@ final class ClientXdsClient extends XdsClient implements XdsResponseHandler, Res
     private final Set<ResourceWatcher> watchers = new HashSet<>();
     @Nullable private ResourceUpdate data;
     private boolean absent;
-    // Tracks whether the deletion has been ignored per server request.
+    // Tracks whether the deletion has been ignored per bootstrap server feature.
     // See https://github.com/grpc/proposal/blob/master/A53-xds-ignore-resource-deletion.md
     private boolean resourceDeletionIgnored;
     @Nullable private ScheduledHandle respTimer;

--- a/xds/src/main/java/io/grpc/xds/XdsLogger.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLogger.java
@@ -81,6 +81,10 @@ final class XdsLogger {
         return Level.FINE;
       case INFO:
         return Level.FINER;
+      case FORCE_INFO:
+        return Level.INFO;
+      case FORCE_WARNING:
+        return Level.WARNING;
       default:
         return Level.FINEST;
     }
@@ -89,6 +93,11 @@ final class XdsLogger {
   /**
    * Log levels. See the table below for the mapping from the XdsLogger levels to
    * Java logger levels.
+   *
+   * <p><b>NOTE:</b>
+   *   Please use {@code FORCE_} levels with care, only when the message is expected to be
+   *   surfaced to the library user. Normally libraries should minimize the usage
+   *   of highly visible logs.
    * <pre>
    * +---------------------+-------------------+
    * | XdsLogger Level     | Java Logger Level |
@@ -97,6 +106,8 @@ final class XdsLogger {
    * | INFO                | FINER             |
    * | WARNING             | FINE              |
    * | ERROR               | FINE              |
+   * | FORCE_INFO          | INFO              |
+   * | FORCE_WARNING       | WARNING           |
    * +---------------------+-------------------+
    * </pre>
    */
@@ -104,6 +115,8 @@ final class XdsLogger {
     DEBUG,
     INFO,
     WARNING,
-    ERROR
+    ERROR,
+    FORCE_INFO,
+    FORCE_WARNING,
   }
 }

--- a/xds/src/test/java/io/grpc/xds/BootstrapperImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/BootstrapperImplTest.java
@@ -578,6 +578,8 @@ public class BootstrapperImplTest {
     ServerInfo serverInfo = Iterables.getOnlyElement(info.servers());
     assertThat(serverInfo.target()).isEqualTo(SERVER_URI);
     assertThat(serverInfo.channelCredentials()).isInstanceOf(InsecureChannelCredentials.class);
+    assertThat(serverInfo.ignoreResourceDeletion()).isFalse();
+    // xds v2: xds v3 disabled
     assertThat(serverInfo.useProtocolV3()).isFalse();
   }
 
@@ -600,7 +602,57 @@ public class BootstrapperImplTest {
     ServerInfo serverInfo = Iterables.getOnlyElement(info.servers());
     assertThat(serverInfo.target()).isEqualTo(SERVER_URI);
     assertThat(serverInfo.channelCredentials()).isInstanceOf(InsecureChannelCredentials.class);
+    assertThat(serverInfo.ignoreResourceDeletion()).isFalse();
+    // xds_v3 enabled
     assertThat(serverInfo.useProtocolV3()).isTrue();
+  }
+
+  @Test
+  public void serverFeatureIgnoreResourceDeletion() throws XdsInitializationException {
+    String rawData = "{\n"
+        + "  \"xds_servers\": [\n"
+        + "    {\n"
+        + "      \"server_uri\": \"" + SERVER_URI + "\",\n"
+        + "      \"channel_creds\": [\n"
+        + "        {\"type\": \"insecure\"}\n"
+        + "      ],\n"
+        + "      \"server_features\": [\"ignore_resource_deletion\"]\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+
+    bootstrapper.setFileReader(createFileReader(BOOTSTRAP_FILE_PATH, rawData));
+    BootstrapInfo info = bootstrapper.bootstrap();
+    ServerInfo serverInfo = Iterables.getOnlyElement(info.servers());
+    assertThat(serverInfo.target()).isEqualTo(SERVER_URI);
+    assertThat(serverInfo.channelCredentials()).isInstanceOf(InsecureChannelCredentials.class);
+    // Only ignore_resource_deletion feature enabled: confirm it's on, and xds_v3 is off.
+    assertThat(serverInfo.useProtocolV3()).isFalse();
+    assertThat(serverInfo.ignoreResourceDeletion()).isTrue();
+  }
+
+  @Test
+  public void serverFeatureIgnoreResourceDeletion_xdsV3() throws XdsInitializationException {
+    String rawData = "{\n"
+        + "  \"xds_servers\": [\n"
+        + "    {\n"
+        + "      \"server_uri\": \"" + SERVER_URI + "\",\n"
+        + "      \"channel_creds\": [\n"
+        + "        {\"type\": \"insecure\"}\n"
+        + "      ],\n"
+        + "      \"server_features\": [\"xds_v3\", \"ignore_resource_deletion\"]\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+
+    bootstrapper.setFileReader(createFileReader(BOOTSTRAP_FILE_PATH, rawData));
+    BootstrapInfo info = bootstrapper.bootstrap();
+    ServerInfo serverInfo = Iterables.getOnlyElement(info.servers());
+    assertThat(serverInfo.target()).isEqualTo(SERVER_URI);
+    assertThat(serverInfo.channelCredentials()).isInstanceOf(InsecureChannelCredentials.class);
+    // xds_v3 and ignore_resource_deletion features enabled: confirm both are on.
+    assertThat(serverInfo.useProtocolV3()).isTrue();
+    assertThat(serverInfo.ignoreResourceDeletion()).isTrue();
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientV2Test.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientV2Test.java
@@ -100,15 +100,26 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 import org.mockito.ArgumentMatcher;
 import org.mockito.InOrder;
 
 /**
  * Tests for {@link ClientXdsClient} with protocol version v2.
  */
-@RunWith(JUnit4.class)
+@RunWith(Parameterized.class)
 public class ClientXdsClientV2Test extends ClientXdsClientTestBase {
+
+  /** Parameterized test cases. */
+  @Parameters(name = "ignoreResourceDeletion={0}")
+  public static Iterable<? extends Boolean> data() {
+    return ImmutableList.of(false, true);
+  }
+
+  @Parameter
+  public boolean ignoreResourceDeletion;
 
   @Override
   protected BindableService createAdsService() {
@@ -166,6 +177,11 @@ public class ClientXdsClientV2Test extends ClientXdsClientTestBase {
   @Override
   protected boolean useProtocolV3() {
     return false;
+  }
+
+  @Override
+  protected boolean ignoreResourceDeletion() {
+    return ignoreResourceDeletion;
   }
 
   private static class DiscoveryRpcCallV2 extends DiscoveryRpcCall {

--- a/xds/src/test/java/io/grpc/xds/ClientXdsClientV3Test.java
+++ b/xds/src/test/java/io/grpc/xds/ClientXdsClientV3Test.java
@@ -108,15 +108,26 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 import org.mockito.ArgumentMatcher;
 import org.mockito.InOrder;
 
 /**
  * Tests for {@link ClientXdsClient} with protocol version v3.
  */
-@RunWith(JUnit4.class)
+@RunWith(Parameterized.class)
 public class ClientXdsClientV3Test extends ClientXdsClientTestBase {
+
+  /** Parameterized test cases. */
+  @Parameters(name = "ignoreResourceDeletion={0}")
+  public static Iterable<? extends Boolean> data() {
+    return ImmutableList.of(false, true);
+  }
+
+  @Parameter
+  public boolean ignoreResourceDeletion;
 
   @Override
   protected BindableService createAdsService() {
@@ -174,6 +185,11 @@ public class ClientXdsClientV3Test extends ClientXdsClientTestBase {
   @Override
   protected boolean useProtocolV3() {
     return true;
+  }
+
+  @Override
+  protected boolean ignoreResourceDeletion() {
+    return ignoreResourceDeletion;
   }
 
   private static class DiscoveryRpcCallV3 extends DiscoveryRpcCall {


### PR DESCRIPTION
As defined in the gRFC [A53: Option for Ignoring xDS Resource Deletion](https://github.com/grpc/proposal/blob/master/A53-xds-ignore-resource-deletion.md).

Note for the reviewer: it'll probably be more convenient to review commit-by-commit. The test refactoring commit can be skipped: it's not required, but was very handy for implementing new tests, and modifying the old ones.
