### PR TITLE
xds: Allow Gradle to use more memory when building interop - GCE

### DIFF
--- a/buildscripts/kokoro/xds.sh
+++ b/buildscripts/kokoro/xds.sh
@@ -8,7 +8,8 @@ fi
 cd github
 
 pushd grpc-java/interop-testing
-../gradlew installDist -x test -PskipCodegen=true -PskipAndroid=true
+GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1g'" \
+  ../gradlew installDist -x test -PskipCodegen=true -PskipAndroid=true
 popd
 
 git clone -b master --single-branch --depth=1 https://github.com/grpc/grpc.git


### PR DESCRIPTION
Same as #9347, but for GCE framework too (xds and xds_v3 jobs).

Should fix "Expiring Daemon because JVM heap space is exhausted".

PR #9269 probably pushed the build
over the edge, but there's been evidence via flakes for a good while
that we've been reaching the limit.

b/238334438
