### PR TITLE
xds: CdsLoadBalancer2 to use acceptResolvedAddresses

### DIFF
--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
@@ -83,12 +83,6 @@ final class CdsLoadBalancer2 extends LoadBalancer {
     if (this.resolvedAddresses != null) {
       return true;
     }
-    // if (resolvedAddresses.getAddresses().isEmpty()) {
-    //   handleNameResolutionError(Status.UNAVAILABLE.withDescription(
-    //       "NameResolver returned no usable address. addrs=" + resolvedAddresses.getAddresses()
-    //           + ", attrs=" + resolvedAddresses.getAttributes()));
-    //   return false;
-    // }
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     this.resolvedAddresses = resolvedAddresses;
     xdsClientPool = resolvedAddresses.getAttributes().get(InternalXdsAttributes.XDS_CLIENT_POOL);

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
@@ -79,10 +79,16 @@ final class CdsLoadBalancer2 extends LoadBalancer {
   }
 
   @Override
-  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     if (this.resolvedAddresses != null) {
-      return;
+      return true;
     }
+    // if (resolvedAddresses.getAddresses().isEmpty()) {
+    //   handleNameResolutionError(Status.UNAVAILABLE.withDescription(
+    //       "NameResolver returned no usable address. addrs=" + resolvedAddresses.getAddresses()
+    //           + ", attrs=" + resolvedAddresses.getAttributes()));
+    //   return false;
+    // }
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     this.resolvedAddresses = resolvedAddresses;
     xdsClientPool = resolvedAddresses.getAttributes().get(InternalXdsAttributes.XDS_CLIENT_POOL);
@@ -91,6 +97,7 @@ final class CdsLoadBalancer2 extends LoadBalancer {
     logger.log(XdsLogLevel.INFO, "Config: {0}", config);
     cdsLbState = new CdsLbState(config.name);
     cdsLbState.start();
+    return true;
   }
 
   @Override

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
@@ -136,7 +136,7 @@ public class CdsLoadBalancer2Test {
     lbRegistry.register(new FakeLoadBalancerProvider("least_request_experimental",
         new LeastRequestLoadBalancerProvider()));
     loadBalancer = new CdsLoadBalancer2(helper, lbRegistry);
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(Collections.<EquivalentAddressGroup>emptyList())
             .setAttributes(


### PR DESCRIPTION
Moving over from handleResolvedAddresses() as part of an API migration.