### PR TITLE
binder: fix binder error prone todo

### DIFF
--- a/binder/src/androidTest/java/io/grpc/binder/BinderChannelSmokeTest.java
+++ b/binder/src/androidTest/java/io/grpc/binder/BinderChannelSmokeTest.java
@@ -234,6 +234,7 @@ public final class BinderChannelSmokeTest {
   }
 
   @Test
+  @SuppressWarnings("GrpcUseClientCallBasedBlockingMethods") //TODO(zivy): fix error prone
   public void testUncaughtServerException() throws Exception {
     // Use a poison parcelable to cause an unexpected Exception in the server's onTransact().
     PoisonParcelable bad = new PoisonParcelable();
@@ -254,6 +255,7 @@ public final class BinderChannelSmokeTest {
   }
 
   @Test
+  @SuppressWarnings("GrpcUseClientCallBasedBlockingMethods") //TODO(zivy): fix error prone
   public void testUncaughtClientException() throws Exception {
     // Use a poison parcelable to cause an unexpected Exception in the client's onTransact().
     parcelableForResponseHeaders = new PoisonParcelable();


### PR DESCRIPTION
[go/bugpattern/GrpcUseClientCallBasedBlockingMethods](https://goto.google.com/bugpattern/GrpcUseClientCallBasedBlockingMethods)