### PR TITLE
Outlier detection load balancer

### DIFF
--- a/api/src/main/java/io/grpc/SynchronizationContext.java
+++ b/api/src/main/java/io/grpc/SynchronizationContext.java
@@ -187,7 +187,8 @@ public final class SynchronizationContext implements Executor {
 
       @Override
       public String toString() {
-        return task.toString() + "(scheduled in SynchronizationContext)";
+        return task.toString() + "(scheduled in SynchronizationContext with delay of " + delay
+            + ")";
       }
     }, initialDelay, delay, unit);
     return new ScheduledHandle(runnable, future);

--- a/api/src/main/java/io/grpc/SynchronizationContext.java
+++ b/api/src/main/java/io/grpc/SynchronizationContext.java
@@ -163,6 +163,36 @@ public final class SynchronizationContext implements Executor {
     return new ScheduledHandle(runnable, future);
   }
 
+  /**
+   * Schedules a task to be added and run via {@link #execute} after an inital delay and then
+   * repeated after the delay until cancelled.
+   *
+   * @param task the task being scheduled
+   * @param initialDelay the delay before the first run
+   * @param delay the delay after the first run.
+   * @param unit the time unit for the delay
+   * @param timerService the {@code ScheduledExecutorService} that provides delayed execution
+   *
+   * @return an object for checking the status and/or cancel the scheduled task
+   */
+  public final ScheduledHandle scheduleWithFixedDelay(
+      final Runnable task, long initialDelay, long delay, TimeUnit unit, ScheduledExecutorService timerService) {
+    final ManagedRunnable runnable = new ManagedRunnable(task);
+    ScheduledFuture<?> future = timerService.scheduleWithFixedDelay(new Runnable() {
+      @Override
+      public void run() {
+        execute(runnable);
+      }
+
+      @Override
+      public String toString() {
+        return task.toString() + "(scheduled in SynchronizationContext)";
+      }
+    }, initialDelay, delay, unit);
+    return new ScheduledHandle(runnable, future);
+  }
+
+
   private static class ManagedRunnable implements Runnable {
     final Runnable task;
     boolean isCancelled;

--- a/api/src/main/java/io/grpc/SynchronizationContext.java
+++ b/api/src/main/java/io/grpc/SynchronizationContext.java
@@ -176,7 +176,8 @@ public final class SynchronizationContext implements Executor {
    * @return an object for checking the status and/or cancel the scheduled task
    */
   public final ScheduledHandle scheduleWithFixedDelay(
-      final Runnable task, long initialDelay, long delay, TimeUnit unit, ScheduledExecutorService timerService) {
+      final Runnable task, long initialDelay, long delay, TimeUnit unit,
+      ScheduledExecutorService timerService) {
     final ManagedRunnable runnable = new ManagedRunnable(task);
     ScheduledFuture<?> future = timerService.scheduleWithFixedDelay(new Runnable() {
       @Override

--- a/api/src/test/java/io/grpc/LoadBalancerRegistryTest.java
+++ b/api/src/test/java/io/grpc/LoadBalancerRegistryTest.java
@@ -41,7 +41,7 @@ public class LoadBalancerRegistryTest {
   @Test
   public void stockProviders() {
     LoadBalancerRegistry defaultRegistry = LoadBalancerRegistry.getDefaultRegistry();
-    assertThat(defaultRegistry.providers()).hasSize(3);
+    assertThat(defaultRegistry.providers()).hasSize(4);
 
     LoadBalancerProvider pickFirst = defaultRegistry.getProvider("pick_first");
     assertThat(pickFirst).isInstanceOf(PickFirstLoadBalancerProvider.class);
@@ -50,6 +50,12 @@ public class LoadBalancerRegistryTest {
     LoadBalancerProvider roundRobin = defaultRegistry.getProvider("round_robin");
     assertThat(roundRobin.getClass().getName()).isEqualTo(
         "io.grpc.util.SecretRoundRobinLoadBalancerProvider$Provider");
+    assertThat(roundRobin.getPriority()).isEqualTo(5);
+
+    LoadBalancerProvider outlierDetection = defaultRegistry.getProvider(
+        "outlier_detection_experimental");
+    assertThat(outlierDetection.getClass().getName()).isEqualTo(
+        "io.grpc.util.OutlierDetectionLoadBalancerProvider");
     assertThat(roundRobin.getPriority()).isEqualTo(5);
 
     LoadBalancerProvider grpclb = defaultRegistry.getProvider("grpclb");

--- a/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
@@ -420,6 +420,10 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
       this.config = config;
     }
 
+    /**
+     * Adds a subchannel to the tracker, while assuring that the subchannel ejection status is
+     * updated to match the tracker's if needed.
+     */
     boolean addSubchannel(OutlierDetectionSubchannel subchannel) {
       // Make sure that the subchannel is in the same ejection state as the new tracker it is
       // associated with.
@@ -488,6 +492,13 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
       ejectionTimeMultiplier = 0;
     }
 
+    /**
+     * Swaps the active and inactive counters.
+     *
+     * <p>Note that this method is not thread safe as the swap is not done atomically. This is
+     * expected to only be called from the timer that is scheduled at a fixed delay, assuring that
+     * only one timer is active at a time.
+     */
     void swapCounters() {
       inactiveCallCounter.reset();
       CallCounter tempCounter = activeCallCounter;
@@ -529,6 +540,7 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
       return currentTimeNanos > maxEjectionTimeNanos;
     }
 
+    /** Tracks both successful and failed call counts. */
     private static class CallCounter {
       AtomicLong successCount = new AtomicLong();
       AtomicLong failureCount = new AtomicLong();

--- a/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
@@ -22,9 +22,13 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ForwardingMap;
 import com.google.common.collect.Iterables;
+import io.grpc.Attributes;
 import io.grpc.ClientStreamTracer;
 import io.grpc.ClientStreamTracer.StreamInfo;
+import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
@@ -35,6 +39,7 @@ import io.grpc.SynchronizationContext.ScheduledHandle;
 import io.grpc.internal.ServiceConfigUtil.PolicySelection;
 import io.grpc.internal.TimeProvider;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -43,7 +48,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
 
 /**
@@ -55,14 +60,18 @@ import javax.annotation.Nullable;
  */
 public class OutlierDetectionLoadBalancer extends LoadBalancer {
 
+  @VisibleForTesting
+  final AddressTrackerMap trackerMap;
+
   private final SynchronizationContext syncContext;
   private final Helper childHelper;
   private final GracefulSwitchLoadBalancer switchLb;
-  private final Map<EquivalentAddressGroup, EquivalentAddressGroupTracker> eagTrackerMap;
   private TimeProvider timeProvider;
   private final ScheduledExecutorService timeService;
   private ScheduledHandle detectionTimerHandle;
   private Long detectionTimerStartNanos;
+
+  private static final Attributes.Key EAG_INFO_ATTR_KEY = Attributes.Key.create("eagInfoKey");
 
   /**
    * Creates a new instance of {@link OutlierDetectionLoadBalancer}.
@@ -70,7 +79,7 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
   public OutlierDetectionLoadBalancer(Helper helper, TimeProvider timeProvider) {
     childHelper = new ChildHelper(checkNotNull(helper, "helper"));
     switchLb = new GracefulSwitchLoadBalancer(childHelper);
-    eagTrackerMap = new HashMap<>();
+    trackerMap = new AddressTrackerMap();
     this.syncContext = checkNotNull(helper.getSynchronizationContext(), "syncContext");
     this.timeService = checkNotNull(helper.getScheduledExecutorService(), "timeService");
     this.timeProvider = timeProvider;
@@ -82,14 +91,10 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
         = (OutlierDetectionLoadBalancerConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
 
     // The map should only retain entries for addresses in this latest update.
-    eagTrackerMap.keySet().retainAll(resolvedAddresses.getAddresses());
+    trackerMap.keySet().retainAll(resolvedAddresses.getAddresses());
 
     // Add any new ones.
-    for (EquivalentAddressGroup eag : resolvedAddresses.getAddresses()) {
-      if (!eagTrackerMap.containsKey(eag)) {
-        eagTrackerMap.put(eag, new EquivalentAddressGroupTracker(config));
-      }
-    }
+    trackerMap.putNewTrackers(config, resolvedAddresses.getAddresses());
 
     switchLb.switchTo(config.childPolicy.getProvider());
 
@@ -109,13 +114,13 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
                 - detectionTimerStartNanos));
       }
 
+      // If a timer has been previously created we need to cancel it and reset all the call counters
+      // for a fresh start.
       if (detectionTimerHandle != null) {
         detectionTimerHandle.cancel();
-        // When starting the timer for the first time we reset all call counters for a clean start.
-        for (EquivalentAddressGroupTracker tracker : eagTrackerMap.values()) {
-          tracker.clearCallCounters();
-        }
+        trackerMap.resetCallCounters();
       }
+
       detectionTimerHandle = syncContext.scheduleWithFixedDelay(new DetectionTimer(config),
           initialDelayNanos, SECONDS.toNanos(config.intervalSecs), NANOSECONDS, timeService);
     } else if (detectionTimerHandle != null) {
@@ -123,12 +128,7 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
       // uneject any addresses we may have ejected.
       detectionTimerHandle.cancel();
       detectionTimerStartNanos = null;
-      for (EquivalentAddressGroupTracker tracker : eagTrackerMap.values()) {
-        if (tracker.isEjected()) {
-          tracker.uneject();
-        }
-        tracker.resetEjectionTimeMultiplier();
-      }
+      trackerMap.cancelTracking();
     }
 
     switchLb.handleResolvedAddresses(resolvedAddresses);
@@ -160,22 +160,12 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
     public void run() {
       detectionTimerStartNanos = timeProvider.currentTimeNanos();
 
-      for (EquivalentAddressGroupTracker tracker : eagTrackerMap.values()) {
-        tracker.swapCounters();
-      }
+      trackerMap.swapCounters();
 
       OutlierEjectionAlgorithm.forConfig(config)
-          .ejectOutliers(eagTrackerMap, detectionTimerStartNanos);
+          .ejectOutliers(trackerMap, detectionTimerStartNanos);
 
-      for (EquivalentAddressGroupTracker tracker : eagTrackerMap.values()) {
-        if (!tracker.isEjected()) {
-          tracker.decrementEjectionTimeMultiplier();
-        }
-
-        if (tracker.isEjected() && tracker.maxEjectionTimeElapsed(detectionTimerStartNanos)) {
-          tracker.uneject();
-        }
-      }
+      trackerMap.maybeUnejectOutliers(detectionTimerStartNanos);
     }
   }
 
@@ -206,8 +196,8 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
       // If the subchannel is associated with a single address that is also already in the map
       // the subchannel will be added to the map and be included in outlier detection.
       List<EquivalentAddressGroup> allAddresses = subchannel.getAllAddresses();
-      if (allAddresses.size() == 1 && eagTrackerMap.containsKey(allAddresses.get(0))) {
-        EquivalentAddressGroupTracker eagInfo = eagTrackerMap.get(allAddresses.get(0));
+      if (allAddresses.size() == 1 && trackerMap.containsKey(allAddresses.get(0))) {
+        AddressTracker eagInfo = trackerMap.get(allAddresses.get(0));
         subchannel.setEquivalentAddressGroupInfo(eagInfo);
         eagInfo.addSubchannel(subchannel);
 
@@ -219,12 +209,17 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
 
       return subchannel;
     }
+
+    @Override
+    public void updateBalancingState(ConnectivityState newState, SubchannelPicker newPicker) {
+      delegate.updateBalancingState(newState, new OutlierDetectionPicker(newPicker));
+    }
   }
 
   class OutlierDetectionSubchannel extends ForwardingSubchannel {
 
     private final Subchannel delegate;
-    private EquivalentAddressGroupTracker eagInfo;
+    private AddressTracker eagInfo;
     private boolean ejected;
     private ConnectivityStateInfo lastSubchannelState;
     private OutlierDetectionSubchannelStateListener subchannelStateListener;
@@ -240,6 +235,11 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
     }
 
     @Override
+    public Attributes getAttributes() {
+      return delegate.getAttributes().toBuilder().set(EAG_INFO_ATTR_KEY, eagInfo).build();
+    }
+
+    @Override
     public void updateAddresses(List<EquivalentAddressGroup> addresses) {
       // Outlier detection only supports subchannels with a single address, but the list of
       // addresses associated with a subchannel can change at any time, so we need to react to
@@ -248,21 +248,21 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
       // No change in address plurality, we replace the single one with a new one.
       if (getAllAddresses().size() == 1 && addresses.size() == 1) {
         // Remove the current subchannel from the old address it is associated with in the map.
-        if (eagTrackerMap.containsKey(getAddresses())) {
-          eagTrackerMap.get(getAddresses()).removeSubchannel(this);
+        if (trackerMap.containsKey(getAddresses())) {
+          trackerMap.get(getAddresses()).removeSubchannel(this);
         }
 
         // If the map has an entry for the new address, we associate this subchannel with it.
         EquivalentAddressGroup newAddress = Iterables.getOnlyElement(addresses);
-        if (eagTrackerMap.containsKey(newAddress)) {
-          EquivalentAddressGroupTracker tracker = eagTrackerMap.get(newAddress);
+        if (trackerMap.containsKey(newAddress)) {
+          AddressTracker tracker = trackerMap.get(newAddress);
           tracker.addSubchannel(this);
 
           // Make sure that the subchannel is in the same ejection state as the new tracker it is
           // associated with.
-          if (tracker.isEjected() && !ejected) {
+          if (tracker.subchannelsEjected() && !ejected) {
             eject();
-          } else if (!tracker.isEjected() && ejected) {
+          } else if (!tracker.subchannelsEjected() && ejected) {
             uneject();
           }
         }
@@ -271,21 +271,21 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
         // outlier detection. Remove it from all trackers and reset the call counters of all the
         // associated trackers.
         // Remove the current subchannel from the old address it is associated with in the map.
-        if (eagTrackerMap.containsKey(getAddresses())) {
-          EquivalentAddressGroupTracker tracker = eagTrackerMap.get(getAddresses());
+        if (trackerMap.containsKey(getAddresses())) {
+          AddressTracker tracker = trackerMap.get(getAddresses());
           tracker.removeSubchannel(this);
           tracker.clearCallCounters();
         }
       } else if (getAllAddresses().size() > 1 && addresses.size() == 1) {
         // If the map has an entry for the new address, we associate this subchannel with it.
         EquivalentAddressGroup eag = Iterables.getOnlyElement(addresses);
-        if (eagTrackerMap.containsKey(eag)) {
-          EquivalentAddressGroupTracker tracker = eagTrackerMap.get(eag);
+        if (trackerMap.containsKey(eag)) {
+          AddressTracker tracker = trackerMap.get(eag);
           tracker.addSubchannel(this);
 
           // If the new address is already in the ejected state, we should also eject this
           // subchannel.
-          if (tracker.isEjected()) {
+          if (tracker.subchannelsEjected()) {
             eject();
           }
         }
@@ -299,9 +299,9 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
 
     /**
      * If the {@link Subchannel} is considered for outlier detection the associated {@link
-     * EquivalentAddressGroupTracker} should be set.
+     * AddressTracker} should be set.
      */
-    void setEquivalentAddressGroupInfo(EquivalentAddressGroupTracker eagInfo) {
+    void setEquivalentAddressGroupInfo(AddressTracker eagInfo) {
       this.eagInfo = eagInfo;
     }
 
@@ -361,15 +361,15 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
     public PickResult pickSubchannel(PickSubchannelArgs args) {
       PickResult pickResult = delegate.pickSubchannel(args);
 
-      // Because we wrap the helper used by the delegate LB we are assured that the subchannel
-      // picked here will be an instance of our OutlierDetectionSubchannel.
-      OutlierDetectionSubchannel subchannel
-          = (OutlierDetectionSubchannel) pickResult.getSubchannel();
+      Subchannel subchannel = pickResult.getSubchannel();
+      if (subchannel != null) {
+        return PickResult.withSubchannel(subchannel,
+            new ResultCountingClientStreamTracerFactory(
+                (AddressTracker) subchannel.getAttributes()
+                    .get(EAG_INFO_ATTR_KEY)));
+      }
 
-      // The subchannel wrapper has served its purpose, we can pass on the wrapped delegate on
-      // in case another layer of wrapping assumes a particular subchannel sub-type.
-      return PickResult.withSubchannel(subchannel.delegate(),
-          new ResultCountingClientStreamTracerFactory(subchannel));
+      return pickResult;
     }
 
     /**
@@ -377,34 +377,34 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
      */
     class ResultCountingClientStreamTracerFactory extends ClientStreamTracer.Factory {
 
-      private final OutlierDetectionSubchannel subchannel;
+      private final AddressTracker tracker;
 
-      ResultCountingClientStreamTracerFactory(OutlierDetectionSubchannel subchannel) {
-        this.subchannel = subchannel;
+      ResultCountingClientStreamTracerFactory(AddressTracker tracker) {
+        this.tracker = tracker;
       }
 
       @Override
       public ClientStreamTracer newClientStreamTracer(StreamInfo info, Metadata headers) {
-        return new ResultCountingClientStreamTracer(subchannel);
+        return new ResultCountingClientStreamTracer(tracker);
       }
     }
 
     /**
      * Counts the results (successful/unsuccessful) of a particular {@link
      * OutlierDetectionSubchannel}s streams and increments the counter in the associated {@link
-     * EquivalentAddressGroupTracker}.
+     * AddressTracker}.
      */
     class ResultCountingClientStreamTracer extends ClientStreamTracer {
 
-      private final OutlierDetectionSubchannel subchannel;
+      AddressTracker tracker;
 
-      public ResultCountingClientStreamTracer(OutlierDetectionSubchannel subchannel) {
-        this.subchannel = subchannel;
+      public ResultCountingClientStreamTracer(AddressTracker tracker) {
+        this.tracker = tracker;
       }
 
       @Override
       public void streamClosed(Status status) {
-        subchannel.eagInfo.incrementCallCount(status.isOk());
+        tracker.incrementCallCount(status.isOk());
       }
     }
   }
@@ -413,7 +413,7 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
    * Tracks additional information about a set of equivalent addresses needed for outlier
    * detection.
    */
-  static class EquivalentAddressGroupTracker {
+  static class AddressTracker {
 
     private final OutlierDetectionLoadBalancerConfig config;
     private CallCounter activeCallCounter = new CallCounter();
@@ -422,7 +422,7 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
     private int ejectionTimeMultiplier;
     private final Set<OutlierDetectionSubchannel> subchannels = new HashSet<>();
 
-    EquivalentAddressGroupTracker(OutlierDetectionLoadBalancerConfig config) {
+    AddressTracker(OutlierDetectionLoadBalancerConfig config) {
       this.config = config;
     }
 
@@ -452,10 +452,14 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
     }
 
     /**
-     * The total number of calls in the active call counter.
+     * The total number of calls in the inactive call counter.
      */
     long volume() {
-      return (long) activeCallCounter.successCount.get() + activeCallCounter.failureCount.get();
+      return inactiveCallCounter.successCount.get() + inactiveCallCounter.failureCount.get();
+    }
+
+    double successRate() {
+      return ((double) inactiveCallCounter.successCount.get()) / volume();
     }
 
     void clearCallCounters() {
@@ -483,7 +487,7 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
     /**
      * Ejects the address from use.
      */
-    void eject(long ejectionTimeNanos) {
+    void ejectSubchannels(long ejectionTimeNanos) {
       this.ejectionTimeNanos = ejectionTimeNanos;
       ejectionTimeMultiplier++;
       for (OutlierDetectionSubchannel subchannel : subchannels) {
@@ -494,7 +498,7 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
     /**
      * Uneject a currently ejected address.
      */
-    void uneject() {
+    void unejectSubchannels() {
       checkState(ejectionTimeNanos == null, "not currently ejected");
       ejectionTimeNanos = null;
       for (OutlierDetectionSubchannel subchannel : subchannels) {
@@ -502,7 +506,7 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
       }
     }
 
-    boolean isEjected() {
+    boolean subchannelsEjected() {
       return ejectionTimeNanos != null;
     }
 
@@ -512,16 +516,116 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
       long maxEjectionTimeNanos = ejectionTimeNanos + Math.min(
           SECONDS.toNanos(config.baseEjectionTimeSecs) * ejectionTimeMultiplier,
           Math.max(SECONDS.toNanos(config.baseEjectionTimeSecs),
-                   SECONDS.toNanos(config.maxEjectionTimeSecs)));
+              SECONDS.toNanos(config.maxEjectionTimeSecs)));
 
       return currentTimeNanos > maxEjectionTimeNanos;
     }
 
     private static class CallCounter {
-      AtomicInteger successCount = new AtomicInteger();
-      AtomicInteger failureCount = new AtomicInteger();
+
+      AtomicLong successCount = new AtomicLong();
+      AtomicLong failureCount = new AtomicLong();
     }
   }
+
+  /**
+   * Maintains a mapping from addresses to their trackers.
+   */
+  static class AddressTrackerMap extends ForwardingMap<EquivalentAddressGroup, AddressTracker> {
+    private final Map<EquivalentAddressGroup, AddressTracker> trackerMap;
+
+    AddressTrackerMap() {
+      trackerMap = new HashMap<>();
+    }
+
+    @Override
+    protected Map<EquivalentAddressGroup, AddressTracker> delegate() {
+      return trackerMap;
+    }
+
+    /** Adds a new tracker for the addresses that don't already have one. */
+    void putNewTrackers(OutlierDetectionLoadBalancerConfig config,
+        Collection<EquivalentAddressGroup> addresses) {
+      for (EquivalentAddressGroup address : addresses) {
+        if (!trackerMap.containsKey(address)) {
+          trackerMap.put(address, new AddressTracker(config));
+        }
+      }
+    }
+
+    /** Resets the call counters for all the trackers in the map. */
+    void resetCallCounters() {
+      for (AddressTracker tracker : trackerMap.values()) {
+        tracker.clearCallCounters();
+      }
+    }
+
+    /**
+     * When OD gets disabled we need to uneject any subchannels that may have been ejected and
+     * to reset the ejection time multiplier.
+     */
+    void cancelTracking() {
+      for (AddressTracker tracker : trackerMap.values()) {
+        if (tracker.subchannelsEjected()) {
+          tracker.unejectSubchannels();
+        }
+        tracker.resetEjectionTimeMultiplier();
+      }
+    }
+
+    /** Swaps the active and inactive counters for each tracker. */
+    void swapCounters() {
+      for (AddressTracker tracker : trackerMap.values()) {
+        tracker.swapCounters();
+      }
+    }
+
+    /**
+     * At the end of a timer run we need to decrement the ejection time multiplier for trackers
+     * that don't have ejected subchannels and uneject ones that have spent the maximum ejection
+     * time allowed.
+     */
+    void maybeUnejectOutliers(Long detectionTimerStartNanos) {
+      for (AddressTracker tracker : trackerMap.values()) {
+        if (!tracker.subchannelsEjected()) {
+          tracker.decrementEjectionTimeMultiplier();
+        }
+
+        if (tracker.subchannelsEjected() && tracker.maxEjectionTimeElapsed(
+            detectionTimerStartNanos)) {
+          tracker.unejectSubchannels();
+        }
+      }
+    }
+
+    /** Returns only the trackers that have the minimum configured volume to be considered. */
+    List<AddressTracker> trackersWithVolume(OutlierDetectionLoadBalancerConfig config) {
+      List<AddressTracker> trackersWithVolume = new ArrayList<>();
+      for (AddressTracker tracker : trackerMap.values()) {
+        if (tracker.volume() >= config.successRateEjection.requestVolume) {
+          trackersWithVolume.add(tracker);
+        }
+      }
+      return trackersWithVolume;
+    }
+
+    /**
+     * How many percent of the addresses would have their subchannels ejected if we proceeded
+     * with the next ejection.
+     */
+    double nextEjectionPercentage() {
+      int totalAddresses = 0;
+      int ejectedAddresses = 0;
+      for (AddressTracker tracker : trackerMap.values()) {
+        totalAddresses++;
+        if (tracker.subchannelsEjected()) {
+          ejectedAddresses++;
+        }
+      }
+      return ((double)ejectedAddresses + 1 / totalAddresses) * 100;
+    }
+  }
+
 
   /**
    * Implementations provide different ways of ejecting outlier addresses..
@@ -530,11 +634,9 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
 
     /**
      * Is the given {@link EquivalentAddressGroup} an outlier based on the past call results stored
-     * in {@link EquivalentAddressGroupTracker}.
+     * in {@link AddressTracker}.
      */
-    void ejectOutliers(
-        Map<EquivalentAddressGroup, EquivalentAddressGroupTracker> eagTrackerMap,
-        long ejectionTimeMillis);
+    void ejectOutliers(AddressTrackerMap trackerMap, long ejectionTimeMillis);
 
     @Nullable
     static OutlierEjectionAlgorithm forConfig(OutlierDetectionLoadBalancerConfig config) {
@@ -558,68 +660,62 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
     }
 
     @Override
-    public void ejectOutliers(
-        Map<EquivalentAddressGroup, EquivalentAddressGroupTracker> eagTrackerMap,
-        long ejectionTimeNanos) {
+    public void ejectOutliers(AddressTrackerMap trackerMap, long ejectionTimeNanos) {
 
       // Only consider addresses that have the minimum request volume specified in the config.
-      List<EquivalentAddressGroupTracker> trackersWithVolume = new ArrayList<>();
-      for (EquivalentAddressGroupTracker tracker : eagTrackerMap.values()) {
-        if (tracker.volume() >= config.successRateEjection.requestVolume) {
-          trackersWithVolume.add(tracker);
-        }
-      }
+      List<AddressTracker> trackersWithVolume = trackerMap.trackersWithVolume(config);
       // If we don't have enough addresses with significant volume then there's nothing to do.
       if (trackersWithVolume.size() < config.successRateEjection.minimumHosts
           || trackersWithVolume.size() == 0) {
         return;
       }
 
-      // Calculate mean and standard deviation of the successful calls.
-      int totalSuccessCount = 0;
-      for (EquivalentAddressGroupTracker tracker : trackersWithVolume) {
-        totalSuccessCount += tracker.activeCallCounter.successCount.get();
+      // Calculate mean and standard deviation of the fractions of successful calls.
+      List<Double> successRates = new ArrayList<>();
+      for (AddressTracker tracker : trackersWithVolume) {
+        successRates.add(tracker.successRate());
       }
-      double mean = totalSuccessCount / trackersWithVolume.size();
+      double mean = mean(successRates);
+      double stdev = standardDeviation(successRates, mean);
 
-      double squaredDifferenceSum = 0;
-      for (EquivalentAddressGroupTracker tracker : trackersWithVolume) {
-        double difference = tracker.activeCallCounter.successCount.get() - mean;
-        squaredDifferenceSum += difference * difference;
-      }
-      double variance = squaredDifferenceSum / trackersWithVolume.size();
-
-      double stdev = Math.sqrt(variance);
-
-      for (EquivalentAddressGroupTracker tracker : eagTrackerMap.values()) {
-        // If we have already ejected addresses past the max percentage, stop here
-        int totalAddresses = 0;
-        int ejectedAddresses = 0;
-        for (EquivalentAddressGroupTracker t : eagTrackerMap.values()) {
-          totalAddresses++;
-          if (t.isEjected()) {
-            ejectedAddresses++;
-          }
-        }
-        double ejectedPercentage = (ejectedAddresses / totalAddresses) * 100;
-        if (ejectedPercentage > config.maxEjectionPercent) {
+      for (AddressTracker tracker : trackerMap.values()) {
+        // If an ejection now would take us past the max configured ejection percentagem stop here.
+        if (trackerMap.nextEjectionPercentage() > config.maxEjectionPercent) {
           return;
         }
 
-        // If this address does not have enough volume to be considered, skip to the next one.
-        if (tracker.volume() < config.successRateEjection.requestVolume) {
-          continue;
-        }
-
         // If success rate is below the threshold, eject the address.
-        double successRate = tracker.activeCallCounter.successCount.get() / tracker.volume();
-        if (successRate < mean - stdev * (config.successRateEjection.stdevFactor / 1000)) {
+        double requiredSuccessRate =
+            mean - stdev * (config.successRateEjection.stdevFactor / 1000f);
+        if (tracker.successRate() < requiredSuccessRate) {
           // Only eject some addresses based on the enforcement percentage.
           if (new Random().nextInt(100) < config.successRateEjection.enforcementPercentage) {
-            tracker.eject(ejectionTimeNanos);
+            tracker.ejectSubchannels(ejectionTimeNanos);
           }
         }
       }
+    }
+
+    /** Calculates the mean of the given values. */
+    static double mean(Collection<Double> values) {
+      double totalValue = 0;
+      for (double value : values) {
+        totalValue += value;
+      }
+
+      return totalValue / values.size();
+    }
+
+    /** Calculates the standard deviation for the given values and their mean. */
+    static double standardDeviation(Collection<Double> values, double mean) {
+      double squaredDifferenceSum = 0;
+      for (double value : values) {
+        double difference = value - mean;
+        squaredDifferenceSum += difference * difference;
+      }
+      double variance = squaredDifferenceSum / values.size();
+
+      return Math.sqrt(variance);
     }
   }
 
@@ -632,23 +728,21 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
     }
 
     @Override
-    public void ejectOutliers(
-        Map<EquivalentAddressGroup, EquivalentAddressGroupTracker> eagTrackerMap,
-        long ejectionTimeMillis) {
+    public void ejectOutliers(AddressTrackerMap trackerMap, long ejectionTimeMillis) {
 
       // If we don't have the minimum amount of addresses the config calls for, then return.
-      if (eagTrackerMap.size() < config.failurePercentageEjection.minimumHosts) {
+      if (trackerMap.size() < config.failurePercentageEjection.minimumHosts) {
         return;
       }
 
       // If this address does not have enough volume to be considered, skip to the next one.
-      for (EquivalentAddressGroupTracker tracker : eagTrackerMap.values()) {
+      for (AddressTracker tracker : trackerMap.values()) {
         // If we have already ejected addresses past the max percentage, stop here.
         int totalAddresses = 0;
         int ejectedAddresses = 0;
-        for (EquivalentAddressGroupTracker t : eagTrackerMap.values()) {
+        for (AddressTracker t : trackerMap.values()) {
           totalAddresses++;
-          if (t.isEjected()) {
+          if (t.subchannelsEjected()) {
             ejectedAddresses++;
           }
         }
@@ -668,7 +762,7 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
         if (failurePercentage > config.failurePercentageEjection.threshold) {
           // Only eject some addresses based on the enforcement percentage.
           if (new Random().nextInt(100) < config.failurePercentageEjection.enforcementPercentage) {
-            tracker.eject(ejectionTimeMillis);
+            tracker.ejectSubchannels(ejectionTimeMillis);
           }
         }
       }
@@ -679,31 +773,91 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
   /**
    * The configuration for {@link OutlierDetectionLoadBalancer}.
    */
-  static final class OutlierDetectionLoadBalancerConfig {
+  public static final class OutlierDetectionLoadBalancerConfig {
 
-    final long intervalSecs;
-    final long baseEjectionTimeSecs;
-    final long maxEjectionTimeSecs;
+    final Long intervalSecs;
+    final Long baseEjectionTimeSecs;
+    final Long maxEjectionTimeSecs;
     final Integer maxEjectionPercent;
     final SuccessRateEjection successRateEjection;
     final FailurePercentageEjection failurePercentageEjection;
     final PolicySelection childPolicy;
 
-    OutlierDetectionLoadBalancerConfig(PolicySelection childPolicy, Long intervalSecs,
+    private OutlierDetectionLoadBalancerConfig(Long intervalSecs,
         Long baseEjectionTimeSecs,
         Long maxEjectionTimeSecs, Integer maxEjectionPercent,
         SuccessRateEjection successRateEjection,
-        FailurePercentageEjection failurePercentageEjection) {
-      this.intervalSecs = intervalSecs != null ? intervalSecs : 10;
-      this.baseEjectionTimeSecs = baseEjectionTimeSecs != null ? baseEjectionTimeSecs : 30;
-      this.maxEjectionTimeSecs = maxEjectionTimeSecs != null ? maxEjectionTimeSecs : 30;
-      this.maxEjectionPercent = maxEjectionPercent != null ? maxEjectionPercent : 10;
+        FailurePercentageEjection failurePercentageEjection,
+        PolicySelection childPolicy) {
+      this.intervalSecs = intervalSecs;
+      this.baseEjectionTimeSecs = baseEjectionTimeSecs;
+      this.maxEjectionTimeSecs = maxEjectionTimeSecs;
+      this.maxEjectionPercent = maxEjectionPercent;
       this.successRateEjection = successRateEjection;
       this.failurePercentageEjection = failurePercentageEjection;
       this.childPolicy = childPolicy;
     }
 
-    static class SuccessRateEjection {
+    public static class Builder {
+      Long intervalSecs = 10L;
+      Long baseEjectionTimeSecs = 30L;
+      Long maxEjectionTimeSecs = 30L;
+      Integer maxEjectionPercent = 10;
+      SuccessRateEjection successRateEjection;
+      FailurePercentageEjection failurePercentageEjection;
+      PolicySelection childPolicy;
+
+      public Builder setIntervalSecs(Long intervalSecs) {
+        checkArgument(intervalSecs != null);
+        this.intervalSecs = intervalSecs;
+        return this;
+      }
+
+      public Builder setBaseEjectionTimeSecs(Long baseEjectionTimeSecs) {
+        checkArgument(baseEjectionTimeSecs != null);
+        this.baseEjectionTimeSecs = baseEjectionTimeSecs;
+        return this;
+      }
+
+      public Builder setMaxEjectionTimeSecs(Long maxEjectionTimeSecs) {
+        checkArgument(maxEjectionTimeSecs != null);
+        this.maxEjectionTimeSecs = maxEjectionTimeSecs;
+        return this;
+      }
+
+      public Builder setMaxEjectionPercent(Integer maxEjectionPercent) {
+        checkArgument(maxEjectionPercent != null);
+        this.maxEjectionPercent = maxEjectionPercent;
+        return this;
+      }
+
+      public Builder setSuccessRateEjection(
+          SuccessRateEjection successRateEjection) {
+        this.successRateEjection = successRateEjection;
+        return this;
+      }
+
+      public Builder setFailurePercentageEjection(
+          FailurePercentageEjection failurePercentageEjection) {
+        this.failurePercentageEjection = failurePercentageEjection;
+        return this;
+      }
+
+      public Builder setChildPolicy(PolicySelection childPolicy) {
+        checkState(childPolicy != null);
+        this.childPolicy = childPolicy;
+        return this;
+      }
+
+      public OutlierDetectionLoadBalancerConfig build() {
+        checkState(childPolicy != null);
+        return new OutlierDetectionLoadBalancerConfig(intervalSecs, baseEjectionTimeSecs,
+            maxEjectionTimeSecs, maxEjectionPercent, successRateEjection, failurePercentageEjection,
+            childPolicy);
+      }
+    }
+
+    public static class SuccessRateEjection {
 
       final Integer stdevFactor;
       final Integer enforcementPercentage;
@@ -712,15 +866,51 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
 
       SuccessRateEjection(Integer stdevFactor, Integer enforcementPercentage, Integer minimumHosts,
           Integer requestVolume) {
-        this.stdevFactor = stdevFactor != null ? stdevFactor : 1900;
-        this.enforcementPercentage = enforcementPercentage != null ? enforcementPercentage : 100;
-        this.minimumHosts = minimumHosts != null ? minimumHosts : 5;
-        this.requestVolume = requestVolume != null ? requestVolume : 100;
+        this.stdevFactor = stdevFactor;
+        this.enforcementPercentage = enforcementPercentage;
+        this.minimumHosts = minimumHosts;
+        this.requestVolume = requestVolume;
+      }
+
+      public static final class Builder {
+
+        Integer stdevFactor = 1900;
+        Integer enforcementPercentage = 100;
+        Integer minimumHosts = 5;
+        Integer requestVolume = 100;
+
+        public Builder setStdevFactor(Integer stdevFactor) {
+          checkArgument(stdevFactor != null);
+          this.stdevFactor = stdevFactor;
+          return this;
+        }
+
+        public Builder setEnforcementPercentage(Integer enforcementPercentage) {
+          checkArgument(enforcementPercentage != null);
+          this.enforcementPercentage = enforcementPercentage;
+          return this;
+        }
+
+        public Builder setMinimumHosts(Integer minimumHosts) {
+          checkArgument(minimumHosts != null);
+          this.minimumHosts = minimumHosts;
+          return this;
+        }
+
+        public Builder setRequestVolume(Integer requestVolume) {
+          checkArgument(requestVolume != null);
+          this.requestVolume = requestVolume;
+          return this;
+        }
+
+        public SuccessRateEjection build() {
+          return new SuccessRateEjection(stdevFactor, enforcementPercentage, minimumHosts,
+              requestVolume);
+        }
       }
     }
 
-    static class FailurePercentageEjection {
-
+    public static class FailurePercentageEjection {
       final Integer threshold;
       final Integer enforcementPercentage;
       final Integer minimumHosts;
@@ -728,10 +918,46 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
 
       FailurePercentageEjection(Integer threshold, Integer enforcementPercentage,
           Integer minimumHosts, Integer requestVolume) {
-        this.threshold = threshold != null ? threshold : 85;
-        this.enforcementPercentage = enforcementPercentage != null ? enforcementPercentage : 100;
-        this.minimumHosts = minimumHosts != null ? minimumHosts : 5;
-        this.requestVolume = requestVolume != null ? requestVolume : 50;
+        this.threshold = threshold;
+        this.enforcementPercentage = enforcementPercentage;
+        this.minimumHosts = minimumHosts;
+        this.requestVolume = requestVolume;
+      }
+
+      public static class Builder {
+        Integer threshold = 85;
+        Integer enforcementPercentage = 100;
+        Integer minimumHosts = 5;
+        Integer requestVolume = 50;
+
+        public Builder setThreshold(Integer threshold) {
+          checkArgument(threshold != null);
+          this.threshold = threshold;
+          return this;
+        }
+
+        public Builder setEnforcementPercentage(Integer enforcementPercentage) {
+          checkArgument(enforcementPercentage != null);
+          this.enforcementPercentage = enforcementPercentage;
+          return this;
+        }
+
+        public Builder setMinimumHosts(Integer minimumHosts) {
+          checkArgument(minimumHosts != null);
+          this.minimumHosts = minimumHosts;
+          return this;
+        }
+
+        public Builder setRequestVolume(Integer requestVolume) {
+          checkArgument(requestVolume != null);
+          this.requestVolume = requestVolume;
+          return this;
+        }
+
+        public FailurePercentageEjection build() {
+          return new FailurePercentageEjection(threshold, enforcementPercentage, minimumHosts,
+              requestVolume);
+        }
       }
     }
 
@@ -742,5 +968,11 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
       // One of the two supported algorithms needs to be configured.
       return successRateEjection != null || failurePercentageEjection != null;
     }
+  }
+
+  /** Math needed in outlier detection. */
+  static class OutlierDetectionMath {
+
+
   }
 }

--- a/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
@@ -268,7 +268,7 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
         if (trackerMap.containsKey(getAddresses())) {
           AddressTracker tracker = trackerMap.get(getAddresses());
           tracker.removeSubchannel(this);
-          tracker.clearCallCounters();
+          tracker.resetCallCounters();
         }
       } else if (getAllAddresses().size() > 1 && addresses.size() == 1) {
         // We go from, previously uneligble, multiple address mode to a single address. If the map
@@ -472,11 +472,9 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
       return ((double)inactiveCallCounter.failureCount.get()) / inactiveVolume();
     }
 
-    void clearCallCounters() {
-      activeCallCounter.successCount.set(0);
-      activeCallCounter.failureCount.set(0);
-      inactiveCallCounter.successCount.set(0);
-      inactiveCallCounter.failureCount.set(0);
+    void resetCallCounters() {
+      activeCallCounter.reset();
+      inactiveCallCounter.reset();
     }
 
     void decrementEjectionTimeMultiplier() {
@@ -489,6 +487,7 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
     }
 
     void swapCounters() {
+      inactiveCallCounter.reset();
       CallCounter tempCounter = activeCallCounter;
       activeCallCounter = inactiveCallCounter;
       inactiveCallCounter = tempCounter;
@@ -529,9 +528,13 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
     }
 
     private static class CallCounter {
-
       AtomicLong successCount = new AtomicLong();
       AtomicLong failureCount = new AtomicLong();
+
+      void reset() {
+        successCount.set(0);
+        failureCount.set(0);
+      }
     }
   }
 
@@ -563,7 +566,7 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
     /** Resets the call counters for all the trackers in the map. */
     void resetCallCounters() {
       for (AddressTracker tracker : trackerMap.values()) {
-        tracker.clearCallCounters();
+        tracker.resetCallCounters();
       }
     }
 

--- a/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
@@ -266,8 +266,7 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
         }
 
         // If the map has an entry for the new address, we associate this subchannel with it.
-        SocketAddress address = Iterables.getOnlyElement(
-            Iterables.getOnlyElement(addressGroups).getAddresses());
+        SocketAddress address = addressGroups.get(0).getAddresses().get(0);
         if (trackerMap.containsKey(address)) {
           trackerMap.get(address).addSubchannel(this);
         }
@@ -276,17 +275,15 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
         // outlier detection. Remove it from all trackers and reset the call counters of all the
         // associated trackers.
         // Remove the current subchannel from the old address it is associated with in the map.
-        if (trackerMap.containsKey(Iterables.getOnlyElement(getAddresses().getAddresses()))) {
-          AddressTracker tracker = trackerMap.get(
-              Iterables.getOnlyElement(getAddresses().getAddresses()));
+        if (trackerMap.containsKey(getAddresses().getAddresses().get(0))) {
+          AddressTracker tracker = trackerMap.get(getAddresses().getAddresses().get(0));
           tracker.removeSubchannel(this);
           tracker.resetCallCounters();
         }
       } else if (!hasSingleAddress(getAllAddresses()) && hasSingleAddress(addressGroups)) {
         // We go from, previously uneligble, multiple address mode to a single address. If the map
         // has an entry for the new address, we associate this subchannel with it.
-        SocketAddress address = Iterables.getOnlyElement(
-            Iterables.getOnlyElement(addressGroups).getAddresses());
+        SocketAddress address = addressGroups.get(0).getAddresses().get(0);
         if (trackerMap.containsKey(address)) {
           AddressTracker tracker = trackerMap.get(address);
           tracker.addSubchannel(this);

--- a/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
@@ -1,0 +1,714 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.util;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.collect.Iterables;
+import io.grpc.ClientStreamTracer;
+import io.grpc.ClientStreamTracer.StreamInfo;
+import io.grpc.ConnectivityStateInfo;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancer;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.SynchronizationContext;
+import io.grpc.SynchronizationContext.ScheduledHandle;
+import io.grpc.internal.ServiceConfigUtil.PolicySelection;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+/**
+ * Wraps a child {@code LoadBalancer} while monitoring for outliers backends and removing them from
+ * use by the child LB.
+ *
+ * <p>This implements the outlier detection gRFC:
+ * https://github.com/grpc/proposal/blob/master/A50-xds-outlier-detection.md
+ */
+public class OutlierDetectionLoadBalancer extends LoadBalancer {
+
+  private final Helper helper;
+  private final SynchronizationContext syncContext;
+  private final Helper childHelper;
+  private final GracefulSwitchLoadBalancer switchLb;
+  private final Map<EquivalentAddressGroup, EquivalentAddressGroupTracker> eagTrackerMap;
+  private Clock clock;
+  private final ScheduledExecutorService timeService;
+  private ScheduledHandle detectionTimerHandle;
+  private Instant detectionTimerStartInstant;
+
+  public OutlierDetectionLoadBalancer(Helper helper) {
+    this.helper = checkNotNull(helper, "helper");
+    childHelper = new ChildHelper(helper);
+    switchLb = new GracefulSwitchLoadBalancer(childHelper);
+    eagTrackerMap = new HashMap();
+    this.syncContext = checkNotNull(helper.getSynchronizationContext(), "syncContext");
+    this.timeService = checkNotNull(helper.getScheduledExecutorService(), "timeService");
+    clock = Clock.systemDefaultZone();
+  }
+
+  @Override
+  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    OutlierDetectionLoadBalancerConfig config
+        = (OutlierDetectionLoadBalancerConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
+
+    // The map should only retain entries for addresses in this latest update.
+    eagTrackerMap.keySet().retainAll(resolvedAddresses.getAddresses());
+
+    // Add any new ones.
+    for (EquivalentAddressGroup eag : resolvedAddresses.getAddresses()) {
+      eagTrackerMap.putIfAbsent(eag, new EquivalentAddressGroupTracker(config));
+    }
+
+    switchLb.switchTo(config.childPolicy.getProvider());
+
+    // If outlier detection is actually configured, start a timer that will periodically try to
+    // detect outliers.
+    if (config.outlierDetectionEnabled()) {
+      Duration initialDelay;
+
+      if (detectionTimerHandle == null) {
+        // On the first go we use the configured interval.
+        initialDelay = config.interval;
+
+        // When starting the timer for the first time we reset all call counters for a clean start.
+        eagTrackerMap.values().forEach(EquivalentAddressGroupTracker::clearCallCounters);
+      } else {
+        // If a timer has been started earlier we cancel it and use the difference between the start
+        // time and now as the interval.
+        detectionTimerHandle.cancel();
+        initialDelay = Duration.ofMillis(Math.max(0L,
+            config.interval.minus(Duration.between(detectionTimerStartInstant, clock.instant()))
+                .toMillis()));
+      }
+
+      detectionTimerHandle = syncContext.scheduleWithFixedDelay(new DetectionTimer(config),
+          initialDelay.toMillis(), config.interval.toMillis(),
+          TimeUnit.MILLISECONDS, timeService);
+    } else if (detectionTimerHandle != null) {
+      // Outlier detection is not configured, but we have a lingering timer. Let's cancel it and
+      // uneject any addresses we may have ejected.
+      detectionTimerHandle.cancel();
+      detectionTimerStartInstant = null;
+      for (EquivalentAddressGroupTracker tracker : eagTrackerMap.values()) {
+        if (tracker.isEjected()) {
+          tracker.uneject();
+        }
+        tracker.resetEjectionTimeMultiplier();
+      }
+    }
+
+    return switchLb.acceptResolvedAddresses(resolvedAddresses);
+  }
+
+  @Override
+  public void handleNameResolutionError(Status error) {
+    switchLb.handleNameResolutionError(error);
+  }
+
+  @Override
+  public void shutdown() {
+    switchLb.shutdown();
+  }
+
+  /**
+   * This timer will be invoked periodically, according to configuration, and it will look for any
+   * outlier subchannels.
+   */
+  class DetectionTimer implements Runnable {
+
+    OutlierDetectionLoadBalancerConfig config;
+
+    DetectionTimer(OutlierDetectionLoadBalancerConfig config) {
+      this.config = config;
+    }
+
+    @Override
+    public void run() {
+      detectionTimerStartInstant = clock.instant();
+
+      eagTrackerMap.values().forEach(EquivalentAddressGroupTracker::swapCounters);
+
+      OutlierEjectionAlgorithm.forConfig(config)
+          .ejectOutliers(eagTrackerMap, detectionTimerStartInstant);
+
+      for (EquivalentAddressGroupTracker tracker : eagTrackerMap.values()) {
+        if (!tracker.isEjected() && tracker.ejectionTimeMultiplier.get() > 0) {
+          tracker.decrementEjectionTimeMultiplier();
+        }
+
+        if (tracker.isEjected() && tracker.maxEjectionTimeElapsed(detectionTimerStartInstant)) {
+          tracker.uneject();
+        }
+      }
+    }
+  }
+
+  /**
+   * This child helper wraps the provided helper so that is can hand out wrapped {@link
+   * OutlierDetectionSubchannel}s and manage the address info map.
+   */
+  class ChildHelper extends ForwardingLoadBalancerHelper {
+
+    private Helper delegate;
+
+    ChildHelper(Helper delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    protected Helper delegate() {
+      return delegate;
+    }
+
+    @Override
+    public Subchannel createSubchannel(CreateSubchannelArgs args) {
+      // Subchannels are wrapped so that we can monitor call results and to trigger failures when
+      // we decide to eject the subchannel.
+      OutlierDetectionSubchannel subchannel = new OutlierDetectionSubchannel(
+          delegate.createSubchannel(args));
+
+      // If the subchannel is associated with a single address that is also already in the map
+      // the subchannel will be added to the map and be included in outlier detection.
+      List<EquivalentAddressGroup> allAddresses = subchannel.getAllAddresses();
+      if (allAddresses.size() == 1 && eagTrackerMap.containsKey(allAddresses.get(0))) {
+        EquivalentAddressGroupTracker eagInfo = eagTrackerMap.get(allAddresses.get(0));
+        subchannel.setEquivalentAddressGroupInfo(eagInfo);
+        eagInfo.addSubchannel(subchannel);
+
+        // If this address has already been ejected, we need to immediately eject this Subchannel.
+        if (eagInfo.ejectionInstant != null) {
+          subchannel.eject();
+        }
+      }
+
+      return subchannel;
+    }
+  }
+
+  class OutlierDetectionSubchannel extends ForwardingSubchannel {
+
+    private final Subchannel delegate;
+    private EquivalentAddressGroupTracker eagInfo;
+    private boolean ejected;
+    private ConnectivityStateInfo lastSubchannelState;
+    private OutlierDetectionSubchannelStateListener subchannelStateListener;
+
+    OutlierDetectionSubchannel(Subchannel delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void start(SubchannelStateListener listener) {
+      subchannelStateListener = new OutlierDetectionSubchannelStateListener(listener);
+      super.start(subchannelStateListener);
+    }
+
+    @Override
+    public void updateAddresses(List<EquivalentAddressGroup> addresses) {
+      // Outlier detection only supports subchannels with a single address, but the list of
+      // addresses associated with a subchannel can change at any time, so we need to react to
+      // changes in the address list plurality.
+
+      // No change in address plurality, we replace the single one with a new one.
+      if (getAllAddresses().size() == 1 && addresses.size() == 1) {
+        // Remove the current subchannel from the old address it is associated with in the map.
+        if (eagTrackerMap.containsKey(getAddresses())) {
+          eagTrackerMap.get(getAddresses()).removeSubchannel(this);
+        }
+
+        // If the map has an entry for the new address, we associate this subchannel with it.
+        EquivalentAddressGroup newAddress = Iterables.getOnlyElement(addresses);
+        if (eagTrackerMap.containsKey(newAddress)) {
+          EquivalentAddressGroupTracker tracker = eagTrackerMap.get(newAddress);
+          tracker.addSubchannel(this);
+
+          // Make sure that the subchannel is in the same ejection state as the new tracker it is
+          // associated with.
+          if (tracker.isEjected() && !ejected) {
+            eject();
+          } else if (!tracker.isEjected() && ejected) {
+            uneject();
+          }
+        }
+      } else if (getAllAddresses().size() == 1 && addresses.size() > 1) {
+        // We go from a single address to having multiple, making this subchannel uneligible for
+        // outlier detection. Remove it from all trackers and reset the call counters of all the
+        // associated trackers.
+        // Remove the current subchannel from the old address it is associated with in the map.
+        if (eagTrackerMap.containsKey(getAddresses())) {
+          EquivalentAddressGroupTracker tracker = eagTrackerMap.get(getAddresses());
+          tracker.removeSubchannel(this);
+          tracker.clearCallCounters();
+        }
+      } else if (getAllAddresses().size() > 1 && addresses.size() == 1) {
+        // If the map has an entry for the new address, we associate this subchannel with it.
+        EquivalentAddressGroup eag = Iterables.getOnlyElement(addresses);
+        if (eagTrackerMap.containsKey(eag)) {
+          EquivalentAddressGroupTracker tracker = eagTrackerMap.get(eag);
+          tracker.addSubchannel(this);
+
+          // If the new address is already in the ejected state, we should also eject this
+          // subchannel.
+          if (tracker.isEjected()) {
+            eject();
+          }
+        }
+      }
+
+      // We could also have multiple addresses and get an update for multiple new ones. This is
+      // a no-op as we will just continue to ignore multiple address subchannels.
+
+      super.updateAddresses(addresses);
+    }
+
+    /**
+     * If the {@link Subchannel} is considered for outlier detection the associated {@link
+     * EquivalentAddressGroupTracker} should be set.
+     */
+    void setEquivalentAddressGroupInfo(EquivalentAddressGroupTracker eagInfo) {
+      this.eagInfo = eagInfo;
+    }
+
+    void eject() {
+      ejected = true;
+      subchannelStateListener.onSubchannelState(
+          ConnectivityStateInfo.forTransientFailure(Status.UNAVAILABLE));
+    }
+
+    void uneject() {
+      ejected = false;
+      if (lastSubchannelState != null) {
+        subchannelStateListener.onSubchannelState(lastSubchannelState);
+      }
+    }
+
+    @Override
+    protected Subchannel delegate() {
+      return delegate;
+    }
+
+    /**
+     * Wraps the actual listener so that state changes from the actual one can be intercepted.
+     */
+    class OutlierDetectionSubchannelStateListener implements SubchannelStateListener {
+
+      private final SubchannelStateListener delegate;
+
+      OutlierDetectionSubchannelStateListener(SubchannelStateListener delegate) {
+        this.delegate = delegate;
+      }
+
+      @Override
+      public void onSubchannelState(ConnectivityStateInfo newState) {
+        if (!ejected) {
+          lastSubchannelState = newState;
+          delegate.onSubchannelState(newState);
+        }
+      }
+    }
+  }
+
+
+  /**
+   * This picker delegates the actual picking logic to a wrapped delegate, but associates a {@link
+   * ClientStreamTracer} with each pick to track the results of each subchannel stream.
+   */
+  class OutlierDetectionPicker extends SubchannelPicker {
+
+    private final SubchannelPicker delegate;
+
+    OutlierDetectionPicker(SubchannelPicker delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public PickResult pickSubchannel(PickSubchannelArgs args) {
+      PickResult pickResult = delegate.pickSubchannel(args);
+
+      // Because we wrap the helper used by the delegate LB we are assured that the subchannel
+      // picked here will be an instance of our OutlierDetectionSubchannel.
+      OutlierDetectionSubchannel subchannel = (OutlierDetectionSubchannel) pickResult.getSubchannel();
+
+      // The subchannel wrapper has served its purpose, we can pass on the wrapped delegate on
+      // in case another layer of wrapping assumes a particular subchannel sub-type.
+      return PickResult.withSubchannel(subchannel.delegate(),
+          new ResultCountingClientStreamTracerFactory(subchannel));
+    }
+
+    /**
+     * Builds instances of {@link ResultCountingClientStreamTracer}.
+     */
+    class ResultCountingClientStreamTracerFactory extends ClientStreamTracer.Factory {
+
+      private final OutlierDetectionSubchannel subchannel;
+
+      ResultCountingClientStreamTracerFactory(OutlierDetectionSubchannel subchannel) {
+        this.subchannel = subchannel;
+      }
+
+      @Override
+      public ClientStreamTracer newClientStreamTracer(StreamInfo info, Metadata headers) {
+        return new ResultCountingClientStreamTracer(subchannel);
+      }
+    }
+
+    /**
+     * Counts the results (successful/unsuccessful) of a particular {@link
+     * OutlierDetectionSubchannel}s streams and increments the counter in the associated {@link
+     * EquivalentAddressGroupTracker}
+     */
+    class ResultCountingClientStreamTracer extends ClientStreamTracer {
+
+      private final OutlierDetectionSubchannel subchannel;
+
+      public ResultCountingClientStreamTracer(OutlierDetectionSubchannel subchannel) {
+        this.subchannel = subchannel;
+      }
+
+      @Override
+      public void streamClosed(Status status) {
+        subchannel.eagInfo.incrementCallCount(status.isOk());
+      }
+    }
+  }
+
+  /**
+   * Tracks additional information about a set of equivalent addresses needed for outlier
+   * detection.
+   */
+  class EquivalentAddressGroupTracker {
+
+    private final OutlierDetectionLoadBalancerConfig config;
+    private CallCounter activeCallCounter = new CallCounter();
+    private CallCounter inactiveCallCounter = new CallCounter();
+    private Instant ejectionInstant;
+    private AtomicInteger ejectionTimeMultiplier;
+    private final Set<OutlierDetectionSubchannel> subchannels = new HashSet();
+
+    EquivalentAddressGroupTracker(OutlierDetectionLoadBalancerConfig config) {
+      this.config = config;
+    }
+
+    boolean addSubchannel(OutlierDetectionSubchannel subchannel) {
+      return subchannels.add(subchannel);
+    }
+
+    boolean removeSubchannel(OutlierDetectionSubchannel subchannel) {
+      return subchannels.remove(subchannel);
+    }
+
+    boolean containsSubchannel(OutlierDetectionSubchannel subchannel) {
+      return subchannels.contains(subchannel);
+    }
+
+    void incrementCallCount(boolean success) {
+      // If neither algorithm is configured, no point in incrementing counters.
+      if (config.successRateEjection == null && config.failurePercentageEjection == null) {
+        return;
+      }
+
+      if (success) {
+        activeCallCounter.successCount.getAndIncrement();
+      } else {
+        activeCallCounter.failureCount.getAndIncrement();
+      }
+    }
+
+    /**
+     * The total number of calls in the active call counter.
+     */
+    long volume() {
+      return activeCallCounter.successCount.get() + activeCallCounter.failureCount.get();
+    }
+
+    void clearCallCounters() {
+      activeCallCounter.successCount.set(0);
+      activeCallCounter.failureCount.set(0);
+      inactiveCallCounter.successCount.set(0);
+      inactiveCallCounter.failureCount.set(0);
+    }
+
+    void decrementEjectionTimeMultiplier() {
+      // The multiplier should not go negative.
+      ejectionTimeMultiplier.updateAndGet(value -> value > 0 ? value : 0);
+    }
+
+    void resetEjectionTimeMultiplier() {
+      ejectionTimeMultiplier.set(0);
+    }
+
+    void swapCounters() {
+      CallCounter tempCounter = activeCallCounter;
+      activeCallCounter = inactiveCallCounter;
+      inactiveCallCounter = activeCallCounter;
+    }
+
+    /**
+     * Ejects the address from use.
+     */
+    void eject(Instant ejectionInstant) {
+      this.ejectionInstant = ejectionInstant;
+      ejectionTimeMultiplier.getAndIncrement();
+      subchannels.forEach(OutlierDetectionSubchannel::eject);
+    }
+
+    /**
+     * Uneject a currently ejected address.
+     */
+    void uneject() {
+      checkState(ejectionInstant == null, "not currently ejected");
+      ejectionInstant = null;
+      subchannels.forEach(OutlierDetectionSubchannel::uneject);
+    }
+
+    boolean isEjected() {
+      return ejectionInstant != null;
+    }
+
+    public boolean maxEjectionTimeElapsed(Instant now) {
+      // The instant in time beyond which the address should no longer be ejected. Also making sure
+      // we honor any maximum ejection time setting.
+      Instant maxEjectionInstant = ejectionInstant.plus(
+          Math.min(config.baseEjectionTime.multipliedBy(
+                  ejectionTimeMultiplier.get()).toMillis(),
+              Math.max(config.baseEjectionTime.toMillis(), config.maxEjectionTime.toMillis())),
+          ChronoUnit.MILLIS);
+      return now.isAfter(maxEjectionInstant);
+    }
+
+    private class CallCounter {
+
+      AtomicInteger successCount;
+      AtomicInteger failureCount;
+    }
+  }
+
+  /**
+   * Implementations provide different ways of ejecting outlier addresses..
+   */
+  interface OutlierEjectionAlgorithm {
+
+    /**
+     * Is the given {@link EquivalentAddressGroup} an outlier based on the past call results stored
+     * in {@link EquivalentAddressGroupTracker}.
+     */
+    void ejectOutliers(
+        Map<EquivalentAddressGroup, EquivalentAddressGroupTracker> eagTrackerMap,
+        Instant ejectionInstant);
+
+    @Nullable
+    static OutlierEjectionAlgorithm forConfig(OutlierDetectionLoadBalancerConfig config) {
+      if (config.successRateEjection != null) {
+        return new SuccessRateOutlierEjectionAlgorithm();
+      } else if (config.failurePercentageEjection != null) {
+        return new FailurePercentageOutlierEjectionAlgorithm();
+      } else {
+        return null;
+      }
+    }
+  }
+
+  static class SuccessRateOutlierEjectionAlgorithm implements OutlierEjectionAlgorithm {
+
+    private final OutlierDetectionLoadBalancerConfig config;
+
+    SuccessRateOutlierEjectionAlgorithm(OutlierDetectionLoadBalancerConfig config) {
+      checkArgument(config.successRateEjection != null, "success rate ejection config is null");
+      this.config = config;
+    }
+
+    @Override
+    public void ejectOutliers(
+        Map<EquivalentAddressGroup, EquivalentAddressGroupTracker> eagTrackerMap,
+        Instant ejectionInstant) {
+
+      // Only consider addresses that have the minimum request volume specified in the config.
+      List<EquivalentAddressGroupTracker> trackersWithVolume = eagTrackerMap.values().stream()
+          .filter(tracker -> tracker.volume() >= config.successRateEjection.requestVolume)
+          .collect(Collectors.toList());
+
+      // If we don't have enough addresses with significant volume then there's nothing to do.
+      if (trackersWithVolume.size() < config.successRateEjection.minimumHosts
+          || trackersWithVolume.size() == 0) {
+        return;
+      }
+
+      // Calculate mean and standard deviation of the successful calls.
+      double mean = trackersWithVolume.stream()
+          .mapToInt(tracker -> tracker.activeCallCounter.successCount.get())
+          .average()
+          .getAsDouble();
+      double variance = trackersWithVolume.stream()
+          .map(tracker -> tracker.activeCallCounter.successCount.get() - mean)
+          .map(difference -> difference * difference).mapToDouble(difference -> difference)
+          .average()
+          .getAsDouble();
+      double stdev = Math.sqrt(variance);
+
+      for (EquivalentAddressGroupTracker tracker : eagTrackerMap.values()) {
+        // If we have already ejected addresses past the max percentage, stop here
+        double ejectedPercentage = eagTrackerMap.values().stream()
+            .mapToInt(t -> t.isEjected() ? 1 : 0).summaryStatistics().getAverage();
+        if (ejectedPercentage > config.maxEjectionPercent) {
+          return;
+        }
+
+        // If this address does not have enough volume to be considered, skip to the next one.
+        if (tracker.volume() < config.successRateEjection.requestVolume) {
+          continue;
+        }
+
+        // If success rate is below the threshold, eject the address.
+        double successRate = tracker.activeCallCounter.successCount.get() / tracker.volume();
+        if (successRate < mean - stdev * (config.successRateEjection.stdevFactor / 1000)) {
+          // Only eject some addresses based on the enforcement percentage.
+          if (new Random().nextInt(100) < config.successRateEjection.enforcementPercentage) {
+            tracker.eject(ejectionInstant);
+          }
+        }
+      }
+    }
+  }
+
+  static class FailurePercentageOutlierEjectionAlgorithm implements OutlierEjectionAlgorithm {
+
+    private final OutlierDetectionLoadBalancerConfig config;
+
+    FailurePercentageOutlierEjectionAlgorithm(OutlierDetectionLoadBalancerConfig config) {
+      this.config = config;
+    }
+
+    @Override
+    public void ejectOutliers(
+        Map<EquivalentAddressGroup, EquivalentAddressGroupTracker> eagTrackerMap,
+        Instant ejectionInstant) {
+
+      // If we don't have the minimum amount of addresses the config calls for, then return.
+      if (eagTrackerMap.size() < config.failurePercentageEjection.minimumHosts) {
+        return;
+      }
+
+      // If this address does not have enough volume to be considered, skip to the next one.
+      for (EquivalentAddressGroupTracker tracker : eagTrackerMap.values()) {
+        // If we have already ejected addresses past the max percentage, stop here.
+        double ejectedPercentage = eagTrackerMap.values().stream()
+            .mapToInt(t -> t.isEjected() ? 1 : 0).summaryStatistics().getAverage();
+        if (ejectedPercentage > config.maxEjectionPercent) {
+          return;
+        }
+
+        if (tracker.volume() < config.failurePercentageEjection.requestVolume) {
+          continue;
+        }
+
+        // If the failure percentage is above the threshold.
+        long failurePercentage =
+            (tracker.activeCallCounter.failureCount.get() / tracker.volume()) * 100;
+        if (failurePercentage > config.failurePercentageEjection.threshold) {
+          // Only eject some addresses based on the enforcement percentage.
+          if (new Random().nextInt(100) < config.failurePercentageEjection.enforcementPercentage) {
+            tracker.eject(ejectionInstant);
+          }
+        }
+      }
+    }
+  }
+
+
+  /**
+   * The configuration for {@link OutlierDetectionLoadBalancer}.
+   */
+  static final class OutlierDetectionLoadBalancerConfig {
+
+    final Duration interval;
+    final Duration baseEjectionTime;
+    final Duration maxEjectionTime;
+    final Integer maxEjectionPercent;
+    final SuccessRateEjection successRateEjection;
+    final FailurePercentageEjection failurePercentageEjection;
+    final PolicySelection childPolicy;
+
+    OutlierDetectionLoadBalancerConfig(Duration interval, Duration baseEjectionTime,
+        Duration maxEjectionTime, Integer maxEjectionPercent, PolicySelection childPolicy,
+        SuccessRateEjection successRateEjection,
+        FailurePercentageEjection failurePercentageEjection) {
+      this.interval = interval != null ? interval : Duration.ofSeconds(10);
+      this.baseEjectionTime = baseEjectionTime != null ? baseEjectionTime : Duration.ofSeconds(30);
+      this.maxEjectionTime = maxEjectionTime != null ? maxEjectionTime : Duration.ofSeconds(30);
+      this.maxEjectionPercent = maxEjectionPercent != null ? maxEjectionPercent : 10;
+      this.successRateEjection = successRateEjection;
+      this.failurePercentageEjection = failurePercentageEjection;
+      this.childPolicy = childPolicy;
+    }
+
+    class SuccessRateEjection {
+
+      final Integer stdevFactor;
+      final Integer enforcementPercentage;
+      final Integer minimumHosts;
+      final Integer requestVolume;
+
+      SuccessRateEjection(Integer stdevFactor, Integer enforcementPercentage, Integer minimumHosts,
+          Integer requestVolume) {
+        this.stdevFactor = stdevFactor != null ? stdevFactor : 1900;
+        this.enforcementPercentage = enforcementPercentage != null ? enforcementPercentage : 100;
+        this.minimumHosts = minimumHosts != null ? minimumHosts : 5;
+        this.requestVolume = requestVolume != null ? requestVolume : 100;
+      }
+    }
+
+    class FailurePercentageEjection {
+
+      final Integer threshold;
+      final Integer enforcementPercentage;
+      final Integer minimumHosts;
+      final Integer requestVolume;
+
+      FailurePercentageEjection(Integer threshold, Integer enforcementPercentage,
+          Integer minimumHosts, Integer requestVolume) {
+        this.threshold = threshold != null ? threshold : 85;
+        this.enforcementPercentage = enforcementPercentage != null ? enforcementPercentage : 100;
+        this.minimumHosts = minimumHosts != null ? minimumHosts : 5;
+        this.requestVolume = requestVolume != null ? requestVolume : 50;
+      }
+    }
+
+    /**
+     * Determine if outlier detection is at all enabled in this config.
+     */
+    boolean outlierDetectionEnabled() {
+      // One of the two supported algorithms needs to be configured.
+      return successRateEjection != null || failurePercentageEjection != null;
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
@@ -425,7 +425,9 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
   static class AddressTracker {
 
     private final OutlierDetectionLoadBalancerConfig config;
-    private CallCounter activeCallCounter = new CallCounter();
+    // Marked as volatile to assure that when the inactive counter is swapped in as the new active
+    // one, all threads see the change and don't hold on to a reference to the now inactive counter.
+    private volatile CallCounter activeCallCounter = new CallCounter();
     private CallCounter inactiveCallCounter = new CallCounter();
     private Long ejectionTimeNanos;
     private int ejectionTimeMultiplier;

--- a/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
@@ -693,7 +693,7 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
       double mean = mean(successRates);
       double stdev = standardDeviation(successRates, mean);
 
-      for (AddressTracker tracker : trackerMap.values()) {
+      for (AddressTracker tracker : trackersWithVolume) {
         // If an ejection now would take us past the max configured ejection percentagem stop here.
         if (trackerMap.nextEjectionPercentage() > config.maxEjectionPercent) {
           return;

--- a/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
@@ -343,8 +343,8 @@ public class OutlierDetectionLoadBalancer extends LoadBalancer {
 
       @Override
       public void onSubchannelState(ConnectivityStateInfo newState) {
+        lastSubchannelState = newState;
         if (!ejected) {
-          lastSubchannelState = newState;
           delegate.onSubchannelState(newState);
         }
       }

--- a/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancerProvider.java
+++ b/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancerProvider.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.util;
+
+import io.grpc.LoadBalancer;
+import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancerProvider;
+import io.grpc.LoadBalancerRegistry;
+import io.grpc.NameResolver.ConfigOrError;
+import io.grpc.Status;
+import io.grpc.internal.JsonUtil;
+import io.grpc.internal.ServiceConfigUtil;
+import io.grpc.internal.ServiceConfigUtil.LbConfig;
+import io.grpc.internal.ServiceConfigUtil.PolicySelection;
+import io.grpc.internal.TimeProvider;
+import io.grpc.util.OutlierDetectionLoadBalancer.OutlierDetectionLoadBalancerConfig;
+import io.grpc.util.OutlierDetectionLoadBalancer.OutlierDetectionLoadBalancerConfig.FailurePercentageEjection;
+import io.grpc.util.OutlierDetectionLoadBalancer.OutlierDetectionLoadBalancerConfig.SuccessRateEjection;
+import java.util.List;
+import java.util.Map;
+
+public final class OutlierDetectionLoadBalancerProvider extends LoadBalancerProvider {
+
+  @Override
+  public LoadBalancer newLoadBalancer(Helper helper) {
+    return new OutlierDetectionLoadBalancer(helper, TimeProvider.SYSTEM_TIME_PROVIDER);
+  }
+
+  @Override
+  public boolean isAvailable() {
+    return true;
+  }
+
+  @Override
+  public int getPriority() {
+    return 5;
+  }
+
+  @Override
+  public String getPolicyName() {
+    return "outlier_detection_experimental";
+  }
+
+  @Override
+  public ConfigOrError parseLoadBalancingPolicyConfig(Map<String, ?> rawConfig) {
+    // Common configuration.
+    Long intervalNanos = JsonUtil.getStringAsDuration(rawConfig, "interval");
+    Long baseEjectionTimeNanos = JsonUtil.getStringAsDuration(rawConfig, "baseEjectionTime");
+    Long maxEjectionTimeNanos = JsonUtil.getStringAsDuration(rawConfig, "maxEjectionTime");
+    Integer maxEjectionPercentage = JsonUtil.getNumberAsInteger(rawConfig,
+        "maxEjectionPercentage");
+
+    OutlierDetectionLoadBalancerConfig.Builder configBuilder
+        = new OutlierDetectionLoadBalancerConfig.Builder();
+    if (intervalNanos != null) {
+      configBuilder.setIntervalNanos(intervalNanos);
+    }
+    if (baseEjectionTimeNanos != null) {
+      configBuilder.setBaseEjectionTimeNanos(baseEjectionTimeNanos);
+    }
+    if (maxEjectionTimeNanos != null) {
+      configBuilder.setMaxEjectionTimeNanos(maxEjectionTimeNanos);
+    }
+    if (maxEjectionPercentage != null) {
+      configBuilder.setMaxEjectionPercent(maxEjectionPercentage);
+    }
+
+    // Success rate ejection specific configuration.
+    Map<String, ?> rawSuccessRateEjection = JsonUtil.getObject(rawConfig, "successRateEjection");
+    if (rawSuccessRateEjection != null) {
+      SuccessRateEjection.Builder successRateEjectionBuilder = new SuccessRateEjection.Builder();
+
+      Integer stdevFactor = JsonUtil.getNumberAsInteger(rawSuccessRateEjection, "stdevFactor");
+      Integer enforcementPercentage = JsonUtil.getNumberAsInteger(rawSuccessRateEjection,
+          "enforcementPercentage");
+      Integer minimumHosts = JsonUtil.getNumberAsInteger(rawSuccessRateEjection, "minimumHosts");
+      Integer requestVolume = JsonUtil.getNumberAsInteger(rawSuccessRateEjection, "requestVolume");
+
+      if (stdevFactor != null) {
+        successRateEjectionBuilder.setStdevFactor(stdevFactor);
+      }
+      if (enforcementPercentage != null) {
+        successRateEjectionBuilder.setEnforcementPercentage(enforcementPercentage);
+      }
+      if (minimumHosts != null) {
+        successRateEjectionBuilder.setMinimumHosts(minimumHosts);
+      }
+      if (requestVolume != null) {
+        successRateEjectionBuilder.setRequestVolume(requestVolume);
+      }
+
+      configBuilder.setSuccessRateEjection(successRateEjectionBuilder.build());
+    }
+
+    // Failure percentage ejection specific configuration.
+    Map<String, ?> rawFailurePercentageEjection = JsonUtil.getObject(rawConfig,
+        "failurePercentageEjection");
+    if (rawFailurePercentageEjection != null) {
+      FailurePercentageEjection.Builder failurePercentageEjectionBuilder
+          = new FailurePercentageEjection.Builder();
+
+      Integer threshold = JsonUtil.getNumberAsInteger(rawFailurePercentageEjection, "threshold");
+      Integer enforcementPercentage = JsonUtil.getNumberAsInteger(rawFailurePercentageEjection,
+          "enforcementPercentage");
+      Integer minimumHosts = JsonUtil.getNumberAsInteger(rawFailurePercentageEjection,
+          "minimumHosts");
+      Integer requestVolume = JsonUtil.getNumberAsInteger(rawFailurePercentageEjection,
+          "requestVolume");
+
+      if (threshold != null) {
+        failurePercentageEjectionBuilder.setThreshold(threshold);
+      }
+      if (enforcementPercentage != null) {
+        failurePercentageEjectionBuilder.setEnforcementPercentage(enforcementPercentage);
+      }
+      if (minimumHosts != null) {
+        failurePercentageEjectionBuilder.setMinimumHosts(minimumHosts);
+      }
+      if (requestVolume != null) {
+        failurePercentageEjectionBuilder.setRequestVolume(requestVolume);
+      }
+
+      configBuilder.setFailurePercentageEjection(failurePercentageEjectionBuilder.build());
+    }
+
+    // Child load balancer configuration.
+    List<LbConfig> childConfigCandidates = ServiceConfigUtil.unwrapLoadBalancingConfigList(
+        JsonUtil.getListOfObjects(rawConfig, "childPolicy"));
+    if (childConfigCandidates == null || childConfigCandidates.isEmpty()) {
+      return ConfigOrError.fromError(Status.INTERNAL.withDescription(
+          "No child policy in outlier_detection_experimental LB policy: "
+              + rawConfig));
+    }
+    ConfigOrError selectedConfig =
+        ServiceConfigUtil.selectLbPolicyFromList(childConfigCandidates,
+            LoadBalancerRegistry.getDefaultRegistry());
+    if (selectedConfig.getError() != null) {
+      return selectedConfig;
+    }
+    configBuilder.setChildPolicy((PolicySelection) selectedConfig.getConfig());
+
+    return ConfigOrError.fromConfig(configBuilder.build());
+  }
+}

--- a/core/src/main/resources/META-INF/services/io.grpc.LoadBalancerProvider
+++ b/core/src/main/resources/META-INF/services/io.grpc.LoadBalancerProvider
@@ -1,2 +1,3 @@
 io.grpc.internal.PickFirstLoadBalancerProvider
 io.grpc.util.SecretRoundRobinLoadBalancerProvider$Provider
+io.grpc.util.OutlierDetectionLoadBalancerProvider

--- a/core/src/test/java/io/grpc/internal/FakeClock.java
+++ b/core/src/test/java/io/grpc/internal/FakeClock.java
@@ -248,7 +248,6 @@ public final class FakeClock {
 
       @Override
       void run() {
-        long startTimeNanos = currentTimeNanos;
         command.run();
         if (!isCancelled()) {
           schedule(this, delayNanos, TimeUnit.NANOSECONDS);

--- a/core/src/test/java/io/grpc/util/OutlierDetectionLoadBalancerProviderTest.java
+++ b/core/src/test/java/io/grpc/util/OutlierDetectionLoadBalancerProviderTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.util;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.grpc.InternalServiceProviders;
+import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancerProvider;
+import io.grpc.NameResolver.ConfigOrError;
+import io.grpc.SynchronizationContext;
+import io.grpc.internal.JsonParser;
+import io.grpc.util.OutlierDetectionLoadBalancer.OutlierDetectionLoadBalancerConfig;
+import java.io.IOException;
+import java.lang.Thread.UncaughtExceptionHandler;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link OutlierDetectionLoadBalancerProvider}.
+ */
+@RunWith(JUnit4.class)
+public class OutlierDetectionLoadBalancerProviderTest {
+
+  private final SynchronizationContext syncContext = new SynchronizationContext(
+      new UncaughtExceptionHandler() {
+        @Override
+        public void uncaughtException(Thread t, Throwable e) {
+          throw new AssertionError(e);
+        }
+      });
+  private final OutlierDetectionLoadBalancerProvider provider
+      = new OutlierDetectionLoadBalancerProvider();
+
+  @Test
+  public void provided() {
+    for (LoadBalancerProvider current : InternalServiceProviders.getCandidatesViaServiceLoader(
+        LoadBalancerProvider.class, getClass().getClassLoader())) {
+      if (current instanceof OutlierDetectionLoadBalancerProvider) {
+        return;
+      }
+    }
+    fail("OutlierDetectionLoadBalancerProvider not registered");
+  }
+
+  @Test
+  public void providesLoadBalancer() {
+    Helper helper = mock(Helper.class);
+    when(helper.getSynchronizationContext()).thenReturn(syncContext);
+    when(helper.getScheduledExecutorService()).thenReturn(mock(ScheduledExecutorService.class));
+    assertThat(provider.newLoadBalancer(helper))
+        .isInstanceOf(OutlierDetectionLoadBalancer.class);
+  }
+
+  @Test
+  public void parseLoadBalancingConfig_defaults() throws IOException {
+    String lbConfig =
+        "{ \"successRateEjection\" : {}, "
+        + "\"failurePercentageEjection\" : {}, "
+        + "\"childPolicy\" : [{\"round_robin\" : {}}]}";
+    ConfigOrError configOrError =
+        provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
+    assertThat(configOrError.getConfig()).isNotNull();
+    OutlierDetectionLoadBalancerConfig config
+        = (OutlierDetectionLoadBalancerConfig) configOrError.getConfig();
+    assertThat(config.successRateEjection).isNotNull();
+    assertThat(config.failurePercentageEjection).isNotNull();
+    assertThat(config.childPolicy.getProvider().getPolicyName()).isEqualTo("round_robin");
+  }
+
+  @Test
+  public void parseLoadBalancingConfig_valuesSet() throws IOException {
+    String lbConfig =
+        "{\"interval\" : \"100s\","
+        + " \"baseEjectionTime\" : \"100s\","
+        + " \"maxEjectionTime\" : \"100s\","
+        + " \"maxEjectionPercentage\" : 100,"
+        + " \"successRateEjection\" : {"
+        + "     \"stdevFactor\" : 100,"
+        + "     \"enforcementPercentage\" : 100,"
+        + "     \"minimumHosts\" : 100,"
+        + "     \"requestVolume\" : 100"
+        + "   },"
+        + " \"failurePercentageEjection\" : {"
+        + "     \"threshold\" : 100,"
+        + "     \"enforcementPercentage\" : 100,"
+        + "     \"minimumHosts\" : 100,"
+        + "     \"requestVolume\" : 100"
+        + "   },"
+        + "\"childPolicy\" : [{\"round_robin\" : {}}]}";
+    ConfigOrError configOrError =
+        provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
+    assertThat(configOrError.getConfig()).isNotNull();
+    OutlierDetectionLoadBalancerConfig config
+        = (OutlierDetectionLoadBalancerConfig) configOrError.getConfig();
+
+    assertThat(config.intervalNanos).isEqualTo(100_000_000_000L);
+    assertThat(config.baseEjectionTimeNanos).isEqualTo(100_000_000_000L);
+    assertThat(config.maxEjectionTimeNanos).isEqualTo(100_000_000_000L);
+    assertThat(config.maxEjectionPercent).isEqualTo(100);
+
+    assertThat(config.successRateEjection).isNotNull();
+    assertThat(config.successRateEjection.stdevFactor).isEqualTo(100);
+    assertThat(config.successRateEjection.enforcementPercentage).isEqualTo(100);
+    assertThat(config.successRateEjection.minimumHosts).isEqualTo(100);
+    assertThat(config.successRateEjection.requestVolume).isEqualTo(100);
+
+    assertThat(config.failurePercentageEjection).isNotNull();
+    assertThat(config.failurePercentageEjection.threshold).isEqualTo(100);
+    assertThat(config.failurePercentageEjection.enforcementPercentage).isEqualTo(100);
+    assertThat(config.failurePercentageEjection.minimumHosts).isEqualTo(100);
+    assertThat(config.failurePercentageEjection.requestVolume).isEqualTo(100);
+
+    assertThat(config.childPolicy.getProvider().getPolicyName()).isEqualTo("round_robin");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, ?> parseJsonObject(String json) throws IOException {
+    return (Map<String, ?>) JsonParser.parse(json);
+  }
+}

--- a/core/src/test/java/io/grpc/util/OutlierDetectionLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/util/OutlierDetectionLoadBalancerTest.java
@@ -1,15 +1,374 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.grpc.util;
 
+import static com.google.common.truth.Truth.assertThat;
+import static io.grpc.ConnectivityState.CONNECTING;
+import static io.grpc.ConnectivityState.READY;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import io.grpc.ConnectivityState;
+import io.grpc.ConnectivityStateInfo;
+import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
+import io.grpc.LoadBalancer.CreateSubchannelArgs;
+import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancer.ResolvedAddresses;
+import io.grpc.LoadBalancer.Subchannel;
+import io.grpc.LoadBalancer.SubchannelPicker;
+import io.grpc.LoadBalancer.SubchannelStateListener;
+import io.grpc.LoadBalancerProvider;
+import io.grpc.LoadBalancerRegistry;
+import io.grpc.Status;
+import io.grpc.SynchronizationContext;
+import io.grpc.internal.FakeClock;
+import io.grpc.internal.FakeClock.ScheduledTask;
+import io.grpc.internal.ServiceConfigUtil.PolicySelection;
+import io.grpc.internal.TestUtils.StandardLoadBalancerProvider;
+import io.grpc.util.OutlierDetectionLoadBalancer.OutlierDetectionLoadBalancerConfig;
+import io.grpc.util.OutlierDetectionLoadBalancer.OutlierDetectionLoadBalancerConfig.SuccessRateEjection;
+import io.grpc.util.RoundRobinLoadBalancer.ReadyPicker;
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.stubbing.Answer;
 
-/** Unit tests for {@link OutlierDetectionLoadBalancer}. */
+/**
+ * Unit tests for {@link OutlierDetectionLoadBalancer}.
+ */
 @RunWith(JUnit4.class)
 public class OutlierDetectionLoadBalancerTest {
 
-  private final LoadBalancer mockDelegate = mock(LoadBalancer.class);
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
+  @Mock
+  private Helper helper;
+  @Mock
+  private LoadBalancer mockChildLb;
+  @Mock
+  private Helper mockHelper;
+  @Mock
+  private SocketAddress mockSocketAddress;
+
+  @Captor
+  private ArgumentCaptor<ConnectivityState> connectivityStateCaptor;
+  @Captor
+  private ArgumentCaptor<SubchannelPicker> errorPickerCaptor;
+  @Captor
+  private ArgumentCaptor<SubchannelPicker> pickerCaptor;
+  @Captor
+  private ArgumentCaptor<ConnectivityState> stateCaptor;
+  @Captor
+  private ArgumentCaptor<CreateSubchannelArgs> createArgsCaptor;
+
+  private final LoadBalancerProvider mockChildLbProvider = new StandardLoadBalancerProvider(
+      "foo_policy") {
+    @Override
+    public LoadBalancer newLoadBalancer(Helper helper) {
+      return mockChildLb;
+    }
+  };
+  private final LoadBalancerProvider roundRobinLbProvider = new StandardLoadBalancerProvider(
+      "round_robin") {
+    @Override
+    public LoadBalancer newLoadBalancer(Helper helper) {
+      return roundRobinLoadBalancer;
+    }
+  };
+  private RoundRobinLoadBalancer roundRobinLoadBalancer;
+
+  private final FakeClock fakeClock = new FakeClock();
+  private final SynchronizationContext syncContext = new SynchronizationContext(
+      new Thread.UncaughtExceptionHandler() {
+        @Override
+        public void uncaughtException(Thread t, Throwable e) {
+          throw new AssertionError(e);
+        }
+      });
+  private LoadBalancerRegistry lbRegistry = new LoadBalancerRegistry();
+  private OutlierDetectionLoadBalancer loadBalancer;
+
+  private final List<EquivalentAddressGroup> servers = Lists.newArrayList();
+  private final Map<List<EquivalentAddressGroup>, Subchannel> subchannels = Maps.newLinkedHashMap();
+  private final Map<Subchannel, SubchannelStateListener> subchannelStateListeners
+      = Maps.newLinkedHashMap();
+
+  @Before
+  public void setUp() {
+    for (int i = 0; i < 3; i++) {
+      SocketAddress addr = new FakeSocketAddress("server" + i);
+      EquivalentAddressGroup eag = new EquivalentAddressGroup(addr);
+      servers.add(eag);
+      Subchannel sc = mock(Subchannel.class);
+      subchannels.put(Arrays.asList(eag), sc);
+    }
+
+    when(mockHelper.getSynchronizationContext()).thenReturn(syncContext);
+    when(mockHelper.getScheduledExecutorService()).thenReturn(
+        fakeClock.getScheduledExecutorService());
+    when(mockHelper.createSubchannel(any(CreateSubchannelArgs.class)))
+        .then(new Answer<Subchannel>() {
+          @Override
+          public Subchannel answer(InvocationOnMock invocation) throws Throwable {
+            CreateSubchannelArgs args = (CreateSubchannelArgs) invocation.getArguments()[0];
+            final Subchannel subchannel = subchannels.get(args.getAddresses());
+            when(subchannel.getAllAddresses()).thenReturn(args.getAddresses());
+            when(subchannel.getAttributes()).thenReturn(args.getAttributes());
+            doAnswer(
+                new Answer<Void>() {
+                  @Override
+                  public Void answer(InvocationOnMock invocation) throws Throwable {
+                    subchannelStateListeners.put(
+                        subchannel, (SubchannelStateListener) invocation.getArguments()[0]);
+                    return null;
+                  }
+                }).when(subchannel).start(any(SubchannelStateListener.class));
+            return subchannel;
+          }
+        });
+
+    roundRobinLoadBalancer = new RoundRobinLoadBalancer(mockHelper);
+    //lbRegistry.register(mockChildLbProvider);
+    lbRegistry.register(roundRobinLbProvider);
+
+    loadBalancer = new OutlierDetectionLoadBalancer(mockHelper, fakeClock.getTimeProvider());
+  }
+
+  @Test
+  public void handleNameResolutionError_noChildLb() {
+    loadBalancer.handleNameResolutionError(Status.DEADLINE_EXCEEDED);
+
+    verify(mockHelper).updateBalancingState(connectivityStateCaptor.capture(),
+        errorPickerCaptor.capture());
+    assertThat(connectivityStateCaptor.getValue()).isEqualTo(ConnectivityState.TRANSIENT_FAILURE);
+  }
+
+  @Test
+  public void handleNameResolutionError_withChildLb() {
+    loadBalancer.handleResolvedAddresses(buildResolvedAddress(defaultSuccessRateConfig(mockChildLbProvider),
+        new EquivalentAddressGroup(mockSocketAddress)));
+    loadBalancer.handleNameResolutionError(Status.DEADLINE_EXCEEDED);
+
+    verify(mockChildLb).handleNameResolutionError(Status.DEADLINE_EXCEEDED);
+  }
+
+  /** {@code shutdown()} is simply delegated. */
+  @Test
+  public void shutdown() {
+    loadBalancer.handleResolvedAddresses(buildResolvedAddress(defaultSuccessRateConfig(mockChildLbProvider),
+        new EquivalentAddressGroup(mockSocketAddress)));
+    loadBalancer.shutdown();
+    verify(mockChildLb).shutdown();
+  }
+
+  /** Base case for accepting new resolved addresses. */
+  @Test
+  public void handleResolvedAddresses() {
+    OutlierDetectionLoadBalancerConfig config = defaultSuccessRateConfig(mockChildLbProvider);
+    ResolvedAddresses resolvedAddresses = buildResolvedAddress(config,
+        new EquivalentAddressGroup(mockSocketAddress));
+
+    loadBalancer.handleResolvedAddresses(resolvedAddresses);
+
+    // Handling of resolved addresses is delegated
+    verify(mockChildLb).handleResolvedAddresses(resolvedAddresses);
+
+    // There is a single pending task to run the outlier detection algorithm
+    assertThat(fakeClock.getPendingTasks()).hasSize(1);
+
+    // The task is scheduled to run after a delay set in the config.
+    ScheduledTask task = fakeClock.getPendingTasks().iterator().next();
+    assertThat(task.getDelay(TimeUnit.SECONDS)).isEqualTo(config.intervalSecs);
+  }
+
+  /** Outlier detection first enabled, then removed. */
+  @Test
+  public void handleResolvedAddresses_outlierDetectionDisabled() {
+    OutlierDetectionLoadBalancerConfig config = defaultSuccessRateConfig(mockChildLbProvider);
+    ResolvedAddresses resolvedAddresses = buildResolvedAddress(config,
+        new EquivalentAddressGroup(mockSocketAddress));
+
+    loadBalancer.handleResolvedAddresses(resolvedAddresses);
+
+    fakeClock.forwardTime(15, TimeUnit.SECONDS);
+
+    // There is a single pending task to run the outlier detection algorithm
+    assertThat(fakeClock.getPendingTasks()).hasSize(1);
+
+    loadBalancer.handleResolvedAddresses(
+        buildResolvedAddress(disabledConfig(), new EquivalentAddressGroup(mockSocketAddress)));
+
+    // Pending task should be gone since OD is disabled.
+    assertThat(fakeClock.getPendingTasks()).isEmpty();
+
+  }
+
+  /** Tests different scenarios when the timer interval in the config changes. */
+  @Test
+  public void handleResolvedAddresses_intervalUpdate() {
+    OutlierDetectionLoadBalancerConfig config = customIntervalConfig(null);
+    ResolvedAddresses resolvedAddresses = buildResolvedAddress(config,
+        new EquivalentAddressGroup(mockSocketAddress));
+
+    loadBalancer.handleResolvedAddresses(resolvedAddresses);
+
+    // Config update has doubled the interval
+    config = customIntervalConfig(config.intervalSecs * 2);
+
+    loadBalancer.handleResolvedAddresses(
+        buildResolvedAddress(config,
+            new EquivalentAddressGroup(mockSocketAddress)));
+
+    // If the timer has not run yet the task is just rescheduled to run after the new delay.
+    assertThat(fakeClock.getPendingTasks()).hasSize(1);
+    ScheduledTask task = fakeClock.getPendingTasks().iterator().next();
+    assertThat(task.getDelay(TimeUnit.SECONDS)).isEqualTo(config.intervalSecs);
+    assertThat(task.dueTimeNanos).isEqualTo(TimeUnit.SECONDS.toNanos(config.intervalSecs));
+
+    // The new interval time has passed. The next task due time should have been pushed back another
+    // interval.
+    fakeClock.forwardTime(config.intervalSecs + 1, TimeUnit.SECONDS);
+    assertThat(fakeClock.getPendingTasks()).hasSize(1);
+    task = fakeClock.getPendingTasks().iterator().next();
+    assertThat(task.dueTimeNanos).isEqualTo(
+        TimeUnit.SECONDS.toNanos(config.intervalSecs + config.intervalSecs + 1));
+
+    // Some time passes and a second update comes down, but now the timer has had a chance to run,
+    // the new delay to timer start should consider when the timer last ran and if the interval is
+    // not changing in the config, the next task due time should remain unchanged.
+    fakeClock.forwardTime(4, TimeUnit.SECONDS);
+    task = fakeClock.getPendingTasks().iterator().next();
+    loadBalancer.handleResolvedAddresses(
+        buildResolvedAddress(config,
+            new EquivalentAddressGroup(mockSocketAddress)));
+    assertThat(task.dueTimeNanos).isEqualTo(
+        TimeUnit.SECONDS.toNanos(config.intervalSecs + config.intervalSecs + 1));
+  }
+
+  // @Test
+  // public void pickAfterResolved() throws Exception {
+  //   final Subchannel readySubchannel = subchannels.values().iterator().next();
+  //
+  //   loadBalancer.handleResolvedAddresses(
+  //       buildResolvedAddress(defaultSuccessRateConfig(roundRobinLbProvider), servers));
+  //
+  //   deliverSubchannelState(readySubchannel, ConnectivityStateInfo.forNonError(READY));
+  //
+  //   verify(mockHelper, times(3)).createSubchannel(createArgsCaptor.capture());
+  //
+  //   List<List<EquivalentAddressGroup>> capturedAddrs = new ArrayList<>();
+  //   for (CreateSubchannelArgs arg : createArgsCaptor.getAllValues()) {
+  //     capturedAddrs.add(arg.getAddresses());
+  //   }
+  //
+  //   assertThat(capturedAddrs).containsAtLeastElementsIn(subchannels.keySet());
+  //   for (Subchannel subchannel : subchannels.values()) {
+  //     verify(subchannel).requestConnection();
+  //     verify(subchannel, never()).shutdown();
+  //   }
+  //   //
+  //   // verify(mockHelper, times(2))
+  //   //     .updateBalancingState(stateCaptor.capture(), pickerCaptor.capture());
+  //   //
+  //   // assertEquals(CONNECTING, stateCaptor.getAllValues().get(0));
+  //   // assertEquals(READY, stateCaptor.getAllValues().get(1));
+  //   // assertThat(getList(pickerCaptor.getValue())).containsExactly(readySubchannel);
+  //   //
+  //   // verifyNoMoreInteractions(mockHelper);
+  // }
+
+
+  private static class FakeSocketAddress extends SocketAddress {
+    final String name;
+
+    FakeSocketAddress(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public String toString() {
+      return "FakeSocketAddress-" + name;
+    }
+  }
+
+  private OutlierDetectionLoadBalancerConfig defaultSuccessRateConfig(
+      LoadBalancerProvider childLbProvider) {
+    return new OutlierDetectionLoadBalancerConfig(new PolicySelection(childLbProvider, null),
+        null, null, null, null,
+        new SuccessRateEjection(null, null, null, null), null);
+  }
+
+  private OutlierDetectionLoadBalancerConfig customIntervalConfig(Long intervalSecs) {
+    return new OutlierDetectionLoadBalancerConfig(new PolicySelection(mockChildLbProvider, null),
+        intervalSecs != null ? intervalSecs : null, null, null, null,
+        new SuccessRateEjection(null, null, null, null), null);
+  }
+
+  private OutlierDetectionLoadBalancerConfig disabledConfig() {
+    return new OutlierDetectionLoadBalancerConfig(new PolicySelection(mockChildLbProvider, null),
+        null, null, null, null,
+        null, null);
+  }
+
+  private ResolvedAddresses buildResolvedAddress(OutlierDetectionLoadBalancerConfig config,
+      EquivalentAddressGroup... servers) {
+    return ResolvedAddresses.newBuilder().setAddresses(ImmutableList.copyOf(servers))
+        .setLoadBalancingPolicyConfig(config).build();
+  }
+
+  private ResolvedAddresses buildResolvedAddress(OutlierDetectionLoadBalancerConfig config,
+      List<EquivalentAddressGroup> servers) {
+    return ResolvedAddresses.newBuilder().setAddresses(ImmutableList.copyOf(servers))
+        .setLoadBalancingPolicyConfig(config).build();
+  }
+
+  private void deliverSubchannelState(Subchannel subchannel, ConnectivityStateInfo newState) {
+    subchannelStateListeners.get(subchannel).onSubchannelState(newState);
+  }
+
+  private static List<Subchannel> getList(SubchannelPicker picker) {
+    return picker instanceof ReadyPicker ? ((ReadyPicker) picker).getList() :
+        Collections.<Subchannel>emptyList();
+  }
 }

--- a/core/src/test/java/io/grpc/util/OutlierDetectionLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/util/OutlierDetectionLoadBalancerTest.java
@@ -1,0 +1,15 @@
+package io.grpc.util;
+
+import static org.mockito.Mockito.mock;
+
+import io.grpc.LoadBalancer;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link OutlierDetectionLoadBalancer}. */
+@RunWith(JUnit4.class)
+public class OutlierDetectionLoadBalancerTest {
+
+  private final LoadBalancer mockDelegate = mock(LoadBalancer.class);
+
+}


### PR DESCRIPTION
Implements a new load balancer that tracks all RPC results to the addresses it is configured with and periodically attempts to detect outlier. It wraps a child load balancer that it hides any addresses that are deemed outliers.

Implementation follows the specification in [gRFC A50: gRPC xDS Outlier Detection Support](https://github.com/grpc/proposal/blob/master/A50-xds-outlier-detection.md)