### PR TITLE
test: fix internal ErrorProne failure

### DIFF
--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
@@ -3516,7 +3516,7 @@ public abstract class XdsClientImplTestBase {
       // Establish the adsStream object
       xdsClient.watchXdsResource(XdsClusterResource.getInstance(), CDS_RESOURCE,
           cdsResourceWatcher);
-      var unused = resourceDiscoveryCalls.take(); // clear this entry
+      DiscoveryRpcCall unused = resourceDiscoveryCalls.take(); // clear this entry
 
       // Shutdown server and initiate a request
       xdsServer.shutdownNow();

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
@@ -3516,7 +3516,7 @@ public abstract class XdsClientImplTestBase {
       // Establish the adsStream object
       xdsClient.watchXdsResource(XdsClusterResource.getInstance(), CDS_RESOURCE,
           cdsResourceWatcher);
-      resourceDiscoveryCalls.take(); // clear this entry
+      var unused = resourceDiscoveryCalls.take(); // clear this entry
 
       // Shutdown server and initiate a request
       xdsServer.shutdownNow();


### PR DESCRIPTION
```
third_party/java_src/grpc/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java:3519: error: [CheckReturnValue] The result of `take()` must be used
      resourceDiscoveryCalls.take(); // clear this entry
```