### PR TITLE
services, xds, orca: use application_utilization and fallback to cpu_utilization if unset in WRR, import cncf/xds

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -86,10 +86,10 @@ def grpc_java_repositories():
     if not native.existing_rule("com_github_cncf_xds"):
         http_archive(
             name = "com_github_cncf_xds",
-            strip_prefix = "xds-32f1caf87195bf3390061c29f18987e51ca56a88",
-            sha256 = "fcd0b50c013452fda9c5e28c131c287b655ebb361271a76ad3bffc08b3ecd82e",
+            strip_prefix = "xds-e9ce68804cb4e64cab5a52e3c8baf840d4ff87b7",
+            sha256 = "0d33b83f8c6368954e72e7785539f0d272a8aba2f6e2e336ed15fd1514bc9899",
             urls = [
-                "https://github.com/cncf/xds/archive/32f1caf87195bf3390061c29f18987e51ca56a88.tar.gz",
+                "https://github.com/cncf/xds/archive/e9ce68804cb4e64cab5a52e3c8baf840d4ff87b7.tar.gz",
             ],
         )
     if not native.existing_rule("com_github_grpc_grpc"):

--- a/services/src/main/java/io/grpc/services/InternalCallMetricRecorder.java
+++ b/services/src/main/java/io/grpc/services/InternalCallMetricRecorder.java
@@ -45,10 +45,10 @@ public final class InternalCallMetricRecorder {
     return recorder.finalizeAndDump2();
   }
 
-  public static MetricReport createMetricReport(double cpuUtilization, double memoryUtilization,
-      double qps, double eps, Map<String, Double> requestCostMetrics,
-      Map<String, Double> utilizationMetrics) {
-    return new MetricReport(cpuUtilization, memoryUtilization, qps, eps, requestCostMetrics,
-        utilizationMetrics);
+  public static MetricReport createMetricReport(double cpuUtilization,
+      double applicationUtilization, double memoryUtilization, double qps, double eps,
+      Map<String, Double> requestCostMetrics, Map<String, Double> utilizationMetrics) {
+    return new MetricReport(cpuUtilization, applicationUtilization, memoryUtilization, qps, eps,
+        requestCostMetrics, utilizationMetrics);
   }
 }

