### PR TITLE
Fix Gradle UP-TO-DATE checking for all tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -273,6 +273,8 @@ subprojects {
         // Detect Maven Enforcer's dependencyConvergence failures. We only care
         // for artifacts used as libraries by others with Maven.
         tasks.register('checkUpperBoundDeps') {
+            inputs.files(configurations.runtimeClasspath).withNormalizer(ClasspathNormalizer)
+            outputs.file("${buildDir}/tmp/${name}") // Fake output for UP-TO-DATE checking
             doLast {
                 requireUpperBoundDepsMatch(configurations.runtimeClasspath, project)
             }

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -69,6 +69,14 @@ tasks.named("jar").configure {
     archiveClassifier = 'original'
 }
 
+tasks.named("distZip").configure {
+    archiveClassifier = "original"
+}
+
+tasks.named("distTar").configure {
+    archiveClassifier = "original"
+}
+
 def xdsPrefixName = 'io.grpc.xds'
 tasks.named("shadowJar").configure {
     archiveClassifier = null

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -181,7 +181,8 @@ tasks.named("shadowJar").configure {
 }
 
 def checkPackageLeakage = tasks.register("checkPackageLeakage") {
-    dependsOn shadowJar
+    inputs.files(shadowJar).withNormalizer(CompileClasspathNormalizer)
+    outputs.file("${buildDir}/tmp/${name}") // Fake output for UP-TO-DATE checking
     doLast {
         def jarEntryPrefixName = prefixName.replaceAll('\\.', '/')
         shadowJar.outputs.getFiles().each { jar ->


### PR DESCRIPTION
The two checker tasks run quickly so don't gain much from UP-TO-DATE,
but it is convenient to not see them in the noise (checkUpperBoundDeps
in particular). Gradle only performs UP-TO-DATE checks (on the inputs)
if the task has both inputs and outputs defined.

The biggest saving was for distZip/distTar/shadowDistZip/shadowDistTar
which were using the same name for the non-shadow and shadow versions.
Thus the output file would always be out-of-date because it had been
rewritten and was invalid. This is worrisome because we could have
"randomly" been using the shadow Zip/Tar at times and the non-shadow
ones at others, although I think in practice the shadow tasks always run
last and so those are the files we'd see. Changing the classifier avoids
the colliding file names. These tasks took ~7 seconds, so incremental
builds are considerably shorter now.