### PR TITLE
interop-test: fix interop test client NPE

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/CustomBackendMetricsLoadBalancerProvider.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/CustomBackendMetricsLoadBalancerProvider.java
@@ -136,7 +136,9 @@ final class CustomBackendMetricsLoadBalancerProvider extends LoadBalancerProvide
                   public void onLoadReport(MetricReport callMetricReport) {
                     AtomicReference<TestOrcaReport> reportRef =
                         args.getCallOptions().getOption(ORCA_RPC_REPORT_KEY);
-                    reportRef.set(fromCallMetricReport(callMetricReport));
+                    if (reportRef != null) {
+                      reportRef.set(fromCallMetricReport(callMetricReport));
+                    }
                   }
                 }));
       }


### PR DESCRIPTION
I am able to reproduce the problem if I let the server send load report on trailer:

```
--- a/xds/src/main/java/io/grpc/xds/orca/OrcaMetricReportingServerInterceptor.java
+++ b/xds/src/main/java/io/grpc/xds/orca/OrcaMetricReportingServerInterceptor.java
@@ -77,9 +77,9 @@ public final class OrcaMetricReportingServerInterceptor implements ServerInterce
           public void close(Status status, Metadata trailers) {
             OrcaLoadReport report = fromInternalReport(
                 InternalCallMetricRecorder.finalizeAndDump2(finalCallMetricRecorder));
-            if (!report.equals(OrcaLoadReport.getDefaultInstance())) {
+//            if (!report.equals(OrcaLoadReport.getDefaultInstance())) {
               trailers.put(ORCA_ENDPOINT_LOAD_METRICS_KEY, report);
-            }
+//            }
             super.close(status, trailers);

```