### PR TITLE
netty: Remove long-dead third_party reference

### DIFF
--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -80,10 +80,6 @@ tasks.named("javadoc").configure {
     exclude 'io/grpc/netty/Internal*'
 }
 
-project.sourceSets {
-    main { java { srcDir "${projectDir}/third_party/netty/java" } }
-}
-
 tasks.named("test").configure {
     // Allow testing Jetty ALPN in TlsTest
     jvmArgs "-javaagent:" + configurations.alpnagent.asPath


### PR DESCRIPTION
This was added in 9ef07916 and should have lived until we upgraded to a newer Netty in 67eefa69.