### PR TITLE
Use Protobuf 21.7 is our code generator

### DIFF
--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -1,6 +1,4 @@
-set PROTOBUF_VER=21.1
-@rem Workaround https://github.com/protocolbuffers/protobuf/issues/10172
-set PROTOBUF_VER_ISSUE_10172=3.%PROTOBUF_VER%
+set PROTOBUF_VER=21.7
 set CMAKE_NAME=cmake-3.3.2-win32-x86
 
 if not exist "protobuf-%PROTOBUF_VER%\build\Release\" (
@@ -25,7 +23,7 @@ set PATH=%PATH%;%cd%\%CMAKE_NAME%\bin
 powershell -command "$ErrorActionPreference = 'stop'; & { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; iwr https://github.com/google/protobuf/archive/v%PROTOBUF_VER%.zip -OutFile protobuf.zip }" || exit /b 1
 powershell -command "$ErrorActionPreference = 'stop'; & { Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory('protobuf.zip', '.') }" || exit /b 1
 del protobuf.zip
-rename protobuf-%PROTOBUF_VER_ISSUE_10172% protobuf-%PROTOBUF_VER%
+rename protobuf-%PROTOBUF_VER% protobuf-%PROTOBUF_VER%
 mkdir protobuf-%PROTOBUF_VER%\build
 pushd protobuf-%PROTOBUF_VER%\build
 

--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -23,7 +23,6 @@ set PATH=%PATH%;%cd%\%CMAKE_NAME%\bin
 powershell -command "$ErrorActionPreference = 'stop'; & { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; iwr https://github.com/google/protobuf/archive/v%PROTOBUF_VER%.zip -OutFile protobuf.zip }" || exit /b 1
 powershell -command "$ErrorActionPreference = 'stop'; & { Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory('protobuf.zip', '.') }" || exit /b 1
 del protobuf.zip
-rename protobuf-%PROTOBUF_VER% protobuf-%PROTOBUF_VER%
 mkdir protobuf-%PROTOBUF_VER%\build
 pushd protobuf-%PROTOBUF_VER%\build
 

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -3,9 +3,7 @@
 # Build protoc
 set -evux -o pipefail
 
-PROTOBUF_VERSION=21.1
-# https://github.com/protocolbuffers/protobuf/issues/10172
-PROTOBUF_VERSION_ISSUE_10172=3.$PROTOBUF_VERSION
+PROTOBUF_VERSION=21.7
 
 # ARCH is x86_64 bit unless otherwise specified.
 ARCH="${ARCH:-x86_64}"
@@ -30,7 +28,7 @@ if [ -f ${INSTALL_DIR}/bin/protoc ]; then
 else
   if [[ ! -d "$DOWNLOAD_DIR"/protobuf-"${PROTOBUF_VERSION}" ]]; then
     curl -Ls https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protobuf-all-${PROTOBUF_VERSION}.tar.gz | tar xz -C $DOWNLOAD_DIR
-    mv "$DOWNLOAD_DIR/protobuf-${PROTOBUF_VERSION_ISSUE_10172}" "$DOWNLOAD_DIR/protobuf-${PROTOBUF_VERSION}"
+    mv "$DOWNLOAD_DIR/protobuf-${PROTOBUF_VERSION}" "$DOWNLOAD_DIR/protobuf-${PROTOBUF_VERSION}"
   fi
   pushd $DOWNLOAD_DIR/protobuf-${PROTOBUF_VERSION}
   # install here so we don't need sudo

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -28,7 +28,6 @@ if [ -f ${INSTALL_DIR}/bin/protoc ]; then
 else
   if [[ ! -d "$DOWNLOAD_DIR"/protobuf-"${PROTOBUF_VERSION}" ]]; then
     curl -Ls https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protobuf-all-${PROTOBUF_VERSION}.tar.gz | tar xz -C $DOWNLOAD_DIR
-    mv "$DOWNLOAD_DIR/protobuf-${PROTOBUF_VERSION}" "$DOWNLOAD_DIR/protobuf-${PROTOBUF_VERSION}"
   fi
   pushd $DOWNLOAD_DIR/protobuf-${PROTOBUF_VERSION}
   # install here so we don't need sudo


### PR DESCRIPTION
This aligns the C++ version we're using for gRPC-generated code with the Java version. This should have no real impact to our users, as there were no features added to .proto files or the like that would be visible to users.