### PR TITLE
android: Min SDK level to 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ gRPC-Java - An RPC library and framework
 Supported Platforms
 -------------------
 
-gRPC-Java supports Java 8 and later. Android minSdkVersion 19 (KitKat) and
+gRPC-Java supports Java 8 and later. Android minSdkVersion 21 (Lollipop) and
 later are supported with [Java 8 language desugaring][android-java-8].
 
 TLS usage on Android typically requires Play Services Dynamic Security Provider.

--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -34,7 +34,7 @@ android {
 
     defaultConfig {
         applicationId "io.grpc.android.integrationtest"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,7 +15,7 @@ android {
     compileSdkVersion 33
     defaultConfig {
         consumerProguardFiles "proguard-rules.txt"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"

--- a/binder/build.gradle
+++ b/binder/build.gradle
@@ -13,7 +13,7 @@ android {
         targetCompatibility 1.8
     }
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -15,7 +15,7 @@ android {
     namespace 'io.grpc.cronet'
     compileSdkVersion 33
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId "io.grpc.clientcacheexample"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 33
         multiDexEnabled true
         versionCode 1

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId "io.grpc.helloworldexample"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId "io.grpc.routeguideexample"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Google Play has dropped support for SDK levels 19 and 20, and so can we.