### PR TITLE
all: fix build with errorprone 2.18

### DIFF
--- a/alts/src/test/java/io/grpc/alts/internal/AesGcmHkdfAeadCrypterTest.java
+++ b/alts/src/test/java/io/grpc/alts/internal/AesGcmHkdfAeadCrypterTest.java
@@ -117,7 +117,7 @@ public final class AesGcmHkdfAeadCrypterTest {
           ByteBuffer.wrap(testVector.plaintext),
           ByteBuffer.wrap(testVector.aad),
           testVector.nonce);
-      String msg = "Failure for test vector " + i;
+      String msg = "Failure for test vector " + i + " " + testVector.comment;
       assertWithMessage(msg)
           .that(ciphertextBuffer.remaining())
           .isEqualTo(bufferSize - testVector.ciphertext.length);
@@ -142,7 +142,7 @@ public final class AesGcmHkdfAeadCrypterTest {
           ByteBuffer.wrap(testVector.ciphertext),
           ByteBuffer.wrap(testVector.aad),
           testVector.nonce);
-      String msg = "Failure for test vector " + i;
+      String msg = "Failure for test vector " + i + " " + testVector.comment;
       assertWithMessage(msg)
           .that(plaintextBuffer.remaining())
           .isEqualTo(bufferSize - testVector.plaintext.length);

