### PR TITLE
Move gcp-observability interop binary out of interop-testing

### DIFF
--- a/buildscripts/observability-test/Dockerfile
+++ b/buildscripts/observability-test/Dockerfile
@@ -22,7 +22,7 @@ FROM openjdk:11.0.16-jdk-slim-bullseye AS build
 WORKDIR /grpc-java
 COPY . .
 
-RUN ./gradlew installDist -x test -PskipCodegen=true -PskipAndroid=true
+RUN ./gradlew :grpc-gcp-observability:interop:installDist -PskipCodegen=true -PskipAndroid=true
 
 
 #
@@ -35,8 +35,8 @@ RUN ./gradlew installDist -x test -PskipCodegen=true -PskipAndroid=true
 
 FROM openjdk:11.0.16-jdk-slim-bullseye
 
-WORKDIR /grpc-java/interop-testing/build
-COPY --from=build /grpc-java/interop-testing/build/. .
+WORKDIR /grpc-java/
+COPY --from=build /grpc-java/gcp-observability/interop/build/install/interop/. .
 
 WORKDIR /grpc-java/buildscripts/observability-test
 COPY --from=build /grpc-java/buildscripts/observability-test/run.sh .

--- a/buildscripts/observability-test/run.sh
+++ b/buildscripts/observability-test/run.sh
@@ -28,13 +28,13 @@ cd "$(dirname "$0")"/../..
 #             $5: num_times
 
 if [ "$1" = "server" ] ; then
-  /grpc-java/interop-testing/build/install/grpc-interop-testing/bin/test-server \
-    --use_tls=false --enable_observability=true \
+  /grpc-java/bin/gcp-observability-interop \
+    server --use_tls=false \
     --port=$2
 
 elif [ "$1" = "client" ] ; then
-  /grpc-java/interop-testing/build/install/grpc-interop-testing/bin/test-client \
-    --use_tls=false --enable_observability=true \
+  /grpc-java/bin/gcp-observability-interop \
+    client --use_tls=false \
     --server_host=$2 --server_port=$3 \
     --test_case=$4 --num_times=$5
 

--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -51,7 +51,6 @@ dependencies {
         // Avoid grpc-netty-shaded dependency
         exclude group: 'io.grpc', module: 'grpc-alts'
         exclude group: 'io.grpc', module: 'grpc-xds'
-        exclude group: 'io.grpc', module: 'grpc-gcp-observability'
     }
     implementation libraries.junit
     implementation libraries.protobuf.java

--- a/gcp-observability/interop/build.gradle
+++ b/gcp-observability/interop/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id "application"
+
+    id "ru.vyarus.animalsniffer"
+}
+
+description = "gRPC: Google Cloud Platform Observability Interop"
+
+dependencies {
+    implementation project(':grpc-interop-testing'),
+            project(':grpc-gcp-observability')
+
+    signature libraries.signature.java
+}
+
+application {
+    mainClass = 'io.grpc.gcp.observability.interop.TestServiceInterop'
+}
+
+tasks.named('startScripts').configure {
+    applicationName = 'gcp-observability-interop'
+}

