### PR TITLE
Revert "Add LoadBalancer.acceptResolvedAddresses()"

### DIFF
--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -124,46 +124,39 @@ public abstract class LoadBalancer {
    *
    * <p>Implementations should not modify the given {@code servers}.
    *
-   * @param resolvedAddresses the resolved server addresses, attributes, and config.
-   * @since 1.21.0
+   * @param servers the resolved server addresses, never empty.
+   * @param attributes extra information from naming system.
+   * @deprecated override {@link #handleResolvedAddresses(ResolvedAddresses) instead}
+   * @since 1.2.0
    */
-  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  @Deprecated
+  public void handleResolvedAddressGroups(
+      List<EquivalentAddressGroup> servers,
+      @NameResolver.ResolutionResultAttr Attributes attributes) {
     if (recursionCount++ == 0) {
-      // Note that the information about the addresses actually being accepted will be lost
-      // if you rely on this method for backward compatibility.
-      acceptResolvedAddresses(resolvedAddresses);
+      handleResolvedAddresses(
+          ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(attributes).build());
     }
     recursionCount = 0;
   }
 
   /**
-   * Accepts newly resolved addresses from the name resolution system. The {@link
-   * EquivalentAddressGroup} addresses should be considered equivalent but may be flattened into a
-   * single list if needed.
+   * Handles newly resolved server groups and metadata attributes from name resolution system.
+   * {@code servers} contained in {@link EquivalentAddressGroup} should be considered equivalent
+   * but may be flattened into a single list if needed.
    *
-   * <p>Implementations can choose to reject the given addresses by returning {@code false}.
-   *
-   * <p>Implementations should not modify the given {@code addresses}.
+   * <p>Implementations should not modify the given {@code servers}.
    *
    * @param resolvedAddresses the resolved server addresses, attributes, and config.
-   * @return {@code true} if the resolved addresses were accepted. {@code false} if rejected.
-   * @since 1.49.0
+   * @since 1.21.0
    */
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-    if (resolvedAddresses.getAddresses().isEmpty()
-        && !canHandleEmptyAddressListFromNameResolution()) {
-      handleNameResolutionError(Status.UNAVAILABLE.withDescription(
-          "NameResolver returned no usable address. addrs=" + resolvedAddresses.getAddresses()
-              + ", attrs=" + resolvedAddresses.getAttributes()));
-      return false;
-    } else {
-      if (recursionCount++ == 0) {
-        handleResolvedAddresses(resolvedAddresses);
-      }
-      recursionCount = 0;
-
-      return true;
+  @SuppressWarnings("deprecation")
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    if (recursionCount++ == 0) {
+      handleResolvedAddressGroups(
+          resolvedAddresses.getAddresses(), resolvedAddresses.getAttributes());
     }
+    recursionCount = 0;
   }
 
   /**

--- a/api/src/test/java/io/grpc/LoadBalancerTest.java
+++ b/api/src/test/java/io/grpc/LoadBalancerTest.java
@@ -235,14 +235,13 @@ public class LoadBalancerTest {
 
   @Deprecated
   @Test
-  public void handleResolvedAddresses_delegatesToAcceptResolvedAddresses() {
+  public void handleResolvedAddressGroups_delegatesToHandleResolvedAddresses() {
     final AtomicReference<ResolvedAddresses> resultCapture = new AtomicReference<>();
 
     LoadBalancer balancer = new LoadBalancer() {
         @Override
-        public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+        public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
           resultCapture.set(resolvedAddresses);
-          return true;
         }
 
         @Override
@@ -261,22 +260,23 @@ public class LoadBalancerTest {
     List<EquivalentAddressGroup> servers = Arrays.asList(
         new EquivalentAddressGroup(new SocketAddress(){}),
         new EquivalentAddressGroup(new SocketAddress(){}));
-    ResolvedAddresses addresses = ResolvedAddresses.newBuilder().setAddresses(servers)
-        .setAttributes(attrs).build();
-    balancer.handleResolvedAddresses(addresses);
+    balancer.handleResolvedAddressGroups(servers, attrs);
     assertThat(resultCapture.get()).isEqualTo(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(attrs).build());
   }
 
   @Deprecated
   @Test
-  public void acceptResolvedAddresses_delegatesToHandleResolvedAddressGroups() {
-    final AtomicReference<ResolvedAddresses> addressesCapture = new AtomicReference<>();
+  public void handleResolvedAddresses_delegatesToHandleResolvedAddressGroups() {
+    final AtomicReference<List<EquivalentAddressGroup>> serversCapture = new AtomicReference<>();
+    final AtomicReference<Attributes> attrsCapture = new AtomicReference<>();
 
     LoadBalancer balancer = new LoadBalancer() {
         @Override
-        public void handleResolvedAddresses(ResolvedAddresses addresses) {
-          addressesCapture.set(addresses);
+        public void handleResolvedAddressGroups(
+            List<EquivalentAddressGroup> servers, Attributes attrs) {
+          serversCapture.set(servers);
+          attrsCapture.set(attrs);
         }
 
         @Override
@@ -295,23 +295,25 @@ public class LoadBalancerTest {
     List<EquivalentAddressGroup> servers = Arrays.asList(
         new EquivalentAddressGroup(new SocketAddress(){}),
         new EquivalentAddressGroup(new SocketAddress(){}));
-    ResolvedAddresses addresses = ResolvedAddresses.newBuilder().setAddresses(servers)
-        .setAttributes(attrs).build();
-    balancer.handleResolvedAddresses(addresses);
-    assertThat(addressesCapture.get().getAddresses()).isEqualTo(servers);
-    assertThat(addressesCapture.get().getAttributes()).isEqualTo(attrs);
+    balancer.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(attrs).build());
+    assertThat(serversCapture.get()).isEqualTo(servers);
+    assertThat(attrsCapture.get()).isEqualTo(attrs);
   }
 
   @Deprecated
   @Test
-  public void acceptResolvedAddresses_noInfiniteLoop() {
-    final List<ResolvedAddresses> addressesCapture = new ArrayList<>();
+  public void handleResolvedAddresses_noInfiniteLoop() {
+    final List<List<EquivalentAddressGroup>> serversCapture = new ArrayList<>();
+    final List<Attributes> attrsCapture = new ArrayList<>();
 
     LoadBalancer balancer = new LoadBalancer() {
       @Override
-      public void handleResolvedAddresses(ResolvedAddresses addresses) {
-        addressesCapture.add(addresses);
-        super.handleResolvedAddresses(addresses);
+      public void handleResolvedAddressGroups(
+          List<EquivalentAddressGroup> servers, Attributes attrs) {
+        serversCapture.add(servers);
+        attrsCapture.add(attrs);
+        super.handleResolvedAddressGroups(servers, attrs);
       }
 
       @Override
@@ -326,12 +328,12 @@ public class LoadBalancerTest {
     List<EquivalentAddressGroup> servers = Arrays.asList(
         new EquivalentAddressGroup(new SocketAddress(){}),
         new EquivalentAddressGroup(new SocketAddress(){}));
-    ResolvedAddresses addresses = ResolvedAddresses.newBuilder().setAddresses(servers)
-        .setAttributes(attrs).build();
-    balancer.handleResolvedAddresses(addresses);
-    assertThat(addressesCapture).hasSize(1);
-    assertThat(addressesCapture.get(0).getAddresses()).isEqualTo(servers);
-    assertThat(addressesCapture.get(0).getAttributes()).isEqualTo(attrs);
+    balancer.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(attrs).build());
+    assertThat(serversCapture).hasSize(1);
+    assertThat(attrsCapture).hasSize(1);
+    assertThat(serversCapture.get(0)).isEqualTo(servers);
+    assertThat(attrsCapture.get(0)).isEqualTo(attrs);
   }
 
   private static class NoopHelper extends LoadBalancer.Helper {

--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
@@ -20,9 +20,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
+import io.grpc.Attributes;
 import io.grpc.ChannelLogger.ChannelLogLevel;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
+import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.PickResult;
@@ -65,14 +67,10 @@ public final class AutoConfiguredLoadBalancerFactory {
 
     @Override
     @Deprecated
-    @SuppressWarnings("InlineMeSuggester")
-    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-    }
+    public void handleResolvedAddressGroups(List<EquivalentAddressGroup> s, Attributes a) {}
 
     @Override
-    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-      return true;
-    }
+    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {}
 
     @Override
     public void handleNameResolutionError(Status error) {}
@@ -99,10 +97,14 @@ public final class AutoConfiguredLoadBalancerFactory {
     }
 
     /**
-     * Returns non-OK status if the delegate rejects the resolvedAddresses (e.g. if it does not
-     * support an empty list).
+     * Returns non-OK status if resolvedAddresses is empty and delegate lb requires address ({@link
+     * LoadBalancer#canHandleEmptyAddressListFromNameResolution()} returns {@code false}). {@code
+     * AutoConfiguredLoadBalancer} doesn't expose {@code
+     * canHandleEmptyAddressListFromNameResolution} because it depends on the delegated LB.
      */
-    boolean tryAcceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    Status tryHandleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+      List<EquivalentAddressGroup> servers = resolvedAddresses.getAddresses();
+      Attributes attributes = resolvedAddresses.getAttributes();
       PolicySelection policySelection =
           (PolicySelection) resolvedAddresses.getLoadBalancingPolicyConfig();
 
@@ -116,7 +118,7 @@ public final class AutoConfiguredLoadBalancerFactory {
           delegate.shutdown();
           delegateProvider = null;
           delegate = new NoopLoadBalancer();
-          return true;
+          return Status.OK;
         }
         policySelection =
             new PolicySelection(defaultProvider, /* config= */ null);
@@ -139,12 +141,20 @@ public final class AutoConfiguredLoadBalancerFactory {
             ChannelLogLevel.DEBUG, "Load-balancing config: {0}", policySelection.config);
       }
 
-      return getDelegate().acceptResolvedAddresses(
-          ResolvedAddresses.newBuilder()
-              .setAddresses(resolvedAddresses.getAddresses())
-              .setAttributes(resolvedAddresses.getAttributes())
-              .setLoadBalancingPolicyConfig(lbConfig)
-              .build());
+      LoadBalancer delegate = getDelegate();
+      if (resolvedAddresses.getAddresses().isEmpty()
+          && !delegate.canHandleEmptyAddressListFromNameResolution()) {
+        return Status.UNAVAILABLE.withDescription(
+            "NameResolver returned no usable address. addrs=" + servers + ", attrs=" + attributes);
+      } else {
+        delegate.handleResolvedAddresses(
+            ResolvedAddresses.newBuilder()
+                .setAddresses(resolvedAddresses.getAddresses())
+                .setAttributes(attributes)
+                .setLoadBalancingPolicyConfig(lbConfig)
+                .build());
+        return Status.OK;
+      }
     }
 
     void handleNameResolutionError(Status error) {

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1860,17 +1860,16 @@ final class ManagedChannelImpl extends ManagedChannel implements
                   .set(LoadBalancer.ATTR_HEALTH_CHECKING_CONFIG, healthCheckingConfig)
                   .build();
             }
