### PR TITLE
gcp-observability: add period to service filter regular expression in logging config (1.50.x backport)

### DIFF
--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/ObservabilityConfigImpl.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/ObservabilityConfigImpl.java
@@ -50,7 +50,7 @@ final class ObservabilityConfigImpl implements ObservabilityConfig {
   private static final double EPSILON = 1e-6;
 
   private static final Pattern METHOD_NAME_REGEX =
-      Pattern.compile("^([*])|((([\\w]+)/((?:\\w+)|[*])))$");
+      Pattern.compile("^([*])|((([\\w.]+)/((?:\\w+)|[*])))$");
 
   private boolean enableCloudLogging = false;
   private boolean enableCloudMonitoring = false;

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/ObservabilityConfigImplTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/ObservabilityConfigImplTest.java
@@ -94,6 +94,19 @@ public class ObservabilityConfigImplTest {
           + "    }\n"
           + "}";
 
+  private static final String VALID_LOG_FILTERS = "{\n"
+      + "    \"project_id\": \"grpc-testing\",\n"
+      + "    \"cloud_logging\": {\n"
+      + "    \"server_rpc_events\": [{\n"
+      + "        \"methods\": [\"service.Service1/*\", \"service2.Service4/method4\"],\n"
+      + "        \"max_metadata_bytes\": 16,\n"
+      + "        \"max_message_bytes\": 64\n"
+      + "    }"
+      + "    ]\n"
+      + "    }\n"
+      + "}";
+
+
   private static final String PROJECT_ID = "{\n"
       + "    \"project_id\": \"grpc-testing\",\n"
       + "    \"cloud_logging\": {},\n"
@@ -459,5 +472,21 @@ public class ObservabilityConfigImplTest {
       assertThat(iae.getMessage()).contains(
           "invalid service or method filter");
     }
+  }
+
+  @Test
+  public void validLogFilter() throws Exception {
+    observabilityConfig.parse(VALID_LOG_FILTERS);
+    assertTrue(observabilityConfig.isEnableCloudLogging());
+    assertThat(observabilityConfig.getProjectId()).isEqualTo("grpc-testing");
+    List<LogFilter> logFilterList = observabilityConfig.getServerLogFilters();
+    assertThat(logFilterList).hasSize(1);
+    assertThat(logFilterList.get(0).headerBytes).isEqualTo(16);
+    assertThat(logFilterList.get(0).messageBytes).isEqualTo(64);
+    assertThat(logFilterList.get(0).excludePattern).isFalse();
+    assertThat(logFilterList.get(0).matchAll).isFalse();
+    assertThat(logFilterList.get(0).services).isEqualTo(Collections.singleton("service.Service1"));
+    assertThat(logFilterList.get(0).methods)
+        .isEqualTo(Collections.singleton("service2.Service4/method4"));
   }
 }


### PR DESCRIPTION
This PR adds period(.) to the service name part of regular expression which is used to validate method or service filter provided in observability configuration.

Backport of  #9631

CC @sanjaypujare