### PR TITLE
netty:Eliminate unused and incorrect stream creation logic in test

### DIFF
--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -148,19 +148,6 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
 
   @Override
   protected AbstractStream stream() throws Exception {
-    if (stream == null) {
-      stream = new NettyClientStream(streamTransportState,
-          TestMethodDescriptors.voidMethod(),
-          new Metadata(),
-          channel(),
-          AsciiString.of("localhost"),
-          AsciiString.of("http"),
-          AsciiString.of("agent"),
-          StatsTraceContext.NOOP,
-          transportTracer,
-          CallOptions.DEFAULT,
-          false);
-    }
     return stream;
   }
 
@@ -1007,4 +994,5 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
       return Utils.statusFromThrowable(f.cause());
     }
   }
+
 }


### PR DESCRIPTION
Since stream is initialized in setup, the stream() method doesn't need to handle a `stream == null` condition.