### PR TITLE
testing-proto: Define supported SourceVersion in annotation test

### DIFF
--- a/testing-proto/src/test/java/io/grpc/testing/protobuf/SimpleServiceTest.java
+++ b/testing-proto/src/test/java/io/grpc/testing/protobuf/SimpleServiceTest.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.MirroredTypeException;
@@ -78,6 +79,11 @@ public class SimpleServiceTest {
   public static class AnnotationProcessor extends AbstractProcessor {
 
     private boolean processedClass = false;
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+      return SourceVersion.latestSupported();
+    }
 
     @Override
     public Set<String> getSupportedAnnotationTypes() {


### PR DESCRIPTION
This fixes the warning during the test run:
```
warning: No SupportedSourceVersion annotation found on io.grpc.testing.protobuf.SimpleServiceTest$AnnotationProcessor, returning RELEASE_6.
warning: Supported source version 'RELEASE_6' from annotation processor 'io.grpc.testing.protobuf.SimpleServiceTest$AnnotationProcessor' less than -source '1.8'
```

Note: authored by @cushon (cl/532476479)