### PR TITLE
RELEASING.md: Reorder contents to make it a bit more streamlined

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -172,6 +172,9 @@ Tagging the Release
     docker_image=gcr.io/grpc-testing/grpc_interop_java:v$MAJOR.$MINOR.$PATCH \
         tools/interop_matrix/testcases/java__master
 
+    # Commit the changes
+    git commit --all -m "Add grpc-java $MAJOR.$MINOR.$PATCH to client_matrix.py"
+
     # Create a PR and run ad-hoc test against your PR
     ```
 [gcr-image]: https://github.com/grpc/grpc/blob/master/tools/interop_matrix/README.md#step-by-step-instructions-for-adding-a-gcr-image-for-a-new-release-for-compatibility-test


### PR DESCRIPTION
I moved items that could be done immediately after the release up into the main release flow. I also stripped some outdated or unnecessary text to make it quicker to follow.

-----

I'll add "upgrade dependencies" at the very, very end, but I felt I needed to clean up all the random stuff at the end of the process to make it more visible. This change also might reduce chances something is forgotten, because we do more up-front.