### PR TITLE
.github/workflows: Bump action major versions

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -9,5 +9,5 @@ jobs:
     name: "Gradle wrapper validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -13,8 +13,8 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v2
+      - uses: dessant/lock-threads@v3
         with:
           github-token: ${{ github.token }}
-          issue-lock-inactive-days: 90
-          pr-lock-inactive-days: 90
+          issue-inactive-days: 90
+          pr-inactive-days: 90

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,14 +21,14 @@ jobs:
       fail-fast: false # Should swap to true if we grow a large matrix
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
       with:
         java-version: ${{ matrix.jre }}
         distribution: 'temurin'
 
     - name: Gradle cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.gradle/caches
@@ -37,7 +37,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gradle-
     - name: Maven cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.m2/repository
@@ -46,7 +46,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Protobuf cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/protobuf-cache
         key: ${{ runner.os }}-maven-${{ hashFiles('buildscripts/make_dependencies.sh') }}
@@ -55,7 +55,7 @@ jobs:
       run: buildscripts/kokoro/unix.sh
     - name: Post Failure Upload Test Reports to Artifacts
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Test Reports (JRE ${{ matrix.jre }})
         path: ./*/build/reports/tests/**
@@ -67,4 +67,4 @@ jobs:
       if: matrix.jre == 8 # Upload once, instead of for each job in the matrix
       run: ./gradlew :grpc-all:coveralls -x compileJava
     - name: Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3


### PR DESCRIPTION
Almost all of these major version bumps are because they upgraded to Node 16, which requires a new minimum version of the Runner (which matters for those maintaining their own runners). The main outlier is lock-threads, which changed the names of its input parameters.