### PR TITLE
Enable indirect addressing using <intent-filter>s.

### DIFF
--- a/binder/src/androidTest/AndroidManifest.xml
+++ b/binder/src/androidTest/AndroidManifest.xml
@@ -8,7 +8,15 @@
   <application android:debuggable="true">
     <uses-library android:name="android.test.runner" />
 
-    <service android:name="io.grpc.binder.HostServices$HostService1" />
-    <service android:name="io.grpc.binder.HostServices$HostService2" />
+    <service android:name="io.grpc.binder.HostServices$HostService1" android:exported="false">
+      <intent-filter>
+        <action android:name="action1"/>
+      </intent-filter>
+    </service>
+    <service android:name="io.grpc.binder.HostServices$HostService2" android:exported="false">
+      <intent-filter>
+        <action android:name="action2"/>
+      </intent-filter>
+    </service>
   </application>
 </manifest>

--- a/binder/src/androidTest/java/io/grpc/binder/BinderChannelSmokeTest.java
+++ b/binder/src/androidTest/java/io/grpc/binder/BinderChannelSmokeTest.java
@@ -22,6 +22,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import android.content.Context;
+import android.content.Intent;
 import android.os.Parcel;
 import android.os.Parcelable;
 import androidx.test.core.app.ApplicationProvider;
@@ -32,7 +33,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
-import io.grpc.ClientCall;
 import io.grpc.ClientInterceptors;
 import io.grpc.ConnectivityState;
 import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
@@ -231,6 +231,18 @@ public final class BinderChannelSmokeTest {
   @Test
   public void testConnectViaTargetUri() throws Exception {
     channel = BinderChannelBuilder.forTarget(SERVER_TARGET_URI, appContext).build();
+    assertThat(doCall("Hello").get()).isEqualTo("Hello");
+  }
+
+  @Test
+  public void testConnectViaIntentFilter() throws Exception {
+    // Compare with the <intent-filter> mapping in AndroidManifest.xml.
+    channel =
+        BinderChannelBuilder.forAddress(
+                AndroidComponentAddress.forBindIntent(
+                    new Intent().setAction("action1").setPackage(appContext.getPackageName())),
+                appContext)
+            .build();
     assertThat(doCall("Hello").get()).isEqualTo("Hello");
   }
 

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -784,9 +784,7 @@ public abstract class BinderTransport
         Context sourceContext, AndroidComponentAddress targetAddress) {
       return InternalLogId.allocate(
           BinderClientTransport.class,
-          sourceContext.getClass().getSimpleName()
-              + "->"
-              + targetAddress.getComponent().toShortString());
+          sourceContext.getClass().getSimpleName() + "->" + targetAddress);
     }
 
     private static Attributes buildClientAttributes(

--- a/binder/src/test/java/io/grpc/binder/AndroidComponentAddressTest.java
+++ b/binder/src/test/java/io/grpc/binder/AndroidComponentAddressTest.java
@@ -50,6 +50,26 @@ public final class AndroidComponentAddressTest {
   }
 
   @Test
+  public void testTargetPackageNullComponentName() {
+    AndroidComponentAddress addr =
+        AndroidComponentAddress.forBindIntent(
+            new Intent().setPackage("com.foo").setAction(ApiConstants.ACTION_BIND));
+    assertThat(addr.getPackage()).isEqualTo("com.foo");
+    assertThat(addr.getComponent()).isNull();
+  }
+
+  @Test
+  public void testTargetPackageNonNullComponentName() {
+    AndroidComponentAddress addr =
+        AndroidComponentAddress.forBindIntent(
+            new Intent()
+                .setComponent(new ComponentName("com.foo", "com.foo.BarService"))
+                .setPackage("com.foo")
+                .setAction(ApiConstants.ACTION_BIND));
+    assertThat(addr.getPackage()).isEqualTo("com.foo");
+  }
+
+  @Test
   public void testAsBindIntent() {
     Intent bindIntent =
         new Intent()


### PR DESCRIPTION
AndroidComponentAddress now accepts an Intent with merely a package restriction, not a full ComponentName. This lets clients avoid hard coding Service class names that they don't control.

Experimental API AndroidComponentAddress#getComponent() becomes nullable, which is technically a breaking change. But we expect the impact will be small since existing callers mostly work with addresses they created themselves, which will have a non-null ComponentName.

Fixes #9062