### PR TITLE
core: Hide RR's ReadyPicker and EmptyPicker

### DIFF
--- a/core/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
@@ -284,7 +284,8 @@ public class RoundRobinLoadBalancer extends LoadBalancer {
     public abstract boolean isEquivalentTo(RoundRobinPicker picker);
   }
 
-  public static class ReadyPicker extends RoundRobinPicker {
+  @VisibleForTesting
+  static class ReadyPicker extends RoundRobinPicker {
     private static final AtomicIntegerFieldUpdater<ReadyPicker> indexUpdater =
         AtomicIntegerFieldUpdater.newUpdater(ReadyPicker.class, "index");
 
@@ -336,7 +337,8 @@ public class RoundRobinLoadBalancer extends LoadBalancer {
     }
   }
 
-  public static final class EmptyPicker extends RoundRobinPicker {
+  @VisibleForTesting
+  static final class EmptyPicker extends RoundRobinPicker {
 
     private final Status status;
 

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -232,13 +232,13 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
   }
 
   @VisibleForTesting
-  final class WeightedRoundRobinPicker extends ReadyPicker {
+  final class WeightedRoundRobinPicker extends RoundRobinPicker {
     private final List<Subchannel> list;
     private final boolean enableOobLoadReport;
     private volatile EdfScheduler scheduler;
 
     WeightedRoundRobinPicker(List<Subchannel> list, boolean enableOobLoadReport) {
-      super(checkNotNull(list, "list"), random.nextInt(list.size()));
+      checkNotNull(list, "list");
       Preconditions.checkArgument(!list.isEmpty(), "empty list");
       this.list = list;
       this.enableOobLoadReport = enableOobLoadReport;


### PR DESCRIPTION
ReadyPicker hasn't been necessary since 111ff60e, when we stopped calling super.pickSubchannel(). EmptyPicker was only used in tests, and we can just compare the class name instead of doing an instanceof check.

Unfortunately, calling getClass() caused Java to start casting the return value of pickerCaptor.getValue() based on its generics. Captors don't verify the type they capture, so using any type other than SubchannelPicker for the pickerCaptor is misleading and hides a cast.