### PR TITLE
Service config parse failures should be UNAVAILABLE

### DIFF
--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancerProvider.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancerProvider.java
@@ -124,7 +124,7 @@ public final class GrpclbLoadBalancerProvider extends LoadBalancerProvider {
     }
     return ConfigOrError.fromError(
         Status
-            .INVALID_ARGUMENT
+            .UNAVAILABLE
             .withDescription(
                 "None of " + policiesTried + " specified child policies are available."));
   }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProvider.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProvider.java
@@ -54,7 +54,7 @@ public class RpcBehaviorLoadBalancerProvider extends LoadBalancerProvider {
     String rpcBehavior = JsonUtil.getString(rawLoadBalancingPolicyConfig, "rpcBehavior");
     if (rpcBehavior == null) {
       return ConfigOrError.fromError(
-          Status.INVALID_ARGUMENT.withDescription("no 'rpcBehavior' defined"));
+          Status.UNAVAILABLE.withDescription("no 'rpcBehavior' defined"));
     }
     return ConfigOrError.fromConfig(new RpcBehaviorConfig(rpcBehavior));
   }

--- a/rls/src/main/java/io/grpc/rls/RlsLoadBalancerProvider.java
+++ b/rls/src/main/java/io/grpc/rls/RlsLoadBalancerProvider.java
@@ -73,7 +73,7 @@ public final class RlsLoadBalancerProvider extends LoadBalancerProvider {
           new LbPolicyConfiguration(routeLookupConfig, routeLookupChannelServiceConfig, lbPolicy));
     } catch (Exception e) {
       return ConfigOrError.fromError(
-          Status.INVALID_ARGUMENT
+          Status.UNAVAILABLE
               .withDescription("can't parse config: " + e.getMessage())
               .withCause(e));
     }

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
@@ -192,7 +192,7 @@ final class CdsLoadBalancer2 extends LoadBalancer {
           root.result.lbPolicyConfig());
       LoadBalancerProvider lbProvider = lbRegistry.getProvider(unwrappedLbConfig.getPolicyName());
       if (lbProvider == null) {
-        throw NameResolver.ConfigOrError.fromError(Status.INVALID_ARGUMENT.withDescription(
+        throw NameResolver.ConfigOrError.fromError(Status.UNAVAILABLE.withDescription(
                 "No provider available for LB: " + unwrappedLbConfig.getPolicyName())).getError()
             .asRuntimeException();
       }

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancerProvider.java
@@ -75,7 +75,7 @@ public class CdsLoadBalancerProvider extends LoadBalancerProvider {
       return ConfigOrError.fromConfig(new CdsConfig(cluster));
     } catch (RuntimeException e) {
       return ConfigOrError.fromError(
-          Status.fromThrowable(e).withDescription(
+          Status.UNAVAILABLE.withCause(e).withDescription(
               "Failed to parse CDS LB config: " + rawLoadBalancingPolicyConfig));
     }
   }

--- a/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancerProvider.java
@@ -110,7 +110,7 @@ public class ClusterManagerLoadBalancerProvider extends LoadBalancerProvider {
       }
     } catch (RuntimeException e) {
       return ConfigOrError.fromError(
-          Status.fromThrowable(e).withDescription(
+          Status.INTERNAL.withCause(e).withDescription(
               "Failed to parse cluster_manager LB config: " + rawConfig));
     }
     return ConfigOrError.fromConfig(new ClusterManagerConfig(parsedChildPolicies));

--- a/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancerProvider.java
@@ -67,13 +67,13 @@ public final class LeastRequestLoadBalancerProvider extends LoadBalancerProvider
         choiceCount = DEFAULT_CHOICE_COUNT;
       }
       if (choiceCount < MIN_CHOICE_COUNT) {
-        return ConfigOrError.fromError(Status.INVALID_ARGUMENT.withDescription(
-            "Invalid 'choiceCount'"));
+        return ConfigOrError.fromError(Status.UNAVAILABLE.withDescription(
+            "Invalid 'choiceCount' in least_request_experimental config"));
       }
       return ConfigOrError.fromConfig(new LeastRequestConfig(choiceCount));
     } catch (RuntimeException e) {
       return ConfigOrError.fromError(
-          Status.fromThrowable(e).withDescription(
+          Status.UNAVAILABLE.withCause(e).withDescription(
               "Failed to parse least_request_experimental LB config: " + rawConfig));
     }
   }

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancerProvider.java
@@ -81,7 +81,7 @@ public final class RingHashLoadBalancerProvider extends LoadBalancerProvider {
     }
     if (minRingSize <= 0 || maxRingSize <= 0 || minRingSize > maxRingSize
         || maxRingSize > MAX_RING_SIZE) {
-      return ConfigOrError.fromError(Status.INVALID_ARGUMENT.withDescription(
+      return ConfigOrError.fromError(Status.UNAVAILABLE.withDescription(
           "Invalid 'mingRingSize'/'maxRingSize'"));
     }
     return ConfigOrError.fromConfig(new RingHashConfig(minRingSize, maxRingSize));

--- a/xds/src/main/java/io/grpc/xds/WeightedTargetLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedTargetLoadBalancerProvider.java
@@ -117,7 +117,7 @@ public final class WeightedTargetLoadBalancerProvider extends LoadBalancerProvid
       return ConfigOrError.fromConfig(new WeightedTargetConfig(parsedChildConfigs));
     } catch (RuntimeException e) {
       return ConfigOrError.fromError(
-          Status.fromThrowable(e).withDescription(
+          Status.INTERNAL.withCause(e).withDescription(
               "Failed to parse weighted_target LB config: " + rawConfig));
     }
   }

--- a/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancerProvider.java
@@ -78,7 +78,7 @@ public final class WrrLocalityLoadBalancerProvider extends LoadBalancerProvider 
       PolicySelection policySelection = (PolicySelection) selectedConfig.getConfig();
       return ConfigOrError.fromConfig(new WrrLocalityConfig(policySelection));
     } catch (RuntimeException e) {
-      return ConfigOrError.fromError(Status.fromThrowable(e)
+      return ConfigOrError.fromError(Status.INTERNAL.withCause(e)
           .withDescription("Failed to parse wrr_locality LB config: " + rawConfig));
     }
   }

