### PR TITLE
xds:fix cancel xds watcher accidentally removes the url

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -332,12 +332,13 @@ final class XdsClientImpl extends XdsClient
         if (!subscriber.isWatched()) {
           subscriber.cancelResourceWatch();
           resourceSubscribers.get(type).remove(resourceName);
-          subscribedResourceTypeUrls.remove(type.typeUrl());
           if (subscriber.xdsChannel != null) {
             subscriber.xdsChannel.adjustResourceSubscription(type);
           }
           if (resourceSubscribers.get(type).isEmpty()) {
             resourceSubscribers.remove(type);
+            subscribedResourceTypeUrls.remove(type.typeUrl());
+
           }
         }
       }


### PR DESCRIPTION
fix b/265017892

When any of the subscribers for a resource has the last watcher cancelled,  the bug will accidentally remove that resource type from the map, which make xds stream not accepting response update for that resource type entirely (pass through, no ACK will send).
This was introduced in https://github.com/grpc/grpc-java/pull/9607 where the resource url map is dynamically controlled by the watchers.
