### PR TITLE
Block during test to allow response to propagate to receiverObserver.

### DIFF
--- a/xds/src/test/java/io/grpc/xds/XdsClientImplV2Test.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplV2Test.java
@@ -18,6 +18,7 @@ package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -104,6 +105,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.mockito.ArgumentMatcher;
+import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
 
 /**
@@ -132,6 +134,12 @@ public class XdsClientImplV2Test extends XdsClientImplTestBase {
         @SuppressWarnings("unchecked")
         StreamObserver<DiscoveryRequest> requestObserver = mock(StreamObserver.class);
         DiscoveryRpcCall call = new DiscoveryRpcCallV2(requestObserver, responseObserver);
+
+        doAnswer((d) -> {
+          call.countdownResponseLatch();
+          return null;
+        }).when(requestObserver).onNext(ArgumentMatchers.any());
+
         resourceDiscoveryCalls.offer(call);
         Context.current().addListener(
             new CancellationListener() {
@@ -227,7 +235,6 @@ public class XdsClientImplV2Test extends XdsClientImplTestBase {
               .setNonce(nonce)
               .build();
       responseObserver.onNext(response);
-      countdownResponseLatch();
     }
 
     @Override

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplV2Test.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplV2Test.java
@@ -227,6 +227,7 @@ public class XdsClientImplV2Test extends XdsClientImplTestBase {
               .setNonce(nonce)
               .build();
       responseObserver.onNext(response);
+      countdownResponseLatch();
     }
 
     @Override

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplV3Test.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplV3Test.java
@@ -18,6 +18,7 @@ package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -112,6 +113,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.mockito.ArgumentMatcher;
+import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
 
 /**
@@ -140,6 +142,12 @@ public class XdsClientImplV3Test extends XdsClientImplTestBase {
         @SuppressWarnings("unchecked")
         StreamObserver<DiscoveryRequest> requestObserver = mock(StreamObserver.class);
         DiscoveryRpcCall call = new DiscoveryRpcCallV3(requestObserver, responseObserver);
+
+        doAnswer((d) -> {
+          call.countdownResponseLatch();
+          return null;
+        }).when(requestObserver).onNext(ArgumentMatchers.any());
+
         resourceDiscoveryCalls.offer(call);
         Context.current().addListener(
             new CancellationListener() {
@@ -235,7 +243,6 @@ public class XdsClientImplV3Test extends XdsClientImplTestBase {
               .setNonce(nonce)
               .build();
       responseObserver.onNext(response);
-      countdownResponseLatch();
     }
 
     @Override

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplV3Test.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplV3Test.java
@@ -235,6 +235,7 @@ public class XdsClientImplV3Test extends XdsClientImplTestBase {
               .setNonce(nonce)
               .build();
       responseObserver.onNext(response);
+      countdownResponseLatch();
     }
 
     @Override


### PR DESCRIPTION
This fixes the race condition that is causing XdsClientImplV3Test.sendingToStoppedServer to be flaky