### PR TITLE
xds: Disallow duplicate addresses in the RingHashLB.

### DIFF
--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -233,8 +233,8 @@ final class RingHashLoadBalancer extends LoadBalancer {
 
     if (!dups.isEmpty()) {
       return dups.entrySet().stream()
-          .map((entry) ->
-              String.format("Address: %s, count: %d", entry.getElement(), entry.getCount() + 1))
+          .map((dup) ->
+              String.format("Address: %s, count: %d", dup.getElement(), dup.getCount() + 1))
           .collect(Collectors.joining("; "));
     }
 

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
@@ -1082,8 +1082,7 @@ public class RingHashLoadBalancerTest {
   @Test
   public void duplicateAddresses() {
     RingHashConfig config = new RingHashConfig(10, 100);
-    List<EquivalentAddressGroup> servers =
-        createRepeatedServerAddrs(1, 2, 3);
+    List<EquivalentAddressGroup> servers = createRepeatedServerAddrs(1, 2, 3);
     boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());


### PR DESCRIPTION
Flag it as an error when the duplicate addresses are passed to acceptResolvedAddresses.

Removed test that was previously checking for specific expected behavior with duplicate addresses.