### PR TITLE
implemented and tested static stride scheduler for weighted round robin load balancing policy

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "editor.rulers": [
-        100
-    ],
-    "github.gitAuthentication": true,
-    "git.terminalAuthentication": false
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "editor.rulers": [
+        100
+    ],
+    "github.gitAuthentication": true,
+    "git.terminalAuthentication": false
+}

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -280,8 +280,8 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
       if (!enableOobLoadReport) {
         return PickResult.withSubchannel(subchannel,
                 OrcaPerRequestUtil.getInstance().newOrcaClientStreamTracerFactory(
-                        subchannelToReportListenerMap.getOrDefault(subchannel,
-                                ((WrrSubchannel) subchannel).new OrcaReportListener(errorUtilizationPenalty))));
+                subchannelToReportListenerMap.getOrDefault(subchannel,
+                ((WrrSubchannel) subchannel).new OrcaReportListener(errorUtilizationPenalty))));
       } else {
         return PickResult.withSubchannel(subchannel);
       }

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -44,7 +44,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -65,15 +64,10 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
   private final ScheduledExecutorService timeService;
   private ScheduledHandle weightUpdateTimer;
   private final Runnable updateWeightTask;
-  private final Random random;
   private final long infTime;
   private final Ticker ticker;
 
-  public WeightedRoundRobinLoadBalancer(Helper helper, Ticker ticker) {
-    this(new WrrHelper(OrcaOobUtil.newOrcaReportingHelper(helper)), ticker, new Random());
-  }
-
-  public WeightedRoundRobinLoadBalancer(WrrHelper helper, Ticker ticker, Random random) {
+  public WeightedRoundRobinLoadBalancer(WrrHelper helper, Ticker ticker) {
     super(helper);
     helper.setLoadBalancer(this);
     this.ticker = checkNotNull(ticker, "ticker");
@@ -81,13 +75,12 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
     this.syncContext = checkNotNull(helper.getSynchronizationContext(), "syncContext");
     this.timeService = checkNotNull(helper.getScheduledExecutorService(), "timeService");
     this.updateWeightTask = new UpdateWeightTask();
-    this.random = random;
     log.log(Level.FINE, "weighted_round_robin LB created");
   }
 
   @VisibleForTesting
-  WeightedRoundRobinLoadBalancer(Helper helper, Ticker ticker, Random random) {
-    this(new WrrHelper(OrcaOobUtil.newOrcaReportingHelper(helper)), ticker, random);
+  WeightedRoundRobinLoadBalancer(Helper helper, Ticker ticker) {
+    this(new WrrHelper(OrcaOobUtil.newOrcaReportingHelper(helper)), ticker);
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -490,9 +490,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
         maxWeight = Math.max(weight, maxWeight);
       }
 
-      // checkArgument(numChannels <= 1, "Couldn't build scheduler: requires at least two weights");
-      // checkArgument(numZeroWeightChannels == numChannels, "Couldn't build scheduler: only zero
-      // weights"); // checks break code
+      checkArgument(numChannels >= 1, "Couldn't build scheduler: requires at least one weight");
 
       double scalingFactor = K_MAX_WEIGHT / maxWeight;
       long meanWeight =

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -330,7 +330,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
 
   /*
    * The Static Stride Scheduler is an implementation of an earliest deadline first (EDF) scheduler
-   * in which each object is chosen periodically with frequency proportional to its weight.
+   * in which each object's deadline is the multiplicative inverse of the object's weight.
    * <p>
    * The way in which this is implemented is through a static stride scheduler. 
    * The Static Stride Scheduler works by iterating through the list of subchannel weights
@@ -397,6 +397,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
       return Integer.toUnsignedLong(sequence.getAndIncrement());
     }
 
+    @VisibleForTesting
     long getSequence() {
       return Integer.toUnsignedLong(sequence.get());
     }

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -348,7 +348,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
     private final int sizeDivisor;
     private final Random random;
     private final AtomicInteger sequence;
-    private static final int K_MAX_WEIGHT = 65535;
+    private static final int K_MAX_WEIGHT = 0xFFFF;
     private static final long UINT32_MAX = 0xFFFF_FFFFL;
 
     StaticStrideScheduler(float[] weights, Random random) {

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -317,27 +317,11 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
     
     // verbose work done (requires optimization)
     private void updateWeightSS() {
-      int weightedChannelCount = 0;
-      double avgWeight = 0;
-      for (Subchannel value : list) {
-        double newWeight = ((WrrSubchannel) value).getWeight();
-        if (newWeight > 0) {
-          avgWeight += newWeight;
-          weightedChannelCount++;
-        }
-      }
-
-      if (weightedChannelCount >= 1) {
-        avgWeight /= 1.0 * weightedChannelCount;
-      } else {
-        avgWeight = 1;
-      }
-
       float[] newWeights = new float[list.size()];
       for (int i = 0; i < list.size(); i++) {
         WrrSubchannel subchannel = (WrrSubchannel) list.get(i);
         double newWeight = subchannel.getWeight();
-        newWeights[i] = newWeight > 0 ? (float) newWeight : (float) avgWeight;
+        newWeights[i] = newWeight > 0 ? (float) newWeight : 0.0f;
       }
 
       StaticStrideScheduler ssScheduler = new StaticStrideScheduler(newWeights);
@@ -485,7 +469,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
       double sumWeight = 0;
       float maxWeight = 0;
       for (float weight : weights) {
-        if (weight == 0) {
+        if (Math.abs(weight - 0.0) < 0.0001) {
           numZeroWeightChannels++;
         }
         sumWeight += weight;

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -503,8 +503,8 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
       return this.sequence.getAndUpdate(seq -> ((seq + 1) % UINT32_MAX));
     }
 
-  /** Selects index of next backend server */
-  int pickChannel() {
+    /** Selects index of next backend server */
+    int pickChannel() {
       while (true) {
         long sequence = this.nextSequence();
         long backendIndex = sequence % this.sizeDivisor;

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -121,7 +121,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
     @Override
     public void run() {
       if (currentPicker != null && currentPicker instanceof WeightedRoundRobinPicker) {
-        ((WeightedRoundRobinPicker)currentPicker).updateWeightSS();
+        ((WeightedRoundRobinPicker) currentPicker).updateWeightSS();
       }
       weightUpdateTimer = syncContext.schedule(this, config.weightUpdatePeriodNanos,
           TimeUnit.NANOSECONDS, timeService);
@@ -315,7 +315,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
       this.edfScheduler = edfScheduler;
     }
     
-    // check correctness of behavior
+    // verbose work done (requires optimization)
     private void updateWeightSS() {
       int weightedChannelCount = 0;
       double avgWeight = 0;
@@ -495,7 +495,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
       checkArgument(numChannels >= 1, "Couldn't build scheduler: requires at least one weight");
 
       double scalingFactor = K_MAX_WEIGHT / maxWeight;
-      long meanWeight =
+      long meanWeight = numZeroWeightChannels == numChannels ? 1 :
           Math.round(scalingFactor * sumWeight / (numChannels - numZeroWeightChannels));
 
       // scales weights s.t. max(weights) == K_MAX_WEIGHT, meanWeight is scaled accordingly

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -59,7 +59,7 @@ import java.util.logging.Logger;
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/9885")
 final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
   private static final Logger log = Logger.getLogger(
-      WeightedRoundRobinLoadBalancer.class.getName());
+          WeightedRoundRobinLoadBalancer.class.getName());
   private WeightedRoundRobinLoadBalancerConfig config;
   private final SynchronizationContext syncContext;
   private final ScheduledExecutorService timeService;
@@ -113,7 +113,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
   @Override
   public RoundRobinPicker createReadyPicker(List<Subchannel> activeList) {
     return new WeightedRoundRobinPicker(activeList, config.enableOobLoadReport,
-        config.errorUtilizationPenalty);
+            config.errorUtilizationPenalty);
   }
 
   private final class UpdateWeightTask implements Runnable {
@@ -123,7 +123,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
         ((WeightedRoundRobinPicker) currentPicker).updateWeight();
       }
       weightUpdateTimer = syncContext.schedule(this, config.weightUpdatePeriodNanos,
-          TimeUnit.NANOSECONDS, timeService);
+              TimeUnit.NANOSECONDS, timeService);
     }
   }
 
@@ -132,7 +132,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
       WrrSubchannel weightedSubchannel = (WrrSubchannel) subchannel;
       if (config.enableOobLoadReport) {
         OrcaOobUtil.setListener(weightedSubchannel,
-            weightedSubchannel.new OrcaReportListener(config.errorUtilizationPenalty),
+                weightedSubchannel.new OrcaReportListener(config.errorUtilizationPenalty),
                 OrcaOobUtil.OrcaReportingConfig.newBuilder()
                         .setReportInterval(config.oobReportingPeriodNanos, TimeUnit.NANOSECONDS)
                         .build());
@@ -206,7 +206,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
         nonEmptySince = infTime;
         return 0;
       } else if (now - nonEmptySince < config.blackoutPeriodNanos
-          && config.blackoutPeriodNanos > 0) {
+              && config.blackoutPeriodNanos > 0) {
         return 0;
       } else {
         return weight;
@@ -230,8 +230,8 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
         double newWeight = 0;
         // Prefer application utilization and fallback to CPU utilization if unset.
         double utilization =
-            report.getApplicationUtilization() > 0 ? report.getApplicationUtilization()
-                : report.getCpuUtilization();
+                report.getApplicationUtilization() > 0 ? report.getApplicationUtilization()
+                        : report.getCpuUtilization();
         if (utilization > 0 && report.getQps() > 0) {
           double penalty = 0;
           if (report.getEps() > 0 && errorUtilizationPenalty > 0) {
@@ -255,19 +255,19 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
   final class WeightedRoundRobinPicker extends RoundRobinPicker {
     private final List<Subchannel> list;
     private final Map<Subchannel, OrcaPerRequestReportListener> subchannelToReportListenerMap =
-        new HashMap<>();
+            new HashMap<>();
     private final boolean enableOobLoadReport;
     private final float errorUtilizationPenalty;
     private volatile StaticStrideScheduler ssScheduler;
 
     WeightedRoundRobinPicker(List<Subchannel> list, boolean enableOobLoadReport,
-        float errorUtilizationPenalty) {
+                             float errorUtilizationPenalty) {
       checkNotNull(list, "list");
       Preconditions.checkArgument(!list.isEmpty(), "empty list");
       this.list = list;
       for (Subchannel subchannel : list) {
         this.subchannelToReportListenerMap.put(subchannel,
-            ((WrrSubchannel) subchannel).new OrcaReportListener(errorUtilizationPenalty));
+                ((WrrSubchannel) subchannel).new OrcaReportListener(errorUtilizationPenalty));
       }
       this.enableOobLoadReport = enableOobLoadReport;
       this.errorUtilizationPenalty = errorUtilizationPenalty;
@@ -279,14 +279,14 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
       Subchannel subchannel = list.get(ssScheduler.pick());
       if (!enableOobLoadReport) {
         return PickResult.withSubchannel(subchannel,
-            OrcaPerRequestUtil.getInstance().newOrcaClientStreamTracerFactory(
-                subchannelToReportListenerMap.getOrDefault(subchannel,
-                    ((WrrSubchannel) subchannel).new OrcaReportListener(errorUtilizationPenalty))));
+                OrcaPerRequestUtil.getInstance().newOrcaClientStreamTracerFactory(
+                        subchannelToReportListenerMap.getOrDefault(subchannel,
+                                ((WrrSubchannel) subchannel).new OrcaReportListener(errorUtilizationPenalty))));
       } else {
         return PickResult.withSubchannel(subchannel);
       }
     }
-    
+
     private void updateWeight() {
       float[] newWeights = new float[list.size()];
       for (int i = 0; i < list.size(); i++) {
@@ -302,9 +302,9 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
     @Override
     public String toString() {
       return MoreObjects.toStringHelper(WeightedRoundRobinPicker.class)
-          .add("enableOobLoadReport", enableOobLoadReport)
-          .add("errorUtilizationPenalty", errorUtilizationPenalty)
-          .add("list", list).toString();
+              .add("enableOobLoadReport", enableOobLoadReport)
+              .add("errorUtilizationPenalty", errorUtilizationPenalty)
+              .add("list", list).toString();
     }
 
     @VisibleForTesting
@@ -323,8 +323,8 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
       }
       // the lists cannot contain duplicate subchannels
       return enableOobLoadReport == other.enableOobLoadReport
-          && Float.compare(errorUtilizationPenalty, other.errorUtilizationPenalty) == 0
-          && list.size() == other.list.size() && new HashSet<>(list).containsAll(other.list);
+              && Float.compare(errorUtilizationPenalty, other.errorUtilizationPenalty) == 0
+              && list.size() == other.list.size() && new HashSet<>(list).containsAll(other.list);
     }
   }
 
@@ -333,13 +333,13 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
    * <p>
    * The Static Stride Scheduler works by iterating through the list of subchannel weights
    * and using modular arithmetic to evenly distribute picks and skips, favoring entries with the
-   * highest weight. It generates a practically equivalent sequence of picks as the EDFScheduler. 
-   * Albeit needing more bandwidth, the Static Stride Scheduler is more performant than the 
+   * highest weight. It generates a practically equivalent sequence of picks as the EDFScheduler.
+   * Albeit needing more bandwidth, the Static Stride Scheduler is more performant than the
    * EDFScheduler, as it removes the need for a priority queue (and thus mutex locks).
    * <p>
    * go/static-stride-scheduler
    * <p>
-   * 
+   *
    * <ul>
    *  <li>nextSequence() - O(1)
    *  <li>pick() - O(n)
@@ -361,7 +361,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
       for (float weight : weights) {
         if (weight > 0.0001) {
           sumWeight += weight;
-          maxWeight = Math.max(weight, maxWeight);  
+          maxWeight = Math.max(weight, maxWeight);
           numWeightedChannels++;
         }
       }
@@ -386,24 +386,24 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
       this.scaledWeights = scaledWeights;
       this.sizeDivisor = numChannels;
       this.sequence = new AtomicInteger(random.nextInt());
-      
+
     }
 
     /** Returns the next sequence number and atomically increases sequence with wraparound. */
     private long nextSequence() {
       return Integer.toUnsignedLong(sequence.getAndIncrement());
     }
-  
+
     public long getSequence() {
       return Integer.toUnsignedLong(sequence.get());
     }
 
     /*
-     * Selects index of next backend server. 
+     * Selects index of next backend server.
      * <p>
      * A 2D array is compactly represented where the row represents the generation and the column
      * represents the backend index. The value of an element is a boolean value which indicates
-     * whether or not a backend should be picked now. An atomically incremented counter keeps track 
+     * whether or not a backend should be picked now. An atomically incremented counter keeps track
      * of our backend and generation through modular arithmetic within the pick() method.
      * An offset is also included to minimize consecutive non-picks of a backend.
      */
@@ -414,7 +414,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
         long generation = sequence / this.sizeDivisor;
         long weight = this.scaledWeights[backendIndex];
         long offset = (long) K_MAX_WEIGHT / 2 * backendIndex;
-        if ((weight * generation + offset) % K_MAX_WEIGHT < K_MAX_WEIGHT - weight) { 
+        if ((weight * generation + offset) % K_MAX_WEIGHT < K_MAX_WEIGHT - weight) {
           continue;
         }
         return backendIndex;

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -121,7 +121,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
     @Override
     public void run() {
       if (currentPicker != null && currentPicker instanceof WeightedRoundRobinPicker) {
-        ((WeightedRoundRobinPicker)currentPicker).updateWeight();
+        ((WeightedRoundRobinPicker)currentPicker).updateWeightSS();
       }
       weightUpdateTimer = syncContext.schedule(this, config.weightUpdatePeriodNanos,
           TimeUnit.NANOSECONDS, timeService);
@@ -259,8 +259,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
         new HashMap<>();
     private final boolean enableOobLoadReport;
     private final float errorUtilizationPenalty;
-    private volatile EdfScheduler scheduler;
-    private volatile StaticStrideScheduler ssScheduler; // what does volatile mean?
+    private volatile StaticStrideScheduler scheduler; // what does volatile mean?
 
     WeightedRoundRobinPicker(List<Subchannel> list, boolean enableOobLoadReport,
         float errorUtilizationPenalty) {
@@ -273,7 +272,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
       }
       this.enableOobLoadReport = enableOobLoadReport;
       this.errorUtilizationPenalty = errorUtilizationPenalty;
-      updateWeight();
+      updateWeightSS();
     }
 
     @Override
@@ -289,7 +288,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
       }
     }
 
