### PR TITLE
xds,googleapis: Default GRPC_EXPERIMENTAL_XDS_FEDERATION to true

### DIFF
--- a/googleapis/src/main/java/io/grpc/googleapis/GoogleCloudToProdNameResolver.java
+++ b/googleapis/src/main/java/io/grpc/googleapis/GoogleCloudToProdNameResolver.java
@@ -66,8 +66,8 @@ final class GoogleCloudToProdNameResolver extends NameResolver {
           || System.getProperty("io.grpc.xds.bootstrapConfig") != null;
   @VisibleForTesting
   static boolean enableFederation =
-      !Strings.isNullOrEmpty(System.getenv("GRPC_EXPERIMENTAL_XDS_FEDERATION"))
-          && Boolean.parseBoolean(System.getenv("GRPC_EXPERIMENTAL_XDS_FEDERATION"));
+      Strings.isNullOrEmpty(System.getenv("GRPC_EXPERIMENTAL_XDS_FEDERATION"))
+          || Boolean.parseBoolean(System.getenv("GRPC_EXPERIMENTAL_XDS_FEDERATION"));
 
   private static final String serverUriOverride =
       System.getenv("GRPC_TEST_ONLY_GOOGLE_C2P_RESOLVER_TRAFFIC_DIRECTOR_URI");

--- a/googleapis/src/test/java/io/grpc/googleapis/GoogleCloudToProdNameResolverTest.java
+++ b/googleapis/src/test/java/io/grpc/googleapis/GoogleCloudToProdNameResolverTest.java
@@ -159,6 +159,7 @@ public class GoogleCloudToProdNameResolverTest {
   public void hasProvidedBootstrapDelegateToDns() {
     GoogleCloudToProdNameResolver.isOnGcp = true;
     GoogleCloudToProdNameResolver.xdsBootstrapProvided = true;
+    GoogleCloudToProdNameResolver.enableFederation = false;
     createResolver();
     resolver.start(mockListener);
     assertThat(delegatedResolver.keySet()).containsExactly("dns");

--- a/xds/src/main/java/io/grpc/xds/BootstrapperImpl.java
+++ b/xds/src/main/java/io/grpc/xds/BootstrapperImpl.java
@@ -57,8 +57,8 @@ class BootstrapperImpl extends Bootstrapper {
 
   // Feature-gating environment variables.
   static boolean enableFederation =
-      !Strings.isNullOrEmpty(System.getenv("GRPC_EXPERIMENTAL_XDS_FEDERATION"))
-          && Boolean.parseBoolean(System.getenv("GRPC_EXPERIMENTAL_XDS_FEDERATION"));
+      Strings.isNullOrEmpty(System.getenv("GRPC_EXPERIMENTAL_XDS_FEDERATION"))
+          || Boolean.parseBoolean(System.getenv("GRPC_EXPERIMENTAL_XDS_FEDERATION"));
 
   // Client features.
   @VisibleForTesting


### PR DESCRIPTION
The federation behavior has stabilized and we are ready to enable the behavior by default. The flag can still be used to disable federation.