### PR TITLE
Rls spec sync

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProvider.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProvider.java
@@ -38,7 +38,7 @@ import javax.annotation.Nonnull;
  * looks for an "rpc_behavior" field in its configuration and includes the value in the
  * "rpc-behavior" metadata entry that is sent to the server. This will cause the test server to
  * behave in a predefined way. Endpoint picking logic is delegated to the
- * {@link RoundRobinLoadBalancer}.
+ * io.grpc.util.RoundRobinLoadBalancer.
  *
  * <p>Initial use case is to prove that a custom load balancer can be configured by the control
  * plane via xDS. An interop test will configure this LB and then verify it has been correctly

--- a/rls/src/main/java/io/grpc/rls/AdaptiveThrottler.java
+++ b/rls/src/main/java/io/grpc/rls/AdaptiveThrottler.java
@@ -44,7 +44,7 @@ final class AdaptiveThrottler implements Throttler {
 
   private static final int DEFAULT_HISTORY_SECONDS = 30;
   private static final int DEFAULT_REQUEST_PADDING = 8;
-  private static final float DEFAULT_RATIO_FOR_ACCEPT = 1.2f;
+  private static final float DEFAULT_RATIO_FOR_ACCEPT = 2.0f;
 
   /**
    * The duration of history of calls used by Adaptive Throttler.

--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -323,6 +323,10 @@ final class CachingRlsLbClient {
         }
       });
     }
+
+    void triggerPendingRPCProcessing() {
+      super.updateBalancingState(state, picker);
+    }
   }
 
   /**
@@ -515,6 +519,10 @@ final class CachingRlsLbClient {
 
     protected long getMinEvictionTime() {
       return 0L;
+    }
+
+    protected void triggerPendingRPCProcessing() {
+      helper.triggerPendingRPCProcessing();
     }
   }
 
@@ -891,7 +899,11 @@ final class CachingRlsLbClient {
 
     public CacheEntry cacheAndClean(RouteLookupRequest key, CacheEntry value) {
       CacheEntry retVal = cache(key, value);
-      fitToLimit(); // force cleanup if new entry pushed cache over max size (in bytes)
+
+      // force cleanup if new entry pushed cache over max size (in bytes)
+      if (fitToLimit()) {
+        value.triggerPendingRPCProcessing();
+      }
       return retVal;
     }
   }

--- a/rls/src/main/java/io/grpc/rls/LinkedHashLruCache.java
+++ b/rls/src/main/java/io/grpc/rls/LinkedHashLruCache.java
@@ -247,7 +247,6 @@ abstract class LinkedHashLruCache<K, V> implements LruCache<K, V> {
    * Returns TRUE if any unexpired entries were removed
    */
   protected final boolean fitToLimit() {
-    long now = ticker.read();
     boolean removedAnyUnexpired = false;
     synchronized (lock) {
       if (estimatedSizeBytes.get() <= estimatedMaxSizeBytes) {
@@ -255,7 +254,7 @@ abstract class LinkedHashLruCache<K, V> implements LruCache<K, V> {
         return false;
       }
       // cleanup expired entries
-      cleanupExpiredEntries(now);
+      cleanupExpiredEntries(now());
 
       // cleanup eldest entry until new size limit
       Iterator<Map.Entry<K, SizedValue>> lruIter = delegate.entrySet().iterator();

--- a/rls/src/main/java/io/grpc/rls/LinkedHashLruCache.java
+++ b/rls/src/main/java/io/grpc/rls/LinkedHashLruCache.java
@@ -118,6 +118,10 @@ abstract class LinkedHashLruCache<K, V> implements LruCache<K, V> {
     return 1;
   }
 
+  protected long estimatedMaxSizeBytes() {
+    return estimatedMaxSizeBytes;
+  }
+
   /** Updates size for given key if entry exists. It is useful if the cache value is mutated. */
   public void updateEntrySize(K key) {
     synchronized (lock) {
@@ -233,15 +237,18 @@ abstract class LinkedHashLruCache<K, V> implements LruCache<K, V> {
     }
   }
 
+  protected long now() {
+    return ticker.read();
+  }
+
   /**
-   * Resizes cache. If new size is smaller than current estimated size, it will free up space by
+   * Cleans up cache if needed to fit into max size bytes by
    * removing expired entries and removing oldest entries by LRU order.
    */
-  public final void resize(int newSizeBytes) {
+  protected final void fitToLimit() {
     long now = ticker.read();
     synchronized (lock) {
-      this.estimatedMaxSizeBytes = newSizeBytes;
-      if (estimatedSizeBytes.get() <= newSizeBytes) {
+      if (estimatedSizeBytes.get() <= estimatedMaxSizeBytes) {
         // new size is larger no need to do cleanup
         return;
       }
@@ -252,10 +259,24 @@ abstract class LinkedHashLruCache<K, V> implements LruCache<K, V> {
       Iterator<Map.Entry<K, SizedValue>> lruIter = delegate.entrySet().iterator();
       while (lruIter.hasNext() && estimatedMaxSizeBytes < this.estimatedSizeBytes.get()) {
         Map.Entry<K, SizedValue> entry = lruIter.next();
+        if (!shouldInvalidateEldestEntry(entry.getKey(), entry.getValue().value)) {
+          break; // Violates some constraint like minimum age so stop our cleanup
+        }
         lruIter.remove();
         // eviction listener will update the estimatedSizeBytes
         evictionListener.onEviction(entry.getKey(), entry.getValue(), EvictionType.SIZE);
       }
+    }
+  }
+
+  /**
+   * Resizes cache. If new size is smaller than current estimated size, it will free up space by
+   * removing expired entries and removing oldest entries by LRU order.
+   */
+  public final void resize(long newSizeBytes) {
+    synchronized (lock) {
+      this.estimatedMaxSizeBytes = newSizeBytes;
+      fitToLimit();
     }
   }
 

--- a/rls/src/main/java/io/grpc/rls/RlsProtoConverters.java
+++ b/rls/src/main/java/io/grpc/rls/RlsProtoConverters.java
@@ -116,12 +116,12 @@ final class RlsProtoConverters {
       // Validate grpc_keybuilders
       checkArgument(!grpcKeybuilders.isEmpty(), "must have at least one GrpcKeyBuilder");
       Set<Name> names = new HashSet<>();
-      Set<String> keys = new HashSet<>();
-      Set<String> extraKeys = new HashSet<>();
       for (GrpcKeyBuilder keyBuilder : grpcKeybuilders) {
         for (Name name : keyBuilder.names()) {
           checkArgument(names.add(name), "duplicate names in grpc_keybuilders: " + name);
         }
+
+        Set<String> keys = new HashSet<>();
         for (NameMatcher header : keyBuilder.headers()) {
           checkKeys(keys, header.key(), "header");
         }
@@ -129,8 +129,8 @@ final class RlsProtoConverters {
           checkKeys(keys, key, "constant");
         }
         String extraKeyStr = keyToString(keyBuilder.extraKeys());
-        checkArgument(extraKeys.add(extraKeyStr),
-            "duplicate extra keys in grpc_keybuilders: " + extraKeyStr);
+        checkArgument(keys.add(extraKeyStr),
+            "duplicate extra key in grpc_keybuilders: " + extraKeyStr);
       }
 
       // Validate lookup_service
@@ -193,7 +193,7 @@ final class RlsProtoConverters {
   private static void checkKeys(Set<String> keys, String key, String keyType) {
     checkArgument(key != null, "unset " + keyType + "  key");
     checkArgument(!key.isEmpty(), "Empty string for " + keyType + " key");
-    checkArgument(keys.add(key), "duplicate " + keyType + " keys in grpc_keybuilders: " + key);
+    checkArgument(keys.add(key), "duplicate " + keyType + " key in grpc_keybuilders: " + key);
   }
 
   private static final class GrpcKeyBuilderConverter {

--- a/rls/src/main/java/io/grpc/rls/RlsRequestFactory.java
+++ b/rls/src/main/java/io/grpc/rls/RlsRequestFactory.java
@@ -52,8 +52,8 @@ final class RlsRequestFactory {
     Map<String, GrpcKeyBuilder> table = new HashMap<>();
     for (GrpcKeyBuilder grpcKeyBuilder : config.grpcKeybuilders()) {
       for (Name name : grpcKeyBuilder.names()) {
-        boolean hasMethod = name.method() == null || name.method().isEmpty();
-        String method = hasMethod ? "*" : name.method();
+        boolean noMethod = name.method() == null || name.method().isEmpty();
+        String method = noMethod ? "*" : name.method();
         String path = "/" + name.service() + "/" + method;
         table.put(path, grpcKeyBuilder);
       }


### PR DESCRIPTION
rls: Update implementation to match spec.
  - Cleanup cache if exceeds max size when add an entry.  Make cache entry size calculations more accurate
  - Trigger pending RPC processing if unexpired backoff entries were removed from the cache by triggering helper to call it's parent updateBalancingState with the same state and picker
 - Introduce minimum time before eviction (5 seconds)
 - Change default accept ratio for AdaptiveThrottler from 1.2 -> 2.0
 - Configuration validation
   - When checking key names for duplicates also look at headers
   - Check extra keys for duplicates

See analysis of implementation versus spec at https://docs.google.com/spreadsheets/d/18w5s1TEebRumWzk1pvWnjiHFGKc6MW-vt8tRLY4eNs0/