### PR TITLE
android-interop: Add testing for API levels 28-30

### DIFF
--- a/buildscripts/kokoro/android-interop.sh
+++ b/buildscripts/kokoro/android-interop.sh
@@ -38,8 +38,11 @@ gcloud firebase test android run \
   --test build/outputs/apk/androidTest/debug/grpc-android-interop-testing-debug-androidTest.apk \
   --environment-variables \
       server_host=grpc-test.sandbox.googleapis.com,server_port=443,test_case=all \
-  --device model=Nexus6P,version=27,locale=en,orientation=portrait \
-  --device model=Nexus6P,version=26,locale=en,orientation=portrait \
+  --device model=Pixel3,version=30,locale=en,orientation=portrait \
+  --device model=Pixel2,version=29,locale=en,orientation=portrait \
+  --device model=Pixel2,version=28,locale=en,orientation=portrait \
+  --device model=Pixel2,version=27,locale=en,orientation=portrait \
+  --device model=Pixel2,version=26,locale=en,orientation=portrait \
   --device model=Nexus6P,version=25,locale=en,orientation=portrait \
   --device model=Nexus6P,version=24,locale=en,orientation=portrait \
   --device model=Nexus6P,version=23,locale=en,orientation=portrait \
@@ -53,8 +56,11 @@ gcloud firebase test android run \
   --type instrumentation \
   --app ../android-interop-testing/build/outputs/apk/debug/grpc-android-interop-testing-debug.apk \
   --test build/outputs/apk/androidTest/debug/grpc-binder-debug-androidTest.apk \
-  --device model=Nexus6P,version=27,locale=en,orientation=portrait \
-  --device model=Nexus6P,version=26,locale=en,orientation=portrait \
+  --device model=Pixel3,version=30,locale=en,orientation=portrait \
+  --device model=Pixel2,version=29,locale=en,orientation=portrait \
+  --device model=Pixel2,version=28,locale=en,orientation=portrait \
+  --device model=Pixel2,version=27,locale=en,orientation=portrait \
+  --device model=Pixel2,version=26,locale=en,orientation=portrait \
   --device model=Nexus6P,version=25,locale=en,orientation=portrait \
   --device model=Nexus6P,version=24,locale=en,orientation=portrait \
   --device model=Nexus6P,version=23,locale=en,orientation=portrait \


### PR DESCRIPTION
Note that this uses Pixel2 and Pixel3. Also swap 26-27 from Nexus6P to Pixel2. We tend to prefer the latest (virtual) device for each API level.

The current models and their supported API levels are available via:
```
gcloud firebase test android models list --filter=form=virtual
```

Pixel2.arm supports 31-32, but is beta, so I didn't swap to it. It also supports the preview 33.