### PR TITLE
stub: remove 2 deprecated methods from MetadataUtils

### DIFF
--- a/stub/src/main/java/io/grpc/stub/MetadataUtils.java
+++ b/stub/src/main/java/io/grpc/stub/MetadataUtils.java
@@ -39,24 +39,6 @@ public final class MetadataUtils {
   private MetadataUtils() {}
 
   /**
-   * Attaches a set of request headers to a stub.
-   *
-   * @param stub to bind the headers to.
-   * @param extraHeaders the headers to be passed by each call on the returned stub.
-   * @return an implementation of the stub with {@code extraHeaders} bound to each call.
-   * @deprecated Use {@code stub.withInterceptors(newAttachHeadersInterceptor(...))} instead.
-   */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1789")
-  @Deprecated
-  @InlineMe(
-      replacement =
-          "stub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(extraHeaders))",
-      imports = "io.grpc.stub.MetadataUtils")
-  public static <T extends AbstractStub<T>> T attachHeaders(T stub, Metadata extraHeaders) {
-    return stub.withInterceptors(newAttachHeadersInterceptor(extraHeaders));
-  }
-
-  /**
    * Returns a client interceptor that attaches a set of headers to requests.
    *
    * @param extraHeaders the headers to be passed by each call that is processed by the returned
@@ -95,31 +77,6 @@ public final class MetadataUtils {
         super.start(responseListener, headers);
       }
     }
-  }
-
-  /**
-   * Captures the last received metadata for a stub. Useful for testing
-   *
-   * @param stub to capture for
-   * @param headersCapture to record the last received headers
-   * @param trailersCapture to record the last received trailers
-   * @return an implementation of the stub that allows to access the last received call's
-   *         headers and trailers via {@code headersCapture} and {@code trailersCapture}.
-   * @deprecated Use {@code stub.withInterceptors(newCaptureMetadataInterceptor())} instead.
-   */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1789")
-  @Deprecated
-  @InlineMe(
-      replacement =
-          "stub.withInterceptors(MetadataUtils.newCaptureMetadataInterceptor(headersCapture,"
-              + " trailersCapture))",
-      imports = "io.grpc.stub.MetadataUtils")
-  public static <T extends AbstractStub<T>> T captureMetadata(
-      T stub,
-      AtomicReference<Metadata> headersCapture,
-      AtomicReference<Metadata> trailersCapture) {
-    return stub.withInterceptors(
-        newCaptureMetadataInterceptor(headersCapture, trailersCapture));
   }
 
   /**

--- a/stub/src/main/java/io/grpc/stub/MetadataUtils.java
+++ b/stub/src/main/java/io/grpc/stub/MetadataUtils.java
@@ -18,12 +18,10 @@ package io.grpc.stub;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.errorprone.annotations.InlineMe;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
-import io.grpc.ExperimentalApi;
 import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
 import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
 import io.grpc.Metadata;


### PR DESCRIPTION
fixes #1789 

(have made sure there is no internal usage of these methods)