### PR TITLE
Revert "Fix for ipv6 link local with scope (#9326)" (1.48.x backport)

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpProtocolNegotiator.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpProtocolNegotiator.java
@@ -19,8 +19,6 @@ package io.grpc.okhttp;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.net.HostAndPort;
-import com.google.common.net.InetAddresses;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.okhttp.internal.OptionalMethod;
 import io.grpc.okhttp.internal.Platform;
@@ -249,9 +247,7 @@ class OkHttpProtocolNegotiator {
           } else {
             SET_USE_SESSION_TICKETS.invokeOptionalWithoutCheckedException(sslSocket, true);
           }
-          if (SET_SERVER_NAMES != null
-              && SNI_HOST_NAME != null
-              && !InetAddresses.isInetAddress(HostAndPort.fromString(hostname).getHost())) {
+          if (SET_SERVER_NAMES != null && SNI_HOST_NAME != null) {
             SET_SERVER_NAMES
                 .invoke(sslParams, Collections.singletonList(SNI_HOST_NAME.newInstance(hostname)));
           } else {


### PR DESCRIPTION
This reverts commit c1abc7f8acb46a3c4500e6cf8352222422e8624f. It
produced compilation issues inside Google. I strongly suspect it isn't
this commit or gRPC's fault, but it prevents further testing until it is
resolved.

CC @jader-eero

Backport of #9375