### PR TITLE
intreop: fix xds interop structured logging

### DIFF
--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -11,6 +11,7 @@ description = "gRPC: Integration Testing"
 
 configurations {
     alpnagent
+    xdsinterop
 }
 
 evaluationDependsOn(project(':grpc-context').path)
@@ -36,13 +37,6 @@ dependencies {
     compileOnly libraries.javax.annotation
     shadow configurations.implementation.getDependencies().minus(xdsDependency)
     shadow project(path: ':grpc-xds', configuration: 'shadow')
-    // TODO(sergiitk): replace with com.google.cloud:google-cloud-logging
-    // Used instead of google-cloud-logging because it's failing
-    // due to a circular dependency on grpc.
-    // https://cloud.google.com/logging/docs/setup/java#the_javautillogging_handler
-    // Error example: "java.util.logging.ErrorManager: 1"
-    // Latest failing version com.google.cloud:google-cloud-logging:2.1.2
-    runtimeOnly group: 'io.github.devatherock', name: 'jul-jsonformatter', version: '1.1.0'
     runtimeOnly libraries.opencensus.impl,
             libraries.netty.tcnative,
             libraries.netty.tcnative.classes,
@@ -54,6 +48,13 @@ dependencies {
             libraries.mockito.core,
             libraries.okhttp
     alpnagent libraries.jetty.alpn.agent
+    // TODO(sergiitk): replace with com.google.cloud:google-cloud-logging
+    // Used instead of google-cloud-logging because it's failing
+    // due to a circular dependency on grpc.
+    // https://cloud.google.com/logging/docs/setup/java#the_javautillogging_handler
+    // Error example: "java.util.logging.ErrorManager: 1"
+    // Latest failing version com.google.cloud:google-cloud-logging:2.1.2
+    xdsinterop group: 'io.github.devatherock', name: 'jul-jsonformatter', version: '1.1.0'
 }
 
 configureProtoCompilation()
@@ -193,6 +194,7 @@ distributions.shadow.contents.into("bin") {
 
 distributions.shadow.contents.into("lib") {
     from(configurations.alpnagent)
+    from(configurations.xdsinterop)
 }
 
 distributions.shadow.distributionBaseName = project.name


### PR DESCRIPTION
No idea if this is correct - my gradle foo is lost.
But it does fix the issue with the missing jar:

```
❯ ./gradlew grpc-interop-testing:installDist -x test  -PskipCodegen=true -PskipAndroid=true --console=plain
❯ l interop-testing/build/install/grpc-interop-testing/lib/ | grep jul
-rw-r--r--   1 sergiitk  primarygroup     12299 Jul  8 19:52 jul-jsonformatter-1.1.0.jar
```

The regression for the missing jar introduced in https://github.com/grpc/grpc-java/pull/9230.