--- a/gcp-observability/interop/src/main/java/io/grpc/gcp/observability/interop/TestServiceInterop.java
+++ b/gcp-observability/interop/src/main/java/io/grpc/gcp/observability/interop/TestServiceInterop.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.gcp.observability.interop;
+
+import io.grpc.gcp.observability.GcpObservability;
+import io.grpc.testing.integration.TestServiceClient;
+import io.grpc.testing.integration.TestServiceServer;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Combined interop client and server for observability testing.
+ */
+public final class TestServiceInterop {
+  public static void main(String[] args) throws Exception {
+    boolean client;
+    if (args.length < 1) {
+      usage();
+      return;
+    }
+    if ("server".equals(args[0])) {
+      client = false;
+    } else if ("client".equals(args[0])) {
+      client = true;
+    } else {
+      usage();
+      return;
+    }
+    args = Arrays.asList(args).subList(1, args.length).toArray(new String[0]);
+    try (GcpObservability gcpObservability = GcpObservability.grpcInit()) {
+      if (client) {
+        TestServiceClient.main(args);
+      } else {
+        TestServiceServer.main(args);
+      }
+      // TODO(stanleycheung): remove this once the observability exporter plugin is able to
+      //                      gracefully flush observability data to cloud at shutdown
+      final int o11yCloseSleepSeconds = 65;
+      System.out.println("Sleeping " + o11yCloseSleepSeconds + " seconds before exiting");
+      Thread.sleep(TimeUnit.MILLISECONDS.convert(o11yCloseSleepSeconds, TimeUnit.SECONDS));
+    }
+  }
+
+  private static void usage() {
+    System.out.println("Usage: client|server [ARGS...]");
+    System.exit(1);
+  }
+}

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -29,7 +29,6 @@ dependencies {
             project(':grpc-services'),
             project(':grpc-stub'),
             project(':grpc-testing'),
-            project(':grpc-gcp-observability'),
             libraries.hdrhistogram,
             libraries.junit,
             libraries.truth,

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
@@ -26,7 +26,6 @@ import io.grpc.ServerCredentials;
 import io.grpc.ServerInterceptors;
 import io.grpc.TlsServerCredentials;
 import io.grpc.alts.AltsServerCredentials;
-import io.grpc.gcp.observability.GcpObservability;
 import io.grpc.internal.testing.TestUtils;
 import io.grpc.services.MetricRecorder;
 import io.grpc.xds.orca.OrcaMetricReportingServerInterceptor;
@@ -59,17 +58,11 @@ public class TestServiceServer {
                 try {
                   System.out.println("Shutting down");
                   server.stop();
-                  if (server.enableObservability) {
-                    server.gcpObservability.close();
-                  }
                 } catch (Exception e) {
                   e.printStackTrace();
                 }
               }
             });
-    if (server.enableObservability) {
-      server.gcpObservability = GcpObservability.grpcInit();
-    }
     server.start();
     System.out.println("Server started on port " + server.port);
     server.blockUntilShutdown();
@@ -82,8 +75,6 @@ public class TestServiceServer {
   private ScheduledExecutorService executor;
   private Server server;
   private int localHandshakerPort = -1;
-  private boolean enableObservability = false;
-  private GcpObservability gcpObservability = null;
 
   @VisibleForTesting
   void parseArgs(String[] args) {
@@ -120,8 +111,6 @@ public class TestServiceServer {
           usage = true;
           break;
         }
-      } else if ("enable_observability".equals(key)) {
-        enableObservability = true;
       } else {
         System.err.println("Unknown argument: " + key);
         usage = true;
@@ -143,9 +132,6 @@ public class TestServiceServer {
               + "\n  --local_handshaker_port=PORT"
               + "\n                        Use local ALTS handshaker service on the specified port "
               + "\n                        for testing. Only effective when --use_alts=true."
-              + "\n  --enable_observability=true|false "
-              + "\n                        Whether to enable GCP Observability. Default: "
-              + s.enableObservability
       );
       System.exit(1);
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -55,6 +55,7 @@ include ":grpc-bom"
 include ":grpc-rls"
 include ":grpc-authz"
 include ":grpc-gcp-observability"
+include ":grpc-gcp-observability:interop"
 include ":grpc-istio-interop-testing"
 
 project(':grpc-api').projectDir = "$rootDir/api" as File
@@ -85,6 +86,7 @@ project(':grpc-bom').projectDir = "$rootDir/bom" as File
 project(':grpc-rls').projectDir = "$rootDir/rls" as File
 project(':grpc-authz').projectDir = "$rootDir/authz" as File
 project(':grpc-gcp-observability').projectDir = "$rootDir/gcp-observability" as File
+project(':grpc-gcp-observability:interop').projectDir = "$rootDir/gcp-observability/interop" as File
 project(':grpc-istio-interop-testing').projectDir = "$rootDir/istio-interop-testing" as File
 
 if (settings.hasProperty('skipCodegen') && skipCodegen.toBoolean()) {


### PR DESCRIPTION
gcp-observability has many dependencies so is a bit annoying in some build systems to get working... just for it not to be used in non-observability scenarios.

grpc-go and c core are using separate binaries for gcp-observability interop testing, so do the same in Java, which makes interop-testing a bit lighter.

CC @YifeiZhuang 