### PR TITLE
gcp-observability, census: add trace information to logs (v1.54.x backport)

### DIFF
--- a/census/src/main/java/io/grpc/census/CensusTracingModule.java
+++ b/census/src/main/java/io/grpc/census/CensusTracingModule.java
@@ -17,6 +17,7 @@
 package io.grpc.census;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.grpc.census.internal.ObservabilityCensusConstants.CLIENT_TRACE_SPAN_CONTEXT_KEY;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.Attributes;
@@ -124,8 +125,8 @@ final class CensusTracingModule {
    */
   @VisibleForTesting
   CallAttemptsTracerFactory newClientCallTracer(
-      @Nullable Span parentSpan, MethodDescriptor<?, ?> method) {
-    return new CallAttemptsTracerFactory(parentSpan, method);
+      @Nullable Span clientSpan, MethodDescriptor<?, ?> method) {
+    return new CallAttemptsTracerFactory(clientSpan, method);
   }
 
   /**
@@ -248,17 +249,11 @@ final class CensusTracingModule {
     private final Span span;
     private final String fullMethodName;
 
-    CallAttemptsTracerFactory(@Nullable Span parentSpan, MethodDescriptor<?, ?> method) {
+    CallAttemptsTracerFactory(@Nullable Span clientSpan, MethodDescriptor<?, ?> method) {
       checkNotNull(method, "method");
       this.isSampledToLocalTracing = method.isSampledToLocalTracing();
       this.fullMethodName = method.getFullMethodName();
-      this.span =
-          censusTracer
-              .spanBuilderWithExplicitParent(
-                  generateTraceSpanName(false, fullMethodName),
-                  parentSpan)
-              .setRecordEvents(true)
-              .startSpan();
+      this.span = clientSpan;
     }
 
     @Override
@@ -461,13 +456,20 @@ final class CensusTracingModule {
       // Safe usage of the unsafe trace API because CONTEXT_SPAN_KEY.get() returns the same value
       // as Tracer.getCurrentSpan() except when no value available when the return value is null
       // for the direct access and BlankSpan when Tracer API is used.
-      final CallAttemptsTracerFactory tracerFactory =
-          newClientCallTracer(
-              io.opencensus.trace.unsafe.ContextUtils.getValue(Context.current()), method);
+      Span parentSpan = io.opencensus.trace.unsafe.ContextUtils.getValue(Context.current());
+      Span clientSpan = censusTracer
+          .spanBuilderWithExplicitParent(
+              generateTraceSpanName(false, method.getFullMethodName()),
+              parentSpan)
+          .setRecordEvents(true)
+          .startSpan();
+
+      final CallAttemptsTracerFactory tracerFactory = newClientCallTracer(clientSpan, method);
       ClientCall<ReqT, RespT> call =
           next.newCall(
               method,
-              callOptions.withStreamTracerFactory(tracerFactory));
+              callOptions.withStreamTracerFactory(tracerFactory)
+                  .withOption(CLIENT_TRACE_SPAN_CONTEXT_KEY, clientSpan.getContext()));
       return new SimpleForwardingClientCall<ReqT, RespT>(call) {
         @Override
         public void start(Listener<RespT> responseListener, Metadata headers) {

--- a/census/src/main/java/io/grpc/census/internal/ObservabilityCensusConstants.java
+++ b/census/src/main/java/io/grpc/census/internal/ObservabilityCensusConstants.java
@@ -26,11 +26,13 @@ import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_STATUS;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.grpc.CallOptions;
 import io.opencensus.contrib.grpc.metrics.RpcViewConstants;
 import io.opencensus.stats.Aggregation;
 import io.opencensus.stats.Measure;
 import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.View;
+import io.opencensus.trace.SpanContext;
 import java.util.Arrays;
 
 // TODO(dnvindhya): Remove metric and view definitions from this class once it is moved to
@@ -41,6 +43,9 @@ import java.util.Arrays;
  */
 @VisibleForTesting
 public final class ObservabilityCensusConstants {
+
+  public static CallOptions.Key<SpanContext> CLIENT_TRACE_SPAN_CONTEXT_KEY
+      = CallOptions.Key.createWithDefault("Client span context for tracing", SpanContext.INVALID);
 
   static final Aggregation AGGREGATION_WITH_BYTES_HISTOGRAM =
       RpcViewConstants.GRPC_CLIENT_SENT_BYTES_PER_RPC_VIEW.getAggregation();

--- a/census/src/test/java/io/grpc/census/CensusTracingAnnotationEventTest.java
+++ b/census/src/test/java/io/grpc/census/CensusTracingAnnotationEventTest.java
@@ -166,7 +166,7 @@ public class CensusTracingAnnotationEventTest {
   @Test
   public void clientBasicTracingUncompressedSizeAnnotation() {
     CallAttemptsTracerFactory callTracer =
-        censusTracing.newClientCallTracer(null, method);
+        censusTracing.newClientCallTracer(spyClientSpan, method);
     Metadata headers = new Metadata();
     ClientStreamTracer clientStreamTracer = callTracer.newClientStreamTracer(STREAM_INFO, headers);
     clientStreamTracer.streamCreated(Attributes.EMPTY, headers);

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/interceptors/InternalLoggingServerInterceptor.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/interceptors/InternalLoggingServerInterceptor.java
@@ -31,6 +31,9 @@ import io.grpc.Status;
 import io.grpc.gcp.observability.interceptors.ConfigFilterHelper.FilterParams;
 import io.grpc.observabilitylog.v1.GrpcLogRecord.EventLogger;
 import io.grpc.observabilitylog.v1.GrpcLogRecord.EventType;
+import io.opencensus.trace.Span;
+import io.opencensus.trace.SpanContext;
+import io.opencensus.trace.unsafe.ContextHandleUtils;
 import java.net.SocketAddress;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -91,6 +94,8 @@ public final class InternalLoggingServerInterceptor implements ServerInterceptor
     Deadline deadline = Context.current().getDeadline();
     final Duration timeout = deadline == null ? null
         : Durations.fromNanos(deadline.timeRemaining(TimeUnit.NANOSECONDS));
+    Span span = ContextHandleUtils.getValue(ContextHandleUtils.currentContext());
+    final SpanContext serverSpanContext = span == null ? SpanContext.INVALID : span.getContext();
 
     FilterParams filterParams =
         filterHelper.logRpcMethod(call.getMethodDescriptor().getFullMethodName(), false);
@@ -113,7 +118,8 @@ public final class InternalLoggingServerInterceptor implements ServerInterceptor
           maxHeaderBytes,
           EventLogger.SERVER,
           callId,
-          peerAddress);
+          peerAddress,
+          serverSpanContext);
     } catch (Exception e) {
       // Catching generic exceptions instead of specific ones for all the events.
       // This way we can catch both expected and unexpected exceptions instead of re-throwing
@@ -139,7 +145,8 @@ public final class InternalLoggingServerInterceptor implements ServerInterceptor
                   maxHeaderBytes,
                   EventLogger.SERVER,
                   callId,
-                  null);
+                  null,
+                  serverSpanContext);
             } catch (Exception e) {
               logger.log(Level.SEVERE, "Unable to log response header", e);
             }
