### PR TITLE
errorprone: enable UnnecessaryAnonymousClass

### DIFF
--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -110,8 +110,6 @@ tasks.withType(JavaCompile).configureEach {
             it.options.errorprone.excludedPaths,
             ".*/src/generated/.*",
             "|")
-    // Reuses source code from grpc-interop-testing, which targets Java 7 (no method references)
-    options.errorprone.check("UnnecessaryAnonymousClass", CheckSeverity.OFF)
 }
 
 configureProtoCompilation()

--- a/binder/build.gradle
+++ b/binder/build.gradle
@@ -90,8 +90,6 @@ tasks.withType(JavaCompile).configureEach {
             "-Xlint:-cast"
     ]
     appendToProperty(it.options.errorprone.excludedPaths, ".*/R.java", "|")
-    // Reuses source code from grpc-core, which targets Java 7 (no method references)
-    options.errorprone.check("UnnecessaryAnonymousClass", CheckSeverity.OFF)
 }
 
 tasks.register("javadocs", Javadoc) {

--- a/build.gradle
+++ b/build.gradle
@@ -246,8 +246,6 @@ subprojects {
         }
 
         tasks.named("compileJava").configure {
-            // This project targets Java 7 (no method references)
-            options.errorprone.check("UnnecessaryAnonymousClass", CheckSeverity.OFF)
             // This project targets Java 7 (no time.Duration class)
             options.errorprone.check("PreferJavaTimeOverload", CheckSeverity.OFF)
             options.errorprone.check("JavaUtilDate", CheckSeverity.OFF)
@@ -257,7 +255,6 @@ subprojects {
         tasks.named("compileTestJava").configure {
             // LinkedList doesn't hurt much in tests and has lots of usages
             options.errorprone.check("JdkObsolete", CheckSeverity.OFF)
-            options.errorprone.check("UnnecessaryAnonymousClass", CheckSeverity.OFF)
             options.errorprone.check("PreferJavaTimeOverload", CheckSeverity.OFF)
             options.errorprone.check("JavaUtilDate", CheckSeverity.OFF)
         }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -108,11 +108,6 @@ plugins.withId("java") {
                 "<T:Lio/grpc/ServerBuilder<TT;>;>Lio/grpc/ServerBuilder<TT;>;");
         }
     }
-
-    tasks.named("compileJmhJava").configure {
-        // This project targets Java 7 (no method references)
-        options.errorprone.check("UnnecessaryAnonymousClass", CheckSeverity.OFF)
-    }
 }
 
 tasks.register("versionFile") {


### PR DESCRIPTION
The Java 7 compatibility rationale no longer holds.
