### PR TITLE
stub: Add null check for responseObserver

### DIFF
--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -73,6 +73,7 @@ public final class ClientCalls {
    */
   public static <ReqT, RespT> void asyncUnaryCall(
       ClientCall<ReqT, RespT> call, ReqT req, StreamObserver<RespT> responseObserver) {
+    checkNotNull(responseObserver, "responseObserver");
     asyncUnaryRequestCall(call, req, responseObserver, false);
   }
 
@@ -86,6 +87,7 @@ public final class ClientCalls {
    */
   public static <ReqT, RespT> void asyncServerStreamingCall(
       ClientCall<ReqT, RespT> call, ReqT req, StreamObserver<RespT> responseObserver) {
+    checkNotNull(responseObserver, "responseObserver");
     asyncUnaryRequestCall(call, req, responseObserver, true);
   }
 
@@ -102,6 +104,7 @@ public final class ClientCalls {
   public static <ReqT, RespT> StreamObserver<ReqT> asyncClientStreamingCall(
       ClientCall<ReqT, RespT> call,
       StreamObserver<RespT> responseObserver) {
+    checkNotNull(responseObserver, "responseObserver");
     return asyncStreamingRequestCall(call, responseObserver, false);
   }
 
@@ -116,6 +119,7 @@ public final class ClientCalls {
    */
   public static <ReqT, RespT> StreamObserver<ReqT> asyncBidiStreamingCall(
       ClientCall<ReqT, RespT> call, StreamObserver<RespT> responseObserver) {
+    checkNotNull(responseObserver, "responseObserver");
     return asyncStreamingRequestCall(call, responseObserver, true);
   }
 

--- a/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
+++ b/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
@@ -65,7 +65,6 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -509,7 +508,7 @@ public class ClientCallsTest {
     NoopClientCall<Integer, String> call = new NoopClientCall<>();
     try {
       ClientCalls.asyncUnaryCall(call, Integer.valueOf(1), null);
-      Assert.fail("Should have gotten an exception for the null responseObserver");
+      fail("Should have gotten an exception for the null responseObserver");
     } catch (NullPointerException e) {
       assertEquals("responseObserver", e.getMessage());
     }
@@ -520,7 +519,7 @@ public class ClientCallsTest {
     NoopClientCall<Integer, String> call = new NoopClientCall<>();
     try {
       ClientCalls.asyncBidiStreamingCall(call, null);
-      Assert.fail("Should have gotten an exception for the null responseObserver");
+      fail("Should have gotten an exception for the null responseObserver");
     } catch (NullPointerException e) {
       assertEquals("responseObserver", e.getMessage());
     }
@@ -531,7 +530,7 @@ public class ClientCallsTest {
     NoopClientCall<Integer, String> call = new NoopClientCall<>();
     try {
       ClientCalls.asyncClientStreamingCall(call, null);
-      Assert.fail("Should have gotten an exception for the null responseObserver");
+      fail("Should have gotten an exception for the null responseObserver");
     } catch (NullPointerException e) {
       assertEquals("responseObserver", e.getMessage());
     }
@@ -542,7 +541,7 @@ public class ClientCallsTest {
     NoopClientCall<Integer, String> call = new NoopClientCall<>();
     try {
       ClientCalls.asyncServerStreamingCall(call, Integer.valueOf(1), null);
-      Assert.fail("Should have gotten an exception for the null responseObserver");
+      fail("Should have gotten an exception for the null responseObserver");
     } catch (NullPointerException e) {
       assertEquals("responseObserver", e.getMessage());
     }

--- a/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
+++ b/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
@@ -65,6 +65,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -501,6 +502,50 @@ public class ClientCallsTest {
     });
     listener.get().onMessage("message");
     assertThat(requests).isEmpty();
+  }
+
+  @Test
+  public void checkForNullInAsyncUnaryCall()  {
+    NoopClientCall<Integer, String> call = new NoopClientCall<>();
+    try {
+      ClientCalls.asyncUnaryCall(call, Integer.valueOf(1), null);
+      Assert.fail("Should have gotten an exception for the null responseObserver");
+    } catch (NullPointerException e) {
+      assertSame("responseObserver", e.getMessage());
+    }
+  }
+
+  @Test
+  public void checkForNullInBidiCall()  {
+    NoopClientCall<Integer, String> call = new NoopClientCall<>();
+    try {
+      ClientCalls.asyncBidiStreamingCall(call, null);
+      Assert.fail("Should have gotten an exception for the null responseObserver");
+    } catch (NullPointerException e) {
+      assertSame("responseObserver", e.getMessage());
+    }
+  }
+
+  @Test
+  public void checkForNullInClientStreamCall()  {
+    NoopClientCall<Integer, String> call = new NoopClientCall<>();
+    try {
+      ClientCalls.asyncClientStreamingCall(call, null);
+      Assert.fail("Should have gotten an exception for the null responseObserver");
+    } catch (NullPointerException e) {
+      assertSame("responseObserver", e.getMessage());
+    }
+  }
+
+  @Test
+  public void checkForNullInServerStreamCall()  {
+    NoopClientCall<Integer, String> call = new NoopClientCall<>();
+    try {
+      ClientCalls.asyncServerStreamingCall(call, Integer.valueOf(1), null);
+      Assert.fail("Should have gotten an exception for the null responseObserver");
+    } catch (NullPointerException e) {
+      assertSame("responseObserver", e.getMessage());
+    }
   }
 
   @Test

--- a/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
+++ b/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -156,8 +155,8 @@ public class ClientCallsTest {
       ClientCalls.blockingUnaryCall(call, req);
       fail("Should fail");
     } catch (StatusRuntimeException e) {
-      assertSame(status, e.getStatus());
-      assertSame(trailers, e.getTrailers());
+      assertEquals(status, e.getStatus());
+      assertEquals(trailers, e.getTrailers());
     }
   }
 
@@ -364,7 +363,7 @@ public class ClientCallsTest {
       Status status = Status.fromThrowable(e);
       assertEquals(Status.INTERNAL, status);
       Metadata metadata = Status.trailersFromThrowable(e);
-      assertSame(trailers, metadata);
+      assertEquals(trailers, metadata);
     }
   }
 
@@ -511,7 +510,7 @@ public class ClientCallsTest {
       ClientCalls.asyncUnaryCall(call, Integer.valueOf(1), null);
       Assert.fail("Should have gotten an exception for the null responseObserver");
     } catch (NullPointerException e) {
-      assertSame("responseObserver", e.getMessage());
+      assertEquals("responseObserver", e.getMessage());
     }
   }
 
@@ -522,7 +521,7 @@ public class ClientCallsTest {
       ClientCalls.asyncBidiStreamingCall(call, null);
       Assert.fail("Should have gotten an exception for the null responseObserver");
     } catch (NullPointerException e) {
-      assertSame("responseObserver", e.getMessage());
+      assertEquals("responseObserver", e.getMessage());
     }
   }
 
@@ -533,7 +532,7 @@ public class ClientCallsTest {
       ClientCalls.asyncClientStreamingCall(call, null);
       Assert.fail("Should have gotten an exception for the null responseObserver");
     } catch (NullPointerException e) {
-      assertSame("responseObserver", e.getMessage());
+      assertEquals("responseObserver", e.getMessage());
     }
   }
 
@@ -544,7 +543,7 @@ public class ClientCallsTest {
       ClientCalls.asyncServerStreamingCall(call, Integer.valueOf(1), null);
       Assert.fail("Should have gotten an exception for the null responseObserver");
     } catch (NullPointerException e) {
-      assertSame("responseObserver", e.getMessage());
+      assertEquals("responseObserver", e.getMessage());
     }
   }
 
