### PR TITLE
Remove unneeded dependency excludes

### DIFF
--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -33,9 +33,7 @@ dependencies {
             libraries.mockito.core,
             libraries.truth
 
-    testImplementation (libraries.guava.testlib) {
-        exclude group: 'junit', module: 'junit'
-    }
+    testImplementation libraries.guava.testlib
     testRuntimeOnly libraries.netty.tcnative,
             libraries.netty.tcnative.classes
     testRuntimeOnly (libraries.netty.transport.epoll) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,10 +41,7 @@ dependencies {
     testImplementation project('::grpc-okhttp')
     testImplementation libraries.androidx.test.core
     testImplementation libraries.junit
-    testImplementation (libraries.robolectric) {
-        // Unreleased change: https://github.com/robolectric/robolectric/pull/5432
-        exclude group: 'com.google.auto.service', module: 'auto-service'
-    }
+    testImplementation libraries.robolectric
     testImplementation libraries.truth
 }
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -21,9 +21,7 @@ dependencies {
     testImplementation testFixtures(project(':grpc-context')),
             project(':grpc-testing'),
             project(':grpc-grpclb')
-    testImplementation (libraries.guava.testlib) {
-        exclude group: 'junit', module: 'junit'
-    }
+    testImplementation libraries.guava.testlib
     jmh project(':grpc-core')
 
     signature libraries.signature.java

--- a/authz/build.gradle
+++ b/authz/build.gradle
@@ -20,9 +20,7 @@ dependencies {
     testImplementation project(':grpc-testing'),
             project(':grpc-testing-proto'),
             testFixtures(project(':grpc-core'))
-    testImplementation (libraries.guava.testlib) {
-        exclude group: 'junit', module: 'junit'
-    }
+    testImplementation libraries.guava.testlib
 
     def xdsDependency = implementation project(':grpc-xds')
     shadow configurations.implementation.getDependencies().minus([xdsDependency])

--- a/binder/build.gradle
+++ b/binder/build.gradle
@@ -47,13 +47,8 @@ dependencies {
     testImplementation libraries.androidx.lifecycle.service
     testImplementation libraries.junit
     testImplementation libraries.mockito.core
-    testImplementation (libraries.robolectric) {
-        // Unreleased change: https://github.com/robolectric/robolectric/pull/5432
-        exclude group: 'com.google.auto.service', module: 'auto-service'
-    }
-    testImplementation (libraries.guava.testlib) {
-        exclude group: 'junit', module: 'junit'
-    }
+    testImplementation libraries.robolectric
+    testImplementation libraries.guava.testlib
     testImplementation libraries.truth
     testImplementation project(':grpc-testing')
     testImplementation testFixtures(project(':grpc-core'))
@@ -70,9 +65,7 @@ dependencies {
     androidTestImplementation libraries.truth
     androidTestImplementation libraries.mockito.android
     androidTestImplementation libraries.androidx.lifecycle.service
-    androidTestImplementation (libraries.guava.testlib) {
-        exclude group: 'junit', module: 'junit'
-    }
+    androidTestImplementation libraries.guava.testlib
     androidTestImplementation testFixtures(project(':grpc-core'))
 }
 

--- a/context/build.gradle
+++ b/context/build.gradle
@@ -22,9 +22,7 @@ dependencies {
     // Explicitly choose the guava version to stay Java 7-compatible. The rest of gRPC can move
     // forward to Java 8-requiring versions. This is also only used for testing, so is unlikely to
     // cause problems.
-    testImplementation ('com.google.guava:guava-testlib:30.1.1-android') {
-        exclude group: 'junit', module: 'junit'
-    }
+    testImplementation 'com.google.guava:guava-testlib:30.1.1-android'
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -37,9 +37,7 @@ dependencies {
             testFixtures(project(':grpc-api')),
             project(':grpc-testing'),
             project(':grpc-grpclb')
-    testImplementation (libraries.guava.testlib) {
-        exclude group: 'junit', module: 'junit'
-    }
+    testImplementation libraries.guava.testlib
 
     testRuntimeOnly project(':grpc-census')
 

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -52,10 +52,7 @@ dependencies {
 
     testImplementation libraries.junit
     testImplementation libraries.mockito.core
-    testImplementation (libraries.robolectric) {
-        // Unreleased change: https://github.com/robolectric/robolectric/pull/5432
-        exclude group: 'com.google.auto.service', module: 'auto-service'
-    }
+    testImplementation libraries.robolectric
 }
 
 task javadocs(type: Javadoc) {

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -16,10 +16,7 @@ dependencies {
     compileOnly libraries.opencensus.api
     runtimeOnly project(":grpc-context") // Pull in newer version than census-api
 
-    testImplementation (libraries.mockito.core) {
-        // prefer our own versions instead of mockito's dependency
-        exclude group: 'org.hamcrest', module: 'hamcrest-core'
-    }
+    testImplementation libraries.mockito.core
 
     testImplementation project(':grpc-testing-proto'),
             testFixtures(project(':grpc-core'))

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -68,9 +68,7 @@ dependencies {
             classifier = "linux-x86_64"
         }
     }
-    testImplementation (libraries.guava.testlib) {
-        exclude group: 'junit', module: 'junit'
-    }
+    testImplementation libraries.guava.testlib
 
     shadow configurations.implementation.getDependencies().minus([nettyDependency])
     shadow project(path: ':grpc-netty-shaded', configuration: 'shadow')


### PR DESCRIPTION
Since 44847bf4e, when we upgraded our JUnit version, the JUnit exclusions have probably not been necessary. e0ac97c4f upgraded Robolectric to a version that had the auto.service problem fixed.