### PR TITLE
binder: Do not fail binder build on javadoc errors

### DIFF
--- a/binder/build.gradle
+++ b/binder/build.gradle
@@ -108,6 +108,9 @@ tasks.register("javadocs", Javadoc) {
             addStringOption('Xdoclint:none', '-quiet')
         }
     }
+    // This is to enable moving to Java 11. An existing problem with javadoc
+    // produces a warning under Java 8, but with Java 11 it fails the build.
+    failOnError false
 }
 
 tasks.register("javadocJar", Jar) {


### PR DESCRIPTION
We will be running this with Java 11, which has elevated some earlier warnings to errors that fail the build. We don't want the build to fail because of this.