### PR TITLE
Do not System.exit(0) from interop client

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -71,7 +71,6 @@ public class TestServiceClient {
     } finally {
       client.tearDown();
     }
-    System.exit(0);
   }
 
   private String serverHost = "localhost";


### PR DESCRIPTION
I noticed that after #9937 was merged, the Java observability tests start to fail.

I track it down to this [System.exit(0)](https://github.com/grpc/grpc-java/blob/master/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java#L74) call in the existing Interop client `main()` method. That line is preventing execution to continue in the new combined Observability Interop test binary [here](https://github.com/grpc/grpc-java/blob/master/gcp-observability/interop/src/main/java/io/grpc/gcp/observability/interop/TestServiceInterop.java#L50-L54).  (The new binary is calling the old binary's `main()` method.)

I think normal execution (no errors) of the existing interop client binary will still end up with a 0 exit status even without that line?