### PR TITLE
Upgrade JUnit to 4.13.2

### DIFF
--- a/core/src/test/java/io/grpc/internal/ReadableBuffersTest.java
+++ b/core/src/test/java/io/grpc/internal/ReadableBuffersTest.java
@@ -19,6 +19,7 @@ package io.grpc.internal;
 import static com.google.common.base.Charsets.UTF_8;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
@@ -32,9 +33,7 @@ import io.grpc.HasByteBuffer;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.InvalidMarkException;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -45,9 +44,6 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ReadableBuffersTest {
   private static final byte[] MSG_BYTES = "hello".getBytes(UTF_8);
-
-  @Rule
-  public final ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void empty_returnsEmptyBuffer() {
@@ -216,8 +212,7 @@ public class ReadableBuffersTest {
     InputStream inputStream = ReadableBuffers.openStream(buffer, true);
     inputStream.mark(5);
     ((Detachable) inputStream).detach();
-    thrown.expect(InvalidMarkException.class);
-    inputStream.reset();
+    assertThrows(InvalidMarkException.class, () -> inputStream.reset());
   }
 
   @Test

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation 'io.grpc:grpc-stub:1.53.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'org.apache.tomcat:annotations-api:6.0.53'
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.google.truth:truth:1.0.1'
     testImplementation 'io.grpc:grpc-testing:1.53.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
     testImplementation "io.grpc:grpc-testing:${grpcVersion}"
-    testImplementation "junit:junit:4.12"
+    testImplementation "junit:junit:4.13.2"
     testImplementation "org.mockito:mockito-core:3.4.0"
 }
 

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     compileOnly "org.apache.tomcat:annotations-api:6.0.53"
     runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation "io.grpc:grpc-testing:${grpcVersion}"
 }
 

--- a/examples/example-hostname/pom.xml
+++ b/examples/example-hostname/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
     testImplementation "io.grpc:grpc-testing:${grpcVersion}"
-    testImplementation "junit:junit:4.12"
+    testImplementation "junit:junit:4.13.2"
     testImplementation "org.mockito:mockito-core:3.4.0"
 }
 

--- a/examples/example-jwt-auth/pom.xml
+++ b/examples/example-jwt-auth/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ hdrhistogram = "org.hdrhistogram:HdrHistogram:2.1.12"
 javax-annotation = "org.apache.tomcat:annotations-api:6.0.53"
 jetty-alpn-agent = "org.mortbay.jetty.alpn:jetty-alpn-agent:2.0.10"
 jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
-junit = "junit:junit:4.12"
+junit = "junit:junit:4.13.2"
 mockito-android = "org.mockito:mockito-android:3.8.0"
 mockito-core = "org.mockito:mockito-core:3.3.3"
 netty-codec-http2 = { module = "io.netty:netty-codec-http2", version.ref = "netty" }


### PR DESCRIPTION
ExpectedException is deprecated, so I fixed the new warnings. However, we are still using ExpectedException many places and had previously supressed the warning. See
https://github.com/grpc/grpc-java/issues/7467 . I did not fix those existing instances that had suppressed the warning, since it is unrelated to the upgrade and we have been free to fix them at any time since we dropped Java 7.