### PR TITLE
xds: Fail RPCs with error details when resources are deleted (1.48.x backport)

### DIFF
--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -288,7 +288,7 @@ public class XdsNameResolverTest {
     resolver.start(mockListener);
     FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();
     xdsClient.deliverLdsResourceNotFound();
-    assertEmptyResolutionResult();
+    assertEmptyResolutionResult(expectedLdsResourceName);
   }
 
   @SuppressWarnings("unchecked")
@@ -346,7 +346,7 @@ public class XdsNameResolverTest {
     FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();
     xdsClient.deliverLdsUpdateForRdsName(RDS_RESOURCE_NAME);
     xdsClient.deliverRdsResourceNotFound(RDS_RESOURCE_NAME);
-    assertEmptyResolutionResult();
+    assertEmptyResolutionResult(RDS_RESOURCE_NAME);
   }
 
   @SuppressWarnings("unchecked")
@@ -374,7 +374,7 @@ public class XdsNameResolverTest {
     reset(mockListener);
     xdsClient.deliverLdsResourceNotFound();  // revoke LDS resource
     assertThat(xdsClient.rdsResource).isNull();  // stop subscribing to stale RDS resource
-    assertEmptyResolutionResult();
+    assertEmptyResolutionResult(expectedLdsResourceName);
 
     reset(mockListener);
     xdsClient.deliverLdsUpdateForRdsName(RDS_RESOURCE_NAME);
@@ -412,7 +412,7 @@ public class XdsNameResolverTest {
 
     reset(mockListener);
     xdsClient.deliverRdsResourceNotFound(RDS_RESOURCE_NAME);  // revoke RDS resource
-    assertEmptyResolutionResult();
+    assertEmptyResolutionResult(RDS_RESOURCE_NAME);
 
     // Simulate management server adds back the previously used RDS resource.
     reset(mockListener);
@@ -470,7 +470,7 @@ public class XdsNameResolverTest {
     resolver.start(mockListener);
     FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();
     xdsClient.deliverLdsUpdate(0L, buildUnmatchedVirtualHosts());
-    assertEmptyResolutionResult();
+    assertEmptyResolutionResult(expectedLdsResourceName);
   }
 
   @Test
@@ -479,7 +479,7 @@ public class XdsNameResolverTest {
     FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();
     xdsClient.deliverLdsUpdateForRdsName(RDS_RESOURCE_NAME);
     xdsClient.deliverRdsUpdate(RDS_RESOURCE_NAME, buildUnmatchedVirtualHosts());
-    assertEmptyResolutionResult();
+    assertEmptyResolutionResult(expectedLdsResourceName);
   }
 
   private List<VirtualHost> buildUnmatchedVirtualHosts() {
@@ -1056,11 +1056,16 @@ public class XdsNameResolverTest {
   }
 
   @SuppressWarnings("unchecked")
-  private void assertEmptyResolutionResult() {
+  private void assertEmptyResolutionResult(String resource) {
     verify(mockListener).onResult(resolutionResultCaptor.capture());
     ResolutionResult result = resolutionResultCaptor.getValue();
     assertThat(result.getAddresses()).isEmpty();
     assertThat((Map<String, ?>) result.getServiceConfig().getConfig()).isEmpty();
+    InternalConfigSelector configSelector = result.getAttributes().get(InternalConfigSelector.KEY);
+    Result configResult = configSelector.selectConfig(
+        new PickSubchannelArgsImpl(call1.methodDescriptor, new Metadata(), CallOptions.DEFAULT));
+    assertThat(configResult.getStatus().getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+    assertThat(configResult.getStatus().getDescription()).contains(resource);
   }
 
   private void assertCallSelectClusterResult(


### PR DESCRIPTION
Previously if LDS/RDS were missing or improperly configured RPCs would
fail with "UNAVAILABLE: NameResolver returned no usable address errors".
That is very confusing and not helpful for debugging.

Ideally we'd also include the node id in this error message, but that's
a bit more involved and this is a huge improvement even without it.

b/237539851

Backport of #9337