### PR TITLE
api:stabilize offloadExecutor.

### DIFF
--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -119,7 +119,6 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * @throws UnsupportedOperationException if unsupported
    * @since 1.25.0
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/6279")
   public T offloadExecutor(Executor executor) {
     throw new UnsupportedOperationException();
   }

--- a/api/src/main/java/io/grpc/NameResolver.java
+++ b/api/src/main/java/io/grpc/NameResolver.java
@@ -366,7 +366,6 @@ public abstract class NameResolver {
      * @since 1.25.0
      */
     @Nullable
-    @ExperimentalApi("https://github.com/grpc/grpc-java/issues/6279")
     public Executor getOffloadExecutor() {
       return executor;
     }
@@ -379,7 +378,6 @@ public abstract class NameResolver {
      * @since 1.49.0
      */
     @Nullable
-    @ExperimentalApi("https://github.com/grpc/grpc-java/issues/9406")
     public String getOverrideAuthority() {
       return overrideAuthority;
     }

--- a/api/src/main/java/io/grpc/NameResolver.java
+++ b/api/src/main/java/io/grpc/NameResolver.java
@@ -378,6 +378,7 @@ public abstract class NameResolver {
      * @since 1.49.0
      */
     @Nullable
+    @ExperimentalApi("https://github.com/grpc/grpc-java/issues/9406")
     public String getOverrideAuthority() {
       return overrideAuthority;
     }
@@ -508,7 +509,6 @@ public abstract class NameResolver {
        *
        * @since 1.25.0
        */
-      @ExperimentalApi("https://github.com/grpc/grpc-java/issues/6279")
       public Builder setOffloadExecutor(Executor executor) {
         this.executor = executor;
         return this;


### PR DESCRIPTION
Remove experimental annotation from the 3 relevant methods
fixes #6279