### PR TITLE
Remove sleep from Observability Interop Test binary now that its done in close() (1.54.x backport)

### DIFF
--- a/gcp-observability/interop/src/main/java/io/grpc/gcp/observability/interop/TestServiceInterop.java
+++ b/gcp-observability/interop/src/main/java/io/grpc/gcp/observability/interop/TestServiceInterop.java
@@ -20,7 +20,6 @@ import io.grpc.gcp.observability.GcpObservability;
 import io.grpc.testing.integration.TestServiceClient;
 import io.grpc.testing.integration.TestServiceServer;
 import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Combined interop client and server for observability testing.
@@ -47,11 +46,6 @@ public final class TestServiceInterop {
       } else {
         TestServiceServer.main(args);
       }
-      // TODO(stanleycheung): remove this once the observability exporter plugin is able to
-      //                      gracefully flush observability data to cloud at shutdown
-      final int o11yCloseSleepSeconds = 65;
-      System.out.println("Sleeping " + o11yCloseSleepSeconds + " seconds before exiting");
-      Thread.sleep(TimeUnit.MILLISECONDS.convert(o11yCloseSleepSeconds, TimeUnit.SECONDS));
     }
   }
 


### PR DESCRIPTION
After #9972, the `sleep()` is done inside Observability `close()`, we can remove this `sleep()` in the Observability Interop test binary.

Backport of #9977

CC @DNVindhya, @stanley-cheung 