### PR TITLE
Avoid NettyServerBuilder when unnecessary

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
@@ -34,12 +34,12 @@ import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
 import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
 import io.grpc.Grpc;
 import io.grpc.InsecureChannelCredentials;
+import io.grpc.InsecureServerCredentials;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Server;
 import io.grpc.Status;
-import io.grpc.netty.NettyServerBuilder;
 import io.grpc.protobuf.services.ProtoReflectionService;
 import io.grpc.services.AdminInterface;
 import io.grpc.stub.StreamObserver;
@@ -242,7 +242,7 @@ public final class XdsTestClient {
 
   private void run() {
     statsServer =
-        NettyServerBuilder.forPort(statsPort)
+        Grpc.newServerBuilderForPort(statsPort, InsecureServerCredentials.create())
             .addService(new XdsStatsImpl())
             .addService(new ConfigureUpdateServiceImpl())
             .addService(ProtoReflectionService.newInstance())

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
@@ -19,6 +19,7 @@ package io.grpc.testing.integration;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
 import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
+import io.grpc.Grpc;
 import io.grpc.InsecureServerCredentials;
 import io.grpc.Metadata;
 import io.grpc.Server;
@@ -28,7 +29,6 @@ import io.grpc.ServerInterceptor;
 import io.grpc.ServerInterceptors;
 import io.grpc.Status;
 import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
-import io.grpc.netty.NettyServerBuilder;
 import io.grpc.protobuf.services.HealthStatusManager;
 import io.grpc.protobuf.services.ProtoReflectionService;
 import io.grpc.services.AdminInterface;
@@ -177,7 +177,7 @@ public final class XdsTestServer {
     health = new HealthStatusManager();
     if (secureMode) {
       maintenanceServer =
-          NettyServerBuilder.forPort(maintenancePort)
+          Grpc.newServerBuilderForPort(maintenancePort, InsecureServerCredentials.create())
               .addService(new XdsUpdateHealthServiceImpl(health))
               .addService(health.getHealthService())
               .addService(ProtoReflectionService.newInstance())
@@ -194,7 +194,7 @@ public final class XdsTestServer {
       server.start();
     } else {
       server =
-          NettyServerBuilder.forPort(port)
+          Grpc.newServerBuilderForPort(port, InsecureServerCredentials.create())
               .addService(
                   ServerInterceptors.intercept(
                       new TestServiceImpl(serverId, host), new TestInfoInterceptor(host)))

--- a/xds/src/test/java/io/grpc/xds/ControlPlaneRule.java
+++ b/xds/src/test/java/io/grpc/xds/ControlPlaneRule.java
@@ -51,9 +51,10 @@ import io.envoyproxy.envoy.extensions.filters.http.router.v3.Router;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.Rds;
+import io.grpc.Grpc;
+import io.grpc.InsecureServerCredentials;
 import io.grpc.NameResolverRegistry;
 import io.grpc.Server;
-import io.grpc.netty.NettyServerBuilder;
 import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
@@ -114,10 +115,11 @@ public class ControlPlaneRule extends TestWatcher {
     try {
       controlPlaneService = new XdsTestControlPlaneService();
       loadReportingService = new XdsTestLoadReportingService();
-      NettyServerBuilder controlPlaneServerBuilder = NettyServerBuilder.forPort(0)
+      server = Grpc.newServerBuilderForPort(0, InsecureServerCredentials.create())
           .addService(controlPlaneService)
-          .addService(loadReportingService);
-      server = controlPlaneServerBuilder.build().start();
+          .addService(loadReportingService)
+          .build()
+          .start();
     } catch (Exception e) {
       throw new AssertionError("unable to start the control plane server", e);
     }


### PR DESCRIPTION
These code locations just needed a generic gRPC server, without any transport-specific configuration. Use vanilla ManagedServerBuilder instead of hard-coding to Netty, as we would suggest to our users.