### PR TITLE
api,core: Add LoadBalancer.acceptResolvedAddresses()

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1852,16 +1852,17 @@ final class ManagedChannelImpl extends ManagedChannel implements
                   .set(LoadBalancer.ATTR_HEALTH_CHECKING_CONFIG, healthCheckingConfig)
                   .build();
             }
+            Attributes attributes = attrBuilder.build();
 
-            Status handleResult = helper.lb.tryHandleResolvedAddresses(
+            boolean addressesAccepted = helper.lb.tryAcceptResolvedAddresses(
                 ResolvedAddresses.newBuilder()
                     .setAddresses(servers)
-                    .setAttributes(attrBuilder.build())
+                    .setAttributes(attributes)
                     .setLoadBalancingPolicyConfig(effectiveServiceConfig.getLoadBalancingConfig())
                     .build());
 
-            if (!handleResult.isOk()) {
-              handleErrorInSyncContext(handleResult.augmentDescription(resolver + " was used"));
+            if (!addressesAccepted) {
+              scheduleExponentialBackOffInSyncContext();
             }
           }
         }

--- a/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
@@ -17,14 +17,10 @@
 package io.grpc.util;
 
 import com.google.common.base.MoreObjects;
-import io.grpc.Attributes;
 import io.grpc.ConnectivityStateInfo;
-import io.grpc.EquivalentAddressGroup;
 import io.grpc.ExperimentalApi;
 import io.grpc.LoadBalancer;
-import io.grpc.NameResolver;
 import io.grpc.Status;
