### PR TITLE
api: Experimental CallCredentials.thisUsesUnstableApi()

### DIFF
--- a/api/src/main/java/io/grpc/CallCredentials.java
+++ b/api/src/main/java/io/grpc/CallCredentials.java
@@ -60,6 +60,7 @@ public abstract class CallCredentials {
    * a no-op implementation. This method is marked deprecated to allow extenders time to remove the
    * method before it is removed here.
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
   @Deprecated
   public void thisUsesUnstableApi() {
   }


### PR DESCRIPTION
The `thisUsesUnstableApi()` method was earlier deprecated and the `@ExperimentalApi` annotation removed. Adding `@ExperimentalApi` back to make it clear that this method can (and will) later be removed.