### PR TITLE
all: use PerfMark.traceTask

### DIFF
--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -623,6 +623,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
             }
           }
         }
+
         callExecutor.execute(new HeadersRead());
       }
     }
@@ -639,7 +640,8 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
 
           @Override
           public void runInContext() {
-            try (TaskCloseable ignore = PerfMark.traceTask("ClientCall$Listener.messagesAvailable")) {
+            try (TaskCloseable ignore =
+                     PerfMark.traceTask("ClientCall$Listener.messagesAvailable")) {
               PerfMark.attachTag(tag);
               PerfMark.linkIn(link);
               runInternal();

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -43,6 +43,7 @@ import io.grpc.ServerCall;
 import io.grpc.Status;
 import io.perfmark.PerfMark;
 import io.perfmark.Tag;
+import io.perfmark.TaskCloseable;
 import java.io.InputStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -89,21 +90,17 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
 
   @Override
   public void request(int numMessages) {
-    PerfMark.startTask("ServerCall.request", tag);
-    try {
+    try (TaskCloseable ignore = PerfMark.traceTask("ServerCall.request")) {
+      PerfMark.attachTag(tag);
       stream.request(numMessages);
-    } finally {
-      PerfMark.stopTask("ServerCall.request", tag);
     }
   }
 
   @Override
   public void sendHeaders(Metadata headers) {
-    PerfMark.startTask("ServerCall.sendHeaders", tag);
-    try {
+    try (TaskCloseable ignore = PerfMark.traceTask("ServerCall.sendHeaders")) {
+      PerfMark.attachTag(tag);
       sendHeadersInternal(headers);
-    } finally {
-      PerfMark.stopTask("ServerCall.sendHeaders", tag);
     }
   }
 
@@ -149,11 +146,9 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
 
   @Override
   public void sendMessage(RespT message) {
-    PerfMark.startTask("ServerCall.sendMessage", tag);
-    try {
+    try (TaskCloseable ignore = PerfMark.traceTask("ServerCall.sendMessage")) {
+      PerfMark.attachTag(tag);
       sendMessageInternal(message);
-    } finally {
-      PerfMark.stopTask("ServerCall.sendMessage", tag);
     }
   }
 
@@ -207,11 +202,9 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
 
   @Override
   public void close(Status status, Metadata trailers) {
-    PerfMark.startTask("ServerCall.close", tag);
-    try {
+    try (TaskCloseable ignore = PerfMark.traceTask("ServerCall.close")) {
+      PerfMark.attachTag(tag);
       closeInternal(status, trailers);
-    } finally {
-      PerfMark.stopTask("ServerCall.close", tag);
     }
   }
 
@@ -311,11 +304,9 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
 
     @Override
     public void messagesAvailable(MessageProducer producer) {
-      PerfMark.startTask("ServerStreamListener.messagesAvailable", call.tag);
-      try {
+      try (TaskCloseable ignore = PerfMark.traceTask("ServerStreamListener.messagesAvailable")) {
+        PerfMark.attachTag(call.tag);
         messagesAvailableInternal(producer);
-      } finally {
-        PerfMark.stopTask("ServerStreamListener.messagesAvailable", call.tag);
       }
     }
 
@@ -346,25 +337,21 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
 
     @Override
     public void halfClosed() {
-      PerfMark.startTask("ServerStreamListener.halfClosed", call.tag);
-      try {
+      try (TaskCloseable ignore = PerfMark.traceTask("ServerStreamListener.halfClosed")) {
+        PerfMark.attachTag(call.tag);
         if (call.cancelled) {
           return;
         }
 
         listener.onHalfClose();
-      } finally {
-        PerfMark.stopTask("ServerStreamListener.halfClosed", call.tag);
       }
     }
 
     @Override
     public void closed(Status status) {
-      PerfMark.startTask("ServerStreamListener.closed", call.tag);
-      try {
+      try (TaskCloseable ignore = PerfMark.traceTask("ServerStreamListener.closed")) {
+        PerfMark.attachTag(call.tag);
         closedInternal(status);
-      } finally {
-        PerfMark.stopTask("ServerStreamListener.closed", call.tag);
       }
     }
 
@@ -390,14 +377,12 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
 
     @Override
     public void onReady() {
-      PerfMark.startTask("ServerStreamListener.onReady", call.tag);
-      try {
+      try (TaskCloseable ignore = PerfMark.traceTask("ServerStreamListener.onReady")) {
+        PerfMark.attachTag(call.tag);
         if (call.cancelled) {
           return;
         }
         listener.onReady();
-      } finally {
-        PerfMark.stopTask("ServerCall.closed", call.tag);
       }
     }
   }

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -58,6 +58,7 @@ import io.grpc.Status;
 import io.perfmark.Link;
 import io.perfmark.PerfMark;
 import io.perfmark.Tag;
+import io.perfmark.TaskCloseable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
@@ -461,11 +462,9 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
     @Override
     public void streamCreated(ServerStream stream, String methodName, Metadata headers) {
       Tag tag = PerfMark.createTag(methodName, stream.streamId());
-      PerfMark.startTask("ServerTransportListener.streamCreated", tag);
-      try {
+      try (TaskCloseable ignore = PerfMark.traceTask("ServerTransportListener.streamCreated")) {
+        PerfMark.attachTag(tag);
         streamCreatedInternal(stream, methodName, headers, tag);
-      } finally {
-        PerfMark.stopTask("ServerTransportListener.streamCreated", tag);
       }
     }
 
@@ -523,12 +522,10 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
 
         @Override
         public void runInContext() {
-          PerfMark.startTask("ServerTransportListener$MethodLookup.startCall", tag);
-          PerfMark.linkIn(link);
-          try {
+          try (TaskCloseable ignore = PerfMark.traceTask("ServerTransportListener$MethodLookup.startCall")) {
+            PerfMark.attachTag(tag);
+            PerfMark.linkIn(link);
             runInternal();
-          } finally {
-            PerfMark.stopTask("ServerTransportListener$MethodLookup.startCall", tag);
           }
         }
 
@@ -598,12 +595,10 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
 
         @Override
         public void runInContext() {
-          PerfMark.startTask("ServerTransportListener$HandleServerCall.startCall", tag);
-          PerfMark.linkIn(link);
-          try {
+          try (TaskCloseable ignore = PerfMark.traceTask("ServerTransportListener$HandleServerCall.startCall")) {
+            PerfMark.linkIn(link);
+            PerfMark.attachTag(tag);
             runInternal();
-          } finally {
-            PerfMark.stopTask("ServerTransportListener$HandleServerCall.startCall", tag);
           }
         }
 
@@ -818,76 +813,64 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
 
     @Override
     public void messagesAvailable(final MessageProducer producer) {
-      PerfMark.startTask("ServerStreamListener.messagesAvailable", tag);
-      final Link link = PerfMark.linkOut();
+      try (TaskCloseable ignore = PerfMark.traceTask("ServerStreamListener.messagesAvailable")) {
+        PerfMark.attachTag(tag);
+        final Link link = PerfMark.linkOut();
+        final class MessagesAvailable extends ContextRunnable {
 
-      final class MessagesAvailable extends ContextRunnable {
+          MessagesAvailable() {
+            super(context);
+          }
 
-        MessagesAvailable() {
-          super(context);
-        }
-
-        @Override
-        public void runInContext() {
-          PerfMark.startTask("ServerCallListener(app).messagesAvailable", tag);
-          PerfMark.linkIn(link);
-          try {
-            getListener().messagesAvailable(producer);
-          } catch (Throwable t) {
-            internalClose(t);
-            throw t;
-          } finally {
-            PerfMark.stopTask("ServerCallListener(app).messagesAvailable", tag);
+          @Override
+          public void runInContext() {
+            try (TaskCloseable ignore = PerfMark.traceTask("ServerCallListener(app).messagesAvailable")) {
+              PerfMark.attachTag(tag);
+              PerfMark.linkIn(link);
+              getListener().messagesAvailable(producer);
+            } catch (Throwable t) {
+              internalClose(t);
+              throw t;
+            }
           }
         }
-      }
 
-      try {
         callExecutor.execute(new MessagesAvailable());
-      } finally {
-        PerfMark.stopTask("ServerStreamListener.messagesAvailable", tag);
       }
     }
 
     @Override
     public void halfClosed() {
-      PerfMark.startTask("ServerStreamListener.halfClosed", tag);
-      final Link link = PerfMark.linkOut();
+      try (TaskCloseable ignore = PerfMark.traceTask("ServerStreamListener.halfClosed")) {
+        PerfMark.attachTag(tag);
+        final Link link = PerfMark.linkOut();
+        final class HalfClosed extends ContextRunnable {
+          HalfClosed() {
+            super(context);
+          }
 
-      final class HalfClosed extends ContextRunnable {
-        HalfClosed() {
-          super(context);
-        }
-
-        @Override
-        public void runInContext() {
-          PerfMark.startTask("ServerCallListener(app).halfClosed", tag);
-          PerfMark.linkIn(link);
-          try {
-            getListener().halfClosed();
-          } catch (Throwable t) {
-            internalClose(t);
-            throw t;
-          } finally {
-            PerfMark.stopTask("ServerCallListener(app).halfClosed", tag);
+          @Override
+          public void runInContext() {
+            try (TaskCloseable ignore = PerfMark.traceTask("ServerStreamListener.halfClosed")) {
+              PerfMark.attachTag(tag);
+              PerfMark.linkIn(link);
+              getListener().halfClosed();
+            } catch (Throwable t) {
+              internalClose(t);
+              throw t;
+            }
           }
         }
-      }
 
-      try {
         callExecutor.execute(new HalfClosed());
-      } finally {
-        PerfMark.stopTask("ServerStreamListener.halfClosed", tag);
       }
     }
 
     @Override
     public void closed(final Status status) {
-      PerfMark.startTask("ServerStreamListener.closed", tag);
-      try {
+      try (TaskCloseable ignore = PerfMark.traceTask("ServerStreamListener.closed")) {
+        PerfMark.attachTag(tag);
         closedInternal(status);
-      } finally {
-        PerfMark.stopTask("ServerStreamListener.closed", tag);
       }
     }
 
@@ -917,12 +900,10 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
 
         @Override
         public void runInContext() {
-          PerfMark.startTask("ServerCallListener(app).closed", tag);
-          PerfMark.linkIn(link);
-          try {
+          try (TaskCloseable ignore = PerfMark.traceTask("ServerCallListener(app).closed")) {
+            PerfMark.attachTag(tag);
+            PerfMark.linkIn(link);
             getListener().closed(status);
-          } finally {
-            PerfMark.stopTask("ServerCallListener(app).closed", tag);
           }
         }
       }
@@ -932,32 +913,29 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
 
     @Override
     public void onReady() {
-      PerfMark.startTask("ServerStreamListener.onReady", tag);
-      final Link link = PerfMark.linkOut();
-      final class OnReady extends ContextRunnable {
-        OnReady() {
-          super(context);
-        }
+      try (TaskCloseable ignore = PerfMark.traceTask("ServerStreamListener.onReady")) {
+        PerfMark.attachTag(tag);
+        final Link link = PerfMark.linkOut();
 
-        @Override
-        public void runInContext() {
-          PerfMark.startTask("ServerCallListener(app).onReady", tag);
-          PerfMark.linkIn(link);
-          try {
-            getListener().onReady();
-          } catch (Throwable t) {
-            internalClose(t);
-            throw t;
-          } finally {
-            PerfMark.stopTask("ServerCallListener(app).onReady", tag);
+        final class OnReady extends ContextRunnable {
+          OnReady() {
+            super(context);
+          }
+
+          @Override
+          public void runInContext() {
+            try (TaskCloseable ignore = PerfMark.traceTask("ServerCallListener(app).onReady")) {
+              PerfMark.attachTag(tag);
+              PerfMark.linkIn(link);
+              getListener().onReady();
+            } catch (Throwable t) {
+              internalClose(t);
+              throw t;
+            }
           }
         }
-      }
 
-      try {
         callExecutor.execute(new OnReady());
-      } finally {
-        PerfMark.stopTask("ServerStreamListener.onReady", tag);
       }
     }
   }

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -522,7 +522,8 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
 
         @Override
         public void runInContext() {
-          try (TaskCloseable ignore = PerfMark.traceTask("ServerTransportListener$MethodLookup.startCall")) {
+          try (TaskCloseable ignore =
+                   PerfMark.traceTask("ServerTransportListener$MethodLookup.startCall")) {
             PerfMark.attachTag(tag);
             PerfMark.linkIn(link);
             runInternal();
@@ -595,7 +596,8 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
 
         @Override
         public void runInContext() {
-          try (TaskCloseable ignore = PerfMark.traceTask("ServerTransportListener$HandleServerCall.startCall")) {
+          try (TaskCloseable ignore =
+                   PerfMark.traceTask("ServerTransportListener$HandleServerCall.startCall")) {
             PerfMark.linkIn(link);
             PerfMark.attachTag(tag);
             runInternal();
@@ -824,7 +826,8 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
 
           @Override
           public void runInContext() {
-            try (TaskCloseable ignore = PerfMark.traceTask("ServerCallListener(app).messagesAvailable")) {
+            try (TaskCloseable ignore =
+                     PerfMark.traceTask("ServerCallListener(app).messagesAvailable")) {
               PerfMark.attachTag(tag);
               PerfMark.linkIn(link);
               getListener().messagesAvailable(producer);
@@ -851,7 +854,7 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
 
           @Override
           public void runInContext() {
-            try (TaskCloseable ignore = PerfMark.traceTask("ServerStreamListener.halfClosed")) {
+            try (TaskCloseable ignore = PerfMark.traceTask("ServerCallListener(app).halfClosed")) {
               PerfMark.attachTag(tag);
               PerfMark.linkIn(link);
               getListener().halfClosed();

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -46,6 +46,7 @@ import io.netty.handler.codec.http2.Http2Stream;
 import io.netty.util.AsciiString;
 import io.perfmark.PerfMark;
 import io.perfmark.Tag;
+import io.perfmark.TaskCloseable;
 import javax.annotation.Nullable;
 
 /**
@@ -117,11 +118,9 @@ class NettyClientStream extends AbstractClientStream {
 
     @Override
     public void writeHeaders(Metadata headers, byte[] requestPayload) {
-      PerfMark.startTask("NettyClientStream$Sink.writeHeaders");
-      try {
+      try (TaskCloseable ignore =
+               PerfMark.traceTask("NettyClientStream$Sink.writeHeaders")) {
         writeHeadersInternal(headers, requestPayload);
-      } finally {
-        PerfMark.stopTask("NettyClientStream$Sink.writeHeaders");
       }
     }
 
@@ -207,21 +206,15 @@ class NettyClientStream extends AbstractClientStream {
     @Override
     public void writeFrame(
         WritableBuffer frame, boolean endOfStream, boolean flush, int numMessages) {
-      PerfMark.startTask("NettyClientStream$Sink.writeFrame");
-      try {
+      try (TaskCloseable ignore = PerfMark.traceTask("NettyClientStream$Sink.writeFrame")) {
         writeFrameInternal(frame, endOfStream, flush, numMessages);
-      } finally {
-        PerfMark.stopTask("NettyClientStream$Sink.writeFrame");
       }
     }
 
     @Override
     public void cancel(Status status) {
-      PerfMark.startTask("NettyClientStream$Sink.cancel");
-      try {
+      try (TaskCloseable ignore = PerfMark.traceTask("NettyClientStream$Sink.cancel")) {
         writeQueue.enqueue(new CancelClientStreamCommand(transportState(), status), true);
-      } finally {
-        PerfMark.stopTask("NettyClientStream$Sink.cancel");
       }
     }
   }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpServerStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpServerStream.java
@@ -28,6 +28,7 @@ import io.grpc.okhttp.internal.framed.ErrorCode;
 import io.grpc.okhttp.internal.framed.Header;
 import io.perfmark.PerfMark;
 import io.perfmark.Tag;
+import io.perfmark.TaskCloseable;
 import java.util.List;
 import javax.annotation.concurrent.GuardedBy;
 import okio.Buffer;
@@ -83,58 +84,49 @@ class OkHttpServerStream extends AbstractServerStream {
   class Sink implements AbstractServerStream.Sink {
     @Override
     public void writeHeaders(Metadata metadata) {
-      PerfMark.startTask("OkHttpServerStream$Sink.writeHeaders");
-      try {
+      try (TaskCloseable ignore =
+               PerfMark.traceTask("OkHttpServerStream$Sink.writeHeaders")) {
         List<Header> responseHeaders = Headers.createResponseHeaders(metadata);
         synchronized (state.lock) {
           state.sendHeaders(responseHeaders);
         }
-      } finally {
-        PerfMark.stopTask("OkHttpServerStream$Sink.writeHeaders");
       }
     }
 
     @Override
     public void writeFrame(WritableBuffer frame, boolean flush, int numMessages) {
-      PerfMark.startTask("OkHttpServerStream$Sink.writeFrame");
-      Buffer buffer = ((OkHttpWritableBuffer) frame).buffer();
-      int size = (int) buffer.size();
-      if (size > 0) {
-        onSendingBytes(size);
-      }
-
-      try {
+      try (TaskCloseable ignore =
+               PerfMark.traceTask("OkHttpServerStream$Sink.writeFrame")) {
+        Buffer buffer = ((OkHttpWritableBuffer) frame).buffer();
+        int size = (int) buffer.size();
+        if (size > 0) {
+          onSendingBytes(size);
+        }
         synchronized (state.lock) {
           state.sendBuffer(buffer, flush);
           transportTracer.reportMessageSent(numMessages);
         }
-      } finally {
-        PerfMark.stopTask("OkHttpServerStream$Sink.writeFrame");
       }
     }
 
     @Override
     public void writeTrailers(Metadata trailers, boolean headersSent, Status status) {
-      PerfMark.startTask("OkHttpServerStream$Sink.writeTrailers");
-      try {
+      try (TaskCloseable ignore =
+               PerfMark.traceTask("OkHttpServerStream$Sink.writeTrailers")) {
         List<Header> responseTrailers = Headers.createResponseTrailers(trailers, headersSent);
         synchronized (state.lock) {
           state.sendTrailers(responseTrailers);
         }
-      } finally {
-        PerfMark.stopTask("OkHttpServerStream$Sink.writeTrailers");
       }
     }
 
     @Override
     public void cancel(Status reason) {
-      PerfMark.startTask("OkHttpServerStream$Sink.cancel");
-      try {
+      try (TaskCloseable ignore =
+               PerfMark.traceTask("OkHttpServerStream$Sink.cancel")) {
         synchronized (state.lock) {
           state.cancel(ErrorCode.CANCEL, reason);
         }
-      } finally {
-        PerfMark.stopTask("OkHttpServerStream$Sink.cancel");
       }
     }
   }


### PR DESCRIPTION
PerfMark was added to gRPC before Java7 features like try-with-resources were allowed.   This changes moves over all the old calls to PerfMark startTask and stopTask to traceTask, which works nicely with TwR.   Useless `finally` blocks are mostly gone.  Some indentation is added to adapt this change, but there should be no functionality changes with this PR, except for the bug mentioned below.

The motivation for this change is `NettyServerStream.cancel`, which accidentally calls `startTask` incorrectly in the finally block.