### PR TITLE
examples: Fix grpc version in gcp-observability (v1.54.x)

### DIFF
--- a/examples/example-gcp-observability/build.gradle
+++ b/examples/example-gcp-observability/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.8
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.54.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.54.1-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.21.7'
 
 dependencies {


### PR DESCRIPTION
gcp-observability was missing from RELEASING.md, so it wasn't updated when we changed the patch release.

CC @DNVindhya 

I checked, and master was already okay. So this is not a backport.