--- a/api/src/main/java/io/grpc/Attributes.java
+++ b/api/src/main/java/io/grpc/Attributes.java
@@ -115,6 +115,7 @@ public final class Attributes {
    * @param <T> type of the value in the key-value pair
    */
   @Immutable
+  @SuppressWarnings("UnusedTypeParameter")
   public static final class Key<T> {
     private final String debugString;
 

--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -772,7 +772,7 @@ public abstract class LoadBalancer {
       Builder() {
       }
 
-      private <T> Builder copyCustomOptions(Object[][] options) {
+      private Builder copyCustomOptions(Object[][] options) {
         customOptions = new Object[options.length][2];
         System.arraycopy(options, 0, customOptions, 0, options.length);
         return this;

--- a/api/src/test/java/io/grpc/CallOptionsTest.java
+++ b/api/src/test/java/io/grpc/CallOptionsTest.java
@@ -33,7 +33,6 @@ import com.google.common.base.Objects;
 import io.grpc.ClientStreamTracer.StreamInfo;
 import io.grpc.internal.SerializingExecutor;
 import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -258,17 +257,6 @@ public class CallOptionsTest {
     @Override
     public long nanoTime() {
       return time;
-    }
-
-    public void reset(long time) {
-      this.time = time;
-    }
-
-    public void increment(long period, TimeUnit unit) {
-      if (period < 0) {
-        throw new IllegalArgumentException();
-      }
-      this.time += unit.toNanos(period);
     }
   }
 

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
@@ -214,6 +214,7 @@ public class TransportBenchmark {
     return stub.unaryCall(BYTE_THROUGHPUT_REQUEST);
   }
 
+  @SuppressWarnings("StaticAssignmentOfThrowable")
   private static final Throwable OK_THROWABLE = new RuntimeException("OK");
 
   @State(Scope.Thread)

--- a/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadClient.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadClient.java
@@ -245,9 +245,9 @@ class LoadClient {
       latenciesBuilder.addBucket(0);
       base = base * resolution;
     }
-    latenciesBuilder.setMaxSeen(intervalHistogram.getMaxValue());
-    latenciesBuilder.setMinSeen(intervalHistogram.getMinNonZeroValue());
-    latenciesBuilder.setCount(intervalHistogram.getTotalCount());
+    latenciesBuilder.setMaxSeen((double) intervalHistogram.getMaxValue());
+    latenciesBuilder.setMinSeen((double) intervalHistogram.getMinNonZeroValue());
+    latenciesBuilder.setCount((double) intervalHistogram.getTotalCount());
     latenciesBuilder.setSum(intervalHistogram.getMean()
         * intervalHistogram.getTotalCount());
     // TODO: No support for sum of squares

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/OpenLoopClient.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/OpenLoopClient.java
@@ -202,7 +202,7 @@ public class OpenLoopClient {
 
     private void waitForRpcsToComplete(int duration) {
       long now = System.nanoTime();
-      long end = now + duration * 1000 * 1000 * 1000;
+      long end = now + duration * 1000L * 1000L * 1000L;
       while (histogram.getTotalCount() < numRpcs && end - now > 0) {
         now = System.nanoTime();
       }

--- a/census/src/main/java/io/grpc/census/CensusStatsModule.java
+++ b/census/src/main/java/io/grpc/census/CensusStatsModule.java
@@ -276,7 +276,7 @@ final class CensusStatsModule {
         outboundWireSize += bytes;
       }
       module.recordRealTimeMetric(
-          startCtx, RpcMeasureConstants.GRPC_CLIENT_SENT_BYTES_PER_METHOD, bytes);
+          startCtx, RpcMeasureConstants.GRPC_CLIENT_SENT_BYTES_PER_METHOD, (double) bytes);
     }
 
     @Override
@@ -288,7 +288,7 @@ final class CensusStatsModule {
         inboundWireSize += bytes;
       }
       module.recordRealTimeMetric(
-          startCtx, RpcMeasureConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_METHOD, bytes);
+          startCtx, RpcMeasureConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_METHOD, (double) bytes);
     }
 
     @Override
@@ -365,21 +365,27 @@ final class CensusStatsModule {
     }
 
     void recordFinishedAttempt() {
-      MeasureMap measureMap = module.statsRecorder.newMeasureMap()
-          // TODO(songya): remove the deprecated measure constants once they are completed removed.
-          .put(DeprecatedCensusConstants.RPC_CLIENT_FINISHED_COUNT, 1)
-          // The latency is double value
-          .put(RpcMeasureConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY, roundtripNanos / NANOS_PER_MILLI)
-          .put(RpcMeasureConstants.GRPC_CLIENT_SENT_MESSAGES_PER_RPC, outboundMessageCount)
-          .put(RpcMeasureConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC, inboundMessageCount)
-          .put(RpcMeasureConstants.GRPC_CLIENT_SENT_BYTES_PER_RPC, outboundWireSize)
-          .put(RpcMeasureConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_RPC, inboundWireSize)
-          .put(
-              DeprecatedCensusConstants.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES,
-              outboundUncompressedSize)
-          .put(
-              DeprecatedCensusConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES,
-              inboundUncompressedSize);
+      MeasureMap measureMap =
+          module
+              .statsRecorder
+              .newMeasureMap()
+              // TODO(songya): remove the deprecated measure constants once they are completed
+              // removed.
+              .put(DeprecatedCensusConstants.RPC_CLIENT_FINISHED_COUNT, 1)
+              // The latency is double value
+              .put(
+                  RpcMeasureConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY,
+                  roundtripNanos / NANOS_PER_MILLI)
+              .put(RpcMeasureConstants.GRPC_CLIENT_SENT_MESSAGES_PER_RPC, outboundMessageCount)
+              .put(RpcMeasureConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC, inboundMessageCount)
+              .put(RpcMeasureConstants.GRPC_CLIENT_SENT_BYTES_PER_RPC, (double) outboundWireSize)
+              .put(RpcMeasureConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_RPC, (double) inboundWireSize)
+              .put(
+                  DeprecatedCensusConstants.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES,
+                  (double) outboundUncompressedSize)
+              .put(
+                  DeprecatedCensusConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES,
+                  (double) inboundUncompressedSize);
       if (statusCode != Code.OK) {
         measureMap.put(DeprecatedCensusConstants.RPC_CLIENT_ERROR_COUNT, 1);
       }
@@ -640,7 +646,7 @@ final class CensusStatsModule {
         outboundWireSize += bytes;
       }
       module.recordRealTimeMetric(
-          parentCtx, RpcMeasureConstants.GRPC_SERVER_SENT_BYTES_PER_METHOD, bytes);
+          parentCtx, RpcMeasureConstants.GRPC_SERVER_SENT_BYTES_PER_METHOD, (double) bytes);
     }
 
     @Override
@@ -652,7 +658,7 @@ final class CensusStatsModule {
         inboundWireSize += bytes;
       }
       module.recordRealTimeMetric(
-          parentCtx, RpcMeasureConstants.GRPC_SERVER_RECEIVED_BYTES_PER_METHOD, bytes);
+          parentCtx, RpcMeasureConstants.GRPC_SERVER_RECEIVED_BYTES_PER_METHOD, (double) bytes);
     }
 
     @Override
@@ -722,21 +728,27 @@ final class CensusStatsModule {
       }
       stopwatch.stop();
       long elapsedTimeNanos = stopwatch.elapsed(TimeUnit.NANOSECONDS);
