### PR TITLE
examples: Fix hostname binary name in README

### DIFF
--- a/examples/example-hostname/README.md
+++ b/examples/example-hostname/README.md
@@ -24,7 +24,7 @@ runs the example.
 To run the hostname example, run:
 
 ```
-$ ./build/install/hostname/bin/hostname-server
+$ ./build/install/hostname-server/bin/hostname-server
 ```
 
 And in a different terminal window run the hello-world client:


### PR DESCRIPTION
The command has been wrong since it was introduced. The hostname-server comes from the applicationName, which hasn't changed.

Addresses #10169