@@ -160,7 +167,8 @@ public final class InternalLoggingServerInterceptor implements ServerInterceptor
                   message,
                   maxMessageBytes,
                   EventLogger.SERVER,
-                  callId);
+                  callId,
+                  serverSpanContext);
             } catch (Exception e) {
               logger.log(Level.SEVERE, "Unable to log response message", e);
             }
@@ -181,7 +189,8 @@ public final class InternalLoggingServerInterceptor implements ServerInterceptor
                   maxHeaderBytes,
                   EventLogger.SERVER,
                   callId,
-                  null);
+                  null,
+                  serverSpanContext);
             } catch (Exception e) {
               logger.log(Level.SEVERE, "Unable to log trailer", e);
             }
@@ -206,7 +215,8 @@ public final class InternalLoggingServerInterceptor implements ServerInterceptor
               message,
               maxMessageBytes,
               EventLogger.SERVER,
-              callId);
+              callId,
+              serverSpanContext);
         } catch (Exception e) {
           logger.log(Level.SEVERE, "Unable to log request message", e);
         }
@@ -223,7 +233,8 @@ public final class InternalLoggingServerInterceptor implements ServerInterceptor
               methodName,
               authority,
               EventLogger.SERVER,
-              callId);
+              callId,
+              serverSpanContext);
         } catch (Exception e) {
           logger.log(Level.SEVERE, "Unable to log half close", e);
         }
@@ -240,7 +251,8 @@ public final class InternalLoggingServerInterceptor implements ServerInterceptor
               methodName,
               authority,
               EventLogger.SERVER,
