### PR TITLE
Fix locality logging

### DIFF
--- a/xds/src/main/java/io/grpc/xds/BootstrapperImpl.java
+++ b/xds/src/main/java/io/grpc/xds/BootstrapperImpl.java
@@ -169,7 +169,7 @@ class BootstrapperImpl extends Bootstrapper {
         if (rawLocality.containsKey("sub_zone")) {
           subZone = JsonUtil.getString(rawLocality, "sub_zone");
         }
-        logger.log(XdsLogLevel.INFO, "Locality region: {0}, zone: {0}, subZone: {0}",
+        logger.log(XdsLogLevel.INFO, "Locality region: {0}, zone: {1}, subZone: {2}",
             region, zone, subZone);
         Locality locality = Locality.create(region, zone, subZone);
         nodeBuilder.setLocality(locality);


### PR DESCRIPTION
The bootstrapping code currently does not log zone and subZone from locality correctly, and only logs region. This commit fixes the logging message format.