### PR TITLE
gcp-observability, census: add trace information to logs

### DIFF
--- a/census/src/main/java/io/grpc/census/CensusTracingModule.java
+++ b/census/src/main/java/io/grpc/census/CensusTracingModule.java
@@ -125,8 +125,8 @@ final class CensusTracingModule {
    */
   @VisibleForTesting
   CallAttemptsTracerFactory newClientCallTracer(
-      @Nullable Span parentSpan, MethodDescriptor<?, ?> method) {
-    return new CallAttemptsTracerFactory(parentSpan, method);
+      @Nullable Span clientSpan, MethodDescriptor<?, ?> method) {
+    return new CallAttemptsTracerFactory(clientSpan, method);
   }
 
   /**
@@ -249,11 +249,11 @@ final class CensusTracingModule {
     private final Span span;
     private final String fullMethodName;
 
-    CallAttemptsTracerFactory(@Nullable Span parentSpan, MethodDescriptor<?, ?> method) {
+    CallAttemptsTracerFactory(@Nullable Span clientSpan, MethodDescriptor<?, ?> method) {
       checkNotNull(method, "method");
       this.isSampledToLocalTracing = method.isSampledToLocalTracing();
       this.fullMethodName = method.getFullMethodName();
-      this.span = parentSpan;
+      this.span = clientSpan;
     }
 
     @Override

--- a/census/src/main/java/io/grpc/census/internal/ObservabilityCensusConstants.java
+++ b/census/src/main/java/io/grpc/census/internal/ObservabilityCensusConstants.java
@@ -26,11 +26,13 @@ import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_STATUS;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.grpc.CallOptions;
 import io.opencensus.contrib.grpc.metrics.RpcViewConstants;
 import io.opencensus.stats.Aggregation;
 import io.opencensus.stats.Measure;
 import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.View;
+import io.opencensus.trace.SpanContext;
 import java.util.Arrays;
 
 // TODO(dnvindhya): Remove metric and view definitions from this class once it is moved to
@@ -41,6 +43,9 @@ import java.util.Arrays;
  */
 @VisibleForTesting
 public final class ObservabilityCensusConstants {
+
+  public static CallOptions.Key<SpanContext> CLIENT_TRACE_SPAN_CONTEXT_KEY
+      = CallOptions.Key.createWithDefault("Client span context for tracing", SpanContext.INVALID);
 
   static final Aggregation AGGREGATION_WITH_BYTES_HISTOGRAM =
       RpcViewConstants.GRPC_CLIENT_SENT_BYTES_PER_RPC_VIEW.getAggregation();

--- a/census/src/test/java/io/grpc/census/CensusTracingAnnotationEventTest.java
+++ b/census/src/test/java/io/grpc/census/CensusTracingAnnotationEventTest.java
@@ -166,7 +166,7 @@ public class CensusTracingAnnotationEventTest {
   @Test
   public void clientBasicTracingUncompressedSizeAnnotation() {
     CallAttemptsTracerFactory callTracer =
-        censusTracing.newClientCallTracer(null, method);
+        censusTracing.newClientCallTracer(spyClientSpan, method);
     Metadata headers = new Metadata();
     ClientStreamTracer clientStreamTracer = callTracer.newClientStreamTracer(STREAM_INFO, headers);
     clientStreamTracer.streamCreated(Attributes.EMPTY, headers);

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/interceptors/InternalLoggingServerInterceptor.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/interceptors/InternalLoggingServerInterceptor.java
@@ -113,7 +113,8 @@ public final class InternalLoggingServerInterceptor implements ServerInterceptor
           maxHeaderBytes,
           EventLogger.SERVER,
           callId,
-          peerAddress);
+          peerAddress,
+          null);
     } catch (Exception e) {
       // Catching generic exceptions instead of specific ones for all the events.
       // This way we can catch both expected and unexpected exceptions instead of re-throwing
@@ -139,6 +140,7 @@ public final class InternalLoggingServerInterceptor implements ServerInterceptor
                   maxHeaderBytes,
                   EventLogger.SERVER,
                   callId,
+                  null,
                   null);
             } catch (Exception e) {
               logger.log(Level.SEVERE, "Unable to log response header", e);
@@ -160,7 +162,8 @@ public final class InternalLoggingServerInterceptor implements ServerInterceptor
                   message,
                   maxMessageBytes,
                   EventLogger.SERVER,
-                  callId);
+                  callId,
+                  null);
             } catch (Exception e) {
               logger.log(Level.SEVERE, "Unable to log response message", e);
             }
@@ -181,6 +184,7 @@ public final class InternalLoggingServerInterceptor implements ServerInterceptor
                   maxHeaderBytes,
                   EventLogger.SERVER,
                   callId,
+                  null,
                   null);
             } catch (Exception e) {
               logger.log(Level.SEVERE, "Unable to log trailer", e);
@@ -206,7 +210,8 @@ public final class InternalLoggingServerInterceptor implements ServerInterceptor
               message,
               maxMessageBytes,
               EventLogger.SERVER,
-              callId);
+              callId,
+              null);
         } catch (Exception e) {
           logger.log(Level.SEVERE, "Unable to log request message", e);
         }
@@ -223,7 +228,8 @@ public final class InternalLoggingServerInterceptor implements ServerInterceptor
               methodName,
               authority,
               EventLogger.SERVER,
-              callId);
+              callId,
+              null);
         } catch (Exception e) {
           logger.log(Level.SEVERE, "Unable to log half close", e);
         }
@@ -240,7 +246,8 @@ public final class InternalLoggingServerInterceptor implements ServerInterceptor
               methodName,
               authority,
               EventLogger.SERVER,
-              callId);
+              callId,
+              null);
         } catch (Exception e) {
           logger.log(Level.SEVERE, "Unable to log cancel", e);
         }

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/interceptors/LogHelper.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/interceptors/LogHelper.java
@@ -35,6 +35,7 @@ import io.grpc.observabilitylog.v1.GrpcLogRecord;
 import io.grpc.observabilitylog.v1.GrpcLogRecord.EventLogger;
 import io.grpc.observabilitylog.v1.GrpcLogRecord.EventType;
 import io.grpc.observabilitylog.v1.Payload;