-    private void updateWeight() {
+    private void updateWeightEdf() {
       int weightedChannelCount = 0;
       double avgWeight = 0;
       for (Subchannel value : list) {
@@ -338,8 +337,8 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
         newWeights[i] = newWeight > 0 ? (float) newWeight : (float) avgWeight;
       }
 
-      StaticStrideScheduler ssScheduler = new StaticStrideScheduler(newWeights);
-      this.ssScheduler = ssScheduler;
+      StaticStrideScheduler scheduler = new StaticStrideScheduler(newWeights);
+      this.scheduler = scheduler;
     }
 
     @Override

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -59,7 +59,7 @@ import java.util.logging.Logger;
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/9885")
 final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
   private static final Logger log = Logger.getLogger(
-          WeightedRoundRobinLoadBalancer.class.getName());
+      WeightedRoundRobinLoadBalancer.class.getName());
   private WeightedRoundRobinLoadBalancerConfig config;
   private final SynchronizationContext syncContext;
   private final ScheduledExecutorService timeService;
@@ -113,7 +113,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
   @Override
   public RoundRobinPicker createReadyPicker(List<Subchannel> activeList) {
     return new WeightedRoundRobinPicker(activeList, config.enableOobLoadReport,
-            config.errorUtilizationPenalty);
+        config.errorUtilizationPenalty);
   }
 
   private final class UpdateWeightTask implements Runnable {
@@ -123,7 +123,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
         ((WeightedRoundRobinPicker) currentPicker).updateWeight();
       }
       weightUpdateTimer = syncContext.schedule(this, config.weightUpdatePeriodNanos,
-              TimeUnit.NANOSECONDS, timeService);
+          TimeUnit.NANOSECONDS, timeService);
     }
   }
 
