### PR TITLE
netty:Auto adjust BDP ping frequency

### DIFF
--- a/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
+++ b/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
@@ -38,7 +38,6 @@ import java.util.concurrent.TimeUnit;
  */
 abstract class AbstractNettyHandler extends GrpcHttp2ConnectionHandler {
   private static final long GRACEFUL_SHUTDOWN_NO_TIMEOUT = -1;
-  public static final int MIN_TIME_RATIO = 5; // pings taking < 1/5 of average are ignored
 
   private final int initialConnectionWindow;
   private final FlowControlPinger flowControlPing;

--- a/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
+++ b/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
@@ -258,7 +258,7 @@ abstract class AbstractNettyHandler extends GrpcHttp2ConnectionHandler {
       dataSizeSincePing = dataSize;
     }
 
-    /** Only used in testing **/
+    // Only used in testing
     @VisibleForTesting
     void setDataSizeAndSincePing(int dataSize) {
       setDataSizeSincePing(dataSize);

--- a/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
+++ b/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
@@ -165,15 +165,18 @@ abstract class AbstractNettyHandler extends GrpcHttp2ConnectionHandler {
       if (!autoTuneFlowControlOn) {
         return;
       }
-      if (lastTargetWindow == 0 && pingCount > 0) {
-        lastTargetWindow =
-            decoder().flowController().initialWindowSize(connection().connectionStream());
-      }
+
       if (!isPinging() && pingLimiter.isPingAllowed()
           && getDataSincePing() * 2 >= lastTargetWindow * pingFrequencyMultiplier) {
         setPinging(true);
         sendPing(ctx());
       }
+
+      if (lastTargetWindow == 0) {
+        lastTargetWindow =
+            decoder().flowController().initialWindowSize(connection().connectionStream());
+      }
+
       incrementDataSincePing(dataLength + paddingLength);
     }
 

--- a/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
+++ b/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
@@ -258,13 +258,12 @@ abstract class AbstractNettyHandler extends GrpcHttp2ConnectionHandler {
       dataSizeSincePing = dataSize;
     }
 
+    /** Only used in testing **/
     @VisibleForTesting
     void setDataSizeAndSincePing(int dataSize) {
       setDataSizeSincePing(dataSize);
       pingFrequencyMultiplier = 1;
-      lastPingTime = (ticker.read() > TimeUnit.SECONDS.toNanos(1))
-          ? ticker.read() - TimeUnit.SECONDS.toNanos(1)
-          : ticker.read() - 1;
+      lastPingTime = ticker.read() ;
     }
   }
 

--- a/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
+++ b/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
@@ -57,18 +57,6 @@ abstract class AbstractNettyHandler extends GrpcHttp2ConnectionHandler {
       Http2Settings initialSettings,
       ChannelLogger negotiationLogger,
       boolean autoFlowControl,
-      PingLimiter pingLimiter) {
-    this(channelUnused, decoder, encoder, initialSettings, negotiationLogger, autoFlowControl,
-        pingLimiter, Ticker.systemTicker());
-  }
-
-  AbstractNettyHandler(
-      ChannelPromise channelUnused,
-      Http2ConnectionDecoder decoder,
-      Http2ConnectionEncoder encoder,
-      Http2Settings initialSettings,
-      ChannelLogger negotiationLogger,
-      boolean autoFlowControl,
       PingLimiter pingLimiter,
       Ticker ticker) {
     super(channelUnused, decoder, encoder, initialSettings, negotiationLogger);
@@ -80,8 +68,10 @@ abstract class AbstractNettyHandler extends GrpcHttp2ConnectionHandler {
     this.initialConnectionWindow = initialSettings.initialWindowSize() == null ? -1 :
         initialSettings.initialWindowSize();
     this.autoTuneFlowControlOn = autoFlowControl;
-    PingLimiter activePingLimiter = (pingLimiter != null) ? pingLimiter :  new AllowPingLimiter();
-    this.flowControlPing = new FlowControlPinger(activePingLimiter);
+    if (pingLimiter == null) {
+      pingLimiter = new AllowPingLimiter();
+    }
+    this.flowControlPing = new FlowControlPinger(pingLimiter);
     this.ticker = checkNotNull(ticker, "ticker");
   }
 

--- a/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
+++ b/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
@@ -208,8 +208,7 @@ abstract class AbstractNettyHandler extends GrpcHttp2ConnectionHandler {
         return;
       }
 
-      // When it is changing we want to react more quickly
-      pingFrequencyMultiplier = Math.max(pingFrequencyMultiplier - 1, 1);
+      pingFrequencyMultiplier = 1; // react more quickly when size is changing
       lastBandwidth = bandwidth;
       lastTargetWindow = targetWindow;
       int increase = targetWindow - currentWindow;

--- a/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
+++ b/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
@@ -16,6 +16,7 @@
 
 package io.grpc.netty;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static io.netty.handler.codec.http2.Http2CodecUtil.getEmbeddedHttp2Exception;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -81,7 +82,7 @@ abstract class AbstractNettyHandler extends GrpcHttp2ConnectionHandler {
     this.autoTuneFlowControlOn = autoFlowControl;
     PingLimiter activePingLimiter = (pingLimiter != null) ? pingLimiter :  new AllowPingLimiter();
     this.flowControlPing = new FlowControlPinger(activePingLimiter);
-    this.ticker = (ticker != null) ? ticker : Ticker.systemTicker();
+    this.ticker = checkNotNull(ticker, "ticker");
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -23,6 +23,7 @@ import static io.grpc.internal.GrpcUtil.DEFAULT_KEEPALIVE_TIMEOUT_NANOS;
 import static io.grpc.internal.GrpcUtil.KEEPALIVE_TIME_NANOS_DISABLED;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Ticker;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.CheckReturnValue;
 import com.google.errorprone.annotations.InlineMe;
@@ -738,7 +739,7 @@ public final class NettyChannelBuilder extends
           maxMessageSize, maxHeaderListSize, keepAliveTimeNanosState.get(), keepAliveTimeoutNanos,
           keepAliveWithoutCalls, options.getAuthority(), options.getUserAgent(),
           tooManyPingsRunnable, transportTracerFactory.create(), options.getEagAttributes(),
-          localSocketPicker, channelLogger, useGetForSafeMethods);
+          localSocketPicker, channelLogger, useGetForSafeMethods, Ticker.systemTicker());
       return transport;
     }
 

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -24,6 +24,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
+import com.google.common.base.Ticker;
 import io.grpc.Attributes;
 import io.grpc.ChannelLogger;
 import io.grpc.InternalChannelz;
