### PR TITLE
census: add per call latency metric

### DIFF
--- a/census/src/main/java/io/grpc/census/internal/ObservabilityCensusConstants.java
+++ b/census/src/main/java/io/grpc/census/internal/ObservabilityCensusConstants.java
@@ -27,6 +27,8 @@ import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER
 
 import io.opencensus.contrib.grpc.metrics.RpcViewConstants;
 import io.opencensus.stats.Aggregation;
+import io.opencensus.stats.Measure;
+import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.View;
 import java.util.Arrays;
 
@@ -36,6 +38,20 @@ public final class ObservabilityCensusConstants {
 
   static final Aggregation AGGREGATION_WITH_BYTES_HISTOGRAM =
       RpcViewConstants.GRPC_CLIENT_SENT_BYTES_PER_RPC_VIEW.getAggregation();
+
+  public static final MeasureDouble API_LATENCY_PER_CALL =
+      Measure.MeasureDouble.create(
+          "grpc.io/client/api_latency",
+          "Time taken by gRPC to complete an RPC from application's perspective",
+          "ms");
+
+  public static final View GRPC_CLIENT_API_LATENCY_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/api_latency"),
+          "Time taken by gRPC to complete an RPC from application's perspective",
+          API_LATENCY_PER_CALL,
+          AGGREGATION_WITH_BYTES_HISTOGRAM,
+          Arrays.asList(GRPC_CLIENT_METHOD, GRPC_CLIENT_STATUS));
 
   public static final View GRPC_CLIENT_SENT_COMPRESSED_MESSAGE_BYTES_PER_RPC_VIEW =
       View.create(

--- a/census/src/main/java/io/grpc/census/internal/ObservabilityCensusConstants.java
+++ b/census/src/main/java/io/grpc/census/internal/ObservabilityCensusConstants.java
@@ -25,6 +25,7 @@ import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_SENT_BYTES_PER_RPC;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_STATUS;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.opencensus.contrib.grpc.metrics.RpcViewConstants;
 import io.opencensus.stats.Aggregation;
 import io.opencensus.stats.Measure;
@@ -32,12 +33,20 @@ import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.View;
 import java.util.Arrays;
 
-/** Temporary holder class for the observability specific OpenCensus constants.
- *  The class will be removed once the new views are added in OpenCensus library. */
+// TODO(dnvindhya): Remove metric and view definitions from this class once it is moved to
+// OpenCensus library.
+/**
+ * Temporary holder class for the observability specific OpenCensus constants. The class will be
+ * removed once the new views are added in OpenCensus library.
+ */
+@VisibleForTesting
 public final class ObservabilityCensusConstants {
 
   static final Aggregation AGGREGATION_WITH_BYTES_HISTOGRAM =
       RpcViewConstants.GRPC_CLIENT_SENT_BYTES_PER_RPC_VIEW.getAggregation();
+
+  static final Aggregation AGGREGATION_WITH_MILLIS_HISTOGRAM =
+      RpcViewConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY_VIEW.getAggregation();
 
   public static final MeasureDouble API_LATENCY_PER_CALL =
       Measure.MeasureDouble.create(
@@ -50,7 +59,7 @@ public final class ObservabilityCensusConstants {
           View.Name.create("grpc.io/client/api_latency"),
           "Time taken by gRPC to complete an RPC from application's perspective",
           API_LATENCY_PER_CALL,
-          AGGREGATION_WITH_BYTES_HISTOGRAM,
+          AGGREGATION_WITH_MILLIS_HISTOGRAM,
           Arrays.asList(GRPC_CLIENT_METHOD, GRPC_CLIENT_STATUS));
 
   public static final View GRPC_CLIENT_SENT_COMPRESSED_MESSAGE_BYTES_PER_RPC_VIEW =

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/GcpObservability.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/GcpObservability.java
@@ -154,6 +154,7 @@ public final class GcpObservability implements AutoCloseable {
     viewManager.registerView(RpcViewConstants.GRPC_CLIENT_COMPLETED_RPC_VIEW);
     viewManager.registerView(RpcViewConstants.GRPC_CLIENT_STARTED_RPC_VIEW);
     viewManager.registerView(RpcViewConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY_VIEW);
+    viewManager.registerView(ObservabilityCensusConstants.GRPC_CLIENT_API_LATENCY_VIEW);
     viewManager.registerView(
         ObservabilityCensusConstants.GRPC_CLIENT_SENT_COMPRESSED_MESSAGE_BYTES_PER_RPC_VIEW);
     viewManager.registerView(


### PR DESCRIPTION
This PR adds a new measure to calculate time taken by gRPC to complete an RPC (i.e `grpc.io/client/api_latency`).

It also enables corresponding view `GRPC_CLIENT_API_LATENCY_VIEW` for `grpc-gcp-observability`.

Note: New measure and view are defined in `grpc-census` temporarily. This will be moved to [opencensus-java](https://github.com/census-instrumentation/opencensus-java) repository later.

CC @ejona86 @sanjaypujare 