### PR TITLE
Add onCloseHandler also for ClientCallStreamObserver

### DIFF
--- a/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
@@ -131,4 +131,12 @@ public abstract class CallStreamObserver<V> implements StreamObserver<V> {
    * @param enable whether to enable compression.
    */
   public abstract void setMessageCompression(boolean enable);
+
+  /**
+   * Sets a {@link Runnable} to be executed when the call is closed.
+   *
+   * @param onCloseHandler to call when the call is closed.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8467")
+  public abstract void setOnCloseHandler(Runnable onCloseHandler);
 }

--- a/stub/src/main/java/io/grpc/stub/ClientCallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCallStreamObserver.java
@@ -109,4 +109,15 @@ public abstract class ClientCallStreamObserver<ReqT> extends CallStreamObserver<
    */
   @Override
   public abstract void setMessageCompression(boolean enable);
+
+  /**
+   * Sets a {@link Runnable} to be executed when the call is closed and the client is encouraged
+   * to abort processing to save resources.
+   *
+   * @param onCloseHandler to call when the call is closed.
+   */
+  @Override
+  public void setOnCloseHandler(Runnable onCloseHandler) {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
@@ -16,8 +16,6 @@
 
 package io.grpc.stub;
 
-import io.grpc.ExperimentalApi;
-
 /**
  * A refinement of {@link CallStreamObserver} to allows for interaction with call
  * cancellation events on the server side. An instance of this class is obtained by casting the
@@ -167,7 +165,7 @@ public abstract class ServerCallStreamObserver<RespT> extends CallStreamObserver
    *
    * @param onCloseHandler to execute when the call has been closed cleanly.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8467")
+  @Override
   public void setOnCloseHandler(Runnable onCloseHandler) {
     throw new UnsupportedOperationException();
   }


### PR DESCRIPTION
I have a need for detecting when the call is closed from the ClientCallStreamObserver (I want to be able to convert the ClientCallStreamObserver to a reactive subscriber, and cancel the subscription when the call is closed).

This change moves the onCloseHandler from ServerCallStreamObserver to CallStreamObserver, in effect also adding it to ClientCallStreamObserver.