### PR TITLE
.github/workflows: Fix duplicate key in testing CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -58,8 +58,9 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: Test Reports (JRE ${{ matrix.jre }})
-        path: ./*/build/reports/tests/**
-        path: ./*/*/build/reports/tests/**
+        path: |
+          ./*/build/reports/tests/**
+          ./*/*/build/reports/tests/**
         retention-days: 14
     - name: Check for modified codegen
       run: test -z "$(git status --porcelain)" || (git status && echo Error Working directory is not clean. Forget to commit generated files? && false)


### PR DESCRIPTION
This has been broken and not running tests since d580bd3 (just a few days ago).