-import java.util.List;
 
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
 public abstract class ForwardingLoadBalancer extends LoadBalancer {
@@ -34,16 +30,13 @@ public abstract class ForwardingLoadBalancer extends LoadBalancer {
   protected abstract LoadBalancer delegate();
 
   @Override
-  @Deprecated
-  public void handleResolvedAddressGroups(
-        List<EquivalentAddressGroup> servers,
-        @NameResolver.ResolutionResultAttr Attributes attributes) {
-    delegate().handleResolvedAddressGroups(servers, attributes);
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    delegate().handleResolvedAddresses(resolvedAddresses);
   }
 
   @Override
-  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-    delegate().handleResolvedAddresses(resolvedAddresses);
+  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    return delegate().acceptResolvedAddresses(resolvedAddresses);
   }
 
   @Override

--- a/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
+++ b/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
@@ -21,8 +21,8 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.ArgumentMatchers.same;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -97,9 +97,8 @@ public class AutoConfiguredLoadBalancerFactoryTest {
 
   @Before
   public void setUp() {
-    when(testLbBalancer.canHandleEmptyAddressListFromNameResolution()).thenCallRealMethod();
-    assertThat(testLbBalancer.canHandleEmptyAddressListFromNameResolution()).isFalse();
-    when(testLbBalancer2.canHandleEmptyAddressListFromNameResolution()).thenReturn(true);
+    when(testLbBalancer.acceptResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(true);
+    when(testLbBalancer2.acceptResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(true);
     defaultRegistry.register(testLbBalancerProvider);
     defaultRegistry.register(testLbBalancerProvider2);
   }
@@ -171,7 +170,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   }
 
   @Test
-  public void handleResolvedAddressGroups_keepOldBalancer() {
+  public void acceptResolvedAddresses_keepOldBalancer() {
     final List<EquivalentAddressGroup> servers =
         Collections.singletonList(new EquivalentAddressGroup(new SocketAddress(){}));
     Helper helper = new TestHelper() {
@@ -184,19 +183,19 @@ public class AutoConfiguredLoadBalancerFactoryTest {
     AutoConfiguredLoadBalancer lb = lbf.newLoadBalancer(helper);
     LoadBalancer oldDelegate = lb.getDelegate();
 
-    Status handleResult = lb.tryHandleResolvedAddresses(
+    boolean addressesAccepted = lb.tryAcceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers)
             .setAttributes(Attributes.EMPTY)
             .setLoadBalancingPolicyConfig(null)
             .build());
 
-    assertThat(handleResult.getCode()).isEqualTo(Status.Code.OK);
+    assertThat(addressesAccepted).isTrue();
     assertThat(lb.getDelegate()).isSameInstanceAs(oldDelegate);
   }
 
   @Test
-  public void handleResolvedAddressGroups_shutsDownOldBalancer() throws Exception {
+  public void acceptResolvedAddresses_shutsDownOldBalancer() throws Exception {
     Map<String, ?> serviceConfig =
         parseConfig("{\"loadBalancingConfig\": [ {\"round_robin\": { } } ] }");
     ConfigOrError lbConfigs = lbf.parseLoadBalancerPolicy(serviceConfig);
@@ -226,13 +225,13 @@ public class AutoConfiguredLoadBalancerFactoryTest {
     };
     lb.setDelegate(testlb);
 
-    Status handleResult = lb.tryHandleResolvedAddresses(
+    boolean addressesAccepted = lb.tryAcceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers)
             .setLoadBalancingPolicyConfig(lbConfigs.getConfig())
             .build());
 
-    assertThat(handleResult.getCode()).isEqualTo(Status.Code.OK);
+    assertThat(addressesAccepted).isTrue();
     assertThat(lb.getDelegateProvider().getClass().getName()).isEqualTo(
         "io.grpc.util.SecretRoundRobinLoadBalancerProvider$Provider");
     assertTrue(shutdown.get());
@@ -240,7 +239,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void handleResolvedAddressGroups_propagateLbConfigToDelegate() throws Exception {
+  public void acceptResolvedAddresses_propagateLbConfigToDelegate() throws Exception {
     Map<String, ?> rawServiceConfig =
         parseConfig("{\"loadBalancingConfig\": [ {\"test_lb\": { \"setting1\": \"high\" } } ] }");
     ConfigOrError lbConfigs = lbf.parseLoadBalancerPolicy(rawServiceConfig);
@@ -251,20 +250,19 @@ public class AutoConfiguredLoadBalancerFactoryTest {
     Helper helper = new TestHelper();
     AutoConfiguredLoadBalancer lb = lbf.newLoadBalancer(helper);
 
-    Status handleResult = lb.tryHandleResolvedAddresses(
+    boolean addressesAccepted = lb.tryAcceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers)
             .setLoadBalancingPolicyConfig(lbConfigs.getConfig())
             .build());
 
     verify(testLbBalancerProvider).newLoadBalancer(same(helper));
-    assertThat(handleResult.getCode()).isEqualTo(Status.Code.OK);
+    assertThat(addressesAccepted).isTrue();
     assertThat(lb.getDelegate()).isSameInstanceAs(testLbBalancer);
     ArgumentCaptor<ResolvedAddresses> resultCaptor =
         ArgumentCaptor.forClass(ResolvedAddresses.class);
-    verify(testLbBalancer).handleResolvedAddresses(resultCaptor.capture());
+    verify(testLbBalancer).acceptResolvedAddresses(resultCaptor.capture());
     assertThat(resultCaptor.getValue().getAddresses()).containsExactlyElementsIn(servers).inOrder();
-    verify(testLbBalancer, atLeast(0)).canHandleEmptyAddressListFromNameResolution();
     ArgumentCaptor<Map<String, ?>> lbConfigCaptor = ArgumentCaptor.forClass(Map.class);
     verify(testLbBalancerProvider).parseLoadBalancingPolicyConfig(lbConfigCaptor.capture());
     assertThat(lbConfigCaptor.getValue()).containsExactly("setting1", "high");
@@ -274,7 +272,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
         parseConfig("{\"loadBalancingConfig\": [ {\"test_lb\": { \"setting1\": \"low\" } } ] }");
     lbConfigs = lbf.parseLoadBalancerPolicy(rawServiceConfig);
 
-    handleResult = lb.tryHandleResolvedAddresses(
+    addressesAccepted = lb.tryAcceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers)
             .setLoadBalancingPolicyConfig(lbConfigs.getConfig())
@@ -282,8 +280,8 @@ public class AutoConfiguredLoadBalancerFactoryTest {
 
     resultCaptor =
         ArgumentCaptor.forClass(ResolvedAddresses.class);
-    verify(testLbBalancer, times(2)).handleResolvedAddresses(resultCaptor.capture());
-    assertThat(handleResult.getCode()).isEqualTo(Status.Code.OK);
+    verify(testLbBalancer, times(2)).acceptResolvedAddresses(resultCaptor.capture());
+    assertThat(addressesAccepted).isTrue();
     assertThat(resultCaptor.getValue().getAddresses()).containsExactlyElementsIn(servers).inOrder();
     verify(testLbBalancerProvider, times(2))
         .parseLoadBalancingPolicyConfig(lbConfigCaptor.capture());
@@ -294,7 +292,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   }
 
   @Test
-  public void handleResolvedAddressGroups_propagateAddrsToDelegate() throws Exception {
+  public void acceptResolvedAddresses_propagateAddrsToDelegate() throws Exception {
     Map<String, ?> rawServiceConfig =
         parseConfig("{\"loadBalancingConfig\": [ {\"test_lb\": { \"setting1\": \"high\" } } ] }");
     ConfigOrError lbConfigs = lbf.parseLoadBalancerPolicy(rawServiceConfig);
@@ -305,56 +303,58 @@ public class AutoConfiguredLoadBalancerFactoryTest {
     List<EquivalentAddressGroup> servers =
         Collections.singletonList(new EquivalentAddressGroup(new InetSocketAddress(8080){}));
 
-    Status handleResult = lb.tryHandleResolvedAddresses(
+    boolean addressesAccepted = lb.tryAcceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers)
             .setLoadBalancingPolicyConfig(lbConfigs.getConfig())
             .build());
 
     verify(testLbBalancerProvider).newLoadBalancer(same(helper));
-    assertThat(handleResult.getCode()).isEqualTo(Status.Code.OK);
+    assertThat(addressesAccepted).isTrue();
     assertThat(lb.getDelegate()).isSameInstanceAs(testLbBalancer);
     ArgumentCaptor<ResolvedAddresses> resultCaptor =
         ArgumentCaptor.forClass(ResolvedAddresses.class);
-    verify(testLbBalancer).handleResolvedAddresses(resultCaptor.capture());
+    verify(testLbBalancer).acceptResolvedAddresses(resultCaptor.capture());
     assertThat(resultCaptor.getValue().getAddresses()).containsExactlyElementsIn(servers).inOrder();
 
     servers =
         Collections.singletonList(new EquivalentAddressGroup(new InetSocketAddress(9090){}));
-    handleResult = lb.tryHandleResolvedAddresses(
+    addressesAccepted = lb.tryAcceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers)
             .setLoadBalancingPolicyConfig(lbConfigs.getConfig())
             .build());
 
-    assertThat(handleResult.getCode()).isEqualTo(Status.Code.OK);
-    verify(testLbBalancer, times(2)).handleResolvedAddresses(resultCaptor.capture());
+    assertThat(addressesAccepted).isTrue();
+    verify(testLbBalancer, times(2)).acceptResolvedAddresses(resultCaptor.capture());
     assertThat(resultCaptor.getValue().getAddresses()).containsExactlyElementsIn(servers).inOrder();
   }
 
   @Test
-  public void handleResolvedAddressGroups_delegateDoNotAcceptEmptyAddressList_nothing()
+  public void acceptResolvedAddresses_delegateDoNotAcceptEmptyAddressList_nothing()
       throws Exception {
+
+    // The test LB will NOT accept the addresses we give them.
+    when(testLbBalancer.acceptResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(false);
+
     Helper helper = new TestHelper();
     AutoConfiguredLoadBalancer lb = lbf.newLoadBalancer(helper);
 
     Map<String, ?> serviceConfig =
         parseConfig("{\"loadBalancingConfig\": [ {\"test_lb\": { \"setting1\": \"high\" } } ] }");
     ConfigOrError lbConfig = lbf.parseLoadBalancerPolicy(serviceConfig);
-    Status handleResult = lb.tryHandleResolvedAddresses(
+    boolean addressesAccepted = lb.tryAcceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(Collections.<EquivalentAddressGroup>emptyList())
             .setLoadBalancingPolicyConfig(lbConfig.getConfig())
             .build());
 
-    assertThat(testLbBalancer.canHandleEmptyAddressListFromNameResolution()).isFalse();
-    assertThat(handleResult.getCode()).isEqualTo(Status.Code.UNAVAILABLE);
-    assertThat(handleResult.getDescription()).startsWith("NameResolver returned no usable address");
+    assertThat(addressesAccepted).isFalse();
     assertThat(lb.getDelegate()).isSameInstanceAs(testLbBalancer);
   }
 
   @Test
-  public void handleResolvedAddressGroups_delegateAcceptsEmptyAddressList()
+  public void acceptResolvedAddresses_delegateAcceptsEmptyAddressList()
       throws Exception {
     Helper helper = new TestHelper();
     AutoConfiguredLoadBalancer lb = lbf.newLoadBalancer(helper);
@@ -363,25 +363,24 @@ public class AutoConfiguredLoadBalancerFactoryTest {
         parseConfig("{\"loadBalancingConfig\": [ {\"test_lb2\": { \"setting1\": \"high\" } } ] }");
     ConfigOrError lbConfigs =
         lbf.parseLoadBalancerPolicy(rawServiceConfig);
-    Status handleResult = lb.tryHandleResolvedAddresses(
+    boolean addressesAccepted = lb.tryAcceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(Collections.<EquivalentAddressGroup>emptyList())
             .setLoadBalancingPolicyConfig(lbConfigs.getConfig())
             .build());
 
-    assertThat(handleResult.getCode()).isEqualTo(Status.Code.OK);
+    assertThat(addressesAccepted).isTrue();
     assertThat(lb.getDelegate()).isSameInstanceAs(testLbBalancer2);
-    assertThat(testLbBalancer2.canHandleEmptyAddressListFromNameResolution()).isTrue();
     ArgumentCaptor<ResolvedAddresses> resultCaptor =
         ArgumentCaptor.forClass(ResolvedAddresses.class);
-    verify(testLbBalancer2).handleResolvedAddresses(resultCaptor.capture());
+    verify(testLbBalancer2).acceptResolvedAddresses(resultCaptor.capture());
     assertThat(resultCaptor.getValue().getAddresses()).isEmpty();
     assertThat(resultCaptor.getValue().getLoadBalancingPolicyConfig())
         .isEqualTo(nextParsedConfigOrError2.get().getConfig());
   }
 
   @Test
-  public void handleResolvedAddressGroups_useSelectedLbPolicy() throws Exception {
+  public void acceptResolvedAddresses_useSelectedLbPolicy() throws Exception {
     Map<String, ?> rawServiceConfig =
         parseConfig("{\"loadBalancingConfig\": [{\"round_robin\": {}}]}");
     ConfigOrError lbConfigs = lbf.parseLoadBalancerPolicy(rawServiceConfig);
@@ -399,18 +398,18 @@ public class AutoConfiguredLoadBalancerFactoryTest {
       }
     };
     AutoConfiguredLoadBalancer lb = lbf.newLoadBalancer(helper);
-    Status handleResult = lb.tryHandleResolvedAddresses(
+    boolean addressesAccepted = lb.tryAcceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers)
             .setLoadBalancingPolicyConfig(lbConfigs.getConfig())
             .build());
-    assertThat(handleResult.getCode()).isEqualTo(Status.Code.OK);
+    assertThat(addressesAccepted).isTrue();
     assertThat(lb.getDelegate().getClass().getName())
         .isEqualTo("io.grpc.util.RoundRobinLoadBalancer");
   }
 
   @Test
-  public void handleResolvedAddressGroups_noLbPolicySelected_defaultToPickFirst() {
+  public void acceptResolvedAddresses_noLbPolicySelected_defaultToPickFirst() {
     final List<EquivalentAddressGroup> servers =
         Collections.singletonList(new EquivalentAddressGroup(new SocketAddress(){}));
     Helper helper = new TestHelper() {
@@ -421,27 +420,27 @@ public class AutoConfiguredLoadBalancerFactoryTest {
       }
     };
     AutoConfiguredLoadBalancer lb = lbf.newLoadBalancer(helper);
-    Status handleResult = lb.tryHandleResolvedAddresses(
+    boolean addressesAccepted = lb.tryAcceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers)
             .setLoadBalancingPolicyConfig(null)
             .build());
-    assertThat(handleResult.getCode()).isEqualTo(Status.Code.OK);
+    assertThat(addressesAccepted).isTrue();
     assertThat(lb.getDelegate()).isInstanceOf(PickFirstLoadBalancer.class);
   }
 
   @Test
-  public void handleResolvedAddressGroups_noLbPolicySelected_defaultToCustomDefault() {
+  public void acceptResolvedAddresses_noLbPolicySelected_defaultToCustomDefault() {
     AutoConfiguredLoadBalancer lb = new AutoConfiguredLoadBalancerFactory("test_lb")
         .newLoadBalancer(new TestHelper());
     List<EquivalentAddressGroup> servers =
         Collections.singletonList(new EquivalentAddressGroup(new SocketAddress(){}));
-    Status handleResult = lb.tryHandleResolvedAddresses(
+    boolean addressesAccepted = lb.tryAcceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers)
             .setLoadBalancingPolicyConfig(null)
             .build());
-    assertThat(handleResult.getCode()).isEqualTo(Status.Code.OK);
+    assertThat(addressesAccepted).isTrue();
     assertThat(lb.getDelegate()).isSameInstanceAs(testLbBalancer);
   }
 
@@ -458,13 +457,13 @@ public class AutoConfiguredLoadBalancerFactoryTest {
 
     AutoConfiguredLoadBalancer lb =
         new AutoConfiguredLoadBalancerFactory(GrpcUtil.DEFAULT_LB_POLICY).newLoadBalancer(helper);
-    Status handleResult = lb.tryHandleResolvedAddresses(
+    boolean addressesAccepted = lb.tryAcceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers)
             .setAttributes(Attributes.EMPTY)
             .build());
 
-    assertThat(handleResult.getCode()).isEqualTo(Status.Code.OK);
+    assertThat(addressesAccepted).isTrue();
     verifyNoMoreInteractions(channelLogger);
 
     ConfigOrError testLbParsedConfig = ConfigOrError.fromConfig("foo");
@@ -472,13 +471,13 @@ public class AutoConfiguredLoadBalancerFactoryTest {
     Map<String, ?> serviceConfig =
         parseConfig("{\"loadBalancingConfig\": [ {\"test_lb\": { } } ] }");
     ConfigOrError lbConfigs = lbf.parseLoadBalancerPolicy(serviceConfig);
-    handleResult = lb.tryHandleResolvedAddresses(
+    addressesAccepted = lb.tryAcceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers)
             .setLoadBalancingPolicyConfig(lbConfigs.getConfig())
             .build());
 
-    assertThat(handleResult.getCode()).isEqualTo(Status.Code.OK);
+    assertThat(addressesAccepted).isTrue();
     verify(channelLogger).log(
         eq(ChannelLogLevel.INFO),
         eq("Load balancer changed from {0} to {1}"),
@@ -495,12 +494,12 @@ public class AutoConfiguredLoadBalancerFactoryTest {
     nextParsedConfigOrError.set(testLbParsedConfig);
     serviceConfig = parseConfig("{\"loadBalancingConfig\": [ {\"test_lb\": { } } ] }");
     lbConfigs = lbf.parseLoadBalancerPolicy(serviceConfig);
-    handleResult = lb.tryHandleResolvedAddresses(
+    addressesAccepted = lb.tryAcceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers)
             .setLoadBalancingPolicyConfig(lbConfigs.getConfig())
             .build());
-    assertThat(handleResult.getCode()).isEqualTo(Status.Code.OK);
+    assertThat(addressesAccepted).isTrue();
     verify(channelLogger).log(
         eq(ChannelLogLevel.DEBUG),
         eq("Load-balancing config: {0}"),
@@ -643,14 +642,13 @@ public class AutoConfiguredLoadBalancerFactoryTest {
 
     @Override
     @Deprecated
-    public void handleResolvedAddressGroups(
-        List<EquivalentAddressGroup> servers, Attributes attributes) {
-      delegate().handleResolvedAddressGroups(servers, attributes);
+    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+      delegate().acceptResolvedAddresses(resolvedAddresses);
     }
 
     @Override
-    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-      delegate().handleResolvedAddresses(resolvedAddresses);
+    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+      return delegate().acceptResolvedAddresses(resolvedAddresses);
     }
 
     @Override

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -154,6 +154,7 @@ public class ManagedChannelImplIdlenessTest {
   @Before
   @SuppressWarnings("deprecation") // For NameResolver.Listener
   public void setUp() {
+    when(mockLoadBalancer.acceptResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(true);
     LoadBalancerRegistry.getDefaultRegistry().register(mockLoadBalancerProvider);
     when(mockNameResolver.getServiceAuthority()).thenReturn(AUTHORITY);
     when(mockNameResolverFactory
@@ -220,7 +221,7 @@ public class ManagedChannelImplIdlenessTest {
 
     ArgumentCaptor<ResolvedAddresses> resolvedAddressCaptor =
         ArgumentCaptor.forClass(ResolvedAddresses.class);
-    verify(mockLoadBalancer).handleResolvedAddresses(resolvedAddressCaptor.capture());
+    verify(mockLoadBalancer).acceptResolvedAddresses(resolvedAddressCaptor.capture());
     assertThat(resolvedAddressCaptor.getValue().getAddresses())
         .containsExactlyElementsIn(servers);
   }

--- a/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
+++ b/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
@@ -568,7 +568,7 @@ public class CachingRlsLbClientTest {
       LoadBalancer loadBalancer = new LoadBalancer() {
 
         @Override
-        public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+        public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
           Map<?, ?> config = (Map<?, ?>) resolvedAddresses.getLoadBalancingPolicyConfig();
           if (DEFAULT_TARGET.equals(config.get("target"))) {
             helper.updateBalancingState(
@@ -590,6 +590,8 @@ public class CachingRlsLbClientTest {
                   }
                 });
           }
+
+          return true;
         }
 
         @Override


### PR DESCRIPTION
Introduces a new acceptResolvedAddresses() method in LoadBalancer that
is to ultimately replace the existing handleResolvedAddresses(). The new
method allows the LoadBalancer implementation to reject the given
addresses by returning false from the method.

The long deprecated handleResolvedAddressGroups is also removed.