### PR TITLE
Move retrieval of elapsed time in handleRpcStreamClosed to make TSan happy

### DIFF
--- a/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
@@ -330,8 +330,17 @@ final class AbstractXdsClient {
         return;
       }
 
+      if (responseReceived || retryBackoffPolicy == null) {
+        // Reset the backoff sequence if had received a response, or backoff sequence
+        // has never been initialized.
+        retryBackoffPolicy = backoffPolicyProvider.get();
+      }
       // Need this here to avoid tsan race condition in XdsClientImplTestBase.sendToNonexistentHost
       long elapsed = stopwatch.elapsed(TimeUnit.NANOSECONDS);
+      long delayNanos = Math.max(0, retryBackoffPolicy.nextBackoffNanos() - elapsed);
+      logger.log(XdsLogLevel.INFO, "Retry ADS stream in {0} ns", delayNanos);
+      rpcRetryTimer = syncContext.schedule(
+          new RpcRetryTask(), delayNanos, TimeUnit.NANOSECONDS, timeService);
 
       checkArgument(!error.isOk(), "unexpected OK status");
       String errorMsg = error.getDescription() != null
@@ -344,17 +353,6 @@ final class AbstractXdsClient {
       xdsResponseHandler.handleStreamClosed(error);
       cleanUp();
 
-      if (responseReceived || retryBackoffPolicy == null) {
-        // Reset the backoff sequence if had received a response, or backoff sequence
-        // has never been initialized.
-        retryBackoffPolicy = backoffPolicyProvider.get();
-      }
-      long delayNanos = Math.max(
-          0,
-          retryBackoffPolicy.nextBackoffNanos() - elapsed);
-      logger.log(XdsLogLevel.INFO, "Retry ADS stream in {0} ns", delayNanos);
-      rpcRetryTimer = syncContext.schedule(
-          new RpcRetryTask(), delayNanos, TimeUnit.NANOSECONDS, timeService);
     }
 
     private void close(Exception error) {

--- a/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/AbstractXdsClient.java
@@ -338,7 +338,6 @@ final class AbstractXdsClient {
       // Need this here to avoid tsan race condition in XdsClientImplTestBase.sendToNonexistentHost
       long elapsed = stopwatch.elapsed(TimeUnit.NANOSECONDS);
       long delayNanos = Math.max(0, retryBackoffPolicy.nextBackoffNanos() - elapsed);
-      logger.log(XdsLogLevel.INFO, "Retry ADS stream in {0} ns", delayNanos);
       rpcRetryTimer = syncContext.schedule(
           new RpcRetryTask(), delayNanos, TimeUnit.NANOSECONDS, timeService);
 
@@ -353,6 +352,7 @@ final class AbstractXdsClient {
       xdsResponseHandler.handleStreamClosed(error);
       cleanUp();
 
+      logger.log(XdsLogLevel.INFO, "Retry ADS stream in {0} ns", delayNanos);
     }
 
     private void close(Exception error) {


### PR DESCRIPTION
Moving the retrieval of elapsed time to before cleanup avoids the meaningless race condition to which TSan objects.

fixes #9920