### PR TITLE
Depend on tools in the exec configuration

### DIFF
--- a/java_grpc_library.bzl
+++ b/java_grpc_library.bzl
@@ -30,12 +30,12 @@ java_rpc_toolchain = rule(
             providers = [JavaInfo],
         ),
         "plugin": attr.label(
-            cfg = "host",
+            cfg = "exec",
             executable = True,
         ),
         "plugin_arg": attr.string(),
         "_protoc": attr.label(
-            cfg = "host",
+            cfg = "exec",
             default = Label("@com_google_protobuf//:protoc"),
             executable = True,
         ),


### PR DESCRIPTION
As of Bazel 4, protoc and most tools are depended on via the exec configuration rather than the host configuration. By also using the exec transition in grpc-java, unnecessary (and very costly) rebuilds of protoc can be prevented.