### PR TITLE
Upgrade Mockito to 3.12.4

### DIFF
--- a/core/src/test/java/io/grpc/internal/MaxConnectionIdleManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/MaxConnectionIdleManagerTest.java
@@ -19,16 +19,19 @@ package io.grpc.internal;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /** Unit tests for {@link MaxConnectionIdleManager}. */
 @RunWith(JUnit4.class)
 public class MaxConnectionIdleManagerTest {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+
   private final FakeClock fakeClock = new FakeClock();
   private final MaxConnectionIdleManager.Ticker ticker = new MaxConnectionIdleManager.Ticker() {
     @Override
@@ -39,11 +42,6 @@ public class MaxConnectionIdleManagerTest {
 
   @Mock
   private Runnable closure;
-
-  @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
-  }
 
   @Test
   public void maxIdleReached() {

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -60,12 +60,15 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 @RunWith(JUnit4.class)
 public class ServerCallImplTest {
   @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule public final ExpectedException thrown = ExpectedException.none();
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+
   @Mock private ServerStream stream;
   @Mock private ServerCall.Listener<Long> callListener;
 
@@ -93,7 +96,6 @@ public class ServerCallImplTest {
 
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
     context = Context.ROOT.withCancellation();
     call = new ServerCallImpl<>(stream, UNARY_METHOD, requestHeaders, context,
         DecompressorRegistry.getDefaultInstance(), CompressorRegistry.getDefaultInstance(),

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -112,7 +112,8 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /** Unit tests for {@link ServerImpl}. */
 @RunWith(JUnit4.class)
@@ -141,6 +142,7 @@ public class ServerImplTest {
 
   @SuppressWarnings("deprecation") // https://github.com/grpc/grpc-java/issues/7467
   @Rule public final ExpectedException thrown = ExpectedException.none();
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
 
   @BeforeClass
   public static void beforeStartUp() {
@@ -201,7 +203,6 @@ public class ServerImplTest {
   /** Set up for test. */
   @Before
   public void startUp() throws IOException {
-    MockitoAnnotations.initMocks(this);
     builder = new ServerImplBuilder(
         new ClientTransportServersBuilder() {
           @Override

--- a/core/src/test/java/io/grpc/util/MutableHandlerRegistryTest.java
+++ b/core/src/test/java/io/grpc/util/MutableHandlerRegistryTest.java
@@ -33,16 +33,20 @@ import io.grpc.ServerServiceDefinition;
 import io.grpc.ServiceDescriptor;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /** Unit tests for {@link MutableHandlerRegistry}. */
 @RunWith(JUnit4.class)
 public class MutableHandlerRegistryTest {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+
   private MutableHandlerRegistry registry = new MutableHandlerRegistry();
 
   @Mock
@@ -68,7 +72,6 @@ public class MutableHandlerRegistryTest {
 
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
     MethodDescriptor<String, Integer> flowMethod = MethodDescriptor.<String, Integer>newBuilder()
         .setType(MethodType.UNKNOWN)
         .setFullMethodName("basic/flow")

--- a/core/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
@@ -67,6 +67,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -74,14 +75,17 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.mockito.stubbing.Answer;
 
 /** Unit test for {@link RoundRobinLoadBalancer}. */
 @RunWith(JUnit4.class)
 public class RoundRobinLoadBalancerTest {
   private static final Attributes.Key<String> MAJOR_KEY = Attributes.Key.create("major-key");
+
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
 
   private RoundRobinLoadBalancer loadBalancer;
   private final List<EquivalentAddressGroup> servers = Lists.newArrayList();
@@ -105,8 +109,6 @@ public class RoundRobinLoadBalancerTest {
 
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
-
     for (int i = 0; i < 3; i++) {
       SocketAddress addr = new FakeSocketAddress("server" + i);
       EquivalentAddressGroup eag = new EquivalentAddressGroup(addr);

--- a/cronet/src/test/java/io/grpc/cronet/CronetChannelBuilderTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetChannelBuilderTest.java
@@ -36,17 +36,19 @@ import io.grpc.testing.TestMethodDescriptors;
 import java.net.InetSocketAddress;
 import java.util.concurrent.ScheduledExecutorService;
 import org.chromium.net.ExperimentalCronetEngine;
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = Build.VERSION_CODES.P)
 public final class CronetChannelBuilderTest {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
 
   @Mock private ExperimentalCronetEngine mockEngine;
   @Mock private ChannelLogger channelLogger;
@@ -54,11 +56,6 @@ public final class CronetChannelBuilderTest {
   private final ClientStreamTracer[] tracers =
       new ClientStreamTracer[]{ new ClientStreamTracer() {} };
   private MethodDescriptor<?, ?> method = TestMethodDescriptors.voidMethod();
-
-  @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
-  }
 
   @Test
   public void alwaysUsePutTrue_cronetStreamIsIdempotent() throws Exception {

--- a/cronet/src/test/java/io/grpc/cronet/CronetClientStreamTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientStreamTest.java
@@ -58,17 +58,20 @@ import org.chromium.net.ExperimentalBidirectionalStream;
 import org.chromium.net.UrlResponseInfo;
 import org.chromium.net.impl.UrlResponseInfoImpl;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = Build.VERSION_CODES.P)
 public final class CronetClientStreamTest {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
 
   @Mock private CronetClientTransport transport;
   private Metadata metadata = new Metadata();
@@ -107,8 +110,6 @@ public final class CronetClientStreamTest {
 
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
-
     SetStreamFactoryRunnable callback = new SetStreamFactoryRunnable(factory);
     clientStream =
         new CronetClientStream(

--- a/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
@@ -42,17 +42,20 @@ import java.net.InetSocketAddress;
 import java.util.concurrent.Executor;
 import org.chromium.net.BidirectionalStream;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = Build.VERSION_CODES.P)
 public final class CronetClientTransportTest {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
 
   private static final String AUTHORITY = "test.example.com";
   private static final Attributes.Key<String> EAG_ATTR_KEY =
@@ -72,8 +75,6 @@ public final class CronetClientTransportTest {
 
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
-
     transport =
         new CronetClientTransport(
             streamFactory,

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/interceptors/ConditionalClientInterceptorTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/interceptors/ConditionalClientInterceptorTest.java
@@ -32,17 +32,20 @@ import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.MethodType;
 import java.util.function.BiPredicate;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /**
  * Tests for {@link ConditionalClientInterceptor}.
  */
 @RunWith(JUnit4.class)
 public class ConditionalClientInterceptorTest {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
 
   private ConditionalClientInterceptor conditionalClientInterceptor;
   @Mock private ClientInterceptor delegate;
@@ -54,7 +57,6 @@ public class ConditionalClientInterceptorTest {
   @Before
   @SuppressWarnings("unchecked")
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
     conditionalClientInterceptor = new ConditionalClientInterceptor(
         delegate, predicate);
     method = MethodDescriptor.newBuilder().setType(MethodType.UNARY)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ jetty-alpn-agent = "org.mortbay.jetty.alpn:jetty-alpn-agent:2.0.10"
 jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
 junit = "junit:junit:4.13.2"
 mockito-android = "org.mockito:mockito-android:3.8.0"
-mockito-core = "org.mockito:mockito-core:3.3.3"
+mockito-core = "org.mockito:mockito-core:3.12.4"
 netty-codec-http2 = { module = "io.netty:netty-codec-http2", version.ref = "netty" }
 netty-handler-proxy = { module = "io.netty:netty-handler-proxy", version.ref = "netty" }
 # Keep the following references of tcnative version in sync whenever it's updated:

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -106,6 +106,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -115,13 +116,16 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.mockito.stubbing.Answer;
 
 /** Unit tests for {@link GrpclbLoadBalancer}. */
 @RunWith(JUnit4.class)
 public class GrpclbLoadBalancerTest {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+
   private static final String SERVICE_AUTHORITY = "api.google.com";
 
   // The tasks are wrapped by SynchronizationContext, so we can't compare the types
@@ -203,7 +207,6 @@ public class GrpclbLoadBalancerTest {
 
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
     mockLbService = mock(LoadBalancerGrpc.LoadBalancerImplBase.class, delegatesTo(
         new LoadBalancerGrpc.LoadBalancerImplBase() {
           @Override

--- a/interop-testing/src/test/java/io/grpc/stub/StubConfigTest.java
+++ b/interop-testing/src/test/java/io/grpc/stub/StubConfigTest.java
@@ -35,18 +35,21 @@ import io.grpc.testing.integration.Messages.SimpleRequest;
 import io.grpc.testing.integration.Messages.SimpleResponse;
 import io.grpc.testing.integration.TestServiceGrpc;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /**
  * Tests for stub reconfiguration.
  */
 @RunWith(JUnit4.class)
 public class StubConfigTest {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
 
   @Mock
   private Channel channel;
@@ -58,7 +61,6 @@ public class StubConfigTest {
    * Sets up mocks.
    */
   @Before public void setUp() {
-    MockitoAnnotations.initMocks(this);
     ClientCall<SimpleRequest, SimpleResponse> call =
         new NoopClientCall<>();
     when(channel.newCall(

--- a/interop-testing/src/test/java/io/grpc/testing/integration/CascadingTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/CascadingTest.java
@@ -52,17 +52,20 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /**
  * Integration test for various forms of cancellation and deadline propagation.
  */
 @RunWith(JUnit4.class)
 public class CascadingTest {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
 
   @Mock
   TestServiceGrpc.TestServiceImplBase service;
@@ -77,7 +80,6 @@ public class CascadingTest {
 
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
     // Use a cached thread pool as we need a thread for each blocked call
     otherWork = Executors.newCachedThreadPool();
     channel = InProcessChannelBuilder.forName("channel").executor(otherWork).build();

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -107,8 +107,9 @@ import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.mockito.stubbing.Answer;
 
 /**
@@ -133,6 +134,8 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
 
   @Rule
   public TestName testNameRule = new TestName();
+  @Rule
+  public final MockitoRule mocks = MockitoJUnit.rule();
   @Mock
   private ManagedClientTransport.Listener listener;
   @Mock
@@ -169,8 +172,6 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
    */
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
-
     doAnswer(
           new Answer<Void>() {
             @Override

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -106,18 +106,21 @@ import javax.annotation.Nullable;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import org.junit.After;
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /**
  * Tests for {@link NettyClientTransport}.
  */
 @RunWith(JUnit4.class)
 public class NettyClientTransportTest {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+
   private static final SslContext SSL_CONTEXT = createSslContext();
 
   @Mock
@@ -140,11 +143,6 @@ public class NettyClientTransportTest {
   private InetSocketAddress address;
   private String authority;
   private NettyServer server;
-
-  @Before
-  public void setup() {
-    MockitoAnnotations.initMocks(this);
-  }
 
   @After
   public void teardown() throws Exception {

--- a/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
@@ -100,8 +100,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.mockito.stubbing.Answer;
 
 /**
@@ -112,6 +113,8 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
 
   @Rule
   public final TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(10));
+  @Rule
+  public final MockitoRule mocks = MockitoJUnit.rule();
 
   private static final AsciiString HTTP_FAKE_METHOD = AsciiString.of("FAKE");
 
@@ -160,8 +163,6 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
 
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
-
     when(streamTracerFactory.newServerStreamTracer(anyString(), any(Metadata.class)))
         .thenReturn(streamTracer);
 

--- a/netty/src/test/java/io/grpc/netty/NettyServerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerTest.java
@@ -73,15 +73,19 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 @RunWith(JUnit4.class)
 public class NettyServerTest {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+
   private final InternalChannelz channelz = new InternalChannelz();
   private final NioEventLoopGroup eventLoop = new NioEventLoopGroup(1);
   private final ChannelFactory<NioServerSocketChannel> channelFactory =
@@ -96,7 +100,6 @@ public class NettyServerTest {
 
   @Before
   public void setup() throws Exception {
-    MockitoAnnotations.initMocks(this);
     when(mockEventLoopGroup.next()).thenReturn(mockEventLoop);
     when(mockEventLoop
         .submit(ArgumentMatchers.<Callable<Map<ChannelFuture, SocketAddress>>>any()))

--- a/netty/src/test/java/io/grpc/netty/NettyStreamTestBase.java
+++ b/netty/src/test/java/io/grpc/netty/NettyStreamTestBase.java
@@ -45,10 +45,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Queue;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.mockito.stubbing.Answer;
 
 /**
@@ -57,6 +59,9 @@ import org.mockito.stubbing.Answer;
 public abstract class NettyStreamTestBase<T extends Stream> {
   protected static final String MESSAGE = "hello world";
   protected static final int STREAM_ID = 1;
+
+  @Rule
+  public final MockitoRule mocks = MockitoJUnit.rule();
 
   @Mock
   protected Channel channel;
@@ -86,8 +91,6 @@ public abstract class NettyStreamTestBase<T extends Stream> {
   /** Set up for test. */
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
-
     when(channel.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
     when(channel.pipeline()).thenReturn(pipeline);
     when(channel.eventLoop()).thenReturn(eventLoop);

--- a/netty/src/test/java/io/grpc/netty/WriteQueueTest.java
+++ b/netty/src/test/java/io/grpc/netty/WriteQueueTest.java
@@ -40,8 +40,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.mockito.stubbing.Answer;
 
 @RunWith(JUnit4.class)
@@ -49,6 +50,8 @@ public class WriteQueueTest {
 
   @Rule
   public final Timeout globalTimeout = Timeout.seconds(60);
+  @Rule
+  public final MockitoRule mocks = MockitoJUnit.rule();
 
   private final Object lock = new Object();
 
@@ -66,7 +69,6 @@ public class WriteQueueTest {
    */
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
     when(channel.newPromise()).thenReturn(promise);
 
     EventLoop eventLoop = Mockito.mock(EventLoop.class);

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
@@ -46,6 +46,7 @@ import java.nio.charset.Charset;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -53,12 +54,15 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.mockito.stubbing.Answer;
 
 @RunWith(JUnit4.class)
 public class OkHttpClientStreamTest {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+
   private static final int MAX_MESSAGE_SIZE = 100;
   private static final int INITIAL_WINDOW_SIZE = 65535;
 
@@ -77,7 +81,6 @@ public class OkHttpClientStreamTest {
 
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
     methodDescriptor = MethodDescriptor.<Void, Void>newBuilder()
         .setType(MethodDescriptor.MethodType.UNARY)
         .setFullMethodName("testService/test")

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -121,7 +121,6 @@ import okio.BufferedSink;
 import okio.BufferedSource;
 import okio.ByteString;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -132,7 +131,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /**
  * Tests for {@link OkHttpClientTransport}.
@@ -155,6 +155,7 @@ public class OkHttpClientTransportTest {
   };
 
   @Rule public final Timeout globalTimeout = Timeout.seconds(10);
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
 
   private MethodDescriptor<Void, Void> method = TestMethodDescriptors.voidMethod();
 
@@ -181,12 +182,6 @@ public class OkHttpClientTransportTest {
       .scheduledExecutorService(new FakeClock().getScheduledExecutorService()) // Executor unused
       .transportExecutor(executor)
       .flowControlWindow(INITIAL_WINDOW_SIZE);
-
-  /** Set up for test. */
-  @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
-  }
 
   @After
   public void tearDown() {

--- a/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
@@ -87,7 +87,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
@@ -123,8 +122,6 @@ public class RlsLoadBalancerTest {
 
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
-
     fakeSearchMethod =
         MethodDescriptor.newBuilder()
             .setFullMethodName("com.google/Search")

--- a/services/src/test/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactoryTest.java
+++ b/services/src/test/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactoryTest.java
@@ -84,6 +84,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -91,14 +92,17 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.hamcrest.MockitoHamcrest;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.mockito.stubbing.Answer;
 
 /** Tests for {@link HealthCheckingLoadBalancerFactory}. */
 @RunWith(JUnit4.class)
 public class HealthCheckingLoadBalancerFactoryTest {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+
   private static final Attributes.Key<String> SUBCHANNEL_ATTR_KEY =
       Attributes.Key.create("subchannel-attr-for-test");
 
@@ -157,8 +161,6 @@ public class HealthCheckingLoadBalancerFactoryTest {
   @Before
   @SuppressWarnings("unchecked")
   public void setup() throws Exception {
-    MockitoAnnotations.initMocks(this);
-
     for (int i = 0; i < NUM_SUBCHANNELS; i++) {
       HealthImpl healthImpl = new HealthImpl();
       healthImpls[i] = healthImpl;

--- a/stub/src/test/java/io/grpc/stub/BaseAbstractStubTest.java
+++ b/stub/src/test/java/io/grpc/stub/BaseAbstractStubTest.java
@@ -27,21 +27,18 @@ import io.grpc.CallOptions;
 import io.grpc.Channel;
 import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /** Standard unit tests for AbstractStub and its subclasses. */
 abstract class BaseAbstractStubTest<T extends AbstractStub<T>> {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
 
   @Mock
   Channel channel;
-
-  @Before
-  public void setup() {
-    MockitoAnnotations.initMocks(this);
-  }
 
   T create(Channel channel) {
     return create(channel, CallOptions.DEFAULT);

--- a/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
+++ b/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
@@ -66,6 +66,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -73,13 +74,16 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /**
  * Unit tests for {@link ClientCalls}.
  */
 @RunWith(JUnit4.class)
 public class ClientCallsTest {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+
   private static final MethodDescriptor<Integer, Integer> UNARY_METHOD =
       MethodDescriptor.<Integer, Integer>newBuilder()
           .setType(MethodDescriptor.MethodType.UNARY)
@@ -104,7 +108,6 @@ public class ClientCallsTest {
 
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
     originalRejectRunnableOnExecutor = ClientCalls.rejectRunnableOnExecutor;
   }
 

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
@@ -66,19 +66,22 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /**
  * Tests for {@link CdsLoadBalancer2}.
  */
 @RunWith(JUnit4.class)
 public class CdsLoadBalancer2Test {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
 
   private static final String CLUSTER = "cluster-foo.googleapis.com";
   private static final String EDS_SERVICE_NAME = "backend-service-1.googleapis.com";
@@ -125,8 +128,6 @@ public class CdsLoadBalancer2Test {
 
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
-
     when(helper.getSynchronizationContext()).thenReturn(syncContext);
     lbRegistry.register(new FakeLoadBalancerProvider(CLUSTER_RESOLVER_POLICY_NAME));
     lbRegistry.register(new FakeLoadBalancerProvider("round_robin"));

--- a/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
@@ -73,17 +73,21 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /**
  * Tests for {@link ClusterImplLoadBalancer}.
  */
 @RunWith(JUnit4.class)
 public class ClusterImplLoadBalancerTest {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+
   private static final String AUTHORITY = "api.google.com";
   private static final String CLUSTER = "cluster-foo.googleapis.com";
   private static final String EDS_SERVICE_NAME = "service.googleapis.com";
@@ -135,7 +139,6 @@ public class ClusterImplLoadBalancerTest {
 
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
     loadBalancer = new ClusterImplLoadBalancer(helper, mockRandom);
   }
 

--- a/xds/src/test/java/io/grpc/xds/ClusterManagerLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterManagerLoadBalancerTest.java
@@ -64,17 +64,20 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /** Tests for {@link ClusterManagerLoadBalancer}. */
 @RunWith(JUnit4.class)
 public class ClusterManagerLoadBalancerTest {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
 
   private final SynchronizationContext syncContext = new SynchronizationContext(
       new Thread.UncaughtExceptionHandler() {
@@ -96,7 +99,6 @@ public class ClusterManagerLoadBalancerTest {
 
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
     when(helper.getSynchronizationContext()).thenReturn(syncContext);
     when(helper.getScheduledExecutorService()).thenReturn(fakeClock.getScheduledExecutorService());
     lbConfigInventory.put("childA", new Object());

--- a/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
@@ -92,6 +92,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -100,11 +101,14 @@ import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /** Tests for {@link ClusterResolverLoadBalancer}. */
 @RunWith(JUnit4.class)
 public class ClusterResolverLoadBalancerTest {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+
   private static final String AUTHORITY = "api.google.com";
   private static final String CLUSTER1 = "cluster-foo.googleapis.com";
   private static final String CLUSTER2 = "cluster-bar.googleapis.com";
@@ -188,8 +192,6 @@ public class ClusterResolverLoadBalancerTest {
 
   @Before
   public void setUp() throws URISyntaxException {
-    MockitoAnnotations.initMocks(this);
-
     lbRegistry.register(new FakeLoadBalancerProvider(PRIORITY_POLICY_NAME));
     lbRegistry.register(new FakeLoadBalancerProvider(CLUSTER_IMPL_POLICY_NAME));
     lbRegistry.register(new FakeLoadBalancerProvider(WEIGHTED_TARGET_POLICY_NAME));

--- a/xds/src/test/java/io/grpc/xds/LeastRequestLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/LeastRequestLoadBalancerTest.java
@@ -73,6 +73,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -80,13 +81,16 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.mockito.stubbing.Answer;
 
 /** Unit test for {@link LeastRequestLoadBalancer}. */
 @RunWith(JUnit4.class)
 public class LeastRequestLoadBalancerTest {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+
   private static final Attributes.Key<String> MAJOR_KEY = Attributes.Key.create("major-key");
 
   private LeastRequestLoadBalancer loadBalancer;
@@ -113,8 +117,6 @@ public class LeastRequestLoadBalancerTest {
 
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
-
     for (int i = 0; i < 3; i++) {
       SocketAddress addr = new FakeSocketAddress("server" + i);
       EquivalentAddressGroup eag = new EquivalentAddressGroup(addr);

--- a/xds/src/test/java/io/grpc/xds/LoadReportClientTest.java
+++ b/xds/src/test/java/io/grpc/xds/LoadReportClientTest.java
@@ -66,7 +66,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /**
  * Unit tests for {@link LoadReportClient}.
@@ -104,6 +105,8 @@ public class LoadReportClientTest {
 
   @Rule
   public final GrpcCleanupRule cleanupRule = new GrpcCleanupRule();
+  @Rule
+  public final MockitoRule mocks = MockitoJUnit.rule();
   private final SynchronizationContext syncContext = new SynchronizationContext(
       new Thread.UncaughtExceptionHandler() {
         @Override
@@ -138,7 +141,6 @@ public class LoadReportClientTest {
   @SuppressWarnings("unchecked")
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
     mockLoadReportingService = mock(LoadReportingServiceGrpc.LoadReportingServiceImplBase.class,
         delegatesTo(
             new LoadReportingServiceGrpc.LoadReportingServiceImplBase() {

--- a/xds/src/test/java/io/grpc/xds/WeightedTargetLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedTargetLoadBalancerTest.java
@@ -60,16 +60,19 @@ import java.util.List;
 import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /** Tests for {@link WeightedTargetLoadBalancer}. */
 @RunWith(JUnit4.class)
 public class WeightedTargetLoadBalancerTest {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
 
   private final SynchronizationContext syncContext = new SynchronizationContext(
       new Thread.UncaughtExceptionHandler() {
@@ -160,7 +163,6 @@ public class WeightedTargetLoadBalancerTest {
 
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
     when(helper.getSynchronizationContext()).thenReturn(syncContext);
     lbRegistry.register(fooLbProvider);
     lbRegistry.register(barLbProvider);

--- a/xds/src/test/java/io/grpc/xds/XdsClientFederationTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientFederationTest.java
@@ -41,7 +41,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /**
  * Tests for xDS control plane federation scenarios.
@@ -62,14 +63,14 @@ public class XdsClientFederationTest {
   public ControlPlaneRule directpathPa = new ControlPlaneRule().setServerHostName(
       "xdstp://server-one/envoy.config.listener.v3.Listener/test-server");
 
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+
   private ObjectPool<XdsClient> xdsClientPool;
   private XdsClient xdsClient;
   private boolean originalFederationStatus;
 
   @Before
   public void setUp() throws XdsInitializationException {
-    MockitoAnnotations.initMocks(this);
-
     originalFederationStatus = BootstrapperImpl.enableFederation;
     BootstrapperImpl.enableFederation = true;
 

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
@@ -121,7 +121,8 @@ import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /**
  * Tests for {@link XdsClientImpl}.
@@ -196,6 +197,8 @@ public abstract class XdsClientImplTestBase {
 
   @Rule
   public final GrpcCleanupRule cleanupRule = new GrpcCleanupRule();
+  @Rule
+  public final MockitoRule mocks = MockitoJUnit.rule();
 
   private final FakeClock fakeClock = new FakeClock();
   protected final BlockingDeque<DiscoveryRpcCall> resourceDiscoveryCalls =
@@ -292,8 +295,6 @@ public abstract class XdsClientImplTestBase {
 
   @Before
   public void setUp() throws IOException {
-    // Init mocks.
-    MockitoAnnotations.initMocks(this);
     when(backoffPolicyProvider.get()).thenReturn(backoffPolicy1, backoffPolicy2);
     when(backoffPolicy1.nextBackoffNanos()).thenReturn(10L, 100L);
     when(backoffPolicy2.nextBackoffNanos()).thenReturn(20L, 200L);

--- a/xds/src/test/java/io/grpc/xds/XdsClientWrapperForServerSdsTestMisc.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientWrapperForServerSdsTestMisc.java
@@ -72,11 +72,13 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /** Migration test XdsServerWrapper from previous XdsClientWrapperForServerSds. */
 @RunWith(JUnit4.class)
@@ -84,6 +86,8 @@ public class XdsClientWrapperForServerSdsTestMisc {
 
   private static final int PORT = 7000;
   private static final int START_WAIT_AFTER_LISTENER_MILLIS = 100;
+
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
 
   private EmbeddedChannel channel;
   private ChannelPipeline pipeline;
@@ -106,7 +110,6 @@ public class XdsClientWrapperForServerSdsTestMisc {
 
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
     tlsContext1 =
             CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT1", "VA1");
     tlsContext2 =

--- a/xds/src/test/java/io/grpc/xds/internal/security/SslContextProviderSupplierTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/security/SslContextProviderSupplierTest.java
@@ -30,30 +30,27 @@ import io.grpc.xds.EnvoyServerProtoData;
 import io.grpc.xds.TlsContextManager;
 import io.netty.handler.ssl.SslContext;
 import java.util.concurrent.Executor;
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /**
  * Unit tests for {@link SslContextProviderSupplier}.
  */
 @RunWith(JUnit4.class)
 public class SslContextProviderSupplierTest {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
 
   @Mock private TlsContextManager mockTlsContextManager;
   private SslContextProviderSupplier supplier;
   private SslContextProvider mockSslContextProvider;
   private EnvoyServerProtoData.UpstreamTlsContext upstreamTlsContext;
   private SslContextProvider.Callback mockCallback;
-
-  @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
-  }
 
   private void prepareSupplier() {
     upstreamTlsContext =

--- a/xds/src/test/java/io/grpc/xds/internal/security/certprovider/FileWatcherCertificateProviderProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/security/certprovider/FileWatcherCertificateProviderProviderTest.java
@@ -30,15 +30,18 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /** Unit tests for {@link FileWatcherCertificateProviderProvider}. */
 @RunWith(JUnit4.class)
 public class FileWatcherCertificateProviderProviderTest {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
 
   @Mock FileWatcherCertificateProvider.Factory fileWatcherCertificateProviderFactory;
   @Mock private FileWatcherCertificateProviderProvider.ScheduledExecutorServiceFactory
@@ -49,7 +52,6 @@ public class FileWatcherCertificateProviderProviderTest {
 
   @Before
   public void setUp() throws IOException {
-    MockitoAnnotations.initMocks(this);
     provider =
         new FileWatcherCertificateProviderProvider(
             fileWatcherCertificateProviderFactory, scheduledExecutorServiceFactory, timeProvider);

--- a/xds/src/test/java/io/grpc/xds/internal/security/certprovider/FileWatcherCertificateProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/security/certprovider/FileWatcherCertificateProviderTest.java
@@ -60,7 +60,8 @@ import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /** Unit tests for {@link FileWatcherCertificateProvider}. */
 @RunWith(JUnit4.class)
@@ -78,6 +79,7 @@ public class FileWatcherCertificateProviderTest {
   private final FakeTimeProvider timeProvider = new FakeTimeProvider();
 
   @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
 
   private String certFile;
   private String keyFile;
@@ -87,8 +89,6 @@ public class FileWatcherCertificateProviderTest {
 
   @Before
   public void setUp() throws IOException {
-    MockitoAnnotations.initMocks(this);
-
     DistributorWatcher watcher = new DistributorWatcher();
     watcher.addWatcher(mockWatcher);
 

--- a/xds/src/test/java/io/grpc/xds/orca/OrcaOobUtilTest.java
+++ b/xds/src/test/java/io/grpc/xds/orca/OrcaOobUtilTest.java
@@ -89,7 +89,8 @@ import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /**
  * Unit tests for {@link OrcaOobUtil} class.
@@ -107,6 +108,7 @@ public class OrcaOobUtilTest {
   private static final OrcaReportingConfig LONG_INTERVAL_CONFIG =
       OrcaReportingConfig.newBuilder().setReportInterval(1232L, TimeUnit.MILLISECONDS).build();
   @Rule public final GrpcCleanupRule cleanupRule = new GrpcCleanupRule();
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
 
   @SuppressWarnings({"rawtypes", "unchecked"})
   private final List<EquivalentAddressGroup>[] eagLists = new List[NUM_SUBCHANNELS];
@@ -181,8 +183,6 @@ public class OrcaOobUtilTest {
 
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
-
     for (int i = 0; i < NUM_SUBCHANNELS; i++) {
       orcaServiceImps[i] = new OpenRcaServiceImp();
       cleanupRule.register(

--- a/xds/src/test/java/io/grpc/xds/orca/OrcaPerRequestUtilTest.java
+++ b/xds/src/test/java/io/grpc/xds/orca/OrcaPerRequestUtilTest.java
@@ -34,20 +34,22 @@ import io.grpc.Metadata;
 import io.grpc.services.MetricReport;
 import io.grpc.xds.orca.OrcaPerRequestUtil.OrcaPerRequestReportListener;
 import io.grpc.xds.orca.OrcaPerRequestUtil.OrcaReportingTracerFactory;
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /**
  * Unit tests for {@link OrcaPerRequestUtil} class.
  */
 @RunWith(JUnit4.class)
 public class OrcaPerRequestUtilTest {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
 
   private static final ClientStreamTracer.StreamInfo STREAM_INFO =
       ClientStreamTracer.StreamInfo.newBuilder().build();
@@ -56,11 +58,6 @@ public class OrcaPerRequestUtilTest {
   private OrcaPerRequestReportListener orcaListener1;
   @Mock
   private OrcaPerRequestReportListener orcaListener2;
-
-  @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
-  }
 
   /**
    * Tests a single load balance policy's listener receive per-request ORCA reports upon call


### PR DESCRIPTION
MockitoAnnotations.initMocks() is deprecated.