### PR TITLE
build.gradle: Add checkForUpdates task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,6 @@
 plugins {
+    id 'java' // changes the behavior of TARGET_JVM_VERSION_ATTRIBUTE
+
     id "com.google.osdetector" apply false
     id "me.champeau.gradle.japicmp" apply false
     id "net.ltgt.errorprone" apply false
@@ -525,6 +527,70 @@ def requireUpperBoundDepsMatch(Configuration conf, Project project) {
         result.selected.dependencies.each {
             queue.add(new DepAndParents(
                 dep: it, parents: depAndParents.parents + [artifact + ":" + version]))
+        }
+    }
+}
+
+repositories {
+    mavenCentral()
+    google()
+}
+
+def isAcceptableVersion(ModuleComponentIdentifier candidate) {
+    String group = candidate.group
+    String module = candidate.module
+    String version = candidate.version
+    if (group == 'com.google.guava')
+        return true
+    if (group == 'io.netty' && version.contains('Final'))
+        return true
+    if (module == 'android-api-level-19')
+        return true
+    return version ==~ /^[0-9]+(\.[0-9]+)+$/
+}
+
+configurations {
+    checkForUpdates {
+        attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+        resolutionStrategy {
+            componentSelection {
+                all {
+                    if (!isAcceptableVersion(it.candidate))
+                        it.reject("Not stable version")
+                }
+            }
+        }
+    }
+}
+
+// Checks every dependency in the version catalog to see if there is a newer
+// version available. The 'checkForUpdates' configuration restricts the
+// versions considered.
+tasks.register('checkForUpdates') {
+    doLast {
+        def updateConf = project.configurations.checkForUpdates
+        updateConf.setVisible(false)
+        updateConf.setTransitive(false)
+        def versionCatalog = project.extensions.getByType(VersionCatalogsExtension).named("libs")
+        versionCatalog.libraryAliases.each { name ->
+            def dep = versionCatalog.findLibrary(name).get().get()
+
+            def oldConf = updateConf.copy()
+            def oldDep = project.dependencies.create(
+                group: dep.group, name: dep.name, version: dep.versionConstraint, classifier: 'pom')
+            oldConf.dependencies.add(oldDep)
+            def oldResolved = oldConf.resolvedConfiguration.resolvedArtifacts.iterator().next()
+
+            def newConf = updateConf.copy()
+            def newDep = project.dependencies.create(
+                group: dep.group, name: dep.name, version: '+', classifier: 'pom')
+            newConf.dependencies.add(newDep)
+            def newResolved = newConf.resolvedConfiguration.resolvedArtifacts.iterator().next()
+            if (oldResolved != newResolved) {
+                def oldId = oldResolved.id.componentIdentifier
+                def newId = newResolved.id.componentIdentifier
+                println("${newId.group}:${newId.module} ${oldId.version} -> ${newId.version}")
+            }
         }
     }
 }


### PR DESCRIPTION
CC @sergiitk 

Example output (after some upgrades that I have queued, so the list is smaller):
```
> Task :checkForUpdates
com.puppycrawl.tools:checkstyle 8.28 -> 10.10.0
com.google.errorprone:error_prone_core 2.10.0 -> 2.18.0
com.google.auth:google-auth-library-credentials 1.4.0 -> 1.16.1
com.google.auth:google-auth-library-oauth2-http 1.4.0 -> 1.16.1
com.google.guava:guava 31.1-android -> 31.1-jre
com.google.guava:guava-testlib 31.1-android -> 31.1-jre
org.mockito:mockito-android 3.12.4 -> 5.3.1
org.mockito:mockito-core 3.12.4 -> 5.3.1
io.netty:netty-codec-http2 4.1.87.Final -> 4.1.92.Final
io.netty:netty-handler-proxy 4.1.87.Final -> 4.1.92.Final
io.netty:netty-tcnative-boringssl-static 2.0.56.Final -> 2.0.61.Final
io.netty:netty-tcnative-classes 2.0.56.Final -> 2.0.61.Final
io.netty:netty-transport-native-epoll 4.1.87.Final -> 4.1.92.Final
io.netty:netty-transport-native-unix-common 4.1.87.Final -> 4.1.92.Final
com.squareup.okio:okio 1.17.5 -> 3.3.0
io.opencensus:opencensus-api 0.31.0 -> 0.31.1
io.opencensus:opencensus-contrib-grpc-metrics 0.31.0 -> 0.31.1
io.opencensus:opencensus-exporter-stats-stackdriver 0.31.0 -> 0.31.1
io.opencensus:opencensus-exporter-trace-stackdriver 0.31.0 -> 0.31.1
io.opencensus:opencensus-impl 0.31.0 -> 0.31.1
org.robolectric:robolectric 4.9.2 -> 4.10.2
com.google.truth:truth 1.0.1 -> 1.1.3
```