### PR TITLE
repositories.bzl: Use valid target name for grpc-services (1.48.x backport)

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -84,10 +84,10 @@ IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS = {
     "io.grpc:grpc-protobuf": "@io_grpc_grpc_java//protobuf",
     "io.grpc:grpc-protobuf-lite": "@io_grpc_grpc_java//protobuf-lite",
     "io.grpc:grpc-rls": "@io_grpc_grpc_java//rls",
-    "io.grpc:grpc-services": "@io_grpc_grpc_java//services",
+    "io.grpc:grpc-services": "@io_grpc_grpc_java//services:services_maven",
     "io.grpc:grpc-stub": "@io_grpc_grpc_java//stub",
     "io.grpc:grpc-testing": "@io_grpc_grpc_java//testing",
-    "io.grpc:grpc-xds": "@io_grpc_grpc_java//xds",
+    "io.grpc:grpc-xds": "@io_grpc_grpc_java//xds:xds_maven",
 }
 
 def grpc_java_repositories():

--- a/xds/BUILD.bazel
+++ b/xds/BUILD.bazel
@@ -6,6 +6,7 @@ load("//:java_grpc_library.bzl", "java_grpc_library")
 # Maven Central.
 java_library(
     name = "xds_maven",
+    visibility = ["//visibility:public"],
     runtime_deps = [
         ":orca",
         ":xds",


### PR DESCRIPTION
This fixes builds including dependencies from Maven that use
io.grpc:grpc-services. It resolves this error:
```
no such target '@io_grpc_grpc_java//services:services': target 'services' not declared in package 'services' defined by services/BUILD.bazel and referenced by '@maven//:io_grpc_grpc_services'
```

Fixes #9419

CC @xushaoxiao

Backport of #9422