### PR TITLE
Use real objects instead of mocks.

### DIFF
--- a/core/src/test/java/io/grpc/internal/ForwardingReadableBufferTest.java
+++ b/core/src/test/java/io/grpc/internal/ForwardingReadableBufferTest.java
@@ -17,11 +17,11 @@
 package io.grpc.internal;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.grpc.ForwardingTestUtil;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Method;
@@ -101,7 +101,7 @@ public class ForwardingReadableBufferTest {
 
   @Test
   public void readBytes_overload2() throws IOException {
-    OutputStream dest = new ByteArrayOutputStream();
+    OutputStream dest = mock(OutputStream.class);
     buffer.readBytes(dest, 1);
 
     verify(delegate).readBytes(dest, 1);

--- a/core/src/test/java/io/grpc/internal/ForwardingReadableBufferTest.java
+++ b/core/src/test/java/io/grpc/internal/ForwardingReadableBufferTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import io.grpc.ForwardingTestUtil;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.util.Collections;

--- a/core/src/test/java/io/grpc/internal/ForwardingReadableBufferTest.java
+++ b/core/src/test/java/io/grpc/internal/ForwardingReadableBufferTest.java
@@ -17,13 +17,12 @@
 package io.grpc.internal;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.grpc.ForwardingTestUtil;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -36,13 +35,10 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-/**
- * Tests for {@link ForwardingReadableBuffer}.
- */
+/** Tests for {@link ForwardingReadableBuffer}. */
 @RunWith(JUnit4.class)
 public class ForwardingReadableBufferTest {
-  @Rule
-  public final MockitoRule mocks = MockitoJUnit.rule();
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
 
   @Mock private ReadableBuffer delegate;
   private ForwardingReadableBuffer buffer;
@@ -55,10 +51,7 @@ public class ForwardingReadableBufferTest {
   @Test
   public void allMethodsForwarded() throws Exception {
     ForwardingTestUtil.testMethodsForwarded(
-        ReadableBuffer.class,
-        delegate,
-        buffer,
-        Collections.<Method>emptyList());
+        ReadableBuffer.class, delegate, buffer, Collections.<Method>emptyList());
   }
 
   @Test
@@ -99,7 +92,7 @@ public class ForwardingReadableBufferTest {
 
   @Test
   public void readBytes_overload1() {
-    ByteBuffer dest = mock(ByteBuffer.class);
+    ByteBuffer dest = ByteBuffer.allocate(0);
     buffer.readBytes(dest);
 
     verify(delegate).readBytes(dest);
@@ -107,7 +100,7 @@ public class ForwardingReadableBufferTest {
 
   @Test
   public void readBytes_overload2() throws IOException {
-    OutputStream dest = mock(OutputStream.class);
+    OutputStream dest = new ByteArrayOutputStream();
     buffer.readBytes(dest, 1);
 
     verify(delegate).readBytes(dest, 1);


### PR DESCRIPTION
My motivation for making this change is that [`ByteBuffer` is becoming
`sealed`](https://download.java.net/java/early_access/loom/docs/api/java.base/java/nio/ByteBuffer.html)
in new versions of Java. This makes it impossible for Mockito's
_current_ default mockmaker to mock it.

That said, Mockito will likely [switch its default
mockmaker](https://github.com/mockito/mockito/issues/2589) to an
alternative that _is_ able to mock `sealed` classes. However, there are
downside to that, such as [slower
performance](https://github.com/mockito/mockito/issues/2589#issuecomment-1192725206),
so it's probably better to leave our options open by avoiding mocking at
all.

And in this case, it's equally easy to use real objects.

As a bonus, I think that real objects makes the code a little easier to
follow: Before, we created mocks that the code under test never
interacted with in any way. (The code just passed them through to a
delegate.) When I first read the tests, I was confused, since I assumed
that the mock we were creating was the same mock that we then passed to
`verify` at the end of the method. That turned out not to be the case.

Given that, I figured I'd switch not only to a real `ByteBuffer` but
also to a real `OutputStream`.