### PR TITLE
all: Copy mustRunAfter from each project's JacocoTestReport

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -52,11 +52,10 @@ tasks.named("javadoc").configure {
 }
 
 tasks.named("jacocoTestReport").configure {
-    dependsOn(subprojects.jacocoTestReport.dependsOn)
-    dependsOn(project(':grpc-interop-testing').jacocoTestReport.dependsOn)
+    mustRunAfter(subprojects.jacocoTestReport.mustRunAfter)
+    mustRunAfter(project(':grpc-interop-testing').jacocoTestReport.mustRunAfter)
     executionData.from files(subprojects.jacocoTestReport.executionData)
             .plus(project(':grpc-interop-testing').jacocoTestReport.executionData)
-            .filter { f -> f.exists() }
     reports {
         xml.required = true
         html.required = true


### PR DESCRIPTION
While JacocoReportBase.getExecutionData() is properly annotated with `@InputFiles` and is a FileCollection, which can propagate dependencies, the JacocoPlugin's configuration of the task [goes through a File][barefile], which doesn't propagate task dependency information. This is overcome in the plugin by mustRunAfter. This may have been on purpose to allow jacocoTestReport to report on the subset of tests already run, but is atypical these days.

Because of that, we need to copy the mustRunAfter from the other JacocoTestReports. The dependsOn weren't doing anything because there were no dependsOn; that configuration is quite old so it's hard to say when they stopped functioning.

This fixes warnings like:
```
  - Gradle detected a problem with the following location: 'grpc-java/core/build/jacoco/test.exec'. Reason: Task ':grpc-all:jacocoTestReport' uses this output of task ':grpc-core:test' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.6/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: 'grpc-java/testing/build/resources/main'. Reason: Task ':grpc-all:jacocoTestReport' uses this output of task ':grpc-testing:processResources' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.6/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```

I was able to trigger the warnings by:
```
./gradlew clean
./gradlew :grpc-core:test
./gradlew :grpc-all:jacocoTestReport
./gradlew :grpc-core:test :grpc-all:jacocoTestReport
```

[barefile]: https://github.com/gradle/gradle/blob/bc4029063cb607d90bd798be37f578957cf67746/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReportBase.java#L162-L168