### PR TITLE
gcp-o11y: Stabilize GcpObservability

### DIFF
--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/GcpObservability.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/GcpObservability.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import io.grpc.ClientInterceptor;
-import io.grpc.ExperimentalApi;
 import io.grpc.InternalGlobalInterceptors;
 import io.grpc.ManagedChannelProvider.ProviderNotFoundException;
 import io.grpc.ServerInterceptor;
@@ -64,7 +63,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /** The main class for gRPC Google Cloud Platform Observability features. */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/8869")
 public final class GcpObservability implements AutoCloseable {
 
   private static final Logger logger = Logger.getLogger(GcpObservability.class.getName());


### PR DESCRIPTION
Removes the ExperimentalApi annotation from GcpObservability.

Contributes to: #8869 