### PR TITLE
(backport v1.57) removed assert statement for static stride scheduler with multiple threads

### DIFF
--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -431,9 +431,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
      * an offset that varies per backend index is also included to the calculation.
      */
     int pick() {
-      int i = 0;
       while (true) {
-        i++;
         long sequence = this.nextSequence();
         int backendIndex = (int) (sequence % scaledWeights.length);
         long generation = sequence / scaledWeights.length;
@@ -442,7 +440,6 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
         if ((weight * generation + offset) % K_MAX_WEIGHT < K_MAX_WEIGHT - weight) {
           continue;
         }
-        assert i <= scaledWeights.length : "scheduler has more than one pass through";
         return backendIndex;
       }
     }


### PR DESCRIPTION
As per #10433, the assert statement seems to cause a timeout in the pick() function of WRR's static stride scheduler. Additionally, the assertion does not have to be true if there are multiple threads involved. Unless a better solution is suggested, removing it seems like the best option.

Fix on master: #10437 