### PR TITLE
servlet: allow skipping grpc-servlet builds with `skipServlet=true`

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -6,16 +6,26 @@ Building is only necessary if you are making changes to gRPC-Java or testing/usi
 
 Building requires JDK 8, as our tests use TLS.
 
+To configure the build settings, create the file
+`<project-root>/gradle.properties`. You can add the following settings to it:
+
+##### `skipCodegen=true`
 grpc-java has a C++ code generation plugin for protoc. Since many Java
 developers don't have C compilers installed and don't need to run or modify the
-codegen, the build can skip it. To skip, create the file
-`<project-root>/gradle.properties` and add `skipCodegen=true`.
+codegen, the build can skip it.
 
+##### `skipAndroid=true` and `android.useAndroidX=true`
 Some parts of grpc-java depend on Android. Since many Java developers don't have
 the Android SDK installed and don't need to run or modify the Android
-components, the build can skip it. To skip, create the file
-`<project-root>/gradle.properties` and add `skipAndroid=true`.
-Otherwise, create the file `<project-root>/gradle.properties` and add `android.useAndroidX=true`.
+components, the build can skip it.
+
+Add `skipAndroid=true` to skip. Otherwise, add `android.useAndroidX=true`.
+
+#### `skipServlet=true`
+`grpc-servlet` tests take a few minutes to run. You may skip the servlet 
+project to speed up the build.
+
+### Building
 
 Then, to build, run:
 ```

--- a/all/build.gradle
+++ b/all/build.gradle
@@ -18,13 +18,19 @@ def subprojects = [
     project(':grpc-protobuf-lite'),
     project(':grpc-rls'),
     project(':grpc-services'),
-    project(':grpc-servlet'),
-    project(':grpc-servlet-jakarta'),
     project(':grpc-stub'),
     project(':grpc-testing'),
     project(':grpc-util'),
     project(':grpc-xds'),
 ]
+
+// Servlet project can be excluded with skipServlet property.
+if (findProject(':grpc-servlet') != null) {
+    subprojects.addAll(
+        project(':grpc-servlet'),
+        project(':grpc-servlet-jakarta'),
+    )
+}
 
 for (subproject in subprojects) {
     if (subproject == project) {

--- a/buildscripts/kokoro/psm-security.sh
+++ b/buildscripts/kokoro/psm-security.sh
@@ -25,7 +25,7 @@ build_java_test_app() {
   cd "${SRC_DIR}"
   GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1g'" \
   ./gradlew --no-daemon grpc-interop-testing:installDist -x test \
-    -PskipCodegen=true -PskipAndroid=true --console=plain
+    -PskipCodegen=true -PskipAndroid=true -PskipServlet=true --console=plain
 
   # Test-run binaries
   run_ignore_exit_code "${SRC_DIR}/${BUILD_APP_PATH}/bin/xds-test-client" --help

--- a/buildscripts/kokoro/xds_k8s_lb.sh
+++ b/buildscripts/kokoro/xds_k8s_lb.sh
@@ -25,7 +25,7 @@ build_java_test_app() {
   cd "${SRC_DIR}"
   GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1g'" \
   ./gradlew --no-daemon grpc-interop-testing:installDist -x test \
-    -PskipCodegen=true -PskipAndroid=true --console=plain
+    -PskipCodegen=true -PskipAndroid=true -PskipServlet=true --console=plain
 
   # Test-run binaries
   run_ignore_exit_code "${SRC_DIR}/${BUILD_APP_PATH}/bin/xds-test-client" --help

--- a/buildscripts/kokoro/xds_url_map.sh
+++ b/buildscripts/kokoro/xds_url_map.sh
@@ -25,7 +25,7 @@ build_java_test_app() {
   cd "${SRC_DIR}"
   GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1g'" \
   ./gradlew --no-daemon grpc-interop-testing:installDist -x test \
-    -PskipCodegen=true -PskipAndroid=true --console=plain
+    -PskipCodegen=true -PskipAndroid=true -PskipServlet=true --console=plain
 
   # Test-run binaries
   run_ignore_exit_code "${SRC_DIR}/${BUILD_APP_PATH}/bin/xds-test-client" --help

--- a/buildscripts/kokoro/xds_v3.sh
+++ b/buildscripts/kokoro/xds_v3.sh
@@ -9,7 +9,7 @@ cd github
 
 pushd grpc-java/interop-testing
 GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1g'" \
-  ../gradlew installDist -x test -PskipCodegen=true -PskipAndroid=true
+  ../gradlew installDist -x test -PskipCodegen=true -PskipAndroid=true -PskipServlet=true
 popd
 
 git clone -b master --single-branch --depth=1 https://github.com/grpc/grpc.git

--- a/settings.gradle
+++ b/settings.gradle
@@ -60,8 +60,6 @@ include ":grpc-all"
 include ":grpc-alts"
 include ":grpc-benchmarks"
 include ":grpc-services"
-include ":grpc-servlet"
-include ":grpc-servlet-jakarta"
 include ":grpc-xds"
 include ":grpc-bom"
 include ":grpc-rls"
@@ -93,8 +91,6 @@ project(':grpc-all').projectDir = "$rootDir/all" as File
 project(':grpc-alts').projectDir = "$rootDir/alts" as File
 project(':grpc-benchmarks').projectDir = "$rootDir/benchmarks" as File
 project(':grpc-services').projectDir = "$rootDir/services" as File
-project(':grpc-servlet').projectDir = "$rootDir/servlet" as File
-project(':grpc-servlet-jakarta').projectDir = "$rootDir/servlet/jakarta" as File
 project(':grpc-xds').projectDir = "$rootDir/xds" as File
 project(':grpc-bom').projectDir = "$rootDir/bom" as File
 project(':grpc-rls').projectDir = "$rootDir/rls" as File
@@ -124,4 +120,13 @@ if (settings.hasProperty('skipAndroid') && skipAndroid.toBoolean()) {
     project(':grpc-android-interop-testing').projectDir = "$rootDir/android-interop-testing" as File
     include ":grpc-binder"
     project(':grpc-binder').projectDir = "$rootDir/binder" as File
+}
+
+if (settings.hasProperty('skipServlet') && skipServlet.toBoolean()) {
+    println '  * Skipping the build of Servlet projects because skipServlet=true'
+} else {
+    include ":grpc-servlet"
+    project(':grpc-servlet').projectDir = "$rootDir/servlet" as File
+    include ":grpc-servlet-jakarta"
+    project(':grpc-servlet-jakarta').projectDir = "$rootDir/servlet/jakarta" as File
 }


### PR DESCRIPTION
`grpc-servlet` tests take a few minutes to run. You may skip the servlet 
project to speed up the build. To skip, create the file `<project-root>/gradle.properties` and add `skipServlet=true`.