### PR TITLE
Avoid accidental Java 9+ dependency with --release

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -16,9 +16,13 @@ sourceSets {
     }
 }
 
-compileContextJava {
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.7
+tasks.named("compileContextJava").configure {
+    if (JavaVersion.current().isJava9Compatible()) {
+        options.release = 7
+    } else {
+        sourceCompatibility = 1.7
+        targetCompatibility = 1.7
+    }
 }
 
 tasks.named("jar").configure {

--- a/build.gradle
+++ b/build.gradle
@@ -182,9 +182,6 @@ subprojects {
     }
 
     plugins.withId("java") {
-        sourceCompatibility = 1.8
-        targetCompatibility = 1.8
-
         dependencies {
             testImplementation libraries.junit,
                     libraries.mockito.core,
@@ -240,6 +237,14 @@ subprojects {
             }
         }
 
+        tasks.withType(JavaCompile).configureEach {
+            if (JavaVersion.current().isJava9Compatible()) {
+                options.release = 8
+            } else {
+                sourceCompatibility = 1.8
+                targetCompatibility = 1.8
+            }
+        }
         tasks.named("compileJava").configure {
             // This project targets Java 7 (no time.Duration class)
             options.errorprone.check("PreferJavaTimeOverload", CheckSeverity.OFF)
@@ -285,10 +290,6 @@ subprojects {
     plugins.withId("me.champeau.jmh") {
         // invoke jmh on a single benchmark class like so:
         //   ./gradlew -PjmhIncludeSingleClass=StatsTraceContextBenchmark clean :grpc-core:jmh
-	tasks.named("compileJmhJava").configure {
-	    sourceCompatibility = 1.8
-	    targetCompatibility = 1.8
-	}
         tasks.named("jmh").configure {
             warmupIterations = 10
             iterations = 10

--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -90,9 +90,6 @@ appengine {
 group = 'io.grpc'   // Generated output GroupId
 version = '1.0-SNAPSHOT'          // Version in generated output
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-
 /** Returns the service name. */
 String getGaeProject() {
     def stream = new ByteArrayOutputStream()

--- a/servlet/build.gradle
+++ b/servlet/build.gradle
@@ -5,10 +5,6 @@ plugins {
 
 description = "gRPC: Servlet"
 
-// javax.servlet-api 4.0 requires a minimum of Java 8, so we might as well use that source level
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-
 def jettyVersion = '10.0.7'
 
 configurations {

--- a/servlet/jakarta/build.gradle
+++ b/servlet/jakarta/build.gradle
@@ -4,8 +4,6 @@ plugins {
 }
 
 description = "gRPC: Jakarta Servlet"
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 // Set up classpaths and source directories for different servlet tests
 configurations {


### PR DESCRIPTION
In d654707 we swapped compiling the uploaded artifacts to Java 11. This caused ABI issues with ByteBuffer, like clear() returning ByteBuffer instead of Buffer.

There are source-level approaches to avoid the accidental ABI dependency on Java 11, but we have no tool able to detect such breakages. We use Animalsniffer for similar cases, but it fails to detect these[1]. Since we have no tool, source-level approaches can't gain the necessary confidence that all incompatibility fixes have been resolved.

Java has had javac-level ways to address this, but they used to require setting bootclasspath. Since Java 9, though, they made it easier and we can use --release, which does exactly what we need.

Fixes #10432

1. https://github.com/mojohaus/animal-sniffer/issues/77