### PR TITLE
testing: create test client for XDS federation integration tests

### DIFF
--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -196,7 +196,7 @@ def xds_federation_test_client = tasks.register("xds_federation_test_client", Cr
     mainClass = "io.grpc.testing.integration.XdsFederationTestClient"
     applicationName = "xds-federation-test-client"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
-    //classPath = startScriptsClasspath.get()
+    // TODO(apolcyn): set classPath?
 }
 
 distributions.shadow.contents.into("bin") {

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -196,7 +196,7 @@ def xds_federation_test_client = tasks.register("xds_federation_test_client", Cr
     mainClass = "io.grpc.testing.integration.XdsFederationTestClient"
     applicationName = "xds-federation-test-client"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
-    // TODO(apolcyn): set classPath?
+    classpath = startScriptsClasspath.get()
 }
 
 distributions.shadow.contents.into("bin") {

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -192,6 +192,13 @@ def xds_test_server = tasks.register("xds_test_server", CreateStartScripts) {
     classpath = startScriptsClasspath.get()
 }
 
+def xds_federation_test_client = tasks.register("xds_federation_test_client", CreateStartScripts) {
+    mainClass = "io.grpc.testing.integration.XdsFederationTestClient"
+    applicationName = "xds-federation-test-client"
+    outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
+    classPath = startScriptsClasspath.get()
+}
+
 distributions.shadow.contents.into("bin") {
     from(test_client)
     from(test_server)
@@ -202,6 +209,7 @@ distributions.shadow.contents.into("bin") {
     from(grpclb_fallback_test_client)
     from(xds_test_client)
     from(xds_test_server)
+    from(xds_federation_test_client)
     fileMode = 0755
 }
 

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -196,7 +196,7 @@ def xds_federation_test_client = tasks.register("xds_federation_test_client", Cr
     mainClass = "io.grpc.testing.integration.XdsFederationTestClient"
     applicationName = "xds-federation-test-client"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
-    classPath = startScriptsClasspath.get()
+    //classPath = startScriptsClasspath.get()
 }
 
 distributions.shadow.contents.into("bin") {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -2095,7 +2095,7 @@ public abstract class AbstractInteropTest {
             totalFailures,
             latencies.getValueAtPercentile(50),
             latencies.getValueAtPercentile(90),
-            latencies.getValueAtPercentile(100));
+            latencies.getValueAtPercentile(100)));
     // check if we timed out
     String timeoutErrorMessage =
         String.format(

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -106,7 +106,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.StringBuilder;
 import java.net.SocketAddress;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -106,6 +106,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.StringBuilder;
 import java.net.SocketAddress;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
@@ -2025,6 +2026,7 @@ public abstract class AbstractInteropTest {
     * and channel creation behavior.
    */
   public void performSoakTest(
+      String serverUri,
       boolean resetChannelPerIteration,
       int soakIterations,
       int maxFailures,
@@ -2057,21 +2059,22 @@ public abstract class AbstractInteropTest {
       SoakIterationResult result = performOneSoakIteration(soakStub);
       SocketAddress peer = clientCallCapture
           .get().getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
-      System.err.print(
+      StringBuilder logStr = new StringBuilder(
           String.format(
               Locale.US,
-              "soak iteration: %d elapsed_ms: %d peer: %s",
-              i, result.getLatencyMs(), peer != null ? peer.toString() : "null"));
+              "soak iteration: %d elapsed_ms: %d peer: %s server_uri: %s",
+              i, result.getLatencyMs(), peer != null ? peer.toString() : "null", serverUri));
       if (!result.getStatus().equals(Status.OK)) {
         totalFailures++;
-        System.err.println(String.format(" failed: %s", result.getStatus()));
+        logStr.append(String.format(" failed: %s", result.getStatus()));
       } else if (result.getLatencyMs() > maxAcceptablePerIterationLatencyMs) {
         totalFailures++;
-        System.err.println(
+        logStr.append(
             " exceeds max acceptable latency: " + maxAcceptablePerIterationLatencyMs);
       } else {
-        System.err.println(" succeeded");
+        logStr.append(" succeeded");
       }
+      System.err.println(logStr.toString());
       iterationsDone++;
       latencies.recordValue(result.getLatencyMs());
       long remainingNs = earliestNextStartNs - System.nanoTime();
@@ -2084,29 +2087,22 @@ public abstract class AbstractInteropTest {
     System.err.println(
         String.format(
             Locale.US,
-            "soak test ran: %d / %d iterations\n"
-                + "total failures: %d\n"
-                + "max failures threshold: %d\n"
-                + "max acceptable per iteration latency ms: %d\n"
-                + " p50 soak iteration latency: %d ms\n"
-                + " p90 soak iteration latency: %d ms\n"
-                + "p100 soak iteration latency: %d ms\n"
-                + "See breakdown above for which iterations succeeded, failed, and "
-                + "why for more info.",
+            "(server_uri: %s) soak test ran: %d / %d iterations. total failures: %d. "
+                + "p50: %d ms, p90: %d ms, p100: %d ms",
+            serverUri,
             iterationsDone,
             soakIterations,
             totalFailures,
-            maxFailures,
-            maxAcceptablePerIterationLatencyMs,
             latencies.getValueAtPercentile(50),
             latencies.getValueAtPercentile(90),
-            latencies.getValueAtPercentile(100)));
+            latencies.getValueAtPercentile(100));
     // check if we timed out
     String timeoutErrorMessage =
         String.format(
             Locale.US,
-            "soak test consumed all %d seconds of time and quit early, only "
-                + "having ran %d out of desired %d iterations.",
+            "(server_uri: %s) soak test consumed all %d seconds of time and quit early, "
+                + "only having ran %d out of desired %d iterations.",
+            serverUri,
             overallTimeoutSeconds,
             iterationsDone,
             soakIterations);
@@ -2115,8 +2111,9 @@ public abstract class AbstractInteropTest {
     String tooManyFailuresErrorMessage =
         String.format(
             Locale.US,
-            "soak test total failures: %d exceeds max failures threshold: %d.",
-            totalFailures, maxFailures);
+            "(server_uri: %s) soak test total failures: %d exceeds max failures "
+                + "threshold: %d.",
+            serverUri, totalFailures, maxFailures);
     assertTrue(tooManyFailuresErrorMessage, totalFailures <= maxFailures);
   }
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -461,6 +461,7 @@ public class TestServiceClient {
 
       case RPC_SOAK: {
         tester.performSoakTest(
+            serverHost,
             false /* resetChannelPerIteration */,
             soakIterations,
             soakMaxFailures,
@@ -472,6 +473,7 @@ public class TestServiceClient {
 
       case CHANNEL_SOAK: {
         tester.performSoakTest(
+            serverHost,
             true /* resetChannelPerIteration */,
             soakIterations,
             soakMaxFailures,

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
@@ -16,6 +16,8 @@
 
 package io.grpc.testing.integration;
 
+import static org.junit.Assert.assertTrue;
+
 import io.grpc.ChannelCredentials;
 import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannelBuilder;
@@ -204,6 +206,7 @@ public final class XdsFederationTestClient {
   class InnerClient extends AbstractInteropTest {
     private String credentialsType;
     private String serverUri;
+    private boolean runSucceeded = false;
 
     public InnerClient(String credentialsType, String serverUri) {
       this.credentialsType = credentialsType;
@@ -211,7 +214,15 @@ public final class XdsFederationTestClient {
     }
 
     /**
-     * Run the intended soak test the client.
+     * Indicates whether run succeeded or not. This must only be called
+     * after run() has finished.
+     */
+    public boolean runSucceeded() {
+      return runSucceeded;
+    }
+
+    /**
+     * Run the intended soak test
      */
     public void run() {
       boolean resetChannelPerIteration;
@@ -232,6 +243,7 @@ public final class XdsFederationTestClient {
             soakMinTimeMsBetweenRpcs,
             soakOverallTimeoutSeconds);
         logger.info("Test case: " + testCase + " done for server: " + serverUri);
+        runSucceeded = true;
       } catch (Exception e) {
         logger.info("Test case: " + testCase + " failed for server: " + serverUri);
         throw new RuntimeException(e);
@@ -270,6 +282,9 @@ public final class XdsFederationTestClient {
     }
     for (Thread t : threads) {
       t.join();
+    }
+    for (InnerClient c : clients) {
+      assertTrue(c.runSucceeded());
     }
     logger.info("Test case: " + testCase + " done for all clients!");
   }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
@@ -170,6 +170,32 @@ public final class XdsFederationTestClient {
     }
   }
 
+  class InnerClient extends AbstractInteropTest {
+    private String credentialsType;
+    private String serverUri;
+
+    public InnerClient(String credentialsType, String serverUri) {
+      this.credentialsType = credentialsType;
+      this.serverUri = serverUri;
+    }
+
+    @Override
+    protected ManagedChannelBuilder<?> createChannelBuilder() {
+      ChannelCredentials channelCredentials;
+      if (customCredentialsType.equals("compute_engine_channel_creds")) {
+        channelCredentials = ComputeEngineChannelCredentials.create();
+      } else if (customCredentialsType.equals("INSECURE_CREDENTIALS")) {
+        channelCredentials = InsecureChannelCredentials.create();
+      } else {
+        throw new IllegalArgumentException(
+              "Unknown custom credentials: " + customCredentialsType);
+      }
+      return NettyChannelBuilder.forTarget(serverUri, channelCredentials)
+          .keepAliveTime(3600, TimeUnit.SECONDS)
+          .keepAliveTimeout(20, TimeUnit.SECONDS);
+    }
+  }
+
   private void run() throws Exception {
     logger.info("Begin test case: " + testCase);
     // create threads according to server URIs

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
@@ -95,6 +95,8 @@ public final class XdsFederationTestClient {
       String value = parts[1];
       if ("server_uris".equals(key)) {
         serverUris = value;
+      } else if ("credentials_types".equals(key)) {
+        credentialsTypes = value;
       } else if ("test_case".equals(key)) {
         testCase = value;
       } else if ("soak_iterations".equals(key)) {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
@@ -222,7 +222,7 @@ public final class XdsFederationTestClient {
     }
 
     /**
-     * Run the intended soak test
+     * Run the intended soak test.
      */
     public void run() {
       boolean resetChannelPerIteration;

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The gRPC Authors
+ * Copyright 2023 The gRPC Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -195,6 +195,10 @@ public final class XdsFederationTestClient {
     }
   }
 
+  /**
+   * Wraps a single client stub configuration and executes a
+   * soak test case with that configuration.
+   */
   class InnerClient extends AbstractInteropTest {
     private String credentialsType;
     private String serverUri;
@@ -204,6 +208,9 @@ public final class XdsFederationTestClient {
       this.serverUri = serverUri;
     }
 
+    /**
+     * Run the intended soak test the client.
+     */
     public void run() {
       boolean resetChannelPerIteration;
       if (testCase.equals("rpc_soak")) {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
@@ -205,7 +205,7 @@ public final class XdsFederationTestClient {
       this.serverUri = serverUri;
     }
 
-    public run() {
+    public void run() {
       try {
         c.performSoakTest(
             serverUri,

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
@@ -33,12 +33,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 /**
- * Test client that verifies that grpclb failover into fallback mode works under
- * different failure modes.
- * This client is suitable for testing fallback with any "grpclb" load-balanced
- * service, but is particularly meant to implement a set of test cases described
- * in an internal doc titled "DirectPath Cloud-to-Prod End-to-End Test Cases",
- * section "gRPC DirectPath-to-CFE fallback".
+ * Test client that can be used to verify that XDS federation works. A list of
+ * server URIs (which can each be load balanced by different XDS servers), can
+ * be configured via flags. A separate thread is created for each of these clients
+ * and the configured test (either rpc_soak or channel_soak) is ran for each client
+ * on each thread.
  */
 public final class XdsFederationTestClient {
   private static final Logger logger =

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
@@ -207,7 +207,7 @@ public final class XdsFederationTestClient {
 
     public void run() {
       try {
-        c.performSoakTest(
+        performSoakTest(
             serverUri,
             resetChannelPerIteration,
             soakIterations,
@@ -241,15 +241,6 @@ public final class XdsFederationTestClient {
 
   private void run() throws Exception {
     logger.info("Begin test case: " + testCase);
-    boolean resetChannelPerIteration;
-    if (testCase.equals("rpc_soak")) {
-      resetChannelPerIteration = false;
-    } else if (testCase.equals("channel_soak")) {
-      resetChannelPerIteration = true;
-    } else {
-      throw new RuntimeException("invalid testcase: " + testCase);
-    }
-    // Run soak tests with each client on separate threads
     ArrayList<Thread> threads = new ArrayList<Thread>();
     for (InnerClient c : clients) {
       Thread t = new Thread(new Runnable() {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
@@ -145,7 +145,7 @@ public final class XdsFederationTestClient {
           + "\n                                        or exceeding the per-iteration max "
           + "\n                                        acceptable latency). Default: "
           + c.soakMaxFailures
-          + "\n  --soak_per_iteration_max_acceptable_latency_ms
+          + "\n  --soak_per_iteration_max_acceptable_latency_ms"
           + "\n                                        The number of milliseconds a "
           + "\n                                        single iteration in the two soak "
           + "\n                                        tests (rpc_soak and channel_soak) "

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
@@ -19,7 +19,6 @@ package io.grpc.testing.integration;
 import io.grpc.ChannelCredentials;
 import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannelBuilder;
-import io.grpc.StatusRuntimeException;
 import io.grpc.alts.ComputeEngineChannelCredentials;
 import io.grpc.netty.NettyChannelBuilder;
 import java.util.ArrayList;
@@ -70,7 +69,7 @@ public final class XdsFederationTestClient {
   private int soakMaxFailures = 0;
   private int soakPerIterationMaxAcceptableLatencyMs = 1000;
   private int soakOverallTimeoutSeconds = 10;
-  private int soakMinTimeMsBetweenRPCs = 0;
+  private int soakMinTimeMsBetweenRpcs = 0;
   private String testCase = "rpc_soak";
   private ArrayList<InnerClient> clients = new ArrayList<InnerClient>();
 
@@ -107,7 +106,7 @@ public final class XdsFederationTestClient {
       } else if ("soak_overall_timeout_seconds".equals(key)) {
         soakOverallTimeoutSeconds = Integer.valueOf(value);
       } else if ("soak_min_time_ms_between_rpcs".equals(key)) {
-        soakMinTimeMsBetweenRPCs = Integer.valueOf(value);
+        soakMinTimeMsBetweenRpcs = Integer.valueOf(value);
       } else {
         System.err.println("Unknown argument: " + key);
         usage = true;
@@ -155,7 +154,7 @@ public final class XdsFederationTestClient {
           + "\n                                        between consecutive RPCs in a soak "
           + "\n                                        test (rpc_soak or channel_soak), "
           + "\n                                        useful for limiting QPS. Default: "
-          + c.soakMinTimeMsBetweenRPCs
+          + c.soakMinTimeMsBetweenRpcs
           + "\n  --test_case=TEST_CASE                 Test case to run. Valid options are:"
           + "\n      rpc_soak: sends --soak_iterations large_unary RPCs"
           + "\n      channel_soak: sends --soak_iterations RPCs, rebuilding the channel "
@@ -221,7 +220,7 @@ public final class XdsFederationTestClient {
             soakIterations,
             soakMaxFailures,
             soakPerIterationMaxAcceptableLatencyMs,
-            soakMinTimeMsBetweenRPCs,
+            soakMinTimeMsBetweenRpcs,
             soakOverallTimeoutSeconds);
         logger.info("Test case: " + testCase + " done for server: " + serverUri);
       } catch (Exception e) {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.testing.integration;
+
+import static com.google.common.base.Charsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.io.CharStreams;
+import io.grpc.Deadline;
+import io.grpc.ManagedChannel;
+import io.grpc.StatusRuntimeException;
+import io.grpc.alts.ComputeEngineChannelBuilder;
+import io.grpc.testing.integration.Messages.GrpclbRouteType;
+import io.grpc.testing.integration.Messages.SimpleRequest;
+import io.grpc.testing.integration.Messages.SimpleResponse;
+import java.io.InputStreamReader;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+/**
+ * Test client that verifies that grpclb failover into fallback mode works under
+ * different failure modes.
+ * This client is suitable for testing fallback with any "grpclb" load-balanced
+ * service, but is particularly meant to implement a set of test cases described
+ * in an internal doc titled "DirectPath Cloud-to-Prod End-to-End Test Cases",
+ * section "gRPC DirectPath-to-CFE fallback".
+ */
+public final class XdsFederationTestClient {
+  private static final Logger logger =
+      Logger.getLogger(XdsFederationTestClient.class.getName());
+
+  /**
+   * Entry point.
+   */
+  public static void main(String[] args) throws Exception {
+    final XdsFederationTestClient client = new XdsFederationTestClient();
+    client.parseArgs(args);
+    Runtime.getRuntime().addShutdownHook(new Thread() {
+      @Override
+      @SuppressWarnings("CatchAndPrintStackTrace")
+      public void run() {
+        System.out.println("Shutting down");
+        try {
+          client.tearDown();
+        } catch (Exception e) {
+          e.printStackTrace();
+        }
+      }
+    });
+    try {
+      client.run();
+    } finally {
+      client.tearDown();
+    }
+    System.exit(0);
+  }
+
+  private String serverUris = "";
+  private String credentialsTypes = "";
+  private int soakIterations = 10;
+  private int soakMaxFailures = 0;
+  private int soakPerIterationMaxAcceptableLatencyMs = 1000;
+  private int soakOverallTimeoutSeconds = 10;
+  private int soakMinTimeMsBetweenRPCs = 0;
+  private String testCase = "rpc_soak";
+
+  private void parseArgs(String[] args) {
+    boolean usage = false;
+    for (String arg : args) {
+      if (!arg.startsWith("--")) {
+        System.err.println("All arguments must start with '--': " + arg);
+        usage = true;
+        break;
+      }
+      String[] parts = arg.substring(2).split("=", 2);
+      String key = parts[0];
+      if ("help".equals(key)) {
+        usage = true;
+        break;
+      }
+      if (parts.length != 2) {
+        System.err.println("All arguments must be of the form --arg=value");
+        usage = true;
+        break;
+      }
+      String value = parts[1];
+      if ("server_uris".equals(key)) {
+        serverUris = value;
+      } else if ("test_case".equals(key)) {
+        testCase = value;
+      } else if ("soak_iterations".equals(key)) {
+        soakIterations = Integer.valueOf(value);
+      } else if ("soak_max_failures".equals(key)) {
+        soakMaxFailures = Integer.valueOf(value);
+      } else if ("soak_per_iteration_max_acceptable_latency_ms".equals(key)) {
+        soakPerIterationMaxAcceptableLatencyMs = Integer.valueOf(value);
+      } else if ("soak_overall_timeout_seconds".equals(key)) {
+        soakOverallTimeoutSeconds = Integer.valueOf(value);
+      } else if ("soak_min_time_ms_between_rpcs".equals(key)) {
+        soakMinTimeMsBetweenRPCs = Integer.valueOf(value);
+      } else {
+        System.err.println("Unknown argument: " + key);
+        usage = true;
+        break;
+      }
+    }
+    if (usage) {
+      GrpclbFallbackTestClient c = new GrpclbFallbackTestClient();
+      System.out.println(
+          "Usage: [ARGS...]"
+          + "\n"
+          + "\n  --server_uris                         Comma separated list of server "
+          + "URIs to make RPCs to. Default: "
+          + c.serverUris
+          + "\n  --credentials_types                   Comma-separated list of "
+          + "\n                                        credentials, each entry is used "
+          + "\n                                        for the server of the "
+          + "\n                                        corresponding index in server_uris. "
+          + "\n                                        Supported values: "
+          + "compute_engine_channel_creds,INSECURE_CREDENTIALS. Default: "
+          + c.credentialsTypes
+          + "\n  --soak_iterations                     The number of iterations to use "
+          + "\n                                        for the two tests: rpc_soak and "
+          + "\n                                        channel_soak. Default: "
+          + c.soakIterations
+          + "\n  --soak_max_failures                   The number of iterations in soak "
+          + "\n                                        tests that are allowed to fail "
+          + "\n                                        (either due to non-OK status code "
+          + "\n                                        or exceeding the per-iteration max "
+          + "\n                                        acceptable latency). Default: "
+          + c.soakMaxFailures
+          + "\n  --soak_per_iteration_max_acceptable_latency_ms
+          + "\n                                        The number of milliseconds a "
+          + "\n                                        single iteration in the two soak "
+          + "\n                                        tests (rpc_soak and channel_soak) "
+          + "\n                                        should take. Default: "
+          + c.soakPerIterationMaxAcceptableLatencyMs
+          + "\n  --soak_overall_timeout_seconds        The overall number of seconds "
+          + "\n                                        after which a soak test should "
+          + "\n                                        stop and fail, if the desired "
+          + "\n                                        number of iterations have not yet "
+          + "\n                                        completed. Default: "
+          + c.soakOverallTimeoutSeconds
+          + "\n  --soak_min_time_ms_between_rpcs       The minimum time in milliseconds "
+          + "\n                                        between consecutive RPCs in a soak "
+          + "\n                                        test (rpc_soak or channel_soak), "
+          + "\n                                        useful for limiting QPS. Default: "
+          + c.soakMinTimeMsBetweenRPCs
+          + "\n  --test_case=TEST_CASE                 Test case to run. Valid options are:"
+          + "\n      rpc_soak: sends --soak_iterations large_unary RPCs"
+          + "\n      channel_soak: sends --soak_iterations RPCs, rebuilding the channel "
+          + "each time."
+          + "\n      Default: " + c.testCase
+      );
+      System.exit(1);
+    }
+  }
+
+  private ManagedChannel createChannel() {
+    if (!customCredentialsType.equals("compute_engine_channel_creds")) {
+      throw new AssertionError(
+          "This test currently only supports "
+          + "--custom_credentials_type=compute_engine_channel_creds. "
+          + "TODO: add support for other types.");
+    }
+    ComputeEngineChannelBuilder builder = ComputeEngineChannelBuilder.forTarget(serverUri);
+    builder.keepAliveTime(3600, TimeUnit.SECONDS);
+    builder.keepAliveTimeout(20, TimeUnit.SECONDS);
+    return builder.build();
+  }
+
+  void initStub() {
+    channel = createChannel();
+    blockingStub = TestServiceGrpc.newBlockingStub(channel);
+  }
+
+  private void tearDown() {
+    try {
+      if (channel != null) {
+        channel.shutdownNow();
+        channel.awaitTermination(1, TimeUnit.SECONDS);
+      }
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+
+  private void runShellCmd(String cmd) throws Exception {
+    if (skipNetCmd) {
+      logger.info("Skip net cmd because --skip_net_cmd is set to true");
+      return;
+    }
+    logger.info("Run shell command: " + cmd);
+    // Do not use bash -c here as bash may not exist in a container
+    ProcessBuilder pb = new ProcessBuilder(cmd.split(" "));
+    pb.redirectErrorStream(true);
+    Process process = pb.start();
+    logger.info("Shell command merged stdout and stderr: "
+        + CharStreams.toString(
+            new InputStreamReader(process.getInputStream(), UTF_8)));
+    int exitCode = process.waitFor();
+    logger.info("Shell command exit code: " + exitCode);
+    assertEquals(0, exitCode);
+  }
+
+  private GrpclbRouteType doRpcAndGetPath(
+      TestServiceGrpc.TestServiceBlockingStub stub, Deadline deadline) {
+    logger.info("doRpcAndGetPath deadline: " + deadline);
+    final SimpleRequest request = SimpleRequest.newBuilder()
+        .setFillGrpclbRouteType(true)
+        .build();
+    GrpclbRouteType result = GrpclbRouteType.GRPCLB_ROUTE_TYPE_UNKNOWN;
+    try {
+      SimpleResponse response = stub
+          .withDeadline(deadline)
+          .unaryCall(request);
+      result = response.getGrpclbRouteType();
+    } catch (StatusRuntimeException ex) {
+      logger.warning("doRpcAndGetPath failed. Status: " + ex);
+      return GrpclbRouteType.GRPCLB_ROUTE_TYPE_UNKNOWN;
+    }
+    logger.info("doRpcAndGetPath. GrpclbRouteType result: " + result);
+    if (result != GrpclbRouteType.GRPCLB_ROUTE_TYPE_FALLBACK
+        && result != GrpclbRouteType.GRPCLB_ROUTE_TYPE_BACKEND) {
+      throw new AssertionError("Received invalid LB route type. This suggests "
+          + "that the server hasn't implemented this test correctly.");
+    }
+    return result;
+  }
+
+  private void waitForFallbackAndDoRpcs(Deadline fallbackDeadline) throws Exception {
+    int fallbackRetryCount = 0;
+    boolean fallBack = false;
+    while (!fallbackDeadline.isExpired()) {
+      GrpclbRouteType grpclbRouteType = doRpcAndGetPath(
+          blockingStub, Deadline.after(1, TimeUnit.SECONDS));
+      if (grpclbRouteType == GrpclbRouteType.GRPCLB_ROUTE_TYPE_BACKEND) {
+        throw new AssertionError("Got grpclb route type backend. Backends are "
+            + "supposed to be unreachable, so this test is broken");
+      }
+      if (grpclbRouteType == GrpclbRouteType.GRPCLB_ROUTE_TYPE_FALLBACK) {
+        logger.info("Made one successful RPC to a fallback. Now expect the "
+            + "same for the rest.");
+        fallBack = true;
+        break;
+      } else {
+        logger.info("Retryable RPC failure on iteration: " + fallbackRetryCount);
+      }
+      fallbackRetryCount++;
+    }
+    if (!fallBack) {
+      throw new AssertionError("Didn't fall back within deadline");
+    }
+    for (int i = 0; i < 30; i++) {
+      assertEquals(
+          GrpclbRouteType.GRPCLB_ROUTE_TYPE_FALLBACK,
+          doRpcAndGetPath(blockingStub, Deadline.after(20, TimeUnit.SECONDS)));
+      Thread.sleep(1000);
+    }
+  }
+
+  private void runFallbackBeforeStartup() throws Exception {
+    runShellCmd(induceFallbackCmd);
+    final Deadline fallbackDeadline = Deadline.after(
+        fallbackDeadlineSeconds, TimeUnit.SECONDS);
+    initStub();
+    waitForFallbackAndDoRpcs(fallbackDeadline);
+  }
+
+  private void runFallbackAfterStartup() throws Exception {
+    initStub();
+    assertEquals(
+        GrpclbRouteType.GRPCLB_ROUTE_TYPE_BACKEND,
+        doRpcAndGetPath(blockingStub, Deadline.after(20, TimeUnit.SECONDS)));
+    runShellCmd(induceFallbackCmd);
+    final Deadline fallbackDeadline = Deadline.after(
+        fallbackDeadlineSeconds, TimeUnit.SECONDS);
+    waitForFallbackAndDoRpcs(fallbackDeadline);
+  }
+
+  // The purpose of this warmup method is to get potentially expensive one-per-process
+  // initialization out of the way, so that we can use aggressive timeouts in the actual
+  // test cases. Note that the warmup phase is done using a separate channel from the
+  // actual test cases, so that we don't affect the states of LB policies in the channel
+  // of the actual test case.
+  private void warmup() throws Exception {
+    logger.info("Begin warmup, performing " + numWarmupRpcs + " RPCs on the warmup channel");
+    ManagedChannel channel = createChannel();
+    TestServiceGrpc.TestServiceBlockingStub stub = TestServiceGrpc.newBlockingStub(channel);
+    for (int i = 0; i < numWarmupRpcs; i++) {
+      doRpcAndGetPath(stub, Deadline.after(1, TimeUnit.SECONDS));
+    }
+    try {
+      channel.shutdownNow();
+      channel.awaitTermination(1, TimeUnit.SECONDS);
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+
+  private void run() throws Exception {
+    warmup();
+    logger.info("Begin test case: " + testCase);
+    if (testCase.equals("fallback_before_startup")) {
+      runFallbackBeforeStartup();
+    } else if (testCase.equals("fallback_after_startup")) {
+      runFallbackAfterStartup();
+    } else {
+      throw new RuntimeException("invalid testcase: " + testCase);
+    }
+    logger.info("Test case: " + testCase + " done!");
+  }
+}

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
@@ -205,8 +205,21 @@ public final class XdsFederationTestClient {
       this.serverUri = serverUri;
     }
 
-    public String getServerUri() {
-      return serverUri;
+    public run() {
+      try {
+        c.performSoakTest(
+            serverUri,
+            resetChannelPerIteration,
+            soakIterations,
+            soakMaxFailures,
+            soakPerIterationMaxAcceptableLatencyMs,
+            soakMinTimeMsBetweenRPCs,
+            soakOverallTimeoutSeconds);
+        logger.info("Test case: " + testCase + " done for server: " + serverUri);
+      } catch (Exception e) {
+        logger.info("Test case: " + testCase + " failed for server: " + serverUri);
+        throw new RuntimeException(e);
+      }
     }
 
     @Override
@@ -242,20 +255,7 @@ public final class XdsFederationTestClient {
       Thread t = new Thread(new Runnable() {
         @Override
         public void run() {
-          try {
-            c.performSoakTest(
-                c.getServerUri(),
-                resetChannelPerIteration,
-                soakIterations,
-                soakMaxFailures,
-                soakPerIterationMaxAcceptableLatencyMs,
-                soakMinTimeMsBetweenRPCs,
-                soakOverallTimeoutSeconds);
-            logger.info("Test case: " + testCase + " done for server: " + c.getServerUri());
-          } catch (Exception e) {
-            logger.info("Test case: " + testCase + " failed for server: " + c.getServerUri());
-            throw new RuntimeException(e);
-          }
+          c.run();
         }
       });
       t.start();

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
@@ -206,6 +206,14 @@ public final class XdsFederationTestClient {
     }
 
     public void run() {
+      boolean resetChannelPerIteration;
+      if (testCase.equals("rpc_soak")) {
+        resetChannelPerIteration = false;
+      } else if (testCase.equals("channel_soak")) {
+        resetChannelPerIteration = true;
+      } else {
+        throw new RuntimeException("invalid testcase: " + testCase);
+      }
       try {
         performSoakTest(
             serverUri,

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
@@ -172,6 +172,17 @@ public final class XdsFederationTestClient {
 
   private void run() throws Exception {
     logger.info("Begin test case: " + testCase);
+    // create threads according to server URIs
+    // class InnerClient extends AbstractInteropTest {
+    //   constructed with: server_uri, credentials_type param
+    //   create channel builder uses those
+    //   we create a thread and pass that to the thread and run
+    //   the soak test o that thread.
+    //   then join  threads
+    // }
+    // start threads
+    // join threads
+    // log that all threads done
     if (testCase.equals("fallback_before_startup")) {
       runFallbackBeforeStartup();
     } else if (testCase.equals("fallback_after_startup")) {


### PR DESCRIPTION
This client can be used as a part of XDS federation integration tests. It can concurrently perform RPCs with different stubs using different underlying XDS servers.

For example, one might perform proxyless service mesh and DirectPath RPCs in the same process with flags like:

```
--server_uris=xds:///${PSM_TARGET},google-c2p:///${DIRECTPATH_TARGET} \
--credentials_types=INSECURE_CREDENTIALS,compute_engine_channel_creds \
--test_case=rpc_soak \
--soak_iterations=10  \
--soak_max_failures=0  \
--soak_per_iteration_max_acceptable_latency_ms=2500 \
--soak_overall_timeout_seconds=300
```

cc @ejona86 

- related C++ PR: https://github.com/grpc/grpc/pull/32020

- related Go PR: https://github.com/grpc/grpc-go/pull/5878

Reviewer note: I needed to comment out `classPath` in the gradle config because I was getting the following error which I'm not immediately sure how to solve:

```
Could not determine the dependencies of task ':grpc-interop-testing:shadowDistTar'.
> Could not create task ':grpc-interop-testing:xds_federation_test_client'.
   > Could not set unknown property 'classPath' for task ':grpc-interop-testing:xds_federation_test_client' of type org.gradle.api.tasks.application.CreateStartScripts
```