### PR TITLE
implement happy eyeballs

### DIFF
--- a/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
@@ -137,6 +137,7 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
     if (oldAddrs.size() == 0 || currentState == CONNECTING || currentState == READY) {
       // start connection attempt at first address
       updateBalancingState(CONNECTING, new Picker(PickResult.withNoResult()));
+      cancelScheduleTask();
       requestConnection();
 
     } else if (currentState == IDLE) {
@@ -146,6 +147,7 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
 
     } else if (currentState == TRANSIENT_FAILURE) {
       // start connection attempt at first address
+      cancelScheduleTask();
       requestConnection();
     }
 

--- a/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
@@ -37,8 +37,8 @@ import io.grpc.SynchronizationContext.ScheduledHandle;
 import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -55,7 +55,7 @@ import javax.annotation.Nullable;
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/10383")
 final class PickFirstLeafLoadBalancer extends LoadBalancer {
   private final Helper helper;
-  private final Map<SocketAddress, SubchannelData> subchannels = new HashMap<>();
+  private final Map<SocketAddress, SubchannelData> subchannels = new LinkedHashMap<>();
   private final int CONNECTION_DELAY_INTERVAL_MS = 250;
   private Index addressIndex;
   @Nullable

--- a/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
@@ -300,14 +300,16 @@ public class PickFirstLeafLoadBalancerTest {
     verify(mockSubchannel1).start(stateListenerCaptor.capture());
     SubchannelStateListener stateListener = stateListenerCaptor.getValue();
     verify(mockSubchannel1).requestConnection();
+    verify(mockHelper).getSynchronizationContext();
+    verify(mockHelper).getScheduledExecutorService();
     stateListener.onSubchannelState(ConnectivityStateInfo.forNonError(CONNECTING));
     verify(mockHelper).updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
 
     loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     verify(mockSubchannel1).requestConnection();
-    verify(mockHelper).getSynchronizationContext();
-    verify(mockHelper).getScheduledExecutorService();
+    verify(mockHelper, times(2)).getSynchronizationContext();
+    verify(mockHelper, times(2)).getScheduledExecutorService();
 
     verify(mockHelper, times(4)).createSubchannel(createArgsCaptor.capture());
     verify(mockHelper).updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
@@ -530,6 +532,8 @@ public class PickFirstLeafLoadBalancerTest {
     SubchannelStateListener stateListener2 = stateListenerCaptor.getValue();
     inOrder.verify(mockHelper).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
     inOrder.verify(mockSubchannel1).requestConnection();
+    inOrder.verify(mockHelper).getSynchronizationContext();
+    inOrder.verify(mockHelper).getScheduledExecutorService();
     stateListener.onSubchannelState(ConnectivityStateInfo.forNonError(CONNECTING));
 
     // calling requestConnection() starts next subchannel
@@ -1690,6 +1694,8 @@ public class PickFirstLeafLoadBalancerTest {
     assertEquals(CONNECTING, loadBalancer.getCurrentState());
     inOrder.verify(mockHelper).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
     inOrder.verify(mockSubchannel1).requestConnection();
+    inOrder.verify(mockHelper).getSynchronizationContext();
+    inOrder.verify(mockHelper).getScheduledExecutorService();
     assertEquals(CONNECTING, loadBalancer.getCurrentState());
 
     // Failing first connection attempt
@@ -1700,6 +1706,8 @@ public class PickFirstLeafLoadBalancerTest {
     // Starting second connection attempt
     assertEquals(CONNECTING, loadBalancer.getCurrentState());
     inOrder.verify(mockSubchannel2).requestConnection();
+    inOrder.verify(mockHelper).getSynchronizationContext();
+    inOrder.verify(mockHelper).getScheduledExecutorService();
     assertEquals(CONNECTING, loadBalancer.getCurrentState());
 
     // Mimic backoff for first address

--- a/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
@@ -204,15 +204,6 @@ public class PickFirstLeafLoadBalancerTest {
             .setLoadBalancingPolicyConfig(new PickFirstLeafLoadBalancerConfig(false)).build());
 
     verify(mockHelper, times(4)).createSubchannel(createArgsCaptor.capture());
-    List<CreateSubchannelArgs> argsList = createArgsCaptor.getAllValues();
-    assertThat(argsList.get(0).getAddresses().get(0)).isEqualTo(servers.get(0));
-    assertThat(argsList.get(1).getAddresses().get(0)).isEqualTo(servers.get(1));
-    assertThat(argsList.get(2).getAddresses().get(0)).isEqualTo(servers.get(2));
-    assertThat(argsList.get(3).getAddresses().get(0)).isEqualTo(servers.get(3));
-    assertThat(argsList.get(0).getAddresses().size()).isEqualTo(1);
-    assertThat(argsList.get(1).getAddresses().size()).isEqualTo(1);
-    assertThat(argsList.get(2).getAddresses().size()).isEqualTo(1);
-    assertThat(argsList.get(3).getAddresses().size()).isEqualTo(1);
     verify(mockHelper).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
     verify(mockSubchannel1).requestConnection();
 
@@ -359,15 +350,6 @@ public class PickFirstLeafLoadBalancerTest {
     loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     inOrder.verify(mockHelper, times(4)).createSubchannel(createArgsCaptor.capture());
-    List<CreateSubchannelArgs> argsList = createArgsCaptor.getAllValues();
-    assertThat(argsList.get(0).getAddresses().get(0)).isEqualTo(servers.get(0));
-    assertThat(argsList.get(1).getAddresses().get(0)).isEqualTo(servers.get(1));
-    assertThat(argsList.get(2).getAddresses().get(0)).isEqualTo(servers.get(2));
-    assertThat(argsList.get(3).getAddresses().get(0)).isEqualTo(servers.get(3));
-    assertThat(argsList.get(0).getAddresses().size()).isEqualTo(1);
-    assertThat(argsList.get(1).getAddresses().size()).isEqualTo(1);
-    assertThat(argsList.get(2).getAddresses().size()).isEqualTo(1);
-    assertThat(argsList.get(3).getAddresses().size()).isEqualTo(1);
     verify(mockSubchannel1).start(stateListenerCaptor.capture());
     SubchannelStateListener stateListener = stateListenerCaptor.getValue();
     verify(mockSubchannel2).start(stateListenerCaptor.capture());
@@ -473,19 +455,6 @@ public class PickFirstLeafLoadBalancerTest {
     loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     inOrder.verify(mockHelper, times(4)).createSubchannel(createArgsCaptor.capture());
-    List<CreateSubchannelArgs> argsList = createArgsCaptor.getAllValues();
-    assertThat(argsList.get(0).getAddresses().get(0)).isEqualTo(servers.get(0));
-    assertThat(argsList.get(1).getAddresses().get(0)).isEqualTo(servers.get(1));
-    assertThat(argsList.get(2).getAddresses().get(0)).isEqualTo(servers.get(2));
-    assertThat(argsList.get(3).getAddresses().get(0)).isEqualTo(servers.get(3));
-    assertThat(argsList.get(0).getAddresses().size()).isEqualTo(1);
-    assertThat(argsList.get(1).getAddresses().size()).isEqualTo(1);
-    assertThat(argsList.get(2).getAddresses().size()).isEqualTo(1);
-    assertThat(argsList.get(3).getAddresses().size()).isEqualTo(1);
-    assertThat(argsList.get(0).getAttributes()).isEqualTo(Attributes.EMPTY);
-    assertThat(argsList.get(1).getAttributes()).isEqualTo(Attributes.EMPTY);
-    assertThat(argsList.get(2).getAttributes()).isEqualTo(Attributes.EMPTY);
-    assertThat(argsList.get(3).getAttributes()).isEqualTo(Attributes.EMPTY);
 
     inOrder.verify(mockHelper).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
     verify(mockSubchannel1).requestConnection();

--- a/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
@@ -1548,6 +1548,8 @@ public class PickFirstLeafLoadBalancerTest {
     assertEquals(CONNECTING, loadBalancer.getCurrentState());
     inOrder.verify(mockHelper).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
     inOrder.verify(mockSubchannel1).requestConnection();
+    inOrder.verify(mockHelper).getSynchronizationContext();
+    inOrder.verify(mockHelper).getScheduledExecutorService();
     assertEquals(CONNECTING, loadBalancer.getCurrentState());
 
     // Failing first connection attempt
@@ -1558,6 +1560,8 @@ public class PickFirstLeafLoadBalancerTest {
     // Starting second connection attempt
     assertEquals(CONNECTING, loadBalancer.getCurrentState());
     inOrder.verify(mockSubchannel2).requestConnection();
+    inOrder.verify(mockHelper).getSynchronizationContext();
+    inOrder.verify(mockHelper).getScheduledExecutorService();
     assertEquals(CONNECTING, loadBalancer.getCurrentState());
 
     // Failing second connection attempt
@@ -1607,6 +1611,8 @@ public class PickFirstLeafLoadBalancerTest {
     // If first subchannel is ready before it completes shutdown, we still choose subchannel 2
     // This can be verified by checking the mock helper.
     stateListener.onSubchannelState(ConnectivityStateInfo.forNonError(READY));
+
+    // Happy Eyeballs, once transient failure is reported, no longer schedules connections.
     verifyNoMoreInteractions(mockHelper);
   }
 

--- a/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
@@ -161,6 +161,8 @@ public class PickFirstLeafLoadBalancerTest {
     assertThat(argsList.get(3).getAddresses().size()).isEqualTo(1);
     verify(mockHelper).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
     verify(mockSubchannel1).requestConnection();
+    verify(mockHelper).getSynchronizationContext();
+    verify(mockHelper).getScheduledExecutorService();
 
     // Calling pickSubchannel() twice gave the same result
     assertEquals(pickerCaptor.getValue().pickSubchannel(mockArgs),
@@ -189,6 +191,8 @@ public class PickFirstLeafLoadBalancerTest {
 
     verify(mockHelper).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
     verify(mockSubchannel1).requestConnection();
+    verify(mockHelper).getSynchronizationContext();
+    verify(mockHelper).getScheduledExecutorService();
 
     // Calling pickSubchannel() twice gave the same result
     assertEquals(pickerCaptor.getValue().pickSubchannel(mockArgs),
@@ -206,6 +210,8 @@ public class PickFirstLeafLoadBalancerTest {
     verify(mockHelper, times(4)).createSubchannel(createArgsCaptor.capture());
     verify(mockHelper).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
     verify(mockSubchannel1).requestConnection();
+    verify(mockHelper).getSynchronizationContext();
+    verify(mockHelper).getScheduledExecutorService();
 
     // Calling pickSubchannel() twice gave the same result
     assertEquals(pickerCaptor.getValue().pickSubchannel(mockArgs),
@@ -300,6 +306,8 @@ public class PickFirstLeafLoadBalancerTest {
     loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     verify(mockSubchannel1).requestConnection();
+    verify(mockHelper).getSynchronizationContext();
+    verify(mockHelper).getScheduledExecutorService();
 
     verify(mockHelper, times(4)).createSubchannel(createArgsCaptor.capture());
     verify(mockHelper).updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
@@ -458,6 +466,8 @@ public class PickFirstLeafLoadBalancerTest {
 
     inOrder.verify(mockHelper).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
     verify(mockSubchannel1).requestConnection();
+    verify(mockHelper).getSynchronizationContext();
+    verify(mockHelper).getScheduledExecutorService();
 
     assertNull(pickerCaptor.getValue().pickSubchannel(mockArgs)
         .getSubchannel());
@@ -476,6 +486,8 @@ public class PickFirstLeafLoadBalancerTest {
         ResolvedAddresses.newBuilder().setAddresses(newServers).setAttributes(affinity).build());
     verify(mockHelper).createSubchannel(createArgsCaptor.capture());
     verify(mockSubchannel1).start(stateListenerCaptor.capture());
+    verify(mockHelper).getSynchronizationContext();
+    verify(mockHelper).getScheduledExecutorService();
     inOrder.verify(mockHelper).updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
     SubchannelStateListener stateListener = stateListenerCaptor.getValue();
 
@@ -523,6 +535,9 @@ public class PickFirstLeafLoadBalancerTest {
     // calling requestConnection() starts next subchannel
     loadBalancer.requestConnection();
     inOrder.verify(mockSubchannel2).requestConnection();
+    inOrder.verify(mockHelper).getSynchronizationContext();
+    inOrder.verify(mockHelper).getScheduledExecutorService();
+
     stateListener2.onSubchannelState(ConnectivityStateInfo.forNonError(CONNECTING));
 
     // calling requestConnection is now a no-op


### PR DESCRIPTION
A part of [dual-stack support](https://github.com/markdroth/proposal/blob/dualstack/A61-IPv4-IPv6-dualstack-backends.md#happy-eyeballs-in-the-pick_first-lb-policy).

[Happy Eyeballs](https://www.rfc-editor.org/rfc/rfc8305) speeds up the time it takes to establish a connection by parallelizing connection attempts.

Finally! #1190 