### PR TITLE
core: Assure that context cancellationCause set (1.49.x backport)

### DIFF
--- a/api/src/main/java/io/grpc/InternalStatus.java
+++ b/api/src/main/java/io/grpc/InternalStatus.java
@@ -16,6 +16,8 @@
 
 package io.grpc;
 
+import javax.annotation.Nullable;
+
 /**
  * Accesses internal data.  Do not use this.
  */
@@ -34,4 +36,14 @@ public final class InternalStatus {
    */
   @Internal
   public static final Metadata.Key<Status> CODE_KEY = Status.CODE_KEY;
+
+  /**
+   * Create a new {@link StatusRuntimeException} with the internal option of skipping the filling
+   * of the stack trace.
+   */
+  @Internal
+  public static final StatusRuntimeException asRuntimeException(Status status,
+      @Nullable Metadata trailers, boolean fillInStackTrace) {
+    return new StatusRuntimeException(status, trailers, fillInStackTrace);
+  }
 }

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Charsets.UTF_8;
 import static io.grpc.internal.GrpcUtil.CONTENT_LENGTH_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -424,7 +425,7 @@ public class ServerCallImplTest {
 
     verify(callListener).onCancel();
     assertTrue(context.isCancelled());
-    assertNull(context.cancellationCause());
+    assertNotNull(context.cancellationCause());
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -130,7 +130,7 @@ public class ServerImplTest {
   private static final Context.Key<String> SERVER_TRACER_ADDED_KEY = Context.key("tracer-added");
   private static final Context.CancellableContext SERVER_CONTEXT =
       Context.ROOT.withValue(SERVER_ONLY, "yes").withCancellation();
-  private static final FakeClock.TaskFilter CONTEXT_CLOSER_TASK_FITLER =
+  private static final FakeClock.TaskFilter CONTEXT_CLOSER_TASK_FILTER =
       new FakeClock.TaskFilter() {
         @Override
         public boolean shouldAccept(Runnable runnable) {
@@ -1085,7 +1085,7 @@ public class ServerImplTest {
     assertTrue(onHalfCloseCalled.get());
 
     streamListener.closed(Status.CANCELLED);
-    assertEquals(1, executor.numPendingTasks(CONTEXT_CLOSER_TASK_FITLER));
+    assertEquals(1, executor.numPendingTasks(CONTEXT_CLOSER_TASK_FILTER));
     assertEquals(2, executor.runDueTasks());
     assertTrue(onCancelCalled.get());
 
@@ -1179,10 +1179,11 @@ public class ServerImplTest {
     assertFalse(callReference.get().isCancelled());
     assertFalse(context.get().isCancelled());
     streamListener.closed(Status.CANCELLED);
-    assertEquals(1, executor.numPendingTasks(CONTEXT_CLOSER_TASK_FITLER));
+    assertEquals(1, executor.numPendingTasks(CONTEXT_CLOSER_TASK_FILTER));
     assertEquals(2, executor.runDueTasks());
     assertTrue(callReference.get().isCancelled());
     assertTrue(context.get().isCancelled());
+    assertThat(context.get().cancellationCause()).isNotNull();
     assertTrue(contextCancelled.get());
   }
 
@@ -1208,6 +1209,7 @@ public class ServerImplTest {
     assertEquals(1, executor.runDueTasks());
     assertFalse(callReference.get().isCancelled());
     assertTrue(context.get().isCancelled());
+    assertThat(context.get().cancellationCause()).isNull();
     assertTrue(contextCancelled.get());
   }
 
@@ -1228,6 +1230,7 @@ public class ServerImplTest {
     
     assertTrue(callReference.get().isCancelled());
     assertTrue(context.get().isCancelled());
+    assertThat(context.get().cancellationCause()).isNotNull();
     assertTrue(contextCancelled.get());
   }
 


### PR DESCRIPTION
Backport of #9501

Makes sure that whenever a context is in a cancelled state, we also have
a cancellationCause