### PR TITLE
okhttp: Avoid DNS lookup in test

### DIFF
--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -1685,7 +1685,7 @@ public class OkHttpClientTransportTest {
   public void invalidAuthorityPropagates() {
     clientTransport = new OkHttpClientTransport(
         channelBuilder.buildTransportFactory(),
-        new InetSocketAddress("host", 1234),
+        new InetSocketAddress("localhost", 1234),
         "invalid_authority",
         "userAgent",
         EAG_ATTRS,


### PR DESCRIPTION
Our tests assume localhost is in /etc/hosts or uses some other form of local-only resolution. But that wouldn't apply to "host". What was happening is this was causing a DNS resolution, which would fail, and the InetSocketAddress would be "unresolved". Thus, the equivalent and faster code would be `InetSocketAddress.createUnresolved("host", 1234)`. But there doesn't seem to be any reason to avoid localhost in this test, so swap to the more typical solution instead.

This should avoid flakes like:
```
io.grpc.okhttp.OkHttpClientTransportTest > invalidAuthorityPropagates FAILED
    org.junit.runners.model.TestTimedOutException: test timed out after 10 seconds
        at java.base@11.0.17/java.net.Inet6AddressImpl.lookupAllHostAddr(Native Method)
        at java.base@11.0.17/java.net.InetAddress$PlatformNameService.lookupAllHostAddr(InetAddress.java:929)
        at java.base@11.0.17/java.net.InetAddress.getAddressesFromNameService(InetAddress.java:1529)
        at java.base@11.0.17/java.net.InetAddress$NameServiceAddresses.get(InetAddress.java:848)
        at java.base@11.0.17/java.net.InetAddress.getAllByName0(InetAddress.java:1519)
        at java.base@11.0.17/java.net.InetAddress.getAllByName(InetAddress.java:1378)
        at java.base@11.0.17/java.net.InetAddress.getAllByName(InetAddress.java:1306)
        at java.base@11.0.17/java.net.InetAddress.getByName(InetAddress.java:1256)
        at java.base@11.0.17/java.net.InetSocketAddress.<init>(InetSocketAddress.java:220)
        at app//io.grpc.okhttp.OkHttpClientTransportTest.invalidAuthorityPropagates(OkHttpClientTransportTest.java:1687)
```

Flake seen in #9849.