### PR TITLE
xds: rename Sds to Security or Xds in various classes to eliminate references to SDS

### DIFF
--- a/xds/src/main/java/io/grpc/xds/FilterChainMatchingProtocolNegotiators.java
+++ b/xds/src/main/java/io/grpc/xds/FilterChainMatchingProtocolNegotiators.java
@@ -20,7 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static io.grpc.xds.InternalXdsAttributes.ATTR_DRAIN_GRACE_NANOS;
 import static io.grpc.xds.InternalXdsAttributes.ATTR_FILTER_CHAIN_SELECTOR_MANAGER;
 import static io.grpc.xds.XdsServerWrapper.ATTR_SERVER_ROUTING_CONFIG;
-import static io.grpc.xds.internal.sds.SdsProtocolNegotiators.ATTR_SERVER_SSL_CONTEXT_PROVIDER_SUPPLIER;
+import static io.grpc.xds.internal.sds.SecurityProtocolNegotiators.ATTR_SERVER_SSL_CONTEXT_PROVIDER_SUPPLIER;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;

--- a/xds/src/main/java/io/grpc/xds/XdsChannelCredentials.java
+++ b/xds/src/main/java/io/grpc/xds/XdsChannelCredentials.java
@@ -22,7 +22,7 @@ import io.grpc.ChannelCredentials;
 import io.grpc.ExperimentalApi;
 import io.grpc.netty.InternalNettyChannelCredentials;
 import io.grpc.netty.InternalProtocolNegotiator;
-import io.grpc.xds.internal.sds.SdsProtocolNegotiators;
+import io.grpc.xds.internal.sds.SecurityProtocolNegotiators;
 
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/7514")
 public class XdsChannelCredentials {
@@ -40,6 +40,6 @@ public class XdsChannelCredentials {
     InternalProtocolNegotiator.ClientFactory fallbackNegotiator =
         InternalNettyChannelCredentials.toNegotiator(checkNotNull(fallback, "fallback"));
     return InternalNettyChannelCredentials.create(
-        SdsProtocolNegotiators.clientProtocolNegotiatorFactory(fallbackNegotiator));
+        SecurityProtocolNegotiators.clientProtocolNegotiatorFactory(fallbackNegotiator));
   }
 }

--- a/xds/src/main/java/io/grpc/xds/XdsServerCredentials.java
+++ b/xds/src/main/java/io/grpc/xds/XdsServerCredentials.java
@@ -22,7 +22,7 @@ import io.grpc.ExperimentalApi;
 import io.grpc.ServerCredentials;
 import io.grpc.netty.InternalNettyServerCredentials;
 import io.grpc.netty.InternalProtocolNegotiator;
-import io.grpc.xds.internal.sds.SdsProtocolNegotiators;
+import io.grpc.xds.internal.sds.SecurityProtocolNegotiators;
 
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/7514")
 public class XdsServerCredentials {
@@ -40,6 +40,6 @@ public class XdsServerCredentials {
     InternalProtocolNegotiator.ServerFactory fallbackNegotiator =
         InternalNettyServerCredentials.toNegotiator(checkNotNull(fallback, "fallback"));
     return InternalNettyServerCredentials.create(
-        SdsProtocolNegotiators.serverProtocolNegotiatorFactory(fallbackNegotiator));
+        SecurityProtocolNegotiators.serverProtocolNegotiatorFactory(fallbackNegotiator));
   }
 }

--- a/xds/src/main/java/io/grpc/xds/internal/certprovider/CertProviderClientSslContextProvider.java
+++ b/xds/src/main/java/io/grpc/xds/internal/certprovider/CertProviderClientSslContextProvider.java
@@ -26,7 +26,7 @@ import io.grpc.Internal;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.xds.Bootstrapper.CertificateProviderInfo;
 import io.grpc.xds.EnvoyServerProtoData.UpstreamTlsContext;
-import io.grpc.xds.internal.sds.trust.SdsTrustManagerFactory;
+import io.grpc.xds.internal.sds.trust.XdsTrustManagerFactory;
 import io.netty.handler.ssl.SslContextBuilder;
 import java.security.cert.CertStoreException;
 import java.security.cert.X509Certificate;
