### PR TITLE
okhttp: Make grpc-util an implementation dependency

### DIFF
--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -15,8 +15,9 @@ tasks.named("jar").configure {
 }
 
 dependencies {
-    api project(':grpc-util')
-    implementation libraries.okio,
+    api project(':grpc-core')
+    implementation project(':grpc-util'),
+            libraries.okio,
             libraries.guava,
             libraries.perfmark.api
     // Make okhttp dependencies compile only


### PR DESCRIPTION
This prevents grpc-util from being exposed on the classpath when
compiling code using grpc-okhttp. grpc-core is still needed because of
AbstractManagedChannelImplBuilder.