### PR TITLE
core: ManagedChannelImpl to always use RetryingNameResolver (1.55.x backport)

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -749,9 +749,6 @@ final class ManagedChannelImpl extends ManagedChannel implements
       String target, @Nullable final String overrideAuthority,
       NameResolver.Factory nameResolverFactory, NameResolver.Args nameResolverArgs) {
     NameResolver resolver = getNameResolver(target, nameResolverFactory, nameResolverArgs);
-    if (overrideAuthority == null) {
-      return resolver;
-    }
 
     // If the nameResolver is not already a RetryingNameResolver, then wrap it with it.
     // This helps guarantee that name resolution retry remains supported even as it has been
@@ -767,6 +764,10 @@ final class ManagedChannelImpl extends ManagedChannel implements
               nameResolverArgs.getScheduledExecutorService(),
               nameResolverArgs.getSynchronizationContext()),
           nameResolverArgs.getSynchronizationContext());
+    }
+
+    if (overrideAuthority == null) {
+      return usedNameResolver;
     }
 
     return new ForwardingNameResolver(usedNameResolver) {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
@@ -139,8 +139,9 @@ public class ManagedChannelImplGetNameResolverTest {
 
   private void testValidTarget(String target, String expectedUriString, URI expectedUri) {
     NameResolver.Factory nameResolverFactory = new FakeNameResolverFactory(expectedUri.getScheme());
-    FakeNameResolver nameResolver = (FakeNameResolver) ManagedChannelImpl.getNameResolver(
-        target, null, nameResolverFactory, NAMERESOLVER_ARGS);
+    FakeNameResolver nameResolver
+        = (FakeNameResolver) ((RetryingNameResolver) ManagedChannelImpl.getNameResolver(
+            target, null, nameResolverFactory, NAMERESOLVER_ARGS)).getRetriedNameResolver();
     assertNotNull(nameResolver);
     assertEquals(expectedUri, nameResolver.uri);
     assertEquals(expectedUriString, nameResolver.uri.toString());


### PR DESCRIPTION
Backport of #10328

`ManagedChannelImpl` did not make sure to use a `RetryingNameResolver` if authority was not overriden. This was not a problem for DNS name resolution as the DNS name resolver factory explicitly returns a `RetryingNameResolver`. For polling name resolvers that do not do this in their factories (like the grpclb name resolver) this meant not having retry at all.

b/289123469