### PR TITLE
Remove old Java 7/8 TLS testing workarounds

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -33,7 +33,6 @@ import io.grpc.alts.ComputeEngineChannelCredentials;
 import io.grpc.alts.GoogleDefaultChannelCredentials;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.JsonParser;
-import io.grpc.internal.testing.TestUtils;
 import io.grpc.netty.InsecureFromHttp1ChannelCredentials;
 import io.grpc.netty.InternalNettyChannelBuilder;
 import io.grpc.netty.NettyChannelBuilder;
@@ -59,8 +58,6 @@ public class TestServiceClient {
    * The main application allowing this client to be launched from the command line.
    */
   public static void main(String[] args) throws Exception {
-    // Let Netty or OkHttp use Conscrypt if it is available.
-    TestUtils.installConscryptIfAvailable();
     final TestServiceClient client = new TestServiceClient();
     client.parseArgs(args);
     customBackendMetricsLoadBalancerProvider = new CustomBackendMetricsLoadBalancerProvider();

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
@@ -26,7 +26,6 @@ import io.grpc.ServerCredentials;
 import io.grpc.ServerInterceptors;
 import io.grpc.TlsServerCredentials;
 import io.grpc.alts.AltsServerCredentials;
-import io.grpc.internal.testing.TestUtils;
 import io.grpc.services.MetricRecorder;
 import io.grpc.testing.TlsTesting;
 import io.grpc.xds.orca.OrcaMetricReportingServerInterceptor;
@@ -39,8 +38,6 @@ import java.util.concurrent.TimeUnit;
 public class TestServiceServer {
   /** The main application allowing this server to be launched from the command line. */
   public static void main(String[] args) throws Exception {
-    // Let Netty use Conscrypt if it is available.
-    TestUtils.installConscryptIfAvailable();
     final TestServiceServer server = new TestServiceServer();
     server.parseArgs(args);
     if (server.useTls) {

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
@@ -44,7 +44,6 @@ import java.net.InetSocketAddress;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -56,13 +55,6 @@ import org.junit.runners.JUnit4;
 public class Http2OkHttpTest extends AbstractInteropTest {
 
   private static final String BAD_HOSTNAME = "I.am.a.bad.hostname";
-
-  @BeforeClass
-  public static void loadConscrypt() throws Exception {
-    // Load conscrypt if it is available. Either Conscrypt or Jetty ALPN needs to be available for
-    // OkHttp to negotiate.
-    TestUtils.installConscryptIfAvailable();
-  }
 
   @Override
   protected ServerBuilder<?> getServerBuilder() {

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2Test.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2Test.java
@@ -41,7 +41,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -52,13 +51,6 @@ import org.junit.runners.Parameterized.Parameters;
  */
 @RunWith(Parameterized.class)
 public class Http2Test extends AbstractInteropTest {
-  @BeforeClass
-  public static void loadConscrypt() throws Exception {
-    // Load conscrypt if it is available. Either Conscrypt or Jetty ALPN needs to be available for
-    // OkHttp to negotiate.
-    TestUtils.installConscryptIfAvailable();
-  }
-
   enum Transport {
     NETTY, OKHTTP;
   }

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -86,7 +86,6 @@ import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http2.StreamBufferingEncoder;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.util.AsciiString;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -301,7 +300,6 @@ public class NettyClientTransportTest {
     InputStream serverKey = TlsTesting.loadCert("server1.key");
     // Don't trust ca.pem, so that client auth fails
     SslContext sslContext = GrpcSslContexts.forServer(serverCert, serverKey)
-        .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE)
         .clientAuth(ClientAuth.REQUIRE)
         .build();
     negotiator = ProtocolNegotiators.serverTls(sslContext);
@@ -312,7 +310,6 @@ public class NettyClientTransportTest {
     InputStream clientKey = TlsTesting.loadCert("client.key");
     SslContext clientContext = GrpcSslContexts.forClient()
         .trustManager(caCert)
-        .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE)
         .keyManager(clientCert, clientKey)
         .build();
     ProtocolNegotiator negotiator = ProtocolNegotiators.tls(clientContext);
@@ -694,7 +691,6 @@ public class NettyClientTransportTest {
     InputStream serverCert = TlsTesting.loadCert("server1.pem");
     InputStream serverKey = TlsTesting.loadCert("server1.key");
     SslContext sslContext = GrpcSslContexts.forServer(serverCert, serverKey)
-        .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE)
         .clientAuth(ClientAuth.NONE)
         .build();
     negotiator = ProtocolNegotiators.serverTls(sslContext, serverExecutorPool);
@@ -707,7 +703,6 @@ public class NettyClientTransportTest {
     InputStream clientKey = TlsTesting.loadCert("client.key");
     SslContext clientContext = GrpcSslContexts.forClient()
         .trustManager(caCert)
-        .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE)
         .keyManager(clientCert, clientKey)
         .build();
     ProtocolNegotiator negotiator = ProtocolNegotiators.tls(clientContext, clientExecutorPool);
@@ -733,8 +728,7 @@ public class NettyClientTransportTest {
 
   private ProtocolNegotiator newNegotiator() throws IOException {
     InputStream caCert = TlsTesting.loadCert("ca.pem");
-    SslContext clientContext = GrpcSslContexts.forClient().trustManager(caCert)
-        .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE).build();
+    SslContext clientContext = GrpcSslContexts.forClient().trustManager(caCert).build();
     return ProtocolNegotiators.tls(clientContext);
   }
 
@@ -804,8 +798,7 @@ public class NettyClientTransportTest {
     try {
       InputStream serverCert = TlsTesting.loadCert("server1.pem");
       InputStream key = TlsTesting.loadCert("server1.key");
-      return GrpcSslContexts.forServer(serverCert, key)
-          .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE).build();
+      return GrpcSslContexts.forServer(serverCert, key).build();
     } catch (IOException ex) {
       throw new RuntimeException(ex);
     }

--- a/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
+++ b/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
@@ -110,7 +110,6 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
-import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import java.io.File;
 import java.io.InputStream;
@@ -193,8 +192,7 @@ public class ProtocolNegotiatorsTest {
   public void setUp() throws Exception {
     InputStream serverCert = TlsTesting.loadCert("server1.pem");
     InputStream key = TlsTesting.loadCert("server1.key");
-    sslContext = GrpcSslContexts.forServer(serverCert, key)
-        .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE).build();
+    sslContext = GrpcSslContexts.forServer(serverCert, key).build();
     engine = SSLContext.getDefault().createSSLEngine();
     engine.setUseClientMode(true);
   }
@@ -801,7 +799,6 @@ public class ProtocolNegotiatorsTest {
         alpnList);
 
     sslContext = GrpcSslContexts.forServer(serverCert, key)
-        .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE)
         .applicationProtocolConfig(apn).build();
 
     ChannelHandler handler = new ServerTlsHandler(grpcHandler, sslContext, null);
@@ -838,7 +835,6 @@ public class ProtocolNegotiatorsTest {
         alpnList);
 
     sslContext = GrpcSslContexts.forServer(serverCert, key)
-        .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE)
         .applicationProtocolConfig(apn).build();
     ChannelHandler handler = new ServerTlsHandler(grpcHandler, sslContext, null);
     pipeline.addLast(handler);
@@ -911,7 +907,6 @@ public class ProtocolNegotiatorsTest {
 
     sslContext = GrpcSslContexts.forClient()
         .keyManager(clientCert, key)
-        .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE)
         .applicationProtocolConfig(apn).build();
 
     ClientTlsHandler handler = new ClientTlsHandler(grpcHandler, sslContext,

--- a/testing/src/main/java/io/grpc/internal/testing/TestUtils.java
+++ b/testing/src/main/java/io/grpc/internal/testing/TestUtils.java
@@ -31,14 +31,12 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.security.KeyStore;
-import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.Security;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
@@ -94,29 +92,6 @@ public class TestUtils {
     } catch (UnknownHostException e) {
       throw new RuntimeException(e);
     }
-  }
-
-  /**
-   * Returns the ciphers preferred to use during tests. They may be chosen because they are widely
-   * available or because they are fast. There is no requirement that they provide confidentiality
-   * or integrity.
-   */
-  public static List<String> preferredTestCiphers() {
-    String[] ciphers;
-    try {
-      ciphers = SSLContext.getDefault().getDefaultSSLParameters().getCipherSuites();
-    } catch (NoSuchAlgorithmException ex) {
-      throw new RuntimeException(ex);
-    }
-    List<String> ciphersMinusGcm = new ArrayList<>();
-    for (String cipher : ciphers) {
-      // The GCM implementation in Java is _very_ slow (~1 MB/s)
-      if (cipher.contains("_GCM_")) {
-        continue;
-      }
-      ciphersMinusGcm.add(cipher);
-    }
-    return Collections.unmodifiableList(ciphersMinusGcm);
   }
 
   /**


### PR DESCRIPTION
Ciphers have been "fast enough" for testing since early Java 8 updates; we haven't needed to override ciphers since we dropped Java 7 support. Java 8u252 had ALPN, so Conscrypt or Jetty ALPN hasn't been necessary for basic testing for a while. We still want specialized testing for Conscrypt, but only tests testing Conscrypt need to care.