### PR TITLE
api: Stabilize io.grpc.CallCredentials

### DIFF
--- a/api/src/main/java/io/grpc/CallCredentials.java
+++ b/api/src/main/java/io/grpc/CallCredentials.java
@@ -56,18 +56,19 @@ public abstract class CallCredentials {
       RequestInfo requestInfo, Executor appExecutor, CallCredentials.MetadataApplier applier);
 
   /**
-   * Should be a noop but never called; tries to make it clearer to implementors that they may break
-   * in the future.
+   * With this class now being stable this method moves from an abstract one to a normal one with
+   * a no-op implementation. This method is marked deprecated to allow extenders time to remove the
+   * method before it is removed here.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
-  public abstract void thisUsesUnstableApi();
+  @Deprecated
+  public void thisUsesUnstableApi() {
+  }
 
   /**
    * The outlet of the produced headers. Not thread-safe.
    *
    * <p>Exactly one of its methods must be called to make the RPC proceed.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
   public abstract static class MetadataApplier {
     /**
      * Called when headers are successfully generated. They will be merged into the original
@@ -84,7 +85,6 @@ public abstract class CallCredentials {
   /**
    * The request-related information passed to {@code CallCredentials.applyRequestMetadata()}.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
   public abstract static class RequestInfo {
     /**
      * The method descriptor of this RPC.

--- a/api/src/main/java/io/grpc/CompositeCallCredentials.java
+++ b/api/src/main/java/io/grpc/CompositeCallCredentials.java
@@ -40,9 +40,6 @@ public final class CompositeCallCredentials extends CallCredentials {
         new WrappingMetadataApplier(requestInfo, appExecutor, applier, Context.current()));
   }
 
-  @Override
-  public void thisUsesUnstableApi() {}
-
   private final class WrappingMetadataApplier extends MetadataApplier {
     private final RequestInfo requestInfo;
     private final Executor appExecutor;

--- a/api/src/test/java/io/grpc/CompositeCallCredentialsTest.java
+++ b/api/src/test/java/io/grpc/CompositeCallCredentialsTest.java
@@ -109,7 +109,5 @@ public final class CompositeCallCredentialsTest {
         applier.fail(status);
       }
     }
-
-    @Override public void thisUsesUnstableApi() {}
   }
 }

--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -95,9 +95,6 @@ final class GoogleAuthLibraryCallCredentials extends io.grpc.CallCredentials
   }
 
   @Override
-  public void thisUsesUnstableApi() {}
-
-  @Override
   public void applyRequestMetadata(
       RequestInfo info, Executor appExecutor, final MetadataApplier applier) {
     SecurityLevel security = info.getSecurityLevel();

--- a/core/src/test/java/io/grpc/internal/FakeCallCredentials.java
+++ b/core/src/test/java/io/grpc/internal/FakeCallCredentials.java
@@ -38,6 +38,4 @@ final class FakeCallCredentials extends CallCredentials {
       CallCredentials.MetadataApplier applier) {
     applier.apply(headers);
   }
-
-  @Override public void thisUsesUnstableApi() {}
 }


### PR DESCRIPTION
Removes the `@ExperimentalApi` annotation from the class and provides an empty implementation for the `thisUsesUnstableApi()` method.