### PR TITLE
gcp-observability: Fix transitive gRPC versions

### DIFF
--- a/gcp-observability/build.gradle
+++ b/gcp-observability/build.gradle
@@ -33,6 +33,8 @@ dependencies {
             libraries.opencensus.contrib.grpc.metrics,
             libraries.opencensus.exporter.stats.stackdriver,
             libraries.opencensus.exporter.trace.stackdriver,
+            project(':grpc-xds'), // Prefer our version
+            project(':grpc-services'), // Prefer our version
             libraries.animalsniffer.annotations, // Prefer our version
             libraries.google.auth.credentials, // Prefer our version
             libraries.protobuf.java.util, // Prefer our version

--- a/gcp-observability/build.gradle
+++ b/gcp-observability/build.gradle
@@ -33,13 +33,14 @@ dependencies {
             libraries.opencensus.contrib.grpc.metrics,
             libraries.opencensus.exporter.stats.stackdriver,
             libraries.opencensus.exporter.trace.stackdriver,
-            project(':grpc-xds'), // Prefer our version
-            project(':grpc-services'), // Prefer our version
+            project(':grpc-xds'), // Align grpc versions
+            project(':grpc-services'), // Align grpc versions
             libraries.animalsniffer.annotations, // Prefer our version
             libraries.google.auth.credentials, // Prefer our version
             libraries.protobuf.java.util, // Prefer our version
             libraries.gson, // Prefer our version
             libraries.perfmark.api, // Prefer our version
+            libraries.re2j, // Prefer our version
             ('com.google.guava:guava:31.1-jre')
 
     runtimeOnly libraries.opencensus.impl


### PR DESCRIPTION
google-cloud-logging brings in xds, services, and netty-shaded versions 1.43.2. grpc-netty-shaded and xds use internal APIs, so their version needs to align with grpc-api and grpc-core.  OpenCensus stackdriver components also brings in netty-shaded version 1.27.2, but it was later in the dependency list so google-cloud-logging's versions won out even if using Maven.

We don't need an explicit dependency on netty-shaded because xds depends on it transitively.

This was discovered because our GAE interop test failed in the course of PR #9858 which added grpc-gcp-observability to interop-testing (and thus also gae-interop-test):
```
Caused by: java.lang.AbstractMethodError: io.grpc.ManagedChannelProvider.getSupportedSocketAddressTypes()Ljava/util/Collection;
    at io.grpc.ManagedChannelRegistry.newChannelBuilder(ManagedChannelRegistry.java:186)
    at io.grpc.ManagedChannelRegistry.newChannelBuilder(ManagedChannelRegistry.java:155)
    at io.grpc.Grpc.newChannelBuilder(Grpc.java:101)
    at io.grpc.testing.integration.LongLivedChannel.<init>(LongLivedChannel.java:44)
    ... 44 more
```

CC @DNVindhya 