### PR TITLE
bazel: Migrate from `cfg = "host"` to `cfg = "exec"`

### DIFF
--- a/java_grpc_library.bzl
+++ b/java_grpc_library.bzl
@@ -30,12 +30,12 @@ java_rpc_toolchain = rule(
             providers = [JavaInfo],
         ),
         "plugin": attr.label(
-            cfg = "host",
+            cfg = "exec",
             executable = True,
         ),
         "plugin_arg": attr.string(),
         "_protoc": attr.label(
-            cfg = "host",
+            cfg = "exec",
             default = Label("@com_google_protobuf//:protoc"),
             executable = True,
         ),


### PR DESCRIPTION
This change migrates from `cfg = "host"` to `cfg = "exec"`.
This is a no-op cleanup: `cfg = "host"` is a deprecated alias for `cfg = "exec"`.

Tested:

```
bazel build //grpclb:grpclb
bazel build //compiler:java_grpc_library_toolchain
bazel build //compiler:grpc_java_plugin
bazel build '//compiler:*'
```

Internal ref cl/487924699