### PR TITLE
core: Pass Locality to toLowerCase() in GrpcUtil

### DIFF
--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -59,6 +59,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -436,7 +437,7 @@ public final class GrpcUtil {
       return false;
     }
 
-    contentType = contentType.toLowerCase();
+    contentType = contentType.toLowerCase(Locale.US);
     if (!contentType.startsWith(CONTENT_TYPE_GRPC)) {
       // Not a gRPC content-type.
       return false;


### PR DESCRIPTION
We pretty much never want to use the system locality, across all our code.