### PR TITLE
buildscripts, psm interop: Don't fail url_map target if sub-target already failed (v1.55.x backport)

### DIFF
--- a/buildscripts/kokoro/xds_url_map.sh
+++ b/buildscripts/kokoro/xds_url_map.sh
@@ -172,7 +172,7 @@ main() {
   build_docker_images_if_needed
   # Run tests
   cd "${TEST_DRIVER_FULL_DIR}"
-  run_test url_map
+  run_test url_map || echo "Failed url_map test"
 }
 
 main "$@"


### PR DESCRIPTION
Backport of #10295 to v1.55.x.
---
We don't want file multiple bugs if any of the sub-tests of the `url_map` test fails.

The same change in core: https://github.com/grpc/grpc/pull/33520