### PR TITLE
compiler: Inform the compiler that GRPC_CODEGEN_FAIL aborts

### DIFF
--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -605,10 +605,8 @@ static void PrintStub(
     case BLOCKING_CLIENT_INTERFACE:
     case FUTURE_CLIENT_INTERFACE:
       GRPC_CODEGEN_FAIL << "Intentionally not creating StubType: " << type;
-      break;
     case ABSTRACT_CLASS:
       GRPC_CODEGEN_FAIL << "Call PrintAbstractClassStub for ABSTRACT_CLASS";
-      break;
     default:
       GRPC_CODEGEN_FAIL << "Cannot determine class name for StubType: " << type;
   }

--- a/compiler/src/java_plugin/cpp/java_generator.h
+++ b/compiler/src/java_plugin/cpp/java_generator.h
@@ -29,7 +29,7 @@ class LogHelper {
 
  public:
   LogHelper(std::ostream* os) : os(os) {}
-  ~LogHelper() {
+  [[ noreturn ]] ~LogHelper() {
     *os << std::endl;
     ::abort();
   }


### PR DESCRIPTION
This is enough for the linter to realize that the missing break cases do not imply fallthrough.