### PR TITLE
core: outlier_detection LB to use acceptResolvedAddresses()

### DIFF
--- a/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
@@ -89,7 +89,7 @@ public final class OutlierDetectionLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     OutlierDetectionLoadBalancerConfig config
         = (OutlierDetectionLoadBalancerConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
 
@@ -142,6 +142,7 @@ public final class OutlierDetectionLoadBalancer extends LoadBalancer {
     switchLb.handleResolvedAddresses(
         resolvedAddresses.toBuilder().setLoadBalancingPolicyConfig(config.childPolicy.getConfig())
             .build());
+    return true;
   }
 
   @Override


### PR DESCRIPTION
Switch OutlierDetectionLoadBalancer to implement
acceptResolvedAddresses() to allow for the evential deprecation of handleResolvedAddresses().