### PR TITLE
Observability Testing: Pass interop parameters to each lang's run.sh as-is

### DIFF
--- a/buildscripts/observability-test/run.sh
+++ b/buildscripts/observability-test/run.sh
@@ -16,29 +16,14 @@
 set -ex
 cd "$(dirname "$0")"/../..
 
-# TODO(stanleycheung): replace positional parameters with explicit parameters
-#
-#             $1: server | client
-#
-# For server: $2: server_port
-#
-# For client: $2: server_host
-#             $3: server_port
-#             $4: test_case
-#             $5: num_times
-
 if [ "$1" = "server" ] ; then
-  /grpc-java/bin/gcp-observability-interop \
-    server --use_tls=false \
-    --port=$2
+  /grpc-java/bin/gcp-observability-interop server --use_tls=false "${@:2}"
 
 elif [ "$1" = "client" ] ; then
-  /grpc-java/bin/gcp-observability-interop \
-    client --use_tls=false \
-    --server_host=$2 --server_port=$3 \
-    --test_case=$4 --num_times=$5
+  /grpc-java/bin/gcp-observability-interop client --use_tls=false "${@:2}"
 
 else
-  echo "Invalid action: $1"
+  echo "Invalid action: $1. Usage:"
+  echo "  $ .../run.sh [server|client] --server_host=<hostname> --server_port=<port> ..."
   exit 1
 fi


### PR DESCRIPTION
Each `run.sh` should just pass those parameters through to the interop client/server binaries as-is.

Framework PR: https://github.com/GoogleCloudPlatform/grpc-gcp-tools/pull/28