### PR TITLE
repositories.bzl: In doc, use | to combine dicts

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -54,17 +54,9 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
 # )
 #
 # If you have your own overrides as well, you can use:
-#     override_targets = dict(
-#         IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS,
+#     override_targets = {
 #         "your.target:artifact": "@//third_party/artifact",
-#     )
-#
-# To combine OVERRIDE_TARGETS from multiple libraries:
-#     override_targets = dict(
-#         IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS.items() +
-#         OTHER_OVERRIDE_TARGETS.items(),
-#         "your.target:artifact": "@//third_party/artifact",
-#     )
+#     } | IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS,
 IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS = {
     "com.google.protobuf:protobuf-java": "@com_google_protobuf//:protobuf_java",
     "com.google.protobuf:protobuf-java-util": "@com_google_protobuf//:protobuf_java_util",


### PR DESCRIPTION
The previous syntax for just adding your own keys doesn't seem to work, but was similar to the approach of using `dict(d, foo=bar)`. You can't have '.' and ':' in a key that way though. The doc was written before Bazel 1.0 and in newer Bazel versions you can just use | to concatenate.

Fixes #10203

CC @aryeh-looker