### PR TITLE
Fix order dependent tests regarding message duration b/271122310

### DIFF
--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/interceptors/InternalLoggingChannelInterceptorTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/interceptors/InternalLoggingChannelInterceptorTest.java
@@ -331,11 +331,12 @@ public class InternalLoggingChannelInterceptorTest {
     @SuppressWarnings("unchecked")
     ClientCall.Listener<byte[]> mockListener = mock(ClientCall.Listener.class);
 
+    int durationSecs = 5;
     ClientCall<byte[], byte[]> interceptedLoggingCall =
         factory.create()
             .interceptCall(
                 method,
-                CallOptions.DEFAULT.withDeadlineAfter(1, TimeUnit.SECONDS),
+                CallOptions.DEFAULT.withDeadlineAfter(durationSecs, TimeUnit.SECONDS),
                 new Channel() {
                   @Override
                   public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
@@ -365,8 +366,8 @@ public class InternalLoggingChannelInterceptorTest {
             AdditionalMatchers.or(ArgumentMatchers.isNull(),
                 ArgumentMatchers.any()));
     Duration timeout = callOptTimeoutCaptor.getValue();
-    assertThat(TimeUnit.SECONDS.toNanos(1) - Durations.toNanos(timeout))
-        .isAtMost(TimeUnit.MILLISECONDS.toNanos(250));
+    assertThat(Math.abs(TimeUnit.SECONDS.toNanos(durationSecs) - Durations.toNanos(timeout)))
+        .isAtMost(TimeUnit.MILLISECONDS.toNanos(750));
   }
 
   @Test
@@ -374,7 +375,7 @@ public class InternalLoggingChannelInterceptorTest {
     final SettableFuture<ClientCall<byte[], byte[]>> callFuture = SettableFuture.create();
     Context.current()
         .withDeadline(
-            Deadline.after(1, TimeUnit.SECONDS),
+            Deadline.after(2, TimeUnit.SECONDS),
             Executors.newSingleThreadScheduledExecutor())
         .run(() -> {
           MethodDescriptor<byte[], byte[]> method =
@@ -391,7 +392,7 @@ public class InternalLoggingChannelInterceptorTest {
               factory.create()
                   .interceptCall(
                       method,
-                      CallOptions.DEFAULT.withDeadlineAfter(1, TimeUnit.SECONDS),
+                      CallOptions.DEFAULT.withDeadlineAfter(5, TimeUnit.SECONDS),
                       new Channel() {
                         @Override
                         public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
@@ -424,8 +425,8 @@ public class InternalLoggingChannelInterceptorTest {
             AdditionalMatchers.or(ArgumentMatchers.isNull(),
                 ArgumentMatchers.any()));
     Duration timeout = contextTimeoutCaptor.getValue();
-    assertThat(TimeUnit.SECONDS.toNanos(1) - Durations.toNanos(timeout))
-        .isAtMost(TimeUnit.MILLISECONDS.toNanos(250));
+    assertThat(Math.abs(TimeUnit.SECONDS.toNanos(2) - Durations.toNanos(timeout)))
+        .isAtMost(TimeUnit.MILLISECONDS.toNanos(750));
   }
 
   @Test
@@ -488,8 +489,8 @@ public class InternalLoggingChannelInterceptorTest {
     Duration timeout = timeoutCaptor.getValue();
     assertThat(LogHelper.min(contextDeadline, callOptionsDeadline))
         .isSameInstanceAs(contextDeadline);
-    assertThat(TimeUnit.SECONDS.toNanos(10) - Durations.toNanos(timeout))
-        .isAtMost(TimeUnit.MILLISECONDS.toNanos(250));
+    assertThat(Math.abs(TimeUnit.SECONDS.toNanos(10) - Durations.toNanos(timeout)))
+        .isAtMost(TimeUnit.MILLISECONDS.toNanos(750));
   }
 
   @Test

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/interceptors/InternalLoggingServerInterceptorTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/interceptors/InternalLoggingServerInterceptorTest.java
@@ -345,7 +345,7 @@ public class InternalLoggingServerInterceptorTest {
         ArgumentMatchers.isNull());
     verifyNoMoreInteractions(mockLogHelper);
     Duration timeout = timeoutCaptor.getValue();
-    assertThat(TimeUnit.SECONDS.toNanos(1) - Durations.toNanos(timeout))
+    assertThat(Math.abs(TimeUnit.SECONDS.toNanos(1) - Durations.toNanos(timeout)))
         .isAtMost(TimeUnit.MILLISECONDS.toNanos(250));
   }
 

--- a/services/src/test/java/io/grpc/protobuf/services/BinlogHelperTest.java
+++ b/services/src/test/java/io/grpc/protobuf/services/BinlogHelperTest.java
@@ -979,7 +979,7 @@ public final class BinlogHelperTest {
         ArgumentMatchers.<SocketAddress>isNull());
     verifyNoMoreInteractions(mockSinkWriter);
     Duration timeout = timeoutCaptor.getValue();
-    assertThat(TimeUnit.SECONDS.toNanos(1) - Durations.toNanos(timeout))
+    assertThat(Math.abs(TimeUnit.SECONDS.toNanos(1) - Durations.toNanos(timeout)))
         .isAtMost(TimeUnit.MILLISECONDS.toNanos(250));
   }
 
@@ -1000,7 +1000,7 @@ public final class BinlogHelperTest {
             .getClientInterceptor(CALL_ID)
             .interceptCall(
                 method,
-                CallOptions.DEFAULT.withDeadlineAfter(1, TimeUnit.SECONDS),
+                CallOptions.DEFAULT.withDeadlineAfter(2, TimeUnit.SECONDS),
                 new Channel() {
                   @Override
                   public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
@@ -1028,15 +1028,15 @@ public final class BinlogHelperTest {
             AdditionalMatchers.or(ArgumentMatchers.<SocketAddress>isNull(),
                 ArgumentMatchers.<SocketAddress>any()));
     Duration timeout = callOptTimeoutCaptor.getValue();
-    assertThat(TimeUnit.SECONDS.toNanos(1) - Durations.toNanos(timeout))
-        .isAtMost(TimeUnit.MILLISECONDS.toNanos(250));
+    assertThat(Math.abs(TimeUnit.SECONDS.toNanos(2) - Durations.toNanos(timeout)))
+        .isAtMost(TimeUnit.MILLISECONDS.toNanos(750));
   }
 
   @Test
   public void clientDeadlineLogged_deadlineSetViaContext() throws Exception {
     // important: deadline is read from the ctx where call was created
     final SettableFuture<ClientCall<byte[], byte[]>> callFuture = SettableFuture.create();
-    Deadline expectedDeadline = Deadline.after(1, TimeUnit.SECONDS);
+    Deadline expectedDeadline = Deadline.after(2, TimeUnit.SECONDS);
     Context.current()
         .withDeadline(
             expectedDeadline, Executors.newSingleThreadScheduledExecutor())
@@ -1055,7 +1055,7 @@ public final class BinlogHelperTest {
                 .getClientInterceptor(CALL_ID)
                 .interceptCall(
                     method,
-                    CallOptions.DEFAULT.withDeadlineAfter(5, TimeUnit.SECONDS),
+                    CallOptions.DEFAULT.withDeadlineAfter(10, TimeUnit.SECONDS),
                     new Channel() {
                       @Override
                       public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
@@ -1089,7 +1089,7 @@ public final class BinlogHelperTest {
     long expectedTimeRemaining = expectedDeadline.timeRemaining(TimeUnit.NANOSECONDS);
     long timeout = Durations.toNanos(callOptTimeoutCaptor.getValue());
     assertThat(Math.abs(expectedTimeRemaining - timeout))
-        .isAtMost(TimeUnit.SECONDS.toNanos(1));
+        .isAtMost(TimeUnit.MILLISECONDS.toNanos(750));
   }
 
   @Test


### PR DESCRIPTION
Fix order dependent tests by changing the initializations and comparison so that elapsed time isn't as significant in identifying whether it was the context or call option's duration that was used.

Test are related to getting duration from either calloptions or context and, because real time was involved, when class loading got in the picture the comparison could exceed the 250 ms limit.