### PR TITLE
Drop Bazel 4 support

### DIFF
--- a/buildscripts/kokoro/bazel.sh
+++ b/buildscripts/kokoro/bazel.sh
@@ -3,7 +3,7 @@
 set -exu -o pipefail
 cat /VERSION
 
-use_bazel.sh 4.0.0
+use_bazel.sh 5.0.0
 bazel version
 
 cd github/grpc-java


### PR DESCRIPTION
Bazel 6 has been released, and we track the two most recent major versions.