### PR TITLE
xds:Fix test flakiness by adding a timeout to verify.

### DIFF
--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
@@ -3536,6 +3536,9 @@ public abstract class XdsClientImplTestBase {
       fakeClock.forwardTime(5, TimeUnit.SECONDS);
       DiscoveryRpcCall call = resourceDiscoveryCalls.poll(3, TimeUnit.SECONDS);
 
+      // NOTE:  There is a ScheduledExecutorService that may get involved due to the reconnect
+      // so you cannot rely on the logic being single threaded.  The timeout() in verifyRequest
+      // is therefore necessary to avoid flakiness.
       // Send a response and do verifications
       verify(ldsResourceWatcher, never()).onResourceDoesNotExist(LDS_RESOURCE);
       call.sendResponse(LDS, mf.buildWrappedResource(testListenerVhosts), VERSION_1, "0001");

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
@@ -3535,7 +3535,6 @@ public abstract class XdsClientImplTestBase {
               .start());
       fakeClock.forwardTime(5, TimeUnit.SECONDS);
       DiscoveryRpcCall call = resourceDiscoveryCalls.poll(3, TimeUnit.SECONDS);
-      Thread.sleep(1); // For some reason the V2 test fails the verifyRequest without this
 
       // Send a response and do verifications
       verify(ldsResourceWatcher, never()).onResourceDoesNotExist(LDS_RESOURCE);

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplV2Test.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplV2Test.java
@@ -105,6 +105,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.mockito.ArgumentMatcher;
 import org.mockito.InOrder;
+import org.mockito.Mockito;
 
 /**
  * Tests for {@link XdsClientImpl} with protocol version v2.
@@ -198,7 +199,7 @@ public class XdsClientImplV2Test extends XdsClientImplTestBase {
     protected void verifyRequest(
         XdsResourceType<?> type, List<String> resources, String versionInfo, String nonce,
         EnvoyProtoData.Node node) {
-      verify(requestObserver).onNext(argThat(new DiscoveryRequestMatcher(
+      verify(requestObserver, Mockito.timeout(2000)).onNext(argThat(new DiscoveryRequestMatcher(
           node.toEnvoyProtoNodeV2(), versionInfo, resources, type.typeUrlV2(), nonce, null, null)));
     }
 
@@ -206,7 +207,7 @@ public class XdsClientImplV2Test extends XdsClientImplTestBase {
     protected void verifyRequestNack(
         XdsResourceType<?> type, List<String> resources, String versionInfo, String nonce,
         EnvoyProtoData.Node node, List<String> errorMessages) {
-      verify(requestObserver).onNext(argThat(new DiscoveryRequestMatcher(
+      verify(requestObserver, Mockito.timeout(2000)).onNext(argThat(new DiscoveryRequestMatcher(
           node.toEnvoyProtoNodeV2(), versionInfo, resources, type.typeUrlV2(), nonce,
           Code.INVALID_ARGUMENT_VALUE, errorMessages)));
     }

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplV3Test.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplV3Test.java
@@ -113,6 +113,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.mockito.ArgumentMatcher;
 import org.mockito.InOrder;
+import org.mockito.Mockito;
 
 /**
  * Tests for {@link XdsClientImpl} with protocol version v3.
@@ -206,7 +207,7 @@ public class XdsClientImplV3Test extends XdsClientImplTestBase {
     protected void verifyRequest(
         XdsResourceType<?> type, List<String> resources, String versionInfo, String nonce,
         EnvoyProtoData.Node node) {
-      verify(requestObserver).onNext(argThat(new DiscoveryRequestMatcher(
+      verify(requestObserver, Mockito.timeout(2000)).onNext(argThat(new DiscoveryRequestMatcher(
           node.toEnvoyProtoNode(), versionInfo, resources, type.typeUrl(), nonce, null, null)));
     }
 
@@ -214,7 +215,7 @@ public class XdsClientImplV3Test extends XdsClientImplTestBase {
     protected void verifyRequestNack(
         XdsResourceType<?> type, List<String> resources, String versionInfo, String nonce,
         EnvoyProtoData.Node node, List<String> errorMessages) {
-      verify(requestObserver).onNext(argThat(new DiscoveryRequestMatcher(
+      verify(requestObserver, Mockito.timeout(2000)).onNext(argThat(new DiscoveryRequestMatcher(
           node.toEnvoyProtoNode(), versionInfo, resources, type.typeUrl(), nonce,
           Code.INVALID_ARGUMENT_VALUE, errorMessages)));
     }


### PR DESCRIPTION
XdsClientImplTestBase.sendingToStoppedServer was flaky on g3, this resolves that. 