### PR TITLE
xds: fix the EDS dups test so it doesn't assume address order

### DIFF
--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
@@ -1096,10 +1096,11 @@ public class RingHashLoadBalancerTest {
     assertThat(result.getStatus().isOk()).isFalse();  // fail the RPC
     assertThat(result.getStatus().getCode())
         .isEqualTo(Code.UNAVAILABLE);  // with error status for the original server hit by hash
-    assertThat(result.getStatus().getDescription()).isEqualTo(
-        "Ring hash lb error: EDS resolution was successful, but there were duplicate "
-            + "addresses: Address: FakeSocketAddress-server1, count: 2; "
-            + "Address: FakeSocketAddress-server2, count: 3");
+    String description = result.getStatus().getDescription();
+    assertThat(description).startsWith(
+        "Ring hash lb error: EDS resolution was successful, but there were duplicate addresses: ");
+    assertThat(description).contains("Address: FakeSocketAddress-server1, count: 2");
+    assertThat(description).contains("Address: FakeSocketAddress-server2, count: 3");
   }
 
   private void deliverSubchannelState(Subchannel subchannel, ConnectivityStateInfo state) {


### PR DESCRIPTION
Fixes `RingHashLoadBalancerTest.duplicateAddresses()` test.

Multiset entries are not ordered. This PR updates the test so it's not assuming the order of addresses in the error message.
