### PR TITLE
test: stop mocking Executor.

### DIFF
--- a/cronet/src/test/java/io/grpc/cronet/CronetClientStreamTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientStreamTest.java
@@ -77,11 +77,16 @@ public final class CronetClientStreamTest {
   private Metadata metadata = new Metadata();
   @Mock private StreamBuilderFactory factory;
   @Mock private ExperimentalBidirectionalStream cronetStream;
-  @Mock private Executor executor;
   @Mock private ClientStreamListener clientListener;
   @Mock private ExperimentalBidirectionalStream.Builder builder;
   private final Object lock = new Object();
   private final TransportTracer transportTracer = TransportTracer.getDefaultFactory().create();
+  private final Executor executor = new Executor() {
+      @Override
+      public void execute(Runnable r) {
+        r.run();
+      }
+    };
   CronetClientStream clientStream;
 
   private MethodDescriptor.Marshaller<Void> marshaller = TestMethodDescriptors.voidMarshaller();

--- a/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
@@ -68,10 +68,15 @@ public final class CronetClientTransportTest {
       new ClientStreamTracer[]{ new ClientStreamTracer() {} };
   private CronetClientTransport transport;
   @Mock private StreamBuilderFactory streamFactory;
-  @Mock private Executor executor;
   private MethodDescriptor<Void, Void> descriptor = TestMethodDescriptors.voidMethod();
   @Mock private ManagedClientTransport.Listener clientTransportListener;
   @Mock private BidirectionalStream.Builder builder;
+  private final Executor executor = new Executor() {
+      @Override
+      public void execute(Runnable r) {
+        r.run();
+      }
+    };
 
   @Before
   public void setUp() {


### PR DESCRIPTION
It is forbidden internally. Error message:

Mocking types which have complex contracts or are easy to construct by other means is forbidden:

'executor' is mocking 'interface java.util.concurrent.Executor'. Use a real executor. Mocks of Executor don't execute submitted tasks at all, which leads to suppressed errors, deadlocks, and brittle tests..