@@ -132,7 +132,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
       WrrSubchannel weightedSubchannel = (WrrSubchannel) subchannel;
       if (config.enableOobLoadReport) {
         OrcaOobUtil.setListener(weightedSubchannel,
-                weightedSubchannel.new OrcaReportListener(config.errorUtilizationPenalty),
+            weightedSubchannel.new OrcaReportListener(config.errorUtilizationPenalty),
                 OrcaOobUtil.OrcaReportingConfig.newBuilder()
                         .setReportInterval(config.oobReportingPeriodNanos, TimeUnit.NANOSECONDS)
                         .build());
@@ -206,7 +206,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
         nonEmptySince = infTime;
         return 0;
       } else if (now - nonEmptySince < config.blackoutPeriodNanos
-              && config.blackoutPeriodNanos > 0) {
+          && config.blackoutPeriodNanos > 0) {
         return 0;
       } else {
         return weight;
@@ -230,8 +230,8 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
         double newWeight = 0;
         // Prefer application utilization and fallback to CPU utilization if unset.
         double utilization =
-                report.getApplicationUtilization() > 0 ? report.getApplicationUtilization()
-                        : report.getCpuUtilization();
+            report.getApplicationUtilization() > 0 ? report.getApplicationUtilization()
+                : report.getCpuUtilization();
         if (utilization > 0 && report.getQps() > 0) {
           double penalty = 0;
           if (report.getEps() > 0 && errorUtilizationPenalty > 0) {
@@ -255,19 +255,19 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
   final class WeightedRoundRobinPicker extends RoundRobinPicker {
     private final List<Subchannel> list;
     private final Map<Subchannel, OrcaPerRequestReportListener> subchannelToReportListenerMap =
-            new HashMap<>();
+        new HashMap<>();
     private final boolean enableOobLoadReport;
     private final float errorUtilizationPenalty;
-    private volatile StaticStrideScheduler ssScheduler;
+    private volatile StaticStrideScheduler scheduler;
 
     WeightedRoundRobinPicker(List<Subchannel> list, boolean enableOobLoadReport,
-                             float errorUtilizationPenalty) {
+        float errorUtilizationPenalty) {
       checkNotNull(list, "list");
       Preconditions.checkArgument(!list.isEmpty(), "empty list");
       this.list = list;
       for (Subchannel subchannel : list) {
         this.subchannelToReportListenerMap.put(subchannel,
-                ((WrrSubchannel) subchannel).new OrcaReportListener(errorUtilizationPenalty));
+            ((WrrSubchannel) subchannel).new OrcaReportListener(errorUtilizationPenalty));
       }
       this.enableOobLoadReport = enableOobLoadReport;
       this.errorUtilizationPenalty = errorUtilizationPenalty;
@@ -276,12 +276,12 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
 
     @Override
     public PickResult pickSubchannel(PickSubchannelArgs args) {
-      Subchannel subchannel = list.get(ssScheduler.pick());
+      Subchannel subchannel = list.get(scheduler.pick());
       if (!enableOobLoadReport) {
         return PickResult.withSubchannel(subchannel,
                 OrcaPerRequestUtil.getInstance().newOrcaClientStreamTracerFactory(
                 subchannelToReportListenerMap.getOrDefault(subchannel,
-                ((WrrSubchannel) subchannel).new OrcaReportListener(errorUtilizationPenalty))));
+                    ((WrrSubchannel) subchannel).new OrcaReportListener(errorUtilizationPenalty))));
       } else {
         return PickResult.withSubchannel(subchannel);
       }
@@ -295,16 +295,16 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
         newWeights[i] = newWeight > 0 ? (float) newWeight : 0.0f;
       }
 
-      StaticStrideScheduler ssScheduler = new StaticStrideScheduler(newWeights, random);
-      this.ssScheduler = ssScheduler;
+      StaticStrideScheduler scheduler = new StaticStrideScheduler(newWeights, random);
+      this.scheduler = scheduler;
     }
 
     @Override
     public String toString() {
       return MoreObjects.toStringHelper(WeightedRoundRobinPicker.class)
-              .add("enableOobLoadReport", enableOobLoadReport)
-              .add("errorUtilizationPenalty", errorUtilizationPenalty)
-              .add("list", list).toString();
+          .add("enableOobLoadReport", enableOobLoadReport)
+          .add("errorUtilizationPenalty", errorUtilizationPenalty)
+          .add("list", list).toString();
     }
 
     @VisibleForTesting
