### PR TITLE
gcp-observability: Avoid non-shadow configurations of xds, alts, netty

### DIFF
--- a/gcp-observability/build.gradle
+++ b/gcp-observability/build.gradle
@@ -29,27 +29,42 @@ dependencies {
     //  in gradle/libs.versions instead
     implementation project(':grpc-protobuf'),
             project(':grpc-stub'),
-            project(':grpc-alts'),
             project(':grpc-census'),
-            ("com.google.cloud:google-cloud-logging:${cloudLoggingVersion}"),
-            libraries.opencensus.contrib.grpc.metrics,
-            libraries.opencensus.exporter.stats.stackdriver,
-            libraries.opencensus.exporter.trace.stackdriver,
-            project(':grpc-xds'), // Align grpc versions
+            libraries.opencensus.contrib.grpc.metrics
+    // Avoid gradle using project dependencies without configuration: shadow
+    implementation ("com.google.cloud:google-cloud-logging:${cloudLoggingVersion}") {
+        exclude group: 'io.grpc', module: 'grpc-alts'
+        exclude group: 'io.grpc', module: 'grpc-netty-shaded'
+        exclude group: 'io.grpc', module: 'grpc-xds'
+    }
+    implementation (libraries.opencensus.exporter.stats.stackdriver) {
+        exclude group: 'io.grpc', module: 'grpc-alts'
+        exclude group: 'io.grpc', module: 'grpc-netty-shaded'
+        exclude group: 'io.grpc', module: 'grpc-xds'
+    }
+    implementation (libraries.opencensus.exporter.trace.stackdriver) {
+        exclude group: 'io.grpc', module: 'grpc-alts'
+        exclude group: 'io.grpc', module: 'grpc-netty-shaded'
+        exclude group: 'io.grpc', module: 'grpc-xds'
+    }
+
+    runtimeOnly libraries.opencensus.impl,
+            project(path: ':grpc-netty-shaded', configuration: 'shadow'),
+            project(path: ':grpc-xds', configuration: 'shadow'),
+            project(path: ':grpc-alts', configuration: 'shadow'),
+            project(':grpc-auth'), // Align grpc versions
+            project(':grpc-core'), // Align grpc versions
+            project(':grpc-grpclb'), // Align grpc versions
             project(':grpc-services'), // Align grpc versions
-            libraries.protobuf.java,
             libraries.protobuf.java.util, // Use our newer version
             ('com.google.api.grpc:proto-google-common-protos:2.14.2'),
             ('com.google.auth:google-auth-library-oauth2-http:1.16.0'),
             ('io.opencensus:opencensus-api:0.31.1'),
             ('com.google.guava:guava:31.1-jre')
 
-    runtimeOnly libraries.opencensus.impl
-
     testImplementation project(':grpc-context').sourceSets.test.output,
             project(':grpc-testing'),
-            project(':grpc-testing-proto'),
-            project(':grpc-netty-shaded')
+            project(':grpc-testing-proto')
     testImplementation (libraries.guava.testlib) {
         exclude group: 'junit', module: 'junit'
     }

--- a/googleapis/build.gradle
+++ b/googleapis/build.gradle
@@ -9,9 +9,9 @@ description = 'gRPC: googleapis'
 
 dependencies {
     api project(':grpc-api')
-    implementation project(':grpc-alts'),
+    implementation project(path: ':grpc-alts', configuration: 'shadow'),
                    project(':grpc-core'),
-                   project(':grpc-xds'),
+                   project(path: ':grpc-xds', configuration: 'shadow'),
                    libraries.guava.jre // JRE required by transitive protobuf-java-util
     testImplementation project(':grpc-core').sourceSets.test.output
 


### PR DESCRIPTION
We have two versions of multiple projects, the non-shadow and the shadow. When using project() references, things are mostly fine, although we may test with a different version than our users would use. However, when a dependency from Maven Central depends on a grpc artifact, it pulls in the non-shadow configuration and messes up gradle's tracking. We shouldn't be using the non-shadow configuration, so this issue is sort of a blessing to improve the test reliability.

Gradle 7 will notice that there's a missing dependency, but it is not deterministic and is very slow to test. Starting in Gradle 8 it is much more reliably triggered which greatly helped the testing efforts. The error in Gradle 7 looks like:
```
> Task :grpc-gcp-observability:interop:startScripts
Execution optimizations have been disabled for task ':grpc-gcp-observability:interop:startScripts' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: 'grpc-java/netty/shaded/build/libs/grpc-netty-shaded-1.54.0-SNAPSHOT-original.jar'. Reason: Task ':grpc-gcp-observability:interop:startScripts' uses this output of task ':grpc-netty-shaded:jar' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.6/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```

Fixes #9992

------

I'm going to make sure to merge #10133 before this one. I don't know if it is necessary as a prerequisite (to claim victory over this dependency issue), but it helped clean up the rats nest so that I could better see what is going on.