### PR TITLE
Revert "xds: prevent concurrent priority LB picker updates (#9363)"

### DIFF
--- a/xds/src/test/java/io/grpc/xds/PriorityLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/PriorityLoadBalancerTest.java
@@ -22,8 +22,8 @@ import static io.grpc.ConnectivityState.IDLE;
 import static io.grpc.ConnectivityState.READY;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 import static io.grpc.xds.XdsSubchannelPickers.BUFFER_PICKER;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doReturn;
@@ -676,7 +676,7 @@ public class PriorityLoadBalancerTest {
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
             .setLoadBalancingPolicyConfig(priorityLbConfig)
             .build());
-    verify(helper).updateBalancingState(eq(CONNECTING), eq(BUFFER_PICKER));
+    verify(helper, times(2)).updateBalancingState(eq(CONNECTING), isA(SubchannelPicker.class));
 
     // LB shutdown and subchannel state change can happen simultaneously. If shutdown runs first,
     // any further balancing state update should be ignored.
@@ -684,26 +684,6 @@ public class PriorityLoadBalancerTest {
     Helper priorityHelper0 = Iterables.getOnlyElement(fooHelpers);  // priority p0
     priorityHelper0.updateBalancingState(READY, mock(SubchannelPicker.class));
     verifyNoMoreInteractions(helper);
-  }
-
-  @Test
-  public void noDuplicateOverallBalancingStateUpdate() {
-    FakeLoadBalancerProvider fakeLbProvider = new FakeLoadBalancerProvider();
-
-    PriorityChildConfig priorityChildConfig0 =
-        new PriorityChildConfig(new PolicySelection(fakeLbProvider, new Object()), true);
-    PriorityChildConfig priorityChildConfig1 =
-        new PriorityChildConfig(new PolicySelection(fakeLbProvider, new Object()), false);
-    PriorityLbConfig priorityLbConfig =
-        new PriorityLbConfig(
-            ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1),
-            ImmutableList.of("p0", "p1"));
-    priorityLb.handleResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
-            .setLoadBalancingPolicyConfig(priorityLbConfig)
-            .build());
-    verify(helper, times(1)).updateBalancingState(any(), any());
   }
 
   private void assertLatestConnectivityState(ConnectivityState expectedState) {
@@ -733,50 +713,5 @@ public class PriorityLoadBalancerTest {
     assertLatestConnectivityState(IDLE);
     PickResult pickResult = pickerCaptor.getValue().pickSubchannel(mock(PickSubchannelArgs.class));
     assertThat(pickResult).isEqualTo(PickResult.withNoResult());
-  }
-
-  private static class FakeLoadBalancerProvider extends LoadBalancerProvider {
-
-    @Override
-    public boolean isAvailable() {
-      return true;
-    }
-
-    @Override
-    public int getPriority() {
-      return 5;
-    }
-
-    @Override
-    public String getPolicyName() {
-      return "foo";
-    }
-
-    @Override
-    public LoadBalancer newLoadBalancer(Helper helper) {
-      return new FakeLoadBalancer(helper);
-    }
-  }
-
-  static class FakeLoadBalancer extends LoadBalancer {
-
-    private Helper helper;
-
-    FakeLoadBalancer(Helper helper) {
-      this.helper = helper;
-    }
-
-    @Override
-    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-      helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(Status.INTERNAL));
-    }
-
-    @Override
-    public void handleNameResolutionError(Status error) {
-    }
-
-    @Override
-    public void shutdown() {
-    }
   }
 }


### PR DESCRIPTION
This reverts commit bcf5cde7dd31de4be3cfc8bf8264681abc8fb292.

Seems to break some tests internally - b/247115476

cc @temawi @ejona86 