### PR TITLE
core: Replace inappropriate picker result status codes

### DIFF
--- a/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
+++ b/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
@@ -16,6 +16,7 @@
 
 package io.grpc.internal;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -33,6 +34,7 @@ import io.grpc.ClientStreamTracer;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.Metadata;
 import io.grpc.Status;
+import io.grpc.Status.Code;
 import io.grpc.internal.ClientStreamListener.RpcProgress;
 import io.grpc.internal.GrpcUtil.Http2Error;
 import io.grpc.testing.TestMethodDescriptors;
@@ -42,6 +44,10 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /** Unit tests for {@link GrpcUtil}. */
 @RunWith(JUnit4.class)
@@ -53,6 +59,11 @@ public class GrpcUtilTest {
 
   @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule public final ExpectedException thrown = ExpectedException.none();
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+
+  @Captor
+  private ArgumentCaptor<Status> statusCaptor;
+
 
   @Test
   public void http2ErrorForCode() {
@@ -266,13 +277,13 @@ public class GrpcUtilTest {
 
     // These are NOT appropriate for a control plane to return.
     ArrayList<Status> inappropriateStatus = Lists.newArrayList(
-        Status.INVALID_ARGUMENT,
-        Status.NOT_FOUND,
-        Status.ALREADY_EXISTS,
-        Status.FAILED_PRECONDITION,
-        Status.ABORTED,
-        Status.OUT_OF_RANGE,
-        Status.DATA_LOSS);
+        Status.INVALID_ARGUMENT.withDescription("bad one").withCause(new RuntimeException()),
+        Status.NOT_FOUND.withDescription("not here").withCause(new RuntimeException()),
+        Status.ALREADY_EXISTS.withDescription("not again").withCause(new RuntimeException()),
+        Status.FAILED_PRECONDITION.withDescription("naah").withCause(new RuntimeException()),
+        Status.ABORTED.withDescription("nope").withCause(new RuntimeException()),
+        Status.OUT_OF_RANGE.withDescription("outta range").withCause(new RuntimeException()),
+        Status.DATA_LOSS.withDescription("lost").withCause(new RuntimeException()));
 
     for (Status status : inappropriateStatus) {
       PickResult pickResult = PickResult.withError(status);
@@ -284,7 +295,12 @@ public class GrpcUtilTest {
       ClientStreamListener listener = mock(ClientStreamListener.class);
       stream.start(listener);
 
-      verify(listener).closed(eq(Status.INTERNAL), eq(RpcProgress.PROCESSED), any(Metadata.class));
+      verify(listener).closed(statusCaptor.capture(), eq(RpcProgress.PROCESSED),
+          any(Metadata.class));
+      Status usedStatus = statusCaptor.getValue();
+      assertThat(usedStatus.getCode()).isEqualTo(Code.INTERNAL);
+      assertThat(usedStatus.getDescription()).contains("Inappropriate status");
+      assertThat(usedStatus.getCause()).isInstanceOf(RuntimeException.class);
     }
   }
 


### PR DESCRIPTION
Certain status codes are inappropriate for a control plane to be returning and indicate a bug in the control plane. These status codes will be replaced by INTERNAL, to make it clearer to see that the control plane is misbehaving.

https://github.com/grpc/proposal/blob/master/A54-restrict-control-plane-status-codes.md