### PR TITLE
core: fix RejectedExecutionException in  Retriable Stream

### DIFF
--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -811,11 +811,6 @@ abstract class RetriableStream<ReqT> implements ClientStream {
     }
   }
 
-  private interface BufferEntry {
-    /** Replays the buffer entry with the given stream. */
-    void runWith(Substream substream);
-  }
-
   private void safeCloseMasterListener(Status status, RpcProgress progress, Metadata metadata) {
     listenerSerializeExecutor.execute(
         new Runnable() {
@@ -825,6 +820,11 @@ abstract class RetriableStream<ReqT> implements ClientStream {
             masterListener.closed(status, progress, metadata);
           }
         });
+  }
+
+  private interface BufferEntry {
+    /** Replays the buffer entry with the given stream. */
+    void runWith(Substream substream);
   }
 
   private final class Sublistener implements ClientStreamListener {
@@ -957,9 +957,7 @@ abstract class RetriableStream<ReqT> implements ClientStream {
             RetryPlan retryPlan = makeRetryDecision(status, trailers);
             if (retryPlan.shouldRetry) {
               // retry
-              Substream newSubstream = createSubstream(
-                  substream.previousAttemptCount + 1,
-                  false);
+              Substream newSubstream = createSubstream(substream.previousAttemptCount + 1, false);
               if (newSubstream == null) {
                 return;
               }

--- a/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
@@ -283,6 +283,7 @@ public class RetriableStreamTest {
     doReturn(mockStream2).when(retriableStreamRecorder).newSubstream(1);
     sublistenerCaptor1.getValue().closed(
         Status.fromCode(RETRIABLE_STATUS_CODE_2), PROCESSED, new Metadata());
+    inOrder.verify(retriableStreamRecorder).newSubstream(1);
     assertEquals(1, fakeClock.numPendingTasks());
 
     // send more messages during backoff
@@ -294,7 +295,6 @@ public class RetriableStreamTest {
     assertEquals(1, fakeClock.numPendingTasks());
     fakeClock.forwardTime(1L, TimeUnit.SECONDS);
     assertEquals(0, fakeClock.numPendingTasks());
-    inOrder.verify(retriableStreamRecorder).newSubstream(1);
     inOrder.verify(mockStream2).setAuthority(AUTHORITY);
     inOrder.verify(mockStream2).setCompressor(COMPRESSOR);
     inOrder.verify(mockStream2).setDecompressorRegistry(DECOMPRESSOR_REGISTRY);
@@ -339,6 +339,7 @@ public class RetriableStreamTest {
     doReturn(mockStream3).when(retriableStreamRecorder).newSubstream(2);
     sublistenerCaptor2.getValue().closed(
         Status.fromCode(RETRIABLE_STATUS_CODE_1), PROCESSED, new Metadata());
+    inOrder.verify(retriableStreamRecorder).newSubstream(2);
     assertEquals(1, fakeClock.numPendingTasks());
 
     // send more messages during backoff
@@ -353,7 +354,6 @@ public class RetriableStreamTest {
     assertEquals(1, fakeClock.numPendingTasks());
     fakeClock.forwardTime(1L, TimeUnit.SECONDS);
     assertEquals(0, fakeClock.numPendingTasks());
-    inOrder.verify(retriableStreamRecorder).newSubstream(2);
     inOrder.verify(mockStream3).setAuthority(AUTHORITY);
     inOrder.verify(mockStream3).setCompressor(COMPRESSOR);
     inOrder.verify(mockStream3).setDecompressorRegistry(DECOMPRESSOR_REGISTRY);
@@ -1127,7 +1127,6 @@ public class RetriableStreamTest {
     sublistenerCaptor1.getValue().closed(
         Status.fromCode(RETRIABLE_STATUS_CODE_1), PROCESSED, new Metadata());
 
-    // bufferSizeTracer.outboundWireSize() quits immediately while backoff b/c substream1 is closed
     assertEquals(1, fakeClock.numPendingTasks());
     bufferSizeTracer.outboundWireSize(2);
     verify(retriableStreamRecorder, never()).postCommit();
@@ -1138,8 +1137,6 @@ public class RetriableStreamTest {
 
     // bufferLimitExceeded
     bufferSizeTracer.outboundWireSize(PER_RPC_BUFFER_LIMIT - 1);
-    verify(retriableStreamRecorder, never()).postCommit();
-    bufferSizeTracer.outboundWireSize(2);
     verify(retriableStreamRecorder).postCommit();
 
     verifyNoMoreInteractions(mockStream1);

--- a/interop-testing/src/test/java/io/grpc/testing/integration/RetryTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/RetryTest.java
@@ -351,8 +351,8 @@ public class RetryTest {
     call.request(1);
     assertInboundMessageRecorded();
     assertInboundWireSizeRecorded(1);
-    assertRpcStatusRecorded(Status.Code.OK, 2000, 2);
-    assertRetryStatsRecorded(1, 0, 10_000);
+    assertRpcStatusRecorded(Status.Code.OK, 12000, 2);
+    assertRetryStatsRecorded(1, 0, 0);
   }
 
   @Test
@@ -416,8 +416,8 @@ public class RetryTest {
     streamClosedLatch.countDown();
     // The call listener is closed.
     verify(mockCallListener, timeout(5000)).onClose(any(Status.class), any(Metadata.class));
-    assertRpcStatusRecorded(Code.CANCELLED, 7_000, 1);
-    assertRetryStatsRecorded(1, 0, 10_000);
+    assertRpcStatusRecorded(Code.CANCELLED, 17_000, 1);
+    assertRetryStatsRecorded(1, 0, 0);
   }
 
   @Test

--- a/interop-testing/src/test/java/io/grpc/testing/integration/RetryTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/RetryTest.java
@@ -410,13 +410,14 @@ public class RetryTest {
     serverCall.request(2);
     assertOutboundWireSizeRecorded(message.length());
     fakeClock.forwardTime(7, SECONDS);
-    call.cancel("Cancelled before commit", null); // A noop substream will commit.
-    // The call listener is closed, but the netty substream listener is not yet closed.
-    verify(mockCallListener, timeout(5000)).onClose(any(Status.class), any(Metadata.class));
+    // A noop substream will commit. But call is not yet closed.
+    call.cancel("Cancelled before commit", null);
     // Let the netty substream listener be closed.
     streamClosedLatch.countDown();
-    assertRetryStatsRecorded(1, 0, 10_000);
+    // The call listener is closed.
+    verify(mockCallListener, timeout(5000)).onClose(any(Status.class), any(Metadata.class));
     assertRpcStatusRecorded(Code.CANCELLED, 7_000, 1);
+    assertRetryStatsRecorded(1, 0, 10_000);
   }
 
   @Test


### PR DESCRIPTION
fix https://github.com/grpc/grpc-java/issues/9547

### revision 1
Add big negative integer to pending stream count when cancelled. The count is used to delay closing master listener until streams fully drained.
Increment pending stream count before creating one. The count is also used to indicate callExecutor is safe to be used. New stream not created if big negative number was added, i.e. stream cancelled. New stream is created if not cancelled, callExecutor is safe to be used, because cancel will be delayed.


### revision 2
1.  incrementing pending stream count only when cancel is not called, otherwise no op. This is to prevent the count never goes to `Integer.MIN_VALUE`.
2. create new streams (retry, hedging) is moved to the main thread, before callExecutor calls drain.
3. minor refactor the masterListener.close() scenario. 
