### PR TITLE
alts: Enable user to configure max number of concurrent ALTS handshakes.

### DIFF
--- a/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
@@ -54,6 +54,7 @@ import javax.annotation.Nullable;
 // TODO(carl-mastrangelo): rename this AltsProtocolNegotiators.
 public final class AltsProtocolNegotiator {
   private static final Logger logger = Logger.getLogger(AltsProtocolNegotiator.class.getName());
+
   static final String ALTS_MAX_CONCURRENT_HANDSHAKES_ENV_VARIABLE =
       "GRPC_ALTS_MAX_CONCURRENT_HANDSHAKES";
   @VisibleForTesting static final int DEFAULT_ALTS_MAX_CONCURRENT_HANDSHAKES = 32;

--- a/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
@@ -427,9 +427,8 @@ public final class AltsProtocolNegotiator {
   }
 
   @VisibleForTesting
-  static int getAltsMaxConcurrentHandshakes() {
-    String altsMaxConcurrentHandshakes = System.getenv(ALTS_MAX_CONCURRENT_HANDSHAKES_ENV_VARIABLE);
-    if (altsMaxConcurrentHandshakes == null) {
+  static int getAltsMaxConcurrentHandshakes(String altsMaxConcurrentHandshakes) {
+  if (altsMaxConcurrentHandshakes == null) {
       return DEFAULT_ALTS_MAX_CONCURRENT_HANDSHAKES;
     }
     try {
@@ -445,6 +444,11 @@ public final class AltsProtocolNegotiator {
           "GRPC_ALTS_MAX_CONCURRENT_HANDSHAKES environment variable set to invalid value.");
       return DEFAULT_ALTS_MAX_CONCURRENT_HANDSHAKES;
     }
+  }
+
+  private static int getAltsMaxConcurrentHandshakes() {
+    return getAltsMaxConcurrentHandshakes(
+        System.getenv(ALTS_MAX_CONCURRENT_HANDSHAKES_ENV_VARIABLE));
   }
 
   private AltsProtocolNegotiator() {}

--- a/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
@@ -428,7 +428,7 @@ public final class AltsProtocolNegotiator {
 
   @VisibleForTesting
   static int getAltsMaxConcurrentHandshakes(String altsMaxConcurrentHandshakes) {
-  if (altsMaxConcurrentHandshakes == null) {
+    if (altsMaxConcurrentHandshakes == null) {
       return DEFAULT_ALTS_MAX_CONCURRENT_HANDSHAKES;
     }
     try {

--- a/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
@@ -54,7 +54,6 @@ import javax.annotation.Nullable;
 // TODO(carl-mastrangelo): rename this AltsProtocolNegotiators.
 public final class AltsProtocolNegotiator {
   private static final Logger logger = Logger.getLogger(AltsProtocolNegotiator.class.getName());
-  @VisibleForTesting
   static final String ALTS_MAX_CONCURRENT_HANDSHAKES_ENV_VARIABLE =
       "GRPC_ALTS_MAX_CONCURRENT_HANDSHAKES";
   @VisibleForTesting static final int DEFAULT_ALTS_MAX_CONCURRENT_HANDSHAKES = 32;

--- a/alts/src/test/java/io/grpc/alts/internal/AltsProtocolNegotiatorTest.java
+++ b/alts/src/test/java/io/grpc/alts/internal/AltsProtocolNegotiatorTest.java
@@ -356,29 +356,24 @@ public class AltsProtocolNegotiatorTest {
 
   @Test
   public void getAltsMaxConcurrentHandshakes_success() throws Exception {
-    System.setProperty(AltsProtocolNegotiator.ALTS_MAX_CONCURRENT_HANDSHAKES_ENV_VARIABLE, "10");
-    assertThat(AltsProtocolNegotiator.getAltsMaxConcurrentHandshakes()).isEqualTo(10);
+    assertThat(AltsProtocolNegotiator.getAltsMaxConcurrentHandshakes("10")).isEqualTo(10);
   }
 
   @Test
   public void getAltsMaxConcurrentHandshakes_envVariableNotSet() throws Exception {
-    System.clearProperty(AltsProtocolNegotiator.ALTS_MAX_CONCURRENT_HANDSHAKES_ENV_VARIABLE);
-    assertThat(AltsProtocolNegotiator.getAltsMaxConcurrentHandshakes())
+    assertThat(AltsProtocolNegotiator.getAltsMaxConcurrentHandshakes(null))
         .isEqualTo(AltsProtocolNegotiator.DEFAULT_ALTS_MAX_CONCURRENT_HANDSHAKES);
   }
 
   @Test
   public void getAltsMaxConcurrentHandshakes_envVariableNotANumber() throws Exception {
-    System.setProperty(
-        AltsProtocolNegotiator.ALTS_MAX_CONCURRENT_HANDSHAKES_ENV_VARIABLE, "not-a-number");
-    assertThat(AltsProtocolNegotiator.getAltsMaxConcurrentHandshakes())
+    assertThat(AltsProtocolNegotiator.getAltsMaxConcurrentHandshakes("not-a-number"))
         .isEqualTo(AltsProtocolNegotiator.DEFAULT_ALTS_MAX_CONCURRENT_HANDSHAKES);
   }
 
   @Test
   public void getAltsMaxConcurrentHandshakes_envVariableNegative() throws Exception {
-    System.setProperty(AltsProtocolNegotiator.ALTS_MAX_CONCURRENT_HANDSHAKES_ENV_VARIABLE, "-10");
-    assertThat(AltsProtocolNegotiator.getAltsMaxConcurrentHandshakes())
+    assertThat(AltsProtocolNegotiator.getAltsMaxConcurrentHandshakes("-10"))
         .isEqualTo(AltsProtocolNegotiator.DEFAULT_ALTS_MAX_CONCURRENT_HANDSHAKES);
   }
 

--- a/alts/src/test/java/io/grpc/alts/internal/AltsProtocolNegotiatorTest.java
+++ b/alts/src/test/java/io/grpc/alts/internal/AltsProtocolNegotiatorTest.java
@@ -354,6 +354,34 @@ public class AltsProtocolNegotiatorTest {
         .isEqualTo(SecurityLevel.PRIVACY_AND_INTEGRITY);
   }
 
+  @Test
+  public void getAltsMaxConcurrentHandshakes_success() throws Exception {
+    System.setProperty(AltsProtocolNegotiator.ALTS_MAX_CONCURRENT_HANDSHAKES_ENV_VARIABLE, "10");
+    assertThat(AltsProtocolNegotiator.getAltsMaxConcurrentHandshakes()).isEqualTo(10);
+  }
+
+  @Test
+  public void getAltsMaxConcurrentHandshakes_envVariableNotSet() throws Exception {
+    System.clearProperty(AltsProtocolNegotiator.ALTS_MAX_CONCURRENT_HANDSHAKES_ENV_VARIABLE);
+    assertThat(AltsProtocolNegotiator.getAltsMaxConcurrentHandshakes())
+        .isEqualTo(AltsProtocolNegotiator.DEFAULT_ALTS_MAX_CONCURRENT_HANDSHAKES);
+  }
+
+  @Test
+  public void getAltsMaxConcurrentHandshakes_envVariableNotANumber() throws Exception {
+    System.setProperty(
+        AltsProtocolNegotiator.ALTS_MAX_CONCURRENT_HANDSHAKES_ENV_VARIABLE, "not-a-number");
+    assertThat(AltsProtocolNegotiator.getAltsMaxConcurrentHandshakes())
+        .isEqualTo(AltsProtocolNegotiator.DEFAULT_ALTS_MAX_CONCURRENT_HANDSHAKES);
+  }
+
+  @Test
+  public void getAltsMaxConcurrentHandshakes_envVariableNegative() throws Exception {
+    System.setProperty(AltsProtocolNegotiator.ALTS_MAX_CONCURRENT_HANDSHAKES_ENV_VARIABLE, "-10");
+    assertThat(AltsProtocolNegotiator.getAltsMaxConcurrentHandshakes())
+        .isEqualTo(AltsProtocolNegotiator.DEFAULT_ALTS_MAX_CONCURRENT_HANDSHAKES);
+  }
+
   private void doHandshake() throws Exception {
     // Capture the client frame and add to the server.
     assertEquals(1, channel.outboundMessages().size());


### PR DESCRIPTION
The logic is straightforward: attempt to read the GRPC_ALTS_MAX_CONCURRENT_HANDSHAKES environment variable and, if it set to an integer, instantiate the handshake queues based on this integer.

Based on go/grpc-alts-concurrent-handshake-cap. See https://github.com/grpc/grpc/pull/32672 for a comparison with the C-core logic.