### PR TITLE
grpclb: switch to use acceptResolvedAddresses()

### DIFF
--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -76,7 +76,7 @@ class GrpclbLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     Attributes attributes = resolvedAddresses.getAttributes();
     List<EquivalentAddressGroup> newLbAddresses = attributes.get(GrpclbConstants.ATTR_LB_ADDRS);
     if (newLbAddresses == null) {
@@ -85,7 +85,7 @@ class GrpclbLoadBalancer extends LoadBalancer {
     if (newLbAddresses.isEmpty() && resolvedAddresses.getAddresses().isEmpty()) {
       handleNameResolutionError(
           Status.UNAVAILABLE.withDescription("No backend or balancer addresses found"));
-      return;
+      return false;
     }
     List<EquivalentAddressGroup> overrideAuthorityLbAddresses =
         new ArrayList<>(newLbAddresses.size());
@@ -114,6 +114,8 @@ class GrpclbLoadBalancer extends LoadBalancer {
     }
     grpclbState.handleAddresses(Collections.unmodifiableList(overrideAuthorityLbAddresses),
         newBackendServers);
+
+    return true;
   }
 
   @Override

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -2735,7 +2735,7 @@ public class GrpclbLoadBalancerTest {
     syncContext.execute(new Runnable() {
       @Override
       public void run() {
-        balancer.handleResolvedAddresses(
+        balancer.acceptResolvedAddresses(
             ResolvedAddresses.newBuilder()
                 .setAddresses(backendAddrs)
                 .setAttributes(attrs)


### PR DESCRIPTION
This is part of a migration to move all LB implementations from handleResolvedAddresses() to this new method.