### PR TITLE
bazel: Export deps from maven stand-in targets

### DIFF
--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -65,13 +65,12 @@ java_library(
 )
 
 # Mirrors the dependencies included in the artifact on Maven Central for usage
-# with maven_install's override_targets. Purposefully does not export any
-# symbols, as it should only be used as a dep for pre-compiled binaries on
-# Maven Central.
+# with maven_install's override_targets. Should only be used as a dep for
+# pre-compiled binaries on Maven Central.
 java_library(
     name = "core_maven",
     visibility = ["//visibility:public"],
-    runtime_deps = [
+    exports = [
         ":inprocess",
         ":internal",
         ":util",

--- a/netty/BUILD.bazel
+++ b/netty/BUILD.bazel
@@ -20,20 +20,21 @@ java_library(
         "@io_netty_netty_codec_http2//jar",
         "@io_netty_netty_codec_socks//jar",
         "@io_netty_netty_common//jar",
-        "@io_netty_netty_transport_native_unix_common//jar",
         "@io_netty_netty_handler//jar",
         "@io_netty_netty_handler_proxy//jar",
         "@io_netty_netty_resolver//jar",
         "@io_netty_netty_transport//jar",
+        "@io_netty_netty_transport_native_unix_common//jar",
         "@io_perfmark_perfmark_api//jar",
     ],
 )
 
 # Mirrors the dependencies included in the artifact on Maven Central for usage
-# with maven_install's override_targets. Purposefully does not export any
-# symbols, as it should only be used as a dep for pre-compiled binaries on
-# Maven Central. Not actually shaded; libraries should not be referencing
-# unstable APIs so there should not be any references to the shaded package.
+# with maven_install's override_targets. Should only be used as a dep for
+# pre-compiled binaries on Maven Central.
+#
+# Not actually shaded; libraries should not be referencing unstable APIs so
+# there should not be any references to the shaded package.
 java_library(
     name = "shaded_maven",
     visibility = ["//visibility:public"],

--- a/services/BUILD.bazel
+++ b/services/BUILD.bazel
@@ -3,12 +3,11 @@ load("//:java_grpc_library.bzl", "java_grpc_library")
 package(default_visibility = ["//visibility:public"])
 
 # Mirrors the dependencies included in the artifact on Maven Central for usage
-# with maven_install's override_targets. Purposefully does not export any
-# symbols, as it should only be used as a dep for pre-compiled binaries on
-# Maven Central.
+# with maven_install's override_targets. Should only be used as a dep for
+# pre-compiled binaries on Maven Central.
 java_library(
     name = "services_maven",
-    runtime_deps = [
+    exports = [
         ":admin",
         ":binarylog",
         ":channelz",

--- a/xds/BUILD.bazel
+++ b/xds/BUILD.bazel
@@ -1,13 +1,12 @@
 load("//:java_grpc_library.bzl", "java_grpc_library")
 
 # Mirrors the dependencies included in the artifact on Maven Central for usage
-# with maven_install's override_targets. Purposefully does not export any
-# symbols, as it should only be used as a dep for pre-compiled binaries on
-# Maven Central.
+# with maven_install's override_targets. Should only be used as a dep for
+# pre-compiled binaries on Maven Central.
 java_library(
     name = "xds_maven",
     visibility = ["//visibility:public"],
-    runtime_deps = [
+    exports = [
         ":orca",
         ":xds",
     ],


### PR DESCRIPTION
If an artifact on Maven Central exposes a type from gRPC on its API surface, then consumers of that artifact need that gRPC API in the compile classpath. Bazel handles this by making hjars for transitive dependencies, but if the dependencies are runtime_deps then Bazel won't generate hjars containing the needed symbols.

We don't export netty-shaded because the classes already don't match Maven Central. If an artifact on Maven Central is exposing a netty-shaded class on its API surface, it wouldn't work anyway since the class simply doesn't exist for the Bazel build.

Fixes #9772