### PR TITLE
Bump protobuf to 3.19.6 (v1.47.x)

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -44,11 +44,11 @@ This section is only necessary if you are making changes to the code
 generation. Most users only need to use `skipCodegen=true` as discussed above.
 
 ### Build Protobuf
-The codegen plugin is C++ code and requires protobuf 3.19.2 or later.
+The codegen plugin is C++ code and requires protobuf 3.19.6 or later.
 
 For Linux, Mac and MinGW:
 ```
-$ PROTOBUF_VERSION=3.19.2
+$ PROTOBUF_VERSION=3.19.6
 $ curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protobuf-all-$PROTOBUF_VERSION.tar.gz
 $ tar xzf protobuf-all-$PROTOBUF_VERSION.tar.gz
 $ cd protobuf-$PROTOBUF_VERSION

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ For protobuf-based codegen integrated with the Maven build system, you can use
       <artifactId>protobuf-maven-plugin</artifactId>
       <version>0.6.1</version>
       <configuration>
-        <protocArtifact>com.google.protobuf:protoc:3.19.2:exe:${os.detected.classifier}</protocArtifact>
+        <protocArtifact>com.google.protobuf:protoc:3.19.6:exe:${os.detected.classifier}</protocArtifact>
         <pluginId>grpc-java</pluginId>
         <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.47.0:exe:${os.detected.classifier}</pluginArtifact>
       </configuration>
@@ -140,7 +140,7 @@ plugins {
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:3.19.2"
+    artifact = "com.google.protobuf:protoc:3.19.6"
   }
   plugins {
     grpc {
@@ -173,7 +173,7 @@ plugins {
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:3.19.2"
+    artifact = "com.google.protobuf:protoc:3.19.6"
   }
   plugins {
     grpc {

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ subprojects {
         nettyVersion = '4.1.72.Final'
         guavaVersion = '31.0.1-android'
         googleauthVersion = '1.4.0'
-        protobufVersion = '3.19.2'
+        protobufVersion = '3.19.6'
         protocVersion = protobufVersion
         opencensusVersion = '0.31.0'
         autovalueVersion = '1.9'

--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -1,4 +1,4 @@
-set PROTOBUF_VER=3.19.2
+set PROTOBUF_VER=3.19.6
 set CMAKE_NAME=cmake-3.3.2-win32-x86
 
 if not exist "protobuf-%PROTOBUF_VER%\cmake\build\Release\" (

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -3,7 +3,7 @@
 # Build protoc
 set -evux -o pipefail
 
-PROTOBUF_VERSION=3.19.2
+PROTOBUF_VERSION=3.19.6
 
 # ARCH is x86_64 bit unless otherwise specified.
 ARCH="${ARCH:-x86_64}"

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -32,7 +32,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.19.2' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.19.6' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.47.1-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -30,7 +30,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.19.2' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.19.6' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.47.1-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -30,7 +30,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.19.2' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.19.6' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.47.1-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/android/strictmode/app/build.gradle
+++ b/examples/android/strictmode/app/build.gradle
@@ -31,7 +31,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.19.2' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.19.6' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.47.1-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -23,7 +23,7 @@ targetCompatibility = 1.8
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.47.1-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.19.2'
+def protobufVersion = '3.19.6'
 def protocVersion = protobufVersion
 
 dependencies {

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.8
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.47.1-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.19.2'
+def protocVersion = '3.19.6'
 
 dependencies {
     // grpc-alts transitively depends on grpc-netty-shaded, grpc-protobuf, and grpc-stub

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.8
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.47.1-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.19.2'
+def protobufVersion = '3.19.6'
 def protocVersion = protobufVersion
 
 

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.47.1-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.19.2</protobuf.version>
+    <protobuf.version>3.19.6</protobuf.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.8
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.47.1-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.19.2'
+def protobufVersion = '3.19.6'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-hostname/pom.xml
+++ b/examples/example-hostname/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.47.1-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protoc.version>3.19.2</protoc.version>
+    <protoc.version>3.19.6</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -23,7 +23,7 @@ targetCompatibility = 1.8
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.47.1-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.19.2'
+def protobufVersion = '3.19.6'
 def protocVersion = protobufVersion
 
 dependencies {

--- a/examples/example-jwt-auth/pom.xml
+++ b/examples/example-jwt-auth/pom.xml
@@ -14,8 +14,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.47.1-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.19.2</protobuf.version>
-    <protoc.version>3.19.2</protoc.version>
+    <protobuf.version>3.19.6</protobuf.version>
+    <protoc.version>3.19.6</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/examples/example-orca/build.gradle
+++ b/examples/example-orca/build.gradle
@@ -18,7 +18,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 def grpcVersion = '1.47.1-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.19.2'
+def protocVersion = '3.19.6'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.8
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.47.1-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.19.2'
+def protocVersion = '3.19.6'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.47.1-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protoc.version>3.19.2</protoc.version>
+    <protoc.version>3.19.6</protoc.version>
     <netty.tcnative.version>2.0.34.Final</netty.tcnative.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>

--- a/examples/example-xds/build.gradle
+++ b/examples/example-xds/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.8
 // updating the version in our release process.
 def grpcVersion = '1.47.1-SNAPSHOT' // CURRENT_GRPC_VERSION
 def nettyTcNativeVersion = '2.0.31.Final'
-def protocVersion = '3.19.2'
+def protocVersion = '3.19.6'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.47.1-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.19.2</protobuf.version>
-    <protoc.version>3.19.2</protoc.version>
+    <protobuf.version>3.19.6</protobuf.version>
+    <protoc.version>3.19.6</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/gcp-observability/build.gradle
+++ b/gcp-observability/build.gradle
@@ -35,6 +35,7 @@ dependencies {
             libraries.perfmark,
             libraries.opencensus_contrib_grpc_metrics,
             libraries.gson,
+	    libraries.protobuf_util, // Prefer our newer version
             ('com.google.guava:guava:31.0.1-jre'),
             ('com.google.errorprone:error_prone_annotations:2.11.0'),
             ('com.google.auth:google-auth-library-credentials:1.4.0'),

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -148,18 +148,18 @@ def com_google_protobuf():
     # This statement defines the @com_google_protobuf repo.
     http_archive(
         name = "com_google_protobuf",
-        sha256 = "9ceef0daf7e8be16cd99ac759271eb08021b53b1c7b6edd399953a76390234cd",
-        strip_prefix = "protobuf-3.19.2",
-        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.19.2.zip"],
+        sha256 = "387e2c559bb2c7c1bc3798c4e6cff015381a79b2758696afcbf8e88730b47389",
+        strip_prefix = "protobuf-3.19.6",
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.19.6.zip"],
     )
 
 def com_google_protobuf_javalite():
     # java_lite_proto_library rules implicitly depend on @com_google_protobuf_javalite
     http_archive(
         name = "com_google_protobuf_javalite",
-        sha256 = "9ceef0daf7e8be16cd99ac759271eb08021b53b1c7b6edd399953a76390234cd",
-        strip_prefix = "protobuf-3.19.2",
-        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.19.2.zip"],
+        sha256 = "387e2c559bb2c7c1bc3798c4e6cff015381a79b2758696afcbf8e88730b47389",
+        strip_prefix = "protobuf-3.19.6",
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.19.6.zip"],
     )
 
 def io_grpc_grpc_proto():


### PR DESCRIPTION
Note that this is _not_ a backport, of #9575 and #9585 as it is to a different protobuf version. So this was re-done from scratch.