@@ -323,8 +323,8 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
       }
       // the lists cannot contain duplicate subchannels
       return enableOobLoadReport == other.enableOobLoadReport
-              && Float.compare(errorUtilizationPenalty, other.errorUtilizationPenalty) == 0
-              && list.size() == other.list.size() && new HashSet<>(list).containsAll(other.list);
+          && Float.compare(errorUtilizationPenalty, other.errorUtilizationPenalty) == 0
+          && list.size() == other.list.size() && new HashSet<>(list).containsAll(other.list);
     }
   }
 

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -468,11 +468,12 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
       double sumWeight = 0;
       float maxWeight = 0;
       for (float weight : weights) {
-        if (Math.abs(weight - 0.0) < 0.0001) { // just equal to 0?
+        if (weight < 0.0001) { // just equal to 0?
           numZeroWeightChannels++;
+        } else {
+          sumWeight += weight;
+          maxWeight = Math.max(weight, maxWeight);  
         }
-        sumWeight += weight;
-        maxWeight = Math.max(weight, maxWeight);
       }
 
       checkArgument(numChannels >= 1, "Couldn't build scheduler: requires at least one weight");
@@ -484,7 +485,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
       // scales weights s.t. max(weights) == K_MAX_WEIGHT, meanWeight is scaled accordingly
       int[] scaledWeights = new int[numChannels];
       for (int i = 0; i < numChannels; i++) {
-        if (Math.abs(weights[i]) < 0.0001) { // just equal to 0?
+        if (weights[i] < 0.0001) { // just equal to 0?
           scaledWeights[i] = meanWeight;
         } else {
           scaledWeights[i] = (int) Math.round(weights[i] * scalingFactor);
@@ -512,7 +513,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
         // is this really that much more efficient than a 2d array?
         long weight = this.scaledWeights[backendIndex];
         if ((weight * generation) % K_MAX_WEIGHT < K_MAX_WEIGHT - weight) { 
-          // wow how does this work/how was it discovered
+          // how does this work/how was it discovered
           continue;
         }
         return backendIndex;

--- a/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
@@ -933,8 +933,71 @@ public class WeightedRoundRobinLoadBalancerTest {
     assertThat(sss.pickChannel()).isEqualTo(1);
     assertThat(sss.pickChannel()).isEqualTo(2);
     assertThat(sss.pickChannel()).isEqualTo(2);
+    assertThat(sss.pickChannel()).isEqualTo(0);
+    assertThat(sss.pickChannel()).isEqualTo(1);
+    assertThat(sss.pickChannel()).isEqualTo(2);
+  }
+
+  @Test
+  public void testRebuildSamePicks() {
+    float[] weights = {3.1f, 1.6f, 2.3f};
+    StaticStrideScheduler sss1 = new StaticStrideScheduler(weights);
+    StaticStrideScheduler sss2 = new StaticStrideScheduler(weights);
+    for (int i = 0; i < 1000; i++) {
+      assertThat(sss1.pickChannel()).isEqualTo(sss2.pickChannel());
+    }
+  }
+
+  @Test
+  public void testStaticStrideSchedulerSimpleExample() {
+    float[] weights = {2.0f, (float) (10.0 / 3.0), 1.0f};
+    StaticStrideScheduler sss = new StaticStrideScheduler(weights);
+    assertThat(sss.pickChannel()).isEqualTo(1);
+    assertThat(sss.pickChannel()).isEqualTo(0);
+    assertThat(sss.pickChannel()).isEqualTo(1);
+    assertThat(sss.pickChannel()).isEqualTo(1);
+    assertThat(sss.pickChannel()).isEqualTo(0);
+    // assertThat(sss.pickChannel()).isEqualTo(2); // edf
+    assertThat(sss.pickChannel()).isEqualTo(1); // sss
+  }
+
+  @Test
+  public void testStaticStrideSchedulerNonIntegers() {
+    float[] weights = {0.5f, 0.3f, 1.0f};
+    StaticStrideScheduler sss = new StaticStrideScheduler(weights);
+    assertThat(sss.pickChannel()).isEqualTo(2);
+    assertThat(sss.pickChannel()).isEqualTo(0);
+    assertThat(sss.pickChannel()).isEqualTo(2);
+    assertThat(sss.pickChannel()).isEqualTo(2);
+    // assertThat(sss.pickChannel()).isEqualTo(1); // edf
+    assertThat(sss.pickChannel()).isEqualTo(0); // sss
+    assertThat(sss.pickChannel()).isEqualTo(1);
+    // sss and edf have diff behaviors?
   }
   
+  // @Test
+  // public void testStaticStrideSchedulerManyIterations() {
+  //   Random random = new Random();
+  //   double totalWeight = 0;
+  //   int capacity = random.nextInt(10) + 1;
+  //   double[] weights = new double[capacity];
+  //   EdfScheduler scheduler = new EdfScheduler(capacity, random);
+  //   for (int i = 0; i < capacity; i++) {
+  //     weights[i] = random.nextDouble();
+  //     scheduler.add(i, weights[i]);
+  //     totalWeight += weights[i];
+  //   }
+  //   Map<Integer, Integer> pickCount = new HashMap<>();
+  //   for (int i = 0; i < 1000; i++) {
+  //     int result = scheduler.pick();
+  //     pickCount.put(result, pickCount.getOrDefault(result, 0) + 1);
+  //   }
+  //   for (int i = 0; i < capacity; i++) {
+  //     assertThat(Math.abs(pickCount.getOrDefault(i, 0) / 1000.0 - weights[i] / totalWeight) )
+  //         .isAtMost(0.01);
+  //   }
+  // }
+
   private static class FakeSocketAddress extends SocketAddress {
     final String name;
 

--- a/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
@@ -63,7 +63,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
-import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CyclicBarrier;
@@ -174,8 +173,7 @@ public class WeightedRoundRobinLoadBalancerTest {
               return subchannel;
             }
             });
-    wrr = new WeightedRoundRobinLoadBalancer(helper, fakeClock.getDeadlineTicker(),
-        new FakeRandom());
+    wrr = new WeightedRoundRobinLoadBalancer(helper, fakeClock.getDeadlineTicker());
   }
 
   @Test
@@ -968,7 +966,6 @@ public class WeightedRoundRobinLoadBalancerTest {
   public void testStaticStrideSchedulerGivenExample1() {
     float[] weights = {10.0f, 20.0f, 30.0f};
     StaticStrideScheduler sss = new StaticStrideScheduler(weights);
-    Random random = new Random();
     double totalWeight = 60;
     Map<Integer, Integer> pickCount = new HashMap<>();
     for (int i = 0; i < 1000; i++) {
@@ -985,7 +982,6 @@ public class WeightedRoundRobinLoadBalancerTest {
   public void testStaticStrideSchedulerGivenExample2() {
     float[] weights = {2.0f, 3.0f, 6.0f};
     StaticStrideScheduler sss = new StaticStrideScheduler(weights);
-    Random random = new Random();
     double totalWeight = 11;
     Map<Integer, Integer> pickCount = new HashMap<>();
     for (int i = 0; i < 1000; i++) {
@@ -1002,7 +998,6 @@ public class WeightedRoundRobinLoadBalancerTest {
   public void testStaticStrideSchedulerNonIntegers1() {
     float[] weights = {2.0f, (float) (10.0 / 3.0), 1.0f};
     StaticStrideScheduler sss = new StaticStrideScheduler(weights);
-    Random random = new Random();
     double totalWeight = 2 + 10.0 / 3.0 + 1.0;
     Map<Integer, Integer> pickCount = new HashMap<>();
     for (int i = 0; i < 1000; i++) {
@@ -1019,7 +1014,6 @@ public class WeightedRoundRobinLoadBalancerTest {
   public void testStaticStrideSchedulerNonIntegers2() {
     float[] weights = {0.5f, 0.3f, 1.0f};
     StaticStrideScheduler sss = new StaticStrideScheduler(weights);
-    Random random = new Random();
     double totalWeight = 1.8;
     Map<Integer, Integer> pickCount = new HashMap<>();
     for (int i = 0; i < 1000; i++) {
@@ -1036,7 +1030,6 @@ public class WeightedRoundRobinLoadBalancerTest {
   public void testTwoWeights() {
     float[] weights = {1.0f, 2.0f};
     StaticStrideScheduler sss = new StaticStrideScheduler(weights);
-    Random random = new Random();
     double totalWeight = 3;
     Map<Integer, Integer> pickCount = new HashMap<>();
     for (int i = 0; i < 1000; i++) {
@@ -1053,7 +1046,6 @@ public class WeightedRoundRobinLoadBalancerTest {
   public void testManyWeights1() {
     float[] weights = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
     StaticStrideScheduler sss = new StaticStrideScheduler(weights);
-    Random random = new Random();
     double totalWeight = 15;
     Map<Integer, Integer> pickCount = new HashMap<>();
     for (int i = 0; i < 1000; i++) {
@@ -1070,7 +1062,6 @@ public class WeightedRoundRobinLoadBalancerTest {
   public void testManyComplexWeights2() {
     float[] weights = {1.2f, 2.4f, 222.56f, 0f, 15.0f, 226342.0f, 5123.0f, 0.0001f};
     StaticStrideScheduler sss = new StaticStrideScheduler(weights);
-    Random random = new Random();
     double totalWeight = 1.2 + 2.4 + 222.56 + 15.0 + 226342.0 + 5123.0 + 0.0001;
     Map<Integer, Integer> pickCount = new HashMap<>();
     for (int i = 0; i < 1000; i++) {
@@ -1092,14 +1083,6 @@ public class WeightedRoundRobinLoadBalancerTest {
 
     @Override public String toString() {
       return "FakeSocketAddress-" + name;
-    }
-  }
-
-  private static class FakeRandom extends Random {
-    @Override
-    public double nextDouble() {
-      // return constant value to disable init deadline randomization in the scheduler
-      return 0.322023;
     }
   }
 }

--- a/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
@@ -1035,6 +1035,27 @@ public class WeightedRoundRobinLoadBalancerTest {
     assertThat(sss.pickChannel()).isEqualTo(1);
   }
 
+  @Test
+  public void testManyWeights() {
+    float[] weights = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+    StaticStrideScheduler sss = new StaticStrideScheduler(weights);
+    assertThat(sss.pickChannel()).isEqualTo(4);
+    assertThat(sss.pickChannel()).isEqualTo(2);
+    assertThat(sss.pickChannel()).isEqualTo(3);
+    assertThat(sss.pickChannel()).isEqualTo(4);
+    assertThat(sss.pickChannel()).isEqualTo(1);
+    assertThat(sss.pickChannel()).isEqualTo(3);
+    assertThat(sss.pickChannel()).isEqualTo(4);
+    assertThat(sss.pickChannel()).isEqualTo(2);
+    assertThat(sss.pickChannel()).isEqualTo(3);
+    assertThat(sss.pickChannel()).isEqualTo(4);
+    assertThat(sss.pickChannel()).isEqualTo(0);
+    assertThat(sss.pickChannel()).isEqualTo(1);
+    assertThat(sss.pickChannel()).isEqualTo(2);
+    assertThat(sss.pickChannel()).isEqualTo(3);
+    assertThat(sss.pickChannel()).isEqualTo(4);
+  }
+
   private static class FakeSocketAddress extends SocketAddress {
     final String name;
 

--- a/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
@@ -986,7 +986,7 @@ public class WeightedRoundRobinLoadBalancerTest {
   }
 
   @Test
-  public void testManyWeights1() {
+  public void testManyWeights() {
     float[] weights = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
     Random random = new Random();
     StaticStrideScheduler sss = new StaticStrideScheduler(weights, random);
@@ -998,12 +998,12 @@ public class WeightedRoundRobinLoadBalancerTest {
     }
     for (int i = 0; i < 5; i++) {
       assertThat(Math.abs(pickCount.getOrDefault(i, 0) / 1000.0 - weights[i] / totalWeight))
-          .isAtMost(0.001);
+          .isAtMost(0.0011);
     }
   }
 
   @Test
-  public void testManyComplexWeights2() {
+  public void testManyComplexWeights() {
     float[] weights = {1.2f, 2.4f, 222.56f, 1.1f, 15.0f, 226342.0f, 5123.0f, 532.2f};
     Random random = new Random();
     StaticStrideScheduler sss = new StaticStrideScheduler(weights, random);
@@ -1040,7 +1040,7 @@ public class WeightedRoundRobinLoadBalancerTest {
   }
 
   @Test
-  public void testWraparound() {
+  public void testImmediateWraparound() {
     float[] weights = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
     Random random = new FakeRandomWraparound();
     StaticStrideScheduler sss = new StaticStrideScheduler(weights, random);
@@ -1057,7 +1057,7 @@ public class WeightedRoundRobinLoadBalancerTest {
   }
   
   @Test
-  public void testWraparound2() {
+  public void testWraparound() {
     float[] weights = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
     Random random = new FakeRandomWraparound2();
     StaticStrideScheduler sss = new StaticStrideScheduler(weights, random);

--- a/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
@@ -1115,7 +1115,6 @@ public class WeightedRoundRobinLoadBalancerTest {
     @Override
     public int nextInt() {
       // return constant value to disable init deadline randomization in the scheduler
-      // sequence will be initialized to 0
       return nextInt;
     }
   }

--- a/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
@@ -894,18 +894,6 @@ public class WeightedRoundRobinLoadBalancerTest {
     assertThat(picks).isEqualTo(expectedPicks);
   }
 
-  @Test
-  public void testEqualSchedulers() {
-    float[] weights = {1.0f, 7.0f, 3.0f, 5.0f, 1.1f};
-    StaticStrideScheduler sss1 = new StaticStrideScheduler(weights);
-    StaticStrideScheduler sss2 = new StaticStrideScheduler(weights);
-    for (int i = 0; i < 100; i++) {
-      int firstChannel = sss1.pickChannel();
-      int secondChannel = sss2.pickChannel();
-      assertThat(firstChannel).isEqualTo(secondChannel);
-    }
-  }
-
   private static class FakeSocketAddress extends SocketAddress {
     final String name;
 

--- a/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
@@ -932,7 +932,7 @@ public class WeightedRoundRobinLoadBalancerTest {
 
   @Test
   public void testAllInvalidWeightsUseOne() {
-    float[] weights = {-1.0f, -0.0f, 0.0f};
+    float[] weights = {-3.1f, -0.0f, 0.0f};
     StaticStrideScheduler sss = new StaticStrideScheduler(weights);
     int[] expectedPicks = new int[] {2, 2, 2};
     int[] picks = new int[3];
@@ -1023,7 +1023,17 @@ public class WeightedRoundRobinLoadBalancerTest {
     // sss and edf have diff behaviors?
   }
 
-  
+  @Test
+  public void testTwoWeights() {
+    float[] weights = {1.0f, 2.0f};
+    StaticStrideScheduler sss = new StaticStrideScheduler(weights);
+    assertThat(sss.pickChannel()).isEqualTo(1);
+    assertThat(sss.pickChannel()).isEqualTo(0);
+    assertThat(sss.pickChannel()).isEqualTo(1);
+    assertThat(sss.pickChannel()).isEqualTo(1);
+    assertThat(sss.pickChannel()).isEqualTo(0);
+    assertThat(sss.pickChannel()).isEqualTo(1);
+  }
 
   private static class FakeSocketAddress extends SocketAddress {
     final String name;

--- a/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
@@ -883,7 +883,7 @@ public class WeightedRoundRobinLoadBalancerTest {
   }
 
   @Test
-  public void testContainsZeroWeight() {
+  public void testContainsZeroWeightUseMean() {
     float[] weights = {3.0f, 0.0f, 1.0f};
     StaticStrideScheduler sss = new StaticStrideScheduler(weights);
     int[] expectedPicks = new int[] {3, 2, 1};
@@ -894,6 +894,47 @@ public class WeightedRoundRobinLoadBalancerTest {
     assertThat(picks).isEqualTo(expectedPicks);
   }
 
+  @Test
+  public void testLargestPickedEveryGeneration() {
+    float[] weights = {1.0f, 2.0f, 3.0f};
+    int mean = 2;
+    StaticStrideScheduler sss = new StaticStrideScheduler(weights);
+    int largestWeightPickCount = 0;
+    int kMaxWeight = 65535;
+    for (int i = 0; i < mean * kMaxWeight; i++) {
+      if (sss.pickChannel() == mean) {
+        largestWeightPickCount += 1;
+      }
+    }
+    assertThat(largestWeightPickCount).isEqualTo(kMaxWeight);
+  }
+
+  @Test
+  public void testStaticStrideSchedulerGivenExample() {
+    float[] weights = {10.0f, 20.0f, 30.0f};
+    StaticStrideScheduler sss = new StaticStrideScheduler(weights);
+    assertThat(sss.pickChannel()).isEqualTo(2);
+    assertThat(sss.pickChannel()).isEqualTo(1);
+    assertThat(sss.pickChannel()).isEqualTo(2);
+    assertThat(sss.pickChannel()).isEqualTo(0);
+    assertThat(sss.pickChannel()).isEqualTo(1);
+    assertThat(sss.pickChannel()).isEqualTo(2);
+  }
+
+  @Test
+  public void testStaticStrideSchedulerGivenExample2() {
+    float[] weights = {2.0f, 3.0f, 6.0f};
+    StaticStrideScheduler sss = new StaticStrideScheduler(weights);
+    assertThat(sss.pickChannel()).isEqualTo(2);
+    assertThat(sss.pickChannel()).isEqualTo(1);
+    assertThat(sss.pickChannel()).isEqualTo(2);
+    assertThat(sss.pickChannel()).isEqualTo(0);
+    assertThat(sss.pickChannel()).isEqualTo(2);
+    assertThat(sss.pickChannel()).isEqualTo(1);
+    assertThat(sss.pickChannel()).isEqualTo(2);
+    assertThat(sss.pickChannel()).isEqualTo(2);
+  }
+  
   private static class FakeSocketAddress extends SocketAddress {
     final String name;
 

--- a/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
@@ -1084,8 +1084,8 @@ public class WeightedRoundRobinLoadBalancerTest {
       pickCount.put(result, pickCount.getOrDefault(result, 0) + 1);
     }
     for (int i = 0; i < 8; i++) {
-      assertThat(Math.abs(pickCount.getOrDefault(i, 0) / 10000.0 - weights[i] / totalWeight) )
-          .isAtMost(2);
+      assertThat(Math.abs(pickCount.getOrDefault(i, 0) / 1000.0 - weights[i] / totalWeight) )
+          .isAtMost(0.01);
     }
   }
 

--- a/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
@@ -865,8 +865,9 @@ public class WeightedRoundRobinLoadBalancerTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void emptyWeights() {
-  List<Float> weights = new ArrayList<>();
+  float[] weights = {};
   StaticStrideScheduler sss = new StaticStrideScheduler(weights);
+  sss.pickChannel();
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
@@ -865,9 +865,9 @@ public class WeightedRoundRobinLoadBalancerTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void emptyWeights() {
-  float[] weights = {};
-  StaticStrideScheduler sss = new StaticStrideScheduler(weights);
-  sss.pickChannel();
+    float[] weights = {};
+    StaticStrideScheduler sss = new StaticStrideScheduler(weights);
+    sss.pickChannel();
   }
 
   @Test
@@ -892,6 +892,18 @@ public class WeightedRoundRobinLoadBalancerTest {
       picks[sss.pickChannel()] += 1;
     }
     assertThat(picks).isEqualTo(expectedPicks);
+  }
+
+  @Test
+  public void testEqualSchedulers() {
+    float[] weights = {1.0f, 7.0f, 3.0f, 5.0f, 1.1f};
+    StaticStrideScheduler sss1 = new StaticStrideScheduler(weights);
+    StaticStrideScheduler sss2 = new StaticStrideScheduler(weights);
+    for (int i = 0; i < 100; i++) {
+      int firstChannel = sss1.pickChannel();
+      int secondChannel = sss2.pickChannel();
+      assertThat(firstChannel).isEqualTo(secondChannel);
+    }
   }
 
   private static class FakeSocketAddress extends SocketAddress {

--- a/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
@@ -339,7 +339,7 @@ public class WeightedRoundRobinLoadBalancerTest {
   }
 
   @Test
-  public void pickByWeight_LargeWeight() {
+  public void pickByWeight_largeWeight() {
     MetricReport report1 = InternalCallMetricRecorder.createMetricReport(
         0.1, 0, 0.1, 999, 0, new HashMap<>(), new HashMap<>());
     MetricReport report2 = InternalCallMetricRecorder.createMetricReport(
@@ -381,6 +381,51 @@ public class WeightedRoundRobinLoadBalancerTest {
 
     pickByWeight(report1, report2, report3, weight1 / totalWeight, weight2 / totalWeight,
         weight3 / totalWeight);
+  }
+
+  @Test
+  public void pickByWeight_lowWeight() {
+    MetricReport report1 = InternalCallMetricRecorder.createMetricReport(
+        0.22, 0, 0.1, 122, 0, new HashMap<>(), new HashMap<>());
+    MetricReport report2 = InternalCallMetricRecorder.createMetricReport(
+        0.7, 0, 0.1, 1, 0, new HashMap<>(), new HashMap<>());
+    MetricReport report3 = InternalCallMetricRecorder.createMetricReport(
+        0.86, 0, 0.1, 80, 0, new HashMap<>(), new HashMap<>());
+    double totalWeight = 122 / 0.22 + 1 / 0.7 + 80 / 0.86;
+
+    pickByWeight(report1, report2, report3, 122 / 0.22 / totalWeight, 1 / 0.7 / totalWeight,
+            80 / 0.86 / totalWeight);
+  }
+
+  @Test
+  public void pickByWeight_lowWeight_useApplicationUtilization() {
+    MetricReport report1 = InternalCallMetricRecorder.createMetricReport(
+        0.22, 0.2, 0.1, 122, 0, new HashMap<>(), new HashMap<>());
+    MetricReport report2 = InternalCallMetricRecorder.createMetricReport(
+        0.7, 0.5, 0.1, 1, 0, new HashMap<>(), new HashMap<>());
+    MetricReport report3 = InternalCallMetricRecorder.createMetricReport(
+        0.86, 0.33, 0.1, 80, 0, new HashMap<>(), new HashMap<>());
+    double totalWeight = 122 / 0.2 + 1 / 0.5 + 80 / 0.33;
+
+    pickByWeight(report1, report2, report3, 122 / 0.2 / totalWeight, 1 / 0.5 / totalWeight,
+            80 / 0.33 / totalWeight);
+  }
+
+  @Test
+  public void pickByWeight_lowWeight_withEps_defaultErrorUtilizationPenalty() {
+    MetricReport report1 = InternalCallMetricRecorder.createMetricReport(
+        0.22, 0, 0.1, 122, 5, new HashMap<>(), new HashMap<>());
+    MetricReport report2 = InternalCallMetricRecorder.createMetricReport(
+        0.7, 0, 0.1, 1, 11, new HashMap<>(), new HashMap<>());
+    MetricReport report3 = InternalCallMetricRecorder.createMetricReport(
+        0.86, 0, 0.1, 80, 1, new HashMap<>(), new HashMap<>());
+    double weight1 = 122 / (0.22 + 5 / 122F * weightedConfig.errorUtilizationPenalty);
+    double weight2 = 1 / (0.7 + 11 / 1F * weightedConfig.errorUtilizationPenalty);
+    double weight3 = 80 / (0.86 + 1 / 80F * weightedConfig.errorUtilizationPenalty);
+    double totalWeight = weight1 + weight2 + weight3;
+
+    pickByWeight(report1, report2, report3, weight1 / totalWeight, weight2 / totalWeight,
+            weight3 / totalWeight);
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
@@ -895,6 +895,54 @@ public class WeightedRoundRobinLoadBalancerTest {
   }
 
   @Test
+  public void testContainsNegativeWeightUseMean() {
+    float[] weights = {3.0f, -1.0f, 1.0f};
+    StaticStrideScheduler sss = new StaticStrideScheduler(weights);
+    int[] expectedPicks = new int[] {3, 2, 1};
+    int[] picks = new int[3];
+    for (int i = 0; i < 6; i++) {
+      picks[sss.pickChannel()] += 1;
+    }
+    assertThat(picks).isEqualTo(expectedPicks);
+  }
+
+  @Test
+  public void testAllSameWeights() {
+    float[] weights = {1.0f, 1.0f, 1.0f};
+    StaticStrideScheduler sss = new StaticStrideScheduler(weights);
+    int[] expectedPicks = new int[] {2, 2, 2};
+    int[] picks = new int[3];
+    for (int i = 0; i < 6; i++) {
+      picks[sss.pickChannel()] += 1;
+    }
+    assertThat(picks).isEqualTo(expectedPicks);
+  }
+
+  @Test
+  public void testAllZeroWeightsUseOne() {
+    float[] weights = {0.0f, 0.0f, 0.0f};
+    StaticStrideScheduler sss = new StaticStrideScheduler(weights);
+    int[] expectedPicks = new int[] {2, 2, 2};
+    int[] picks = new int[3];
+    for (int i = 0; i < 6; i++) {
+      picks[sss.pickChannel()] += 1;
+    }
+    assertThat(picks).isEqualTo(expectedPicks);
+  }
+
+  @Test
+  public void testAllInvalidWeightsUseOne() {
+    float[] weights = {-1.0f, -0.0f, 0.0f};
+    StaticStrideScheduler sss = new StaticStrideScheduler(weights);
+    int[] expectedPicks = new int[] {2, 2, 2};
+    int[] picks = new int[3];
+    for (int i = 0; i < 6; i++) {
+      picks[sss.pickChannel()] += 1;
+    }
+    assertThat(picks).isEqualTo(expectedPicks);
+  }
+
+  @Test
   public void testLargestPickedEveryGeneration() {
     float[] weights = {1.0f, 2.0f, 3.0f};
     int mean = 2;
@@ -910,7 +958,7 @@ public class WeightedRoundRobinLoadBalancerTest {
   }
 
   @Test
-  public void testStaticStrideSchedulerGivenExample() {
+  public void testStaticStrideSchedulerGivenExample1() {
     float[] weights = {10.0f, 20.0f, 30.0f};
     StaticStrideScheduler sss = new StaticStrideScheduler(weights);
     assertThat(sss.pickChannel()).isEqualTo(2);
@@ -946,10 +994,10 @@ public class WeightedRoundRobinLoadBalancerTest {
     for (int i = 0; i < 1000; i++) {
       assertThat(sss1.pickChannel()).isEqualTo(sss2.pickChannel());
     }
-  }
+  } // will fail if sequence is non-deterministic
 
   @Test
-  public void testStaticStrideSchedulerSimpleExample() {
+  public void testStaticStrideSchedulerNonIntegers1() {
     float[] weights = {2.0f, (float) (10.0 / 3.0), 1.0f};
     StaticStrideScheduler sss = new StaticStrideScheduler(weights);
     assertThat(sss.pickChannel()).isEqualTo(1);
@@ -962,7 +1010,7 @@ public class WeightedRoundRobinLoadBalancerTest {
   }
 
   @Test
-  public void testStaticStrideSchedulerNonIntegers() {
+  public void testStaticStrideSchedulerNonIntegers2() {
     float[] weights = {0.5f, 0.3f, 1.0f};
     StaticStrideScheduler sss = new StaticStrideScheduler(weights);
     assertThat(sss.pickChannel()).isEqualTo(2);
@@ -974,29 +1022,8 @@ public class WeightedRoundRobinLoadBalancerTest {
     assertThat(sss.pickChannel()).isEqualTo(1);
     // sss and edf have diff behaviors?
   }
+
   
-  // @Test
-  // public void testStaticStrideSchedulerManyIterations() {
-  //   Random random = new Random();
-  //   double totalWeight = 0;
-  //   int capacity = random.nextInt(10) + 1;
-  //   double[] weights = new double[capacity];
-  //   EdfScheduler scheduler = new EdfScheduler(capacity, random);
-  //   for (int i = 0; i < capacity; i++) {
-  //     weights[i] = random.nextDouble();
-  //     scheduler.add(i, weights[i]);
-  //     totalWeight += weights[i];
-  //   }
-  //   Map<Integer, Integer> pickCount = new HashMap<>();
-  //   for (int i = 0; i < 1000; i++) {
-  //     int result = scheduler.pick();
-  //     pickCount.put(result, pickCount.getOrDefault(result, 0) + 1);
-  //   }
-  //   for (int i = 0; i < capacity; i++) {
-  //     assertThat(Math.abs(pickCount.getOrDefault(i, 0) / 1000.0 - weights[i] / totalWeight) )
-  //         .isAtMost(0.01);
-  //   }
-  // }
 
   private static class FakeSocketAddress extends SocketAddress {
     final String name;


### PR DESCRIPTION
The core of the Weighted Round Robin load balancer policy on the client side is a stride scheduler originally implemented by an [EDFScheduler](http://google3/net/rpc2/edf_scheduler.h;rcl=438515966). However, the mutex lock required by the EDFScheduler has been a frequent source of thread contention at high request rates and a block on other cost saving efforts.

The Static Stride Scheduler is a generator of a practically equivalent sequence of picks as EDFScheduler. It removes the need for a priority queue (and thus a lock) and improves latency at high request rates. 

[go/static-stride-scheduler](https://g3doc.corp.google.com/production/rpc/stubs/g3doc/loadbalancing/static_stride_scheduler.md?cl=head)