### PR TITLE
rls: Change AdaptiveThrottler to use Ticker instead of TimeProvider

### DIFF
--- a/rls/src/main/java/io/grpc/rls/AdaptiveThrottler.java
+++ b/rls/src/main/java/io/grpc/rls/AdaptiveThrottler.java
@@ -249,14 +249,14 @@ final class AdaptiveThrottler implements Throttler {
     /** Gets the current slot. */
     private Slot getSlot(long now) {
       Slot currentSlot = slots.get(currentIndex);
-      if (now < currentSlot.endNanos) {
+      if (now - currentSlot.endNanos < 0) {
         return currentSlot;
       } else {
         long slotBoundary = getSlotEndTime(now);
         synchronized (this) {
           int index = currentIndex;
           currentSlot = slots.get(index);
-          if (now < currentSlot.endNanos) {
+          if (now - currentSlot.endNanos < 0) {
             return currentSlot;
           }
           int newIndex = (index == NUM_SLOTS - 1) ? 0 : index + 1;

--- a/rls/src/main/java/io/grpc/rls/AdaptiveThrottler.java
+++ b/rls/src/main/java/io/grpc/rls/AdaptiveThrottler.java
@@ -311,7 +311,7 @@ final class AdaptiveThrottler implements Throttler {
       int index = currentIndex;
 
       long accumulated = 0L;
-      long prevSlotEnd = Long.MAX_VALUE;
+      Long prevSlotEnd = null;
       for (int i = 0; i < NUM_SLOTS; i++) {
         if (index < 0) {
           index = NUM_SLOTS - 1;
@@ -324,12 +324,13 @@ final class AdaptiveThrottler implements Throttler {
 
         long currentSlotEnd = currentSlot.endNanos;
 
-        if (currentSlotEnd <= intervalStart || currentSlotEnd > prevSlotEnd) {
+        if (currentSlotEnd - intervalStart <= 0
+            || (prevSlotEnd != null && currentSlotEnd - prevSlotEnd > 0)) {
           break;
         }
         prevSlotEnd = currentSlotEnd;
 
-        if (currentSlotEnd > intervalEnd) {
+        if (currentSlotEnd - intervalEnd > 0) {
           continue;
         }
         accumulated = accumulated + currentSlot.count;

--- a/rls/src/test/java/io/grpc/rls/AdaptiveThrottlerTest.java
+++ b/rls/src/test/java/io/grpc/rls/AdaptiveThrottlerTest.java
@@ -21,7 +21,6 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.common.base.Ticker;
 import io.grpc.internal.FakeClock;
 import java.util.concurrent.TimeUnit;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -30,22 +29,15 @@ import org.junit.runners.JUnit4;
 public class AdaptiveThrottlerTest {
   private static final float TOLERANCE = 0.0001f;
 
-  private FakeClock fakeClock;
-  private Ticker fakeTicker;
-  private AdaptiveThrottler throttler;
-
-  @Before
-  public void setUp() {
-    fakeClock = new FakeClock();
-    fakeTicker = fakeClock.getTicker();
-    throttler =
-        new AdaptiveThrottler.Builder()
-            .setHistorySeconds(1)
-            .setRatioForAccepts(1.0f)
-            .setRequestsPadding(1)
-            .setTicker(fakeTicker)
-            .build();
-  }
+  private final FakeClock fakeClock = new FakeClock();
+  private final Ticker fakeTicker = fakeClock.getTicker();
+  private final AdaptiveThrottler throttler =
+      new AdaptiveThrottler.Builder()
+          .setHistorySeconds(1)
+          .setRatioForAccepts(1.0f)
+          .setRequestsPadding(1)
+          .setTicker(fakeTicker)
+          .build();
 
   @Test
   public void shouldThrottle() {
@@ -124,7 +116,9 @@ public class AdaptiveThrottlerTest {
    */
   @Test
   public void negativeTickerValues() {
-    fakeClock.forwardTime(-300, TimeUnit.MILLISECONDS);
+    long rewindAmount = TimeUnit.MILLISECONDS.toNanos(300) + fakeClock.getTicker().read();
+    fakeClock.forwardTime(-1 * rewindAmount, TimeUnit.NANOSECONDS);
+    assertThat(fakeClock.getTicker().read()).isEqualTo(TimeUnit.MILLISECONDS.toNanos(-300));
     shouldThrottle();
   }
 }

--- a/rls/src/test/java/io/grpc/rls/AdaptiveThrottlerTest.java
+++ b/rls/src/test/java/io/grpc/rls/AdaptiveThrottlerTest.java
@@ -117,6 +117,11 @@ public class AdaptiveThrottlerTest {
         .of(2.0f / 3.0f);
   }
 
+  /**
+   * Check that when the ticker returns a negative value for now that the slot detection logic
+   * is correctly handled and then when the value transitions from negative to positive that things
+   * continue to work correctly.
+   */
   @Test
   public void negativeTickerValues() {
     fakeClock.forwardTime(-300, TimeUnit.MILLISECONDS);

--- a/rls/src/test/java/io/grpc/rls/AdaptiveThrottlerTest.java
+++ b/rls/src/test/java/io/grpc/rls/AdaptiveThrottlerTest.java
@@ -82,7 +82,8 @@ public class AdaptiveThrottlerTest {
         .of(1.0f / 3.0f);
 
     // Skip to half second mark from the beginning (half the duration).
-    fakeClock.forwardTime(500 - (fakeClock.currentTimeMillis() - startTime), TimeUnit.MILLISECONDS);
+    fakeClock.forwardTime(500 - (fakeClock.currentTimeMillis() - startTime),
+        TimeUnit.MILLISECONDS);
 
     // Request 3, throttled by backend
     assertThat(throttler.shouldThrottle(0.4f)).isFalse();


### PR DESCRIPTION
Ticker is based on System.nanoTime, so isn't affected by updates to the system clock like TimeProvider is.

Fixes #9048 