### PR TITLE
.github/workflows: Add Bazel CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -72,3 +72,22 @@ jobs:
       run: ./gradlew :grpc-all:coveralls -PskipAndroid=true -x compileJava
     - name: Codecov
       uses: codecov/codecov-action@v3
+
+  bazel:
+    runs-on: ubuntu-latest
+    env:
+      USE_BAZEL_VERSION: 5.0.0
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Bazel cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/bazel/*/cache
+          ~/.cache/bazelisk/downloads
+        key: ${{ runner.os }}-bazel-${{ env.USE_BAZEL_VERSION }}-${{ hashFiles('WORKSPACE', 'repositories.bzl') }}
+
+    - name: Run bazel build
+      run: bazelisk build //...


### PR DESCRIPTION
This will replace the kokoro-based CI. We need to upgrade the image Kokoro runs on, but it is easier to add a GitHub Actions CI than to run a one-off test on a new image with Kokoro.

A clean run takes 10 minutes and a cached run takes 8.5. So it is a little bit slower than the 5.5 minutes on Kokoro, but still pretty quick.

----

This is related to #10045. CC @larry-safran 