### PR TITLE
Revert RpcBehaviorLoadBalancerProvider.acceptResolvedAddresses()

### DIFF
--- a/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
@@ -35,11 +35,6 @@ public abstract class ForwardingLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-    return delegate().acceptResolvedAddresses(resolvedAddresses);
-  }
-
-  @Override
   public void handleNameResolutionError(Status error) {
     delegate().handleNameResolutionError(error);
   }

--- a/core/src/test/java/io/grpc/util/ForwardingLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/util/ForwardingLoadBalancerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.mock;
 
 import io.grpc.ForwardingTestUtil;
 import io.grpc.LoadBalancer;
+import io.grpc.LoadBalancer.ResolvedAddresses;
 import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,6 +44,7 @@ public class ForwardingLoadBalancerTest {
         LoadBalancer.class,
         mockDelegate,
         new TestBalancer(),
-        Arrays.asList());
+        Arrays.asList(
+            LoadBalancer.class.getMethod("acceptResolvedAddresses", ResolvedAddresses.class)));
   }
 }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProvider.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProvider.java
@@ -111,10 +111,10 @@ public class RpcBehaviorLoadBalancerProvider extends LoadBalancerProvider {
     }
 
     @Override
-    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       helper.setRpcBehavior(
           ((RpcBehaviorConfig) resolvedAddresses.getLoadBalancingPolicyConfig()).rpcBehavior);
-      return delegateLb.acceptResolvedAddresses(resolvedAddresses);
+      delegateLb.handleResolvedAddresses(resolvedAddresses);
     }
   }
 

--- a/interop-testing/src/test/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProviderTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProviderTest.java
@@ -79,12 +79,12 @@ public class RpcBehaviorLoadBalancerProviderTest {
   }
 
   @Test
-  public void acceptResolvedAddressesDelegated() {
+  public void handleResolvedAddressesDelegated() {
     RpcBehaviorLoadBalancer lb = new RpcBehaviorLoadBalancer(new RpcBehaviorHelper(mockHelper),
         mockDelegateLb);
     ResolvedAddresses resolvedAddresses = buildResolvedAddresses(buildConfig());
-    assertThat(lb.acceptResolvedAddresses(resolvedAddresses)).isFalse();
-    verify(mockDelegateLb).acceptResolvedAddresses(resolvedAddresses);
+    lb.handleResolvedAddresses(resolvedAddresses);
+    verify(mockDelegateLb).handleResolvedAddresses(resolvedAddresses);
   }
 
   @Test


### PR DESCRIPTION
A recent change (#10030) to move this test load balancer to use `acceptResolvedAddresses()` caused a test failure that a subsequent commit (#10050  failed to remedy. Reverting both for now since we are so close to release branch cut. I will make another go at this later.