### PR TITLE
removed strict dns check for unknown keys

### DIFF
--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -43,11 +43,9 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -74,14 +72,6 @@ public class DnsNameResolver extends NameResolver {
 
   // From https://github.com/grpc/proposal/blob/master/A2-service-configs-in-dns.md
   static final String SERVICE_CONFIG_PREFIX = "grpc_config=";
-  private static final Set<String> SERVICE_CONFIG_CHOICE_KEYS =
-      Collections.unmodifiableSet(
-          new HashSet<>(
-              Arrays.asList(
-                  SERVICE_CONFIG_CHOICE_CLIENT_LANGUAGE_KEY,
-                  SERVICE_CONFIG_CHOICE_PERCENTAGE_KEY,
-                  SERVICE_CONFIG_CHOICE_CLIENT_HOSTNAME_KEY,
-                  SERVICE_CONFIG_CHOICE_SERVICE_CONFIG_KEY)));
 
   // From https://github.com/grpc/proposal/blob/master/A2-service-configs-in-dns.md
   private static final String SERVICE_CONFIG_NAME_PREFIX = "_grpc_config.";
@@ -488,10 +478,6 @@ public class DnsNameResolver extends NameResolver {
   @VisibleForTesting
   static Map<String, ?> maybeChooseServiceConfig(
       Map<String, ?> choice, Random random, String hostname) {
-    for (Map.Entry<String, ?> entry : choice.entrySet()) {
-      Verify.verify(SERVICE_CONFIG_CHOICE_KEYS.contains(entry.getKey()), "Bad key: %s", entry);
-    }
-
     List<String> clientLanguages = getClientLanguagesFromChoice(choice);
     if (clientLanguages != null && !clientLanguages.isEmpty()) {
       boolean javaPresent = false;

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -886,16 +886,7 @@ public class DnsNameResolverTest {
     assertEquals(0, fakeClock.numPendingTasks());
     assertEquals(0, fakeExecutor.numPendingTasks());
   }
-
-  @Test
-  public void maybeChooseServiceConfig_failsOnMisspelling() {
-    Map<String, Object> bad = new LinkedHashMap<>();
-    bad.put("parcentage", 1.0);
-    thrown.expectMessage("Bad key");
-
-    DnsNameResolver.maybeChooseServiceConfig(bad, new Random(), "host");
-  }
-
+  
   @Test
   public void maybeChooseServiceConfig_clientLanguageMatchesJava() {
     Map<String, Object> choice = new LinkedHashMap<>();

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -886,6 +886,14 @@ public class DnsNameResolverTest {
     assertEquals(0, fakeClock.numPendingTasks());
     assertEquals(0, fakeExecutor.numPendingTasks());
   }
+
+  @Test
+  public void maybeChooseServiceConfig_nullOnMispelling() {
+    Map<String, Object> bad = new LinkedHashMap<>();
+    bad.put("parcentage", 1.0);
+    thrown.expectMessage("key '{parcentage=1.0}' missing in 'serviceConfig'");
+    DnsNameResolver.maybeChooseServiceConfig(bad, new Random(), "host");
+  }
   
   @Test
   public void maybeChooseServiceConfig_clientLanguageMatchesJava() {


### PR DESCRIPTION
#6579 describes a service config validation issue.

Specifically, the [service config error handling proposal](https://github.com/grpc/proposal/blob/master/A21-service-config-error-handling.md) details that we should ignore unknown keys in our service config. This is consistent with the C and Go implementations.

However, a [different proposal](https://github.com/grpc/proposal/blob/master/A2-service-configs-in-dns.md#canarying-changes) suggests that an unknown field should invalidate a service config. 

This is a fix that is consistent with the former proposal (and the C and Go implementations) and ignores unknown keys in our service config.

(no consensus reached, on hold)