### PR TITLE
Bump compileSdkVersion and finalize setAllowActivityStarts API.

### DIFF
--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -30,7 +30,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     defaultConfig {
         applicationId "io.grpc.android.integrationtest"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    compileSdkVersion 33
+    compileSdkVersion 34
     defaultConfig {
         consumerProguardFiles "proguard-rules.txt"
         minSdkVersion 19

--- a/binder/build.gradle
+++ b/binder/build.gradle
@@ -7,7 +7,7 @@ description = 'gRPC BinderChannel'
 
 android {
     namespace 'io.grpc.binder'
-    compileSdkVersion 33
+    compileSdkVersion 34
     compileOptions {
         sourceCompatibility 1.8
         targetCompatibility 1.8

--- a/binder/src/main/java/io/grpc/binder/BindServiceFlags.java
+++ b/binder/src/main/java/io/grpc/binder/BindServiceFlags.java
@@ -18,6 +18,7 @@ package io.grpc.binder;
 
 import static android.content.Context.BIND_ABOVE_CLIENT;
 import static android.content.Context.BIND_ADJUST_WITH_ACTIVITY;
+import static android.content.Context.BIND_ALLOW_ACTIVITY_STARTS;
 import static android.content.Context.BIND_ALLOW_OOM_MANAGEMENT;
 import static android.content.Context.BIND_AUTO_CREATE;
 import static android.content.Context.BIND_IMPORTANT;
@@ -29,7 +30,6 @@ import static java.lang.Integer.toHexString;
 
 import android.os.Build;
 import androidx.annotation.RequiresApi;
-import io.grpc.ExperimentalApi;
 
 /**
  * An immutable set of flags affecting the behavior of {@link android.content.Context#bindService}.
@@ -103,24 +103,16 @@ public final class BindServiceFlags {
       return setFlag(BIND_ADJUST_WITH_ACTIVITY, newValue);
     }
 
-    // TODO(b/274061424): Reference official constant and add RequiresApi declaration in place of
-    // informal Javadoc warning when U is final.
     /**
      * Sets or clears the {@code android.content.Context#BIND_ALLOW_ACTIVITY_STARTS} flag.
-     *
-     * <p>This method allows for testing and development on Android U developer previews. Before
-     * releasing production code which depends on this flag, verify that either the
-     * {@code BIND_ALLOW_ACTIVITY_STARTS} flag has not changed from 0x200 during SDK development,
-     * or wait for this method to be updated to point to the final flag and made non-experimental.
      *
      * <p>This flag has no additional meaning at the gRPC layer. See the Android docs for more.
      *
      * @return this, for fluent construction
      */
-    @ExperimentalApi("To be finalized after Android U SDK finalization")
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
     public Builder setAllowActivityStarts(boolean newValue) {
-      // https://developer.android.com/reference/android/content/Context#BIND_ALLOW_ACTIVITY_STARTS
-      return setFlag(0x200, newValue);
+      return setFlag(BIND_ALLOW_ACTIVITY_STARTS, newValue);
     }
 
     /**

--- a/binder/src/test/java/io/grpc/binder/BindServiceFlagsTest.java
+++ b/binder/src/test/java/io/grpc/binder/BindServiceFlagsTest.java
@@ -92,7 +92,6 @@ public final class BindServiceFlagsTest {
                 | Context.BIND_NOT_FOREGROUND
                 | Context.BIND_NOT_PERCEPTIBLE
                 | Context.BIND_WAIVE_PRIORITY
-                // TODO(b/274061424): Use Context.BIND_ALLOW_ACTIVITY_STARTS when U is final.
-                | 0x200);
+                | Context.BIND_ALLOW_ACTIVITY_STARTS);
   }
 }

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -6,7 +6,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     defaultConfig {
         applicationId "io.grpc.clientcacheexample"

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -6,7 +6,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     defaultConfig {
         applicationId "io.grpc.helloworldexample"

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -6,7 +6,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     defaultConfig {
         applicationId "io.grpc.routeguideexample"

--- a/examples/android/strictmode/app/build.gradle
+++ b/examples/android/strictmode/app/build.gradle
@@ -6,7 +6,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     defaultConfig {
         applicationId "io.grpc.strictmodehelloworldexample"


### PR DESCRIPTION
Per https://developer.android.com/about/versions/14#beta-3, Android U has reached the platform stability milestone which means that all external APIs are finalized.

We can thus bump the compileSdkVersion to 34 (U) and begin using APIs added there. We leave targetSdkVersion unchanged for now to avoid the broader evaluation of whether deeper changes may be necessary as part of the upgrade; this simply allows compile-time access to newer APIs without changing runtime behavior.

See b/274061424