### PR TITLE
Rebuild Android generated code for java.lang.String

### DIFF
--- a/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/LoadBalancerStatsServiceGrpc.java
+++ b/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/LoadBalancerStatsServiceGrpc.java
@@ -15,7 +15,7 @@ public final class LoadBalancerStatsServiceGrpc {
 
   private LoadBalancerStatsServiceGrpc() {}
 
-  public static final String SERVICE_NAME = "grpc.testing.LoadBalancerStatsService";
+  public static final java.lang.String SERVICE_NAME = "grpc.testing.LoadBalancerStatsService";
 
   // Static method descriptors that strictly reflect the proto.
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.LoadBalancerStatsRequest,

--- a/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -12,7 +12,7 @@ public final class MetricsServiceGrpc {
 
   private MetricsServiceGrpc() {}
 
-  public static final String SERVICE_NAME = "grpc.testing.MetricsService";
+  public static final java.lang.String SERVICE_NAME = "grpc.testing.MetricsService";
 
   // Static method descriptors that strictly reflect the proto.
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.EmptyMessage,

--- a/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -15,7 +15,7 @@ public final class ReconnectServiceGrpc {
 
   private ReconnectServiceGrpc() {}
 
-  public static final String SERVICE_NAME = "grpc.testing.ReconnectService";
+  public static final java.lang.String SERVICE_NAME = "grpc.testing.ReconnectService";
 
   // Static method descriptors that strictly reflect the proto.
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.ReconnectParams,

--- a/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -16,7 +16,7 @@ public final class TestServiceGrpc {
 
   private TestServiceGrpc() {}
 
-  public static final String SERVICE_NAME = "grpc.testing.TestService";
+  public static final java.lang.String SERVICE_NAME = "grpc.testing.TestService";
 
   // Static method descriptors that strictly reflect the proto.
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.EmptyProtos.Empty,

--- a/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -16,7 +16,7 @@ public final class UnimplementedServiceGrpc {
 
   private UnimplementedServiceGrpc() {}
 
-  public static final String SERVICE_NAME = "grpc.testing.UnimplementedService";
+  public static final java.lang.String SERVICE_NAME = "grpc.testing.UnimplementedService";
 
   // Static method descriptors that strictly reflect the proto.
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.EmptyProtos.Empty,

--- a/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/XdsUpdateClientConfigureServiceGrpc.java
+++ b/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/XdsUpdateClientConfigureServiceGrpc.java
@@ -15,7 +15,7 @@ public final class XdsUpdateClientConfigureServiceGrpc {
 
   private XdsUpdateClientConfigureServiceGrpc() {}
 
-  public static final String SERVICE_NAME = "grpc.testing.XdsUpdateClientConfigureService";
+  public static final java.lang.String SERVICE_NAME = "grpc.testing.XdsUpdateClientConfigureService";
 
   // Static method descriptors that strictly reflect the proto.
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.ClientConfigureRequest,

--- a/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/XdsUpdateHealthServiceGrpc.java
+++ b/android-interop-testing/src/generated/debug/grpc/io/grpc/testing/integration/XdsUpdateHealthServiceGrpc.java
@@ -15,7 +15,7 @@ public final class XdsUpdateHealthServiceGrpc {
 
   private XdsUpdateHealthServiceGrpc() {}
 
-  public static final String SERVICE_NAME = "grpc.testing.XdsUpdateHealthService";
+  public static final java.lang.String SERVICE_NAME = "grpc.testing.XdsUpdateHealthService";
 
   // Static method descriptors that strictly reflect the proto.
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.EmptyProtos.Empty,

--- a/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/LoadBalancerStatsServiceGrpc.java
+++ b/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/LoadBalancerStatsServiceGrpc.java
@@ -15,7 +15,7 @@ public final class LoadBalancerStatsServiceGrpc {
 
   private LoadBalancerStatsServiceGrpc() {}
 
-  public static final String SERVICE_NAME = "grpc.testing.LoadBalancerStatsService";
+  public static final java.lang.String SERVICE_NAME = "grpc.testing.LoadBalancerStatsService";
 
   // Static method descriptors that strictly reflect the proto.
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.LoadBalancerStatsRequest,

--- a/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -12,7 +12,7 @@ public final class MetricsServiceGrpc {
 
   private MetricsServiceGrpc() {}
 
-  public static final String SERVICE_NAME = "grpc.testing.MetricsService";
+  public static final java.lang.String SERVICE_NAME = "grpc.testing.MetricsService";
 
   // Static method descriptors that strictly reflect the proto.
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.EmptyMessage,

--- a/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -15,7 +15,7 @@ public final class ReconnectServiceGrpc {
 
   private ReconnectServiceGrpc() {}
 
-  public static final String SERVICE_NAME = "grpc.testing.ReconnectService";
+  public static final java.lang.String SERVICE_NAME = "grpc.testing.ReconnectService";
 
   // Static method descriptors that strictly reflect the proto.
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.ReconnectParams,

--- a/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -16,7 +16,7 @@ public final class TestServiceGrpc {
 
   private TestServiceGrpc() {}
 
-  public static final String SERVICE_NAME = "grpc.testing.TestService";
+  public static final java.lang.String SERVICE_NAME = "grpc.testing.TestService";
 
   // Static method descriptors that strictly reflect the proto.
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.EmptyProtos.Empty,

--- a/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -16,7 +16,7 @@ public final class UnimplementedServiceGrpc {
 
   private UnimplementedServiceGrpc() {}
 
-  public static final String SERVICE_NAME = "grpc.testing.UnimplementedService";
+  public static final java.lang.String SERVICE_NAME = "grpc.testing.UnimplementedService";
 
   // Static method descriptors that strictly reflect the proto.
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.EmptyProtos.Empty,

--- a/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/XdsUpdateClientConfigureServiceGrpc.java
+++ b/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/XdsUpdateClientConfigureServiceGrpc.java
@@ -15,7 +15,7 @@ public final class XdsUpdateClientConfigureServiceGrpc {
 
   private XdsUpdateClientConfigureServiceGrpc() {}
 
-  public static final String SERVICE_NAME = "grpc.testing.XdsUpdateClientConfigureService";
+  public static final java.lang.String SERVICE_NAME = "grpc.testing.XdsUpdateClientConfigureService";
 
   // Static method descriptors that strictly reflect the proto.
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.ClientConfigureRequest,

--- a/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/XdsUpdateHealthServiceGrpc.java
+++ b/android-interop-testing/src/generated/release/grpc/io/grpc/testing/integration/XdsUpdateHealthServiceGrpc.java
@@ -15,7 +15,7 @@ public final class XdsUpdateHealthServiceGrpc {
 
   private XdsUpdateHealthServiceGrpc() {}
 
-  public static final String SERVICE_NAME = "grpc.testing.XdsUpdateHealthService";
+  public static final java.lang.String SERVICE_NAME = "grpc.testing.XdsUpdateHealthService";
 
   // Static method descriptors that strictly reflect the proto.
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.EmptyProtos.Empty,


### PR DESCRIPTION
3808e707 (#10321) fixed references of String to be java.lang.String, but failed to update the Android build.

CC @pkwarren 