### PR TITLE
compiler: configureEach instead of each+configure

### DIFF
--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -183,25 +183,19 @@ protobuf {
         grpc { path = javaPluginPath }
     }
     generateProtoTasks {
-        all().each { task ->
-            task.configure {
-                dependsOn 'java_pluginExecutable'
-                inputs.file javaPluginPath
-            }
+        all().configureEach {
+            dependsOn 'java_pluginExecutable'
+            inputs.file javaPluginPath
         }
-        ofSourceSet('test').each { task ->
-            task.configure {
-                plugins { grpc {} }
-            }
+        ofSourceSet('test').configureEach {
+            plugins { grpc {} }
         }
-        ofSourceSet('testLite').each { task ->
-            task.configure {
-                builtins {
-                    java { option 'lite' }
-                }
-                plugins {
-                    grpc { option 'lite' }
-                }
+        ofSourceSet('testLite').configureEach {
+            builtins {
+                java { option 'lite' }
+            }
+            plugins {
+                grpc { option 'lite' }
             }
         }
     }


### PR DESCRIPTION
each+configure serves no purpose, because the task has already been realized with the each. This was just a faulty conversion in 0ff9f37b9e, although it was because I thought the each was specialized API from the protobuf plugin, not the normal container each.