### PR TITLE
interop test: fix project evaluation order

### DIFF
--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -14,7 +14,7 @@ configurations {
     alpnagent
 }
 
-evaluationDependsOn(project(':grpc-context').path)
+evaluationDependsOn(project(':grpc-core').path)
 
 dependencies {
     implementation project(path: ':grpc-alts', configuration: 'shadow'),

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -15,6 +15,8 @@ configurations {
 }
 
 evaluationDependsOn(project(':grpc-core').path)
+evaluationDependsOn(project(':grpc-context').path)
+evaluationDependsOn(project(':grpc-api').path)
 
 dependencies {
     implementation project(path: ':grpc-alts', configuration: 'shadow'),


### PR DESCRIPTION
```
zivy-macbookpro:grpc-java-v1 zivy$ ./gradlew  :grpc-interop-testing:test

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/zivy/src/grpc-java-v1/interop-testing/build.gradle' line: 54

* What went wrong:
A problem occurred evaluating project ':grpc-interop-testing'.
> Could not get unknown property 'sourceSets' for project ':grpc-api' of type org.gradle.api.Project.


BUILD FAILED in 1s
```