### PR TITLE
retries:Remove early commit for transparent retries with none remaining. (1.54.x backport)

### DIFF
--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -932,29 +932,15 @@ abstract class RetriableStream<ReqT> implements ClientStream {
             return;
           }
           if (isHedging) {
-            boolean commit = false;
             synchronized (lock) {
               // Although this operation is not done atomically with
               // noMoreTransparentRetry.compareAndSet(false, true), it does not change the size() of
               // activeHedges, so neither does it affect the commitment decision of other threads,
               // nor do the commitment decision making threads affect itself.
               state = state.replaceActiveHedge(substream, newSubstream);
-
-              // optimization for early commit
-              if (!hasPotentialHedging(state)
-                  && state.activeHedges.size() == 1) {
-                commit = true;
-              }
-            }
-            if (commit) {
-              commitAndRun(newSubstream);
-            }
-          } else {
-            if (retryPolicy == null || retryPolicy.maxAttempts == 1) {
-              // optimization for early commit
-              commitAndRun(newSubstream);
             }
           }
+
           callExecutor.execute(new Runnable() {
             @Override
             public void run() {

--- a/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
@@ -1971,7 +1971,7 @@ public class RetriableStreamTest {
   }
 
   @Test
-  public void noRetry_transparentRetry_earlyCommit() {
+  public void noRetry_transparentRetry_noEarlyCommit() {
     ClientStream mockStream1 = mock(ClientStream.class);
     ClientStream mockStream2 = mock(ClientStream.class);
     InOrder inOrder = inOrder(retriableStreamRecorder, mockStream1, mockStream2);
@@ -1999,7 +1999,7 @@ public class RetriableStreamTest {
     inOrder.verify(retriableStreamRecorder).newSubstream(0);
     ArgumentCaptor<ClientStreamListener> sublistenerCaptor2 =
         ArgumentCaptor.forClass(ClientStreamListener.class);
-    inOrder.verify(retriableStreamRecorder).postCommit();
+    verify(retriableStreamRecorder, never()).postCommit();
     inOrder.verify(mockStream2).start(sublistenerCaptor2.capture());
     inOrder.verify(mockStream2).isReady();
     inOrder.verifyNoMoreInteractions();


### PR DESCRIPTION
RetriableStream was trying to do an optimization by doing early commits when there were not going to be any further explicit retries, but it should never have been done.  This is removing the optimization and reversing the test that checked for an early commit.

Fixes #10011

Backport of #10066