### PR TITLE
core: OutlierDetectionLoadBalancer to pass child LB config.

### DIFF
--- a/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
@@ -139,7 +139,9 @@ public final class OutlierDetectionLoadBalancer extends LoadBalancer {
       trackerMap.cancelTracking();
     }
 
-    switchLb.handleResolvedAddresses(resolvedAddresses);
+    switchLb.handleResolvedAddresses(
+        resolvedAddresses.toBuilder().setLoadBalancingPolicyConfig(config.childPolicy.getConfig())
+            .build());
   }
 
   @Override

--- a/core/src/test/java/io/grpc/util/OutlierDetectionLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/util/OutlierDetectionLoadBalancerTest.java
@@ -233,7 +233,9 @@ public class OutlierDetectionLoadBalancerTest {
     loadBalancer.handleResolvedAddresses(resolvedAddresses);
 
     // Handling of resolved addresses is delegated
-    verify(mockChildLb).handleResolvedAddresses(resolvedAddresses);
+    verify(mockChildLb).handleResolvedAddresses(
+        resolvedAddresses.toBuilder().setLoadBalancingPolicyConfig(config.childPolicy.getConfig())
+            .build());
 
     // There is a single pending task to run the outlier detection algorithm
     assertThat(fakeClock.getPendingTasks()).hasSize(1);


### PR DESCRIPTION
The outlier detection config was incorrectly being passed to the wrapped child LB.
This PR has the outlier detection LB correctly extract the child LB config from the
outlier detection config and pass that to the child LB.