### PR TITLE
api: Replace ErrorPicker with FixedResultPicker

### DIFF
--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -1413,7 +1413,7 @@ public abstract class LoadBalancer {
   }
 
   /**
-   * A picker that always returns a erroring pick.
+   * A picker that always returns an erring pick.
    *
    * @deprecated Use {@code new FixedResultPicker(PickResult.withError(error))} instead.
    */

--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -1412,6 +1412,12 @@ public abstract class LoadBalancer {
     public abstract LoadBalancer newLoadBalancer(Helper helper);
   }
 
+  /**
+   * A picker that always returns a erroring pick.
+   *
+   * @deprecated Use {@code new FixedResultPicker(PickResult.withError(error))} instead.
+   */
+  @Deprecated
   public static final class ErrorPicker extends SubchannelPicker {
 
     private final Status error;
@@ -1433,4 +1439,22 @@ public abstract class LoadBalancer {
     }
   }
 
+  /** A picker that always returns the same result. */
+  public static final class FixedResultPicker extends SubchannelPicker {
+    private final PickResult result;
+
+    public FixedResultPicker(PickResult result) {
+      this.result = Preconditions.checkNotNull(result, "result");
+    }
+
+    @Override
+    public PickResult pickSubchannel(PickSubchannelArgs args) {
+      return result;
+    }
+
+    @Override
+    public String toString() {
+      return "FixedResultPicker(" + result + ")";
+    }
+  }
 }

--- a/util/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.MoreObjects;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.ExperimentalApi;
@@ -57,21 +56,9 @@ public final class GracefulSwitchLoadBalancer extends ForwardingLoadBalancer {
 
     @Override
     public void handleNameResolutionError(final Status error) {
-      class ErrorPicker extends SubchannelPicker {
-        @Override
-        public PickResult pickSubchannel(PickSubchannelArgs args) {
-          return PickResult.withError(error);
-        }
-
-        @Override
-        public String toString() {
-          return MoreObjects.toStringHelper(ErrorPicker.class).add("error", error).toString();
-        }
-      }
-
       helper.updateBalancingState(
           ConnectivityState.TRANSIENT_FAILURE,
-          new ErrorPicker());
+          new FixedResultPicker(PickResult.withError(error)));
     }
 
     @Override

--- a/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
@@ -83,7 +83,7 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
   }
 
   protected SubchannelPicker getErrorPicker(Status error)  {
-    return new ErrorPicker(error);
+    return new FixedResultPicker(PickResult.withError(error));
   }
 
   @VisibleForTesting

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
@@ -103,7 +103,8 @@ final class CdsLoadBalancer2 extends LoadBalancer {
     if (cdsLbState != null && cdsLbState.childLb != null) {
       cdsLbState.childLb.handleNameResolutionError(error);
     } else {
-      helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(error));
+      helper.updateBalancingState(
+          TRANSIENT_FAILURE, new FixedResultPicker(PickResult.withError(error)));
     }
   }
 
@@ -211,7 +212,8 @@ final class CdsLoadBalancer2 extends LoadBalancer {
       }
 
       if (loopStatus != null) {
-        helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(loopStatus));
+        helper.updateBalancingState(
+            TRANSIENT_FAILURE, new FixedResultPicker(PickResult.withError(loopStatus)));
         return;
       }
 
@@ -223,7 +225,8 @@ final class CdsLoadBalancer2 extends LoadBalancer {
         Status unavailable =
             Status.UNAVAILABLE.withDescription("CDS error: found 0 leaf (logical DNS or EDS) "
                 + "clusters for root cluster " + root.name);
-        helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(unavailable));
+        helper.updateBalancingState(
+            TRANSIENT_FAILURE, new FixedResultPicker(PickResult.withError(unavailable)));
         return;
       }
 
@@ -295,7 +298,8 @@ final class CdsLoadBalancer2 extends LoadBalancer {
       if (childLb != null) {
         childLb.handleNameResolutionError(error);
       } else {
-        helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(error));
+        helper.updateBalancingState(
+            TRANSIENT_FAILURE, new FixedResultPicker(PickResult.withError(error)));
       }
     }
 

--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -143,7 +143,8 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
     if (childSwitchLb != null) {
       childSwitchLb.handleNameResolutionError(error);
     } else {
-      helper.updateBalancingState(ConnectivityState.TRANSIENT_FAILURE, new ErrorPicker(error));
+      helper.updateBalancingState(
+          ConnectivityState.TRANSIENT_FAILURE, new FixedResultPicker(PickResult.withError(error)));
     }
   }
 

--- a/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
@@ -197,7 +197,8 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
       if (childLb != null) {
         childLb.handleNameResolutionError(error);
       } else {
-        helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(error));
+        helper.updateBalancingState(
+            TRANSIENT_FAILURE, new FixedResultPicker(PickResult.withError(error)));
       }
     }
 
@@ -240,7 +241,8 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
               Status.UNAVAILABLE.withCause(endpointNotFound.getCause())
                   .withDescription(endpointNotFound.getDescription());
         }
-        helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(endpointNotFound));
+        helper.updateBalancingState(
+            TRANSIENT_FAILURE, new FixedResultPicker(PickResult.withError(endpointNotFound)));
         if (childLb != null) {
           childLb.shutdown();
           childLb = null;
@@ -275,7 +277,8 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
         if (childLb != null) {
           childLb.handleNameResolutionError(error);
         } else {
-          helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(error));
+          helper.updateBalancingState(
+              TRANSIENT_FAILURE, new FixedResultPicker(PickResult.withError(error)));
         }
       }
     }

