### PR TITLE
ExperimentalApi annotation removal for app interaction library

### DIFF
--- a/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
+++ b/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
@@ -22,7 +22,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
-import io.grpc.ExperimentalApi;
 import java.net.SocketAddress;
 
 /**
@@ -41,7 +40,6 @@ import java.net.SocketAddress;
  * fields, namely, an action of {@link ApiConstants#ACTION_BIND}, an empty category set and null
  * type and data URI.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
 public class AndroidComponentAddress extends SocketAddress { // NOTE: Only temporarily non-final.
   private static final long serialVersionUID = 0L;
 

--- a/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
@@ -25,7 +25,6 @@ import com.google.common.base.Supplier;
 import com.google.errorprone.annotations.DoNotCall;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
-import io.grpc.ExperimentalApi;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerStreamTracer;
@@ -48,7 +47,6 @@ import javax.annotation.Nullable;
 /**
  * Builder for a server that services requests from an Android Service.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
 public final class BinderServerBuilder
     extends ForwardingServerBuilder<BinderServerBuilder> {
 

--- a/binder/src/main/java/io/grpc/binder/IBinderReceiver.java
+++ b/binder/src/main/java/io/grpc/binder/IBinderReceiver.java
@@ -17,11 +17,9 @@
 package io.grpc.binder;
 
 import android.os.IBinder;
-import io.grpc.ExperimentalApi;
 import javax.annotation.Nullable;
 
 /** A container for at most one instance of {@link IBinder}, useful as an "out parameter". */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
 public final class IBinderReceiver {
   @Nullable private IBinder value;
 

--- a/binder/src/main/java/io/grpc/binder/ParcelableUtils.java
+++ b/binder/src/main/java/io/grpc/binder/ParcelableUtils.java
@@ -17,7 +17,6 @@
 package io.grpc.binder;
 
 import android.os.Parcelable;
-import io.grpc.ExperimentalApi;
 import io.grpc.Metadata;
 import io.grpc.binder.internal.MetadataHelper;
 
@@ -26,7 +25,6 @@ import io.grpc.binder.internal.MetadataHelper;
  *
  * <p>This class models the same pattern as the {@code ProtoLiteUtils} class.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
 public final class ParcelableUtils {
 
   private ParcelableUtils() {}

--- a/binder/src/main/java/io/grpc/binder/SecurityPolicies.java
+++ b/binder/src/main/java/io/grpc/binder/SecurityPolicies.java
@@ -32,7 +32,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.hash.Hashing;
 import com.google.errorprone.annotations.CheckReturnValue;
-import io.grpc.ExperimentalApi;
 import io.grpc.Status;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,7 +41,6 @@ import java.util.List;
 
 /** Static factory methods for creating standard security policies. */
 @CheckReturnValue
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
 public final class SecurityPolicies {
 
   private static final int MY_UID = Process.myUid();

--- a/binder/src/main/java/io/grpc/binder/SecurityPolicy.java
+++ b/binder/src/main/java/io/grpc/binder/SecurityPolicy.java
@@ -16,7 +16,6 @@
 
 package io.grpc.binder;
 
-import io.grpc.ExperimentalApi;
 import io.grpc.Status;
 import javax.annotation.CheckReturnValue;
 
@@ -37,7 +36,6 @@ import javax.annotation.CheckReturnValue;
  * re-installation of the applications involved.
  */
 @CheckReturnValue
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
 public abstract class SecurityPolicy {
 
   protected SecurityPolicy() {}

--- a/binder/src/main/java/io/grpc/binder/ServerSecurityPolicy.java
+++ b/binder/src/main/java/io/grpc/binder/ServerSecurityPolicy.java
@@ -17,7 +17,6 @@
 package io.grpc.binder;
 
 import com.google.common.collect.ImmutableMap;
-import io.grpc.ExperimentalApi;
 import io.grpc.Status;
 import java.util.HashMap;
 import java.util.Map;
@@ -28,7 +27,6 @@ import javax.annotation.CheckReturnValue;
  *
  * Contains a default policy, and optional policies for each server.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
 public final class ServerSecurityPolicy {
 
   private final SecurityPolicy defaultPolicy;


### PR DESCRIPTION
Removing the @experimentalapi annotation for APIs used by the App Interaction Library to enable gRPC to be used as dependency for IPCs for Jetpack.