### PR TITLE
.github/workflows: Save subproject reports on test failure

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -59,6 +59,7 @@ jobs:
       with:
         name: Test Reports (JRE ${{ matrix.jre }})
         path: ./*/build/reports/tests/**
+        path: ./*/*/build/reports/tests/**
         retention-days: 14
     - name: Check for modified codegen
       run: test -z "$(git status --porcelain)" || (git status && echo Error Working directory is not clean. Forget to commit generated files? && false)


### PR DESCRIPTION
There was recently a failure with the Tomcat test in servlet/jakarta:
```
io.grpc.servlet.jakarta.TomcatInteropTest > pingPong FAILED
    java.lang.AssertionError at AbstractInteropTest.java:845
        Caused by: io.grpc.StatusRuntimeException at Status.java:539
...
* What went wrong:
Execution failed for task ':grpc-servlet-jakarta:tomcat10Test'.
> There were failing tests. See the report at: file:///home/runner/work/grpc-java/grpc-java/servlet/jakarta/build/reports/tests/tomcat10Test/index.html
```

But we couldn't get more details because servlet/jakarta didn't match the artifact glob.