-              callId);
+              callId,
+              serverSpanContext);
         } catch (Exception e) {
           logger.log(Level.SEVERE, "Unable to log cancel", e);
         }

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/interceptors/LogHelper.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/interceptors/LogHelper.java
@@ -36,6 +36,7 @@ import io.grpc.observabilitylog.v1.GrpcLogRecord;
 import io.grpc.observabilitylog.v1.GrpcLogRecord.EventLogger;
 import io.grpc.observabilitylog.v1.GrpcLogRecord.EventType;
 import io.grpc.observabilitylog.v1.Payload;
+import io.opencensus.trace.SpanContext;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -88,7 +89,8 @@ public class LogHelper {
       GrpcLogRecord.EventLogger eventLogger,
       String callId,
       // null on client side
-      @Nullable SocketAddress peerAddress) {
+      @Nullable SocketAddress peerAddress,
+      SpanContext spanContext) {
     checkNotNull(serviceName, "serviceName");
     checkNotNull(methodName, "methodName");
     checkNotNull(authority, "authority");
@@ -114,7 +116,7 @@ public class LogHelper {
     if (peerAddress != null) {
       logEntryBuilder.setPeer(socketAddressToProto(peerAddress));
     }
-    sink.write(logEntryBuilder.build());
+    sink.write(logEntryBuilder.build(), spanContext);
   }
 
   /**
@@ -129,7 +131,8 @@ public class LogHelper {
       int maxHeaderBytes,
       GrpcLogRecord.EventLogger eventLogger,
       String callId,
-      @Nullable SocketAddress peerAddress) {
+      @Nullable SocketAddress peerAddress,
+      SpanContext spanContext) {
     checkNotNull(serviceName, "serviceName");
     checkNotNull(methodName, "methodName");
     checkNotNull(authority, "authority");
@@ -155,7 +158,7 @@ public class LogHelper {
     if (peerAddress != null) {
       logEntryBuilder.setPeer(socketAddressToProto(peerAddress));
     }
-    sink.write(logEntryBuilder.build());
+    sink.write(logEntryBuilder.build(), spanContext);
   }
 
   /**
@@ -171,7 +174,8 @@ public class LogHelper {
       int maxHeaderBytes,
       GrpcLogRecord.EventLogger eventLogger,
       String callId,
-      @Nullable SocketAddress peerAddress) {
+      @Nullable SocketAddress peerAddress,
+      SpanContext spanContext) {
     checkNotNull(serviceName, "serviceName");
     checkNotNull(methodName, "methodName");
     checkNotNull(authority, "authority");
@@ -205,7 +209,7 @@ public class LogHelper {
     if (peerAddress != null) {
       logEntryBuilder.setPeer(socketAddressToProto(peerAddress));
     }
-    sink.write(logEntryBuilder.build());
+    sink.write(logEntryBuilder.build(), spanContext);
   }
 
   /**
@@ -220,7 +224,8 @@ public class LogHelper {
       T message,
       int maxMessageBytes,
       EventLogger eventLogger,
-      String callId) {
+      String callId,
+      SpanContext spanContext) {
     checkNotNull(serviceName, "serviceName");
     checkNotNull(methodName, "methodName");
     checkNotNull(authority, "authority");
@@ -260,7 +265,7 @@ public class LogHelper {
       logEntryBuilder.setPayload(pair.payloadBuilder)
           .setPayloadTruncated(pair.truncated);
     }
-    sink.write(logEntryBuilder.build());
+    sink.write(logEntryBuilder.build(), spanContext);
   }
 
   /**
@@ -272,7 +277,8 @@ public class LogHelper {
       String methodName,
       String authority,
       GrpcLogRecord.EventLogger eventLogger,
-      String callId) {
+      String callId,
+      SpanContext spanContext) {
     checkNotNull(serviceName, "serviceName");
     checkNotNull(methodName, "methodName");
     checkNotNull(authority, "authority");
@@ -286,7 +292,7 @@ public class LogHelper {
         .setType(EventType.CLIENT_HALF_CLOSE)
         .setLogger(eventLogger)
         .setCallId(callId);
-    sink.write(logEntryBuilder.build());
+    sink.write(logEntryBuilder.build(), spanContext);
   }
 
   /**
@@ -298,7 +304,8 @@ public class LogHelper {
       String methodName,
       String authority,
       GrpcLogRecord.EventLogger eventLogger,
-      String callId) {
+      String callId,
+      SpanContext spanContext) {
     checkNotNull(serviceName, "serviceName");
     checkNotNull(methodName, "methodName");
     checkNotNull(authority, "authority");
@@ -312,7 +319,7 @@ public class LogHelper {
         .setType(EventType.CANCEL)
         .setLogger(eventLogger)
         .setCallId(callId);
-    sink.write(logEntryBuilder.build());
+    sink.write(logEntryBuilder.build(), spanContext);
   }
 
   // TODO(DNVindhya): Evaluate if we need following clause for metadata logging in GcpObservability

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/Sink.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/Sink.java
@@ -18,6 +18,7 @@ package io.grpc.gcp.observability.logging;
 
 import io.grpc.Internal;
 import io.grpc.observabilitylog.v1.GrpcLogRecord;
+import io.opencensus.trace.SpanContext;
 
 /**
  * Sink for GCP observability.
@@ -27,7 +28,7 @@ public interface Sink {
   /**
    * Writes the {@code message} to the destination.
    */
-  void write(GrpcLogRecord message);
+  void write(GrpcLogRecord message, SpanContext spanContext);
 
   /**
    * Closes the sink.

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/TraceLoggingHelper.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/logging/TraceLoggingHelper.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.gcp.observability.logging;
+
+import com.google.cloud.logging.LogEntry;
+import com.google.common.annotations.VisibleForTesting;
+import io.grpc.Internal;
+import io.opencensus.trace.SpanContext;
+import io.opencensus.trace.TraceId;
+
+@Internal
+public class TraceLoggingHelper {
+
+  private final String tracePrefix;
+
+  public TraceLoggingHelper(String projectId) {
+    this.tracePrefix = "projects/" + projectId + "/traces/";;
+  }
+
+  @VisibleForTesting
+  void enhanceLogEntry(LogEntry.Builder builder, SpanContext spanContext) {
+    addTracingData(tracePrefix, spanContext, builder);
+  }
+
+  private static void addTracingData(
+      String tracePrefix, SpanContext spanContext, LogEntry.Builder builder) {
+    builder.setTrace(formatTraceId(tracePrefix, spanContext.getTraceId()));
+    builder.setSpanId(spanContext.getSpanId().toLowerBase16());
+    builder.setTraceSampled(spanContext.getTraceOptions().isSampled());
+  }
+
+  private static String formatTraceId(String tracePrefix, TraceId traceId) {
+    return tracePrefix + traceId.toLowerBase16();
+  }
+}

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/interceptors/InternalLoggingServerInterceptorTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/interceptors/InternalLoggingServerInterceptorTest.java
@@ -45,6 +45,7 @@ import io.grpc.gcp.observability.interceptors.ConfigFilterHelper.FilterParams;
 import io.grpc.internal.NoopServerCall;
 import io.grpc.observabilitylog.v1.GrpcLogRecord.EventLogger;
 import io.grpc.observabilitylog.v1.GrpcLogRecord.EventType;
+import io.opencensus.trace.SpanContext;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -171,7 +172,8 @@ public class InternalLoggingServerInterceptorTest {
           eq(filterParams.headerBytes()),
           eq(EventLogger.SERVER),
           anyString(),
-          same(peer));
+          same(peer),
+          eq(SpanContext.INVALID));
       verifyNoMoreInteractions(mockLogHelper);
     }
 
@@ -191,7 +193,8 @@ public class InternalLoggingServerInterceptorTest {
           eq(filterParams.headerBytes()),
           eq(EventLogger.SERVER),
           anyString(),
-          ArgumentMatchers.isNull());
+          ArgumentMatchers.isNull(),
+          eq(SpanContext.INVALID));
       verifyNoMoreInteractions(mockLogHelper);
       assertSame(serverInitial, actualServerInitial.get());
     }
@@ -212,7 +215,8 @@ public class InternalLoggingServerInterceptorTest {
           same(request),
           eq(filterParams.messageBytes()),
           eq(EventLogger.SERVER),
-          anyString());
+          anyString(),
+          eq(SpanContext.INVALID));
       verifyNoMoreInteractions(mockLogHelper);
       verify(mockListener).onMessage(same(request));
     }
@@ -229,7 +233,8 @@ public class InternalLoggingServerInterceptorTest {
           eq("method"),
           eq("the-authority"),
           eq(EventLogger.SERVER),
-          anyString());
+          anyString(),
+          eq(SpanContext.INVALID));
       verifyNoMoreInteractions(mockLogHelper);
       verify(mockListener).onHalfClose();
     }
@@ -250,7 +255,8 @@ public class InternalLoggingServerInterceptorTest {
           same(response),
           eq(filterParams.messageBytes()),
           eq(EventLogger.SERVER),
-          anyString());
+          anyString(),
+          eq(SpanContext.INVALID));
       verifyNoMoreInteractions(mockLogHelper);
       assertSame(response, actualResponse.get());
     }
@@ -273,7 +279,8 @@ public class InternalLoggingServerInterceptorTest {
           eq(filterParams.headerBytes()),
           eq(EventLogger.SERVER),
           anyString(),
-          ArgumentMatchers.isNull());
+          ArgumentMatchers.isNull(),
+          eq(SpanContext.INVALID));
       verifyNoMoreInteractions(mockLogHelper);
       assertSame(status, actualStatus.get());
       assertSame(trailers, actualTrailers.get());
@@ -291,7 +298,8 @@ public class InternalLoggingServerInterceptorTest {
           eq("method"),
           eq("the-authority"),
           eq(EventLogger.SERVER),
-          anyString());
+          anyString(),
+          eq(SpanContext.INVALID));
       verify(mockListener).onCancel();
     }
   }
@@ -342,7 +350,8 @@ public class InternalLoggingServerInterceptorTest {
         eq(filterParams.headerBytes()),
         eq(EventLogger.SERVER),
         anyString(),
-        ArgumentMatchers.isNull());
+        ArgumentMatchers.isNull(),
+            eq(SpanContext.INVALID));
     verifyNoMoreInteractions(mockLogHelper);
     Duration timeout = timeoutCaptor.getValue();
     assertThat(TimeUnit.SECONDS.toNanos(1) - Durations.toNanos(timeout))

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/logging/GcpLogSinkTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/logging/GcpLogSinkTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.MonitoredResource;
 import com.google.cloud.logging.LogEntry;
@@ -31,9 +32,15 @@ import com.google.protobuf.Duration;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import com.google.protobuf.util.Durations;
+import io.grpc.gcp.observability.ObservabilityConfig;
 import io.grpc.observabilitylog.v1.GrpcLogRecord;
 import io.grpc.observabilitylog.v1.GrpcLogRecord.EventLogger;
 import io.grpc.observabilitylog.v1.GrpcLogRecord.EventType;
+import io.opencensus.trace.SpanContext;
+import io.opencensus.trace.SpanId;
+import io.opencensus.trace.TraceId;
+import io.opencensus.trace.TraceOptions;
+import io.opencensus.trace.Tracestate;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -105,13 +112,16 @@ public class GcpLogSinkTest {
       .build();
   @Mock
   private Logging mockLogging;
+  @Mock
+  private ObservabilityConfig mockConfig;
 
   @Test
   @SuppressWarnings("unchecked")
   public void verifyWrite() throws Exception {
+    when(mockConfig.getCustomTags()).thenReturn(CUSTOM_TAGS);
     GcpLogSink sink = new GcpLogSink(mockLogging, DEST_PROJECT_NAME, LOCATION_TAGS,
-        CUSTOM_TAGS, Collections.emptySet());
-    sink.write(LOG_PROTO);
+        mockConfig, Collections.emptySet(), new TraceLoggingHelper(DEST_PROJECT_NAME));
+    sink.write(LOG_PROTO, null);
 
     ArgumentCaptor<Collection<LogEntry>> logEntrySetCaptor = ArgumentCaptor.forClass(
         (Class) Collection.class);
@@ -127,10 +137,11 @@ public class GcpLogSinkTest {
   @Test
   @SuppressWarnings("unchecked")
   public void verifyWriteWithTags() {
+    when(mockConfig.getCustomTags()).thenReturn(CUSTOM_TAGS);
     GcpLogSink sink = new GcpLogSink(mockLogging, DEST_PROJECT_NAME, LOCATION_TAGS,
-        CUSTOM_TAGS, Collections.emptySet());
+        mockConfig, Collections.emptySet(), new TraceLoggingHelper(DEST_PROJECT_NAME));
     MonitoredResource expectedMonitoredResource = GcpLogSink.getResource(LOCATION_TAGS);
-    sink.write(LOG_PROTO);
+    sink.write(LOG_PROTO, null);
 
     ArgumentCaptor<Collection<LogEntry>> logEntrySetCaptor = ArgumentCaptor.forClass(
         (Class) Collection.class);
@@ -150,10 +161,11 @@ public class GcpLogSinkTest {
   @SuppressWarnings("unchecked")
   public void emptyCustomTags_labelsNotSet() {
     Map<String, String> emptyCustomTags = null;
+    when(mockConfig.getCustomTags()).thenReturn(emptyCustomTags);
     Map<String, String> expectedEmptyLabels = new HashMap<>();
     GcpLogSink sink = new GcpLogSink(mockLogging, DEST_PROJECT_NAME, LOCATION_TAGS,
-        emptyCustomTags, Collections.emptySet());
-    sink.write(LOG_PROTO);
+        mockConfig, Collections.emptySet(), new TraceLoggingHelper(DEST_PROJECT_NAME));
+    sink.write(LOG_PROTO, null);
 
     ArgumentCaptor<Collection<LogEntry>> logEntrySetCaptor = ArgumentCaptor.forClass(
         (Class) Collection.class);
@@ -169,12 +181,13 @@ public class GcpLogSinkTest {
   @SuppressWarnings("unchecked")
   public void emptyCustomTags_setSourceProject() {
     Map<String, String> emptyCustomTags = null;
+    when(mockConfig.getCustomTags()).thenReturn(emptyCustomTags);
     String projectId = "PROJECT";
     Map<String, String> expectedLabels = GcpLogSink.getCustomTags(emptyCustomTags, LOCATION_TAGS,
         projectId);
     GcpLogSink sink = new GcpLogSink(mockLogging, projectId, LOCATION_TAGS,
-        emptyCustomTags, Collections.emptySet());
-    sink.write(LOG_PROTO);
+        mockConfig, Collections.emptySet(), new TraceLoggingHelper(DEST_PROJECT_NAME));
+    sink.write(LOG_PROTO, null);
 
     ArgumentCaptor<Collection<LogEntry>> logEntrySetCaptor = ArgumentCaptor.forClass(
         (Class) Collection.class);
@@ -189,8 +202,8 @@ public class GcpLogSinkTest {
   @Test
   public void verifyClose() throws Exception {
     GcpLogSink sink = new GcpLogSink(mockLogging, DEST_PROJECT_NAME, LOCATION_TAGS,
-        CUSTOM_TAGS, Collections.emptySet());
-    sink.write(LOG_PROTO);
+        mockConfig, Collections.emptySet(), new TraceLoggingHelper(DEST_PROJECT_NAME));
+    sink.write(LOG_PROTO, null);
     verify(mockLogging, times(1)).write(anyIterable());
     sink.close();
     verify(mockLogging).close();
@@ -200,8 +213,106 @@ public class GcpLogSinkTest {
   @Test
   public void verifyExclude() throws Exception {
     Sink mockSink = new GcpLogSink(mockLogging, DEST_PROJECT_NAME, LOCATION_TAGS,
-        CUSTOM_TAGS, Collections.singleton("service"));
-    mockSink.write(LOG_PROTO);
+        mockConfig, Collections.singleton("service"), new TraceLoggingHelper(DEST_PROJECT_NAME));
+    mockSink.write(LOG_PROTO, null);
     verifyNoInteractions(mockLogging);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void verifyNoTraceDataInLogs_withTraceDisabled() throws Exception {
+    SpanContext validSpanContext = SpanContext.create(
+        TraceId.fromLowerBase16("4c6af40c499951eb7de2777ba1e4fefa"),
+        SpanId.fromLowerBase16("de52e84d13dd232d"),
+        TraceOptions.builder().setIsSampled(true).build(),
+        Tracestate.builder().build());
+
+    TraceLoggingHelper traceLoggingHelper = new TraceLoggingHelper(DEST_PROJECT_NAME);
+    when(mockConfig.isEnableCloudTracing()).thenReturn(false);
+    Sink mockSink = new GcpLogSink(mockLogging, DEST_PROJECT_NAME, LOCATION_TAGS,
+        mockConfig, Collections.emptySet(), traceLoggingHelper);
+    mockSink.write(LOG_PROTO, validSpanContext);
+
+    ArgumentCaptor<Collection<LogEntry>> logEntrySetCaptor = ArgumentCaptor.forClass(
+        (Class) Collection.class);
+    verify(mockLogging, times(1)).write(logEntrySetCaptor.capture());
+    for (Iterator<LogEntry> it = logEntrySetCaptor.getValue().iterator(); it.hasNext(); ) {
+      LogEntry entry = it.next();
+      assertThat(entry.getTrace()).isNull(); // Field not present
+      assertThat(entry.getSpanId()).isNull(); // Field not present
+      assertThat(entry.getTraceSampled()).isFalse(); // Default value
+      assertThat(entry.getPayload().getData()).isEqualTo(EXPECTED_STRUCT_LOG_PROTO);
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void verifyTraceDataInLogs_withValidSpanContext() throws Exception {
+    CharSequence traceIdSeq = "4c6af40c499951eb7de2777ba1e4fefa";
+    CharSequence spanIdSeq = "de52e84d13dd232d";
+    TraceId traceId = TraceId.fromLowerBase16(traceIdSeq);
+    SpanId spanId = SpanId.fromLowerBase16(spanIdSeq);
+    boolean traceSampled = true;
+
+    SpanContext validSpanContext = SpanContext.create(traceId, spanId,
+        TraceOptions.builder().setIsSampled(traceSampled).build(),
+        Tracestate.builder().build());
+
+    TraceLoggingHelper traceLoggingHelper = new TraceLoggingHelper(DEST_PROJECT_NAME);
+    when(mockConfig.isEnableCloudTracing()).thenReturn(true);
+    Sink mockSink = new GcpLogSink(mockLogging, DEST_PROJECT_NAME, LOCATION_TAGS,
+        mockConfig, Collections.emptySet(), traceLoggingHelper);
+    mockSink.write(LOG_PROTO, validSpanContext);
+
+    String expectedTrace = "projects/" + DEST_PROJECT_NAME + "/traces/" + traceIdSeq;
+
+    ArgumentCaptor<Collection<LogEntry>> logEntrySetCaptor = ArgumentCaptor.forClass(
+        (Class) Collection.class);
+    verify(mockLogging, times(1)).write(logEntrySetCaptor.capture());
+    for (Iterator<LogEntry> it = logEntrySetCaptor.getValue().iterator(); it.hasNext(); ) {
+      LogEntry entry = it.next();
+      assertThat(entry.getTrace()).isEqualTo(expectedTrace);
+      assertThat(entry.getSpanId()).isEqualTo("" + spanIdSeq);
+      assertThat(entry.getTraceSampled()).isEqualTo(traceSampled);
+      assertThat(entry.getPayload().getData()).isEqualTo(EXPECTED_STRUCT_LOG_PROTO);
+    }
+
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void verifyTraceDataLogs_withNullSpanContext() throws Exception {
+    TraceLoggingHelper traceLoggingHelper = new TraceLoggingHelper(DEST_PROJECT_NAME);
+    when(mockConfig.isEnableCloudTracing()).thenReturn(true);
+    Sink mockSink = new GcpLogSink(mockLogging, DEST_PROJECT_NAME, LOCATION_TAGS,
+        mockConfig, Collections.emptySet(), traceLoggingHelper);
+
+    String expectedTrace =
+        "projects/" + DEST_PROJECT_NAME + "/traces/00000000000000000000000000000000";
+    String expectedSpanId = "0000000000000000";
+
+    ArgumentCaptor<Collection<LogEntry>> logEntrySetCaptor = ArgumentCaptor.forClass(
+        (Class) Collection.class);
+
+    // Client log with default span context
+    mockSink.write(LOG_PROTO , SpanContext.INVALID);
+    verify(mockLogging, times(1)).write(logEntrySetCaptor.capture());
+    for (Iterator<LogEntry> it = logEntrySetCaptor.getValue().iterator(); it.hasNext(); ) {
+      LogEntry entry = it.next();
+      assertThat(entry.getTrace()).isEqualTo(expectedTrace);
+      assertThat(entry.getSpanId()).isEqualTo(expectedSpanId);
+      assertThat(entry.getTraceSampled()).isFalse();
+    }
+
+    // Server log
+    GrpcLogRecord serverLogProto = LOG_PROTO.toBuilder().setLogger(EventLogger.SERVER).build();
+    mockSink.write(serverLogProto , SpanContext.INVALID);
+    verify(mockLogging, times(2)).write(logEntrySetCaptor.capture());
+    for (Iterator<LogEntry> it = logEntrySetCaptor.getValue().iterator(); it.hasNext(); ) {
+      LogEntry entry = it.next();
+      assertThat(entry.getTrace()).isEqualTo(expectedTrace);
+      assertThat(entry.getSpanId()).isEqualTo(expectedSpanId);
+      assertThat(entry.getTraceSampled()).isFalse();
+    }
   }
 }

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/logging/TraceLoggingHelperTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/logging/TraceLoggingHelperTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.gcp.observability.logging;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.logging.LogEntry;
+import io.opencensus.trace.SpanContext;
+import io.opencensus.trace.SpanId;
+import io.opencensus.trace.TraceId;
+import io.opencensus.trace.TraceOptions;
+import io.opencensus.trace.Tracestate;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link TraceLoggingHelper}.
+ */
+@RunWith(JUnit4.class)
+public class TraceLoggingHelperTest {
+
+  private static final String PROJECT = "PROJECT";
+  private static final Tracestate EMPTY_TRACESTATE = Tracestate.builder().build();
+  private static TraceLoggingHelper traceLoggingHelper;
+
+  @Before
+  public void setUp() {
+    traceLoggingHelper = new TraceLoggingHelper(PROJECT);
+  }
+
+  @Test
+  public void enhanceLogEntry_AddSampledSpanContextToLogEntry() {
+    SpanContext spanContext = SpanContext.create(
+        TraceId.fromLowerBase16("5ce724c382c136b2a67bb447e6a6bd27"),
+        SpanId.fromLowerBase16("de52e84d13dd232d"),
+        TraceOptions.builder().setIsSampled(true).build(),
+        EMPTY_TRACESTATE);
+    LogEntry logEntry = getEnhancedLogEntry(traceLoggingHelper, spanContext);
+    assertThat(logEntry.getTraceSampled()).isTrue();
+    assertThat(logEntry.getTrace())
+        .isEqualTo("projects/PROJECT/traces/5ce724c382c136b2a67bb447e6a6bd27");
+    assertThat(logEntry.getSpanId()).isEqualTo("de52e84d13dd232d");
+  }
+
+  @Test
+  public void enhanceLogEntry_AddNonSampledSpanContextToLogEntry() {
+    SpanContext spanContext = SpanContext.create(
+        TraceId.fromLowerBase16("649a8a64db2d0c757fd06bb1bfe84e2c"),
+        SpanId.fromLowerBase16("731e102335b7a5a0"),
+        TraceOptions.builder().setIsSampled(false).build(),
+        EMPTY_TRACESTATE);
+    LogEntry logEntry = getEnhancedLogEntry(traceLoggingHelper, spanContext);
+    assertThat(logEntry.getTraceSampled()).isFalse();
+    assertThat(logEntry.getTrace())
+        .isEqualTo("projects/PROJECT/traces/649a8a64db2d0c757fd06bb1bfe84e2c");
+    assertThat(logEntry.getSpanId()).isEqualTo("731e102335b7a5a0");
+  }
+
+  @Test
+  public void enhanceLogEntry_AddBlankSpanContextToLogEntry() {
+    SpanContext spanContext = SpanContext.INVALID;
+    LogEntry logEntry = getEnhancedLogEntry(traceLoggingHelper, spanContext);
+    assertThat(logEntry.getTraceSampled()).isFalse();
+    assertThat(logEntry.getTrace())
+        .isEqualTo("projects/PROJECT/traces/00000000000000000000000000000000");
+    assertThat(logEntry.getSpanId()).isEqualTo("0000000000000000");
+  }
+
+  private static LogEntry getEnhancedLogEntry(TraceLoggingHelper traceLoggingHelper,
+      SpanContext spanContext) {
+    LogEntry.Builder logEntryBuilder = LogEntry.newBuilder(null);
+    traceLoggingHelper.enhanceLogEntry(logEntryBuilder, spanContext);
+    return logEntryBuilder.build();
+  }
+}


### PR DESCRIPTION
Backport of #9963 to v1.54.x.
---
This PR adds trace information (TraceId, SpanId and TraceSampled) fields to LogEntry, when both logging and tracing are enabled in gcp-observability. 

For server-side logs, span information was readily available using Span.getContext() propagated via `io.grpc.Context`. Similar approach is not feasible for client-side architecture.

Client SpanContext which has all the information required to be added to logs is propagated to the logging interceptor via `io.grpc.CallOptions`.

CC @ejona86 @sanjaypujare 