### PR TITLE
buildscripts: Build Android with main build in linux_artifacts

### DIFF
--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -112,7 +112,8 @@ import net.ltgt.gradle.errorprone.CheckSeverity
 
 tasks.withType(JavaCompile).configureEach {
     options.compilerArgs += [
-            "-Xlint:-cast"
+            "-Xlint:-cast",
+            "-Xlint:-deprecation", // https://github.com/grpc/grpc-java/issues/10298
     ]
     appendToProperty(it.options.errorprone.excludedPaths, ".*/R.java", "|")
     appendToProperty(

--- a/binder/build.gradle
+++ b/binder/build.gradle
@@ -82,6 +82,7 @@ tasks.withType(JavaCompile).configureEach {
     options.compilerArgs += [
             "-Xlint:-cast"
     ]
+    options.compilerArgs -= ["-Werror"] // https://github.com/grpc/grpc-java/issues/10297
     appendToProperty(it.options.errorprone.excludedPaths, ".*/R.java", "|")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ subprojects {
             "-Xlint:-try"
         ]
         it.options.encoding = "UTF-8"
+        // Avoid Gradle OOM.
+        // https://docs.gradle.org/current/userguide/performance.html#run_the_compiler_as_a_separate_process
+        it.options.fork = true
         if (rootProject.hasProperty('failOnWarnings') && rootProject.failOnWarnings.toBoolean()) {
             it.options.compilerArgs += ["-Werror"]
         }

--- a/buildscripts/grpc-java-artifacts/Dockerfile
+++ b/buildscripts/grpc-java-artifacts/Dockerfile
@@ -7,7 +7,7 @@ RUN yum install -y \
             gcc-c++.i686 \
             glibc-devel \
             glibc-devel.i686 \
-            java-1.8.0-openjdk-devel \
+            java-11-openjdk-devel \
             libstdc++-devel \
             libstdc++-devel.i686 \
             libstdc++-static \
@@ -15,9 +15,19 @@ RUN yum install -y \
             libtool \
             make \
             tar \
+            unzip \
             which \
             && \
     yum clean all
+
+ENV ANDROID_HOME=/opt/Android/Sdk
+RUN mkdir -p "$ANDROID_HOME/cmdline-tools" && \
+    curl -Ls -o cmdline.zip \
+        "https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip" && \
+    unzip -qd "$ANDROID_HOME/cmdline-tools" cmdline.zip && \
+    rm cmdline.zip && \
+    mv "$ANDROID_HOME/cmdline-tools/cmdline-tools" "$ANDROID_HOME/cmdline-tools/latest" && \
+    yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses
 
 # Install Maven
 RUN curl -Ls https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.3.9/apache-maven-3.3.9-bin.tar.gz | \

--- a/buildscripts/kokoro/android-interop.sh
+++ b/buildscripts/kokoro/android-interop.sh
@@ -16,7 +16,7 @@ export CXXFLAGS=-I/tmp/protobuf/include
 export LD_LIBRARY_PATH=/tmp/protobuf/lib
 export OS_NAME=$(uname)
 
-echo y | ${ANDROID_HOME}/tools/bin/sdkmanager "build-tools;28.0.3"
+(yes || true) | "${ANDROID_HOME}/tools/bin/sdkmanager" --licenses
 
 # Proto deps
 buildscripts/make_dependencies.sh

--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -23,7 +23,7 @@ cat <<EOF >> gradle.properties
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m
 EOF
 
-echo y | ${ANDROID_HOME}/tools/bin/sdkmanager "build-tools;28.0.3"
+(yes || true) | "${ANDROID_HOME}/tools/bin/sdkmanager" --licenses
 
 # Proto deps
 buildscripts/make_dependencies.sh

--- a/buildscripts/kokoro/linux_artifacts.sh
+++ b/buildscripts/kokoro/linux_artifacts.sh
@@ -13,45 +13,6 @@ trap spongify_logs EXIT
 "$GRPC_JAVA_DIR"/buildscripts/build_docker.sh
 "$GRPC_JAVA_DIR"/buildscripts/run_in_docker.sh grpc-java-artifacts-x86 /grpc-java/buildscripts/build_artifacts_in_docker.sh
 
-# grpc-android, grpc-cronet and grpc-binder require the Android SDK, so build outside of Docker and
-# use --include-build for its grpc-core dependency
-echo y | ${ANDROID_HOME}/tools/bin/sdkmanager "build-tools;28.0.3"
-
-# The sdkmanager needs Java 8, but now we switch to 11 as the Android builds
-# require it
-sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
-unset JAVA_HOME
-
-LOCAL_MVN_TEMP=$(mktemp -d)
-GRADLE_FLAGS="-Pandroid.useAndroidX=true"
-pushd "$GRPC_JAVA_DIR/android"
-../gradlew publish \
-  -Dorg.gradle.parallel=false \
-  -PskipCodegen=true \
-  -PrepositoryDir="$LOCAL_MVN_TEMP" \
-  $GRADLE_FLAGS
-popd
-
-pushd "$GRPC_JAVA_DIR/cronet"
-../gradlew publish \
-  -Dorg.gradle.parallel=false \
-  -PskipCodegen=true \
-  -PrepositoryDir="$LOCAL_MVN_TEMP" \
-  $GRADLE_FLAGS
-popd
-
-pushd "$GRPC_JAVA_DIR/binder"
-../gradlew publish \
-  -Dorg.gradle.parallel=false \
-  -PskipCodegen=true \
-  -PrepositoryDir="$LOCAL_MVN_TEMP" \
-  $GRADLE_FLAGS
-popd
-
-readonly MVN_ARTIFACT_DIR="${MVN_ARTIFACT_DIR:-$GRPC_JAVA_DIR/mvn-artifacts}"
-mkdir -p "$MVN_ARTIFACT_DIR"
-cp -r "$LOCAL_MVN_TEMP"/* "$MVN_ARTIFACT_DIR"/
-
 "$GRPC_JAVA_DIR"/buildscripts/run_in_docker.sh grpc-java-artifacts-multiarch env \
   SKIP_TESTS=true ARCH=aarch_64 /grpc-java/buildscripts/kokoro/unix.sh
 "$GRPC_JAVA_DIR"/buildscripts/run_in_docker.sh grpc-java-artifacts-multiarch env \

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -47,8 +47,12 @@ GRADLE_FLAGS+=" -PtargetArch=$ARCH"
 GRADLE_FLAGS+=" -Pcheckstyle.ignoreFailures=false"
 GRADLE_FLAGS+=" -PfailOnWarnings=true"
 GRADLE_FLAGS+=" -PerrorProne=true"
-GRADLE_FLAGS+=" -PskipAndroid=true"
 GRADLE_FLAGS+=" -Dorg.gradle.parallel=true"
+if [[ -z "${ALL_ARTIFACTS:-}" ]]; then
+  GRADLE_FLAGS+=" -PskipAndroid=true"
+else
+  GRADLE_FLAGS+=" -Pandroid.useAndroidX=true"
+fi
 export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1g'"
 
 # Make protobuf discoverable by :grpc-compiler


### PR DESCRIPTION
Note that this changes the JDK used to compile releases to Java 11. That should only impact the appearance of the Javadoc.

This adds the Android SDK to the build container, removing the dependency on the Android SDK being available on the CI host. This allows running on newer Kokoro images. 'Android' and 'Android interop' CIs still depend on the Android SDK being available on the host, but since they aren't used as part of the release process, they can more easily migrate off Kokoro as part of future work.

This also causes Android components to now be built with -Werror, as we use -PfailOnWarnings=true in unix.sh but were missing it from the Android build invocations.

Gradle will auto-download the necessary version of build-tools. We don't want to download it ourselves because the version we specify might not even be used. Looking at logs, we were previously downloading a version that was unused.