### PR TITLE
exclude generated error prone

### DIFF
--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -132,6 +132,11 @@ tasks.named("compileJava").configure {
             it.options.errorprone.excludedPaths,
             ".*/build/generated/sources/annotationProcessor/java/.*",
             "|")
+    // remove after upgrade error-prone
+    appendToProperty(
+            it.options.errorprone.excludedPaths,
+            ".*/build/tmp/compileJava/compileTransaction/annotation-output/io/grpc/xds/.*",
+            "|")
 }
 
 tasks.named("jar").configure {


### PR DESCRIPTION
compile failures workaround:

https://github.com/google/error-prone/pull/2923

```
xds/build/tmp/compileJava/compileTransaction/annotation-output/io/grpc/xds/AutoValue_XdsClusterResource_CdsUpdate.java:314: warning: [AutoValueSubclassLeaked] Do not refer to the autogenerated AutoValue_ class outside the file containing the corresponding @AutoValue base class.
```