### PR TITLE
xds: Add dummy LRS service for control plane tests

### DIFF
--- a/xds/src/test/java/io/grpc/xds/ControlPlaneRule.java
+++ b/xds/src/test/java/io/grpc/xds/ControlPlaneRule.java
@@ -83,6 +83,7 @@ public class ControlPlaneRule extends TestWatcher {
   private String serverHostName;
   private Server server;
   private XdsTestControlPlaneService controlPlaneService;
+  private XdsTestLoadReportingService loadReportingService;
   private XdsNameResolverProvider nameResolverProvider;
 
   public ControlPlaneRule() {
@@ -112,8 +113,10 @@ public class ControlPlaneRule extends TestWatcher {
     // Start the control plane server.
     try {
       controlPlaneService = new XdsTestControlPlaneService();
+      loadReportingService = new XdsTestLoadReportingService();
       NettyServerBuilder controlPlaneServerBuilder = NettyServerBuilder.forPort(0)
-          .addService(controlPlaneService);
+          .addService(controlPlaneService)
+          .addService(loadReportingService);
       server = controlPlaneServerBuilder.build().start();
     } catch (Exception e) {
       throw new AssertionError("unable to start the control plane server", e);

--- a/xds/src/test/java/io/grpc/xds/XdsTestLoadReportingService.java
+++ b/xds/src/test/java/io/grpc/xds/XdsTestLoadReportingService.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import io.envoyproxy.envoy.service.load_stats.v3.LoadReportingServiceGrpc;
+import io.envoyproxy.envoy.service.load_stats.v3.LoadStatsRequest;
+import io.envoyproxy.envoy.service.load_stats.v3.LoadStatsResponse;
+import io.grpc.stub.StreamObserver;
+
+/**
+ * This dummy implementation is just used to allow tests that utilize load reporting to successfully
+ * connect to a test control plane server. It can be later expanded to e.g. store the requests it
+ * receives for tests to verify.
+ */
+final class XdsTestLoadReportingService extends
+    LoadReportingServiceGrpc.LoadReportingServiceImplBase {
+
+  @Override
+  public StreamObserver<LoadStatsRequest> streamLoadStats(
+      StreamObserver<LoadStatsResponse> responseObserver) {
+    return new StreamObserver<LoadStatsRequest>() {
+      @Override
+      public void onNext(LoadStatsRequest request) {
+        responseObserver.onNext(LoadStatsResponse.newBuilder().build());
+      }
+
+      @Override
+      public void onError(Throwable t) {
+      }
+
+      @Override
+      public void onCompleted() {
+      }
+    };
+  }
+}

--- a/xds/src/test/java/io/grpc/xds/XdsTestLoadReportingService.java
+++ b/xds/src/test/java/io/grpc/xds/XdsTestLoadReportingService.java
@@ -40,10 +40,12 @@ final class XdsTestLoadReportingService extends
 
       @Override
       public void onError(Throwable t) {
+        responseObserver.onError(t);
       }
 
       @Override
       public void onCompleted() {
+        responseObserver.onCompleted();
       }
     };
   }


### PR DESCRIPTION
`LoadReportingClient` not being able to connect to a `LoadReportingService` in the test control plane server is the probable cause for the flaky test behavior described in #10015. When the `LoadReportingClient` is not able to connect to the service, it would set the `lrsStream` field to null. This is racing with the test execution and results in occasional test failures.

This PR sets a dummy `LoadReportingService` in the control plane server, allowing the test to properly open an LRS stream to the control plane.