### PR TITLE
testing: Move some internal classes to testFixtures

### DIFF
--- a/core/src/test/java/io/grpc/inprocess/InProcessClientTransportFactoryTest.java
+++ b/core/src/test/java/io/grpc/inprocess/InProcessClientTransportFactoryTest.java
@@ -16,8 +16,8 @@
 
 package io.grpc.inprocess;
 
+import io.grpc.internal.AbstractClientTransportFactoryTest;
 import io.grpc.internal.ClientTransportFactory;
-import io.grpc.internal.testing.AbstractClientTransportFactoryTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -61,7 +61,7 @@ import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.Status;
 import io.grpc.internal.ClientCallImpl.ClientStreamProvider;
 import io.grpc.internal.ManagedChannelServiceConfig.MethodInfo;
-import io.grpc.internal.testing.SingleMessageProducer;
+import io.grpc.internal.SingleMessageProducer;
 import io.grpc.testing.TestMethodDescriptors;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
@@ -42,7 +42,7 @@ import io.grpc.DecompressorRegistry;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.ClientStreamListener.RpcProgress;
-import io.grpc.internal.testing.SingleMessageProducer;
+import io.grpc.internal.SingleMessageProducer;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.concurrent.TimeUnit;

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -47,7 +47,7 @@ import io.grpc.SecurityLevel;
 import io.grpc.ServerCall;
 import io.grpc.Status;
 import io.grpc.internal.ServerCallImpl.ServerStreamListenerImpl;
-import io.grpc.internal.testing.SingleMessageProducer;
+import io.grpc.internal.SingleMessageProducer;
 import io.perfmark.PerfMark;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -78,7 +78,7 @@ import io.grpc.Status.Code;
 import io.grpc.StringMarshaller;
 import io.grpc.internal.ServerImpl.JumpToApplicationThreadServerStreamListener;
 import io.grpc.internal.ServerImplBuilder.ClientTransportServersBuilder;
-import io.grpc.internal.testing.SingleMessageProducer;
+import io.grpc.internal.SingleMessageProducer;
 import io.grpc.internal.testing.TestServerStreamTracer;
 import io.grpc.util.MutableHandlerRegistry;
 import io.perfmark.PerfMark;

--- a/core/src/testFixtures/java/io/grpc/internal/AbstractClientTransportFactoryTest.java
+++ b/core/src/testFixtures/java/io/grpc/internal/AbstractClientTransportFactoryTest.java
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-package io.grpc.internal.testing;
+package io.grpc.internal;
 
 import io.grpc.ChannelLogger;
-import io.grpc.internal.ClientTransportFactory;
 import java.net.InetSocketAddress;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/core/src/testFixtures/java/io/grpc/internal/SingleMessageProducer.java
+++ b/core/src/testFixtures/java/io/grpc/internal/SingleMessageProducer.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package io.grpc.internal.testing;
+package io.grpc.internal;
 
-import io.grpc.internal.StreamListener;
 import java.io.InputStream;
 import javax.annotation.Nullable;
 

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportFactoryTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportFactoryTest.java
@@ -16,8 +16,8 @@
 
 package io.grpc.netty;
 
+import io.grpc.internal.AbstractClientTransportFactoryTest;
 import io.grpc.internal.ClientTransportFactory;
-import io.grpc.internal.testing.AbstractClientTransportFactoryTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportFactoryTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportFactoryTest.java
@@ -16,8 +16,8 @@
 
 package io.grpc.okhttp;
 
+import io.grpc.internal.AbstractClientTransportFactoryTest;
 import io.grpc.internal.ClientTransportFactory;
-import io.grpc.internal.testing.AbstractClientTransportFactoryTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 


### PR DESCRIPTION
These two classes are precisely the purpose of test fixtures. Move them close to the classes they make easier to use in tests.