### PR TITLE
Bump versions for assorted dependencies (1.48.x backport)

### DIFF
--- a/gcp-observability/build.gradle
+++ b/gcp-observability/build.gradle
@@ -21,7 +21,6 @@ description = "gRPC: Google Cloud Platform Observability"
 
 dependencies {
     def cloudLoggingVersion = '3.6.1'
-    def opencensusExporterVersion = '0.31.0'
 
     annotationProcessor libraries.auto.value
     api project(':grpc-api')
@@ -30,22 +29,15 @@ dependencies {
             project(':grpc-stub'),
             project(':grpc-alts'),
             project(':grpc-census'),
-            libraries.google.auth.oauth2Http,
-            libraries.auto.value.annotations,
-            libraries.perfmark.api,
-            libraries.opencensus.contrib.grpc.metrics,
-            libraries.gson,
-	    libraries.protobuf.java.util,
-            ('com.google.guava:guava:31.1-jre'),
-            ('com.google.auth:google-auth-library-credentials:1.4.0'),
-            ('org.checkerframework:checker-qual:3.20.0'),
-            ('com.google.auto.value:auto-value-annotations:1.9'),
-            ('com.google.http-client:google-http-client:1.41.0'),
-            ('com.google.http-client:google-http-client-gson:1.41.0'),
-            ('com.google.api.grpc:proto-google-common-protos:2.7.1'),
             ("com.google.cloud:google-cloud-logging:${cloudLoggingVersion}"),
-            ("io.opencensus:opencensus-exporter-stats-stackdriver:${opencensusExporterVersion}"),
-            ("io.opencensus:opencensus-exporter-trace-stackdriver:${opencensusExporterVersion}")
+            libraries.opencensus.exporter.stats.stackdriver,
+            libraries.opencensus.exporter.trace.stackdriver,
+            libraries.animalsniffer.annotations, // Prefer our version
+            libraries.google.auth.credentials, // Prefer our version
+            libraries.protobuf.java.util, // Prefer our version
+            libraries.gson, // Prefer our version
+            libraries.perfmark.api, // Prefer our version
+            ('com.google.guava:guava:31.1-jre')
 
     runtimeOnly libraries.opencensus.impl
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,24 +12,24 @@ protobuf = "3.21.1"
 
 [libraries]
 android-annotations = "com.google.android:annotations:4.1.1.4"
-androidx-annotation = "androidx.annotation:annotation:1.1.0"
+androidx-annotation = "androidx.annotation:annotation:1.4.0"
 androidx-core = "androidx.core:core:1.3.0"
 androidx-lifecycle-common = "androidx.lifecycle:lifecycle-common:2.3.0"
 androidx-lifecycle-service = "androidx.lifecycle:lifecycle-service:2.3.0"
-androidx-test-core = "androidx.test:core:1.3.0"
-androidx-test-ext-junit = "androidx.test.ext:junit:1.1.2"
-androidx-test-rules = "androidx.test:rules:1.3.0"
-animalsniffer-annotations = "org.codehaus.mojo:animal-sniffer-annotations:1.19"
+androidx-test-core = "androidx.test:core:1.4.0"
+androidx-test-ext-junit = "androidx.test.ext:junit:1.1.3"
+androidx-test-rules = "androidx.test:rules:1.4.0"
+animalsniffer-annotations = "org.codehaus.mojo:animal-sniffer-annotations:1.21"
 auto-value = { module = "com.google.auto.value:auto-value", version.ref = "autovalue" }
 auto-value-annotations = { module = "com.google.auto.value:auto-value-annotations", version.ref = "autovalue" }
 commons-math3 = "org.apache.commons:commons-math3:3.6.1"
-conscrypt = "org.conscrypt:conscrypt-openjdk-uber:2.5.1"
+conscrypt = "org.conscrypt:conscrypt-openjdk-uber:2.5.2"
 cronet-api = "org.chromium.net:cronet-api:92.4515.131"
-cronet-embedded = "org.chromium.net:cronet-embedded:92.4515.131"
-errorprone-annotations = "com.google.errorprone:error_prone_annotations:2.11.0"
+cronet-embedded = "org.chromium.net:cronet-embedded:102.5005.125"
+errorprone-annotations = "com.google.errorprone:error_prone_annotations:2.14.0"
 errorprone-core = "com.google.errorprone:error_prone_core:2.10.0"
 errorprone-javac = "com.google.errorprone:javac:9+181-r4173-1"
-google-api-protos = "com.google.api.grpc:proto-google-common-protos:2.0.1"
+google-api-protos = "com.google.api.grpc:proto-google-common-protos:2.9.0"
 google-auth-credentials = { module = "com.google.auth:google-auth-library-credentials", version.ref = "googleauth" }
 google-auth-oauth2Http = { module = "com.google.auth:google-auth-library-oauth2-http", version.ref = "googleauth" }
 gson = "com.google.code.gson:gson:2.9.0"
@@ -37,7 +37,6 @@ guava = { module = "com.google.guava:guava", version.ref = "guava" }
 guava-betaChecker = "com.google.guava:guava-beta-checker:1.0"
 guava-testlib = { module = "com.google.guava:guava-testlib", version.ref = "guava" }
 hdrhistogram = "org.hdrhistogram:HdrHistogram:2.1.12"
-instrumentation-api = "com.google.instrumentation:instrumentation-api:0.4.3"
 javax-annotation = "org.apache.tomcat:annotations-api:6.0.53"
 jetty-alpn-agent = "org.mortbay.jetty.alpn:jetty-alpn-agent:2.0.10"
 jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
@@ -46,26 +45,27 @@ mockito-android = "org.mockito:mockito-android:3.8.0"
 mockito-core = "org.mockito:mockito-core:3.3.3"
 netty-codec-http2 = { module = "io.netty:netty-codec-http2", version.ref = "netty" }
 netty-handler-proxy = { module = "io.netty:netty-handler-proxy", version.ref = "netty" }
-netty-transport-epoll = { module = "io.netty:netty-transport-native-epoll", version.ref = "netty" }
 # Keep the following references of tcnative version in sync whenever it's updated:
 #   SECURITY.md (multiple occurrences)
 #   examples/example-tls/build.gradle
 #   examples/example-tls/pom.xml
 netty-tcnative = { module = "io.netty:netty-tcnative-boringssl-static", version.ref = "nettytcnative" }
 netty-tcnative-classes = { module = "io.netty:netty-tcnative-classes", version.ref = "nettytcnative" }
+netty-transport-epoll = { module = "io.netty:netty-transport-native-epoll", version.ref = "netty" }
 netty-unix-common = { module = "io.netty:netty-transport-native-unix-common", version.ref = "netty" }
-okhttp = "com.squareup.okhttp:okhttp:2.7.4"
+okhttp = "com.squareup.okhttp:okhttp:2.7.5"
 okio = "com.squareup.okio:okio:1.17.5"
 opencensus-api = { module = "io.opencensus:opencensus-api", version.ref = "opencensus" }
 opencensus-contrib-grpc-metrics = { module = "io.opencensus:opencensus-contrib-grpc-metrics", version.ref = "opencensus" }
+opencensus-exporter-stats-stackdriver = { module = "io.opencensus:opencensus-exporter-stats-stackdriver", version.ref = "opencensus" }
+opencensus-exporter-trace-stackdriver = { module = "io.opencensus:opencensus-exporter-trace-stackdriver", version.ref = "opencensus" }
 opencensus-impl = { module = "io.opencensus:opencensus-impl", version.ref = "opencensus" }
-opencensus-impl-lite = { module = "io.opencensus:opencensus-impl-lite", version.ref = "opencensus" }
 opencensus-proto = "io.opencensus:opencensus-proto:0.2.0"
 perfmark-api = "io.perfmark:perfmark-api:0.25.0"
 protobuf-java = { module = "com.google.protobuf:protobuf-java", version.ref = "protobuf" }
 protobuf-java-util = { module = "com.google.protobuf:protobuf-java-util", version.ref = "protobuf" }
 protobuf-javalite = { module = "com.google.protobuf:protobuf-javalite", version.ref = "protobuf" }
 protobuf-protoc = { module = "com.google.protobuf:protoc", version.ref = "protobuf" }
-re2j = "com.google.re2j:re2j:1.5"
-robolectric = "org.robolectric:robolectric:4.4"
+re2j = "com.google.re2j:re2j:1.6"
+robolectric = "org.robolectric:robolectric:4.8.1"
 truth = "com.google.truth:truth:1.0.1"


### PR DESCRIPTION
If I didn't upgrade X there is probably a reason, but worst-case the
reason was "I was lazy." I did the easy stuff, so if upgrading caused
problems of any real sort I skipped it and moved on. The main other
reason is there's some stuff we're more conservative about upgrading,
but you can't distinguish one from the other in this commit.

Backport of #9329