### PR TITLE
README.md: Revert reference to protobuf 3.23.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ For protobuf-based codegen integrated with the Maven build system, you can use
       <artifactId>protobuf-maven-plugin</artifactId>
       <version>0.6.1</version>
       <configuration>
-        <protocArtifact>com.google.protobuf:protoc:3.23.4:exe:${os.detected.classifier}</protocArtifact>
+        <protocArtifact>com.google.protobuf:protoc:3.22.3:exe:${os.detected.classifier}</protocArtifact>
         <pluginId>grpc-java</pluginId>
         <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.57.0:exe:${os.detected.classifier}</pluginArtifact>
       </configuration>
@@ -157,7 +157,7 @@ plugins {
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:3.23.4"
+    artifact = "com.google.protobuf:protoc:3.22.3"
   }
   plugins {
     grpc {
@@ -190,7 +190,7 @@ plugins {
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:3.23.4"
+    artifact = "com.google.protobuf:protoc:3.22.3"
   }
   plugins {
     grpc {


### PR DESCRIPTION
The README describes the released version of gRPC. But the most recent release doesn't use protobuf 3.23.4. Telling people to use protoc 3.23.4 is asking for breakages because they will be running with protobuf-java 3.22.3, which is a downgrade.

The bump to 3.23.4 was incorrectly done in #10359.

CC @larry-safran 