### PR TITLE
core: server stream should not deliver halfClose() when call is immediately cancelled(#9362) (v1.48 backport)

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerStream.java
@@ -217,8 +217,8 @@ public abstract class AbstractServerStream extends AbstractStream
     @Override
     public void deframerClosed(boolean hasPartialMessage) {
       deframerClosed = true;
-      if (endOfStream) {
-        if (!immediateCloseRequested && hasPartialMessage) {
+      if (endOfStream && !immediateCloseRequested) {
+        if (hasPartialMessage) {
           // We've received the entire stream and have data available but we don't have
           // enough to read the next frame ... this is bad.
           deframeFailed(


### PR DESCRIPTION

Fix a bug where the server stream delivers halfClose() to the call during cancellation. It happens when call has a short deadline. Server sees `INTERNAL, desc: Half-closed without a request` due to the bug.

backport of #9362