### PR TITLE
[core,api,auth: Choose executor based on need for thread affinity

### DIFF
--- a/api/src/main/java/io/grpc/InternalMayRequireSpecificExecutor.java
+++ b/api/src/main/java/io/grpc/InternalMayRequireSpecificExecutor.java
@@ -1,0 +1,6 @@
+package io.grpc;
+
+@Internal
+public interface InternalMayRequireSpecificExecutor {
+    boolean isSpecificExecutorRequired();
+}

--- a/api/src/main/java/io/grpc/InternalMayRequireSpecificExecutor.java
+++ b/api/src/main/java/io/grpc/InternalMayRequireSpecificExecutor.java
@@ -1,6 +1,22 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.grpc;
 
 @Internal
 public interface InternalMayRequireSpecificExecutor {
-    boolean isSpecificExecutorRequired();
+  boolean isSpecificExecutorRequired();
 }

--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -24,6 +24,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.BaseEncoding;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.InternalMayRequireSpecificExecutor;
 import io.grpc.SecurityLevel;
 import io.grpc.Status;
 import io.grpc.StatusException;
@@ -44,7 +45,8 @@ import javax.annotation.Nullable;
 /**
  * Wraps {@link Credentials} as a {@link io.grpc.CallCredentials}.
  */
-final class GoogleAuthLibraryCallCredentials extends io.grpc.CallCredentials {
+final class GoogleAuthLibraryCallCredentials extends io.grpc.CallCredentials
+    implements InternalMayRequireSpecificExecutor {
   private static final Logger log
       = Logger.getLogger(GoogleAuthLibraryCallCredentials.class.getName());
   private static final JwtHelper jwtHelper
@@ -58,6 +60,8 @@ final class GoogleAuthLibraryCallCredentials extends io.grpc.CallCredentials {
 
   private Metadata lastHeaders;
   private Map<String, List<String>> lastMetadata;
+
+  private Boolean requiresSpecificExecutor;
 
   public GoogleAuthLibraryCallCredentials(Credentials creds) {
     this(creds, jwtHelper);
@@ -353,4 +357,30 @@ final class GoogleAuthLibraryCallCredentials extends io.grpc.CallCredentials {
       return creds;
     }
   }
+
+  /**
+   * This method is to support the hack for AppEngineCredentials which need to run on a
+   * specific thread.
+   * @return Whether a specific executor is needed or if any executor can be used
+   */
+  @Override
+  public boolean isSpecificExecutorRequired() {
+    // Cache the value so we only need to try to load the class once
+    if (requiresSpecificExecutor == null) {
+      if (googleCredentialsClass == null) {
+        requiresSpecificExecutor = Boolean.FALSE;
+      } else {
+        try {
+          requiresSpecificExecutor =
+              Class.forName("com.google.auth.oauth2.AppEngineCredentials")
+                  .isAssignableFrom(googleCredentialsClass);
+        } catch (ClassNotFoundException e) {
+          requiresSpecificExecutor = Boolean.FALSE;
+        }
+      }
+    }
+
+    return requiresSpecificExecutor;
+  }
+
 }

--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -379,7 +379,7 @@ final class GoogleAuthLibraryCallCredentials extends io.grpc.CallCredentials
   public boolean isSpecificExecutorRequired() {
     // Cache the value so we only need to try to load the class once
     if (requiresSpecificExecutor == null) {
-      if (creds == null || appEngineCredentialsClass == null) {
+      if (appEngineCredentialsClass == null) {
         requiresSpecificExecutor = Boolean.FALSE;
       } else {
         requiresSpecificExecutor = appEngineCredentialsClass.isInstance(creds);

--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The gRPC Authors
+ * Copyright 2016,2022 The gRPC Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,9 @@ import com.google.auth.Credentials;
 import com.google.auth.RequestMetadataCallback;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.BaseEncoding;
+import io.grpc.InternalMayRequireSpecificExecutor;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
-import io.grpc.InternalMayRequireSpecificExecutor;
 import io.grpc.SecurityLevel;
 import io.grpc.Status;
 import io.grpc.StatusException;

--- a/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The gRPC Authors
+ * Copyright 2016,2022 The gRPC Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,9 +27,9 @@ import io.grpc.ChannelCredentials;
 import io.grpc.ChannelLogger;
 import io.grpc.ClientStreamTracer;
 import io.grpc.CompositeCallCredentials;
+import io.grpc.InternalMayRequireSpecificExecutor;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
-import io.grpc.InternalMayRequireSpecificExecutor;
 import io.grpc.SecurityLevel;
 import io.grpc.Status;
 import io.grpc.internal.MetadataApplierImpl.MetadataApplierListener;
@@ -150,9 +150,9 @@ final class CallCredentialsApplyingTransportFactory implements ClientTransportFa
           // Ideally would always use appExecutor and we could eliminate the interface
           // InternalMayRequireSpecificExecutor
           Executor executor;
-          if (creds instanceof InternalMayRequireSpecificExecutor &&
-              ((InternalMayRequireSpecificExecutor)creds).isSpecificExecutorRequired() &&
-              callOptions.getExecutor() != null) {
+          if (creds instanceof InternalMayRequireSpecificExecutor
+              && ((InternalMayRequireSpecificExecutor)creds).isSpecificExecutorRequired()
+              && callOptions.getExecutor() != null) {
             executor = callOptions.getExecutor();
           } else {
             executor = appExecutor;

--- a/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
@@ -146,7 +146,8 @@ final class CallCredentialsApplyingTransportFactory implements ClientTransportFa
           };
         try {
           // Hack to allow appengine to work when using AppEngineCredentials (b/244209681)
-          // since processing must happen on a specific thread
+          // since processing must happen on a specific thread.
+          //
           // Ideally would always use appExecutor and we could eliminate the interface
           // InternalMayRequireSpecificExecutor
           Executor executor;


### PR DESCRIPTION
[core,api,auth: Choose the callOptions executor when applying request metadata to credentials during newStream based upon whether AppEngineCredentials are being used as they require a specific thread to do the processing.

Add an interface to differentiate whether the specific thread is needed.

Fixes b/244209681