### PR TITLE
Change ArgumentCaptor.forClass(null) to ArgumentCaptor.forClass(Foo.class)

### DIFF
--- a/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
+++ b/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
@@ -144,7 +144,7 @@ public class CallCredentialsApplyingTest {
 
     transport.newStream(method, origHeaders, callOptions, tracers);
 
-    ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(RequestInfo.class);
     verify(mockCreds).applyRequestMetadata(infoCaptor.capture(), same(mockExecutor),
         any(CallCredentials.MetadataApplier.class));
     RequestInfo info = infoCaptor.getValue();
@@ -169,7 +169,7 @@ public class CallCredentialsApplyingTest {
         callOptions.withAuthority("calloptions-authority").withExecutor(anotherExecutor),
         tracers);
 
-    ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(RequestInfo.class);
     verify(mockCreds).applyRequestMetadata(infoCaptor.capture(),
         same(mockExecutor), any(CallCredentials.MetadataApplier.class));
     RequestInfo info = infoCaptor.getValue();
@@ -189,7 +189,7 @@ public class CallCredentialsApplyingTest {
 
     transport.newStream(method, origHeaders, callOptions, tracers);
 
-    ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(RequestInfo.class);
     verify(mockCreds).applyRequestMetadata(
             infoCaptor.capture(), same(mockExecutor),
             any(io.grpc.CallCredentials.MetadataApplier.class));
@@ -213,7 +213,7 @@ public class CallCredentialsApplyingTest {
             callOptions.withAuthority("calloptions-authority").withExecutor(anotherExecutor),
             tracers);
 
-    ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(RequestInfo.class);
     verify(mockCreds).applyRequestMetadata(
             infoCaptor.capture(), same(mockExecutor),
             any(io.grpc.CallCredentials.MetadataApplier.class));
@@ -333,7 +333,8 @@ public class CallCredentialsApplyingTest {
     DelayedStream stream = (DelayedStream) transport.newStream(
         method, origHeaders, callOptions, tracers);
 
-    ArgumentCaptor<CallCredentials.MetadataApplier> applierCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<CallCredentials.MetadataApplier> applierCaptor =
+        ArgumentCaptor.forClass(CallCredentials.MetadataApplier.class);
     verify(mockCreds).applyRequestMetadata(any(RequestInfo.class),
         same(mockExecutor), applierCaptor.capture());
     verify(mockTransport, never()).newStream(
@@ -359,7 +360,8 @@ public class CallCredentialsApplyingTest {
   @Test
   public void delayedShutdown_shutdownShutdownNowThenApply() {
     transport.newStream(method, origHeaders, callOptions, tracers);
-    ArgumentCaptor<CallCredentials.MetadataApplier> applierCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<CallCredentials.MetadataApplier> applierCaptor =
+        ArgumentCaptor.forClass(CallCredentials.MetadataApplier.class);
     verify(mockCreds).applyRequestMetadata(any(RequestInfo.class),
         same(mockExecutor), applierCaptor.capture());
     transport.shutdown(Status.UNAVAILABLE);
@@ -380,7 +382,8 @@ public class CallCredentialsApplyingTest {
   @Test
   public void delayedShutdown_shutdownThenApplyThenShutdownNow() {
     transport.newStream(method, origHeaders, callOptions, tracers);
-    ArgumentCaptor<CallCredentials.MetadataApplier> applierCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<CallCredentials.MetadataApplier> applierCaptor =
+        ArgumentCaptor.forClass(CallCredentials.MetadataApplier.class);
     verify(mockCreds).applyRequestMetadata(any(RequestInfo.class),
         same(mockExecutor), applierCaptor.capture());
     transport.shutdown(Status.UNAVAILABLE);
@@ -408,7 +411,8 @@ public class CallCredentialsApplyingTest {
     transport.newStream(method, origHeaders, callOptions, tracers);
     transport.newStream(method, origHeaders, callOptions, tracers);
     transport.newStream(method, origHeaders, callOptions, tracers);
-    ArgumentCaptor<CallCredentials.MetadataApplier> applierCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<CallCredentials.MetadataApplier> applierCaptor =
+        ArgumentCaptor.forClass(CallCredentials.MetadataApplier.class);
     verify(mockCreds, times(3)).applyRequestMetadata(any(RequestInfo.class),
         same(mockExecutor), applierCaptor.capture());
     applierCaptor.getAllValues().get(1).apply(headers);
@@ -436,7 +440,8 @@ public class CallCredentialsApplyingTest {
     DelayedStream stream = (DelayedStream) transport.newStream(
         method, origHeaders, callOptions, tracers);
 
-    ArgumentCaptor<CallCredentials.MetadataApplier> applierCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<CallCredentials.MetadataApplier> applierCaptor =
+        ArgumentCaptor.forClass(CallCredentials.MetadataApplier.class);
     verify(mockCreds).applyRequestMetadata(any(RequestInfo.class),
         same(mockExecutor), applierCaptor.capture());
 

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -395,7 +395,7 @@ public class ClientCallImplTest {
 
   @Test
   public void methodInfoDeadlinePropagatedToStream() {
-    ArgumentCaptor<CallOptions> callOptionsCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<CallOptions> callOptionsCaptor = ArgumentCaptor.forClass(CallOptions.class);
     CallOptions callOptions = baseCallOptions.withDeadline(Deadline.after(2000, SECONDS));
 
     // Case: config Deadline expires later than CallOptions Deadline

--- a/core/src/test/java/io/grpc/internal/ConfigSelectingClientCallTest.java
+++ b/core/src/test/java/io/grpc/internal/ConfigSelectingClientCallTest.java
@@ -132,7 +132,7 @@ public class ConfigSelectingClientCallTest {
         method,
         CallOptions.DEFAULT);
     configSelectingClientCall.start(callListener, new Metadata());
-    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
     verify(callListener).onClose(statusCaptor.capture(), any(Metadata.class));
     assertThat(statusCaptor.getValue().getCode()).isEqualTo(Status.Code.DEADLINE_EXCEEDED);
 
@@ -157,7 +157,7 @@ public class ConfigSelectingClientCallTest {
         method,
         CallOptions.DEFAULT);
     configSelectingClientCall.start(callListener, new Metadata());
-    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
     verify(callListener).onClose(statusCaptor.capture(), any(Metadata.class));
     // ... so it should be represented as an internal error to highlight the control plane bug.
     assertThat(statusCaptor.getValue().getCode()).isEqualTo(Status.Code.INTERNAL);

--- a/core/src/test/java/io/grpc/internal/DelayedClientCallTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientCallTest.java
@@ -108,7 +108,8 @@ public class DelayedClientCallTest {
         callExecutor, fakeClock.getScheduledExecutorService(), Deadline.after(10, SECONDS));
     delayedClientCall.start(listener, new Metadata());
     callMeMaybe(delayedClientCall.setCall(mockRealCall));
-    ArgumentCaptor<Listener<Integer>> listenerCaptor = ArgumentCaptor.forClass(null);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Listener<Integer>> listenerCaptor = ArgumentCaptor.forClass(Listener.class);
     verify(mockRealCall).start(listenerCaptor.capture(), any(Metadata.class));
     Listener<Integer> realCallListener = listenerCaptor.getValue();
     Metadata metadata = new Metadata();
@@ -133,7 +134,8 @@ public class DelayedClientCallTest {
     callMeMaybe(delayedClientCall.setCall(mockRealCall));
     delayedClientCall.start(listener, new Metadata());
     delayedClientCall.request(1);
-    ArgumentCaptor<Listener<Integer>> listenerCaptor = ArgumentCaptor.forClass(null);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Listener<Integer>> listenerCaptor = ArgumentCaptor.forClass(Listener.class);
     verify(mockRealCall).start(listenerCaptor.capture(), any(Metadata.class));
     Listener<Integer> realCallListener = listenerCaptor.getValue();
     verify(mockRealCall).request(1);
@@ -150,7 +152,8 @@ public class DelayedClientCallTest {
     Runnable r = delayedClientCall.setCall(mockRealCall);
     assertThat(r).isNotNull();
     r.run();
-    ArgumentCaptor<Listener<Integer>> listenerCaptor = ArgumentCaptor.forClass(null);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Listener<Integer>> listenerCaptor = ArgumentCaptor.forClass(Listener.class);
     verify(mockRealCall).start(listenerCaptor.capture(), any(Metadata.class));
     Listener<Integer> realCallListener = listenerCaptor.getValue();
     verify(mockRealCall).request(1);
@@ -185,7 +188,8 @@ public class DelayedClientCallTest {
     assertThat(r).isNotNull();
     r.run();
     delayedClientCall.cancel("cancel", new StatusException(Status.CANCELLED));
-    ArgumentCaptor<Listener<Integer>> listenerCaptor = ArgumentCaptor.forClass(null);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Listener<Integer>> listenerCaptor = ArgumentCaptor.forClass(Listener.class);
     verify(mockRealCall).start(listenerCaptor.capture(), any(Metadata.class));
     Listener<Integer> realCallListener = listenerCaptor.getValue();
     verify(mockRealCall).request(1);

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -325,7 +325,7 @@ public class ManagedChannelImplIdlenessTest {
     call.start(mockCallListener, new Metadata());
 
     // Verify that we have exited the idle mode
-    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
     verify(mockLoadBalancerProvider).newLoadBalancer(helperCaptor.capture());
     deliverResolutionResult();
     Helper helper = helperCaptor.getValue();
@@ -373,7 +373,7 @@ public class ManagedChannelImplIdlenessTest {
     call.start(mockCallListener, new Metadata());
 
     // Verify that we have exited the idle mode
-    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
     verify(mockLoadBalancerProvider).newLoadBalancer(helperCaptor.capture());
     deliverResolutionResult();
     Helper helper = helperCaptor.getValue();
@@ -412,7 +412,7 @@ public class ManagedChannelImplIdlenessTest {
   public void updateSubchannelAddresses_newAddressConnects() {
     ClientCall<String, Integer> call = channel.newCall(method, CallOptions.DEFAULT);
     call.start(mockCallListener, new Metadata()); // Create LB
-    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
     verify(mockLoadBalancerProvider).newLoadBalancer(helperCaptor.capture());
     deliverResolutionResult();
     Helper helper = helperCaptor.getValue();
@@ -436,7 +436,7 @@ public class ManagedChannelImplIdlenessTest {
   public void updateSubchannelAddresses_existingAddressDoesNotConnect() {
     ClientCall<String, Integer> call = channel.newCall(method, CallOptions.DEFAULT);
     call.start(mockCallListener, new Metadata()); // Create LB
-    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
     verify(mockLoadBalancerProvider).newLoadBalancer(helperCaptor.capture());
     deliverResolutionResult();
     Helper helper = helperCaptor.getValue();
@@ -461,7 +461,7 @@ public class ManagedChannelImplIdlenessTest {
     call.start(mockCallListener, new Metadata());
 
     // Verify that we have exited the idle mode
-    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
     verify(mockLoadBalancerProvider).newLoadBalancer(helperCaptor.capture());
     Helper helper = helperCaptor.getValue();
     deliverResolutionResult();
@@ -510,7 +510,7 @@ public class ManagedChannelImplIdlenessTest {
   public void updateOobChannelAddresses_newAddressConnects() {
     ClientCall<String, Integer> call = channel.newCall(method, CallOptions.DEFAULT);
     call.start(mockCallListener, new Metadata()); // Create LB
-    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
     verify(mockLoadBalancerProvider).newLoadBalancer(helperCaptor.capture());
     deliverResolutionResult();
     Helper helper = helperCaptor.getValue();
@@ -534,7 +534,7 @@ public class ManagedChannelImplIdlenessTest {
   public void updateOobChannelAddresses_existingAddressDoesNotConnect() {
     ClientCall<String, Integer> call = channel.newCall(method, CallOptions.DEFAULT);
     call.start(mockCallListener, new Metadata()); // Create LB
-    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
     verify(mockLoadBalancerProvider).newLoadBalancer(helperCaptor.capture());
     Helper helper = helperCaptor.getValue();
     deliverResolutionResult();

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -315,7 +315,7 @@ public class ManagedChannelImplTest {
 
       assertEquals(numExpectedTasks, timer.numPendingTasks());
 
-      ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(null);
+      ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
       verify(mockLoadBalancerProvider).newLoadBalancer(helperCaptor.capture());
       helper = helperCaptor.getValue();
     }
@@ -402,7 +402,8 @@ public class ManagedChannelImplTest {
     Subchannel subchannel =
         createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
     requestConnectionSafely(helper, subchannel);
-    ArgumentCaptor<ClientTransportOptions> transportOptionCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<ClientTransportOptions> transportOptionCaptor =
+        ArgumentCaptor.forClass(ClientTransportOptions.class);
     verify(mockTransportFactory)
         .newClientTransport(
             any(SocketAddress.class), transportOptionCaptor.capture(), any(ChannelLogger.class));
@@ -427,7 +428,8 @@ public class ManagedChannelImplTest {
     final Subchannel subchannel =
         createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
     requestConnectionSafely(helper, subchannel);
-    ArgumentCaptor<ClientTransportOptions> transportOptionCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<ClientTransportOptions> transportOptionCaptor =
+        ArgumentCaptor.forClass(ClientTransportOptions.class);
     verify(mockTransportFactory)
         .newClientTransport(
             any(SocketAddress.class), transportOptionCaptor.capture(), any(ChannelLogger.class));
@@ -494,7 +496,7 @@ public class ManagedChannelImplTest {
     ClientCall<String, Integer> call = channel.newCall(method, CallOptions.DEFAULT);
     call.start(mockCallListener, headers);
 
-    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
     verify(mockLoadBalancerProvider).newLoadBalancer(helperCaptor.capture());
     helper = helperCaptor.getValue();
     // Make the transport available
@@ -520,7 +522,7 @@ public class ManagedChannelImplTest {
     updateBalancingStateSafely(helper, READY, mockPicker);
     executor.runDueTasks();
 
-    ArgumentCaptor<CallOptions> callOptionsCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<CallOptions> callOptionsCaptor = ArgumentCaptor.forClass(CallOptions.class);
     verify(mockTransport).newStream(
         same(method), same(headers), callOptionsCaptor.capture(),
         ArgumentMatchers.<ClientStreamTracer[]>any());
@@ -576,7 +578,7 @@ public class ManagedChannelImplTest {
     ClientCall<String, Integer> call = channel.newCall(method, CallOptions.DEFAULT);
     call.start(mockCallListener, headers);
 
-    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
     verify(mockLoadBalancerProvider).newLoadBalancer(helperCaptor.capture());
     helper = helperCaptor.getValue();
     // Make the transport available
@@ -599,7 +601,7 @@ public class ManagedChannelImplTest {
     updateBalancingStateSafely(helper, READY, mockPicker);
     executor.runDueTasks();
 
-    ArgumentCaptor<CallOptions> callOptionsCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<CallOptions> callOptionsCaptor = ArgumentCaptor.forClass(CallOptions.class);
     verify(mockTransport).newStream(
         same(method), same(headers), callOptionsCaptor.capture(),
         ArgumentMatchers.<ClientStreamTracer[]>any());
@@ -2270,9 +2272,10 @@ public class ManagedChannelImplTest {
         .thenReturn(PickResult.withSubchannel(subchannel));
     updateBalancingStateSafely(helper, READY, mockPicker);
     executor.runDueTasks();
-    ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(null);
-    ArgumentCaptor<Executor> executorArgumentCaptor = ArgumentCaptor.forClass(null);
-    ArgumentCaptor<CallCredentials.MetadataApplier> applierCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(RequestInfo.class);
+    ArgumentCaptor<Executor> executorArgumentCaptor = ArgumentCaptor.forClass(Executor.class);
+    ArgumentCaptor<CallCredentials.MetadataApplier> applierCaptor =
+        ArgumentCaptor.forClass(CallCredentials.MetadataApplier.class);
     verify(creds).applyRequestMetadata(infoCaptor.capture(),
         executorArgumentCaptor.capture(), applierCaptor.capture());
     assertSame(offloadExecutor,
@@ -2435,7 +2438,7 @@ public class ManagedChannelImplTest {
 
     // call getState() with requestConnection = true
     assertEquals(IDLE, channel.getState(true));
-    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
     verify(mockLoadBalancerProvider).newLoadBalancer(helperCaptor.capture());
     helper = helperCaptor.getValue();
 
@@ -2732,7 +2735,7 @@ public class ManagedChannelImplTest {
 
   private void verifyCallListenerClosed(
       ClientCall.Listener<Integer> listener, Status.Code code, Throwable cause) {
-    ArgumentCaptor<Status> captor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<Status> captor = ArgumentCaptor.forClass(Status.class);
     verify(listener).onClose(captor.capture(), any(Metadata.class));
     Status rpcStatus = captor.getValue();
     assertEquals(code, rpcStatus.getCode());
@@ -3343,7 +3346,7 @@ public class ManagedChannelImplTest {
   public void channelsAndSubchannels_instrumented_state() throws Exception {
     createChannel();
 
-    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
     verify(mockLoadBalancerProvider).newLoadBalancer(helperCaptor.capture());
     helper = helperCaptor.getValue();
 

--- a/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
+++ b/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
@@ -186,7 +186,7 @@ public class ServiceConfigErrorHandlingTest {
     }
 
     assertEquals(numExpectedTasks, timer.numPendingTasks());
-    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
     verify(mockLoadBalancerProvider).newLoadBalancer(helperCaptor.capture());
   }
 

--- a/core/src/test/java/io/grpc/util/GracefulSwitchLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/util/GracefulSwitchLoadBalancerTest.java
@@ -479,7 +479,7 @@ public class GracefulSwitchLoadBalancerTest {
   @Test
   public void transientFailureOnInitialResolutionError() {
     gracefulSwitchLb.handleNameResolutionError(Status.DATA_LOSS);
-    ArgumentCaptor<SubchannelPicker> pickerCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<SubchannelPicker> pickerCaptor = ArgumentCaptor.forClass(SubchannelPicker.class);
     verify(mockHelper).updateBalancingState(eq(TRANSIENT_FAILURE), pickerCaptor.capture());
     SubchannelPicker picker = pickerCaptor.getValue();
     assertThat(picker.pickSubchannel(mock(PickSubchannelArgs.class)).getStatus().getCode())

--- a/interop-testing/src/test/java/io/grpc/testing/integration/RetryTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/RetryTest.java
@@ -300,7 +300,7 @@ public class RetryTest {
         Status.UNAVAILABLE.withDescription("2nd attempt failed"),
         new Metadata());
     // no more retry
-    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
     verify(mockCallListener, timeout(5000)).onClose(statusCaptor.capture(), any(Metadata.class));
     assertThat(statusCaptor.getValue().getDescription()).contains("2nd attempt failed");
   }

--- a/xds/src/test/java/io/grpc/xds/WeightedTargetLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedTargetLoadBalancerTest.java
@@ -179,7 +179,8 @@ public class WeightedTargetLoadBalancerTest {
 
   @Test
   public void handleResolvedAddresses() {
-    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor =
+        ArgumentCaptor.forClass(ResolvedAddresses.class);
     Attributes.Key<Object> fakeKey = Attributes.Key.create("fake_key");
     Object fakeValue = new Object();
 
@@ -260,8 +261,8 @@ public class WeightedTargetLoadBalancerTest {
 
   @Test
   public void handleNameResolutionError() {
-    ArgumentCaptor<SubchannelPicker> pickerCaptor = ArgumentCaptor.forClass(null);
-    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<SubchannelPicker> pickerCaptor = ArgumentCaptor.forClass(SubchannelPicker.class);
+    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
 
     // Error before any child balancer created.
     weightedTargetLb.handleNameResolutionError(Status.DATA_LOSS);
@@ -326,7 +327,7 @@ public class WeightedTargetLoadBalancerTest {
         new ErrorPicker(Status.DATA_LOSS),
         new ErrorPicker(Status.DATA_LOSS)
     };
-    ArgumentCaptor<SubchannelPicker> pickerCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<SubchannelPicker> pickerCaptor = ArgumentCaptor.forClass(SubchannelPicker.class);
 
     // One child balancer goes to TRANSIENT_FAILURE.
     childHelpers.get(1).updateBalancingState(TRANSIENT_FAILURE, failurePickers[1]);

--- a/xds/src/test/java/io/grpc/xds/XdsServerBuilderTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerBuilderTest.java
@@ -103,7 +103,7 @@ public class XdsServerBuilderTest {
     assertThat(socketAddress.getPort()).isGreaterThan(-1);
     if (mockXdsServingStatusListener != null) {
       if (notServingStatus != null) {
-        ArgumentCaptor<Throwable> argCaptor = ArgumentCaptor.forClass(null);
+        ArgumentCaptor<Throwable> argCaptor = ArgumentCaptor.forClass(Throwable.class);
         verify(mockXdsServingStatusListener, times(1)).onNotServing(argCaptor.capture());
         Throwable throwable = argCaptor.getValue();
         assertThat(throwable).isInstanceOf(StatusException.class);

--- a/xds/src/test/java/io/grpc/xds/internal/security/SslContextProviderSupplierTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/security/SslContextProviderSupplierTest.java
@@ -80,7 +80,8 @@ public class SslContextProviderSupplierTest {
         .findOrCreateClientSslContextProvider(eq(upstreamTlsContext));
     verify(mockTlsContextManager, times(0))
         .releaseClientSslContextProvider(any(SslContextProvider.class));
-    ArgumentCaptor<SslContextProvider.Callback> callbackCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<SslContextProvider.Callback> callbackCaptor =
+        ArgumentCaptor.forClass(SslContextProvider.Callback.class);
     verify(mockSslContextProvider, times(1)).addCallback(callbackCaptor.capture());
     SslContextProvider.Callback capturedCallback = callbackCaptor.getValue();
     assertThat(capturedCallback).isNotNull();
@@ -99,7 +100,8 @@ public class SslContextProviderSupplierTest {
   public void get_onException() {
     prepareSupplier();
     callUpdateSslContext();
-    ArgumentCaptor<SslContextProvider.Callback> callbackCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<SslContextProvider.Callback> callbackCaptor =
+        ArgumentCaptor.forClass(SslContextProvider.Callback.class);
     verify(mockSslContextProvider, times(1)).addCallback(callbackCaptor.capture());
     SslContextProvider.Callback capturedCallback = callbackCaptor.getValue();
     assertThat(capturedCallback).isNotNull();

--- a/xds/src/test/java/io/grpc/xds/internal/security/certprovider/FileWatcherCertificateProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/security/certprovider/FileWatcherCertificateProviderTest.java
@@ -352,7 +352,7 @@ public class FileWatcherCertificateProviderTest {
     if (code == null && throwableType == null && causeMessages == null) {
       verify(mockWatcher, never()).onError(any(Status.class));
     } else {
-      ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(null);
+      ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
       verify(mockWatcher, times(1)).onError(statusCaptor.capture());
       Status status = statusCaptor.getValue();
       assertThat(status.getCode()).isEqualTo(code);
@@ -375,7 +375,8 @@ public class FileWatcherCertificateProviderTest {
   private void verifyWatcherUpdates(String certPemFile, String rootPemFile)
       throws IOException, CertificateException {
     if (certPemFile != null) {
-      ArgumentCaptor<List<X509Certificate>> certChainCaptor = ArgumentCaptor.forClass(null);
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<List<X509Certificate>> certChainCaptor = ArgumentCaptor.forClass(List.class);
       verify(mockWatcher, times(1))
           .updateCertificate(any(PrivateKey.class), certChainCaptor.capture());
       List<X509Certificate> certChain = certChainCaptor.getValue();
@@ -387,7 +388,8 @@ public class FileWatcherCertificateProviderTest {
           .updateCertificate(any(PrivateKey.class), ArgumentMatchers.<X509Certificate>anyList());
     }
     if (rootPemFile != null) {
-      ArgumentCaptor<List<X509Certificate>> rootsCaptor = ArgumentCaptor.forClass(null);
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<List<X509Certificate>> rootsCaptor = ArgumentCaptor.forClass(List.class);
       verify(mockWatcher, times(1)).updateTrustedRoots(rootsCaptor.capture());
       List<X509Certificate> roots = rootsCaptor.getValue();
       assertThat(roots).hasSize(1);

--- a/xds/src/test/java/io/grpc/xds/orca/OrcaOobUtilTest.java
+++ b/xds/src/test/java/io/grpc/xds/orca/OrcaOobUtilTest.java
@@ -239,7 +239,8 @@ public class OrcaOobUtilTest {
 
     // Calling createSubchannel() on orcaHelper correctly passes augmented CreateSubchannelArgs
     // to origHelper.
-    ArgumentCaptor<CreateSubchannelArgs> createArgsCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<CreateSubchannelArgs> createArgsCaptor =
+        ArgumentCaptor.forClass(CreateSubchannelArgs.class);
     for (int i = 0; i < NUM_SUBCHANNELS; i++) {
       String subchannelAttrValue = "eag attr " + i;
       Attributes attrs =
@@ -322,7 +323,8 @@ public class OrcaOobUtilTest {
 
     // Calling createSubchannel() on child helper correctly passes augmented CreateSubchannelArgs
     // to origHelper.
-    ArgumentCaptor<CreateSubchannelArgs> createArgsCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<CreateSubchannelArgs> createArgsCaptor =
+        ArgumentCaptor.forClass(CreateSubchannelArgs.class);
     for (int i = 0; i < NUM_SUBCHANNELS; i++) {
       String subchannelAttrValue = "eag attr " + i;
       Attributes attrs =
@@ -667,8 +669,7 @@ public class OrcaOobUtilTest {
     orcaServiceImps[0].calls.peek().responseObserver.onNext(report);
     assertLog(subchannels[0].logs, "DEBUG: Received an ORCA report: " + report);
     // Only parent helper's listener receives the report.
-    ArgumentCaptor<MetricReport> parentReportCaptor =
-        ArgumentCaptor.forClass(null);
+    ArgumentCaptor<MetricReport> parentReportCaptor = ArgumentCaptor.forClass(MetricReport.class);
     verify(mockOrcaListener1).onLoadReport(parentReportCaptor.capture());
     assertThat(OrcaPerRequestUtilTest.reportEqual(parentReportCaptor.getValue(),
         OrcaPerRequestUtil.fromOrcaLoadReport(report))).isTrue();
@@ -679,8 +680,7 @@ public class OrcaOobUtilTest {
     orcaServiceImps[0].calls.peek().responseObserver.onNext(report);
     assertLog(subchannels[0].logs, "DEBUG: Received an ORCA report: " + report);
     // Both helper receives the same report instance.
-    ArgumentCaptor<MetricReport> childReportCaptor =
-        ArgumentCaptor.forClass(null);
+    ArgumentCaptor<MetricReport> childReportCaptor = ArgumentCaptor.forClass(MetricReport.class);
     verify(mockOrcaListener1, times(2))
         .onLoadReport(parentReportCaptor.capture());
     verify(mockOrcaListener2)

--- a/xds/src/test/java/io/grpc/xds/orca/OrcaPerRequestUtilTest.java
+++ b/xds/src/test/java/io/grpc/xds/orca/OrcaPerRequestUtilTest.java
@@ -83,7 +83,8 @@ public class OrcaPerRequestUtilTest {
         OrcaPerRequestUtil.getInstance()
             .newOrcaClientStreamTracerFactory(fakeDelegateFactory, orcaListener1);
     ClientStreamTracer tracer = factory.newClientStreamTracer(STREAM_INFO, new Metadata());
-    ArgumentCaptor<ClientStreamTracer.StreamInfo> streamInfoCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<ClientStreamTracer.StreamInfo> streamInfoCaptor =
+        ArgumentCaptor.forClass(ClientStreamTracer.StreamInfo.class);
     verify(fakeDelegateFactory)
         .newClientStreamTracer(streamInfoCaptor.capture(), any(Metadata.class));
     ClientStreamTracer.StreamInfo capturedInfo = streamInfoCaptor.getValue();
@@ -99,8 +100,7 @@ public class OrcaPerRequestUtilTest {
         OrcaReportingTracerFactory.ORCA_ENDPOINT_LOAD_METRICS_KEY,
         OrcaLoadReport.getDefaultInstance());
     tracer.inboundTrailers(trailer);
-    ArgumentCaptor<MetricReport> reportCaptor =
-        ArgumentCaptor.forClass(null);
+    ArgumentCaptor<MetricReport> reportCaptor = ArgumentCaptor.forClass(MetricReport.class);
     verify(orcaListener1).onLoadReport(reportCaptor.capture());
     assertThat(reportEqual(reportCaptor.getValue(),
         OrcaPerRequestUtil.fromOrcaLoadReport(OrcaLoadReport.getDefaultInstance()))).isTrue();
@@ -144,7 +144,8 @@ public class OrcaPerRequestUtilTest {
     // Child factory will augment the StreamInfo and pass it to the parent factory.
     ClientStreamTracer childTracer =
         childFactory.newClientStreamTracer(STREAM_INFO, new Metadata());
-    ArgumentCaptor<ClientStreamTracer.StreamInfo> streamInfoCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<ClientStreamTracer.StreamInfo> streamInfoCaptor =
+        ArgumentCaptor.forClass(ClientStreamTracer.StreamInfo.class);
     verify(parentFactory).newClientStreamTracer(streamInfoCaptor.capture(), any(Metadata.class));
     ClientStreamTracer.StreamInfo parentStreamInfo = streamInfoCaptor.getValue();
     assertThat(parentStreamInfo).isNotEqualTo(STREAM_INFO);
@@ -162,10 +163,8 @@ public class OrcaPerRequestUtilTest {
         OrcaReportingTracerFactory.ORCA_ENDPOINT_LOAD_METRICS_KEY,
         OrcaLoadReport.getDefaultInstance());
     childTracer.inboundTrailers(trailer);
-    ArgumentCaptor<MetricReport> parentReportCap =
-        ArgumentCaptor.forClass(null);
-    ArgumentCaptor<MetricReport> childReportCap =
-        ArgumentCaptor.forClass(null);
+    ArgumentCaptor<MetricReport> parentReportCap = ArgumentCaptor.forClass(MetricReport.class);
+    ArgumentCaptor<MetricReport> childReportCap = ArgumentCaptor.forClass(MetricReport.class);
     verify(orcaListener1).onLoadReport(parentReportCap.capture());
     verify(orcaListener2).onLoadReport(childReportCap.capture());
     assertThat(reportEqual(parentReportCap.getValue(),

--- a/xds/src/test/java/io/grpc/xds/orca/OrcaServiceImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/orca/OrcaServiceImplTest.java
@@ -132,7 +132,7 @@ public class OrcaServiceImplTest {
     oobServer.shutdownNow();
     assertThat(fakeClock.forwardTime(1, TimeUnit.SECONDS)).isEqualTo(0);
     assertThat(((OrcaServiceImpl)orcaServiceImpl).clientCount.get()).isEqualTo(0);
-    ArgumentCaptor<Status> callCloseCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<Status> callCloseCaptor = ArgumentCaptor.forClass(Status.class);
     verify(listener).onClose(callCloseCaptor.capture(), any());
     assertThat(callCloseCaptor.getValue().getCode()).isEqualTo(Status.Code.UNAVAILABLE);
   }
@@ -232,7 +232,7 @@ public class OrcaServiceImplTest {
     channel.shutdownNow();
     assertThat(fakeClock.forwardTime(1, TimeUnit.SECONDS)).isEqualTo(0);
     assertThat(((OrcaServiceImpl)orcaServiceImpl).clientCount.get()).isEqualTo(0);
-    ArgumentCaptor<Status> callCloseCaptor = ArgumentCaptor.forClass(null);
+    ArgumentCaptor<Status> callCloseCaptor = ArgumentCaptor.forClass(Status.class);
     verify(listener, times(2)).onClose(callCloseCaptor.capture(), any());
     assertThat(callCloseCaptor.getValue().getCode()).isEqualTo(Status.Code.UNAVAILABLE);
   }


### PR DESCRIPTION
The former will [soon throw NullPointerException][notnull].

[notnull]: https://github.com/mockito/mockito/commit/fe1cb2de0923e78bf7d7ae46cbab792dd4e94136#diff-8d274a9bda2d871524d15bbfcd6272bd893a47e6b1a0b460d82a8845615f26daR31

This is an export of cl/499211958