### PR TITLE
Add BIND_ALLOW_ACTIVITY_STARTS to BindServiceFlags.

### DIFF
--- a/binder/src/main/java/io/grpc/binder/BindServiceFlags.java
+++ b/binder/src/main/java/io/grpc/binder/BindServiceFlags.java
@@ -27,7 +27,9 @@ import static android.content.Context.BIND_NOT_PERCEPTIBLE;
 import static android.content.Context.BIND_WAIVE_PRIORITY;
 import static java.lang.Integer.toHexString;
 
+import android.os.Build;
 import androidx.annotation.RequiresApi;
+import io.grpc.ExperimentalApi;
 
 /**
  * An immutable set of flags affecting the behavior of {@link android.content.Context#bindService}.
@@ -99,6 +101,26 @@ public final class BindServiceFlags {
      */
     public Builder setAdjustWithActivity(boolean newValue) {
       return setFlag(BIND_ADJUST_WITH_ACTIVITY, newValue);
+    }
+
+    // TODO(b/274061424): Reference official constant and add RequiresApi declaration in place of
+    // informal Javadoc warning when U is final.
+    /**
+     * Sets or clears the {@code android.content.Context#BIND_ALLOW_ACTIVITY_STARTS} flag.
+     *
+     * <p>This method allows for testing and development on Android U developer previews. Before
+     * releasing production code which depends on this flag, verify that either the
+     * {@code BIND_ALLOW_ACTIVITY_STARTS} flag has not changed from 0x200 during SDK development,
+     * or wait for this method to be updated to point to the final flag and made non-experimental.
+     *
+     * <p>This flag has no additional meaning at the gRPC layer. See the Android docs for more.
+     *
+     * @return this, for fluent construction
+     */
+    @ExperimentalApi("To be finalized after Android U SDK finalization")
+    public Builder setAllowActivityStarts(boolean newValue) {
+      // https://developer.android.com/reference/android/content/Context#BIND_ALLOW_ACTIVITY_STARTS
+      return setFlag(0x200, newValue);
     }
 
     /**

--- a/binder/src/test/java/io/grpc/binder/BindServiceFlagsTest.java
+++ b/binder/src/test/java/io/grpc/binder/BindServiceFlagsTest.java
@@ -73,6 +73,7 @@ public final class BindServiceFlagsTest {
                 .setAutoCreate(true)
                 .setAdjustWithActivity(true)
                 .setAboveClient(true)
+                .setAllowActivityStarts(true)
                 .setAllowOomManagement(true)
                 .setImportant(true)
                 .setIncludeCapabilities(true)
@@ -90,6 +91,8 @@ public final class BindServiceFlagsTest {
                 | Context.BIND_INCLUDE_CAPABILITIES
                 | Context.BIND_NOT_FOREGROUND
                 | Context.BIND_NOT_PERCEPTIBLE
-                | Context.BIND_WAIVE_PRIORITY);
+                | Context.BIND_WAIVE_PRIORITY
+                // TODO(b/274061424): Use Context.BIND_ALLOW_ACTIVITY_STARTS when U is final.
+                | 0x200);
   }
 }


### PR DESCRIPTION
This flag is added in the U SDK, which is still under development. Since it's just a numeric constant, we copy the value until it is stable and mark the API is experimental, with appropriate warnings about depending on it from production code.

A follow-up change will be made after SDK finalization to point to the official constant (or otherwise update to match any SDK changes), at which point we can remove the `@ExternalApi` annotation.

See b/274061424