### PR TITLE
core: ForwardingLoadBalancer to forward acceptResolvedAddresses()

### DIFF
--- a/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
@@ -35,6 +35,11 @@ public abstract class ForwardingLoadBalancer extends LoadBalancer {
   }
 
   @Override
+  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    return delegate().acceptResolvedAddresses(resolvedAddresses);
+  }
+
+  @Override
   public void handleNameResolutionError(Status error) {
     delegate().handleNameResolutionError(error);
   }

--- a/core/src/test/java/io/grpc/util/ForwardingLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/util/ForwardingLoadBalancerTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.mock;
 
 import io.grpc.ForwardingTestUtil;
 import io.grpc.LoadBalancer;
-import io.grpc.LoadBalancer.ResolvedAddresses;
 import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,7 +43,6 @@ public class ForwardingLoadBalancerTest {
         LoadBalancer.class,
         mockDelegate,
         new TestBalancer(),
-        Arrays.asList(
-            LoadBalancer.class.getMethod("acceptResolvedAddresses", ResolvedAddresses.class)));
+        Arrays.asList());
   }
 }


### PR DESCRIPTION
`ForwardingLoadBalancer` was not forwarding `acceptResolvedAddresses()` calls to its delegate. This was not an issue before because the LBs that extended `ForwardingLoadBalancer` all implemented `handleResolvedAddresses()`. With the push to deprecate `handleResolvedAddresses()` `RpcBehaviorLoadBalancerProvider` recently changed to use `acceptResolvedAddresses()` but this caused problems in internal interop tests as that method was not being delegated.

This should fix b/277724057