### PR TITLE
Handle Aggregate cluster loops and dups

### DIFF
--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
@@ -190,12 +190,6 @@ final class CdsLoadBalancer2 extends LoadBalancer {
               queue.addAll(clusterState.childClusterStates.values());
             } else {
               // Do cleanup
-              // for (String nameCausingLoops : namesCausingLoops) {
-              //   ClusterState removedCS = clusterState.childClusterStates.remove(nameCausingLoops);
-              //   xdsClient.cancelXdsResourceWatch(
-              //       XdsClusterResource.getInstance(), nameCausingLoops, removedCS);
-              // }
-
               if (childLb != null) {
                 childLb.shutdown();
                 childLb = null;

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
@@ -487,7 +488,6 @@ public class CdsLoadBalancer2Test {
     CdsUpdate update3 = CdsUpdate.forEds(cluster3, EDS_SERVICE_NAME, LRS_SERVER_INFO, 100L,
         upstreamTlsContext, outlierDetection).roundRobinLbPolicy().build();
     xdsClient.deliverCdsUpdate(cluster3, update3);
-    FakeLoadBalancer childBalancer = null;
     verify(helper).updateBalancingState(
         eq(ConnectivityState.TRANSIENT_FAILURE), pickerCaptor.capture());
     Status unavailable = Status.UNAVAILABLE.withDescription(
@@ -495,12 +495,6 @@ public class CdsLoadBalancer2Test {
             + " cluster cluster-foo.googleapis.com, named [cluster-01.googleapis.com,"
             + " cluster-02.googleapis.com]");
     assertPicker(pickerCaptor.getValue(), unavailable, null);
-
-    // cluster2 revoked
-    xdsClient.deliverResourceNotExist(cluster2);
-    assertThat(xdsClient.watchers.keySet())
-        .containsExactly(CLUSTER, cluster1, cluster2);  // cancelled subscription to cluster3
-    assertThat(childBalancers).isEmpty();
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
@@ -500,7 +500,7 @@ public class CdsLoadBalancer2Test {
   }
 
   @Test
-  public void aggregateCluster_withLoops_afterEDS() {
+  public void aggregateCluster_withLoops_afterEds() {
     String cluster1 = "cluster-01.googleapis.com";
     // CLUSTER (aggr.) -> [cluster1]
     CdsUpdate update =

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
@@ -24,7 +24,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;


### PR DESCRIPTION
For duplicate children, just ignore them
For loops, Put the channels into TRANSIENT_FAILURE like when no edge policy is provided

Note, to handle loop detection being done after state objects are created, I updated FakeXdsClient watcher map value to be a collection (as is true for XdsClientImpl).

Fixes go/grpc-lb-xds-tracker row 22 (not tracked as an issue)