### PR TITLE
interop-testing: Hack runtimeOnly deps to be available at runtime

### DIFF
--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -34,7 +34,6 @@ dependencies {
     def xdsDependency = implementation project(':grpc-xds')
 
     compileOnly libraries.javax.annotation
-    shadow configurations.implementation.getDependencies().minus(xdsDependency)
     shadow project(path: ':grpc-xds', configuration: 'shadow')
     // TODO(sergiitk): replace with com.google.cloud:google-cloud-logging
     // Used instead of google-cloud-logging because it's failing
@@ -42,8 +41,10 @@ dependencies {
     // https://cloud.google.com/logging/docs/setup/java#the_javautillogging_handler
     // Error example: "java.util.logging.ErrorManager: 1"
     // Latest failing version com.google.cloud:google-cloud-logging:2.1.2
-    runtimeOnly group: 'io.github.devatherock', name: 'jul-jsonformatter', version: '1.1.0'
-    runtimeOnly libraries.opencensus.impl,
+    // TODO(ejona): These should be compileOnly, but that doesn't get picked up
+    // for the shadow runtime
+    implementation group: 'io.github.devatherock', name: 'jul-jsonformatter', version: '1.1.0'
+    implementation libraries.opencensus.impl,
             libraries.netty.tcnative,
             libraries.netty.tcnative.classes,
             project(':grpc-grpclb'),
@@ -54,6 +55,7 @@ dependencies {
             libraries.mockito.core,
             libraries.okhttp
     alpnagent libraries.jetty.alpn.agent
+    shadow configurations.implementation.getDependencies().minus(xdsDependency)
 }
 
 configureProtoCompilation()


### PR DESCRIPTION
RuntimeOnly dependencies have been missing since 3624d59. This is
because the implementation configuration extendsFrom the shadow
configuration, so any of the things like runtimeOnly are being lost.
This change isn't "correct" but it stops the bleeding with minimal cost.
It is probably incorrect to be using shadow plugin in interop-testing at
all.

CC @YifeiZhuang 