### PR TITLE
okhttp: Comment out VisibleForTesting annotation

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -104,7 +104,7 @@ public final class OkHttpChannelBuilder extends
     PLAINTEXT
   }
 
-  @VisibleForTesting
+  // @VisibleForTesting
   static final ConnectionSpec INTERNAL_DEFAULT_CONNECTION_SPEC =
       new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
           .cipherSuites(

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpServerBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpServerBuilder.java
@@ -125,7 +125,7 @@ public final class OkHttpServerBuilder extends ForwardingServerBuilder<OkHttpSer
     return serverImplBuilder;
   }
 
-  @VisibleForTesting
+  // @VisibleForTesting
   OkHttpServerBuilder setTransportTracerFactory(TransportTracer.Factory transportTracerFactory) {
     this.transportTracerFactory = transportTracerFactory;
     return this;


### PR DESCRIPTION
Android linters can't recognize the difference when VisibleForTesting
is used because the method has different visibility, or because
the method only intended for testing.

Because of that linter complains when VisibleForTesting methods are
used in the production code.

Ideally we want to replace or remove this annotation, as its
usage for marking altered visibility for testing purposes is
discouraged since guava v30.0.