### PR TITLE
Fix ManagedChannelBuilder

### DIFF
--- a/servlet/src/jettyTest/java/io/grpc/servlet/GrpcServletSmokeTest.java
+++ b/servlet/src/jettyTest/java/io/grpc/servlet/GrpcServletSmokeTest.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import io.grpc.BindableService;
 import io.grpc.Channel;
-import io.grpc.ManagedChannelBuilder;
+import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.testing.GrpcCleanupRule;
 import io.grpc.testing.integration.Messages.Payload;
 import io.grpc.testing.integration.Messages.SimpleRequest;
@@ -99,7 +99,7 @@ public class GrpcServletSmokeTest {
   @Test
   public void unaryCall() {
     Channel channel = cleanupRule.register(
-        ManagedChannelBuilder.forAddress(HOST, port).usePlaintext().build());
+        NettyChannelBuilder.forAddress(HOST, port).usePlaintext().build());
     SimpleResponse response = TestServiceGrpc.newBlockingStub(channel).unaryCall(
         SimpleRequest.newBuilder()
             .setResponseSize(1234)

--- a/servlet/src/jettyTest/java/io/grpc/servlet/GrpcServletSmokeTest.java
+++ b/servlet/src/jettyTest/java/io/grpc/servlet/GrpcServletSmokeTest.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import io.grpc.BindableService;
 import io.grpc.Channel;
-import io.grpc.netty.NettyChannelBuilder;
+import io.grpc.ManagedChannelBuilder;
 import io.grpc.testing.GrpcCleanupRule;
 import io.grpc.testing.integration.Messages.Payload;
 import io.grpc.testing.integration.Messages.SimpleRequest;
@@ -99,7 +99,7 @@ public class GrpcServletSmokeTest {
   @Test
   public void unaryCall() {
     Channel channel = cleanupRule.register(
-        NettyChannelBuilder.forAddress(HOST, port).usePlaintext().build());
+        ManagedChannelBuilder.forAddress(HOST, port).usePlaintext().build());
     SimpleResponse response = TestServiceGrpc.newBlockingStub(channel).unaryCall(
         SimpleRequest.newBuilder()
             .setResponseSize(1234)

--- a/servlet/src/jettyTest/java/io/grpc/servlet/JettyInteropTest.java
+++ b/servlet/src/jettyTest/java/io/grpc/servlet/JettyInteropTest.java
@@ -83,10 +83,9 @@ public class JettyInteropTest extends AbstractInteropTest {
 
   @Override
   protected ManagedChannelBuilder<?> createChannelBuilder() {
-    NettyChannelBuilder builder =
-            (NettyChannelBuilder) ManagedChannelBuilder.forAddress(HOST, port)
-                    .usePlaintext()
-                    .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE);
+    NettyChannelBuilder builder = NettyChannelBuilder.forAddress(HOST, port)
+                                  .usePlaintext()
+                                  .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE);
     InternalNettyChannelBuilder.setStatsEnabled(builder, false);
     builder.intercept(createCensusStatsClientInterceptor());
     return builder;

--- a/servlet/src/tomcatTest/java/io/grpc/servlet/TomcatInteropTest.java
+++ b/servlet/src/tomcatTest/java/io/grpc/servlet/TomcatInteropTest.java
@@ -94,10 +94,9 @@ public class TomcatInteropTest extends AbstractInteropTest {
 
   @Override
   protected ManagedChannelBuilder<?> createChannelBuilder() {
-    NettyChannelBuilder builder =
-            (NettyChannelBuilder) ManagedChannelBuilder.forAddress(HOST, port)
-                    .usePlaintext()
-                    .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE);
+    NettyChannelBuilder builder = NettyChannelBuilder.forAddress(HOST, port)
+                                  .usePlaintext()
+                                  .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE);
     InternalNettyChannelBuilder.setStatsEnabled(builder, false);
     builder.intercept(createCensusStatsClientInterceptor());
     return builder;

--- a/servlet/src/undertowTest/java/io/grpc/servlet/UndertowInteropTest.java
+++ b/servlet/src/undertowTest/java/io/grpc/servlet/UndertowInteropTest.java
@@ -111,7 +111,7 @@ public class UndertowInteropTest extends AbstractInteropTest {
 
   @Override
   protected ManagedChannelBuilder<?> createChannelBuilder() {
-    NettyChannelBuilder builder = (NettyChannelBuilder) ManagedChannelBuilder
+    NettyChannelBuilder builder = NettyChannelBuilder
             .forAddress(HOST, port)
             .usePlaintext()
             .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE);


### PR DESCRIPTION
Use `NettyChannelBuilder` instead

#9858 needed this when a new dependency is added