### PR TITLE
Limit ring hash max size to 4K

### DIFF
--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancerProvider.java
@@ -26,6 +26,7 @@ import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.Status;
 import io.grpc.internal.JsonUtil;
 import io.grpc.xds.RingHashLoadBalancer.RingHashConfig;
+import io.grpc.xds.RingHashOptions;
 import java.util.Map;
 
 /**
@@ -73,17 +74,18 @@ public final class RingHashLoadBalancerProvider extends LoadBalancerProvider {
   public ConfigOrError parseLoadBalancingPolicyConfig(Map<String, ?> rawLoadBalancingPolicyConfig) {
     Long minRingSize = JsonUtil.getNumberAsLong(rawLoadBalancingPolicyConfig, "minRingSize");
     Long maxRingSize = JsonUtil.getNumberAsLong(rawLoadBalancingPolicyConfig, "maxRingSize");
+    long maxRingSizeCap = RingHashOptions.getMaxRingSizeCap();
     if (minRingSize == null) {
       minRingSize = DEFAULT_MIN_RING_SIZE;
     }
     if (maxRingSize == null) {
       maxRingSize = DEFAULT_MAX_RING_SIZE;
     }
-    if (minRingSize > MAX_RING_SIZE_CAP) {
-      minRingSize = MAX_RING_SIZE_CAP;
+    if (minRingSize > maxRingSizeCap) {
+      minRingSize = maxRingSizeCap;
     }
-    if (maxRingSize > MAX_RING_SIZE_CAP) {
-      maxRingSize = MAX_RING_SIZE_CAP;
+    if (maxRingSize > maxRingSizeCap) {
+      maxRingSize = maxRingSizeCap;
     }
     if (minRingSize <= 0 || maxRingSize <= 0 || minRingSize > maxRingSize) {
       return ConfigOrError.fromError(Status.UNAVAILABLE.withDescription(

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancerProvider.java
@@ -74,7 +74,7 @@ public final class RingHashLoadBalancerProvider extends LoadBalancerProvider {
   public ConfigOrError parseLoadBalancingPolicyConfig(Map<String, ?> rawLoadBalancingPolicyConfig) {
     Long minRingSize = JsonUtil.getNumberAsLong(rawLoadBalancingPolicyConfig, "minRingSize");
     Long maxRingSize = JsonUtil.getNumberAsLong(rawLoadBalancingPolicyConfig, "maxRingSize");
-    long maxRingSizeCap = RingHashOptions.getMaxRingSizeCap();
+    long maxRingSizeCap = RingHashOptions.getRingSizeCap();
     if (minRingSize == null) {
       minRingSize = DEFAULT_MIN_RING_SIZE;
     }

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancerProvider.java
@@ -41,10 +41,6 @@ public final class RingHashLoadBalancerProvider extends LoadBalancerProvider {
   // Same as ClientXdsClient.DEFAULT_RING_HASH_LB_POLICY_MAX_RING_SIZE
   @VisibleForTesting
   static final long DEFAULT_MAX_RING_SIZE = 4 * 1024L;
-  // An upper bound on max ring size to limit memory usage.
-  // TODO(apolcyn): make MAX_RING_SIZE_CAP configurable, ideally on a per-channel
-  // basis but possibly as a global.
-  static final long MAX_RING_SIZE_CAP = 4 * 1024L;
 
   private static final boolean enableRingHash =
       Strings.isNullOrEmpty(System.getenv("GRPC_XDS_EXPERIMENTAL_ENABLE_RING_HASH"))

--- a/xds/src/main/java/io/grpc/xds/RingHashOptions.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashOptions.java
@@ -56,9 +56,16 @@ import javax.annotation.Nullable;
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/9718")
 public final class RingHashOptions {
-  private static volatile maxRingSizeCap = 4096;
+  // Same as ClientXdsClient.DEFAULT_RING_HASH_LB_POLICY_MAX_RING_SIZE
+  @VisibleForTesting
+  static final long MAX_RING_SIZE_CAP = 8 * 1024 * 1024L;
 
-  public static setMaxRingSizeCap(long cap) {
+  // Same as RingHashLoadBalancerProvider.DEFAULT_MAX_RING_SIZE
+  private static volatile long maxRingSizeCap = 4 * 1024L;
+
+  public static setMaxRingSizeCap(long maxRingSizeCap) {
+    maxRingSizeCap = Math.max(1, maxRingSizeCap);
+    maxRingSizeCap = Math.min(MAX_RING_SIZE_CAP, maxRingSizeCap);
     RingHashOptions.maxRingSizeCap = maxRingSizeCap;
   }
 }

--- a/xds/src/main/java/io/grpc/xds/RingHashOptions.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashOptions.java
@@ -16,6 +16,7 @@
 
 package io.grpc.xds;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.grpc.ExperimentalApi;
 
 /**

--- a/xds/src/main/java/io/grpc/xds/RingHashOptions.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashOptions.java
@@ -37,12 +37,13 @@ public final class RingHashOptions {
   // Limits ring hash sizes to restrict client memory usage.
   private static volatile long ringSizeCap = DEFAULT_RING_SIZE_CAP;
 
+  private RingHashOptions() {} // Prevent instantiation
+
   /**
-   * Set the global limit for min and max ring hash sizes. Note that
-   * this limit is clamped between 1 and 8M, and attempts to set
-   * the limit lower or higher than that range will be silently
-   * moved to the nearest number within that range. Defaults initially
-   * to 4K.
+   * Set the global limit for the min and max number of ring hash entries per ring.
+   * Note that this limit is clamped between 1 entry and 8,388,608 entries, and new
+   * limits lying outside that range will be silently moved to the nearest number within
+   * that range. Defaults initially to 4096 entries.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/9718")
   public static void setRingSizeCap(long ringSizeCap) {

--- a/xds/src/main/java/io/grpc/xds/RingHashOptions.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashOptions.java
@@ -30,9 +30,12 @@ public final class RingHashOptions {
   // Same as ClientXdsClient.DEFAULT_RING_HASH_LB_POLICY_MAX_RING_SIZE
   @VisibleForTesting
   static final long MAX_RING_SIZE_CAP = 8 * 1024 * 1024L;
-
+  @VisibleForTesting
   // Same as RingHashLoadBalancerProvider.DEFAULT_MAX_RING_SIZE
-  private static volatile long ringSizeCap = 4 * 1024L;
+  static final long DEFAULT_RING_SIZE_CAP = 4 * 1024L;
+
+  // Limits ring hash sizes to restrict client memory usage.
+  private static volatile long ringSizeCap = DEFAULT_RING_SIZE_CAP;
 
   /**
    * Set the global limit for min and max ring hash sizes. Note that

--- a/xds/src/main/java/io/grpc/xds/RingHashOptions.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashOptions.java
@@ -16,38 +16,6 @@
 
 package io.grpc.xds;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
-import static io.grpc.ConnectivityState.CONNECTING;
-import static io.grpc.ConnectivityState.IDLE;
-import static io.grpc.ConnectivityState.READY;
-import static io.grpc.ConnectivityState.SHUTDOWN;
-import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
-
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.Sets;
-import io.grpc.Attributes;
-import io.grpc.ConnectivityState;
-import io.grpc.ConnectivityStateInfo;
-import io.grpc.EquivalentAddressGroup;
-import io.grpc.InternalLogId;
-import io.grpc.LoadBalancer;
-import io.grpc.Status;
-import io.grpc.SynchronizationContext;
-import io.grpc.xds.XdsLogger.XdsLogLevel;
-import io.grpc.xds.XdsSubchannelPickers.ErrorPicker;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
-import javax.annotation.Nullable;
-
 /**
  * Utility class that provides a way to configure ring hash size limits. This is applicable
  * for clients that use the ring hash load balancing policy. Note that size limits involve

--- a/xds/src/main/java/io/grpc/xds/RingHashOptions.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashOptions.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static io.grpc.ConnectivityState.CONNECTING;
+import static io.grpc.ConnectivityState.IDLE;
+import static io.grpc.ConnectivityState.READY;
+import static io.grpc.ConnectivityState.SHUTDOWN;
+import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.Sets;
+import io.grpc.Attributes;
+import io.grpc.ConnectivityState;
+import io.grpc.ConnectivityStateInfo;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.InternalLogId;
+import io.grpc.LoadBalancer;
+import io.grpc.Status;
+import io.grpc.SynchronizationContext;
+import io.grpc.xds.XdsLogger.XdsLogLevel;
+import io.grpc.xds.XdsSubchannelPickers.ErrorPicker;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nullable;
+
+/**
+ * Utility class that provides a way to configure ring hash size limits. This is applicable
+ * for clients that use the ring hash load balancing policy. Note that ring
+ * hash size limits involve a tradeoff between client memory consumption and accuracy of
+ * backend weights used for load balancing. Also see https://github.com/grpc/proposal/pull/338.
+ */
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/9718")
+public final class RingHashOptions {
+  private static volatile maxRingSizeCap = 4096;
+
+  public static setMaxRingSizeCap(long cap) {
+    RingHashOptions.maxRingSizeCap = maxRingSizeCap;
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/RingHashOptions.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashOptions.java
@@ -16,6 +16,8 @@
 
 package io.grpc.xds;
 
+import io.grpc.ExperimentalApi;
+
 /**
  * Utility class that provides a way to configure ring hash size limits. This is applicable
  * for clients that use the ring hash load balancing policy. Note that size limits involve

--- a/xds/src/main/java/io/grpc/xds/RingHashOptions.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashOptions.java
@@ -50,9 +50,9 @@ import javax.annotation.Nullable;
 
 /**
  * Utility class that provides a way to configure ring hash size limits. This is applicable
- * for clients that use the ring hash load balancing policy. Note that ring
- * hash size limits involve a tradeoff between client memory consumption and accuracy of
- * backend weights used for load balancing. Also see https://github.com/grpc/proposal/pull/338.
+ * for clients that use the ring hash load balancing policy. Note that size limits involve
+ * a tradeoff between client memory consumption and accuracy of load balancing weight
+ * representations. Also see https://github.com/grpc/proposal/pull/338.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/9718")
 public final class RingHashOptions {
@@ -61,11 +61,27 @@ public final class RingHashOptions {
   static final long MAX_RING_SIZE_CAP = 8 * 1024 * 1024L;
 
   // Same as RingHashLoadBalancerProvider.DEFAULT_MAX_RING_SIZE
-  private static volatile long maxRingSizeCap = 4 * 1024L;
+  private static volatile long ringSizeCap = 4 * 1024L;
 
-  public static setMaxRingSizeCap(long maxRingSizeCap) {
-    maxRingSizeCap = Math.max(1, maxRingSizeCap);
-    maxRingSizeCap = Math.min(MAX_RING_SIZE_CAP, maxRingSizeCap);
-    RingHashOptions.maxRingSizeCap = maxRingSizeCap;
+  /**
+   * Set the global limit for min and max ring hash sizes. Note that
+   * this limit is clamped between 1 and 8M, and attempts to set
+   * the limit lower or higher than that range will be silently
+   * moved to the nearest number within that range. Defaults initially
+   * to 4K.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/9718")
+  public static void setRingSizeCap(long ringSizeCap) {
+    ringSizeCap = Math.max(1, ringSizeCap);
+    ringSizeCap = Math.min(MAX_RING_SIZE_CAP, ringSizeCap);
+    RingHashOptions.ringSizeCap = ringSizeCap;
+  }
+
+  /**
+   * Get the global limit for min and max ring hash sizes.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/9718")
+  public static long getRingSizeCap() {
+    return RingHashOptions.ringSizeCap;
   }
 }

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerProviderTest.java
@@ -118,7 +118,7 @@ public class RingHashLoadBalancerProviderTest {
 
   @Test
   public void parseLoadBalancingConfig_ringTooLargeUsesCap() throws IOException {
-    long ringSize = RingHashLoadBalancerProvider.MAX_RING_SIZE_CAP + 1;
+    long ringSize = RingHashOptions.MAX_RING_SIZE_CAP + 1;
     String lbConfig =
         String.format(Locale.US, "{\"minRingSize\" : 10, \"maxRingSize\" : %d}", ringSize);
     ConfigOrError configOrError =
@@ -126,12 +126,11 @@ public class RingHashLoadBalancerProviderTest {
     assertThat(configOrError.getConfig()).isNotNull();
     RingHashConfig config = (RingHashConfig) configOrError.getConfig();
     assertThat(config.minRingSize).isEqualTo(10);
-    assertThat(config.maxRingSize).isEqualTo(RingHashLoadBalancerProvider.MAX_RING_SIZE_CAP);
+    assertThat(config.maxRingSize).isEqualTo(RingHashOptions.DEFAULT_RING_SIZE_CAP);
   }
 
   @Test
   public void parseLoadBalancingConfig_ringCapCanBeRaised() throws IOException {
-    long originalMaxRingSizeCap = RingHashOptions.getRingSizeCap();
     RingHashOptions.setRingSizeCap(RingHashOptions.MAX_RING_SIZE_CAP);
     long ringSize = RingHashOptions.MAX_RING_SIZE_CAP;
     String lbConfig =
@@ -141,15 +140,14 @@ public class RingHashLoadBalancerProviderTest {
         provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
     assertThat(configOrError.getConfig()).isNotNull();
     RingHashConfig config = (RingHashConfig) configOrError.getConfig();
-    assertThat(config.minRingSize).isEqualTo(RingHashLoadBalancerProvider.MAX_RING_SIZE_CAP);
-    assertThat(config.maxRingSize).isEqualTo(RingHashLoadBalancerProvider.MAX_RING_SIZE_CAP);
+    assertThat(config.minRingSize).isEqualTo(RingHashOptions.MAX_RING_SIZE_CAP);
+    assertThat(config.maxRingSize).isEqualTo(RingHashOptions.MAX_RING_SIZE_CAP);
     // Reset to avoid affecting subsequent test cases
-    RingHashOptions.setRingSizeCap(originalMaxRingSizeCap);
+    RingHashOptions.setRingSizeCap(RingHashOptions.DEFAULT_RING_SIZE_CAP);
   }
 
   @Test
   public void parseLoadBalancingConfig_ringCapIsClampedTo8M() throws IOException {
-    long originalMaxRingSizeCap = RingHashOptions.getRingSizeCap();
     RingHashOptions.setRingSizeCap(RingHashOptions.MAX_RING_SIZE_CAP + 1);
     long ringSize = RingHashOptions.MAX_RING_SIZE_CAP + 1;
     String lbConfig =
@@ -159,17 +157,16 @@ public class RingHashLoadBalancerProviderTest {
         provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
     assertThat(configOrError.getConfig()).isNotNull();
     RingHashConfig config = (RingHashConfig) configOrError.getConfig();
-    assertThat(config.minRingSize).isEqualTo(RingHashLoadBalancerProvider.MAX_RING_SIZE_CAP);
-    assertThat(config.maxRingSize).isEqualTo(RingHashLoadBalancerProvider.MAX_RING_SIZE_CAP);
+    assertThat(config.minRingSize).isEqualTo(RingHashOptions.MAX_RING_SIZE_CAP);
+    assertThat(config.maxRingSize).isEqualTo(RingHashOptions.MAX_RING_SIZE_CAP);
     // Reset to avoid affecting subsequent test cases
-    RingHashOptions.setRingSizeCap(originalMaxRingSizeCap);
+    RingHashOptions.setRingSizeCap(RingHashOptions.DEFAULT_RING_SIZE_CAP);
   }
 
   @Test
   public void parseLoadBalancingConfig_ringCapCanBeLowered() throws IOException {
-    long originalMaxRingSizeCap = RingHashOptions.getRingSizeCap();
     RingHashOptions.setRingSizeCap(1);
-    long ringSize = RingHashOptions.MAX_RING_SIZE_CAP;
+    long ringSize = 2;
     String lbConfig =
         String.format(
             Locale.US, "{\"minRingSize\" : %d, \"maxRingSize\" : %d}", ringSize, ringSize);
@@ -180,14 +177,13 @@ public class RingHashLoadBalancerProviderTest {
     assertThat(config.minRingSize).isEqualTo(1);
     assertThat(config.maxRingSize).isEqualTo(1);
     // Reset to avoid affecting subsequent test cases
-    RingHashOptions.setRingSizeCap(originalMaxRingSizeCap);
+    RingHashOptions.setRingSizeCap(RingHashOptions.DEFAULT_RING_SIZE_CAP);
   }
 
   @Test
   public void parseLoadBalancingConfig_ringCapLowerLimitIs1() throws IOException {
-    long originalMaxRingSizeCap = RingHashOptions.getRingSizeCap();
     RingHashOptions.setRingSizeCap(0);
-    long ringSize = RingHashOptions.MAX_RING_SIZE_CAP;
+    long ringSize = 2;
     String lbConfig =
         String.format(
             Locale.US, "{\"minRingSize\" : %d, \"maxRingSize\" : %d}", ringSize, ringSize);
@@ -198,7 +194,7 @@ public class RingHashLoadBalancerProviderTest {
     assertThat(config.minRingSize).isEqualTo(1);
     assertThat(config.maxRingSize).isEqualTo(1);
     // Reset to avoid affecting subsequent test cases
-    RingHashOptions.setRingSizeCap(originalMaxRingSizeCap);
+    RingHashOptions.setRingSizeCap(RingHashOptions.DEFAULT_RING_SIZE_CAP);
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerProviderTest.java
@@ -116,16 +116,29 @@ public class RingHashLoadBalancerProviderTest {
   }
 
   @Test
-  public void parseLoadBalancingConfig_invalid_ringTooLarge() throws IOException {
-    long ringSize = RingHashLoadBalancerProvider.MAX_RING_SIZE + 1;
+  public void parseLoadBalancingConfig_ringTooLargeUsesCap() throws IOException {
+    long ringSize = RingHashLoadBalancerProvider.MAX_RING_SIZE_CAP + 1;
     String lbConfig =
         String.format(Locale.US, "{\"minRingSize\" : 10, \"maxRingSize\" : %d}", ringSize);
     ConfigOrError configOrError =
         provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
     assertThat(configOrError.getError()).isNotNull();
-    assertThat(configOrError.getError().getCode()).isEqualTo(Code.UNAVAILABLE);
-    assertThat(configOrError.getError().getDescription())
-        .isEqualTo("Invalid 'mingRingSize'/'maxRingSize'");
+    RingHashConfig config = (RingHashConfig) configOrError.getConfig();
+    assertThat(config.minRingSize).isEqualTo(10);
+    assertThat(config.maxRingSize).isEqualTo(RingHashLoadBalancerProvider.MAX_RING_SIZE_CAP);
+  }
+
+  @Test
+  public void parseLoadBalancingConfig_ringMinAndMaxTooLargeUsesCap() throws IOException {
+    long ringSize = RingHashLoadBalancerProvider.MAX_RING_SIZE_CAP + 1;
+    String lbConfig =
+        String.format(Locale.US, "{\"minRingSize\" : %d, \"maxRingSize\" : %d}", ringSize, ringSize);
+    ConfigOrError configOrError =
+        provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
+    assertThat(configOrError.getError()).isNotNull();
+    RingHashConfig config = (RingHashConfig) configOrError.getConfig();
+    assertThat(config.minRingSize).isEqualTo(RingHashLoadBalancerProvider.MAX_RING_SIZE_CAP);
+    assertThat(config.maxRingSize).isEqualTo(RingHashLoadBalancerProvider.MAX_RING_SIZE_CAP);
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerProviderTest.java
@@ -122,7 +122,7 @@ public class RingHashLoadBalancerProviderTest {
         String.format(Locale.US, "{\"minRingSize\" : 10, \"maxRingSize\" : %d}", ringSize);
     ConfigOrError configOrError =
         provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
-    assertThat(configOrError.getError()).isNotNull();
+    assertThat(configOrError.getConfig()).isNotNull();
     RingHashConfig config = (RingHashConfig) configOrError.getConfig();
     assertThat(config.minRingSize).isEqualTo(10);
     assertThat(config.maxRingSize).isEqualTo(RingHashLoadBalancerProvider.MAX_RING_SIZE_CAP);
@@ -136,7 +136,7 @@ public class RingHashLoadBalancerProviderTest {
             Locale.US, "{\"minRingSize\" : %d, \"maxRingSize\" : %d}", ringSize, ringSize);
     ConfigOrError configOrError =
         provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
-    assertThat(configOrError.getError()).isNotNull();
+    assertThat(configOrError.getConfig()).isNotNull();
     RingHashConfig config = (RingHashConfig) configOrError.getConfig();
     assertThat(config.minRingSize).isEqualTo(RingHashLoadBalancerProvider.MAX_RING_SIZE_CAP);
     assertThat(config.maxRingSize).isEqualTo(RingHashLoadBalancerProvider.MAX_RING_SIZE_CAP);

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerProviderTest.java
@@ -165,6 +165,7 @@ public class RingHashLoadBalancerProviderTest {
     RingHashOptions.setRingSizeCap(originalMaxRingSizeCap);
   }
 
+  @Test
   public void parseLoadBalancingConfig_ringCapCanBeLowered() throws IOException {
     long originalMaxRingSizeCap = RingHashOptions.getRingSizeCap();
     RingHashOptions.setRingSizeCap(1);
@@ -182,6 +183,7 @@ public class RingHashLoadBalancerProviderTest {
     RingHashOptions.setRingSizeCap(originalMaxRingSizeCap);
   }
 
+  @Test
   public void parseLoadBalancingConfig_ringCapLowerLimitIs1() throws IOException {
     long originalMaxRingSizeCap = RingHashOptions.getRingSizeCap();
     RingHashOptions.setRingSizeCap(0);

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerProviderTest.java
@@ -132,7 +132,8 @@ public class RingHashLoadBalancerProviderTest {
   public void parseLoadBalancingConfig_ringMinAndMaxTooLargeUsesCap() throws IOException {
     long ringSize = RingHashLoadBalancerProvider.MAX_RING_SIZE_CAP + 1;
     String lbConfig =
-        String.format(Locale.US, "{\"minRingSize\" : %d, \"maxRingSize\" : %d}", ringSize, ringSize);
+        String.format(
+            Locale.US, "{\"minRingSize\" : %d, \"maxRingSize\" : %d}", ringSize, ringSize);
     ConfigOrError configOrError =
         provider.parseLoadBalancingPolicyConfig(parseJsonObject(lbConfig));
     assertThat(configOrError.getError()).isNotNull();

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerProviderTest.java
@@ -144,7 +144,7 @@ public class RingHashLoadBalancerProviderTest {
     assertThat(config.minRingSize).isEqualTo(RingHashLoadBalancerProvider.MAX_RING_SIZE_CAP);
     assertThat(config.maxRingSize).isEqualTo(RingHashLoadBalancerProvider.MAX_RING_SIZE_CAP);
     // Reset to avoid affecting subsequent test cases
-    RingHashOptions.setMaxRingSizeCap(originalMaxRingSizeCap);
+    RingHashOptions.setRingSizeCap(originalMaxRingSizeCap);
   }
 
   @Test
@@ -162,7 +162,7 @@ public class RingHashLoadBalancerProviderTest {
     assertThat(config.minRingSize).isEqualTo(RingHashLoadBalancerProvider.MAX_RING_SIZE_CAP);
     assertThat(config.maxRingSize).isEqualTo(RingHashLoadBalancerProvider.MAX_RING_SIZE_CAP);
     // Reset to avoid affecting subsequent test cases
-    RingHashOptions.setMaxRingSizeCap(originalMaxRingSizeCap);
+    RingHashOptions.setRingSizeCap(originalMaxRingSizeCap);
   }
 
   public void parseLoadBalancingConfig_ringCapCanBeLowered() throws IOException {
@@ -179,7 +179,7 @@ public class RingHashLoadBalancerProviderTest {
     assertThat(config.minRingSize).isEqualTo(1);
     assertThat(config.maxRingSize).isEqualTo(1);
     // Reset to avoid affecting subsequent test cases
-    RingHashOptions.setMaxRingSizeCap(originalMaxRingSizeCap);
+    RingHashOptions.setRingSizeCap(originalMaxRingSizeCap);
   }
 
   public void parseLoadBalancingConfig_ringCapLowerLimitIs1() throws IOException {
@@ -196,7 +196,7 @@ public class RingHashLoadBalancerProviderTest {
     assertThat(config.minRingSize).isEqualTo(1);
     assertThat(config.maxRingSize).isEqualTo(1);
     // Reset to avoid affecting subsequent test cases
-    RingHashOptions.setMaxRingSizeCap(originalMaxRingSizeCap);
+    RingHashOptions.setRingSizeCap(originalMaxRingSizeCap);
   }
 
   @Test


### PR DESCRIPTION
Implements https://github.com/grpc/proposal/pull/338 for Java.

Note: a configuration option (preferable taking the form of a dial option, but possibly using a global) is left as a TODO.

cc @ejona86 

