### PR TITLE
interop-testing: Start mgmt server before xds server

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
@@ -176,14 +176,6 @@ public final class XdsTestServer {
     }
     health = new HealthStatusManager();
     if (secureMode) {
-      server =
-          XdsServerBuilder.forPort(
-                  port, XdsServerCredentials.create(InsecureServerCredentials.create()))
-              .addService(
-                  ServerInterceptors.intercept(
-                      new TestServiceImpl(serverId, host), new TestInfoInterceptor(host)))
-              .build();
-      server.start();
       maintenanceServer =
           NettyServerBuilder.forPort(maintenancePort)
               .addService(new XdsUpdateHealthServiceImpl(health))
@@ -192,6 +184,14 @@ public final class XdsTestServer {
               .addServices(AdminInterface.getStandardServices())
               .build();
       maintenanceServer.start();
+      server =
+          XdsServerBuilder.forPort(
+                  port, XdsServerCredentials.create(InsecureServerCredentials.create()))
+              .addService(
+                  ServerInterceptors.intercept(
+                      new TestServiceImpl(serverId, host), new TestInfoInterceptor(host)))
+              .build();
+      server.start();
     } else {
       server =
           NettyServerBuilder.forPort(port)


### PR DESCRIPTION
The xds server can take a really long time to start if the xds resources are slow to load. Ideally the management server would be available during this time so we can inspect the server. The server health still won't go to SERVING until the xds server starts, which is appropriate.

CC @sanjaypujare 