### PR TITLE
Upgrade to Gradle 8.2.1 and upgrade plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ For non-Android protobuf-based codegen integrated with the Gradle build system,
 you can use [protobuf-gradle-plugin][]:
 ```gradle
 plugins {
-    id 'com.google.protobuf' version '0.9.1'
+    id 'com.google.protobuf' version '0.9.4'
 }
 
 protobuf {
@@ -185,7 +185,7 @@ use protobuf-gradle-plugin but specify the 'lite' options:
 
 ```gradle
 plugins {
-    id 'com.google.protobuf' version '0.9.1'
+    id 'com.google.protobuf' version '0.9.4'
 }
 
 protobuf {

--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -122,4 +122,16 @@ tasks.withType(JavaCompile).configureEach {
             "|")
 }
 
+afterEvaluate {
+    // Hack to workaround "Task ':grpc-android-interop-testing:extractIncludeDebugProto' uses this
+    // output of task ':grpc-context:jar' without declaring an explicit or implicit dependency." The
+    // issue started when grpc-context became empty.
+    tasks.named('extractIncludeDebugProto').configure {
+        dependsOn project(':grpc-context').tasks.named('jar')
+    }
+    tasks.named('extractIncludeReleaseProto').configure {
+        dependsOn project(':grpc-context').tasks.named('jar')
+    }
+}
+
 configureProtoCompilation()

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -20,8 +20,8 @@ tasks.named("compileContextJava").configure {
     if (JavaVersion.current().isJava9Compatible()) {
         options.release = 7
     } else {
-        sourceCompatibility = 1.7
-        targetCompatibility = 1.7
+        sourceCompatibility = JavaVersion.VERSION_1_7
+        targetCompatibility = JavaVersion.VERSION_1_7
     }
 }
 

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -105,12 +105,14 @@ def benchmark_worker = tasks.register("benchmark_worker", CreateStartScripts) {
     classpath = startScripts.classpath
 }
 
