### PR TITLE
Avoid repeating grpc version in Android documentation

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -104,8 +104,6 @@ Tagging the Release
    # Bump documented gRPC versions.
    # Also update protoc version to match protobuf version in gradle/libs.versions.toml.
    $ ${EDITOR:-nano -w} README.md
-   $ ${EDITOR:-nano -w} documentation/android-channel-builder.md
-   $ ${EDITOR:-nano -w} cronet/README.md
    
    $ git commit -a -m "Update README etc to reference $MAJOR.$MINOR.$PATCH"
    ```

--- a/cronet/README.md
+++ b/cronet/README.md
@@ -22,13 +22,9 @@ See the example app at https://github.com/GoogleChrome/cronet-sample/blob/master
 
 ## Example usage:
 
-In your app module's `build.gradle` file, include a dependency on both `grpc-cronet` and the 
-Google Play Services Client Library for Cronet
-
-```
-implementation 'io.grpc:grpc-cronet:1.54.0'
-implementation 'com.google.android.gms:play-services-cronet:16.0.0'
-```
+In your app module's `build.gradle` file, include a dependency on both
+`io.grpc:grpc-cronet` and the Google Play Services Client Library for Cronet,
+`com.google.android.gms:play-services-cronet`.
 
 In cases where Cronet cannot be loaded from Google Play services, there is a less performant 
 implementation of Cronet's API that can be used. Depend on `org.chromium.net:cronet-fallback` 

--- a/documentation/android-channel-builder.md
+++ b/documentation/android-channel-builder.md
@@ -32,13 +32,8 @@ connection management on Android devices.*
 
 ## Example usage:
 
-In your `build.gradle` file, include a dependency on both `grpc-android` and
-`grpc-okhttp`:
-
-```
-implementation 'io.grpc:grpc-android:1.54.0'
-implementation 'io.grpc:grpc-okhttp:1.54.0'
-```
+In your `build.gradle` file, include a dependency on both `io.grpc:grpc-android` and
+`io.grpc:grpc-okhttp`.
 
 You also need permission to access the device's network state in your
 `AndroidManifest.xml`:


### PR DESCRIPTION
This removes some steps from the release process. These two locations aren't special enough in way that deserves manually changing the version each release.