--- a/xds/src/main/java/io/grpc/xds/PriorityLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/PriorityLoadBalancer.java
@@ -126,7 +126,8 @@ final class PriorityLoadBalancer extends LoadBalancer {
       }
     }
     if (gotoTransientFailure) {
-      updateOverallState(null, TRANSIENT_FAILURE, new ErrorPicker(error));
+      updateOverallState(
+          null, TRANSIENT_FAILURE, new FixedResultPicker(PickResult.withError(error)));
     }
   }
 
@@ -225,8 +226,8 @@ final class PriorityLoadBalancer extends LoadBalancer {
           // The child is deactivated.
           return;
         }
-        picker = new ErrorPicker(
-            Status.UNAVAILABLE.withDescription("Connection timeout for priority " + priority));
+        picker = new FixedResultPicker(PickResult.withError(
+            Status.UNAVAILABLE.withDescription("Connection timeout for priority " + priority)));
         logger.log(XdsLogLevel.DEBUG, "Priority {0} failed over to next", priority);
         currentPriority = null; // reset currentPriority to guarantee failover happen
         tryNextPriority();

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -270,7 +270,8 @@ final class RingHashLoadBalancer extends LoadBalancer {
   @Override
   public void handleNameResolutionError(Status error) {
     if (currentState != READY) {
-      helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(error));
+      helper.updateBalancingState(
+          TRANSIENT_FAILURE, new FixedResultPicker(PickResult.withError(error)));
     }
   }
 

--- a/xds/src/main/java/io/grpc/xds/WeightedTargetLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedTargetLoadBalancer.java
@@ -114,7 +114,8 @@ final class WeightedTargetLoadBalancer extends LoadBalancer {
   public void handleNameResolutionError(Status error) {
     logger.log(XdsLogLevel.WARNING, "Received name resolution error: {0}", error);
     if (childBalancers.isEmpty()) {
-      helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(error));
+      helper.updateBalancingState(
+          TRANSIENT_FAILURE, new FixedResultPicker(PickResult.withError(error)));
     }
     for (LoadBalancer childBalancer : childBalancers.values()) {
       childBalancer.handleNameResolutionError(error);

--- a/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancer.java
@@ -78,14 +78,14 @@ final class WrrLocalityLoadBalancer extends LoadBalancer {
       Integer localityWeight = eagAttrs.get(InternalXdsAttributes.ATTR_LOCALITY_WEIGHT);
 
       if (locality == null) {
-        helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(
-            Status.UNAVAILABLE.withDescription("wrr_locality error: no locality provided")));
+        helper.updateBalancingState(TRANSIENT_FAILURE, new FixedResultPicker(PickResult.withError(
+            Status.UNAVAILABLE.withDescription("wrr_locality error: no locality provided"))));
         return false;
       }
       if (localityWeight == null) {
-        helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(
+        helper.updateBalancingState(TRANSIENT_FAILURE, new FixedResultPicker(PickResult.withError(
             Status.UNAVAILABLE.withDescription(
-                "wrr_locality error: no weight provided for locality " + locality)));
+                "wrr_locality error: no weight provided for locality " + locality))));
         return false;
       }
 

--- a/xds/src/test/java/io/grpc/xds/ClusterManagerLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterManagerLoadBalancerTest.java
@@ -365,7 +365,8 @@ public class ClusterManagerLoadBalancerTest {
       config = resolvedAddresses.getLoadBalancingPolicyConfig();
 
       if (failing) {
-        helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(Status.INTERNAL));
+        helper.updateBalancingState(
+            TRANSIENT_FAILURE, new FixedResultPicker(PickResult.withError(Status.INTERNAL)));
       }
       return true;
     }

--- a/xds/src/test/java/io/grpc/xds/WeightedTargetLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedTargetLoadBalancerTest.java
@@ -39,7 +39,7 @@ import com.google.common.collect.Iterables;
 import io.grpc.Attributes;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
-import io.grpc.LoadBalancer.ErrorPicker;
+import io.grpc.LoadBalancer.FixedResultPicker;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
@@ -324,10 +324,10 @@ public class WeightedTargetLoadBalancerTest {
         mock(SubchannelPicker.class),
         mock(SubchannelPicker.class)};
     final SubchannelPicker[] failurePickers = new SubchannelPicker[]{
-        new ErrorPicker(Status.CANCELLED),
-        new ErrorPicker(Status.ABORTED),
-        new ErrorPicker(Status.DATA_LOSS),
-        new ErrorPicker(Status.DATA_LOSS)
+        new FixedResultPicker(PickResult.withError(Status.CANCELLED)),
+        new FixedResultPicker(PickResult.withError(Status.ABORTED)),
+        new FixedResultPicker(PickResult.withError(Status.DATA_LOSS)),
+        new FixedResultPicker(PickResult.withError(Status.DATA_LOSS))
     };
     ArgumentCaptor<SubchannelPicker> pickerCaptor = ArgumentCaptor.forClass(SubchannelPicker.class);
 
@@ -463,7 +463,8 @@ public class WeightedTargetLoadBalancerTest {
 
     @Override
     public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-      helper.updateBalancingState(TRANSIENT_FAILURE, new ErrorPicker(Status.INTERNAL));
+      helper.updateBalancingState(
+          TRANSIENT_FAILURE, new FixedResultPicker(PickResult.withError(Status.INTERNAL)));
     }
 
     @Override


### PR DESCRIPTION
FixedResultPicker can be used in more situations. Note that WrrLocalityLoadBalancerTest's test was changed non-trivially. The noChildLb test was particularly nasty as it assumed LoadBalancer.ErrorPicker had same toString() as
GracefulSwitchLoadBalancer's ErrorPicker.