### PR TITLE
xds: do not expose orca proto in ORCA api (#9366) (v1.48 backport)

### DIFF
--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -83,6 +83,9 @@ if [[ -z "${SKIP_TESTS:-}" ]]; then
   ../gradlew build $GRADLE_FLAGS
   popd
   # TODO(zpencer): also build the GAE examples
+  pushd examples/example-orca
+  ../gradlew build $GRADLE_FLAGS
+  popd
 fi
 
 LOCAL_MVN_TEMP=$(mktemp -d)

--- a/examples/example-orca/src/main/java/io/grpc/examples/orca/CustomBackendMetricsLoadBalancerProvider.java
+++ b/examples/example-orca/src/main/java/io/grpc/examples/orca/CustomBackendMetricsLoadBalancerProvider.java
@@ -20,11 +20,11 @@ import io.grpc.ConnectivityState;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
+import io.grpc.services.MetricReport;
 import io.grpc.util.ForwardingLoadBalancer;
 import io.grpc.util.ForwardingLoadBalancerHelper;
 import io.grpc.xds.orca.OrcaOobUtil;
 import io.grpc.xds.orca.OrcaPerRequestUtil;
-import io.grpc.xds.shaded.com.github.xds.data.orca.v3.OrcaLoadReport;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -87,7 +87,7 @@ final class CustomBackendMetricsLoadBalancerProvider extends LoadBalancerProvide
         // otherwise it is treated as server minimum report interval.
         OrcaOobUtil.setListener(subchannel, new OrcaOobUtil.OrcaOobReportListener() {
               @Override
-              public void onLoadReport(OrcaLoadReport orcaLoadReport) {
+              public void onLoadReport(MetricReport orcaLoadReport) {
                 System.out.println("Example load balancer received OOB metrics report:\n"
                     + orcaLoadReport);
               }
@@ -129,7 +129,7 @@ final class CustomBackendMetricsLoadBalancerProvider extends LoadBalancerProvide
             OrcaPerRequestUtil.getInstance().newOrcaClientStreamTracerFactory(
                 new OrcaPerRequestUtil.OrcaPerRequestReportListener() {
                   @Override
-                  public void onLoadReport(OrcaLoadReport orcaLoadReport) {
+                  public void onLoadReport(MetricReport orcaLoadReport) {
                     System.out.println("Example load balancer received per-rpc metrics report:\n"
                         + orcaLoadReport);
                   }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/CustomBackendMetricsLoadBalancerProvider.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/CustomBackendMetricsLoadBalancerProvider.java
@@ -23,7 +23,7 @@ import io.grpc.ConnectivityState;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
-import io.grpc.services.CallMetricRecorder;
+import io.grpc.services.MetricReport;
 import io.grpc.testing.integration.Messages.TestOrcaReport;
 import io.grpc.util.ForwardingLoadBalancer;
 import io.grpc.util.ForwardingLoadBalancerHelper;
@@ -87,7 +87,7 @@ final class CustomBackendMetricsLoadBalancerProvider extends LoadBalancerProvide
         Subchannel subchannel = super.createSubchannel(args);
         OrcaOobUtil.setListener(subchannel, new OrcaOobUtil.OrcaOobReportListener() {
               @Override
-              public void onLoadReport(CallMetricRecorder.CallMetricReport orcaLoadReport) {
+              public void onLoadReport(MetricReport orcaLoadReport) {
                 latestOobReport = fromCallMetricReport(orcaLoadReport);
               }
             },
@@ -133,7 +133,7 @@ final class CustomBackendMetricsLoadBalancerProvider extends LoadBalancerProvide
             OrcaPerRequestUtil.getInstance().newOrcaClientStreamTracerFactory(
                 new OrcaPerRequestUtil.OrcaPerRequestReportListener() {
                   @Override
-                  public void onLoadReport(CallMetricRecorder.CallMetricReport callMetricReport) {
+                  public void onLoadReport(MetricReport callMetricReport) {
                     AtomicReference<TestOrcaReport> reportRef =
                         args.getCallOptions().getOption(ORCA_RPC_REPORT_KEY);
                     reportRef.set(fromCallMetricReport(callMetricReport));
@@ -143,8 +143,7 @@ final class CustomBackendMetricsLoadBalancerProvider extends LoadBalancerProvide
     }
   }
 
-  private static TestOrcaReport fromCallMetricReport(
-      CallMetricRecorder.CallMetricReport callMetricReport) {
+  private static TestOrcaReport fromCallMetricReport(MetricReport callMetricReport) {
     return TestOrcaReport.newBuilder()
         .setCpuUtilization(callMetricReport.getCpuUtilization())
         .setMemoryUtilization(callMetricReport.getMemoryUtilization())

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
@@ -141,7 +141,7 @@ public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
       recorder.recordUtilizationMetric(entry.getKey(), entry.getValue());
     }
     for (Map.Entry<String, Double> entry : report.getRequestCostMap().entrySet()) {
-      recorder.recordCallMetric(entry.getKey(), entry.getValue());
+      recorder.recordRequestCostMetric(entry.getKey(), entry.getValue());
     }
   }
 

--- a/services/BUILD.bazel
+++ b/services/BUILD.bazel
@@ -43,6 +43,7 @@ java_library(
         "//api",
         "//context",
         "@com_google_code_findbugs_jsr305//jar",
+        "@com_google_errorprone_error_prone_annotations//jar",
         "@com_google_guava_guava//jar",
     ],
 )

--- a/services/BUILD.bazel
+++ b/services/BUILD.bazel
@@ -37,6 +37,7 @@ java_library(
     srcs = [
         "src/main/java/io/grpc/services/CallMetricRecorder.java",
         "src/main/java/io/grpc/services/MetricRecorder.java",
+        "src/main/java/io/grpc/services/MetricReport.java",
     ],
     deps = [
         "//api",

--- a/services/src/main/java/io/grpc/services/CallMetricRecorder.java
+++ b/services/src/main/java/io/grpc/services/CallMetricRecorder.java
@@ -53,7 +53,8 @@ public final class CallMetricRecorder {
     private Map<String, Double> utilizationMetrics;
 
     /**
-     * Create a report for all backend metrics.
+     * A gRPC object of orca load report. LB policies listening at per-rpc or oob orca load reports
+     * will be notified of the metrics data in this data format.
      */
     CallMetricReport(double cpuUtilization, double memoryUtilization,
                             Map<String, Double> requestCostMetrics,

--- a/services/src/main/java/io/grpc/services/CallMetricRecorder.java
+++ b/services/src/main/java/io/grpc/services/CallMetricRecorder.java
@@ -16,8 +16,6 @@
 
 package io.grpc.services;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.Context;
 import io.grpc.ExperimentalApi;
@@ -45,42 +43,6 @@ public final class CallMetricRecorder {
   private double cpuUtilizationMetric = 0;
   private double memoryUtilizationMetric = 0;
   private volatile boolean disabled;
-
-  public static final class CallMetricReport {
-    private double cpuUtilization;
-    private double memoryUtilization;
-    private Map<String, Double> requestCostMetrics;
-    private Map<String, Double> utilizationMetrics;
-
-    /**
-     * A gRPC object of orca load report. LB policies listening at per-rpc or oob orca load reports
-     * will be notified of the metrics data in this data format.
-     */
-    CallMetricReport(double cpuUtilization, double memoryUtilization,
-                            Map<String, Double> requestCostMetrics,
-                            Map<String, Double> utilizationMetrics) {
-      this.cpuUtilization = cpuUtilization;
-      this.memoryUtilization = memoryUtilization;
-      this.requestCostMetrics = checkNotNull(requestCostMetrics, "requestCostMetrics");
-      this.utilizationMetrics = checkNotNull(utilizationMetrics, "utilizationMetrics");
-    }
-
-    public double getCpuUtilization() {
-      return cpuUtilization;
-    }
-
-    public double getMemoryUtilization() {
-      return memoryUtilization;
-    }
-
-    public Map<String, Double> getRequestCostMetrics() {
-      return requestCostMetrics;
-    }
-
-    public Map<String, Double> getUtilizationMetrics() {
-      return utilizationMetrics;
-    }
-  }
 
   /**
    * Returns the call metric recorder attached to the current {@link Context}.  If there is none,
@@ -201,13 +163,13 @@ public final class CallMetricRecorder {
    *
    * @return a per-request ORCA reports containing all saved metrics.
    */
-  CallMetricReport finalizeAndDump2() {
+  MetricReport finalizeAndDump2() {
     Map<String, Double> savedRequestCostMetrics = finalizeAndDump();
     Map<String, Double> savedUtilizationMetrics = utilizationMetrics.get();
     if (savedUtilizationMetrics == null) {
       savedUtilizationMetrics = Collections.emptyMap();
     }
-    return new CallMetricReport(cpuUtilizationMetric,
+    return new MetricReport(cpuUtilizationMetric,
         memoryUtilizationMetric, Collections.unmodifiableMap(savedRequestCostMetrics),
         Collections.unmodifiableMap(savedUtilizationMetrics)
     );

--- a/services/src/main/java/io/grpc/services/CallMetricRecorder.java
+++ b/services/src/main/java/io/grpc/services/CallMetricRecorder.java
@@ -17,6 +17,7 @@
 package io.grpc.services;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.errorprone.annotations.InlineMe;
 import io.grpc.Context;
 import io.grpc.ExperimentalApi;
 import java.util.Collections;
@@ -92,8 +93,25 @@ public final class CallMetricRecorder {
    *
    * @return this recorder object
    * @since 1.47.0
+   * @deprecated use {@link #recordRequestCostMetric} instead.
+   *     This method will be removed in the future.
    */
+  @Deprecated
+  @InlineMe(replacement = "this.recordRequestCostMetric(name, value)")
   public CallMetricRecorder recordCallMetric(String name, double value) {
+    return recordRequestCostMetric(name, value);
+  }
+
+  /**
+   * Records a call metric measurement for request cost.
+   * If RPC has already finished, this method is no-op.
+   *
+   * <p>A latter record will overwrite its former name-sakes.
+   *
+   * @return this recorder object
+   * @since 1.48.1
+   */
+  public CallMetricRecorder recordRequestCostMetric(String name, double value) {
     if (disabled) {
       return this;
     }

--- a/services/src/main/java/io/grpc/services/InternalCallMetricRecorder.java
+++ b/services/src/main/java/io/grpc/services/InternalCallMetricRecorder.java
@@ -44,4 +44,12 @@ public final class InternalCallMetricRecorder {
   public static CallMetricRecorder.CallMetricReport finalizeAndDump2(CallMetricRecorder recorder) {
     return recorder.finalizeAndDump2();
   }
+
+  public static CallMetricRecorder.CallMetricReport createMetricReport(
+      double cpuUtilization, double memoryUtilization,
+      Map<String, Double> requestCostMetrics,
+      Map<String, Double> utilizationMetrics) {
+    return new CallMetricRecorder.CallMetricReport(cpuUtilization, memoryUtilization,
+        requestCostMetrics, utilizationMetrics);
+  }
 }

--- a/services/src/main/java/io/grpc/services/InternalCallMetricRecorder.java
+++ b/services/src/main/java/io/grpc/services/InternalCallMetricRecorder.java
@@ -41,15 +41,13 @@ public final class InternalCallMetricRecorder {
     return recorder.finalizeAndDump();
   }
 
-  public static CallMetricRecorder.CallMetricReport finalizeAndDump2(CallMetricRecorder recorder) {
+  public static MetricReport finalizeAndDump2(CallMetricRecorder recorder) {
     return recorder.finalizeAndDump2();
   }
 
-  public static CallMetricRecorder.CallMetricReport createMetricReport(
-      double cpuUtilization, double memoryUtilization,
-      Map<String, Double> requestCostMetrics,
-      Map<String, Double> utilizationMetrics) {
-    return new CallMetricRecorder.CallMetricReport(cpuUtilization, memoryUtilization,
+  public static MetricReport createMetricReport(double cpuUtilization, double memoryUtilization,
+      Map<String, Double> requestCostMetrics, Map<String, Double> utilizationMetrics) {
+    return new MetricReport(cpuUtilization, memoryUtilization,
         requestCostMetrics, utilizationMetrics);
   }
 }

--- a/services/src/main/java/io/grpc/services/InternalMetricRecorder.java
+++ b/services/src/main/java/io/grpc/services/InternalMetricRecorder.java
@@ -29,7 +29,7 @@ public final class InternalMetricRecorder {
   private InternalMetricRecorder() {
   }
 
-  public static CallMetricRecorder.CallMetricReport getMetricReport(MetricRecorder recorder) {
+  public static MetricReport getMetricReport(MetricRecorder recorder) {
     return recorder.getMetricReport();
   }
 }

--- a/services/src/main/java/io/grpc/services/MetricRecorder.java
+++ b/services/src/main/java/io/grpc/services/MetricRecorder.java
@@ -86,8 +86,8 @@ public final class MetricRecorder {
     memoryUtilization = 0;
   }
 
-  CallMetricRecorder.CallMetricReport getMetricReport() {
-    return new CallMetricRecorder.CallMetricReport(cpuUtilization, memoryUtilization,
+  MetricReport getMetricReport() {
+    return new MetricReport(cpuUtilization, memoryUtilization,
         Collections.emptyMap(), Collections.unmodifiableMap(metricsData));
   }
 }

--- a/services/src/main/java/io/grpc/services/MetricReport.java
+++ b/services/src/main/java/io/grpc/services/MetricReport.java
@@ -18,6 +18,7 @@ package io.grpc.services;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.MoreObjects;
 import io.grpc.ExperimentalApi;
 import java.util.Map;
 
@@ -55,5 +56,15 @@ public final class MetricReport {
 
   public Map<String, Double> getUtilizationMetrics() {
     return utilizationMetrics;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("cpuUtilization", cpuUtilization)
+        .add("memoryUtilization", memoryUtilization)
+        .add("requestCost", requestCostMetrics)
+        .add("utilization", utilizationMetrics)
+        .toString();
   }
 }

--- a/services/src/main/java/io/grpc/services/MetricReport.java
+++ b/services/src/main/java/io/grpc/services/MetricReport.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.services;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import io.grpc.ExperimentalApi;
+import java.util.Map;
+
+/**
+ * A gRPC object of orca load report. LB policies listening at per-rpc or oob orca load reports
+ * will be notified of the metrics data in this data format.
+ */
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/9381")
+public final class MetricReport {
+  private double cpuUtilization;
+  private double memoryUtilization;
+  private Map<String, Double> requestCostMetrics;
+  private Map<String, Double> utilizationMetrics;
+
+  MetricReport(double cpuUtilization, double memoryUtilization,
+                   Map<String, Double> requestCostMetrics,
+                   Map<String, Double> utilizationMetrics) {
+    this.cpuUtilization = cpuUtilization;
+    this.memoryUtilization = memoryUtilization;
+    this.requestCostMetrics = checkNotNull(requestCostMetrics, "requestCostMetrics");
+    this.utilizationMetrics = checkNotNull(utilizationMetrics, "utilizationMetrics");
+  }
+
+  public double getCpuUtilization() {
+    return cpuUtilization;
+  }
+
+  public double getMemoryUtilization() {
+    return memoryUtilization;
+  }
+
+  public Map<String, Double> getRequestCostMetrics() {
+    return requestCostMetrics;
+  }
+
+  public Map<String, Double> getUtilizationMetrics() {
+    return utilizationMetrics;
+  }
+}

--- a/services/src/test/java/io/grpc/services/CallMetricRecorderTest.java
+++ b/services/src/test/java/io/grpc/services/CallMetricRecorderTest.java
@@ -47,7 +47,7 @@ public class CallMetricRecorderTest {
     recorder.recordCpuUtilizationMetric(0.1928);
     recorder.recordMemoryUtilizationMetric(47.4);
 
-    CallMetricRecorder.CallMetricReport dump = recorder.finalizeAndDump2();
+    MetricReport dump = recorder.finalizeAndDump2();
     Truth.assertThat(dump.getUtilizationMetrics())
         .containsExactly("util1", 154353.423, "util2", 0.1367, "util3", 1437.34);
     Truth.assertThat(dump.getRequestCostMetrics())
@@ -76,7 +76,7 @@ public class CallMetricRecorderTest {
     recorder.recordMemoryUtilizationMetric(9384.0);
     recorder.recordUtilizationMetric("util1", 84323.3);
 
-    CallMetricRecorder.CallMetricReport dump = recorder.finalizeAndDump2();
+    MetricReport dump = recorder.finalizeAndDump2();
     Truth.assertThat(dump.getRequestCostMetrics())
         .containsExactly("cost1", 4654.67, "cost2", 75.83);
     Truth.assertThat(dump.getMemoryUtilization()).isEqualTo(9384.0);

--- a/services/src/test/java/io/grpc/services/CallMetricRecorderTest.java
+++ b/services/src/test/java/io/grpc/services/CallMetricRecorderTest.java
@@ -41,9 +41,9 @@ public class CallMetricRecorderTest {
     recorder.recordUtilizationMetric("util1", 154353.423);
     recorder.recordUtilizationMetric("util2", 0.1367);
     recorder.recordUtilizationMetric("util3", 1437.34);
-    recorder.recordCallMetric("cost1", 37465.12);
-    recorder.recordCallMetric("cost2", 10293.0);
-    recorder.recordCallMetric("cost3", 1.0);
+    recorder.recordRequestCostMetric("cost1", 37465.12);
+    recorder.recordRequestCostMetric("cost2", 10293.0);
+    recorder.recordRequestCostMetric("cost3", 1.0);
     recorder.recordCpuUtilizationMetric(0.1928);
     recorder.recordMemoryUtilizationMetric(47.4);
 
@@ -65,11 +65,11 @@ public class CallMetricRecorderTest {
 
   @Test
   public void lastValueWinForMetricsWithSameName() {
-    recorder.recordCallMetric("cost1", 3412.5435);
-    recorder.recordCallMetric("cost2", 6441.341);
-    recorder.recordCallMetric("cost1", 6441.341);
-    recorder.recordCallMetric("cost1", 4654.67);
-    recorder.recordCallMetric("cost2", 75.83);
+    recorder.recordRequestCostMetric("cost1", 3412.5435);
+    recorder.recordRequestCostMetric("cost2", 6441.341);
+    recorder.recordRequestCostMetric("cost1", 6441.341);
+    recorder.recordRequestCostMetric("cost1", 4654.67);
+    recorder.recordRequestCostMetric("cost2", 75.83);
     recorder.recordMemoryUtilizationMetric(1.3);
     recorder.recordMemoryUtilizationMetric(3.1);
     recorder.recordUtilizationMetric("util1", 28374.21);

--- a/xds/src/main/java/io/grpc/xds/orca/OrcaMetricReportingServerInterceptor.java
+++ b/xds/src/main/java/io/grpc/xds/orca/OrcaMetricReportingServerInterceptor.java
@@ -31,6 +31,7 @@ import io.grpc.Status;
 import io.grpc.protobuf.ProtoUtils;
 import io.grpc.services.CallMetricRecorder;
 import io.grpc.services.InternalCallMetricRecorder;
+import io.grpc.services.MetricReport;
 
 /**
  * A {@link ServerInterceptor} that intercepts a {@link ServerCall} by running server-side RPC
@@ -89,8 +90,7 @@ public final class OrcaMetricReportingServerInterceptor implements ServerInterce
         next);
   }
 
-  private static OrcaLoadReport fromInternalReport(
-      CallMetricRecorder.CallMetricReport internalReport) {
+  private static OrcaLoadReport fromInternalReport(MetricReport internalReport) {
     return OrcaLoadReport.newBuilder()
         .setCpuUtilization(internalReport.getCpuUtilization())
         .setMemUtilization(internalReport.getMemoryUtilization())

--- a/xds/src/main/java/io/grpc/xds/orca/OrcaOobUtil.java
+++ b/xds/src/main/java/io/grpc/xds/orca/OrcaOobUtil.java
@@ -51,6 +51,7 @@ import io.grpc.SynchronizationContext.ScheduledHandle;
 import io.grpc.internal.BackoffPolicy;
 import io.grpc.internal.ExponentialBackoffPolicy;
 import io.grpc.internal.GrpcUtil;
+import io.grpc.services.CallMetricRecorder;
 import io.grpc.util.ForwardingLoadBalancerHelper;
 import io.grpc.util.ForwardingSubchannel;
 import java.util.HashMap;
@@ -168,9 +169,9 @@ public final class OrcaOobUtil {
      * <p>Note this callback will be invoked from the {@link SynchronizationContext} of the
      * delegated helper, implementations should not block.
      *
-     * @param report load report in the format of ORCA protocol.
+     * @param report load report in the format of grpc {@link CallMetricRecorder.CallMetricReport}.
      */
-    void onLoadReport(OrcaLoadReport report);
+    void onLoadReport(CallMetricRecorder.CallMetricReport report);
   }
 
   static final Attributes.Key<SubchannelImpl> ORCA_REPORTING_STATE_KEY =
@@ -450,8 +451,10 @@ public final class OrcaOobUtil {
           callHasResponded = true;
           backoffPolicy = null;
           subchannelLogger.log(ChannelLogLevel.DEBUG, "Received an ORCA report: {0}", response);
+          CallMetricRecorder.CallMetricReport metricReport =
+              OrcaPerRequestUtil.fromOrcaLoadReport(response);
           for (OrcaOobReportListener listener : configs.keySet()) {
-            listener.onLoadReport(response);
+            listener.onLoadReport(metricReport);
           }
           call.request(1);
         }

--- a/xds/src/main/java/io/grpc/xds/orca/OrcaOobUtil.java
+++ b/xds/src/main/java/io/grpc/xds/orca/OrcaOobUtil.java
@@ -51,7 +51,7 @@ import io.grpc.SynchronizationContext.ScheduledHandle;
 import io.grpc.internal.BackoffPolicy;
 import io.grpc.internal.ExponentialBackoffPolicy;
 import io.grpc.internal.GrpcUtil;
-import io.grpc.services.CallMetricRecorder;
+import io.grpc.services.MetricReport;
 import io.grpc.util.ForwardingLoadBalancerHelper;
 import io.grpc.util.ForwardingSubchannel;
 import java.util.HashMap;
@@ -169,9 +169,9 @@ public final class OrcaOobUtil {
      * <p>Note this callback will be invoked from the {@link SynchronizationContext} of the
      * delegated helper, implementations should not block.
      *
-     * @param report load report in the format of grpc {@link CallMetricRecorder.CallMetricReport}.
+     * @param report load report in the format of grpc {@link MetricReport}.
      */
-    void onLoadReport(CallMetricRecorder.CallMetricReport report);
+    void onLoadReport(MetricReport report);
   }
 
   static final Attributes.Key<SubchannelImpl> ORCA_REPORTING_STATE_KEY =
@@ -451,8 +451,7 @@ public final class OrcaOobUtil {
           callHasResponded = true;
           backoffPolicy = null;
           subchannelLogger.log(ChannelLogLevel.DEBUG, "Received an ORCA report: {0}", response);
-          CallMetricRecorder.CallMetricReport metricReport =
-              OrcaPerRequestUtil.fromOrcaLoadReport(response);
+          MetricReport metricReport = OrcaPerRequestUtil.fromOrcaLoadReport(response);
           for (OrcaOobReportListener listener : configs.keySet()) {
             listener.onLoadReport(metricReport);
           }

--- a/xds/src/main/java/io/grpc/xds/orca/OrcaPerRequestUtil.java
+++ b/xds/src/main/java/io/grpc/xds/orca/OrcaPerRequestUtil.java
@@ -28,8 +28,8 @@ import io.grpc.LoadBalancer;
 import io.grpc.Metadata;
 import io.grpc.internal.ForwardingClientStreamTracer;
 import io.grpc.protobuf.ProtoUtils;
-import io.grpc.services.CallMetricRecorder;
 import io.grpc.services.InternalCallMetricRecorder;
+import io.grpc.services.MetricReport;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -182,9 +182,9 @@ public abstract class OrcaPerRequestUtil {
      * <p>Note this callback will be invoked from the network thread as the RPC finishes,
      * implementations should not block.
      *
-     * @param report load report in the format of grpc {@link CallMetricRecorder.CallMetricReport}.
+     * @param report load report in the format of grpc {@link MetricReport}.
      */
-    void onLoadReport(CallMetricRecorder.CallMetricReport report);
+    void onLoadReport(MetricReport report);
   }
 
   /**
@@ -252,7 +252,7 @@ public abstract class OrcaPerRequestUtil {
     }
   }
 
-  static CallMetricRecorder.CallMetricReport fromOrcaLoadReport(OrcaLoadReport loadReport) {
+  static MetricReport fromOrcaLoadReport(OrcaLoadReport loadReport) {
     return InternalCallMetricRecorder.createMetricReport(loadReport.getCpuUtilization(),
         loadReport.getMemUtilization(), loadReport.getRequestCostMap(),
         loadReport.getUtilizationMap());
@@ -271,7 +271,7 @@ public abstract class OrcaPerRequestUtil {
     }
 
     void onReport(OrcaLoadReport report) {
-      CallMetricRecorder.CallMetricReport metricReport = fromOrcaLoadReport(report);
+      MetricReport metricReport = fromOrcaLoadReport(report);
       for (OrcaPerRequestReportListener listener : listeners) {
         listener.onLoadReport(metricReport);
       }

--- a/xds/src/main/java/io/grpc/xds/orca/OrcaPerRequestUtil.java
+++ b/xds/src/main/java/io/grpc/xds/orca/OrcaPerRequestUtil.java
@@ -28,6 +28,8 @@ import io.grpc.LoadBalancer;
 import io.grpc.Metadata;
 import io.grpc.internal.ForwardingClientStreamTracer;
 import io.grpc.protobuf.ProtoUtils;
+import io.grpc.services.CallMetricRecorder;
+import io.grpc.services.InternalCallMetricRecorder;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -175,14 +177,14 @@ public abstract class OrcaPerRequestUtil {
   public interface OrcaPerRequestReportListener {
 
     /**
-     * Invoked when an per-request ORCA report is received.
+     * Invoked when a per-request ORCA report is received.
      *
      * <p>Note this callback will be invoked from the network thread as the RPC finishes,
      * implementations should not block.
      *
-     * @param report load report in the format of ORCA format.
+     * @param report load report in the format of grpc {@link CallMetricRecorder.CallMetricReport}.
      */
-    void onLoadReport(OrcaLoadReport report);
+    void onLoadReport(CallMetricRecorder.CallMetricReport report);
   }
 
   /**
@@ -250,6 +252,12 @@ public abstract class OrcaPerRequestUtil {
     }
   }
 
+  static CallMetricRecorder.CallMetricReport fromOrcaLoadReport(OrcaLoadReport loadReport) {
+    return InternalCallMetricRecorder.createMetricReport(loadReport.getCpuUtilization(),
+        loadReport.getMemUtilization(), loadReport.getRequestCostMap(),
+        loadReport.getUtilizationMap());
+  }
+
   /**
    * A container class to hold registered {@link OrcaPerRequestReportListener}s and invoke all of
    * them when an {@link OrcaLoadReport} is received.
@@ -263,8 +271,9 @@ public abstract class OrcaPerRequestUtil {
     }
 
     void onReport(OrcaLoadReport report) {
+      CallMetricRecorder.CallMetricReport metricReport = fromOrcaLoadReport(report);
       for (OrcaPerRequestReportListener listener : listeners) {
-        listener.onLoadReport(report);
+        listener.onLoadReport(metricReport);
       }
     }
   }

--- a/xds/src/main/java/io/grpc/xds/orca/OrcaServiceImpl.java
+++ b/xds/src/main/java/io/grpc/xds/orca/OrcaServiceImpl.java
@@ -26,9 +26,9 @@ import com.google.protobuf.util.Durations;
 import io.grpc.BindableService;
 import io.grpc.ServerServiceDefinition;
 import io.grpc.SynchronizationContext;
-import io.grpc.services.CallMetricRecorder;
 import io.grpc.services.InternalMetricRecorder;
 import io.grpc.services.MetricRecorder;
+import io.grpc.services.MetricReport;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import java.util.concurrent.ScheduledExecutorService;
@@ -146,7 +146,7 @@ public final class OrcaServiceImpl implements BindableService {
   }
 
   private OrcaLoadReport generateMetricsReport() {
-    CallMetricRecorder.CallMetricReport internalReport =
+    MetricReport internalReport =
         InternalMetricRecorder.getMetricReport(metricRecorder);
     return OrcaLoadReport.newBuilder().setCpuUtilization(internalReport.getCpuUtilization())
         .setMemUtilization(internalReport.getMemoryUtilization())

--- a/xds/src/test/java/io/grpc/xds/orca/OrcaMetricReportingServerInterceptorTest.java
+++ b/xds/src/test/java/io/grpc/xds/orca/OrcaMetricReportingServerInterceptorTest.java
@@ -90,7 +90,7 @@ public class OrcaMetricReportingServerInterceptorTest {
                   entry.getValue());
             }
             for (Map.Entry<String, Double> entry : applicationCostMetrics.entrySet()) {
-              CallMetricRecorder.getCurrent().recordCallMetric(entry.getKey(),
+              CallMetricRecorder.getCurrent().recordRequestCostMetric(entry.getKey(),
                   entry.getValue());
             }
             CallMetricRecorder.getCurrent().recordCpuUtilizationMetric(cpuUtilizationMetrics);

--- a/xds/src/test/java/io/grpc/xds/orca/OrcaOobUtilTest.java
+++ b/xds/src/test/java/io/grpc/xds/orca/OrcaOobUtilTest.java
@@ -62,7 +62,7 @@ import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.internal.BackoffPolicy;
 import io.grpc.internal.FakeClock;
-import io.grpc.services.CallMetricRecorder;
+import io.grpc.services.MetricReport;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
 import io.grpc.util.ForwardingLoadBalancerHelper;
@@ -667,7 +667,7 @@ public class OrcaOobUtilTest {
     orcaServiceImps[0].calls.peek().responseObserver.onNext(report);
     assertLog(subchannels[0].logs, "DEBUG: Received an ORCA report: " + report);
     // Only parent helper's listener receives the report.
-    ArgumentCaptor<CallMetricRecorder.CallMetricReport> parentReportCaptor =
+    ArgumentCaptor<MetricReport> parentReportCaptor =
         ArgumentCaptor.forClass(null);
     verify(mockOrcaListener1).onLoadReport(parentReportCaptor.capture());
     assertThat(OrcaPerRequestUtilTest.reportEqual(parentReportCaptor.getValue(),
@@ -679,7 +679,7 @@ public class OrcaOobUtilTest {
     orcaServiceImps[0].calls.peek().responseObserver.onNext(report);
     assertLog(subchannels[0].logs, "DEBUG: Received an ORCA report: " + report);
     // Both helper receives the same report instance.
-    ArgumentCaptor<CallMetricRecorder.CallMetricReport> childReportCaptor =
+    ArgumentCaptor<MetricReport> childReportCaptor =
         ArgumentCaptor.forClass(null);
     verify(mockOrcaListener1, times(2))
         .onLoadReport(parentReportCaptor.capture());

--- a/xds/src/test/java/io/grpc/xds/orca/OrcaPerRequestUtilTest.java
+++ b/xds/src/test/java/io/grpc/xds/orca/OrcaPerRequestUtilTest.java
@@ -31,7 +31,7 @@ import com.github.xds.data.orca.v3.OrcaLoadReport;
 import com.google.common.base.Objects;
 import io.grpc.ClientStreamTracer;
 import io.grpc.Metadata;
-import io.grpc.services.CallMetricRecorder;
+import io.grpc.services.MetricReport;
 import io.grpc.xds.orca.OrcaPerRequestUtil.OrcaPerRequestReportListener;
 import io.grpc.xds.orca.OrcaPerRequestUtil.OrcaReportingTracerFactory;
 import org.junit.Before;
@@ -99,29 +99,28 @@ public class OrcaPerRequestUtilTest {
         OrcaReportingTracerFactory.ORCA_ENDPOINT_LOAD_METRICS_KEY,
         OrcaLoadReport.getDefaultInstance());
     tracer.inboundTrailers(trailer);
-    ArgumentCaptor<CallMetricRecorder.CallMetricReport> reportCaptor =
+    ArgumentCaptor<MetricReport> reportCaptor =
         ArgumentCaptor.forClass(null);
     verify(orcaListener1).onLoadReport(reportCaptor.capture());
     assertThat(reportEqual(reportCaptor.getValue(),
         OrcaPerRequestUtil.fromOrcaLoadReport(OrcaLoadReport.getDefaultInstance()))).isTrue();
   }
 
-  static final class MetricsReportMatcher implements
-      ArgumentMatcher<CallMetricRecorder.CallMetricReport> {
-    private CallMetricRecorder.CallMetricReport original;
+  static final class MetricsReportMatcher implements ArgumentMatcher<MetricReport> {
+    private MetricReport original;
 
-    public MetricsReportMatcher(CallMetricRecorder.CallMetricReport report) {
+    public MetricsReportMatcher(MetricReport report) {
       this.original = report;
     }
 
     @Override
-    public boolean matches(CallMetricRecorder.CallMetricReport argument) {
+    public boolean matches(MetricReport argument) {
       return reportEqual(original, argument);
     }
   }
 
-  static boolean reportEqual(CallMetricRecorder.CallMetricReport a,
-                             CallMetricRecorder.CallMetricReport b) {
+  static boolean reportEqual(MetricReport a,
+                             MetricReport b) {
     return a.getCpuUtilization() == b.getCpuUtilization()
         && a.getMemoryUtilization() == b.getMemoryUtilization()
         && Objects.equal(a.getRequestCostMetrics(), b.getRequestCostMetrics())
@@ -163,9 +162,9 @@ public class OrcaPerRequestUtilTest {
         OrcaReportingTracerFactory.ORCA_ENDPOINT_LOAD_METRICS_KEY,
         OrcaLoadReport.getDefaultInstance());
     childTracer.inboundTrailers(trailer);
-    ArgumentCaptor<CallMetricRecorder.CallMetricReport> parentReportCap =
+    ArgumentCaptor<MetricReport> parentReportCap =
         ArgumentCaptor.forClass(null);
-    ArgumentCaptor<CallMetricRecorder.CallMetricReport> childReportCap =
+    ArgumentCaptor<MetricReport> childReportCap =
         ArgumentCaptor.forClass(null);
     verify(orcaListener1).onLoadReport(parentReportCap.capture());
     verify(orcaListener2).onLoadReport(childReportCap.capture());

--- a/xds/src/test/java/io/grpc/xds/orca/OrcaPerRequestUtilTest.java
+++ b/xds/src/test/java/io/grpc/xds/orca/OrcaPerRequestUtilTest.java
@@ -19,7 +19,7 @@ package io.grpc.xds.orca;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -28,8 +28,10 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.github.xds.data.orca.v3.OrcaLoadReport;
+import com.google.common.base.Objects;
 import io.grpc.ClientStreamTracer;
 import io.grpc.Metadata;
+import io.grpc.services.CallMetricRecorder;
 import io.grpc.xds.orca.OrcaPerRequestUtil.OrcaPerRequestReportListener;
 import io.grpc.xds.orca.OrcaPerRequestUtil.OrcaReportingTracerFactory;
 import org.junit.Before;
@@ -37,6 +39,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -96,9 +99,33 @@ public class OrcaPerRequestUtilTest {
         OrcaReportingTracerFactory.ORCA_ENDPOINT_LOAD_METRICS_KEY,
         OrcaLoadReport.getDefaultInstance());
     tracer.inboundTrailers(trailer);
-    ArgumentCaptor<OrcaLoadReport> reportCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<CallMetricRecorder.CallMetricReport> reportCaptor =
+        ArgumentCaptor.forClass(null);
     verify(orcaListener1).onLoadReport(reportCaptor.capture());
-    assertThat(reportCaptor.getValue()).isEqualTo(OrcaLoadReport.getDefaultInstance());
+    assertThat(reportEqual(reportCaptor.getValue(),
+        OrcaPerRequestUtil.fromOrcaLoadReport(OrcaLoadReport.getDefaultInstance()))).isTrue();
+  }
+
+  static final class MetricsReportMatcher implements
+      ArgumentMatcher<CallMetricRecorder.CallMetricReport> {
+    private CallMetricRecorder.CallMetricReport original;
+
+    public MetricsReportMatcher(CallMetricRecorder.CallMetricReport report) {
+      this.original = report;
+    }
+
+    @Override
+    public boolean matches(CallMetricRecorder.CallMetricReport argument) {
+      return reportEqual(original, argument);
+    }
+  }
+
+  static boolean reportEqual(CallMetricRecorder.CallMetricReport a,
+                             CallMetricRecorder.CallMetricReport b) {
+    return a.getCpuUtilization() == b.getCpuUtilization()
+        && a.getMemoryUtilization() == b.getMemoryUtilization()
+        && Objects.equal(a.getRequestCostMetrics(), b.getRequestCostMetrics())
+        && Objects.equal(a.getUtilizationMetrics(), b.getUtilizationMetrics());
   }
 
   /**
@@ -136,11 +163,14 @@ public class OrcaPerRequestUtilTest {
         OrcaReportingTracerFactory.ORCA_ENDPOINT_LOAD_METRICS_KEY,
         OrcaLoadReport.getDefaultInstance());
     childTracer.inboundTrailers(trailer);
-    ArgumentCaptor<OrcaLoadReport> parentReportCap = ArgumentCaptor.forClass(null);
-    ArgumentCaptor<OrcaLoadReport> childReportCap = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<CallMetricRecorder.CallMetricReport> parentReportCap =
+        ArgumentCaptor.forClass(null);
+    ArgumentCaptor<CallMetricRecorder.CallMetricReport> childReportCap =
+        ArgumentCaptor.forClass(null);
     verify(orcaListener1).onLoadReport(parentReportCap.capture());
     verify(orcaListener2).onLoadReport(childReportCap.capture());
-    assertThat(parentReportCap.getValue()).isEqualTo(OrcaLoadReport.getDefaultInstance());
+    assertThat(reportEqual(parentReportCap.getValue(),
+        OrcaPerRequestUtil.fromOrcaLoadReport(OrcaLoadReport.getDefaultInstance()))).isTrue();
     assertThat(childReportCap.getValue()).isSameInstanceAs(parentReportCap.getValue());
   }
 
@@ -159,11 +189,12 @@ public class OrcaPerRequestUtilTest {
     ClientStreamTracer parentTracer =
         parentFactory.newClientStreamTracer(STREAM_INFO, new Metadata());
     Metadata trailer = new Metadata();
+    OrcaLoadReport report = OrcaLoadReport.getDefaultInstance();
     trailer.put(
-        OrcaReportingTracerFactory.ORCA_ENDPOINT_LOAD_METRICS_KEY,
-        OrcaLoadReport.getDefaultInstance());
+        OrcaReportingTracerFactory.ORCA_ENDPOINT_LOAD_METRICS_KEY, report);
     parentTracer.inboundTrailers(trailer);
-    verify(orcaListener1).onLoadReport(eq(OrcaLoadReport.getDefaultInstance()));
+    verify(orcaListener1).onLoadReport(
+        argThat(new MetricsReportMatcher(OrcaPerRequestUtil.fromOrcaLoadReport(report))));
     verifyNoInteractions(childFactory);
     verifyNoInteractions(orcaListener2);
   }


### PR DESCRIPTION
The fix avoids shaded dependency of orca protos

backport of #9366 #9382 #9403 #9410 #9411