### PR TITLE
api, core: rename ChannelBuilders' nameResolverFactory to nameResolverFactory_deprecated as a precursor to removing the method

### DIFF
--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -118,8 +118,8 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
 
   @Deprecated
   @Override
-  public T nameResolverFactory(NameResolver.Factory resolverFactory) {
-    delegate().nameResolverFactory(resolverFactory);
+  public T nameResolverFactory_deprecated(NameResolver.Factory resolverFactory) {
+    delegate().nameResolverFactory_deprecated(resolverFactory);
     return thisT();
   }
 

--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -226,7 +226,7 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    */
   @Deprecated
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1770")
-  public abstract T nameResolverFactory(NameResolver.Factory resolverFactory);
+  public abstract T nameResolverFactory_deprecated(NameResolver.Factory resolverFactory);
 
   /**
    * Sets the default load-balancing policy that will be used if the service config doesn't specify

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -133,8 +133,8 @@ public abstract class AbstractManagedChannelImplBuilder
 
   @Deprecated
   @Override
-  public T nameResolverFactory(NameResolver.Factory resolverFactory) {
-    delegate().nameResolverFactory(resolverFactory);
+  public T nameResolverFactory_deprecated(NameResolver.Factory resolverFactory) {
+    delegate().nameResolverFactory_deprecated(resolverFactory);
     return thisT();
   }
 

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1632,7 +1632,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
 
       @SuppressWarnings("deprecation")
       ResolvingOobChannelBuilder builder = new ResolvingOobChannelBuilder()
-          .nameResolverFactory(nameResolverFactory);
+          .nameResolverFactory_deprecated(nameResolverFactory);
 
       return builder
           // TODO(zdapeng): executors should not outlive the parent channel.

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -350,7 +350,8 @@ public final class ManagedChannelImplBuilder
 
   @Deprecated
   @Override
-  public ManagedChannelImplBuilder nameResolverFactory(NameResolver.Factory resolverFactory) {
+  public ManagedChannelImplBuilder nameResolverFactory_deprecated(
+      NameResolver.Factory resolverFactory) {
     Preconditions.checkState(directServerAddress == null,
         "directServerAddress is set (%s), which forbids the use of NameResolverFactory",
         directServerAddress);

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
@@ -204,7 +204,7 @@ public class ManagedChannelImplBuilderTest {
   @SuppressWarnings("deprecation")
   public void nameResolverFactory_normal() {
     NameResolver.Factory nameResolverFactory = mock(NameResolver.Factory.class);
-    assertEquals(builder, builder.nameResolverFactory(nameResolverFactory));
+    assertEquals(builder, builder.nameResolverFactory_deprecated(nameResolverFactory));
     assertEquals(nameResolverFactory, builder.nameResolverFactory);
   }
 
@@ -212,15 +212,15 @@ public class ManagedChannelImplBuilderTest {
   @SuppressWarnings("deprecation")
   public void nameResolverFactory_null() {
     NameResolver.Factory defaultValue = builder.nameResolverFactory;
-    builder.nameResolverFactory(mock(NameResolver.Factory.class));
-    assertEquals(builder, builder.nameResolverFactory(null));
+    builder.nameResolverFactory_deprecated(mock(NameResolver.Factory.class));
+    assertEquals(builder, builder.nameResolverFactory_deprecated(null));
     assertEquals(defaultValue, builder.nameResolverFactory);
   }
 
   @Test(expected = IllegalStateException.class)
   @SuppressWarnings("deprecation")
   public void nameResolverFactory_notAllowedWithDirectAddress() {
-    directAddressBuilder.nameResolverFactory(mock(NameResolver.Factory.class));
+    directAddressBuilder.nameResolverFactory_deprecated(mock(NameResolver.Factory.class));
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -167,7 +167,7 @@ public class ManagedChannelImplIdlenessTest {
         new UnsupportedClientTransportFactoryBuilder(), null);
 
     builder
-        .nameResolverFactory(mockNameResolverFactory)
+        .nameResolverFactory_deprecated(mockNameResolverFactory)
         .defaultLoadBalancingPolicy(MOCK_POLICY_NAME)
         .idleTimeout(IDLE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
         .userAgent(USER_AGENT);

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -334,7 +334,7 @@ public class ManagedChannelImplTest {
 
   private void configureBuilder(ManagedChannelImplBuilder channelBuilder) {
     channelBuilder
-        .nameResolverFactory(new FakeNameResolverFactory.Builder(expectedUri).build())
+        .nameResolverFactory_deprecated(new FakeNameResolverFactory.Builder(expectedUri).build())
         .defaultLoadBalancingPolicy(MOCK_POLICY_NAME)
         .userAgent(USER_AGENT)
         .idleTimeout(ManagedChannelImplBuilder.IDLE_MODE_MAX_TIMEOUT_DAYS, TimeUnit.DAYS)
@@ -386,7 +386,7 @@ public class ManagedChannelImplTest {
         Attributes.newBuilder()
             .set(ATTR_AUTHORITY_OVERRIDE, "resolver.override.authority")
             .build());
-    channelBuilder.nameResolverFactory(
+    channelBuilder.nameResolverFactory_deprecated(
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(Collections.singletonList(addressGroup))
             .build());
@@ -412,7 +412,7 @@ public class ManagedChannelImplTest {
         Attributes.newBuilder()
             .set(ATTR_AUTHORITY_OVERRIDE, "resolver.override.authority")
             .build());
-    channelBuilder.nameResolverFactory(
+    channelBuilder.nameResolverFactory_deprecated(
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(Collections.singletonList(addressGroup))
             .build());
@@ -441,7 +441,7 @@ public class ManagedChannelImplTest {
 
   @Test
   public void idleModeDisabled() {
-    channelBuilder.nameResolverFactory(
+    channelBuilder.nameResolverFactory_deprecated(
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(Collections.singletonList(new EquivalentAddressGroup(socketAddress)))
             .build());
@@ -471,7 +471,7 @@ public class ManagedChannelImplTest {
     FakeNameResolverFactory nameResolverFactory =
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(ImmutableList.of(addressGroup)).build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     channel = new ManagedChannelImpl(
         channelBuilder, mockTransportFactory, new FakeBackoffPolicyProvider(),
         balancerRpcExecutorPool, timer.getStopwatchSupplier(),
@@ -533,7 +533,7 @@ public class ManagedChannelImplTest {
     FakeNameResolverFactory nameResolverFactory =
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(ImmutableList.of(addressGroup)).build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     channel = new ManagedChannelImpl(
         channelBuilder, mockTransportFactory, new FakeBackoffPolicyProvider(),
         balancerRpcExecutorPool, timer.getStopwatchSupplier(),
@@ -609,7 +609,7 @@ public class ManagedChannelImplTest {
 
   @Test
   public void shutdownWithNoTransportsEverCreated() {
-    channelBuilder.nameResolverFactory(
+    channelBuilder.nameResolverFactory_deprecated(
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(Collections.singletonList(new EquivalentAddressGroup(socketAddress)))
             .build());
@@ -624,7 +624,7 @@ public class ManagedChannelImplTest {
 
   @Test
   public void shutdownNow_pendingCallShouldFail() {
-    channelBuilder.nameResolverFactory(
+    channelBuilder.nameResolverFactory_deprecated(
         new FakeNameResolverFactory.Builder(expectedUri)
             .setResolvedAtStart(false)
             .setServers(Collections.singletonList(new EquivalentAddressGroup(socketAddress)))
@@ -643,7 +643,7 @@ public class ManagedChannelImplTest {
 
   @Test
   public void shutdownWithNoNameResolution_newCallShouldFail() {
-    channelBuilder.nameResolverFactory(
+    channelBuilder.nameResolverFactory_deprecated(
         new FakeNameResolverFactory.Builder(expectedUri)
             .setResolvedAtStart(false)
             .setServers(Collections.singletonList(new EquivalentAddressGroup(socketAddress)))
@@ -768,7 +768,7 @@ public class ManagedChannelImplTest {
   private void subtestCallsAndShutdown(boolean shutdownNow, boolean shutdownNowAfterShutdown) {
     FakeNameResolverFactory nameResolverFactory =
         new FakeNameResolverFactory.Builder(expectedUri).build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     createChannel();
     verify(executorPool).getObject();
     ClientStream mockStream = mock(ClientStream.class);
@@ -917,7 +917,7 @@ public class ManagedChannelImplTest {
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(Collections.singletonList(new EquivalentAddressGroup(socketAddress)))
             .build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     Status resolutionError = Status.UNAVAILABLE.withDescription("Resolution failed");
     createChannel();
 
@@ -1064,7 +1064,7 @@ public class ManagedChannelImplTest {
             .setResolvedAtStart(false)
             .setServers(Collections.singletonList(new EquivalentAddressGroup(socketAddress)))
             .build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     createChannel();
 
     verify(mockLoadBalancerProvider).newLoadBalancer(any(Helper.class));
@@ -1089,7 +1089,7 @@ public class ManagedChannelImplTest {
     };
     FakeNameResolverFactory nsFactory = new FakeNameResolverFactory.Builder(expectedUri)
         .setResolvedAtStart(false).build();
-    channelBuilder.nameResolverFactory(nsFactory);
+    channelBuilder.nameResolverFactory_deprecated(nsFactory);
     createChannel();
 
     CallOptions callOptions = CallOptions.DEFAULT.withStreamTracerFactory(factory);
@@ -1126,7 +1126,7 @@ public class ManagedChannelImplTest {
     // Delay the success of name resolution until allResolved() is called.
     FakeNameResolverFactory nameResolverFactory =
         new FakeNameResolverFactory.Builder(expectedUri).setResolvedAtStart(false).build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     createChannel();
 
     channel.shutdown();
@@ -1163,7 +1163,7 @@ public class ManagedChannelImplTest {
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(Collections.singletonList(new EquivalentAddressGroup(resolvedAddrs)))
             .build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     createChannel();
 
     // Start the call
@@ -1308,7 +1308,7 @@ public class ManagedChannelImplTest {
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(Collections.singletonList(new EquivalentAddressGroup(resolvedAddrs)))
             .build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     createChannel();
 
     // Start a wait-for-ready call
@@ -1712,7 +1712,7 @@ public class ManagedChannelImplTest {
 
     // Verify that resolving oob channel does not
     oob = helper.createResolvingOobChannelBuilder("oobauthority")
-        .nameResolverFactory(
+        .nameResolverFactory_deprecated(
             new FakeNameResolverFactory.Builder(URI.create("oobauthority")).build())
         .defaultLoadBalancingPolicy(MOCK_POLICY_NAME)
         .idleTimeout(ManagedChannelImplBuilder.IDLE_MODE_MAX_TIMEOUT_DAYS, TimeUnit.DAYS)
@@ -1798,7 +1798,7 @@ public class ManagedChannelImplTest {
         new FakeCallCredentials(metadataKey, oobChannelCredValue));
     ManagedChannel oob = helper.createResolvingOobChannelBuilder(
             "fake://oobauthority/", oobChannelCreds)
-        .nameResolverFactory(
+        .nameResolverFactory_deprecated(
             new FakeNameResolverFactory.Builder(URI.create("fake://oobauthority/")).build())
         .defaultLoadBalancingPolicy(MOCK_POLICY_NAME)
         .idleTimeout(ManagedChannelImplBuilder.IDLE_MODE_MAX_TIMEOUT_DAYS, TimeUnit.DAYS)
@@ -2059,7 +2059,7 @@ public class ManagedChannelImplTest {
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(Collections.singletonList(new EquivalentAddressGroup(socketAddress)))
             .build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     createChannel();
     OobChannel oobChannel = (OobChannel) helper.createOobChannel(
         Collections.singletonList(addressGroup), "oobAuthority");
@@ -2321,7 +2321,7 @@ public class ManagedChannelImplTest {
 
   @Test
   public void getState_loadBalancerSupportsChannelState() {
-    channelBuilder.nameResolverFactory(
+    channelBuilder.nameResolverFactory_deprecated(
         new FakeNameResolverFactory.Builder(expectedUri).setResolvedAtStart(false).build());
     createChannel();
     assertEquals(IDLE, channel.getState(false));
@@ -2332,7 +2332,7 @@ public class ManagedChannelImplTest {
 
   @Test
   public void getState_withRequestConnect() {
-    channelBuilder.nameResolverFactory(
+    channelBuilder.nameResolverFactory_deprecated(
         new FakeNameResolverFactory.Builder(expectedUri).setResolvedAtStart(false).build());
     requestConnection = false;
     createChannel();
@@ -2355,7 +2355,7 @@ public class ManagedChannelImplTest {
   @SuppressWarnings("deprecation")
   @Test
   public void getState_withRequestConnect_IdleWithLbRunning() {
-    channelBuilder.nameResolverFactory(
+    channelBuilder.nameResolverFactory_deprecated(
         new FakeNameResolverFactory.Builder(expectedUri).setResolvedAtStart(false).build());
     createChannel();
     verify(mockLoadBalancerProvider).newLoadBalancer(any(Helper.class));
@@ -2378,7 +2378,7 @@ public class ManagedChannelImplTest {
       }
     };
 
-    channelBuilder.nameResolverFactory(
+    channelBuilder.nameResolverFactory_deprecated(
         new FakeNameResolverFactory.Builder(expectedUri).setResolvedAtStart(false).build());
     createChannel();
     assertEquals(IDLE, channel.getState(false));
@@ -2411,7 +2411,7 @@ public class ManagedChannelImplTest {
       }
     };
 
-    channelBuilder.nameResolverFactory(
+    channelBuilder.nameResolverFactory_deprecated(
         new FakeNameResolverFactory.Builder(expectedUri).setResolvedAtStart(false).build());
     createChannel();
     assertEquals(IDLE, channel.getState(false));
@@ -2472,7 +2472,7 @@ public class ManagedChannelImplTest {
     long idleTimeoutMillis = 2000L;
     FakeNameResolverFactory nameResolverFactory =
         new FakeNameResolverFactory.Builder(expectedUri).build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     channelBuilder.idleTimeout(idleTimeoutMillis, TimeUnit.MILLISECONDS);
     createChannel();
 
@@ -2600,7 +2600,7 @@ public class ManagedChannelImplTest {
 
       @Override public void shutdown() {}
     };
-    channelBuilder.nameResolverFactory(new NameResolver.Factory() {
+    channelBuilder.nameResolverFactory_deprecated(new NameResolver.Factory() {
       @Override public NameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
         return failingResolver;
       }
@@ -2676,7 +2676,7 @@ public class ManagedChannelImplTest {
     Status pickError = Status.UNAVAILABLE.withDescription("pick result error");
     long idleTimeoutMillis = 1000L;
     channelBuilder.idleTimeout(idleTimeoutMillis, TimeUnit.MILLISECONDS);
-    channelBuilder.nameResolverFactory(
+    channelBuilder.nameResolverFactory_deprecated(
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(Collections.singletonList(new EquivalentAddressGroup(socketAddress)))
             .build());
@@ -2766,7 +2766,7 @@ public class ManagedChannelImplTest {
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(Collections.singletonList(new EquivalentAddressGroup(socketAddress)))
             .build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     createChannel();
 
     // Start a call that will be buffered in delayedTransport
@@ -2895,7 +2895,7 @@ public class ManagedChannelImplTest {
 
   @Test
   public void updateBalancingStateWithShutdownShouldBeIgnored() {
-    channelBuilder.nameResolverFactory(
+    channelBuilder.nameResolverFactory_deprecated(
         new FakeNameResolverFactory.Builder(expectedUri).setResolvedAtStart(false).build());
     createChannel();
     assertEquals(IDLE, channel.getState(false));
@@ -2914,7 +2914,7 @@ public class ManagedChannelImplTest {
   public void balancerRefreshNameResolution() {
     FakeNameResolverFactory nameResolverFactory =
         new FakeNameResolverFactory.Builder(expectedUri).build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     createChannel();
 
     FakeNameResolverFactory.FakeNameResolver resolver = nameResolverFactory.resolvers.get(0);
@@ -2927,7 +2927,7 @@ public class ManagedChannelImplTest {
   public void resetConnectBackoff_noOpWhenChannelShutdown() {
     FakeNameResolverFactory nameResolverFactory =
         new FakeNameResolverFactory.Builder(expectedUri).build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     createChannel();
 
     channel.shutdown();
@@ -2942,7 +2942,7 @@ public class ManagedChannelImplTest {
   public void resetConnectBackoff_noOpWhenNameResolverNotStarted() {
     FakeNameResolverFactory nameResolverFactory =
         new FakeNameResolverFactory.Builder(expectedUri).build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     requestConnection = false;
     createChannel();
 
@@ -3004,7 +3004,7 @@ public class ManagedChannelImplTest {
     Status error = Status.UNAVAILABLE.withDescription("simulated error");
     FakeNameResolverFactory nameResolverFactory =
         new FakeNameResolverFactory.Builder(expectedUri).setError(error).build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     createChannel(true);
 
     assertThat(getStats(channel).channelTrace.events).contains(new ChannelTrace.Event.Builder()
@@ -3022,7 +3022,7 @@ public class ManagedChannelImplTest {
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(Collections.singletonList(new EquivalentAddressGroup(socketAddress)))
             .build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     createChannel();
     assertThat(getStats(channel).channelTrace.events).contains(new ChannelTrace.Event.Builder()
         .setDescription("Address resolved: "
@@ -3040,7 +3040,7 @@ public class ManagedChannelImplTest {
     servers.add(new EquivalentAddressGroup(socketAddress));
     FakeNameResolverFactory nameResolverFactory =
         new FakeNameResolverFactory.Builder(expectedUri).setServers(servers).build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     createChannel();
 
     int prevSize = getStats(channel).channelTrace.events.size();
@@ -3078,7 +3078,7 @@ public class ManagedChannelImplTest {
     servers.add(new EquivalentAddressGroup(socketAddress));
     FakeNameResolverFactory nameResolverFactory =
         new FakeNameResolverFactory.Builder(expectedUri).setServers(servers).build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     createChannel();
 
     int prevSize = getStats(channel).channelTrace.events.size();
@@ -3488,7 +3488,7 @@ public class ManagedChannelImplTest {
     nameResolverFactory.nextConfigOrError.set(
         ConfigOrError.fromConfig(managedChannelServiceConfig));
 
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     channelBuilder.executor(MoreExecutors.directExecutor());
     channelBuilder.enableRetry();
     RetriableStream.setRandom(
@@ -3603,7 +3603,7 @@ public class ManagedChannelImplTest {
     nameResolverFactory.nextConfigOrError.set(
         ConfigOrError.fromConfig(managedChannelServiceConfig));
 
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     channelBuilder.executor(MoreExecutors.directExecutor());
     channelBuilder.enableRetry();
 
@@ -3742,7 +3742,7 @@ public class ManagedChannelImplTest {
         null);
     customBuilder.executorPool = executorPool;
     customBuilder.channelz = channelz;
-    ManagedChannel mychannel = customBuilder.nameResolverFactory(factory).build();
+    ManagedChannel mychannel = customBuilder.nameResolverFactory_deprecated(factory).build();
 
     ClientCall<Void, Void> call1 =
         mychannel.newCall(TestMethodDescriptors.voidMethod(), CallOptions.DEFAULT);
@@ -3823,7 +3823,7 @@ public class ManagedChannelImplTest {
           return "fakescheme";
         }
       };
-    channelBuilder.nameResolverFactory(factory).proxyDetector(neverProxy);
+    channelBuilder.nameResolverFactory_deprecated(factory).proxyDetector(neverProxy);
     createChannel();
 
     NameResolver.Args args = capturedArgs.get();
@@ -3923,7 +3923,7 @@ public class ManagedChannelImplTest {
       FakeNameResolverFactory nameResolverFactory =
           new FakeNameResolverFactory.Builder(expectedUri)
               .setServers(ImmutableList.of(addressGroup)).build();
-      channelBuilder.nameResolverFactory(nameResolverFactory);
+      channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
       channelBuilder.disableServiceConfigLookUp();
 
       Map<String, Object> rawServiceConfig =
@@ -3959,7 +3959,7 @@ public class ManagedChannelImplTest {
       FakeNameResolverFactory nameResolverFactory =
           new FakeNameResolverFactory.Builder(expectedUri)
               .setServers(ImmutableList.of(addressGroup)).build();
-      channelBuilder.nameResolverFactory(nameResolverFactory);
+      channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
       channelBuilder.disableServiceConfigLookUp();
       Map<String, Object> defaultServiceConfig =
           parseConfig("{\"methodConfig\":[{"
@@ -3997,7 +3997,7 @@ public class ManagedChannelImplTest {
       FakeNameResolverFactory nameResolverFactory =
           new FakeNameResolverFactory.Builder(expectedUri)
               .setServers(ImmutableList.of(addressGroup)).build();
-      channelBuilder.nameResolverFactory(nameResolverFactory);
+      channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
 
       Map<String, Object> rawServiceConfig =
           parseConfig("{\"methodConfig\":[{"
@@ -4042,7 +4042,7 @@ public class ManagedChannelImplTest {
       FakeNameResolverFactory nameResolverFactory =
           new FakeNameResolverFactory.Builder(expectedUri)
               .setServers(ImmutableList.of(addressGroup)).build();
-      channelBuilder.nameResolverFactory(nameResolverFactory);
+      channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
       Map<String, Object> defaultServiceConfig =
           parseConfig("{\"methodConfig\":[{"
               + "\"name\":[{\"service\":\"SimpleService1\"}],"
@@ -4077,7 +4077,7 @@ public class ManagedChannelImplTest {
       FakeNameResolverFactory nameResolverFactory =
           new FakeNameResolverFactory.Builder(expectedUri)
               .setServers(ImmutableList.of(addressGroup)).build();
-      channelBuilder.nameResolverFactory(nameResolverFactory);
+      channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
       Map<String, Object> defaultServiceConfig =
           parseConfig("{\"methodConfig\":[{"
               + "\"name\":[{\"service\":\"SimpleService1\"}],"
@@ -4104,7 +4104,7 @@ public class ManagedChannelImplTest {
       FakeNameResolverFactory nameResolverFactory =
           new FakeNameResolverFactory.Builder(expectedUri)
               .setServers(ImmutableList.of(addressGroup)).build();
-      channelBuilder.nameResolverFactory(nameResolverFactory);
+      channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
 
       Map<String, Object> rawServiceConfig = Collections.emptyMap();
       ManagedChannelServiceConfig managedChannelServiceConfig =
@@ -4128,7 +4128,7 @@ public class ManagedChannelImplTest {
     FakeNameResolverFactory nameResolverFactory =
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(ImmutableList.of(addressGroup)).build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     channelBuilder.disableServiceConfigLookUp();
     Map<String, Object> defaultServiceConfig =
         parseConfig("{\"methodConfig\":[{"
@@ -4154,7 +4154,7 @@ public class ManagedChannelImplTest {
     FakeNameResolverFactory nameResolverFactory =
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(ImmutableList.of(addressGroup)).build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     Map<String, Object> defaultServiceConfig =
         parseConfig("{\"methodConfig\":[{"
             + "\"name\":[{\"service\":\"SimpleService1\"}],"
@@ -4182,7 +4182,7 @@ public class ManagedChannelImplTest {
           new FakeNameResolverFactory.Builder(expectedUri)
               .setServers(Collections.singletonList(new EquivalentAddressGroup(socketAddress)))
               .build();
-      channelBuilder.nameResolverFactory(nameResolverFactory);
+      channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
 
       Map<String, Object> rawServiceConfig =
           parseConfig("{\"healthCheckConfig\": {\"serviceName\": \"service1\"}}");
@@ -4209,7 +4209,8 @@ public class ManagedChannelImplTest {
     String oobTarget = "fake://second.example.com";
     URI oobUri = new URI(oobTarget);
     channelBuilder
-        .nameResolverFactory(new FakeNameResolverFactory.Builder(expectedUri, oobUri).build());
+        .nameResolverFactory_deprecated(new FakeNameResolverFactory.Builder(expectedUri, oobUri)
+            .build());
     createChannel();
 
     ManagedChannel resolvedOobChannel = null;

--- a/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
+++ b/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
@@ -203,7 +203,7 @@ public class ServiceConfigErrorHandlingTest {
         new UnsupportedClientTransportFactoryBuilder(), new FixedPortProvider(DEFAULT_PORT));
 
     channelBuilder
-        .nameResolverFactory(new FakeNameResolverFactory.Builder(expectedUri).build())
+        .nameResolverFactory_deprecated(new FakeNameResolverFactory.Builder(expectedUri).build())
         .defaultLoadBalancingPolicy(MOCK_POLICY_NAME)
         .userAgent(USER_AGENT)
         .idleTimeout(ManagedChannelImplBuilder.IDLE_MODE_MAX_TIMEOUT_DAYS, TimeUnit.DAYS)
@@ -238,7 +238,7 @@ public class ServiceConfigErrorHandlingTest {
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(Collections.emptyList())
             .build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
 
     Map<String, Object> rawServiceConfig =
         parseJson("{\"loadBalancingConfig\": [{\"round_robin\": {}}]}");
@@ -258,7 +258,7 @@ public class ServiceConfigErrorHandlingTest {
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(new ArrayList<>(ImmutableList.of(addressGroup)))
             .build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
 
     Map<String, Object> rawServiceConfig =
         parseJson("{\"loadBalancingConfig\": [{\"mock_lb\": {\"check\": \"12\"}}]}");
@@ -296,7 +296,7 @@ public class ServiceConfigErrorHandlingTest {
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(Collections.emptyList())
             .build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
 
     Map<String, Object> rawServiceConfig =
         parseJson("{\"loadBalancingConfig\": [{\"mock_lb\": {\"check\": \"val\"}}]}");
@@ -322,7 +322,7 @@ public class ServiceConfigErrorHandlingTest {
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(ImmutableList.of(addressGroup))
             .build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
 
     Map<String, Object> rawServiceConfig =
         parseJson("{\"loadBalancingConfig\": [{\"mock_lb\": {\"check\": \"foo\"}}]}");
@@ -347,7 +347,7 @@ public class ServiceConfigErrorHandlingTest {
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(ImmutableList.of(addressGroup))
             .build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     nameResolverFactory.nextRawServiceConfig.set(null);
 
     createChannel();
@@ -369,7 +369,7 @@ public class ServiceConfigErrorHandlingTest {
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(ImmutableList.of(addressGroup))
             .build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     Map<String, Object> defaultServiceConfig =
         parseJson("{\"loadBalancingConfig\": [{\"mock_lb\": {\"check\": \"foo\"}}]}");
     channelBuilder.defaultServiceConfig(defaultServiceConfig);
@@ -398,7 +398,7 @@ public class ServiceConfigErrorHandlingTest {
     nameResolverFactory.nextRawServiceConfig.set(
         parseJson("{\"loadBalancingConfig\": [{\"mock_lb\": {\"no_check\": \"foo\"}}]}"));
     nextLbPolicyConfigError.set(error);
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
 
     createChannel();
 
@@ -416,7 +416,7 @@ public class ServiceConfigErrorHandlingTest {
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(ImmutableList.of(addressGroup))
             .build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     Map<String, Object> defaultServiceConfig =
         parseJson("{\"loadBalancingConfig\": [{\"mock_lb\": {\"check\": \"mate\"}}]}");
     channelBuilder.defaultServiceConfig(defaultServiceConfig);
@@ -441,7 +441,7 @@ public class ServiceConfigErrorHandlingTest {
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(ImmutableList.of(addressGroup))
             .build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
 
     Map<String, Object> rawServiceConfig =
         parseJson("{\"loadBalancingConfig\": [{\"mock_lb\": {\"check\": \"1st raw config\"}}]}");
@@ -486,7 +486,7 @@ public class ServiceConfigErrorHandlingTest {
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(ImmutableList.of(addressGroup))
             .build();
-    channelBuilder.nameResolverFactory(nameResolverFactory);
+    channelBuilder.nameResolverFactory_deprecated(nameResolverFactory);
     Map<String, Object> defaultServiceConfig =
         parseJson("{\"loadBalancingConfig\": [{\"mock_lb\": {\"check\": \"mate\"}}]}");
     channelBuilder.defaultServiceConfig(defaultServiceConfig);


### PR DESCRIPTION
first step in fixing #7133

The method will be eventually removed after user responses to the renaming

CC @ejona86 