### PR TITLE
xds: Wait for sync context before assertions in federation test

### DIFF
--- a/xds/src/main/java/io/grpc/xds/LoadReportClient.java
+++ b/xds/src/main/java/io/grpc/xds/LoadReportClient.java
@@ -57,7 +57,8 @@ final class LoadReportClient {
   private final Channel channel;
   private final Context context;
   private final Node node;
-  private final SynchronizationContext syncContext;
+  @VisibleForTesting
+  final SynchronizationContext syncContext;
   private final ScheduledExecutorService timerService;
   private final Stopwatch retryStopwatch;
   private final BackoffPolicy.Provider backoffPolicyProvider;


### PR DESCRIPTION
Fixes #10015