-      MeasureMap measureMap = module.statsRecorder.newMeasureMap()
-          // TODO(songya): remove the deprecated measure constants once they are completed removed.
-          .put(DeprecatedCensusConstants.RPC_SERVER_FINISHED_COUNT, 1)
-          // The latency is double value
-          .put(RpcMeasureConstants.GRPC_SERVER_SERVER_LATENCY, elapsedTimeNanos / NANOS_PER_MILLI)
-          .put(RpcMeasureConstants.GRPC_SERVER_SENT_MESSAGES_PER_RPC, outboundMessageCount)
-          .put(RpcMeasureConstants.GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC, inboundMessageCount)
-          .put(RpcMeasureConstants.GRPC_SERVER_SENT_BYTES_PER_RPC, outboundWireSize)
-          .put(RpcMeasureConstants.GRPC_SERVER_RECEIVED_BYTES_PER_RPC, inboundWireSize)
-          .put(
-              DeprecatedCensusConstants.RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES,
-              outboundUncompressedSize)
-          .put(
-              DeprecatedCensusConstants.RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES,
-              inboundUncompressedSize);
+      MeasureMap measureMap =
+          module
+              .statsRecorder
+              .newMeasureMap()
+              // TODO(songya): remove the deprecated measure constants once they are completed
+              // removed.
+              .put(DeprecatedCensusConstants.RPC_SERVER_FINISHED_COUNT, 1)
+              // The latency is double value
+              .put(
+                  RpcMeasureConstants.GRPC_SERVER_SERVER_LATENCY,
+                  elapsedTimeNanos / NANOS_PER_MILLI)
+              .put(RpcMeasureConstants.GRPC_SERVER_SENT_MESSAGES_PER_RPC, outboundMessageCount)
+              .put(RpcMeasureConstants.GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC, inboundMessageCount)
+              .put(RpcMeasureConstants.GRPC_SERVER_SENT_BYTES_PER_RPC, (double) outboundWireSize)
+              .put(RpcMeasureConstants.GRPC_SERVER_RECEIVED_BYTES_PER_RPC, (double) inboundWireSize)
+              .put(
+                  DeprecatedCensusConstants.RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES,
+                  (double) outboundUncompressedSize)
+              .put(
+                  DeprecatedCensusConstants.RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES,
+                  (double) inboundUncompressedSize);
       if (!status.isOk()) {
         measureMap.put(DeprecatedCensusConstants.RPC_SERVER_ERROR_COUNT, 1);
       }

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -256,7 +256,7 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
     channelz.addClientSocket(transport);
     pendingTransport = transport;
     transports.add(transport);
-    Runnable runnable = transport.start(new TransportListener(transport, address));
+    Runnable runnable = transport.start(new TransportListener(transport));
     if (runnable != null) {
       syncContext.executeLater(runnable);
     }
