### PR TITLE
Always update the TagContext in filterContext()

### DIFF
--- a/census/src/main/java/io/grpc/census/CensusStatsModule.java
+++ b/census/src/main/java/io/grpc/census/CensusStatsModule.java
@@ -751,10 +751,7 @@ final class CensusStatsModule {
 
     @Override
     public Context filterContext(Context context) {
-      if (!module.tagger.empty().equals(parentCtx)) {
-        return ContextUtils.withValue(context, parentCtx);
-      }
-      return context;
+      return ContextUtils.withValue(context, parentCtx);
     }
   }
 


### PR DESCRIPTION
This is a potential optimization, depending on the OpenCensus implementation installed. Currently, the code checks TagContext equality against the empty TagContext as an optimization to avoid updating the Context, but checking equality may not be cheaper than updating the Context. In particular, this condition is almost always true, because we [update the parentCtx with an additional
tag](https://github.com/grpc/grpc-java/blob/bacf18db8dcfbf50006eadaac1693fbce74bc550/census/src/main/java/io/grpc/census/CensusStatsModule.java#L770-L774). It's only true when there is no OpenCensus implementation (i.e. some kind of no-op implementation that ignores TagContexts) or when the empty TagContext already has that tag set to the specific value which varies depending on the RPC method.

For the default OpenCensus implementation, the equality check is equality between two maps. Other implementations may require additional work to determine equality.

Basically, we are trading off rarely avoiding updating the Context for always doing at least a map equality or potentially even more depending on the OpenCensus implementation in use. Given this, it makes sense to just always update the Context.