### PR TITLE
example-android: Add android:exported="true" tag

### DIFF
--- a/examples/android/helloworld/app/src/main/AndroidManifest.xml
+++ b/examples/android/helloworld/app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
         android:theme="@style/Base.V7.Theme.AppCompat.Light" >
         <activity
             android:name=".HelloworldActivity"
-            android:label="@string/app_name" >
+            android:label="@string/app_name"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
Add android:exported="true" tag to activities/services/receivers that specify an intent filter.

Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` when the corresponding component has an intent filter defined. Future versions of the manifest merger, as well as the Android platform and the Playstore enforce this.

ref cl/469539970