### PR TITLE
Encode the service authority in xDSNameResolver

### DIFF
--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -895,9 +895,19 @@ public final class GrpcUtil {
         .unmodifiableSet(new HashSet<>(Arrays.asList(':', '[', ']', '@')));
 
     private static boolean shouldEscape(char c) {
-      if (Character.isLetterOrDigit(c)) {
+      // Only encode ASCII.
+      if (c > 127) {
         return false;
       }
+      // Letters don't need an escape.
+      if (((c >= 'a') && (c <= 'z')) || ((c >= 'A') && (c <= 'Z'))) {
+        return false;
+      }
+      // Numbers don't need to be escaped.
+      if ((c >= '0' && c <= '9'))  {
+        return false;
+      }
+      // Don't escape allowed characters.
       if (UNRESERVED_CHARACTERS.contains(c)
           || SUB_DELIMS.contains(c)
           || AUTHORITY_DELIMS.contains(c)) {

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -91,7 +91,7 @@ public final class GrpcUtil {
           Status.Code.ABORTED,
           Status.Code.OUT_OF_RANGE,
           Status.Code.DATA_LOSS));
-  
+
   public static final Charset US_ASCII = Charset.forName("US-ASCII");
 
   /**

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -526,8 +526,8 @@ public final class GrpcUtil {
    */
   public static String checkAuthority(String authority) {
     URI uri = authorityToUri(authority);
-    checkArgument(uri.getHost() != null, "No host in authority '%s'", authority);
-    checkArgument(uri.getUserInfo() == null,
+    // Verify that the user Info is not provided.
+    checkArgument(uri.getAuthority().indexOf('@') == -1,
         "Userinfo must not be present on authority: '%s'", authority);
     return authority;
   }

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -864,71 +864,78 @@ public final class GrpcUtil {
   /**
    * Percent encode the {@code authority} based on
    * https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.
-   * 
+   *
    * <p>When escaping a String, the following rules apply:
    *
    * <ul>
-   *   <li>The alphanumeric characters "a" through "z", "A" through "Z" and "0" through "9" remain 
+   *   <li>The alphanumeric characters "a" through "z", "A" through "Z" and "0" through "9" remain
    *       the same.
    *   <li>The unreserved characters ".", "-", "~", and "_" remain the same.
    *   <li>The general delimiters for authority, "[", "]", "@" and ":" remain the same.
    *   <li>The subdelimiters "!", "$", "&amp;", "'", "(", ")", "*", "+", ",", ";", and "=" remain
    *       the same.
    *   <li>The space character " " is converted into %20.
-   *   <li>All other characters are converted into one or more bytes using UTF-8 encoding and 
-   *       each byte is then represented by the 3-character string "%XY", where "XY" is the 
-   *       two-digit, uppercase, hexadecimal representation of the byte value.
+   *   <li>All other characters are converted into one or more bytes using UTF-8 encoding and each
+   *       byte is then represented by the 3-character string "%XY", where "XY" is the two-digit,
+   *       uppercase, hexadecimal representation of the byte value.
    * </ul>
+   * 
+   * <p>This section does not use URLEscapers from Guava Net as its not Android-friendly thus core
+   *    can't depend on it.
    */
   public static class AuthorityEscaper {
     // Escapers should output upper case hex digits.
     private static final char[] UPPER_HEX_DIGITS = "0123456789ABCDEF".toCharArray();
-    private static final Set<Character> unreservedCharacters = new HashSet<>(Arrays.asList('-', '_', '.', '~'));
-    private static final Set<Character> subdelimiters = new HashSet<>(
-        Arrays.asList('!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '='));
-    private static final Set<Character> authorityDelims = new HashSet<>(Arrays.asList(':', '[', ']', '@'));
+    private static final Set<Character> unreservedCharacters =
+        new HashSet<>(Arrays.asList('-', '_', '.', '~'));
+    private static final Set<Character> subdelimiters =
+        new HashSet<>(Arrays.asList('!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '='));
+    private static final Set<Character> authorityDelims =
+        new HashSet<>(Arrays.asList(':', '[', ']', '@'));
 
     private static boolean shouldEscape(char c) {
       if (Character.isLetterOrDigit(c)) {
         return false;
       }
-      if (unreservedCharacters.contains(c) || subdelimiters.contains(c) || authorityDelims.contains(c)) {
+      if (unreservedCharacters.contains(c)
+          || subdelimiters.contains(c)
+          || authorityDelims.contains(c)) {
         return false;
       }
       return true;
     }
 
-  public static String encodeAuthority(String authority) {
-    Preconditions.checkNotNull(authority, "authority");
-    int authorityLength = authority.length();
-    int hexCount = 0;
-    // Calculate how many characters actually need escaping.
-    for (int index = 0; index < authorityLength; index++) {
-      char c = authority.charAt(index);
-      if (shouldEscape(c)) {
-        hexCount++;
+    public static String encodeAuthority(String authority) {
+      Preconditions.checkNotNull(authority, "authority");
+      int authorityLength = authority.length();
+      int hexCount = 0;
+      // Calculate how many characters actually need escaping.
+      for (int index = 0; index < authorityLength; index++) {
+        char c = authority.charAt(index);
+        if (shouldEscape(c)) {
+          hexCount++;
+        }
       }
-    }
-    // If no char need escaping, just return the original string back.
-    if (hexCount == 0) {
-      return authority;
-    }
+      // If no char need escaping, just return the original string back.
+      if (hexCount == 0) {
+        return authority;
+      }
 
-    // Allocate enough space as encoded characters need 2 extra chars.
-    StringBuilder encoded_authority = new StringBuilder( (2 * hexCount) + authorityLength);
-    for (int index = 0; index < authorityLength; index++) {
-      char c = authority.charAt(index);
-      if (shouldEscape(c)) {
-         encoded_authority.append('%');
-         encoded_authority.append(UPPER_HEX_DIGITS[c >>> 4]);
-         encoded_authority.append(UPPER_HEX_DIGITS[c & 0xF]);
-      } else {
-        encoded_authority.append(c);
+      // Allocate enough space as encoded characters need 2 extra chars.
+      StringBuilder encoded_authority = new StringBuilder((2 * hexCount) + authorityLength);
+      for (int index = 0; index < authorityLength; index++) {
+        char c = authority.charAt(index);
+        if (shouldEscape(c)) {
+          encoded_authority.append('%');
+          encoded_authority.append(UPPER_HEX_DIGITS[c >>> 4]);
+          encoded_authority.append(UPPER_HEX_DIGITS[c & 0xF]);
+        } else {
+          encoded_authority.append(c);
+        }
       }
+      return encoded_authority.toString();
     }
-    return encoded_authority.toString();
   }
- }
 
   private GrpcUtil() {}
 }

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -886,20 +886,21 @@ public final class GrpcUtil {
   public static class AuthorityEscaper {
     // Escapers should output upper case hex digits.
     private static final char[] UPPER_HEX_DIGITS = "0123456789ABCDEF".toCharArray();
-    private static final Set<Character> unreservedCharacters =
-        new HashSet<>(Arrays.asList('-', '_', '.', '~'));
-    private static final Set<Character> subdelimiters =
-        new HashSet<>(Arrays.asList('!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '='));
-    private static final Set<Character> authorityDelims =
-        new HashSet<>(Arrays.asList(':', '[', ']', '@'));
+    private static final Set<Character> UNRESERVED_CHARACTERS = Collections
+        .unmodifiableSet(new HashSet<>(Arrays.asList('-', '_', '.', '~')));
+    private static final Set<Character> SUB_DELIMS = Collections
+        .unmodifiableSet(new HashSet<>(
+            Arrays.asList('!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=')));
+    private static final Set<Character> AUTHORITY_DELIMS = Collections
+        .unmodifiableSet(new HashSet<>(Arrays.asList(':', '[', ']', '@')));
 
     private static boolean shouldEscape(char c) {
       if (Character.isLetterOrDigit(c)) {
         return false;
       }
-      if (unreservedCharacters.contains(c)
-          || subdelimiters.contains(c)
-          || authorityDelims.contains(c)) {
+      if (UNRESERVED_CHARACTERS.contains(c)
+          || SUB_DELIMS.contains(c)
+          || AUTHORITY_DELIMS.contains(c)) {
         return false;
       }
       return true;

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -25,6 +25,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
+import com.google.common.escape.Escaper;
+import com.google.common.net.PercentEscaper;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.grpc.CallOptions;
@@ -90,6 +92,34 @@ public final class GrpcUtil {
           Status.Code.OUT_OF_RANGE,
           Status.Code.DATA_LOSS));
 
+  private static final String URL_AUTHORITY_SAFE_CHARS = "-._~" // Unreserved characters.
+      + "!$&'()*+,;=" // The subdelim characters
+      + ":[]@"; // The gendelim characters permitted in authority.
+
+  private static final Escaper URL_AUTHORITY_ESCAPER = new PercentEscaper(URL_AUTHORITY_SAFE_CHARS, false);
+  
+  /**
+   * Percent encode the {@code authority} based on
+   * https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.
+   * 
+   * <p>
+   * When escaping a String, the following rules apply:
+   *
+   * <ul>
+   *  <li>The alphanumeric characters "a" through "z", "A" through "Z" and "0" through "9" remain the same.
+   *  <li>The unreserved characters ".", "-", "~", and "_" remain the same.
+   *  <li>The general delimiters for authority, "[", "]", "@" and ":" remain the
+   *      same.
+   *  <li>The subdelimiters "!", "$", "&amp;", "'", "(", ")", "*", "+", ",", ";", and "=" remain the same.
+   *  <li>The space character " " is converted into %20.
+   *  <li>All other characters are converted into one or more bytes using UTF-8 encoding and each byte is then 
+   *      represented by the 3-character string "%XY", where "XY" is the two-digit, uppercase, hexadecimal 
+   *      representation of the byte value.
+   */
+  public static Escaper urlAuthorityEscaper() {
+    return URL_AUTHORITY_ESCAPER;
+  }
+  
   public static final Charset US_ASCII = Charset.forName("US-ASCII");
 
   /**

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -96,7 +96,8 @@ public final class GrpcUtil {
       + "!$&'()*+,;=" // The subdelim characters
       + ":[]@"; // The gendelim characters permitted in authority.
 
-  private static final Escaper URL_AUTHORITY_ESCAPER = new PercentEscaper(URL_AUTHORITY_SAFE_CHARS, false);
+  private static final Escaper URL_AUTHORITY_ESCAPER = new PercentEscaper(URL_AUTHORITY_SAFE_CHARS,
+      false);
   
   /**
    * Percent encode the {@code authority} based on
@@ -106,15 +107,18 @@ public final class GrpcUtil {
    * When escaping a String, the following rules apply:
    *
    * <ul>
-   *  <li>The alphanumeric characters "a" through "z", "A" through "Z" and "0" through "9" remain the same.
+   *  <li>The alphanumeric characters "a" through "z", "A" through "Z" and "0" through "9" remain 
+   *      the same.
    *  <li>The unreserved characters ".", "-", "~", and "_" remain the same.
    *  <li>The general delimiters for authority, "[", "]", "@" and ":" remain the
    *      same.
-   *  <li>The subdelimiters "!", "$", "&amp;", "'", "(", ")", "*", "+", ",", ";", and "=" remain the same.
+   *  <li>The subdelimiters "!", "$", "&amp;", "'", "(", ")", "*", "+", ",", ";", and "=" remain
+   *      the same.
    *  <li>The space character " " is converted into %20.
-   *  <li>All other characters are converted into one or more bytes using UTF-8 encoding and each byte is then 
-   *      represented by the 3-character string "%XY", where "XY" is the two-digit, uppercase, hexadecimal 
-   *      representation of the byte value.
+   *  <li>All other characters are converted into one or more bytes using UTF-8 encoding and 
+   *      each byte is then represented by the 3-character string "%XY", where "XY" is the 
+   *      two-digit, uppercase, hexadecimal representation of the byte value.
+   * </ul>
    */
   public static Escaper urlAuthorityEscaper() {
     return URL_AUTHORITY_ESCAPER;

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -103,8 +103,7 @@ public final class GrpcUtil {
    * Percent encode the {@code authority} based on
    * https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.
    * 
-   * <p>
-   * When escaping a String, the following rules apply:
+   * <p>When escaping a String, the following rules apply:
    *
    * <ul>
    *  <li>The alphanumeric characters "a" through "z", "A" through "Z" and "0" through "9" remain 

--- a/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
+++ b/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
@@ -164,6 +164,28 @@ public class GrpcUtilTest {
   }
 
   @Test
+  public void urlAuthorityEscape_ipv6Address() {
+    assertEquals(GrpcUtil.urlAuthorityEscaper().escape("[::1]"), "[::1]");
+  }
+
+  @Test
+  public void urlAuthorityEscape_userInAuthority() {
+    assertEquals(GrpcUtil.urlAuthorityEscaper().escape("user@host"), "user@host");
+  }
+
+  @Test
+  public void urlAuthorityEscape_slashesAreEncoded() {
+    assertEquals(GrpcUtil.urlAuthorityEscaper().escape("project/123/network/abc/service"),
+        "project%2F123%2Fnetwork%2Fabc%2Fservice");
+  }
+
+  @Test
+  public void urlAuthorityEscape_allowedCharsAreNotEncoded() {
+    assertEquals(GrpcUtil.urlAuthorityEscaper().escape("-._~!$&'()*+,;=@:[]"),
+        "-._~!$&'()*+,;=@:[]");
+  }
+
+  @Test
   public void checkAuthority_failsOnNull() {
     thrown.expect(NullPointerException.class);
 

--- a/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
+++ b/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
@@ -196,7 +196,7 @@ public class GrpcUtilTest {
   @Test
   public void urlAuthorityEscape_unicodeAreNotEncoded() {
     assertEquals(
-        "\u00F6\u00AE", GrpcUtil.AuthorityEscaper.encodeAuthority("\u00F6\u00AE"));
+        "ö®", GrpcUtil.AuthorityEscaper.encodeAuthority("ö®"));
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
+++ b/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
@@ -165,24 +165,25 @@ public class GrpcUtilTest {
 
   @Test
   public void urlAuthorityEscape_ipv6Address() {
-    assertEquals(GrpcUtil.urlAuthorityEscaper().escape("[::1]"), "[::1]");
+    assertEquals("[::1]", GrpcUtil.AuthorityEscaper.encodeAuthority("[::1]"));
   }
 
   @Test
   public void urlAuthorityEscape_userInAuthority() {
-    assertEquals(GrpcUtil.urlAuthorityEscaper().escape("user@host"), "user@host");
+    assertEquals("user@host", GrpcUtil.AuthorityEscaper.encodeAuthority("user@host"));
   }
 
   @Test
   public void urlAuthorityEscape_slashesAreEncoded() {
-    assertEquals(GrpcUtil.urlAuthorityEscaper().escape("project/123/network/abc/service"),
-        "project%2F123%2Fnetwork%2Fabc%2Fservice");
+    assertEquals(
+        "project%2F123%2Fnetwork%2Fabc%2Fservice",
+        GrpcUtil.AuthorityEscaper.encodeAuthority("project/123/network/abc/service"));
   }
 
   @Test
   public void urlAuthorityEscape_allowedCharsAreNotEncoded() {
-    assertEquals(GrpcUtil.urlAuthorityEscaper().escape("-._~!$&'()*+,;=@:[]"),
-        "-._~!$&'()*+,;=@:[]");
+    assertEquals(
+        "-._~!$&'()*+,;=@:[]", GrpcUtil.AuthorityEscaper.encodeAuthority("-._~!$&'()*+,;=@:[]"));
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
+++ b/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
@@ -199,13 +199,6 @@ public class GrpcUtilTest {
     GrpcUtil.checkAuthority("[ : : 1]");
   }
 
-  @Test
-  public void checkAuthority_failsOnInvalidHost() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("No host in authority");
-
-    GrpcUtil.checkAuthority("bad_host");
-  }
 
   @Test
   public void checkAuthority_userInfoNotAllowed() {

--- a/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
+++ b/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
@@ -187,6 +187,19 @@ public class GrpcUtilTest {
   }
 
   @Test
+  public void urlAuthorityEscape_allLettersAndNumbers() {
+    assertEquals(
+        "abcdefghijklmnopqrstuvwxyz0123456789",
+        GrpcUtil.AuthorityEscaper.encodeAuthority("abcdefghijklmnopqrstuvwxyz0123456789"));
+  }
+
+  @Test
+  public void urlAuthorityEscape_unicodeAreNotEncoded() {
+    assertEquals(
+        "\u00F6\u00AE", GrpcUtil.AuthorityEscaper.encodeAuthority("\u00F6\u00AE"));
+  }
+
+  @Test
   public void checkAuthority_failsOnNull() {
     thrown.expect(NullPointerException.class);
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
@@ -368,7 +368,7 @@ public class ManagedChannelImplBuilderTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void overrideAuthority_invalid() {
-    builder.overrideAuthority("not_allowed");
+    builder.overrideAuthority("user@not_allowed");
   }
 
   @Test

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -150,7 +150,7 @@ final class XdsNameResolver extends NameResolver {
 
     // The name might have multiple slashes so encode it before verifying.
     // If the encoding fails, fallback to the non-encoded string.
-    String authority = GrpcUtil.urlAuthorityEscaper().escape(checkNotNull(name, "name"));
+    String authority = GrpcUtil.AuthorityEscaper.encodeAuthority(checkNotNull(name, "name"));
     
     // Verify the authority using encoding, but use non-escaped version for
     // serviceAuthority.

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -101,6 +101,8 @@ final class XdsNameResolver extends NameResolver {
   static boolean enableTimeout =
       Strings.isNullOrEmpty(System.getenv("GRPC_XDS_EXPERIMENTAL_ENABLE_TIMEOUT"))
           || Boolean.parseBoolean(System.getenv("GRPC_XDS_EXPERIMENTAL_ENABLE_TIMEOUT"));
+  
+  private static String authorityEncoding = "UTF-8";
 
   private final InternalLogId logId;
   private final XdsLogger logger;
@@ -157,12 +159,10 @@ final class XdsNameResolver extends NameResolver {
     // The name might have multiple slashes so encode it before verifying.
     // If the encoding fails, fallback to the non-encoded string.
     try {
-      authority = URLEncoder.encode(checkNotNull(name, "name"), "UTF-8");
+      authority = URLEncoder.encode(checkNotNull(name, "name"), authorityEncoding);
     } catch (UnsupportedEncodingException e) {
-      // If UTF-8 is unsupported fallback to non-encoded path.
-      logger.log(XdsLogLevel.ERROR,
-          "Encoding of authority failed, falling back to non-encoded string");
-      authority = name;
+      // This should never happen since all JVMs must support UTF-8.
+      throw new RuntimeException(e);
     }
     // Verify the authority using encoding, but use non-decoded version for
     // serviceAuthority.

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -68,7 +68,6 @@ import io.grpc.xds.XdsNameResolverProvider.CallCounterProvider;
 import io.grpc.xds.XdsNameResolverProvider.XdsClientPoolFactory;
 import io.grpc.xds.XdsRouteConfigureResource.RdsUpdate;
 import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -149,13 +149,8 @@ final class XdsNameResolver extends NameResolver {
     this.targetAuthority = targetAuthority;
 
     // The name might have multiple slashes so encode it before verifying.
-    // If the encoding fails, fallback to the non-encoded string.
     String authority = GrpcUtil.AuthorityEscaper.encodeAuthority(checkNotNull(name, "name"));
-    
-    // Verify the authority using encoding, but use non-escaped version for
-    // serviceAuthority.
-    GrpcUtil.checkAuthority(authority);
-    serviceAuthority = name;
+    serviceAuthority = GrpcUtil.checkAuthority(authority);
 
     this.overrideAuthority = overrideAuthority;
     this.serviceConfigParser = checkNotNull(serviceConfigParser, "serviceConfigParser");

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -26,7 +26,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
-import com.google.common.net.UrlEscapers;
 import com.google.gson.Gson;
 import com.google.protobuf.util.Durations;
 import io.grpc.Attributes;
@@ -151,7 +150,7 @@ final class XdsNameResolver extends NameResolver {
 
     // The name might have multiple slashes so encode it before verifying.
     // If the encoding fails, fallback to the non-encoded string.
-    String authority = UrlEscapers.urlPathSegmentEscaper().escape(checkNotNull(name, "name"));
+    String authority = GrpcUtil.urlAuthorityEscaper().escape(checkNotNull(name, "name"));
     
     // Verify the authority using encoding, but use non-escaped version for
     // serviceAuthority.

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -154,7 +154,7 @@ final class XdsNameResolver extends NameResolver {
     logger = XdsLogger.withLogId(logId);
     String authority;
 
-    //  The name might have multiple slashes so encode it before verifying.
+    // The name might have multiple slashes so encode it before verifying.
     // If the encoding fails, fallback to the non-encoded string.
     try {
       authority = URLEncoder.encode(checkNotNull(name, "name"), "UTF-8");

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -153,7 +153,7 @@ final class XdsNameResolver extends NameResolver {
     // If the encoding fails, fallback to the non-encoded string.
     String authority = UrlEscapers.urlPathSegmentEscaper().escape(checkNotNull(name, "name"));
     
-    // Verify the authority using encoding, but use non-decoded version for
+    // Verify the authority using encoding, but use non-escaped version for
     // serviceAuthority.
     GrpcUtil.checkAuthority(authority);
     serviceAuthority = name;

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -67,7 +67,6 @@ import io.grpc.xds.XdsLogger.XdsLogLevel;
 import io.grpc.xds.XdsNameResolverProvider.CallCounterProvider;
 import io.grpc.xds.XdsNameResolverProvider.XdsClientPoolFactory;
 import io.grpc.xds.XdsRouteConfigureResource.RdsUpdate;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -160,7 +160,8 @@ final class XdsNameResolver extends NameResolver {
       authority = URLEncoder.encode(checkNotNull(name, "name"), "UTF-8");
     } catch (UnsupportedEncodingException e) {
       // If UTF-8 is unsupported fallback to non-encoded path.
-      logger.log(XdsLogLevel.ERROR, "Encoding of authority failed, falling back to non-encoded string");
+      logger.log(XdsLogLevel.ERROR,
+          "Encoding of authority failed, falling back to non-encoded string");
       authority = name;
     }
     // Verify the authority using encoding, but use non-decoded version for

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -100,7 +100,7 @@ final class XdsNameResolver extends NameResolver {
   static boolean enableTimeout =
       Strings.isNullOrEmpty(System.getenv("GRPC_XDS_EXPERIMENTAL_ENABLE_TIMEOUT"))
           || Boolean.parseBoolean(System.getenv("GRPC_XDS_EXPERIMENTAL_ENABLE_TIMEOUT"));
-  
+
   private final InternalLogId logId;
   private final XdsLogger logger;
   @Nullable
@@ -149,7 +149,6 @@ final class XdsNameResolver extends NameResolver {
       FilterRegistry filterRegistry, @Nullable Map<String, ?> bootstrapOverride) {
     this.targetAuthority = targetAuthority;
 
-
     // The name might have multiple slashes so encode it before verifying.
     // If the encoding fails, fallback to the non-encoded string.
     String authority = UrlEscapers.urlPathSegmentEscaper().escape(checkNotNull(name, "name"));
@@ -169,7 +168,6 @@ final class XdsNameResolver extends NameResolver {
     this.random = checkNotNull(random, "random");
     this.filterRegistry = checkNotNull(filterRegistry, "filterRegistry");
     randomChannelId = random.nextLong();
-
     logId = InternalLogId.allocate("xds-resolver", name);
     logger = XdsLogger.withLogId(logId);
     logger.log(XdsLogLevel.INFO, "Created resolver for {0}", name);

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
@@ -64,12 +64,12 @@ public final class XdsNameResolverProvider extends NameResolverProvider {
    * and bootstrap.
    */
   public static XdsNameResolverProvider createForTest(String scheme,
-      @Nullable Map<String, ?> bootstrapOverride) {
+                                                      @Nullable Map<String, ?> bootstrapOverride) {
     return new XdsNameResolverProvider(scheme, bootstrapOverride);
   }
 
   @Override
-  public XdsNameResolver newNameResolver(URI targetUri, Args args)  {
+  public XdsNameResolver newNameResolver(URI targetUri, Args args) {
     if (scheme.equals(targetUri.getScheme())) {
       String targetPath = checkNotNull(targetUri.getPath(), "targetPath");
       Preconditions.checkArgument(

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
@@ -23,9 +23,12 @@ import io.grpc.Internal;
 import io.grpc.NameResolver.Args;
 import io.grpc.NameResolverProvider;
 import io.grpc.internal.ObjectPool;
+
+
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -64,12 +67,12 @@ public final class XdsNameResolverProvider extends NameResolverProvider {
    * and bootstrap.
    */
   public static XdsNameResolverProvider createForTest(String scheme,
-                                                      @Nullable Map<String, ?> bootstrapOverride) {
+      @Nullable Map<String, ?> bootstrapOverride) {
     return new XdsNameResolverProvider(scheme, bootstrapOverride);
   }
 
   @Override
-  public XdsNameResolver newNameResolver(URI targetUri, Args args) {
+  public XdsNameResolver newNameResolver(URI targetUri, Args args)  {
     if (scheme.equals(targetUri.getScheme())) {
       String targetPath = checkNotNull(targetUri.getPath(), "targetPath");
       Preconditions.checkArgument(

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
@@ -23,12 +23,9 @@ import io.grpc.Internal;
 import io.grpc.NameResolver.Args;
 import io.grpc.NameResolverProvider;
 import io.grpc.internal.ObjectPool;
-
-
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverProviderTest.java
@@ -103,21 +103,26 @@ public class XdsNameResolverProviderTest {
 
   @Test
   public void validName_noAuthority() {
-    XdsNameResolver resolver =
-        provider.newNameResolver(URI.create("xds:///foo.googleapis.com"), args);
+    XdsNameResolver resolver = provider.newNameResolver(URI.create("xds:///foo.googleapis.com"), args);
     assertThat(resolver).isNotNull();
     assertThat(resolver.getServiceAuthority()).isEqualTo("foo.googleapis.com");
   }
 
   @Test
-  public void invalidName_hostnameContainsUnderscore() {
-    URI uri = URI.create("xds:///foo_bar.googleapis.com");
-    try {
-      provider.newNameResolver(uri, args);
-      fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) {
-      // Expected
-    }
+  public void validName_urlExtractedAuthorityInvalidWithoutEncoding() {
+    XdsNameResolver resolver = provider.newNameResolver(URI.create("xds:///1234/path/foo.googleapis.com:8080"),
+        args);
+    assertThat(resolver).isNotNull();
+    assertThat(resolver.getServiceAuthority()).isEqualTo("1234/path/foo.googleapis.com:8080");
+  }
+
+  @Test
+  public void validName_urlwithTargetAuthorityAndExtractedAuthorityInvalidWithoutEncoding() {
+    XdsNameResolver resolver = provider.newNameResolver(
+        URI.create("xds://trafficdirector.google.com/1234/path-to-service/foo.googleapis.com:8080"),
+        args);
+    assertThat(resolver).isNotNull();
+    assertThat(resolver.getServiceAuthority()).isEqualTo("1234/path-to-service/foo.googleapis.com:8080");
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverProviderTest.java
@@ -114,7 +114,7 @@ public class XdsNameResolverProviderTest {
     XdsNameResolver resolver = 
         provider.newNameResolver(URI.create("xds:///1234/path/foo.googleapis.com:8080"), args);
     assertThat(resolver).isNotNull();
-    assertThat(resolver.getServiceAuthority()).isEqualTo("1234/path/foo.googleapis.com:8080");
+    assertThat(resolver.getServiceAuthority()).isEqualTo("1234%2Fpath%2Ffoo.googleapis.com:8080");
   }
 
   @Test
@@ -122,7 +122,7 @@ public class XdsNameResolverProviderTest {
     XdsNameResolver resolver = provider.newNameResolver(URI.create(
         "xds://trafficdirector.google.com/1234/path/foo.googleapis.com:8080"), args);
     assertThat(resolver).isNotNull();
-    assertThat(resolver.getServiceAuthority()).isEqualTo("1234/path/foo.googleapis.com:8080");
+    assertThat(resolver.getServiceAuthority()).isEqualTo("1234%2Fpath%2Ffoo.googleapis.com:8080");
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverProviderTest.java
@@ -103,26 +103,26 @@ public class XdsNameResolverProviderTest {
 
   @Test
   public void validName_noAuthority() {
-    XdsNameResolver resolver = provider.newNameResolver(URI.create("xds:///foo.googleapis.com"), args);
+    XdsNameResolver resolver = 
+        provider.newNameResolver(URI.create("xds:///foo.googleapis.com"), args);
     assertThat(resolver).isNotNull();
     assertThat(resolver.getServiceAuthority()).isEqualTo("foo.googleapis.com");
   }
 
   @Test
   public void validName_urlExtractedAuthorityInvalidWithoutEncoding() {
-    XdsNameResolver resolver = provider.newNameResolver(URI.create("xds:///1234/path/foo.googleapis.com:8080"),
-        args);
+    XdsNameResolver resolver = 
+        provider.newNameResolver(URI.create("xds:///1234/path/foo.googleapis.com:8080"), args);
     assertThat(resolver).isNotNull();
     assertThat(resolver.getServiceAuthority()).isEqualTo("1234/path/foo.googleapis.com:8080");
   }
 
   @Test
   public void validName_urlwithTargetAuthorityAndExtractedAuthorityInvalidWithoutEncoding() {
-    XdsNameResolver resolver = provider.newNameResolver(
-        URI.create("xds://trafficdirector.google.com/1234/path-to-service/foo.googleapis.com:8080"),
-        args);
+    XdsNameResolver resolver = provider.newNameResolver(URI.create(
+        "xds://trafficdirector.google.com/1234/path/foo.googleapis.com:8080"), args);
     assertThat(resolver).isNotNull();
-    assertThat(resolver.getServiceAuthority()).isEqualTo("1234/path-to-service/foo.googleapis.com:8080");
+    assertThat(resolver.getServiceAuthority()).isEqualTo("1234/path/foo.googleapis.com:8080");
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverProviderTest.java
@@ -103,7 +103,7 @@ public class XdsNameResolverProviderTest {
 
   @Test
   public void validName_noAuthority() {
-    XdsNameResolver resolver = 
+    XdsNameResolver resolver =
         provider.newNameResolver(URI.create("xds:///foo.googleapis.com"), args);
     assertThat(resolver).isNotNull();
     assertThat(resolver.getServiceAuthority()).isEqualTo("foo.googleapis.com");


### PR DESCRIPTION
Encode the service authority before passing it into gRPC util in the xDS name resolver to handle xDS requests which might contain multiple slashes. Example: xds:///path/to/service:port.

As currently the underlying Java URI library does not break the encoded authority into host/port correctly simplify the check to just look for '@' as we are only interested in checking for user info to validate the authority for HTTP.

This change also leads to few changes in unit tests that relied on this check for invalid authorities which now will be considered valid. 

Just like https://github.com/grpc/grpc-java/pull/9376, depending on Guava packages such as URLEscapers or PercentEscapers leads to internal failures(Ex: Unresolvable reference to com.google.common.escape.Escaper from io.grpc.internal.GrpcUtil). To avoid these issues create an in house version that is heavily inspired by grpc-go/grpc.

cc: @ejona86 