### PR TITLE
xds: fix flaky xds test

### DIFF
--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
@@ -3567,11 +3567,10 @@ public abstract class XdsClientImplTestBase {
     // Setup xdsClient to fail on stream creation
     XdsClientImpl client = createXdsClient("some.garbage");
     client.watchXdsResource(XdsListenerResource.getInstance(), LDS_RESOURCE, ldsResourceWatcher);
-    fakeClock.forwardTime(20, TimeUnit.SECONDS);
-
     verify(ldsResourceWatcher, Mockito.timeout(5000).times(1)).onError(ArgumentMatchers.any());
-    fakeClock.forwardTime(50, TimeUnit.SECONDS); // Trigger rpcRetry if appropriate
-    assertThat(fakeClock.getPendingTasks(LDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
+    assertThat(fakeClock.numPendingTasks()).isEqualTo(1); //retry
+    assertThat(fakeClock.getPendingTasks().iterator().next().toString().contains("RpcRetryTask"))
+        .isTrue();
     client.shutdown();
   }
 


### PR DESCRIPTION
fix tsan data race b/269942507

```
Details
==================
WARNING: ThreadSanitizer: data race (pid=5874)
  Read of size 8 at 0x0000cd26bec8 by thread T25:
    #0 io.grpc.internal.FakeClock$2.read()J FakeClock.java:61 
    #1 com.google.common.base.Stopwatch.elapsedNanos()J Stopwatch.java:222 
    #2 com.google.common.base.Stopwatch.elapsed(Ljava/util/concurrent/TimeUnit;)J Stopwatch.java:239 
    #3 io.grpc.xds.ControlPlaneClient$AbstractAdsStream.handleRpcStreamClosed(Lio/grpc/Status;)V ControlPlaneClient.java:339 
    #4 io.grpc.xds.ControlPlaneClient$AbstractAdsStream.handleRpcError(Ljava/lang/Throwable;)V ControlPlaneClient.java:321 
    #5 io.grpc.xds.ControlPlaneClient$AdsStreamV3$1$2.run()V ControlPlaneClient.java:423 
    #6 io.grpc.SynchronizationContext.drain()V SynchronizationContext.java:95 
    #7 io.grpc.SynchronizationContext.execute(Ljava/lang/Runnable;)V SynchronizationContext.java:127 
    #8 io.grpc.xds.ControlPlaneClient$AdsStreamV3$1.onError(Ljava/lang/Throwable;)V ControlPlaneClient.java:420 
    #9 io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onClose(Lio/grpc/Status;Lio/grpc/Metadata;)V ClientCalls.java:487 
    #10 io.grpc.PartialForwardingClientCallListener.onClose(Lio/grpc/Status;Lio/grpc/Metadata;)V PartialForwardingClientCallListener.java:39 
    #11 io.grpc.ForwardingClientCallListener.onClose(Lio/grpc/Status;Lio/grpc/Metadata;)V ForwardingClientCallListener.java:23 
    #12 io.grpc.ForwardingClientCallListener$SimpleForwardingClientCallListener.onClose(Lio/grpc/Status;Lio/grpc/Metadata;)V ForwardingClientCallListener.java:40 
    #13 io.grpc.census.CensusStatsModule$StatsClientInterceptor$1$1.onClose(Lio/grpc/Status;Lio/grpc/Metadata;)V CensusStatsModule.java:814 
    #14 io.grpc.PartialForwardingClientCallListener.onClose(Lio/grpc/Status;Lio/grpc/Metadata;)V PartialForwardingClientCallListener.java:39 
    #15 io.grpc.ForwardingClientCallListener.onClose(Lio/grpc/Status;Lio/grpc/Metadata;)V ForwardingClientCallListener.java:23 
    #16 io.grpc.ForwardingClientCallListener$SimpleForwardingClientCallListener.onClose(Lio/grpc/Status;Lio/grpc/Metadata;)V ForwardingClientCallListener.java:40 
    #17 io.grpc.census.CensusTracingModule$TracingClientInterceptor$1$1.onClose(Lio/grpc/Status;Lio/grpc/Metadata;)V CensusTracingModule.java:494 
    #18 io.grpc.internal.DelayedClientCall$DelayedListener$3.run()V DelayedClientCall.java:489 
    #19 io.grpc.internal.DelayedClientCall$DelayedListener.delayOrExecute(Ljava/lang/Runnable;)V DelayedClientCall.java:453 
    #20 io.grpc.internal.DelayedClientCall$DelayedListener.onClose(Lio/grpc/Status;Lio/grpc/Metadata;)V DelayedClientCall.java:486 
    #21 io.grpc.internal.ClientCallImpl.closeObserver(Lio/grpc/ClientCall$Listener;Lio/grpc/Status;Lio/grpc/Metadata;)V ClientCallImpl.java:567 
    #22 io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal()V ClientCallImpl.java:735 
    #23 io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext()V ClientCallImpl.java:716 
    #24 io.grpc.internal.ContextRunnable.run()V ContextRunnable.java:37 
    #25 io.grpc.internal.SerializingExecutor.run()V SerializingExecutor.java:133 
    #26 java.util.concurrent.ThreadPoolExecutor.runWorker(Ljava/util/concurrent/ThreadPoolExecutor$Worker;)V ThreadPoolExecutor.java:1130 
    #27 java.util.concurrent.ThreadPoolExecutor$Worker.run()V ThreadPoolExecutor.java:630 
    #28 java.lang.Thread.run()V Thread.java:830 
    #29 (Generated Stub) <null> 

  Previous write of size 8 at 0x0000cd26bec8 by thread T5 (mutexes: write M0, write M1, write M2):
    #0 io.grpc.internal.FakeClock.forwardTime(JLjava/util/concurrent/TimeUnit;)I FakeClock.java:367 
    #1 io.grpc.xds.XdsClientImplTestBase.sendToNonexistentHost()V XdsClientImplTestBase.java:3570 
    #2 (Generated Stub) <null> 
```

plus fix flakiness:

```
value of: getPendingTasks()
expected to be empty
but was : [[due=70000000100, task=io.grpc.xds.ControlPlaneClient$RpcRetryTask@7e4579c7(scheduled in SynchronizationContext)]]
	at io.grpc.xds.XdsClientImplTestBase.tearDown(XdsClientImplTestBase.java:391)
```

successful run after fix
https://fusion2.corp.google.com/invocations/8cf2f2d4-caae-43af-9334-c44b886decba/targets



cc. @ejona86 