### PR TITLE
core: Deprecate ForwardingChannelBuilder

### DIFF
--- a/alts/src/main/java/io/grpc/alts/AltsChannelBuilder.java
+++ b/alts/src/main/java/io/grpc/alts/AltsChannelBuilder.java
@@ -18,7 +18,7 @@ package io.grpc.alts;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.ExperimentalApi;
-import io.grpc.ForwardingChannelBuilder;
+import io.grpc.ForwardingChannelBuilder2;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.internal.GrpcUtil;
@@ -32,7 +32,7 @@ import javax.annotation.Nullable;
  * commmunication between two cloud VMs using ALTS.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4151")
-public final class AltsChannelBuilder extends ForwardingChannelBuilder<AltsChannelBuilder> {
+public final class AltsChannelBuilder extends ForwardingChannelBuilder2<AltsChannelBuilder> {
   private final NettyChannelBuilder delegate;
   private final AltsChannelCredentials.Builder credentialsBuilder =
       new AltsChannelCredentials.Builder();

--- a/alts/src/main/java/io/grpc/alts/ComputeEngineChannelBuilder.java
+++ b/alts/src/main/java/io/grpc/alts/ComputeEngineChannelBuilder.java
@@ -16,7 +16,7 @@
 
 package io.grpc.alts;
 
-import io.grpc.ForwardingChannelBuilder;
+import io.grpc.ForwardingChannelBuilder2;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.netty.NettyChannelBuilder;
@@ -26,7 +26,7 @@ import io.grpc.netty.NettyChannelBuilder;
  * using ALTS if applicable and using TLS as fallback.
  */
 public final class ComputeEngineChannelBuilder
-    extends ForwardingChannelBuilder<ComputeEngineChannelBuilder> {
+    extends ForwardingChannelBuilder2<ComputeEngineChannelBuilder> {
 
   private final NettyChannelBuilder delegate;
 

--- a/alts/src/main/java/io/grpc/alts/ComputeEngineChannelBuilder.java
+++ b/alts/src/main/java/io/grpc/alts/ComputeEngineChannelBuilder.java
@@ -45,6 +45,7 @@ public final class ComputeEngineChannelBuilder
   }
 
   @Override
+  @SuppressWarnings("deprecation") // Not extending ForwardingChannelBuilder to preserve ABI.
   protected NettyChannelBuilder delegate() {
     return delegate;
   }

--- a/alts/src/main/java/io/grpc/alts/ComputeEngineChannelBuilder.java
+++ b/alts/src/main/java/io/grpc/alts/ComputeEngineChannelBuilder.java
@@ -45,7 +45,7 @@ public final class ComputeEngineChannelBuilder
   }
 
   @Override
-  @SuppressWarnings("deprecation") // Not extending ForwardingChannelBuilder to preserve ABI.
+  @SuppressWarnings("deprecation") // Not extending ForwardingChannelBuilder2 to preserve ABI.
   protected NettyChannelBuilder delegate() {
     return delegate;
   }

--- a/alts/src/main/java/io/grpc/alts/ComputeEngineChannelBuilder.java
+++ b/alts/src/main/java/io/grpc/alts/ComputeEngineChannelBuilder.java
@@ -16,7 +16,7 @@
 
 package io.grpc.alts;
 
-import io.grpc.ForwardingChannelBuilder2;
+import io.grpc.ForwardingChannelBuilder;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.netty.NettyChannelBuilder;
@@ -26,7 +26,7 @@ import io.grpc.netty.NettyChannelBuilder;
  * using ALTS if applicable and using TLS as fallback.
  */
 public final class ComputeEngineChannelBuilder
-    extends ForwardingChannelBuilder2<ComputeEngineChannelBuilder> {
+    extends ForwardingChannelBuilder<ComputeEngineChannelBuilder> {
 
   private final NettyChannelBuilder delegate;
 

--- a/alts/src/main/java/io/grpc/alts/GoogleDefaultChannelBuilder.java
+++ b/alts/src/main/java/io/grpc/alts/GoogleDefaultChannelBuilder.java
@@ -16,7 +16,7 @@
 
 package io.grpc.alts;
 
-import io.grpc.ForwardingChannelBuilder2;
+import io.grpc.ForwardingChannelBuilder;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.netty.NettyChannelBuilder;
@@ -26,7 +26,7 @@ import io.grpc.netty.NettyChannelBuilder;
  * using ALTS if applicable and using TLS as fallback.
  */
 public final class GoogleDefaultChannelBuilder
-    extends ForwardingChannelBuilder2<GoogleDefaultChannelBuilder> {
+    extends ForwardingChannelBuilder<GoogleDefaultChannelBuilder> {
 
   private final NettyChannelBuilder delegate;
 

--- a/alts/src/main/java/io/grpc/alts/GoogleDefaultChannelBuilder.java
+++ b/alts/src/main/java/io/grpc/alts/GoogleDefaultChannelBuilder.java
@@ -45,7 +45,7 @@ public final class GoogleDefaultChannelBuilder
   }
 
   @Override
-  @SuppressWarnings("deprecation") // Not extending ForwardingChannelBuilder to preserve ABI.
+  @SuppressWarnings("deprecation") // Not extending ForwardingChannelBuilder2 to preserve ABI.
   protected NettyChannelBuilder delegate() {
     return delegate;
   }

--- a/alts/src/main/java/io/grpc/alts/GoogleDefaultChannelBuilder.java
+++ b/alts/src/main/java/io/grpc/alts/GoogleDefaultChannelBuilder.java
@@ -16,7 +16,7 @@
 
 package io.grpc.alts;
 
-import io.grpc.ForwardingChannelBuilder;
+import io.grpc.ForwardingChannelBuilder2;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.netty.NettyChannelBuilder;
@@ -26,7 +26,7 @@ import io.grpc.netty.NettyChannelBuilder;
  * using ALTS if applicable and using TLS as fallback.
  */
 public final class GoogleDefaultChannelBuilder
-    extends ForwardingChannelBuilder<GoogleDefaultChannelBuilder> {
+    extends ForwardingChannelBuilder2<GoogleDefaultChannelBuilder> {
 
   private final NettyChannelBuilder delegate;
 

--- a/alts/src/main/java/io/grpc/alts/GoogleDefaultChannelBuilder.java
+++ b/alts/src/main/java/io/grpc/alts/GoogleDefaultChannelBuilder.java
@@ -45,6 +45,7 @@ public final class GoogleDefaultChannelBuilder
   }
 
   @Override
+  @SuppressWarnings("deprecation") // Not extending ForwardingChannelBuilder to preserve ABI.
   protected NettyChannelBuilder delegate() {
     return delegate;
   }

--- a/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
+++ b/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
@@ -32,6 +32,7 @@ import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 import io.grpc.ConnectivityState;
 import io.grpc.ExperimentalApi;
+import io.grpc.ForwardingChannelBuilder;
 import io.grpc.InternalManagedChannelProvider;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -52,9 +53,7 @@ import javax.annotation.concurrent.GuardedBy;
  *
  * @since 1.12.0
  */
-@SuppressWarnings("deprecation")
-public final class AndroidChannelBuilder
-    extends io.grpc.ForwardingChannelBuilder<AndroidChannelBuilder> {
+public final class AndroidChannelBuilder extends ForwardingChannelBuilder<AndroidChannelBuilder> {
 
   private static final String LOG_TAG = "AndroidChannelBuilder";
 
@@ -157,6 +156,7 @@ public final class AndroidChannelBuilder
   }
 
   @Override
+  @SuppressWarnings("deprecation") // Not extending ForwardingChannelBuilder to preserve ABI.
   protected ManagedChannelBuilder<?> delegate() {
     return delegateBuilder;
   }

--- a/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
+++ b/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
@@ -53,6 +53,7 @@ import javax.annotation.concurrent.GuardedBy;
  *
  * @since 1.12.0
  */
+@SuppressWarnings("deprecation")
 public final class AndroidChannelBuilder extends ForwardingChannelBuilder<AndroidChannelBuilder> {
 
   private static final String LOG_TAG = "AndroidChannelBuilder";

--- a/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
+++ b/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
@@ -32,7 +32,7 @@ import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 import io.grpc.ConnectivityState;
 import io.grpc.ExperimentalApi;
-import io.grpc.ForwardingChannelBuilder;
+import io.grpc.ForwardingChannelBuilder2;
 import io.grpc.InternalManagedChannelProvider;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -53,7 +53,7 @@ import javax.annotation.concurrent.GuardedBy;
  *
  * @since 1.12.0
  */
-public final class AndroidChannelBuilder extends ForwardingChannelBuilder<AndroidChannelBuilder> {
+public final class AndroidChannelBuilder extends ForwardingChannelBuilder2<AndroidChannelBuilder> {
 
   private static final String LOG_TAG = "AndroidChannelBuilder";
 

--- a/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
+++ b/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
@@ -32,7 +32,7 @@ import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 import io.grpc.ConnectivityState;
 import io.grpc.ExperimentalApi;
-import io.grpc.ForwardingChannelBuilder2;
+import io.grpc.ForwardingChannelBuilder;
 import io.grpc.InternalManagedChannelProvider;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -53,7 +53,7 @@ import javax.annotation.concurrent.GuardedBy;
  *
  * @since 1.12.0
  */
-public final class AndroidChannelBuilder extends ForwardingChannelBuilder2<AndroidChannelBuilder> {
+public final class AndroidChannelBuilder extends ForwardingChannelBuilder<AndroidChannelBuilder> {
 
   private static final String LOG_TAG = "AndroidChannelBuilder";
 

--- a/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
+++ b/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
@@ -32,7 +32,6 @@ import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 import io.grpc.ConnectivityState;
 import io.grpc.ExperimentalApi;
-import io.grpc.ForwardingChannelBuilder;
 import io.grpc.InternalManagedChannelProvider;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -54,7 +53,8 @@ import javax.annotation.concurrent.GuardedBy;
  * @since 1.12.0
  */
 @SuppressWarnings("deprecation")
-public final class AndroidChannelBuilder extends ForwardingChannelBuilder<AndroidChannelBuilder> {
+public final class AndroidChannelBuilder
+    extends io.grpc.ForwardingChannelBuilder<AndroidChannelBuilder> {
 
   private static final String LOG_TAG = "AndroidChannelBuilder";
 

--- a/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
+++ b/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
@@ -156,7 +156,7 @@ public final class AndroidChannelBuilder extends ForwardingChannelBuilder<Androi
   }
 
   @Override
-  @SuppressWarnings("deprecation") // Not extending ForwardingChannelBuilder to preserve ABI.
+  @SuppressWarnings("deprecation") // Not extending ForwardingChannelBuilder2 to preserve ABI.
   protected ManagedChannelBuilder<?> delegate() {
     return delegateBuilder;
   }

--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
  * A {@link ManagedChannelBuilder} that delegates all its builder methods to another builder by
  * default.
  *
- * <p>Important! Use {@link ForwardingChannelBuilder2} instead!
+ * <p>DEPRECATED: Use {@link ForwardingChannelBuilder2} instead!
  *
  * <p>This class mistakenly used {@code <T extends ForwardingChannelBuilder<T>>} which causes
  * return types to be {@link ForwardingChannelBuilder} instead of {@link ManagedChannelBuilder}.
@@ -35,9 +35,7 @@ import javax.annotation.Nullable;
  *
  * @param <T> The type of the subclass extending this abstract class.
  * @since 1.7.0
- * @deprecated As of 1.60.0, use {@link ForwardingChannelBuilder2} instead.
  */
-@Deprecated
 public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilder<T>>
     extends ForwardingChannelBuilder2<T> {
   /**
@@ -45,6 +43,23 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
    */
   protected ForwardingChannelBuilder() {
   }
+
+
+  /**
+   * Returns the delegated {@code ManagedChannelBuilder}.
+   *
+   * <p>NOTE: this method is marked deprecated instead the class itself, so that classes extending
+   * {@link ForwardingChannelBuilder2} won't need class-level
+   * {@code @SuppressWarnings("deprecation")} annotation. Such annotation would suppress all
+   * deprecation warnings in all methods, inadvertently hiding any real deprecation warnings needing
+   * to be addressed. However, each child class is expected to implement {@code delegate()}.
+   * Therefore, the {@code @Deprecated} annotation is added to this method, and not to the class.
+   *
+   * @deprecated As of 1.60.0, use {@link ForwardingChannelBuilder2} instead.
+   */
+  @Override
+  @Deprecated
+  protected abstract ManagedChannelBuilder<?> delegate();
 
   @Override
   public T directExecutor() {

--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -35,11 +35,11 @@ import javax.annotation.Nullable;
  *
  * @param <T> The type of the subclass extending this abstract class.
  * @since 1.7.0
+ * @deprecated Use {@link ForwardingChannelBuilder2} instead.
  */
+@Deprecated
 public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilder<T>>
     extends ForwardingChannelBuilder2<T> {
-  // TODO(sergiitk): deprecate after stabilizing
-
   /**
    * The default constructor.
    */

--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
  *
  * @param <T> The type of the subclass extending this abstract class.
  * @since 1.7.0
- * @deprecated Use {@link ForwardingChannelBuilder2} instead.
+ * @deprecated As of 1.60.0, use {@link ForwardingChannelBuilder2} instead.
  */
 @Deprecated
 public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilder<T>>

--- a/api/src/test/java/io/grpc/ForwardingChannelBuilderTest.java
+++ b/api/src/test/java/io/grpc/ForwardingChannelBuilderTest.java
@@ -32,7 +32,6 @@ import org.junit.runners.JUnit4;
  * Unit tests for {@link ForwardingChannelBuilder}.
  */
 @RunWith(JUnit4.class)
-@SuppressWarnings("deprecation")
 public class ForwardingChannelBuilderTest {
   private final ManagedChannelBuilder<?> mockDelegate = mock(ManagedChannelBuilder.class);
 
@@ -40,6 +39,7 @@ public class ForwardingChannelBuilderTest {
 
   private final class TestBuilder extends ForwardingChannelBuilder<TestBuilder> {
     @Override
+    @SuppressWarnings("deprecation")
     protected ManagedChannelBuilder<?> delegate() {
       return mockDelegate;
     }

--- a/api/src/test/java/io/grpc/ForwardingChannelBuilderTest.java
+++ b/api/src/test/java/io/grpc/ForwardingChannelBuilderTest.java
@@ -32,6 +32,7 @@ import org.junit.runners.JUnit4;
  * Unit tests for {@link ForwardingChannelBuilder}.
  */
 @RunWith(JUnit4.class)
+@SuppressWarnings("deprecation")
 public class ForwardingChannelBuilderTest {
   private final ManagedChannelBuilder<?> mockDelegate = mock(ManagedChannelBuilder.class);
 

--- a/api/src/test/java/io/grpc/ManagedChannelRegistryTest.java
+++ b/api/src/test/java/io/grpc/ManagedChannelRegistryTest.java
@@ -125,7 +125,7 @@ public class ManagedChannelRegistryTest {
         return NewChannelBuilderResult.error("dodging");
       }
     });
-    class MockChannelBuilder extends ForwardingChannelBuilder<MockChannelBuilder> {
+    class MockChannelBuilder extends ForwardingChannelBuilder2<MockChannelBuilder> {
       @Override public ManagedChannelBuilder<?> delegate() {
         throw new UnsupportedOperationException();
       }
@@ -199,7 +199,7 @@ public class ManagedChannelRegistryTest {
         throw new AssertionError();
       }
     });
-    class MockChannelBuilder extends ForwardingChannelBuilder<MockChannelBuilder> {
+    class MockChannelBuilder extends ForwardingChannelBuilder2<MockChannelBuilder> {
       @Override public ManagedChannelBuilder<?> delegate() {
         throw new UnsupportedOperationException();
       }
@@ -282,7 +282,7 @@ public class ManagedChannelRegistryTest {
     NameResolverRegistry nameResolverRegistry = new NameResolverRegistry();
 
     ManagedChannelRegistry registry = new ManagedChannelRegistry();
-    class MockChannelBuilder extends ForwardingChannelBuilder<MockChannelBuilder> {
+    class MockChannelBuilder extends ForwardingChannelBuilder2<MockChannelBuilder> {
       @Override public ManagedChannelBuilder<?> delegate() {
         throw new UnsupportedOperationException();
       }
@@ -320,7 +320,7 @@ public class ManagedChannelRegistryTest {
     });
 
     ManagedChannelRegistry registry = new ManagedChannelRegistry();
-    class MockChannelBuilder extends ForwardingChannelBuilder<MockChannelBuilder> {
+    class MockChannelBuilder extends ForwardingChannelBuilder2<MockChannelBuilder> {
       @Override public ManagedChannelBuilder<?> delegate() {
         throw new UnsupportedOperationException();
       }
@@ -351,7 +351,7 @@ public class ManagedChannelRegistryTest {
 
     ManagedChannelRegistry registry = new ManagedChannelRegistry();
 
-    class MockChannelBuilder extends ForwardingChannelBuilder<MockChannelBuilder> {
+    class MockChannelBuilder extends ForwardingChannelBuilder2<MockChannelBuilder> {
       @Override public ManagedChannelBuilder<?> delegate() {
         throw new UnsupportedOperationException();
       }

--- a/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
@@ -26,7 +26,7 @@ import com.google.errorprone.annotations.DoNotCall;
 import io.grpc.ChannelCredentials;
 import io.grpc.ChannelLogger;
 import io.grpc.ExperimentalApi;
-import io.grpc.ForwardingChannelBuilder;
+import io.grpc.ForwardingChannelBuilder2;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.binder.internal.BinderTransport;
@@ -51,8 +51,7 @@ import javax.annotation.Nullable;
  *     Services</a>
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
-public final class BinderChannelBuilder
-    extends ForwardingChannelBuilder<BinderChannelBuilder> {
+public final class BinderChannelBuilder extends ForwardingChannelBuilder2<BinderChannelBuilder> {
 
   /**
    * Creates a channel builder that will bind to a remote Android service.

--- a/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
@@ -51,7 +51,6 @@ import javax.annotation.Nullable;
  *     Services</a>
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
-@SuppressWarnings("deprecation")
 public final class BinderChannelBuilder
     extends ForwardingChannelBuilder<BinderChannelBuilder> {
 

--- a/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
@@ -51,8 +51,7 @@ import javax.annotation.Nullable;
  *     Services</a>
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
-public final class BinderChannelBuilder
-    extends ForwardingChannelBuilder<BinderChannelBuilder> {
+public final class BinderChannelBuilder extends ForwardingChannelBuilder<BinderChannelBuilder> {
 
   /**
    * Creates a channel builder that will bind to a remote Android service.
@@ -231,6 +230,7 @@ public final class BinderChannelBuilder
   }
 
   @Override
+  @SuppressWarnings("deprecation") // Not extending ForwardingChannelBuilder to preserve ABI.
   protected ManagedChannelBuilder<?> delegate() {
     return managedChannelImplBuilder;
   }

--- a/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
@@ -51,6 +51,7 @@ import javax.annotation.Nullable;
  *     Services</a>
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
+@SuppressWarnings("deprecation")
 public final class BinderChannelBuilder
     extends ForwardingChannelBuilder<BinderChannelBuilder> {
 

--- a/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
@@ -51,7 +51,8 @@ import javax.annotation.Nullable;
  *     Services</a>
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
-public final class BinderChannelBuilder extends ForwardingChannelBuilder<BinderChannelBuilder> {
+public final class BinderChannelBuilder
+    extends ForwardingChannelBuilder<BinderChannelBuilder> {
 
   /**
    * Creates a channel builder that will bind to a remote Android service.

--- a/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
@@ -26,7 +26,7 @@ import com.google.errorprone.annotations.DoNotCall;
 import io.grpc.ChannelCredentials;
 import io.grpc.ChannelLogger;
 import io.grpc.ExperimentalApi;
-import io.grpc.ForwardingChannelBuilder2;
+import io.grpc.ForwardingChannelBuilder;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.binder.internal.BinderTransport;
@@ -51,7 +51,7 @@ import javax.annotation.Nullable;
  *     Services</a>
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
-public final class BinderChannelBuilder extends ForwardingChannelBuilder2<BinderChannelBuilder> {
+public final class BinderChannelBuilder extends ForwardingChannelBuilder<BinderChannelBuilder> {
 
   /**
    * Creates a channel builder that will bind to a remote Android service.

--- a/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
@@ -230,7 +230,7 @@ public final class BinderChannelBuilder extends ForwardingChannelBuilder<BinderC
   }
 
   @Override
-  @SuppressWarnings("deprecation") // Not extending ForwardingChannelBuilder to preserve ABI.
+  @SuppressWarnings("deprecation") // Not extending ForwardingChannelBuilder2 to preserve ABI.
   protected ManagedChannelBuilder<?> delegate() {
     return managedChannelImplBuilder;
   }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -49,7 +49,7 @@ import io.grpc.Context;
 import io.grpc.Deadline;
 import io.grpc.DecompressorRegistry;
 import io.grpc.EquivalentAddressGroup;
-import io.grpc.ForwardingChannelBuilder;
+import io.grpc.ForwardingChannelBuilder2;
 import io.grpc.ForwardingClientCall;
 import io.grpc.Grpc;
 import io.grpc.InternalChannelz;
@@ -1593,7 +1593,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
       checkNotNull(channelCreds, "channelCreds");
 
       final class ResolvingOobChannelBuilder
-          extends ForwardingChannelBuilder<ResolvingOobChannelBuilder> {
+          extends ForwardingChannelBuilder2<ResolvingOobChannelBuilder> {
         final ManagedChannelBuilder<?> delegate;
 
         ResolvingOobChannelBuilder() {

--- a/interop-testing/src/test/java/io/grpc/ChannelAndServerBuilderTest.java
+++ b/interop-testing/src/test/java/io/grpc/ChannelAndServerBuilderTest.java
@@ -68,9 +68,8 @@ public class ChannelAndServerBuilderTest {
         classes.add(new Object[]{clazz});
         continue;
       }
-      // ForwardingChannelBuilder extends ForwardingChannelBuilder2, not need for extra checks.
       if (ManagedChannelBuilder.class.isAssignableFrom(clazz)
-          && clazz != ManagedChannelBuilder.class && clazz != ForwardingChannelBuilder.class) {
+          && clazz != ManagedChannelBuilder.class && clazz != ForwardingChannelBuilder2.class) {
         classes.add(new Object[]{clazz});
       }
     }

--- a/interop-testing/src/test/java/io/grpc/ChannelAndServerBuilderTest.java
+++ b/interop-testing/src/test/java/io/grpc/ChannelAndServerBuilderTest.java
@@ -19,6 +19,7 @@ package io.grpc;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.ClassPath;
 import com.google.common.reflect.ClassPath.ClassInfo;
 import com.google.common.truth.Truth;
@@ -46,17 +47,29 @@ public class ChannelAndServerBuilderTest {
   public Class<?> builderClass;
 
   /**
-   * Javadoc.
+   * Returns the list of classes that have ServerBuilder or ManagedChannelBuilder in their class
+   * hierarchy and need to be checked for proper overrides of the static constructors.
    */
   @Parameters(name = "class={0}")
   public static Collection<Object[]> params() throws Exception {
     ClassLoader loader = ChannelAndServerBuilderTest.class.getClassLoader();
-    Collection<ClassInfo> classInfos =
+    ImmutableSet<ClassInfo> classInfos =
         ClassPath.from(loader).getTopLevelClassesRecursive("io.grpc");
+
     // Java 9 doesn't expose the URLClassLoader, which breaks searching through the classpath
     if (classInfos.isEmpty()) {
       return new ArrayList<>();
     }
+
+    // Exceptions from the check classes themselves, and ForwardingChannelBuilder.
+    // ForwardingChannelBuilder is deprecated and was stripped off of unnecessary methods,
+    // which it inherits from ForwardingChannelBuilder2.
+    @SuppressWarnings("deprecation")
+    ImmutableSet<Class<?>> ignoreClasses = ImmutableSet.of(
+        ServerBuilder.class,
+        ManagedChannelBuilder.class,
+        ForwardingChannelBuilder.class);
+
     List<Object[]> classes = new ArrayList<>();
     for (ClassInfo classInfo : classInfos) {
       String className = classInfo.getName();
@@ -64,12 +77,11 @@ public class ChannelAndServerBuilderTest {
         continue;
       }
       Class<?> clazz = Class.forName(className, false /*initialize*/, loader);
-      if (ServerBuilder.class.isAssignableFrom(clazz) && clazz != ServerBuilder.class) {
-        classes.add(new Object[]{clazz});
+      if (ignoreClasses.contains(clazz)) {
         continue;
       }
-      if (ManagedChannelBuilder.class.isAssignableFrom(clazz)
-          && clazz != ManagedChannelBuilder.class && clazz != ForwardingChannelBuilder2.class) {
+      if (ServerBuilder.class.isAssignableFrom(clazz)
+          || ManagedChannelBuilder.class.isAssignableFrom(clazz)) {
         classes.add(new Object[]{clazz});
       }
     }

--- a/interop-testing/src/test/java/io/grpc/ChannelAndServerBuilderTest.java
+++ b/interop-testing/src/test/java/io/grpc/ChannelAndServerBuilderTest.java
@@ -64,7 +64,6 @@ public class ChannelAndServerBuilderTest {
     // Exceptions from the check classes themselves, and ForwardingChannelBuilder.
     // ForwardingChannelBuilder is deprecated and was stripped off of unnecessary methods,
     // which it inherits from ForwardingChannelBuilder2.
-    @SuppressWarnings("deprecation")
     ImmutableSet<Class<?>> ignoreClasses = ImmutableSet.of(
         ServerBuilder.class,
         ManagedChannelBuilder.class,

--- a/interop-testing/src/test/java/io/grpc/ChannelAndServerBuilderTest.java
+++ b/interop-testing/src/test/java/io/grpc/ChannelAndServerBuilderTest.java
@@ -19,7 +19,6 @@ package io.grpc;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.ClassPath;
 import com.google.common.reflect.ClassPath.ClassInfo;
 import com.google.common.truth.Truth;
@@ -47,28 +46,17 @@ public class ChannelAndServerBuilderTest {
   public Class<?> builderClass;
 
   /**
-   * Returns the list of classes that have ServerBuilder or ManagedChannelBuilder in their class
-   * hierarchy and need to be checked for proper overrides of the static constructors.
+   * Javadoc.
    */
   @Parameters(name = "class={0}")
   public static Collection<Object[]> params() throws Exception {
     ClassLoader loader = ChannelAndServerBuilderTest.class.getClassLoader();
-    ImmutableSet<ClassInfo> classInfos =
+    Collection<ClassInfo> classInfos =
         ClassPath.from(loader).getTopLevelClassesRecursive("io.grpc");
-
     // Java 9 doesn't expose the URLClassLoader, which breaks searching through the classpath
     if (classInfos.isEmpty()) {
       return new ArrayList<>();
     }
-
-    // Exceptions from the check classes themselves, and ForwardingChannelBuilder.
-    // ForwardingChannelBuilder is deprecated and was stripped off of unnecessary methods,
-    // which it inherits from ForwardingChannelBuilder2.
-    ImmutableSet<Class<?>> ignoreClasses = ImmutableSet.of(
-        ServerBuilder.class,
-        ManagedChannelBuilder.class,
-        ForwardingChannelBuilder.class);
-
     List<Object[]> classes = new ArrayList<>();
     for (ClassInfo classInfo : classInfos) {
       String className = classInfo.getName();
@@ -76,11 +64,13 @@ public class ChannelAndServerBuilderTest {
         continue;
       }
       Class<?> clazz = Class.forName(className, false /*initialize*/, loader);
-      if (ignoreClasses.contains(clazz)) {
+      if (ServerBuilder.class.isAssignableFrom(clazz) && clazz != ServerBuilder.class) {
+        classes.add(new Object[]{clazz});
         continue;
       }
-      if (ServerBuilder.class.isAssignableFrom(clazz)
-          || ManagedChannelBuilder.class.isAssignableFrom(clazz)) {
+      // ForwardingChannelBuilder extends ForwardingChannelBuilder2, not need for extra checks.
+      if (ManagedChannelBuilder.class.isAssignableFrom(clazz)
+          && clazz != ManagedChannelBuilder.class && clazz != ForwardingChannelBuilder.class) {
         classes.add(new Object[]{clazz});
       }
     }

--- a/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
+++ b/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
@@ -40,7 +40,7 @@ import io.grpc.ChannelCredentials;
 import io.grpc.ChannelLogger;
 import io.grpc.ConnectivityState;
 import io.grpc.EquivalentAddressGroup;
-import io.grpc.ForwardingChannelBuilder;
+import io.grpc.ForwardingChannelBuilder2;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.PickResult;
@@ -817,7 +817,7 @@ public class CachingRlsLbClientTest {
       final InProcessChannelBuilder builder =
           InProcessChannelBuilder.forName(target).directExecutor();
 
-      class CleaningChannelBuilder extends ForwardingChannelBuilder<CleaningChannelBuilder> {
+      class CleaningChannelBuilder extends ForwardingChannelBuilder2<CleaningChannelBuilder> {
 
         @Override
         protected ManagedChannelBuilder<?> delegate() {

--- a/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
@@ -36,7 +36,7 @@ import io.grpc.ChannelLogger;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
-import io.grpc.ForwardingChannelBuilder;
+import io.grpc.ForwardingChannelBuilder2;
 import io.grpc.LoadBalancer.CreateSubchannelArgs;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.PickResult;
@@ -519,7 +519,7 @@ public class RlsLoadBalancerTest {
       final InProcessChannelBuilder builder =
           InProcessChannelBuilder.forName(target).directExecutor();
 
-      class CleaningChannelBuilder extends ForwardingChannelBuilder<CleaningChannelBuilder> {
+      class CleaningChannelBuilder extends ForwardingChannelBuilder2<CleaningChannelBuilder> {
 
         @Override
         protected ManagedChannelBuilder<?> delegate() {


### PR DESCRIPTION
Deprecate `ForwardingChannelBuilder` in favor of `ForwardingChannelBuilder2`