--- a/xds/src/test/java/io/grpc/xds/LeastRequestLoadBalancerProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/LeastRequestLoadBalancerProviderTest.java
@@ -96,9 +96,9 @@ public class LeastRequestLoadBalancerProviderTest {
     ConfigOrError configOrError =
         provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
     assertThat(configOrError.getError()).isNotNull();
-    assertThat(configOrError.getError().getCode()).isEqualTo(Code.INVALID_ARGUMENT);
+    assertThat(configOrError.getError().getCode()).isEqualTo(Code.UNAVAILABLE);
     assertThat(configOrError.getError().getDescription())
-        .isEqualTo("Invalid 'choiceCount'");
+        .isEqualTo("Invalid 'choiceCount' in least_request_experimental config");
   }
 
   @Test
@@ -107,9 +107,9 @@ public class LeastRequestLoadBalancerProviderTest {
     ConfigOrError configOrError =
         provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
     assertThat(configOrError.getError()).isNotNull();
-    assertThat(configOrError.getError().getCode()).isEqualTo(Code.INVALID_ARGUMENT);
+    assertThat(configOrError.getError().getCode()).isEqualTo(Code.UNAVAILABLE);
     assertThat(configOrError.getError().getDescription())
-        .isEqualTo("Invalid 'choiceCount'");
+        .isEqualTo("Invalid 'choiceCount' in least_request_experimental config");
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/MetadataLoadBalancerProvider.java
+++ b/xds/src/test/java/io/grpc/xds/MetadataLoadBalancerProvider.java
@@ -45,13 +45,13 @@ public class MetadataLoadBalancerProvider extends LoadBalancerProvider {
     String metadataKey = JsonUtil.getString(rawLoadBalancingPolicyConfig, "metadataKey");
     if (metadataKey == null) {
       return NameResolver.ConfigOrError.fromError(
-          Status.INVALID_ARGUMENT.withDescription("no 'metadataKey' defined"));
+          Status.UNAVAILABLE.withDescription("no 'metadataKey' defined"));
     }
 
     String metadataValue = JsonUtil.getString(rawLoadBalancingPolicyConfig, "metadataValue");
     if (metadataValue == null) {
       return NameResolver.ConfigOrError.fromError(
-          Status.INVALID_ARGUMENT.withDescription("no 'metadataValue' defined"));
+          Status.UNAVAILABLE.withDescription("no 'metadataValue' defined"));
     }
 
     return NameResolver.ConfigOrError.fromConfig(

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerProviderTest.java
@@ -98,7 +98,7 @@ public class RingHashLoadBalancerProviderTest {
     ConfigOrError configOrError =
         provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
     assertThat(configOrError.getError()).isNotNull();
-    assertThat(configOrError.getError().getCode()).isEqualTo(Code.INVALID_ARGUMENT);
+    assertThat(configOrError.getError().getCode()).isEqualTo(Code.UNAVAILABLE);
     assertThat(configOrError.getError().getDescription())
         .isEqualTo("Invalid 'mingRingSize'/'maxRingSize'");
   }
@@ -109,7 +109,7 @@ public class RingHashLoadBalancerProviderTest {
     ConfigOrError configOrError =
         provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
     assertThat(configOrError.getError()).isNotNull();
-    assertThat(configOrError.getError().getCode()).isEqualTo(Code.INVALID_ARGUMENT);
+    assertThat(configOrError.getError().getCode()).isEqualTo(Code.UNAVAILABLE);
     assertThat(configOrError.getError().getDescription())
         .isEqualTo("Invalid 'mingRingSize'/'maxRingSize'");
   }
@@ -121,7 +121,7 @@ public class RingHashLoadBalancerProviderTest {
     ConfigOrError configOrError =
         provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
     assertThat(configOrError.getError()).isNotNull();
-    assertThat(configOrError.getError().getCode()).isEqualTo(Code.INVALID_ARGUMENT);
+    assertThat(configOrError.getError().getCode()).isEqualTo(Code.UNAVAILABLE);
     assertThat(configOrError.getError().getDescription())
         .isEqualTo("Invalid 'mingRingSize'/'maxRingSize'");
   }
@@ -132,7 +132,7 @@ public class RingHashLoadBalancerProviderTest {
     ConfigOrError configOrError =
         provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
     assertThat(configOrError.getError()).isNotNull();
-    assertThat(configOrError.getError().getCode()).isEqualTo(Code.INVALID_ARGUMENT);
+    assertThat(configOrError.getError().getCode()).isEqualTo(Code.UNAVAILABLE);
     assertThat(configOrError.getError().getDescription())
         .isEqualTo("Invalid 'mingRingSize'/'maxRingSize'");
   }
@@ -143,7 +143,7 @@ public class RingHashLoadBalancerProviderTest {
     ConfigOrError configOrError =
         provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
     assertThat(configOrError.getError()).isNotNull();
-    assertThat(configOrError.getError().getCode()).isEqualTo(Code.INVALID_ARGUMENT);
+    assertThat(configOrError.getError().getCode()).isEqualTo(Code.UNAVAILABLE);
     assertThat(configOrError.getError().getDescription())
         .isEqualTo("Invalid 'mingRingSize'/'maxRingSize'");
   }


### PR DESCRIPTION
INVALID_ARGUMENT is propagated to the data plane if no previous config
is available. INVALID_ARGUMENT is reserved for application use; LBs
should pretty much use UNAVAILABLE exclusively.

While most of the changes are in xds, there do not appear to be likely
xds code paths that would propagate a bad status to the data plane.
Internal policies either don't use parseLoadBalancingPolicyConfig() and
instead have their configuration objects constructed directly or are
constructed transitively through the cluster manager which uses INTERNAL
if there's a child failure. There was a worrisome hole before this
commit for StatusRuntimeExceptions received by the cluster manager, but
the audit didn't find any locations throwing such an exception.
User-selected policies produce a NACK and are protected from the
existing xds client watcher paths. The worst that appears could happen
is the channel could panic (which uses INTERNAL) if a bug let a bad
configuration through.