### PR TITLE
api: Add grpc-okhttp to suggestions if no server is available

### DIFF
--- a/api/src/main/java/io/grpc/ServerRegistry.java
+++ b/api/src/main/java/io/grpc/ServerRegistry.java
@@ -138,7 +138,8 @@ public final class ServerRegistry {
     List<ServerProvider> providers = providers();
     if (providers.isEmpty()) {
       throw new ProviderNotFoundException("No functional server found. "
-          + "Try adding a dependency on the grpc-netty or grpc-netty-shaded artifact");
+          + "Try adding a dependency on the grpc-netty, grpc-netty-shaded, or grpc-okhttp "
+          + "artifact");
     }
     StringBuilder error = new StringBuilder();
     for (ServerProvider provider : providers()) {


### PR DESCRIPTION
Since 3b61799 OkHttp can support Grpc.newServerBuilderForPort().