### PR TITLE
Upgrade to Gradle 8.3

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -78,9 +78,11 @@ def createStartScripts(String mainClassName) {
         outputDir = new File(project.buildDir, 'tmp/scripts/' + name)
         classpath = startScripts.classpath
     }
-    applicationDistribution.into('bin') {
-        from(newTask)
-        fileMode = 0755
+    application {
+        applicationDistribution.into('bin') {
+            from(newTask)
+            fileMode = 0755
+        }
     }
 }
 

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -1,8 +1,7 @@
 plugins {
     // Provide convenience executables for trying out the examples.
     id 'application'
-    // ASSUMES GRADLE 5.6 OR HIGHER. Use plugin version 0.8.10 with earlier gradle versions
-    id 'com.google.protobuf' version '0.8.17'
+    id 'com.google.protobuf' version '0.9.4'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
 }
@@ -71,8 +70,10 @@ task helloWorldAltsClient(type: CreateStartScripts) {
     classpath = startScripts.classpath
 }
 
-applicationDistribution.into('bin') {
-    from(helloWorldAltsServer)
-    from(helloWorldAltsClient)
-    fileMode = 0755
+application {
+    applicationDistribution.into('bin') {
+        from(helloWorldAltsServer)
+        from(helloWorldAltsClient)
+        fileMode = 0755
+    }
 }

--- a/examples/example-debug/build.gradle
+++ b/examples/example-debug/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'application' // Provide convenience executables for trying out the examples.
     id 'java'
 
-    id "com.google.protobuf" version "0.8.17"
+    id "com.google.protobuf" version "0.9.4"
 
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
@@ -71,8 +71,10 @@ task HostnameDebuggableServer(type: CreateStartScripts) {
     classpath = startScripts.classpath
 }
 
-applicationDistribution.into('bin') {
-    from(HelloWorldDebuggableClient)
-    from(HostnameDebuggableServer)
-    fileMode = 0755
+application {
+    applicationDistribution.into('bin') {
+        from(HelloWorldDebuggableClient)
+        from(HostnameDebuggableServer)
+        fileMode = 0755
+    }
 }

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -1,8 +1,7 @@
 plugins {
     // Provide convenience executables for trying out the examples.
     id 'application'
-    // ASSUMES GRADLE 5.6 OR HIGHER. Use plugin version 0.8.10 with earlier gradle versions
-    id 'com.google.protobuf' version '0.8.17'
+    id 'com.google.protobuf' version '0.9.4'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
 }
@@ -69,7 +68,9 @@ task googleAuthClient(type: CreateStartScripts) {
     classpath = startScripts.classpath
 }
 
-applicationDistribution.into('bin') {
-    from(googleAuthClient)
-    fileMode = 0755
+application {
+    applicationDistribution.into('bin') {
+        from(googleAuthClient)
+        fileMode = 0755
+    }
 }

--- a/examples/example-gcp-observability/build.gradle
+++ b/examples/example-gcp-observability/build.gradle
@@ -1,8 +1,7 @@
 plugins {
     // Provide convenience executables for trying out the examples.
     id 'application'
-    // ASSUMES GRADLE 5.6 OR HIGHER. Use plugin version 0.8.10 with earlier gradle versions
-    id 'com.google.protobuf' version '0.8.17'
+    id 'com.google.protobuf' version '0.9.4'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
     id 'java'
@@ -63,8 +62,10 @@ task ObservabilityHelloWorldClient(type: CreateStartScripts) {
     classpath = startScripts.classpath
 }
 
-applicationDistribution.into('bin') {
-    from(ObservabilityHelloWorldServer)
-    from(ObservabilityHelloWorldClient)
-    fileMode = 0755
+application {
+    applicationDistribution.into('bin') {
+        from(ObservabilityHelloWorldServer)
+        from(ObservabilityHelloWorldClient)
+        fileMode = 0755
+    }
 }

--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'application' // Provide convenience executables for trying out the examples.
     id 'java'
 
-    id "com.google.protobuf" version "0.8.17"
+    id "com.google.protobuf" version "0.9.4"
     id 'com.google.cloud.tools.jib' version '3.1.4' // For releasing to Docker Hub
 }
 

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -1,8 +1,7 @@
 plugins {
     // Provide convenience executables for trying out the examples.
     id 'application'
-    // ASSUMES GRADLE 5.6 OR HIGHER. Use plugin version 0.8.10 with earlier gradle versions
-    id 'com.google.protobuf' version '0.8.17'
+    id 'com.google.protobuf' version '0.9.4'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
 }
@@ -79,8 +78,10 @@ task hellowWorldJwtAuthClient(type: CreateStartScripts) {
     classpath = startScripts.classpath
 }
 
-applicationDistribution.into('bin') {
-    from(hellowWorldJwtAuthServer)
-    from(hellowWorldJwtAuthClient)
-    fileMode = 0755
+application {
+    applicationDistribution.into('bin') {
+        from(hellowWorldJwtAuthServer)
+        from(hellowWorldJwtAuthClient)
+        fileMode = 0755
+    }
 }

--- a/examples/example-orca/build.gradle
+++ b/examples/example-orca/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'application' // Provide convenience executables for trying out the examples.
-    // ASSUMES GRADLE 5.6 OR HIGHER. Use plugin version 0.8.10 with earlier gradle versions
-    id 'com.google.protobuf' version '0.8.17'
+    id 'com.google.protobuf' version '0.9.4'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
     id 'java'
@@ -57,8 +56,10 @@ task CustomBackendMetricsServer(type: CreateStartScripts) {
     classpath = startScripts.classpath
 }
 
-applicationDistribution.into('bin') {
-    from(CustomBackendMetricsClient)
-    from(CustomBackendMetricsServer)
-    fileMode = 0755
+application {
+    applicationDistribution.into('bin') {
+        from(CustomBackendMetricsClient)
+        from(CustomBackendMetricsServer)
+        fileMode = 0755
+    }
 }

--- a/examples/example-reflection/build.gradle
+++ b/examples/example-reflection/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'application' // Provide convenience executables for trying out the examples.
-    // ASSUMES GRADLE 5.6 OR HIGHER. Use plugin version 0.8.10 with earlier gradle versions
-    id 'com.google.protobuf' version '0.8.17'
+    id 'com.google.protobuf' version '0.9.4'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
     id 'java'
@@ -50,7 +49,9 @@ task ReflectionServer(type: CreateStartScripts) {
     classpath = startScripts.classpath
 }
 
-applicationDistribution.into('bin') {
-    from(ReflectionServer)
-    fileMode = 0755
+application {
+    applicationDistribution.into('bin') {
+        from(ReflectionServer)
+        fileMode = 0755
+    }
 }

--- a/examples/example-servlet/build.gradle
+++ b/examples/example-servlet/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    // ASSUMES GRADLE 5.6 OR HIGHER. Use plugin version 0.8.10 with earlier gradle versions
-    id 'com.google.protobuf' version '0.8.17'
+    id 'com.google.protobuf' version '0.9.4'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
     id 'war'

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -1,8 +1,7 @@
 plugins {
     // Provide convenience executables for trying out the examples.
     id 'application'
-    // ASSUMES GRADLE 5.6 OR HIGHER. Use plugin version 0.8.10 with earlier gradle versions
-    id 'com.google.protobuf' version '0.8.17'
+    id 'com.google.protobuf' version '0.9.4'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
 }
@@ -71,8 +70,10 @@ task helloWorldTlsClient(type: CreateStartScripts) {
     classpath = startScripts.classpath
 }
 
-applicationDistribution.into('bin') {
-    from(helloWorldTlsServer)
-    from(helloWorldTlsClient)
-    fileMode = 0755
+application {
+    applicationDistribution.into('bin') {
+        from(helloWorldTlsServer)
+        from(helloWorldTlsClient)
+        fileMode = 0755
+    }
 }

--- a/examples/example-xds/build.gradle
+++ b/examples/example-xds/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'application' // Provide convenience executables for trying out the examples.
-    // ASSUMES GRADLE 5.6 OR HIGHER. Use plugin version 0.8.10 with earlier gradle versions
-    id 'com.google.protobuf' version '0.8.17'
+    id 'com.google.protobuf' version '0.9.4'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
     id 'java'
@@ -63,8 +62,10 @@ task xdsHelloWorldServer(type: CreateStartScripts) {
     classpath = startScripts.classpath
 }
 
-applicationDistribution.into('bin') {
-    from(xdsHelloWorldClient)
-    from(xdsHelloWorldServer)
-    fileMode = 0755
+application {
+    applicationDistribution.into('bin') {
+        from(xdsHelloWorldClient)
+        from(xdsHelloWorldServer)
+        fileMode = 0755
+    }
 }

--- a/examples/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Examples are updated to use the new version as well, which wasn't done last time in f3f4ed4ef. That noticed some things that were missed before.