### PR TITLE
core: Don't forward acceptResolvedAddresses()

### DIFF
--- a/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
@@ -35,11 +35,6 @@ public abstract class ForwardingLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-    return delegate().acceptResolvedAddresses(resolvedAddresses);
-  }
-
-  @Override
   public void handleNameResolutionError(Status error) {
     delegate().handleNameResolutionError(error);
   }

--- a/core/src/test/java/io/grpc/util/ForwardingLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/util/ForwardingLoadBalancerTest.java
@@ -20,8 +20,8 @@ import static org.mockito.Mockito.mock;
 
 import io.grpc.ForwardingTestUtil;
 import io.grpc.LoadBalancer;
-import java.lang.reflect.Method;
-import java.util.Collections;
+import io.grpc.LoadBalancer.ResolvedAddresses;
+import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -44,6 +44,7 @@ public class ForwardingLoadBalancerTest {
         LoadBalancer.class,
         mockDelegate,
         new TestBalancer(),
-        Collections.<Method>emptyList());
+        Arrays.asList(
+            LoadBalancer.class.getMethod("acceptResolvedAddresses", ResolvedAddresses.class)));
   }
 }


### PR DESCRIPTION
Forwarding acceptResolvedAddresses() to a delegate in ForwardingLoadBalancer can cause problems if an extending class expects its handleResolvedAddresses implementation to be called even when a client calls handleResolvedAddresses(). This would not happen as ForwardingLoadBalancer would directly send the call to the delegate.