### PR TITLE
Build Improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ subprojects {
                     all().each { task ->
                         // Recompile protos when build.gradle has been changed, because
                         // it's possible the version of protoc has been changed.
-                        task.inputs.file "${rootProject.projectDir}/build.gradle"
+                        task.inputs.file("${rootProject.projectDir}/build.gradle").withPathSensitivity(PathSensitivity.RELATIVE)
                         if (isAndroid) {
                             task.builtins {
                                 java { option 'lite' }

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,9 @@ subprojects {
                     all().each { task ->
                         // Recompile protos when build.gradle has been changed, because
                         // it's possible the version of protoc has been changed.
-                        task.inputs.file("${rootProject.projectDir}/build.gradle").withPathSensitivity(PathSensitivity.RELATIVE)
+                        task.inputs.file("${rootProject.projectDir}/build.gradle")
+                          .withPathSensitivity(PathSensitivity.RELATIVE)
+                          .withPropertyName('root build.gradle')
                         if (isAndroid) {
                             task.builtins {
                                 java { option 'lite' }

--- a/netty/shaded/build.gradle
+++ b/netty/shaded/build.gradle
@@ -1,4 +1,5 @@
 import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.CacheableTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.TransformerContext
 import org.gradle.api.file.FileTreeElement
 import shadow.org.apache.tools.zip.ZipOutputStream
@@ -140,6 +141,7 @@ tasks.named("test").configure {
  * A Transformer which updates the Netty JAR META-INF/ resources to accurately
  * reference shaded class names.
  */
+@CacheableTransformer
 class NettyResourceTransformer implements Transformer {
 
     // A map of resource file paths to be modified


### PR DESCRIPTION
This PR fixes a pair of issues that prevent complete cacheability of certain tasks in the project's build:

1. All proto tasks rely on the root `build.gradle` file in such a way that the dependency is registered with the full absolute path of the project on the local node. This makes it impossible to cache those tasks between two nodes with a different directory layout. Fixed by specifying that the file path should be relative to the project dir.
2. The `NettyResourceTransformer` object in `netty/shaded/build.gradle` is not explicitly marked as cacheable. This, I admit, I took more of a guess that it was an oversight, but if there's a reason, I can drop that from the PR.

UPDATE:

These are the build scans that demonstrate the change:

1. [Build scan from master](https://scans.gradle.com/s/47el63djedbuo)
2. [Build scan from PR](https://scans.gradle.com/s/5hvf4werwteky)

You can clearly see here that tasks move "not cacheable" to "cacheable" as a result of this change.
