### PR TITLE
Remove old Protobuf Gradle Plugin caching workaround

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,11 +68,6 @@ subprojects {
                 }
                 generateProtoTasks {
                     all().each { task ->
-                        // Recompile protos when build.gradle has been changed, because
-                        // it's possible the version of protoc has been changed.
-                        task.inputs.file("${rootProject.projectDir}/build.gradle")
-                          .withPathSensitivity(PathSensitivity.RELATIVE)
-                          .withPropertyName('root build.gradle')
                         if (isAndroid) {
                             task.builtins {
                                 java { option 'lite' }


### PR DESCRIPTION
This has been fixed in the Protobuf Gradle Plugin since probably 0.8.13.