### PR TITLE
Add fix for xdstp replacement for encoded authorities

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -105,6 +105,8 @@ final class XdsNameResolver extends NameResolver {
   @Nullable
   private final String targetAuthority;
   private final String serviceAuthority;
+  // Encoded version of the service authority as per 
+  // https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.
   private final String encodedServiceAuthority;
   private final String overrideAuthority;
   private final ServiceConfigParser serviceConfigParser;

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -105,6 +105,7 @@ final class XdsNameResolver extends NameResolver {
   @Nullable
   private final String targetAuthority;
   private final String serviceAuthority;
+  private final String encodedServiceAuthority;
   private final String overrideAuthority;
   private final ServiceConfigParser serviceConfigParser;
   private final SynchronizationContext syncContext;
@@ -149,8 +150,9 @@ final class XdsNameResolver extends NameResolver {
     this.targetAuthority = targetAuthority;
 
     // The name might have multiple slashes so encode it before verifying.
-    String authority = GrpcUtil.AuthorityEscaper.encodeAuthority(checkNotNull(name, "name"));
-    serviceAuthority = GrpcUtil.checkAuthority(authority);
+    serviceAuthority = checkNotNull(name, "name");
+    this.encodedServiceAuthority = 
+      GrpcUtil.checkAuthority(GrpcUtil.AuthorityEscaper.encodeAuthority(serviceAuthority));
 
     this.overrideAuthority = overrideAuthority;
     this.serviceConfigParser = checkNotNull(serviceConfigParser, "serviceConfigParser");
@@ -169,7 +171,7 @@ final class XdsNameResolver extends NameResolver {
 
   @Override
   public String getServiceAuthority() {
-    return serviceAuthority;
+    return encodedServiceAuthority;
   }
 
   @Override


### PR DESCRIPTION
Recently the logic in xDS Name resolver was changed to support encoded authorities: https://github.com/grpc/grpc-java/pull/10207.

This seems to cause an issue for xdstp replacements which would percent encode the authority for the replacement causing double encoding.

For example:

URI = xds:///path/to/service
Authority = path%2Fto%2Fservice
xdstp resource = xdstp://<target-authority>/envoy.config.listener.v3.Listener/path%252Fto%252Fservice

Here the authority is encoded due to slashes and during replacement we percent encode it again causing %2F to change to %252F.

To avoid this issue, use the encoded authority only for the getServiceAuthority() API and for all other use cases retain the unencoded authority. 

@ejona86 