### PR TITLE
core: Optional address shuffle in PickFirstLoadBalancer

### DIFF
--- a/core/src/main/java/io/grpc/internal/PickFirstLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLoadBalancer.java
@@ -31,6 +31,7 @@ import io.grpc.Status;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 
@@ -65,7 +66,8 @@ final class PickFirstLoadBalancer extends LoadBalancer {
           = (PickFirstLoadBalancerConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
       if (config.shuffleAddressList != null && config.shuffleAddressList) {
         servers = new ArrayList<EquivalentAddressGroup>(servers);
-        Collections.shuffle(servers);
+        Collections.shuffle(servers,
+            config.randomSeed != null ? new Random(config.randomSeed) : new Random());
       }
     }
 
@@ -219,8 +221,16 @@ final class PickFirstLoadBalancer extends LoadBalancer {
     @Nullable
     public final Boolean shuffleAddressList;
 
+    // For testing purposes only, not meant to be parsed from a real config.
+    @Nullable final Long randomSeed;
+
     public PickFirstLoadBalancerConfig(@Nullable Boolean shuffleAddressList) {
+      this(shuffleAddressList, null);
+    }
+
+    PickFirstLoadBalancerConfig(@Nullable Boolean shuffleAddressList, @Nullable Long randomSeed) {
       this.shuffleAddressList = shuffleAddressList;
+      this.randomSeed = randomSeed;
     }
   }
 }

--- a/core/src/main/java/io/grpc/internal/PickFirstLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLoadBalancer.java
@@ -22,9 +22,7 @@ import static io.grpc.ConnectivityState.IDLE;
 import static io.grpc.ConnectivityState.SHUTDOWN;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Strings;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
