### PR TITLE
Promoting binder out of experimental status

### DIFF
--- a/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
+++ b/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
@@ -40,7 +40,7 @@ import java.net.SocketAddress;
  * fields, namely, an action of {@link ApiConstants#ACTION_BIND}, an empty category set and null
  * type and data URI.
  */
-public class AndroidComponentAddress extends SocketAddress { // NOTE: Only temporarily non-final.
+public final class AndroidComponentAddress extends SocketAddress {
   private static final long serialVersionUID = 0L;
 
   private final Intent bindIntent; // An "explicit" Intent. In other words, getComponent() != null.
@@ -101,6 +101,10 @@ public class AndroidComponentAddress extends SocketAddress { // NOTE: Only tempo
         new Intent(ApiConstants.ACTION_BIND).setComponent(component));
   }
 
+  /**
+   * Returns the Authority which is the package name of the target app.
+   * See {@link android.content.ComponentName}.
+   */
   public String getAuthority() {
     return getComponent().getPackageName();
   }

--- a/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
+++ b/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
@@ -47,6 +47,7 @@ public final class AndroidComponentAddress extends SocketAddress {
 
   protected AndroidComponentAddress(Intent bindIntent) {
     checkArgument(bindIntent.getComponent() != null, "Missing required component");
+    checkArgument(bindIntent.getPackage() != null, "Missing required package");
     this.bindIntent = bindIntent;
   }
 

--- a/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
+++ b/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
@@ -22,7 +22,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
-import io.grpc.ExperimentalApi;
 import java.net.SocketAddress;
 
 /**
@@ -41,7 +40,6 @@ import java.net.SocketAddress;
  * fields, namely, an action of {@link ApiConstants#ACTION_BIND}, an empty category set and null
  * type and data URI.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
 public class AndroidComponentAddress extends SocketAddress { // NOTE: Only temporarily non-final.
   private static final long serialVersionUID = 0L;
 

--- a/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
+++ b/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
@@ -47,7 +47,6 @@ public final class AndroidComponentAddress extends SocketAddress {
 
   protected AndroidComponentAddress(Intent bindIntent) {
     checkArgument(bindIntent.getComponent() != null, "Missing required component");
-    checkArgument(bindIntent.getPackage() != null, "Missing required package");
     this.bindIntent = bindIntent;
   }
 

--- a/binder/src/main/java/io/grpc/binder/BinderInternal.java
+++ b/binder/src/main/java/io/grpc/binder/BinderInternal.java
@@ -1,0 +1,16 @@
+package io.grpc.binder;
+
+import android.os.IBinder;
+
+/**
+ * Helper class to expose IBinderReceiver methods for legacy internal builders.
+ */
+public class BinderInternal {
+
+  /**
+   * Set the receiver's {@link IBinder} using {@link IBinderReceiver#set(IBinder)}.
+   */
+  static void setIBinder(IBinderReceiver receiver, IBinder binder) {
+    receiver.set(binder);
+  }
+}

--- a/binder/src/main/java/io/grpc/binder/BinderInternal.java
+++ b/binder/src/main/java/io/grpc/binder/BinderInternal.java
@@ -1,10 +1,28 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.grpc.binder;
 
 import android.os.IBinder;
+import io.grpc.Internal;
 
 /**
  * Helper class to expose IBinderReceiver methods for legacy internal builders.
  */
+@Internal
 public class BinderInternal {
 
   /**

--- a/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
@@ -92,11 +92,14 @@ public final class BinderServerBuilder
           streamTracerFactories,
           securityPolicy,
           inboundParcelablePolicy);
-      // binderReceiver.set(server.getHostBinder());
       BinderInternal.setIBinder(binderReceiver, server.getHostBinder());
       return server;
     });
 
+    // Disable stats and tracing by default.
+    serverImplBuilder.setStatsEnabled(false);
+    serverImplBuilder.setTracingEnabled(false);
+    
     BinderTransportSecurity.installAuthInterceptor(this);
   }
 

--- a/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
@@ -25,7 +25,6 @@ import com.google.common.base.Supplier;
 import com.google.errorprone.annotations.DoNotCall;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
-import io.grpc.ExperimentalApi;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerStreamTracer;
@@ -48,7 +47,6 @@ import javax.annotation.Nullable;
 /**
  * Builder for a server that services requests from an Android Service.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
 public final class BinderServerBuilder
     extends ForwardingServerBuilder<BinderServerBuilder> {
 

--- a/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
@@ -23,8 +23,6 @@ import android.app.Service;
 import android.os.IBinder;
 import com.google.common.base.Supplier;
 import com.google.errorprone.annotations.DoNotCall;
-import io.grpc.CompressorRegistry;
-import io.grpc.DecompressorRegistry;
 import io.grpc.ExperimentalApi;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
@@ -97,11 +95,6 @@ public final class BinderServerBuilder
       binderReceiver.set(server.getHostBinder());
       return server;
     });
-
-    // Disable compression by default, since there's little benefit when all communication is
-    // on-device, and it means sending supported-encoding headers with every call.
-    decompressorRegistry(DecompressorRegistry.emptyInstance());
-    compressorRegistry(CompressorRegistry.newEmptyInstance());
 
     // Disable stats and tracing by default.
     serverImplBuilder.setStatsEnabled(false);

--- a/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
@@ -99,7 +99,7 @@ public final class BinderServerBuilder
     // Disable stats and tracing by default.
     serverImplBuilder.setStatsEnabled(false);
     serverImplBuilder.setTracingEnabled(false);
-    
+
     BinderTransportSecurity.installAuthInterceptor(this);
   }
 

--- a/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
@@ -158,6 +158,7 @@ public final class BinderServerBuilder
   }
 
   /** Sets the policy for inbound parcelable objects. */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public BinderServerBuilder inboundParcelablePolicy(
       InboundParcelablePolicy inboundParcelablePolicy) {
     this.inboundParcelablePolicy = checkNotNull(inboundParcelablePolicy, "inboundParcelablePolicy");

--- a/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
@@ -92,13 +92,10 @@ public final class BinderServerBuilder
           streamTracerFactories,
           securityPolicy,
           inboundParcelablePolicy);
-      binderReceiver.set(server.getHostBinder());
+      // binderReceiver.set(server.getHostBinder());
+      BinderInternal.setIBinder(binderReceiver, server.getHostBinder());
       return server;
     });
-
-    // Disable stats and tracing by default.
-    serverImplBuilder.setStatsEnabled(false);
-    serverImplBuilder.setTracingEnabled(false);
 
     BinderTransportSecurity.installAuthInterceptor(this);
   }
@@ -158,6 +155,9 @@ public final class BinderServerBuilder
     return this;
   }
 
