### PR TITLE
android-interop-testing: Remove usage of Netty for grpc server

### DIFF
--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -88,8 +88,7 @@ dependencies {
 
     compileOnly libraries.javax.annotation
 
-    androidTestImplementation project(':grpc-netty'),
-            'androidx.test.ext:junit:1.1.3',
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3',
             'androidx.test:runner:1.4.0'
 }
 

--- a/android-interop-testing/src/androidTest/java/io/grpc/android/integrationtest/UdsChannelInteropTest.java
+++ b/android-interop-testing/src/androidTest/java/io/grpc/android/integrationtest/UdsChannelInteropTest.java
@@ -22,9 +22,10 @@ import android.net.LocalSocketAddress.Namespace;
 import androidx.test.InstrumentationRegistry;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.rule.ActivityTestRule;
+import io.grpc.Grpc;
+import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
 import io.grpc.android.UdsChannelBuilder;
-import io.grpc.netty.NettyServerBuilder;
 import io.grpc.testing.integration.TestServiceImpl;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
@@ -68,7 +69,7 @@ public class UdsChannelInteropTest {
 
     // Start local server.
     server =
-        NettyServerBuilder.forPort(0)
+        Grpc.newServerBuilderForPort(0, InsecureServerCredentials.create())
             .maxInboundMessageSize(16 * 1024 * 1024)
             .addService(new TestServiceImpl(serverExecutor))
             .build();


### PR DESCRIPTION
We have the OkHttp server these days, so we don't need to use Netty. Use the generic API instead of hard-coding OkHttp.

We've seen some recent interop failures. We aren't entirely sure what is going on, but we have seen some Netty usages in logcat. Since we don't even want Netty on Android, just get rid of it and even if it doesn't help with the failures things are better dependency-wise.