### PR TITLE
grpclb: no SRV lookup for "metadata.google.internal."

### DIFF
--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbNameResolver.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbNameResolver.java
@@ -76,7 +76,10 @@ final class GrpclbNameResolver extends DnsNameResolver {
     ResourceResolver resourceResolver = getResourceResolver();
     if (resourceResolver != null) {
       try {
-        srvRecords = resourceResolver.resolveSrv(GRPCLB_NAME_PREFIX + getHost());
+        // This host behaves "unconventionally" with SRV records - we exclude it here.
+        if (!getHost().equals("metadata.google.internal.")) {
+          srvRecords = resourceResolver.resolveSrv(GRPCLB_NAME_PREFIX + getHost());
+        }
       } catch (Exception e) {
         srvRecordsException = e;
       }


### PR DESCRIPTION
This change is to address b/269159638 about GCP metadata server returning an unexpected REFUSED status instead of NXDOMAIN. This causes a 15s delay with older versions of systemd-resolved.

This issue was observed with systemd 245.4. Version 251 worked without issue.  