### PR TITLE
android,binder,cronet: .aar file when publishing (1.55.x backport)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id "maven-publish"
 
     id "com.android.library"
-    id "digital.wup.android-maven-publish"
 }
 
 description = 'gRPC: Android'
@@ -23,6 +22,12 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions { abortOnError true }
+    publishing {
+        singleVariant('release') {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
 }
 
 repositories {
@@ -73,10 +78,9 @@ tasks.register("sourcesJar", Jar) {
 publishing {
     publications {
         maven {
-            from components.android
-
-            artifact javadocJar
-            artifact sourcesJar
+            afterEvaluate {
+                from components.release
+            }
         }
     }
 }

--- a/binder/build.gradle
+++ b/binder/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "maven-publish"
     id "com.android.library"
-    id "digital.wup.android-maven-publish"
 }
 
 description = 'gRPC BinderChannel'
@@ -38,6 +37,12 @@ android {
         multiDexEnabled true
     }
     lintOptions { abortOnError false }
+    publishing {
+        singleVariant('release') {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
 }
 
 repositories {
@@ -129,10 +134,9 @@ tasks.register("sourcesJar", Jar) {
 publishing {
     publications {
         maven {
-            from components.android
-
-            artifact javadocJar
-            artifact sourcesJar
+            afterEvaluate {
+                from components.release
+            }
         }
     }
 }

--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -20,7 +20,7 @@ cat <<EOF >> gradle.properties
 # https://docs.gradle.org/current/userguide/build_environment.html#sec:configuring_jvm_memory
 # Increased due to java.lang.OutOfMemoryError: Metaspace failures, "JVM heap
 # space is exhausted", and to increase build speed
-org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m
 EOF
 
 echo y | ${ANDROID_HOME}/tools/bin/sdkmanager "build-tools;28.0.3"

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -31,6 +31,14 @@ fi
 # ARCH is x86_64 unless otherwise specified.
 ARCH="${ARCH:-x86_64}"
 
+cat <<EOF >> gradle.properties
+# defaults to -Xmx512m -XX:MaxMetaspaceSize=256m
+# https://docs.gradle.org/current/userguide/build_environment.html#sec:configuring_jvm_memory
+# Increased due to java.lang.OutOfMemoryError: Metaspace failures, "JVM heap
+# space is exhausted", and to increase build speed
+org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m
+EOF
+
 ARCH="$ARCH" buildscripts/make_dependencies.sh
 
 # Set properties via flags, do not pollute gradle.properties

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id "maven-publish"
 
     id "com.android.library"
-    id "digital.wup.android-maven-publish"
 }
 
 description = "gRPC: Cronet Android"
@@ -35,6 +34,12 @@ android {
     }
     testOptions { unitTests { includeAndroidResources = true } }
     lintOptions { disable 'InvalidPackage' }
+    publishing {
+        singleVariant('release') {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
 }
 
 dependencies {
@@ -83,10 +88,9 @@ task sourcesJar(type: Jar) {
 publishing {
     publications {
         maven {
-            from components.android
-
-            artifact javadocJar
-            artifact sourcesJar
+            afterEvaluate {
+                from components.release
+            }
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,6 @@ pluginManagement {
         id "com.google.cloud.tools.jib" version "3.3.1"
         id "com.google.osdetector" version "1.7.1"
         id "com.google.protobuf" version "0.9.1"
-        id "digital.wup.android-maven-publish" version "3.6.3"
         id "me.champeau.gradle.japicmp" version "0.3.0"
         id "me.champeau.jmh" version "0.6.8"
         id "net.ltgt.errorprone" version "3.0.1"


### PR DESCRIPTION
Backport of #10138

The upgraded Android Gradle Plugin no longer played nice with the `android-maven-publish` plugin used earlier to produce Android library .aar files. No .aar files were being published at all.

This removes the android-maven-publish plugin that is no longer needed with the newer version of AGP and updates the `grpc-android`, `grpc-binder` and `grpc-cronet` to use the native Android library publishing features of AGP.

Using the `grpc-android` project as an example, before these changes the files produced by the publishing step were:

```
-rw-r--r--@ 1 tmwilson  wheel  287157 May  4 16:15 grpc-android-1.56.0-20230504.231500-1-javadoc.jar
-rw-r--r--@ 1 tmwilson  wheel      32 May  4 16:15 grpc-android-1.56.0-20230504.231500-1-javadoc.jar.md5
-rw-r--r--@ 1 tmwilson  wheel      40 May  4 16:15 grpc-android-1.56.0-20230504.231500-1-javadoc.jar.sha1
-rw-r--r--@ 1 tmwilson  wheel      64 May  4 16:15 grpc-android-1.56.0-20230504.231500-1-javadoc.jar.sha256
-rw-r--r--@ 1 tmwilson  wheel     128 May  4 16:15 grpc-android-1.56.0-20230504.231500-1-javadoc.jar.sha512
-rw-r--r--@ 1 tmwilson  wheel    8513 May  4 16:15 grpc-android-1.56.0-20230504.231500-1-sources.jar
-rw-r--r--@ 1 tmwilson  wheel      32 May  4 16:15 grpc-android-1.56.0-20230504.231500-1-sources.jar.md5
-rw-r--r--@ 1 tmwilson  wheel      40 May  4 16:15 grpc-android-1.56.0-20230504.231500-1-sources.jar.sha1
-rw-r--r--@ 1 tmwilson  wheel      64 May  4 16:15 grpc-android-1.56.0-20230504.231500-1-sources.jar.sha256
-rw-r--r--@ 1 tmwilson  wheel     128 May  4 16:15 grpc-android-1.56.0-20230504.231500-1-sources.jar.sha512
-rw-r--r--@ 1 tmwilson  wheel    1643 May  4 16:15 grpc-android-1.56.0-20230504.231500-1.pom
-rw-r--r--@ 1 tmwilson  wheel      32 May  4 16:15 grpc-android-1.56.0-20230504.231500-1.pom.md5
-rw-r--r--@ 1 tmwilson  wheel      40 May  4 16:15 grpc-android-1.56.0-20230504.231500-1.pom.sha1
-rw-r--r--@ 1 tmwilson  wheel      64 May  4 16:15 grpc-android-1.56.0-20230504.231500-1.pom.sha256
-rw-r--r--@ 1 tmwilson  wheel     128 May  4 16:15 grpc-android-1.56.0-20230504.231500-1.pom.sha512
-rw-r--r--@ 1 tmwilson  wheel    1028 May  4 16:15 maven-metadata.xml
-rw-r--r--@ 1 tmwilson  wheel      32 May  4 16:15 maven-metadata.xml.md5
-rw-r--r--@ 1 tmwilson  wheel      40 May  4 16:15 maven-metadata.xml.sha1
-rw-r--r--@ 1 tmwilson  wheel      64 May  4 16:15 maven-metadata.xml.sha256
-rw-r--r--@ 1 tmwilson  wheel     128 May  4 16:15 maven-metadata.xml.sha512
```

After the change get get:

```
-rw-r--r--@ 1 tmwilson  wheel  292629 May  5 11:32 grpc-android-1.56.0-20230505.183236-1-javadoc.jar
-rw-r--r--@ 1 tmwilson  wheel      32 May  5 11:32 grpc-android-1.56.0-20230505.183236-1-javadoc.jar.md5
-rw-r--r--@ 1 tmwilson  wheel      40 May  5 11:32 grpc-android-1.56.0-20230505.183236-1-javadoc.jar.sha1
-rw-r--r--@ 1 tmwilson  wheel      64 May  5 11:32 grpc-android-1.56.0-20230505.183236-1-javadoc.jar.sha256
-rw-r--r--@ 1 tmwilson  wheel     128 May  5 11:32 grpc-android-1.56.0-20230505.183236-1-javadoc.jar.sha512
-rw-r--r--@ 1 tmwilson  wheel    8843 May  5 11:32 grpc-android-1.56.0-20230505.183236-1-sources.jar
-rw-r--r--@ 1 tmwilson  wheel      32 May  5 11:32 grpc-android-1.56.0-20230505.183236-1-sources.jar.md5
-rw-r--r--@ 1 tmwilson  wheel      40 May  5 11:32 grpc-android-1.56.0-20230505.183236-1-sources.jar.sha1
-rw-r--r--@ 1 tmwilson  wheel      64 May  5 11:32 grpc-android-1.56.0-20230505.183236-1-sources.jar.sha256
-rw-r--r--@ 1 tmwilson  wheel     128 May  5 11:32 grpc-android-1.56.0-20230505.183236-1-sources.jar.sha512
-rw-r--r--@ 1 tmwilson  wheel   15933 May  5 11:32 grpc-android-1.56.0-20230505.183236-1.aar
-rw-r--r--@ 1 tmwilson  wheel      32 May  5 11:32 grpc-android-1.56.0-20230505.183236-1.aar.md5
-rw-r--r--@ 1 tmwilson  wheel      40 May  5 11:32 grpc-android-1.56.0-20230505.183236-1.aar.sha1
-rw-r--r--@ 1 tmwilson  wheel      64 May  5 11:32 grpc-android-1.56.0-20230505.183236-1.aar.sha256
-rw-r--r--@ 1 tmwilson  wheel     128 May  5 11:32 grpc-android-1.56.0-20230505.183236-1.aar.sha512
-rw-r--r--@ 1 tmwilson  wheel    1643 May  5 11:32 grpc-android-1.56.0-20230505.183236-1.pom
-rw-r--r--@ 1 tmwilson  wheel      32 May  5 11:32 grpc-android-1.56.0-20230505.183236-1.pom.md5
-rw-r--r--@ 1 tmwilson  wheel      40 May  5 11:32 grpc-android-1.56.0-20230505.183236-1.pom.sha1
-rw-r--r--@ 1 tmwilson  wheel      64 May  5 11:32 grpc-android-1.56.0-20230505.183236-1.pom.sha256
-rw-r--r--@ 1 tmwilson  wheel     128 May  5 11:32 grpc-android-1.56.0-20230505.183236-1.pom.sha512
-rw-r--r--@ 1 tmwilson  wheel    1202 May  5 11:32 maven-metadata.xml
-rw-r--r--@ 1 tmwilson  wheel      32 May  5 11:32 maven-metadata.xml.md5
-rw-r--r--@ 1 tmwilson  wheel      40 May  5 11:32 maven-metadata.xml.sha1
-rw-r--r--@ 1 tmwilson  wheel      64 May  5 11:32 maven-metadata.xml.sha256
-rw-r--r--@ 1 tmwilson  wheel     128 May  5 11:32 maven-metadata.xml.sha512
```

The `diff` output from comparing the old POM with the new is:

```
7c7
<   <packaging>pom</packaging>
---
>   <packaging>aar</packaging>
```