### PR TITLE
Fix issue: grpc-previous-rpc-attempts not added to initial response metadata

### DIFF
--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -817,6 +817,7 @@ abstract class RetriableStream<ReqT> implements ClientStream {
 
     @Override
     public void headersRead(final Metadata headers) {
+      headers.put(GRPC_PREVIOUS_RPC_ATTEMPTS, String.valueOf(substream.previousAttemptCount));
       commitAndRun(substream);
       if (state.winningSubstream == substream) {
         if (throttle != null) {

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -252,7 +252,7 @@ abstract class RetriableStream<ReqT> implements ClientStream {
       Metadata originalHeaders, int previousAttemptCount) {
     Metadata newHeaders = new Metadata();
     newHeaders.merge(originalHeaders);
-    if (previousAttemptCount >= 0) {
+    if (previousAttemptCount > 0) {
       newHeaders.put(GRPC_PREVIOUS_RPC_ATTEMPTS, String.valueOf(previousAttemptCount));
     }
     return newHeaders;

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -817,7 +817,9 @@ abstract class RetriableStream<ReqT> implements ClientStream {
 
     @Override
     public void headersRead(final Metadata headers) {
-      headers.put(GRPC_PREVIOUS_RPC_ATTEMPTS, String.valueOf(substream.previousAttemptCount));
+      if (substream.previousAttemptCount > 0) {
+        headers.put(GRPC_PREVIOUS_RPC_ATTEMPTS, String.valueOf(substream.previousAttemptCount));
+      }
       commitAndRun(substream);
       if (state.winningSubstream == substream) {
         if (throttle != null) {

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -252,7 +252,7 @@ abstract class RetriableStream<ReqT> implements ClientStream {
       Metadata originalHeaders, int previousAttemptCount) {
     Metadata newHeaders = new Metadata();
     newHeaders.merge(originalHeaders);
-    if (previousAttemptCount > 0) {
+    if (previousAttemptCount >= 0) {
       newHeaders.put(GRPC_PREVIOUS_RPC_ATTEMPTS, String.valueOf(previousAttemptCount));
     }
     return newHeaders;

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -818,6 +818,7 @@ abstract class RetriableStream<ReqT> implements ClientStream {
     @Override
     public void headersRead(final Metadata headers) {
       if (substream.previousAttemptCount > 0) {
+        headers.discardAll(GRPC_PREVIOUS_RPC_ATTEMPTS);
         headers.put(GRPC_PREVIOUS_RPC_ATTEMPTS, String.valueOf(substream.previousAttemptCount));
       }
       commitAndRun(substream);

--- a/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
@@ -1165,7 +1165,7 @@ public class RetriableStreamTest {
     Metadata originalHeaders = new Metadata();
     Metadata headers = retriableStream.updateHeaders(originalHeaders, 0);
     assertNotSame(originalHeaders, headers);
-    assertNull(headers.get(GRPC_PREVIOUS_RPC_ATTEMPTS));
+    assertEquals("0", headers.get(GRPC_PREVIOUS_RPC_ATTEMPTS));
 
     headers = retriableStream.updateHeaders(originalHeaders, 345);
     assertEquals("345", headers.get(GRPC_PREVIOUS_RPC_ATTEMPTS));

--- a/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
@@ -1165,7 +1165,7 @@ public class RetriableStreamTest {
     Metadata originalHeaders = new Metadata();
     Metadata headers = retriableStream.updateHeaders(originalHeaders, 0);
     assertNotSame(originalHeaders, headers);
-    assertEquals("0", headers.get(GRPC_PREVIOUS_RPC_ATTEMPTS));
+    assertNull(headers.get(GRPC_PREVIOUS_RPC_ATTEMPTS));
 
     headers = retriableStream.updateHeaders(originalHeaders, 345);
     assertEquals("345", headers.get(GRPC_PREVIOUS_RPC_ATTEMPTS));

--- a/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
@@ -43,6 +43,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.ClientStreamTracer;
 import io.grpc.Codec;
@@ -1031,11 +1032,15 @@ public class RetriableStreamTest {
     ArgumentCaptor<ClientStreamListener> sublistenerCaptor2 =
             ArgumentCaptor.forClass(ClientStreamListener.class);
     verify(mockStream2).start(sublistenerCaptor2.capture());
-    sublistenerCaptor2.getValue().headersRead(new Metadata());
+    Metadata headers = new Metadata();
+    headers.put(GRPC_PREVIOUS_RPC_ATTEMPTS, "3");
+    sublistenerCaptor2.getValue().headersRead(headers);
 
     ArgumentCaptor<Metadata> metadataCaptor = ArgumentCaptor.forClass(Metadata.class);
     verify(masterListener).headersRead(metadataCaptor.capture());
-    assertEquals("1", metadataCaptor.getValue().get(GRPC_PREVIOUS_RPC_ATTEMPTS));
+    Iterable<String> iterable = metadataCaptor.getValue().getAll(GRPC_PREVIOUS_RPC_ATTEMPTS);
+    assertEquals(1, Iterables.size(iterable));
+    assertEquals("1", iterable.iterator().next());
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
@@ -992,6 +992,25 @@ public class RetriableStreamTest {
   }
 
   @Test
+  public void notAdd0PrevRetryAttemptsToRespHeaders() {
+    ClientStream mockStream1 = mock(ClientStream.class);
+    doReturn(mockStream1).when(retriableStreamRecorder).newSubstream(0);
+
+    retriableStream.start(masterListener);
+
+    ArgumentCaptor<ClientStreamListener> sublistenerCaptor =
+            ArgumentCaptor.forClass(ClientStreamListener.class);
+    verify(mockStream1).start(sublistenerCaptor.capture());
+
+    sublistenerCaptor.getValue().headersRead(new Metadata());
+
+    ArgumentCaptor<Metadata> metadataCaptor =
+            ArgumentCaptor.forClass(Metadata.class);
+    verify(masterListener).headersRead(metadataCaptor.capture());
+    assertEquals(null, metadataCaptor.getValue().get(GRPC_PREVIOUS_RPC_ATTEMPTS));
+  }
+
+  @Test
   public void addPrevRetryAttemptsToRespHeaders() {
     ClientStream mockStream1 = mock(ClientStream.class);
     doReturn(mockStream1).when(retriableStreamRecorder).newSubstream(0);

--- a/stub/src/main/java/io/grpc/stub/ServerCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCalls.java
@@ -130,7 +130,7 @@ public final class ServerCalls {
           call.getMethodDescriptor().getType().clientSendsOneMessage(),
           "asyncUnaryRequestCall is only for clientSendsOneMessage methods");
       String preRpcAttempts = null;
-      if(headers.containsKey(GRPC_PREVIOUS_RPC_ATTEMPTS)) {
+      if (headers.containsKey(GRPC_PREVIOUS_RPC_ATTEMPTS)) {
         preRpcAttempts = headers.get(GRPC_PREVIOUS_RPC_ATTEMPTS);
       }
       ServerCallStreamObserverImpl<ReqT, RespT> responseObserver =
@@ -238,7 +238,7 @@ public final class ServerCalls {
     @Override
     public ServerCall.Listener<ReqT> startCall(ServerCall<ReqT, RespT> call, Metadata headers) {
       String preRpcAttempts = null;
-      if(headers.containsKey(GRPC_PREVIOUS_RPC_ATTEMPTS)) {
+      if (headers.containsKey(GRPC_PREVIOUS_RPC_ATTEMPTS)) {
         preRpcAttempts = headers.get(GRPC_PREVIOUS_RPC_ATTEMPTS);
       }
       ServerCallStreamObserverImpl<ReqT, RespT> responseObserver =
@@ -349,7 +349,8 @@ public final class ServerCalls {
     private String preRpcAttempts;
 
     // Non private to avoid synthetic class
-    ServerCallStreamObserverImpl(ServerCall<ReqT, RespT> call, boolean serverStreamingOrBidi, String preRpcAttempts) {
+    ServerCallStreamObserverImpl(
+            ServerCall<ReqT, RespT> call, boolean serverStreamingOrBidi, String preRpcAttempts) {
       this.call = call;
       this.serverStreamingOrBidi = serverStreamingOrBidi;
       this.preRpcAttempts = preRpcAttempts;
@@ -388,7 +389,7 @@ public final class ServerCalls {
       checkState(!completed, "Stream is already completed, no further calls are allowed");
       if (!sentHeaders) {
         Metadata metadata = new Metadata();
-        if(preRpcAttempts != null) {
+        if (preRpcAttempts != null) {
           metadata.put(GRPC_PREVIOUS_RPC_ATTEMPTS, preRpcAttempts);
         }
         call.sendHeaders(metadata);


### PR DESCRIPTION
Fixes #9641

Add `grpc-previous-rpc-attempts` to headers when response metadata is initialized.