### PR TITLE
Remove unnecessary thisUsesUnstableApi from CallCredentials impls

### DIFF
--- a/alts/src/main/java/io/grpc/alts/FailingCallCredentials.java
+++ b/alts/src/main/java/io/grpc/alts/FailingCallCredentials.java
@@ -38,7 +38,4 @@ final class FailingCallCredentials extends CallCredentials {
       CallCredentials.MetadataApplier applier) {
     applier.fail(status);
   }
-
-  @Override
-  public void thisUsesUnstableApi() {}
 }

--- a/examples/example-jwt-auth/src/main/java/io/grpc/examples/jwtauth/JwtCredential.java
+++ b/examples/example-jwt-auth/src/main/java/io/grpc/examples/jwtauth/JwtCredential.java
@@ -60,9 +60,4 @@ public class JwtCredential extends CallCredentials {
       }
     });
   }
-
-  @Override
-  public void thisUsesUnstableApi() {
-    // noop
-  }
 }


### PR DESCRIPTION
This method has been unnecessary/deprecated since dd2dc21d.