### PR TITLE
okhttp: Use normal server cert when testing trust checking

### DIFF
--- a/okhttp/src/test/java/io/grpc/okhttp/TlsTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/TlsTest.java
@@ -173,8 +173,8 @@ public class TlsTest {
   @Test
   public void untrustedServer_fails() throws Exception {
     ServerCredentials serverCreds;
-    try (InputStream serverCert = TlsTesting.loadCert("badserver.pem");
-         InputStream serverPrivateKey = TlsTesting.loadCert("badserver.key");
+    try (InputStream serverCert = TlsTesting.loadCert("server1.pem");
+         InputStream serverPrivateKey = TlsTesting.loadCert("server1.key");
          InputStream caCert = TlsTesting.loadCert("ca.pem")) {
       serverCreds = TlsServerCredentials.newBuilder()
           .keyManager(serverCert, serverPrivateKey)
@@ -183,11 +183,9 @@ public class TlsTest {
     }
     ChannelCredentials channelCreds;
     try (InputStream clientCertChain = TlsTesting.loadCert("client.pem");
-         InputStream clientPrivateKey = TlsTesting.loadCert("client.key");
-         InputStream caCert = TlsTesting.loadCert("ca.pem")) {
+         InputStream clientPrivateKey = TlsTesting.loadCert("client.key")) {
       channelCreds = TlsChannelCredentials.newBuilder()
           .keyManager(clientCertChain, clientPrivateKey)
-          .trustManager(caCert)
           .build();
     }
     Server server = grpcCleanupRule.register(server(serverCreds));


### PR DESCRIPTION
Previously, untrustedServer_fails could have been failing for the same reason as unmatchedServerSubjectAlternativeNames_fails. The implementation could have been broken and not checking the cert chain but still checking the hostname. We'd either need to override the authority to match the badserver cert or use the normal server certificates. It is best to use the normal server certificates as mtls_succeeds confirms the configuration is correct and so our test is failing for the right reason.