### PR TITLE
Move name resolution retry from managed channel to name resolver.

### DIFF
--- a/api/src/main/java/io/grpc/NameResolver.java
+++ b/api/src/main/java/io/grpc/NameResolver.java
@@ -143,7 +143,7 @@ public abstract class NameResolver {
    * @since 1.53.0
    */
   public final void addResolutionResultListener(ResolutionResultListener listener) {
-    checkArgument(listener != null);
+    checkArgument(listener != null, "listener");
     resolutionResultListeners.add(listener);
   }
 

--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -318,6 +318,7 @@ public class DnsNameResolver extends NameResolver {
           result = doResolve(false);
           if (result.error != null) {
             savedListener.onError(result.error);
+            fireResolutionResultEvent(false);
             return;
           }
           if (result.addresses != null) {
@@ -330,7 +331,7 @@ public class DnsNameResolver extends NameResolver {
             resolutionResultBuilder.setAttributes(result.attributes);
           }
         }
-        savedListener.onResult(resolutionResultBuilder.build());
+        fireResolutionResultEvent(savedListener.onResult(resolutionResultBuilder.build()));
       } catch (IOException e) {
         savedListener.onError(
             Status.UNAVAILABLE.withDescription("Unable to resolve host " + host).withCause(e));

--- a/core/src/main/java/io/grpc/internal/DnsNameResolverProvider.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolverProvider.java
@@ -47,19 +47,23 @@ public final class DnsNameResolverProvider extends NameResolverProvider {
   private static final String SCHEME = "dns";
 
   @Override
-  public DnsNameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
+  public NameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
     if (SCHEME.equals(targetUri.getScheme())) {
       String targetPath = Preconditions.checkNotNull(targetUri.getPath(), "targetPath");
       Preconditions.checkArgument(targetPath.startsWith("/"),
           "the path component (%s) of the target (%s) must start with '/'", targetPath, targetUri);
       String name = targetPath.substring(1);
-      return new DnsNameResolver(
-          targetUri.getAuthority(),
-          name,
-          args,
-          GrpcUtil.SHARED_CHANNEL_EXECUTOR,
-          Stopwatch.createUnstarted(),
-          InternalServiceProviders.isAndroid(getClass().getClassLoader()));
+      return new RetryingNameResolver(
+          new DnsNameResolver(
+              targetUri.getAuthority(),
+              name,
+              args,
+              GrpcUtil.SHARED_CHANNEL_EXECUTOR,
+              Stopwatch.createUnstarted(),
+              InternalServiceProviders.isAndroid(getClass().getClassLoader())),
+          new ExponentialBackoffPolicy.Provider(),
+          args.getScheduledExecutorService(),
+          args.getSynchronizationContext());
     } else {
       return null;
     }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -280,6 +280,10 @@ final class ManagedChannelImpl extends ManagedChannel implements
   // Must be mutated and read from constructor or syncContext
   // used for channel tracing when value changed
   private ManagedChannelServiceConfig lastServiceConfig = EMPTY_SERVICE_CONFIG;
+  // Must be mutated and read from constructor or syncContext
+  // Denotes if the last resolved addresses were accepted by the load balancer. A {@code null}
+  // value indicates no attempt has been made yet.
+  private Boolean lastAddressesAccepted;
 
   @Nullable
   private final ManagedChannelServiceConfig defaultServiceConfig;
@@ -367,7 +371,6 @@ final class ManagedChannelImpl extends ManagedChannel implements
       checkState(lbHelper != null, "lbHelper is null");
     }
     if (nameResolver != null) {
-      cancelNameResolverBackoff();
       nameResolver.shutdown();
       nameResolverStarted = false;
       if (channelIsActive) {
@@ -450,39 +453,12 @@ final class ManagedChannelImpl extends ManagedChannel implements
     idleTimer.reschedule(idleTimeoutMillis, TimeUnit.MILLISECONDS);
   }
 
-  // Run from syncContext
-  @VisibleForTesting
-  class DelayedNameResolverRefresh implements Runnable {
-    @Override
-    public void run() {
-      scheduledNameResolverRefresh = null;
-      refreshNameResolution();
-    }
-  }
-
-  // Must be used from syncContext
-  @Nullable private ScheduledHandle scheduledNameResolverRefresh;
-  // The policy to control backoff between name resolution attempts. Non-null when an attempt is
-  // scheduled. Must be used from syncContext
-  @Nullable private BackoffPolicy nameResolverBackoffPolicy;
-
-  // Must be run from syncContext
-  private void cancelNameResolverBackoff() {
-    syncContext.throwIfNotInThisSynchronizationContext();
-    if (scheduledNameResolverRefresh != null) {
-      scheduledNameResolverRefresh.cancel();
-      scheduledNameResolverRefresh = null;
-      nameResolverBackoffPolicy = null;
-    }
-  }
-
   /**
-   * Force name resolution refresh to happen immediately and reset refresh back-off. Must be run
+   * Force name resolution refresh to happen immediately. Must be run
    * from syncContext.
    */
   private void refreshAndResetNameResolution() {
     syncContext.throwIfNotInThisSynchronizationContext();
-    cancelNameResolverBackoff();
     refreshNameResolution();
   }
 
@@ -1337,7 +1313,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
         if (shutdown.get()) {
           return;
         }
-        if (scheduledNameResolverRefresh != null && scheduledNameResolverRefresh.isPending()) {
+        if (lastAddressesAccepted != null && !lastAddressesAccepted) {
           checkState(nameResolverStarted, "name resolver must be started");
           refreshAndResetNameResolution();
         }
@@ -1736,7 +1712,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
     }
 
     @Override
-    public void onResult(final ResolutionResult resolutionResult) {
+    public boolean onResult(final ResolutionResult resolutionResult) {
       final class NamesResolved implements Runnable {
 
         @SuppressWarnings("ReferenceEquality")
@@ -1745,6 +1721,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
           if (ManagedChannelImpl.this.nameResolver != resolver) {
             return;
           }
+          lastAddressesAccepted = false;
 
           List<EquivalentAddressGroup> servers = resolutionResult.getAddresses();
           channelLogger.log(
@@ -1758,7 +1735,6 @@ final class ManagedChannelImpl extends ManagedChannel implements
             lastResolutionState = ResolutionState.SUCCESS;
           }
 
-          nameResolverBackoffPolicy = null;
           ConfigOrError configOrError = resolutionResult.getServiceConfig();
           InternalConfigSelector resolvedConfigSelector =
               resolutionResult.getAttributes().get(InternalConfigSelector.KEY);
@@ -1816,6 +1792,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
                 // we later check for these error codes when investigating pick results in
                 // GrpcUtil.getTransportFromPickResult().
                 onError(configOrError.getError());
+                lastAddressesAccepted = false;
                 return;
               } else {
                 effectiveServiceConfig = lastServiceConfig;
@@ -1859,21 +1836,24 @@ final class ManagedChannelImpl extends ManagedChannel implements
             }
             Attributes attributes = attrBuilder.build();
 
-            boolean addressesAccepted = helper.lb.tryAcceptResolvedAddresses(
+            lastAddressesAccepted = helper.lb.tryAcceptResolvedAddresses(
                 ResolvedAddresses.newBuilder()
                     .setAddresses(servers)
                     .setAttributes(attributes)
                     .setLoadBalancingPolicyConfig(effectiveServiceConfig.getLoadBalancingConfig())
                     .build());
-
-            if (!addressesAccepted) {
-              scheduleExponentialBackOffInSyncContext();
-            }
           }
         }
       }
 
       syncContext.execute(new NamesResolved());
+
+      // If NameResolved did not assign a value to lastAddressesAccepted, we assume there was an
+      // exception and set it to false.
+      if (lastAddressesAccepted == null) {
+        lastAddressesAccepted = false;
+      }
+      return lastAddressesAccepted;
     }
 
     @Override
@@ -1903,29 +1883,6 @@ final class ManagedChannelImpl extends ManagedChannel implements
       }
 
       helper.lb.handleNameResolutionError(error);
-
-      scheduleExponentialBackOffInSyncContext();
-    }
-
-    private void scheduleExponentialBackOffInSyncContext() {
-      if (scheduledNameResolverRefresh != null && scheduledNameResolverRefresh.isPending()) {
-        // The name resolver may invoke onError multiple times, but we only want to
-        // schedule one backoff attempt
-        // TODO(ericgribkoff) Update contract of NameResolver.Listener or decide if we
-        // want to reset the backoff interval upon repeated onError() calls
-        return;
-      }
-      if (nameResolverBackoffPolicy == null) {
-        nameResolverBackoffPolicy = backoffPolicyProvider.get();
-      }
-      long delayNanos = nameResolverBackoffPolicy.nextBackoffNanos();
-      channelLogger.log(
-          ChannelLogLevel.DEBUG,
-          "Scheduling DNS resolution backoff for {0} ns", delayNanos);
-      scheduledNameResolverRefresh =
-          syncContext.schedule(
-              new DelayedNameResolverRefresh(), delayNanos, TimeUnit.NANOSECONDS,
-              transportFactory .getScheduledExecutorService());
     }
   }
 

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1466,7 +1466,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
       final class LoadBalancerRefreshNameResolution implements Runnable {
         @Override
         public void run() {
-          refreshNameResolution();
+          ManagedChannelImpl.this.refreshNameResolution();
         }
       }
 

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -457,11 +457,6 @@ final class ManagedChannelImpl extends ManagedChannel implements
    * Force name resolution refresh to happen immediately. Must be run
    * from syncContext.
    */
