### PR TITLE
bazel: Replace ctx.host_configuration with ctx.configuration

### DIFF
--- a/java_grpc_library.bzl
+++ b/java_grpc_library.bzl
@@ -85,7 +85,7 @@ def _java_rpc_library_impl(ctx):
     args = ctx.actions.args()
     args.add(toolchain.plugin, format = "--plugin=protoc-gen-rpc-plugin=%s")
     args.add("--rpc-plugin_out={0}:{1}".format(toolchain.plugin_arg, srcjar.path))
-    args.add_joined("--descriptor_set_in", descriptor_set_in, join_with = ctx.host_configuration.host_path_separator)
+    args.add_joined("--descriptor_set_in", descriptor_set_in, join_with = ctx.configuration.host_path_separator)
     args.add_all(srcs, map_each = _path_ignoring_repository)
 
     ctx.actions.run(


### PR DESCRIPTION
Replace ctx.host_configuration.host_path_separator with ctx.configuration.host_path_separator.

This is because

1. we're removing ctx.host_configuration
2. host_path_separator's value doesn't depend on the configuration (the API is misleading by embedding it under ctx.configuration). So this is a no-op.

Internal ref cl/494008561.