### PR TITLE
xds: Synchronize access to test control plane collections

### DIFF
--- a/xds/src/test/java/io/grpc/xds/XdsTestControlPlaneService.java
+++ b/xds/src/test/java/io/grpc/xds/XdsTestControlPlaneService.java
@@ -25,6 +25,7 @@ import io.envoyproxy.envoy.service.discovery.v3.DiscoveryRequest;
 import io.envoyproxy.envoy.service.discovery.v3.DiscoveryResponse;
 import io.grpc.SynchronizationContext;
 import io.grpc.stub.StreamObserver;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -75,25 +76,32 @@ final class XdsTestControlPlaneService extends
       "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment";
 
   private final Map<String, HashMap<String, Message>> xdsResources = new HashMap<>();
-  private ImmutableMap<String, HashMap<StreamObserver<DiscoveryResponse>, Set<String>>> subscribers
+  private ImmutableMap<String, Map<StreamObserver<DiscoveryResponse>, Set<String>>> subscribers
       = ImmutableMap.of(
-          ADS_TYPE_URL_LDS, new HashMap<StreamObserver<DiscoveryResponse>, Set<String>>(),
-          ADS_TYPE_URL_RDS, new HashMap<StreamObserver<DiscoveryResponse>, Set<String>>(),
-          ADS_TYPE_URL_CDS, new HashMap<StreamObserver<DiscoveryResponse>, Set<String>>(),
-          ADS_TYPE_URL_EDS, new HashMap<StreamObserver<DiscoveryResponse>, Set<String>>()
-          );
+      ADS_TYPE_URL_LDS,
+      Collections.synchronizedMap(new HashMap<StreamObserver<DiscoveryResponse>, Set<String>>()),
+      ADS_TYPE_URL_RDS,
+      Collections.synchronizedMap(new HashMap<StreamObserver<DiscoveryResponse>, Set<String>>()),
+      ADS_TYPE_URL_CDS,
+      Collections.synchronizedMap(new HashMap<StreamObserver<DiscoveryResponse>, Set<String>>()),
+      ADS_TYPE_URL_EDS,
+      Collections.synchronizedMap(new HashMap<StreamObserver<DiscoveryResponse>, Set<String>>()));
   private final ImmutableMap<String, AtomicInteger> xdsVersions = ImmutableMap.of(
       ADS_TYPE_URL_LDS, new AtomicInteger(1),
       ADS_TYPE_URL_RDS, new AtomicInteger(1),
       ADS_TYPE_URL_CDS, new AtomicInteger(1),
       ADS_TYPE_URL_EDS, new AtomicInteger(1)
   );
-  private final ImmutableMap<String, HashMap<StreamObserver<DiscoveryResponse>, AtomicInteger>>
+  private final ImmutableMap<String, Map<StreamObserver<DiscoveryResponse>, AtomicInteger>>
       xdsNonces = ImmutableMap.of(
-      ADS_TYPE_URL_LDS, new HashMap<StreamObserver<DiscoveryResponse>, AtomicInteger>(),
-      ADS_TYPE_URL_RDS, new HashMap<StreamObserver<DiscoveryResponse>, AtomicInteger>(),
-      ADS_TYPE_URL_CDS, new HashMap<StreamObserver<DiscoveryResponse>, AtomicInteger>(),
-      ADS_TYPE_URL_EDS, new HashMap<StreamObserver<DiscoveryResponse>, AtomicInteger>()
+      ADS_TYPE_URL_LDS,
+      Collections.synchronizedMap(new HashMap<StreamObserver<DiscoveryResponse>, AtomicInteger>()),
+      ADS_TYPE_URL_RDS,
+      Collections.synchronizedMap(new HashMap<StreamObserver<DiscoveryResponse>, AtomicInteger>()),
+      ADS_TYPE_URL_CDS,
+      Collections.synchronizedMap(new HashMap<StreamObserver<DiscoveryResponse>, AtomicInteger>()),
+      ADS_TYPE_URL_EDS,
+      Collections.synchronizedMap(new HashMap<StreamObserver<DiscoveryResponse>, AtomicInteger>())
   );
 
 