+import io.opencensus.trace.SpanContext;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -87,7 +88,9 @@ public class LogHelper {
       GrpcLogRecord.EventLogger eventLogger,
       String callId,
       // null on client side
-      @Nullable SocketAddress peerAddress) {
+      @Nullable SocketAddress peerAddress,
+      // null on server side
+      @Nullable SpanContext spanContext) {
     checkNotNull(serviceName, "serviceName");
     checkNotNull(methodName, "methodName");
     checkNotNull(authority, "authority");
@@ -113,7 +116,7 @@ public class LogHelper {
     if (peerAddress != null) {
       logEntryBuilder.setPeer(socketAddressToProto(peerAddress));
     }
-    sink.write(logEntryBuilder.build());
+    sink.write(logEntryBuilder.build(), spanContext);
   }
 
   /**
@@ -128,7 +131,9 @@ public class LogHelper {
       int maxHeaderBytes,
       GrpcLogRecord.EventLogger eventLogger,
       String callId,
-      @Nullable SocketAddress peerAddress) {
+      @Nullable SocketAddress peerAddress,
+      // null on server side
+      @Nullable SpanContext spanContext) {
     checkNotNull(serviceName, "serviceName");
     checkNotNull(methodName, "methodName");
     checkNotNull(authority, "authority");
@@ -154,7 +159,7 @@ public class LogHelper {
     if (peerAddress != null) {
       logEntryBuilder.setPeer(socketAddressToProto(peerAddress));
     }
-    sink.write(logEntryBuilder.build());
+    sink.write(logEntryBuilder.build(), spanContext);
   }
 
   /**
@@ -170,7 +175,9 @@ public class LogHelper {
       int maxHeaderBytes,
       GrpcLogRecord.EventLogger eventLogger,
       String callId,
-      @Nullable SocketAddress peerAddress) {
+      @Nullable SocketAddress peerAddress,
+      // null on server side
+      @Nullable SpanContext spanContext) {
     checkNotNull(serviceName, "serviceName");
     checkNotNull(methodName, "methodName");
     checkNotNull(authority, "authority");
@@ -204,7 +211,7 @@ public class LogHelper {
     if (peerAddress != null) {
       logEntryBuilder.setPeer(socketAddressToProto(peerAddress));
     }
-    sink.write(logEntryBuilder.build());
+    sink.write(logEntryBuilder.build(), spanContext);
   }
 
   /**
@@ -219,7 +226,9 @@ public class LogHelper {
       T message,
       int maxMessageBytes,
       EventLogger eventLogger,
-      String callId) {
+      String callId,
+      // null on server side
+      @Nullable SpanContext spanContext) {
     checkNotNull(serviceName, "serviceName");
     checkNotNull(methodName, "methodName");
     checkNotNull(authority, "authority");
@@ -259,7 +268,7 @@ public class LogHelper {
       logEntryBuilder.setPayload(pair.payloadBuilder)
           .setPayloadTruncated(pair.truncated);
     }
-    sink.write(logEntryBuilder.build());
+    sink.write(logEntryBuilder.build(), spanContext);
   }
 
   /**
@@ -271,7 +280,9 @@ public class LogHelper {
       String methodName,
       String authority,
       GrpcLogRecord.EventLogger eventLogger,
-      String callId) {
+      String callId,
+      // null on server side
+      @Nullable SpanContext spanContext) {
     checkNotNull(serviceName, "serviceName");
     checkNotNull(methodName, "methodName");
     checkNotNull(authority, "authority");
@@ -285,7 +296,7 @@ public class LogHelper {
         .setType(EventType.CLIENT_HALF_CLOSE)
         .setLogger(eventLogger)
         .setCallId(callId);
-    sink.write(logEntryBuilder.build());
+    sink.write(logEntryBuilder.build(), spanContext);
   }
 
   /**
@@ -297,7 +308,9 @@ public class LogHelper {
       String methodName,
       String authority,
       GrpcLogRecord.EventLogger eventLogger,
-      String callId) {
+      String callId,
+      // null on server side
+      @Nullable SpanContext spanContext) {
     checkNotNull(serviceName, "serviceName");
     checkNotNull(methodName, "methodName");
     checkNotNull(authority, "authority");
@@ -311,7 +324,7 @@ public class LogHelper {
         .setType(EventType.CANCEL)
         .setLogger(eventLogger)
         .setCallId(callId);
-    sink.write(logEntryBuilder.build());
+    sink.write(logEntryBuilder.build(), spanContext);
   }
 
   // TODO(DNVindhya): Evaluate if we need following clause for metadata logging in GcpObservability

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/interceptors/LogHelper.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/interceptors/LogHelper.java
@@ -90,8 +90,7 @@ public class LogHelper {
       String callId,
       // null on client side
       @Nullable SocketAddress peerAddress,
-      // null on server side
-      @Nullable SpanContext spanContext) {
+      SpanContext spanContext) {
     checkNotNull(serviceName, "serviceName");
     checkNotNull(methodName, "methodName");
     checkNotNull(authority, "authority");
@@ -133,8 +132,7 @@ public class LogHelper {
       GrpcLogRecord.EventLogger eventLogger,
       String callId,
       @Nullable SocketAddress peerAddress,
-      // null on server side
-      @Nullable SpanContext spanContext) {
+      SpanContext spanContext) {
     checkNotNull(serviceName, "serviceName");
     checkNotNull(methodName, "methodName");
     checkNotNull(authority, "authority");
@@ -177,8 +175,7 @@ public class LogHelper {
       GrpcLogRecord.EventLogger eventLogger,
       String callId,
       @Nullable SocketAddress peerAddress,
-      // null on server side
-      @Nullable SpanContext spanContext) {
+      SpanContext spanContext) {
     checkNotNull(serviceName, "serviceName");
     checkNotNull(methodName, "methodName");
     checkNotNull(authority, "authority");
@@ -228,8 +225,7 @@ public class LogHelper {
       int maxMessageBytes,
       EventLogger eventLogger,
       String callId,
-      // null on server side
-      @Nullable SpanContext spanContext) {
+      SpanContext spanContext) {
     checkNotNull(serviceName, "serviceName");
     checkNotNull(methodName, "methodName");
     checkNotNull(authority, "authority");
@@ -282,8 +278,7 @@ public class LogHelper {
       String authority,
       GrpcLogRecord.EventLogger eventLogger,
       String callId,
-      // null on server side
-      @Nullable SpanContext spanContext) {
+      SpanContext spanContext) {
     checkNotNull(serviceName, "serviceName");
     checkNotNull(methodName, "methodName");
     checkNotNull(authority, "authority");
@@ -310,8 +305,7 @@ public class LogHelper {
       String authority,
       GrpcLogRecord.EventLogger eventLogger,
       String callId,
-      // null on server side
-      @Nullable SpanContext spanContext) {
+      SpanContext spanContext) {
     checkNotNull(serviceName, "serviceName");
     checkNotNull(methodName, "methodName");
     checkNotNull(authority, "authority");

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/GcpLogSink.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/GcpLogSink.java
@@ -36,7 +36,6 @@ import io.grpc.Internal;
 import io.grpc.gcp.observability.ObservabilityConfig;
 import io.grpc.internal.JsonParser;
 import io.grpc.observabilitylog.v1.GrpcLogRecord;
-import io.grpc.observabilitylog.v1.GrpcLogRecord.EventLogger;
 import io.opencensus.trace.SpanContext;
 import java.io.IOException;
 import java.time.Instant;
@@ -47,7 +46,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
 /**
@@ -107,7 +105,7 @@ public class GcpLogSink implements Sink {
    * @param logProto gRPC logging proto containing the message to be logged
    */
   @Override
-  public void write(GrpcLogRecord logProto, @Nullable SpanContext spanContext) {
+  public void write(GrpcLogRecord logProto, SpanContext spanContext) {
     if (gcpLoggingClient == null) {
       synchronized (this) {
         if (gcpLoggingClient == null) {
@@ -135,7 +133,7 @@ public class GcpLogSink implements Sink {
         grpcLogEntryBuilder.setLabels(customTags);
       }
 
-      addTraceData(grpcLogEntryBuilder, spanContext, logProto.getLogger() == EventLogger.CLIENT);
+      addTraceData(grpcLogEntryBuilder, spanContext);
       grpcLogEntry = grpcLogEntryBuilder.build();
 
       synchronized (this) {
@@ -154,13 +152,12 @@ public class GcpLogSink implements Sink {
     }
   }
 
-  void addTraceData(LogEntry.Builder builder, SpanContext spanContext, boolean isClient) {
+  void addTraceData(LogEntry.Builder builder, SpanContext spanContext) {
     if (!isTraceEnabled) {
       return;
     }
-    traceLoggingHelper.enhanceLogEntry(builder, isClient ? spanContext : SpanContext.INVALID);
+    traceLoggingHelper.enhanceLogEntry(builder, spanContext);
   }
-
 
   Logging createLoggingClient() {
     LoggingOptions.Builder builder = LoggingOptions.newBuilder();

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/Sink.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/Sink.java
@@ -18,6 +18,7 @@ package io.grpc.gcp.observability.logging;
 
 import io.grpc.Internal;
 import io.grpc.observabilitylog.v1.GrpcLogRecord;
+import io.opencensus.trace.SpanContext;
 
 /**
  * Sink for GCP observability.
@@ -27,7 +28,7 @@ public interface Sink {
   /**
    * Writes the {@code message} to the destination.
    */
-  void write(GrpcLogRecord message);
+  void write(GrpcLogRecord message, SpanContext spanContext);
 
   /**
    * Closes the sink.

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/TraceLoggingHelper.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/TraceLoggingHelper.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.gcp.observability.logging;
+
+import com.google.cloud.logging.LogEntry;
+import com.google.common.annotations.VisibleForTesting;
+import io.opencensus.trace.Span;
+import io.opencensus.trace.SpanContext;
+import io.opencensus.trace.TraceId;
+import io.opencensus.trace.unsafe.ContextHandleUtils;
+
+public class TraceLoggingHelper {
+
+  private final String tracePrefix;
+
+  public TraceLoggingHelper(String projectId) {
+    this.tracePrefix = "projects/" + projectId + "/traces/";;
+  }
+
+  @VisibleForTesting
+  void enhanceLogEntry(LogEntry.Builder builder, SpanContext spanContext) {
+    addTracingData(tracePrefix,
+        spanContext != null && spanContext.isValid() ? spanContext : getServerSpanContext(),
+        builder);
+  }
+
+  private static SpanContext getServerSpanContext() {
+    Span span = ContextHandleUtils.getValue(ContextHandleUtils.currentContext());
+    return span == null ? SpanContext.INVALID : span.getContext();
+  }
+
+  private static void addTracingData(
+      String tracePrefix, SpanContext spanContext, LogEntry.Builder builder) {
+    builder.setTrace(formatTraceId(tracePrefix, spanContext.getTraceId()));
+    builder.setSpanId(spanContext.getSpanId().toLowerBase16());
+    builder.setTraceSampled(spanContext.getTraceOptions().isSampled());
+  }
+
+  private static String formatTraceId(String tracePrefix, TraceId traceId) {
+    return tracePrefix + traceId.toLowerBase16();
+  }
+}

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/TraceLoggingHelper.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/TraceLoggingHelper.java
@@ -18,11 +18,11 @@ package io.grpc.gcp.observability.logging;
 
 import com.google.cloud.logging.LogEntry;
 import com.google.common.annotations.VisibleForTesting;
-import io.opencensus.trace.Span;
+import io.grpc.Internal;
 import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.TraceId;
-import io.opencensus.trace.unsafe.ContextHandleUtils;
 
+@Internal
 public class TraceLoggingHelper {
 
   private final String tracePrefix;
@@ -33,14 +33,7 @@ public class TraceLoggingHelper {
 
   @VisibleForTesting
   void enhanceLogEntry(LogEntry.Builder builder, SpanContext spanContext) {
-    addTracingData(tracePrefix,
-        spanContext != null && spanContext.isValid() ? spanContext : getServerSpanContext(),
-        builder);
-  }
-
-  private static SpanContext getServerSpanContext() {
-    Span span = ContextHandleUtils.getValue(ContextHandleUtils.currentContext());
-    return span == null ? SpanContext.INVALID : span.getContext();
+    addTracingData(tracePrefix, spanContext, builder);
   }
 
   private static void addTracingData(

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/interceptors/InternalLoggingServerInterceptorTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/interceptors/InternalLoggingServerInterceptorTest.java
@@ -171,7 +171,8 @@ public class InternalLoggingServerInterceptorTest {
           eq(filterParams.headerBytes()),
           eq(EventLogger.SERVER),
           anyString(),
-          same(peer));
+          same(peer),
+          ArgumentMatchers.isNull());
       verifyNoMoreInteractions(mockLogHelper);
     }
 
@@ -191,6 +192,7 @@ public class InternalLoggingServerInterceptorTest {
           eq(filterParams.headerBytes()),
           eq(EventLogger.SERVER),
           anyString(),
+          ArgumentMatchers.isNull(),
           ArgumentMatchers.isNull());
       verifyNoMoreInteractions(mockLogHelper);
       assertSame(serverInitial, actualServerInitial.get());
@@ -212,7 +214,8 @@ public class InternalLoggingServerInterceptorTest {
           same(request),
           eq(filterParams.messageBytes()),
           eq(EventLogger.SERVER),
-          anyString());
+          anyString(),
+          ArgumentMatchers.isNull());
       verifyNoMoreInteractions(mockLogHelper);
       verify(mockListener).onMessage(same(request));
     }
@@ -229,7 +232,8 @@ public class InternalLoggingServerInterceptorTest {
           eq("method"),
           eq("the-authority"),
           eq(EventLogger.SERVER),
-          anyString());
+          anyString(),
+          ArgumentMatchers.isNull());
       verifyNoMoreInteractions(mockLogHelper);
       verify(mockListener).onHalfClose();
     }
@@ -250,7 +254,8 @@ public class InternalLoggingServerInterceptorTest {
           same(response),
           eq(filterParams.messageBytes()),
           eq(EventLogger.SERVER),
-          anyString());
+          anyString(),
+          ArgumentMatchers.isNull());
       verifyNoMoreInteractions(mockLogHelper);
       assertSame(response, actualResponse.get());
     }
@@ -273,6 +278,7 @@ public class InternalLoggingServerInterceptorTest {
           eq(filterParams.headerBytes()),
           eq(EventLogger.SERVER),
           anyString(),
+          ArgumentMatchers.isNull(),
           ArgumentMatchers.isNull());
       verifyNoMoreInteractions(mockLogHelper);
       assertSame(status, actualStatus.get());
@@ -291,7 +297,8 @@ public class InternalLoggingServerInterceptorTest {
           eq("method"),
           eq("the-authority"),
           eq(EventLogger.SERVER),
-          anyString());
+          anyString(),
+          ArgumentMatchers.isNull());
       verify(mockListener).onCancel();
     }
   }
@@ -342,7 +349,8 @@ public class InternalLoggingServerInterceptorTest {
         eq(filterParams.headerBytes()),
         eq(EventLogger.SERVER),
         anyString(),
-        ArgumentMatchers.isNull());
+        ArgumentMatchers.isNull(),
+            ArgumentMatchers.isNull());
     verifyNoMoreInteractions(mockLogHelper);
     Duration timeout = timeoutCaptor.getValue();
     assertThat(TimeUnit.SECONDS.toNanos(1) - Durations.toNanos(timeout))

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/interceptors/InternalLoggingServerInterceptorTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/interceptors/InternalLoggingServerInterceptorTest.java
@@ -45,6 +45,7 @@ import io.grpc.gcp.observability.interceptors.ConfigFilterHelper.FilterParams;
 import io.grpc.internal.NoopServerCall;
 import io.grpc.observabilitylog.v1.GrpcLogRecord.EventLogger;
 import io.grpc.observabilitylog.v1.GrpcLogRecord.EventType;
+import io.opencensus.trace.SpanContext;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -172,7 +173,7 @@ public class InternalLoggingServerInterceptorTest {
           eq(EventLogger.SERVER),
           anyString(),
           same(peer),
-          ArgumentMatchers.isNull());
+          eq(SpanContext.INVALID));
       verifyNoMoreInteractions(mockLogHelper);
     }
 
@@ -193,7 +194,7 @@ public class InternalLoggingServerInterceptorTest {
           eq(EventLogger.SERVER),
           anyString(),
           ArgumentMatchers.isNull(),
-          ArgumentMatchers.isNull());
+          eq(SpanContext.INVALID));
       verifyNoMoreInteractions(mockLogHelper);
       assertSame(serverInitial, actualServerInitial.get());
     }
@@ -215,7 +216,7 @@ public class InternalLoggingServerInterceptorTest {
           eq(filterParams.messageBytes()),
           eq(EventLogger.SERVER),
           anyString(),
-          ArgumentMatchers.isNull());
+          eq(SpanContext.INVALID));
       verifyNoMoreInteractions(mockLogHelper);
       verify(mockListener).onMessage(same(request));
     }
@@ -233,7 +234,7 @@ public class InternalLoggingServerInterceptorTest {
           eq("the-authority"),
           eq(EventLogger.SERVER),
           anyString(),
-          ArgumentMatchers.isNull());
+          eq(SpanContext.INVALID));
       verifyNoMoreInteractions(mockLogHelper);
       verify(mockListener).onHalfClose();
     }
@@ -255,7 +256,7 @@ public class InternalLoggingServerInterceptorTest {
           eq(filterParams.messageBytes()),
           eq(EventLogger.SERVER),
           anyString(),
-          ArgumentMatchers.isNull());
+          eq(SpanContext.INVALID));
       verifyNoMoreInteractions(mockLogHelper);
       assertSame(response, actualResponse.get());
     }
@@ -279,7 +280,7 @@ public class InternalLoggingServerInterceptorTest {
           eq(EventLogger.SERVER),
           anyString(),
           ArgumentMatchers.isNull(),
-          ArgumentMatchers.isNull());
+          eq(SpanContext.INVALID));
       verifyNoMoreInteractions(mockLogHelper);
       assertSame(status, actualStatus.get());
       assertSame(trailers, actualTrailers.get());
@@ -298,7 +299,7 @@ public class InternalLoggingServerInterceptorTest {
           eq("the-authority"),
           eq(EventLogger.SERVER),
           anyString(),
-          ArgumentMatchers.isNull());
+          eq(SpanContext.INVALID));
       verify(mockListener).onCancel();
     }
   }
@@ -350,7 +351,7 @@ public class InternalLoggingServerInterceptorTest {
         eq(EventLogger.SERVER),
         anyString(),
         ArgumentMatchers.isNull(),
-            ArgumentMatchers.isNull());
+            eq(SpanContext.INVALID));
     verifyNoMoreInteractions(mockLogHelper);
     Duration timeout = timeoutCaptor.getValue();
     assertThat(TimeUnit.SECONDS.toNanos(1) - Durations.toNanos(timeout))

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/interceptors/LogHelperTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/interceptors/LogHelperTest.java
@@ -85,6 +85,11 @@ public class LogHelperTest {
       SpanId.fromLowerBase16("de52e84d13dd232d"),
       TraceOptions.builder().setIsSampled(true).build(),
       Tracestate.builder().build());
+  private static final SpanContext SERVER_SPAN_CONTEXT = SpanContext.create(
+      TraceId.fromLowerBase16("549a8a64db2d0c757fdf6bb1bfe84e2c"),
+      SpanId.fromLowerBase16("a5b7704614fe903d"),
+      TraceOptions.builder().setIsSampled(true).build(),
+      Tracestate.builder().build());
 
   private final Metadata nonEmptyMetadata = new Metadata();
   private final Sink sink = mock(GcpLogSink.class);
@@ -317,13 +322,13 @@ public class LogHelperTest {
           EventLogger.SERVER,
           callId,
           peerAddress,
-          null);
+          SERVER_SPAN_CONTEXT);
       verify(sink).write(
           base.toBuilder()
               .setPeer(LogHelper.socketAddressToProto(peerAddress))
               .setLogger(EventLogger.SERVER)
               .build(),
-          null);
+          SERVER_SPAN_CONTEXT);
     }
 
     // timeout is null
@@ -420,13 +425,13 @@ public class LogHelperTest {
           EventLogger.SERVER,
           callId,
           null,
-          null);
+          SERVER_SPAN_CONTEXT);
       verify(sink).write(
           base.toBuilder()
               .setLogger(EventLogger.SERVER)
               .clearPeer()
               .build(),
-          null);
+          SERVER_SPAN_CONTEXT);
     }
 
     // peerAddress is not null (error on server)
@@ -441,7 +446,7 @@ public class LogHelperTest {
           EventLogger.SERVER,
           callId,
           peerAddress,
-          null);
+          SERVER_SPAN_CONTEXT);
 
       fail();
     } catch (IllegalArgumentException expected) {
@@ -510,13 +515,14 @@ public class LogHelperTest {
           HEADER_LIMIT,
           EventLogger.SERVER,
           callId,
-          null, null);
+          null,
+          SERVER_SPAN_CONTEXT);
       verify(sink).write(
           base.toBuilder()
               .clearPeer()
               .setLogger(EventLogger.SERVER)
               .build(),
-          null);
+          SERVER_SPAN_CONTEXT);
     }
 
     // peer address is null
@@ -653,12 +659,12 @@ public class LogHelperTest {
           MESSAGE_LIMIT,
           EventLogger.SERVER,
           callId,
-          null);
+          SERVER_SPAN_CONTEXT);
       verify(sink).write(
           base.toBuilder()
               .setLogger(EventLogger.SERVER)
               .build(),
-          null);
+          SERVER_SPAN_CONTEXT);
     }
     // response message, logged on server
     {
@@ -672,13 +678,13 @@ public class LogHelperTest {
           MESSAGE_LIMIT,
           EventLogger.SERVER,
           callId,
-          null);
+          SpanContext.INVALID);
       verify(sink).write(
           base.toBuilder()
               .setType(EventType.SERVER_MESSAGE)
               .setLogger(EventLogger.SERVER)
               .build(),
-          null);
+          SpanContext.INVALID);
     }
     // message is not of type : com.google.protobuf.Message or byte[]
     {

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/logging/GcpLogSinkTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/logging/GcpLogSinkTest.java
@@ -287,26 +287,16 @@ public class GcpLogSinkTest {
     Sink mockSink = new GcpLogSink(mockLogging, DEST_PROJECT_NAME, LOCATION_TAGS,
         mockConfig, Collections.emptySet(), traceLoggingHelper);
 
-    // Client log
-    mockSink.write(LOG_PROTO, null);
-
     String expectedTrace =
         "projects/" + DEST_PROJECT_NAME + "/traces/00000000000000000000000000000000";
     String expectedSpanId = "0000000000000000";
 
     ArgumentCaptor<Collection<LogEntry>> logEntrySetCaptor = ArgumentCaptor.forClass(
         (Class) Collection.class);
-    verify(mockLogging, times(1)).write(logEntrySetCaptor.capture());
-    for (Iterator<LogEntry> it = logEntrySetCaptor.getValue().iterator(); it.hasNext(); ) {
-      LogEntry entry = it.next();
-      assertThat(entry.getTrace()).isEqualTo(expectedTrace);
-      assertThat(entry.getSpanId()).isEqualTo(expectedSpanId);
-      assertThat(entry.getTraceSampled()).isFalse();
-    }
 
     // Client log with default span context
     mockSink.write(LOG_PROTO , SpanContext.INVALID);
-    verify(mockLogging, times(2)).write(logEntrySetCaptor.capture());
+    verify(mockLogging, times(1)).write(logEntrySetCaptor.capture());
     for (Iterator<LogEntry> it = logEntrySetCaptor.getValue().iterator(); it.hasNext(); ) {
       LogEntry entry = it.next();
       assertThat(entry.getTrace()).isEqualTo(expectedTrace);
@@ -316,8 +306,8 @@ public class GcpLogSinkTest {
 
     // Server log
     GrpcLogRecord serverLogProto = LOG_PROTO.toBuilder().setLogger(EventLogger.SERVER).build();
-    mockSink.write(serverLogProto , null);
-    verify(mockLogging, times(3)).write(logEntrySetCaptor.capture());
+    mockSink.write(serverLogProto , SpanContext.INVALID);
+    verify(mockLogging, times(2)).write(logEntrySetCaptor.capture());
     for (Iterator<LogEntry> it = logEntrySetCaptor.getValue().iterator(); it.hasNext(); ) {
       LogEntry entry = it.next();
       assertThat(entry.getTrace()).isEqualTo(expectedTrace);

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/logging/GcpLogSinkTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/logging/GcpLogSinkTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.MonitoredResource;
 import com.google.cloud.logging.LogEntry;
@@ -31,9 +32,15 @@ import com.google.protobuf.Duration;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import com.google.protobuf.util.Durations;
+import io.grpc.gcp.observability.ObservabilityConfig;
 import io.grpc.observabilitylog.v1.GrpcLogRecord;
 import io.grpc.observabilitylog.v1.GrpcLogRecord.EventLogger;
 import io.grpc.observabilitylog.v1.GrpcLogRecord.EventType;
+import io.opencensus.trace.SpanContext;
+import io.opencensus.trace.SpanId;
+import io.opencensus.trace.TraceId;
+import io.opencensus.trace.TraceOptions;
+import io.opencensus.trace.Tracestate;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -105,13 +112,16 @@ public class GcpLogSinkTest {
       .build();
   @Mock
   private Logging mockLogging;
+  @Mock
+  private ObservabilityConfig mockConfig;
 
   @Test
   @SuppressWarnings("unchecked")
   public void verifyWrite() throws Exception {
+    when(mockConfig.getCustomTags()).thenReturn(CUSTOM_TAGS);
     GcpLogSink sink = new GcpLogSink(mockLogging, DEST_PROJECT_NAME, LOCATION_TAGS,
-        CUSTOM_TAGS, Collections.emptySet());
-    sink.write(LOG_PROTO);
+        mockConfig, Collections.emptySet(), new TraceLoggingHelper(DEST_PROJECT_NAME));
+    sink.write(LOG_PROTO, null);
 
     ArgumentCaptor<Collection<LogEntry>> logEntrySetCaptor = ArgumentCaptor.forClass(
         (Class) Collection.class);
@@ -127,10 +137,11 @@ public class GcpLogSinkTest {
   @Test
   @SuppressWarnings("unchecked")
   public void verifyWriteWithTags() {
+    when(mockConfig.getCustomTags()).thenReturn(CUSTOM_TAGS);
     GcpLogSink sink = new GcpLogSink(mockLogging, DEST_PROJECT_NAME, LOCATION_TAGS,
-        CUSTOM_TAGS, Collections.emptySet());
+        mockConfig, Collections.emptySet(), new TraceLoggingHelper(DEST_PROJECT_NAME));
     MonitoredResource expectedMonitoredResource = GcpLogSink.getResource(LOCATION_TAGS);
-    sink.write(LOG_PROTO);
+    sink.write(LOG_PROTO, null);
 
     ArgumentCaptor<Collection<LogEntry>> logEntrySetCaptor = ArgumentCaptor.forClass(
         (Class) Collection.class);
@@ -150,10 +161,11 @@ public class GcpLogSinkTest {
   @SuppressWarnings("unchecked")
   public void emptyCustomTags_labelsNotSet() {
     Map<String, String> emptyCustomTags = null;
+    when(mockConfig.getCustomTags()).thenReturn(emptyCustomTags);
     Map<String, String> expectedEmptyLabels = new HashMap<>();
     GcpLogSink sink = new GcpLogSink(mockLogging, DEST_PROJECT_NAME, LOCATION_TAGS,
-        emptyCustomTags, Collections.emptySet());
-    sink.write(LOG_PROTO);
+        mockConfig, Collections.emptySet(), new TraceLoggingHelper(DEST_PROJECT_NAME));
+    sink.write(LOG_PROTO, null);
 
     ArgumentCaptor<Collection<LogEntry>> logEntrySetCaptor = ArgumentCaptor.forClass(
         (Class) Collection.class);
@@ -169,12 +181,13 @@ public class GcpLogSinkTest {
   @SuppressWarnings("unchecked")
   public void emptyCustomTags_setSourceProject() {
     Map<String, String> emptyCustomTags = null;
+    when(mockConfig.getCustomTags()).thenReturn(emptyCustomTags);
     String projectId = "PROJECT";
     Map<String, String> expectedLabels = GcpLogSink.getCustomTags(emptyCustomTags, LOCATION_TAGS,
         projectId);
     GcpLogSink sink = new GcpLogSink(mockLogging, projectId, LOCATION_TAGS,
-        emptyCustomTags, Collections.emptySet());
-    sink.write(LOG_PROTO);
+        mockConfig, Collections.emptySet(), new TraceLoggingHelper(DEST_PROJECT_NAME));
+    sink.write(LOG_PROTO, null);
 
     ArgumentCaptor<Collection<LogEntry>> logEntrySetCaptor = ArgumentCaptor.forClass(
         (Class) Collection.class);
@@ -189,8 +202,8 @@ public class GcpLogSinkTest {
   @Test
   public void verifyClose() throws Exception {
     GcpLogSink sink = new GcpLogSink(mockLogging, DEST_PROJECT_NAME, LOCATION_TAGS,
-        CUSTOM_TAGS, Collections.emptySet());
-    sink.write(LOG_PROTO);
+        mockConfig, Collections.emptySet(), new TraceLoggingHelper(DEST_PROJECT_NAME));
+    sink.write(LOG_PROTO, null);
     verify(mockLogging, times(1)).write(anyIterable());
     sink.close();
     verify(mockLogging).close();
@@ -200,8 +213,116 @@ public class GcpLogSinkTest {
   @Test
   public void verifyExclude() throws Exception {
     Sink mockSink = new GcpLogSink(mockLogging, DEST_PROJECT_NAME, LOCATION_TAGS,
-        CUSTOM_TAGS, Collections.singleton("service"));
-    mockSink.write(LOG_PROTO);
+        mockConfig, Collections.singleton("service"), new TraceLoggingHelper(DEST_PROJECT_NAME));
+    mockSink.write(LOG_PROTO, null);
     verifyNoInteractions(mockLogging);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void verifyNoTraceDataInLogs_withTraceDisabled() throws Exception {
+    SpanContext validSpanContext = SpanContext.create(
+        TraceId.fromLowerBase16("4c6af40c499951eb7de2777ba1e4fefa"),
+        SpanId.fromLowerBase16("de52e84d13dd232d"),
+        TraceOptions.builder().setIsSampled(true).build(),
+        Tracestate.builder().build());
+
+    TraceLoggingHelper traceLoggingHelper = new TraceLoggingHelper(DEST_PROJECT_NAME);
+    when(mockConfig.isEnableCloudTracing()).thenReturn(false);
+    Sink mockSink = new GcpLogSink(mockLogging, DEST_PROJECT_NAME, LOCATION_TAGS,
+        mockConfig, Collections.emptySet(), traceLoggingHelper);
+    mockSink.write(LOG_PROTO, validSpanContext);
+
+    ArgumentCaptor<Collection<LogEntry>> logEntrySetCaptor = ArgumentCaptor.forClass(
+        (Class) Collection.class);
+    verify(mockLogging, times(1)).write(logEntrySetCaptor.capture());
+    for (Iterator<LogEntry> it = logEntrySetCaptor.getValue().iterator(); it.hasNext(); ) {
+      LogEntry entry = it.next();
+      assertThat(entry.getTrace()).isNull(); // Field not present
+      assertThat(entry.getSpanId()).isNull(); // Field not present
+      assertThat(entry.getTraceSampled()).isFalse(); // Default value
+      assertThat(entry.getPayload().getData()).isEqualTo(EXPECTED_STRUCT_LOG_PROTO);
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void verifyTraceDataInLogs_withValidSpanContext() throws Exception {
+    CharSequence traceIdSeq = "4c6af40c499951eb7de2777ba1e4fefa";
+    CharSequence spanIdSeq = "de52e84d13dd232d";
+    TraceId traceId = TraceId.fromLowerBase16(traceIdSeq);
+    SpanId spanId = SpanId.fromLowerBase16(spanIdSeq);
+    boolean traceSampled = true;
+
+    SpanContext validSpanContext = SpanContext.create(traceId, spanId,
+        TraceOptions.builder().setIsSampled(traceSampled).build(),
+        Tracestate.builder().build());
+
+    TraceLoggingHelper traceLoggingHelper = new TraceLoggingHelper(DEST_PROJECT_NAME);
+    when(mockConfig.isEnableCloudTracing()).thenReturn(true);
+    Sink mockSink = new GcpLogSink(mockLogging, DEST_PROJECT_NAME, LOCATION_TAGS,
+        mockConfig, Collections.emptySet(), traceLoggingHelper);
+    mockSink.write(LOG_PROTO, validSpanContext);
+
+    String expectedTrace = "projects/" + DEST_PROJECT_NAME + "/traces/" + traceIdSeq;
+
+    ArgumentCaptor<Collection<LogEntry>> logEntrySetCaptor = ArgumentCaptor.forClass(
+        (Class) Collection.class);
+    verify(mockLogging, times(1)).write(logEntrySetCaptor.capture());
+    for (Iterator<LogEntry> it = logEntrySetCaptor.getValue().iterator(); it.hasNext(); ) {
+      LogEntry entry = it.next();
+      assertThat(entry.getTrace()).isEqualTo(expectedTrace);
+      assertThat(entry.getSpanId()).isEqualTo("" + spanIdSeq);
+      assertThat(entry.getTraceSampled()).isEqualTo(traceSampled);
+      assertThat(entry.getPayload().getData()).isEqualTo(EXPECTED_STRUCT_LOG_PROTO);
+    }
+
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void verifyTraceDataLogs_withNullSpanContext() throws Exception {
+    TraceLoggingHelper traceLoggingHelper = new TraceLoggingHelper(DEST_PROJECT_NAME);
+    when(mockConfig.isEnableCloudTracing()).thenReturn(true);
+    Sink mockSink = new GcpLogSink(mockLogging, DEST_PROJECT_NAME, LOCATION_TAGS,
+        mockConfig, Collections.emptySet(), traceLoggingHelper);
+
+    // Client log
+    mockSink.write(LOG_PROTO, null);
+
+    String expectedTrace =
+        "projects/" + DEST_PROJECT_NAME + "/traces/00000000000000000000000000000000";
+    String expectedSpanId = "0000000000000000";
+
+    ArgumentCaptor<Collection<LogEntry>> logEntrySetCaptor = ArgumentCaptor.forClass(
+        (Class) Collection.class);
+    verify(mockLogging, times(1)).write(logEntrySetCaptor.capture());
+    for (Iterator<LogEntry> it = logEntrySetCaptor.getValue().iterator(); it.hasNext(); ) {
+      LogEntry entry = it.next();
+      assertThat(entry.getTrace()).isEqualTo(expectedTrace);
+      assertThat(entry.getSpanId()).isEqualTo(expectedSpanId);
+      assertThat(entry.getTraceSampled()).isFalse();
+    }
+
+    // Client log with default span context
+    mockSink.write(LOG_PROTO , SpanContext.INVALID);
+    verify(mockLogging, times(2)).write(logEntrySetCaptor.capture());
+    for (Iterator<LogEntry> it = logEntrySetCaptor.getValue().iterator(); it.hasNext(); ) {
+      LogEntry entry = it.next();
+      assertThat(entry.getTrace()).isEqualTo(expectedTrace);
+      assertThat(entry.getSpanId()).isEqualTo(expectedSpanId);
+      assertThat(entry.getTraceSampled()).isFalse();
+    }
+
+    // Server log
+    GrpcLogRecord serverLogProto = LOG_PROTO.toBuilder().setLogger(EventLogger.SERVER).build();
+    mockSink.write(serverLogProto , null);
+    verify(mockLogging, times(3)).write(logEntrySetCaptor.capture());
+    for (Iterator<LogEntry> it = logEntrySetCaptor.getValue().iterator(); it.hasNext(); ) {
+      LogEntry entry = it.next();
+      assertThat(entry.getTrace()).isEqualTo(expectedTrace);
+      assertThat(entry.getSpanId()).isEqualTo(expectedSpanId);
+      assertThat(entry.getTraceSampled()).isFalse();
+    }
   }
 }

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/logging/TraceLoggingHelperTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/logging/TraceLoggingHelperTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.gcp.observability.logging;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.logging.LogEntry;
+import io.opencensus.trace.SpanContext;
+import io.opencensus.trace.SpanId;
+import io.opencensus.trace.TraceId;
+import io.opencensus.trace.TraceOptions;
+import io.opencensus.trace.Tracestate;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link TraceLoggingHelper}.
+ */
+@RunWith(JUnit4.class)
+public class TraceLoggingHelperTest {
+
+  private static final String PROJECT = "PROJECT";
+  private static final Tracestate EMPTY_TRACESTATE = Tracestate.builder().build();
+  private static TraceLoggingHelper traceLoggingHelper;
+
+  @Before
+  public void setUp() {
+    traceLoggingHelper = new TraceLoggingHelper(PROJECT);
+  }
+
+  @Test
+  public void enhanceLogEntry_AddSampledSpanContextToLogEntry() {
+    SpanContext spanContext = SpanContext.create(
+        TraceId.fromLowerBase16("5ce724c382c136b2a67bb447e6a6bd27"),
+        SpanId.fromLowerBase16("de52e84d13dd232d"),
+        TraceOptions.builder().setIsSampled(true).build(),
+        EMPTY_TRACESTATE);
+    LogEntry logEntry = getEnhancedLogEntry(traceLoggingHelper, spanContext);
+    assertThat(logEntry.getTraceSampled()).isTrue();
+    assertThat(logEntry.getTrace())
+        .isEqualTo("projects/PROJECT/traces/5ce724c382c136b2a67bb447e6a6bd27");
+    assertThat(logEntry.getSpanId()).isEqualTo("de52e84d13dd232d");
+  }
+
+  @Test
+  public void enhanceLogEntry_AddNonSampledSpanContextToLogEntry() {
+    SpanContext spanContext = SpanContext.create(
+        TraceId.fromLowerBase16("649a8a64db2d0c757fd06bb1bfe84e2c"),
+        SpanId.fromLowerBase16("731e102335b7a5a0"),
+        TraceOptions.builder().setIsSampled(false).build(),
+        EMPTY_TRACESTATE);
+    LogEntry logEntry = getEnhancedLogEntry(traceLoggingHelper, spanContext);
+    assertThat(logEntry.getTraceSampled()).isFalse();
+    assertThat(logEntry.getTrace())
+        .isEqualTo("projects/PROJECT/traces/649a8a64db2d0c757fd06bb1bfe84e2c");
+    assertThat(logEntry.getSpanId()).isEqualTo("731e102335b7a5a0");
+  }
+
+  @Test
+  public void enhanceLogEntry_AddBlankSpanContextToLogEntry() {
+    SpanContext spanContext = SpanContext.INVALID;
+    LogEntry logEntry = getEnhancedLogEntry(traceLoggingHelper, spanContext);
+    assertThat(logEntry.getTraceSampled()).isFalse();
+    assertThat(logEntry.getTrace())
+        .isEqualTo("projects/PROJECT/traces/00000000000000000000000000000000");
+    assertThat(logEntry.getSpanId()).isEqualTo("0000000000000000");
+  }
+
+  private static LogEntry getEnhancedLogEntry(TraceLoggingHelper traceLoggingHelper,
+      SpanContext spanContext) {
+    LogEntry.Builder logEntryBuilder = LogEntry.newBuilder(null);
+    traceLoggingHelper.enhanceLogEntry(logEntryBuilder, spanContext);
+    return logEntryBuilder.build();
+  }
+}


### PR DESCRIPTION
This PR adds trace information (TraceId, SpanId and TraceSampled) fields to LogEntry, when both logging and tracing are enabled in gcp-observability. 

For server-side logs, span information was readily available using Span.getContext() propagated via `io.grpc.Context`. Similar approach is not feasible for client-side architecture.

Client SpanContext which has all the information required to be added to logs is propagated to the logging interceptor via `io.grpc.CallOptions`.

CC @ejona86 @sanjaypujare 