### PR TITLE
api: Deprecate the old way of handling resolved addresses in LB

### DIFF
--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
+import com.google.errorprone.annotations.InlineMe;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -126,7 +127,13 @@ public abstract class LoadBalancer {
    *
    * @param resolvedAddresses the resolved server addresses, attributes, and config.
    * @since 1.21.0
+   * @deprecated Please override {@code acceptResolvedAddresses()} instead. Also note that
+   *     {@code canHandleEmptyAddressListFromNameResolution()} is deprecated as well as
+   *     {@code acceptResolvedAddresses()} should now indicate the acceptance of the addresses with
+   *     its return value.
    */
+  @Deprecated
+  @InlineMe(replacement = "acceptResolvedAddresses(resolvedAddresses)")
   public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     if (recursionCount++ == 0) {
       // Note that the information about the addresses actually being accepted will be lost
@@ -141,7 +148,9 @@ public abstract class LoadBalancer {
    * EquivalentAddressGroup} addresses should be considered equivalent but may be flattened into a
    * single list if needed.
    *
-   * <p>Implementations can choose to reject the given addresses by returning {@code false}.
+   * <p>Implementations can choose to reject the given addresses by returning {@code false}. Please
+   * note that an empty list of addresses could be provided and that the deprecated {@code
+   * canHandleEmptyAddressListFromNameResolution()} will be ignored when this method is overwritten.
    *
    * <p>Implementations should not modify the given {@code addresses}.
    *
@@ -379,7 +388,16 @@ public abstract class LoadBalancer {
    *
    * <p>This method should always return a constant value.  It's not specified when this will be
    * called.
+   *
+   * <p>Note that this method is only called when the deprecated {@code handleResolvedAddresses()}
+   * is overwritten.
+   *
+   * @deprecated Instead of overwriting this and {@code handleResolvedAddresses()} please only
+   *     overwrite {@code acceptResolvedAddresses()}. In that method you can indicate if the
+   *     addresses provided by the name resolver are acceptable with the {@code boolean} return
+   *     value.
    */
+  @Deprecated
   public boolean canHandleEmptyAddressListFromNameResolution() {
     return false;
   }

--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -22,7 +22,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
-import com.google.errorprone.annotations.InlineMe;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -133,7 +132,7 @@ public abstract class LoadBalancer {
    *     its return value.
    */
   @Deprecated
-  @InlineMe(replacement = "acceptResolvedAddresses(resolvedAddresses)")
+  @SuppressWarnings("InlineMeSuggester")
   public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     if (recursionCount++ == 0) {
       // Note that the information about the addresses actually being accepted will be lost
@@ -398,6 +397,7 @@ public abstract class LoadBalancer {
    *     value.
    */
   @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
   public boolean canHandleEmptyAddressListFromNameResolution() {
     return false;
   }

--- a/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
@@ -30,6 +30,7 @@ public abstract class ForwardingLoadBalancer extends LoadBalancer {
   protected abstract LoadBalancer delegate();
 
   @Override
+  @SuppressWarnings("deprecation")
   public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     delegate().handleResolvedAddresses(resolvedAddresses);
   }
@@ -52,6 +53,7 @@ public abstract class ForwardingLoadBalancer extends LoadBalancer {
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public boolean canHandleEmptyAddressListFromNameResolution() {
     return delegate().canHandleEmptyAddressListFromNameResolution();
   }

--- a/core/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
@@ -43,6 +43,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 public final class GracefulSwitchLoadBalancer extends ForwardingLoadBalancer {
   private final LoadBalancer defaultBalancer = new LoadBalancer() {
     @Override
+    @SuppressWarnings("deprecation")
     public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       //  Most LB policies using this class will receive child policy configuration within the
       //  service config, so they are naturally calling switchTo() just before

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -153,6 +153,7 @@ class GrpclbLoadBalancer extends LoadBalancer {
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public boolean canHandleEmptyAddressListFromNameResolution() {
     return true;
   }


### PR DESCRIPTION
Deprecates `handleResolvedAddresses()` and `canHandleEmptyAddressListFromNameResolution()` methods from LoadBalancer. These are planned for removal in release v1.56.0.

Comments are also updated to further instruct extenders of LoadBalancer on the use of `acceptResolvedAddresses()`