-  private void refreshAndResetNameResolution() {
-    syncContext.throwIfNotInThisSynchronizationContext();
-    refreshNameResolution();
-  }
-
   private void refreshNameResolution() {
     syncContext.throwIfNotInThisSynchronizationContext();
     if (nameResolverStarted) {
@@ -1266,7 +1261,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
   // Must be called from syncContext
   private void handleInternalSubchannelState(ConnectivityStateInfo newState) {
     if (newState.getState() == TRANSIENT_FAILURE || newState.getState() == IDLE) {
-      refreshAndResetNameResolution();
+      refreshNameResolution();
     }
   }
 
@@ -1315,7 +1310,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
         }
         if (lastAddressesAccepted != null && !lastAddressesAccepted) {
           checkState(nameResolverStarted, "name resolver must be started");
-          refreshAndResetNameResolution();
+          refreshNameResolution();
         }
         for (InternalSubchannel subchannel : subchannels) {
           subchannel.resetConnectBackoff();
@@ -1471,7 +1466,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
       final class LoadBalancerRefreshNameResolution implements Runnable {
         @Override
         public void run() {
-          refreshAndResetNameResolution();
+          refreshNameResolution();
         }
       }
 

--- a/core/src/main/java/io/grpc/internal/RetryScheduler.java
+++ b/core/src/main/java/io/grpc/internal/RetryScheduler.java
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 /**
- * Schedules a retry operation according to a {@link BackoffPolicy}. The retry is run withing a
+ * Schedules a retry operation according to a {@link BackoffPolicy}. The retry is run within a
  * {@link SynchronizationContext}. At most one retry is scheduled at a time.
  */
 final class RetryScheduler {

--- a/core/src/main/java/io/grpc/internal/RetryScheduler.java
+++ b/core/src/main/java/io/grpc/internal/RetryScheduler.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import io.grpc.SynchronizationContext;
+import io.grpc.SynchronizationContext.ScheduledHandle;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+/**
+ * Schedules a retry operation according to a {@link BackoffPolicy}. The retry is run withing a
+ * {@link SynchronizationContext}. At most one retry is scheduled at a time.
+ */
+final class RetryScheduler {
+  private final Runnable retryOperation;
+  private final ScheduledExecutorService scheduledExecutorService;
+  private final SynchronizationContext syncContext;
+  private final BackoffPolicy.Provider policyProvider;
+
+  private BackoffPolicy policy;
+  private ScheduledHandle scheduledHandle;
+
+  private static final Logger logger = Logger.getLogger(RetryScheduler.class.getName());
+
+  RetryScheduler(Runnable retryOperation, ScheduledExecutorService scheduledExecutorService,
+      SynchronizationContext syncContext, BackoffPolicy.Provider policyProvider) {
+    this.retryOperation = retryOperation;
+    this.scheduledExecutorService = scheduledExecutorService;
+    this.syncContext = syncContext;
+    this.policyProvider = policyProvider;
+  }
+
+  /**
+   * Schedules a future retry operation. Only allows one retry to be scheduled at any given time.
+   *
+   * @return The delay in nanos before the operation fires or -1 if it was not scheduled.
+   */
+  long schedule() {
+    if (policy == null) {
+      policy = policyProvider.get();
+    }
+    // If a retry is already scheduled, take no further action.
+    if (scheduledHandle != null && scheduledHandle.isPending()) {
+      return -1;
+    }
+    long delayNanos = policy.nextBackoffNanos();
+    scheduledHandle = syncContext.schedule(retryOperation, delayNanos, TimeUnit.NANOSECONDS,
+        scheduledExecutorService);
+    logger.fine("Scheduling DNS resolution backoff for " + delayNanos + "ns");
+
+    return delayNanos;
+  }
+
+  /**
+   * Resets the {@link RetryScheduler} and cancels any pending retry task. The policy will be
+   * cleared thus also resetting any state associated with it (e.g. a backoff multiplier).
+   */
+  void reset() {
+    if (scheduledHandle != null && scheduledHandle.isPending()) {
+      scheduledHandle.cancel();
+    }
+    policy = null;
+  }
+
+}

--- a/core/src/main/java/io/grpc/internal/RetryingNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/RetryingNameResolver.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.grpc.NameResolver;
+import io.grpc.SynchronizationContext;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * This wrapper class can add retry capability to any polling {@link NameResolver} implementation
+ * that supports calling {@link ResolutionResultListener}s with the outcome of each resolution.
+ *
+ * <p>The {@link NameResolver} used with this
+ */
+final class RetryingNameResolver extends ForwardingNameResolver {
+
+  private final NameResolver retriedNameResolver;
+  private final RetryScheduler retryScheduler;
+
+  /**
+   * Creates a new {@link RetryingNameResolver}.
+   *
+   * @param retriedNameResolver A {@link NameResolver} that will have failed attempt retried.
+   * @param backoffPolicyProvider Provides the policy used to backoff from retry attempts
+   * @param scheduledExecutorService Executes any retry attempts
+   * @param syncContext All retries happen within the given {@code SyncContext}
+   */
+  RetryingNameResolver(NameResolver retriedNameResolver,
+      BackoffPolicy.Provider backoffPolicyProvider,
+      ScheduledExecutorService scheduledExecutorService,
+      SynchronizationContext syncContext) {
+    super(retriedNameResolver);
+    this.retriedNameResolver = retriedNameResolver;
+    this.retriedNameResolver.addResolutionResultListener(new RetryResolutionResultListener());
+    this.retryScheduler = new RetryScheduler(new DelayedNameResolverRefresh(),
+        scheduledExecutorService, syncContext, backoffPolicyProvider);
+  }
+
+  @Override
+  public void shutdown() {
+    super.shutdown();
+    retryScheduler.reset();
+  }
+
+  /**
+   * @return The {@link NameResolver} that is getting its failed attempts retried.
+   */
+  public NameResolver getRetriedNameResolver() {
+    return retriedNameResolver;
+  }
+
+  @VisibleForTesting
+  class DelayedNameResolverRefresh implements Runnable {
+    @Override
+    public void run() {
+      refresh();
+    }
+  }
+
+  private class RetryResolutionResultListener implements ResolutionResultListener {
+
+    @Override
+    public void resolutionAttempted(boolean successful) {
+      if (successful) {
+        retryScheduler.reset();
+      } else {
+        retryScheduler.schedule();
+      }
+    }
+  }
+}

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -303,11 +303,11 @@ public class DnsNameResolverTest {
     final List<InetAddress> answer2 = createAddressList(1);
     String name = "foo.googleapis.com";
 
-    DnsNameResolver resolver
-        = (DnsNameResolver) newResolver(name, 81, isAndroid).getRetriedNameResolver();
+    RetryingNameResolver resolver = newResolver(name, 81, isAndroid);
+    DnsNameResolver dnsResolver = (DnsNameResolver) resolver.getRetriedNameResolver();
     AddressResolver mockResolver = mock(AddressResolver.class);
     when(mockResolver.resolveAddress(anyString())).thenReturn(answer1).thenReturn(answer2);
-    resolver.setAddressResolver(mockResolver);
+    dnsResolver.setAddressResolver(mockResolver);
 
     resolver.start(mockListener);
     assertEquals(1, fakeExecutor.runDueTasks());
@@ -331,11 +331,11 @@ public class DnsNameResolverTest {
   public void testExecutor_default() throws Exception {
     final List<InetAddress> answer = createAddressList(2);
 
-    DnsNameResolver resolver
-        = (DnsNameResolver) newResolver("foo.googleapis.com", 81).getRetriedNameResolver();
+    RetryingNameResolver resolver = newResolver("foo.googleapis.com", 81);
+    DnsNameResolver dnsResolver = (DnsNameResolver) resolver.getRetriedNameResolver();
     AddressResolver mockResolver = mock(AddressResolver.class);
     when(mockResolver.resolveAddress(anyString())).thenReturn(answer);
-    resolver.setAddressResolver(mockResolver);
+    dnsResolver.setAddressResolver(mockResolver);
 
     resolver.start(mockListener);
     assertEquals(1, fakeExecutor.runDueTasks());
@@ -372,11 +372,12 @@ public class DnsNameResolverTest {
                 })
             .build();
 
-    DnsNameResolver resolver = (DnsNameResolver) newResolver(
-        "foo.googleapis.com", Stopwatch.createUnstarted(), false, args).getRetriedNameResolver();
+    RetryingNameResolver resolver = newResolver(
+        "foo.googleapis.com", Stopwatch.createUnstarted(), false, args);
+    DnsNameResolver dnsResolver = (DnsNameResolver) resolver.getRetriedNameResolver();
     AddressResolver mockResolver = mock(AddressResolver.class);
     when(mockResolver.resolveAddress(anyString())).thenReturn(answer);
-    resolver.setAddressResolver(mockResolver);
+    dnsResolver.setAddressResolver(mockResolver);
 
     resolver.start(mockListener);
     assertEquals(0, fakeExecutor.runDueTasks());
@@ -398,14 +399,14 @@ public class DnsNameResolverTest {
     String name = "foo.googleapis.com";
     FakeTicker fakeTicker = new FakeTicker();
 
-    DnsNameResolver resolver = (DnsNameResolver) newResolver(
-        name, 81, GrpcUtil.NOOP_PROXY_DETECTOR,
-        Stopwatch.createUnstarted(fakeTicker)).getRetriedNameResolver();
+    RetryingNameResolver resolver = newResolver(
+        name, 81, GrpcUtil.NOOP_PROXY_DETECTOR, Stopwatch.createUnstarted(fakeTicker));
+    DnsNameResolver dnsResolver = (DnsNameResolver) resolver.getRetriedNameResolver();
     AddressResolver mockResolver = mock(AddressResolver.class);
     when(mockResolver.resolveAddress(anyString()))
         .thenReturn(answer1)
         .thenThrow(new AssertionError("should not called twice"));
-    resolver.setAddressResolver(mockResolver);
+    dnsResolver.setAddressResolver(mockResolver);
 
     resolver.start(mockListener);
     assertEquals(1, fakeExecutor.runDueTasks());
@@ -432,14 +433,14 @@ public class DnsNameResolverTest {
     String name = "foo.googleapis.com";
     FakeTicker fakeTicker = new FakeTicker();
 
-    DnsNameResolver resolver = (DnsNameResolver) newResolver(
-        name, 81, GrpcUtil.NOOP_PROXY_DETECTOR,
-        Stopwatch.createUnstarted(fakeTicker)).getRetriedNameResolver();
+    RetryingNameResolver resolver = newResolver(
+        name, 81, GrpcUtil.NOOP_PROXY_DETECTOR, Stopwatch.createUnstarted(fakeTicker));
+    DnsNameResolver dnsResolver = (DnsNameResolver) resolver.getRetriedNameResolver();
     AddressResolver mockResolver = mock(AddressResolver.class);
     when(mockResolver.resolveAddress(anyString()))
         .thenReturn(answer)
         .thenThrow(new AssertionError("should not reach here."));
-    resolver.setAddressResolver(mockResolver);
+    dnsResolver.setAddressResolver(mockResolver);
 
     resolver.start(mockListener);
     assertEquals(1, fakeExecutor.runDueTasks());
@@ -468,13 +469,13 @@ public class DnsNameResolverTest {
     String name = "foo.googleapis.com";
     FakeTicker fakeTicker = new FakeTicker();
 
-    DnsNameResolver resolver = (DnsNameResolver) newResolver(
-        name, 81, GrpcUtil.NOOP_PROXY_DETECTOR,
-        Stopwatch.createUnstarted(fakeTicker)).getRetriedNameResolver();
+    RetryingNameResolver resolver = newResolver(
+        name, 81, GrpcUtil.NOOP_PROXY_DETECTOR, Stopwatch.createUnstarted(fakeTicker));
+    DnsNameResolver dnsResolver = (DnsNameResolver) resolver.getRetriedNameResolver();
     AddressResolver mockResolver = mock(AddressResolver.class);
     when(mockResolver.resolveAddress(anyString())).thenReturn(answer1)
         .thenReturn(answer2);
-    resolver.setAddressResolver(mockResolver);
+    dnsResolver.setAddressResolver(mockResolver);
 
     resolver.start(mockListener);
     assertEquals(1, fakeExecutor.runDueTasks());
@@ -513,12 +514,12 @@ public class DnsNameResolverTest {
     String name = "foo.googleapis.com";
     FakeTicker fakeTicker = new FakeTicker();
 
-    DnsNameResolver resolver = (DnsNameResolver) newResolver(
-        name, 81, GrpcUtil.NOOP_PROXY_DETECTOR,
-        Stopwatch.createUnstarted(fakeTicker)).getRetriedNameResolver();
+    RetryingNameResolver resolver = newResolver(
+        name, 81, GrpcUtil.NOOP_PROXY_DETECTOR, Stopwatch.createUnstarted(fakeTicker));
+    DnsNameResolver dnsResolver = (DnsNameResolver) resolver.getRetriedNameResolver();
     AddressResolver mockResolver = mock(AddressResolver.class);
     when(mockResolver.resolveAddress(anyString())).thenReturn(answer1).thenReturn(answer2);
-    resolver.setAddressResolver(mockResolver);
+    dnsResolver.setAddressResolver(mockResolver);
 
     resolver.start(mockListener);
     assertEquals(1, fakeExecutor.runDueTasks());
@@ -548,9 +549,9 @@ public class DnsNameResolverTest {
   @Test
   public void resolve_emptyResult() throws Exception {
     DnsNameResolver.enableTxt = true;
-    DnsNameResolver nr
-        = (DnsNameResolver) newResolver("dns:///addr.fake:1234", 443).getRetriedNameResolver();
-    nr.setAddressResolver(new AddressResolver() {
+    RetryingNameResolver resolver = newResolver("dns:///addr.fake:1234", 443);
+    DnsNameResolver dnsResolver = (DnsNameResolver) resolver.getRetriedNameResolver();
+    dnsResolver.setAddressResolver(new AddressResolver() {
       @Override
       public List<InetAddress> resolveAddress(String host) throws Exception {
         return Collections.emptyList();
@@ -560,9 +561,9 @@ public class DnsNameResolverTest {
     when(mockResourceResolver.resolveTxt(anyString()))
         .thenReturn(Collections.<String>emptyList());
 
-    nr.setResourceResolver(mockResourceResolver);
+    dnsResolver.setResourceResolver(mockResourceResolver);
 
-    nr.start(mockListener);
+    resolver.start(mockListener);
     assertThat(fakeExecutor.runDueTasks()).isEqualTo(1);
 
     ArgumentCaptor<ResolutionResult> ac = ArgumentCaptor.forClass(ResolutionResult.class);
@@ -583,9 +584,9 @@ public class DnsNameResolverTest {
     when(mockListener.onResult(isA(ResolutionResult.class))).thenReturn(false);
 
     DnsNameResolver.enableTxt = true;
-    DnsNameResolver nr
-        = (DnsNameResolver) newResolver("dns:///addr.fake:1234", 443).getRetriedNameResolver();
-    nr.setAddressResolver(new AddressResolver() {
+    RetryingNameResolver resolver = newResolver("dns:///addr.fake:1234", 443);
+    DnsNameResolver dnsResolver = (DnsNameResolver) resolver.getRetriedNameResolver();
+    dnsResolver.setAddressResolver(new AddressResolver() {
       @Override
       public List<InetAddress> resolveAddress(String host) throws Exception {
         return Collections.emptyList();
@@ -595,9 +596,9 @@ public class DnsNameResolverTest {
     when(mockResourceResolver.resolveTxt(anyString()))
         .thenReturn(Collections.<String>emptyList());
 
-    nr.setResourceResolver(mockResourceResolver);
+    dnsResolver.setResourceResolver(mockResourceResolver);
 
-    nr.start(mockListener);
+    resolver.start(mockListener);
     assertThat(fakeExecutor.runDueTasks()).isEqualTo(1);
 
     ArgumentCaptor<ResolutionResult> ac = ArgumentCaptor.forClass(ResolutionResult.class);
@@ -622,9 +623,10 @@ public class DnsNameResolverTest {
         .thenReturn(Collections.singletonList(backendAddr));
     String name = "foo.googleapis.com";
 
-    DnsNameResolver resolver = (DnsNameResolver) newResolver(name, 81).getRetriedNameResolver();
-    resolver.setAddressResolver(mockAddressResolver);
-    resolver.setResourceResolver(null);
+    RetryingNameResolver resolver = newResolver(name, 81);
+    DnsNameResolver dnsResolver = (DnsNameResolver) resolver.getRetriedNameResolver();
+    dnsResolver.setAddressResolver(mockAddressResolver);
+    dnsResolver.setResourceResolver(null);
     resolver.start(mockListener);
     assertEquals(1, fakeExecutor.runDueTasks());
     verify(mockListener).onResult(resultCaptor.capture());
@@ -649,9 +651,10 @@ public class DnsNameResolverTest {
         .thenThrow(new IOException("no addr"));
     String name = "foo.googleapis.com";
 
-    DnsNameResolver resolver = (DnsNameResolver) newResolver(name, 81).getRetriedNameResolver();
-    resolver.setAddressResolver(mockAddressResolver);
-    resolver.setResourceResolver(null);
+    RetryingNameResolver resolver = newResolver(name, 81);
+    DnsNameResolver dnsResolver = (DnsNameResolver) resolver.getRetriedNameResolver();
+    dnsResolver.setAddressResolver(mockAddressResolver);
+    dnsResolver.setResourceResolver(null);
     resolver.start(mockListener);
     assertEquals(1, fakeExecutor.runDueTasks());
     verify(mockListener).onError(errorCaptor.capture());
@@ -692,10 +695,10 @@ public class DnsNameResolverTest {
             .build();
 
     String name = "foo.googleapis.com";
-    DnsNameResolver resolver = (DnsNameResolver) newResolver(
-        name, Stopwatch.createUnstarted(), false, args).getRetriedNameResolver();
-    resolver.setAddressResolver(mockAddressResolver);
-    resolver.setResourceResolver(mockResourceResolver);
+    RetryingNameResolver resolver = newResolver(name, Stopwatch.createUnstarted(), false, args);
+    DnsNameResolver dnsResolver = (DnsNameResolver) resolver.getRetriedNameResolver();
+    dnsResolver.setAddressResolver(mockAddressResolver);
+    dnsResolver.setResourceResolver(mockResourceResolver);
 
     resolver.start(mockListener);
     assertEquals(1, fakeExecutor.runDueTasks());
@@ -751,9 +754,10 @@ public class DnsNameResolverTest {
     when(mockResourceResolver.resolveTxt(anyString()))
         .thenThrow(new Exception("something like javax.naming.NamingException"));
 
-    DnsNameResolver resolver = (DnsNameResolver) newResolver(name, 81).getRetriedNameResolver();
-    resolver.setAddressResolver(mockAddressResolver);
-    resolver.setResourceResolver(mockResourceResolver);
+    RetryingNameResolver resolver = newResolver(name, 81);
+    DnsNameResolver dnsResolver = (DnsNameResolver) resolver.getRetriedNameResolver();
+    dnsResolver.setAddressResolver(mockAddressResolver);
+    dnsResolver.setResourceResolver(mockResourceResolver);
     resolver.start(mockListener);
     assertEquals(1, fakeExecutor.runDueTasks());
     verify(mockListener).onResult(resultCaptor.capture());
@@ -783,9 +787,10 @@ public class DnsNameResolverTest {
     when(mockResourceResolver.resolveTxt(anyString()))
         .thenReturn(Collections.singletonList("grpc_config=something invalid"));
 
-    DnsNameResolver resolver = (DnsNameResolver) newResolver(name, 81).getRetriedNameResolver();
-    resolver.setAddressResolver(mockAddressResolver);
-    resolver.setResourceResolver(mockResourceResolver);
+    RetryingNameResolver resolver = newResolver(name, 81);
+    DnsNameResolver dnsResolver = (DnsNameResolver) resolver.getRetriedNameResolver();
+    dnsResolver.setAddressResolver(mockAddressResolver);
+    dnsResolver.setResourceResolver(mockResourceResolver);
     resolver.start(mockListener);
     assertEquals(1, fakeExecutor.runDueTasks());
     verify(mockListener).onResult(resultCaptor.capture());
@@ -848,11 +853,12 @@ public class DnsNameResolverTest {
               .setPassword("password").build();
         }
       };
-    DnsNameResolver resolver = (DnsNameResolver) newResolver(
-        name, port, alwaysDetectProxy, Stopwatch.createUnstarted()).getRetriedNameResolver();
+    RetryingNameResolver resolver = newResolver(
+        name, port, alwaysDetectProxy, Stopwatch.createUnstarted());
+    DnsNameResolver dnsResolver = (DnsNameResolver) resolver.getRetriedNameResolver();
     AddressResolver mockAddressResolver = mock(AddressResolver.class);
     when(mockAddressResolver.resolveAddress(anyString())).thenThrow(new AssertionError());
-    resolver.setAddressResolver(mockAddressResolver);
+    dnsResolver.setAddressResolver(mockAddressResolver);
     resolver.start(mockListener);
     assertEquals(1, fakeExecutor.runDueTasks());
 

--- a/core/src/test/java/io/grpc/internal/ForwardingNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/ForwardingNameResolverTest.java
@@ -80,8 +80,8 @@ public class ForwardingNameResolverTest {
   public void start_observer() {
     NameResolver.Listener2 listener = new NameResolver.Listener2() {
       @Override
-      public void onResult(ResolutionResult result) {
-
+      public boolean onResult(ResolutionResult result) {
+        return true;
       }
 
       @Override

--- a/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
@@ -602,7 +602,7 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
 
       private class NameResolverListener extends NameResolver.Listener2 {
         @Override
-        public void onResult(final ResolutionResult resolutionResult) {
+        public boolean onResult(final ResolutionResult resolutionResult) {
           class NameResolved implements Runnable {
             @Override
             public void run() {
@@ -634,6 +634,7 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
           }
 
           syncContext.execute(new NameResolved());
+          return true;
         }
 
         @Override


### PR DESCRIPTION
This change has these main aspects to it:

1. Removal of any name resolution responsibility from ManagedChannelImpl
2. Creation of a new RetryScheduler to own generic retry logic
    - Can also be used outside the name resolution context
4. Creation of a new RetryingNameScheduler that can be used to wrap any polling name resolver to add retry capability
5. A new facility in NameResolver to allow implementations to notify listeners on the success of name resolution attempts
    - RetryingNameScheduler relies on this