-            Attributes attributes = attrBuilder.build();
 
-            boolean addressesAccepted = helper.lb.tryAcceptResolvedAddresses(
+            Status handleResult = helper.lb.tryHandleResolvedAddresses(
                 ResolvedAddresses.newBuilder()
                     .setAddresses(servers)
-                    .setAttributes(attributes)
+                    .setAttributes(attrBuilder.build())
                     .setLoadBalancingPolicyConfig(effectiveServiceConfig.getLoadBalancingConfig())
                     .build());
 
-            if (!addressesAccepted) {
-              scheduleExponentialBackOffInSyncContext();
+            if (!handleResult.isOk()) {
+              handleErrorInSyncContext(handleResult.augmentDescription(resolver + " was used"));
             }
           }
         }

--- a/core/src/main/java/io/grpc/internal/PickFirstLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLoadBalancer.java
@@ -45,7 +45,7 @@ final class PickFirstLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     List<EquivalentAddressGroup> servers = resolvedAddresses.getAddresses();
     if (subchannel == null) {
       final Subchannel subchannel = helper.createSubchannel(
@@ -67,8 +67,6 @@ final class PickFirstLoadBalancer extends LoadBalancer {
     } else {
       subchannel.updateAddresses(servers);
     }
-
-    return true;
   }
 
   @Override

--- a/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
@@ -17,10 +17,14 @@
 package io.grpc.util;
 
 import com.google.common.base.MoreObjects;
+import io.grpc.Attributes;
 import io.grpc.ConnectivityStateInfo;
+import io.grpc.EquivalentAddressGroup;
 import io.grpc.ExperimentalApi;
 import io.grpc.LoadBalancer;
+import io.grpc.NameResolver;
 import io.grpc.Status;
+import java.util.List;
 
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
 public abstract class ForwardingLoadBalancer extends LoadBalancer {
@@ -31,13 +35,15 @@ public abstract class ForwardingLoadBalancer extends LoadBalancer {
 
   @Override
   @Deprecated
-  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-    delegate().handleResolvedAddresses(resolvedAddresses);
+  public void handleResolvedAddressGroups(
+        List<EquivalentAddressGroup> servers,
+        @NameResolver.ResolutionResultAttr Attributes attributes) {
+    delegate().handleResolvedAddressGroups(servers, attributes);
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-    return delegate().acceptResolvedAddresses(resolvedAddresses);
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    delegate().handleResolvedAddresses(resolvedAddresses);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
@@ -35,7 +35,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  * will keep using the old policy until the new policy reports READY or the old policy exits READY.
  *
  * <p>The balancer must {@link #switchTo(LoadBalancer.Factory) switch to} a policy prior to {@link
- * LoadBalancer#acceptResolvedAddresses(ResolvedAddresses) handling resolved addresses} for the
+ * LoadBalancer#handleResolvedAddresses(ResolvedAddresses) handling resolved addresses} for the
  * first time.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/5999")
@@ -43,7 +43,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 public final class GracefulSwitchLoadBalancer extends ForwardingLoadBalancer {
   private final LoadBalancer defaultBalancer = new LoadBalancer() {
     @Override
-    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       //  Most LB policies using this class will receive child policy configuration within the
       //  service config, so they are naturally calling switchTo() just before
       //  handleResolvedAddresses(), within their own handleResolvedAddresses(). If switchTo() is

--- a/core/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
@@ -69,7 +69,7 @@ final class RoundRobinLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     List<EquivalentAddressGroup> servers = resolvedAddresses.getAddresses();
     Set<EquivalentAddressGroup> currentAddrs = subchannels.keySet();
     Map<EquivalentAddressGroup, EquivalentAddressGroup> latestAddrs = stripAttrs(servers);
@@ -126,8 +126,6 @@ final class RoundRobinLoadBalancer extends LoadBalancer {
     for (Subchannel removedSubchannel : removedSubchannels) {
       shutdownSubchannel(removedSubchannel);
     }
-
-    return !resolvedAddresses.getAddresses().isEmpty();
   }
 
   @Override

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -154,7 +154,6 @@ public class ManagedChannelImplIdlenessTest {
   @Before
   @SuppressWarnings("deprecation") // For NameResolver.Listener
   public void setUp() {
-    when(mockLoadBalancer.acceptResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(true);
     LoadBalancerRegistry.getDefaultRegistry().register(mockLoadBalancerProvider);
     when(mockNameResolver.getServiceAuthority()).thenReturn(AUTHORITY);
     when(mockNameResolverFactory
@@ -221,7 +220,7 @@ public class ManagedChannelImplIdlenessTest {
 
     ArgumentCaptor<ResolvedAddresses> resolvedAddressCaptor =
         ArgumentCaptor.forClass(ResolvedAddresses.class);
-    verify(mockLoadBalancer).acceptResolvedAddresses(resolvedAddressCaptor.capture());
+    verify(mockLoadBalancer).handleResolvedAddresses(resolvedAddressCaptor.capture());
     assertThat(resolvedAddressCaptor.getValue().getAddresses())
         .containsExactlyElementsIn(servers);
   }

--- a/core/src/test/java/io/grpc/internal/PickFirstLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/internal/PickFirstLoadBalancerTest.java
@@ -121,7 +121,7 @@ public class PickFirstLoadBalancerTest {
 
   @Test
   public void pickAfterResolved() throws Exception {
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
 
     verify(mockHelper).createSubchannel(createArgsCaptor.capture());
@@ -139,7 +139,7 @@ public class PickFirstLoadBalancerTest {
 
   @Test
   public void requestConnectionPicker() throws Exception {
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
 
     InOrder inOrder = inOrder(mockHelper, mockSubchannel);
@@ -164,7 +164,7 @@ public class PickFirstLoadBalancerTest {
 
   @Test
   public void refreshNameResolutionAfterSubchannelConnectionBroken() {
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     verify(mockHelper).createSubchannel(any(CreateSubchannelArgs.class));
 
@@ -196,11 +196,11 @@ public class PickFirstLoadBalancerTest {
 
   @Test
   public void pickAfterResolvedAndUnchanged() throws Exception {
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     verify(mockSubchannel).start(any(SubchannelStateListener.class));
     verify(mockSubchannel).requestConnection();
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     verify(mockSubchannel).updateAddresses(eq(servers));
     verifyNoMoreInteractions(mockSubchannel);
@@ -223,7 +223,7 @@ public class PickFirstLoadBalancerTest {
 
     InOrder inOrder = inOrder(mockHelper, mockSubchannel);
 
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     inOrder.verify(mockHelper).createSubchannel(createArgsCaptor.capture());
     verify(mockSubchannel).start(any(SubchannelStateListener.class));
@@ -233,7 +233,7 @@ public class PickFirstLoadBalancerTest {
     verify(mockSubchannel).requestConnection();
     assertEquals(mockSubchannel, pickerCaptor.getValue().pickSubchannel(mockArgs).getSubchannel());
 
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(newServers).setAttributes(affinity).build());
     inOrder.verify(mockSubchannel).updateAddresses(eq(newServers));
 
@@ -245,7 +245,7 @@ public class PickFirstLoadBalancerTest {
   public void pickAfterStateChangeAfterResolution() throws Exception {
     InOrder inOrder = inOrder(mockHelper);
 
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     inOrder.verify(mockHelper).createSubchannel(createArgsCaptor.capture());
     CreateSubchannelArgs args = createArgsCaptor.getValue();
@@ -297,7 +297,7 @@ public class PickFirstLoadBalancerTest {
         .updateBalancingState(any(ConnectivityState.class), any(SubchannelPicker.class));
     verify(mockSubchannel, never()).requestConnection();
 
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     inOrder.verify(mockHelper).createSubchannel(createArgsCaptor.capture());
     CreateSubchannelArgs args = createArgsCaptor.getValue();
@@ -318,7 +318,7 @@ public class PickFirstLoadBalancerTest {
   @Test
   public void nameResolutionErrorWithStateChanges() throws Exception {
     InOrder inOrder = inOrder(mockHelper);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     inOrder.verify(mockHelper).createSubchannel(createArgsCaptor.capture());
     verify(mockSubchannel).start(stateListenerCaptor.capture());
@@ -358,7 +358,7 @@ public class PickFirstLoadBalancerTest {
     loadBalancer.requestConnection();
 
     verify(mockSubchannel, never()).requestConnection();
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     verify(mockSubchannel).requestConnection();
 

--- a/core/src/test/java/io/grpc/util/GracefulSwitchLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/util/GracefulSwitchLoadBalancerTest.java
@@ -22,6 +22,7 @@ import static io.grpc.ConnectivityState.READY;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 import static io.grpc.util.GracefulSwitchLoadBalancer.BUFFER_PICKER;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -86,6 +87,35 @@ public class GracefulSwitchLoadBalancerTest {
   }
 
   @Test
+  public void canHandleEmptyAddressListFromNameResolutionForwardedToLatestPolicy() {
+    gracefulSwitchLb.switchTo(lbProviders.get(lbPolicies[0]));
+    LoadBalancer lb0 = balancers.get(lbPolicies[0]);
+    Helper helper0 = helpers.get(lb0);
+    SubchannelPicker picker = mock(SubchannelPicker.class);
+    helper0.updateBalancingState(READY, picker);
+
+    assertThat(gracefulSwitchLb.canHandleEmptyAddressListFromNameResolution()).isFalse();
+    doReturn(true).when(lb0).canHandleEmptyAddressListFromNameResolution();
+    assertThat(gracefulSwitchLb.canHandleEmptyAddressListFromNameResolution()).isTrue();
+
+    gracefulSwitchLb.switchTo(lbProviders.get(lbPolicies[1]));
+    LoadBalancer lb1 = balancers.get(lbPolicies[1]);
+
+    assertThat(gracefulSwitchLb.canHandleEmptyAddressListFromNameResolution()).isFalse();
+
+    doReturn(true).when(lb1).canHandleEmptyAddressListFromNameResolution();
+    assertThat(gracefulSwitchLb.canHandleEmptyAddressListFromNameResolution()).isTrue();
+
+    gracefulSwitchLb.switchTo(lbProviders.get(lbPolicies[2]));
+    LoadBalancer lb2 = balancers.get(lbPolicies[2]);
+
+    assertThat(gracefulSwitchLb.canHandleEmptyAddressListFromNameResolution()).isFalse();
+
+    doReturn(true).when(lb2).canHandleEmptyAddressListFromNameResolution();
+    assertThat(gracefulSwitchLb.canHandleEmptyAddressListFromNameResolution()).isTrue();
+  }
+
+  @Test
   public void handleResolvedAddressesAndNameResolutionErrorForwardedToLatestPolicy() {
     gracefulSwitchLb.switchTo(lbProviders.get(lbPolicies[0]));
     LoadBalancer lb0 = balancers.get(lbPolicies[0]);
@@ -94,17 +124,17 @@ public class GracefulSwitchLoadBalancerTest {
     helper0.updateBalancingState(READY, picker);
 
     ResolvedAddresses addresses = newFakeAddresses();
-    gracefulSwitchLb.acceptResolvedAddresses(addresses);
-    verify(lb0).acceptResolvedAddresses(addresses);
+    gracefulSwitchLb.handleResolvedAddresses(addresses);
+    verify(lb0).handleResolvedAddresses(addresses);
     gracefulSwitchLb.handleNameResolutionError(Status.DATA_LOSS);
     verify(lb0).handleNameResolutionError(Status.DATA_LOSS);
 
     gracefulSwitchLb.switchTo(lbProviders.get(lbPolicies[1]));
     LoadBalancer lb1 = balancers.get(lbPolicies[1]);
     addresses = newFakeAddresses();
-    gracefulSwitchLb.acceptResolvedAddresses(addresses);
-    verify(lb0, never()).acceptResolvedAddresses(addresses);
-    verify(lb1).acceptResolvedAddresses(addresses);
+    gracefulSwitchLb.handleResolvedAddresses(addresses);
+    verify(lb0, never()).handleResolvedAddresses(addresses);
+    verify(lb1).handleResolvedAddresses(addresses);
     gracefulSwitchLb.handleNameResolutionError(Status.ALREADY_EXISTS);
     verify(lb0, never()).handleNameResolutionError(Status.ALREADY_EXISTS);
     verify(lb1).handleNameResolutionError(Status.ALREADY_EXISTS);
@@ -113,10 +143,10 @@ public class GracefulSwitchLoadBalancerTest {
     verify(lb1).shutdown();
     LoadBalancer lb2 = balancers.get(lbPolicies[2]);
     addresses = newFakeAddresses();
-    gracefulSwitchLb.acceptResolvedAddresses(addresses);
-    verify(lb0, never()).acceptResolvedAddresses(addresses);
-    verify(lb1, never()).acceptResolvedAddresses(addresses);
-    verify(lb2).acceptResolvedAddresses(addresses);
+    gracefulSwitchLb.handleResolvedAddresses(addresses);
+    verify(lb0, never()).handleResolvedAddresses(addresses);
+    verify(lb1, never()).handleResolvedAddresses(addresses);
+    verify(lb2).handleResolvedAddresses(addresses);
     gracefulSwitchLb.handleNameResolutionError(Status.CANCELLED);
     verify(lb0, never()).handleNameResolutionError(Status.CANCELLED);
     verify(lb1, never()).handleNameResolutionError(Status.CANCELLED);

--- a/core/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
@@ -148,7 +148,7 @@ public class RoundRobinLoadBalancerTest {
   @Test
   public void pickAfterResolved() throws Exception {
     final Subchannel readySubchannel = subchannels.values().iterator().next();
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     deliverSubchannelState(readySubchannel, ConnectivityStateInfo.forNonError(READY));
 
@@ -199,7 +199,7 @@ public class RoundRobinLoadBalancerTest {
 
     InOrder inOrder = inOrder(mockHelper);
 
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(currentServers).setAttributes(affinity)
             .build());
 
@@ -221,7 +221,7 @@ public class RoundRobinLoadBalancerTest {
     // This time with Attributes
     List<EquivalentAddressGroup> latestServers = Lists.newArrayList(oldEag2, newEag);
 
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(latestServers).setAttributes(affinity).build());
 
     verify(newSubchannel, times(1)).requestConnection();
@@ -241,7 +241,7 @@ public class RoundRobinLoadBalancerTest {
     assertThat(getList(picker)).containsExactly(oldSubchannel, newSubchannel);
 
     // test going from non-empty to empty
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(Collections.<EquivalentAddressGroup>emptyList())
             .setAttributes(affinity)
@@ -256,7 +256,7 @@ public class RoundRobinLoadBalancerTest {
   @Test
   public void pickAfterStateChange() throws Exception {
     InOrder inOrder = inOrder(mockHelper);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(Attributes.EMPTY)
             .build());
     Subchannel subchannel = loadBalancer.getSubchannels().iterator().next();
@@ -296,7 +296,7 @@ public class RoundRobinLoadBalancerTest {
   @Test
   public void ignoreShutdownSubchannelStateChange() {
     InOrder inOrder = inOrder(mockHelper);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(Attributes.EMPTY)
             .build());
     inOrder.verify(mockHelper).updateBalancingState(eq(CONNECTING), isA(EmptyPicker.class));
@@ -315,7 +315,7 @@ public class RoundRobinLoadBalancerTest {
   @Test
   public void stayTransientFailureUntilReady() {
     InOrder inOrder = inOrder(mockHelper);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(Attributes.EMPTY)
             .build());
 
@@ -353,7 +353,7 @@ public class RoundRobinLoadBalancerTest {
   @Test
   public void refreshNameResolutionWhenSubchannelConnectionBroken() {
     InOrder inOrder = inOrder(mockHelper);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(Attributes.EMPTY)
             .build());
 
@@ -420,7 +420,7 @@ public class RoundRobinLoadBalancerTest {
   @Test
   public void nameResolutionErrorWithActiveChannels() throws Exception {
     final Subchannel readySubchannel = subchannels.values().iterator().next();
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     deliverSubchannelState(readySubchannel, ConnectivityStateInfo.forNonError(READY));
     loadBalancer.handleNameResolutionError(Status.NOT_FOUND.withDescription("nameResolutionError"));
@@ -449,7 +449,7 @@ public class RoundRobinLoadBalancerTest {
     Subchannel sc2 = subchannelIterator.next();
     Subchannel sc3 = subchannelIterator.next();
 
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(Attributes.EMPTY)
             .build());
     verify(sc1, times(1)).requestConnection();

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -76,7 +76,7 @@ class GrpclbLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     Attributes attributes = resolvedAddresses.getAttributes();
     List<EquivalentAddressGroup> newLbAddresses = attributes.get(GrpclbConstants.ATTR_LB_ADDRS);
     if (newLbAddresses == null) {
@@ -85,7 +85,7 @@ class GrpclbLoadBalancer extends LoadBalancer {
     if (newLbAddresses.isEmpty() && resolvedAddresses.getAddresses().isEmpty()) {
       handleNameResolutionError(
           Status.UNAVAILABLE.withDescription("No backend or balancer addresses found"));
-      return false;
+      return;
     }
     List<EquivalentAddressGroup> overrideAuthorityLbAddresses =
         new ArrayList<>(newLbAddresses.size());
@@ -114,8 +114,6 @@ class GrpclbLoadBalancer extends LoadBalancer {
     }
     grpclbState.handleAddresses(Collections.unmodifiableList(overrideAuthorityLbAddresses),
         newBackendServers);
-
-    return true;
   }
 
   @Override
@@ -150,6 +148,11 @@ class GrpclbLoadBalancer extends LoadBalancer {
     if (grpclbState != null) {
       grpclbState.propagateError(error);
     }
+  }
+
+  @Override
+  public boolean canHandleEmptyAddressListFromNameResolution() {
+    return true;
   }
 
   @VisibleForTesting

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -2735,7 +2735,7 @@ public class GrpclbLoadBalancerTest {
     syncContext.execute(new Runnable() {
       @Override
       public void run() {
-        balancer.acceptResolvedAddresses(
+        balancer.handleResolvedAddresses(
             ResolvedAddresses.newBuilder()
                 .setAddresses(backendAddrs)
                 .setAttributes(attrs)

--- a/interop-testing/src/main/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProvider.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProvider.java
@@ -111,12 +111,10 @@ public class RpcBehaviorLoadBalancerProvider extends LoadBalancerProvider {
     }
 
     @Override
-    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       helper.setRpcBehavior(
           ((RpcBehaviorConfig) resolvedAddresses.getLoadBalancingPolicyConfig()).rpcBehavior);
-      delegateLb.acceptResolvedAddresses(resolvedAddresses);
-
-      return true;
+      delegateLb.handleResolvedAddresses(resolvedAddresses);
     }
   }
 

--- a/interop-testing/src/test/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProviderTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProviderTest.java
@@ -83,8 +83,8 @@ public class RpcBehaviorLoadBalancerProviderTest {
     RpcBehaviorLoadBalancer lb = new RpcBehaviorLoadBalancer(new RpcBehaviorHelper(mockHelper),
         mockDelegateLb);
     ResolvedAddresses resolvedAddresses = buildResolvedAddresses(buildConfig());
-    lb.acceptResolvedAddresses(resolvedAddresses);
-    verify(mockDelegateLb).acceptResolvedAddresses(resolvedAddresses);
+    lb.handleResolvedAddresses(resolvedAddresses);
+    verify(mockDelegateLb).handleResolvedAddresses(resolvedAddresses);
   }
 
   @Test

--- a/rls/src/main/java/io/grpc/rls/LbPolicyConfiguration.java
+++ b/rls/src/main/java/io/grpc/rls/LbPolicyConfiguration.java
@@ -302,7 +302,7 @@ final class LbPolicyConfiguration {
           new Runnable() {
             @Override
             public void run() {
-              lb.acceptResolvedAddresses(
+              lb.handleResolvedAddresses(
                   childLbResolvedAddressFactory.create(lbConfig.getConfig()));
               lb.requestConnection();
             }

--- a/rls/src/main/java/io/grpc/rls/RlsLoadBalancer.java
+++ b/rls/src/main/java/io/grpc/rls/RlsLoadBalancer.java
@@ -49,7 +49,7 @@ final class RlsLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(ChannelLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     LbPolicyConfiguration lbPolicyConfiguration =
         (LbPolicyConfiguration) resolvedAddresses.getLoadBalancingPolicyConfig();
@@ -78,8 +78,6 @@ final class RlsLoadBalancer extends LoadBalancer {
       //  not required.
       this.lbPolicyConfiguration = lbPolicyConfiguration;
     }
-
-    return true;
   }
 
   @Override

--- a/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
+++ b/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
@@ -566,7 +566,7 @@ public class CachingRlsLbClientTest {
       LoadBalancer loadBalancer = new LoadBalancer() {
 
         @Override
-        public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+        public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
           Map<?, ?> config = (Map<?, ?>) resolvedAddresses.getLoadBalancingPolicyConfig();
           if (DEFAULT_TARGET.equals(config.get("target"))) {
             helper.updateBalancingState(
@@ -588,8 +588,6 @@ public class CachingRlsLbClientTest {
                   }
                 });
           }
-
-          return true;
         }
 
         @Override

--- a/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
@@ -412,7 +412,7 @@ public class RlsLoadBalancerTest {
     ConfigOrError parsedConfigOrError =
         provider.parseLoadBalancingPolicyConfig(getServiceConfig());
     assertThat(parsedConfigOrError.getConfig()).isNotNull();
-    rlsLb.acceptResolvedAddresses(ResolvedAddresses.newBuilder()
+    rlsLb.handleResolvedAddresses(ResolvedAddresses.newBuilder()
         .setAddresses(ImmutableList.of(new EquivalentAddressGroup(mock(SocketAddress.class))))
         .setLoadBalancingPolicyConfig(parsedConfigOrError.getConfig())
         .build());

--- a/services/src/main/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactory.java
+++ b/services/src/main/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactory.java
@@ -179,14 +179,14 @@ final class HealthCheckingLoadBalancerFactory extends LoadBalancer.Factory {
     }
 
     @Override
-    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       Map<String, ?> healthCheckingConfig =
           resolvedAddresses
               .getAttributes()
               .get(LoadBalancer.ATTR_HEALTH_CHECKING_CONFIG);
       String serviceName = ServiceConfigUtil.getHealthCheckedServiceName(healthCheckingConfig);
       helper.setHealthCheckedService(serviceName);
-      return super.acceptResolvedAddresses(resolvedAddresses);
+      super.handleResolvedAddresses(resolvedAddresses);
     }
 
     @Override

--- a/services/src/test/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactoryTest.java
+++ b/services/src/test/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactoryTest.java
@@ -193,16 +193,15 @@ public class HealthCheckingLoadBalancerFactoryTest {
         boolean shutdown;
 
         @Override
-        public boolean acceptResolvedAddresses(final ResolvedAddresses resolvedAddresses) {
+        public void handleResolvedAddresses(final ResolvedAddresses resolvedAddresses) {
           syncContext.execute(new Runnable() {
               @Override
               public void run() {
                 if (!shutdown) {
-                  hcLb.acceptResolvedAddresses(resolvedAddresses);
+                  hcLb.handleResolvedAddresses(resolvedAddresses);
                 }
               }
             });
-          return true;
         }
 
         @Override
@@ -252,9 +251,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.acceptResolvedAddresses(result);
+    hcLbEventDelivery.handleResolvedAddresses(result);
 
-    verify(origLb).acceptResolvedAddresses(result);
+    verify(origLb).handleResolvedAddresses(result);
     verify(origHelper, atLeast(0)).getSynchronizationContext();
     verify(origHelper, atLeast(0)).getScheduledExecutorService();
     verifyNoMoreInteractions(origHelper);
@@ -373,9 +372,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.acceptResolvedAddresses(result);
+    hcLbEventDelivery.handleResolvedAddresses(result);
 
-    verify(origLb).acceptResolvedAddresses(result);
+    verify(origLb).handleResolvedAddresses(result);
     verifyNoMoreInteractions(origLb);
 
     // We create 2 Subchannels. One of them connects to a server that doesn't implement health check
@@ -442,9 +441,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.acceptResolvedAddresses(result);
+    hcLbEventDelivery.handleResolvedAddresses(result);
 
-    verify(origLb).acceptResolvedAddresses(result);
+    verify(origLb).handleResolvedAddresses(result);
     verifyNoMoreInteractions(origLb);
 
     FakeSubchannel subchannel = unwrap(createSubchannel(0, Attributes.EMPTY));
@@ -513,9 +512,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.acceptResolvedAddresses(result);
+    hcLbEventDelivery.handleResolvedAddresses(result);
 
-    verify(origLb).acceptResolvedAddresses(result);
+    verify(origLb).handleResolvedAddresses(result);
     verifyNoMoreInteractions(origLb);
 
     SubchannelStateListener mockStateListener = mockStateListeners[0];
@@ -606,9 +605,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(Attributes.EMPTY)
         .build();
-    hcLbEventDelivery.acceptResolvedAddresses(result1);
+    hcLbEventDelivery.handleResolvedAddresses(result1);
 
-    verify(origLb).acceptResolvedAddresses(result1);
+    verify(origLb).handleResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     // First, create Subchannels 0
@@ -627,8 +626,8 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.acceptResolvedAddresses(result2);
-    verify(origLb).acceptResolvedAddresses(result2);
+    hcLbEventDelivery.handleResolvedAddresses(result2);
+    verify(origLb).handleResolvedAddresses(result2);
 
     // Health check started on existing Subchannel
     assertThat(healthImpls[0].calls).hasSize(1);
@@ -650,9 +649,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.acceptResolvedAddresses(result1);
+    hcLbEventDelivery.handleResolvedAddresses(result1);
 
-    verify(origLb).acceptResolvedAddresses(result1);
+    verify(origLb).handleResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     Subchannel subchannel = createSubchannel(0, Attributes.EMPTY);
@@ -673,7 +672,7 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(Attributes.EMPTY)
         .build();
-    hcLbEventDelivery.acceptResolvedAddresses(result2);
+    hcLbEventDelivery.handleResolvedAddresses(result2);
 
     // Health check RPC cancelled.
     assertThat(serverCall.cancelled).isTrue();
@@ -681,7 +680,7 @@ public class HealthCheckingLoadBalancerFactoryTest {
     inOrder.verify(mockStateListeners[0]).onSubchannelState(
         eq(ConnectivityStateInfo.forNonError(READY)));
 
-    inOrder.verify(origLb).acceptResolvedAddresses(result2);
+    inOrder.verify(origLb).handleResolvedAddresses(result2);
 
     verifyNoMoreInteractions(origLb, mockStateListeners[0]);
     assertThat(healthImpl.calls).isEmpty();
@@ -694,9 +693,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.acceptResolvedAddresses(result);
+    hcLbEventDelivery.handleResolvedAddresses(result);
 
-    verify(origLb).acceptResolvedAddresses(result);
+    verify(origLb).handleResolvedAddresses(result);
     verifyNoMoreInteractions(origLb);
 
     Subchannel subchannel = createSubchannel(0, Attributes.EMPTY);
@@ -723,7 +722,7 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(Attributes.EMPTY)
         .build();
-    hcLbEventDelivery.acceptResolvedAddresses(result2);
+    hcLbEventDelivery.handleResolvedAddresses(result2);
 
     // Retry timer is cancelled
     assertThat(clock.getPendingTasks()).isEmpty();
@@ -735,7 +734,7 @@ public class HealthCheckingLoadBalancerFactoryTest {
     inOrder.verify(mockStateListeners[0]).onSubchannelState(
         eq(ConnectivityStateInfo.forNonError(READY)));
 
-    inOrder.verify(origLb).acceptResolvedAddresses(result2);
+    inOrder.verify(origLb).handleResolvedAddresses(result2);
 
     verifyNoMoreInteractions(origLb, mockStateListeners[0]);
   }
@@ -747,9 +746,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.acceptResolvedAddresses(result1);
+    hcLbEventDelivery.handleResolvedAddresses(result1);
 
-    verify(origLb).acceptResolvedAddresses(result1);
+    verify(origLb).handleResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     Subchannel subchannel = createSubchannel(0, Attributes.EMPTY);
@@ -769,9 +768,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(Attributes.EMPTY)
         .build();
-    hcLbEventDelivery.acceptResolvedAddresses(result2);
+    hcLbEventDelivery.handleResolvedAddresses(result2);
 
-    inOrder.verify(origLb).acceptResolvedAddresses(result2);
+    inOrder.verify(origLb).handleResolvedAddresses(result2);
 
     // Underlying subchannel is now ready
     deliverSubchannelState(0, ConnectivityStateInfo.forNonError(READY));
@@ -793,9 +792,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.acceptResolvedAddresses(result1);
+    hcLbEventDelivery.handleResolvedAddresses(result1);
 
-    verify(origLb).acceptResolvedAddresses(result1);
+    verify(origLb).handleResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     Subchannel subchannel = createSubchannel(0, Attributes.EMPTY);
@@ -819,9 +818,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         eq(ConnectivityStateInfo.forNonError(READY)));
 
     // Service config returns with the same health check name.
-    hcLbEventDelivery.acceptResolvedAddresses(result1);
+    hcLbEventDelivery.handleResolvedAddresses(result1);
     // It's delivered to origLb, but nothing else happens
-    inOrder.verify(origLb).acceptResolvedAddresses(result1);
+    inOrder.verify(origLb).handleResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb, mockListener);
 
     // Service config returns a different health check name.
@@ -830,8 +829,8 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.acceptResolvedAddresses(result2);
-    inOrder.verify(origLb).acceptResolvedAddresses(result2);
+    hcLbEventDelivery.handleResolvedAddresses(result2);
+    inOrder.verify(origLb).handleResolvedAddresses(result2);
 
     // Current health check RPC cancelled.
     assertThat(serverCall.cancelled).isTrue();
@@ -853,9 +852,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.acceptResolvedAddresses(result1);
+    hcLbEventDelivery.handleResolvedAddresses(result1);
 
-    verify(origLb).acceptResolvedAddresses(result1);
+    verify(origLb).handleResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     Subchannel subchannel = createSubchannel(0, Attributes.EMPTY);
@@ -884,9 +883,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
 
     // Service config returns with the same health check name.
 
-    hcLbEventDelivery.acceptResolvedAddresses(result1);
+    hcLbEventDelivery.handleResolvedAddresses(result1);
     // It's delivered to origLb, but nothing else happens
-    inOrder.verify(origLb).acceptResolvedAddresses(result1);
+    inOrder.verify(origLb).handleResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb, mockListener);
     assertThat(clock.getPendingTasks()).hasSize(1);
     assertThat(healthImpl.calls).isEmpty();
@@ -897,13 +896,13 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.acceptResolvedAddresses(result2);
+    hcLbEventDelivery.handleResolvedAddresses(result2);
 
     // Concluded CONNECTING state
     inOrder.verify(mockListener).onSubchannelState(
         eq(ConnectivityStateInfo.forNonError(CONNECTING)));
 
-    inOrder.verify(origLb).acceptResolvedAddresses(result2);
+    inOrder.verify(origLb).handleResolvedAddresses(result2);
 
     // Current retry timer cancelled
     assertThat(clock.getPendingTasks()).isEmpty();
@@ -924,9 +923,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.acceptResolvedAddresses(result1);
+    hcLbEventDelivery.handleResolvedAddresses(result1);
 
-    verify(origLb).acceptResolvedAddresses(result1);
+    verify(origLb).handleResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     Subchannel subchannel = createSubchannel(0, Attributes.EMPTY);
@@ -944,9 +943,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
     inOrder.verifyNoMoreInteractions();
 
     // Service config returns with the same health check name.
-    hcLbEventDelivery.acceptResolvedAddresses(result1);
+    hcLbEventDelivery.handleResolvedAddresses(result1);
     // It's delivered to origLb, but nothing else happens
-    inOrder.verify(origLb).acceptResolvedAddresses(result1);
+    inOrder.verify(origLb).handleResolvedAddresses(result1);
     assertThat(healthImpl.calls).isEmpty();
     verifyNoMoreInteractions(origLb);
 
@@ -956,9 +955,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.acceptResolvedAddresses(result2);
+    hcLbEventDelivery.handleResolvedAddresses(result2);
 
-    inOrder.verify(origLb).acceptResolvedAddresses(result2);
+    inOrder.verify(origLb).handleResolvedAddresses(result2);
 
     // Underlying subchannel is now ready
     deliverSubchannelState(0, ConnectivityStateInfo.forNonError(READY));
@@ -1001,9 +1000,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.acceptResolvedAddresses(result);
+    hcLbEventDelivery.handleResolvedAddresses(result);
 
-    verify(origLb).acceptResolvedAddresses(result);
+    verify(origLb).handleResolvedAddresses(result);
     verifyNoMoreInteractions(origLb);
     ServerSideCall[] serverCalls = new ServerSideCall[NUM_SUBCHANNELS];
 
@@ -1075,8 +1074,8 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.acceptResolvedAddresses(result);
-    verify(origLb).acceptResolvedAddresses(result);
+    hcLbEventDelivery.handleResolvedAddresses(result);
+    verify(origLb).handleResolvedAddresses(result);
     createSubchannel(0, Attributes.EMPTY);
     assertThat(healthImpls[0].calls).isEmpty();
     deliverSubchannelState(0, ConnectivityStateInfo.forNonError(READY));

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
@@ -79,9 +79,9 @@ final class CdsLoadBalancer2 extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     if (this.resolvedAddresses != null) {
-      return true;
+      return;
     }
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     this.resolvedAddresses = resolvedAddresses;
@@ -91,7 +91,6 @@ final class CdsLoadBalancer2 extends LoadBalancer {
     logger.log(XdsLogLevel.INFO, "Config: {0}", config);
     cdsLbState = new CdsLbState(config.name);
     cdsLbState.start();
-    return true;
   }
 
   @Override
@@ -210,7 +209,7 @@ final class CdsLoadBalancer2 extends LoadBalancer {
       if (childLb == null) {
         childLb = lbRegistry.getProvider(CLUSTER_RESOLVER_POLICY_NAME).newLoadBalancer(helper);
       }
-      childLb.acceptResolvedAddresses(
+      childLb.handleResolvedAddresses(
           resolvedAddresses.toBuilder().setLoadBalancingPolicyConfig(config).build());
     }
 

--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -102,7 +102,7 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     Attributes attributes = resolvedAddresses.getAttributes();
     if (xdsClientPool == null) {
@@ -129,7 +129,7 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
     childLbHelper.updateDropPolicies(config.dropCategories);
     childLbHelper.updateMaxConcurrentRequests(config.maxConcurrentRequests);
     childLbHelper.updateSslContextProviderSupplier(config.tlsContext);
-    return childLb.acceptResolvedAddresses(
+    childLb.handleResolvedAddresses(
         resolvedAddresses.toBuilder()
             .setAttributes(attributes)
             .setLoadBalancingPolicyConfig(config.childPolicy.getConfig())
@@ -160,6 +160,11 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
     if (xdsClient != null) {
       xdsClient = xdsClientPool.returnObject(xdsClient);
     }
+  }
+
+  @Override
+  public boolean canHandleEmptyAddressListFromNameResolution() {
+    return true;
   }
 
   /**

--- a/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
@@ -109,7 +109,7 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     if (xdsClientPool == null) {
       xdsClientPool = resolvedAddresses.getAttributes().get(InternalXdsAttributes.XDS_CLIENT_POOL);
@@ -121,10 +121,8 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
       logger.log(XdsLogLevel.DEBUG, "Config: {0}", config);
       delegate.switchTo(new ClusterResolverLbStateFactory());
       this.config = config;
-      return delegate.acceptResolvedAddresses(resolvedAddresses);
+      delegate.handleResolvedAddresses(resolvedAddresses);
     }
-
-    return true;
   }
 
   @Override
@@ -168,7 +166,7 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
     }
 
     @Override
-    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       this.resolvedAddresses = resolvedAddresses;
       ClusterResolverConfig config =
           (ClusterResolverConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
@@ -186,8 +184,6 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
         clusterStates.put(instance.cluster, state);
         state.start();
       }
-
-      return true;
     }
 
     @Override
@@ -253,7 +249,7 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
       if (childLb == null) {
         childLb = lbRegistry.getProvider(PRIORITY_POLICY_NAME).newLoadBalancer(helper);
       }
-      childLb.acceptResolvedAddresses(
+      childLb.handleResolvedAddresses(
           resolvedAddresses.toBuilder()
               .setLoadBalancingPolicyConfig(childConfig)
               .setAddresses(Collections.unmodifiableList(addresses))

--- a/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancer.java
@@ -88,7 +88,7 @@ final class LeastRequestLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     LeastRequestConfig config =
         (LeastRequestConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
     // Config may be null if least_request is used outside xDS
@@ -146,8 +146,6 @@ final class LeastRequestLoadBalancer extends LoadBalancer {
     for (Subchannel removedSubchannel : removedSubchannels) {
       shutdownSubchannel(removedSubchannel);
     }
-
-    return true;
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/PriorityLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/PriorityLoadBalancer.java
@@ -81,7 +81,7 @@ final class PriorityLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     this.resolvedAddresses = resolvedAddresses;
     PriorityLbConfig config = (PriorityLbConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
@@ -102,8 +102,6 @@ final class PriorityLoadBalancer extends LoadBalancer {
     // Not to report connecting in case a pending priority bumps up on top of the current READY
     // priority.
     tryNextPriority(false);
-
-    return true;
   }
 
   @Override
@@ -279,7 +277,7 @@ final class PriorityLoadBalancer extends LoadBalancer {
         policy = newPolicy;
         lb.switchTo(lbProvider);
       }
-      lb.acceptResolvedAddresses(
+      lb.handleResolvedAddresses(
           resolvedAddresses.toBuilder()
               .setAddresses(AddressFilter.filter(resolvedAddresses.getAddresses(), priority))
               .setLoadBalancingPolicyConfig(childPolicySelection.getConfig())

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -81,13 +81,13 @@ final class RingHashLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     List<EquivalentAddressGroup> addrList = resolvedAddresses.getAddresses();
     if (addrList.isEmpty()) {
       handleNameResolutionError(Status.UNAVAILABLE.withDescription("Ring hash lb error: EDS "
           + "resolution was successful, but returned server addresses are empty."));
-      return false;
+      return;
     }
     Map<EquivalentAddressGroup, EquivalentAddressGroup> latestAddrs = stripAttrs(addrList);
     Set<EquivalentAddressGroup> removedAddrs =
@@ -162,8 +162,6 @@ final class RingHashLoadBalancer extends LoadBalancer {
     for (Subchannel subchann : removedSubchannels) {
       shutdownSubchannel(subchann);
     }
-
-    return true;
   }
 
   private static List<RingEntry> buildRing(

--- a/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancer.java
@@ -61,7 +61,7 @@ final class WrrLocalityLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
 
     // The configuration with the child policy is combined with the locality weights
@@ -76,7 +76,7 @@ final class WrrLocalityLoadBalancer extends LoadBalancer {
       Status unavailable =
           Status.UNAVAILABLE.withDescription("wrr_locality error: no locality weights provided");
       helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(unavailable));
-      return false;
+      return;
     }
 
     // Weighted target LB expects a WeightedPolicySelection for each locality as it will create a
@@ -97,7 +97,7 @@ final class WrrLocalityLoadBalancer extends LoadBalancer {
             .discard(InternalXdsAttributes.ATTR_LOCALITY_WEIGHTS).build()).build();
 
     switchLb.switchTo(lbRegistry.getProvider(WEIGHTED_TARGET_POLICY_NAME));
-    return switchLb.acceptResolvedAddresses(
+    switchLb.handleResolvedAddresses(
         resolvedAddresses.toBuilder()
             .setLoadBalancingPolicyConfig(new WeightedTargetConfig(weightedPolicySelections))
             .build());

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
@@ -130,7 +130,7 @@ public class CdsLoadBalancer2Test {
     lbRegistry.register(new FakeLoadBalancerProvider("least_request_experimental",
         new LeastRequestLoadBalancerProvider()));
     loadBalancer = new CdsLoadBalancer2(helper, lbRegistry);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(Collections.<EquivalentAddressGroup>emptyList())
             .setAttributes(
@@ -627,9 +627,8 @@ public class CdsLoadBalancer2Test {
     }
 
     @Override
-    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       config = resolvedAddresses.getLoadBalancingPolicyConfig();
-      return true;
     }
 
     @Override

--- a/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
@@ -282,7 +282,7 @@ public class ClusterImplLoadBalancerTest {
     config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO, null,
         Collections.singletonList(DropOverload.create("lb", 1_000_000)),
         new PolicySelection(weightedTargetProvider, weightedTargetConfig), null);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(Collections.singletonList(endpoint))
             .setAttributes(
@@ -571,7 +571,7 @@ public class ClusterImplLoadBalancerTest {
 
   private void deliverAddressesAndConfig(List<EquivalentAddressGroup> addresses,
       ClusterImplConfig config) {
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(addresses)
             .setAttributes(
@@ -677,11 +677,10 @@ public class ClusterImplLoadBalancerTest {
     }
 
     @Override
-    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       addresses = resolvedAddresses.getAddresses();
       config = resolvedAddresses.getLoadBalancingPolicyConfig();
       attributes = resolvedAddresses.getAttributes();
-      return true;
     }
 
     @Override

--- a/xds/src/test/java/io/grpc/xds/ClusterManagerLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterManagerLoadBalancerTest.java
@@ -267,7 +267,7 @@ public class ClusterManagerLoadBalancerTest {
   }
 
   private void deliverResolvedAddresses(final Map<String, String> childPolicies, boolean failing) {
-    clusterManagerLoadBalancer.acceptResolvedAddresses(
+    clusterManagerLoadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(Collections.<EquivalentAddressGroup>emptyList())
             .setLoadBalancingPolicyConfig(buildConfig(childPolicies, failing))
@@ -348,14 +348,12 @@ public class ClusterManagerLoadBalancerTest {
     }
 
     @Override
-    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       config = resolvedAddresses.getLoadBalancingPolicyConfig();
 
       if (failing) {
         helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(Status.INTERNAL));
       }
-
-      return !failing;
     }
 
     @Override

--- a/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
@@ -985,7 +985,7 @@ public class ClusterResolverLoadBalancerTest {
   }
 
   private void deliverLbConfig(ClusterResolverConfig config) {
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(Collections.<EquivalentAddressGroup>emptyList())
             .setAttributes(
@@ -1221,11 +1221,10 @@ public class ClusterResolverLoadBalancerTest {
     }
 
     @Override
-    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       addresses = resolvedAddresses.getAddresses();
       config = resolvedAddresses.getLoadBalancingPolicyConfig();
       attributes = resolvedAddresses.getAttributes();
-      return true;
     }
 
     @Override

--- a/xds/src/test/java/io/grpc/xds/LeastRequestLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/LeastRequestLoadBalancerTest.java
@@ -155,7 +155,7 @@ public class LeastRequestLoadBalancerTest {
   @Test
   public void pickAfterResolved() throws Exception {
     final Subchannel readySubchannel = subchannels.values().iterator().next();
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     deliverSubchannelState(readySubchannel, ConnectivityStateInfo.forNonError(READY));
 
@@ -206,7 +206,7 @@ public class LeastRequestLoadBalancerTest {
 
     InOrder inOrder = inOrder(mockHelper);
 
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(currentServers).setAttributes(affinity)
             .build());
 
@@ -228,7 +228,7 @@ public class LeastRequestLoadBalancerTest {
     // This time with Attributes
     List<EquivalentAddressGroup> latestServers = Lists.newArrayList(oldEag2, newEag);
 
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(latestServers).setAttributes(affinity).build());
 
     verify(newSubchannel, times(1)).requestConnection();
@@ -248,7 +248,7 @@ public class LeastRequestLoadBalancerTest {
     assertThat(getList(picker)).containsExactly(oldSubchannel, newSubchannel);
 
     // test going from non-empty to empty
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(Collections.<EquivalentAddressGroup>emptyList())
             .setAttributes(affinity)
@@ -263,7 +263,7 @@ public class LeastRequestLoadBalancerTest {
   @Test
   public void pickAfterStateChange() throws Exception {
     InOrder inOrder = inOrder(mockHelper);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(Attributes.EMPTY)
             .build());
     Subchannel subchannel = loadBalancer.getSubchannels().iterator().next();
@@ -305,7 +305,7 @@ public class LeastRequestLoadBalancerTest {
     final LeastRequestConfig oldConfig = new LeastRequestConfig(4);
     final LeastRequestConfig newConfig = new LeastRequestConfig(6);
     final Subchannel readySubchannel = subchannels.values().iterator().next();
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity)
             .setLoadBalancingPolicyConfig(oldConfig).build());
     deliverSubchannelState(readySubchannel, ConnectivityStateInfo.forNonError(READY));
@@ -317,7 +317,7 @@ public class LeastRequestLoadBalancerTest {
     pickerCaptor.getValue().pickSubchannel(mockArgs);
     verify(mockRandom, times(oldConfig.choiceCount)).nextInt(1);
 
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity)
             .setLoadBalancingPolicyConfig(newConfig).build());
     verify(mockHelper, times(3))
@@ -332,7 +332,7 @@ public class LeastRequestLoadBalancerTest {
   @Test
   public void ignoreShutdownSubchannelStateChange() {
     InOrder inOrder = inOrder(mockHelper);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(Attributes.EMPTY)
             .build());
     inOrder.verify(mockHelper).updateBalancingState(eq(CONNECTING), isA(EmptyPicker.class));
@@ -351,7 +351,7 @@ public class LeastRequestLoadBalancerTest {
   @Test
   public void stayTransientFailureUntilReady() {
     InOrder inOrder = inOrder(mockHelper);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(Attributes.EMPTY)
             .build());
 
@@ -389,7 +389,7 @@ public class LeastRequestLoadBalancerTest {
   @Test
   public void refreshNameResolutionWhenSubchannelConnectionBroken() {
     InOrder inOrder = inOrder(mockHelper);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(Attributes.EMPTY)
             .build());
 
@@ -419,7 +419,7 @@ public class LeastRequestLoadBalancerTest {
   public void pickerLeastRequest() throws Exception {
     int choiceCount = 2;
     // This should add inFlight counters to all subchannels.
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(Attributes.EMPTY)
             .setLoadBalancingPolicyConfig(new LeastRequestConfig(choiceCount))
             .build());
@@ -505,7 +505,7 @@ public class LeastRequestLoadBalancerTest {
   public void nameResolutionErrorWithActiveChannels() throws Exception {
     int choiceCount = 8;
     final Subchannel readySubchannel = subchannels.values().iterator().next();
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setLoadBalancingPolicyConfig(new LeastRequestConfig(choiceCount))
             .setAddresses(servers).setAttributes(affinity).build());
@@ -538,7 +538,7 @@ public class LeastRequestLoadBalancerTest {
     Subchannel sc2 = subchannelIterator.next();
     Subchannel sc3 = subchannelIterator.next();
 
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(Attributes.EMPTY)
             .build());
     verify(sc1, times(1)).requestConnection();

--- a/xds/src/test/java/io/grpc/xds/MetadataLoadBalancerProvider.java
+++ b/xds/src/test/java/io/grpc/xds/MetadataLoadBalancerProvider.java
@@ -108,13 +108,11 @@ public class MetadataLoadBalancerProvider extends LoadBalancerProvider {
     }
 
     @Override
-    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       MetadataLoadBalancerConfig config
           = (MetadataLoadBalancerConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
       helper.setMetadata(config.metadataKey, config.metadataValue);
-      delegateLb.acceptResolvedAddresses(resolvedAddresses);
-
-      return true;
+      delegateLb.handleResolvedAddresses(resolvedAddresses);
     }
   }
 

--- a/xds/src/test/java/io/grpc/xds/PriorityLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/PriorityLoadBalancerTest.java
@@ -157,7 +157,7 @@ public class PriorityLoadBalancerTest {
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1,
                 "p2", priorityChildConfig2),
             ImmutableList.of("p0", "p1", "p2"));
-    priorityLb.acceptResolvedAddresses(
+    priorityLb.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(addresses)
             .setAttributes(attributes)
@@ -166,7 +166,7 @@ public class PriorityLoadBalancerTest {
     assertThat(fooBalancers).hasSize(1);
     assertThat(barBalancers).isEmpty();
     LoadBalancer fooBalancer0 = Iterables.getOnlyElement(fooBalancers);
-    verify(fooBalancer0).acceptResolvedAddresses(resolvedAddressesCaptor.capture());
+    verify(fooBalancer0).handleResolvedAddresses(resolvedAddressesCaptor.capture());
     ResolvedAddresses addressesReceived = resolvedAddressesCaptor.getValue();
     assertThat(addressesReceived.getAddresses()).isEmpty();
     assertThat(addressesReceived.getAttributes()).isEqualTo(attributes);
@@ -177,7 +177,7 @@ public class PriorityLoadBalancerTest {
     assertThat(fooBalancers).hasSize(1);
     assertThat(barBalancers).hasSize(1);
     LoadBalancer barBalancer0 = Iterables.getOnlyElement(barBalancers);
-    verify(barBalancer0).acceptResolvedAddresses(resolvedAddressesCaptor.capture());
+    verify(barBalancer0).handleResolvedAddresses(resolvedAddressesCaptor.capture());
     addressesReceived = resolvedAddressesCaptor.getValue();
     assertThat(Iterables.getOnlyElement(addressesReceived.getAddresses()).getAddresses())
         .containsExactly(socketAddress);
@@ -189,7 +189,7 @@ public class PriorityLoadBalancerTest {
     assertThat(fooBalancers).hasSize(2);
     assertThat(barBalancers).hasSize(1);
     LoadBalancer fooBalancer1 = Iterables.getLast(fooBalancers);
-    verify(fooBalancer1).acceptResolvedAddresses(resolvedAddressesCaptor.capture());
+    verify(fooBalancer1).handleResolvedAddresses(resolvedAddressesCaptor.capture());
     addressesReceived = resolvedAddressesCaptor.getValue();
     assertThat(addressesReceived.getAddresses()).isEmpty();
     assertThat(addressesReceived.getAttributes()).isEqualTo(attributes);
@@ -206,14 +206,14 @@ public class PriorityLoadBalancerTest {
             ImmutableMap.of("p1",
                 new PriorityChildConfig(new PolicySelection(barLbProvider, newBarConfig), true)),
             ImmutableList.of("p1"));
-    priorityLb.acceptResolvedAddresses(
+    priorityLb.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(newAddresses)
             .setLoadBalancingPolicyConfig(newPriorityLbConfig)
             .build());
     assertThat(fooBalancers).hasSize(2);
     assertThat(barBalancers).hasSize(1);
-    verify(barBalancer0, times(2)).acceptResolvedAddresses(resolvedAddressesCaptor.capture());
+    verify(barBalancer0, times(2)).handleResolvedAddresses(resolvedAddressesCaptor.capture());
     addressesReceived = resolvedAddressesCaptor.getValue();
     assertThat(Iterables.getOnlyElement(addressesReceived.getAddresses()).getAddresses())
         .containsExactly(newSocketAddress);
@@ -238,7 +238,7 @@ public class PriorityLoadBalancerTest {
 
     PriorityLbConfig priorityLbConfig =
         new PriorityLbConfig(ImmutableMap.of("p0", priorityChildConfig0), ImmutableList.of("p0"));
-    priorityLb.acceptResolvedAddresses(
+    priorityLb.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(priorityLbConfig)
@@ -250,7 +250,7 @@ public class PriorityLoadBalancerTest {
 
     priorityLbConfig =
         new PriorityLbConfig(ImmutableMap.of("p1", priorityChildConfig1), ImmutableList.of("p1"));
-    priorityLb.acceptResolvedAddresses(
+    priorityLb.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(priorityLbConfig)
@@ -281,7 +281,7 @@ public class PriorityLoadBalancerTest {
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1,
                 "p2", priorityChildConfig2, "p3", priorityChildConfig3),
             ImmutableList.of("p0", "p1", "p2", "p3"));
-    priorityLb.acceptResolvedAddresses(
+    priorityLb.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(priorityLbConfig)
@@ -409,7 +409,7 @@ public class PriorityLoadBalancerTest {
         new PriorityLbConfig(
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1),
             ImmutableList.of("p0", "p1"));
-    priorityLb.acceptResolvedAddresses(
+    priorityLb.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(priorityLbConfig)
@@ -445,7 +445,7 @@ public class PriorityLoadBalancerTest {
         new PriorityLbConfig(
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1),
             ImmutableList.of("p0", "p1"));
-    priorityLb.acceptResolvedAddresses(
+    priorityLb.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(priorityLbConfig)
@@ -483,7 +483,7 @@ public class PriorityLoadBalancerTest {
         new PriorityLbConfig(
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1),
             ImmutableList.of("p0", "p1"));
-    priorityLb.acceptResolvedAddresses(
+    priorityLb.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(priorityLbConfig)
@@ -516,7 +516,7 @@ public class PriorityLoadBalancerTest {
 
     // resolution update without priority change does not trigger failover
     Attributes.Key<String> fooKey = Attributes.Key.create("fooKey");
-    priorityLb.acceptResolvedAddresses(
+    priorityLb.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(priorityLbConfig)
@@ -545,7 +545,7 @@ public class PriorityLoadBalancerTest {
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1,
                 "p2", priorityChildConfig2, "p3", priorityChildConfig3),
             ImmutableList.of("p0", "p1", "p2", "p3"));
-    priorityLb.acceptResolvedAddresses(
+    priorityLb.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(priorityLbConfig)
@@ -643,7 +643,7 @@ public class PriorityLoadBalancerTest {
         new PriorityLbConfig(
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1),
             ImmutableList.of("p0", "p1"));
-    priorityLb.acceptResolvedAddresses(
+    priorityLb.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(priorityLbConfig)
@@ -670,7 +670,7 @@ public class PriorityLoadBalancerTest {
         new PriorityLbConfig(
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1),
             ImmutableList.of("p0", "p1"));
-    priorityLb.acceptResolvedAddresses(
+    priorityLb.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(priorityLbConfig)

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
@@ -156,7 +156,7 @@ public class RingHashLoadBalancerTest {
   public void subchannelLazyConnectUntilPicked() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1);  // one server
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper).createSubchannel(any(CreateSubchannelArgs.class));
@@ -187,7 +187,7 @@ public class RingHashLoadBalancerTest {
   public void subchannelNotAutoReconnectAfterReenteringIdle() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1);  // one server
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     Subchannel subchannel = Iterables.getOnlyElement(subchannels.values());
@@ -217,7 +217,7 @@ public class RingHashLoadBalancerTest {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1);
     InOrder inOrder = Mockito.inOrder(helper);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     inOrder.verify(helper, times(2)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -278,7 +278,7 @@ public class RingHashLoadBalancerTest {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1, 1);
     InOrder inOrder = Mockito.inOrder(helper);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     inOrder.verify(helper, times(4)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -336,7 +336,7 @@ public class RingHashLoadBalancerTest {
   public void subchannelStayInTransientFailureUntilBecomeReady() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -378,7 +378,7 @@ public class RingHashLoadBalancerTest {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
     InOrder inOrder = Mockito.inOrder(helper);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -394,7 +394,7 @@ public class RingHashLoadBalancerTest {
     verifyConnection(1);
 
     servers = createWeightedServerAddrs(1,1);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     inOrder.verify(helper)
@@ -422,7 +422,7 @@ public class RingHashLoadBalancerTest {
   public void ignoreShutdownSubchannelStateChange() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -442,7 +442,7 @@ public class RingHashLoadBalancerTest {
   public void deterministicPickWithHostsPartiallyRemoved() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1, 1, 1);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     InOrder inOrder = Mockito.inOrder(helper);
@@ -470,7 +470,7 @@ public class RingHashLoadBalancerTest {
       Attributes attr = addr.getAttributes().toBuilder().set(CUSTOM_KEY, "custom value").build();
       updatedServers.add(new EquivalentAddressGroup(addr.getAddresses(), attr));
     }
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(updatedServers).setLoadBalancingPolicyConfig(config).build());
     verify(subchannels.get(Collections.singletonList(servers.get(0))))
@@ -487,7 +487,7 @@ public class RingHashLoadBalancerTest {
   public void deterministicPickWithNewHostsAdded() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1);  // server0 and server1
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     InOrder inOrder = Mockito.inOrder(helper);
@@ -511,7 +511,7 @@ public class RingHashLoadBalancerTest {
     assertThat(subchannel.getAddresses()).isEqualTo(servers.get(1));
 
     servers = createWeightedServerAddrs(1, 1, 1, 1, 1);  // server2, server3, server4 added
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     inOrder.verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -526,7 +526,7 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -583,7 +583,7 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -649,7 +649,7 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -687,7 +687,7 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -718,7 +718,7 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -749,7 +749,7 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -784,7 +784,7 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -822,7 +822,7 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -864,7 +864,7 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -908,7 +908,7 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -943,7 +943,7 @@ public class RingHashLoadBalancerTest {
   public void hostSelectionProportionalToWeights() {
     RingHashConfig config = new RingHashConfig(10000, 100000);  // large ring
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 10, 100); // 1:10:100
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -979,7 +979,7 @@ public class RingHashLoadBalancerTest {
   public void hostSelectionProportionalToRepeatedAddressCount() {
     RingHashConfig config = new RingHashConfig(10000, 100000);
     List<EquivalentAddressGroup> servers = createRepeatedServerAddrs(1, 10, 100);  // 1:10:100
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
@@ -1027,7 +1027,7 @@ public class RingHashLoadBalancerTest {
   public void nameResolutionErrorWithActiveSubchannels() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1);
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     verify(helper).createSubchannel(any(CreateSubchannelArgs.class));

--- a/xds/src/test/java/io/grpc/xds/WeightedTargetLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedTargetLoadBalancerTest.java
@@ -200,7 +200,7 @@ public class WeightedTargetLoadBalancerTest {
     eag2 = AddressFilter.setPathFilter(eag2, ImmutableList.of("target2"));
     EquivalentAddressGroup eag3 = new EquivalentAddressGroup(socketAddresses[3]);
     eag3 = AddressFilter.setPathFilter(eag3, ImmutableList.of("target3"));
-    weightedTargetLb.acceptResolvedAddresses(
+    weightedTargetLb.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.of(eag0, eag1, eag2, eag3))
             .setAttributes(Attributes.newBuilder().set(fakeKey, fakeValue).build())
@@ -213,7 +213,7 @@ public class WeightedTargetLoadBalancerTest {
     assertThat(barLbCreated).isEqualTo(2);
 
     for (int i = 0; i < childBalancers.size(); i++) {
-      verify(childBalancers.get(i)).acceptResolvedAddresses(resolvedAddressesCaptor.capture());
+      verify(childBalancers.get(i)).handleResolvedAddresses(resolvedAddressesCaptor.capture());
       ResolvedAddresses resolvedAddresses = resolvedAddressesCaptor.getValue();
       assertThat(resolvedAddresses.getLoadBalancingPolicyConfig()).isEqualTo(configs[i]);
       assertThat(resolvedAddresses.getAttributes().get(fakeKey)).isEqualTo(fakeValue);
@@ -238,7 +238,7 @@ public class WeightedTargetLoadBalancerTest {
         "target4",
         new WeightedPolicySelection(
             newWeights[3], new PolicySelection(fooLbProvider, newConfigs[3])));
-    weightedTargetLb.acceptResolvedAddresses(
+    weightedTargetLb.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(new WeightedTargetConfig(newTargets))
@@ -252,7 +252,7 @@ public class WeightedTargetLoadBalancerTest {
     verify(childBalancers.get(0)).shutdown();
     for (int i = 1; i < childBalancers.size(); i++) {
       verify(childBalancers.get(i), atLeastOnce())
-          .acceptResolvedAddresses(resolvedAddressesCaptor.capture());
+          .handleResolvedAddresses(resolvedAddressesCaptor.capture());
       assertThat(resolvedAddressesCaptor.getValue().getLoadBalancingPolicyConfig())
           .isEqualTo(newConfigs[i - 1]);
     }
@@ -280,7 +280,7 @@ public class WeightedTargetLoadBalancerTest {
         "target2", weightedLbConfig2,
         // {foo, 40, config3}
         "target3", weightedLbConfig3);
-    weightedTargetLb.acceptResolvedAddresses(
+    weightedTargetLb.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(new WeightedTargetConfig(targets))
@@ -307,7 +307,7 @@ public class WeightedTargetLoadBalancerTest {
         "target2", weightedLbConfig2,
         // {foo, 40, config3}
         "target3", weightedLbConfig3);
-    weightedTargetLb.acceptResolvedAddresses(
+    weightedTargetLb.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(new WeightedTargetConfig(targets))
@@ -388,7 +388,7 @@ public class WeightedTargetLoadBalancerTest {
     Map<String, WeightedPolicySelection> targets = ImmutableMap.of(
         "target0", weightedLbConfig0,
         "target1", weightedLbConfig1);
-    weightedTargetLb.acceptResolvedAddresses(
+    weightedTargetLb.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(new WeightedTargetConfig(targets))
@@ -414,7 +414,7 @@ public class WeightedTargetLoadBalancerTest {
             weights[0], new PolicySelection(fakeLbProvider, configs[0])),
         "target3", new WeightedPolicySelection(
             weights[3], new PolicySelection(fakeLbProvider, configs[3])));
-    weightedTargetLb.acceptResolvedAddresses(
+    weightedTargetLb.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(new WeightedTargetConfig(targets))
@@ -459,9 +459,8 @@ public class WeightedTargetLoadBalancerTest {
     }
 
     @Override
-    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(Status.INTERNAL));
-      return true;
     }
 
     @Override

--- a/xds/src/test/java/io/grpc/xds/WrrLocalityLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WrrLocalityLoadBalancerTest.java
@@ -129,7 +129,7 @@ public class WrrLocalityLoadBalancerTest {
 
     // Assert that the child policy and the locality weights were correctly mapped to a
     // WeightedTargetConfig.
-    verify(mockWeightedTargetLb).acceptResolvedAddresses(resolvedAddressesCaptor.capture());
+    verify(mockWeightedTargetLb).handleResolvedAddresses(resolvedAddressesCaptor.capture());
     Object config = resolvedAddressesCaptor.getValue().getLoadBalancingPolicyConfig();
     assertThat(config).isInstanceOf(WeightedTargetConfig.class);
     WeightedTargetConfig wtConfig = (WeightedTargetConfig) config;
@@ -190,7 +190,7 @@ public class WrrLocalityLoadBalancerTest {
 
     // Assert that the child policy and the locality weights were correctly mapped to a
     // WeightedTargetConfig.
-    verify(mockWeightedTargetLb).acceptResolvedAddresses(resolvedAddressesCaptor.capture());
+    verify(mockWeightedTargetLb).handleResolvedAddresses(resolvedAddressesCaptor.capture());
     assertThat(resolvedAddressesCaptor.getValue().getAttributes()
         .get(InternalXdsAttributes.ATTR_LOCALITY_WEIGHTS)).isNull();
   }
@@ -219,7 +219,7 @@ public class WrrLocalityLoadBalancerTest {
   }
 
   private void deliverAddresses(WrrLocalityConfig config, Map<Locality, Integer> localityWeights) {
-    loadBalancer.acceptResolvedAddresses(
+    loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(ImmutableList.of(eag)).setAttributes(
                 Attributes.newBuilder()
                     .set(InternalXdsAttributes.ATTR_LOCALITY_WEIGHTS, localityWeights).build())


### PR DESCRIPTION
Reverts grpc/grpc-java#8742

This is breaking some internal interop tests, reverting for now and merging back later with the fix.