### PR TITLE
buildscripts: Fix prepare_qemu to not assume system already has emulation

### DIFF
--- a/buildscripts/qemu_helpers/prepare_qemu.sh
+++ b/buildscripts/qemu_helpers/prepare_qemu.sh
@@ -6,7 +6,7 @@
 set -ex
 
 # show pre-existing qemu registration
-cat /proc/sys/fs/binfmt_misc/qemu-aarch64
+cat /proc/sys/fs/binfmt_misc/qemu-aarch64 || true
 
 # Kokoro ubuntu1604 workers have already qemu-user and qemu-user-static packages installed, but it's and old version that:
 # * prints warning about some syscalls (e.g "qemu: Unsupported syscall: 278")


### PR DESCRIPTION
Apparently our Kokoro image has this done already, and my laptop as well. But the newer Kokoro image and other computers like my desktop don't have it already.