### PR TITLE
xds: deletion only to watchers of same control plane

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -477,8 +477,11 @@ final class XdsClientImpl extends XdsClient
       }
 
       // For State of the World services, notify watchers when their watched resource is missing
-      // from the ADS update.
-      subscriber.onAbsent();
+      // from the ADS update. Note that we can only do this if the resource update is coming from
+      // the same xDS server that the ResourceSubscriber is subscribed to.
+      if (subscriber.serverInfo.target().equals(args.serverInfo.target())) {
+        subscriber.onAbsent();
+      }
     }
   }
 

--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -479,7 +479,7 @@ final class XdsClientImpl extends XdsClient
       // For State of the World services, notify watchers when their watched resource is missing
       // from the ADS update. Note that we can only do this if the resource update is coming from
       // the same xDS server that the ResourceSubscriber is subscribed to.
-      if (subscriber.serverInfo.target().equals(args.serverInfo.target())) {
+      if (subscriber.serverInfo.equals(args.serverInfo)) {
         subscriber.onAbsent();
       }
     }

--- a/xds/src/test/java/io/grpc/xds/ControlPlaneRule.java
+++ b/xds/src/test/java/io/grpc/xds/ControlPlaneRule.java
@@ -127,7 +127,7 @@ public class ControlPlaneRule extends TestWatcher {
 
   @Override protected void finished(Description description) {
     if (server != null) {
-      server.shutdown();
+      server.shutdownNow();
       try {
         if (!server.awaitTermination(5, TimeUnit.SECONDS)) {
           logger.log(Level.SEVERE, "Timed out waiting for server shutdown");

--- a/xds/src/test/java/io/grpc/xds/ControlPlaneRule.java
+++ b/xds/src/test/java/io/grpc/xds/ControlPlaneRule.java
@@ -126,7 +126,6 @@ public class ControlPlaneRule extends TestWatcher {
 
   @Override protected void finished(Description description) {
     if (server != null) {
-      System.out.println(">>> shutting down server on port " + server.getPort());
       server.shutdown();
       try {
         logger.info("awaiting termination");

--- a/xds/src/test/java/io/grpc/xds/ControlPlaneRule.java
+++ b/xds/src/test/java/io/grpc/xds/ControlPlaneRule.java
@@ -128,14 +128,12 @@ public class ControlPlaneRule extends TestWatcher {
     if (server != null) {
       server.shutdown();
       try {
-        logger.info("awaiting termination");
         if (!server.awaitTermination(5, TimeUnit.SECONDS)) {
           logger.log(Level.SEVERE, "Timed out waiting for server shutdown");
         }
       } catch (InterruptedException e) {
         throw new AssertionError("unable to shut down control plane server", e);
       }
-      logger.info("server terminated");
     }
     NameResolverRegistry.getDefaultRegistry().deregister(nameResolverProvider);
   }

--- a/xds/src/test/java/io/grpc/xds/ControlPlaneRule.java
+++ b/xds/src/test/java/io/grpc/xds/ControlPlaneRule.java
@@ -85,12 +85,13 @@ public class ControlPlaneRule extends TestWatcher {
   private XdsTestControlPlaneService controlPlaneService;
   private XdsNameResolverProvider nameResolverProvider;
 
-  public ControlPlaneRule(String serverHostName) {
-    this.serverHostName = serverHostName;
+  public ControlPlaneRule() {
+    serverHostName = "test-server";
   }
 
-  public ControlPlaneRule() {
-    this("test-server");
+  public ControlPlaneRule setServerHostName(String serverHostName) {
+    this.serverHostName = serverHostName;
+    return this;
   }
 
   /**

--- a/xds/src/test/java/io/grpc/xds/XdsClientFederationTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientFederationTest.java
@@ -93,7 +93,6 @@ public class XdsClientFederationTest {
         "xdstp://server-one/envoy.config.listener.v3.Listener/test-server", mockDirectPathWatcher);
     verify(mockDirectPathWatcher, timeout(20000)).onResourceDoesNotExist(
         "xdstp://server-one/envoy.config.listener.v3.Listener/test-server");
-    verify(mockWatcher, timeout(20000)).onResourceDoesNotExist("test-server");
 
     // Add a normal server resource and observe a changed event on the normal watcher and
     // a onResourceDoesNotExist() on the DirectPath watcher as it's resource is not yet created.

--- a/xds/src/test/java/io/grpc/xds/XdsClientFederationTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientFederationTest.java
@@ -77,7 +77,6 @@ public class XdsClientFederationTest {
   @After
   public void cleanUp() throws InterruptedException {
     BootstrapperImpl.enableFederation = originalFederationStatus;
-    xdsClient.shutdown();
     xdsClientPool.returnObject(xdsClient);
   }
 

--- a/xds/src/test/java/io/grpc/xds/XdsClientFederationTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientFederationTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2023 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.grpc.xds.XdsClient.ResourceWatcher;
+import io.grpc.xds.XdsListenerResource.LdsUpdate;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Tests for xDS control plane federation scenarios.
+ */
+@RunWith(JUnit4.class)
+public class XdsClientFederationTest {
+
+  @Mock
+  private ResourceWatcher<LdsUpdate> mockDirectPathWatcher;
+
+  @Mock
+  private ResourceWatcher<LdsUpdate> mockWatcher;
+
+  private static final String SERVER_LISTENER_TEMPLATE_NO_REPLACEMENT =
+      "grpc/server?udpa.resource.listening_address=";
+
+  @Rule
+  public ControlPlaneRule trafficdirector = new ControlPlaneRule("test-server");
+
+  @Rule
+  public ControlPlaneRule directpathPa = new ControlPlaneRule(
+      "xdstp://server-one/envoy.config.listener.v3.Listener/test-server");
+
+  private XdsClient xdsClient;
+  private boolean originalFederationStatus;
+
+  @Before
+  public void setUp() throws XdsInitializationException {
+    MockitoAnnotations.initMocks(this);
+
+    originalFederationStatus = BootstrapperImpl.enableFederation;
+    BootstrapperImpl.enableFederation = true;
+
+    SharedXdsClientPoolProvider clientPoolProvider = new SharedXdsClientPoolProvider();
+    clientPoolProvider.setBootstrapOverride(defaultBootstrapOverride());
+    xdsClient = clientPoolProvider.getOrCreate().getObject();
+  }
+
+  @After
+  public void cleanUp() throws InterruptedException {
+    BootstrapperImpl.enableFederation = originalFederationStatus;
+  }
+
+  // Assures that resource deletions happening in one control plane do not trigger deletion events
+  /// in watchers of resources on other control planes.
+  @Test
+  public void isolatedResourceDeletions() throws InterruptedException {
+    // Add the mock watcher for the normal server resource. The test control plane will send
+    // a deletion event.
+    xdsClient.watchXdsResource(XdsListenerResource.getInstance(), "test-server", mockWatcher);
+    verify(mockWatcher, timeout(20000)).onResourceDoesNotExist("test-server");
+
+    // Add the watcher for the DirectPath server.
+    xdsClient.watchXdsResource(XdsListenerResource.getInstance(),
+        "xdstp://server-one/envoy.config.listener.v3.Listener/test-server", mockDirectPathWatcher);
+    verify(mockDirectPathWatcher, timeout(20000)).onResourceDoesNotExist(
+        "xdstp://server-one/envoy.config.listener.v3.Listener/test-server");
+    verify(mockWatcher, timeout(20000)).onResourceDoesNotExist("test-server");
+
+    // Add a normal server resource and observe a changed event on the normal watcher and
+    // a onResourceDoesNotExist() on the DirectPath watcher as it's resource is not yet created.
+    trafficdirector.setLdsConfig(ControlPlaneRule.buildServerListener(),
+        ControlPlaneRule.buildClientListener("test-server"));
+    verify(mockWatcher, timeout(20000)).onChanged(isA(LdsUpdate.class));
+    verify(mockDirectPathWatcher, timeout(20000)).onResourceDoesNotExist(
+        "xdstp://server-one/envoy.config.listener.v3.Listener/test-server");
+
+    // Modifying the DirectPath server resource triggers a changed event on the DirectPath watcher.
+    directpathPa.setLdsConfig(ControlPlaneRule.buildServerListener(),
+        ControlPlaneRule.buildClientListener(
+            "xdstp://server-one/envoy.config.listener.v3.Listener/test-server"));
+    verify(mockDirectPathWatcher, timeout(20000)).onChanged(isA(LdsUpdate.class));
+
+    // And the crux of the test: deleting a resource (here by renaming it) in one control plane
+    // (here the "normal TrafficDirector" one) should not trigger an onResourceDoesNotExist() call
+    // on a watcher of another control plane (here the DirectPath one).
+    trafficdirector.setLdsConfig(ControlPlaneRule.buildServerListener(),
+        ControlPlaneRule.buildClientListener("new-server"));
+    verify(mockWatcher, timeout(20000)).onResourceDoesNotExist("test-server");
+    verifyNoMoreInteractions(mockDirectPathWatcher);
+  }
+
+  private Map<String, ?> defaultBootstrapOverride() {
+    return ImmutableMap.of(
+        "node", ImmutableMap.of(
+            "id", UUID.randomUUID().toString(),
+            "cluster", "cluster0"),
+        "xds_servers", ImmutableList.of(
+            ImmutableMap.of(
+                "server_uri", "localhost:" + trafficdirector.getServer().getPort(),
+                "channel_creds", Collections.singletonList(
+                    ImmutableMap.of("type", "insecure")
+                ),
+                "server_features", Collections.singletonList("xds_v3")
+            )
+        ),
+        "authorities", ImmutableMap.of(
+            "", ImmutableMap.of(),
+            "server-one", ImmutableMap.of(
+                "xds_servers", ImmutableList.of(
+                    ImmutableMap.of(
+                        "server_uri", "localhost:" + directpathPa.getServer().getPort(),
+                        "channel_creds", Collections.singletonList(
+                            ImmutableMap.of("type", "insecure")
+                        ),
+                        "server_features", Collections.singletonList("xds_v3")
+                    )
+                )
+            ),
+            "server-two", ImmutableMap.of()
+        ),
+        "server_listener_resource_name_template", SERVER_LISTENER_TEMPLATE_NO_REPLACEMENT
+    );
+  }
+}

--- a/xds/src/test/java/io/grpc/xds/XdsClientFederationTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientFederationTest.java
@@ -93,7 +93,7 @@ public class XdsClientFederationTest {
             "xdstp://server-one/envoy.config.listener.v3.Listener/test-server"));
 
     // By setting the LDS config with a new server name we effectively make the old server to go
-    // away as it is not in the configuration anymore. This change in one control plain (here the
+    // away as it is not in the configuration anymore. This change in one control plane (here the
     // "normal TrafficDirector" one) should not trigger an onResourceDoesNotExist() call on a
     // watcher of another control plane (here the DirectPath one).
     trafficdirector.setLdsConfig(ControlPlaneRule.buildServerListener(),

--- a/xds/src/test/java/io/grpc/xds/XdsClientFederationTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientFederationTest.java
@@ -52,10 +52,10 @@ public class XdsClientFederationTest {
       "grpc/server?udpa.resource.listening_address=";
 
   @Rule
-  public ControlPlaneRule trafficdirector = new ControlPlaneRule("test-server");
+  public ControlPlaneRule trafficdirector = new ControlPlaneRule().setServerHostName("test-server");
 
   @Rule
-  public ControlPlaneRule directpathPa = new ControlPlaneRule(
+  public ControlPlaneRule directpathPa = new ControlPlaneRule().setServerHostName(
       "xdstp://server-one/envoy.config.listener.v3.Listener/test-server");
 
   private XdsClient xdsClient;

--- a/xds/src/test/java/io/grpc/xds/XdsClientFederationTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientFederationTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.grpc.xds.Filter.NamedFilterConfig;
 import io.grpc.xds.XdsClient.ResourceWatcher;
 import io.grpc.xds.XdsListenerResource.LdsUpdate;
 import java.util.Collections;
@@ -82,15 +83,24 @@ public class XdsClientFederationTest {
    */
   @Test
   public void isolatedResourceDeletions() throws InterruptedException {
-    xdsClient.watchXdsResource(XdsListenerResource.getInstance(), "test-server", mockWatcher);
-    xdsClient.watchXdsResource(XdsListenerResource.getInstance(),
-        "xdstp://server-one/envoy.config.listener.v3.Listener/test-server", mockDirectPathWatcher);
-
     trafficdirector.setLdsConfig(ControlPlaneRule.buildServerListener(),
         ControlPlaneRule.buildClientListener("test-server"));
     directpathPa.setLdsConfig(ControlPlaneRule.buildServerListener(),
         ControlPlaneRule.buildClientListener(
             "xdstp://server-one/envoy.config.listener.v3.Listener/test-server"));
+
+    xdsClient.watchXdsResource(XdsListenerResource.getInstance(), "test-server", mockWatcher);
+    xdsClient.watchXdsResource(XdsListenerResource.getInstance(),
+        "xdstp://server-one/envoy.config.listener.v3.Listener/test-server", mockDirectPathWatcher);
+
+    verify(mockWatcher, timeout(2000)).onChanged(
+        LdsUpdate.forApiListener(
+            HttpConnectionManager.forRdsName(0, "route-config.googleapis.com", ImmutableList.of(
+                new NamedFilterConfig("terminal-filter", RouterFilter.ROUTER_CONFIG)))));
+    verify(mockDirectPathWatcher, timeout(2000)).onChanged(
+        LdsUpdate.forApiListener(
+            HttpConnectionManager.forRdsName(0, "route-config.googleapis.com", ImmutableList.of(
+                new NamedFilterConfig("terminal-filter", RouterFilter.ROUTER_CONFIG)))));
 
     // By setting the LDS config with a new server name we effectively make the old server to go
     // away as it is not in the configuration anymore. This change in one control plane (here the


### PR DESCRIPTION
When XdsClient learns that a control plane no longer tracks a resource, it should only notify watchers associated with that control plane.

This matters in control plane federation cases when more than one control plane is in use.