### PR TITLE
Fix jmh -PjmhIncludeSingleClass

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -300,7 +300,7 @@ subprojects {
             // depends on core; core's testCompile depends on testing)
             includeTests = false
             if (project.hasProperty('jmhIncludeSingleClass')) {
-                include = [
+                includes = [
                     project.property('jmhIncludeSingleClass')
                 ]
             }


### PR DESCRIPTION
I would have assumed a JMH plugin update renamed include to includes, but I don't see a mention to it in the plugin changelog. Either it was an undocumented rename, or devs just kept fixing it locally and not fixing upstream. In either case, it works now.