### PR TITLE
xds: handle the handlerRemoved callback to skip updateSslContext processing (1.55.x backport)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/internal/security/SecurityProtocolNegotiators.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/SecurityProtocolNegotiators.java
@@ -209,6 +209,9 @@ public final class SecurityProtocolNegotiators {
 
             @Override
             public void updateSslContext(SslContext sslContext) {
+              if (ctx.isRemoved()) {
+                return;
+              }
               logger.log(
                   Level.FINEST,
                   "ClientSdsHandler.updateSslContext authority={0}, ctx.name={1}",


### PR DESCRIPTION
To fix the issue in https://groups.google.com/g/grpc-io/c/KR5FCi5wD0s/m/eEtHNszmAgAJ

Backport of #10118