### PR TITLE
RELEASING.md: use glob for example file names (1.54.x backport)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,18 +26,8 @@ $ VERSION_FILES=(
   examples/android/helloworld/app/build.gradle
   examples/android/routeguide/app/build.gradle
   examples/android/strictmode/app/build.gradle
-  examples/example-alts/build.gradle
-  examples/example-gauth/build.gradle
-  examples/example-gauth/pom.xml
-  examples/example-jwt-auth/build.gradle
-  examples/example-jwt-auth/pom.xml
-  examples/example-hostname/build.gradle
-  examples/example-hostname/pom.xml
-  examples/example-servlet/build.gradle
-  examples/example-tls/build.gradle
-  examples/example-tls/pom.xml
-  examples/example-xds/build.gradle
-  examples/example-orca/build.gradle
+  examples/example-*/build.gradle
+  examples/example-*/pom.xml
   )
 ```
 


### PR DESCRIPTION
This PR uses glob `example-*` instead of explicitly adding all the example `build.gradle` and `pom.xml` files which has gRPC versions.

This change fixes instances like `example-gcp-observability/build.gradle` (a new example) was added and `RELEASING.md` was not updated to include the new file.

Backport of #9998

CC @DNVindhya 