### PR TITLE
gcp-o11y: disable recording real-time metrics

### DIFF
--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/GcpObservability.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/GcpObservability.java
@@ -132,9 +132,9 @@ public final class GcpObservability implements AutoCloseable {
     }
     if (config.isEnableCloudMonitoring()) {
       clientInterceptors.add(getConditionalInterceptor(
-          InternalCensusStatsAccessor.getClientInterceptor(true, true, true, true)));
+          InternalCensusStatsAccessor.getClientInterceptor(true, true, false, true)));
       tracerFactories.add(
-          InternalCensusStatsAccessor.getServerStreamTracerFactory(true, true, true));
+          InternalCensusStatsAccessor.getServerStreamTracerFactory(true, true, false));
     }
     if (config.isEnableCloudTracing()) {
       clientInterceptors.add(


### PR DESCRIPTION
This PR disables recording real time metrics, which are just being recorded and not exported by observability.