### PR TITLE
api: Make offload executor's purpose more clear

### DIFF
--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -117,7 +117,9 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   public abstract T executor(Executor executor);
 
   /**
-   * Provides a custom executor that will be used for operations that block or are expensive.
+   * Provides a custom executor that will be used for operations that block or are expensive, to
+   * avoid blocking asynchronous code paths. For example, DNS queries and OAuth token fetching over
+   * HTTP could use this executor.
    *
    * <p>It's an optional parameter. If the user has not provided an executor when the channel is
    * built, the builder will use a static cached thread pool.


### PR DESCRIPTION
Blocking can be confused with the blocking stub, which is unrelated. I'm purposefully not saying "it is used only for X," as that isn't what we need from the API. But it is still helpful to users to describe the sorts of things that use it.

Fixes #10508