### PR TITLE
api: Target schema should be case insensitive

### DIFF
--- a/api/src/main/java/io/grpc/NameResolverProvider.java
+++ b/api/src/main/java/io/grpc/NameResolverProvider.java
@@ -61,6 +61,8 @@ public abstract class NameResolverProvider extends NameResolver.Factory {
    * delegates to {@link Factory#getDefaultScheme()} before {@link NameResolver.Factory} is
    * deprecated in https://github.com/grpc/grpc-java/issues/7133.
    *
+   * <p>The scheme should be lower-case.
+   *
    * @since 1.40.0
    * */
   protected String getScheme() {

--- a/api/src/main/java/io/grpc/NameResolverRegistry.java
+++ b/api/src/main/java/io/grpc/NameResolverRegistry.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -162,7 +163,11 @@ public final class NameResolverRegistry {
     @Override
     @Nullable
     public NameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
-      NameResolverProvider provider = providers().get(targetUri.getScheme());
+      String scheme = targetUri.getScheme();
+      if (scheme == null) {
+        return null;
+      }
+      NameResolverProvider provider = providers().get(scheme.toLowerCase(Locale.US));
       return provider == null ? null : provider.newNameResolver(targetUri, args);
     }
 

--- a/api/src/test/java/io/grpc/NameResolverRegistryTest.java
+++ b/api/src/test/java/io/grpc/NameResolverRegistryTest.java
@@ -183,7 +183,11 @@ public class NameResolverRegistryTest {
         });
 
     assertThat(registry.asFactory().newNameResolver(uri, args)).isNull();
+    assertThat(registry.asFactory().newNameResolver(URI.create("/0.0.0.0:80"), args)).isNull();
+    assertThat(registry.asFactory().newNameResolver(URI.create("///0.0.0.0:80"), args)).isNull();
     assertThat(registry.asFactory().newNameResolver(URI.create("other:///0.0.0.0:80"), args))
+            .isSameInstanceAs(nr);
+    assertThat(registry.asFactory().newNameResolver(URI.create("OTHER:///0.0.0.0:80"), args))
             .isSameInstanceAs(nr);
     assertThat(registry.asFactory().getDefaultScheme()).isEqualTo("dns");
   }


### PR DESCRIPTION
URI schema are case-insensitive. Previously the code would do case-sensitive matching. We expect NameResolverProviders to return the typical canonical scheme formatting, which is lower-case. If a NameResolverProvider returns an unexpected string (upper case, unicode, etc), then it simply won't ever match. Channel users, however, can use either casing in target strings.

The code implicitly already handled relative URIs by returning null, as Map.get(null) returned null.