### PR TITLE
rls:Fix throttling in route lookup (b/262779100)

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
@@ -414,7 +414,7 @@ public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
 
         // Schedule the next response chunk if there is one.
         Chunk nextChunk = chunks.peek();
-        if (nextChunk != null) {
+        if (nextChunk != null && !executor.isShutdown()) {
           scheduled = true;
           // TODO(ejona): cancel future if RPC is cancelled
           Future<?> unused = executor.schedule(new LogExceptionRunnable(dispatchTask),

--- a/interop-testing/src/test/java/io/grpc/testing/integration/NettyFlowControlTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/NettyFlowControlTest.java
@@ -217,7 +217,7 @@ public class NettyFlowControlTest {
           wasCompleted = true;
           lastWindow = curWindow;
           onCompleted();
-        } else {
+        } else if (!wasCompleted) {
           lastWindow = curWindow;
         }
       }

--- a/interop-testing/src/test/java/io/grpc/testing/integration/NettyFlowControlTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/NettyFlowControlTest.java
@@ -147,10 +147,11 @@ public class NettyFlowControlTest {
     // deal with cases that either don't cause a window update or hit max window
     expectedWindow = Math.min(MAX_WINDOW, Math.max(expectedWindow, REGULAR_WINDOW));
 
-    // Range looks large, but this allows for only one extra/missed window update
+    // Range looks large, but this allows for only one extra/missed window update plus
+    // bdpPing variations.
     // (one extra update causes a 2x difference and one missed update causes a .5x difference)
     assertTrue("Window was " + lastWindow + " expecting " + expectedWindow,
-        lastWindow < 2 * expectedWindow);
+        lastWindow < 2.2 * expectedWindow);
     assertTrue("Window was " + lastWindow + " expecting " + expectedWindow,
         expectedWindow < 2 * lastWindow);
   }
@@ -194,6 +195,7 @@ public class NettyFlowControlTest {
     final CountDownLatch latch = new CountDownLatch(1);
     final long expectedWindow;
     int lastWindow;
+    boolean wasCompleted;
 
     public TestStreamObserver(
         AtomicReference<GrpcHttp2ConnectionHandler> grpcHandlerRef, long window) {
@@ -206,9 +208,18 @@ public class NettyFlowControlTest {
     public void onNext(StreamingOutputCallResponse value) {
       GrpcHttp2ConnectionHandler grpcHandler = grpcHandlerRef.get();
       Http2Stream connectionStream = grpcHandler.connection().connectionStream();
-      lastWindow = grpcHandler.decoder().flowController().initialWindowSize(connectionStream);
-      if (lastWindow >= expectedWindow) {
-        onCompleted();
+      int curWindow = grpcHandler.decoder().flowController().initialWindowSize(connectionStream);
+      synchronized (this) {
+        if (curWindow >= expectedWindow) {
+          if (wasCompleted) {
+            return;
+          }
+          wasCompleted = true;
+          lastWindow = curWindow;
+          onCompleted();
+        } else {
+          lastWindow = curWindow;
+        }
       }
     }
 

--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -38,8 +38,6 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
 import io.grpc.Status;
-import io.grpc.StatusException;
-import io.grpc.StatusRuntimeException;
 import io.grpc.SynchronizationContext;
 import io.grpc.SynchronizationContext.ScheduledHandle;
 import io.grpc.internal.BackoffPolicy;
@@ -221,7 +219,7 @@ final class CachingRlsLbClient {
                 logger.log(ChannelLogLevel.DEBUG, "Error looking up route:", t);
                 response.setException(t);
 
-                throttler.registerBackendResponse(getCause(t) instanceof ThrottledException);
+                throttler.registerBackendResponse(true);
                 helper.propagateRlsError();
               }
 
@@ -271,27 +269,6 @@ final class CachingRlsLbClient {
       rlsChannel.shutdownNow();
       rlsPicker.close();
     }
-  }
-
-  /**
-   * If passed a StatusException or a StatusRuntimeException extract the status
-   * and then return its cause.  Otherwise return the argument.
-   * @param t Value to parse
-   * @return Status.getCause() if status is available or t
-   */
-  private Throwable getCause(Throwable t) {
-    Status status = null;
-    if (t instanceof StatusException) {
-      status = ((StatusException) t).getStatus();
-    } else if (t instanceof StatusRuntimeException) {
-      status = ((StatusRuntimeException) t).getStatus();
-    }
-
-    if (status != null) {
-      return status.getCause();
-    }
-
-    return t;
   }
 
   /**

--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -282,7 +282,7 @@ final class CachingRlsLbClient {
   private Throwable getCause(Throwable t) {
     Status status = null;
     if (t instanceof StatusException) {
-       status = ((StatusException) t).getStatus();
+      status = ((StatusException) t).getStatus();
     } else if (t instanceof StatusRuntimeException) {
       status = ((StatusRuntimeException) t).getStatus();
     }

--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -38,6 +38,8 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
 import io.grpc.Status;
+import io.grpc.StatusException;
+import io.grpc.StatusRuntimeException;
 import io.grpc.SynchronizationContext;
 import io.grpc.SynchronizationContext.ScheduledHandle;
 import io.grpc.internal.BackoffPolicy;
@@ -218,7 +220,8 @@ final class CachingRlsLbClient {
               public void onError(Throwable t) {
                 logger.log(ChannelLogLevel.DEBUG, "Error looking up route:", t);
                 response.setException(t);
-                throttler.registerBackendResponse(t instanceof ThrottledException);
+
+                throttler.registerBackendResponse(getCause(t) instanceof ThrottledException);
                 helper.propagateRlsError();
               }
 
@@ -268,6 +271,27 @@ final class CachingRlsLbClient {
       rlsChannel.shutdownNow();
       rlsPicker.close();
     }
+  }
+
+  /**
+   * If passed a StatusException or a StatusRuntimeException extract the status
+   * and then return its cause.  Otherwise return the argument.
+   * @param t Value to parse
+   * @return Status.getCause() if status is available or t
+   */
+  private Throwable getCause(Throwable t) {
+    Status status = null;
+    if (t instanceof StatusException) {
+       status = ((StatusException) t).getStatus();
+    } else if (t instanceof StatusRuntimeException) {
+      status = ((StatusRuntimeException) t).getStatus();
+    }
+
+    if (status != null) {
+      return status.getCause();
+    }
+
+    return t;
   }
 
   /**

--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -218,13 +218,13 @@ final class CachingRlsLbClient {
               public void onError(Throwable t) {
                 logger.log(ChannelLogLevel.DEBUG, "Error looking up route:", t);
                 response.setException(t);
-                throttler.registerBackendResponse(false);
+                throttler.registerBackendResponse(t instanceof ThrottledException);
                 helper.propagateRlsError();
               }
 
               @Override
               public void onCompleted() {
-                throttler.registerBackendResponse(true);
+                throttler.registerBackendResponse(false);
               }
             });
     return response;

--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -218,7 +218,6 @@ final class CachingRlsLbClient {
               public void onError(Throwable t) {
                 logger.log(ChannelLogLevel.DEBUG, "Error looking up route:", t);
                 response.setException(t);
-
                 throttler.registerBackendResponse(true);
                 helper.propagateRlsError();
               }

--- a/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
+++ b/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
@@ -396,6 +396,95 @@ public class CachingRlsLbClientTest {
   }
 
   @Test
+  public void get_withAdaptiveThrottler() throws Exception {
+    AdaptiveThrottler adaptiveThrottler =
+        new AdaptiveThrottler.Builder()
+            .setHistorySeconds(1)
+            .setRatioForAccepts(1.0f)
+            .setRequestsPadding(1)
+            .setTicker(fakeClock.getTicker())
+            .build();
+
+    this.rlsLbClient =
+        CachingRlsLbClient.newBuilder()
+            .setBackoffProvider(fakeBackoffProvider)
+            .setResolvedAddressesFactory(resolvedAddressFactory)
+            .setEvictionListener(evictionListener)
+            .setHelper(helper)
+            .setLbPolicyConfig(lbPolicyConfiguration)
+            .setThrottler(adaptiveThrottler)
+            .setTicker(fakeClock.getTicker())
+            .build();
+    InOrder inOrder = inOrder(helper);
+    RouteLookupRequest routeLookupRequest = RouteLookupRequest.create(ImmutableMap.of(
+        "server", "bigtable.googleapis.com", "service-key", "service1", "method-key", "create"));
+    rlsServerImpl.setLookupTable(
+        ImmutableMap.of(
+            routeLookupRequest,
+            RouteLookupResponse.create(
+                ImmutableList.of("primary.cloudbigtable.googleapis.com"),
+                "header-rls-data-value")));
+
+    // valid channel
+    CachedRouteLookupResponse resp = getInSyncContext(routeLookupRequest);
+    assertThat(resp.isPending()).isTrue();
+    fakeClock.forwardTime(SERVER_LATENCY_MILLIS, TimeUnit.MILLISECONDS);
+
+    resp = getInSyncContext(routeLookupRequest);
+    assertThat(resp.hasData()).isTrue();
+
+    ArgumentCaptor<SubchannelPicker> pickerCaptor = ArgumentCaptor.forClass(SubchannelPicker.class);
+    ArgumentCaptor<ConnectivityState> stateCaptor =
+        ArgumentCaptor.forClass(ConnectivityState.class);
+    inOrder.verify(helper, times(2))
+        .updateBalancingState(stateCaptor.capture(), pickerCaptor.capture());
+
+    Metadata headers = new Metadata();
+    PickResult pickResult = pickerCaptor.getValue().pickSubchannel(
+        new PickSubchannelArgsImpl(
+            TestMethodDescriptors.voidMethod().toBuilder().setFullMethodName("service1/create")
+                .build(),
+            headers,
+            CallOptions.DEFAULT));
+    assertThat(pickResult.getSubchannel()).isNotNull();
+    assertThat(headers.get(RLS_DATA_KEY)).isEqualTo("header-rls-data-value");
+
+    // move backoff further back to only test error behavior
+    fakeBackoffProvider.nextPolicy = createBackoffPolicy(100, TimeUnit.MILLISECONDS);
+    // try to get invalid
+    RouteLookupRequest invalidRouteLookupRequest =
+        RouteLookupRequest.create(ImmutableMap.<String, String>of());
+    CachedRouteLookupResponse errorResp = getInSyncContext(invalidRouteLookupRequest);
+    assertThat(errorResp.isPending()).isTrue();
+    fakeClock.forwardTime(SERVER_LATENCY_MILLIS, TimeUnit.MILLISECONDS);
+
+    errorResp = getInSyncContext(invalidRouteLookupRequest);
+    assertThat(errorResp.hasError()).isTrue();
+
+    // Channel is still READY because the subchannel for method /service1/create is still READY.
+    // Method /doesn/exists will use fallback child balancer and fail immediately.
+    inOrder.verify(helper)
+        .updateBalancingState(eq(ConnectivityState.READY), pickerCaptor.capture());
+    PickSubchannelArgsImpl invalidArgs = getInvalidArgs(headers);
+    pickResult = pickerCaptor.getValue().pickSubchannel(invalidArgs);
+    assertThat(pickResult.getStatus().getCode()).isEqualTo(Code.UNAVAILABLE);
+    assertThat(pickResult.getStatus().getDescription()).contains("fallback not available");
+    long time = fakeClock.getTicker().read();
+    assertThat(adaptiveThrottler.requestStat.get(time)).isEqualTo(2L);
+    assertThat(adaptiveThrottler.throttledStat.get(time)).isEqualTo(1L);
+  }
+
+  private PickSubchannelArgsImpl getInvalidArgs(Metadata headers) {
+    PickSubchannelArgsImpl invalidArgs = new PickSubchannelArgsImpl(
+        TestMethodDescriptors.voidMethod().toBuilder()
+            .setFullMethodName("doesn/exists")
+            .build(),
+        headers,
+        CallOptions.DEFAULT);
+    return invalidArgs;
+  }
+
+  @Test
   public void get_childPolicyWrapper_reusedForSameTarget() throws Exception {
     setUpRlsLbClient();
     RouteLookupRequest routeLookupRequest = RouteLookupRequest.create(ImmutableMap.of(


### PR DESCRIPTION
Fixes b/262779100

Previously, registerBackendResponse was being passed the opposite value from what it should have been.  Thus, successes were being registered as throttled and all errors were registered as not throttled by the backend.  Now it is only registered as throttled when there is an error and the cause is a ThrottledException. 