### PR TITLE
xds: Update logic so that an error being reported when stream is closed gets propagated to subscribers 

### DIFF
--- a/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
@@ -217,6 +217,11 @@ final class AbstractXdsClient {
       return;
     }
 
+    if (isInBackoff()) {
+      rpcRetryTimer.cancel();
+      rpcRetryTimer = null;
+    }
+
     timerLaunch.startSubscriberTimersIfNeeded(serverInfo);
   }
 
@@ -319,17 +324,25 @@ final class AbstractXdsClient {
     }
 
     private void handleRpcStreamClosed(Status error) {
-      checkArgument(!error.isOk(), "unexpected OK status");
-      if (closed) {
+      if (shutdown) {
+        closed = true;
+        if (rpcRetryTimer != null && rpcRetryTimer.isPending()) {
+          rpcRetryTimer.cancel();
+        }
         return;
       }
+
+      checkArgument(!error.isOk(), "unexpected OK status");
+      String errorMsg =
+          closed
+              ? "ADS stream failed with status {0}: {1}. Cause: {2}"
+              : "ADS stream closed with status {0}: {1}. Cause: {2}";
       logger.log(
-          XdsLogLevel.ERROR,
-          "ADS stream closed with status {0}: {1}. Cause: {2}",
-          error.getCode(), error.getDescription(), error.getCause());
+          XdsLogLevel.ERROR, errorMsg, error.getCode(), error.getDescription(), error.getCause());
       closed = true;
       xdsResponseHandler.handleStreamClosed(error);
       cleanUp();
+
       if (responseReceived || retryBackoffPolicy == null) {
         // Reset the backoff sequence if had received a response, or backoff sequence
         // has never been initialized.

--- a/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
@@ -325,10 +325,6 @@ final class AbstractXdsClient {
 
     private void handleRpcStreamClosed(Status error) {
       if (shutdown) {
-        closed = true;
-        if (rpcRetryTimer != null && rpcRetryTimer.isPending()) {
-          rpcRetryTimer.cancel();
-        }
         return;
       }
 

--- a/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
@@ -436,7 +436,7 @@ final class AbstractXdsClient {
           });
         }
       };
-      requestWriter = stub.withWaitForReady().streamAggregatedResources(responseReader);
+      requestWriter = stub.streamAggregatedResources(responseReader);
     }
 
     @Override

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
@@ -97,7 +97,6 @@ import io.grpc.xds.XdsListenerResource.LdsUpdate;
 import io.grpc.xds.XdsRouteConfigureResource.RdsUpdate;
 import io.grpc.xds.internal.security.CommonTlsContextTestsUtil;
 import java.io.IOException;
-import java.net.UnknownHostException;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
@@ -107,6 +107,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
@@ -3592,6 +3593,35 @@ public abstract class XdsClientImplTestBase {
     }
   }
 
+  @Test
+  public void sendingToPermanentlyStoppedServer() throws Exception {
+    // Setup xdsClient to fail on stream creation
+    XdsChannelFactory xdsChannelFactory = new XdsChannelFactory() {
+      @Override
+      ManagedChannel create(ServerInfo serverInfo) {
+        throw new IllegalArgumentException("Can not create channel for " + serverInfo);
+      }
+    };
+    xdsClient =
+        new XdsClientImpl(
+            xdsChannelFactory,
+            xdsClient.getBootstrapInfo(),
+            Context.ROOT,
+            fakeClock.getScheduledExecutorService(),
+            backoffPolicyProvider,
+            fakeClock.getStopwatchSupplier(),
+            timeProvider,
+            tlsContextManager);
+
+    try {
+      xdsClient.watchXdsResource(XdsListenerResource.getInstance(), LDS_RESOURCE,
+          ldsResourceWatcher);
+      Assert.fail("Expected failure creating stream didn't happen");
+    } catch (AssertionError e) {
+      assertThat(e).hasMessageThat().contains(
+          "Can not create channel for ServerInfo{target=trafficdirector.googleapis.com");
+    }
+  }
 
   private <T extends ResourceUpdate> DiscoveryRpcCall startResourceWatcher(
       XdsResourceType<T> type, String name, ResourceWatcher<T> watcher) {

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
@@ -3611,11 +3611,10 @@ public abstract class XdsClientImplTestBase {
       fakeClock.forwardTime(20, TimeUnit.SECONDS);
     } catch (AssertionError e) {
       assertThat(e.getCause()).isInstanceOf(IllegalArgumentException.class);
+      client.shutdown();
       return;
     }
     Assert.fail("Expected exception for bad url not thrown");
-    verify(ldsResourceWatcher).onError(errorCaptor.capture());
-    assertThat(fakeClock.getPendingTasks(LDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isNotEmpty();
   }
 
   @Test
@@ -3628,10 +3627,7 @@ public abstract class XdsClientImplTestBase {
     verify(ldsResourceWatcher, Mockito.timeout(5000).times(1)).onError(ArgumentMatchers.any());
     fakeClock.forwardTime(50, TimeUnit.SECONDS); // Trigger rpcRetry if appropriate
     assertThat(fakeClock.getPendingTasks(LDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
-    // Get rid of rpcRetryTask that should have been scheduled since still cannot talk to server
-    for (ScheduledTask task : fakeClock.getPendingTasks()) {
-      task.cancel(true);
-    }
+    client.shutdown();
   }
 
   private XdsClientImpl createXdsClient(String serverUri) {


### PR DESCRIPTION
Eliminated waitForReady in XdsClient's stub. (Addresses the needs of TD Client Migration team)

The AbstractAdsStream.handleRpcStreamClosed method is used to handle both rpc error and rpc completed. Previously, if AbstractAdsStream.closed == true, then all the logic in handleRpcStreamClosed was skipped. Now it is only skipped if shutdown == true.

Additionally, adds some cleanup.