### PR TITLE
all: Remove grpc-context from grpc-all

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -10,7 +10,6 @@ description = "gRPC: All"
 def subprojects = [
     project(':grpc-api'),
     project(':grpc-auth'),
-    project(':grpc-context'),
     project(':grpc-core'),
     project(':grpc-grpclb'),
     project(':grpc-netty'),


### PR DESCRIPTION
grpc-context is empty, so isn't needed. Including it also causes the warning:
```
> Task :grpc-all:javadoc
Resolution of the configuration :grpc-context:compileClasspath was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behaviour has been deprecated and is scheduled to be removed in Gradle 8.0. See https://docs.gradle.org/7.6/userguide/viewing_debugging_dependencies.html#sub:resolving-unsafe-configuration-resolution-errors for more details.
```