### PR TITLE
xds: Include unknown type in channel logger warning

### DIFF
--- a/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
@@ -301,13 +301,12 @@ final class AbstractXdsClient {
 
     final void handleRpcResponse(XdsResourceType<?> type, String versionInfo, List<Any> resources,
                                  String nonce) {
+      checkNotNull(type, "type");
       if (closed) {
         return;
       }
       responseReceived = true;
-      if (type != null) {
-        respNonces.put(type, nonce);
-      }
+      respNonces.put(type, nonce);
       xdsResponseHandler.handleResourceResponse(type, serverInfo, versionInfo, resources, nonce);
     }
 
@@ -390,6 +389,13 @@ final class AbstractXdsClient {
                 logger.log(
                     XdsLogLevel.DEBUG, "Received {0} response:\n{1}", type,
                     MessagePrinter.print(response));
+              }
+              if (type == null) {
+                logger.log(
+                    XdsLogLevel.WARNING,
+                    "Ignore an unknown type of DiscoveryResponse: {0}",
+                    response.getTypeUrl());
+                return;
               }
               handleRpcResponse(type, response.getVersionInfo(), response.getResourcesList(),
                   response.getNonce());

--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -167,11 +167,8 @@ final class XdsClientImpl extends XdsClient
   public void handleResourceResponse(
       XdsResourceType<?> xdsResourceType, ServerInfo serverInfo, String versionInfo,
       List<Any> resources, String nonce) {
+    checkNotNull(xdsResourceType, "xdsResourceType");
     syncContext.throwIfNotInThisSynchronizationContext();
-    if (xdsResourceType == null) {
-      logger.log(XdsLogLevel.WARNING, "Ignore an unknown type of DiscoveryResponse");
-      return;
-    }
     Set<String> toParseResourceNames = null;
     if (!(xdsResourceType == XdsListenerResource.getInstance()
         || xdsResourceType == XdsRouteConfigureResource.getInstance())


### PR DESCRIPTION
This makes the log statement more useful and easier to determine whether this was expected behavior.