### PR TITLE
okhttp: Remove unnecessary client certs in TlsTest

### DIFF
--- a/okhttp/src/test/java/io/grpc/okhttp/TlsTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/TlsTest.java
@@ -69,6 +69,27 @@ public class TlsTest {
   }
 
   @Test
+  public void basicTls_succeeds() throws Exception {
+    ServerCredentials serverCreds;
+    try (InputStream serverCert = TlsTesting.loadCert("server1.pem");
+         InputStream serverPrivateKey = TlsTesting.loadCert("server1.key")) {
+      serverCreds = TlsServerCredentials.newBuilder()
+          .keyManager(serverCert, serverPrivateKey)
+          .build();
+    }
+    ChannelCredentials channelCreds;
+    try (InputStream caCert = TlsTesting.loadCert("ca.pem")) {
+      channelCreds = TlsChannelCredentials.newBuilder()
+          .trustManager(caCert)
+          .build();
+    }
+    Server server = grpcCleanupRule.register(server(serverCreds));
+    ManagedChannel channel = grpcCleanupRule.register(clientChannel(server, channelCreds));
+
+    SimpleServiceGrpc.newBlockingStub(channel).unaryRpc(SimpleRequest.getDefaultInstance());
+  }
+
+  @Test
   public void mtls_succeeds() throws Exception {
     ServerCredentials serverCreds;
     try (InputStream serverCert = TlsTesting.loadCert("server1.pem");
@@ -174,20 +195,12 @@ public class TlsTest {
   public void untrustedServer_fails() throws Exception {
     ServerCredentials serverCreds;
     try (InputStream serverCert = TlsTesting.loadCert("server1.pem");
-         InputStream serverPrivateKey = TlsTesting.loadCert("server1.key");
-         InputStream caCert = TlsTesting.loadCert("ca.pem")) {
+         InputStream serverPrivateKey = TlsTesting.loadCert("server1.key")) {
       serverCreds = TlsServerCredentials.newBuilder()
           .keyManager(serverCert, serverPrivateKey)
-          .trustManager(caCert)
           .build();
     }
-    ChannelCredentials channelCreds;
-    try (InputStream clientCertChain = TlsTesting.loadCert("client.pem");
-         InputStream clientPrivateKey = TlsTesting.loadCert("client.key")) {
-      channelCreds = TlsChannelCredentials.newBuilder()
-          .keyManager(clientCertChain, clientPrivateKey)
-          .build();
-    }
+    ChannelCredentials channelCreds = TlsChannelCredentials.create();
     Server server = grpcCleanupRule.register(server(serverCreds));
     ManagedChannel channel = grpcCleanupRule.register(clientChannel(server, channelCreds));
 
@@ -198,19 +211,14 @@ public class TlsTest {
   public void unmatchedServerSubjectAlternativeNames_fails() throws Exception {
     ServerCredentials serverCreds;
     try (InputStream serverCert = TlsTesting.loadCert("server1.pem");
-         InputStream serverPrivateKey = TlsTesting.loadCert("server1.key");
-         InputStream caCert = TlsTesting.loadCert("ca.pem")) {
+         InputStream serverPrivateKey = TlsTesting.loadCert("server1.key")) {
       serverCreds = TlsServerCredentials.newBuilder()
           .keyManager(serverCert, serverPrivateKey)
-          .trustManager(caCert)
           .build();
     }
     ChannelCredentials channelCreds;
-    try (InputStream clientCertChain = TlsTesting.loadCert("client.pem");
-         InputStream clientPrivateKey = TlsTesting.loadCert("client.key");
-         InputStream caCert = TlsTesting.loadCert("ca.pem")) {
+    try (InputStream caCert = TlsTesting.loadCert("ca.pem")) {
       channelCreds = TlsChannelCredentials.newBuilder()
-          .keyManager(clientCertChain, clientPrivateKey)
           .trustManager(caCert)
           .build();
     }


### PR DESCRIPTION
This simplifies the tests and makes them more clear. basicTls_succeeds was added to confirm excluding the client cert functions.