### PR TITLE
binder/test: Stop running Robolectric tests on APIs < 19.

### DIFF
--- a/binder/src/main/java/io/grpc/binder/SecurityPolicies.java
+++ b/binder/src/main/java/io/grpc/binder/SecurityPolicies.java
@@ -26,6 +26,7 @@ import android.content.pm.Signature;
 import android.os.Build;
 import android.os.Build.VERSION;
 import android.os.Process;
+import androidx.annotation.RequiresApi;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
@@ -188,12 +189,12 @@ public final class SecurityPolicies {
    * Creates {@link SecurityPolicy} which checks if the app is a device owner app. See
    * {@link DevicePolicyManager}.
    */
-  public static SecurityPolicy isDeviceOwner(Context applicationContext) {
+  @androidx.annotation.RequiresApi(18)
+  public static io.grpc.binder.SecurityPolicy isDeviceOwner(Context applicationContext) {
     DevicePolicyManager devicePolicyManager =
         (DevicePolicyManager) applicationContext.getSystemService(Context.DEVICE_POLICY_SERVICE);
     return anyPackageWithUidSatisfies(
-        applicationContext,
-        pkg -> VERSION.SDK_INT >= 18 && devicePolicyManager.isDeviceOwnerApp(pkg),
+        applicationContext, pkg -> devicePolicyManager.isDeviceOwnerApp(pkg),
         "Rejected by device owner policy. No packages found for UID.",
         "Rejected by device owner policy");
   }

--- a/binder/src/test/java/io/grpc/binder/SecurityPoliciesTest.java
+++ b/binder/src/test/java/io/grpc/binder/SecurityPoliciesTest.java
@@ -30,9 +30,6 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.Signature;
-import android.os.Build;
-import android.os.Build.VERSION;
-import android.os.Build.VERSION_CODES;
 import android.os.Process;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.common.collect.ImmutableList;
@@ -333,7 +330,7 @@ public final class SecurityPoliciesTest {
   }
 
   @Test
-  @Config(sdk = 18)
+  @Config(sdk = 19)
   public void testIsDeviceOwner_succeedsForDeviceOwner() throws Exception {
     PackageInfo info =
         newBuilder().setPackageName(OTHER_UID_PACKAGE_NAME).setSignatures(SIG2).build();
@@ -348,7 +345,7 @@ public final class SecurityPoliciesTest {
   }
 
   @Test
-  @Config(sdk = 18)
+  @Config(sdk = 19)
   public void testIsDeviceOwner_failsForNotDeviceOwner() throws Exception {
     PackageInfo info =
         newBuilder().setPackageName(OTHER_UID_PACKAGE_NAME).setSignatures(SIG2).build();
@@ -361,25 +358,13 @@ public final class SecurityPoliciesTest {
   }
 
   @Test
-  @Config(sdk = 18)
+  @Config(sdk = 19)
   public void testIsDeviceOwner_failsWhenNoPackagesForUid() throws Exception {
     policy = SecurityPolicies.isDeviceOwner(appContext);
 
     assertThat(policy.checkAuthorization(OTHER_UID).getCode()).isEqualTo(Status.UNAUTHENTICATED.getCode());
   }
 
-  @Test
-  @Config(sdk = 17)
-  public void testIsDeviceOwner_failsForSdkLevelTooLow() throws Exception {
-    PackageInfo info =
-        newBuilder().setPackageName(OTHER_UID_PACKAGE_NAME).setSignatures(SIG2).build();
-
-    installPackages(OTHER_UID, info);
-
-    policy = SecurityPolicies.isDeviceOwner(appContext);
-
-    assertThat(policy.checkAuthorization(OTHER_UID).getCode()).isEqualTo(Status.PERMISSION_DENIED.getCode());
-  }
 
   @Test
   @Config(sdk = 21)


### PR DESCRIPTION
This is a port of internal cl/547560711