### PR TITLE
gcp-observability: update configuration variable to enable cloud tracing (1.49.x backport) 

### DIFF
--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/ObservabilityConfigImpl.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/ObservabilityConfigImpl.java
@@ -82,7 +82,7 @@ final class ObservabilityConfigImpl implements ObservabilityConfig {
       if (value != null) {
         enableCloudMonitoring = value;
       }
-      value = JsonUtil.getBoolean(config, "enable_cloud_tracing");
+      value = JsonUtil.getBoolean(config, "enable_cloud_trace");
       if (value != null) {
         enableCloudTracing = value;
       }

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/ObservabilityConfigImplTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/ObservabilityConfigImplTest.java
@@ -80,26 +80,26 @@ public class ObservabilityConfigImplTest {
 
   private static final String ENABLE_CLOUD_MONITORING_AND_TRACING = "{\n"
       + "    \"enable_cloud_monitoring\": true,\n"
-      + "    \"enable_cloud_tracing\": true\n"
+      + "    \"enable_cloud_trace\": true\n"
       + "}";
 
   private static final String GLOBAL_TRACING_ALWAYS_SAMPLER = "{\n"
-      + "    \"enable_cloud_tracing\": true,\n"
+      + "    \"enable_cloud_trace\": true,\n"
       + "    \"global_trace_sampling_rate\": 1.00\n"
       + "}";
 
   private static final String GLOBAL_TRACING_NEVER_SAMPLER = "{\n"
-      + "    \"enable_cloud_tracing\": true,\n"
+      + "    \"enable_cloud_trace\": true,\n"
       + "    \"global_trace_sampling_rate\": 0.00\n"
       + "}";
 
   private static final String GLOBAL_TRACING_PROBABILISTIC_SAMPLER = "{\n"
-      + "    \"enable_cloud_tracing\": true,\n"
+      + "    \"enable_cloud_trace\": true,\n"
       + "    \"global_trace_sampling_rate\": 0.75\n"
       + "}";
 
   private static final String GLOBAL_TRACING_DEFAULT_SAMPLER = "{\n"
-      + "    \"enable_cloud_tracing\": true\n"
+      + "    \"enable_cloud_trace\": true\n"
       + "}";
 
   private static final String GLOBAL_TRACING_BADPROBABILISTIC_SAMPLER = "{\n"


### PR DESCRIPTION
This PR updates config variable to enable tracing in observability from `enable_cloud_tracing` to `enable_cloud_trace` as mentioned in User Guide.

CC @sanjaypujare

Backport of #9463 