@@ -143,7 +144,8 @@ class NettyClientHandler extends AbstractNettyHandler {
       TransportTracer transportTracer,
       Attributes eagAttributes,
       String authority,
-      ChannelLogger negotiationLogger) {
+      ChannelLogger negotiationLogger,
+      Ticker ticker) {
     Preconditions.checkArgument(maxHeaderListSize > 0, "maxHeaderListSize must be positive");
     Http2HeadersDecoder headersDecoder = new GrpcHttp2ClientHeadersDecoder(maxHeaderListSize);
     Http2FrameReader frameReader = new DefaultHttp2FrameReader(headersDecoder);
@@ -169,7 +171,8 @@ class NettyClientHandler extends AbstractNettyHandler {
         transportTracer,
         eagAttributes,
         authority,
-        negotiationLogger);
+        negotiationLogger,
+        ticker);
   }
 
   @VisibleForTesting
@@ -187,7 +190,8 @@ class NettyClientHandler extends AbstractNettyHandler {
       TransportTracer transportTracer,
       Attributes eagAttributes,
       String authority,
-      ChannelLogger negotiationLogger) {
+      ChannelLogger negotiationLogger,
+      Ticker ticker) {
     Preconditions.checkNotNull(connection, "connection");
     Preconditions.checkNotNull(frameReader, "frameReader");
     Preconditions.checkNotNull(lifecycleManager, "lifecycleManager");
@@ -237,7 +241,8 @@ class NettyClientHandler extends AbstractNettyHandler {
         eagAttributes,
         authority,
         autoFlowControl,
-        pingCounter);
+        pingCounter,
+        ticker);
   }
 
   private NettyClientHandler(
@@ -253,9 +258,10 @@ class NettyClientHandler extends AbstractNettyHandler {
       Attributes eagAttributes,
       String authority,
       boolean autoFlowControl,
-      PingLimiter pingLimiter) {
+      PingLimiter pingLimiter,
+      Ticker ticker) {
     super(/* channelUnused= */ null, decoder, encoder, settings,
-        negotiationLogger, autoFlowControl, pingLimiter);
+        negotiationLogger, autoFlowControl, pingLimiter, ticker);
     this.lifecycleManager = lifecycleManager;
     this.keepAliveManager = keepAliveManager;
     this.stopwatchFactory = stopwatchFactory;

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -20,7 +20,6 @@ import static io.grpc.internal.GrpcUtil.KEEPALIVE_TIME_NANOS_DISABLED;
 import static io.netty.channel.ChannelOption.ALLOCATOR;
 import static io.netty.channel.ChannelOption.SO_KEEPALIVE;
 
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
@@ -115,23 +114,6 @@ class NettyClientTransport implements ConnectionClientTransport {
       boolean keepAliveWithoutCalls, String authority, @Nullable String userAgent,
       Runnable tooManyPingsRunnable, TransportTracer transportTracer, Attributes eagAttributes,
       LocalSocketPicker localSocketPicker, ChannelLogger channelLogger,
-      boolean useGetForSafeMethods) {
-    this(address,channelFactory, channelOptions, group, negotiator, autoFlowControl,
-        flowControlWindow, maxMessageSize, maxHeaderListSize, keepAliveTimeNanos,
-        keepAliveTimeoutNanos, keepAliveWithoutCalls, authority, userAgent, tooManyPingsRunnable,
-        transportTracer, eagAttributes, localSocketPicker, channelLogger, useGetForSafeMethods,
-        Ticker.systemTicker());
-  }
-
-  NettyClientTransport(
-      SocketAddress address, ChannelFactory<? extends Channel> channelFactory,
-      Map<ChannelOption<?>, ?> channelOptions, EventLoopGroup group,
-      ProtocolNegotiator negotiator, boolean autoFlowControl, int flowControlWindow,
-      int maxMessageSize, int maxHeaderListSize,
-      long keepAliveTimeNanos, long keepAliveTimeoutNanos,
-      boolean keepAliveWithoutCalls, String authority, @Nullable String userAgent,
-      Runnable tooManyPingsRunnable, TransportTracer transportTracer, Attributes eagAttributes,
-      LocalSocketPicker localSocketPicker, ChannelLogger channelLogger,
       boolean useGetForSafeMethods, Ticker ticker) {
 
     this.negotiator = Preconditions.checkNotNull(negotiator, "negotiator");
@@ -158,7 +140,7 @@ class NettyClientTransport implements ConnectionClientTransport {
     this.logId = InternalLogId.allocate(getClass(), remoteAddress.toString());
     this.channelLogger = Preconditions.checkNotNull(channelLogger, "channelLogger");
     this.useGetForSafeMethods = useGetForSafeMethods;
-    this.ticker = (ticker != null) ? ticker : Ticker.systemTicker();
+    this.ticker = Preconditions.checkNotNull(ticker, "ticker");
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -191,34 +191,7 @@ class NettyServerHandler extends AbstractNettyHandler {
         maxConnectionAgeGraceInNanos,
         permitKeepAliveWithoutCalls,
         permitKeepAliveTimeInNanos,
-        eagAttributes);
-  }
-
-  static NettyServerHandler newHandler(
-      ChannelPromise channelUnused,
-      Http2FrameReader frameReader,
-      Http2FrameWriter frameWriter,
-      ServerTransportListener transportListener,
-      List<? extends ServerStreamTracer.Factory> streamTracerFactories,
-      TransportTracer transportTracer,
-      int maxStreams,
-      boolean autoFlowControl,
-      int flowControlWindow,
-      int maxHeaderListSize,
-      int maxMessageSize,
-      long keepAliveTimeInNanos,
-      long keepAliveTimeoutInNanos,
-      long maxConnectionIdleInNanos,
-      long maxConnectionAgeInNanos,
-      long maxConnectionAgeGraceInNanos,
-      boolean permitKeepAliveWithoutCalls,
-      long permitKeepAliveTimeInNanos,
-      Attributes eagAttributes) {
-    return newHandler(channelUnused, frameReader,frameWriter, transportListener,
-        streamTracerFactories, transportTracer, maxStreams, autoFlowControl, flowControlWindow,
-        maxHeaderListSize, maxMessageSize, keepAliveTimeInNanos, keepAliveTimeoutInNanos,
-        maxConnectionIdleInNanos, maxConnectionAgeInNanos, maxConnectionAgeGraceInNanos,
-        permitKeepAliveWithoutCalls, permitKeepAliveTimeInNanos, eagAttributes,
+        eagAttributes,
         Ticker.systemTicker());
   }
 

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -34,6 +34,7 @@ import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.AUTHORI
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.base.Ticker;
 import io.grpc.Attributes;
 import io.grpc.ChannelLogger;
 import io.grpc.ChannelLogger.ChannelLogLevel;
@@ -213,6 +214,35 @@ class NettyServerHandler extends AbstractNettyHandler {
       boolean permitKeepAliveWithoutCalls,
       long permitKeepAliveTimeInNanos,
       Attributes eagAttributes) {
+    return newHandler(channelUnused, frameReader,frameWriter, transportListener,
+        streamTracerFactories, transportTracer, maxStreams, autoFlowControl, flowControlWindow,
+        maxHeaderListSize, maxMessageSize, keepAliveTimeInNanos, keepAliveTimeoutInNanos,
+        maxConnectionIdleInNanos, maxConnectionAgeInNanos, maxConnectionAgeGraceInNanos,
+        permitKeepAliveWithoutCalls, permitKeepAliveTimeInNanos, eagAttributes,
+        Ticker.systemTicker());
+  }
+
+  static NettyServerHandler newHandler(
+      ChannelPromise channelUnused,
+      Http2FrameReader frameReader,
+      Http2FrameWriter frameWriter,
+      ServerTransportListener transportListener,
+      List<? extends ServerStreamTracer.Factory> streamTracerFactories,
+      TransportTracer transportTracer,
+      int maxStreams,
+      boolean autoFlowControl,
+      int flowControlWindow,
+      int maxHeaderListSize,
+      int maxMessageSize,
+      long keepAliveTimeInNanos,
+      long keepAliveTimeoutInNanos,
+      long maxConnectionIdleInNanos,
+      long maxConnectionAgeInNanos,
+      long maxConnectionAgeGraceInNanos,
+      boolean permitKeepAliveWithoutCalls,
+      long permitKeepAliveTimeInNanos,
+      Attributes eagAttributes,
+      Ticker ticker) {
     Preconditions.checkArgument(maxStreams > 0, "maxStreams must be positive: %s", maxStreams);
     Preconditions.checkArgument(flowControlWindow > 0, "flowControlWindow must be positive: %s",
         flowControlWindow);
@@ -245,6 +275,10 @@ class NettyServerHandler extends AbstractNettyHandler {
     settings.maxConcurrentStreams(maxStreams);
     settings.maxHeaderListSize(maxHeaderListSize);
 
+    if (ticker == null) {
+      ticker = Ticker.systemTicker();
+    }
+
     return new NettyServerHandler(
         channelUnused,
         connection,
@@ -258,7 +292,7 @@ class NettyServerHandler extends AbstractNettyHandler {
         maxConnectionAgeInNanos, maxConnectionAgeGraceInNanos,
         keepAliveEnforcer,
         autoFlowControl,
-        eagAttributes);
+        eagAttributes, ticker);
   }
 
   private NettyServerHandler(
@@ -278,9 +312,10 @@ class NettyServerHandler extends AbstractNettyHandler {
       long maxConnectionAgeGraceInNanos,
       final KeepAliveEnforcer keepAliveEnforcer,
       boolean autoFlowControl,
-      Attributes eagAttributes) {
+      Attributes eagAttributes,
+      Ticker ticker) {
     super(channelUnused, decoder, encoder, settings, new ServerChannelLogger(),
-        autoFlowControl, null);
+        autoFlowControl, null, ticker);
 
     final MaxConnectionIdleManager maxConnectionIdleManager;
     if (maxConnectionIdleInNanos == MAX_CONNECTION_IDLE_NANOS_DISABLED) {
@@ -325,7 +360,6 @@ class NettyServerHandler extends AbstractNettyHandler {
     this.transportListener = checkNotNull(transportListener, "transportListener");
     this.streamTracerFactories = checkNotNull(streamTracerFactories, "streamTracerFactories");
     this.transportTracer = checkNotNull(transportTracer, "transportTracer");
-
     // Set the frame listener on the decoder.
     decoder().frameListener(new FrameListener());
   }

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -147,7 +147,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
   }
 
   @Override
-  protected AbstractStream stream() {
+  protected AbstractStream stream() throws Exception {
     if (stream == null) {
       stream = new NettyClientStream(streamTransportState,
           TestMethodDescriptors.voidMethod(),

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.common.base.Ticker;
 import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
@@ -196,7 +197,7 @@ public class NettyClientTransportTest {
         newNegotiator(), false, DEFAULT_WINDOW_SIZE, DEFAULT_MAX_MESSAGE_SIZE,
         GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE, KEEPALIVE_TIME_NANOS_DISABLED, 1L, false, authority,
         null /* user agent */, tooManyPingsRunnable, new TransportTracer(), Attributes.EMPTY,
-        new SocketPicker(), new FakeChannelLogger(), false);
+        new SocketPicker(), new FakeChannelLogger(), false, Ticker.systemTicker());
     transports.add(transport);
     callMeMaybe(transport.start(clientTransportListener));
 
@@ -448,7 +449,7 @@ public class NettyClientTransportTest {
         newNegotiator(), false, DEFAULT_WINDOW_SIZE, DEFAULT_MAX_MESSAGE_SIZE,
         GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE, KEEPALIVE_TIME_NANOS_DISABLED, 1, false, authority,
         null, tooManyPingsRunnable, new TransportTracer(), Attributes.EMPTY, new SocketPicker(),
-        new FakeChannelLogger(), false);
+        new FakeChannelLogger(), false, Ticker.systemTicker());
     transports.add(transport);
 
     // Should not throw
@@ -763,7 +764,8 @@ public class NettyClientTransportTest {
         negotiator, false, DEFAULT_WINDOW_SIZE, maxMsgSize, maxHeaderListSize,
         keepAliveTimeNano, keepAliveTimeoutNano,
         false, authority, userAgent, tooManyPingsRunnable,
-        new TransportTracer(), eagAttributes, new SocketPicker(), new FakeChannelLogger(), false);
+        new TransportTracer(), eagAttributes, new SocketPicker(), new FakeChannelLogger(), false,
+        Ticker.systemTicker());
     transports.add(transport);
     return transport;
   }

--- a/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
+++ b/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
@@ -545,7 +545,7 @@ public abstract class NettyHandlerTestBase<T extends Http2ConnectionHandler> {
   }
 
   @Test
-  private void testPingBackoff() throws Exception {
+  public void testPingBackoff() throws Exception {
     AbstractNettyHandler localHandler = setupPingTest();
     long pingData = localHandler.flowControlPing().payload();
     ByteBuf data40KbBuf = initXkbBuffer(40);

--- a/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
+++ b/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
@@ -332,7 +332,7 @@ public abstract class NettyHandlerTestBase<T extends Http2ConnectionHandler> {
     return handler().connection();
   }
 
-  protected abstract AbstractStream stream();
+  protected abstract AbstractStream stream() throws Exception;
 
   @CanIgnoreReturnValue
   protected final ChannelFuture enqueue(WriteQueue.QueuedCommand command) {

--- a/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
@@ -71,7 +71,6 @@ import io.grpc.internal.StatsTraceContext;
 import io.grpc.internal.StreamListener;
 import io.grpc.internal.testing.TestServerStreamTracer;
 import io.grpc.netty.GrpcHttp2HeadersUtils.GrpcHttp2ServerHeadersDecoder;
-import io.grpc.testing.TestMethodDescriptors;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelFuture;
@@ -1284,21 +1283,13 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
   }
 
   @Override
-  protected AbstractStream stream() {
+  protected AbstractStream stream()  {
     if (stream == null) {
-      NettyServerStream.TransportState state = new NettyServerStream.TransportState(
-          handler(),
-          channel().eventLoop(),
-          connection().connectionStream(),
-          DEFAULT_MAX_MESSAGE_SIZE,
-          stream.statsTraceContext(),
-          transportTracer,
-          TestMethodDescriptors.voidMethod().getFullMethodName());
-
-      stream = new NettyServerStream(channel(), state, Attributes.EMPTY,
-          "test-authority", stream.statsTraceContext(), transportTracer);
-      stream.transportState().setListener(new NoopListener());
-      state.onStreamAllocated();
+      try {
+        makeStream();
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to make stream", e);
+      }
     }
 
     return stream;

--- a/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
@@ -84,7 +84,6 @@ import io.netty.handler.codec.http2.Http2LocalFlowController;
 import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.codec.http2.Http2Stream;
 import io.netty.util.AsciiString;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -1293,41 +1292,6 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
     }
 
     return stream;
-  }
-
-  private static final class NoopListener implements ServerStreamListener {
-    @Override
-    public void messagesAvailable(MessageProducer producer) {
-      InputStream message;
-      while ((message = producer.next()) != null) {
-        try {
-          message.close();
-        } catch (IOException e) {
-          // Close any remaining messages
-          int errorsInClose = 0;
-          while ((message = producer.next()) != null) {
-            try {
-              message.close();
-            } catch (IOException ignore) {
-              errorsInClose++;
-            }
-          }
-          String errMsg = (errorsInClose == 0)
-              ? e.getMessage()
-              : String.format("There were %d errors during message close", errorsInClose);
-          throw new RuntimeException(errMsg, e);
-        }
-      }
-    }
-
-    @Override
-    public void halfClosed() {}
-
-    @Override
-    public void closed(Status status) {}
-
-    @Override
-    public void onReady() {}
   }
 
 }

--- a/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
@@ -1282,13 +1282,9 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
   }
 
   @Override
-  protected AbstractStream stream()  {
+  protected AbstractStream stream() throws Exception {
     if (stream == null) {
-      try {
-        makeStream();
-      } catch (Exception e) {
-        throw new RuntimeException("Failed to make stream", e);
-      }
+      makeStream();
     }
 
     return stream;


### PR DESCRIPTION
Only initiate a BDP ping after every X bytes of data where X is a multiple of the window size that increases when the window isn't changing.  

Added a ticker to the Netty handlers so that bandwidth could be properly controlled from tests.

Fixes #8260