### PR TITLE
gcp-o11y: add sleep in Observability close()

### DIFF
--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/GcpObservability.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/GcpObservability.java
@@ -128,6 +128,7 @@ public final class GcpObservability implements AutoCloseable {
           Thread.sleep(
               TimeUnit.MILLISECONDS.convert(2 * METRICS_EXPORT_INTERVAL, TimeUnit.SECONDS));
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           logger.log(Level.SEVERE, "Caught exception during sleep", e);
         }
       }


### PR DESCRIPTION
This PR adds sleep in `close()` for metrics and/or traces to be flushed before closing observability.

Currently sleep is set to 2 * [Metrics export interval (30 secs)].

CC @sanjaypujare @ejona86 
CC @stanley-cheung : this might alter inter-op tests results