### PR TITLE
Migrate many usages of TestUtils.loadCert() to the public TlsTesting

### DIFF
--- a/authz/src/test/java/io/grpc/authz/AuthorizationEnd2EndTest.java
+++ b/authz/src/test/java/io/grpc/authz/AuthorizationEnd2EndTest.java
@@ -35,8 +35,8 @@ import io.grpc.TlsChannelCredentials;
 import io.grpc.TlsServerCredentials;
 import io.grpc.TlsServerCredentials.ClientAuth;
 import io.grpc.internal.FakeClock;
-import io.grpc.internal.testing.TestUtils;
 import io.grpc.stub.StreamObserver;
+import io.grpc.testing.TlsTesting;
 import io.grpc.testing.protobuf.SimpleRequest;
 import io.grpc.testing.protobuf.SimpleResponse;
 import io.grpc.testing.protobuf.SimpleServiceGrpc;
@@ -343,11 +343,6 @@ public class AuthorizationEnd2EndTest {
   @Test
   public void staticAuthzAllowsRpcWithPrincipalsFieldOnMtlsAuthenticatedConnectionTest() 
         throws Exception {
-    File caCertFile = TestUtils.loadCert(CA_PEM_FILE);
-    File serverKey0File = TestUtils.loadCert(SERVER_0_KEY_FILE);
-    File serverCert0File = TestUtils.loadCert(SERVER_0_PEM_FILE);
-    File clientKey0File = TestUtils.loadCert(CLIENT_0_KEY_FILE);
-    File clientCert0File = TestUtils.loadCert(CLIENT_0_PEM_FILE);
     String policy = "{"
         + " \"name\" : \"authz\" ,"
         + " \"allow_rules\": ["
@@ -361,14 +356,14 @@ public class AuthorizationEnd2EndTest {
         + "}";
     AuthorizationServerInterceptor interceptor = createStaticAuthorizationInterceptor(policy);
     ServerCredentials serverCredentials = TlsServerCredentials.newBuilder()
-        .keyManager(serverCert0File, serverKey0File)
-        .trustManager(caCertFile)
+        .keyManager(TlsTesting.loadCert(SERVER_0_PEM_FILE), TlsTesting.loadCert(SERVER_0_KEY_FILE))
+        .trustManager(TlsTesting.loadCert(CA_PEM_FILE))
         .clientAuth(ClientAuth.REQUIRE)
         .build();
     initServerWithAuthzInterceptor(interceptor, serverCredentials);
     ChannelCredentials channelCredentials = TlsChannelCredentials.newBuilder()
-        .keyManager(clientCert0File, clientKey0File)
-        .trustManager(caCertFile)
+        .keyManager(TlsTesting.loadCert(CLIENT_0_PEM_FILE), TlsTesting.loadCert(CLIENT_0_KEY_FILE))
+        .trustManager(TlsTesting.loadCert(CA_PEM_FILE))
         .build();
     getStub(channelCredentials).unaryRpc(SimpleRequest.getDefaultInstance());
   }
@@ -376,9 +371,6 @@ public class AuthorizationEnd2EndTest {
   @Test
   public void staticAuthzAllowsRpcWithPrincipalsFieldOnTlsAuthenticatedConnectionTest() 
         throws Exception {
-    File caCertFile = TestUtils.loadCert(CA_PEM_FILE);
-    File serverKey0File = TestUtils.loadCert(SERVER_0_KEY_FILE);
-    File serverCert0File = TestUtils.loadCert(SERVER_0_PEM_FILE);
     String policy = "{"
         + " \"name\" : \"authz\" ,"
         + " \"allow_rules\": ["
@@ -392,13 +384,13 @@ public class AuthorizationEnd2EndTest {
         + "}";
     AuthorizationServerInterceptor interceptor = createStaticAuthorizationInterceptor(policy);
     ServerCredentials serverCredentials = TlsServerCredentials.newBuilder()
-        .keyManager(serverCert0File, serverKey0File)
-        .trustManager(caCertFile)
+        .keyManager(TlsTesting.loadCert(SERVER_0_PEM_FILE), TlsTesting.loadCert(SERVER_0_KEY_FILE))
+        .trustManager(TlsTesting.loadCert(CA_PEM_FILE))
         .clientAuth(ClientAuth.OPTIONAL)
         .build();
     initServerWithAuthzInterceptor(interceptor, serverCredentials);
     ChannelCredentials channelCredentials = TlsChannelCredentials.newBuilder()
-        .trustManager(caCertFile)
+        .trustManager(TlsTesting.loadCert(CA_PEM_FILE))
         .build();
     getStub(channelCredentials).unaryRpc(SimpleRequest.getDefaultInstance());
   }

--- a/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadServer.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadServer.java
@@ -36,10 +36,10 @@ import io.grpc.benchmarks.proto.BenchmarkServiceGrpc;
 import io.grpc.benchmarks.proto.Control;
 import io.grpc.benchmarks.proto.Stats;
 import io.grpc.benchmarks.qps.AsyncServer;
-import io.grpc.internal.testing.TestUtils;
+import io.grpc.testing.TlsTesting;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
-import java.io.File;
+import java.io.InputStream;
 import java.lang.management.ManagementFactory;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -115,8 +115,8 @@ final class LoadServer {
       }
     }
     if (config.hasSecurityParams()) {
-      File cert = TestUtils.loadCert("server1.pem");
-      File key = TestUtils.loadCert("server1.key");
+      InputStream cert = TlsTesting.loadCert("server1.pem");
+      InputStream key = TlsTesting.loadCert("server1.key");
       serverBuilder.useTransportSecurity(cert, key);
     }
     benchmarkService = new AsyncServer.BenchmarkServiceImpl();

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
@@ -23,18 +23,18 @@ import io.grpc.Status;
 import io.grpc.benchmarks.Utils;
 import io.grpc.benchmarks.proto.BenchmarkServiceGrpc;
 import io.grpc.benchmarks.proto.Messages;
-import io.grpc.internal.testing.TestUtils;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import io.grpc.stub.StreamObservers;
+import io.grpc.testing.TlsTesting;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.util.concurrent.DefaultThreadFactory;
-import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Iterator;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinPool.ForkJoinWorkerThreadFactory;
@@ -164,8 +164,8 @@ public class AsyncServer {
       System.out.println("Using fake CA for TLS certificate.\n"
           + "Run the Java client with --tls --testca");
 
-      File cert = TestUtils.loadCert("server1.pem");
-      File key = TestUtils.loadCert("server1.key");
+      InputStream cert = TlsTesting.loadCert("server1.pem");
+      InputStream key = TlsTesting.loadCert("server1.key");
       builder.useTransportSecurity(cert, key);
     }
     if (config.directExecutor) {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
@@ -38,11 +38,11 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.Status;
 import io.grpc.StatusException;
-import io.grpc.internal.testing.TestUtils;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.StreamObserver;
+import io.grpc.testing.TlsTesting;
 import io.netty.handler.ssl.SslContext;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -345,7 +345,7 @@ public class StressTestClient {
     if (useTestCa) {
       try {
         sslContext = GrpcSslContexts.forClient().trustManager(
-            TestUtils.loadCert("ca.pem")).build();
+            TlsTesting.loadCert("ca.pem")).build();
       } catch (Exception ex) {
         throw new RuntimeException(ex);
       }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -39,6 +39,7 @@ import io.grpc.netty.InternalNettyChannelBuilder;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.okhttp.InternalOkHttpChannelBuilder;
 import io.grpc.okhttp.OkHttpChannelBuilder;
+import io.grpc.testing.TlsTesting;
 import java.io.File;
 import java.io.FileInputStream;
 import java.nio.charset.Charset;
@@ -537,7 +538,7 @@ public class TestServiceClient {
         } else {
           try {
             channelCredentials = TlsChannelCredentials.newBuilder()
-                .trustManager(TestUtils.loadCert("ca.pem"))
+                .trustManager(TlsTesting.loadCert("ca.pem"))
                 .build();
           } catch (Exception ex) {
             throw new RuntimeException(ex);

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
@@ -28,6 +28,7 @@ import io.grpc.TlsServerCredentials;
 import io.grpc.alts.AltsServerCredentials;
 import io.grpc.internal.testing.TestUtils;
 import io.grpc.services.MetricRecorder;
+import io.grpc.testing.TlsTesting;
 import io.grpc.xds.orca.OrcaMetricReportingServerInterceptor;
 import io.grpc.xds.orca.OrcaServiceImpl;
 import java.util.concurrent.Executors;
@@ -151,7 +152,7 @@ public class TestServiceServer {
       }
     } else if (useTls) {
       serverCreds = TlsServerCredentials.create(
-          TestUtils.loadCert("server1.pem"), TestUtils.loadCert("server1.key"));
+          TlsTesting.loadCert("server1.pem"), TlsTesting.loadCert("server1.key"));
     } else {
       serverCreds = InsecureServerCredentials.create();
     }

--- a/interop-testing/src/test/java/io/grpc/testing/integration/ConcurrencyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/ConcurrencyTest.java
@@ -29,10 +29,10 @@ import io.grpc.TlsChannelCredentials;
 import io.grpc.TlsServerCredentials;
 import io.grpc.internal.testing.TestUtils;
 import io.grpc.stub.StreamObserver;
+import io.grpc.testing.TlsTesting;
 import io.grpc.testing.integration.Messages.ResponseParameters;
 import io.grpc.testing.integration.Messages.StreamingOutputCallRequest;
 import io.grpc.testing.integration.Messages.StreamingOutputCallResponse;
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -188,13 +188,9 @@ public class ConcurrencyTest {
    * Creates and starts a new {@link TestServiceImpl} server.
    */
   private Server newServer() throws IOException {
-    File serverCertChainFile = TestUtils.loadCert("server1.pem");
-    File serverPrivateKeyFile = TestUtils.loadCert("server1.key");
-    File serverTrustedCaCerts = TestUtils.loadCert("ca.pem");
-
     ServerCredentials serverCreds = TlsServerCredentials.newBuilder()
-        .keyManager(serverCertChainFile, serverPrivateKeyFile)
-        .trustManager(serverTrustedCaCerts)
+        .keyManager(TlsTesting.loadCert("server1.pem"), TlsTesting.loadCert("server1.key"))
+        .trustManager(TlsTesting.loadCert("ca.pem"))
         .clientAuth(TlsServerCredentials.ClientAuth.REQUIRE)
         .build();
 
@@ -205,13 +201,9 @@ public class ConcurrencyTest {
   }
 
   private ManagedChannel newClientChannel() throws IOException {
-    File clientCertChainFile = TestUtils.loadCert("client.pem");
-    File clientPrivateKeyFile = TestUtils.loadCert("client.key");
-    File clientTrustedCaCerts = TestUtils.loadCert("ca.pem");
-
     ChannelCredentials channelCreds = TlsChannelCredentials.newBuilder()
-        .keyManager(clientCertChainFile, clientPrivateKeyFile)
-        .trustManager(clientTrustedCaCerts)
+        .keyManager(TlsTesting.loadCert("client.pem"), TlsTesting.loadCert("client.key"))
+        .trustManager(TlsTesting.loadCert("ca.pem"))
         .build();
 
     return Grpc.newChannelBuilder("localhost:" + server.getPort(), channelCreds)

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
@@ -26,6 +26,7 @@ import io.grpc.netty.InternalNettyChannelBuilder;
 import io.grpc.netty.InternalNettyServerBuilder;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.NettyServerBuilder;
+import io.grpc.testing.TlsTesting;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import org.junit.Test;
@@ -43,8 +44,8 @@ public class Http2NettyTest extends AbstractInteropTest {
     // Starts the server with HTTPS.
     try {
       ServerCredentials serverCreds = TlsServerCredentials.newBuilder()
-          .keyManager(TestUtils.loadCert("server1.pem"), TestUtils.loadCert("server1.key"))
-          .trustManager(TestUtils.loadCert("ca.pem"))
+          .keyManager(TlsTesting.loadCert("server1.pem"), TlsTesting.loadCert("server1.key"))
+          .trustManager(TlsTesting.loadCert("ca.pem"))
           .clientAuth(TlsServerCredentials.ClientAuth.REQUIRE)
           .build();
       NettyServerBuilder builder = NettyServerBuilder.forPort(0, serverCreds)
@@ -62,8 +63,8 @@ public class Http2NettyTest extends AbstractInteropTest {
   protected NettyChannelBuilder createChannelBuilder() {
     try {
       ChannelCredentials channelCreds = TlsChannelCredentials.newBuilder()
-          .keyManager(TestUtils.loadCert("client.pem"), TestUtils.loadCert("client.key"))
-          .trustManager(TestUtils.loadCert("ca.pem"))
+          .keyManager(TlsTesting.loadCert("client.pem"), TlsTesting.loadCert("client.key"))
+          .trustManager(TlsTesting.loadCert("ca.pem"))
           .build();
       NettyChannelBuilder builder = NettyChannelBuilder
           .forAddress("localhost", ((InetSocketAddress) getListenAddress()).getPort(), channelCreds)

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
@@ -37,6 +37,7 @@ import io.grpc.okhttp.InternalOkHttpChannelBuilder;
 import io.grpc.okhttp.OkHttpChannelBuilder;
 import io.grpc.okhttp.internal.Platform;
 import io.grpc.stub.StreamObserver;
+import io.grpc.testing.TlsTesting;
 import io.grpc.testing.integration.EmptyProtos.Empty;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -68,7 +69,7 @@ public class Http2OkHttpTest extends AbstractInteropTest {
     // Starts the server with HTTPS.
     try {
       ServerCredentials serverCreds = TlsServerCredentials.create(
-          TestUtils.loadCert("server1.pem"), TestUtils.loadCert("server1.key"));
+          TlsTesting.loadCert("server1.pem"), TlsTesting.loadCert("server1.key"));
       NettyServerBuilder builder = NettyServerBuilder.forPort(0, serverCreds)
           .flowControlWindow(AbstractInteropTest.TEST_FLOW_CONTROL_WINDOW)
           .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE);
@@ -86,7 +87,7 @@ public class Http2OkHttpTest extends AbstractInteropTest {
     ChannelCredentials channelCreds;
     try {
       channelCreds = TlsChannelCredentials.newBuilder()
-          .trustManager(TestUtils.loadCert("ca.pem"))
+          .trustManager(TlsTesting.loadCert("ca.pem"))
           .build();
     } catch (IOException ex) {
       throw new RuntimeException(ex);

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2Test.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2Test.java
@@ -36,6 +36,7 @@ import io.grpc.okhttp.InternalOkHttpServerBuilder;
 import io.grpc.okhttp.OkHttpChannelBuilder;
 import io.grpc.okhttp.OkHttpServerBuilder;
 import io.grpc.stub.MetadataUtils;
+import io.grpc.testing.TlsTesting;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -87,7 +88,7 @@ public class Http2Test extends AbstractInteropTest {
     ServerCredentials serverCreds;
     try {
       serverCreds = TlsServerCredentials.create(
-          TestUtils.loadCert("server1.pem"), TestUtils.loadCert("server1.key"));
+          TlsTesting.loadCert("server1.pem"), TlsTesting.loadCert("server1.key"));
     } catch (IOException ex) {
       throw new RuntimeException(ex);
     }
@@ -115,7 +116,7 @@ public class Http2Test extends AbstractInteropTest {
     ChannelCredentials channelCreds;
     try {
       channelCreds = TlsChannelCredentials.newBuilder()
-          .trustManager(TestUtils.loadCert("ca.pem"))
+          .trustManager(TlsTesting.loadCert("ca.pem"))
           .build();
     } catch (Exception ex) {
       throw new RuntimeException(ex);

--- a/netty/shaded/src/testShadow/java/io/grpc/netty/shaded/ShadingTest.java
+++ b/netty/shaded/src/testShadow/java/io/grpc/netty/shaded/ShadingTest.java
@@ -26,7 +26,6 @@ import io.grpc.ManagedChannel;
 import io.grpc.Server;
 import io.grpc.ServerCredentials;
 import io.grpc.TlsServerCredentials;
-import io.grpc.internal.testing.TestUtils;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
@@ -34,6 +33,7 @@ import io.grpc.netty.shaded.io.grpc.netty.NettySslContextChannelCredentials;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslProvider;
 import io.grpc.stub.StreamObserver;
+import io.grpc.testing.TlsTesting;
 import io.grpc.testing.protobuf.SimpleRequest;
 import io.grpc.testing.protobuf.SimpleResponse;
 import io.grpc.testing.protobuf.SimpleServiceGrpc;
@@ -112,13 +112,13 @@ public final class ShadingTest {
   @Test
   public void tcnative() throws Exception {
     ServerCredentials serverCreds = TlsServerCredentials.create(
-        TestUtils.loadCert("server1.pem"), TestUtils.loadCert("server1.key"));
+        TlsTesting.loadCert("server1.pem"), TlsTesting.loadCert("server1.key"));
     server = Grpc.newServerBuilderForPort(0, serverCreds)
         .addService(new SimpleServiceImpl())
         .build().start();
     ChannelCredentials creds = NettySslContextChannelCredentials.create(
         GrpcSslContexts.configure(SslContextBuilder.forClient(), SslProvider.OPENSSL)
-            .trustManager(TestUtils.loadCert("ca.pem")).build());
+            .trustManager(TlsTesting.loadCert("ca.pem")).build());
     channel = Grpc.newChannelBuilder("localhost:" + server.getPort(), creds)
         .overrideAuthority("foo.test.google.fr")
         .build();

--- a/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
+++ b/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
@@ -34,6 +34,7 @@ import io.grpc.TlsServerCredentials;
 import io.grpc.TlsServerCredentials.ClientAuth;
 import io.grpc.internal.testing.TestUtils;
 import io.grpc.stub.StreamObserver;
+import io.grpc.testing.TlsTesting;
 import io.grpc.testing.protobuf.SimpleRequest;
 import io.grpc.testing.protobuf.SimpleResponse;
 import io.grpc.testing.protobuf.SimpleServiceGrpc;
@@ -98,20 +99,13 @@ public class AdvancedTlsTest {
     serverCert0File = TestUtils.loadCert(SERVER_0_PEM_FILE);
     clientKey0File = TestUtils.loadCert(CLIENT_0_KEY_FILE);
     clientCert0File = TestUtils.loadCert(CLIENT_0_PEM_FILE);
-    caCert = CertificateUtils.getX509Certificates(
-        TestUtils.class.getResourceAsStream("/certs/" + CA_PEM_FILE));
-    serverKey0 = CertificateUtils.getPrivateKey(
-        TestUtils.class.getResourceAsStream("/certs/" + SERVER_0_KEY_FILE));
-    serverCert0 = CertificateUtils.getX509Certificates(
-        TestUtils.class.getResourceAsStream("/certs/" + SERVER_0_PEM_FILE));
-    clientKey0 = CertificateUtils.getPrivateKey(
-        TestUtils.class.getResourceAsStream("/certs/" + CLIENT_0_KEY_FILE));
-    clientCert0 = CertificateUtils.getX509Certificates(
-        TestUtils.class.getResourceAsStream("/certs/" + CLIENT_0_PEM_FILE));
-    serverKeyBad = CertificateUtils.getPrivateKey(
-        TestUtils.class.getResourceAsStream("/certs/" + SERVER_BAD_KEY_FILE));
-    serverCertBad = CertificateUtils.getX509Certificates(
-        TestUtils.class.getResourceAsStream("/certs/" + SERVER_BAD_PEM_FILE));
+    caCert = CertificateUtils.getX509Certificates(TlsTesting.loadCert(CA_PEM_FILE));
+    serverKey0 = CertificateUtils.getPrivateKey(TlsTesting.loadCert(SERVER_0_KEY_FILE));
+    serverCert0 = CertificateUtils.getX509Certificates(TlsTesting.loadCert(SERVER_0_PEM_FILE));
+    clientKey0 = CertificateUtils.getPrivateKey(TlsTesting.loadCert(CLIENT_0_KEY_FILE));
+    clientCert0 = CertificateUtils.getX509Certificates(TlsTesting.loadCert(CLIENT_0_PEM_FILE));
+    serverKeyBad = CertificateUtils.getPrivateKey(TlsTesting.loadCert(SERVER_BAD_KEY_FILE));
+    serverCertBad = CertificateUtils.getX509Certificates(TlsTesting.loadCert(SERVER_BAD_PEM_FILE));
   }
 
   @After

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -68,6 +68,7 @@ import io.grpc.internal.TransportTracer;
 import io.grpc.internal.testing.TestUtils;
 import io.grpc.netty.NettyChannelBuilder.LocalSocketPicker;
 import io.grpc.netty.NettyTestUtil.TrackingObjectPoolForTest;
+import io.grpc.testing.TlsTesting;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelDuplexHandler;
@@ -88,7 +89,6 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.util.AsciiString;
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
@@ -297,8 +297,8 @@ public class NettyClientTransportTest {
 
   @Test
   public void tlsNegotiationFailurePropagatesToStatus() throws Exception {
-    File serverCert = TestUtils.loadCert("server1.pem");
-    File serverKey = TestUtils.loadCert("server1.key");
+    InputStream serverCert = TlsTesting.loadCert("server1.pem");
+    InputStream serverKey = TlsTesting.loadCert("server1.key");
     // Don't trust ca.pem, so that client auth fails
     SslContext sslContext = GrpcSslContexts.forServer(serverCert, serverKey)
         .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE)
@@ -307,9 +307,9 @@ public class NettyClientTransportTest {
     negotiator = ProtocolNegotiators.serverTls(sslContext);
     startServer();
 
-    File caCert = TestUtils.loadCert("ca.pem");
-    File clientCert = TestUtils.loadCert("client.pem");
-    File clientKey = TestUtils.loadCert("client.key");
+    InputStream caCert = TlsTesting.loadCert("ca.pem");
+    InputStream clientCert = TlsTesting.loadCert("client.pem");
+    InputStream clientKey = TlsTesting.loadCert("client.key");
     SslContext clientContext = GrpcSslContexts.forClient()
         .trustManager(caCert)
         .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE)
@@ -691,8 +691,8 @@ public class NettyClientTransportTest {
     assertEquals(false, serverExecutorPool.isInUse());
     assertEquals(false, clientExecutorPool.isInUse());
 
-    File serverCert = TestUtils.loadCert("server1.pem");
-    File serverKey = TestUtils.loadCert("server1.key");
+    InputStream serverCert = TlsTesting.loadCert("server1.pem");
+    InputStream serverKey = TlsTesting.loadCert("server1.key");
     SslContext sslContext = GrpcSslContexts.forServer(serverCert, serverKey)
         .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE)
         .clientAuth(ClientAuth.NONE)
@@ -702,9 +702,9 @@ public class NettyClientTransportTest {
     // after starting the server, the Executor in the server pool should be used
     assertEquals(true, serverExecutorPool.isInUse());
 
-    File caCert = TestUtils.loadCert("ca.pem");
-    File clientCert = TestUtils.loadCert("client.pem");
-    File clientKey = TestUtils.loadCert("client.key");
+    InputStream caCert = TlsTesting.loadCert("ca.pem");
+    InputStream clientCert = TlsTesting.loadCert("client.pem");
+    InputStream clientKey = TlsTesting.loadCert("client.key");
     SslContext clientContext = GrpcSslContexts.forClient()
         .trustManager(caCert)
         .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE)
@@ -732,7 +732,7 @@ public class NettyClientTransportTest {
   }
 
   private ProtocolNegotiator newNegotiator() throws IOException {
-    File caCert = TestUtils.loadCert("ca.pem");
+    InputStream caCert = TlsTesting.loadCert("ca.pem");
     SslContext clientContext = GrpcSslContexts.forClient().trustManager(caCert)
         .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE).build();
     return ProtocolNegotiators.tls(clientContext);
@@ -802,8 +802,8 @@ public class NettyClientTransportTest {
 
   private static SslContext createSslContext() {
     try {
-      File serverCert = TestUtils.loadCert("server1.pem");
-      File key = TestUtils.loadCert("server1.key");
+      InputStream serverCert = TlsTesting.loadCert("server1.pem");
+      InputStream key = TlsTesting.loadCert("server1.key");
       return GrpcSslContexts.forServer(serverCert, key)
           .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE).build();
     } catch (IOException ex) {

--- a/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
+++ b/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
@@ -67,6 +67,7 @@ import io.grpc.netty.ProtocolNegotiators.ClientTlsProtocolNegotiator;
 import io.grpc.netty.ProtocolNegotiators.HostPort;
 import io.grpc.netty.ProtocolNegotiators.ServerTlsHandler;
 import io.grpc.netty.ProtocolNegotiators.WaitUntilActiveHandler;
+import io.grpc.testing.TlsTesting;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
@@ -112,6 +113,7 @@ import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import java.io.File;
+import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.security.KeyStore;
@@ -189,8 +191,8 @@ public class ProtocolNegotiatorsTest {
 
   @Before
   public void setUp() throws Exception {
-    File serverCert = TestUtils.loadCert("server1.pem");
-    File key = TestUtils.loadCert("server1.key");
+    InputStream serverCert = TlsTesting.loadCert("server1.pem");
+    InputStream key = TlsTesting.loadCert("server1.key");
     sslContext = GrpcSslContexts.forServer(serverCert, key)
         .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE).build();
     engine = SSLContext.getDefault().createSSLEngine();
@@ -789,8 +791,8 @@ public class ProtocolNegotiatorsTest {
       }
     };
 
-    File serverCert = TestUtils.loadCert("server1.pem");
-    File key = TestUtils.loadCert("server1.key");
+    InputStream serverCert = TlsTesting.loadCert("server1.pem");
+    InputStream key = TlsTesting.loadCert("server1.key");
     List<String> alpnList = Arrays.asList("managed_mtls", "h2");
     ApplicationProtocolConfig apn = new ApplicationProtocolConfig(
         ApplicationProtocolConfig.Protocol.ALPN,
@@ -826,8 +828,8 @@ public class ProtocolNegotiatorsTest {
       }
     };
 
-    File serverCert = TestUtils.loadCert("server1.pem");
-    File key = TestUtils.loadCert("server1.key");
+    InputStream serverCert = TlsTesting.loadCert("server1.pem");
+    InputStream key = TlsTesting.loadCert("server1.key");
     List<String> alpnList = Arrays.asList("managed_mtls", "h2");
     ApplicationProtocolConfig apn = new ApplicationProtocolConfig(
         ApplicationProtocolConfig.Protocol.ALPN,
@@ -898,8 +900,8 @@ public class ProtocolNegotiatorsTest {
     };
     DefaultEventLoopGroup elg = new DefaultEventLoopGroup(1);
 
-    File clientCert = TestUtils.loadCert("client.pem");
-    File key = TestUtils.loadCert("client.key");
+    InputStream clientCert = TlsTesting.loadCert("client.pem");
+    InputStream key = TlsTesting.loadCert("client.key");
     List<String> alpnList = Arrays.asList("managed_mtls", "h2");
     ApplicationProtocolConfig apn = new ApplicationProtocolConfig(
         ApplicationProtocolConfig.Protocol.ALPN,

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
@@ -41,6 +41,7 @@ import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.SharedResourceHolder;
 import io.grpc.internal.testing.TestUtils;
 import io.grpc.testing.GrpcCleanupRule;
+import io.grpc.testing.TlsTesting;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -313,7 +314,7 @@ public class OkHttpChannelBuilderTest {
   public void sslSocketFactoryFrom_tls_mtls_passwordUnsupported() throws Exception {
     ChannelCredentials creds = TlsChannelCredentials.newBuilder()
         .keyManager(
-            TestUtils.loadCert("server1.pem"), TestUtils.loadCert("server1.key"), "password")
+            TlsTesting.loadCert("server1.pem"), TlsTesting.loadCert("server1.key"), "password")
         .build();
     OkHttpChannelBuilder.SslSocketFactoryResult result =
         OkHttpChannelBuilder.sslSocketFactoryFrom(creds);

--- a/testing/src/main/java/io/grpc/internal/testing/TestUtils.java
+++ b/testing/src/main/java/io/grpc/internal/testing/TestUtils.java
@@ -18,6 +18,7 @@ package io.grpc.internal.testing;
 
 import com.google.common.base.Throwables;
 import io.grpc.internal.ConscryptLoader;
+import io.grpc.testing.TlsTesting;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -125,8 +126,7 @@ public class TestUtils {
    * @param name  name of a file in src/main/resources/certs.
    */
   public static File loadCert(String name) throws IOException {
-    InputStream
-        in = new BufferedInputStream(TestUtils.class.getResourceAsStream("/certs/" + name));
+    InputStream in = new BufferedInputStream(TlsTesting.loadCert(name));
     File tmpFile = File.createTempFile(name, "");
     tmpFile.deleteOnExit();
 
@@ -154,7 +154,7 @@ public class TestUtils {
       throws CertificateException, IOException {
     CertificateFactory cf = CertificateFactory.getInstance("X.509");
 
-    InputStream in = TestUtils.class.getResourceAsStream("/certs/" + fileName);
+    InputStream in = TlsTesting.loadCert(fileName);
     try {
       return (X509Certificate) cf.generateCertificate(in);
     } finally {

--- a/xds/src/test/java/io/grpc/xds/internal/security/CommonTlsContextTestsUtil.java
+++ b/xds/src/test/java/io/grpc/xds/internal/security/CommonTlsContextTestsUtil.java
@@ -31,6 +31,7 @@ import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.DownstreamTlsCont
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext;
 import io.envoyproxy.envoy.type.matcher.v3.StringMatcher;
 import io.grpc.internal.testing.TestUtils;
+import io.grpc.testing.TlsTesting;
 import io.grpc.xds.EnvoyServerProtoData;
 import io.grpc.xds.internal.security.trust.CertificateUtils;
 import io.netty.handler.ssl.SslContext;
@@ -200,9 +201,9 @@ public class CommonTlsContextTestsUtil {
     }
   }
 
-  /** Gets contents of a resource from TestUtils.class loader. */
+  /** Gets contents of a certs resource. */
   public static String getResourceContents(String resourceName) throws IOException {
-    InputStream inputStream = TestUtils.class.getResourceAsStream("/certs/" + resourceName);
+    InputStream inputStream = TlsTesting.loadCert(resourceName);
     String text = null;
     try (Reader reader = new InputStreamReader(inputStream, UTF_8)) {
       text = CharStreams.toString(reader);

--- a/xds/src/test/java/io/grpc/xds/internal/security/trust/XdsTrustManagerFactoryTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/security/trust/XdsTrustManagerFactoryTest.java
@@ -28,6 +28,7 @@ import io.envoyproxy.envoy.config.core.v3.DataSource;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateValidationContext;
 import io.envoyproxy.envoy.type.matcher.v3.StringMatcher;
 import io.grpc.internal.testing.TestUtils;
+import io.grpc.testing.TlsTesting;
 import java.io.IOException;
 import java.security.cert.CertStoreException;
 import java.security.cert.CertificateException;
@@ -58,7 +59,7 @@ public class XdsTrustManagerFactoryTest {
     assertThat(acceptedIssuers).hasLength(1);
     X509Certificate caCert = acceptedIssuers[0];
     assertThat(caCert)
-        .isEqualTo(CertificateUtils.toX509Certificates(TestUtils.loadCert(CA_PEM_FILE))[0]);
+        .isEqualTo(CertificateUtils.toX509Certificates(TlsTesting.loadCert(CA_PEM_FILE))[0]);
   }
 
   @Test
@@ -78,7 +79,7 @@ public class XdsTrustManagerFactoryTest {
     assertThat(acceptedIssuers).hasLength(1);
     X509Certificate caCert = acceptedIssuers[0];
     assertThat(caCert)
-        .isEqualTo(CertificateUtils.toX509Certificates(TestUtils.loadCert(CA_PEM_FILE))[0]);
+        .isEqualTo(CertificateUtils.toX509Certificates(TlsTesting.loadCert(CA_PEM_FILE))[0]);
   }
 
   @Test
@@ -101,7 +102,7 @@ public class XdsTrustManagerFactoryTest {
     assertThat(acceptedIssuers).hasLength(1);
     X509Certificate caCert = acceptedIssuers[0];
     assertThat(caCert)
-        .isEqualTo(CertificateUtils.toX509Certificates(TestUtils.loadCert(CA_PEM_FILE))[0]);
+        .isEqualTo(CertificateUtils.toX509Certificates(TlsTesting.loadCert(CA_PEM_FILE))[0]);
   }
 
   @Test
@@ -114,7 +115,7 @@ public class XdsTrustManagerFactoryTest {
         new XdsTrustManagerFactory(new X509Certificate[]{x509Cert}, staticValidationContext);
     XdsX509TrustManager xdsX509TrustManager = (XdsX509TrustManager) factory.getTrustManagers()[0];
     X509Certificate[] serverChain =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     xdsX509TrustManager.checkServerTrusted(serverChain, "RSA");
   }
 
@@ -143,7 +144,7 @@ public class XdsTrustManagerFactoryTest {
         new XdsTrustManagerFactory(new X509Certificate[]{x509Cert}, staticValidationContext);
     XdsX509TrustManager xdsX509TrustManager = (XdsX509TrustManager) factory.getTrustManagers()[0];
     X509Certificate[] serverChain =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     try {
       xdsX509TrustManager.checkServerTrusted(serverChain, "RSA");
       Assert.fail("no exception thrown");
@@ -164,7 +165,7 @@ public class XdsTrustManagerFactoryTest {
         new XdsTrustManagerFactory(new X509Certificate[]{x509Cert}, staticValidationContext);
     XdsX509TrustManager xdsX509TrustManager = (XdsX509TrustManager) factory.getTrustManagers()[0];
     X509Certificate[] clientChain =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     try {
       xdsX509TrustManager.checkClientTrusted(clientChain, "RSA");
       Assert.fail("no exception thrown");
@@ -182,7 +183,7 @@ public class XdsTrustManagerFactoryTest {
         new XdsTrustManagerFactory(getCertContextFromPath(CA_PEM_FILE));
     XdsX509TrustManager xdsX509TrustManager = (XdsX509TrustManager) factory.getTrustManagers()[0];
     X509Certificate[] serverChain =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     xdsX509TrustManager.checkServerTrusted(serverChain, "RSA");
   }
 
@@ -193,7 +194,7 @@ public class XdsTrustManagerFactoryTest {
         new XdsTrustManagerFactory(getCertContextFromPath(CA_PEM_FILE));
     XdsX509TrustManager xdsX509TrustManager = (XdsX509TrustManager) factory.getTrustManagers()[0];
     X509Certificate[] clientChain =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(CLIENT_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(CLIENT_PEM_FILE));
     xdsX509TrustManager.checkClientTrusted(clientChain, "RSA");
   }
 
@@ -204,7 +205,7 @@ public class XdsTrustManagerFactoryTest {
         new XdsTrustManagerFactory(getCertContextFromPath(CA_PEM_FILE));
     XdsX509TrustManager xdsX509TrustManager = (XdsX509TrustManager) factory.getTrustManagers()[0];
     X509Certificate[] serverChain =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(BAD_SERVER_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(BAD_SERVER_PEM_FILE));
     try {
       xdsX509TrustManager.checkServerTrusted(serverChain, "RSA");
       Assert.fail("no exception thrown");
@@ -222,7 +223,7 @@ public class XdsTrustManagerFactoryTest {
         new XdsTrustManagerFactory(getCertContextFromPath(CA_PEM_FILE));
     XdsX509TrustManager xdsX509TrustManager = (XdsX509TrustManager) factory.getTrustManagers()[0];
     X509Certificate[] clientChain =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(BAD_CLIENT_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(BAD_CLIENT_PEM_FILE));
     try {
       xdsX509TrustManager.checkClientTrusted(clientChain, "RSA");
       Assert.fail("no exception thrown");

--- a/xds/src/test/java/io/grpc/xds/internal/security/trust/XdsX509TrustManagerTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/security/trust/XdsX509TrustManagerTest.java
@@ -33,7 +33,7 @@ import com.google.common.collect.ImmutableList;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateValidationContext;
 import io.envoyproxy.envoy.type.matcher.v3.RegexMatcher;
 import io.envoyproxy.envoy.type.matcher.v3.StringMatcher;
-import io.grpc.internal.testing.TestUtils;
+import io.grpc.testing.TlsTesting;
 import java.io.IOException;
 import java.security.cert.CertStoreException;
 import java.security.cert.CertificateException;
@@ -74,7 +74,7 @@ public class XdsX509TrustManagerTest {
   public void nullCertContextTest() throws CertificateException, IOException {
     trustManager = new XdsX509TrustManager(null, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
   }
 
@@ -83,7 +83,7 @@ public class XdsX509TrustManagerTest {
     CertificateValidationContext certContext = CertificateValidationContext.getDefaultInstance();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
   }
 
@@ -125,7 +125,7 @@ public class XdsX509TrustManagerTest {
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(CLIENT_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(CLIENT_PEM_FILE));
     try {
       trustManager.verifySubjectAltNameInChain(certs);
       fail("no exception thrown");
@@ -146,7 +146,7 @@ public class XdsX509TrustManagerTest {
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
   }
 
@@ -163,7 +163,7 @@ public class XdsX509TrustManagerTest {
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     try {
       trustManager.verifySubjectAltNameInChain(certs);
       fail("no exception thrown");
@@ -181,7 +181,7 @@ public class XdsX509TrustManagerTest {
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
   }
 
@@ -197,7 +197,7 @@ public class XdsX509TrustManagerTest {
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
   }
 
@@ -211,7 +211,7 @@ public class XdsX509TrustManagerTest {
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     try {
       trustManager.verifySubjectAltNameInChain(certs);
       fail("no exception thrown");
@@ -232,7 +232,7 @@ public class XdsX509TrustManagerTest {
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
   }
 
@@ -245,7 +245,7 @@ public class XdsX509TrustManagerTest {
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
   }
 
@@ -259,7 +259,7 @@ public class XdsX509TrustManagerTest {
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     try {
       trustManager.verifySubjectAltNameInChain(certs);
       fail("no exception thrown");
@@ -277,7 +277,7 @@ public class XdsX509TrustManagerTest {
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
   }
 
@@ -290,7 +290,7 @@ public class XdsX509TrustManagerTest {
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
   }
 
@@ -304,7 +304,7 @@ public class XdsX509TrustManagerTest {
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     try {
       trustManager.verifySubjectAltNameInChain(certs);
       fail("no exception thrown");
@@ -322,7 +322,7 @@ public class XdsX509TrustManagerTest {
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
   }
 
@@ -338,7 +338,7 @@ public class XdsX509TrustManagerTest {
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
   }
 
@@ -354,7 +354,7 @@ public class XdsX509TrustManagerTest {
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
   }
 
@@ -370,7 +370,7 @@ public class XdsX509TrustManagerTest {
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
   }
 
@@ -386,7 +386,7 @@ public class XdsX509TrustManagerTest {
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     try {
       trustManager.verifySubjectAltNameInChain(certs);
       fail("no exception thrown");
@@ -409,7 +409,7 @@ public class XdsX509TrustManagerTest {
             .build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
   }
 
@@ -422,7 +422,7 @@ public class XdsX509TrustManagerTest {
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     try {
       trustManager.verifySubjectAltNameInChain(certs);
       fail("no exception thrown");
@@ -445,7 +445,7 @@ public class XdsX509TrustManagerTest {
             .build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
   }
 
@@ -463,7 +463,7 @@ public class XdsX509TrustManagerTest {
             .build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
   }
 
@@ -480,7 +480,7 @@ public class XdsX509TrustManagerTest {
         CertificateValidationContext.newBuilder().addMatchSubjectAltNames(stringMatcher).build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     try {
       trustManager.verifySubjectAltNameInChain(certs);
       fail("no exception thrown");
@@ -501,7 +501,7 @@ public class XdsX509TrustManagerTest {
             .build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     trustManager.verifySubjectAltNameInChain(certs);
   }
 
@@ -517,7 +517,7 @@ public class XdsX509TrustManagerTest {
             .build();
     trustManager = new XdsX509TrustManager(certContext, mockDelegate);
     X509Certificate[] certs =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     try {
       trustManager.verifySubjectAltNameInChain(certs);
       fail("no exception thrown");
@@ -531,7 +531,7 @@ public class XdsX509TrustManagerTest {
       throws CertificateException, IOException, CertStoreException {
     TestSslEngine sslEngine = buildTrustManagerAndGetSslEngine();
     X509Certificate[] serverCerts =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     trustManager.checkServerTrusted(serverCerts, "ECDHE_ECDSA", sslEngine);
     verify(sslEngine, times(1)).getHandshakeSession();
   }
@@ -541,7 +541,7 @@ public class XdsX509TrustManagerTest {
       throws CertificateException, IOException, CertStoreException {
     TestSslEngine sslEngine = buildTrustManagerAndGetSslEngine();
     X509Certificate[] badServerCert =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(BAD_SERVER_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(BAD_SERVER_PEM_FILE));
     try {
       trustManager.checkServerTrusted(badServerCert, "ECDHE_ECDSA", sslEngine);
       fail("exception expected");
@@ -557,7 +557,7 @@ public class XdsX509TrustManagerTest {
       throws CertificateException, IOException, CertStoreException {
     TestSslSocket sslSocket = buildTrustManagerAndGetSslSocket();
     X509Certificate[] serverCerts =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(SERVER_1_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     trustManager.checkServerTrusted(serverCerts, "ECDHE_ECDSA", sslSocket);
     verify(sslSocket, times(1)).isConnected();
     verify(sslSocket, times(1)).getHandshakeSession();
@@ -568,7 +568,7 @@ public class XdsX509TrustManagerTest {
       throws CertificateException, IOException, CertStoreException {
     TestSslSocket sslSocket = buildTrustManagerAndGetSslSocket();
     X509Certificate[] badServerCert =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(BAD_SERVER_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(BAD_SERVER_PEM_FILE));
     try {
       trustManager.checkServerTrusted(badServerCert, "ECDHE_ECDSA", sslSocket);
       fail("exception expected");
@@ -628,7 +628,7 @@ public class XdsX509TrustManagerTest {
   private SSLParameters buildTrustManagerAndGetSslParameters()
       throws CertificateException, IOException, CertStoreException {
     X509Certificate[] caCerts =
-        CertificateUtils.toX509Certificates(TestUtils.loadCert(CA_PEM_FILE));
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(CA_PEM_FILE));
     trustManager = XdsTrustManagerFactory.createSdsX509TrustManager(caCerts,
         null);
     when(mockSession.getProtocol()).thenReturn("TLSv1.2");


### PR DESCRIPTION
TlsTesting.loadCert() is a public API and so should be preferred over our internal utility. It avoids creating a temp file that has to be deleted by a shutdown hook. Usages that needed a file were not migrated.