### PR TITLE
core: fix outlier detection default ejection time

### DIFF
--- a/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
@@ -880,7 +880,7 @@ public final class OutlierDetectionLoadBalancer extends LoadBalancer {
     public static class Builder {
       Long intervalNanos = 10_000_000_000L; // 10s
       Long baseEjectionTimeNanos = 30_000_000_000L; // 30s
-      Long maxEjectionTimeNanos = 30_000_000_000L; // 30s
+      Long maxEjectionTimeNanos = 300_000_000_000L; // 300s
       Integer maxEjectionPercent = 10;
       SuccessRateEjection successRateEjection;
       FailurePercentageEjection failurePercentageEjection;


### PR DESCRIPTION
This updates the value to match what is specified in [gRFC A50](https://github.com/grpc/proposal/blob/master/A50-xds-outlier-detection.md).

Based on PR #9806 by @richardartoul that can't be merged without CLA authorization.