### PR TITLE
xds: Priority LB to use acceptResolvedAddresses()

### DIFF
--- a/xds/src/main/java/io/grpc/xds/PriorityLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/PriorityLoadBalancer.java
@@ -81,7 +81,7 @@ final class PriorityLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     this.resolvedAddresses = resolvedAddresses;
     PriorityLbConfig config = (PriorityLbConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
@@ -100,6 +100,7 @@ final class PriorityLoadBalancer extends LoadBalancer {
       }
     }
     tryNextPriority();
+    return true;
   }
 
   @Override


### PR DESCRIPTION
Part of a migration to move load balancers away from handleResolvedAddresses()