### PR TITLE
core,grpclb: Resolve isAndroid only once on class loading

### DIFF
--- a/core/src/main/java/io/grpc/internal/DnsNameResolverProvider.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolverProvider.java
@@ -46,6 +46,9 @@ public final class DnsNameResolverProvider extends NameResolverProvider {
 
   private static final String SCHEME = "dns";
 
+  private static final boolean IS_ANDROID = InternalServiceProviders
+      .isAndroid(DnsNameResolverProvider.class.getClassLoader());
+
   @Override
   public NameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
     if (SCHEME.equals(targetUri.getScheme())) {
@@ -60,7 +63,7 @@ public final class DnsNameResolverProvider extends NameResolverProvider {
               args,
               GrpcUtil.SHARED_CHANNEL_EXECUTOR,
               Stopwatch.createUnstarted(),
-              InternalServiceProviders.isAndroid(getClass().getClassLoader())),
+              IS_ANDROID),
           new BackoffPolicyRetryScheduler(
               new ExponentialBackoffPolicy.Provider(),
               args.getScheduledExecutorService(),

--- a/grpclb/src/main/java/io/grpc/grpclb/SecretGrpclbNameResolverProvider.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/SecretGrpclbNameResolverProvider.java
@@ -53,6 +53,9 @@ final class SecretGrpclbNameResolverProvider {
 
     private static final String SCHEME = "dns";
 
+    private static final boolean IS_ANDROID = InternalServiceProviders
+        .isAndroid(SecretGrpclbNameResolverProvider.class.getClassLoader());
+
     @Override
     public GrpclbNameResolver newNameResolver(URI targetUri, Args args) {
       if (SCHEME.equals(targetUri.getScheme())) {
@@ -68,7 +71,7 @@ final class SecretGrpclbNameResolverProvider {
             args,
             GrpcUtil.SHARED_CHANNEL_EXECUTOR,
             Stopwatch.createUnstarted(),
-            InternalServiceProviders.isAndroid(getClass().getClassLoader()));
+            IS_ANDROID);
       } else {
         return null;
       }


### PR DESCRIPTION
Motivation:

When multiple NameResolvers are created, the Classloader is scanned every time trying to figure out if the Platform is Android. This expensive work could be done only once.

Modification:

Cache isAndroid resolution in a constant.

Result:

Less expensive multiple NameResolvers instantiation.