### PR TITLE
googleapis: Allow user set c2p bootstrap config

### DIFF
--- a/googleapis/src/main/java/io/grpc/googleapis/GoogleCloudToProdNameResolver.java
+++ b/googleapis/src/main/java/io/grpc/googleapis/GoogleCloudToProdNameResolver.java
@@ -157,34 +157,34 @@ final class GoogleCloudToProdNameResolver extends NameResolver {
       @Override
       public void run() {
         ImmutableMap<String, ?> rawBootstrap = null;
-        // User provided bootstrap configs are only supported with federation. If federation is
-        // not enabled or there is no user provided config, we set a custom bootstrap override.
-        // Otherwise, we don't set the override, which will allow a user provided bootstrap config
-        // to take effect.
-        if (!enableFederation || !xdsBootstrapProvided) {
-          try {
+        try {
+          // User provided bootstrap configs are only supported with federation. If federation is
+          // not enabled or there is no user provided config, we set a custom bootstrap override.
+          // Otherwise, we don't set the override, which will allow a user provided bootstrap config
+          // to take effect.
+          if (!enableFederation || !xdsBootstrapProvided) {
             rawBootstrap = generateBootstrap(queryZoneMetadata(METADATA_URL_ZONE),
                 queryIpv6SupportMetadata(METADATA_URL_SUPPORT_IPV6));
-          } catch (IOException e) {
-            listener.onError(
-                Status.INTERNAL.withDescription("Unable to get metadata").withCause(e));
           }
-        }
-
-        final ImmutableMap<String, ?> finalRawBootstrap = rawBootstrap;
-        syncContext.execute(new Runnable() {
-          @Override
-          public void run() {
-            if (!shutdown) {
-              if (finalRawBootstrap != null) {
-                bootstrapSetter.setBootstrap(finalRawBootstrap);
+        } catch (IOException e) {
+          listener.onError(
+              Status.INTERNAL.withDescription("Unable to get metadata").withCause(e));
+        } finally {
+          final ImmutableMap<String, ?> finalRawBootstrap = rawBootstrap;
+          syncContext.execute(new Runnable() {
+            @Override
+            public void run() {
+              if (!shutdown) {
+                if (finalRawBootstrap != null) {
+                  bootstrapSetter.setBootstrap(finalRawBootstrap);
+                }
+                delegate.start(listener);
+                succeeded = true;
               }
-              delegate.start(listener);
-              succeeded = true;
+              resolving = false;
             }
-            resolving = false;
-          }
-        });
+          });
+        }
       }
     }
 


### PR DESCRIPTION
Instead of always overriding the bootstrap with a custom c2p config, now we allow user defined ones to also be used. This only applies when running in GCP with federation.