### PR TITLE
interop-testing: Stop using Shadow Gradle Plugin

### DIFF
--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id "java"
     id "maven-publish"
 
-    id "com.github.johnrengelman.shadow"
     id "com.google.protobuf"
     id "ru.vyarus.animalsniffer"
 }
@@ -31,25 +30,21 @@ dependencies {
             project(':grpc-services'),
             project(':grpc-stub'),
             project(':grpc-testing'),
+            project(path: ':grpc-xds', configuration: 'shadow'),
             libraries.hdrhistogram,
             libraries.junit,
             libraries.truth,
             libraries.opencensus.contrib.grpc.metrics,
             libraries.google.auth.oauth2Http
-    def xdsDependency = implementation project(':grpc-xds')
-
     compileOnly libraries.javax.annotation
-    shadow project(path: ':grpc-xds', configuration: 'shadow')
     // TODO(sergiitk): replace with com.google.cloud:google-cloud-logging
     // Used instead of google-cloud-logging because it's failing
     // due to a circular dependency on grpc.
     // https://cloud.google.com/logging/docs/setup/java#the_javautillogging_handler
     // Error example: "java.util.logging.ErrorManager: 1"
     // Latest failing version com.google.cloud:google-cloud-logging:2.1.2
-    // TODO(ejona): These should be compileOnly, but that doesn't get picked up
-    // for the shadow runtime
-    implementation group: 'io.github.devatherock', name: 'jul-jsonformatter', version: '1.1.0'
-    implementation libraries.opencensus.impl,
+    runtimeOnly group: 'io.github.devatherock', name: 'jul-jsonformatter', version: '1.1.0'
+    runtimeOnly libraries.opencensus.impl,
             libraries.netty.tcnative,
             libraries.netty.tcnative.classes,
             project(':grpc-grpclb'),
@@ -60,7 +55,6 @@ dependencies {
             libraries.mockito.core,
             libraries.okhttp
     alpnagent libraries.jetty.alpn.agent
-    shadow configurations.implementation.getDependencies().minus(xdsDependency)
 
     signature libraries.signature.java
     signature libraries.signature.android
@@ -74,47 +68,13 @@ tasks.named("compileJava").configure {
     // This isn't a library; it can use beta APIs
     options.errorprone.check("BetaApi", CheckSeverity.OFF)
 }
-tasks.named("jar").configure {
-    // Must use a different archiveClassifier to avoid conflicting with shadowJar
-    archiveClassifier = 'original'
-}
-
-tasks.named("distZip").configure {
-    archiveClassifier = "original"
-}
-
-tasks.named("distTar").configure {
-    archiveClassifier = "original"
-}
-
-def xdsPrefixName = 'io.grpc.xds'
-tasks.named("shadowJar").configure {
-    archiveClassifier = null
-    dependencies {
-        exclude(dependency {true})
-    }
-    relocate 'com.github.xds', "${xdsPrefixName}.shaded.com.github.xds"
-}
-
 tasks.named("test").configure {
     // For the automated tests, use Jetty ALPN.
     jvmArgs "-javaagent:" + configurations.alpnagent.asPath
 }
 
-tasks.named("startShadowScripts").configure {
-    enabled = false
-}
-tasks.named("installDist").configure {
-    dependsOn installShadowDist
-    enabled = false
-}
-
 // For the generated scripts, use Netty tcnative (i.e. OpenSSL).
 // Note that OkHttp currently only supports ALPN, so OpenSSL version >= 1.0.2 is required.
-
-def startScriptsClasspath = provider {
-    shadowJar.outputs.files + configurations.shadow
-}
 
 def test_client = tasks.register("test_client", CreateStartScripts) {
     mainClass = "io.grpc.testing.integration.TestServiceClient"
@@ -123,7 +83,7 @@ def test_client = tasks.register("test_client", CreateStartScripts) {
         "-javaagent:JAVAAGENT_APP_HOME" + configurations.alpnagent.singleFile.name
     ]
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
-    classpath = startScriptsClasspath.get()
+    classpath = startScripts.classpath
     doLast {
         unixScript.text = unixScript.text.replace('JAVAAGENT_APP_HOME', '\'"\$APP_HOME"\'/lib/')
         windowsScript.text = windowsScript.text.replace('JAVAAGENT_APP_HOME', '%APP_HOME%\\lib\\')
@@ -134,21 +94,21 @@ def test_server = tasks.register("test_server", CreateStartScripts) {
     mainClass = "io.grpc.testing.integration.TestServiceServer"
     applicationName = "test-server"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
-    classpath = startScriptsClasspath.get()
+    classpath = startScripts.classpath
 }
 
 def reconnect_test_client = tasks.register("reconnect_test_client", CreateStartScripts) {
     mainClass = "io.grpc.testing.integration.ReconnectTestClient"
     applicationName = "reconnect-test-client"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
-    classpath = startScriptsClasspath.get()
+    classpath = startScripts.classpath
 }
 
 def stresstest_client = tasks.register("stresstest_client", CreateStartScripts) {
     mainClass = "io.grpc.testing.integration.StressTestClient"
     applicationName = "stresstest-client"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
-    classpath = startScriptsClasspath.get()
+    classpath = startScripts.classpath
     defaultJvmOpts = [
         "-verbose:gc",
         "-XX:+PrintFlagsFinal"
@@ -159,14 +119,14 @@ def http2_client = tasks.register("http2_client", CreateStartScripts) {
     mainClass = "io.grpc.testing.integration.Http2Client"
     applicationName = "http2-client"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
-    classpath = startScriptsClasspath.get()
+    classpath = startScripts.classpath
 }
 
 def grpclb_long_lived_affinity_test_client = tasks.register("grpclb_long_lived_affinity_test_client", CreateStartScripts) {
     mainClass = "io.grpc.testing.integration.GrpclbLongLivedAffinityTestClient"
     applicationName = "grpclb-long-lived-affinity-test-client"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
-    classpath = startScriptsClasspath.get()
+    classpath = startScripts.classpath
     defaultJvmOpts = [
         "-Dio.grpc.internal.DnsNameResolverProvider.enable_service_config=true"
     ]
@@ -176,7 +136,7 @@ def grpclb_fallback_test_client = tasks.register("grpclb_fallback_test_client", 
     mainClass = "io.grpc.testing.integration.GrpclbFallbackTestClient"
     applicationName = "grpclb-fallback-test-client"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
-    classpath = startScriptsClasspath.get()
+    classpath = startScripts.classpath
     defaultJvmOpts = [
         "-Dio.grpc.internal.DnsNameResolverProvider.enable_service_config=true"
     ]
@@ -186,24 +146,24 @@ def xds_test_client = tasks.register("xds_test_client", CreateStartScripts) {
     mainClass = "io.grpc.testing.integration.XdsTestClient"
     applicationName = "xds-test-client"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
-    classpath = startScriptsClasspath.get()
+    classpath = startScripts.classpath
 }
 
 def xds_test_server = tasks.register("xds_test_server", CreateStartScripts) {
     mainClass = "io.grpc.testing.integration.XdsTestServer"
     applicationName = "xds-test-server"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
-    classpath = startScriptsClasspath.get()
+    classpath = startScripts.classpath
 }
 
 def xds_federation_test_client = tasks.register("xds_federation_test_client", CreateStartScripts) {
     mainClass = "io.grpc.testing.integration.XdsFederationTestClient"
     applicationName = "xds-federation-test-client"
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
-    classpath = startScriptsClasspath.get()
+    classpath = startScripts.classpath
 }
 
-distributions.shadow.contents.into("bin") {
+applicationDistribution.into("bin") {
     from(test_client)
     from(test_server)
     from(reconnect_test_client)
@@ -217,23 +177,15 @@ distributions.shadow.contents.into("bin") {
     fileMode = 0755
 }
 
-distributions.shadow.contents.into("lib") {
+applicationDistribution.into("lib") {
     from(configurations.alpnagent)
 }
-
-distributions.shadow.distributionBaseName = project.name
-// to please shadowJar
-mainClassName = 'io.grpc.testing.integration.TestServiceClient'
 
 publishing {
     publications {
         maven(MavenPublication) {
-            // We want this to throw an exception if it isn't working
-            def originalJar = artifacts.find { dep -> dep.classifier == 'original'}
-            artifacts.remove(originalJar)
-
-            artifact shadowDistZip
-            artifact shadowDistTar
+            artifact distZip
+            artifact distTar
         }
     }
 }


### PR DESCRIPTION
This essentially reverts 3624d59b. In 6609f11f we removed the reference to OrcaLoadReport, which meant shadow has no longer been necessary.