### PR TITLE
gcp observability: Update Docker images to eclipse-temurin

### DIFF
--- a/buildscripts/observability-test/Dockerfile
+++ b/buildscripts/observability-test/Dockerfile
@@ -17,10 +17,17 @@
 # Stage 1: Build the interop test client and server
 #
 
-FROM openjdk:11.0.16-jdk-slim-bullseye AS build
+FROM eclipse-temurin:11-jdk AS build
 
 WORKDIR /grpc-java
 COPY . .
+
+# Intentionally after the app COPY to force the update on each build.
+# Update Ubuntu system packages:
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && apt-get -y autoremove \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN ./gradlew :grpc-gcp-observability:interop:installDist -PskipCodegen=true -PskipAndroid=true
 
@@ -33,7 +40,7 @@ RUN ./gradlew :grpc-gcp-observability:interop:installDist -PskipCodegen=true -Ps
 #   with the given parameters.
 #
 
-FROM openjdk:11.0.16-jdk-slim-bullseye
+FROM eclipse-temurin:11-jre
 
 WORKDIR /grpc-java/
 COPY --from=build /grpc-java/gcp-observability/interop/build/install/interop/. .

--- a/buildscripts/observability-test/Dockerfile
+++ b/buildscripts/observability-test/Dockerfile
@@ -22,13 +22,6 @@ FROM eclipse-temurin:11-jdk AS build
 WORKDIR /grpc-java
 COPY . .
 
-# Intentionally after the app COPY to force the update on each build.
-# Update Ubuntu system packages:
-RUN apt-get update \
-    && apt-get -y upgrade \
-    && apt-get -y autoremove \
-    && rm -rf /var/lib/apt/lists/*
-
 RUN ./gradlew :grpc-gcp-observability:interop:installDist -PskipCodegen=true -PskipAndroid=true
 
 
@@ -47,5 +40,12 @@ COPY --from=build /grpc-java/gcp-observability/interop/build/install/interop/. .
 
 WORKDIR /grpc-java/buildscripts/observability-test
 COPY --from=build /grpc-java/buildscripts/observability-test/run.sh .
+
+# Intentionally after the app COPY to force the update on each build.
+# Update Ubuntu system packages:
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && apt-get -y autoremove \
+    && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["/grpc-java/buildscripts/observability-test/run.sh"]


### PR DESCRIPTION
Sergii noticed that the GCP Observability Integration testing docker image in the `microsvcs-testing` project popped up on the vulnerabilities dashboard. So we need to fix which base docker image we use. Similar to the fix in #10191

 - Perform software update so that we install patches for latest vulnerabilities.