### PR TITLE
gradle: Remove version pinning from POMs

### DIFF
--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -95,8 +95,7 @@ publishing {
                     def dependencyNode = dependenciesNode.appendNode('dependency')
                     dependencyNode.appendNode('groupId', dep.group)
                     dependencyNode.appendNode('artifactId', dep.name)
-                    def version = (dep.name == 'grpc-netty-shaded') ? '[' + dep.version + ']' : dep.version
-                    dependencyNode.appendNode('version', version)
+                    dependencyNode.appendNode('version', dep.version)
                     dependencyNode.appendNode('scope', 'compile')
                 }
                 asNode().dependencies[0].replaceNode(dependenciesNode)

--- a/build.gradle
+++ b/build.gradle
@@ -355,21 +355,6 @@ subprojects {
                                 organizationUrl = "https://www.google.com"
                             }
                         }
-
-                        withXml {
-                            if (!(project.name in
-                            [
-                                "grpc-stub",
-                                "grpc-protobuf",
-                                "grpc-protobuf-lite",
-                            ])) {
-                                asNode().dependencies.'*'.findAll() { dep ->
-                                    dep.artifactId.text() in ['grpc-api', 'grpc-core']
-                                }.each() { core ->
-                                    core.version*.value = "[" + core.version.text() + "]"
-                                }
-                            }
-                        }
                     }
                 }
             }

--- a/googleapis/build.gradle
+++ b/googleapis/build.gradle
@@ -17,20 +17,3 @@ dependencies {
 
     signature libraries.signature.java
 }
-
-publishing {
-    publications {
-        maven(MavenPublication) {
-            pom {
-                withXml {
-                    // Since internal APIs are used, pin the version.
-                    asNode().dependencies.'*'.findAll() { dep ->
-                        dep.artifactId.text() in ['grpc-alts', 'grpc-xds']
-                    }.each() { core ->
-                        core.version*.value = "[" + core.version.text() + "]"
-                    }
-                }
-            }
-        }
-    }
-}

--- a/netty/shaded/build.gradle
+++ b/netty/shaded/build.gradle
@@ -111,15 +111,6 @@ publishing {
                     core.scope*.value = "compile"
                 }
             }
-
-            // shadow.component() is run after the main build.gradle's withXml
-            pom.withXml {
-                asNode().dependencies.'*'.findAll() { dep ->
-                    dep.artifactId.text() in ['grpc-api', 'grpc-core']
-                }.each() { core ->
-                    core.version*.value = "[" + core.version.text() + "]"
-                }
-            }
         }
     }
 }

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -247,8 +247,7 @@ publishing {
                     def dependencyNode = dependenciesNode.appendNode('dependency')
                     dependencyNode.appendNode('groupId', dep.group)
                     dependencyNode.appendNode('artifactId', dep.name)
-                    def version = (dep.name == 'grpc-netty-shaded') ? '[' + dep.version + ']' : dep.version
-                    dependencyNode.appendNode('version', version)
+                    dependencyNode.appendNode('version', dep.version)
                     dependencyNode.appendNode('scope', 'compile')
                 }
                 asNode().dependencies[0].replaceNode(dependenciesNode)


### PR DESCRIPTION
The pinning is unreliable in Maven and ignored by Gradle. I'm not at all convinced that we are pinning/not pinning in appropriate projects. The pinning also serves less of a purpose since we started encouraging the BOM and grpc-netty-shaded. Netty's HTTP/2 API has also become somewhat stable compared to its earlier history. If we notice an up-tick in version skew, we can reinstate it.

The pinning is annoying in the build.gradle code and causes Maven/Gradle to download the version list once a day, which can be troublesome to users unaware of how to tell the tools to work offline.

It also opens our users to platform issues like seen in #10043 and #10086 where Maven Central's version list was incorrectly generated. Or like #9664 where Gradle Plugin's repository caches packages from JCenter but the version list is not as cachable so exposed us to JCenter instability.

This fixes #8357, by way of "we think we won't worry any more." See 90db93b9 when it was originally introduced. And issues like #8337, #3634.