### PR TITLE
gcp-observability: add new *compressed_bytes_per_rpc views

### DIFF
--- a/census/src/main/java/io/grpc/census/internal/ObservabilityCensusConstants.java
+++ b/census/src/main/java/io/grpc/census/internal/ObservabilityCensusConstants.java
@@ -61,7 +61,7 @@ public final class ObservabilityCensusConstants {
   public static final View GRPC_CLIENT_SENT_COMPRESSED_MESSAGE_BYTES_PER_RPC =
       View.create(
           View.Name.create("grpc.io/client/sent_compressed_message_bytes_per_rpc"),
-          "Sent compressed message bytes per RPC",
+          "Compressed message bytes sent per client RPC attempt",
           GRPC_CLIENT_SENT_BYTES_PER_RPC,
           AGGREGATION_WITH_BYTES_HISTOGRAM,
           Arrays.asList(GRPC_CLIENT_METHOD, GRPC_CLIENT_STATUS));
@@ -69,7 +69,7 @@ public final class ObservabilityCensusConstants {
   public static final View GRPC_CLIENT_RECEIVED_COMPRESSED_MESSAGE_BYTES_PER_RPC =
       View.create(
           View.Name.create("grpc.io/client/received_compressed_message_bytes_per_rpc"),
-          "Received compressed message bytes per RPC",
+          "Compressed message bytes received per client RPC attempt",
           GRPC_CLIENT_RECEIVED_BYTES_PER_RPC,
           AGGREGATION_WITH_BYTES_HISTOGRAM,
           Arrays.asList(GRPC_CLIENT_METHOD, GRPC_CLIENT_STATUS));
@@ -77,7 +77,7 @@ public final class ObservabilityCensusConstants {
   public static final View GRPC_SERVER_SENT_COMPRESSED_MESSAGE_BYTES_PER_RPC =
       View.create(
           View.Name.create("grpc.io/server/sent_compressed_message_bytes_per_rpc"),
-          "Sent compressed message bytes per RPC",
+          "Compressed message bytes sent per server RPC",
           GRPC_SERVER_SENT_BYTES_PER_RPC,
           AGGREGATION_WITH_BYTES_HISTOGRAM,
           Arrays.asList(GRPC_SERVER_METHOD, GRPC_SERVER_STATUS));
@@ -85,7 +85,7 @@ public final class ObservabilityCensusConstants {
   public static final View GRPC_SERVER_RECEIVED_COMPRESSED_MESSAGE_BYTES_PER_RPC =
       View.create(
           View.Name.create("grpc.io/server/received_compressed_message_bytes_per_rpc"),
-          "Received compressed message bytes per RPC",
+          "Compressed message bytes received per server RPC",
           GRPC_SERVER_RECEIVED_BYTES_PER_RPC,
           AGGREGATION_WITH_BYTES_HISTOGRAM,
           Arrays.asList(GRPC_SERVER_METHOD, GRPC_SERVER_STATUS));

--- a/census/src/main/java/io/grpc/census/internal/ObservabilityCensusConstants.java
+++ b/census/src/main/java/io/grpc/census/internal/ObservabilityCensusConstants.java
@@ -25,38 +25,17 @@ import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_SENT_BYTES_PER_RPC;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_STATUS;
 
+import io.opencensus.contrib.grpc.metrics.RpcViewConstants;
 import io.opencensus.stats.Aggregation;
-import io.opencensus.stats.Aggregation.Distribution;
-import io.opencensus.stats.BucketBoundaries;
 import io.opencensus.stats.View;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 /** Temporary holder class for the observability specific OpenCensus constants.
  *  The class will be removed once the new views are added in OpenCensus library. */
 public final class ObservabilityCensusConstants {
 
-  static final List<Double> RPC_BYTES_BUCKET_BOUNDARIES =
-      Collections.unmodifiableList(
-          Arrays.asList(
-              0.0,
-              1024.0,
-              2048.0,
-              4096.0,
-              16384.0,
-              65536.0,
-              262144.0,
-              1048576.0,
-              4194304.0,
-              16777216.0,
-              67108864.0,
-              268435456.0,
-              1073741824.0,
-              4294967296.0));
-
   static final Aggregation AGGREGATION_WITH_BYTES_HISTOGRAM =
-      Distribution.create(BucketBoundaries.create(RPC_BYTES_BUCKET_BOUNDARIES));
+      RpcViewConstants.GRPC_CLIENT_SENT_BYTES_PER_RPC_VIEW.getAggregation();
 
   public static final View GRPC_CLIENT_SENT_COMPRESSED_MESSAGE_BYTES_PER_RPC =
       View.create(

--- a/census/src/main/java/io/grpc/census/internal/ObservabilityCensusConstants.java
+++ b/census/src/main/java/io/grpc/census/internal/ObservabilityCensusConstants.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.census.internal;
+
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_METHOD;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_RPC;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_SENT_BYTES_PER_RPC;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_STATUS;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_METHOD;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_RECEIVED_BYTES_PER_RPC;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_SENT_BYTES_PER_RPC;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_STATUS;
+
+import io.opencensus.stats.Aggregation;
+import io.opencensus.stats.Aggregation.Distribution;
+import io.opencensus.stats.BucketBoundaries;
+import io.opencensus.stats.View;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/** Temporary holder class for the observability specific OpenCensus constants.
+ *  The class will be removed once the new views are added in OpenCensus library. */
+public final class ObservabilityCensusConstants {
+
+  static final List<Double> RPC_BYTES_BUCKET_BOUNDARIES =
+      Collections.unmodifiableList(
+          Arrays.asList(
+              0.0,
+              1024.0,
+              2048.0,
+              4096.0,
+              16384.0,
+              65536.0,
+              262144.0,
+              1048576.0,
+              4194304.0,
+              16777216.0,
+              67108864.0,
+              268435456.0,
+              1073741824.0,
+              4294967296.0));
+
+  static final Aggregation AGGREGATION_WITH_BYTES_HISTOGRAM =
+      Distribution.create(BucketBoundaries.create(RPC_BYTES_BUCKET_BOUNDARIES));
+
+  public static final View GRPC_CLIENT_SENT_COMPRESSED_MESSAGE_BYTES_PER_RPC =
+      View.create(
+          View.Name.create("grpc.io/client/sent_compressed_message_bytes_per_rpc"),
+          "Sent compressed message bytes per RPC",
+          GRPC_CLIENT_SENT_BYTES_PER_RPC,
+          AGGREGATION_WITH_BYTES_HISTOGRAM,
+          Arrays.asList(GRPC_CLIENT_METHOD, GRPC_CLIENT_STATUS));
+
+  public static final View GRPC_CLIENT_RECEIVED_COMPRESSED_MESSAGE_BYTES_PER_RPC =
+      View.create(
+          View.Name.create("grpc.io/client/received_compressed_message_bytes_per_rpc"),
+          "Received compressed message bytes per RPC",
+          GRPC_CLIENT_RECEIVED_BYTES_PER_RPC,
+          AGGREGATION_WITH_BYTES_HISTOGRAM,
+          Arrays.asList(GRPC_CLIENT_METHOD, GRPC_CLIENT_STATUS));
+
+  public static final View GRPC_SERVER_SENT_COMPRESSED_MESSAGE_BYTES_PER_RPC =
+      View.create(
+          View.Name.create("grpc.io/server/sent_compressed_message_bytes_per_rpc"),
+          "Sent compressed message bytes per RPC",
+          GRPC_SERVER_SENT_BYTES_PER_RPC,
+          AGGREGATION_WITH_BYTES_HISTOGRAM,
+          Arrays.asList(GRPC_SERVER_METHOD, GRPC_SERVER_STATUS));
+
+  public static final View GRPC_SERVER_RECEIVED_COMPRESSED_MESSAGE_BYTES_PER_RPC =
+      View.create(
+          View.Name.create("grpc.io/server/received_compressed_message_bytes_per_rpc"),
+          "Received compressed message bytes per RPC",
+          GRPC_SERVER_RECEIVED_BYTES_PER_RPC,
+          AGGREGATION_WITH_BYTES_HISTOGRAM,
+          Arrays.asList(GRPC_SERVER_METHOD, GRPC_SERVER_STATUS));
+
+  private ObservabilityCensusConstants() {}
+}

--- a/census/src/main/java/io/grpc/census/internal/ObservabilityCensusConstants.java
+++ b/census/src/main/java/io/grpc/census/internal/ObservabilityCensusConstants.java
@@ -37,7 +37,7 @@ public final class ObservabilityCensusConstants {
   static final Aggregation AGGREGATION_WITH_BYTES_HISTOGRAM =
       RpcViewConstants.GRPC_CLIENT_SENT_BYTES_PER_RPC_VIEW.getAggregation();
 
-  public static final View GRPC_CLIENT_SENT_COMPRESSED_MESSAGE_BYTES_PER_RPC =
+  public static final View GRPC_CLIENT_SENT_COMPRESSED_MESSAGE_BYTES_PER_RPC_VIEW =
       View.create(
           View.Name.create("grpc.io/client/sent_compressed_message_bytes_per_rpc"),
           "Compressed message bytes sent per client RPC attempt",
@@ -45,7 +45,7 @@ public final class ObservabilityCensusConstants {
           AGGREGATION_WITH_BYTES_HISTOGRAM,
           Arrays.asList(GRPC_CLIENT_METHOD, GRPC_CLIENT_STATUS));
 
-  public static final View GRPC_CLIENT_RECEIVED_COMPRESSED_MESSAGE_BYTES_PER_RPC =
+  public static final View GRPC_CLIENT_RECEIVED_COMPRESSED_MESSAGE_BYTES_PER_RPC_VIEW =
       View.create(
           View.Name.create("grpc.io/client/received_compressed_message_bytes_per_rpc"),
           "Compressed message bytes received per client RPC attempt",
@@ -53,7 +53,7 @@ public final class ObservabilityCensusConstants {
           AGGREGATION_WITH_BYTES_HISTOGRAM,
           Arrays.asList(GRPC_CLIENT_METHOD, GRPC_CLIENT_STATUS));
 
-  public static final View GRPC_SERVER_SENT_COMPRESSED_MESSAGE_BYTES_PER_RPC =
+  public static final View GRPC_SERVER_SENT_COMPRESSED_MESSAGE_BYTES_PER_RPC_VIEW =
       View.create(
           View.Name.create("grpc.io/server/sent_compressed_message_bytes_per_rpc"),
           "Compressed message bytes sent per server RPC",
@@ -61,7 +61,7 @@ public final class ObservabilityCensusConstants {
           AGGREGATION_WITH_BYTES_HISTOGRAM,
           Arrays.asList(GRPC_SERVER_METHOD, GRPC_SERVER_STATUS));
 
-  public static final View GRPC_SERVER_RECEIVED_COMPRESSED_MESSAGE_BYTES_PER_RPC =
+  public static final View GRPC_SERVER_RECEIVED_COMPRESSED_MESSAGE_BYTES_PER_RPC_VIEW =
       View.create(
           View.Name.create("grpc.io/server/received_compressed_message_bytes_per_rpc"),
           "Compressed message bytes received per server RPC",

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/GcpObservability.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/GcpObservability.java
@@ -155,18 +155,18 @@ public final class GcpObservability implements AutoCloseable {
     viewManager.registerView(RpcViewConstants.GRPC_CLIENT_STARTED_RPC_VIEW);
     viewManager.registerView(RpcViewConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY_VIEW);
     viewManager.registerView(
-        ObservabilityCensusConstants.GRPC_CLIENT_SENT_COMPRESSED_MESSAGE_BYTES_PER_RPC);
+        ObservabilityCensusConstants.GRPC_CLIENT_SENT_COMPRESSED_MESSAGE_BYTES_PER_RPC_VIEW);
     viewManager.registerView(
-        ObservabilityCensusConstants.GRPC_CLIENT_RECEIVED_COMPRESSED_MESSAGE_BYTES_PER_RPC);
+        ObservabilityCensusConstants.GRPC_CLIENT_RECEIVED_COMPRESSED_MESSAGE_BYTES_PER_RPC_VIEW);
 
     // server views
     viewManager.registerView(RpcViewConstants.GRPC_SERVER_COMPLETED_RPC_VIEW);
     viewManager.registerView(RpcViewConstants.GRPC_SERVER_STARTED_RPC_VIEW);
     viewManager.registerView(RpcViewConstants.GRPC_SERVER_SERVER_LATENCY_VIEW);
     viewManager.registerView(
-        ObservabilityCensusConstants.GRPC_SERVER_SENT_COMPRESSED_MESSAGE_BYTES_PER_RPC);
+        ObservabilityCensusConstants.GRPC_SERVER_SENT_COMPRESSED_MESSAGE_BYTES_PER_RPC_VIEW);
     viewManager.registerView(
-        ObservabilityCensusConstants.GRPC_SERVER_RECEIVED_COMPRESSED_MESSAGE_BYTES_PER_RPC);
+        ObservabilityCensusConstants.GRPC_SERVER_RECEIVED_COMPRESSED_MESSAGE_BYTES_PER_RPC_VIEW);
   }
 
   @VisibleForTesting

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/GcpObservability.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/GcpObservability.java
@@ -28,6 +28,7 @@ import io.grpc.ServerInterceptor;
 import io.grpc.ServerStreamTracer;
 import io.grpc.census.InternalCensusStatsAccessor;
 import io.grpc.census.InternalCensusTracingAccessor;
+import io.grpc.census.internal.ObservabilityCensusConstants;
 import io.grpc.gcp.observability.interceptors.ConditionalClientInterceptor;
 import io.grpc.gcp.observability.interceptors.ConfigFilterHelper;
 import io.grpc.gcp.observability.interceptors.InternalLoggingChannelInterceptor;
@@ -152,10 +153,20 @@ public final class GcpObservability implements AutoCloseable {
     // client views
     viewManager.registerView(RpcViewConstants.GRPC_CLIENT_COMPLETED_RPC_VIEW);
     viewManager.registerView(RpcViewConstants.GRPC_CLIENT_STARTED_RPC_VIEW);
+    viewManager.registerView(RpcViewConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY_VIEW);
+    viewManager.registerView(
+        ObservabilityCensusConstants.GRPC_CLIENT_SENT_COMPRESSED_MESSAGE_BYTES_PER_RPC);
+    viewManager.registerView(
+        ObservabilityCensusConstants.GRPC_CLIENT_RECEIVED_COMPRESSED_MESSAGE_BYTES_PER_RPC);
 
     // server views
     viewManager.registerView(RpcViewConstants.GRPC_SERVER_COMPLETED_RPC_VIEW);
     viewManager.registerView(RpcViewConstants.GRPC_SERVER_STARTED_RPC_VIEW);
+    viewManager.registerView(RpcViewConstants.GRPC_SERVER_SERVER_LATENCY_VIEW);
+    viewManager.registerView(
+        ObservabilityCensusConstants.GRPC_SERVER_SENT_COMPRESSED_MESSAGE_BYTES_PER_RPC);
+    viewManager.registerView(
+        ObservabilityCensusConstants.GRPC_SERVER_RECEIVED_COMPRESSED_MESSAGE_BYTES_PER_RPC);
   }
 
   @VisibleForTesting


### PR DESCRIPTION
This PR adds new views for payload metrics and registers new views along with latency related views for gcp-observability. 

List of new views for payload metrics:
Client Views
* `grpc.io/client/sent_compressed_message_bytes_per_rpc`
* `grpc.io/client/received_compressed_message_bytes_per_rpc`

Server Views
* `grpc.io/server/sent_compressed_message_bytes_per_rpc`
* `grpc.io/server/received_compressed_message_bytes_per_rpc`

Note: Payload related views are defined in `grpc-census` temporarily. This will be moved to [`opencensus-java`](https://github.com/census-instrumentation/opencensus-java) repository later.

The above listed views along with latency related views are enabled for `gcp-observability`.

CC @sanjaypujare @ejona86