### PR TITLE
core: Don't propagate inappropriate name resolution errors.

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1898,7 +1898,11 @@ final class ManagedChannelImpl extends ManagedChannel implements
         return;
       }
 
-      helper.lb.handleNameResolutionError(error);
+      // There is a chance that name resolution failed due to an "inappropriate" error that the
+      // control plane server should have not return to the client. Those should not bleed down to
+      // the LB and end up being used as pick result errors. These error codes are replaced with
+      // INTERNAL to make it clear that an inappropriate error code has been returned.
+      helper.lb.handleNameResolutionError(GrpcUtil.replaceInappropriateControlPlaneStatus(error));
 
       scheduleExponentialBackOffInSyncContext();
     }

--- a/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
+++ b/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
@@ -405,7 +405,10 @@ public class ServiceConfigErrorHandlingTest {
     ArgumentCaptor<Status> statusCaptor =
         ArgumentCaptor.forClass(Status.class);
     verify(mockLoadBalancer).handleNameResolutionError(statusCaptor.capture());
-    assertThat(statusCaptor.getValue()).isEqualTo(error);
+    Status actualStatus = statusCaptor.getValue();
+    assertThat(actualStatus.getCode()).isEqualTo(Status.Code.INTERNAL);
+    assertThat(actualStatus.getDescription()).contains("Inappropriate status code");
+    assertThat(actualStatus.getCause()).isNull();
 
     assertThat(channel.getState(true)).isEqualTo(ConnectivityState.TRANSIENT_FAILURE);
   }


### PR DESCRIPTION
If a control plane server responds with an "inappropriate" error code during name resolution, it gets converted to an INTERNAL error to make it clear that the server is not behaving correctly.

https://github.com/grpc/proposal/blob/master/A54-restrict-control-plane-status-codes.md