### PR TITLE
census: Trace annotation for reporting inbound message sizes

### DIFF
--- a/census/src/main/java/io/grpc/census/CensusTracingModule.java
+++ b/census/src/main/java/io/grpc/census/CensusTracingModule.java
@@ -42,6 +42,7 @@ import io.opencensus.trace.Status;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.propagation.BinaryFormat;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.logging.Level;
@@ -228,16 +229,14 @@ final class CensusTracingModule {
 
   private void recordAnnotation(
       Span span, MessageEvent.Type type, int seqNo, boolean isCompressed, long size) {
-    StringBuilder messageTypeBuilder = new StringBuilder("compressed");
-    if (!isCompressed) {
-      messageTypeBuilder.insert(0, "un");
-    }
+    String messageType = isCompressed ? "compressed" : "uncompressed";
     Map<String, AttributeValue> attributes = new HashMap<>();
     attributes.put("id", AttributeValue.longAttributeValue(seqNo));
-    attributes.put("type", AttributeValue.stringAttributeValue(messageTypeBuilder.toString()));
+    attributes.put("type", AttributeValue.stringAttributeValue(messageType));
 
-    String messageDirection = type.name().equalsIgnoreCase("Sent") ? "↗ " : "↘ ";
-    String inlineDescription = messageDirection + size + " bytes " + type.name().toLowerCase();
+    String messageDirection = type == MessageEvent.Type.SENT ? "↗ " : "↘ ";
+    String inlineDescription =
+        messageDirection + size + " bytes " + type.name().toLowerCase(Locale.US);
     span.addAnnotation(inlineDescription, attributes);
   }
 

--- a/census/src/main/java/io/grpc/census/InternalCensusTracingAccessor.java
+++ b/census/src/main/java/io/grpc/census/InternalCensusTracingAccessor.java
@@ -36,42 +36,21 @@ public final class InternalCensusTracingAccessor {
    * Returns a {@link ClientInterceptor} with default tracing implementation.
    */
   public static ClientInterceptor getClientInterceptor() {
-    return getClientInterceptor(true);
-  }
-
-  /**
-   * Returns the client interceptor that facilitates Census-based stats reporting.
-   *
-   * @param addMessageEvents add message events to Spans
-   * @return a {@link ClientInterceptor} with default tracing implementation.
-   */
-  public static ClientInterceptor getClientInterceptor(
-      boolean addMessageEvents) {
     CensusTracingModule censusTracing =
         new CensusTracingModule(
             Tracing.getTracer(),
-            Tracing.getPropagationComponent().getBinaryFormat(),
-            addMessageEvents);
+            Tracing.getPropagationComponent().getBinaryFormat());
     return censusTracing.getClientInterceptor();
   }
 
   /**
-   * Returns a {@link ServerStreamTracer.Factory} with default stats implementation.
+   * Returns a {@link ServerStreamTracer.Factory} with default tracing implementation.
    */
   public static ServerStreamTracer.Factory getServerStreamTracerFactory() {
-    return getServerStreamTracerFactory(true);
-  }
-
-  /**
-   * Returns a {@link ServerStreamTracer.Factory} with default stats implementation.
-   */
-  public static ServerStreamTracer.Factory getServerStreamTracerFactory(
-      boolean addMessageEvents) {
     CensusTracingModule censusTracing =
         new CensusTracingModule(
             Tracing.getTracer(),
-            Tracing.getPropagationComponent().getBinaryFormat(),
-            addMessageEvents);
+            Tracing.getPropagationComponent().getBinaryFormat());
     return censusTracing.getServerTracerFactory();
   }
 }

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/GcpObservability.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/GcpObservability.java
@@ -134,8 +134,8 @@ public final class GcpObservability implements AutoCloseable {
     }
     if (config.isEnableCloudTracing()) {
       clientInterceptors.add(
-          getConditionalInterceptor(InternalCensusTracingAccessor.getClientInterceptor(false)));
-      tracerFactories.add(InternalCensusTracingAccessor.getServerStreamTracerFactory(false));
+          getConditionalInterceptor(InternalCensusTracingAccessor.getClientInterceptor()));
+      tracerFactories.add(InternalCensusTracingAccessor.getServerStreamTracerFactory());
     }
 
     InternalGlobalInterceptors.setInterceptorsTracers(


### PR DESCRIPTION
This PR uses [OpenCensus Annotation](https://www.javadoc.io/static/io.opencensus/opencensus-api/0.31.0/io/opencensus/trace/Annotation.html) to report message size [bytes] for inbound/received messages in traces.

`addMessageEvent` API which is currently used expects both uncompressed and compressed message (optional) sizes to be reported at the same. Since decompression for messages happens at a later point in time, reporting compressed message as is and reporting uncompressed size as `-1` renders the size as _0 bytes received_ in cloud tracing front end.

As a workaround, we add _two annotations for each received message_:
* For compressed message size
* For uncompressed message size (when it is available)

This PR also removes `addMessageEvents` a flag introduced in PR #9485 to temporarily suppress message events for gcp-observability 

CC @ejona86 @sanjaypujare 