### PR TITLE
Restrict checkUpperBoundDeps to library dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -504,6 +504,11 @@ def requireUpperBoundDepsMatch(Configuration conf, Project project) {
                 + "to diagnose")
         }
         result.selected.dependencies.each {
+            // Category.CATEGORY_ATTRIBUTE is the inappropriate Attribute because it is "desugared".
+            // https://github.com/gradle/gradle/issues/8854
+            Attribute<String> category = Attribute.of('org.gradle.category', String)
+            if (it.resolvedVariant.attributes.getAttribute(category) != Category.LIBRARY)
+                return
             queue.add(new DepAndParents(
                 dep: it, parents: depAndParents.parents + [artifact + ":" + version]))
         }


### PR DESCRIPTION
Guava 32.1.0 added Gradle Module Metadata to their artifact (they still use Maven for their build). Because of that, we're now seeing less normal dependencies that were confusing checkUpperBoundDeps.  Obviously 'null' is not the version we were looking for.

We aren't upgrading to Guava 32.1.x yet as there's still other problems.

```
Execution failed for task ':grpc-census:checkUpperBoundDeps'.
> Maven version skew: com.google.guava:guava-parent (32.1.1-jre != null) Bad version dependency path: [project ':grpc-census', com.google.guava:guava:32.1.1-android] Run './gradlew :grpc-census:dependencies --configuration runtimeClasspath' to diagnose
```