### PR TITLE
gcp-observability: remove unregistering stackdriverexporter (1.49.x backport)

### DIFF
--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/GcpLogSink.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/GcpLogSink.java
@@ -148,6 +148,7 @@ public class GcpLogSink implements Sink {
     ImmutableMap.Builder<String, String> tagsBuilder = ImmutableMap.builder();
     String sourceProjectId = locationTags.get("project_id");
     if (!Strings.isNullOrEmpty(destinationProjectId)
+        && !Strings.isNullOrEmpty(sourceProjectId)
         && !Objects.equals(sourceProjectId, destinationProjectId)) {
       tagsBuilder.put("source_project_id", sourceProjectId);
     }


### PR DESCRIPTION
This PR removes unregistering Stackdriver<Stats/Trace>Exporter because unregister shutdowns the channel even before creating metric descriptors causing RunTimeException.

Added a null check for sourceProjectId for non-GCP instances.

Backport of #9442 

CC @sanjaypujare 