### PR TITLE
api,stub:Stabilize part of compression agreed to in the stabilization meeting

### DIFF
--- a/api/src/main/java/io/grpc/CallOptions.java
+++ b/api/src/main/java/io/grpc/CallOptions.java
@@ -138,13 +138,12 @@ public final class CallOptions {
 
   /**
    * Sets the compression to use for the call.  The compressor must be a valid name known in the
-   * {@link CompressorRegistry}.
+   * {@link CompressorRegistry}.  By default, the "gzip" compressor will be available.
    *
    * <p>It is only safe to call this if the server supports the compression format chosen. There is
    * no negotiation performed; if the server does not support the compression chosen, the call will
    * fail.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
   public CallOptions withCompression(@Nullable String compressorName) {
     Builder builder = toBuilder(this);
     builder.compressorName = compressorName;
@@ -207,7 +206,6 @@ public final class CallOptions {
   /**
    * Returns the compressor's name.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
   @Nullable
   public String getCompressor() {
     return compressorName;

--- a/api/src/main/java/io/grpc/ServerCall.java
+++ b/api/src/main/java/io/grpc/ServerCall.java
@@ -194,10 +194,10 @@ public abstract class ServerCall<ReqT, RespT> {
   }
 
   /**
-   * Sets the compression algorithm for this call.  If the server does not support the compression
-   * algorithm, the call will fail.  This method may only be called before {@link #sendHeaders}.
-   * The compressor to use will be looked up in the {@link CompressorRegistry}.  Default gRPC
-   * servers support the "gzip" compressor.
+   * Sets the compression algorithm for this call.  This compression is utilized for sending.  If
+   * the server does not support the compression algorithm, the call will fail.  This method may
+   * only be called before {@link #sendHeaders}.  The compressor to use will be looked up in the
+   * {@link CompressorRegistry}.  Default gRPC servers support the "gzip" compressor.
    *
    * <p>It is safe to call this even if the client does not support the compression format chosen.
    * The implementation will handle negotiation with the client and may fall back to no compression.

--- a/api/src/main/java/io/grpc/ServerCall.java
+++ b/api/src/main/java/io/grpc/ServerCall.java
@@ -189,7 +189,6 @@ public abstract class ServerCall<ReqT, RespT> {
    * encoding has been negotiated, this is a no-op. By default per-message compression is enabled,
    * but may not have any effect if compression is not enabled on the call.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
   public void setMessageCompression(boolean enabled) {
     // noop
   }
@@ -206,7 +205,6 @@ public abstract class ServerCall<ReqT, RespT> {
    * @param compressor the name of the compressor to use.
    * @throws IllegalArgumentException if the compressor name can not be found.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
   public void setCompression(String compressor) {
     // noop
   }

--- a/stub/src/main/java/io/grpc/stub/AbstractStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractStub.java
@@ -163,14 +163,11 @@ public abstract class AbstractStub<S extends AbstractStub<S>> {
   /**
    *  Set's the compressor name to use for the call.  It is the responsibility of the application
    *  to make sure the server supports decoding the compressor picked by the client.  To be clear,
-   *  this is the compressor used by the stub to compress messages to the server.  To get
-   *  compressed responses from the server, set the appropriate {@link io.grpc.DecompressorRegistry}
-   *  on the {@link io.grpc.ManagedChannelBuilder}.
+   *  this is the compressor used by the stub to compress messages to the server.
    *
    * @since 1.0.0
    * @param compressorName the name (e.g. "gzip") of the compressor to use.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
   public final S withCompression(String compressorName) {
     return build(channel, callOptions.withCompression(compressorName));
   }


### PR DESCRIPTION
Stabilize the following by removing `@ExperimentalApi`

CallOptions.withCompression
CallOptions.getCompressor
ServerCall.setCompression - make clear it is for sending
ServerCall. setMessageCompression
AbstractStub.withCompression - update javadoc to stop implying have to call decompressionRegistry


addresses parts of #1704 that were agreed to in the stabilization meeting