### PR TITLE
gae-interop-testing: Fix javadoc task

### DIFF
--- a/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/NettyClientInteropServlet.java
+++ b/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/NettyClientInteropServlet.java
@@ -128,7 +128,7 @@ public final class NettyClientInteropServlet extends HttpServlet {
     }
   }
 
-  public static final class Tester extends AbstractInteropTest {
+  static final class Tester extends AbstractInteropTest {
     @Override
     protected ManagedChannelBuilder<?> createChannelBuilder() {
       assertEquals(


### PR DESCRIPTION
We don't really care about the javadoc task, but it does exist and can be triggered by running `./gradlew javadoc` from the root. It was broken because it was exposing AbstractInteropTest on its API surface, and AbstractInteropTest did not expose grpc-testing as an API dependency. We don't actually want the class exposed, so we hide it.

This fixes the error:
```
> Task :grpc-gae-interop-testing-jdk8:javadoc FAILED
javadoc: error - An internal exception has occurred.
        (com.sun.tools.javac.code.Symbol$CompletionFailure: class file for io.grpc.internal.testing.StreamRecorder not found)
Please file a bug against the javadoc tool via the Java bug reporting page
(http://bugreport.java.com) after checking the Bug Database (http://bugs.java.com)
for duplicates. Include error messages and the following diagnostic in your report. Thank you.
com.sun.tools.javac.code.Symbol$CompletionFailure: class file for io.grpc.internal.testing.StreamRecorder not found
1 error
```