### PR TITLE
API stabilization: getRequestMarshaller, getResponseMarshaller

### DIFF
--- a/api/src/main/java/io/grpc/MethodDescriptor.java
+++ b/api/src/main/java/io/grpc/MethodDescriptor.java
@@ -324,7 +324,6 @@ public final class MethodDescriptor<ReqT, RespT> {
    *
    * @since 1.1.0
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2592")
   public Marshaller<ReqT> getRequestMarshaller() {
     return requestMarshaller;
   }
@@ -334,7 +333,6 @@ public final class MethodDescriptor<ReqT, RespT> {
    *
    * @since 1.1.0
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2592")
   public Marshaller<RespT> getResponseMarshaller() {
     return responseMarshaller;
   }


### PR DESCRIPTION
Closes #2592: MethodDescriptor.getRequestMarshaller, MethodDescriptor.getResponseMarshaller