### PR TITLE
interop client: fix soak test bug where we can crash if peer wasn't set

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -2054,12 +2054,12 @@ public abstract class AbstractInteropTest {
             .withInterceptors(recordClientCallInterceptor(clientCallCapture));
       }
       SoakIterationResult result = performOneSoakIteration(soakStub);
-      String peer = clientCallCapture
-          .get().getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR).toString();
+      Attributes.Key<SocketAddress> peer = clientCallCapture
+          .get().getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
       System.err.print(
           String.format(
               "soak iteration: %d elapsed_ms: %d peer: %s",
-              i, result.getLatencyMs(), peer));
+              i, result.getLatencyMs(), peer != null ? peer.toString() : "null"));
       if (!result.getStatus().equals(Status.OK)) {
         totalFailures++;
         System.err.println(String.format(" failed: %s", result.getStatus()));

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -2054,7 +2054,7 @@ public abstract class AbstractInteropTest {
             .withInterceptors(recordClientCallInterceptor(clientCallCapture));
       }
       SoakIterationResult result = performOneSoakIteration(soakStub);
-      Attributes.Key<SocketAddress> peer = clientCallCapture
+      SocketAddress peer = clientCallCapture
           .get().getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
       System.err.print(
           String.format(


### PR DESCRIPTION
Noticed this crash in a couple of c-build failures

cc @ejona86 