### PR TITLE
xds: Fix import scripts deleting the wrong files, use of trap, and full git clone

### DIFF
--- a/xds/third_party/envoy/import.sh
+++ b/xds/third_party/envoy/import.sh
@@ -13,15 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Update VERSION then in this directory run ./import.sh
+# Update VERSION then execute this script
 
 set -e
-BRANCH=main
 # import VERSION from the google internal copybara_version.txt for Envoy
 VERSION=0478eba2a495027bf6ac8e787c42e2f5b9eb553b
-GIT_REPO="https://github.com/envoyproxy/envoy.git"
-GIT_BASE_DIR=envoy
-SOURCE_PROTO_BASE_DIR=envoy/api
+DOWNLOAD_URL="https://github.com/envoyproxy/envoy/archive/${VERSION}.tar.gz"
+DOWNLOAD_BASE_DIR="envoy-${VERSION}"
+SOURCE_PROTO_BASE_DIR="${DOWNLOAD_BASE_DIR}/api"
 TARGET_PROTO_BASE_DIR=src/main/proto
 # Sorted alphabetically.
 FILES=(
@@ -181,19 +180,13 @@ envoy/type/v3/semantic_version.proto
 
 pushd `git rev-parse --show-toplevel`/xds/third_party/envoy
 
-# clone the envoy github repo in a tmp directory
+# put the repo in a tmp directory
 tmpdir="$(mktemp -d)"
 trap "rm -rf ${tmpdir}" EXIT
+curl -Ls "${DOWNLOAD_URL}" | tar xz -C "${tmpdir}"
 
-pushd "${tmpdir}"
-git clone -b $BRANCH $GIT_REPO
-trap "rm -rf $GIT_BASE_DIR" EXIT
-cd "$GIT_BASE_DIR"
-git checkout $VERSION
-popd
-
-cp -p "${tmpdir}/${GIT_BASE_DIR}/LICENSE" LICENSE
-cp -p "${tmpdir}/${GIT_BASE_DIR}/NOTICE" NOTICE
+cp -p "${tmpdir}/${DOWNLOAD_BASE_DIR}/LICENSE" LICENSE
+cp -p "${tmpdir}/${DOWNLOAD_BASE_DIR}/NOTICE" NOTICE
 
 rm -rf "${TARGET_PROTO_BASE_DIR}"
 mkdir -p "${TARGET_PROTO_BASE_DIR}"

--- a/xds/third_party/googleapis/import.sh
+++ b/xds/third_party/googleapis/import.sh
@@ -13,14 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Update VERSION then in this directory run ./import.sh
+# Update VERSION then execute this script
 
 set -e
-BRANCH=master
 VERSION=ca1372c6d7bcb199638ebfdb40d2b2660bab7b88
-GIT_REPO="https://github.com/googleapis/googleapis.git"
-GIT_BASE_DIR=googleapis
-SOURCE_PROTO_BASE_DIR=googleapis
+DOWNLOAD_URL="https://github.com/googleapis/googleapis/archive/${VERSION}.tar.gz"
+DOWNLOAD_BASE_DIR="googleapis-${VERSION}"
+SOURCE_PROTO_BASE_DIR="${DOWNLOAD_BASE_DIR}"
 TARGET_PROTO_BASE_DIR=src/main/proto
 # Sorted alphabetically.
 FILES=(
@@ -30,18 +29,12 @@ google/api/expr/v1alpha1/syntax.proto
 
 pushd `git rev-parse --show-toplevel`/xds/third_party/googleapis
 
-# clone the googleapis github repo in a tmp directory
+# put the repo in a tmp directory
 tmpdir="$(mktemp -d)"
 trap "rm -rf ${tmpdir}" EXIT
+curl -Ls "${DOWNLOAD_URL}" | tar xz -C "${tmpdir}"
 
-pushd "${tmpdir}"
-git clone -b $BRANCH $GIT_REPO
-trap "rm -rf $GIT_BASE_DIR" EXIT
-cd "$GIT_BASE_DIR"
-git checkout $VERSION
-popd
-
-cp -p "${tmpdir}/${GIT_BASE_DIR}/LICENSE" LICENSE
+cp -p "${tmpdir}/${DOWNLOAD_BASE_DIR}/LICENSE" LICENSE
 
 rm -rf "${TARGET_PROTO_BASE_DIR}"
 mkdir -p "${TARGET_PROTO_BASE_DIR}"

--- a/xds/third_party/protoc-gen-validate/import.sh
+++ b/xds/third_party/protoc-gen-validate/import.sh
@@ -13,33 +13,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Update GIT_ORIGIN_REV_ID then in this directory run ./import.sh
+# Update VERSION then execute this script
 
 set -e
-BRANCH=main
-# import GIT_ORIGIN_REV_ID from one of the google internal CLs
-GIT_ORIGIN_REV_ID=dfcdc5ea103dda467963fb7079e4df28debcfd28
-GIT_REPO="https://github.com/envoyproxy/protoc-gen-validate.git"
-GIT_BASE_DIR=protoc-gen-validate
-SOURCE_PROTO_BASE_DIR=protoc-gen-validate
+# import VERSION from one of the google internal CLs
+VERSION=dfcdc5ea103dda467963fb7079e4df28debcfd28
+DOWNLOAD_URL="https://github.com/envoyproxy/protoc-gen-validate/archive/${VERSION}.tar.gz"
+DOWNLOAD_BASE_DIR="protoc-gen-validate-${VERSION}"
+SOURCE_PROTO_BASE_DIR="${DOWNLOAD_BASE_DIR}"
 TARGET_PROTO_BASE_DIR=src/main/proto
 # Sorted alphabetically.
 FILES=(
 validate/validate.proto
 )
 
-# clone the protoc-gen-validate github repo in a tmp directory
+pushd `git rev-parse --show-toplevel`/xds/third_party/protoc-gen-validate
+
+# put the repo in a tmp directory
 tmpdir="$(mktemp -d)"
-pushd "${tmpdir}"
-rm -rf "$GIT_BASE_DIR"
-git clone -b $BRANCH $GIT_REPO
-cd "$GIT_BASE_DIR"
-git checkout $GIT_ORIGIN_REV_ID
-popd
+trap "rm -rf ${tmpdir}" EXIT
+curl -Ls "${DOWNLOAD_URL}" | tar xz -C "${tmpdir}"
 
-cp -p "${tmpdir}/${GIT_BASE_DIR}/LICENSE" LICENSE
-cp -p "${tmpdir}/${GIT_BASE_DIR}/NOTICE" NOTICE
+cp -p "${tmpdir}/${DOWNLOAD_BASE_DIR}/LICENSE" LICENSE
+cp -p "${tmpdir}/${DOWNLOAD_BASE_DIR}/NOTICE" NOTICE
 
+rm -rf "${TARGET_PROTO_BASE_DIR}"
 mkdir -p "${TARGET_PROTO_BASE_DIR}"
 pushd "${TARGET_PROTO_BASE_DIR}"
 
@@ -51,4 +49,4 @@ do
 done
 popd
 
-rm -rf "$tmpdir"
+popd

--- a/xds/third_party/xds/import.sh
+++ b/xds/third_party/xds/import.sh
@@ -13,15 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Update VERSION then in this directory run ./import.sh
+# Update VERSION then execute this script
 
 set -e
-BRANCH=main
 # import VERSION from one of the google internal CLs
 VERSION=e9ce68804cb4e64cab5a52e3c8baf840d4ff87b7
-GIT_REPO="https://github.com/cncf/xds.git"
-GIT_BASE_DIR=xds
-SOURCE_PROTO_BASE_DIR=xds
+DOWNLOAD_URL="https://github.com/cncf/xds/archive/${VERSION}.tar.gz"
+DOWNLOAD_BASE_DIR="xds-${VERSION}"
+SOURCE_PROTO_BASE_DIR="${DOWNLOAD_BASE_DIR}"
 TARGET_PROTO_BASE_DIR=src/main/proto
 # Sorted alphabetically.
 FILES=(
@@ -54,18 +53,12 @@ xds/type/v3/typed_struct.proto
 
 pushd `git rev-parse --show-toplevel`/xds/third_party/xds
 
-# clone the xds github repo in a tmp directory
+# put the repo in a tmp directory
 tmpdir="$(mktemp -d)"
-trap "rm -rf $tmpdir" EXIT
+trap "rm -rf ${tmpdir}" EXIT
+curl -Ls "${DOWNLOAD_URL}" | tar xz -C "${tmpdir}"
 
-pushd "${tmpdir}"
-git clone -b $BRANCH $GIT_REPO
-trap "rm -rf $GIT_BASE_DIR" EXIT
-cd "$GIT_BASE_DIR"
-git checkout $VERSION
-popd
-
-cp -p "${tmpdir}/${GIT_BASE_DIR}/LICENSE" LICENSE
+cp -p "${tmpdir}/${DOWNLOAD_BASE_DIR}/LICENSE" LICENSE
 
 rm -rf "${TARGET_PROTO_BASE_DIR}"
 mkdir -p "${TARGET_PROTO_BASE_DIR}"


### PR DESCRIPTION
The scripts used `git rev-parse --show-toplevel` so it appeared they could be used from any directory. But references to "GIT_BASE_DIR" weren't absolute, so it did matter the starting directory. And it mattered in a big way for xds/import.sh as if you ran it from the grpc-java directory it would delete the xds directory in grpc-java, not third_party.

The trap that deleted the GIT_BASE_DIR was very broken. In addition to potentially deleting the wrong directory, it was unnecessary because that directory was in tmpdir. But you can only have one trap per signal, so this unnecessary trap disabled the trap that deleted tmpdir.

The script needed a full clone because it needed to check out a specific commit. To work with --depth 1 you have to use some convoluted syntax. But just downloading a tar.gz is easy and seems should work fine on Mac.

protoc-gen-validate/import.sh didn't have the trap problem, but seemed to have drifted from the other scritps. All the scripts were synced to match.