### PR TITLE
.github/workflows: Pass COVERALLS_REPO_TOKEN to coveralls task

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -65,6 +65,8 @@ jobs:
 
     - name: Coveralls
       if: matrix.jre == 8 # Upload once, instead of for each job in the matrix
+      env:
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       run: ./gradlew :grpc-all:coveralls -x compileJava
     - name: Codecov
       uses: codecov/codecov-action@v3


### PR DESCRIPTION
The coveralls task has been silently failing since we migrated to GitHub Actions, away form Travis-CI:
```
no COVERALLS_REPO_TOKEN environmental variable found

no available CI service
> Task :grpc-all:coveralls

BUILD SUCCESSFUL in 23s
7 actionable tasks: 1 executed, 6 up-to-date
```

We'd rather not deal with private tokens, but the Coveralls GitHub Action [only supports lcov][1] which makes it unhelpful for Java. Looking deeper, yep, we [aren't the only ones impacted][2]:

[1]: https://github.com/marketplace/actions/coveralls-github-action
[2]: https://github.com/coverallsapp/github-action/issues/22