### PR TITLE
gcp-o11y: add default custom tag for metrics exporter (v1.54.x backport)

### DIFF
--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/GcpObservability.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/GcpObservability.java
@@ -51,7 +51,12 @@ import io.opencensus.trace.AttributeValue;
 import io.opencensus.trace.Tracing;
 import io.opencensus.trace.config.TraceConfig;
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -64,10 +69,13 @@ public final class GcpObservability implements AutoCloseable {
 
   private static final Logger logger = Logger.getLogger(GcpObservability.class.getName());
   private static final int METRICS_EXPORT_INTERVAL = 30;
+
+  static final String DEFAULT_METRIC_CUSTOM_TAG_KEY = "opencensus_task";
   @VisibleForTesting
   static final ImmutableSet<String> SERVICES_TO_EXCLUDE = ImmutableSet.of(
       "google.logging.v2.LoggingServiceV2", "google.monitoring.v3.MetricService",
       "google.devtools.cloudtrace.v2.TraceService");
+
   private static GcpObservability instance = null;
   private final Sink sink;
   private final ObservabilityConfig config;
@@ -199,12 +207,17 @@ public final class GcpObservability implements AutoCloseable {
       if (projectId != null) {
         statsConfigurationBuilder.setProjectId(projectId);
       }
+      Map<LabelKey, LabelValue> constantLabels = new HashMap<>();
+      constantLabels.put(
+          LabelKey.create(DEFAULT_METRIC_CUSTOM_TAG_KEY, DEFAULT_METRIC_CUSTOM_TAG_KEY),
+          LabelValue.create(generateDefaultMetricTagValue()));
       if (customTags != null) {
-        Map<LabelKey, LabelValue> constantLabels = customTags.entrySet().stream()
-            .collect(Collectors.toMap(e -> LabelKey.create(e.getKey(), e.getKey()),
-                e -> LabelValue.create(e.getValue())));
-        statsConfigurationBuilder.setConstantLabels(constantLabels);
+        for (Map.Entry<String, String> mapEntry : customTags.entrySet()) {
+          constantLabels.putIfAbsent(LabelKey.create(mapEntry.getKey(), mapEntry.getKey()),
+              LabelValue.create(mapEntry.getValue()));
+        }
       }
+      statsConfigurationBuilder.setConstantLabels(constantLabels);
       statsConfigurationBuilder.setExportInterval(Duration.create(METRICS_EXPORT_INTERVAL, 0));
       StackdriverStatsExporter.createAndRegister(statsConfigurationBuilder.build());
     }
@@ -226,6 +239,20 @@ public final class GcpObservability implements AutoCloseable {
       }
       StackdriverTraceExporter.createAndRegister(traceConfigurationBuilder.build());
     }
+  }
+
+  private static String generateDefaultMetricTagValue() {
+    final String jvmName = ManagementFactory.getRuntimeMXBean().getName();
+    if (jvmName.indexOf('@') < 1) {
+      String hostname = "localhost";
+      try {
+        hostname = InetAddress.getLocalHost().getHostName();
+      } catch (UnknownHostException e) {
+        logger.log(Level.INFO, "Unable to get the hostname.", e);
+      }
+      return "java-" + new SecureRandom().nextInt() + "@" + hostname;
+    }
+    return "java-" + jvmName;
   }
 
   private GcpObservability(


### PR DESCRIPTION
Backport of #9982 to v1.54.x.
---
This PR adds a default custom tag for metrics, irrespective of custom tags being present in the observability configuration. 

OpenCensus by default adds a custom tag [opencenus_task](https://docs.google.com/document/d/1sWC-XD277cM0PXxAhzJKY2X0Uj2W7bVoSv-jvnA0N8Q/edit?resourcekey=0-l-wqh1fctxZXHCUrvZv2BQ#heading=h.xy85j580eik0) for metrics which gets overriden if custom tags are set.

The unique custom tag is required to ensure the uniqueness of the Timeseries. The format of the default custom tag is: `java-{PID}@{HOSTNAME}`, if `{PID}` is not available a random number will be used