### PR TITLE
compiler: Don't mention C++ Protobuf version in build message

### DIFF
--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -201,7 +201,7 @@ protobuf {
     }
 }
 
-println "*** Building codegen requires Protobuf version ${libs.versions.protobuf.get()}"
+println "*** Building codegen requires Protobuf"
 println "*** Please refer to https://github.com/grpc/grpc-java/blob/master/COMPILING.md#how-to-build-code-generation-plugin"
 
 tasks.register("buildArtifacts", Copy) {


### PR DESCRIPTION
There's been minor version skew between Java and C++ many times because certain releases are one-language-only. And now we have more severe skew, where we can't readily upgrade to newer C++ Protobuf versions because of build complexity. Let's just remove the version, and have the canonical C++ Protobuf version live in COMPILING.md.

See #10317

CC @pkwarren