### PR TITLE
xds: Avoid NPE from update after removing subscriptions

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/ClientXdsClient.java
@@ -175,8 +175,11 @@ final class ClientXdsClient extends XdsClient implements XdsResponseHandler, Res
       logger.log(XdsLogLevel.WARNING, "Ignore an unknown type of DiscoveryResponse");
       return;
     }
-    Set<String> toParseResourceNames = (resourceType == LDS || resourceType == RDS ) ? null :
-        resourceSubscribers.get(xdsResourceType).keySet();
+    Set<String> toParseResourceNames = null;
+    if (!(resourceType == LDS || resourceType == RDS)
+        && resourceSubscribers.containsKey(xdsResourceType)) {
+      toParseResourceNames = resourceSubscribers.get(xdsResourceType).keySet();
+    }
     XdsResourceType.Args args = new XdsResourceType.Args(serverInfo, versionInfo, nonce,
         bootstrapInfo, filterRegistry, loadBalancerRegistry, tlsContextManager,
         toParseResourceNames);


### PR DESCRIPTION
This fixes a regression in commit e1ad984. I'd create a test, but the NPE gets thrown away in the context of the current test setup so can't be created as quickly as we'd like to fix this. I have manually tested in a custom reproduction to confirm it resolves the NPE.

Seen at b/248326695

```
java.lang.AssertionError: java.lang.NullPointerException
        at io.grpc.xds.ClientXdsClient$1.uncaughtException(ClientXdsClient.java:89)
        at io.grpc.SynchronizationContext.drain(SynchronizationContext.java:97)
        at io.grpc.SynchronizationContext.execute(SynchronizationContext.java:127)
        at io.grpc.xds.ClientXdsClient.cancelXdsResourceWatch(ClientXdsClient.java:327)
        at io.grpc.xds.ClusterResolverLoadBalancer$ClusterResolverLbState$EdsClusterState.shutdown(ClusterResolverLoadBalancer.java:378)
        at io.grpc.xds.ClusterResolverLoadBalancer$ClusterResolverLbState.shutdown(ClusterResolverLoadBalancer.java:206)
        at io.grpc.util.GracefulSwitchLoadBalancer.shutdown(GracefulSwitchLoadBalancer.java:195)
        at io.grpc.xds.ClusterResolverLoadBalancer.shutdown(ClusterResolverLoadBalancer.java:141)
        at io.grpc.xds.CdsLoadBalancer2$CdsLbState.shutdown(CdsLoadBalancer2.java:136)
        at io.grpc.xds.CdsLoadBalancer2.shutdown(CdsLoadBalancer2.java:110)
        at io.grpc.util.GracefulSwitchLoadBalancer.shutdown(GracefulSwitchLoadBalancer.java:195)
        at io.grpc.xds.ClusterManagerLoadBalancer$ChildLbState.shutdown(ClusterManagerLoadBalancer.java:256)
        at io.grpc.xds.ClusterManagerLoadBalancer.shutdown(ClusterManagerLoadBalancer.java:138)
        at io.grpc.internal.AutoConfiguredLoadBalancerFactory$AutoConfiguredLoadBalancer.shutdown(AutoConfiguredLoadBalancerFactory.java:164)
        at io.grpc.internal.ManagedChannelImpl.shutdownNameResolverAndLoadBalancer(ManagedChannelImpl.java:381)
        at io.grpc.internal.ManagedChannelImpl.access$8200(ManagedChannelImpl.java:118)
        at io.grpc.internal.ManagedChannelImpl$DelayedTransportListener.transportTerminated(ManagedChannelImpl.java:2174)
        at io.grpc.internal.DelayedClientTransport$3.run(DelayedClientTransport.java:122)
        at io.grpc.SynchronizationContext.drain(SynchronizationContext.java:95)
        at io.grpc.SynchronizationContext.execute(SynchronizationContext.java:127)
        at io.grpc.internal.ManagedChannelImpl$RealChannel.shutdown(ManagedChannelImpl.java:1057)
        at io.grpc.internal.ManagedChannelImpl.shutdown(ManagedChannelImpl.java:817)
        at io.grpc.internal.ManagedChannelImpl.shutdownNow(ManagedChannelImpl.java:837)
        at io.grpc.internal.ManagedChannelImpl.shutdownNow(ManagedChannelImpl.java:117)
        at io.grpc.internal.ForwardingManagedChannel.shutdownNow(ForwardingManagedChannel.java:52)
        at io.grpc.internal.ManagedChannelOrphanWrapper.shutdownNow(ManagedChannelOrphanWrapper.java:65)
        at io.grpc.testing.integration.GrpclbFallbackTestClient.tearDown(GrpclbFallbackTestClient.java:178)
        at io.grpc.testing.integration.GrpclbFallbackTestClient.main(GrpclbFallbackTestClient.java:67)
Caused by: java.lang.NullPointerException
        at io.grpc.xds.ClientXdsClient.handleResourceResponse(ClientXdsClient.java:179)
        at io.grpc.xds.AbstractXdsClient$AbstractAdsStream.handleRpcResponse(AbstractXdsClient.java:358)
        at io.grpc.xds.AbstractXdsClient$AdsStreamV3$1$1.run(AbstractXdsClient.java:511)
        at io.grpc.SynchronizationContext.drain(SynchronizationContext.java:95)
        ... 26 more
```

CC @YifeiZhuang @sergiitk 