### PR TITLE
[No need to review] Testing Google auth library 1.12.2 on v1.50.x branch

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,6 +53,8 @@ jobs:
 
     - name: Build
       run: buildscripts/kokoro/unix.sh
+      env:
+        GRADLE_FLAGS: -x checkUpperBoundDeps -x javadoc
     - name: Post Failure Upload Test Reports to Artifacts
       if: ${{ failure() }}
       uses: actions/upload-artifact@v2

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -35,7 +35,7 @@ ARCH="$ARCH" buildscripts/make_dependencies.sh
 GRADLE_FLAGS="${GRADLE_FLAGS:-}"
 GRADLE_FLAGS+=" -PtargetArch=$ARCH"
 GRADLE_FLAGS+=" -Pcheckstyle.ignoreFailures=false"
-GRADLE_FLAGS+=" -PfailOnWarnings=true"
+# GRADLE_FLAGS+=" -PfailOnWarnings=true"
 GRADLE_FLAGS+=" -PerrorProne=true"
 GRADLE_FLAGS+=" -PskipAndroid=true"
 GRADLE_FLAGS+=" -Dorg.gradle.parallel=true"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 animalsniffer = "1.18"
 autovalue = "1.9"
 checkstyle = "6.17"
-googleauth = "1.4.0"
+googleauth = "1.12.2"
 guava = "31.1-android"
 netty = '4.1.79.Final'
 nettytcnative = '2.0.54.Final'


### PR DESCRIPTION
No need to review. Testing Google auth library 1.12.2 on v1.50.x branch using GitHub CI.

Previous: https://github.com/grpc/grpc-java/pull/9925/files (I marked it success)