### PR TITLE
core: Replace AtomicInteger.updateAndGet with compareAndSet

### DIFF
--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -225,9 +225,12 @@ abstract class RetriableStream<ReqT> implements ClientStream {
   @Nullable // returns null when cancelled
   private Substream createSubstream(int previousAttemptCount, boolean isTransparentRetry) {
     // increment only when >= 0, i.e. not cancelled
-    if (inFlightSubStreams.updateAndGet(value -> value < 0 ? value : value + 1) < 0) {
-      return null;
-    }
+    int inFlight = inFlightSubStreams.get();
+    do {
+      if (inFlight < 0) {
+        return null;
+      }
+    } while (!inFlightSubStreams.compareAndSet(inFlight, inFlight + 1));
     Substream sub = new Substream(previousAttemptCount);
     // one tracer per substream
     final ClientStreamTracer bufferSizeTracer = new BufferSizeTracer(sub);

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -225,8 +225,9 @@ abstract class RetriableStream<ReqT> implements ClientStream {
   @Nullable // returns null when cancelled
   private Substream createSubstream(int previousAttemptCount, boolean isTransparentRetry) {
     // increment only when >= 0, i.e. not cancelled
-    int inFlight = inFlightSubStreams.get();
+    int inFlight;
     do {
+      inFlight = inFlightSubStreams.get();
       if (inFlight < 0) {
         return null;
       }


### PR DESCRIPTION
updateAndGet is only available in API level 24+. It is unclear why AnimalSniffer didn't detect this.

This was noticed when doing the import, but the Android CI has also been failing because of it.