--- a/services/src/main/java/io/grpc/services/MetricRecorder.java
+++ b/services/src/main/java/io/grpc/services/MetricRecorder.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class MetricRecorder {
   private volatile ConcurrentHashMap<String, Double> metricsData = new ConcurrentHashMap<>();
   private volatile double cpuUtilization;
+  private volatile double applicationUtilization;
   private volatile double memoryUtilization;
   private volatile double qps;
   private volatile double eps;
@@ -69,7 +70,7 @@ public final class MetricRecorder {
    * are ignored.
    */
   public void setCpuUtilizationMetric(double value) {
-    if (!MetricRecorderHelper.isCpuUtilizationValid(value)) {
+    if (!MetricRecorderHelper.isCpuOrApplicationUtilizationValid(value)) {
       return;
     }
     cpuUtilization = value;
@@ -80,6 +81,24 @@ public final class MetricRecorder {
    */
   public void clearCpuUtilizationMetric() {
     cpuUtilization = 0;
+  }
+
+  /**
+   * Update the application specific utilization metrics data in the range [0, inf). Values outside
+   * the valid range are ignored.
+   */
+  public void setApplicationUtilizationMetric(double value) {
+    if (!MetricRecorderHelper.isCpuOrApplicationUtilizationValid(value)) {
+      return;
+    }
+    applicationUtilization = value;
+  }
+
+  /**
+   * Clear the application specific utilization metrics data.
+   */
+  public void clearApplicationUtilizationMetric() {
+    applicationUtilization = 0;
   }
 
   /**
@@ -135,7 +154,7 @@ public final class MetricRecorder {
   }
 
   MetricReport getMetricReport() {
-    return new MetricReport(cpuUtilization, memoryUtilization, qps, eps,
+    return new MetricReport(cpuUtilization, applicationUtilization, memoryUtilization, qps, eps,
         Collections.emptyMap(), Collections.unmodifiableMap(metricsData));
   }
 }

--- a/services/src/main/java/io/grpc/services/MetricRecorderHelper.java
+++ b/services/src/main/java/io/grpc/services/MetricRecorderHelper.java
@@ -30,11 +30,12 @@ final class MetricRecorderHelper {
   }
 
   /**
-   * Return true if the cpu utilization value is in the range [0, inf) and false otherwise.
-   * Occasionally users have over 100% cpu utilization and get a runaway effect where the backend
-   * with highest qps gets more and more qps sent to it. So we allow cpu utilization > 1.0.
+   * Return true if the cpu utilization or application specific utilization value is in the range
+   * [0, inf) and false otherwise. Occasionally users have over 100% cpu utilization and get a
+   * runaway effect where the backend with highest qps gets more and more qps sent to it. So we
+   * allow cpu utilization > 1.0, similarly for application specific utilization.
    */
-  static boolean isCpuUtilizationValid(double utilization) {
+  static boolean isCpuOrApplicationUtilizationValid(double utilization) {
     return utilization >= 0.0;
   }
 

--- a/services/src/main/java/io/grpc/services/MetricReport.java
+++ b/services/src/main/java/io/grpc/services/MetricReport.java
@@ -29,16 +29,18 @@ import java.util.Map;
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/9381")
 public final class MetricReport {
   private double cpuUtilization;
+  private double applicationUtilization;
   private double memoryUtilization;
   private double qps;
   private double eps;
   private Map<String, Double> requestCostMetrics;
   private Map<String, Double> utilizationMetrics;
 
-  MetricReport(double cpuUtilization, double memoryUtilization, double qps, double eps,
-               Map<String, Double> requestCostMetrics,
-               Map<String, Double> utilizationMetrics) {
+  MetricReport(double cpuUtilization, double applicationUtilization, double memoryUtilization,
+      double qps, double eps, Map<String, Double> requestCostMetrics,
+      Map<String, Double> utilizationMetrics) {
     this.cpuUtilization = cpuUtilization;
+    this.applicationUtilization = applicationUtilization;
     this.memoryUtilization = memoryUtilization;
     this.qps = qps;
     this.eps = eps;
@@ -48,6 +50,10 @@ public final class MetricReport {
 
   public double getCpuUtilization() {
     return cpuUtilization;
+  }
+
+  public double getApplicationUtilization() {
+    return applicationUtilization;
   }
 
   public double getMemoryUtilization() {
@@ -74,6 +80,7 @@ public final class MetricReport {
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("cpuUtilization", cpuUtilization)
+        .add("applicationUtilization", applicationUtilization)
         .add("memoryUtilization", memoryUtilization)
         .add("requestCost", requestCostMetrics)
         .add("utilization", utilizationMetrics)

--- a/services/src/test/java/io/grpc/services/CallMetricRecorderTest.java
+++ b/services/src/test/java/io/grpc/services/CallMetricRecorderTest.java
@@ -45,6 +45,7 @@ public class CallMetricRecorderTest {
     recorder.recordRequestCostMetric("cost2", 10293.0);
     recorder.recordRequestCostMetric("cost3", 1.0);
     recorder.recordCpuUtilizationMetric(0.1928);
+    recorder.recordApplicationUtilizationMetric(0.9987);
     recorder.recordMemoryUtilizationMetric(0.474);
     recorder.recordQpsMetric(2522.54);
     recorder.recordEpsMetric(1.618);
@@ -55,15 +56,18 @@ public class CallMetricRecorderTest {
     Truth.assertThat(dump.getRequestCostMetrics())
         .containsExactly("cost1", 37465.12, "cost2", 10293.0, "cost3", 1.0);
     Truth.assertThat(dump.getCpuUtilization()).isEqualTo(0.1928);
+    Truth.assertThat(dump.getApplicationUtilization()).isEqualTo(0.9987);
     Truth.assertThat(dump.getMemoryUtilization()).isEqualTo(0.474);
     Truth.assertThat(dump.getQps()).isEqualTo(2522.54);
     Truth.assertThat(dump.getEps()).isEqualTo(1.618);
     Truth.assertThat(dump.toString()).contains("eps=1.618");
+    Truth.assertThat(dump.toString()).contains("applicationUtilization=0.9987");
   }
 
   @Test
   public void noMetricsRecordedAfterSnapshot() {
     Map<String, Double> initDump = recorder.finalizeAndDump();
+    recorder.recordApplicationUtilizationMetric(0.01);
     recorder.recordUtilizationMetric("cost", 0.154353423);
     recorder.recordQpsMetric(3.14159);
     recorder.recordEpsMetric(1.618);
@@ -87,6 +91,7 @@ public class CallMetricRecorderTest {
   @Test
   public void noMetricsRecordedIfUtilizationAndQpsAreLessThanLowerBound() {
     recorder.recordCpuUtilizationMetric(-0.001);
+    recorder.recordApplicationUtilizationMetric(-0.001);
     recorder.recordMemoryUtilizationMetric(-0.001);
     recorder.recordQpsMetric(-0.001);
     recorder.recordEpsMetric(-0.001);
@@ -94,6 +99,7 @@ public class CallMetricRecorderTest {
 
     MetricReport dump = recorder.finalizeAndDump2();
     Truth.assertThat(dump.getCpuUtilization()).isEqualTo(0);
+    Truth.assertThat(dump.getApplicationUtilization()).isEqualTo(0);
     Truth.assertThat(dump.getMemoryUtilization()).isEqualTo(0);
     Truth.assertThat(dump.getQps()).isEqualTo(0);
     Truth.assertThat(dump.getEps()).isEqualTo(0);
@@ -108,6 +114,8 @@ public class CallMetricRecorderTest {
     recorder.recordRequestCostMetric("cost1", 6441.341);
     recorder.recordRequestCostMetric("cost1", 4654.67);
     recorder.recordRequestCostMetric("cost2", 75.83);
+    recorder.recordApplicationUtilizationMetric(0.92);
+    recorder.recordApplicationUtilizationMetric(1.78);
     recorder.recordMemoryUtilizationMetric(0.13);
     recorder.recordMemoryUtilizationMetric(0.31);
     recorder.recordUtilizationMetric("util1", 0.2837421);
@@ -121,6 +129,7 @@ public class CallMetricRecorderTest {
     MetricReport dump = recorder.finalizeAndDump2();
     Truth.assertThat(dump.getRequestCostMetrics())
         .containsExactly("cost1", 4654.67, "cost2", 75.83);
+    Truth.assertThat(dump.getApplicationUtilization()).isEqualTo(1.78);
     Truth.assertThat(dump.getMemoryUtilization()).isEqualTo(0.93840);
     Truth.assertThat(dump.getUtilizationMetrics())
         .containsExactly("util1", 0.843233);

--- a/xds/src/main/java/io/grpc/xds/orca/OrcaMetricReportingServerInterceptor.java
+++ b/xds/src/main/java/io/grpc/xds/orca/OrcaMetricReportingServerInterceptor.java
@@ -115,6 +115,7 @@ public final class OrcaMetricReportingServerInterceptor implements ServerInterce
   private static OrcaLoadReport.Builder fromInternalReport(MetricReport internalReport) {
     return OrcaLoadReport.newBuilder()
         .setCpuUtilization(internalReport.getCpuUtilization())
+        .setApplicationUtilization(internalReport.getApplicationUtilization())
         .setMemUtilization(internalReport.getMemoryUtilization())
         .setRpsFractional(internalReport.getQps())
         .setEps(internalReport.getEps())
@@ -137,6 +138,10 @@ public final class OrcaMetricReportingServerInterceptor implements ServerInterce
     double cpu = callMetricRecorderReport.getCpuUtilization();
     if (isReportValueSet(cpu)) {
       metricRecorderReportBuilder.setCpuUtilization(cpu);
+    }
+    double applicationUtilization = callMetricRecorderReport.getApplicationUtilization();
+    if (isReportValueSet(applicationUtilization)) {
+      metricRecorderReportBuilder.setApplicationUtilization(applicationUtilization);
     }
     double mem = callMetricRecorderReport.getMemoryUtilization();
     if (isReportValueSet(mem)) {

--- a/xds/src/main/java/io/grpc/xds/orca/OrcaPerRequestUtil.java
+++ b/xds/src/main/java/io/grpc/xds/orca/OrcaPerRequestUtil.java
@@ -254,8 +254,9 @@ public abstract class OrcaPerRequestUtil {
 
   static MetricReport fromOrcaLoadReport(OrcaLoadReport loadReport) {
     return InternalCallMetricRecorder.createMetricReport(loadReport.getCpuUtilization(),
-        loadReport.getMemUtilization(), loadReport.getRpsFractional(), loadReport.getEps(),
-        loadReport.getRequestCostMap(), loadReport.getUtilizationMap());
+        loadReport.getApplicationUtilization(), loadReport.getMemUtilization(),
+        loadReport.getRpsFractional(), loadReport.getEps(), loadReport.getRequestCostMap(),
+        loadReport.getUtilizationMap());
   }
 
   /**

--- a/xds/src/main/java/io/grpc/xds/orca/OrcaServiceImpl.java
+++ b/xds/src/main/java/io/grpc/xds/orca/OrcaServiceImpl.java
@@ -149,6 +149,7 @@ public final class OrcaServiceImpl implements BindableService {
     MetricReport internalReport =
         InternalMetricRecorder.getMetricReport(metricRecorder);
     return OrcaLoadReport.newBuilder().setCpuUtilization(internalReport.getCpuUtilization())
+        .setApplicationUtilization(internalReport.getApplicationUtilization())
         .setMemUtilization(internalReport.getMemoryUtilization())
         .setRpsFractional(internalReport.getQps())
         .setEps(internalReport.getEps())

--- a/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
@@ -214,10 +214,10 @@ public class WeightedRoundRobinLoadBalancerTest {
     WrrSubchannel weightedSubchannel2 = (WrrSubchannel) weightedPicker.getList().get(1);
     weightedSubchannel1.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
         InternalCallMetricRecorder.createMetricReport(
-            0.1, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
+            0.1, 0, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
     weightedSubchannel2.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
         InternalCallMetricRecorder.createMetricReport(
-            0.2, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
+            0.2, 0, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
     assertThat(fakeClock.forwardTime(11, TimeUnit.SECONDS)).isEqualTo(1);
     assertThat(weightedPicker.pickSubchannel(mockArgs)
             .getSubchannel()).isEqualTo(weightedSubchannel1);
@@ -260,10 +260,10 @@ public class WeightedRoundRobinLoadBalancerTest {
     WrrSubchannel weightedSubchannel2 = (WrrSubchannel) weightedPicker.getList().get(1);
     weightedSubchannel1.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
         InternalCallMetricRecorder.createMetricReport(
-            0.1, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
+            0.1, 0, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
     weightedSubchannel2.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
         InternalCallMetricRecorder.createMetricReport(
-            0.9, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
+            0.9, 0, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
     assertThat(fakeClock.forwardTime(11, TimeUnit.SECONDS)).isEqualTo(1);
     PickResult pickResult = weightedPicker.pickSubchannel(mockArgs);
     assertThat(pickResult.getSubchannel()).isEqualTo(weightedSubchannel1);
@@ -340,11 +340,11 @@ public class WeightedRoundRobinLoadBalancerTest {
   @Test
   public void pickByWeight_LargeWeight() {
     MetricReport report1 = InternalCallMetricRecorder.createMetricReport(
-        0.1, 0.1, 999, 0, new HashMap<>(), new HashMap<>());
+        0.1, 0, 0.1, 999, 0, new HashMap<>(), new HashMap<>());
     MetricReport report2 = InternalCallMetricRecorder.createMetricReport(
-        0.9, 0.1, 2, 0, new HashMap<>(), new HashMap<>());
+        0.9, 0, 0.1, 2, 0, new HashMap<>(), new HashMap<>());
     MetricReport report3 = InternalCallMetricRecorder.createMetricReport(
-        0.86, 0.1, 100, 0, new HashMap<>(), new HashMap<>());
+        0.86, 0, 0.1, 100, 0, new HashMap<>(), new HashMap<>());
     double totalWeight = 999 / 0.1 + 2 / 0.9 + 100 / 0.86;
 
     pickByWeight(report1, report2, report3, 999 / 0.1 / totalWeight, 2 / 0.9 / totalWeight,
@@ -352,13 +352,27 @@ public class WeightedRoundRobinLoadBalancerTest {
   }
 
   @Test
+  public void pickByWeight_largeWeight_useApplicationUtilization() {
+    MetricReport report1 = InternalCallMetricRecorder.createMetricReport(
+        0.44, 0.1, 0.1, 999, 0, new HashMap<>(), new HashMap<>());
+    MetricReport report2 = InternalCallMetricRecorder.createMetricReport(
+        0.12, 0.9, 0.1, 2, 0, new HashMap<>(), new HashMap<>());
+    MetricReport report3 = InternalCallMetricRecorder.createMetricReport(
+        0.33, 0.86, 0.1, 100, 0, new HashMap<>(), new HashMap<>());
+    double totalWeight = 999 / 0.1 + 2 / 0.9 + 100 / 0.86;
+
+    pickByWeight(report1, report2, report3, 999 / 0.1 / totalWeight, 2 / 0.9 / totalWeight,
+        100 / 0.86 / totalWeight);
+  }
+
+  @Test
   public void pickByWeight_largeWeight_withEps_defaultErrorUtilizationPenalty() {
     MetricReport report1 = InternalCallMetricRecorder.createMetricReport(
-        0.1, 0.1, 999, 13, new HashMap<>(), new HashMap<>());
+        0.1, 0, 0.1, 999, 13, new HashMap<>(), new HashMap<>());
     MetricReport report2 = InternalCallMetricRecorder.createMetricReport(
-        0.9, 0.1, 2, 1.8, new HashMap<>(), new HashMap<>());
+        0.9, 0, 0.1, 2, 1.8, new HashMap<>(), new HashMap<>());
     MetricReport report3 = InternalCallMetricRecorder.createMetricReport(
-        0.86, 0.1, 100, 3, new HashMap<>(), new HashMap<>());
+        0.86, 0, 0.1, 100, 3, new HashMap<>(), new HashMap<>());
     double weight1 = 999 / (0.1 + 13 / 999F * weightedConfig.errorUtilizationPenalty);
     double weight2 = 2 / (0.9 + 1.8 / 2F * weightedConfig.errorUtilizationPenalty);
     double weight3 = 100 / (0.86 + 3 / 100F * weightedConfig.errorUtilizationPenalty);
@@ -371,11 +385,11 @@ public class WeightedRoundRobinLoadBalancerTest {
   @Test
   public void pickByWeight_normalWeight() {
     MetricReport report1 = InternalCallMetricRecorder.createMetricReport(
-            0.12, 0.1, 22, 0, new HashMap<>(), new HashMap<>());
+        0.12, 0, 0.1, 22, 0, new HashMap<>(), new HashMap<>());
     MetricReport report2 = InternalCallMetricRecorder.createMetricReport(
-        0.28, 0.1, 40, 0, new HashMap<>(), new HashMap<>());
+        0.28, 0, 0.1, 40, 0, new HashMap<>(), new HashMap<>());
     MetricReport report3 = InternalCallMetricRecorder.createMetricReport(
-        0.86, 0.1, 100, 0, new HashMap<>(), new HashMap<>());
+        0.86, 0, 0.1, 100, 0, new HashMap<>(), new HashMap<>());
     double totalWeight = 22 / 0.12 + 40 / 0.28 + 100 / 0.86;
     pickByWeight(report1, report2, report3, 22 / 0.12 / totalWeight,
             40 / 0.28 / totalWeight, 100 / 0.86 / totalWeight
@@ -383,13 +397,27 @@ public class WeightedRoundRobinLoadBalancerTest {
   }
 
   @Test
+  public void pickByWeight_normalWeight_useApplicationUtilization() {
+    MetricReport report1 = InternalCallMetricRecorder.createMetricReport(
+        0.72, 0.12, 0.1, 22, 0, new HashMap<>(), new HashMap<>());
+    MetricReport report2 = InternalCallMetricRecorder.createMetricReport(
+        0.98, 0.28, 0.1, 40, 0, new HashMap<>(), new HashMap<>());
+    MetricReport report3 = InternalCallMetricRecorder.createMetricReport(
+        0.99, 0.86, 0.1, 100, 0, new HashMap<>(), new HashMap<>());
+    double totalWeight = 22 / 0.12 + 40 / 0.28 + 100 / 0.86;
+    pickByWeight(report1, report2, report3, 22 / 0.12 / totalWeight,
+        40 / 0.28 / totalWeight, 100 / 0.86 / totalWeight
+    );
+  }
+
+  @Test
   public void pickByWeight_normalWeight_withEps_defaultErrorUtilizationPenalty() {
     MetricReport report1 = InternalCallMetricRecorder.createMetricReport(
-        0.12, 0.1, 22, 19.7, new HashMap<>(), new HashMap<>());
+        0.12, 0, 0.1, 22, 19.7, new HashMap<>(), new HashMap<>());
     MetricReport report2 = InternalCallMetricRecorder.createMetricReport(
-        0.28, 0.1, 40, 0.998, new HashMap<>(), new HashMap<>());
+        0.28, 0, 0.1, 40, 0.998, new HashMap<>(), new HashMap<>());
     MetricReport report3 = InternalCallMetricRecorder.createMetricReport(
-        0.86, 0.1, 100, 3.14159, new HashMap<>(), new HashMap<>());
+        0.86, 0, 0.1, 100, 3.14159, new HashMap<>(), new HashMap<>());
     double weight1 = 22 / (0.12 + 19.7 / 22F * weightedConfig.errorUtilizationPenalty);
     double weight2 = 40 / (0.28 + 0.998 / 40F * weightedConfig.errorUtilizationPenalty);
     double weight3 = 100 / (0.86 + 3.14159 / 100F * weightedConfig.errorUtilizationPenalty);
@@ -405,11 +433,11 @@ public class WeightedRoundRobinLoadBalancerTest {
         .setErrorUtilizationPenalty(1.75F).build();
 
     MetricReport report1 = InternalCallMetricRecorder.createMetricReport(
-        0.12, 0.1, 22, 19.7, new HashMap<>(), new HashMap<>());
+        0.12, 0, 0.1, 22, 19.7, new HashMap<>(), new HashMap<>());
     MetricReport report2 = InternalCallMetricRecorder.createMetricReport(
-        0.28, 0.1, 40, 0.998, new HashMap<>(), new HashMap<>());
+        0.28, 0, 0.1, 40, 0.998, new HashMap<>(), new HashMap<>());
     MetricReport report3 = InternalCallMetricRecorder.createMetricReport(
-        0.86, 0.1, 100, 3.14159, new HashMap<>(), new HashMap<>());
+        0.86, 0, 0.1, 100, 3.14159, new HashMap<>(), new HashMap<>());
     double weight1 = 22 / (0.12 + 19.7 / 22F * weightedConfig.errorUtilizationPenalty);
     double weight2 = 40 / (0.28 + 0.998 / 40F * weightedConfig.errorUtilizationPenalty);
     double weight3 = 100 / (0.86 + 3.14159 / 100F * weightedConfig.errorUtilizationPenalty);
@@ -425,11 +453,11 @@ public class WeightedRoundRobinLoadBalancerTest {
         .setErrorUtilizationPenalty(1.75F).build();
 
     MetricReport report1 = InternalCallMetricRecorder.createMetricReport(
-        0, 0.1, 22, 19.7, new HashMap<>(), new HashMap<>());
+        0, 0, 0.1, 22, 19.7, new HashMap<>(), new HashMap<>());
     MetricReport report2 = InternalCallMetricRecorder.createMetricReport(
-        0, 0.1, 40, 0.998, new HashMap<>(), new HashMap<>());
+        0, 0, 0.1, 40, 0.998, new HashMap<>(), new HashMap<>());
     MetricReport report3 = InternalCallMetricRecorder.createMetricReport(
-        0, 0.1, 100, 3.14159, new HashMap<>(), new HashMap<>());
+        0, 0, 0.1, 100, 3.14159, new HashMap<>(), new HashMap<>());
     double avgSubchannelPickRatio = 1.0 / 3;
 
     pickByWeight(report1, report2, report3, avgSubchannelPickRatio, avgSubchannelPickRatio,
@@ -480,10 +508,10 @@ public class WeightedRoundRobinLoadBalancerTest {
     WrrSubchannel weightedSubchannel2 = (WrrSubchannel) weightedPicker.getList().get(1);
     weightedSubchannel1.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
         InternalCallMetricRecorder.createMetricReport(
-            0.1, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
+            0.1, 0, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
     weightedSubchannel2.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
         InternalCallMetricRecorder.createMetricReport(
-            0.2, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
+            0.2, 0, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
     assertThat(fakeClock.forwardTime(5, TimeUnit.SECONDS)).isEqualTo(1);
     Map<Subchannel, Integer> pickCount = new HashMap<>();
     for (int i = 0; i < 1000; i++) {
@@ -540,10 +568,10 @@ public class WeightedRoundRobinLoadBalancerTest {
     WrrSubchannel weightedSubchannel2 = (WrrSubchannel) weightedPicker.getList().get(1);
     weightedSubchannel1.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
         InternalCallMetricRecorder.createMetricReport(
-            0.1, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
+            0.1, 0, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
     weightedSubchannel2.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
         InternalCallMetricRecorder.createMetricReport(
-            0.2, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
+            0.2, 0, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
     assertThat(fakeClock.forwardTime(11, TimeUnit.SECONDS)).isEqualTo(1);
     assertThat(weightedPicker.pickSubchannel(mockArgs)
         .getSubchannel()).isEqualTo(weightedSubchannel1);
@@ -557,10 +585,10 @@ public class WeightedRoundRobinLoadBalancerTest {
     assertThat(fakeClock.getPendingTasks().size()).isEqualTo(1);
     weightedSubchannel1.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
         InternalCallMetricRecorder.createMetricReport(
-            0.2, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
+            0.2, 0, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
     weightedSubchannel2.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
         InternalCallMetricRecorder.createMetricReport(
-            0.1, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
+            0.1, 0, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
     //timer fires, new weight updated
     assertThat(fakeClock.forwardTime(500, TimeUnit.MILLISECONDS)).isEqualTo(1);
     assertThat(weightedPicker.pickSubchannel(mockArgs)
@@ -591,10 +619,10 @@ public class WeightedRoundRobinLoadBalancerTest {
     WrrSubchannel weightedSubchannel2 = (WrrSubchannel) weightedPicker.getList().get(1);
     weightedSubchannel1.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
         InternalCallMetricRecorder.createMetricReport(
-            0.1, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
+            0.1, 0, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
     weightedSubchannel2.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
         InternalCallMetricRecorder.createMetricReport(
-            0.2, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
+            0.2, 0, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
     assertThat(fakeClock.forwardTime(10, TimeUnit.SECONDS)).isEqualTo(1);
     Map<Subchannel, Integer> pickCount = new HashMap<>();
     for (int i = 0; i < 1000; i++) {
@@ -655,7 +683,7 @@ public class WeightedRoundRobinLoadBalancerTest {
       WrrSubchannel subchannel = (WrrSubchannel)pickResult.getSubchannel();
       subchannel.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
           InternalCallMetricRecorder.createMetricReport(
-              0.1, 0.1, qpsByChannel.get(subchannel), 0,
+              0.1, 0, 0.1, qpsByChannel.get(subchannel), 0,
               new HashMap<>(), new HashMap<>()));
     }
     assertThat(Math.abs(pickCount.get(weightedSubchannel1) / 1000.0 - 1.0 / 2))
@@ -671,7 +699,7 @@ public class WeightedRoundRobinLoadBalancerTest {
       WrrSubchannel subchannel = (WrrSubchannel) pickResult.getSubchannel();
       subchannel.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
           InternalCallMetricRecorder.createMetricReport(
-              0.1, 0.1, qpsByChannel.get(subchannel), 0,
+              0.1, 0, 0.1, qpsByChannel.get(subchannel), 0,
               new HashMap<>(), new HashMap<>()));
       fakeClock.forwardTime(50, TimeUnit.MILLISECONDS);
     }
@@ -710,10 +738,10 @@ public class WeightedRoundRobinLoadBalancerTest {
     WrrSubchannel weightedSubchannel3 = (WrrSubchannel) weightedPicker.getList().get(2);
     weightedSubchannel1.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
         InternalCallMetricRecorder.createMetricReport(
-            0.1, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
+            0.1, 0, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
     weightedSubchannel2.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
         InternalCallMetricRecorder.createMetricReport(
-            0.2, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
+            0.2, 0, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
     assertThat(fakeClock.forwardTime(10, TimeUnit.SECONDS)).isEqualTo(1);
     Map<Subchannel, Integer> pickCount = new HashMap<>();
     for (int i = 0; i < 1000; i++) {
@@ -754,10 +782,10 @@ public class WeightedRoundRobinLoadBalancerTest {
     WrrSubchannel weightedSubchannel2 = (WrrSubchannel) weightedPicker.getList().get(1);
     weightedSubchannel1.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
         InternalCallMetricRecorder.createMetricReport(
-            0.1, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
+            0.1, 0, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
     weightedSubchannel2.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
         InternalCallMetricRecorder.createMetricReport(
-            0.2, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
+            0.2, 0, 0.1, 1, 0, new HashMap<>(), new HashMap<>()));
     CyclicBarrier barrier = new CyclicBarrier(2);
     Map<Subchannel, AtomicInteger> pickCount = new ConcurrentHashMap<>();
     pickCount.put(weightedSubchannel1, new AtomicInteger(0));

--- a/xds/src/test/java/io/grpc/xds/orca/OrcaPerRequestUtilTest.java
+++ b/xds/src/test/java/io/grpc/xds/orca/OrcaPerRequestUtilTest.java
@@ -119,6 +119,7 @@ public class OrcaPerRequestUtilTest {
   static boolean reportEqual(MetricReport a,
                              MetricReport b) {
     return a.getCpuUtilization() == b.getCpuUtilization()
+        && a.getApplicationUtilization() == b.getApplicationUtilization()
         && a.getMemoryUtilization() == b.getMemoryUtilization()
         && a.getQps() == b.getQps()
         && a.getEps() == b.getEps()

--- a/xds/src/test/java/io/grpc/xds/orca/OrcaServiceImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/orca/OrcaServiceImplTest.java
@@ -143,6 +143,7 @@ public class OrcaServiceImplTest {
     ClientCall<OrcaLoadReportRequest, OrcaLoadReport> call = channel.newCall(
         OpenRcaServiceGrpc.getStreamCoreMetricsMethod(), CallOptions.DEFAULT);
     defaultTestService.putUtilizationMetric("buffer", 0.2);
+    defaultTestService.setApplicationUtilizationMetric(0.314159);
     defaultTestService.setQpsMetric(1.9);
     defaultTestService.setEpsMetric(0.2233);
     call.start(listener, new Metadata());
@@ -151,10 +152,11 @@ public class OrcaServiceImplTest {
     call.halfClose();
     call.request(1);
     OrcaLoadReport expect = OrcaLoadReport.newBuilder().putUtilization("buffer", 0.2)
-        .setRpsFractional(1.9).setEps(0.2233).build();
+        .setApplicationUtilization(0.314159).setRpsFractional(1.9).setEps(0.2233).build();
     verify(listener).onMessage(eq(expect));
     reset(listener);
     defaultTestService.removeUtilizationMetric("buffer0");
+    defaultTestService.clearApplicationUtilizationMetric();
     defaultTestService.clearQpsMetric();
     defaultTestService.clearEpsMetric();
     assertThat(fakeClock.forwardTime(500, TimeUnit.NANOSECONDS)).isEqualTo(0);
@@ -248,6 +250,7 @@ public class OrcaServiceImplTest {
     ImmutableMap<String, Double> firstUtilization = ImmutableMap.of("util", 0.1);
     OrcaLoadReport goldenReport = OrcaLoadReport.newBuilder()
         .setCpuUtilization(random.nextDouble() * 10)
+        .setApplicationUtilization(random.nextDouble() * 10)
         .setMemUtilization(random.nextDouble())
         .putAllUtilization(firstUtilization)
         .putUtilization("queue", 1.0)
@@ -255,6 +258,7 @@ public class OrcaServiceImplTest {
         .setEps(1.618)
         .build();
     defaultTestService.setCpuUtilizationMetric(goldenReport.getCpuUtilization());
+    defaultTestService.setApplicationUtilizationMetric(goldenReport.getApplicationUtilization());
     defaultTestService.setMemoryUtilizationMetric(goldenReport.getMemUtilization());
     defaultTestService.setAllUtilizationMetrics(firstUtilization);
     defaultTestService.putUtilizationMetric("queue", 1.0);
@@ -265,6 +269,7 @@ public class OrcaServiceImplTest {
     assertThat(reports.next()).isEqualTo(goldenReport);
 
     defaultTestService.clearCpuUtilizationMetric();
+    defaultTestService.clearApplicationUtilizationMetric();
     defaultTestService.clearMemoryUtilizationMetric();
     defaultTestService.clearQpsMetric();
     defaultTestService.clearEpsMetric();
@@ -281,6 +286,7 @@ public class OrcaServiceImplTest {
     assertThat(reports.next()).isEqualTo(goldenReport);
 
     defaultTestService.setCpuUtilizationMetric(-0.001);
+    defaultTestService.setApplicationUtilizationMetric(-0.001);
     defaultTestService.setMemoryUtilizationMetric(-0.001);
     defaultTestService.setMemoryUtilizationMetric(1.001);
     defaultTestService.setQpsMetric(-0.001);

--- a/xds/third_party/xds/import.sh
+++ b/xds/third_party/xds/import.sh
@@ -18,7 +18,7 @@
 set -e
 BRANCH=main
 # import VERSION from one of the google internal CLs
-VERSION=32f1caf87195bf3390061c29f18987e51ca56a88
+VERSION=e9ce68804cb4e64cab5a52e3c8baf840d4ff87b7
 GIT_REPO="https://github.com/cncf/xds.git"
 GIT_BASE_DIR=xds
 SOURCE_PROTO_BASE_DIR=xds

--- a/xds/third_party/xds/src/main/proto/xds/data/orca/v3/orca_load_report.proto
+++ b/xds/third_party/xds/src/main/proto/xds/data/orca/v3/orca_load_report.proto
@@ -14,8 +14,10 @@ import "validate/validate.proto";
 
 message OrcaLoadReport {
   // CPU utilization expressed as a fraction of available CPU resources. This
-  // should be derived from the latest sample or measurement.
-  double cpu_utilization = 1 [(validate.rules).double.gte = 0, (validate.rules).double.lte = 1];
+  // should be derived from the latest sample or measurement. The value may be
+  // larger than 1.0 when the usage exceeds the reporter dependent notion of
+  // soft limits.
+  double cpu_utilization = 1 [(validate.rules).double.gte = 0];
 
   // Memory utilization expressed as a fraction of available memory
   // resources. This should be derived from the latest sample or measurement.
@@ -45,4 +47,12 @@ message OrcaLoadReport {
 
   // Application specific opaque metrics.
   map<string, double> named_metrics = 8;
+
+  // Application specific utilization expressed as a fraction of available
+  // resources. For example, an application may report the max of CPU and memory
+  // utilization for better load balancing if it is both CPU and memory bound.
+  // This should be derived from the latest sample or measurement.
+  // The value may be larger than 1.0 when the usage exceeds the reporter
+  // dependent notion of soft limits.
+  double application_utilization = 9 [(validate.rules).double.gte = 0];
 }


### PR DESCRIPTION
* Import cncf/xds: original cl/538546518
* Add new APIs to `CallMetricRecorder` and `MetricRecorder` for `application_utilization`
* Use `application_utilization` and fallback to `cpu_utilization` if unset for client-side WRR
