### PR TITLE
android-interop-testing: Avoid JRE Guava from Protobuf 22.3 upgrade

### DIFF
--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -83,6 +83,7 @@ dependencies {
 
     implementation (project(':grpc-services')) {
         exclude group: 'com.google.protobuf'
+        exclude group: 'com.google.guava'
     }
 
     compileOnly libraries.javax.annotation


### PR DESCRIPTION
This fixes the interop test on API levels 19-23