### PR TITLE
Upgrade Android Gradle plugin to 7.4.0

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -65,6 +65,6 @@ jobs:
 
     - name: Coveralls
       if: matrix.jre == 8 # Upload once, instead of for each job in the matrix
-      run: ./gradlew :grpc-all:coveralls -x compileJava
+      run: ./gradlew :grpc-all:coveralls -PskipAndroid=true -x compileJava
     - name: Codecov
       uses: codecov/codecov-action@v3

--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -11,6 +11,7 @@ repositories {
 }
 
 android {
+    namespace 'io.grpc.android.integrationtest'
     sourceSets {
         main {
             java {
@@ -29,12 +30,12 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    compileSdkVersion 29
+    compileSdkVersion 31
 
     defaultConfig {
         applicationId "io.grpc.android.integrationtest"
         minSdkVersion 19
-        targetSdkVersion 29
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -48,7 +49,7 @@ android {
         }
     }
     lintOptions {
-        disable 'InvalidPackage', 'HardcodedText',
+        disable 'InvalidPackage', 'HardcodedText', 'UsingOnClickInXml',
                 'MissingClass' // https://github.com/grpc/grpc-java/issues/8799
     }
 }

--- a/android-interop-testing/proguard-rules.pro
+++ b/android-interop-testing/proguard-rules.pro
@@ -21,3 +21,7 @@
 
 # Ignores: can't find referenced method from grpc-testing's compileOnly dependency on Truth
 -dontwarn io.grpc.testing.DeadlineSubject
+
+-keepclassmembers class io.grpc.testing.integration.Messages$* {
+    *;
+}

--- a/android-interop-testing/src/androidTest/AndroidManifest.xml
+++ b/android-interop-testing/src/androidTest/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.grpc.android.integrationtest.test" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <instrumentation
         android:name="androidx.test.runner.AndroidJUnitRunner"

--- a/android-interop-testing/src/main/AndroidManifest.xml
+++ b/android-interop-testing/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.grpc.android.integrationtest" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <uses-permission android:name="android.permission.INTERNET" />
 
@@ -12,6 +11,7 @@
         android:name="androidx.multidex.MultiDexApplication" >
         <activity
             android:name=".TesterActivity"
+            android:exported="true"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,15 +8,16 @@ plugins {
 description = 'gRPC: Android'
 
 android {
+    namespace 'io.grpc.android'
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    compileSdkVersion 29
+    compileSdkVersion 31
     defaultConfig {
         consumerProguardFiles "proguard-rules.txt"
         minSdkVersion 19
-        targetSdkVersion 29
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.grpc.android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" >
 
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 

--- a/binder/build.gradle
+++ b/binder/build.gradle
@@ -7,6 +7,7 @@ plugins {
 description = 'gRPC BinderChannel'
 
 android {
+    namespace 'io.grpc.binder'
     sourceSets {
         test {
             java {
@@ -23,14 +24,14 @@ android {
             }
         }
     }
-    compileSdkVersion 30
+    compileSdkVersion 31
     compileOptions {
         sourceCompatibility 1.8
         targetCompatibility 1.8
     }
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/binder/src/androidTest/AndroidManifest.xml
+++ b/binder/src/androidTest/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.grpc.binder">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" >
 
   <instrumentation
       android:name="androidx.test.runner.AndroidJUnitRunner"

--- a/binder/src/main/AndroidManifest.xml
+++ b/binder/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.grpc.binder">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" >
 </manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,4 @@
 plugins {
-    id "com.android.application" apply false // Necessary for Android plugin to find its classes
-    id "com.android.library" apply false
     id "com.google.osdetector" apply false
     id "me.champeau.gradle.japicmp" apply false
     id "net.ltgt.errorprone" apply false

--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -28,6 +28,11 @@ echo y | ${ANDROID_HOME}/tools/bin/sdkmanager "build-tools;28.0.3"
 # Proto deps
 buildscripts/make_dependencies.sh
 
+# Build Android with Java 11, this adds it to the PATH
+sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
+# Unset any existing JAVA_HOME env var to stop Gradle from using it
+unset JAVA_HOME
+
 GRADLE_FLAGS="-Pandroid.useAndroidX=true"
 
 ./gradlew \
@@ -70,6 +75,7 @@ cp "$BASE_DIR/github/grpc-java/buildscripts/set_github_status.py" "$SET_GITHUB_S
 
 
 # Collect APK size and dex count stats for the helloworld example
+sudo update-java-alternatives --set java-1.8.0-openjdk-amd64
 
 HELLO_WORLD_OUTPUT_DIR="$BASE_DIR/github/grpc-java/examples/android/helloworld/app/build/outputs"
 
@@ -87,6 +93,7 @@ new_apk_size="$(stat --printf=%s $HELLO_WORLD_OUTPUT_DIR/apk/release/app-release
 
 
 # Get the APK size and dex count stats using the pull request base commit
+sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
 
 cd $BASE_DIR/github/grpc-java
 ./gradlew clean
@@ -96,6 +103,7 @@ git checkout HEAD^
 cd examples/android/helloworld/
 ../../gradlew build
 
+sudo update-java-alternatives --set java-1.8.0-openjdk-amd64
 read -r ignored old_dex_count < \
   <("${ANDROID_HOME}/tools/bin/apkanalyzer" dex references app/build/outputs/apk/release/app-release-unsigned.apk)
 

--- a/buildscripts/kokoro/linux_artifacts.sh
+++ b/buildscripts/kokoro/linux_artifacts.sh
@@ -16,6 +16,12 @@ trap spongify_logs EXIT
 # grpc-android, grpc-cronet and grpc-binder require the Android SDK, so build outside of Docker and
 # use --include-build for its grpc-core dependency
 echo y | ${ANDROID_HOME}/tools/bin/sdkmanager "build-tools;28.0.3"
+
+# The sdkmanager needs Java 8, but now we switch to 11 as the Android builds
+# require it
+sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
+unset JAVA_HOME
+
 LOCAL_MVN_TEMP=$(mktemp -d)
 GRADLE_FLAGS="-Pandroid.useAndroidX=true"
 pushd "$GRPC_JAVA_DIR/android"

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -13,10 +13,11 @@ repositories {
 }
 
 android {
-    compileSdkVersion 29
+    namespace 'io.grpc.cronet'
+    compileSdkVersion 31
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 29
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/cronet/src/main/AndroidManifest.xml
+++ b/cronet/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.grpc.cronet" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -6,12 +6,12 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    compileSdkVersion 29
+    compileSdkVersion 31
 
     defaultConfig {
         applicationId "io.grpc.clientcacheexample"
         minSdkVersion 19
-        targetSdkVersion 29
+        targetSdkVersion 31
         multiDexEnabled true
         versionCode 1
         versionName "1.0"

--- a/examples/android/clientcache/app/src/main/AndroidManifest.xml
+++ b/examples/android/clientcache/app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
         android:theme="@style/Base.V7.Theme.AppCompat.Light" >
         <activity
             android:name="io.grpc.clientcacheexample.ClientCacheExampleActivity"
-            android:label="@string/app_name" >
+            android:label="@string/app_name"
+            android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -6,12 +6,12 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    compileSdkVersion 29
+    compileSdkVersion 31
 
     defaultConfig {
         applicationId "io.grpc.helloworldexample"
         minSdkVersion 19
-        targetSdkVersion 29
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
     }

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -6,12 +6,12 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    compileSdkVersion 29
+    compileSdkVersion 31
 
     defaultConfig {
         applicationId "io.grpc.routeguideexample"
         minSdkVersion 19
-        targetSdkVersion 29
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
     }

--- a/examples/android/routeguide/app/src/main/AndroidManifest.xml
+++ b/examples/android/routeguide/app/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".RouteGuideActivity"
-            android:label="@string/app_name" >
+            android:label="@string/app_name"
+            android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/examples/android/strictmode/app/build.gradle
+++ b/examples/android/strictmode/app/build.gradle
@@ -6,13 +6,13 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    compileSdkVersion 29
+    compileSdkVersion 31
 
     defaultConfig {
         applicationId "io.grpc.strictmodehelloworldexample"
         // API level 28 is required for StrictMode penaltyListener
         minSdkVersion 28
-        targetSdkVersion 29
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
     }

--- a/examples/android/strictmode/app/src/main/AndroidManifest.xml
+++ b/examples/android/strictmode/app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
         android:theme="@style/Base.V7.Theme.AppCompat.Light" >
         <activity
             android:name=".StrictModeHelloworldActivity"
-            android:label="@string/app_name" >
+            android:label="@string/app_name"
+            android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
     plugins {
-        id "com.android.application" version "4.2.0"
-        id "com.android.library" version "4.2.0"
+        id "com.android.application" version "7.4.0"
+        id "com.android.library" version "7.4.0"
         id "com.github.johnrengelman.shadow" version "7.1.2"
         id "com.github.kt3k.coveralls" version "2.12.0"
         id "com.google.cloud.tools.jib" version "3.3.1"


### PR DESCRIPTION
This is the latest version of the plugin supported by the Gradle version
in use at the moment (7.6).

Note that this also upgrades the R8 optimizer to a version (4.0.48) that
now uses "full mode" optimization by default.

This also splits off Android projects to run under Java 11 (Gradle
plugin requirement) while the other projects continue to run under Java
8.