### PR TITLE
Upgrade Protobuf Java to 3.22.3 (aka 22.3)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --cxxopt=-std=c++14 --host_cxxopt=-std=c++14

--- a/all/build.gradle
+++ b/all/build.gradle
@@ -36,6 +36,7 @@ evaluationDependsOn(':grpc-interop-testing')
 
 dependencies {
     api subprojects.minus([project(':grpc-protobuf-lite')])
+    implementation libraries.guava.jre // JRE required by transitive protobuf-java-util
 }
 
 tasks.named("javadoc").configure {

--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -19,7 +19,7 @@ dependencies {
             project(':grpc-stub'),
             libraries.protobuf.java,
             libraries.conscrypt,
-            libraries.guava,
+            libraries.guava.jre, // JRE required by protobuf-java-util from grpclb
             libraries.google.auth.oauth2Http
     def nettyDependency = implementation project(':grpc-netty')
     compileOnly libraries.javax.annotation

--- a/authz/build.gradle
+++ b/authz/build.gradle
@@ -11,7 +11,8 @@ description = "gRPC: Authorization"
 
 dependencies {
     implementation project(':grpc-protobuf'),
-            project(':grpc-core')
+            project(':grpc-core'),
+            libraries.guava.jre // JRE required by transitive protobuf-java-util
 
     annotationProcessor libraries.auto.value
     compileOnly libraries.javax.annotation

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/AbstractConfigurationBuilder.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/AbstractConfigurationBuilder.java
@@ -147,6 +147,7 @@ public abstract class AbstractConfigurationBuilder<T extends Configuration>
   }
 
   @Override
+  @SuppressWarnings("InlineMeInliner") // String.repeat() requires Java 11
   public final void printUsage() {
     System.out.println("Usage: [ARGS...]");
     int column1Width = 0;
@@ -210,6 +211,7 @@ public abstract class AbstractConfigurationBuilder<T extends Configuration>
     return "--" + name + type;
   }
 
+  @SuppressWarnings("InlineMeInliner") // String.repeat() requires Java 11
   private static String wordWrap(String text, int startPos, int maxPos) {
     StringBuilder builder = new StringBuilder();
     int pos = startPos;

--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -1,0 +1,1 @@
+build --cxxopt=-std=c++14 --host_cxxopt=-std=c++14

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -28,6 +28,8 @@ load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")
 
 grpc_java_repositories()
 
+# Protobuf now requires C++14 or higher, which requires Bazel configuration
+# outside the WORKSPACE. See .bazelrc in this directory.
 load("@com_google_protobuf//:protobuf_deps.bzl", "PROTOBUF_MAVEN_ARTIFACTS")
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -32,7 +32,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.21.7' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.22.3' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.55.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -30,7 +30,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.21.7' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.22.3' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.55.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -30,7 +30,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.21.7' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.22.3' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.55.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/android/strictmode/app/build.gradle
+++ b/examples/android/strictmode/app/build.gradle
@@ -31,7 +31,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.21.7' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.22.3' }
     plugins {
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.55.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.8
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.55.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.21.7'
+def protobufVersion = '3.22.3'
 def protocVersion = protobufVersion
 
 dependencies {

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.8
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.55.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.21.7'
+def protocVersion = '3.22.3'
 
 dependencies {
     // grpc-alts transitively depends on grpc-netty-shaded, grpc-protobuf, and grpc-stub

--- a/examples/example-debug/build.gradle
+++ b/examples/example-debug/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.8
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.55.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.21.7'
+def protobufVersion = '3.22.3'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-debug/pom.xml
+++ b/examples/example-debug/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.55.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protoc.version>3.21.7</protoc.version>
+    <protoc.version>3.22.3</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -54,6 +54,11 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
       <scope>runtime</scope>
+    </dependency>
+    <dependency> <!-- prevent downgrade of version in protobuf-java-util from grpc-services -->
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>31.1-jre</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.8
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.55.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.21.7'
+def protobufVersion = '3.22.3'
 def protocVersion = protobufVersion
 
 

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.55.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.21.7</protobuf.version>
+    <protobuf.version>3.22.3</protobuf.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/examples/example-gcp-observability/build.gradle
+++ b/examples/example-gcp-observability/build.gradle
@@ -25,7 +25,7 @@ targetCompatibility = 1.8
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.55.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.21.7'
+def protocVersion = '3.22.3'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.8
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.55.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.21.7'
+def protobufVersion = '3.22.3'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-hostname/pom.xml
+++ b/examples/example-hostname/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.55.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protoc.version>3.21.7</protoc.version>
+    <protoc.version>3.22.3</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -54,6 +54,11 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
       <scope>runtime</scope>
+    </dependency>
+    <dependency> <!-- prevent downgrade of version in protobuf-java-util from grpc-services -->
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>31.1-jre</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -23,7 +23,7 @@ targetCompatibility = 1.8
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.55.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.21.7'
+def protobufVersion = '3.22.3'
 def protocVersion = protobufVersion
 
 dependencies {

--- a/examples/example-jwt-auth/pom.xml
+++ b/examples/example-jwt-auth/pom.xml
@@ -14,8 +14,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.55.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.21.7</protobuf.version>
-    <protoc.version>3.21.7</protoc.version>
+    <protobuf.version>3.22.3</protobuf.version>
+    <protoc.version>3.22.3</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/examples/example-orca/build.gradle
+++ b/examples/example-orca/build.gradle
@@ -18,7 +18,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 def grpcVersion = '1.55.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.21.7'
+def protocVersion = '3.22.3'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-reflection/build.gradle
+++ b/examples/example-reflection/build.gradle
@@ -18,7 +18,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 def grpcVersion = '1.55.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.21.7'
+def protocVersion = '3.22.3'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-servlet/build.gradle
+++ b/examples/example-servlet/build.gradle
@@ -16,7 +16,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 def grpcVersion = '1.55.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.21.7'
+def protocVersion = '3.22.3'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}",

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.8
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.55.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.21.7'
+def protocVersion = '3.22.3'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.55.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protoc.version>3.21.7</protoc.version>
+    <protoc.version>3.22.3</protoc.version>
     <netty.tcnative.version>2.0.56.Final</netty.tcnative.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/examples/example-xds/build.gradle
+++ b/examples/example-xds/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.8
 // updating the version in our release process.
 def grpcVersion = '1.55.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 def nettyTcNativeVersion = '2.0.56.Final'
-def protocVersion = '3.21.7'
+def protocVersion = '3.22.3'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.55.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.21.7</protobuf.version>
-    <protoc.version>3.21.7</protoc.version>
+    <protobuf.version>3.22.3</protobuf.version>
+    <protoc.version>3.22.3</protoc.version>
     <!-- required for JDK 8 -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -59,6 +59,11 @@
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.9.0</version> <!-- prevent downgrade via protobuf-java-util -->
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>31.1-jre</version> <!-- prevent downgrade of version in protobuf-java-util -->
     </dependency>
     <dependency>
       <groupId>org.apache.tomcat</groupId>

--- a/gcp-observability/build.gradle
+++ b/gcp-observability/build.gradle
@@ -37,7 +37,8 @@ dependencies {
             libraries.opencensus.exporter.trace.stackdriver,
             project(':grpc-xds'), // Align grpc versions
             project(':grpc-services'), // Align grpc versions
-            ('com.google.protobuf:protobuf-java:3.21.12'),
+            libraries.protobuf.java,
+            libraries.protobuf.java.util, // Use our newer version
             ('com.google.api.grpc:proto-google-common-protos:2.14.2'),
             ('com.google.auth:google-auth-library-oauth2-http:1.16.0'),
             ('io.opencensus:opencensus-api:0.31.1'),

--- a/googleapis/build.gradle
+++ b/googleapis/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation project(':grpc-alts'),
                    project(':grpc-core'),
                    project(':grpc-xds'),
-                   libraries.guava
+                   libraries.guava.jre // JRE required by transitive protobuf-java-util
     testImplementation project(':grpc-core').sourceSets.test.output
 
     signature libraries.signature.java

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ guava = "31.1-android"
 netty = '4.1.87.Final'
 nettytcnative = '2.0.56.Final'
 opencensus = "0.31.0"
-protobuf = "3.21.7"
+protobuf = "3.22.3"
 
 [libraries]
 android-annotations = "com.google.android:annotations:4.1.1.4"
@@ -36,6 +36,7 @@ gson = "com.google.code.gson:gson:2.9.0"
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 guava-betaChecker = "com.google.guava:guava-beta-checker:1.0"
 guava-testlib = { module = "com.google.guava:guava-testlib", version.ref = "guava" }
+guava-jre = "com.google.guava:guava:31.1-jre"
 hdrhistogram = "org.hdrhistogram:HdrHistogram:2.1.12"
 javax-annotation = "org.apache.tomcat:annotations-api:6.0.53"
 jetty-alpn-agent = "org.mortbay.jetty.alpn:jetty-alpn-agent:2.0.10"

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -150,18 +150,18 @@ def com_google_protobuf():
     # This statement defines the @com_google_protobuf repo.
     http_archive(
         name = "com_google_protobuf",
-        sha256 = "c72840a5081484c4ac20789ea5bb5d5de6bc7c477ad76e7109fda2bc4e630fe6",
-        strip_prefix = "protobuf-3.21.7",
-        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.21.7.zip"],
+        sha256 = "5d0f05587aa3ad56079b4c4481dcb462267e5f1075d905c321f8ed6339e74ab0",
+        strip_prefix = "protobuf-22.3",
+        urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protobuf-22.3.zip"],
     )
 
 def com_google_protobuf_javalite():
     # java_lite_proto_library rules implicitly depend on @com_google_protobuf_javalite
     http_archive(
         name = "com_google_protobuf_javalite",
-        sha256 = "c72840a5081484c4ac20789ea5bb5d5de6bc7c477ad76e7109fda2bc4e630fe6",
-        strip_prefix = "protobuf-3.21.7",
-        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.21.7.zip"],
+        sha256 = "5d0f05587aa3ad56079b4c4481dcb462267e5f1075d905c321f8ed6339e74ab0",
+        strip_prefix = "protobuf-22.3",
+        urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protobuf-22.3.zip"],
     )
 
 def io_grpc_grpc_proto():

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -23,7 +23,7 @@ dependencies {
             project(':grpc-stub'),
             project(':grpc-core')
     implementation libraries.protobuf.java.util,
-            libraries.guava
+            libraries.guava.jre // JRE required by protobuf-java-util
 
     runtimeOnly libraries.errorprone.annotations
 


### PR DESCRIPTION
The version used by protoc-gen-grpc-java will be upgraded separately, because of large C++ build changes necessary. But that won't impact users at all. We are upgrading to protoc 22.3; only the grpc plugin is not upgraded.

Bazel is upgraded for both Java and C++.

------

~This is ready but I'm not sure we want it... yet. Protobuf 22 had some serious C++ changes to the build system, dependencies, and required compilers that is delaying upgrading of some parts of the ecosystem (like our compiler plugin). Thus leaving this as draft until things appear ready to proceed.~

C core has committed to upgrading to 22.x, https://github.com/grpc/grpc/pull/32606 . Some parts may still be ongoing (https://github.com/grpc/grpc/issues/32851), but such things will block their next release.

The C++ upgrade will be handled separately. It can actually be upgraded completely independently (before or after) from Java.