### PR TITLE
xds: fix javadoc warning

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -708,7 +708,6 @@ final class XdsClientImpl extends XdsClient implements XdsResponseHandler, Resou
     }
   }
 
-  @VisibleForTesting
   static final class ResourceInvalidException extends Exception {
     private static final long serialVersionUID = 0L;
 

--- a/xds/src/main/java/io/grpc/xds/XdsRouteConfigureResource.java
+++ b/xds/src/main/java/io/grpc/xds/XdsRouteConfigureResource.java
@@ -17,7 +17,6 @@
 package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.grpc.xds.XdsRouteConfigureResource.RdsUpdate;
 
 import com.github.udpa.udpa.type.v1.TypedStruct;
 import com.google.common.annotations.VisibleForTesting;
@@ -50,6 +49,7 @@ import io.grpc.xds.VirtualHost.Route.RouteMatch;
 import io.grpc.xds.VirtualHost.Route.RouteMatch.PathMatcher;
 import io.grpc.xds.XdsClient.ResourceUpdate;
 import io.grpc.xds.XdsClientImpl.ResourceInvalidException;
+import io.grpc.xds.XdsRouteConfigureResource.RdsUpdate;
 import io.grpc.xds.internal.Matchers;
 import io.grpc.xds.internal.Matchers.FractionMatcher;
 import io.grpc.xds.internal.Matchers.HeaderMatcher;


### PR DESCRIPTION
fix 
```
> Task :grpc-xds:javadoc
/Users/zivy/src/grpc-java-2/xds/src/main/java/io/grpc/xds/XdsClientImpl.java:711: error: cannot find symbol
  @VisibleForTesting
   ^
  symbol:   class VisibleForTesting
  location: class XdsClientImpl
/Users/zivy/src/grpc-java-2/xds/src/main/java/io/grpc/xds/XdsRouteConfigureResource.java:672: error: cannot find symbol
  static final class RdsUpdate implements ResourceUpdate {
                                          ^
  symbol:   class ResourceUpdate
  location: class XdsRouteConfigureResource
```