### PR TITLE
Revert "Change the default for staleAge to be maxAge - 1 minute"

### DIFF
--- a/rls/src/main/java/io/grpc/rls/RlsProtoConverters.java
+++ b/rls/src/main/java/io/grpc/rls/RlsProtoConverters.java
@@ -153,7 +153,7 @@ final class RlsProtoConverters {
         maxAge = MAX_AGE_NANOS;
       }
       if (staleAge == null) {
-        staleAge = maxAge >= MINUTES.toNanos(2) ? maxAge - MINUTES.toNanos(1) : maxAge;
+        staleAge = MAX_AGE_NANOS;
       }
       maxAge = Math.min(maxAge, MAX_AGE_NANOS);
       staleAge = Math.min(staleAge, maxAge);

--- a/rls/src/test/java/io/grpc/rls/RlsProtoConvertersTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsProtoConvertersTest.java
@@ -354,7 +354,7 @@ public class RlsProtoConvertersTest {
             .lookupService("service1")
             .lookupServiceTimeoutInNanos(TimeUnit.SECONDS.toNanos(10))
             .maxAgeInNanos(TimeUnit.MINUTES.toNanos(5))
-            .staleAgeInNanos(TimeUnit.MINUTES.toNanos(4))
+            .staleAgeInNanos(TimeUnit.MINUTES.toNanos(5))
             .cacheSizeBytes(5 * 1024 * 1024)
             .defaultTarget("us_east_1.cloudbigtable.googleapis.com")
             .build();


### PR DESCRIPTION
Reverts grpc/grpc-java#10397 as it makes Java inconsistent with the other languages.