### PR TITLE
Fix for ipv6 link local with scope (1.48.x backport)

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpProtocolNegotiator.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpProtocolNegotiator.java
@@ -19,6 +19,8 @@ package io.grpc.okhttp;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.net.HostAndPort;
+import com.google.common.net.InetAddresses;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.okhttp.internal.OptionalMethod;
 import io.grpc.okhttp.internal.Platform;
@@ -247,7 +249,9 @@ class OkHttpProtocolNegotiator {
           } else {
             SET_USE_SESSION_TICKETS.invokeOptionalWithoutCheckedException(sslSocket, true);
           }
-          if (SET_SERVER_NAMES != null && SNI_HOST_NAME != null) {
+          if (SET_SERVER_NAMES != null
+              && SNI_HOST_NAME != null
+              && !InetAddresses.isInetAddress(HostAndPort.fromString(hostname).getHost())) {
             SET_SERVER_NAMES
                 .invoke(sslParams, Collections.singletonList(SNI_HOST_NAME.newInstance(hostname)));
           } else {


### PR DESCRIPTION
Fix for ipv6 link local with scope. If you try to connect passing address like "ipv6%wlan0" it will use 

```
public SNIHostName(String hostname) {
        super(0, (hostname = IDN.toASCII((String)Objects.requireNonNull(hostname, "Server name value of host_name cannot be null"), 2)).getBytes(StandardCharsets.US_ASCII));
        this.hostname = hostname;
        this.checkHostName();
    }
```

Which raises hostname is not valid because this method doesn't accept non ASCII characters. With the change it will use 

```
public SNIHostName(byte[] encoded) {
        super(0, encoded);

        try {
            CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder().onMalformedInput(CodingErrorAction.REPORT).onUnmappableCharacter(CodingErrorAction.REPORT);
            this.hostname = IDN.toASCII(decoder.decode(ByteBuffer.wrap(encoded)).toString());
        } catch (CharacterCodingException | RuntimeException var3) {
            throw new IllegalArgumentException("The encoded server name value is invalid", var3);
        }

        this.checkHostName();
    }
```
Now scoped ipv6 link is supported. 😄 

Backport of #9326