### PR TITLE
Updating ServerInterceptors.java to support different marshallers for Request and Response messages.

### DIFF
--- a/api/src/main/java/io/grpc/ServerInterceptors.java
+++ b/api/src/main/java/io/grpc/ServerInterceptors.java
@@ -184,6 +184,32 @@ public final class ServerInterceptors {
   public static <T> ServerServiceDefinition useMarshalledMessages(
       final ServerServiceDefinition serviceDef,
       final MethodDescriptor.Marshaller<T> marshaller) {
+    return useMarshalledMessages(serviceDef, marshaller, marshaller);
+  }
+
+  /**
+   * Create a new {@code ServerServiceDefinition} with {@link MethodDescriptor} for deserializing requests and
+   * separate {@link MethodDescriptor} for serializing responses. The {@code ServerCallHandler} created will
+   * automatically convert back to the original types for request and response before calling the existing {@code
+   * ServerCallHandler}.  Calling this method combined with the intercept methods will allow the developer to choose
+   * whether to intercept messages of ReqT/RespT, or the modeled types of their application.  This can also be
+   * chained to
+   * allow for interceptors to handle messages as multiple different ReqT/RespT types within the chain if the added
+   * cost of
+   * serialization is not a concern.
+   *
+   * @param serviceDef         the sevice definition to add request and response marshallers to.
+   * @param requestMarshaller  request marshaller
+   * @param responseMarshaller response marshaller
+   * @param <ReqT>             the request payload type
+   * @param <RespT>            the response payload type.
+   * @return a wrapped version of {@code serviceDef} with the ReqT and RespT conversion applied.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/9870")
+  public static <ReqT, RespT> ServerServiceDefinition useMarshalledMessages(
+      final ServerServiceDefinition serviceDef,
+      final MethodDescriptor.Marshaller<ReqT> requestMarshaller,
+      final MethodDescriptor.Marshaller<RespT> responseMarshaller) {
     List<ServerMethodDefinition<?, ?>> wrappedMethods =
         new ArrayList<>();
     List<MethodDescriptor<?, ?>> wrappedDescriptors =
@@ -191,8 +217,8 @@ public final class ServerInterceptors {
     // Wrap the descriptors
     for (final ServerMethodDefinition<?, ?> definition : serviceDef.getMethods()) {
       final MethodDescriptor<?, ?> originalMethodDescriptor = definition.getMethodDescriptor();
-      final MethodDescriptor<T, T> wrappedMethodDescriptor =
-          originalMethodDescriptor.toBuilder(marshaller, marshaller).build();
+      final MethodDescriptor<ReqT, RespT> wrappedMethodDescriptor =
+          originalMethodDescriptor.toBuilder(requestMarshaller, responseMarshaller).build();
       wrappedDescriptors.add(wrappedMethodDescriptor);
       wrappedMethods.add(wrapMethod(definition, wrappedMethodDescriptor));
     }

--- a/api/src/main/java/io/grpc/ServerInterceptors.java
+++ b/api/src/main/java/io/grpc/ServerInterceptors.java
@@ -188,15 +188,14 @@ public final class ServerInterceptors {
   }
 
   /**
-   * Create a new {@code ServerServiceDefinition} with {@link MethodDescriptor} for deserializing requests and
-   * separate {@link MethodDescriptor} for serializing responses. The {@code ServerCallHandler} created will
-   * automatically convert back to the original types for request and response before calling the existing {@code
-   * ServerCallHandler}.  Calling this method combined with the intercept methods will allow the developer to choose
-   * whether to intercept messages of ReqT/RespT, or the modeled types of their application.  This can also be
-   * chained to
-   * allow for interceptors to handle messages as multiple different ReqT/RespT types within the chain if the added
-   * cost of
-   * serialization is not a concern.
+   * Create a new {@code ServerServiceDefinition} with {@link MethodDescriptor} for deserializing
+   * requests and separate {@link MethodDescriptor} for serializing responses. The {@code
+   * ServerCallHandler} created will automatically convert back to the original types for request
+   * and response before calling the existing {@code ServerCallHandler}.  Calling this method
+   * combined with the intercept methods will allow the developer to choose whether to intercept
+   * messages of ReqT/RespT, or the modeled types of their application. This can also be chained
+   * to allow for interceptors to handle messages as multiple different ReqT/RespT types within
+   * the chain if the added cost of serialization is not a concern.
    *
    * @param serviceDef         the sevice definition to add request and response marshallers to.
    * @param requestMarshaller  request marshaller

--- a/api/src/test/java/io/grpc/ServerInterceptorsTest.java
+++ b/api/src/test/java/io/grpc/ServerInterceptorsTest.java
@@ -426,8 +426,8 @@ public class ServerInterceptorsTest {
   }
 
   /**
-   * Tests the {@link ServerInterceptors#useMarshalledMessages(ServerServiceDefinition, Marshaller, Marshaller)}.
-   * Makes sure that on incoming request the request marshaller's stream method is called and on response the
+   * Tests the ServerInterceptors#useMarshalledMessages()} with two marshallers. Makes sure that
+   * on incoming request the request marshaller's stream method is called and on response the
    * response marshaller's parse method is called
    */
   @Test
@@ -458,7 +458,7 @@ public class ServerInterceptorsTest {
       @Override
       public String parse(InputStream stream) {
         requestFlowOrder.add("ResponseParse");
-       return null;
+        return null;
       }
     };
     final Marshaller<Holder> dummyMarshaller = new Marshaller<Holder>() {
@@ -489,8 +489,8 @@ public class ServerInterceptorsTest {
     ServerServiceDefinition serviceDef = ServerServiceDefinition.builder(
             new ServiceDescriptor("basic", wrappedMethod))
         .addMethod(wrappedMethod, handler).build();
-    ServerServiceDefinition intercepted = ServerInterceptors.useMarshalledMessages(serviceDef, requestMarshaller,
-        responseMarshaller);
+    ServerServiceDefinition intercepted = ServerInterceptors.useMarshalledMessages(serviceDef,
+        requestMarshaller, responseMarshaller);
     ServerMethodDefinition<String, String> serverMethod =
         (ServerMethodDefinition<String, String>) intercepted.getMethod("basic/wrapped");
     ServerCall<String, String> serverCall = new NoopServerCall<>();

--- a/api/src/test/java/io/grpc/ServerInterceptorsTest.java
+++ b/api/src/test/java/io/grpc/ServerInterceptorsTest.java
@@ -33,7 +33,6 @@ import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.ServerCall.Listener;
 import io.grpc.internal.NoopServerCall;
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -440,38 +439,26 @@ public class ServerInterceptorsTest {
       @Override
       public InputStream stream(String value) {
         requestFlowOrder.add("RequestStream");
-        return new ByteArrayInputStream(value.getBytes());
+        return null;
       }
 
       @Override
       public String parse(InputStream stream) {
         requestFlowOrder.add("RequestParse");
-        try {
-          byte[] bytes = new byte[stream.available()];
-          stream.read(bytes);
-          return new String(bytes);
-        } catch (IOException e) {
-          throw new RuntimeException(e);
-        }
+        return null;
       }
     };
     final Marshaller<String> responseMarshaller = new Marshaller<String>() {
       @Override
       public InputStream stream(String value) {
         requestFlowOrder.add("ResponseStream");
-        return new ByteArrayInputStream(value.getBytes());
+        return null;
       }
 
       @Override
       public String parse(InputStream stream) {
         requestFlowOrder.add("ResponseParse");
-        try {
-          byte[] bytes = new byte[stream.available()];
-          stream.read(bytes);
-          return new String(bytes);
-        } catch (IOException e) {
-          throw new RuntimeException(e);
-        }
+       return null;
       }
     };
     final Marshaller<Holder> dummyMarshaller = new Marshaller<Holder>() {


### PR DESCRIPTION
Updating ServerInterceptors to support different marshallers for requests and responses.
See https://github.com/grpc/grpc-java/issues/9870 for more details.