### PR TITLE
protobuf: update external javadoc link (v1.48.x backport)

### DIFF
--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -28,4 +28,4 @@ dependencies {
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
 }
 
-javadoc.options.links 'https://developers.google.com/protocol-buffers/docs/reference/java/'
+javadoc.options.links 'https://protobuf.dev/reference/java/api-docs/'


### PR DESCRIPTION
Backport of #9890 to v1.48.x.
---
Builds, both local and on GitHub, have been failing during protobuf javadoc generation  with:

`javadoc: error - Error fetching URL: https://developers.google.com/protocol-buffers/docs/reference/java/`

Looks like this link now redirects to another place and that gradle can't follow that redirect.