### PR TITLE
COMPILING.md: Fix protobuf version number to 21.7

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -44,11 +44,11 @@ This section is only necessary if you are making changes to the code
 generation. Most users only need to use `skipCodegen=true` as discussed above.
 
 ### Build Protobuf
-The codegen plugin is C++ code and requires protobuf 3.21.7 or later.
+The codegen plugin is C++ code and requires protobuf 21.7 or later.
 
 For Linux, Mac and MinGW:
 ```
-$ PROTOBUF_VERSION=3.21.7
+$ PROTOBUF_VERSION=21.7
 $ curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protobuf-all-$PROTOBUF_VERSION.tar.gz
 $ tar xzf protobuf-all-$PROTOBUF_VERSION.tar.gz
 $ cd protobuf-$PROTOBUF_VERSION


### PR DESCRIPTION
This is essentially a repeat of b118e00c, but for our compiling documentation. Protobuf has two versions nowadays: 3.21.7 for Java and 21.7 for protobuf as a whole. For 21.1 they tagged it both as 21.1 and 3.21.1, but they didn't do that for 3.21.7.

Fixes #9582

CC @veblush 