--- a/xds/src/test/java/io/grpc/xds/XdsTestControlPlaneService.java
+++ b/xds/src/test/java/io/grpc/xds/XdsTestControlPlaneService.java
@@ -25,11 +25,11 @@ import io.envoyproxy.envoy.service.discovery.v3.DiscoveryRequest;
 import io.envoyproxy.envoy.service.discovery.v3.DiscoveryResponse;
 import io.grpc.SynchronizationContext;
 import io.grpc.stub.StreamObserver;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -78,14 +78,10 @@ final class XdsTestControlPlaneService extends
   private final Map<String, HashMap<String, Message>> xdsResources = new HashMap<>();
   private ImmutableMap<String, Map<StreamObserver<DiscoveryResponse>, Set<String>>> subscribers
       = ImmutableMap.of(
-      ADS_TYPE_URL_LDS,
-      Collections.synchronizedMap(new HashMap<StreamObserver<DiscoveryResponse>, Set<String>>()),
-      ADS_TYPE_URL_RDS,
-      Collections.synchronizedMap(new HashMap<StreamObserver<DiscoveryResponse>, Set<String>>()),
-      ADS_TYPE_URL_CDS,
-      Collections.synchronizedMap(new HashMap<StreamObserver<DiscoveryResponse>, Set<String>>()),
-      ADS_TYPE_URL_EDS,
-      Collections.synchronizedMap(new HashMap<StreamObserver<DiscoveryResponse>, Set<String>>()));
+      ADS_TYPE_URL_LDS, new ConcurrentHashMap<StreamObserver<DiscoveryResponse>, Set<String>>(),
+      ADS_TYPE_URL_RDS, new ConcurrentHashMap<StreamObserver<DiscoveryResponse>, Set<String>>(),
+      ADS_TYPE_URL_CDS, new ConcurrentHashMap<StreamObserver<DiscoveryResponse>, Set<String>>(),
+      ADS_TYPE_URL_EDS, new ConcurrentHashMap<StreamObserver<DiscoveryResponse>, Set<String>>());
   private final ImmutableMap<String, AtomicInteger> xdsVersions = ImmutableMap.of(
       ADS_TYPE_URL_LDS, new AtomicInteger(1),
       ADS_TYPE_URL_RDS, new AtomicInteger(1),
@@ -94,14 +90,10 @@ final class XdsTestControlPlaneService extends
   );
   private final ImmutableMap<String, Map<StreamObserver<DiscoveryResponse>, AtomicInteger>>
       xdsNonces = ImmutableMap.of(
-      ADS_TYPE_URL_LDS,
-      Collections.synchronizedMap(new HashMap<StreamObserver<DiscoveryResponse>, AtomicInteger>()),
-      ADS_TYPE_URL_RDS,
-      Collections.synchronizedMap(new HashMap<StreamObserver<DiscoveryResponse>, AtomicInteger>()),
-      ADS_TYPE_URL_CDS,
-      Collections.synchronizedMap(new HashMap<StreamObserver<DiscoveryResponse>, AtomicInteger>()),
-      ADS_TYPE_URL_EDS,
-      Collections.synchronizedMap(new HashMap<StreamObserver<DiscoveryResponse>, AtomicInteger>())
+      ADS_TYPE_URL_LDS, new ConcurrentHashMap<StreamObserver<DiscoveryResponse>, AtomicInteger>(),
+      ADS_TYPE_URL_RDS, new ConcurrentHashMap<StreamObserver<DiscoveryResponse>, AtomicInteger>(),
+      ADS_TYPE_URL_CDS, new ConcurrentHashMap<StreamObserver<DiscoveryResponse>, AtomicInteger>(),
+      ADS_TYPE_URL_EDS, new ConcurrentHashMap<StreamObserver<DiscoveryResponse>, AtomicInteger>()
   );
 
 


### PR DESCRIPTION
This is to eliminate concurrent modification issues when XdsTestControlPlaneService is used by multiple threads.

Fixes: #9938