### PR TITLE
buildscripts: increase PSM Security test timeout to 4h (v1.48.x backport)

### DIFF
--- a/buildscripts/kokoro/psm-security.cfg
+++ b/buildscripts/kokoro/psm-security.cfg
@@ -2,7 +2,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-java/buildscripts/kokoro/psm-security.sh"
-timeout_mins: 180
+timeout_mins: 240
 
 action {
   define_artifacts {


### PR DESCRIPTION
Backport of #10065 to v1.48.x.
---
The total time PSM Security takes to run was getting close to 3h lately. Adding an extra hour to allow for a larger margin of error.

ref b/259690410