### PR TITLE
rls: Support multiple returned targets from RLS Server

### DIFF
--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -518,7 +518,7 @@ final class CachingRlsLbClient {
       // TODO(creamsoup) fallback to other targets if first one is not available
       childPolicyWrapper =
           refCountedChildPolicyWrapperFactory
-              .createOrGet(response.targets().get(0));
+              .createOrGet(response.targets());
       long now = ticker.read();
       expireTime = now + maxAgeNanos;
       staleTime = now + staleAgeNanos;

--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -623,14 +623,12 @@ final class CachingRlsLbClient {
     void cleanup() {
       synchronized (lock) {
         for (ChildPolicyWrapper policyWrapper : childPolicyWrappers)
-        refCountedChildPolicyWrapperFactory.release(policyWrapper);
+          refCountedChildPolicyWrapperFactory.release(policyWrapper);
       }
     }
 
     @Override
     public String toString() {
-//      StringBuilder policyWrapperBuiler = new StringBuilder();
-//      for (ChildPolicyWrapper)
       return MoreObjects.toStringHelper(this)
           .add("request", request)
           .add("response", response)

--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -57,7 +57,6 @@ import io.grpc.rls.RlsProtoData.RouteLookupResponse;
 import io.grpc.rls.Throttler.ThrottledException;
 import io.grpc.stub.StreamObserver;
 import io.grpc.util.ForwardingLoadBalancerHelper;
-import jdk.internal.joptsimple.internal.Strings;
 
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -57,9 +57,12 @@ import io.grpc.rls.RlsProtoData.RouteLookupResponse;
 import io.grpc.rls.Throttler.ThrottledException;
 import io.grpc.stub.StreamObserver;
 import io.grpc.util.ForwardingLoadBalancerHelper;
+import jdk.internal.joptsimple.internal.Strings;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -372,6 +375,15 @@ final class CachingRlsLbClient {
       return dataCacheEntry.getChildPolicyWrapper();
     }
 
+    @VisibleForTesting
+    @Nullable
+    ChildPolicyWrapper getChildPolicyWrapper(String target) {
+      if (!hasData()) {
+        return null;
+      }
+      return dataCacheEntry.getChildPolicyWrapper(target);
+    }
+
     @Nullable
     String getHeaderData() {
       if (!hasData()) {
@@ -509,14 +521,13 @@ final class CachingRlsLbClient {
     private final RouteLookupResponse response;
     private final long expireTime;
     private final long staleTime;
-    private final ChildPolicyWrapper childPolicyWrapper;
+    private final List<ChildPolicyWrapper> childPolicyWrappers;
 
     // GuardedBy CachingRlsLbClient.lock
     DataCacheEntry(RouteLookupRequest request, final RouteLookupResponse response) {
       super(request);
       this.response = checkNotNull(response, "response");
-      // TODO(creamsoup) fallback to other targets if first one is not available
-      childPolicyWrapper =
+      childPolicyWrappers =
           refCountedChildPolicyWrapperFactory
               .createOrGet(response.targets());
       long now = ticker.read();
@@ -563,9 +574,29 @@ final class CachingRlsLbClient {
       }
     }
 
+    @VisibleForTesting
+    ChildPolicyWrapper getChildPolicyWrapper(String target) {
+      for (ChildPolicyWrapper childPolicyWrapper : childPolicyWrappers) {
+        if (childPolicyWrapper.getTarget().equals(target)) {
+          return childPolicyWrapper;
+        }
+      }
+
+      throw new RuntimeException("Target not found:" + target);
+    }
+
     @Nullable
     ChildPolicyWrapper getChildPolicyWrapper() {
-      return childPolicyWrapper;
+      if (childPolicyWrappers == null || childPolicyWrappers.isEmpty()) {
+        return null;
+      }
+
+      for (ChildPolicyWrapper childPolicyWrapper : childPolicyWrappers) {
+        if (childPolicyWrapper.getState() != ConnectivityState.TRANSIENT_FAILURE) {
+          return childPolicyWrapper;
+        }
+      }
+      return childPolicyWrappers.get(0);
     }
 
     String getHeaderData() {
@@ -591,18 +622,21 @@ final class CachingRlsLbClient {
     @Override
     void cleanup() {
       synchronized (lock) {
-        refCountedChildPolicyWrapperFactory.release(childPolicyWrapper);
+        for (ChildPolicyWrapper policyWrapper : childPolicyWrappers)
+        refCountedChildPolicyWrapperFactory.release(policyWrapper);
       }
     }
 
     @Override
     public String toString() {
+//      StringBuilder policyWrapperBuiler = new StringBuilder();
+//      for (ChildPolicyWrapper)
       return MoreObjects.toStringHelper(this)
           .add("request", request)
           .add("response", response)
           .add("expireTime", expireTime)
           .add("staleTime", staleTime)
-          .add("childPolicyWrapper", childPolicyWrapper)
+          .add("childPolicyWrapper", childPolicyWrappers)
           .toString();
     }
   }
@@ -898,7 +932,8 @@ final class CachingRlsLbClient {
       boolean hasFallback = defaultTarget != null && !defaultTarget.isEmpty();
       if (response.hasData()) {
         ChildPolicyWrapper childPolicyWrapper = response.getChildPolicyWrapper();
-        SubchannelPicker picker = childPolicyWrapper.getPicker();
+        SubchannelPicker picker =
+            (childPolicyWrapper != null) ? childPolicyWrapper.getPicker() : null;
         if (picker == null) {
           return PickResult.withNoResult();
         }

--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -634,7 +634,7 @@ final class CachingRlsLbClient {
           .add("response", response)
           .add("expireTime", expireTime)
           .add("staleTime", staleTime)
-          .add("childPolicyWrapper", childPolicyWrappers)
+          .add("childPolicyWrappers", childPolicyWrappers)
           .toString();
     }
   }

--- a/rls/src/main/java/io/grpc/rls/LbPolicyConfiguration.java
+++ b/rls/src/main/java/io/grpc/rls/LbPolicyConfiguration.java
@@ -36,6 +36,7 @@ import io.grpc.rls.ChildLoadBalancerHelper.ChildLoadBalancerHelperProvider;
 import io.grpc.rls.RlsProtoData.RouteLookupConfig;
 import io.grpc.util.ForwardingLoadBalancerHelper;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -214,6 +215,9 @@ final class LbPolicyConfiguration {
     private final ChildLbStatusListener childLbStatusListener;
     private final ChildLoadBalancingPolicy childPolicy;
     private final ResolvedAddressFactory childLbResolvedAddressFactory;
+    private static final List<ConnectivityState> OK_STATES =
+        Arrays.asList(ConnectivityState.READY, ConnectivityState.IDLE);
+
 
     public RefCountedChildPolicyWrapperFactory(
         ChildLoadBalancingPolicy childPolicy,
@@ -248,6 +252,11 @@ final class LbPolicyConfiguration {
     }
 
     // GuardedBy CachingRlsLbClient.lock
+    ChildPolicyWrapper createOrGet(List<String> targets) {
+      return createOrGet(findBestTarget(targets));
+    }
+
+    // GuardedBy CachingRlsLbClient.lock
     void release(ChildPolicyWrapper childPolicyWrapper) {
       checkNotNull(childPolicyWrapper, "childPolicyWrapper");
       String target = childPolicyWrapper.getTarget();
@@ -257,6 +266,30 @@ final class LbPolicyConfiguration {
       if (existing.isReleased()) {
         childPolicyMap.remove(target);
       }
+    }
+
+    private String findBestTarget(List<String> targets) {
+      checkArgument(!targets.isEmpty(), "Empty list of target properties");
+
+      // Look for a policy that is READY or IDLE
+      for (String target : targets) {
+        RefCountedChildPolicyWrapper policyWrapper = childPolicyMap.get(target);
+        if (policyWrapper != null && OK_STATES.contains(policyWrapper.getObjectState())) {
+          return target;
+        }
+      }
+
+      // Look for a policy that is CONNECTING
+      for (String target : targets) {
+        RefCountedChildPolicyWrapper policyWrapper = childPolicyMap.get(target);
+        if (policyWrapper != null
+            && ConnectivityState.CONNECTING == policyWrapper.getObjectState()) {
+          return target;
+        }
+      }
+
+      // Return the first policy
+      return targets.get(0);
     }
   }
 
@@ -310,6 +343,10 @@ final class LbPolicyConfiguration {
 
     ChildPolicyReportingHelper getHelper() {
       return helper;
+    }
+
+    public ConnectivityState getState() {
+      return state;
     }
 
     void refreshState() {
@@ -422,6 +459,10 @@ final class LbPolicyConfiguration {
 
     boolean isReleased() {
       return childPolicyWrapper == null;
+    }
+
+    ConnectivityState getObjectState() {
+      return childPolicyWrapper.getState();
     }
 
     static RefCountedChildPolicyWrapper of(ChildPolicyWrapper childPolicyWrapper) {

--- a/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
+++ b/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
@@ -434,7 +434,9 @@ public class CachingRlsLbClientTest {
     rlsServerImpl.setLookupTable(
         ImmutableMap.of(
             routeLookupRequest,
-            RouteLookupResponse.create(ImmutableList.of("target1", "target2", "target3"), "header")));
+            RouteLookupResponse.create(
+                ImmutableList.of("target1", "target2", "target3"),
+                "header")));
 
     CachedRouteLookupResponse resp = getInSyncContext(routeLookupRequest);
     assertThat(resp.isPending()).isTrue();

--- a/rls/src/test/java/io/grpc/rls/LbPolicyConfigurationTest.java
+++ b/rls/src/test/java/io/grpc/rls/LbPolicyConfigurationTest.java
@@ -17,6 +17,7 @@
 package io.grpc.rls;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -45,6 +46,8 @@ import io.grpc.rls.LbPolicyConfiguration.ChildPolicyWrapper.ChildPolicyReporting
 import io.grpc.rls.LbPolicyConfiguration.InvalidChildPolicyConfigException;
 import io.grpc.rls.LbPolicyConfiguration.RefCountedChildPolicyWrapperFactory;
 import java.lang.Thread.UncaughtExceptionHandler;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -120,6 +123,72 @@ public class LbPolicyConfigurationTest {
     }
   }
 
+  private void setState(ChildPolicyWrapper policyWrapper, ConnectivityState newState) {
+    policyWrapper.getHelper().updateBalancingState(newState, picker);
+  }
+  
+  @Test
+  public void childLoadBalancingPolicy_multiTarget() {
+    List<String> targets = new ArrayList<>();
+    List<ChildPolicyWrapper> policyWrappers = new ArrayList<>();
+
+    for (int i = 1; i <= 3; i++) {
+      String target = "target" + i;
+      targets.add(target);
+      policyWrappers.add(factory.createOrGet(target));
+    }
+
+    // Set to states: null, READY, null
+    setState(policyWrappers.get(1), ConnectivityState.READY);
+    ChildPolicyWrapper childPolicy = factory.createOrGet(targets);
+    assertSame(policyWrappers.get(1), childPolicy);
+    factory.release(childPolicy);
+
+    // Set to states: null, CONNECTING, null
+    setState(policyWrappers.get(1), ConnectivityState.CONNECTING);
+    childPolicy = factory.createOrGet(targets);
+    assertSame(policyWrappers.get(1), childPolicy);
+    factory.release(childPolicy);
+
+    // Set to states: null, CONNECTING, READY
+    setState(policyWrappers.get(2), ConnectivityState.READY);
+    childPolicy = factory.createOrGet(targets);
+    assertSame(policyWrappers.get(2), childPolicy);
+    factory.release(childPolicy);
+
+    // Set to states: READY, CONNECTING, READY
+    setState(policyWrappers.get(0), ConnectivityState.READY);
+    childPolicy = factory.createOrGet(targets);
+    assertSame(policyWrappers.get(0), childPolicy);
+    factory.release(childPolicy);
+
+    // Set to states: TRANSIENT_FAILURE, CONNECTING, READY
+    setState(policyWrappers.get(0), ConnectivityState.TRANSIENT_FAILURE);
+    childPolicy = factory.createOrGet(targets);
+    assertSame(policyWrappers.get(2), childPolicy);
+    factory.release(childPolicy);
+
+    // Set to states: TRANSIENT_FAILURE, TRANSIENT_FAILURE, TRANSIENT_FAILURE
+    setState(policyWrappers.get(1), ConnectivityState.TRANSIENT_FAILURE);
+    setState(policyWrappers.get(2), ConnectivityState.TRANSIENT_FAILURE);
+    childPolicy = factory.createOrGet(targets);
+    assertSame(policyWrappers.get(0), childPolicy);
+    factory.release(childPolicy);
+
+    // Set to states: CONNECTING, CONNECTING, CONNECTING
+    setState(policyWrappers.get(0), ConnectivityState.CONNECTING);
+    setState(policyWrappers.get(1), ConnectivityState.CONNECTING);
+    setState(policyWrappers.get(2), ConnectivityState.CONNECTING);
+    childPolicy = factory.createOrGet(targets);
+    assertSame(policyWrappers.get(0), childPolicy);
+    factory.release(childPolicy);
+
+    // Cleanup
+    for (ChildPolicyWrapper policyWrapper : policyWrappers) {
+      factory.release(policyWrapper);
+    }
+  }
+  
   @Test
   public void childLoadBalancingPolicy_effectiveChildPolicy() {
     LoadBalancerProvider mockProvider = mock(LoadBalancerProvider.class);


### PR DESCRIPTION
Pick the first target that is in a good state (READY or IDLE).  If none, then pick the first target in CONNECTING state.  If none, use the first target.

Fixes #9236