### PR TITLE
xds: Allow Gradle to use more memory when building interop (v1.47.x backport)

### DIFF
--- a/buildscripts/kokoro/psm-security.sh
+++ b/buildscripts/kokoro/psm-security.sh
@@ -23,6 +23,7 @@ readonly BUILD_APP_PATH="interop-testing/build/install/grpc-interop-testing"
 build_java_test_app() {
   echo "Building Java test app"
   cd "${SRC_DIR}"
+  GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1g'" \
   ./gradlew --no-daemon grpc-interop-testing:installDist -x test \
     -PskipCodegen=true -PskipAndroid=true --console=plain
 

--- a/buildscripts/kokoro/xds_k8s_lb.sh
+++ b/buildscripts/kokoro/xds_k8s_lb.sh
@@ -23,6 +23,7 @@ readonly BUILD_APP_PATH="interop-testing/build/install/grpc-interop-testing"
 build_java_test_app() {
   echo "Building Java test app"
   cd "${SRC_DIR}"
+  GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1g'" \
   ./gradlew --no-daemon grpc-interop-testing:installDist -x test \
     -PskipCodegen=true -PskipAndroid=true --console=plain
 

--- a/buildscripts/kokoro/xds_url_map.sh
+++ b/buildscripts/kokoro/xds_url_map.sh
@@ -23,6 +23,7 @@ readonly BUILD_APP_PATH="interop-testing/build/install/grpc-interop-testing"
 build_java_test_app() {
   echo "Building Java test app"
   cd "${SRC_DIR}"
+  GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1g'" \
   ./gradlew --no-daemon grpc-interop-testing:installDist -x test \
     -PskipCodegen=true -PskipAndroid=true --console=plain
 


### PR DESCRIPTION
Backport of #9347 to v1.47.x.
---
Should fix "Expiring Daemon because JVM heap space is exhausted".

https://github.com/grpc/grpc-java/pull/9269 probably pushed the build
over the edge, but there's been evidence via flakes for a good while
that we've been reaching the limit.

b/238334438

CC @sergiitk 