### PR TITLE
protobuf: update external javadoc link (1.50.x backport)

### DIFF
--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -30,5 +30,5 @@ dependencies {
 }
 
 tasks.named("javadoc").configure {
-    options.links 'https://developers.google.com/protocol-buffers/docs/reference/java/'
+    options.links 'https://protobuf.dev/reference/java/api-docs/'
 }


### PR DESCRIPTION
Builds, both local and on GitHub, have been failing during protobuf javadoc generation  with:

`javadoc: error - Error fetching URL: https://developers.google.com/protocol-buffers/docs/reference/java/`

Looks like this link now redirects to another place and that gradle can't follow that redirect.

Backport of #9890. Seeing the error in #10019