@@ -838,7 +837,7 @@ public class ClientCallsTest {
       Status status = Status.fromThrowable(e);
       assertEquals(Status.INTERNAL, status);
       Metadata metadata = Status.trailersFromThrowable(e);
-      assertSame(trailers, metadata);
+      assertEquals(trailers, metadata);
     }
   }
 

--- a/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
+++ b/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -155,8 +156,8 @@ public class ClientCallsTest {
       ClientCalls.blockingUnaryCall(call, req);
       fail("Should fail");
     } catch (StatusRuntimeException e) {
-      assertEquals(status, e.getStatus());
-      assertEquals(trailers, e.getTrailers());
+      assertSame(status, e.getStatus());
+      assertSame(trailers, e.getTrailers());
     }
   }
 
@@ -363,7 +364,7 @@ public class ClientCallsTest {
       Status status = Status.fromThrowable(e);
       assertEquals(Status.INTERNAL, status);
       Metadata metadata = Status.trailersFromThrowable(e);
-      assertEquals(trailers, metadata);
+      assertSame(trailers, metadata);
     }
   }
 
@@ -837,7 +838,7 @@ public class ClientCallsTest {
       Status status = Status.fromThrowable(e);
       assertEquals(Status.INTERNAL, status);
       Metadata metadata = Status.trailersFromThrowable(e);
-      assertEquals(trailers, metadata);
+      assertSame(trailers, metadata);
     }
   }
 


### PR DESCRIPTION
Add null check for responseObserver in the methods for initiating a call that take a responseObserver argument.  This insures a fail fast with a clearer cause instead of an NPE when the observer is first used.

Fixes #10064