### PR TITLE
interop-testing: Correctly expose API types to dependents

### DIFF
--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -166,7 +166,3 @@ tasks.register("runInteropTestRemote") {
         throw new GradleException("Interop test failed:\nthrowable:${caught}")
     }
 }
-
-tasks.named("javadoc").configure {
-    enabled = false
-}

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "application"
-    id "java"
+    id "java-library"
     id "maven-publish"
 
     id "com.google.protobuf"
@@ -21,17 +21,19 @@ dependencies {
             project(':grpc-googleapis'),
             project(':grpc-netty'),
             project(':grpc-okhttp'),
-            project(':grpc-protobuf'),
             project(':grpc-rls'),
             project(':grpc-services'),
-            project(':grpc-stub'),
             project(':grpc-testing'),
             project(path: ':grpc-xds', configuration: 'shadow'),
             libraries.hdrhistogram,
-            libraries.junit,
             libraries.truth,
             libraries.opencensus.contrib.grpc.metrics,
-            libraries.google.auth.oauth2Http
+            libraries.google.auth.oauth2Http,
+            libraries.guava.jre // Fix checkUpperBoundDeps using -android
+    api project(':grpc-api'),
+            project(':grpc-stub'),
+            project(':grpc-protobuf'),
+            libraries.junit
     compileOnly libraries.javax.annotation
     // TODO(sergiitk): replace with com.google.cloud:google-cloud-logging
     // Used instead of google-cloud-logging because it's failing

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -2130,7 +2130,7 @@ public abstract class AbstractInteropTest {
     assertTrue(tooManyFailuresErrorMessage, totalFailures <= maxFailures);
   }
 
-  protected static void assertSuccess(StreamRecorder<?> recorder) {
+  private static void assertSuccess(StreamRecorder<?> recorder) {
     if (recorder.getError() != null) {
       throw new AssertionError(recorder.getError());
     }


### PR DESCRIPTION
Interop-testing is both binaries and a library. It hadn't been updated to use java-library and to expose API-surface dependencies to dependents.

This fixes the error:
```
> Task :grpc-gae-interop-testing-jdk8:javadoc FAILED
javadoc: error - An internal exception has occurred.
        (com.sun.tools.javac.code.Symbol$CompletionFailure: class file for io.grpc.internal.testing.StreamRecorder not found)
Please file a bug against the javadoc tool via the Java bug reporting page
(http://bugreport.java.com) after checking the Bug Database (http://bugs.java.com)
for duplicates. Include error messages and the following diagnostic in your report. Thank you.
com.sun.tools.javac.code.Symbol$CompletionFailure: class file for io.grpc.internal.testing.StreamRecorder not found
1 error
```