### PR TITLE
rls: Refresh name resolution on rejected addresses

### DIFF
--- a/rls/src/main/java/io/grpc/rls/LbPolicyConfiguration.java
+++ b/rls/src/main/java/io/grpc/rls/LbPolicyConfiguration.java
@@ -302,12 +302,11 @@ final class LbPolicyConfiguration {
           new Runnable() {
             @Override
             public void run() {
-              if (lb.acceptResolvedAddresses(
+              if (!lb.acceptResolvedAddresses(
                   childLbResolvedAddressFactory.create(lbConfig.getConfig()))) {
-                lb.requestConnection();
-              } else {
                 helper.refreshNameResolution();
               }
+              lb.requestConnection();
             }
           });
     }

--- a/rls/src/main/java/io/grpc/rls/LbPolicyConfiguration.java
+++ b/rls/src/main/java/io/grpc/rls/LbPolicyConfiguration.java
@@ -302,9 +302,12 @@ final class LbPolicyConfiguration {
           new Runnable() {
             @Override
             public void run() {
-              lb.handleResolvedAddresses(
-                  childLbResolvedAddressFactory.create(lbConfig.getConfig()));
-              lb.requestConnection();
+              if (lb.acceptResolvedAddresses(
+                  childLbResolvedAddressFactory.create(lbConfig.getConfig()))) {
+                lb.requestConnection();
+              } else {
+                helper.refreshNameResolution();
+              }
             }
           });
     }

--- a/rls/src/test/java/io/grpc/rls/LbPolicyConfigurationTest.java
+++ b/rls/src/test/java/io/grpc/rls/LbPolicyConfigurationTest.java
@@ -57,6 +57,7 @@ public class LbPolicyConfigurationTest {
 
   private final Helper helper = mock(Helper.class);
   private final LoadBalancerProvider lbProvider = mock(LoadBalancerProvider.class);
+  private final LoadBalancer lb = mock(LoadBalancer.class);
   private final SubchannelStateManager subchannelStateManager = new SubchannelStateManagerImpl();
   private final SubchannelPicker picker = mock(SubchannelPicker.class);
   private final ChildLbStatusListener childLbStatusListener = mock(ChildLbStatusListener.class);
@@ -91,7 +92,7 @@ public class LbPolicyConfigurationTest {
               }
             }))
         .when(helper).getSynchronizationContext();
-    doReturn(mock(LoadBalancer.class)).when(lbProvider).newLoadBalancer(any(Helper.class));
+    doReturn(lb).when(lbProvider).newLoadBalancer(any(Helper.class));
     doReturn(ConfigOrError.fromConfig(new Object()))
         .when(lbProvider).parseLoadBalancingPolicyConfig(ArgumentMatchers.<Map<String, ?>>any());
   }
@@ -118,6 +119,13 @@ public class LbPolicyConfigurationTest {
     } catch (IllegalStateException e) {
       assertThat(e).hasMessageThat().contains("already released");
     }
+  }
+
+  @Test
+  public void childPolicyWrapper_addressesRejected() {
+    when(lb.acceptResolvedAddresses(any(ResolvedAddresses.class))).thenReturn(false);
+    factory.createOrGet("target");
+    verify(helper).refreshNameResolution();
   }
 
   @Test


### PR DESCRIPTION
If a child load balancer rejects the addresses it if given all we can do is to trigger a name resolution refresh and hope for a better set of addresses.