### PR TITLE
core: Stabilize forwarding builders

### DIFF
--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -36,7 +36,6 @@ import javax.annotation.Nullable;
  * @param <T> The type of the subclass extending this abstract class.
  * @since 1.7.0
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/3363")
 public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilder<T>>
     extends ForwardingChannelBuilder2<T> {
   // TODO(sergiitk): deprecate after stabilizing
@@ -237,8 +236,7 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
   /**
    * Returns the correctly typed version of the builder.
    */
-  protected final T thisT() {
-    // TODO(sergiitk): make private when stabilizing.
+  private T thisT() {
     @SuppressWarnings("unchecked")
     T thisT = (T) this;
     return thisT;

--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder2.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder2.java
@@ -34,7 +34,6 @@ import javax.annotation.Nullable;
  * @param <T> The type of the subclass extending this abstract class.
  * @since 1.59.0
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/10585")
 public abstract class ForwardingChannelBuilder2<T extends ManagedChannelBuilder<T>>
     extends ManagedChannelBuilder<T> {
 

--- a/api/src/main/java/io/grpc/ForwardingServerBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingServerBuilder.java
@@ -30,7 +30,6 @@ import javax.annotation.Nullable;
  * @param <T> The type of the subclass extending this abstract class.
  * @since 1.34.0
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/7393")
 public abstract class ForwardingServerBuilder<T extends ServerBuilder<T>> extends ServerBuilder<T> {
 
   /** The default constructor. */


### PR DESCRIPTION
- `ForwardingServerBuilder`
- `ForwardingChannelBuilder` - will be deprecated immediately after stabilization, ref #10587
- `ForwardingChannelBuilder2` - should be used instead of `ForwardingChannelBuilder`

Closes #3363
Closes #7393 
Closes #10585