-applicationDistribution.into("bin") {
-    from(qps_client)
-    from(openloop_client)
-    from(qps_server)
-    from(benchmark_worker)
-    fileMode = 0755
+application {
+    applicationDistribution.into("bin") {
+        from(qps_client)
+        from(openloop_client)
+        from(qps_server)
+        from(benchmark_worker)
+        fileMode = 0755
+    }
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -241,8 +241,8 @@ subprojects {
             if (JavaVersion.current().isJava9Compatible()) {
                 options.release = 8
             } else {
-                sourceCompatibility = 1.8
-                targetCompatibility = 1.8
+                sourceCompatibility = JavaVersion.VERSION_1_8
+                targetCompatibility = JavaVersion.VERSION_1_8
             }
         }
         tasks.named("compileJava").configure {

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -136,8 +136,10 @@ model {
     }
 }
 
-configurations {
-    testLiteImplementation
+sourceSets {
+    testLite {
+        proto { setSrcDirs(['src/test/proto']) }
+    }
 }
 
 dependencies {
@@ -147,12 +149,6 @@ dependencies {
     testLiteImplementation project(':grpc-protobuf-lite'),
             project(':grpc-stub'),
             libraries.javax.annotation
-}
-
-sourceSets {
-    testLite {
-        proto { setSrcDirs(['src/test/proto']) }
-    }
 }
 
 tasks.named("compileTestJava").configure {
@@ -214,7 +210,9 @@ tasks.register("buildArtifacts", Copy) {
     into artifactStagingPath
 }
 
-archivesBaseName = "$protocPluginBaseName"
+base {
+    archivesName = "$protocPluginBaseName"
+}
 
 def checkArtifacts = tasks.register("checkArtifacts") {
     dependsOn buildArtifacts

--- a/examples/android/clientcache/build.gradle
+++ b/examples/android/clientcache/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.0'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.1"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.4"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/android/helloworld/build.gradle
+++ b/examples/android/helloworld/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.0'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.1"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.4"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/android/routeguide/build.gradle
+++ b/examples/android/routeguide/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.0'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.1"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.4"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/android/strictmode/build.gradle
+++ b/examples/android/strictmode/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.0'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.1"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.4"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     // Provide convenience executables for trying out the examples.
     id 'application'
-    id 'com.google.protobuf' version '0.9.1'
+    id 'com.google.protobuf' version '0.9.4'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
 }
@@ -13,8 +13,10 @@ repositories {
     mavenLocal()
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 // IMPORTANT: You probably want the non-SNAPSHOT version of gRPC. Make sure you
 // are looking at a tagged version of the example and not "master"!

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -15,8 +15,10 @@ repositories {
     mavenLocal()
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 // IMPORTANT: You probably want the non-SNAPSHOT version of gRPC. Make sure you
 // are looking at a tagged version of the example and not "master"!

--- a/examples/example-debug/build.gradle
+++ b/examples/example-debug/build.gradle
@@ -15,8 +15,10 @@ repositories {
     mavenLocal()
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 // IMPORTANT: You probably want the non-SNAPSHOT version of gRPC. Make sure you
 // are looking at a tagged version of the example and not "master"!

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -15,8 +15,10 @@ repositories {
     mavenLocal()
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 // IMPORTANT: You probably want the non-SNAPSHOT version of gRPC. Make sure you
 // are looking at a tagged version of the example and not "master"!

--- a/examples/example-gcp-observability/build.gradle
+++ b/examples/example-gcp-observability/build.gradle
@@ -16,8 +16,10 @@ repositories {
     mavenLocal()
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 // IMPORTANT: You probably want the non-SNAPSHOT version of gRPC. Make sure you
 // are looking at a tagged version of the example and not "master"!

--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -13,8 +13,10 @@ repositories {
     mavenLocal()
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 // IMPORTANT: You probably want the non-SNAPSHOT version of gRPC. Make sure you
 // are looking at a tagged version of the example and not "master"!

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -14,8 +14,10 @@ repositories {
     mavenLocal()
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 // IMPORTANT: You probably want the non-SNAPSHOT version of gRPC. Make sure you
 // are looking at a tagged version of the example and not "master"!

--- a/examples/example-orca/build.gradle
+++ b/examples/example-orca/build.gradle
@@ -14,8 +14,10 @@ repositories {
     mavenLocal()
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 def grpcVersion = '1.58.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.23.4'

--- a/examples/example-reflection/build.gradle
+++ b/examples/example-reflection/build.gradle
@@ -14,8 +14,10 @@ repositories {
     mavenLocal()
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 def grpcVersion = '1.58.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.23.4'

--- a/examples/example-servlet/build.gradle
+++ b/examples/example-servlet/build.gradle
@@ -12,8 +12,10 @@ repositories {
     mavenLocal()
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 def grpcVersion = '1.58.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.23.4'

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -15,8 +15,10 @@ repositories {
     mavenLocal()
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 // IMPORTANT: You probably want the non-SNAPSHOT version of gRPC. Make sure you
 // are looking at a tagged version of the example and not "master"!

--- a/examples/example-xds/build.gradle
+++ b/examples/example-xds/build.gradle
@@ -14,8 +14,10 @@ repositories {
     mavenLocal()
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 // IMPORTANT: You probably want the non-SNAPSHOT version of gRPC. Make sure you
 // are looking at a tagged version of the example and not "master"!

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -158,22 +158,24 @@ def xds_federation_test_client = tasks.register("xds_federation_test_client", Cr
     classpath = startScripts.classpath
 }
 
-applicationDistribution.into("bin") {
-    from(test_client)
-    from(test_server)
-    from(reconnect_test_client)
-    from(stresstest_client)
-    from(http2_client)
-    from(grpclb_long_lived_affinity_test_client)
-    from(grpclb_fallback_test_client)
-    from(xds_test_client)
-    from(xds_test_server)
-    from(xds_federation_test_client)
-    fileMode = 0755
-}
+application {
+    applicationDistribution.into("bin") {
+        from(test_client)
+        from(test_server)
+        from(reconnect_test_client)
+        from(stresstest_client)
+        from(http2_client)
+        from(grpclb_long_lived_affinity_test_client)
+        from(grpclb_fallback_test_client)
+        from(xds_test_client)
+        from(xds_test_server)
+        from(xds_federation_test_client)
+        fileMode = 0755
+    }
 
-applicationDistribution.into("lib") {
-    from(configurations.alpnagent)
+    applicationDistribution.into("lib") {
+        from(configurations.alpnagent)
+    }
 }
 
 publishing {

--- a/netty/shaded/build.gradle
+++ b/netty/shaded/build.gradle
@@ -1,9 +1,9 @@
 import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.CacheableTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.TransformerContext
+import org.apache.tools.zip.ZipOutputStream
+import org.apache.tools.zip.ZipEntry
 import org.gradle.api.file.FileTreeElement
-import shadow.org.apache.tools.zip.ZipOutputStream
-import shadow.org.apache.tools.zip.ZipEntry
 
 plugins {
     id "java"

--- a/servlet/build.gradle
+++ b/servlet/build.gradle
@@ -7,13 +7,6 @@ description = "gRPC: Servlet"
 
 def jettyVersion = '10.0.7'
 
-configurations {
-    itImplementation.extendsFrom(implementation)
-    undertowTestImplementation.extendsFrom(itImplementation)
-    tomcatTestImplementation.extendsFrom(itImplementation)
-    jettyTestImplementation.extendsFrom(itImplementation)
-}
-
 sourceSets {
     // Create a test sourceset for each classpath - could be simplified if we made new test directories
     undertowTest {}
@@ -23,6 +16,13 @@ sourceSets {
     if (JavaVersion.current().isJava11Compatible()) {
         jettyTest {}
     }
+}
+
+configurations {
+    itImplementation.extendsFrom(implementation)
+    undertowTestImplementation.extendsFrom(itImplementation)
+    tomcatTestImplementation.extendsFrom(itImplementation)
+    jettyTestImplementation.extendsFrom(itImplementation)
 }
 
 tasks.named("jar").configure {

--- a/servlet/jakarta/build.gradle
+++ b/servlet/jakarta/build.gradle
@@ -6,13 +6,6 @@ plugins {
 description = "gRPC: Jakarta Servlet"
 
 // Set up classpaths and source directories for different servlet tests
-configurations {
-    itImplementation.extendsFrom(implementation)
-    jettyTestImplementation.extendsFrom(itImplementation)
-    tomcatTestImplementation.extendsFrom(itImplementation)
-    undertowTestImplementation.extendsFrom(itImplementation)
-}
-
 sourceSets {
     undertowTest {
         java {
@@ -32,6 +25,18 @@ sourceSets {
             }
         }
     }
+}
+
+configurations {
+    itImplementation.extendsFrom(implementation)
+    jettyTestImplementation.extendsFrom(itImplementation)
+    tomcatTestImplementation.extendsFrom(itImplementation)
+    undertowTestImplementation.extendsFrom(itImplementation)
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 // Mechanically transform sources from grpc-servlet to use the corrected packages

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,17 +1,26 @@
 pluginManagement {
     plugins {
+        // https://developer.android.com/build/releases/gradle-plugin
         id "com.android.application" version "7.4.0"
         id "com.android.library" version "7.4.0"
-        id "com.github.johnrengelman.shadow" version "7.1.2"
+        // https://github.com/johnrengelman/shadow/releases
+        id "com.github.johnrengelman.shadow" version "8.1.1"
         id "com.github.kt3k.coveralls" version "2.12.2"
-        id "com.google.cloud.tools.appengine" version "2.4.4"
-        id "com.google.cloud.tools.jib" version "3.3.1"
+        // https://github.com/GoogleCloudPlatform/app-gradle-plugin/releases
+        id "com.google.cloud.tools.appengine" version "2.4.5"
+        // https://github.com/GoogleContainerTools/jib/blob/master/jib-gradle-plugin/CHANGELOG.md
+        id "com.google.cloud.tools.jib" version "3.3.2"
         id "com.google.osdetector" version "1.7.3"
-        id "com.google.protobuf" version "0.9.3"
+        // https://github.com/google/protobuf-gradle-plugin/releases
+        id "com.google.protobuf" version "0.9.4"
+        // https://github.com/melix/japicmp-gradle-plugin/blob/master/CHANGELOG.txt
         id "me.champeau.gradle.japicmp" version "0.4.1"
+        // https://github.com/melix/jmh-gradle-plugin/releases
         id "me.champeau.jmh" version "0.7.1"
+        // https://github.com/tbroyer/gradle-errorprone-plugin/releases
         id "net.ltgt.errorprone" version "3.1.0"
-        id "ru.vyarus.animalsniffer" version "1.7.0"
+        // https://github.com/xvik/gradle-animalsniffer-plugin/releases
+        id "ru.vyarus.animalsniffer" version "1.7.1"
     }
     resolutionStrategy {
         eachPlugin {


### PR DESCRIPTION
Most changes are migrating from conventions to the equivalent extensions. JMH, AppEngine, and Jib plugins trigger future compatibility warnings with `--warning-mode all`.

The movement of configurations was to allow sourceSets to create the configurations and then we just configure them. When configurations were before sourceSets, we'd implicitly create the configuration.

The examples were _not_ updated to the newer Gradle, although the non-Android examples work with the newer Gradle. The Android examples use an older Android Gradle Plugin which will need to be upgraded first. https://github.com/grpc/grpc-java/issues/10445