### PR TITLE
xds: fix RouteConfiguration not supporting contains and stringMatcher

### DIFF
--- a/xds/src/test/java/io/grpc/xds/XdsClientImplDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplDataTest.java
@@ -131,6 +131,7 @@ import io.grpc.xds.VirtualHost.Route.RouteMatch.PathMatcher;
 import io.grpc.xds.XdsClientImpl.ResourceInvalidException;
 import io.grpc.xds.XdsClusterResource.CdsUpdate;
 import io.grpc.xds.XdsResourceType.StructOrError;
+import io.grpc.xds.internal.Matchers;
 import io.grpc.xds.internal.Matchers.FractionMatcher;
 import io.grpc.xds.internal.Matchers.HeaderMatcher;
 import java.util.Arrays;
@@ -479,6 +480,28 @@ public class XdsClientImplDataTest {
     StructOrError<HeaderMatcher> struct = XdsRouteConfigureResource.parseHeaderMatcher(proto);
     assertThat(struct.getErrorDetail()).isNotNull();
     assertThat(struct.getStruct()).isNull();
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void parseHeaderMatcher_withStringMatcher() {
+    io.envoyproxy.envoy.type.matcher.v3.StringMatcher stringMatcherProto =
+            io.envoyproxy.envoy.type.matcher.v3.StringMatcher.newBuilder()
+                    .setPrefix("service-foo")
+                    .setIgnoreCase(false)
+                    .build();
+
+    io.envoyproxy.envoy.config.route.v3.HeaderMatcher proto =
+            io.envoyproxy.envoy.config.route.v3.HeaderMatcher.newBuilder()
+                    .setName("authority")
+                    .setStringMatch(stringMatcherProto)
+                    .setInvertMatch(false)
+                    .build();
+    StructOrError<HeaderMatcher> struct = XdsRouteConfigureResource.parseHeaderMatcher(proto);
+    assertThat(struct.getErrorDetail()).isNull();
+    assertThat(struct.getStruct()).isEqualTo(
+            HeaderMatcher.forString("authority", Matchers.StringMatcher
+                    .forPrefix("service-foo", false), false));
   }
 
   @Test


### PR DESCRIPTION
[HeaderMatcher needs to support stringMatcher and contains](https://github.com/envoyproxy/envoy/blob/main/api/envoy/config/route/v3/route_components.proto#L2189), and the analysis of HeaderMatcher has already been implemented in [MatcherParser](https://github.com/grpc/grpc-java/blob/master/xds/src/main/java/io/grpc/xds/internal/MatcherParser.java). Therefore, I  did the replacement.
