### PR TITLE
examples: Android examples to use AGP 7.4.0

### DIFF
--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -53,13 +53,13 @@ fi
 # Build examples
 
 cd ./examples/android/clientcache
-../../gradlew build
+../../gradlew build $GRADLE_FLAGS
 cd ../routeguide
-../../gradlew build
+../../gradlew build $GRADLE_FLAGS
 cd ../helloworld
-../../gradlew build
+../../gradlew build $GRADLE_FLAGS
 cd ../strictmode
-../../gradlew build
+../../gradlew build $GRADLE_FLAGS
 
 # Skip APK size and dex count comparisons for non-PR builds
 

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -51,7 +51,7 @@ protobuf {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:27.0.2'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
 
     // You need to build grpc-java to obtain these libraries below.
     implementation 'io.grpc:grpc-okhttp:1.58.0-SNAPSHOT' // CURRENT_GRPC_VERSION

--- a/examples/android/clientcache/app/src/main/java/io/grpc/clientcacheexample/ClientCacheExampleActivity.java
+++ b/examples/android/clientcache/app/src/main/java/io/grpc/clientcacheexample/ClientCacheExampleActivity.java
@@ -20,7 +20,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.text.method.ScrollingMovementMethod;
 import android.util.Log;

--- a/examples/android/clientcache/build.gradle
+++ b/examples/android/clientcache/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0'
+        classpath 'com.android.tools.build:gradle:7.4.0'
         classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.4"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -49,7 +49,7 @@ protobuf {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:27.0.2'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
 
     // You need to build grpc-java to obtain these libraries below.
     implementation 'io.grpc:grpc-okhttp:1.58.0-SNAPSHOT' // CURRENT_GRPC_VERSION

--- a/examples/android/helloworld/app/src/main/java/io/grpc/helloworldexample/HelloworldActivity.java
+++ b/examples/android/helloworld/app/src/main/java/io/grpc/helloworldexample/HelloworldActivity.java
@@ -20,7 +20,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.text.method.ScrollingMovementMethod;
 import android.view.View;

--- a/examples/android/helloworld/build.gradle
+++ b/examples/android/helloworld/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0'
+        classpath 'com.android.tools.build:gradle:7.4.0'
         classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.4"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -49,7 +49,7 @@ protobuf {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:27.0.2'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
 
     // You need to build grpc-java to obtain these libraries below.
     implementation 'io.grpc:grpc-okhttp:1.58.0-SNAPSHOT' // CURRENT_GRPC_VERSION

--- a/examples/android/routeguide/app/src/main/java/io/grpc/routeguideexample/RouteGuideActivity.java
+++ b/examples/android/routeguide/app/src/main/java/io/grpc/routeguideexample/RouteGuideActivity.java
@@ -19,7 +19,7 @@ package io.grpc.routeguideexample;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.text.method.ScrollingMovementMethod;
 import android.view.View;

--- a/examples/android/routeguide/build.gradle
+++ b/examples/android/routeguide/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0'
+        classpath 'com.android.tools.build:gradle:7.4.0'
         classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.4"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/examples/android/strictmode/app/build.gradle
+++ b/examples/android/strictmode/app/build.gradle
@@ -50,7 +50,7 @@ protobuf {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
 
     // You need to build grpc-java to obtain these libraries below.
     implementation 'io.grpc:grpc-okhttp:1.58.0-SNAPSHOT' // CURRENT_GRPC_VERSION

--- a/examples/android/strictmode/app/src/main/java/io/grpc/strictmodehelloworldexample/StrictModeHelloworldActivity.java
+++ b/examples/android/strictmode/app/src/main/java/io/grpc/strictmodehelloworldexample/StrictModeHelloworldActivity.java
@@ -26,7 +26,7 @@ import android.os.StrictMode;
 import android.os.StrictMode.OnVmViolationListener;
 import android.os.StrictMode.VmPolicy;
 import android.os.strictmode.Violation;
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.text.method.ScrollingMovementMethod;
 import android.view.View;

--- a/examples/android/strictmode/build.gradle
+++ b/examples/android/strictmode/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0'
+        classpath 'com.android.tools.build:gradle:7.4.0'
         classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.4"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Upgrades the Android examples to use Android Gradle Plugin 7.4.0.

Fixes #10445