### PR TITLE
Fix throwing LBProvider.parseLoadBalancingConfig() impls

### DIFF
--- a/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancerProvider.java
+++ b/core/src/main/java/io/grpc/util/OutlierDetectionLoadBalancerProvider.java
@@ -59,6 +59,16 @@ public final class OutlierDetectionLoadBalancerProvider extends LoadBalancerProv
 
   @Override
   public ConfigOrError parseLoadBalancingPolicyConfig(Map<String, ?> rawConfig) {
+    try {
+      return parseLoadBalancingPolicyConfigInternal(rawConfig);
+    } catch (RuntimeException e) {
+      return ConfigOrError.fromError(
+          Status.UNAVAILABLE.withCause(e).withDescription(
+              "Failed parsing configuration for " + getPolicyName()));
+    }
+  }
+
+  private ConfigOrError parseLoadBalancingPolicyConfigInternal(Map<String, ?> rawConfig) {
     // Common configuration.
     Long intervalNanos = JsonUtil.getStringAsDuration(rawConfig, "interval");
     Long baseEjectionTimeNanos = JsonUtil.getStringAsDuration(rawConfig, "baseEjectionTime");

--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancerProvider.java
@@ -25,6 +25,7 @@ import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.NameResolver.ConfigOrError;
+import io.grpc.Status;
 import io.grpc.internal.ServiceConfigUtil.PolicySelection;
 import io.grpc.xds.Bootstrapper.ServerInfo;
 import io.grpc.xds.Endpoints.DropOverload;
@@ -60,7 +61,8 @@ public final class ClusterImplLoadBalancerProvider extends LoadBalancerProvider 
 
   @Override
   public ConfigOrError parseLoadBalancingPolicyConfig(Map<String, ?> rawLoadBalancingPolicyConfig) {
-    throw new UnsupportedOperationException("not supported as top-level LB policy");
+    return ConfigOrError.fromError(
+        Status.INTERNAL.withDescription(getPolicyName() + " cannot be used from service config"));
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancerProvider.java
@@ -24,6 +24,7 @@ import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.NameResolver.ConfigOrError;
+import io.grpc.Status;
 import io.grpc.internal.ServiceConfigUtil.PolicySelection;
 import io.grpc.xds.Bootstrapper.ServerInfo;
 import io.grpc.xds.EnvoyServerProtoData.OutlierDetection;
@@ -58,7 +59,8 @@ public final class ClusterResolverLoadBalancerProvider extends LoadBalancerProvi
 
   @Override
   public ConfigOrError parseLoadBalancingPolicyConfig(Map<String, ?> rawLoadBalancingPolicyConfig) {
-    throw new UnsupportedOperationException("not supported as top-level LB policy");
+    return ConfigOrError.fromError(
+        Status.INTERNAL.withDescription(getPolicyName() + " cannot be used from service config"));
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/PriorityLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/PriorityLoadBalancerProvider.java
@@ -25,6 +25,7 @@ import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.NameResolver.ConfigOrError;
+import io.grpc.Status;
 import io.grpc.internal.ServiceConfigUtil.PolicySelection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -57,7 +58,8 @@ public final class PriorityLoadBalancerProvider extends LoadBalancerProvider {
 
   @Override
   public ConfigOrError parseLoadBalancingPolicyConfig(Map<String, ?> rawConfig) {
-    throw new UnsupportedOperationException();
+    return ConfigOrError.fromError(
+        Status.INTERNAL.withDescription(getPolicyName() + " cannot be used from service config"));
   }
 
   static final class PriorityLbConfig {

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancerProvider.java
@@ -68,6 +68,17 @@ public final class RingHashLoadBalancerProvider extends LoadBalancerProvider {
 
   @Override
   public ConfigOrError parseLoadBalancingPolicyConfig(Map<String, ?> rawLoadBalancingPolicyConfig) {
+    try {
+      return parseLoadBalancingPolicyConfigInternal(rawLoadBalancingPolicyConfig);
+    } catch (RuntimeException e) {
+      return ConfigOrError.fromError(
+          Status.UNAVAILABLE.withCause(e).withDescription(
+              "Failed parsing configuration for " + getPolicyName()));
+    }
+  }
+
+  private ConfigOrError parseLoadBalancingPolicyConfigInternal(
+      Map<String, ?> rawLoadBalancingPolicyConfig) {
     Long minRingSize = JsonUtil.getNumberAsLong(rawLoadBalancingPolicyConfig, "minRingSize");
     Long maxRingSize = JsonUtil.getNumberAsLong(rawLoadBalancingPolicyConfig, "maxRingSize");
     long maxRingSizeCap = RingHashOptions.getRingSizeCap();


### PR DESCRIPTION
LoadBalancers in general should never throw, but
parseLoadBalancingConfig() in particular has a return value to communicate the error. Throwing can be a bit unpredictable, but at its most trivial form causes a channel panic. There's no reason to throw explicitly and calls to JsonUtil have to be protected by a try-catch because it can throw.

CC @YifeiZhuang 