+  /**
+   * Always fails. TLS is not supported in BinderServer.
+   */
   @Override
   public BinderServerBuilder useTransportSecurity(File certChain, File privateKey) {
     throw new UnsupportedOperationException("TLS not supported in BinderServer");

--- a/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
@@ -25,6 +25,7 @@ import com.google.common.base.Supplier;
 import com.google.errorprone.annotations.DoNotCall;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
+import io.grpc.ExperimentalApi;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerStreamTracer;
@@ -115,12 +116,14 @@ public final class BinderServerBuilder
   }
 
   /** Enable stats collection using census. */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public BinderServerBuilder enableStats() {
     serverImplBuilder.setStatsEnabled(true);
     return this;
   }
 
   /** Enable tracing using census. */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public BinderServerBuilder enableTracing() {
     serverImplBuilder.setTracingEnabled(true);
     return this;

--- a/binder/src/main/java/io/grpc/binder/IBinderReceiver.java
+++ b/binder/src/main/java/io/grpc/binder/IBinderReceiver.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
 
 /** A container for at most one instance of {@link IBinder}, useful as an "out parameter". */
 public final class IBinderReceiver {
-  @Nullable private IBinder value;
+  @Nullable private volatile IBinder value;
 
   /** Constructs a new, initially empty, container. */
   public IBinderReceiver() {}

--- a/binder/src/main/java/io/grpc/binder/IBinderReceiver.java
+++ b/binder/src/main/java/io/grpc/binder/IBinderReceiver.java
@@ -28,11 +28,11 @@ public final class IBinderReceiver {
 
   /** Returns the contents of this container or null if it is empty. */
   @Nullable
-  public synchronized IBinder get() {
+  public IBinder get() {
     return value;
   }
 
-  public synchronized void set(IBinder value) {
+  public void set(IBinder value) {
     this.value = value;
   }
 }

--- a/binder/src/main/java/io/grpc/binder/IBinderReceiver.java
+++ b/binder/src/main/java/io/grpc/binder/IBinderReceiver.java
@@ -17,11 +17,9 @@
 package io.grpc.binder;
 
 import android.os.IBinder;
-import io.grpc.ExperimentalApi;
 import javax.annotation.Nullable;
 
 /** A container for at most one instance of {@link IBinder}, useful as an "out parameter". */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
 public final class IBinderReceiver {
   @Nullable private IBinder value;
 

--- a/binder/src/main/java/io/grpc/binder/IBinderReceiver.java
+++ b/binder/src/main/java/io/grpc/binder/IBinderReceiver.java
@@ -32,7 +32,7 @@ public final class IBinderReceiver {
     return value;
   }
 
-  public void set(IBinder value) {
+  protected void set(IBinder value) {
     this.value = value;
   }
 }

--- a/binder/src/main/java/io/grpc/binder/ParcelableUtils.java
+++ b/binder/src/main/java/io/grpc/binder/ParcelableUtils.java
@@ -17,7 +17,6 @@
 package io.grpc.binder;
 
 import android.os.Parcelable;
-import io.grpc.ExperimentalApi;
 import io.grpc.Metadata;
 import io.grpc.binder.internal.MetadataHelper;
 
@@ -26,7 +25,6 @@ import io.grpc.binder.internal.MetadataHelper;
  *
  * <p>This class models the same pattern as the {@code ProtoLiteUtils} class.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
 public final class ParcelableUtils {
 
   private ParcelableUtils() {}

--- a/binder/src/main/java/io/grpc/binder/SecurityPolicies.java
+++ b/binder/src/main/java/io/grpc/binder/SecurityPolicies.java
@@ -49,14 +49,14 @@ public final class SecurityPolicies {
 
   private SecurityPolicies() {}
 
-  /**
-   * Creates a default {@link SecurityPolicy}.
-   */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public static ServerSecurityPolicy serverInternalOnly() {
     return new ServerSecurityPolicy();
   }
 
+  /**
+   * Creates a default {@link SecurityPolicy} that checks authorization based on UID.
+   */
   public static SecurityPolicy internalOnly() {
     return new SecurityPolicy() {
       @Override

--- a/binder/src/main/java/io/grpc/binder/SecurityPolicies.java
+++ b/binder/src/main/java/io/grpc/binder/SecurityPolicies.java
@@ -32,7 +32,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.hash.Hashing;
 import com.google.errorprone.annotations.CheckReturnValue;
-import io.grpc.ExperimentalApi;
 import io.grpc.Status;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,7 +41,6 @@ import java.util.List;
 
 /** Static factory methods for creating standard security policies. */
 @CheckReturnValue
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
 public final class SecurityPolicies {
 
   private static final int MY_UID = Process.myUid();

--- a/binder/src/main/java/io/grpc/binder/SecurityPolicies.java
+++ b/binder/src/main/java/io/grpc/binder/SecurityPolicies.java
@@ -49,6 +49,9 @@ public final class SecurityPolicies {
 
   private SecurityPolicies() {}
 
+  /**
+   * Creates a default {@link SecurityPolicy}.
+   */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public static ServerSecurityPolicy serverInternalOnly() {
     return new ServerSecurityPolicy();

--- a/binder/src/main/java/io/grpc/binder/SecurityPolicies.java
+++ b/binder/src/main/java/io/grpc/binder/SecurityPolicies.java
@@ -156,7 +156,6 @@ public final class SecurityPolicies {
    * @throws IllegalArgumentException if {@code requiredSignatureSha256Hashes} is empty, or if any
    *     of the {@code requiredSignatureSha256Hashes} are not of length 32.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public static SecurityPolicy oneOfSignatureSha256Hash(
       PackageManager packageManager,
       String packageName,

--- a/binder/src/main/java/io/grpc/binder/SecurityPolicies.java
+++ b/binder/src/main/java/io/grpc/binder/SecurityPolicies.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.hash.Hashing;
 import com.google.errorprone.annotations.CheckReturnValue;
+import io.grpc.ExperimentalApi;
 import io.grpc.Status;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,6 +49,7 @@ public final class SecurityPolicies {
 
   private SecurityPolicies() {}
 
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public static ServerSecurityPolicy serverInternalOnly() {
     return new ServerSecurityPolicy();
   }
@@ -64,6 +66,7 @@ public final class SecurityPolicies {
     };
   }
 
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public static SecurityPolicy permissionDenied(String description) {
     Status denied = Status.PERMISSION_DENIED.withDescription(description);
     return new SecurityPolicy() {
@@ -82,6 +85,7 @@ public final class SecurityPolicies {
    * @param requiredSignature the allowed signature of the allowed package.
    * @throws NullPointerException if any of the inputs are {@code null}.
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public static SecurityPolicy hasSignature(
       PackageManager packageManager, String packageName, Signature requiredSignature) {
     return oneOfSignatures(
@@ -97,6 +101,7 @@ public final class SecurityPolicies {
    * @throws NullPointerException if any of the inputs are {@code null}.
    * @throws IllegalArgumentException if {@code requiredSignatureSha256Hash} is not of length 32.
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public static SecurityPolicy hasSignatureSha256Hash(
       PackageManager packageManager, String packageName, byte[] requiredSignatureSha256Hash) {
     return oneOfSignatureSha256Hash(
@@ -112,6 +117,7 @@ public final class SecurityPolicies {
    * @throws NullPointerException if any of the inputs are {@code null}.
    * @throws IllegalArgumentException if {@code requiredSignatures} is empty.
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public static SecurityPolicy oneOfSignatures(
       PackageManager packageManager,
       String packageName,
@@ -147,6 +153,7 @@ public final class SecurityPolicies {
    * @throws IllegalArgumentException if {@code requiredSignatureSha256Hashes} is empty, or if any
    *     of the {@code requiredSignatureSha256Hashes} are not of length 32.
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public static SecurityPolicy oneOfSignatureSha256Hash(
       PackageManager packageManager,
       String packageName,
@@ -178,6 +185,7 @@ public final class SecurityPolicies {
    * Creates {@link SecurityPolicy} which checks if the app is a device owner app. See
    * {@link DevicePolicyManager}.
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public static SecurityPolicy isDeviceOwner(Context applicationContext) {
     DevicePolicyManager devicePolicyManager =
         (DevicePolicyManager) applicationContext.getSystemService(Context.DEVICE_POLICY_SERVICE);
@@ -192,6 +200,7 @@ public final class SecurityPolicies {
    * Creates {@link SecurityPolicy} which checks if the app is a profile owner app. See
    * {@link DevicePolicyManager}.
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public static SecurityPolicy isProfileOwner(Context applicationContext) {
     DevicePolicyManager devicePolicyManager =
         (DevicePolicyManager) applicationContext.getSystemService(Context.DEVICE_POLICY_SERVICE);
@@ -206,6 +215,7 @@ public final class SecurityPolicies {
    * Creates {@link SecurityPolicy} which checks if the app is a profile owner app on an
    * organization-owned device. See {@link DevicePolicyManager}.
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public static SecurityPolicy isProfileOwnerOnOrganizationOwnedDevice(Context applicationContext) {
     DevicePolicyManager devicePolicyManager =
         (DevicePolicyManager) applicationContext.getSystemService(Context.DEVICE_POLICY_SERVICE);
@@ -331,6 +341,7 @@ public final class SecurityPolicies {
    * @throws NullPointerException if any of the inputs are {@code null}.
    * @throws IllegalArgumentException if {@code securityPolicies} is empty.
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public static SecurityPolicy allOf(SecurityPolicy... securityPolicies) {
     Preconditions.checkNotNull(securityPolicies, "securityPolicies");
     Preconditions.checkArgument(securityPolicies.length > 0, "securityPolicies must not be empty");
@@ -370,6 +381,7 @@ public final class SecurityPolicies {
    * @throws NullPointerException if any of the inputs are {@code null}.
    * @throws IllegalArgumentException if {@code securityPolicies} is empty.
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public static SecurityPolicy anyOf(SecurityPolicy... securityPolicies) {
     Preconditions.checkNotNull(securityPolicies, "securityPolicies");
     Preconditions.checkArgument(securityPolicies.length > 0, "securityPolicies must not be empty");
@@ -416,6 +428,7 @@ public final class SecurityPolicies {
    * @throws NullPointerException if any of the inputs are {@code null}
    * @throws IllegalArgumentException if {@code permissions} is empty
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public static SecurityPolicy hasPermissions(
       PackageManager packageManager, ImmutableSet<String> permissions) {
     Preconditions.checkNotNull(packageManager, "packageManager");

--- a/binder/src/main/java/io/grpc/binder/SecurityPolicies.java
+++ b/binder/src/main/java/io/grpc/binder/SecurityPolicies.java
@@ -185,7 +185,6 @@ public final class SecurityPolicies {
    * Creates {@link SecurityPolicy} which checks if the app is a device owner app. See
    * {@link DevicePolicyManager}.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public static SecurityPolicy isDeviceOwner(Context applicationContext) {
     DevicePolicyManager devicePolicyManager =
         (DevicePolicyManager) applicationContext.getSystemService(Context.DEVICE_POLICY_SERVICE);
@@ -200,7 +199,6 @@ public final class SecurityPolicies {
    * Creates {@link SecurityPolicy} which checks if the app is a profile owner app. See
    * {@link DevicePolicyManager}.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public static SecurityPolicy isProfileOwner(Context applicationContext) {
     DevicePolicyManager devicePolicyManager =
         (DevicePolicyManager) applicationContext.getSystemService(Context.DEVICE_POLICY_SERVICE);
@@ -215,7 +213,6 @@ public final class SecurityPolicies {
    * Creates {@link SecurityPolicy} which checks if the app is a profile owner app on an
    * organization-owned device. See {@link DevicePolicyManager}.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public static SecurityPolicy isProfileOwnerOnOrganizationOwnedDevice(Context applicationContext) {
     DevicePolicyManager devicePolicyManager =
         (DevicePolicyManager) applicationContext.getSystemService(Context.DEVICE_POLICY_SERVICE);
@@ -341,7 +338,6 @@ public final class SecurityPolicies {
    * @throws NullPointerException if any of the inputs are {@code null}.
    * @throws IllegalArgumentException if {@code securityPolicies} is empty.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public static SecurityPolicy allOf(SecurityPolicy... securityPolicies) {
     Preconditions.checkNotNull(securityPolicies, "securityPolicies");
     Preconditions.checkArgument(securityPolicies.length > 0, "securityPolicies must not be empty");
@@ -381,7 +377,6 @@ public final class SecurityPolicies {
    * @throws NullPointerException if any of the inputs are {@code null}.
    * @throws IllegalArgumentException if {@code securityPolicies} is empty.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public static SecurityPolicy anyOf(SecurityPolicy... securityPolicies) {
     Preconditions.checkNotNull(securityPolicies, "securityPolicies");
     Preconditions.checkArgument(securityPolicies.length > 0, "securityPolicies must not be empty");
@@ -428,7 +423,6 @@ public final class SecurityPolicies {
    * @throws NullPointerException if any of the inputs are {@code null}
    * @throws IllegalArgumentException if {@code permissions} is empty
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
   public static SecurityPolicy hasPermissions(
       PackageManager packageManager, ImmutableSet<String> permissions) {
     Preconditions.checkNotNull(packageManager, "packageManager");

--- a/binder/src/main/java/io/grpc/binder/SecurityPolicy.java
+++ b/binder/src/main/java/io/grpc/binder/SecurityPolicy.java
@@ -16,7 +16,6 @@
 
 package io.grpc.binder;
 
-import io.grpc.ExperimentalApi;
 import io.grpc.Status;
 import javax.annotation.CheckReturnValue;
 
@@ -37,7 +36,6 @@ import javax.annotation.CheckReturnValue;
  * re-installation of the applications involved.
  */
 @CheckReturnValue
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
 public abstract class SecurityPolicy {
 
   protected SecurityPolicy() {}

--- a/binder/src/main/java/io/grpc/binder/ServerSecurityPolicy.java
+++ b/binder/src/main/java/io/grpc/binder/ServerSecurityPolicy.java
@@ -17,7 +17,6 @@
 package io.grpc.binder;
 
 import com.google.common.collect.ImmutableMap;
-import io.grpc.ExperimentalApi;
 import io.grpc.Status;
 import java.util.HashMap;
 import java.util.Map;
@@ -28,7 +27,6 @@ import javax.annotation.CheckReturnValue;
  *
  * Contains a default policy, and optional policies for each server.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
 public final class ServerSecurityPolicy {
 
   private final SecurityPolicy defaultPolicy;


### PR DESCRIPTION
Removing the @experimentalapi annotation for APIs used by the App Interaction Library to enable gRPC to be used as dependency for IPCs for Jetpack.