### PR TITLE
interop client: introduce --additional_metadata flag to let client optionally send extra metadata

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -415,42 +415,6 @@ public abstract class AbstractInteropTest {
         true, true, true, false /* real-time metrics */);
   }
 
-  /* Parses input string as a semi-colon-separated list of colon-separated key/value pairs.
-   * Allow any character but semicolons in values.
-   * If the string is emtpy, return null.
-   * Otherwise, return a client interceptor which inserts the provided metadata.
-   */
-  @Nullable
-  protected final ClientInterceptor maybeCreateAdditionalMetadataInterceptor(
-      String additionalMd)
-      throws IllegalArgumentException {
-    if (additionalMd.length() == 0) {
-      return null;
-    }
-    Metadata m = new Metadata();
-    while (additionalMd.length() > 0) {
-      int i = additionalMd.indexOf(':');
-      if (i < 0) {
-        throw new IllegalArgumentException(
-            "error parsing additional metadata string: no colon separte found");
-      }
-      Metadata.Key<String> key = Metadata.Key.of(
-          additionalMd.substring(0, i), Metadata.ASCII_STRING_MARSHALLER);
-      additionalMd = additionalMd.substring(i + 1);
-      i = additionalMd.indexOf(';');
-      if (i < 0) {
-        m.put(key, additionalMd);
-        break;
-      }
-      m.put(key, additionalMd.substring(0, i));
-      if (i == additionalMd.length() - 1) {
-        break;
-      }
-      additionalMd = additionalMd.substring(i + 1);
-    }
-    return MetadataUtils.newAttachHeadersInterceptor(m);
-  }
-
   /**
    * Override this when custom census module presence is different from {@link #metricsExpected()}.
    */

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -421,7 +421,9 @@ public abstract class AbstractInteropTest {
    * Otherwise, return a client interceptor which inserts the provided metadata.
    */
   @Nullable
-  protected final ClientInterceptor maybeCreateAdditionalMetadataInterceptor(String additionalMd) throws IllegalArgumentException {
+  protected final ClientInterceptor maybeCreateAdditionalMetadataInterceptor(
+      String additionalMd)
+      throws IllegalArgumentException {
     if (additionalMd.length() == 0) {
       return null;
     }
@@ -429,9 +431,11 @@ public abstract class AbstractInteropTest {
     while (additionalMd.length() > 0) {
       int i = additionalMd.indexOf(':');
       if (i < 0) {
-        throw new IllegalArgumentException("error parsing additional metadata string: no colon separte found");
+        throw new IllegalArgumentException(
+            "error parsing additional metadata string: no colon separte found");
       }
-      Metadata.Key<String> key = Metadata.Key.of(additionalMd.substring(0, i), Metadata.ASCII_STRING_MARSHALLER);
+      Metadata.Key<String> key = Metadata.Key.of(
+          additionalMd.substring(0, i), Metadata.ASCII_STRING_MARSHALLER);
       additionalMd = additionalMd.substring(i + 1);
       i = additionalMd.indexOf(';');
       if (i < 0) {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -607,7 +607,7 @@ public class TestServiceClient {
           nettyBuilder.defaultServiceConfig(serviceConfig);
         }
         if (addMdInterceptor != null) {
-          channelBuilder.intercept(addMdInterceptor);
+          nettyBuilder.intercept(addMdInterceptor);
         }
         return nettyBuilder.intercept(createCensusStatsClientInterceptor());
       }
@@ -633,7 +633,7 @@ public class TestServiceClient {
         okBuilder.defaultServiceConfig(serviceConfig);
       }
       if (addMdInterceptor != null) {
-        channelBuilder.intercept(addMdInterceptor);
+        okBuilder.intercept(addMdInterceptor);
       }
       return okBuilder.intercept(createCensusStatsClientInterceptor());
     }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -533,7 +533,6 @@ public class TestServiceClient {
     for (String pair : pairs) {
       String[] parts = pair.split(':', 2);
       if (parts.length != 2) {
-        throw new Blah();
         throw new IllegalArgumentException(
             "error parsing --additional_metadata string, expected k:v pairs separated by ;");
       }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -98,7 +98,7 @@ public class TestServiceClient {
   private int soakMinTimeMsBetweenRpcs = 0;
   private int soakOverallTimeoutSeconds =
       soakIterations * soakPerIterationMaxAcceptableLatencyMs / 1000;
-  private String additionalMetadata;
+  private String additionalMetadata = "";
   private static LoadBalancerProvider customBackendMetricsLoadBalancerProvider;
 
   private Tester tester = new Tester();

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -529,9 +529,9 @@ public class TestServiceClient {
       return null;
     }
     Metadata metadata = new Metadata();
-    String[] pairs = additionalMd.split(';', -1);
+    String[] pairs = additionalMd.split(";", -1);
     for (String pair : pairs) {
-      String[] parts = pair.split(':', 2);
+      String[] parts = pair.split(":", 2);
       if (parts.length != 2) {
         throw new IllegalArgumentException(
             "error parsing --additional_metadata string, expected k:v pairs separated by ;");

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -528,28 +528,19 @@ public class TestServiceClient {
     if (additionalMd.length() == 0) {
       return null;
     }
-    Metadata m = new Metadata();
-    while (additionalMd.length() > 0) {
-      int i = additionalMd.indexOf(':');
-      if (i < 0) {
+    Metadata metadata = new Metadata();
+    String[] pairs = additionalMd.split(';', -1);
+    for (String pair : pairs) {
+      String[] parts = pair.split(':', 2);
+      if (parts.length != 2) {
+        throw new Blah();
         throw new IllegalArgumentException(
-            "error parsing additional metadata string: no colon separte found");
+            "error parsing --additional_metadata string, expected k:v pairs separated by ;");
       }
-      Metadata.Key<String> key = Metadata.Key.of(
-          additionalMd.substring(0, i), Metadata.ASCII_STRING_MARSHALLER);
-      additionalMd = additionalMd.substring(i + 1);
-      i = additionalMd.indexOf(';');
-      if (i < 0) {
-        m.put(key, additionalMd);
-        break;
-      }
-      m.put(key, additionalMd.substring(0, i));
-      if (i == additionalMd.length() - 1) {
-        break;
-      }
-      additionalMd = additionalMd.substring(i + 1);
+      Metadata.Key<String> key = Metadata.Key.of(parts[0], Metadata.ASCII_STRING_MARSHALLER);
+      metadata.put(key, parts[1]);
     }
-    return MetadataUtils.newAttachHeadersInterceptor(m);
+    return MetadataUtils.newAttachHeadersInterceptor(metadata);
   }
 
   private class Tester extends AbstractInteropTest {


### PR DESCRIPTION
This is a Java analogue of a C++ PR from a while ago: https://github.com/grpc/grpc/pull/18156/files

Also created a Go PR in https://github.com/grpc/grpc-go/pull/6295 to do the same thing.

This flag will be useful for some RLS integration tests where we need to have the client set certain headers for routing purposes.

cc @temawi @ejona86 