### PR TITLE
xds: remove ResourceType enum, use XdsResourceType instead

### DIFF
--- a/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
@@ -48,7 +48,6 @@ import io.grpc.stub.StreamObserver;
 import io.grpc.xds.Bootstrapper.ServerInfo;
 import io.grpc.xds.EnvoyProtoData.Node;
 import io.grpc.xds.XdsClient.ResourceStore;
-import io.grpc.xds.XdsClient.ResourceUpdate;
 import io.grpc.xds.XdsClient.XdsResponseHandler;
 import io.grpc.xds.XdsClientImpl.XdsChannelFactory;
 import io.grpc.xds.XdsLogger.XdsLogLevel;

--- a/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
@@ -82,7 +82,7 @@ final class AbstractXdsClient {
   // Last successfully applied version_info for each resource type. Starts with empty string.
   // A version_info is used to update management server with client's most recent knowledge of
   // resources.
-  private final Map<ResourceType, String> versions = new HashMap<>();
+  private final Map<XdsResourceType<?>, String> versions = new HashMap<>();
 
   private boolean shutdown;
   @Nullable
@@ -160,8 +160,7 @@ final class AbstractXdsClient {
     if (adsStream == null) {
       startRpcStream();
     }
-    Collection<String> resources = resourceStore.getSubscribedResources(serverInfo,
-        resourceType.typeName());
+    Collection<String> resources = resourceStore.getSubscribedResources(serverInfo, resourceType);
     if (resources != null) {
       adsStream.sendDiscoveryRequest(resourceType, resources);
     }
@@ -172,11 +171,10 @@ final class AbstractXdsClient {
    * and sends an ACK request to the management server.
    */
   // Must be synchronized.
-  void ackResponse(XdsResourceType<?> xdsResourceType, String versionInfo, String nonce) {
-    ResourceType type = xdsResourceType.typeName();
+  void ackResponse(XdsResourceType<?> type, String versionInfo, String nonce) {
     versions.put(type, versionInfo);
     logger.log(XdsLogLevel.INFO, "Sending ACK for {0} update, nonce: {1}, current version: {2}",
-        type, nonce, versionInfo);
+        type.typeName(), nonce, versionInfo);
     Collection<String> resources = resourceStore.getSubscribedResources(serverInfo, type);
     if (resources == null) {
       resources = Collections.emptyList();
@@ -189,11 +187,10 @@ final class AbstractXdsClient {
    * accepted version) to the management server.
    */
   // Must be synchronized.
-  void nackResponse(XdsResourceType<?> xdsResourceType, String nonce, String errorDetail) {
-    ResourceType type = xdsResourceType.typeName();
+  void nackResponse(XdsResourceType<?> type, String nonce, String errorDetail) {
     String versionInfo = versions.getOrDefault(type, "");
     logger.log(XdsLogLevel.INFO, "Sending NACK for {0} update, nonce: {1}, current version: {2}",
-        type, nonce, versionInfo);
+        type.typeName(), nonce, versionInfo);
     Collection<String> resources = resourceStore.getSubscribedResources(serverInfo, type);
     if (resources == null) {
       resources = Collections.emptyList();
@@ -239,77 +236,38 @@ final class AbstractXdsClient {
         return;
       }
       startRpcStream();
-      for (ResourceType type : ResourceType.values()) {
-        if (type == ResourceType.UNKNOWN) {
-          continue;
-        }
+      for (XdsResourceType<?> type : resourceStore.getXdsResourceTypes()) {
         Collection<String> resources = resourceStore.getSubscribedResources(serverInfo, type);
         if (resources != null) {
-          adsStream.sendDiscoveryRequest(resourceStore.getXdsResourceType(type), resources);
+          adsStream.sendDiscoveryRequest(type, resources);
         }
       }
       xdsResponseHandler.handleStreamRestarted(serverInfo);
     }
   }
 
-  // TODO(zivy) : remove and replace with XdsResourceType
-  enum ResourceType {
-    UNKNOWN, LDS, RDS, CDS, EDS;
-
-    String typeUrl() {
-      switch (this) {
-        case LDS:
-          return ADS_TYPE_URL_LDS;
-        case RDS:
-          return ADS_TYPE_URL_RDS;
-        case CDS:
-          return ADS_TYPE_URL_CDS;
-        case EDS:
-          return ADS_TYPE_URL_EDS;
-        case UNKNOWN:
-        default:
-          throw new AssertionError("Unknown or missing case in enum switch: " + this);
-      }
-    }
-
-    String typeUrlV2() {
-      switch (this) {
-        case LDS:
-          return ADS_TYPE_URL_LDS_V2;
-        case RDS:
-          return ADS_TYPE_URL_RDS_V2;
-        case CDS:
-          return ADS_TYPE_URL_CDS_V2;
-        case EDS:
-          return ADS_TYPE_URL_EDS_V2;
-        case UNKNOWN:
-        default:
-          throw new AssertionError("Unknown or missing case in enum switch: " + this);
-      }
-    }
-
-    @VisibleForTesting
-    static ResourceType fromTypeUrl(String typeUrl) {
-      switch (typeUrl) {
-        case ADS_TYPE_URL_LDS:
-          // fall trough
-        case ADS_TYPE_URL_LDS_V2:
-          return LDS;
-        case ADS_TYPE_URL_RDS:
-          // fall through
-        case ADS_TYPE_URL_RDS_V2:
-          return RDS;
-        case ADS_TYPE_URL_CDS:
-          // fall through
-        case ADS_TYPE_URL_CDS_V2:
-          return CDS;
-        case ADS_TYPE_URL_EDS:
-          // fall through
-        case ADS_TYPE_URL_EDS_V2:
-          return EDS;
-        default:
-          return UNKNOWN;
-      }
+  @VisibleForTesting
+  @Nullable
+  static XdsResourceType<?> fromTypeUrl(String typeUrl) {
+    switch (typeUrl) {
+      case ADS_TYPE_URL_LDS:
+        // fall trough
+      case ADS_TYPE_URL_LDS_V2:
+        return XdsListenerResource.getInstance();
+      case ADS_TYPE_URL_RDS:
+        // fall through
+      case ADS_TYPE_URL_RDS_V2:
+        return XdsRouteConfigureResource.getInstance();
+      case ADS_TYPE_URL_CDS:
+        // fall through
+      case ADS_TYPE_URL_CDS_V2:
+        return XdsClusterResource.getInstance();
+      case ADS_TYPE_URL_EDS:
+        // fall through
+      case ADS_TYPE_URL_EDS_V2:
+        return XdsEndpointResource.getInstance();
+      default:
+        return null;
     }
   }
 
@@ -322,7 +280,7 @@ final class AbstractXdsClient {
     // used for management server to identify which response the client is ACKing/NACking.
     // To avoid confusion, client-initiated requests will always use the nonce in
     // most recently received responses of each resource type.
-    private final Map<ResourceType, String> respNonces = new HashMap<>();
+    private final Map<XdsResourceType<?>, String> respNonces = new HashMap<>();
 
     abstract void start();
 
@@ -334,27 +292,27 @@ final class AbstractXdsClient {
      * client-initiated discovery requests, use {@link
      * #sendDiscoveryRequest(XdsResourceType, Collection)}.
      */
-    abstract void sendDiscoveryRequest(ResourceType type, String version,
+    abstract void sendDiscoveryRequest(XdsResourceType<?> type, String version,
         Collection<String> resources, String nonce, @Nullable String errorDetail);
 
     /**
      * Sends a client-initiated discovery request.
      */
-    final void sendDiscoveryRequest(XdsResourceType<? extends ResourceUpdate> xdsResourceType,
-                                    Collection<String> resources) {
-      ResourceType type = xdsResourceType.typeName();
+    final void sendDiscoveryRequest(XdsResourceType<?> type, Collection<String> resources) {
       logger.log(XdsLogLevel.INFO, "Sending {0} request for resources: {1}", type, resources);
       sendDiscoveryRequest(type, versions.getOrDefault(type, ""), resources,
           respNonces.getOrDefault(type, ""), null);
     }
 
-    final void handleRpcResponse(
-        ResourceType type, String versionInfo, List<Any> resources, String nonce) {
+    final void handleRpcResponse(XdsResourceType<?> type, String versionInfo, List<Any> resources,
+                                 String nonce) {
       if (closed) {
         return;
       }
       responseReceived = true;
-      respNonces.put(type, nonce);
+      if (type != null) {
+        respNonces.put(type, nonce);
+      }
       xdsResponseHandler.handleResourceResponse(type, serverInfo, versionInfo, resources, nonce);
     }
 
@@ -422,7 +380,7 @@ final class AbstractXdsClient {
               syncContext.execute(new Runnable() {
                 @Override
                 public void run() {
-                  ResourceType type = ResourceType.fromTypeUrl(response.getTypeUrl());
+                  XdsResourceType<?> type = fromTypeUrl(response.getTypeUrl());
                   if (logger.isLoggable(XdsLogLevel.DEBUG)) {
                     logger.log(
                         XdsLogLevel.DEBUG, "Received {0} response:\n{1}", type,
@@ -458,8 +416,9 @@ final class AbstractXdsClient {
     }
 
     @Override
-    void sendDiscoveryRequest(ResourceType type, String versionInfo, Collection<String> resources,
-        String nonce, @Nullable String errorDetail) {
+    void sendDiscoveryRequest(XdsResourceType<?> type, String versionInfo,
+                              Collection<String> resources, String nonce,
+                              @Nullable String errorDetail) {
       checkState(requestWriter != null, "ADS stream has not been started");
       io.envoyproxy.envoy.api.v2.DiscoveryRequest.Builder builder =
           io.envoyproxy.envoy.api.v2.DiscoveryRequest.newBuilder()
@@ -502,7 +461,7 @@ final class AbstractXdsClient {
           syncContext.execute(new Runnable() {
             @Override
             public void run() {
-              ResourceType type = ResourceType.fromTypeUrl(response.getTypeUrl());
+              XdsResourceType<?> type = fromTypeUrl(response.getTypeUrl());
               if (logger.isLoggable(XdsLogLevel.DEBUG)) {
                 logger.log(
                     XdsLogLevel.DEBUG, "Received {0} response:\n{1}", type,
@@ -538,8 +497,9 @@ final class AbstractXdsClient {
     }
 
     @Override
-    void sendDiscoveryRequest(ResourceType type, String versionInfo, Collection<String> resources,
-        String nonce, @Nullable String errorDetail) {
+    void sendDiscoveryRequest(XdsResourceType<?> type, String versionInfo,
+                              Collection<String> resources, String nonce,
+                              @Nullable String errorDetail) {
       checkState(requestWriter != null, "ADS stream has not been started");
       DiscoveryRequest.Builder builder =
           DiscoveryRequest.newBuilder()

--- a/xds/src/main/java/io/grpc/xds/CsdsService.java
+++ b/xds/src/main/java/io/grpc/xds/CsdsService.java
@@ -33,7 +33,6 @@ import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.internal.ObjectPool;
 import io.grpc.stub.StreamObserver;
-import io.grpc.xds.AbstractXdsClient.ResourceType;
 import io.grpc.xds.XdsClient.ResourceMetadata;
 import io.grpc.xds.XdsClient.ResourceMetadata.ResourceMetadataStatus;
 import io.grpc.xds.XdsClient.ResourceMetadata.UpdateFailureState;
@@ -156,12 +155,12 @@ public final class CsdsService extends
     ClientConfig.Builder builder = ClientConfig.newBuilder()
         .setNode(xdsClient.getBootstrapInfo().node().toEnvoyProtoNode());
 
-    Map<ResourceType, Map<String, ResourceMetadata>> metadataByType =
+    Map<XdsResourceType<?>, Map<String, ResourceMetadata>> metadataByType =
         awaitSubscribedResourcesMetadata(xdsClient.getSubscribedResourcesMetadataSnapshot());
 
-    for (Map.Entry<ResourceType, Map<String, ResourceMetadata>> metadataByTypeEntry
+    for (Map.Entry<XdsResourceType<?>, Map<String, ResourceMetadata>> metadataByTypeEntry
         : metadataByType.entrySet()) {
-      ResourceType type = metadataByTypeEntry.getKey();
+      XdsResourceType<?> type = metadataByTypeEntry.getKey();
       Map<String, ResourceMetadata> metadataByResourceName = metadataByTypeEntry.getValue();
       for (Map.Entry<String, ResourceMetadata> metadataEntry : metadataByResourceName.entrySet()) {
         String resourceName = metadataEntry.getKey();
@@ -187,8 +186,9 @@ public final class CsdsService extends
     return builder.build();
   }
 
-  private static Map<ResourceType, Map<String, ResourceMetadata>> awaitSubscribedResourcesMetadata(
-      ListenableFuture<Map<ResourceType, Map<String, ResourceMetadata>>> future)
+  private static Map<XdsResourceType<?>, Map<String, ResourceMetadata>>
+      awaitSubscribedResourcesMetadata(
+      ListenableFuture<Map<XdsResourceType<?>, Map<String, ResourceMetadata>>> future)
       throws InterruptedException {
     try {
       // Normally this shouldn't take long, but add some slack for cases like a cold JVM.

--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -25,7 +25,6 @@ import com.google.common.net.UrlEscapers;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.Any;
 import io.grpc.Status;
-import io.grpc.xds.AbstractXdsClient.ResourceType;
 import io.grpc.xds.Bootstrapper.ServerInfo;
 import io.grpc.xds.LoadStatsManager2.ClusterDropStats;
 import io.grpc.xds.LoadStatsManager2.ClusterLocalityStats;
@@ -296,7 +295,7 @@ abstract class XdsClient {
    * a map ("resource name": "resource metadata").
    */
   // Must be synchronized.
-  ListenableFuture<Map<ResourceType, Map<String, ResourceMetadata>>>
+  ListenableFuture<Map<XdsResourceType<?>, Map<String, ResourceMetadata>>>
       getSubscribedResourcesMetadataSnapshot() {
     throw new UnsupportedOperationException();
   }
@@ -347,8 +346,8 @@ abstract class XdsClient {
   interface XdsResponseHandler {
     /** Called when a xds response is received. */
     void handleResourceResponse(
-        ResourceType resourceType, ServerInfo serverInfo, String versionInfo, List<Any> resources,
-        String nonce);
+        XdsResourceType<?> resourceType, ServerInfo serverInfo, String versionInfo,
+        List<Any> resources, String nonce);
 
     /** Called when the ADS stream is closed passively. */
     // Must be synchronized.
@@ -369,9 +368,9 @@ abstract class XdsClient {
      */
     // Must be synchronized.
     @Nullable
-    Collection<String> getSubscribedResources(ServerInfo serverInfo, ResourceType type);
+    Collection<String> getSubscribedResources(ServerInfo serverInfo,
+                                              XdsResourceType<? extends ResourceUpdate> type);
 
-    @Nullable
-    XdsResourceType<? extends ResourceUpdate> getXdsResourceType(ResourceType type);
+    Collection<XdsResourceType<? extends ResourceUpdate>> getXdsResourceTypes();
   }
 }

--- a/xds/src/main/java/io/grpc/xds/XdsClusterResource.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClusterResource.java
@@ -17,9 +17,6 @@
 package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.grpc.xds.AbstractXdsClient.ResourceType;
-import static io.grpc.xds.AbstractXdsClient.ResourceType.CDS;
-import static io.grpc.xds.AbstractXdsClient.ResourceType.EDS;
 import static io.grpc.xds.Bootstrapper.ServerInfo;
 
 import com.google.auto.value.AutoValue;
@@ -77,8 +74,8 @@ class XdsClusterResource extends XdsResourceType<CdsUpdate> {
   }
 
   @Override
-  ResourceType typeName() {
-    return CDS;
+  String typeName() {
+    return "CDS";
   }
 
   @Override
@@ -93,8 +90,8 @@ class XdsClusterResource extends XdsResourceType<CdsUpdate> {
 
   @Nullable
   @Override
-  ResourceType dependentResource() {
-    return EDS;
+  XdsResourceType<?> dependentResource() {
+    return XdsEndpointResource.getInstance();
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/XdsEndpointResource.java
+++ b/xds/src/main/java/io/grpc/xds/XdsEndpointResource.java
@@ -17,8 +17,6 @@
 package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.grpc.xds.AbstractXdsClient.ResourceType;
-import static io.grpc.xds.AbstractXdsClient.ResourceType.EDS;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
@@ -66,8 +64,8 @@ class XdsEndpointResource extends XdsResourceType<EdsUpdate> {
   }
 
   @Override
-  ResourceType typeName() {
-    return EDS;
+  String typeName() {
+    return "EDS";
   }
 
   @Override
@@ -82,7 +80,7 @@ class XdsEndpointResource extends XdsResourceType<EdsUpdate> {
 
   @Nullable
   @Override
-  ResourceType dependentResource() {
+  XdsResourceType<?> dependentResource() {
     return null;
   }
 

--- a/xds/src/main/java/io/grpc/xds/XdsListenerResource.java
+++ b/xds/src/main/java/io/grpc/xds/XdsListenerResource.java
@@ -17,9 +17,6 @@
 package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.grpc.xds.AbstractXdsClient.ResourceType;
-import static io.grpc.xds.AbstractXdsClient.ResourceType.LDS;
-import static io.grpc.xds.AbstractXdsClient.ResourceType.RDS;
 import static io.grpc.xds.XdsClient.ResourceUpdate;
 import static io.grpc.xds.XdsClientImpl.ResourceInvalidException;
 import static io.grpc.xds.XdsClusterResource.validateCommonTlsContext;
@@ -81,8 +78,8 @@ class XdsListenerResource extends XdsResourceType<LdsUpdate> {
   }
 
   @Override
-  ResourceType typeName() {
-    return LDS;
+  String typeName() {
+    return "LDS";
   }
 
   @Override
@@ -102,8 +99,8 @@ class XdsListenerResource extends XdsResourceType<LdsUpdate> {
 
   @Nullable
   @Override
-  ResourceType dependentResource() {
-    return RDS;
+  XdsResourceType<?> dependentResource() {
+    return XdsRouteConfigureResource.getInstance();
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -47,7 +47,6 @@ import io.grpc.Status.Code;
 import io.grpc.SynchronizationContext;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.ObjectPool;
-import io.grpc.xds.AbstractXdsClient.ResourceType;
 import io.grpc.xds.Bootstrapper.AuthorityInfo;
 import io.grpc.xds.Bootstrapper.BootstrapInfo;
 import io.grpc.xds.ClusterSpecifierPlugin.PluginConfig;
@@ -202,8 +201,9 @@ final class XdsNameResolver extends NameResolver {
       replacement = XdsClient.percentEncodePath(replacement);
     }
     String ldsResourceName = expandPercentS(listenerNameTemplate, replacement);
-    if (!XdsClient.isResourceNameValid(ldsResourceName, ResourceType.LDS.typeUrl())
-        && !XdsClient.isResourceNameValid(ldsResourceName, ResourceType.LDS.typeUrlV2())) {
+    if (!XdsClient.isResourceNameValid(ldsResourceName, XdsListenerResource.getInstance().typeUrl())
+        && !XdsClient.isResourceNameValid(ldsResourceName,
+        XdsListenerResource.getInstance().typeUrlV2())) {
       listener.onError(Status.INVALID_ARGUMENT.withDescription(
           "invalid listener resource URI for service authority: " + serviceAuthority));
       return;

--- a/xds/src/main/java/io/grpc/xds/XdsResourceType.java
+++ b/xds/src/main/java/io/grpc/xds/XdsResourceType.java
@@ -17,7 +17,6 @@
 package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.grpc.xds.AbstractXdsClient.ResourceType;
 import static io.grpc.xds.Bootstrapper.ServerInfo;
 import static io.grpc.xds.XdsClient.ResourceUpdate;
 import static io.grpc.xds.XdsClient.canonifyResourceName;
@@ -80,7 +79,7 @@ abstract class XdsResourceType<T extends ResourceUpdate> {
 
   abstract Class<? extends com.google.protobuf.Message> unpackedClassName();
 
-  abstract ResourceType typeName();
+  abstract String typeName();
 
   abstract String typeUrl();
 
@@ -88,7 +87,7 @@ abstract class XdsResourceType<T extends ResourceUpdate> {
 
   // Non-null for  State of the World resources.
   @Nullable
-  abstract ResourceType dependentResource();
+  abstract XdsResourceType<?> dependentResource();
 
   static class Args {
     final ServerInfo serverInfo;

--- a/xds/src/main/java/io/grpc/xds/XdsRouteConfigureResource.java
+++ b/xds/src/main/java/io/grpc/xds/XdsRouteConfigureResource.java
@@ -17,8 +17,6 @@
 package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.grpc.xds.AbstractXdsClient.ResourceType;
-import static io.grpc.xds.AbstractXdsClient.ResourceType.RDS;
 import static io.grpc.xds.XdsRouteConfigureResource.RdsUpdate;
 
 import com.github.udpa.udpa.type.v1.TypedStruct;
@@ -95,8 +93,8 @@ class XdsRouteConfigureResource extends XdsResourceType<RdsUpdate> {
   }
 
   @Override
-  ResourceType typeName() {
-    return RDS;
+  String typeName() {
+    return "RDS";
   }
 
   @Override
@@ -111,7 +109,7 @@ class XdsRouteConfigureResource extends XdsResourceType<RdsUpdate> {
 
   @Nullable
   @Override
-  ResourceType dependentResource() {
+  XdsResourceType<?> dependentResource() {
     return null;
   }
 

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
@@ -17,7 +17,6 @@
 package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
-import static io.grpc.xds.AbstractXdsClient.ResourceType.CDS;
 import static io.grpc.xds.XdsLbPolicies.CLUSTER_RESOLVER_POLICY_NAME;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -657,7 +656,7 @@ public class CdsLoadBalancer2Test {
     @SuppressWarnings("unchecked")
     <T extends ResourceUpdate> void watchXdsResource(XdsResourceType<T> type, String resourceName,
                           ResourceWatcher<T> watcher) {
-      assertThat(type.typeName()).isEqualTo(CDS);
+      assertThat(type.typeName()).isEqualTo("CDS");
       assertThat(watchers).doesNotContainKey(resourceName);
       watchers.put(resourceName, (ResourceWatcher<CdsUpdate>)watcher);
     }
@@ -667,7 +666,7 @@ public class CdsLoadBalancer2Test {
     <T extends ResourceUpdate> void cancelXdsResourceWatch(XdsResourceType<T> type,
                                                            String resourceName,
                                                            ResourceWatcher<T> watcher) {
-      assertThat(type.typeName()).isEqualTo(CDS);
+      assertThat(type.typeName()).isEqualTo("CDS");
       assertThat(watchers).containsKey(resourceName);
       watchers.remove(resourceName);
     }

--- a/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
@@ -17,7 +17,6 @@
 package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
-import static io.grpc.xds.AbstractXdsClient.ResourceType.EDS;
 import static io.grpc.xds.XdsLbPolicies.CLUSTER_IMPL_POLICY_NAME;
 import static io.grpc.xds.XdsLbPolicies.PRIORITY_POLICY_NAME;
 import static io.grpc.xds.XdsLbPolicies.WEIGHTED_TARGET_POLICY_NAME;
@@ -1176,7 +1175,7 @@ public class ClusterResolverLoadBalancerTest {
     @SuppressWarnings("unchecked")
     <T extends ResourceUpdate> void watchXdsResource(XdsResourceType<T> type, String resourceName,
                           ResourceWatcher<T> watcher) {
-      assertThat(type.typeName()).isEqualTo(EDS);
+      assertThat(type.typeName()).isEqualTo("EDS");
       assertThat(watchers).doesNotContainKey(resourceName);
       watchers.put(resourceName, (ResourceWatcher<EdsUpdate>) watcher);
     }
@@ -1186,7 +1185,7 @@ public class ClusterResolverLoadBalancerTest {
     <T extends ResourceUpdate> void cancelXdsResourceWatch(XdsResourceType<T> type,
                                                            String resourceName,
                                                            ResourceWatcher<T> watcher) {
-      assertThat(type.typeName()).isEqualTo(EDS);
+      assertThat(type.typeName()).isEqualTo("EDS");
       assertThat(watchers).containsKey(resourceName);
       watchers.remove(resourceName);
     }

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplDataTest.java
@@ -115,7 +115,6 @@ import io.grpc.lookup.v1.GrpcKeyBuilder.Name;
 import io.grpc.lookup.v1.NameMatcher;
 import io.grpc.lookup.v1.RouteLookupClusterSpecifier;
 import io.grpc.lookup.v1.RouteLookupConfig;
-import io.grpc.xds.AbstractXdsClient.ResourceType;
 import io.grpc.xds.Bootstrapper.ServerInfo;
 import io.grpc.xds.ClusterSpecifierPlugin.NamedPluginConfig;
 import io.grpc.xds.ClusterSpecifierPlugin.PluginConfig;
@@ -2699,21 +2698,28 @@ public class XdsClientImplDataTest {
   @Test
   public void validateResourceName() {
     String traditionalResource = "cluster1.google.com";
-    assertThat(XdsClient.isResourceNameValid(traditionalResource, ResourceType.CDS.typeUrl()))
+    assertThat(XdsClient.isResourceNameValid(traditionalResource,
+        XdsClusterResource.getInstance().typeUrl()))
         .isTrue();
-    assertThat(XdsClient.isResourceNameValid(traditionalResource, ResourceType.RDS.typeUrlV2()))
+    assertThat(XdsClient.isResourceNameValid(traditionalResource,
+        XdsRouteConfigureResource.getInstance().typeUrlV2()))
         .isTrue();
 
     String invalidPath = "xdstp:/abc/efg";
-    assertThat(XdsClient.isResourceNameValid(invalidPath, ResourceType.CDS.typeUrl())).isFalse();
+    assertThat(XdsClient.isResourceNameValid(invalidPath,
+        XdsClusterResource.getInstance().typeUrl())).isFalse();
 
     String invalidPath2 = "xdstp:///envoy.config.route.v3.RouteConfiguration";
-    assertThat(XdsClient.isResourceNameValid(invalidPath2, ResourceType.RDS.typeUrl())).isFalse();
+    assertThat(XdsClient.isResourceNameValid(invalidPath2,
+        XdsRouteConfigureResource.getInstance().typeUrl())).isFalse();
 
     String typeMatch = "xdstp:///envoy.config.route.v3.RouteConfiguration/foo/route1";
-    assertThat(XdsClient.isResourceNameValid(typeMatch, ResourceType.LDS.typeUrl())).isFalse();
-    assertThat(XdsClient.isResourceNameValid(typeMatch, ResourceType.RDS.typeUrl())).isTrue();
-    assertThat(XdsClient.isResourceNameValid(typeMatch, ResourceType.RDS.typeUrlV2())).isFalse();
+    assertThat(XdsClient.isResourceNameValid(typeMatch,
+        XdsListenerResource.getInstance().typeUrl())).isFalse();
+    assertThat(XdsClient.isResourceNameValid(typeMatch,
+        XdsRouteConfigureResource.getInstance().typeUrl())).isTrue();
+    assertThat(XdsClient.isResourceNameValid(typeMatch,
+        XdsRouteConfigureResource.getInstance().typeUrlV2())).isFalse();
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplV2Test.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplV2Test.java
@@ -92,7 +92,6 @@ import io.grpc.Context;
 import io.grpc.Context.CancellationListener;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
-import io.grpc.xds.AbstractXdsClient.ResourceType;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -197,7 +196,7 @@ public class XdsClientImplV2Test extends XdsClientImplTestBase {
 
     @Override
     protected void verifyRequest(
-        ResourceType type, List<String> resources, String versionInfo, String nonce,
+        XdsResourceType<?> type, List<String> resources, String versionInfo, String nonce,
         EnvoyProtoData.Node node) {
       verify(requestObserver).onNext(argThat(new DiscoveryRequestMatcher(
           node.toEnvoyProtoNodeV2(), versionInfo, resources, type.typeUrlV2(), nonce, null, null)));
@@ -205,7 +204,7 @@ public class XdsClientImplV2Test extends XdsClientImplTestBase {
 
     @Override
     protected void verifyRequestNack(
-        ResourceType type, List<String> resources, String versionInfo, String nonce,
+        XdsResourceType<?> type, List<String> resources, String versionInfo, String nonce,
         EnvoyProtoData.Node node, List<String> errorMessages) {
       verify(requestObserver).onNext(argThat(new DiscoveryRequestMatcher(
           node.toEnvoyProtoNodeV2(), versionInfo, resources, type.typeUrlV2(), nonce,
@@ -219,7 +218,7 @@ public class XdsClientImplV2Test extends XdsClientImplTestBase {
 
     @Override
     protected void sendResponse(
-        ResourceType type, List<Any> resources, String versionInfo, String nonce) {
+        XdsResourceType<?> type, List<Any> resources, String versionInfo, String nonce) {
       DiscoveryResponse response =
           DiscoveryResponse.newBuilder()
               .setVersionInfo(versionInfo)

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplV3Test.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplV3Test.java
@@ -99,7 +99,6 @@ import io.grpc.Context;
 import io.grpc.Context.CancellationListener;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
-import io.grpc.xds.AbstractXdsClient.ResourceType;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -205,7 +204,7 @@ public class XdsClientImplV3Test extends XdsClientImplTestBase {
 
     @Override
     protected void verifyRequest(
-        ResourceType type, List<String> resources, String versionInfo, String nonce,
+        XdsResourceType<?> type, List<String> resources, String versionInfo, String nonce,
         EnvoyProtoData.Node node) {
       verify(requestObserver).onNext(argThat(new DiscoveryRequestMatcher(
           node.toEnvoyProtoNode(), versionInfo, resources, type.typeUrl(), nonce, null, null)));
@@ -213,7 +212,7 @@ public class XdsClientImplV3Test extends XdsClientImplTestBase {
 
     @Override
     protected void verifyRequestNack(
-        ResourceType type, List<String> resources, String versionInfo, String nonce,
+        XdsResourceType<?> type, List<String> resources, String versionInfo, String nonce,
         EnvoyProtoData.Node node, List<String> errorMessages) {
       verify(requestObserver).onNext(argThat(new DiscoveryRequestMatcher(
           node.toEnvoyProtoNode(), versionInfo, resources, type.typeUrl(), nonce,
@@ -227,7 +226,7 @@ public class XdsClientImplV3Test extends XdsClientImplTestBase {
 
     @Override
     protected void sendResponse(
-        ResourceType type, List<Any> resources, String versionInfo, String nonce) {
+        XdsResourceType<?> type, List<Any> resources, String versionInfo, String nonce) {
       DiscoveryResponse response =
           DiscoveryResponse.newBuilder()
               .setVersionInfo(versionInfo)

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -2089,14 +2089,14 @@ public class XdsNameResolverTest {
                                                     ResourceWatcher<T> watcher) {
 
       switch (resourceType.typeName()) {
-        case LDS:
+        case "LDS":
           assertThat(ldsResource).isNull();
           assertThat(ldsWatcher).isNull();
           assertThat(resourceName).isEqualTo(expectedLdsResourceName);
           ldsResource = resourceName;
           ldsWatcher = (ResourceWatcher<LdsUpdate>) watcher;
           break;
-        case RDS:
+        case "RDS":
           assertThat(rdsResource).isNull();
           assertThat(rdsWatcher).isNull();
           rdsResource = resourceName;
@@ -2111,14 +2111,14 @@ public class XdsNameResolverTest {
                                                            String resourceName,
                                                            ResourceWatcher<T> watcher) {
       switch (type.typeName()) {
-        case LDS:
+        case "LDS":
           assertThat(ldsResource).isNotNull();
           assertThat(ldsWatcher).isNotNull();
           assertThat(resourceName).isEqualTo(expectedLdsResourceName);
           ldsResource = null;
           ldsWatcher = null;
           break;
-        case RDS:
+        case "RDS":
           assertThat(rdsResource).isNotNull();
           assertThat(rdsWatcher).isNotNull();
           rdsResource = null;

--- a/xds/src/test/java/io/grpc/xds/XdsServerTestHelper.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerTestHelper.java
@@ -184,12 +184,12 @@ public class XdsServerTestHelper {
                                                      String resourceName,
                                                      ResourceWatcher<T> watcher) {
       switch (resourceType.typeName()) {
-        case LDS:
+        case "LDS":
           assertThat(ldsWatcher).isNull();
           ldsWatcher = (ResourceWatcher<LdsUpdate>) watcher;
           ldsResource.set(resourceName);
           break;
-        case RDS:
+        case "RDS":
           //re-register is not allowed.
           assertThat(rdsWatchers.put(resourceName, (ResourceWatcher<RdsUpdate>)watcher)).isNull();
           rdsCount.countDown();
@@ -203,12 +203,12 @@ public class XdsServerTestHelper {
                                                            String resourceName,
                                 ResourceWatcher<T> watcher) {
       switch (type.typeName()) {
-        case LDS:
+        case "LDS":
           assertThat(ldsWatcher).isNotNull();
           ldsResource = null;
           ldsWatcher = null;
           break;
-        case RDS:
+        case "RDS":
           rdsWatchers.remove(resourceName);
           break;
         default:


### PR DESCRIPTION
Follow up #9444 
Now the xds resources are dynamically managed in resourceStore in xdsClient. The types is a xdsResourceType, singleton.
There is no longer hardcoded static list of known resource types, the subscription list is the source of truth.
AbstractXdsClient that manages AdsStream will only accept the xds resource types that has already has watchers subscribed to, same behaviour as before.
Calling out that CSDS got slight behaviour changes: when it gets the subscribed resource snapshots, only the xds resource types that are actively subscribed will show up in the result map. The tests that might depend on this needs attention.

cc. @ejona86 