@@ -533,12 +533,10 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
   /** Listener for real transports. */
   private class TransportListener implements ManagedClientTransport.Listener {
     final ConnectionClientTransport transport;
-    final SocketAddress address;
     boolean shutdownInitiated = false;
 
-    TransportListener(ConnectionClientTransport transport, SocketAddress address) {
+    TransportListener(ConnectionClientTransport transport) {
       this.transport = transport;
-      this.address = address;
     }
 
     @Override

--- a/core/src/main/java/io/grpc/internal/JndiResourceResolverFactory.java
+++ b/core/src/main/java/io/grpc/internal/JndiResourceResolverFactory.java
@@ -43,6 +43,7 @@ import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 final class JndiResourceResolverFactory implements DnsNameResolver.ResourceResolverFactory {
 
   @Nullable
+  @SuppressWarnings("StaticAssignmentOfThrowable")
   private static final Throwable JNDI_UNAVAILABILITY_CAUSE = initJndi();
 
   // @UsedReflectively
@@ -194,8 +195,7 @@ final class JndiResourceResolverFactory implements DnsNameResolver.ResourceResol
 
   @VisibleForTesting
   @IgnoreJRERequirement
-  // Hashtable is required. https://github.com/google/error-prone/issues/1766
-  @SuppressWarnings("JdkObsolete")
+  @SuppressWarnings({"JdkObsolete", "BanJNDI"})
   // javax.naming.* is only loaded reflectively and is never loaded for Android
   // The lint issue id is supposed to be "InvalidPackage" but it doesn't work, don't know why.
   // Use "all" as the lint issue id to suppress all types of lint error.

--- a/core/src/main/java/io/grpc/internal/ManagedChannelOrphanWrapper.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelOrphanWrapper.java
@@ -80,6 +80,8 @@ final class ManagedChannelOrphanWrapper extends ForwardingManagedChannel {
 
     private static final boolean ENABLE_ALLOCATION_TRACKING =
         Boolean.parseBoolean(System.getProperty(ALLOCATION_SITE_PROPERTY_NAME, "true"));
+
+    @SuppressWarnings("StaticAssignmentOfThrowable")
     private static final RuntimeException missingCallSite = missingCallSite();
 
     private final ReferenceQueue<ManagedChannelOrphanWrapper> refqueue;

--- a/core/src/main/java/io/grpc/internal/StatsTraceContext.java
+++ b/core/src/main/java/io/grpc/internal/StatsTraceContext.java
@@ -119,10 +119,11 @@ public final class StatsTraceContext {
   }
 
   /**
-   * See {@link ServerStreamTracer#filterContext}.  For server-side only.
+   * See {@link ServerStreamTracer#filterContext}. For server-side only.
    *
    * <p>Called from {@link io.grpc.internal.ServerImpl}.
    */
+  @SuppressWarnings("UnusedTypeParameter")
   public <ReqT, RespT> Context serverFilterContext(Context context) {
     Context ctx = checkNotNull(context, "context");
     for (StreamTracer tracer : tracers) {

--- a/core/src/test/java/io/grpc/internal/KeepAliveManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/KeepAliveManagerTest.java
@@ -105,9 +105,9 @@ public final class KeepAliveManagerTest {
   @Test
   public void clientKeepAlivePinger_pingTimeout() {
     ConnectionClientTransport transport = mock(ConnectionClientTransport.class);
-    keepAlivePinger = new ClientKeepAlivePinger(transport);
+    ClientKeepAlivePinger pinger = new ClientKeepAlivePinger(transport);
 
-    keepAlivePinger.onPingTimeout();
+    pinger.onPingTimeout();
 
     ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
     verify(transport).shutdownNow(statusCaptor.capture());
@@ -120,8 +120,8 @@ public final class KeepAliveManagerTest {
   @Test
   public void clientKeepAlivePinger_pingFailure() {
     ConnectionClientTransport transport = mock(ConnectionClientTransport.class);
-    keepAlivePinger = new ClientKeepAlivePinger(transport);
-    keepAlivePinger.ping();
+    ClientKeepAlivePinger pinger = new ClientKeepAlivePinger(transport);
+    pinger.ping();
     ArgumentCaptor<ClientTransport.PingCallback> pingCallbackCaptor =
         ArgumentCaptor.forClass(ClientTransport.PingCallback.class);
     verify(transport).ping(pingCallbackCaptor.capture(), isA(Executor.class));

--- a/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
@@ -162,13 +162,17 @@ public class RetriableStreamTest {
     }
 
     @Override
+    @SuppressWarnings("DirectInvocationOnMock")
     void postCommit() {
       retriableStreamRecorder.postCommit();
     }
 
     @Override
+    @SuppressWarnings("DirectInvocationOnMock")
     ClientStream newSubstream(
-        Metadata metadata, ClientStreamTracer.Factory tracerFactory, int previousAttempts,
+        Metadata metadata,
+        ClientStreamTracer.Factory tracerFactory,
+        int previousAttempts,
         boolean isTransparentRetry) {
       bufferSizeTracer =
           tracerFactory.newClientStreamTracer(STREAM_INFO, metadata);
@@ -178,6 +182,7 @@ public class RetriableStreamTest {
     }
 
     @Override
+    @SuppressWarnings("DirectInvocationOnMock")
     Status prestart() {
       return retriableStreamRecorder.prestart();
     }

--- a/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
+++ b/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
@@ -587,8 +587,6 @@ public class ServiceConfigErrorHandlingTest {
 
       final ServiceConfigParser serviceConfigParser;
       Listener2 listener;
-      boolean shutdown;
-      int refreshCalled;
 
       FakeNameResolver(ServiceConfigParser serviceConfigParser) {
         this.serviceConfigParser = serviceConfigParser;
@@ -606,7 +604,6 @@ public class ServiceConfigErrorHandlingTest {
       }
 
       @Override public void refresh() {
-        refreshCalled++;
         resolved();
       }
 
@@ -623,7 +620,6 @@ public class ServiceConfigErrorHandlingTest {
       }
 
       @Override public void shutdown() {
-        shutdown = true;
       }
 
       @Override

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -633,10 +633,6 @@ public class GrpclbLoadBalancerTest {
 
   @Test
   public void abundantInitialResponse() {
-    Metadata headers = new Metadata();
-    PickSubchannelArgs args = mock(PickSubchannelArgs.class);
-    when(args.getHeaders()).thenReturn(headers);
-
     List<EquivalentAddressGroup> grpclbBalancerList = createResolvedBalancerAddresses(1);
     deliverResolvedAddresses(Collections.<EquivalentAddressGroup>emptyList(), grpclbBalancerList);
     assertEquals(1, fakeOobChannels.size());
@@ -719,10 +715,6 @@ public class GrpclbLoadBalancerTest {
 
   @Test
   public void raceBetweenLoadReportingAndLbStreamClosure() {
-    Metadata headers = new Metadata();
-    PickSubchannelArgs args = mock(PickSubchannelArgs.class);
-    when(args.getHeaders()).thenReturn(headers);
-
     List<EquivalentAddressGroup> grpclbBalancerList = createResolvedBalancerAddresses(1);
     deliverResolvedAddresses(Collections.<EquivalentAddressGroup>emptyList(), grpclbBalancerList);
     assertEquals(1, fakeOobChannels.size());

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -939,7 +939,7 @@ public abstract class AbstractInteropTest {
     requestStream.onCompleted();
     recorder.awaitCompletion();
     assertSuccess(recorder);
-    assertEquals(responseSizes.size() * numRequests, recorder.getValues().size());
+    assertEquals(responseSizes.size() * (long) numRequests, recorder.getValues().size());
     for (int ix = 0; ix < recorder.getValues().size(); ++ix) {
       StreamingOutputCallResponse response = recorder.getValues().get(ix);
       int length = response.getPayload().getBody().size();
@@ -973,7 +973,7 @@ public abstract class AbstractInteropTest {
     requestStream.onCompleted();
     recorder.awaitCompletion();
     assertSuccess(recorder);
-    assertEquals(responseSizes.size() * numRequests, recorder.getValues().size());
+    assertEquals(responseSizes.size() * (long) numRequests, recorder.getValues().size());
     for (int ix = 0; ix < recorder.getValues().size(); ++ix) {
       StreamingOutputCallResponse response = recorder.getValues().get(ix);
       int length = response.getPayload().getBody().size();
@@ -1125,7 +1125,8 @@ public abstract class AbstractInteropTest {
     requestStream.onCompleted();
     recorder.awaitCompletion();
     assertSuccess(recorder);
-    org.junit.Assert.assertEquals(responseSizes.size() * numRequests, recorder.getValues().size());
+    org.junit.Assert.assertEquals(
+        responseSizes.size() * (long) numRequests, recorder.getValues().size());
 
     // Assert that our side channel object is echoed back in both headers and trailers
     Assert.assertEquals(metadataValue, headersCapture.get().get(Util.METADATA_KEY));

--- a/interop-testing/src/main/java/io/grpc/testing/integration/Http2Client.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/Http2Client.java
@@ -272,7 +272,7 @@ public final class Http2Client {
       threadpool = MoreExecutors.listeningDecorator(newFixedThreadPool(numThreads));
       List<ListenableFuture<?>> workerFutures = new ArrayList<>();
       for (int i = 0; i < numThreads; i++) {
-        workerFutures.add(threadpool.submit(new MaxStreamsWorker(i, simpleRequest)));
+        workerFutures.add(threadpool.submit(new MaxStreamsWorker(i)));
       }
       ListenableFuture<?> f = Futures.allAsList(workerFutures);
       f.get(timeoutSeconds, TimeUnit.SECONDS);
@@ -314,11 +314,9 @@ public final class Http2Client {
 
     private class MaxStreamsWorker implements Runnable {
       int threadNum;
-      SimpleRequest request;
 
-      MaxStreamsWorker(int threadNum, SimpleRequest request) {
+      MaxStreamsWorker(int threadNum) {
         this.threadNum = threadNum;
-        this.request = request;
       }
 
       @Override

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
@@ -338,7 +338,7 @@ public final class XdsTestServer {
           try {
             int timeout = Integer.parseInt(
                 callBehavior.substring(CALL_BEHAVIOR_SLEEP_VALUE.length()));
-            Thread.sleep(timeout * 1000);
+            Thread.sleep(timeout * 1000L);
           } catch (NumberFormatException e) {
             newCall.close(
                 Status.INVALID_ARGUMENT.withDescription(

--- a/interop-testing/src/test/java/io/grpc/testing/integration/NettyFlowControlTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/NettyFlowControlTest.java
@@ -190,8 +190,6 @@ public class NettyFlowControlTest {
   private static class TestStreamObserver implements StreamObserver<StreamingOutputCallResponse> {
 
     final AtomicReference<GrpcHttp2ConnectionHandler> grpcHandlerRef;
-    final long startRequestNanos;
-    long endRequestNanos;
     final CountDownLatch latch = new CountDownLatch(1);
     final long expectedWindow;
     int lastWindow;
@@ -200,7 +198,6 @@ public class NettyFlowControlTest {
     public TestStreamObserver(
         AtomicReference<GrpcHttp2ConnectionHandler> grpcHandlerRef, long window) {
       this.grpcHandlerRef = grpcHandlerRef;
-      startRequestNanos = System.nanoTime();
       expectedWindow = window;
     }
 
@@ -232,10 +229,6 @@ public class NettyFlowControlTest {
     @Override
     public void onCompleted() {
       latch.countDown();
-    }
-
-    public long getElapsedTime() {
-      return endRequestNanos - startRequestNanos;
     }
 
     public int waitFor(long duration, TimeUnit unit) throws InterruptedException {

--- a/interop-testing/src/test/java/io/grpc/testing/integration/ProxyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/ProxyTest.java
@@ -93,7 +93,7 @@ public class ProxyTest {
     }
     Collections.sort(rtts);
     long rtt = rtts.get(0);
-    assertEquals(latency, rtt, .5 * latency);
+    assertEquals(latency, (double) rtt, .5 * latency);
   }
 
   @Test
@@ -126,7 +126,7 @@ public class ProxyTest {
     }
     Collections.sort(rtts);
     long rtt = rtts.get(0);
-    assertEquals(latency, rtt, .5 * latency);
+    assertEquals(latency, (double) rtt, .5 * latency);
   }
 
   @Test

--- a/istio-interop-testing/src/main/java/io/grpc/testing/istio/EchoTestServer.java
+++ b/istio-interop-testing/src/main/java/io/grpc/testing/istio/EchoTestServer.java
@@ -494,10 +494,6 @@ public final class EchoTestServer {
       }
     }
 
-    void writeMessage(String message) {
-      sb.append(message);
-    }
-
     @Override
     public String toString() {
       return sb.toString();

--- a/netty/src/main/java/io/grpc/netty/JettyTlsUtil.java
+++ b/netty/src/main/java/io/grpc/netty/JettyTlsUtil.java
@@ -34,6 +34,7 @@ final class JettyTlsUtil {
 
   private static class Java9AlpnUnavailabilityCauseHolder {
 
+    @SuppressWarnings("StaticAssignmentOfThrowable")
     static final Throwable cause = checkAlpnAvailability();
 
     static Throwable checkAlpnAvailability() {
@@ -56,9 +57,8 @@ final class JettyTlsUtil {
     }
   }
 
-  /**
-   * Indicates whether or not the Jetty ALPN jar is installed in the boot classloader.
-   */
+  /** Indicates whether or not the Jetty ALPN jar is installed in the boot classloader. */
+  @SuppressWarnings("StaticAssignmentOfThrowable")
   static synchronized boolean isJettyAlpnConfigured() {
     try {
       Class.forName("org.eclipse.jetty.alpn.ALPN", true, null);
@@ -78,9 +78,8 @@ final class JettyTlsUtil {
     return jettyAlpnUnavailabilityCause;
   }
 
-  /**
-   * Indicates whether or not the Jetty NPN jar is installed in the boot classloader.
-   */
+  /** Indicates whether or not the Jetty NPN jar is installed in the boot classloader. */
+  @SuppressWarnings("StaticAssignmentOfThrowable")
   static synchronized boolean isJettyNpnConfigured() {
     try {
       Class.forName("org.eclipse.jetty.npn.NextProtoNego", true, null);

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -877,7 +877,7 @@ class NettyClientHandler extends AbstractNettyHandler {
   /** If {@code statusCode} is non-null, it will be used instead of the http2 error code mapping. */
   private Status statusFromH2Error(
       Status.Code statusCode, String context, long errorCode, byte[] debugData) {
-    Status status = GrpcUtil.Http2Error.statusForCode((int) errorCode);
+    Status status = GrpcUtil.Http2Error.statusForCode(errorCode);
     if (statusCode == null) {
       statusCode = status.getCode();
     }

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -555,6 +555,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
   }
 
   private class TransportStateImpl extends NettyClientStream.TransportState {
+    @SuppressWarnings("DirectInvocationOnMock")
     public TransportStateImpl(NettyClientHandler handler, int maxMessageSize) {
       super(
           handler,

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -887,12 +887,10 @@ public class NettyClientTransportTest {
 
   private static final class EchoServerStreamListener implements ServerStreamListener {
     final ServerStream stream;
-    final String method;
     final Metadata headers;
 
-    EchoServerStreamListener(ServerStream stream, String method, Metadata headers) {
+    EchoServerStreamListener(ServerStream stream, Metadata headers) {
       this.stream = stream;
-      this.method = method;
       this.headers = headers;
     }
 
@@ -932,7 +930,7 @@ public class NettyClientTransportTest {
       return new ServerTransportListener() {
         @Override
         public void streamCreated(ServerStream stream, String method, Metadata headers) {
-          EchoServerStreamListener listener = new EchoServerStreamListener(stream, method, headers);
+          EchoServerStreamListener listener = new EchoServerStreamListener(stream, headers);
           stream.setListener(listener);
           stream.writeHeaders(new Metadata());
           stream.request(1);

--- a/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
@@ -431,7 +431,7 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
     verifyWrite().writeSettings(
         any(ChannelHandlerContext.class), captor.capture(), any(ChannelPromise.class));
 
-    assertEquals(maxConcurrentStreams, captor.getValue().maxConcurrentStreams().intValue());
+    assertEquals(maxConcurrentStreams, captor.getValue().maxConcurrentStreams().longValue());
   }
 
   @Test
@@ -443,7 +443,7 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
     verifyWrite().writeSettings(
         any(ChannelHandlerContext.class), captor.capture(), any(ChannelPromise.class));
 
-    assertEquals(maxHeaderListSize, captor.getValue().maxHeaderListSize().intValue());
+    assertEquals(maxHeaderListSize, captor.getValue().maxHeaderListSize().longValue());
   }
 
   @Test

--- a/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
@@ -281,6 +281,7 @@ public class NettyServerStreamTest extends NettyStreamTestBase<NettyServerStream
   }
 
   @Override
+  @SuppressWarnings("DirectInvocationOnMock")
   protected NettyServerStream createStream() {
     when(handler.getWriteQueue()).thenReturn(writeQueue);
     StatsTraceContext statsTraceCtx = StatsTraceContext.NOOP;

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpServerTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpServerTransportTest.java
@@ -70,7 +70,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import okio.Buffer;
 import okio.BufferedSource;
 import okio.ByteString;
@@ -130,6 +129,7 @@ public class OkHttpServerTransportTest {
   @Rule public final Timeout globalTimeout = Timeout.seconds(10);
 
   @Before
+  @SuppressWarnings("DirectInvocationOnMock")
   public void setUp() throws Exception {
     doAnswer(answerVoid((Boolean outDone, Integer streamId, BufferedSource in, Integer length) -> {
       in.require(length);
@@ -1294,7 +1294,6 @@ public class OkHttpServerTransportTest {
 
     Deque<String> messages = new ArrayDeque<>();
     boolean halfClosedCalled;
-    boolean onReadyCalled;
     Status status;
     CountDownLatch closed = new CountDownLatch(1);
 
@@ -1335,19 +1334,6 @@ public class OkHttpServerTransportTest {
 
     @Override
     public void onReady() {
-      onReadyCalled = true;
-    }
-
-    boolean isOnReadyCalled() {
-      boolean value = onReadyCalled;
-      onReadyCalled = false;
-      return value;
-    }
-
-    void waitUntilStreamClosed() throws InterruptedException, TimeoutException {
-      if (!closed.await(TIME_OUT_MS, TimeUnit.MILLISECONDS)) {
-        throw new TimeoutException("Failed waiting stream to be closed.");
-      }
     }
 
     static String getContent(InputStream message) throws IOException {

--- a/okhttp/src/test/java/io/grpc/okhttp/OptionalMethodTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OptionalMethodTest.java
@@ -50,6 +50,7 @@ public class OptionalMethodTest {
   }
 
   private static class PrivateClass {
+    @SuppressWarnings("UnusedMethod")
     public String testMethod(String arg) {
       return arg;
     }

--- a/rls/src/main/java/io/grpc/rls/LinkedHashLruCache.java
+++ b/rls/src/main/java/io/grpc/rls/LinkedHashLruCache.java
@@ -371,7 +371,7 @@ abstract class LinkedHashLruCache<K, V> implements LruCache<K, V> {
 
     @Override
     public void onEviction(K key, SizedValue value, EvictionType cause) {
-      estimatedSizeBytes.addAndGet(-1 * value.size);
+      estimatedSizeBytes.addAndGet(-1L * value.size);
       if (delegate != null) {
         delegate.onEviction(key, value.value, cause);
       }

--- a/services/src/main/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactory.java
+++ b/services/src/main/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactory.java
@@ -163,13 +163,9 @@ final class HealthCheckingLoadBalancerFactory extends LoadBalancer.Factory {
   private static final class HealthCheckingLoadBalancer extends ForwardingLoadBalancer {
     final LoadBalancer delegate;
     final HelperImpl helper;
-    final SynchronizationContext syncContext;
-    final ScheduledExecutorService timerService;
 
     HealthCheckingLoadBalancer(HelperImpl helper, LoadBalancer delegate) {
       this.helper = checkNotNull(helper, "helper");
-      this.syncContext = checkNotNull(helper.getSynchronizationContext(), "syncContext");
-      this.timerService = checkNotNull(helper.getScheduledExecutorService(), "timerService");
       this.delegate = checkNotNull(delegate, "delegate");
     }
 

--- a/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
@@ -1349,15 +1349,5 @@ public class ClusterResolverLoadBalancerTest {
       shutdown = true;
       childBalancers.remove(this);
     }
-
-    void deliverSubchannelState(final Subchannel subchannel, ConnectivityState state) {
-      SubchannelPicker picker = new SubchannelPicker() {
-        @Override
-        public PickResult pickSubchannel(PickSubchannelArgs args) {
-          return PickResult.withSubchannel(subchannel);
-        }
-      };
-      helper.updateBalancingState(state, picker);
-    }
   }
 }

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -2043,12 +2043,8 @@ public class XdsNameResolverTest {
   }
 
   private final class FakeXdsClientPoolFactory implements XdsClientPoolFactory {
-    Map<String, ?> bootstrap;
-
     @Override
-    public void setBootstrapOverride(Map<String, ?> bootstrap) {
-      this.bootstrap = bootstrap;
-    }
+    public void setBootstrapOverride(Map<String, ?> bootstrap) {}
 
     @Override
     @Nullable

--- a/xds/src/test/java/io/grpc/xds/XdsServerWrapperTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerWrapperTest.java
@@ -943,8 +943,8 @@ public class XdsServerWrapperTest {
     xdsClient.ldsResource.get(5, TimeUnit.SECONDS);
     verify(mockBuilder).intercept(interceptorCaptor.capture());
     ConfigApplyingInterceptor interceptor = interceptorCaptor.getValue();
-    ServerRoutingConfig routingConfig = createRoutingConfig("/FooService/barMethod",
-            "foo.google.com", "filter-type-url");
+    ServerRoutingConfig routingConfig =
+        createRoutingConfig("/FooService/barMethod", "foo.google.com");
     ServerCall<Void, Void> serverCall = mock(ServerCall.class);
     when(serverCall.getAttributes()).thenReturn(
         Attributes.newBuilder().set(ATTR_SERVER_ROUTING_CONFIG,
@@ -983,8 +983,8 @@ public class XdsServerWrapperTest {
     xdsClient.ldsResource.get(5, TimeUnit.SECONDS);
     verify(mockBuilder).intercept(interceptorCaptor.capture());
     ConfigApplyingInterceptor interceptor = interceptorCaptor.getValue();
-    ServerRoutingConfig routingConfig = createRoutingConfig("/FooService/barMethod",
-            "foo.google.com", "filter-type-url");
+    ServerRoutingConfig routingConfig =
+        createRoutingConfig("/FooService/barMethod", "foo.google.com");
     ServerCall<Void, Void> serverCall = mock(ServerCall.class);
     when(serverCall.getAttributes()).thenReturn(
             Attributes.newBuilder()
@@ -1024,10 +1024,12 @@ public class XdsServerWrapperTest {
     xdsClient.ldsResource.get(5, TimeUnit.SECONDS);
     verify(mockBuilder).intercept(interceptorCaptor.capture());
     ConfigApplyingInterceptor interceptor = interceptorCaptor.getValue();
-    ServerRoutingConfig routingConfig = createRoutingConfig("/FooService/barMethod",
-        "foo.google.com", "filter-type-url", Route.RouteAction.forCluster(
-            "cluster", Collections.<Route.RouteAction.HashPolicy>emptyList(), null, null
-        ));
+    ServerRoutingConfig routingConfig =
+        createRoutingConfig(
+            "/FooService/barMethod",
+            "foo.google.com",
+            Route.RouteAction.forCluster(
+                "cluster", Collections.<Route.RouteAction.HashPolicy>emptyList(), null, null));
     ServerCall<Void, Void> serverCall = mock(ServerCall.class);
     when(serverCall.getAttributes()).thenReturn(
         Attributes.newBuilder()
@@ -1286,13 +1288,12 @@ public class XdsServerWrapperTest {
         "");
   }
 
-  private static ServerRoutingConfig createRoutingConfig(String path, String domain,
-                                                         String filterType) {
-    return createRoutingConfig(path, domain, filterType, null);
+  private static ServerRoutingConfig createRoutingConfig(String path, String domain) {
+    return createRoutingConfig(path, domain, null);
   }
 
-  private static ServerRoutingConfig createRoutingConfig(String path, String domain,
-      String filterType, Route.RouteAction action) {
+  private static ServerRoutingConfig createRoutingConfig(
+      String path, String domain, Route.RouteAction action) {
     RouteMatch routeMatch =
         RouteMatch.create(
             PathMatcher.fromPath(path, true),
@@ -1302,8 +1303,6 @@ public class XdsServerWrapperTest {
         Arrays.asList(Route.forAction(routeMatch, action,
             ImmutableMap.<String, FilterConfig>of())),
         Collections.<String, FilterConfig>emptyMap());
-    FilterConfig f0 = mock(FilterConfig.class);
-    when(f0.typeUrl()).thenReturn(filterType);
     return ServerRoutingConfig.create(ImmutableList.<VirtualHost>of(virtualHost),
         ImmutableMap.<Route, ServerInterceptor>of()
     );

--- a/xds/third_party/zero-allocation-hashing/test/java/io/grpc/xds/XxHash64Test.java
+++ b/xds/third_party/zero-allocation-hashing/test/java/io/grpc/xds/XxHash64Test.java
@@ -136,7 +136,7 @@ public class XxHash64Test {
         long eightByteExpected = f.hashBytes(bytes);
         assertEquals("byte hash", oneByteExpected, f.hashByte((byte) -1));
         assertEquals("short hash", twoByteExpected, f.hashShort((short) -1));
-        assertEquals("char hash", twoByteExpected, f.hashChar((char) -1));
+        assertEquals("char hash", twoByteExpected, f.hashChar(Character.MAX_VALUE));
         assertEquals("int hash", fourByteExpected, f.hashInt(-1));
         assertEquals("long hash", eightByteExpected, f.hashLong(-1L));
       }


### PR DESCRIPTION
errorprone cannot be updated past 2.10 because later versions do not support Java 8.

Fixes https://github.com/grpc/grpc-java/issues/9916.