### PR TITLE
netty: Eliminate buffer release when there is an error as caller still owns the buffer.

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyAdaptiveCumulator.java
+++ b/netty/src/main/java/io/grpc/netty/NettyAdaptiveCumulator.java
@@ -204,11 +204,8 @@ class NettyAdaptiveCumulator implements Cumulator {
       composite.addFlattenedComponents(true, newTail);
       // New tail's ownership transferred to the composite buf.
       newTail = null;
-      in.release();
-      in = null;
-      // Restore the reader. In case it fails we restore the reader after releasing/forgetting
-      // the input and the new tail so that finally block can handles them properly.
       composite.readerIndex(prevReader);
+      in.release(); // Successful so took over ownership of in
     } finally {
       // If new tail's ownership isn't transferred to the composite buf.
       // Release it to prevent a leak.

--- a/netty/src/main/java/io/grpc/netty/NettyAdaptiveCumulator.java
+++ b/netty/src/main/java/io/grpc/netty/NettyAdaptiveCumulator.java
@@ -210,10 +210,6 @@ class NettyAdaptiveCumulator implements Cumulator {
       // the input and the new tail so that finally block can handles them properly.
       composite.readerIndex(prevReader);
     } finally {
-      // Input buffer was merged with the tail.
-      if (in != null) {
-        in.release();
-      }
       // If new tail's ownership isn't transferred to the composite buf.
       // Release it to prevent a leak.
       if (newTail != null) {

--- a/netty/src/test/java/io/grpc/netty/NettyAdaptiveCumulatorTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyAdaptiveCumulatorTest.java
@@ -533,13 +533,12 @@ public class NettyAdaptiveCumulatorTest {
 
       try {
         NettyAdaptiveCumulator.mergeWithCompositeTail(alloc, compositeThrows, in);
+        in = null; // On success it would be released
         fail("Cumulator didn't throw");
       } catch (UnsupportedOperationException actualError) {
         assertSame(expectedError, actualError);
         // Because of error, ownership shouldn't have changed so should not have been released.
-        int inRefCnt = in.refCnt();
-        in.release();
-        assertEquals(1, inRefCnt);
+        assertEquals(1, in.refCnt());
         // Tail released
         assertEquals(0, tail.refCnt());
         // Composite cumulation is retained
@@ -547,6 +546,9 @@ public class NettyAdaptiveCumulatorTest {
         // Composite cumulation loses the tail
         assertEquals(0, compositeThrows.numComponents());
       } finally {
+        if (in != null) {
+          in.release();
+        }
         compositeThrows.release();
       }
     }
@@ -571,13 +573,12 @@ public class NettyAdaptiveCumulatorTest {
 
       try {
         NettyAdaptiveCumulator.mergeWithCompositeTail(mockAlloc, compositeRo, in);
+        in = null; // On success it would be released
         fail("Cumulator didn't throw");
       } catch (UnsupportedOperationException actualError) {
-        int inRefCnt = in.refCnt();
-        in.release();
         assertSame(expectedError, actualError);
         // Because of error, ownership shouldn't have changed so should not have been released.
-        assertEquals(1, inRefCnt);
+        assertEquals(1, in.refCnt());
         // New buffer released
         assertEquals(0, newTail.refCnt());
         // Composite cumulation is retained
@@ -585,6 +586,9 @@ public class NettyAdaptiveCumulatorTest {
         // Composite cumulation loses the tail
         assertEquals(0, compositeRo.numComponents());
       } finally {
+        if (in != null) {
+          in.release();
+        }
         compositeRo.release();
       }
     }

--- a/netty/src/test/java/io/grpc/netty/NettyAdaptiveCumulatorTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyAdaptiveCumulatorTest.java
@@ -537,7 +537,9 @@ public class NettyAdaptiveCumulatorTest {
       } catch (UnsupportedOperationException actualError) {
         assertSame(expectedError, actualError);
         // Because of error, ownership shouldn't have changed so should not have been released.
-        assertEquals(1, in.refCnt());
+        int inRefCnt = in.refCnt();
+        in.release();
+        assertEquals(1, inRefCnt);
         // Tail released
         assertEquals(0, tail.refCnt());
         // Composite cumulation is retained
@@ -546,7 +548,6 @@ public class NettyAdaptiveCumulatorTest {
         assertEquals(0, compositeThrows.numComponents());
       } finally {
         compositeThrows.release();
-        in.release();
       }
     }
 
@@ -572,9 +573,11 @@ public class NettyAdaptiveCumulatorTest {
         NettyAdaptiveCumulator.mergeWithCompositeTail(mockAlloc, compositeRo, in);
         fail("Cumulator didn't throw");
       } catch (UnsupportedOperationException actualError) {
+        int inRefCnt = in.refCnt();
+        in.release();
         assertSame(expectedError, actualError);
         // Because of error, ownership shouldn't have changed so should not have been released.
-        assertEquals(1, in.refCnt());
+        assertEquals(1, inRefCnt);
         // New buffer released
         assertEquals(0, newTail.refCnt());
         // Composite cumulation is retained
@@ -583,7 +586,6 @@ public class NettyAdaptiveCumulatorTest {
         assertEquals(0, compositeRo.numComponents());
       } finally {
         compositeRo.release();
-        in.release();
       }
     }
   }

--- a/netty/src/test/java/io/grpc/netty/NettyAdaptiveCumulatorTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyAdaptiveCumulatorTest.java
@@ -536,7 +536,7 @@ public class NettyAdaptiveCumulatorTest {
         fail("Cumulator didn't throw");
       } catch (UnsupportedOperationException actualError) {
         assertSame(expectedError, actualError);
-        // Input must be released unless its ownership has been to the composite cumulation.
+        // Because of error, ownership shouldn't have changed so should not have been released.
         assertEquals(1, in.refCnt());
         // Tail released
         assertEquals(0, tail.refCnt());
@@ -573,7 +573,7 @@ public class NettyAdaptiveCumulatorTest {
         fail("Cumulator didn't throw");
       } catch (UnsupportedOperationException actualError) {
         assertSame(expectedError, actualError);
-        // Input must be released unless its ownership has been to the composite cumulation.
+        // Because of error, ownership shouldn't have changed so should not have been released.
         assertEquals(1, in.refCnt());
         // New buffer released
         assertEquals(0, newTail.refCnt());

--- a/netty/src/test/java/io/grpc/netty/NettyAdaptiveCumulatorTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyAdaptiveCumulatorTest.java
@@ -537,7 +537,7 @@ public class NettyAdaptiveCumulatorTest {
       } catch (UnsupportedOperationException actualError) {
         assertSame(expectedError, actualError);
         // Input must be released unless its ownership has been to the composite cumulation.
-        assertEquals(0, in.refCnt());
+        assertEquals(1, in.refCnt());
         // Tail released
         assertEquals(0, tail.refCnt());
         // Composite cumulation is retained
@@ -546,6 +546,7 @@ public class NettyAdaptiveCumulatorTest {
         assertEquals(0, compositeThrows.numComponents());
       } finally {
         compositeThrows.release();
+        in.release();
       }
     }
 
@@ -573,7 +574,7 @@ public class NettyAdaptiveCumulatorTest {
       } catch (UnsupportedOperationException actualError) {
         assertSame(expectedError, actualError);
         // Input must be released unless its ownership has been to the composite cumulation.
-        assertEquals(0, in.refCnt());
+        assertEquals(1, in.refCnt());
         // New buffer released
         assertEquals(0, newTail.refCnt());
         // Composite cumulation is retained
@@ -582,6 +583,7 @@ public class NettyAdaptiveCumulatorTest {
         assertEquals(0, compositeRo.numComponents());
       } finally {
         compositeRo.release();
+        in.release();
       }
     }
   }


### PR DESCRIPTION
Fixes #10255