### PR TITLE
buildscripts, psm interop: Don't fail target if sub-target already failed (v1.52.x backport)

### DIFF
--- a/buildscripts/kokoro/psm-security.sh
+++ b/buildscripts/kokoro/psm-security.sh
@@ -180,9 +180,6 @@ main() {
     run_test $test || (( ++failed_tests ))
   done
   echo "Failed test suites: ${failed_tests}"
-  if (( failed_tests > 0 )); then
-    exit 1
-  fi
 }
 
 main "$@"

--- a/buildscripts/kokoro/xds_k8s_lb.sh
+++ b/buildscripts/kokoro/xds_k8s_lb.sh
@@ -181,9 +181,6 @@ main() {
     run_test $test || (( ++failed_tests ))
   done
   echo "Failed test suites: ${failed_tests}"
-  if (( failed_tests > 0 )); then
-    exit 1
-  fi
 }
 
 main "$@"


### PR DESCRIPTION
Backport of #10232 to v1.52.x.
---
We configured TestGrid to file bug separately for each failed sub-target, if we still fail the main target, TestGrid will fail duplicate bugs.
The same change in core: https://github.com/grpc/grpc/pull/33222