### PR TITLE
build.gradle: Avoid assignment to japicmp configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -433,8 +433,8 @@ subprojects {
         // Add a japicmp task that compares the current .jar with baseline .jar
         tasks.register("japicmp", me.champeau.gradle.japicmp.JapicmpTask) {
             dependsOn jar
-            oldClasspath = files(baselineArtifact)
-            newClasspath = files(jar.archiveFile)
+            oldClasspath.from baselineArtifact
+            newClasspath.from jar.archiveFile
             onlyBinaryIncompatibleModified = false
             // Be quiet about things that did not change
             onlyModified = true


### PR DESCRIPTION
Instead of assignment, it now seems to be a FileCollection that you modify. This has probably been broken since f458f22.

```
> Could not create task ':grpc-auth:japicmp'.
   > Cannot set the value of read-only property 'oldClasspath' for task ':grpc-auth:japicmp' of type me.champeau.gradle.japicmp.JapicmpTask.
```

The change works with or without the files(), but the conversion is just not needed anymore as it is handled by FileCollection.