### PR TITLE
compiler: add missing break in switch statement

### DIFF
--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -608,6 +608,7 @@ static void PrintStub(
       break;
     case ABSTRACT_CLASS:
       GRPC_CODEGEN_FAIL << "Call PrintAbstractClassStub for ABSTRACT_CLASS";
+      break;
     default:
       GRPC_CODEGEN_FAIL << "Cannot determine class name for StubType: " << type;
   }


### PR DESCRIPTION
Linters don't like this kind of stuff.