### PR TITLE
core: Outlier detection to use acceptResolvedAddresses()

### DIFF
--- a/util/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
@@ -146,10 +146,9 @@ public final class OutlierDetectionLoadBalancer extends LoadBalancer {
       trackerMap.cancelTracking();
     }
 
-    switchLb.handleResolvedAddresses(
+    return switchLb.acceptResolvedAddresses(
         resolvedAddresses.toBuilder().setLoadBalancingPolicyConfig(config.childPolicy.getConfig())
             .build());
-    return true;
   }
 
   @Override


### PR DESCRIPTION
Use this instead of the deprecated handleResolvedAddresses() when calling the switchLb.