### PR TITLE
servlet: Remove unused dependency on grpc-util in tests

### DIFF
--- a/servlet/build.gradle
+++ b/servlet/build.gradle
@@ -42,8 +42,7 @@ dependencies {
 
     itImplementation project(':grpc-servlet'),
             project(':grpc-netty'),
-            project(':grpc-core').sourceSets.test.runtimeClasspath,
-            project(':grpc-util').sourceSets.test.runtimeClasspath,
+            testFixtures(project(':grpc-core')),
             libraries.junit
     itImplementation(project(':grpc-interop-testing')) {
         // Avoid grpc-netty-shaded dependency

--- a/servlet/build.gradle
+++ b/servlet/build.gradle
@@ -56,8 +56,10 @@ dependencies {
 
     jettyTestImplementation "org.eclipse.jetty:jetty-servlet:${jettyVersion}",
             "org.eclipse.jetty.http2:http2-server:${jettyVersion}",
-            "org.eclipse.jetty:jetty-client:${jettyVersion}"
-            project(':grpc-testing')
+            "org.eclipse.jetty:jetty-client:${jettyVersion}",
+            project(':grpc-testing'),
+            libraries.truth,
+            libraries.protobuf.java
 }
 
 test {

--- a/servlet/jakarta/build.gradle
+++ b/servlet/jakarta/build.gradle
@@ -79,8 +79,7 @@ dependencies {
 
     itImplementation project(':grpc-servlet-jakarta'),
             project(':grpc-netty'),
-            project(':grpc-core').sourceSets.test.runtimeClasspath,
-            project(':grpc-util').sourceSets.test.runtimeClasspath,
+            testFixtures(project(':grpc-core')),
             libraries.junit
     itImplementation(project(':grpc-interop-testing')) {
         // Avoid grpc-netty-shaded dependency


### PR DESCRIPTION
Also convert to testFixtures, like we did elsewhere.