### PR TITLE
Handle unexpected exceptions on binder threads

### DIFF
--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -420,8 +420,9 @@ public abstract class BinderTransport
     } catch (RuntimeException e) {
       synchronized (this) {
         // This unhandled exception may have put us in an inconsistent state. Force terminate the
-        // whole transport so that clients can retry with a fresh instance on both sides.
-        logger.log(Level.SEVERE, "Unhandled Exception", e);
+        // whole transport to alert our peer to the problem and so that clients can retry with a
+        // fresh transport on both sides.
+        logger.log(Level.SEVERE, "Terminating transport for uncaught Exception", e);
         shutdownInternal(Status.INTERNAL.withCause(e), true);
         return false;
       }

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -418,12 +418,12 @@ public abstract class BinderTransport
     try {
       return handleTransactionInternal(code, parcel);
     } catch (RuntimeException e) {
+      logger.log(Level.SEVERE,
+          "Terminating transport for uncaught Exception in transaction " + code, e);
       synchronized (this) {
         // This unhandled exception may have put us in an inconsistent state. Force terminate the
-        // whole transport so our peer knows something is wrong and so that clients who retry will
-        // enjoy a fresh transport instance on both sides.
-        logger.log(Level.SEVERE,
-            "Terminating transport for uncaught Exception in transaction " + code, e);
+        // whole transport so our peer knows something is wrong and so that clients can retry with
+        // a fresh transport instance on both sides.
         shutdownInternal(Status.INTERNAL.withCause(e), true);
         return false;
       }

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -420,9 +420,10 @@ public abstract class BinderTransport
     } catch (RuntimeException e) {
       synchronized (this) {
         // This unhandled exception may have put us in an inconsistent state. Force terminate the
-        // whole transport to alert our peer to the problem and so that clients can retry with a
-        // fresh transport on both sides.
-        logger.log(Level.SEVERE, "Terminating transport for uncaught Exception", e);
+        // whole transport so our peer knows something is wrong and so that clients who retry will
+        // enjoy a fresh transport instance on both sides.
+        logger.log(Level.SEVERE,
+            "Terminating transport for uncaught Exception in transaction " + code, e);
         shutdownInternal(Status.INTERNAL.withCause(e), true);
         return false;
       }


### PR DESCRIPTION
All BinderTransport transactions are oneway which means uncaught Exceptions processing them are merely logged locally and not propagated to the peer. This PR adds a top level catch block that handles the unexpected by shutting down the whole transport. This makes our peer aware of the problem immediately (instead of relying on a deadline) and gives clients a fresh transport instance to handle any retries.