### PR TITLE
gcp-o11y: add sleep in Observability close() (v1.54.x backport)

### DIFF
--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/GcpObservability.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/GcpObservability.java
@@ -53,11 +53,16 @@ import io.opencensus.trace.config.TraceConfig;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /** The main class for gRPC Google Cloud Platform Observability features. */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8869")
 public final class GcpObservability implements AutoCloseable {
+
+  private static final Logger logger = Logger.getLogger(GcpObservability.class.getName());
   private static final int METRICS_EXPORT_INTERVAL = 30;
   @VisibleForTesting
   static final ImmutableSet<String> SERVICES_TO_EXCLUDE = ImmutableSet.of(
@@ -117,6 +122,16 @@ public final class GcpObservability implements AutoCloseable {
         throw new IllegalStateException("GcpObservability already closed!");
       }
       sink.close();
+      if (config.isEnableCloudMonitoring() || config.isEnableCloudTracing()) {
+        try {
+          // Sleeping before shutdown to ensure all metrics and traces are flushed
+          Thread.sleep(
+              TimeUnit.MILLISECONDS.convert(2 * METRICS_EXPORT_INTERVAL, TimeUnit.SECONDS));
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          logger.log(Level.SEVERE, "Caught exception during sleep", e);
+        }
+      }
       instance = null;
     }
   }


### PR DESCRIPTION
Backport of #9972 to v1.54.x.
---
This PR adds sleep in `close()` for metrics and/or traces to be flushed before closing observability.

Currently sleep is set to 2 * [Metrics export interval (30 secs)].

CC @sanjaypujare @ejona86 
CC @stanley-cheung : this might alter inter-op tests results