### PR TITLE
alts:Remove character from matcher  that was dropped from JDK generated error message

### DIFF
--- a/alts/src/test/java/io/grpc/alts/internal/TsiTest.java
+++ b/alts/src/test/java/io/grpc/alts/internal/TsiTest.java
@@ -36,7 +36,7 @@ import javax.crypto.AEADBadTagException;
 
 /** Utility class that provides tests for implementations of {@link TsiHandshaker}. */
 public final class TsiTest {
-  private static final String DECRYPTION_FAILURE_RE = "Tag mismatch!|BAD_DECRYPT";
+  private static final String DECRYPTION_FAILURE_RE = "Tag mismatch|BAD_DECRYPT";
 
   private TsiTest() {}
 


### PR DESCRIPTION
The DECRYPTION_FAILURE_RE matcher had an exclamation point that was dropped from the related error message between Java 11 and 19.