### PR TITLE
Bump to Gradle 7.6 and update plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ For non-Android protobuf-based codegen integrated with the Gradle build system,
 you can use [protobuf-gradle-plugin][]:
 ```gradle
 plugins {
-    id 'com.google.protobuf' version '0.8.18'
+    id 'com.google.protobuf' version '0.9.1'
 }
 
 protobuf {
@@ -181,7 +181,7 @@ use protobuf-gradle-plugin but specify the 'lite' options:
 
 ```gradle
 plugins {
-    id 'com.google.protobuf' version '0.8.18'
+    id 'com.google.protobuf' version '0.9.1'
 }
 
 protobuf {

--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,6 @@ subprojects {
     if (!project.hasProperty('errorProne') || errorProne.toBoolean()) {
         dependencies {
             errorprone libs.errorprone.core
-            errorproneJavac libs.errorprone.javac
         }
     } else {
         // Disable Error Prone

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -164,6 +164,10 @@ tasks.named("compileTestLiteJava").configure {
     options.errorprone.excludedPaths = ".*/build/generated/source/proto/.*"
 }
 
+tasks.named("checkstyleTestLite").configure {
+    enabled = false
+}
+
 protobuf {
     protoc {
         if (project.hasProperty('protoc')) {

--- a/examples/android/clientcache/build.gradle
+++ b/examples/android/clientcache/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.0'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.18"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.1"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/android/helloworld/build.gradle
+++ b/examples/android/helloworld/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.0'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.18"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.1"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/android/routeguide/build.gradle
+++ b/examples/android/routeguide/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.0'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.18"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.1"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/android/strictmode/build.gradle
+++ b/examples/android/strictmode/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.0'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.18"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.1"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,8 +1,7 @@
 plugins {
     // Provide convenience executables for trying out the examples.
     id 'application'
-    // ASSUMES GRADLE 5.6 OR HIGHER. Use plugin version 0.8.10 with earlier gradle versions
-    id 'com.google.protobuf' version '0.8.18'
+    id 'com.google.protobuf' version '0.9.1'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
 }

--- a/examples/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,6 @@ cronet-api = "org.chromium.net:cronet-api:92.4515.131"
 cronet-embedded = "org.chromium.net:cronet-embedded:102.5005.125"
 errorprone-annotations = "com.google.errorprone:error_prone_annotations:2.14.0"
 errorprone-core = "com.google.errorprone:error_prone_core:2.10.0"
-errorprone-javac = "com.google.errorprone:javac:9+181-r4173-1"
 google-api-protos = "com.google.api.grpc:proto-google-common-protos:2.9.0"
 google-auth-credentials = { module = "com.google.auth:google-auth-library-credentials", version.ref = "googleauth" }
 google-auth-oauth2Http = { module = "com.google.auth:google-auth-library-oauth2-http", version.ref = "googleauth" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,14 +4,14 @@ pluginManagement {
         id "com.android.library" version "4.2.0"
         id "com.github.johnrengelman.shadow" version "7.1.2"
         id "com.github.kt3k.coveralls" version "2.12.0"
-        id "com.google.cloud.tools.jib" version "3.2.1"
-        id "com.google.osdetector" version "1.7.0"
-        id "com.google.protobuf" version "0.8.19"
+        id "com.google.cloud.tools.jib" version "3.3.1"
+        id "com.google.osdetector" version "1.7.1"
+        id "com.google.protobuf" version "0.9.1"
         id "digital.wup.android-maven-publish" version "3.6.3"
         id "me.champeau.gradle.japicmp" version "0.3.0"
-        id "me.champeau.jmh" version "0.6.6"
-        id "net.ltgt.errorprone" version "2.0.2"
-        id "ru.vyarus.animalsniffer" version "1.5.4"
+        id "me.champeau.jmh" version "0.6.8"
+        id "net.ltgt.errorprone" version "3.0.1"
+        id "ru.vyarus.animalsniffer" version "1.6.0"
     }
     resolutionStrategy {
         eachPlugin {
@@ -25,8 +25,6 @@ pluginManagement {
         google()
     }
 }
-
-enableFeaturePreview('VERSION_CATALOGS')
 
 rootProject.name = "grpc"
 include ":grpc-api"


### PR DESCRIPTION
As normal, Android versions weren't touched as it tends to be special to upgrade.

The errorprone plugin handles errorproneJavac for us now, since it hasn't changed in five years. VERSION_CATALOGS is already enabled by default and graduated out of preview.

Fixes #9802

-----

FYI, I released protobuf-gradle-plugin 0.9.2 yesterday, but I had already prepared this. I'll do a separate PR to upgrade to 0.9.2.