### PR TITLE
core, services, util: export util from core and move gson dep to services for the checkUpperBoundDeps error

### DIFF
--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -49,6 +49,6 @@ java_library(
     exports = [
         ":internal",
         "//api",
-        "//inprocess",
+        "//util",
     ],
 )

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -24,8 +24,8 @@ dependencies {
             libraries.guava.jre // JRE required by protobuf-java-util
 
     runtimeOnly libraries.errorprone.annotations,
-            libraries.j2objc.annotations // Explicit dependency to keep in step with version used by guava
-
+            libraries.j2objc.annotations, // Explicit dependency to keep in step with version used by guava
+            libraries.gson  // to fix checkUpperBoundDeps error here
     compileOnly libraries.javax.annotation
     testImplementation project(':grpc-testing'),
             libraries.netty.transport.epoll, // for DomainSocketAddress

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -13,7 +13,6 @@ dependencies {
 
     implementation libraries.animalsniffer.annotations,
             libraries.guava
-    runtimeOnly libraries.gson  // to fix checkUpperBoundDeps error in services
     testImplementation testFixtures(project(':grpc-api')),
             testFixtures(project(':grpc-core')),
             project(':grpc-testing')


### PR DESCRIPTION
- move the gson dependency to services from util to resolve the checkUpperBoundDeps error
- for bazel build export util instead of inprocess from core 

(this is from the trailing comments in https://github.com/grpc/grpc-java/pull/10362)
