### PR TITLE
xds interop: Update Docker images to `eclipse-temurin:11-jre`

### DIFF
--- a/buildscripts/xds-k8s/test-client.Dockerfile
+++ b/buildscripts/xds-k8s/test-client.Dockerfile
@@ -1,5 +1,5 @@
 # Build runtime image.
-FROM eclipse-temurin:11.0.19_7-jdk-alpine
+FROM eclipse-temurin:11.0.19_7-jre
 
 ENV APP_DIR=/usr/src/app
 WORKDIR $APP_DIR

--- a/buildscripts/xds-k8s/test-client.Dockerfile
+++ b/buildscripts/xds-k8s/test-client.Dockerfile
@@ -1,5 +1,5 @@
 # Build runtime image.
-FROM openjdk:11.0.9.1-jdk
+FROM openjdk:11.0.19_7-jdk
 
 ENV APP_DIR=/usr/src/app
 WORKDIR $APP_DIR

--- a/buildscripts/xds-k8s/test-client.Dockerfile
+++ b/buildscripts/xds-k8s/test-client.Dockerfile
@@ -11,5 +11,12 @@ COPY grpc-interop-testing/ $APP_DIR/
 COPY logging*.properties $APP_DIR/
 ENV JAVA_OPTS="-Djava.util.logging.config.file=$APP_DIR/logging-json.properties"
 
+# Intentially after the app COPY to force the update on each build.
+# Update Ubuntu system packages:
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && apt-get -y autoremove \
+    && rm -rf /var/lib/apt/lists/*
+
 # Client
 ENTRYPOINT ["bin/xds-test-client"]

--- a/buildscripts/xds-k8s/test-client.Dockerfile
+++ b/buildscripts/xds-k8s/test-client.Dockerfile
@@ -1,5 +1,5 @@
 # Build runtime image.
-FROM eclipse-temurin:11.0.19_7-jre
+FROM eclipse-temurin:11-jre
 
 ENV APP_DIR=/usr/src/app
 WORKDIR $APP_DIR
@@ -11,7 +11,7 @@ COPY grpc-interop-testing/ $APP_DIR/
 COPY logging*.properties $APP_DIR/
 ENV JAVA_OPTS="-Djava.util.logging.config.file=$APP_DIR/logging-json.properties"
 
-# Intentially after the app COPY to force the update on each build.
+# Intentionally after the app COPY to force the update on each build.
 # Update Ubuntu system packages:
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/buildscripts/xds-k8s/test-client.Dockerfile
+++ b/buildscripts/xds-k8s/test-client.Dockerfile
@@ -1,5 +1,5 @@
 # Build runtime image.
-FROM eclipse-temurin:11.0.19_7-jdk
+FROM eclipse-temurin:11.0.19_7-jdk-alpine
 
 ENV APP_DIR=/usr/src/app
 WORKDIR $APP_DIR

--- a/buildscripts/xds-k8s/test-client.Dockerfile
+++ b/buildscripts/xds-k8s/test-client.Dockerfile
@@ -1,5 +1,5 @@
 # Build runtime image.
-FROM openjdk:11.0.19_7-jdk
+FROM eclipse-temurin:11.0.19_7-jdk
 
 ENV APP_DIR=/usr/src/app
 WORKDIR $APP_DIR

--- a/buildscripts/xds-k8s/test-server.Dockerfile
+++ b/buildscripts/xds-k8s/test-server.Dockerfile
@@ -1,5 +1,5 @@
 # Build runtime image.
-FROM eclipse-temurin:11.0.19_7-jdk-alpine
+FROM eclipse-temurin:11.0.19_7-jre
 
 ENV APP_DIR=/usr/src/app
 WORKDIR $APP_DIR

--- a/buildscripts/xds-k8s/test-server.Dockerfile
+++ b/buildscripts/xds-k8s/test-server.Dockerfile
@@ -1,5 +1,5 @@
 # Build runtime image.
-FROM openjdk:11.0.9.1-jdk
+FROM openjdk:11.0.19_7-jdk
 
 ENV APP_DIR=/usr/src/app
 WORKDIR $APP_DIR

--- a/buildscripts/xds-k8s/test-server.Dockerfile
+++ b/buildscripts/xds-k8s/test-server.Dockerfile
@@ -1,5 +1,5 @@
 # Build runtime image.
-FROM eclipse-temurin:11.0.19_7-jre
+FROM eclipse-temurin:11-jre
 
 ENV APP_DIR=/usr/src/app
 WORKDIR $APP_DIR
@@ -11,7 +11,7 @@ COPY grpc-interop-testing/ $APP_DIR/
 COPY logging*.properties $APP_DIR/
 ENV JAVA_OPTS="-Djava.util.logging.config.file=$APP_DIR/logging-json.properties"
 
-# Intentially after the app COPY to force the update on each build.
+# Intentionally after the app COPY to force the update on each build.
 # Update Ubuntu system packages:
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/buildscripts/xds-k8s/test-server.Dockerfile
+++ b/buildscripts/xds-k8s/test-server.Dockerfile
@@ -11,5 +11,12 @@ COPY grpc-interop-testing/ $APP_DIR/
 COPY logging*.properties $APP_DIR/
 ENV JAVA_OPTS="-Djava.util.logging.config.file=$APP_DIR/logging-json.properties"
 
+# Intentially after the app COPY to force the update on each build.
+# Update Ubuntu system packages:
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && apt-get -y autoremove \
+    && rm -rf /var/lib/apt/lists/*
+
 # Server
 ENTRYPOINT ["bin/xds-test-server"]

--- a/buildscripts/xds-k8s/test-server.Dockerfile
+++ b/buildscripts/xds-k8s/test-server.Dockerfile
@@ -1,5 +1,5 @@
 # Build runtime image.
-FROM eclipse-temurin:11.0.19_7-jdk
+FROM eclipse-temurin:11.0.19_7-jdk-alpine
 
 ENV APP_DIR=/usr/src/app
 WORKDIR $APP_DIR

--- a/buildscripts/xds-k8s/test-server.Dockerfile
+++ b/buildscripts/xds-k8s/test-server.Dockerfile
@@ -1,5 +1,5 @@
 # Build runtime image.
-FROM openjdk:11.0.19_7-jdk
+FROM eclipse-temurin:11.0.19_7-jdk
 
 ENV APP_DIR=/usr/src/app
 WORKDIR $APP_DIR


### PR DESCRIPTION
- Update to xDS Test Client and xDS test server Docker images to `eclipse-temurin:11-jre`. 
- Perform software update so that we install patches for latest vulnerabilities.