### PR TITLE
.github: Use checkout@v3 for Bazel

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -79,7 +79,7 @@ jobs:
       USE_BAZEL_VERSION: 5.0.0
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Bazel cache
       uses: actions/cache@v3


### PR DESCRIPTION
The other jobs were swapped to v3 in 38311e8730. Bazel was added later with the older version.

This fixes the warning:
```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```