### PR TITLE
Add gradle.properties for common settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Gradle
 build
-gradle.properties
 .gradle
 local.properties
 out

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -9,13 +9,12 @@ Building requires JDK 8, as our tests use TLS.
 grpc-java has a C++ code generation plugin for protoc. Since many Java
 developers don't have C compilers installed and don't need to run or modify the
 codegen, the build can skip it. To skip, create the file
-`<project-root>/gradle.properties` and add `skipCodegen=true`.
+`<user-home>/.gradle/gradle.properties` and add `skipCodegen=true`.
 
 Some parts of grpc-java depend on Android. Since many Java developers don't have
 the Android SDK installed and don't need to run or modify the Android
 components, the build can skip it. To skip, create the file
-`<project-root>/gradle.properties` and add `skipAndroid=true`.
-Otherwise, create the file `<project-root>/gradle.properties` and add `android.useAndroidX=true`.
+`<user-home>/.gradle/gradle.properties` and add `skipAndroid=true`.
 
 Then, to build, run:
 ```
@@ -87,7 +86,7 @@ Gradle to find protobuf:
 ```
 
 Since specifying those properties every build is bothersome, you can instead
-create ``<project-root>\gradle.properties`` with contents like:
+create ``%USERPROFILE%\.gradle\gradle.properties`` with contents like:
 ```
 vcProtobufInclude=C:\\path\\to\\protobuf\\src
 vcProtobufLibs=C:\\path\\to\\protobuf\\vsprojects\\Release
@@ -103,14 +102,14 @@ default, the `targetArch=x86_32` is necessary.
 If you have both MinGW and VC++ installed on Windows, VC++ will be used by
 default. To override this default and use MinGW, add ``-PvcDisable=true``
 to your Gradle command line or add ``vcDisable=true`` to your
-``<project-root>\gradle.properties``.
+``%USERPROFILE%\.gradle\gradle.properties``.
 
 ### Notes for Unsupported Operating Systems
 The build script pulls pre-compiled ``protoc`` from Maven Central by default.
 We have built ``protoc`` binaries for popular systems, but they may not work
 for your system. If ``protoc`` cannot be downloaded or would not run, you can
 use the one that has been built by your own, by adding this property to
-``<project-root>/gradle.properties``:
+``<user-home>/.gradle/gradle.properties``:
 ```
 protoc=/path/to/protoc
 ```

--- a/buildscripts/kokoro/android-interop.sh
+++ b/buildscripts/kokoro/android-interop.sh
@@ -10,7 +10,6 @@ fi
 
 cd github/grpc-java
 
-export GRADLE_OPTS=-Xmx512m
 export LDFLAGS=-L/tmp/protobuf/lib
 export CXXFLAGS=-I/tmp/protobuf/include
 export LD_LIBRARY_PATH=/tmp/protobuf/lib
@@ -21,12 +20,10 @@ echo y | ${ANDROID_HOME}/tools/bin/sdkmanager "build-tools;28.0.3"
 # Proto deps
 buildscripts/make_dependencies.sh
 
-GRADLE_FLAGS="-Pandroid.useAndroidX=true"
-
 # Build and run interop instrumentation tests on Firebase Test Lab
 cd android-interop-testing
-../gradlew assembleDebug $GRADLE_FLAGS
-../gradlew assembleDebugAndroidTest $GRADLE_FLAGS
+../gradlew assembleDebug
+../gradlew assembleDebugAndroidTest
 gcloud firebase test android run \
   --type instrumentation \
   --app build/outputs/apk/debug/grpc-android-interop-testing-debug.apk \
@@ -43,7 +40,7 @@ gcloud firebase test android run \
 
 # Build and run binderchannel instrumentation tests on Firebase Test Lab
 cd ../binder
-../gradlew assembleDebugAndroidTest $GRADLE_FLAGS
+../gradlew assembleDebugAndroidTest
 gcloud firebase test android run \
   --type instrumentation \
   --app ../android-interop-testing/build/outputs/apk/debug/grpc-android-interop-testing-debug.apk \

--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -15,20 +15,10 @@ export CXXFLAGS=-I/tmp/protobuf/include
 export LD_LIBRARY_PATH=/tmp/protobuf/lib
 export OS_NAME=$(uname)
 
-cat <<EOF >> gradle.properties
-# defaults to -Xmx512m -XX:MaxMetaspaceSize=256m
-# https://docs.gradle.org/current/userguide/build_environment.html#sec:configuring_jvm_memory
-# Increased due to java.lang.OutOfMemoryError: Metaspace failures, "JVM heap
-# space is exhausted", and to increase build speed
-org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
-EOF
-
 echo y | ${ANDROID_HOME}/tools/bin/sdkmanager "build-tools;28.0.3"
 
 # Proto deps
 buildscripts/make_dependencies.sh
-
-GRADLE_FLAGS="-Pandroid.useAndroidX=true"
 
 ./gradlew \
     :grpc-android-interop-testing:build \
@@ -36,8 +26,7 @@ GRADLE_FLAGS="-Pandroid.useAndroidX=true"
     :grpc-cronet:build \
     :grpc-binder:build \
     assembleAndroidTest \
-    publishToMavenLocal \
-    $GRADLE_FLAGS
+    publishToMavenLocal
 
 if [[ ! -z $(git status --porcelain) ]]; then
   git status
@@ -92,7 +81,7 @@ cd $BASE_DIR/github/grpc-java
 ./gradlew clean
 git checkout HEAD^
 ./gradlew --stop  # use a new daemon to build the previous commit
-./gradlew publishToMavenLocal $GRADLE_FLAGS
+./gradlew publishToMavenLocal
 cd examples/android/helloworld/
 ../../gradlew build
 

--- a/buildscripts/kokoro/gae-interop.sh
+++ b/buildscripts/kokoro/gae-interop.sh
@@ -29,7 +29,6 @@ cd "$GRPC_JAVA_DIR"
 ## Deploy the dummy 'default' version of the service
 ##
 GRADLE_FLAGS="--stacktrace -DgaeStopPreviousVersion=false -PskipCodegen=true -PskipAndroid=true"
-export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1g'"
 
 # Deploy the dummy 'default' version. We only require that it exists when cleanup() is called.
 # It ok if we race with another run and fail here, because the end result is idempotent.

--- a/buildscripts/kokoro/linux_artifacts.sh
+++ b/buildscripts/kokoro/linux_artifacts.sh
@@ -17,29 +17,25 @@ trap spongify_logs EXIT
 # use --include-build for its grpc-core dependency
 echo y | ${ANDROID_HOME}/tools/bin/sdkmanager "build-tools;28.0.3"
 LOCAL_MVN_TEMP=$(mktemp -d)
-GRADLE_FLAGS="-Pandroid.useAndroidX=true"
 pushd "$GRPC_JAVA_DIR/android"
 ../gradlew publish \
   -Dorg.gradle.parallel=false \
   -PskipCodegen=true \
-  -PrepositoryDir="$LOCAL_MVN_TEMP" \
-  $GRADLE_FLAGS
+  -PrepositoryDir="$LOCAL_MVN_TEMP"
 popd
 
 pushd "$GRPC_JAVA_DIR/cronet"
 ../gradlew publish \
   -Dorg.gradle.parallel=false \
   -PskipCodegen=true \
-  -PrepositoryDir="$LOCAL_MVN_TEMP" \
-  $GRADLE_FLAGS
+  -PrepositoryDir="$LOCAL_MVN_TEMP"
 popd
 
 pushd "$GRPC_JAVA_DIR/binder"
 ../gradlew publish \
   -Dorg.gradle.parallel=false \
   -PskipCodegen=true \
-  -PrepositoryDir="$LOCAL_MVN_TEMP" \
-  $GRADLE_FLAGS
+  -PrepositoryDir="$LOCAL_MVN_TEMP"
 popd
 
 readonly MVN_ARTIFACT_DIR="${MVN_ARTIFACT_DIR:-$GRPC_JAVA_DIR/mvn-artifacts}"

--- a/buildscripts/kokoro/psm-security.sh
+++ b/buildscripts/kokoro/psm-security.sh
@@ -23,7 +23,6 @@ readonly BUILD_APP_PATH="interop-testing/build/install/grpc-interop-testing"
 build_java_test_app() {
   echo "Building Java test app"
   cd "${SRC_DIR}"
-  GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1g'" \
   ./gradlew --no-daemon grpc-interop-testing:installDist -x test \
     -PskipCodegen=true -PskipAndroid=true --console=plain
 

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -38,8 +38,6 @@ GRADLE_FLAGS+=" -Pcheckstyle.ignoreFailures=false"
 GRADLE_FLAGS+=" -PfailOnWarnings=true"
 GRADLE_FLAGS+=" -PerrorProne=true"
 GRADLE_FLAGS+=" -PskipAndroid=true"
-GRADLE_FLAGS+=" -Dorg.gradle.parallel=true"
-export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1g'"
 
 # Make protobuf discoverable by :grpc-compiler
 export LD_LIBRARY_PATH=/tmp/protobuf/lib
@@ -89,7 +87,7 @@ if [[ -z "${SKIP_TESTS:-}" ]]; then
 fi
 
 LOCAL_MVN_TEMP=$(mktemp -d)
-# Note that this disables parallel=true from GRADLE_FLAGS
+# Note that this disables parallel=true from gradle.properties
 if [[ -z "${ALL_ARTIFACTS:-}" ]]; then
   if [[ "$ARCH" = "aarch_64" || "$ARCH" = "ppcle_64" ]]; then
     GRADLE_FLAGS+=" -x grpc-compiler:generateTestProto -x grpc-compiler:generateTestLiteProto"

--- a/buildscripts/kokoro/windows32.bat
+++ b/buildscripts/kokoro/windows32.bat
@@ -29,7 +29,6 @@ SET FAIL_ON_WARNINGS=true
 SET VC_PROTOBUF_LIBS=%ESCWORKSPACE%\\grpc-java-helper32\\protobuf-%PROTOBUF_VER%\\build\\Release
 SET VC_PROTOBUF_INCLUDE=%ESCWORKSPACE%\\grpc-java-helper32\\protobuf-%PROTOBUF_VER%\\build\\include
 SET GRADLE_FLAGS=-PtargetArch=%TARGET_ARCH% -PfailOnWarnings=%FAIL_ON_WARNINGS% -PvcProtobufLibs=%VC_PROTOBUF_LIBS% -PvcProtobufInclude=%VC_PROTOBUF_INCLUDE% -PskipAndroid=true
-SET GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1g'"
 
 cmd.exe /C "%WORKSPACE%\gradlew.bat %GRADLE_FLAGS% build"
 set GRADLEEXIT=%ERRORLEVEL%

--- a/buildscripts/kokoro/windows64.bat
+++ b/buildscripts/kokoro/windows64.bat
@@ -28,7 +28,6 @@ SET FAIL_ON_WARNINGS=true
 SET VC_PROTOBUF_LIBS=%ESCWORKSPACE%\\grpc-java-helper64\\protobuf-%PROTOBUF_VER%\\build\\Release
 SET VC_PROTOBUF_INCLUDE=%ESCWORKSPACE%\\grpc-java-helper64\\protobuf-%PROTOBUF_VER%\\build\\include
 SET GRADLE_FLAGS=-PtargetArch=%TARGET_ARCH% -PfailOnWarnings=%FAIL_ON_WARNINGS% -PvcProtobufLibs=%VC_PROTOBUF_LIBS% -PvcProtobufInclude=%VC_PROTOBUF_INCLUDE% -PskipAndroid=true
-SET GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1g'"
 
 @rem make sure no daemons have any files open
 cmd.exe /C "%WORKSPACE%\gradlew.bat --stop"

--- a/buildscripts/kokoro/xds.sh
+++ b/buildscripts/kokoro/xds.sh
@@ -8,8 +8,7 @@ fi
 cd github
 
 pushd grpc-java/interop-testing
-GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1g'" \
-  ../gradlew installDist -x test -PskipCodegen=true -PskipAndroid=true
+../gradlew installDist -x test -PskipCodegen=true -PskipAndroid=true
 popd
 
 git clone -b master --single-branch --depth=1 https://github.com/grpc/grpc.git

--- a/buildscripts/kokoro/xds_k8s_lb.sh
+++ b/buildscripts/kokoro/xds_k8s_lb.sh
@@ -23,7 +23,6 @@ readonly BUILD_APP_PATH="interop-testing/build/install/grpc-interop-testing"
 build_java_test_app() {
   echo "Building Java test app"
   cd "${SRC_DIR}"
-  GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1g'" \
   ./gradlew --no-daemon grpc-interop-testing:installDist -x test \
     -PskipCodegen=true -PskipAndroid=true --console=plain
 

--- a/buildscripts/kokoro/xds_url_map.sh
+++ b/buildscripts/kokoro/xds_url_map.sh
@@ -23,7 +23,6 @@ readonly BUILD_APP_PATH="interop-testing/build/install/grpc-interop-testing"
 build_java_test_app() {
   echo "Building Java test app"
   cd "${SRC_DIR}"
-  GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1g'" \
   ./gradlew --no-daemon grpc-interop-testing:installDist -x test \
     -PskipCodegen=true -PskipAndroid=true --console=plain
 

--- a/buildscripts/run_arm64_tests_in_docker.sh
+++ b/buildscripts/run_arm64_tests_in_docker.sh
@@ -10,13 +10,7 @@ else
   DOCKER_ARGS=
 fi
 
-
-cat <<EOF >> "${grpc_java_dir}/gradle.properties"
-skipAndroid=true
-skipCodegen=true
-org.gradle.parallel=true
-org.gradle.jvmargs=-Xmx1024m
-EOF
+GRADLE_FLAGS="-PskipAndroid=true -PskipCodegen=true"
 
 export JAVA_OPTS="-Duser.home=/grpc-java/.current-user-home -Djava.util.prefs.userRoot=/grpc-java/.current-user-home/.java/.userPrefs"
 
@@ -27,7 +21,7 @@ export JAVA_OPTS="-Duser.home=/grpc-java/.current-user-home -Djava.util.prefs.us
 docker run $DOCKER_ARGS --rm=true -v "${grpc_java_dir}":/grpc-java -w /grpc-java \
   --user "$(id -u):$(id -g)" -e JAVA_OPTS \
   openjdk:11-jdk-slim-buster \
-  ./gradlew build -x test
+  ./gradlew $GRADLE_FLAGS build -x test
 
 # Build and run java tests under aarch64 image.
 # To be able to run this docker container on x64 machine, one needs to have
@@ -44,4 +38,4 @@ docker run $DOCKER_ARGS --rm=true -v "${grpc_java_dir}":/grpc-java -w /grpc-java
 docker run $DOCKER_ARGS --rm=true -v "${grpc_java_dir}":/grpc-java -w /grpc-java \
   --user "$(id -u):$(id -g)" -e JAVA_OPTS \
   arm64v8/openjdk:11-jdk-slim-buster \
-  ./gradlew build
+  ./gradlew $GRADLE_FLAGS build

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,7 @@
+android.useAndroidX=true
+# defaults to -Xmx512m -XX:MaxMetaspaceSize=256m
+# https://docs.gradle.org/current/userguide/build_environment.html#sec:configuring_jvm_memory
+# Increased due to java.lang.OutOfMemoryError: Metaspace failures, "JVM heap
+# space is exhausted", and to increase build speed
+org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
+org.gradle.parallel=true


### PR DESCRIPTION
We've had continual problems with builds running out of memory. Using gradle.properties means it can't really be used by individual devs any more, but should greatly improve chances of getting good build settings.