### PR TITLE
examples: Swap to Channel/ServerCredentials API

### DIFF
--- a/examples/example-alts/src/main/java/io/grpc/examples/alts/HelloWorldAltsClient.java
+++ b/examples/example-alts/src/main/java/io/grpc/examples/alts/HelloWorldAltsClient.java
@@ -16,7 +16,8 @@
 
 package io.grpc.examples.alts;
 
-import io.grpc.alts.AltsChannelBuilder;
+import io.grpc.alts.AltsChannelCredentials;
+import io.grpc.Grpc;
 import io.grpc.ManagedChannel;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.HelloReply;
@@ -81,7 +82,8 @@ public final class HelloWorldAltsClient {
   private void run(String[] args) throws InterruptedException {
     parseArgs(args);
     ExecutorService executor = Executors.newFixedThreadPool(1);
-    ManagedChannel channel = AltsChannelBuilder.forTarget(serverAddress).executor(executor).build();
+    ManagedChannel channel = Grpc.newChannelBuilder(serverAddress, AltsChannelCredentials.create())
+        .executor(executor).build();
     try {
       GreeterGrpc.GreeterBlockingStub stub = GreeterGrpc.newBlockingStub(channel);
       HelloReply resp = stub.sayHello(HelloRequest.newBuilder().setName("Waldo").build());

--- a/examples/example-alts/src/main/java/io/grpc/examples/alts/HelloWorldAltsServer.java
+++ b/examples/example-alts/src/main/java/io/grpc/examples/alts/HelloWorldAltsServer.java
@@ -16,7 +16,8 @@
 
 package io.grpc.examples.alts;
 
-import io.grpc.alts.AltsServerBuilder;
+import io.grpc.alts.AltsServerCredentials;
+import io.grpc.Grpc;
 import io.grpc.Server;
 import io.grpc.examples.helloworld.GreeterGrpc.GreeterImplBase;
 import io.grpc.examples.helloworld.HelloReply;
@@ -82,7 +83,7 @@ public final class HelloWorldAltsServer extends GreeterImplBase {
   private void start(String[] args) throws IOException, InterruptedException {
     parseArgs(args);
     server =
-        AltsServerBuilder.forPort(port)
+        Grpc.newServerBuilderForPort(port, AltsServerCredentials.create())
             .addService(this)
             .executor(Executors.newFixedThreadPool(1))
             .build();

--- a/examples/example-hostname/src/main/java/io/grpc/examples/hostname/HostnameServer.java
+++ b/examples/example-hostname/src/main/java/io/grpc/examples/hostname/HostnameServer.java
@@ -16,6 +16,8 @@
 
 package io.grpc.examples.hostname;
 
+import io.grpc.Grpc;
+import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
@@ -49,7 +51,7 @@ public final class HostnameServer {
       hostname = args[1];
     }
     HealthStatusManager health = new HealthStatusManager();
-    final Server server = ServerBuilder.forPort(port)
+    final Server server = Grpc.newServerBuilderForPort(port, InsecureServerCredentials.create())
         .addService(new HostnameGreeter(hostname))
         .addService(ProtoReflectionService.newInstance())
         .addService(health.getHealthService())

--- a/examples/example-jwt-auth/src/main/java/io/grpc/examples/jwtauth/AuthClient.java
+++ b/examples/example-jwt-auth/src/main/java/io/grpc/examples/jwtauth/AuthClient.java
@@ -17,8 +17,9 @@
 package io.grpc.examples.jwtauth;
 
 import io.grpc.CallCredentials;
+import io.grpc.Grpc;
+import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
@@ -42,12 +43,9 @@ public class AuthClient {
   AuthClient(CallCredentials callCredentials, String host, int port) {
     this(
         callCredentials,
-        ManagedChannelBuilder
-            .forAddress(host, port)
-            // Channels are secure by default (via SSL/TLS). For this example we disable TLS
-            // to avoid needing certificates, but it is recommended to use a secure channel
-            // while passing credentials.
-            .usePlaintext()
+        // For this example we use plaintext to avoid needing certificates, but it is
+        // recommended to use TlsChannelCredentials.
+        Grpc.newChannelBuilderForAddress(host, port, InsecureChannelCredentials.create())
             .build());
   }
 

--- a/examples/example-jwt-auth/src/main/java/io/grpc/examples/jwtauth/AuthServer.java
+++ b/examples/example-jwt-auth/src/main/java/io/grpc/examples/jwtauth/AuthServer.java
@@ -16,8 +16,9 @@
 
 package io.grpc.examples.jwtauth;
 
+import io.grpc.Grpc;
+import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
@@ -41,7 +42,7 @@ public class AuthServer {
   }
 
   private void start() throws IOException {
-    server = ServerBuilder.forPort(port)
+    server = Grpc.newServerBuilderForPort(port, InsecureServerCredentials.create())
         .addService(new GreeterImpl())
         .intercept(new JwtServerInterceptor())  // add the JwtServerInterceptor
         .build()

--- a/examples/example-orca/src/main/java/io/grpc/examples/orca/CustomBackendMetricsClient.java
+++ b/examples/example-orca/src/main/java/io/grpc/examples/orca/CustomBackendMetricsClient.java
@@ -19,9 +19,10 @@ package io.grpc.examples.orca;
 import static io.grpc.examples.orca.CustomBackendMetricsLoadBalancerProvider.EXAMPLE_LOAD_BALANCER;
 
 import io.grpc.Channel;
+import io.grpc.Grpc;
+import io.grpc.InsecureChannelCredentials;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.HelloReply;
@@ -91,9 +92,8 @@ public class CustomBackendMetricsClient {
 
     LoadBalancerRegistry.getDefaultRegistry().register(
         new CustomBackendMetricsLoadBalancerProvider());
-    ManagedChannel channel = ManagedChannelBuilder.forTarget(target)
+    ManagedChannel channel = Grpc.newChannelBuilder(target, InsecureChannelCredentials.create())
         .defaultLoadBalancingPolicy(EXAMPLE_LOAD_BALANCER)
-        .usePlaintext()
         .build();
     try {
       CustomBackendMetricsClient client = new CustomBackendMetricsClient(channel);

--- a/examples/example-orca/src/main/java/io/grpc/examples/orca/CustomBackendMetricsServer.java
+++ b/examples/example-orca/src/main/java/io/grpc/examples/orca/CustomBackendMetricsServer.java
@@ -21,8 +21,9 @@ import io.grpc.BindableService;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
+import io.grpc.Grpc;
+import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
 import io.grpc.services.CallMetricRecorder;
 import io.grpc.services.InternalCallMetricRecorder;
 import io.grpc.services.MetricRecorder;
@@ -57,7 +58,7 @@ public class CustomBackendMetricsServer {
     // configuration to be as short as 1s, suitable for test demonstration.
     BindableService orcaOobService =
         OrcaServiceImpl.createService(executor, metricRecorder, 1, TimeUnit.SECONDS);
-    server = ServerBuilder.forPort(port)
+    server = Grpc.newServerBuilderForPort(port, InsecureServerCredentials.create())
         .addService(new GreeterImpl())
         // Enable OOB custom backend metrics reporting.
         .addService(orcaOobService)

--- a/examples/src/main/java/io/grpc/examples/advanced/HelloJsonClient.java
+++ b/examples/src/main/java/io/grpc/examples/advanced/HelloJsonClient.java
@@ -20,8 +20,9 @@ import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 
 import io.grpc.CallOptions;
 import io.grpc.Channel;
+import io.grpc.Grpc;
+import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.MethodDescriptor;
 import io.grpc.StatusRuntimeException;
 import io.grpc.examples.helloworld.GreeterGrpc;
@@ -49,8 +50,7 @@ public final class HelloJsonClient {
 
   /** Construct client connecting to HelloWorld server at {@code host:port}. */
   public HelloJsonClient(String host, int port) {
-    channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext()
+    channel = Grpc.newChannelBuilderForAddress(host, port, InsecureChannelCredentials.create())
         .build();
     blockingStub = new HelloJsonStub(channel);
   }

--- a/examples/src/main/java/io/grpc/examples/advanced/HelloJsonServer.java
+++ b/examples/src/main/java/io/grpc/examples/advanced/HelloJsonServer.java
@@ -19,8 +19,9 @@ package io.grpc.examples.advanced;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 
 import io.grpc.BindableService;
+import io.grpc.Grpc;
+import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
 import io.grpc.ServerServiceDefinition;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.HelloReply;
@@ -50,7 +51,7 @@ public class HelloJsonServer {
   private void start() throws IOException {
     /* The port on which the server should run */
     int port = 50051;
-    server = ServerBuilder.forPort(port)
+    server = Grpc.newServerBuilderForPort(port, InsecureServerCredentials.create())
         .addService(new GreeterImpl())
         .build()
         .start();

--- a/examples/src/main/java/io/grpc/examples/errorhandling/DetailErrorSample.java
+++ b/examples/src/main/java/io/grpc/examples/errorhandling/DetailErrorSample.java
@@ -27,11 +27,12 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.rpc.DebugInfo;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
+import io.grpc.Grpc;
+import io.grpc.InsecureChannelCredentials;
+import io.grpc.InsecureServerCredentials;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
 import io.grpc.Status;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.GreeterGrpc.GreeterBlockingStub;
@@ -73,7 +74,8 @@ public class DetailErrorSample {
   private ManagedChannel channel;
 
   void run() throws Exception {
-    Server server = ServerBuilder.forPort(0).addService(new GreeterGrpc.GreeterImplBase() {
+    Server server = Grpc.newServerBuilderForPort(0, InsecureServerCredentials.create())
+        .addService(new GreeterGrpc.GreeterImplBase() {
       @Override
       public void sayHello(HelloRequest request, StreamObserver<HelloReply> responseObserver) {
         Metadata trailers = new Metadata();
@@ -82,8 +84,8 @@ public class DetailErrorSample {
             .asRuntimeException(trailers));
       }
     }).build().start();
-    channel =
-        ManagedChannelBuilder.forAddress("localhost", server.getPort()).usePlaintext().build();
+    channel = Grpc.newChannelBuilderForAddress(
+          "localhost", server.getPort(), InsecureChannelCredentials.create()).build();
 
     blockingCall();
     futureCallDirect();

--- a/examples/src/main/java/io/grpc/examples/errorhandling/ErrorHandlingClient.java
+++ b/examples/src/main/java/io/grpc/examples/errorhandling/ErrorHandlingClient.java
@@ -25,11 +25,12 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.Uninterruptibles;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
+import io.grpc.Grpc;
+import io.grpc.InsecureChannelCredentials;
+import io.grpc.InsecureServerCredentials;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
 import io.grpc.Status;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.GreeterGrpc.GreeterBlockingStub;
@@ -55,15 +56,16 @@ public class ErrorHandlingClient {
 
   void run() throws Exception {
     // Port 0 means that the operating system will pick an available port to use.
-    Server server = ServerBuilder.forPort(0).addService(new GreeterGrpc.GreeterImplBase() {
+    Server server = Grpc.newServerBuilderForPort(0, InsecureServerCredentials.create())
+        .addService(new GreeterGrpc.GreeterImplBase() {
       @Override
       public void sayHello(HelloRequest request, StreamObserver<HelloReply> responseObserver) {
         responseObserver.onError(Status.INTERNAL
             .withDescription("Eggplant Xerxes Crybaby Overbite Narwhal").asRuntimeException());
       }
     }).build().start();
-    channel =
-        ManagedChannelBuilder.forAddress("localhost", server.getPort()).usePlaintext().build();
+    channel = Grpc.newChannelBuilderForAddress(
+        "localhost", server.getPort(), InsecureChannelCredentials.create()).build();
 
     blockingCall();
     futureCallDirect();

--- a/examples/src/main/java/io/grpc/examples/experimental/CompressingHelloWorldClient.java
+++ b/examples/src/main/java/io/grpc/examples/experimental/CompressingHelloWorldClient.java
@@ -16,8 +16,9 @@
 
 package io.grpc.examples.experimental;
 
+import io.grpc.Grpc;
+import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.HelloReply;
@@ -42,8 +43,7 @@ public class CompressingHelloWorldClient {
 
   /** Construct client connecting to HelloWorld server at {@code host:port}. */
   public CompressingHelloWorldClient(String host, int port) {
-    channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext()
+    channel = Grpc.newChannelBuilderForAddress(host, port, InsecureChannelCredentials.create())
         .build();
     blockingStub = GreeterGrpc.newBlockingStub(channel);
   }

--- a/examples/src/main/java/io/grpc/examples/experimental/CompressingHelloWorldServerAllMethods.java
+++ b/examples/src/main/java/io/grpc/examples/experimental/CompressingHelloWorldServerAllMethods.java
@@ -20,9 +20,10 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
+import io.grpc.Grpc;
+import io.grpc.InsecureServerCredentials;
 import io.grpc.Metadata;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
 import io.grpc.ServerCall;
 import io.grpc.ServerCall.Listener;
 import io.grpc.ServerCallHandler;
@@ -44,7 +45,7 @@ public class CompressingHelloWorldServerAllMethods {
   private void start() throws IOException {
     /* The port on which the server should run */
     int port = 50051;
-    server = ServerBuilder.forPort(port)
+    server = Grpc.newServerBuilderForPort(port, InsecureServerCredentials.create())
         /* This method call adds the Interceptor to enable compressed server responses for all RPCs */
         .intercept(new ServerInterceptor() {
           @Override

--- a/examples/src/main/java/io/grpc/examples/experimental/CompressingHelloWorldServerPerMethod.java
+++ b/examples/src/main/java/io/grpc/examples/experimental/CompressingHelloWorldServerPerMethod.java
@@ -20,8 +20,9 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
+import io.grpc.Grpc;
+import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
@@ -40,7 +41,7 @@ public class CompressingHelloWorldServerPerMethod {
   private void start() throws IOException {
     /* The port on which the server should run */
     int port = 50051;
-    server = ServerBuilder.forPort(port)
+    server = Grpc.newServerBuilderForPort(port, InsecureServerCredentials.create())
         .addService(new GreeterImpl())
         .build()
         .start();

--- a/examples/src/main/java/io/grpc/examples/header/CustomHeaderClient.java
+++ b/examples/src/main/java/io/grpc/examples/header/CustomHeaderClient.java
@@ -19,8 +19,9 @@ package io.grpc.examples.header;
 import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
+import io.grpc.Grpc;
+import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.HelloReply;
@@ -43,8 +44,8 @@ public class CustomHeaderClient {
    * A custom client.
    */
   private CustomHeaderClient(String host, int port) {
-    originChannel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext()
+    originChannel = Grpc
+        .newChannelBuilderForAddress(host, port, InsecureChannelCredentials.create())
         .build();
     ClientInterceptor interceptor = new HeaderClientInterceptor();
     Channel channel = ClientInterceptors.intercept(originChannel, interceptor);

--- a/examples/src/main/java/io/grpc/examples/header/CustomHeaderServer.java
+++ b/examples/src/main/java/io/grpc/examples/header/CustomHeaderServer.java
@@ -16,8 +16,9 @@
 
 package io.grpc.examples.header;
 
+import io.grpc.Grpc;
+import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptors;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.HelloReply;
@@ -39,7 +40,7 @@ public class CustomHeaderServer {
   private Server server;
 
   private void start() throws IOException {
-    server = ServerBuilder.forPort(PORT)
+    server = Grpc.newServerBuilderForPort(PORT, InsecureServerCredentials.create())
         .addService(ServerInterceptors.intercept(new GreeterImpl(), new HeaderServerInterceptor()))
         .build()
         .start();

--- a/examples/src/main/java/io/grpc/examples/hedging/HedgingHelloWorldClient.java
+++ b/examples/src/main/java/io/grpc/examples/hedging/HedgingHelloWorldClient.java
@@ -20,6 +20,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.gson.Gson;
 import com.google.gson.stream.JsonReader;
+import io.grpc.Grpc;
+import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
@@ -51,11 +53,8 @@ public class HedgingHelloWorldClient {
 
   /** Construct client connecting to HelloWorld server at {@code host:port}. */
   public HedgingHelloWorldClient(String host, int port, boolean hedging) {
-
-    ManagedChannelBuilder<?> channelBuilder = ManagedChannelBuilder.forAddress(host, port)
-        // Channels are secure by default (via SSL/TLS). For the example we disable TLS to avoid
-        // needing certificates.
-        .usePlaintext();
+    ManagedChannelBuilder<?> channelBuilder
+        = Grpc.newChannelBuilderForAddress(host, port, InsecureChannelCredentials.create());
     if (hedging) {
       Map<String, ?> hedgingServiceConfig =
           new Gson()

--- a/examples/src/main/java/io/grpc/examples/hedging/HedgingHelloWorldServer.java
+++ b/examples/src/main/java/io/grpc/examples/hedging/HedgingHelloWorldServer.java
@@ -16,9 +16,10 @@
 
 package io.grpc.examples.hedging;
 
+import io.grpc.Grpc;
+import io.grpc.InsecureServerCredentials;
 import io.grpc.Metadata;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
 import io.grpc.ServerCall;
 import io.grpc.ServerCall.Listener;
 import io.grpc.ServerCallHandler;
@@ -43,7 +44,7 @@ public class HedgingHelloWorldServer {
   private void start() throws IOException {
     /* The port on which the server should run */
     int port = 50051;
-    server = ServerBuilder.forPort(port)
+    server = Grpc.newServerBuilderForPort(port, InsecureServerCredentials.create())
         .addService(new GreeterImpl())
         .intercept(new LatencyInjectionInterceptor())
         .build()

--- a/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldClient.java
+++ b/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldClient.java
@@ -17,8 +17,9 @@
 package io.grpc.examples.helloworld;
 
 import io.grpc.Channel;
+import io.grpc.Grpc;
+import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -81,10 +82,10 @@ public class HelloWorldClient {
     // Create a communication channel to the server, known as a Channel. Channels are thread-safe
     // and reusable. It is common to create channels at the beginning of your application and reuse
     // them until the application shuts down.
-    ManagedChannel channel = ManagedChannelBuilder.forTarget(target)
-        // Channels are secure by default (via SSL/TLS). For the example we disable TLS to avoid
-        // needing certificates.
-        .usePlaintext()
+    //
+    // For the example we use plaintext insecure credentials to avoid needing TLS certificates. To
+    // use TLS, use TlsChannelCredentials instead.
+    ManagedChannel channel = Grpc.newChannelBuilder(target, InsecureChannelCredentials.create())
         .build();
     try {
       HelloWorldClient client = new HelloWorldClient(channel);

--- a/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldServer.java
+++ b/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldServer.java
@@ -16,8 +16,9 @@
 
 package io.grpc.examples.helloworld;
 
+import io.grpc.Grpc;
+import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
@@ -34,7 +35,7 @@ public class HelloWorldServer {
   private void start() throws IOException {
     /* The port on which the server should run */
     int port = 50051;
-    server = ServerBuilder.forPort(port)
+    server = Grpc.newServerBuilderForPort(port, InsecureServerCredentials.create())
         .addService(new GreeterImpl())
         .build()
         .start();

--- a/examples/src/main/java/io/grpc/examples/retrying/RetryingHelloWorldClient.java
+++ b/examples/src/main/java/io/grpc/examples/retrying/RetryingHelloWorldClient.java
@@ -20,6 +20,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.gson.Gson;
 import com.google.gson.stream.JsonReader;
+import io.grpc.Grpc;
+import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
@@ -64,10 +66,8 @@ public class RetryingHelloWorldClient {
    */
   public RetryingHelloWorldClient(String host, int port, boolean enableRetries) {
 
-    ManagedChannelBuilder<?> channelBuilder = ManagedChannelBuilder.forAddress(host, port)
-        // Channels are secure by default (via SSL/TLS). For the example we disable TLS to avoid
-        // needing certificates.
-        .usePlaintext();
+    ManagedChannelBuilder<?> channelBuilder
+        = Grpc.newChannelBuilderForAddress(host, port, InsecureChannelCredentials.create());
     if (enableRetries) {
       Map<String, ?> serviceConfig = getRetryingServiceConfig();
       logger.info("Client started with retrying configuration: " + serviceConfig);

--- a/examples/src/main/java/io/grpc/examples/retrying/RetryingHelloWorldServer.java
+++ b/examples/src/main/java/io/grpc/examples/retrying/RetryingHelloWorldServer.java
@@ -19,8 +19,9 @@ package io.grpc.examples.retrying;
 import java.text.DecimalFormat;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
+import io.grpc.Grpc;
+import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
 import io.grpc.Status;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.HelloReply;
@@ -43,7 +44,7 @@ public class RetryingHelloWorldServer {
   private void start() throws IOException {
     /* The port on which the server should run */
     int port = 50051;
-    server = ServerBuilder.forPort(port)
+    server = Grpc.newServerBuilderForPort(port, InsecureServerCredentials.create())
         .addService(new GreeterImpl())
         .build()
         .start();

--- a/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideClient.java
+++ b/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideClient.java
@@ -19,8 +19,9 @@ package io.grpc.examples.routeguide;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Message;
 import io.grpc.Channel;
+import io.grpc.Grpc;
+import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.examples.routeguide.RouteGuideGrpc.RouteGuideBlockingStub;
@@ -259,7 +260,8 @@ public class RouteGuideClient {
       return;
     }
 
-    ManagedChannel channel = ManagedChannelBuilder.forTarget(target).usePlaintext().build();
+    ManagedChannel channel = Grpc.newChannelBuilder(target, InsecureChannelCredentials.create())
+        .build();
     try {
       RouteGuideClient client = new RouteGuideClient(channel);
       // Looking for a valid feature

--- a/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
+++ b/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
@@ -25,6 +25,8 @@ import static java.lang.Math.sqrt;
 import static java.lang.Math.toRadians;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
+import io.grpc.Grpc;
+import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
@@ -55,7 +57,8 @@ public class RouteGuideServer {
 
   /** Create a RouteGuide server listening on {@code port} using {@code featureFile} database. */
   public RouteGuideServer(int port, URL featureFile) throws IOException {
-    this(ServerBuilder.forPort(port), port, RouteGuideUtil.parseFeatures(featureFile));
+    this(Grpc.newServerBuilderForPort(port, InsecureServerCredentials.create()),
+        port, RouteGuideUtil.parseFeatures(featureFile));
   }
 
   /** Create a RouteGuide server using serverBuilder as a base and features as data. */


### PR DESCRIPTION
This makes it more obvious when plaintext vs TLS is being used and is the preferred API.

I did not change the Google Auth example, because it is doing things a weird way and changing it would be more invasive. I also didn't update the Android examples.