### PR TITLE
CheckedForwardingClientCall should pass trailers from the caught exception

### DIFF
--- a/api/src/main/java/io/grpc/ClientInterceptors.java
+++ b/api/src/main/java/io/grpc/ClientInterceptors.java
@@ -236,7 +236,9 @@ public class ClientInterceptors {
         // to a NO-OP one to prevent the IllegalStateException. The user will finally get notified
         // about the error through the listener.
         delegate = (ClientCall<ReqT, RespT>) NOOP_CALL;
-        responseListener.onClose(Status.fromThrowable(e), new Metadata());
+        Metadata trailersFromThrowable = Status.trailersFromThrowable(e);
+        Metadata trailers = trailersFromThrowable != null ? trailersFromThrowable : new Metadata();
+        responseListener.onClose(Status.fromThrowable(e), trailers);
       }
     }
   }

--- a/api/src/main/java/io/grpc/ClientInterceptors.java
+++ b/api/src/main/java/io/grpc/ClientInterceptors.java
@@ -236,9 +236,11 @@ public class ClientInterceptors {
         // to a NO-OP one to prevent the IllegalStateException. The user will finally get notified
         // about the error through the listener.
         delegate = (ClientCall<ReqT, RespT>) NOOP_CALL;
-        Metadata trailersFromThrowable = Status.trailersFromThrowable(e);
-        Metadata trailers = trailersFromThrowable != null ? trailersFromThrowable : new Metadata();
-        responseListener.onClose(Status.fromThrowable(e), trailers);
+        Metadata trailers = Status.trailersFromThrowable(e);
+        responseListener.onClose(
+          Status.fromThrowable(e),
+          trailers != null ? trailers : new Metadata()
+        );
       }
     }
   }

--- a/api/src/main/java/io/grpc/ClientInterceptors.java
+++ b/api/src/main/java/io/grpc/ClientInterceptors.java
@@ -238,8 +238,8 @@ public class ClientInterceptors {
         delegate = (ClientCall<ReqT, RespT>) NOOP_CALL;
         Metadata trailers = Status.trailersFromThrowable(e);
         responseListener.onClose(
-          Status.fromThrowable(e),
-          trailers != null ? trailers : new Metadata()
+            Status.fromThrowable(e),
+            trailers != null ? trailers : new Metadata()
         );
       }
     }


### PR DESCRIPTION
`StatusException` thrown from `checkedStart()` may have `trailers`. Therefore, `CheckedForwardingClientCall` should pass the `trailers` to `responseListener.onClose()`.