### PR TITLE
Remove build usages of Jetty ALPN

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,19 +52,6 @@ for reviewers:
   Project maintainers are obligated to squash those commits into one when
   merging.
 
-## Running tests
-
-### Jetty ALPN setup for IntelliJ
-
-The tests in interop-testing project require jetty-alpn agent running in the background
-otherwise they'll fail. Here are instructions on how to setup IntellJ IDEA to enable running
-those tests in IDE:
-
-* Settings -> Build Tools -> Gradle -> Runner -> select Gradle Test Runner
-* View -> Tool Windows -> Gradle -> Edit Run Configuration -> Defaults -> JUnit -> Before lauch -> + -> Run Gradle task, enter the task in the build.gradle that sets the javaagent.
-
-Step 1 must be taken, otherwise by the default JUnit Test Runner running a single test in IDE will trigger all the tests.
-
 ## Guidelines for Pull Requests
 How to get your contributions merged smoothly and quickly.
  

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -14,10 +14,6 @@ tasks.named("jmh").configure {
     jvmArgs = ["-server", "-Xms2g", "-Xmx2g"]
 }
 
-configurations {
-    alpnagent
-}
-
 tasks.named("jar").configure {
     manifest {
         attributes('Automatic-Module-Name': 'io.grpc.benchmarks')
@@ -43,7 +39,6 @@ dependencies {
         }
     }
     compileOnly libraries.javax.annotation
-    alpnagent libraries.jetty.alpn.agent
 
     testImplementation libraries.junit,
             libraries.mockito.core

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,7 +42,6 @@ guava-jre = "com.google.guava:guava:32.1.3-jre"
 hdrhistogram = "org.hdrhistogram:HdrHistogram:2.1.12"
 javax-annotation = "org.apache.tomcat:annotations-api:6.0.53"
 j2objc-annotations = " com.google.j2objc:j2objc-annotations:2.8"
-jetty-alpn-agent = "org.mortbay.jetty.alpn:jetty-alpn-agent:2.0.10"
 jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
 junit = "junit:junit:4.13.2"
 # Update notes / 2023-07-19 sergiitk:

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -9,10 +9,6 @@ plugins {
 
 description = "gRPC: Integration Testing"
 
-configurations {
-    alpnagent
-}
-
 dependencies {
     implementation project(path: ':grpc-alts', configuration: 'shadow'),
             project(':grpc-auth'),
@@ -54,7 +50,6 @@ dependencies {
             project(':grpc-core'),
             libraries.mockito.core,
             libraries.okhttp
-    alpnagent libraries.jetty.alpn.agent
 
     signature libraries.signature.java
     signature libraries.signature.android
@@ -68,10 +63,6 @@ tasks.named("compileJava").configure {
     // This isn't a library; it can use beta APIs
     options.errorprone.check("BetaApi", CheckSeverity.OFF)
 }
-tasks.named("test").configure {
-    // For the automated tests, use Jetty ALPN.
-    jvmArgs "-javaagent:" + configurations.alpnagent.asPath
-}
 
 // For the generated scripts, use Netty tcnative (i.e. OpenSSL).
 // Note that OkHttp currently only supports ALPN, so OpenSSL version >= 1.0.2 is required.
@@ -79,15 +70,8 @@ tasks.named("test").configure {
 def test_client = tasks.register("test_client", CreateStartScripts) {
     mainClass = "io.grpc.testing.integration.TestServiceClient"
     applicationName = "test-client"
-    defaultJvmOpts = [
-        "-javaagent:JAVAAGENT_APP_HOME" + configurations.alpnagent.singleFile.name
-    ]
     outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
     classpath = startScripts.classpath
-    doLast {
-        unixScript.text = unixScript.text.replace('JAVAAGENT_APP_HOME', '\'"\$APP_HOME"\'/lib/')
-        windowsScript.text = windowsScript.text.replace('JAVAAGENT_APP_HOME', '%APP_HOME%\\lib\\')
-    }
 }
 
 def test_server = tasks.register("test_server", CreateStartScripts) {
@@ -176,10 +160,6 @@ application {
         from(xds_test_server)
         from(xds_federation_test_client)
         fileMode = 0755
-    }
-
-    applicationDistribution.into("lib") {
-        from(configurations.alpnagent)
     }
 }
 

--- a/istio-interop-testing/build.gradle
+++ b/istio-interop-testing/build.gradle
@@ -9,10 +9,6 @@ plugins {
 
 description = "gRPC: Istio Interop testing"
 
-configurations {
-    alpnagent
-}
-
 dependencies {
     implementation  project(':grpc-core'),
             project(':grpc-netty'),
@@ -31,7 +27,6 @@ dependencies {
             libraries.mockito.core,
             libraries.junit,
             libraries.truth
-    alpnagent libraries.jetty.alpn.agent
 
     signature libraries.signature.java
 }

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -9,10 +9,6 @@ plugins {
 
 description = "gRPC: Netty"
 
-configurations {
-    alpnagent
-}
-
 tasks.named("jar").configure {
     manifest {
         attributes('Automatic-Module-Name': 'io.grpc.netty')
@@ -71,7 +67,6 @@ dependencies {
     }
     signature libraries.signature.java
     signature libraries.signature.android
-    alpnagent libraries.jetty.alpn.agent
 }
 
 import net.ltgt.gradle.errorprone.CheckSeverity
@@ -87,11 +82,6 @@ tasks.named("javadoc").configure {
     exclude 'io/grpc/netty/GrpcHttp2ConnectionHandler.java'
     exclude 'io/grpc/netty/Internal*'
     exclude 'io/grpc/netty/ProtocolNegotiationEvent.java'
-}
-
-tasks.named("test").configure {
-    // Allow testing Jetty ALPN in TlsTest
-    jvmArgs "-javaagent:" + configurations.alpnagent.asPath
 }
 
 tasks.named("jmh").configure {


### PR DESCRIPTION
It wasn't actually being used. Since Java 8u252 in early 2020 we've been using ALPN from the JDK. The Jetty ALPN Agent has been a noop.

We do keep the Jetty ALPN support in the code and tests, but we don't have the infrastructure to actually run it.

-----

This is a re-do of #4857, but instead of swapping to Conscript we just use the JDK.