### PR TITLE
Fix issue: CallOptions is not thread-safe.

### DIFF
--- a/api/src/main/java/io/grpc/CallOptions.java
+++ b/api/src/main/java/io/grpc/CallOptions.java
@@ -483,7 +483,7 @@ public final class CallOptions {
   /**
    * Copy CallOptions.
    */
-  private Builder toBuilder(CallOptions other) {
+  private static Builder toBuilder(CallOptions other) {
     return new Builder()
             .deadline(other.deadline)
             .executor(other.executor)

--- a/api/src/main/java/io/grpc/CallOptions.java
+++ b/api/src/main/java/io/grpc/CallOptions.java
@@ -192,7 +192,7 @@ public final class CallOptions {
    * This method should be rarely used because the default is without 'wait for ready'.
    */
   public CallOptions withoutWaitForReady() {
-    Builder builder = new Builder();
+    Builder builder = toBuilder(this);
     builder.waitForReady = Boolean.FALSE;
     return builder.build();
   }

--- a/api/src/main/java/io/grpc/CallOptions.java
+++ b/api/src/main/java/io/grpc/CallOptions.java
@@ -16,19 +16,19 @@
 
 package io.grpc;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 
-import javax.annotation.CheckReturnValue;
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
-
-import static com.google.common.base.Preconditions.checkArgument;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
 
 /**
  * The collection of runtime options for a new RPC call.
@@ -290,7 +290,7 @@ public final class CallOptions {
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2861")
   public CallOptions withStreamTracerFactory(ClientStreamTracer.Factory factory) {
     ArrayList<ClientStreamTracer.Factory> newList =
-          new ArrayList<>(streamTracerFactories.size() + 1);
+        new ArrayList<>(streamTracerFactories.size() + 1);
     newList.addAll(streamTracerFactories);
     newList.add(factory);
     CallOptions newOptions = fullBuild(this)
@@ -515,16 +515,16 @@ public final class CallOptions {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-          .add("deadline", deadline)
-          .add("authority", authority)
-          .add("callCredentials", credentials)
-          .add("executor", executor != null ? executor.getClass() : null)
-          .add("compressorName", compressorName)
-          .add("customOptions", Arrays.deepToString(customOptions))
-          .add("waitForReady", isWaitForReady())
-          .add("maxInboundMessageSize", maxInboundMessageSize)
-          .add("maxOutboundMessageSize", maxOutboundMessageSize)
-          .add("streamTracerFactories", streamTracerFactories)
-          .toString();
+        .add("deadline", deadline)
+        .add("authority", authority)
+        .add("callCredentials", credentials)
+        .add("executor", executor != null ? executor.getClass() : null)
+        .add("compressorName", compressorName)
+        .add("customOptions", Arrays.deepToString(customOptions))
+        .add("waitForReady", isWaitForReady())
+        .add("maxInboundMessageSize", maxInboundMessageSize)
+        .add("maxOutboundMessageSize", maxOutboundMessageSize)
+        .add("streamTracerFactories", streamTracerFactories)
+        .toString();
   }
 }

--- a/api/src/main/java/io/grpc/CallOptions.java
+++ b/api/src/main/java/io/grpc/CallOptions.java
@@ -35,48 +35,123 @@ import javax.annotation.concurrent.Immutable;
  *
  * <p>A field that is not set is {@code null}.
  */
-@Immutable
 @CheckReturnValue
 public final class CallOptions {
   /**
    * A blank {@code CallOptions} that all fields are not set.
    */
-  public static final CallOptions DEFAULT = new CallOptions();
-
-  // Although {@code CallOptions} is immutable, its fields are not final, so that we can initialize
-  // them outside of constructor. Otherwise the constructor will have a potentially long list of
-  // unnamed arguments, which is undesirable.
-  @Nullable
-  private Deadline deadline;
-  
-  @Nullable
-  private Executor executor;
+  public static final CallOptions DEFAULT = new Builder().build();
 
   @Nullable
-  private String authority;
+  private final Deadline deadline;
 
   @Nullable
-  private CallCredentials credentials;
+  private final Executor executor;
 
   @Nullable
-  private String compressorName;
+  private final String authority;
 
-  private Object[][] customOptions;
+  @Nullable
+  private final CallCredentials credentials;
 
-  // Unmodifiable list
-  private List<ClientStreamTracer.Factory> streamTracerFactories = Collections.emptyList();
+  @Nullable
+  private final String compressorName;
+
+  private final Object[][] customOptions;
+
+  private final List<ClientStreamTracer.Factory> streamTracerFactories;
 
   /**
    * Opposite to fail fast.
    */
   @Nullable
-  private Boolean waitForReady;
+  private final Boolean waitForReady;
 
   @Nullable
-  private Integer maxInboundMessageSize;
+  private final Integer maxInboundMessageSize;
   @Nullable
-  private Integer maxOutboundMessageSize;
+  private final Integer maxOutboundMessageSize;
 
+  private CallOptions(Builder builder) {
+    this.deadline = builder.deadline;
+    this.executor = builder.executor;
+    this.authority = builder.authority;
+    this.credentials = builder.credentials;
+    this.compressorName = builder.compressorName;
+    this.customOptions = builder.customOptions;
+    this.streamTracerFactories = builder.streamTracerFactories;
+    this.waitForReady = builder.waitForReady;
+    this.maxInboundMessageSize = builder.maxInboundMessageSize;
+    this.maxOutboundMessageSize = builder.maxOutboundMessageSize;
+  }
+
+  private static class Builder {
+    private Deadline deadline;
+    private Executor executor;
+    private String authority;
+    private CallCredentials credentials;
+    private String compressorName;
+    private Object[][] customOptions = new Object[0][2];
+    // Unmodifiable list
+    private List<ClientStreamTracer.Factory> streamTracerFactories = Collections.emptyList();
+    private Boolean waitForReady;
+    private Integer maxInboundMessageSize;
+    private Integer maxOutboundMessageSize;
+
+    private Builder deadline(Deadline deadline) {
+      this.deadline = deadline;
+      return this;
+    }
+
+    private Builder executor(Executor executor) {
+      this.executor = executor;
+      return this;
+    }
+
+    private Builder authority(String authority) {
+      this.authority = authority;
+      return this;
+    }
+
+    private Builder credentials(CallCredentials credentials) {
+      this.credentials = credentials;
+      return this;
+    }
+
+    private Builder compressorName(String compressorName) {
+      this.compressorName = compressorName;
+      return this;
+    }
+
+    private Builder customOptions(Object[][] customOptions) {
+      this.customOptions = customOptions;
+      return this;
+    }
+
+    private Builder waitForReady(Boolean waitForReady) {
+      this.waitForReady = waitForReady;
+      return this;
+    }
+
+    private Builder maxInboundMessageSize(Integer maxInboundMessageSize) {
+      this.maxInboundMessageSize = maxInboundMessageSize;
+      return this;
+    }
+
+    private Builder maxOutboundMessageSize(Integer maxOutboundMessageSize) {
+      this.maxOutboundMessageSize = maxOutboundMessageSize;
+      return this;
+    }
+
+    private Builder streamTracerFactories(List<ClientStreamTracer.Factory> streamTracerFactories) {
+      this.streamTracerFactories = streamTracerFactories;
+      return this;
+    }
+
+    private CallOptions build() {
+      return new CallOptions(this);
+    }
+  }
 
   /**
    * Override the HTTP/2 authority the channel claims to be connecting to. <em>This is not
@@ -89,8 +164,7 @@ public final class CallOptions {
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1767")
   public CallOptions withAuthority(@Nullable String authority) {
-    CallOptions newOptions = new CallOptions(this);
-    newOptions.authority = authority;
+    CallOptions newOptions = fullBuild(this).authority(authority).build();
     return newOptions;
   }
 
@@ -98,8 +172,7 @@ public final class CallOptions {
    * Returns a new {@code CallOptions} with the given call credentials.
    */
   public CallOptions withCallCredentials(@Nullable CallCredentials credentials) {
-    CallOptions newOptions = new CallOptions(this);
-    newOptions.credentials = credentials;
+    CallOptions newOptions = fullBuild(this).credentials(credentials).build();
     return newOptions;
   }
 
@@ -113,8 +186,7 @@ public final class CallOptions {
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
   public CallOptions withCompression(@Nullable String compressorName) {
-    CallOptions newOptions = new CallOptions(this);
-    newOptions.compressorName = compressorName;
+    CallOptions newOptions = fullBuild(this).compressorName(compressorName).build();
     return newOptions;
   }
 
@@ -127,8 +199,7 @@ public final class CallOptions {
    * @param deadline the deadline or {@code null} for unsetting the deadline.
    */
   public CallOptions withDeadline(@Nullable Deadline deadline) {
-    CallOptions newOptions = new CallOptions(this);
-    newOptions.deadline = deadline;
+    CallOptions newOptions = fullBuild(this).deadline(deadline).build();
     return newOptions;
   }
 
@@ -156,8 +227,7 @@ public final class CallOptions {
    * fails RPCs without sending them if unable to connect.
    */
   public CallOptions withWaitForReady() {
-    CallOptions newOptions = new CallOptions(this);
-    newOptions.waitForReady = Boolean.TRUE;
+    CallOptions newOptions = fullBuild(this).waitForReady(Boolean.TRUE).build();
     return newOptions;
   }
 
@@ -166,8 +236,7 @@ public final class CallOptions {
    * This method should be rarely used because the default is without 'wait for ready'.
    */
   public CallOptions withoutWaitForReady() {
-    CallOptions newOptions = new CallOptions(this);
-    newOptions.waitForReady = Boolean.FALSE;
+    CallOptions newOptions = new Builder().waitForReady(Boolean.FALSE).build();
     return newOptions;
   }
 
@@ -208,8 +277,7 @@ public final class CallOptions {
    * executor specified with {@link ManagedChannelBuilder#executor}.
    */
   public CallOptions withExecutor(@Nullable Executor executor) {
-    CallOptions newOptions = new CallOptions(this);
-    newOptions.executor = executor;
+    CallOptions newOptions = fullBuild(this).executor(executor).build();
     return newOptions;
   }
 
@@ -221,12 +289,13 @@ public final class CallOptions {
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2861")
   public CallOptions withStreamTracerFactory(ClientStreamTracer.Factory factory) {
-    CallOptions newOptions = new CallOptions(this);
     ArrayList<ClientStreamTracer.Factory> newList =
-        new ArrayList<>(streamTracerFactories.size() + 1);
+            new ArrayList<>(streamTracerFactories.size() + 1);
     newList.addAll(streamTracerFactories);
     newList.add(factory);
-    newOptions.streamTracerFactories = Collections.unmodifiableList(newList);
+    CallOptions newOptions = fullBuild(this)
+            .streamTracerFactories(Collections.unmodifiableList(newList))
+            .build();
     return newOptions;
   }
 
@@ -319,7 +388,7 @@ public final class CallOptions {
     Preconditions.checkNotNull(key, "key");
     Preconditions.checkNotNull(value, "value");
 
-    CallOptions newOptions = new CallOptions(this);
+    Builder builder = fullBuild(this);
     int existingIdx = -1;
     for (int i = 0; i < customOptions.length; i++) {
       if (key.equals(customOptions[i][0])) {
@@ -328,7 +397,9 @@ public final class CallOptions {
       }
     }
 
-    newOptions.customOptions = new Object[customOptions.length + (existingIdx == -1 ? 1 : 0)][2];
+    CallOptions newOptions = builder
+            .customOptions(new Object[customOptions.length + (existingIdx == -1 ? 1 : 0)][2])
+            .build();
     System.arraycopy(customOptions, 0, newOptions.customOptions, 0, customOptions.length);
 
     if (existingIdx == -1) {
@@ -368,10 +439,6 @@ public final class CallOptions {
     return executor;
   }
 
-  private CallOptions() {
-    customOptions = new Object[0][2];
-  }
-
   /**
    * Returns whether <a href="https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md">
    * 'wait for ready'</a> option is enabled for the call. 'Fail fast' is the default option for gRPC
@@ -392,8 +459,9 @@ public final class CallOptions {
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2563")
   public CallOptions withMaxInboundMessageSize(int maxSize) {
     checkArgument(maxSize >= 0, "invalid maxsize %s", maxSize);
-    CallOptions newOptions = new CallOptions(this);
-    newOptions.maxInboundMessageSize = maxSize;
+    CallOptions newOptions = fullBuild(this)
+            .maxInboundMessageSize(maxSize)
+            .build();
     return newOptions;
   }
 
@@ -403,8 +471,9 @@ public final class CallOptions {
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2563")
   public CallOptions withMaxOutboundMessageSize(int maxSize) {
     checkArgument(maxSize >= 0, "invalid maxsize %s", maxSize);
-    CallOptions newOptions = new CallOptions(this);
-    newOptions.maxOutboundMessageSize = maxSize;
+    CallOptions newOptions = fullBuild(this)
+            .maxOutboundMessageSize(maxSize)
+            .build();
     return newOptions;
   }
 
@@ -427,34 +496,35 @@ public final class CallOptions {
   }
 
   /**
-   * Copy constructor.
+   * Copy CallOptions.
    */
-  private CallOptions(CallOptions other) {
-    deadline = other.deadline;
-    authority = other.authority;
-    credentials = other.credentials;
-    executor = other.executor;
-    compressorName = other.compressorName;
-    customOptions = other.customOptions;
-    waitForReady = other.waitForReady;
-    maxInboundMessageSize = other.maxInboundMessageSize;
-    maxOutboundMessageSize = other.maxOutboundMessageSize;
-    streamTracerFactories = other.streamTracerFactories;
+  private Builder fullBuild(CallOptions other) {
+    return new Builder()
+            .deadline(other.deadline)
+            .executor(other.executor)
+            .authority(other.authority)
+            .credentials(other.credentials)
+            .compressorName(other.compressorName)
+            .customOptions(other.customOptions)
+            .streamTracerFactories(other.streamTracerFactories)
+            .waitForReady(other.waitForReady)
+            .maxInboundMessageSize(other.maxInboundMessageSize)
+            .maxOutboundMessageSize(other.maxOutboundMessageSize);
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("deadline", deadline)
-        .add("authority", authority)
-        .add("callCredentials", credentials)
-        .add("executor", executor != null ? executor.getClass() : null)
-        .add("compressorName", compressorName)
-        .add("customOptions", Arrays.deepToString(customOptions))
-        .add("waitForReady", isWaitForReady())
-        .add("maxInboundMessageSize", maxInboundMessageSize)
-        .add("maxOutboundMessageSize", maxOutboundMessageSize)
-        .add("streamTracerFactories", streamTracerFactories)
-        .toString();
+            .add("deadline", deadline)
+            .add("authority", authority)
+            .add("callCredentials", credentials)
+            .add("executor", executor != null ? executor.getClass() : null)
+            .add("compressorName", compressorName)
+            .add("customOptions", Arrays.deepToString(customOptions))
+            .add("waitForReady", isWaitForReady())
+            .add("maxInboundMessageSize", maxInboundMessageSize)
+            .add("maxOutboundMessageSize", maxOutboundMessageSize)
+            .add("streamTracerFactories", streamTracerFactories)
+            .toString();
   }
 }

--- a/api/src/main/java/io/grpc/CallOptions.java
+++ b/api/src/main/java/io/grpc/CallOptions.java
@@ -99,56 +99,6 @@ public final class CallOptions {
     Integer maxInboundMessageSize;
     Integer maxOutboundMessageSize;
 
-    private Builder deadline(Deadline deadline) {
-      this.deadline = deadline;
-      return this;
-    }
-
-    private Builder executor(Executor executor) {
-      this.executor = executor;
-      return this;
-    }
-
-    private Builder authority(String authority) {
-      this.authority = authority;
-      return this;
-    }
-
-    private Builder credentials(CallCredentials credentials) {
-      this.credentials = credentials;
-      return this;
-    }
-
-    private Builder compressorName(String compressorName) {
-      this.compressorName = compressorName;
-      return this;
-    }
-
-    private Builder customOptions(Object[][] customOptions) {
-      this.customOptions = customOptions;
-      return this;
-    }
-
-    private Builder waitForReady(Boolean waitForReady) {
-      this.waitForReady = waitForReady;
-      return this;
-    }
-
-    private Builder maxInboundMessageSize(Integer maxInboundMessageSize) {
-      this.maxInboundMessageSize = maxInboundMessageSize;
-      return this;
-    }
-
-    private Builder maxOutboundMessageSize(Integer maxOutboundMessageSize) {
-      this.maxOutboundMessageSize = maxOutboundMessageSize;
-      return this;
-    }
-
-    private Builder streamTracerFactories(List<ClientStreamTracer.Factory> streamTracerFactories) {
-      this.streamTracerFactories = Collections.unmodifiableList(streamTracerFactories);
-      return this;
-    }
-
     private CallOptions build() {
       return new CallOptions(this);
     }
@@ -165,14 +115,18 @@ public final class CallOptions {
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1767")
   public CallOptions withAuthority(@Nullable String authority) {
-    return toBuilder(this).authority(authority).build();
+    Builder builder = toBuilder(this);
+    builder.authority = authority;
+    return builder.build();
   }
 
   /**
    * Returns a new {@code CallOptions} with the given call credentials.
    */
   public CallOptions withCallCredentials(@Nullable CallCredentials credentials) {
-    return toBuilder(this).credentials(credentials).build();
+    Builder builder = toBuilder(this);
+    builder.credentials = credentials;
+    return builder.build();
   }
 
   /**
@@ -185,7 +139,9 @@ public final class CallOptions {
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
   public CallOptions withCompression(@Nullable String compressorName) {
-    return toBuilder(this).compressorName(compressorName).build();
+    Builder builder = toBuilder(this);
+    builder.compressorName = compressorName;
+    return builder.build();
   }
 
   /**
@@ -197,7 +153,9 @@ public final class CallOptions {
    * @param deadline the deadline or {@code null} for unsetting the deadline.
    */
   public CallOptions withDeadline(@Nullable Deadline deadline) {
-    return toBuilder(this).deadline(deadline).build();
+    Builder builder = toBuilder(this);
+    builder.deadline = deadline;
+    return builder.build();
   }
 
   /**
@@ -224,7 +182,9 @@ public final class CallOptions {
    * fails RPCs without sending them if unable to connect.
    */
   public CallOptions withWaitForReady() {
-    return toBuilder(this).waitForReady(Boolean.TRUE).build();
+    Builder builder = toBuilder(this);
+    builder.waitForReady = Boolean.TRUE;
+    return builder.build();
   }
 
   /**
@@ -232,7 +192,9 @@ public final class CallOptions {
    * This method should be rarely used because the default is without 'wait for ready'.
    */
   public CallOptions withoutWaitForReady() {
-    return new Builder().waitForReady(Boolean.FALSE).build();
+    Builder builder = new Builder();
+    builder.waitForReady = Boolean.FALSE;
+    return builder.build();
   }
 
   /**
@@ -272,7 +234,9 @@ public final class CallOptions {
    * executor specified with {@link ManagedChannelBuilder#executor}.
    */
   public CallOptions withExecutor(@Nullable Executor executor) {
-    return toBuilder(this).executor(executor).build();
+    Builder builder = toBuilder(this);
+    builder.executor = executor;
+    return builder.build();
   }
 
   /**
@@ -287,7 +251,9 @@ public final class CallOptions {
         new ArrayList<>(streamTracerFactories.size() + 1);
     newList.addAll(streamTracerFactories);
     newList.add(factory);
-    return toBuilder(this).streamTracerFactories(newList).build();
+    Builder builder = toBuilder(this);
+    builder.streamTracerFactories = Collections.unmodifiableList(newList);
+    return builder.build();
   }
 
   /**
@@ -388,9 +354,8 @@ public final class CallOptions {
       }
     }
 
-    CallOptions newOptions = builder
-            .customOptions(new Object[customOptions.length + (existingIdx == -1 ? 1 : 0)][2])
-            .build();
+    builder.customOptions = new Object[customOptions.length + (existingIdx == -1 ? 1 : 0)][2];
+    CallOptions newOptions = builder.build();
     System.arraycopy(customOptions, 0, newOptions.customOptions, 0, customOptions.length);
 
     if (existingIdx == -1) {
@@ -450,7 +415,9 @@ public final class CallOptions {
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2563")
   public CallOptions withMaxInboundMessageSize(int maxSize) {
     checkArgument(maxSize >= 0, "invalid maxsize %s", maxSize);
-    return toBuilder(this).maxInboundMessageSize(maxSize).build();
+    Builder builder = toBuilder(this);
+    builder.maxInboundMessageSize = maxSize;
+    return builder.build();
   }
 
   /**
@@ -459,7 +426,9 @@ public final class CallOptions {
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2563")
   public CallOptions withMaxOutboundMessageSize(int maxSize) {
     checkArgument(maxSize >= 0, "invalid maxsize %s", maxSize);
-    return toBuilder(this).maxOutboundMessageSize(maxSize).build();
+    Builder builder = toBuilder(this);
+    builder.maxOutboundMessageSize = maxSize;
+    return builder.build();
   }
 
   /**
@@ -484,17 +453,18 @@ public final class CallOptions {
    * Copy CallOptions.
    */
   private static Builder toBuilder(CallOptions other) {
-    return new Builder()
-            .deadline(other.deadline)
-            .executor(other.executor)
-            .authority(other.authority)
-            .credentials(other.credentials)
-            .compressorName(other.compressorName)
-            .customOptions(other.customOptions)
-            .streamTracerFactories(other.streamTracerFactories)
-            .waitForReady(other.waitForReady)
-            .maxInboundMessageSize(other.maxInboundMessageSize)
-            .maxOutboundMessageSize(other.maxOutboundMessageSize);
+    Builder builder = new Builder();
+    builder.deadline = other.deadline;
+    builder.executor = other.executor;
+    builder.authority = other.authority;
+    builder.credentials = other.credentials;
+    builder.compressorName = other.compressorName;
+    builder.customOptions = other.customOptions;
+    builder.streamTracerFactories = other.streamTracerFactories;
+    builder.waitForReady = other.waitForReady;
+    builder.maxInboundMessageSize = other.maxInboundMessageSize;
+    builder.maxOutboundMessageSize = other.maxOutboundMessageSize;
+    return builder;
   }
 
   @Override

--- a/api/src/main/java/io/grpc/CallOptions.java
+++ b/api/src/main/java/io/grpc/CallOptions.java
@@ -355,18 +355,17 @@ public final class CallOptions {
     }
 
     builder.customOptions = new Object[customOptions.length + (existingIdx == -1 ? 1 : 0)][2];
-    CallOptions newOptions = builder.build();
-    System.arraycopy(customOptions, 0, newOptions.customOptions, 0, customOptions.length);
+    System.arraycopy(customOptions, 0, builder.customOptions, 0, customOptions.length);
 
     if (existingIdx == -1) {
       // Add a new option
-      newOptions.customOptions[customOptions.length] = new Object[] {key, value};
+      builder.customOptions[customOptions.length] = new Object[] {key, value};
     } else {
       // Replace an existing option
-      newOptions.customOptions[existingIdx] = new Object[] {key, value};
+      builder.customOptions[existingIdx] = new Object[] {key, value};
     }
 
-    return newOptions;
+    return builder.build();
   }
 
   /**

--- a/api/src/main/java/io/grpc/CallOptions.java
+++ b/api/src/main/java/io/grpc/CallOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The gRPC Authors
+ * Copyright 2015, 2022 The gRPC Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -290,7 +290,7 @@ public final class CallOptions {
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2861")
   public CallOptions withStreamTracerFactory(ClientStreamTracer.Factory factory) {
     ArrayList<ClientStreamTracer.Factory> newList =
-            new ArrayList<>(streamTracerFactories.size() + 1);
+          new ArrayList<>(streamTracerFactories.size() + 1);
     newList.addAll(streamTracerFactories);
     newList.add(factory);
     CallOptions newOptions = fullBuild(this)
@@ -515,16 +515,16 @@ public final class CallOptions {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-            .add("deadline", deadline)
-            .add("authority", authority)
-            .add("callCredentials", credentials)
-            .add("executor", executor != null ? executor.getClass() : null)
-            .add("compressorName", compressorName)
-            .add("customOptions", Arrays.deepToString(customOptions))
-            .add("waitForReady", isWaitForReady())
-            .add("maxInboundMessageSize", maxInboundMessageSize)
-            .add("maxOutboundMessageSize", maxOutboundMessageSize)
-            .add("streamTracerFactories", streamTracerFactories)
-            .toString();
+          .add("deadline", deadline)
+          .add("authority", authority)
+          .add("callCredentials", credentials)
+          .add("executor", executor != null ? executor.getClass() : null)
+          .add("compressorName", compressorName)
+          .add("customOptions", Arrays.deepToString(customOptions))
+          .add("waitForReady", isWaitForReady())
+          .add("maxInboundMessageSize", maxInboundMessageSize)
+          .add("maxOutboundMessageSize", maxOutboundMessageSize)
+          .add("streamTracerFactories", streamTracerFactories)
+          .toString();
   }
 }

--- a/api/src/main/java/io/grpc/CallOptions.java
+++ b/api/src/main/java/io/grpc/CallOptions.java
@@ -16,19 +16,19 @@
 
 package io.grpc;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.CheckReturnValue;
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.Immutable;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * The collection of runtime options for a new RPC call.


### PR DESCRIPTION
Fixes #9658 

Although `CallOptions` is annotated by `@Immutable`, its fields are not final. So it's not truly immutable, namely not thread-safe.

This PR add `final` to all fields of `CallOptions` and remove `@Immutable`. Using internal builder class to keep flexibility of constructing `CallOptions `.