### PR TITLE
Context.Storage deprecated method attach() removed, doAttach() made abstract

### DIFF
--- a/api/src/context/java/io/grpc/Context.java
+++ b/api/src/context/java/io/grpc/Context.java
@@ -1000,16 +1000,6 @@ public class Context {
    */
   public abstract static class Storage {
     /**
-     * Unused.
-     *
-     * @deprecated This is an old API that is no longer used.
-     */
-    @Deprecated
-    public void attach(Context toAttach) {
-      throw new UnsupportedOperationException("Deprecated. Do not call.");
-    }
-
-    /**
      * Implements {@link io.grpc.Context#attach}.
      *
      * <p>Caution: {@link Context#attach()} interprets a return value of {@code null} to mean
@@ -1022,13 +1012,7 @@ public class Context {
      *        as the {@code toRestore} parameter. {@code null} is a valid return value, but see
      *        caution note.
      */
-    public Context doAttach(Context toAttach) {
-      // This is a default implementation to help migrate existing Storage implementations that
-      // have an attach() method but no doAttach() method.
-      Context current = current();
-      attach(toAttach);
-      return current;
-    }
+    public abstract Context doAttach(Context toAttach);
 
     /**
      * Implements {@link io.grpc.Context#detach}.


### PR DESCRIPTION
#2462 contains the discussion about the `attach(Context)` method.

The `doAttach(Context)` method has been made abstract and the `attach(Context)` method has been deleted. 

There are no open-source or g3 dependencies for this method. 

There is only [one affected repo](https://sourcegraph.com/github.com/quarkusio/quarkus/-/blob/extensions/grpc/runtime/src/main/java/io/grpc/override/ContextStorageOverride.java) from [this query](https://sourcegraph.com/search?q=context:global+class+ContextStorageOverride+lang:java&patternType=standard&sm=0&groupBy=repo), which shouldn't block us from making this change.