### PR TITLE
xds: handle the handlerRemoved callback to skip updateSslContext processing

### DIFF
--- a/xds/src/main/java/io/grpc/xds/internal/security/SecurityProtocolNegotiators.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/SecurityProtocolNegotiators.java
@@ -180,6 +180,7 @@ public final class SecurityProtocolNegotiators {
       extends InternalProtocolNegotiators.ProtocolNegotiationHandler {
     private final GrpcHttp2ConnectionHandler grpcHandler;
     private final SslContextProviderSupplier sslContextProviderSupplier;
+    private volatile boolean handlerRemoved;
 
     ClientSdsHandler(
         GrpcHttp2ConnectionHandler grpcHandler,
@@ -209,6 +210,9 @@ public final class SecurityProtocolNegotiators {
 
             @Override
             public void updateSslContext(SslContext sslContext) {
+              if (handlerRemoved) {
+                return;
+              }
               logger.log(
                   Level.FINEST,
                   "ClientSdsHandler.updateSslContext authority={0}, ctx.name={1}",
@@ -228,6 +232,12 @@ public final class SecurityProtocolNegotiators {
             }
           }
       );
+    }
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+      handlerRemoved = true;
+      super.handlerRemoved(ctx);
     }
 
     @Override


### PR DESCRIPTION
To fix the issue in https://groups.google.com/g/grpc-io/c/KR5FCi5wD0s/m/eEtHNszmAgAJ