@@ -62,7 +62,7 @@ public final class CertProviderClientSslContextProvider extends CertProviderSslC
     SslContextBuilder sslContextBuilder =
         GrpcSslContexts.forClient()
             .trustManager(
-                new SdsTrustManagerFactory(
+                new XdsTrustManagerFactory(
                     savedTrustedRoots.toArray(new X509Certificate[0]),
                     certificateValidationContextdationContext));
     if (isMtls()) {

--- a/xds/src/main/java/io/grpc/xds/internal/certprovider/CertProviderServerSslContextProvider.java
+++ b/xds/src/main/java/io/grpc/xds/internal/certprovider/CertProviderServerSslContextProvider.java
@@ -26,7 +26,7 @@ import io.grpc.Internal;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.xds.Bootstrapper.CertificateProviderInfo;
 import io.grpc.xds.EnvoyServerProtoData.DownstreamTlsContext;
-import io.grpc.xds.internal.sds.trust.SdsTrustManagerFactory;
+import io.grpc.xds.internal.sds.trust.XdsTrustManagerFactory;
 import io.netty.handler.ssl.SslContextBuilder;
 
 import java.io.IOException;
@@ -66,7 +66,7 @@ public final class CertProviderServerSslContextProvider extends CertProviderSslC
     setClientAuthValues(
         sslContextBuilder,
         isMtls()
-            ? new SdsTrustManagerFactory(
+            ? new XdsTrustManagerFactory(
                 savedTrustedRoots.toArray(new X509Certificate[0]),
                 certificateValidationContextdationContext)
             : null);

--- a/xds/src/main/java/io/grpc/xds/internal/sds/SecurityProtocolNegotiators.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/SecurityProtocolNegotiators.java
@@ -48,13 +48,14 @@ import javax.annotation.Nullable;
  * context.
  */
 @VisibleForTesting
-public final class SdsProtocolNegotiators {
+public final class SecurityProtocolNegotiators {
 
   // Prevent instantiation.
-  private SdsProtocolNegotiators() {
+  private SecurityProtocolNegotiators() {
   }
 
-  private static final Logger logger = Logger.getLogger(SdsProtocolNegotiators.class.getName());
+  private static final Logger logger
+      = Logger.getLogger(SecurityProtocolNegotiators.class.getName());
 
   private static final AsciiString SCHEME = AsciiString.of("http");
 

--- a/xds/src/main/java/io/grpc/xds/internal/sds/SslContextProvider.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/SslContextProvider.java
@@ -24,7 +24,7 @@ import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext;
 import io.grpc.xds.EnvoyServerProtoData.BaseTlsContext;
 import io.grpc.xds.EnvoyServerProtoData.DownstreamTlsContext;
 import io.grpc.xds.EnvoyServerProtoData.UpstreamTlsContext;
-import io.grpc.xds.internal.sds.trust.SdsTrustManagerFactory;
+import io.grpc.xds.internal.sds.trust.XdsTrustManagerFactory;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
@@ -70,11 +70,11 @@ public abstract class SslContextProvider implements Closeable {
   }
 
   protected void setClientAuthValues(
-      SslContextBuilder sslContextBuilder, SdsTrustManagerFactory sdsTrustManagerFactory)
+      SslContextBuilder sslContextBuilder, XdsTrustManagerFactory xdsTrustManagerFactory)
       throws CertificateException, IOException, CertStoreException {
     DownstreamTlsContext downstreamTlsContext = getDownstreamTlsContext();
-    if (sdsTrustManagerFactory != null) {
-      sslContextBuilder.trustManager(sdsTrustManagerFactory);
+    if (xdsTrustManagerFactory != null) {
+      sslContextBuilder.trustManager(xdsTrustManagerFactory);
       sslContextBuilder.clientAuth(
           downstreamTlsContext.isRequireClientCertificate()
               ? ClientAuth.REQUIRE

--- a/xds/src/main/java/io/grpc/xds/internal/sds/SslContextProviderSupplier.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/SslContextProviderSupplier.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 
 /**
  * Enables Client or server side to initialize this object with the received {@link BaseTlsContext}
- * and communicate it to the consumer i.e. {@link SdsProtocolNegotiators}
+ * and communicate it to the consumer i.e. {@link SecurityProtocolNegotiators}
  * to lazily evaluate the {@link SslContextProvider}. The supplier prevents credentials leakage in
  * cases where the user is not using xDS credentials but the client/server contains a non-default
  * {@link BaseTlsContext}.

--- a/xds/src/main/java/io/grpc/xds/internal/sds/trust/XdsTrustManagerFactory.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/trust/XdsTrustManagerFactory.java
@@ -43,15 +43,15 @@ import javax.net.ssl.X509ExtendedTrustManager;
 
 /**
  * Factory class used by providers of {@link TlsContextManagerImpl} to provide a
- * {@link SdsX509TrustManager} for trust and SAN checks.
+ * {@link XdsX509TrustManager} for trust and SAN checks.
  */
-public final class SdsTrustManagerFactory extends SimpleTrustManagerFactory {
+public final class XdsTrustManagerFactory extends SimpleTrustManagerFactory {
 
-  private static final Logger logger = Logger.getLogger(SdsTrustManagerFactory.class.getName());
-  private SdsX509TrustManager sdsX509TrustManager;
+  private static final Logger logger = Logger.getLogger(XdsTrustManagerFactory.class.getName());
+  private XdsX509TrustManager xdsX509TrustManager;
 
   /** Constructor constructs from a {@link CertificateValidationContext}. */
-  public SdsTrustManagerFactory(CertificateValidationContext certificateValidationContext)
+  public XdsTrustManagerFactory(CertificateValidationContext certificateValidationContext)
       throws CertificateException, IOException, CertStoreException {
     this(
         getTrustedCaFromCertContext(certificateValidationContext),
@@ -59,13 +59,13 @@ public final class SdsTrustManagerFactory extends SimpleTrustManagerFactory {
         false);
   }
 
-  public SdsTrustManagerFactory(
+  public XdsTrustManagerFactory(
           X509Certificate[] certs, CertificateValidationContext staticCertificateValidationContext)
           throws CertStoreException {
     this(certs, staticCertificateValidationContext, true);
   }
 
-  private SdsTrustManagerFactory(
+  private XdsTrustManagerFactory(
       X509Certificate[] certs,
       CertificateValidationContext certificateValidationContext,
       boolean validationContextIsStatic)
@@ -75,7 +75,7 @@ public final class SdsTrustManagerFactory extends SimpleTrustManagerFactory {
           certificateValidationContext == null || !certificateValidationContext.hasTrustedCa(),
           "only static certificateValidationContext expected");
     }
-    sdsX509TrustManager = createSdsX509TrustManager(certs, certificateValidationContext);
+    xdsX509TrustManager = createSdsX509TrustManager(certs, certificateValidationContext);
   }
 
   private static X509Certificate[] getTrustedCaFromCertContext(
@@ -100,7 +100,7 @@ public final class SdsTrustManagerFactory extends SimpleTrustManagerFactory {
   }
 
   @VisibleForTesting
-  static SdsX509TrustManager createSdsX509TrustManager(
+  static XdsX509TrustManager createSdsX509TrustManager(
       X509Certificate[] certs, CertificateValidationContext certContext) throws CertStoreException {
     TrustManagerFactory tmf = null;
     try {
@@ -133,7 +133,7 @@ public final class SdsTrustManagerFactory extends SimpleTrustManagerFactory {
     if (myDelegate == null) {
       throw new CertStoreException("Native X509 TrustManager not found.");
     }
-    return new SdsX509TrustManager(certContext, myDelegate);
+    return new XdsX509TrustManager(certContext, myDelegate);
   }
 
   @Override
@@ -148,6 +148,6 @@ public final class SdsTrustManagerFactory extends SimpleTrustManagerFactory {
 
   @Override
   protected TrustManager[] engineGetTrustManagers() {
-    return new TrustManager[] {sdsX509TrustManager};
+    return new TrustManager[] {xdsX509TrustManager};
   }
 }

--- a/xds/src/main/java/io/grpc/xds/internal/sds/trust/XdsX509TrustManager.java
+++ b/xds/src/main/java/io/grpc/xds/internal/sds/trust/XdsX509TrustManager.java
@@ -41,7 +41,7 @@ import javax.net.ssl.X509TrustManager;
  * Extension of {@link X509ExtendedTrustManager} that implements verification of
  * SANs (subject-alternate-names) against the list in CertificateValidationContext.
  */
-final class SdsX509TrustManager extends X509ExtendedTrustManager implements X509TrustManager {
+final class XdsX509TrustManager extends X509ExtendedTrustManager implements X509TrustManager {
 
   // ref: io.grpc.okhttp.internal.OkHostnameVerifier and
   // sun.security.x509.GeneralNameInterface
@@ -52,8 +52,8 @@ final class SdsX509TrustManager extends X509ExtendedTrustManager implements X509
   private final X509ExtendedTrustManager delegate;
   private final CertificateValidationContext certContext;
 
-  SdsX509TrustManager(@Nullable CertificateValidationContext certContext,
-      X509ExtendedTrustManager delegate) {
+  XdsX509TrustManager(@Nullable CertificateValidationContext certContext,
+                      X509ExtendedTrustManager delegate) {
     checkNotNull(delegate, "delegate");
     this.certContext = certContext;
     this.delegate = delegate;

--- a/xds/src/test/java/io/grpc/xds/FilterChainMatchingProtocolNegotiatorsTest.java
+++ b/xds/src/test/java/io/grpc/xds/FilterChainMatchingProtocolNegotiatorsTest.java
@@ -18,7 +18,7 @@ package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.xds.XdsServerWrapper.ATTR_SERVER_ROUTING_CONFIG;
-import static io.grpc.xds.internal.sds.SdsProtocolNegotiators.ATTR_SERVER_SSL_CONTEXT_PROVIDER_SUPPLIER;
+import static io.grpc.xds.internal.sds.SecurityProtocolNegotiators.ATTR_SERVER_SSL_CONTEXT_PROVIDER_SUPPLIER;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/xds/src/test/java/io/grpc/xds/XdsClientWrapperForServerSdsTestMisc.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientWrapperForServerSdsTestMisc.java
@@ -18,7 +18,7 @@ package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.xds.FilterChainMatchingProtocolNegotiators.FilterChainMatchingHandler.FilterChainSelector.NO_FILTER_CHAIN;
-import static io.grpc.xds.internal.sds.SdsProtocolNegotiators.ATTR_SERVER_SSL_CONTEXT_PROVIDER_SUPPLIER;
+import static io.grpc.xds.internal.sds.SecurityProtocolNegotiators.ATTR_SERVER_SSL_CONTEXT_PROVIDER_SUPPLIER;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;

--- a/xds/src/test/java/io/grpc/xds/internal/sds/SecurityProtocolNegotiatorsTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/sds/SecurityProtocolNegotiatorsTest.java
@@ -22,7 +22,7 @@ import static io.grpc.xds.internal.sds.CommonTlsContextTestsUtil.CLIENT_KEY_FILE
 import static io.grpc.xds.internal.sds.CommonTlsContextTestsUtil.CLIENT_PEM_FILE;
 import static io.grpc.xds.internal.sds.CommonTlsContextTestsUtil.SERVER_1_KEY_FILE;
 import static io.grpc.xds.internal.sds.CommonTlsContextTestsUtil.SERVER_1_PEM_FILE;
-import static io.grpc.xds.internal.sds.SdsProtocolNegotiators.ATTR_SERVER_SSL_CONTEXT_PROVIDER_SUPPLIER;
+import static io.grpc.xds.internal.sds.SecurityProtocolNegotiators.ATTR_SERVER_SSL_CONTEXT_PROVIDER_SUPPLIER;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -52,8 +52,8 @@ import io.grpc.xds.EnvoyServerProtoData.UpstreamTlsContext;
 import io.grpc.xds.InternalXdsAttributes;
 import io.grpc.xds.TlsContextManager;
 import io.grpc.xds.internal.certprovider.CommonCertProviderTestUtils;
-import io.grpc.xds.internal.sds.SdsProtocolNegotiators.ClientSdsHandler;
-import io.grpc.xds.internal.sds.SdsProtocolNegotiators.ClientSdsProtocolNegotiator;
+import io.grpc.xds.internal.sds.SecurityProtocolNegotiators.ClientSdsHandler;
+import io.grpc.xds.internal.sds.SecurityProtocolNegotiators.ClientSdsProtocolNegotiator;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
@@ -83,9 +83,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link SdsProtocolNegotiators}. */
+/** Unit tests for {@link SecurityProtocolNegotiators}. */
 @RunWith(JUnit4.class)
-public class SdsProtocolNegotiatorsTest {
+public class SecurityProtocolNegotiatorsTest {
 
   private final GrpcHttp2ConnectionHandler grpcHandler =
       FakeGrpcHttp2ConnectionHandler.newHandler();
@@ -156,8 +156,8 @@ public class SdsProtocolNegotiatorsTest {
     SslContextProviderSupplier sslContextProviderSupplier =
         new SslContextProviderSupplier(upstreamTlsContext,
             new TlsContextManagerImpl(bootstrapInfoForClient));
-    SdsProtocolNegotiators.ClientSdsHandler clientSdsHandler =
-        new SdsProtocolNegotiators.ClientSdsHandler(grpcHandler, sslContextProviderSupplier);
+    SecurityProtocolNegotiators.ClientSdsHandler clientSdsHandler =
+        new SecurityProtocolNegotiators.ClientSdsHandler(grpcHandler, sslContextProviderSupplier);
     pipeline.addLast(clientSdsHandler);
     channelHandlerCtx = pipeline.context(clientSdsHandler);
     assertNotNull(channelHandlerCtx); // clientSdsHandler ctx is non-null since we just added it
@@ -221,8 +221,8 @@ public class SdsProtocolNegotiatorsTest {
             "google_cloud_private_spiffe-server", true, true);
 
     TlsContextManagerImpl tlsContextManager = new TlsContextManagerImpl(bootstrapInfoForServer);
-    SdsProtocolNegotiators.HandlerPickerHandler handlerPickerHandler =
-        new SdsProtocolNegotiators.HandlerPickerHandler(grpcHandler,
+    SecurityProtocolNegotiators.HandlerPickerHandler handlerPickerHandler =
+        new SecurityProtocolNegotiators.HandlerPickerHandler(grpcHandler,
                 InternalProtocolNegotiators.serverPlaintext());
     pipeline.addLast(handlerPickerHandler);
     channelHandlerCtx = pipeline.context(handlerPickerHandler);
@@ -236,7 +236,7 @@ public class SdsProtocolNegotiatorsTest {
     pipeline.fireUserEventTriggered(InternalProtocolNegotiationEvent.withAttributes(event, attr));
     channelHandlerCtx = pipeline.context(handlerPickerHandler);
     assertThat(channelHandlerCtx).isNull();
-    channelHandlerCtx = pipeline.context(SdsProtocolNegotiators.ServerSdsHandler.class);
+    channelHandlerCtx = pipeline.context(SecurityProtocolNegotiators.ServerSdsHandler.class);
     assertThat(channelHandlerCtx).isNotNull();
 
     SslContextProviderSupplier sslContextProviderSupplier =
@@ -259,7 +259,7 @@ public class SdsProtocolNegotiatorsTest {
     Object fromFuture = future.get(2, TimeUnit.SECONDS);
     assertThat(fromFuture).isInstanceOf(SslContext.class);
     channel.runPendingTasks();
-    channelHandlerCtx = pipeline.context(SdsProtocolNegotiators.ServerSdsHandler.class);
+    channelHandlerCtx = pipeline.context(SecurityProtocolNegotiators.ServerSdsHandler.class);
     assertThat(channelHandlerCtx).isNull();
 
     // pipeline should only have SslHandler and ServerTlsHandler
@@ -287,8 +287,8 @@ public class SdsProtocolNegotiatorsTest {
         };
     pipeline = channel.pipeline();
 
-    SdsProtocolNegotiators.HandlerPickerHandler handlerPickerHandler =
-        new SdsProtocolNegotiators.HandlerPickerHandler(
+    SecurityProtocolNegotiators.HandlerPickerHandler handlerPickerHandler =
+        new SecurityProtocolNegotiators.HandlerPickerHandler(
             grpcHandler, mockProtocolNegotiator);
     pipeline.addLast(handlerPickerHandler);
     channelHandlerCtx = pipeline.context(handlerPickerHandler);
@@ -313,8 +313,8 @@ public class SdsProtocolNegotiatorsTest {
     ChannelHandler mockChannelHandler = mock(ChannelHandler.class);
     ProtocolNegotiator mockProtocolNegotiator = mock(ProtocolNegotiator.class);
     when(mockProtocolNegotiator.newHandler(grpcHandler)).thenReturn(mockChannelHandler);
-    SdsProtocolNegotiators.HandlerPickerHandler handlerPickerHandler =
-        new SdsProtocolNegotiators.HandlerPickerHandler(
+    SecurityProtocolNegotiators.HandlerPickerHandler handlerPickerHandler =
+        new SecurityProtocolNegotiators.HandlerPickerHandler(
             grpcHandler, mockProtocolNegotiator);
     pipeline.addLast(handlerPickerHandler);
     channelHandlerCtx = pipeline.context(handlerPickerHandler);
@@ -333,8 +333,8 @@ public class SdsProtocolNegotiatorsTest {
 
   @Test
   public void nullTlsContext_nullFallbackProtocolNegotiator_expectException() {
-    SdsProtocolNegotiators.HandlerPickerHandler handlerPickerHandler =
-        new SdsProtocolNegotiators.HandlerPickerHandler(
+    SecurityProtocolNegotiators.HandlerPickerHandler handlerPickerHandler =
+        new SecurityProtocolNegotiators.HandlerPickerHandler(
             grpcHandler, null);
     pipeline.addLast(handlerPickerHandler);
     channelHandlerCtx = pipeline.context(handlerPickerHandler);
@@ -368,8 +368,8 @@ public class SdsProtocolNegotiatorsTest {
     SslContextProviderSupplier sslContextProviderSupplier =
         new SslContextProviderSupplier(upstreamTlsContext,
             new TlsContextManagerImpl(bootstrapInfoForClient));
-    SdsProtocolNegotiators.ClientSdsHandler clientSdsHandler =
-        new SdsProtocolNegotiators.ClientSdsHandler(grpcHandler, sslContextProviderSupplier);
+    SecurityProtocolNegotiators.ClientSdsHandler clientSdsHandler =
+        new SecurityProtocolNegotiators.ClientSdsHandler(grpcHandler, sslContextProviderSupplier);
 
     pipeline.addLast(clientSdsHandler);
     channelHandlerCtx = pipeline.context(clientSdsHandler);

--- a/xds/src/test/java/io/grpc/xds/internal/sds/trust/XdsTrustManagerFactoryTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/sds/trust/XdsTrustManagerFactoryTest.java
@@ -38,22 +38,22 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link SdsTrustManagerFactory}. */
+/** Unit tests for {@link XdsTrustManagerFactory}. */
 @RunWith(JUnit4.class)
-public class SdsTrustManagerFactoryTest {
+public class XdsTrustManagerFactoryTest {
 
   @Test
   public void constructor_fromFile() throws CertificateException, IOException, CertStoreException {
-    SdsTrustManagerFactory factory =
-        new SdsTrustManagerFactory(getCertContextFromPath(CA_PEM_FILE));
+    XdsTrustManagerFactory factory =
+        new XdsTrustManagerFactory(getCertContextFromPath(CA_PEM_FILE));
     assertThat(factory).isNotNull();
     TrustManager[] tms = factory.getTrustManagers();
     assertThat(tms).isNotNull();
     assertThat(tms).hasLength(1);
     TrustManager myTm = tms[0];
-    assertThat(myTm).isInstanceOf(SdsX509TrustManager.class);
-    SdsX509TrustManager sdsX509TrustManager = (SdsX509TrustManager) myTm;
-    X509Certificate[] acceptedIssuers = sdsX509TrustManager.getAcceptedIssuers();
+    assertThat(myTm).isInstanceOf(XdsX509TrustManager.class);
+    XdsX509TrustManager xdsX509TrustManager = (XdsX509TrustManager) myTm;
+    X509Certificate[] acceptedIssuers = xdsX509TrustManager.getAcceptedIssuers();
     assertThat(acceptedIssuers).isNotNull();
     assertThat(acceptedIssuers).hasLength(1);
     X509Certificate caCert = acceptedIssuers[0];
@@ -64,16 +64,16 @@ public class SdsTrustManagerFactoryTest {
   @Test
   public void constructor_fromInlineBytes()
       throws CertificateException, IOException, CertStoreException {
-    SdsTrustManagerFactory factory =
-        new SdsTrustManagerFactory(getCertContextFromPathAsInlineBytes(CA_PEM_FILE));
+    XdsTrustManagerFactory factory =
+        new XdsTrustManagerFactory(getCertContextFromPathAsInlineBytes(CA_PEM_FILE));
     assertThat(factory).isNotNull();
     TrustManager[] tms = factory.getTrustManagers();
     assertThat(tms).isNotNull();
     assertThat(tms).hasLength(1);
     TrustManager myTm = tms[0];
-    assertThat(myTm).isInstanceOf(SdsX509TrustManager.class);
-    SdsX509TrustManager sdsX509TrustManager = (SdsX509TrustManager) myTm;
-    X509Certificate[] acceptedIssuers = sdsX509TrustManager.getAcceptedIssuers();
+    assertThat(myTm).isInstanceOf(XdsX509TrustManager.class);
+    XdsX509TrustManager xdsX509TrustManager = (XdsX509TrustManager) myTm;
+    X509Certificate[] acceptedIssuers = xdsX509TrustManager.getAcceptedIssuers();
     assertThat(acceptedIssuers).isNotNull();
     assertThat(acceptedIssuers).hasLength(1);
     X509Certificate caCert = acceptedIssuers[0];
@@ -87,16 +87,16 @@ public class SdsTrustManagerFactoryTest {
     X509Certificate x509Cert = TestUtils.loadX509Cert(CA_PEM_FILE);
     CertificateValidationContext staticValidationContext = buildStaticValidationContext("san1",
         "san2");
-    SdsTrustManagerFactory factory =
-        new SdsTrustManagerFactory(new X509Certificate[]{x509Cert}, staticValidationContext);
+    XdsTrustManagerFactory factory =
+        new XdsTrustManagerFactory(new X509Certificate[]{x509Cert}, staticValidationContext);
     assertThat(factory).isNotNull();
     TrustManager[] tms = factory.getTrustManagers();
     assertThat(tms).isNotNull();
     assertThat(tms).hasLength(1);
     TrustManager myTm = tms[0];
-    assertThat(myTm).isInstanceOf(SdsX509TrustManager.class);
-    SdsX509TrustManager sdsX509TrustManager = (SdsX509TrustManager) myTm;
-    X509Certificate[] acceptedIssuers = sdsX509TrustManager.getAcceptedIssuers();
+    assertThat(myTm).isInstanceOf(XdsX509TrustManager.class);
+    XdsX509TrustManager xdsX509TrustManager = (XdsX509TrustManager) myTm;
+    X509Certificate[] acceptedIssuers = xdsX509TrustManager.getAcceptedIssuers();
     assertThat(acceptedIssuers).isNotNull();
     assertThat(acceptedIssuers).hasLength(1);
     X509Certificate caCert = acceptedIssuers[0];
@@ -110,12 +110,12 @@ public class SdsTrustManagerFactoryTest {
     X509Certificate x509Cert = TestUtils.loadX509Cert(CA_PEM_FILE);
     CertificateValidationContext staticValidationContext = buildStaticValidationContext("san1",
         "waterzooi.test.google.be");
-    SdsTrustManagerFactory factory =
-        new SdsTrustManagerFactory(new X509Certificate[]{x509Cert}, staticValidationContext);
-    SdsX509TrustManager sdsX509TrustManager = (SdsX509TrustManager) factory.getTrustManagers()[0];
+    XdsTrustManagerFactory factory =
+        new XdsTrustManagerFactory(new X509Certificate[]{x509Cert}, staticValidationContext);
+    XdsX509TrustManager xdsX509TrustManager = (XdsX509TrustManager) factory.getTrustManagers()[0];
     X509Certificate[] serverChain =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
-    sdsX509TrustManager.checkServerTrusted(serverChain, "RSA");
+    xdsX509TrustManager.checkServerTrusted(serverChain, "RSA");
   }
 
   @Test
@@ -123,7 +123,7 @@ public class SdsTrustManagerFactoryTest {
           throws CertificateException, IOException, CertStoreException {
     X509Certificate x509Cert = TestUtils.loadX509Cert(CA_PEM_FILE);
     try {
-      new SdsTrustManagerFactory(
+      new XdsTrustManagerFactory(
               new X509Certificate[] {x509Cert}, getCertContextFromPath(CA_PEM_FILE));
       Assert.fail("no exception thrown");
     } catch (IllegalArgumentException expected) {
@@ -139,13 +139,13 @@ public class SdsTrustManagerFactoryTest {
     X509Certificate x509Cert = TestUtils.loadX509Cert(CA_PEM_FILE);
     CertificateValidationContext staticValidationContext = buildStaticValidationContext("san1",
         "san2");
-    SdsTrustManagerFactory factory =
-        new SdsTrustManagerFactory(new X509Certificate[]{x509Cert}, staticValidationContext);
-    SdsX509TrustManager sdsX509TrustManager = (SdsX509TrustManager) factory.getTrustManagers()[0];
+    XdsTrustManagerFactory factory =
+        new XdsTrustManagerFactory(new X509Certificate[]{x509Cert}, staticValidationContext);
+    XdsX509TrustManager xdsX509TrustManager = (XdsX509TrustManager) factory.getTrustManagers()[0];
     X509Certificate[] serverChain =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     try {
-      sdsX509TrustManager.checkServerTrusted(serverChain, "RSA");
+      xdsX509TrustManager.checkServerTrusted(serverChain, "RSA");
       Assert.fail("no exception thrown");
     } catch (CertificateException expected) {
       assertThat(expected)
@@ -160,13 +160,13 @@ public class SdsTrustManagerFactoryTest {
     X509Certificate x509Cert = TestUtils.loadX509Cert(CA_PEM_FILE);
     CertificateValidationContext staticValidationContext = buildStaticValidationContext("san1",
         "san2");
-    SdsTrustManagerFactory factory =
-        new SdsTrustManagerFactory(new X509Certificate[]{x509Cert}, staticValidationContext);
-    SdsX509TrustManager sdsX509TrustManager = (SdsX509TrustManager) factory.getTrustManagers()[0];
+    XdsTrustManagerFactory factory =
+        new XdsTrustManagerFactory(new X509Certificate[]{x509Cert}, staticValidationContext);
+    XdsX509TrustManager xdsX509TrustManager = (XdsX509TrustManager) factory.getTrustManagers()[0];
     X509Certificate[] clientChain =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     try {
-      sdsX509TrustManager.checkClientTrusted(clientChain, "RSA");
+      xdsX509TrustManager.checkClientTrusted(clientChain, "RSA");
       Assert.fail("no exception thrown");
     } catch (CertificateException expected) {
       assertThat(expected)
@@ -178,35 +178,35 @@ public class SdsTrustManagerFactoryTest {
   @Test
   public void checkServerTrusted_goodCert()
       throws CertificateException, IOException, CertStoreException {
-    SdsTrustManagerFactory factory =
-        new SdsTrustManagerFactory(getCertContextFromPath(CA_PEM_FILE));
-    SdsX509TrustManager sdsX509TrustManager = (SdsX509TrustManager) factory.getTrustManagers()[0];
+    XdsTrustManagerFactory factory =
+        new XdsTrustManagerFactory(getCertContextFromPath(CA_PEM_FILE));
+    XdsX509TrustManager xdsX509TrustManager = (XdsX509TrustManager) factory.getTrustManagers()[0];
     X509Certificate[] serverChain =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
-    sdsX509TrustManager.checkServerTrusted(serverChain, "RSA");
+    xdsX509TrustManager.checkServerTrusted(serverChain, "RSA");
   }
 
   @Test
   public void checkClientTrusted_goodCert()
       throws CertificateException, IOException, CertStoreException {
-    SdsTrustManagerFactory factory =
-        new SdsTrustManagerFactory(getCertContextFromPath(CA_PEM_FILE));
-    SdsX509TrustManager sdsX509TrustManager = (SdsX509TrustManager) factory.getTrustManagers()[0];
+    XdsTrustManagerFactory factory =
+        new XdsTrustManagerFactory(getCertContextFromPath(CA_PEM_FILE));
+    XdsX509TrustManager xdsX509TrustManager = (XdsX509TrustManager) factory.getTrustManagers()[0];
     X509Certificate[] clientChain =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(CLIENT_PEM_FILE));
-    sdsX509TrustManager.checkClientTrusted(clientChain, "RSA");
+    xdsX509TrustManager.checkClientTrusted(clientChain, "RSA");
   }
 
   @Test
   public void checkServerTrusted_badCert_throwsException()
       throws CertificateException, IOException, CertStoreException {
-    SdsTrustManagerFactory factory =
-        new SdsTrustManagerFactory(getCertContextFromPath(CA_PEM_FILE));
-    SdsX509TrustManager sdsX509TrustManager = (SdsX509TrustManager) factory.getTrustManagers()[0];
+    XdsTrustManagerFactory factory =
+        new XdsTrustManagerFactory(getCertContextFromPath(CA_PEM_FILE));
+    XdsX509TrustManager xdsX509TrustManager = (XdsX509TrustManager) factory.getTrustManagers()[0];
     X509Certificate[] serverChain =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(BAD_SERVER_PEM_FILE));
     try {
-      sdsX509TrustManager.checkServerTrusted(serverChain, "RSA");
+      xdsX509TrustManager.checkServerTrusted(serverChain, "RSA");
       Assert.fail("no exception thrown");
     } catch (CertificateException expected) {
       assertThat(expected)
@@ -218,13 +218,13 @@ public class SdsTrustManagerFactoryTest {
   @Test
   public void checkClientTrusted_badCert_throwsException()
       throws CertificateException, IOException, CertStoreException {
-    SdsTrustManagerFactory factory =
-        new SdsTrustManagerFactory(getCertContextFromPath(CA_PEM_FILE));
-    SdsX509TrustManager sdsX509TrustManager = (SdsX509TrustManager) factory.getTrustManagers()[0];
+    XdsTrustManagerFactory factory =
+        new XdsTrustManagerFactory(getCertContextFromPath(CA_PEM_FILE));
+    XdsX509TrustManager xdsX509TrustManager = (XdsX509TrustManager) factory.getTrustManagers()[0];
     X509Certificate[] clientChain =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(BAD_CLIENT_PEM_FILE));
     try {
-      sdsX509TrustManager.checkClientTrusted(clientChain, "RSA");
+      xdsX509TrustManager.checkClientTrusted(clientChain, "RSA");
       Assert.fail("no exception thrown");
     } catch (CertificateException expected) {
       assertThat(expected)

--- a/xds/src/test/java/io/grpc/xds/internal/sds/trust/XdsX509TrustManagerTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/sds/trust/XdsX509TrustManagerTest.java
@@ -54,10 +54,10 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 /**
- * Unit tests for {@link SdsX509TrustManager}.
+ * Unit tests for {@link XdsX509TrustManager}.
  */
 @RunWith(JUnit4.class)
-public class SdsX509TrustManagerTest {
+public class XdsX509TrustManagerTest {
 
   @Rule
   public final MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -68,11 +68,11 @@ public class SdsX509TrustManagerTest {
   @Mock
   private SSLSession mockSession;
 
-  private SdsX509TrustManager trustManager;
+  private XdsX509TrustManager trustManager;
 
   @Test
   public void nullCertContextTest() throws CertificateException, IOException {
-    trustManager = new SdsX509TrustManager(null, mockDelegate);
+    trustManager = new XdsX509TrustManager(null, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
@@ -81,7 +81,7 @@ public class SdsX509TrustManagerTest {
   @Test
   public void emptySanListContextTest() throws CertificateException, IOException {
     CertificateValidationContext certContext = CertificateValidationContext.getDefaultInstance();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
@@ -93,7 +93,7 @@ public class SdsX509TrustManagerTest {
     @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     try {
       trustManager.verifySubjectAltNameInChain(null);
       fail("no exception thrown");
@@ -108,7 +108,7 @@ public class SdsX509TrustManagerTest {
     @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     try {
       trustManager.verifySubjectAltNameInChain(new X509Certificate[0]);
       fail("no exception thrown");
@@ -123,7 +123,7 @@ public class SdsX509TrustManagerTest {
     @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(CLIENT_PEM_FILE));
     try {
@@ -144,7 +144,7 @@ public class SdsX509TrustManagerTest {
     @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
@@ -161,7 +161,7 @@ public class SdsX509TrustManagerTest {
     @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     try {
@@ -179,7 +179,7 @@ public class SdsX509TrustManagerTest {
     @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
@@ -195,7 +195,7 @@ public class SdsX509TrustManagerTest {
     @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
@@ -209,7 +209,7 @@ public class SdsX509TrustManagerTest {
     @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     try {
@@ -230,7 +230,7 @@ public class SdsX509TrustManagerTest {
     @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
@@ -243,7 +243,7 @@ public class SdsX509TrustManagerTest {
     @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
@@ -257,7 +257,7 @@ public class SdsX509TrustManagerTest {
     @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     try {
@@ -275,7 +275,7 @@ public class SdsX509TrustManagerTest {
     @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
@@ -288,7 +288,7 @@ public class SdsX509TrustManagerTest {
     @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
@@ -302,7 +302,7 @@ public class SdsX509TrustManagerTest {
     @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     try {
@@ -320,7 +320,7 @@ public class SdsX509TrustManagerTest {
     @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
@@ -336,7 +336,7 @@ public class SdsX509TrustManagerTest {
     @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
@@ -352,7 +352,7 @@ public class SdsX509TrustManagerTest {
     @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
@@ -368,7 +368,7 @@ public class SdsX509TrustManagerTest {
     @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
@@ -384,7 +384,7 @@ public class SdsX509TrustManagerTest {
     @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     try {
@@ -407,7 +407,7 @@ public class SdsX509TrustManagerTest {
             .addMatchSubjectAltNames(stringMatcher)
             .addMatchSubjectAltNames(stringMatcher1)
             .build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
@@ -420,7 +420,7 @@ public class SdsX509TrustManagerTest {
     @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     try {
@@ -443,7 +443,7 @@ public class SdsX509TrustManagerTest {
             .addMatchSubjectAltNames(stringMatcher)
             .addMatchSubjectAltNames(stringMatcher1) // should match suffix test.youTube.Com
             .build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
@@ -461,7 +461,7 @@ public class SdsX509TrustManagerTest {
             .addMatchSubjectAltNames(stringMatcher)
             .addMatchSubjectAltNames(stringMatcher1) // should contain est.Google.f
             .build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
@@ -478,7 +478,7 @@ public class SdsX509TrustManagerTest {
     @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     try {
@@ -499,7 +499,7 @@ public class SdsX509TrustManagerTest {
             .addMatchSubjectAltNames(stringMatcher)
             .addMatchSubjectAltNames(stringMatcher1)
             .build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
@@ -515,7 +515,7 @@ public class SdsX509TrustManagerTest {
             .addMatchSubjectAltNames(stringMatcher)
             .addMatchSubjectAltNames(stringMatcher1)
             .build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
     try {
@@ -590,7 +590,7 @@ public class SdsX509TrustManagerTest {
     @SuppressWarnings("deprecation")
     CertificateValidationContext certContext =
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
-    trustManager = new SdsX509TrustManager(certContext, mockDelegate);
+    trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate mockCert = mock(X509Certificate.class);
 
     when(mockCert.getSubjectAlternativeNames())
@@ -629,7 +629,7 @@ public class SdsX509TrustManagerTest {
       throws CertificateException, IOException, CertStoreException {
     X509Certificate[] caCerts =
         CertificateUtils.toX509Certificates(TestUtils.loadCert(CA_PEM_FILE));
-    trustManager = SdsTrustManagerFactory.createSdsX509TrustManager(caCerts,
+    trustManager = XdsTrustManagerFactory.createSdsX509TrustManager(caCerts,
         null);
     when(mockSession.getProtocol()).thenReturn("TLSv1.2");
     when(mockSession.getPeerHost()).thenReturn("peer-host-from-mock");


### PR DESCRIPTION
1st installment.

CC @ejona86 