### PR TITLE
xds interop: Update Docker images to `eclipse-temurin:11-jre` (v1.55.x backport)

### DIFF
--- a/buildscripts/xds-k8s/test-client.Dockerfile
+++ b/buildscripts/xds-k8s/test-client.Dockerfile
@@ -1,5 +1,5 @@
 # Build runtime image.
-FROM openjdk:11.0.9.1-jdk
+FROM eclipse-temurin:11-jre
 
 ENV APP_DIR=/usr/src/app
 WORKDIR $APP_DIR
@@ -10,6 +10,13 @@ COPY grpc-interop-testing/ $APP_DIR/
 # Copy all logging profiles, use json logging by default
 COPY logging*.properties $APP_DIR/
 ENV JAVA_OPTS="-Djava.util.logging.config.file=$APP_DIR/logging-json.properties"
+
+# Intentionally after the app COPY to force the update on each build.
+# Update Ubuntu system packages:
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && apt-get -y autoremove \
+    && rm -rf /var/lib/apt/lists/*
 
 # Client
 ENTRYPOINT ["bin/xds-test-client"]

--- a/buildscripts/xds-k8s/test-server.Dockerfile
+++ b/buildscripts/xds-k8s/test-server.Dockerfile
@@ -1,5 +1,5 @@
 # Build runtime image.
-FROM openjdk:11.0.9.1-jdk
+FROM eclipse-temurin:11-jre
 
 ENV APP_DIR=/usr/src/app
 WORKDIR $APP_DIR
@@ -10,6 +10,13 @@ COPY grpc-interop-testing/ $APP_DIR/
 # Copy all logging profiles, use json logging by default
 COPY logging*.properties $APP_DIR/
 ENV JAVA_OPTS="-Djava.util.logging.config.file=$APP_DIR/logging-json.properties"
+
+# Intentionally after the app COPY to force the update on each build.
+# Update Ubuntu system packages:
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && apt-get -y autoremove \
+    && rm -rf /var/lib/apt/lists/*
 
 # Server
 ENTRYPOINT ["bin/xds-test-server"]


### PR DESCRIPTION
Backport of #10172 to v1.55.x.
---
- Update to xDS Test Client and xDS test server Docker images to `eclipse-temurin:11-jre`. 
- Perform software update so that we install patches for latest vulnerabilities.