### PR TITLE
fix: Copy quota project id when creating Self Signed JWT creds from Service Account Creds (1.49.x backport)

### DIFF
--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -298,6 +298,11 @@ final class GoogleAuthLibraryCallCredentials extends io.grpc.CallCredentials {
         Method setter = builderClass.getMethod("setPrivateKeyId", getter.getReturnType());
         methodPairs.add(new MethodPair(getter, setter));
       }
+      {
+        Method getter = serviceAccountClass.getMethod("getQuotaProjectId");
+        Method setter = builderClass.getMethod("setQuotaProjectId", getter.getReturnType());
+        methodPairs.add(new MethodPair(getter, setter));
+      }
     }
 
     /**

--- a/auth/src/test/java/io/grpc/auth/GoogleAuthLibraryCallCredentialsTest.java
+++ b/auth/src/test/java/io/grpc/auth/GoogleAuthLibraryCallCredentialsTest.java
@@ -379,6 +379,7 @@ public class GoogleAuthLibraryCallCredentialsTest {
             .setClientEmail("test-email@example.com")
             .setPrivateKey(pair.getPrivate())
             .setPrivateKeyId("test-private-key-id")
+            .setQuotaProjectId("test-quota-project-id")
             .build();
     GoogleAuthLibraryCallCredentials callCredentials =
         new GoogleAuthLibraryCallCredentials(credentials);
@@ -401,6 +402,10 @@ public class GoogleAuthLibraryCallCredentialsTest {
         || "https://example.com:123/a.service".equals(payload.get("aud")));
     assertEquals("test-email@example.com", payload.get("iss"));
     assertEquals("test-email@example.com", payload.get("sub"));
+
+    Metadata.Key<String> quotaProject = Metadata.Key
+        .of("X-Goog-User-Project", Metadata.ASCII_STRING_MARSHALLER);
+    assertEquals("test-quota-project-id", Iterables.getOnlyElement(headers.getAll(quotaProject)));
   }
 
   private int runPendingRunnables() {


### PR DESCRIPTION
[ServiceAccountCredentials](https://github.com/googleapis/google-auth-library-java/blob/7f2c535ab7c842a672d6761f4cd80df88e1a37ed/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java) is converted to [ServiceAccountJwtAccessCredentials](https://github.com/googleapis/google-auth-library-java/blob/7f2c535ab7c842a672d6761f4cd80df88e1a37ed/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java) if no scopes have been specified. 

During this conversion, a [set of values](https://github.com/grpc/grpc-java/blob/7bdca0c0efa7a77587738cd6556b9f5d6f9c640e/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java?ln=297#L297) are copied over. Quotaprojectid is not part of the list. Adding it so that if user species `quota-project-id`, we set the `x-goog-user-project` header 

Backport of #9438