### PR TITLE
test:Report the values that were compared rather than the underlying durat…

### DIFF
--- a/context/src/test/java/io/grpc/testing/DeadlineSubject.java
+++ b/context/src/test/java/io/grpc/testing/DeadlineSubject.java
@@ -25,7 +25,6 @@ import com.google.common.truth.ComparableSubject;
 import com.google.common.truth.FailureMetadata;
 import com.google.common.truth.Subject;
 import io.grpc.Deadline;
-import java.math.BigInteger;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
@@ -33,6 +32,7 @@ import javax.annotation.Nullable;
 /** Propositions for {@link Deadline} subjects. */
 @SuppressWarnings("rawtypes") // Generics in this class are going away in a subsequent Truth.
 public final class DeadlineSubject extends ComparableSubject {
+  public static final double NANOSECONDS_IN_A_SECOND = SECONDS.toNanos(1) * 1.0;
   private static final Subject.Factory<DeadlineSubject, Deadline> deadlineFactory =
       new Factory();
 
@@ -61,14 +61,14 @@ public final class DeadlineSubject extends ComparableSubject {
         checkNotNull(actual, "actual value cannot be null. expected=%s", expected);
 
         // This is probably overkill, but easier than thinking about overflow.
-        BigInteger actualTimeRemaining = BigInteger.valueOf(actual.timeRemaining(NANOSECONDS));
-        BigInteger expectedTimeRemaining = BigInteger.valueOf(expected.timeRemaining(NANOSECONDS));
-        BigInteger deltaNanos = BigInteger.valueOf(timeUnit.toNanos(delta));
-        if (actualTimeRemaining.subtract(expectedTimeRemaining).abs().compareTo(deltaNanos) > 0) {
+        long actualNanos = actual.timeRemaining(NANOSECONDS);
+        long expectedNanos = expected.timeRemaining(NANOSECONDS);
+        long deltaNanos = timeUnit.toNanos(delta) ;
+        if (Math.abs(actualNanos - expectedNanos) > deltaNanos) {
           failWithoutActual(
-              fact("expected", expectedTimeRemaining.doubleValue() / SECONDS.toNanos(1)),
-              fact("but was", actualTimeRemaining.doubleValue() / SECONDS.toNanos(1)),
-              fact("outside tolerance in seconds", deltaNanos.doubleValue() / SECONDS.toNanos(1)));
+              fact("expected", expectedNanos / NANOSECONDS_IN_A_SECOND),
+              fact("but was", expectedNanos  / NANOSECONDS_IN_A_SECOND),
+              fact("outside tolerance in seconds",  deltaNanos  / NANOSECONDS_IN_A_SECOND));
         }
       }
     };

--- a/context/src/test/java/io/grpc/testing/DeadlineSubject.java
+++ b/context/src/test/java/io/grpc/testing/DeadlineSubject.java
@@ -19,6 +19,7 @@ package io.grpc.testing;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.Fact.fact;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.google.common.truth.ComparableSubject;
 import com.google.common.truth.FailureMetadata;
@@ -65,9 +66,9 @@ public final class DeadlineSubject extends ComparableSubject {
         BigInteger deltaNanos = BigInteger.valueOf(timeUnit.toNanos(delta));
         if (actualTimeRemaining.subtract(expectedTimeRemaining).abs().compareTo(deltaNanos) > 0) {
           failWithoutActual(
-              fact("expected", expected),
-              fact("but was", actual),
-              fact("outside tolerance in ns", deltaNanos));
+              fact("expected", expectedTimeRemaining.doubleValue() / SECONDS.toNanos(1)),
+              fact("but was", actualTimeRemaining.doubleValue() / SECONDS.toNanos(1)),
+              fact("outside tolerance in seconds", deltaNanos.doubleValue() / SECONDS.toNanos(1)));
         }
       }
     };


### PR DESCRIPTION
Eliminate usage of BigInteger as its usage could lead to flakiness due to potential class loading issues and it is completely unnecessary.

Report the values that were compared rather than the underlying durations that generated those values and continue to change over time.

CallOptionsTest.withDeadlineAfter frequently fails even though the reported values seem to be within the specified delta.  Having the reported values differ from what is actually compared is confusing.

Fixes #6757 