### PR TITLE
Download Maven from Maven Central

### DIFF
--- a/buildscripts/grpc-java-artifacts/Dockerfile
+++ b/buildscripts/grpc-java-artifacts/Dockerfile
@@ -20,6 +20,6 @@ RUN yum install -y \
     yum clean all
 
 # Install Maven
-RUN curl -Ls http://dlcdn.apache.org/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz | \
+RUN curl -Ls https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.3.9/apache-maven-3.3.9-bin.tar.gz | \
     tar xz -C /var/local
 ENV PATH /var/local/apache-maven-3.3.9/bin:$PATH


### PR DESCRIPTION
Maven deleted older binaries from their CDN, so the download was failing. Maven Central seems it'll be more stable.

CC @sergiitk 