@@ -46,10 +44,6 @@ final class PickFirstLoadBalancer extends LoadBalancer {
   private final Helper helper;
   private Subchannel subchannel;
   private ConnectivityState currentState = IDLE;
-  @VisibleForTesting
-  static boolean enablePickFirstConfig =
-      !Strings.isNullOrEmpty(System.getenv("GRPC_EXPERIMENTAL_PICKFIRST_LB_CONFIG"))
-          && Boolean.parseBoolean(System.getenv("GRPC_EXPERIMENTAL_PICKFIRST_LB_CONFIG"));
 
   PickFirstLoadBalancer(Helper helper) {
     this.helper = checkNotNull(helper, "helper");
@@ -67,7 +61,7 @@ final class PickFirstLoadBalancer extends LoadBalancer {
 
     // We can optionally be configured to shuffle the address list. This can help better distribute
     // the load.
-    if (enablePickFirstConfig && resolvedAddresses.getLoadBalancingPolicyConfig() != null) {
+    if (resolvedAddresses.getLoadBalancingPolicyConfig() instanceof PickFirstLoadBalancerConfig) {
       PickFirstLoadBalancerConfig config
           = (PickFirstLoadBalancerConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
       if (config.shuffleAddressList != null && config.shuffleAddressList) {

--- a/core/src/main/java/io/grpc/internal/PickFirstLoadBalancerProvider.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLoadBalancerProvider.java
@@ -16,6 +16,8 @@
 
 package io.grpc.internal;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.NameResolver;
@@ -30,6 +32,11 @@ import java.util.Map;
  * down the address list and sticks to the first that works.
  */
 public final class PickFirstLoadBalancerProvider extends LoadBalancerProvider {
+  private static final String NO_CONFIG = "no service config";
+  private static final String SHUFFLE_ADDRESS_LIST_KEY = "shuffleAddressList";
+  private static final String CONFIG_FLAG_NAME = "GRPC_EXPERIMENTAL_PICKFIRST_LB_CONFIG";
+  @VisibleForTesting
+  static boolean enablePickFirstConfig = !Strings.isNullOrEmpty(System.getenv(CONFIG_FLAG_NAME));
 
   @Override
   public boolean isAvailable() {
@@ -54,8 +61,12 @@ public final class PickFirstLoadBalancerProvider extends LoadBalancerProvider {
   @Override
   public ConfigOrError parseLoadBalancingPolicyConfig(
       Map<String, ?> rawLoadBalancingPolicyConfig) {
-    return ConfigOrError.fromConfig(
-        new PickFirstLoadBalancerConfig(JsonUtil.getBoolean(rawLoadBalancingPolicyConfig,
-            "shuffleAddressList")));
+    if (enablePickFirstConfig) {
+      return ConfigOrError.fromConfig(
+          new PickFirstLoadBalancerConfig(JsonUtil.getBoolean(rawLoadBalancingPolicyConfig,
+              SHUFFLE_ADDRESS_LIST_KEY)));
+    } else {
+      return ConfigOrError.fromConfig(NO_CONFIG);
+    }
   }
 }

--- a/core/src/main/java/io/grpc/internal/PickFirstLoadBalancerProvider.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLoadBalancerProvider.java
@@ -20,6 +20,7 @@ import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.NameResolver;
 import io.grpc.NameResolver.ConfigOrError;
+import io.grpc.internal.PickFirstLoadBalancer.PickFirstLoadBalancerConfig;
 import java.util.Map;
 
 /**
@@ -29,7 +30,6 @@ import java.util.Map;
  * down the address list and sticks to the first that works.
  */
 public final class PickFirstLoadBalancerProvider extends LoadBalancerProvider {
-  private static final String NO_CONFIG = "no service config";
 
   @Override
   public boolean isAvailable() {
@@ -54,6 +54,8 @@ public final class PickFirstLoadBalancerProvider extends LoadBalancerProvider {
   @Override
   public ConfigOrError parseLoadBalancingPolicyConfig(
       Map<String, ?> rawLoadBalancingPolicyConfig) {
-    return ConfigOrError.fromConfig(NO_CONFIG);
+    return ConfigOrError.fromConfig(
+        new PickFirstLoadBalancerConfig(JsonUtil.getBoolean(rawLoadBalancingPolicyConfig,
+            "shuffleAddressList")));
   }
 }

--- a/core/src/test/java/io/grpc/internal/PickFirstLoadBalancerProviderTest.java
+++ b/core/src/test/java/io/grpc/internal/PickFirstLoadBalancerProviderTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.grpc.internal;
 
 import static com.google.common.truth.Truth.assertThat;

--- a/core/src/test/java/io/grpc/internal/PickFirstLoadBalancerProviderTest.java
+++ b/core/src/test/java/io/grpc/internal/PickFirstLoadBalancerProviderTest.java
@@ -1,0 +1,45 @@
+package io.grpc.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.grpc.NameResolver.ConfigOrError;
+import io.grpc.internal.PickFirstLoadBalancer.PickFirstLoadBalancerConfig;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class PickFirstLoadBalancerProviderTest {
+
+  @After
+  public void resetConfigFlag() {
+    PickFirstLoadBalancerProvider.enablePickFirstConfig = false;
+  }
+
+  @Test
+  public void parseWithConfigEnabled() {
+    PickFirstLoadBalancerProvider.enablePickFirstConfig = true;
+    Map<String, Object> rawConfig = new HashMap<>();
+    rawConfig.put("shuffleAddressList", true);
+    ConfigOrError parsedConfig = new PickFirstLoadBalancerProvider().parseLoadBalancingPolicyConfig(
+        rawConfig);
+    PickFirstLoadBalancerConfig config = (PickFirstLoadBalancerConfig) parsedConfig.getConfig();
+
+    assertThat(config.shuffleAddressList).isTrue();
+  }
+
+  @Test
+  public void parseWithConfigDisabled() {
+    PickFirstLoadBalancerProvider.enablePickFirstConfig = false;
+    Map<String, Object> rawConfig = new HashMap<>();
+    rawConfig.put("shuffleAddressList", true);
+    ConfigOrError parsedConfig = new PickFirstLoadBalancerProvider().parseLoadBalancingPolicyConfig(
+        rawConfig);
+    String config = (String) parsedConfig.getConfig();
+
+    assertThat(config).isEqualTo("no service config");
+  }
+}

--- a/core/src/test/java/io/grpc/internal/PickFirstLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/internal/PickFirstLoadBalancerTest.java
@@ -121,6 +121,7 @@ public class PickFirstLoadBalancerTest {
   @After
   public void tearDown() throws Exception {
     verifyNoMoreInteractions(mockArgs);
+    PickFirstLoadBalancer.enablePickFirstConfig = false;
   }
 
   @Test
@@ -143,6 +144,7 @@ public class PickFirstLoadBalancerTest {
 
   @Test
   public void pickAfterResolved_shuffle() throws Exception {
+    PickFirstLoadBalancer.enablePickFirstConfig = true;
     loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity)
             .setLoadBalancingPolicyConfig(new PickFirstLoadBalancerConfig(true, 123L)).build());


### PR DESCRIPTION
If provided with the new PickFirstLoadBalancerConfig, PickFirstLoadBalancer will shuffle the list of addresses it receives from the name resolver.