### PR TITLE
core, netty, okhttp: implement new logic for nameResolverFactory API in channelBuilder

### DIFF
--- a/alts/src/main/java/io/grpc/alts/HandshakerServiceChannel.java
+++ b/alts/src/main/java/io/grpc/alts/HandshakerServiceChannel.java
@@ -27,6 +27,7 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.concurrent.DefaultThreadFactory;
+import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -57,7 +58,7 @@ final class HandshakerServiceChannel {
       EventLoopGroup eventGroup =
           new NioEventLoopGroup(1, new DefaultThreadFactory("handshaker pool", true));
       ManagedChannel channel = NettyChannelBuilder.forTarget(target)
-          .channelType(NioSocketChannel.class)
+          .channelType(NioSocketChannel.class, InetSocketAddress.class)
           .directExecutor()
           .eventLoopGroup(eventGroup)
           .usePlaintext()

--- a/alts/src/test/java/io/grpc/alts/internal/GoogleDefaultProtocolNegotiatorTest.java
+++ b/alts/src/test/java/io/grpc/alts/internal/GoogleDefaultProtocolNegotiatorTest.java
@@ -61,7 +61,7 @@ public final class GoogleDefaultProtocolNegotiatorTest {
 
       @Override
       public Channel getObject() {
-        return InProcessChannelBuilder.forName("test").build();
+        return InProcessChannelBuilder.forName("inprocess:///test").build();
       }
 
       @Override

--- a/alts/src/test/java/io/grpc/alts/internal/GoogleDefaultProtocolNegotiatorTest.java
+++ b/alts/src/test/java/io/grpc/alts/internal/GoogleDefaultProtocolNegotiatorTest.java
@@ -61,7 +61,7 @@ public final class GoogleDefaultProtocolNegotiatorTest {
 
       @Override
       public Channel getObject() {
-        return InProcessChannelBuilder.forName("inprocess:///test").build();
+        return InProcessChannelBuilder.forName("test").build();
       }
 
       @Override

--- a/api/src/main/java/io/grpc/ManagedChannelRegistry.java
+++ b/api/src/main/java/io/grpc/ManagedChannelRegistry.java
@@ -161,12 +161,13 @@ public final class ManagedChannelRegistry {
     NameResolverProvider nameResolverProvider = null;
     try {
       URI uri = new URI(target);
-      nameResolverProvider = nameResolverRegistry.get(uri.getScheme());
+      nameResolverProvider = nameResolverRegistry.getProviderForScheme(uri.getScheme());
     } catch (URISyntaxException ignore) {
       // bad URI found, just ignore and continue
     }
     if (nameResolverProvider == null) {
-      nameResolverProvider = nameResolverRegistry.get(nameResolverRegistry.getDefaultScheme());
+      nameResolverProvider = nameResolverRegistry.getProviderForScheme(
+          nameResolverRegistry.getDefaultScheme());
     }
     Collection<Class<? extends SocketAddress>> nameResolverSocketAddressTypes
         = (nameResolverProvider != null)

--- a/api/src/main/java/io/grpc/ManagedChannelRegistry.java
+++ b/api/src/main/java/io/grpc/ManagedChannelRegistry.java
@@ -19,8 +19,6 @@ package io.grpc;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.net.SocketAddress;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -158,17 +156,8 @@ public final class ManagedChannelRegistry {
   @VisibleForTesting
   ManagedChannelBuilder<?> newChannelBuilder(NameResolverRegistry nameResolverRegistry,
       String target, ChannelCredentials creds) {
-    NameResolverProvider nameResolverProvider = null;
-    try {
-      URI uri = new URI(target);
-      nameResolverProvider = nameResolverRegistry.providers().get(uri.getScheme());
-    } catch (URISyntaxException ignore) {
-      // bad URI found, just ignore and continue
-    }
-    if (nameResolverProvider == null) {
-      nameResolverProvider = nameResolverRegistry.providers().get(
-          nameResolverRegistry.asFactory().getDefaultScheme());
-    }
+    NameResolverProvider nameResolverProvider = NameResolverRegistry
+        .getNameResolverProvider(nameResolverRegistry, target);
     Collection<Class<? extends SocketAddress>> nameResolverSocketAddressTypes
         = (nameResolverProvider != null)
         ? nameResolverProvider.getProducedSocketAddressTypes() :

--- a/api/src/main/java/io/grpc/ManagedChannelRegistry.java
+++ b/api/src/main/java/io/grpc/ManagedChannelRegistry.java
@@ -156,8 +156,8 @@ public final class ManagedChannelRegistry {
   @VisibleForTesting
   ManagedChannelBuilder<?> newChannelBuilder(NameResolverRegistry nameResolverRegistry,
       String target, ChannelCredentials creds) {
-    NameResolverProvider nameResolverProvider = NameResolverRegistry
-        .getNameResolverProvider(nameResolverRegistry, target);
+    NameResolverProvider nameResolverProvider = nameResolverRegistry
+        .getNameResolverProvider(target);
     Collection<Class<? extends SocketAddress>> nameResolverSocketAddressTypes
         = (nameResolverProvider != null)
         ? nameResolverProvider.getProducedSocketAddressTypes() :

--- a/api/src/main/java/io/grpc/NameResolverProvider.java
+++ b/api/src/main/java/io/grpc/NameResolverProvider.java
@@ -75,7 +75,7 @@ public abstract class NameResolverProvider extends NameResolver.Factory {
    *
    * @return the {@link SocketAddress} types this provider's name-resolver is capable of producing.
    */
-  protected Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
+  public Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
     return Collections.singleton(InetSocketAddress.class);
   }
 }

--- a/api/src/main/java/io/grpc/NameResolverRegistry.java
+++ b/api/src/main/java/io/grpc/NameResolverRegistry.java
@@ -62,7 +62,7 @@ public final class NameResolverRegistry {
     return defaultScheme;
   }
 
-  public NameResolverProvider get(String scheme) {
+  public NameResolverProvider getProviderForScheme(String scheme) {
     if (scheme == null) {
       return null;
     }
@@ -173,7 +173,7 @@ public final class NameResolverRegistry {
     @Override
     @Nullable
     public NameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
-      NameResolverProvider provider = get(targetUri.getScheme());
+      NameResolverProvider provider = getProviderForScheme(targetUri.getScheme());
       return provider == null ? null : provider.newNameResolver(targetUri, args);
     }
 

--- a/api/src/main/java/io/grpc/NameResolverRegistry.java
+++ b/api/src/main/java/io/grpc/NameResolverRegistry.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -157,6 +158,22 @@ public final class NameResolverRegistry {
       logger.log(Level.FINE, "Unable to find DNS NameResolver", e);
     }
     return Collections.unmodifiableList(list);
+  }
+
+  public static NameResolverProvider getNameResolverProvider(
+      NameResolverRegistry nameResolverRegistry, String target) {
+    NameResolverProvider nameResolverProvider = null;
+    try {
+      URI uri = new URI(target);
+      nameResolverProvider = nameResolverRegistry.providers().get(uri.getScheme());
+    } catch (URISyntaxException ignore) {
+      // bad URI found, just ignore and continue
+    }
+    if (nameResolverProvider == null) {
+      nameResolverProvider = nameResolverRegistry.providers().get(
+          nameResolverRegistry.asFactory().getDefaultScheme());
+    }
+    return nameResolverProvider;
   }
 
   private final class NameResolverFactory extends NameResolver.Factory {

--- a/api/src/main/java/io/grpc/NameResolverRegistry.java
+++ b/api/src/main/java/io/grpc/NameResolverRegistry.java
@@ -59,6 +59,22 @@ public final class NameResolverRegistry {
   @GuardedBy("this")
   private ImmutableMap<String, NameResolverProvider> effectiveProviders = ImmutableMap.of();
 
+  public NameResolverProvider getNameResolverProvider(
+      String target) {
+    NameResolverProvider nameResolverProvider = null;
+    try {
+      URI uri = new URI(target);
+      nameResolverProvider = providers().get(uri.getScheme());
+    } catch (URISyntaxException ignore) {
+      // bad URI found, just ignore and continue
+    }
+    if (nameResolverProvider == null) {
+      nameResolverProvider = providers().get(
+          asFactory().getDefaultScheme());
+    }
+    return nameResolverProvider;
+  }
+
 
   /**
    * Register a provider.
@@ -158,22 +174,6 @@ public final class NameResolverRegistry {
       logger.log(Level.FINE, "Unable to find DNS NameResolver", e);
     }
     return Collections.unmodifiableList(list);
-  }
-
-  public static NameResolverProvider getNameResolverProvider(
-      NameResolverRegistry nameResolverRegistry, String target) {
-    NameResolverProvider nameResolverProvider = null;
-    try {
-      URI uri = new URI(target);
-      nameResolverProvider = nameResolverRegistry.providers().get(uri.getScheme());
-    } catch (URISyntaxException ignore) {
-      // bad URI found, just ignore and continue
-    }
-    if (nameResolverProvider == null) {
-      nameResolverProvider = nameResolverRegistry.providers().get(
-          nameResolverRegistry.asFactory().getDefaultScheme());
-    }
-    return nameResolverProvider;
   }
 
   private final class NameResolverFactory extends NameResolver.Factory {

--- a/api/src/test/java/io/grpc/ManagedChannelRegistryTest.java
+++ b/api/src/test/java/io/grpc/ManagedChannelRegistryTest.java
@@ -173,13 +173,13 @@ public class ManagedChannelRegistryTest {
 
     nameResolverRegistry.register(new BaseNameResolverProvider(true, 5, "sc1") {
       @Override
-      protected Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
+      public Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
         return Collections.singleton(SocketAddress1.class);
       }
     });
     nameResolverRegistry.register(new BaseNameResolverProvider(true, 6, "sc2") {
       @Override
-      protected Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
+      public Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
         fail("Should not be called");
         throw new AssertionError();
       }
@@ -234,7 +234,7 @@ public class ManagedChannelRegistryTest {
 
     nameResolverRegistry.register(new BaseNameResolverProvider(true, 5, "sc1") {
       @Override
-      protected Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
+      public Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
         return ImmutableSet.of(SocketAddress1.class, SocketAddress2.class);
       }
     });
@@ -314,7 +314,7 @@ public class ManagedChannelRegistryTest {
 
     nameResolverRegistry.register(new BaseNameResolverProvider(true, 5, "sc1") {
       @Override
-      protected Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
+      public Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
         return Collections.singleton(SocketAddress1.class);
       }
     });

--- a/api/src/test/java/io/grpc/NameResolverRegistryTest.java
+++ b/api/src/test/java/io/grpc/NameResolverRegistryTest.java
@@ -203,12 +203,14 @@ public class NameResolverRegistryTest {
   public void baseProviders() {
     Map<String, NameResolverProvider> providers =
             NameResolverRegistry.getDefaultRegistry().providers();
-    assertThat(providers).hasSize(1);
+    assertThat(providers).hasSize(2);
     // 2 name resolvers from grpclb and core, higher priority one is returned.
     assertThat(providers.get("dns").getClass().getName())
         .isEqualTo("io.grpc.grpclb.SecretGrpclbNameResolverProvider$Provider");
     assertThat(NameResolverRegistry.getDefaultRegistry().asFactory().getDefaultScheme())
         .isEqualTo("dns");
+    assertThat(providers.get("inprocess").getClass().getName())
+        .isEqualTo("io.grpc.inprocess.InProcessNameResolverProvider");
   }
 
   @Test

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
@@ -110,7 +110,7 @@ public class TransportBenchmark {
             .channelType(LocalServerChannel.class);
         channelBuilder = NettyChannelBuilder.forAddress(address)
             .eventLoopGroup(group)
-            .channelType(LocalChannel.class)
+            .channelType(LocalChannel.class, LocalAddress.class)
             .negotiationType(NegotiationType.PLAINTEXT);
         groupToShutdown = group;
         break;
@@ -134,7 +134,7 @@ public class TransportBenchmark {
               .asSubclass(Channel.class);
         channelBuilder = NettyChannelBuilder.forAddress(address)
             .eventLoopGroup(group)
-            .channelType(channelClass)
+            .channelType(channelClass, InetSocketAddress.class)
             .negotiationType(NegotiationType.PLAINTEXT);
         groupToShutdown = group;
         break;

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
@@ -207,7 +207,7 @@ public abstract class AbstractBenchmark {
       serverBuilder = NettyServerBuilder.forAddress(address, serverCreds);
       serverBuilder.channelType(LocalServerChannel.class);
       channelBuilder = NettyChannelBuilder.forAddress(address);
-      channelBuilder.channelType(LocalChannel.class);
+      channelBuilder.channelType(LocalChannel.class, LocalAddress.class);
     } else {
       ServerSocket sock = new ServerSocket();
       // Pick a port using an ephemeral socket.
@@ -216,7 +216,8 @@ public abstract class AbstractBenchmark {
       sock.close();
       serverBuilder = NettyServerBuilder.forAddress(address, serverCreds)
           .channelType(NioServerSocketChannel.class);
-      channelBuilder = NettyChannelBuilder.forAddress(address).channelType(NioSocketChannel.class);
+      channelBuilder = NettyChannelBuilder.forAddress(address).channelType(NioSocketChannel.class,
+          InetSocketAddress.class);
     }
 
     if (serverExecutor == ExecutorType.DIRECT) {

--- a/benchmarks/src/main/java/io/grpc/benchmarks/Utils.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/Utils.java
@@ -130,21 +130,21 @@ public final class Utils {
       case NETTY_NIO:
         builder
             .eventLoopGroup(new NioEventLoopGroup(0, tf))
-            .channelType(NioSocketChannel.class);
+            .channelType(NioSocketChannel.class, InetSocketAddress.class);
         break;
 
       case NETTY_EPOLL:
         // These classes only work on Linux.
         builder
             .eventLoopGroup(new EpollEventLoopGroup(0, tf))
-            .channelType(EpollSocketChannel.class);
+            .channelType(EpollSocketChannel.class, InetSocketAddress.class);
         break;
 
       case NETTY_UNIX_DOMAIN_SOCKET:
         // These classes only work on Linux.
         builder
             .eventLoopGroup(new EpollEventLoopGroup(0, tf))
-            .channelType(EpollDomainSocketChannel.class);
+            .channelType(EpollDomainSocketChannel.class, DomainSocketAddress.class);
         break;
 
       default:

--- a/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
@@ -400,5 +400,10 @@ public final class BinderChannelBuilder
       executorService = scheduledExecutorPool.returnObject(executorService);
       offloadExecutor = offloadExecutorPool.returnObject(offloadExecutor);
     }
+
+    @Override
+    public Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
+      return Collections.singleton(AndroidComponentAddress.class);
+    }
   }
 }

--- a/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
@@ -39,6 +39,7 @@ import io.grpc.internal.ManagedChannelImplBuilder.ClientTransportFactoryBuilder;
 import io.grpc.internal.ObjectPool;
 import io.grpc.internal.SharedResourcePool;
 import java.net.SocketAddress;
+import java.util.Collections;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;

--- a/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
@@ -39,6 +39,7 @@ import io.grpc.internal.ManagedChannelImplBuilder.ClientTransportFactoryBuilder;
 import io.grpc.internal.ObjectPool;
 import io.grpc.internal.SharedResourcePool;
 import java.net.SocketAddress;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;

--- a/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
@@ -34,6 +34,7 @@ import io.grpc.SecurityLevel;
 import io.grpc.Status;
 import io.grpc.internal.MetadataApplierImpl.MetadataApplierListener;
 import java.net.SocketAddress;
+import java.util.Collection;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -72,6 +73,11 @@ final class CallCredentialsApplyingTransportFactory implements ClientTransportFa
   @Override
   public void close() {
     delegate.close();
+  }
+
+  @Override
+  public Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
+    return delegate.getSupportedSocketAddressTypes();
   }
 
   private class CallCredentialsApplyingTransport extends ForwardingConnectionClientTransport {

--- a/core/src/main/java/io/grpc/internal/ClientTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransportFactory.java
@@ -25,6 +25,7 @@ import io.grpc.ChannelLogger;
 import io.grpc.HttpConnectProxiedSocketAddress;
 import java.io.Closeable;
 import java.net.SocketAddress;
+import java.util.Collection;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
@@ -72,6 +73,11 @@ public interface ClientTransportFactory extends Closeable {
    */
   @Override
   void close();
+
+  /**
+   * Returns the {@link SocketAddress} types this transport supports.
+   */
+  Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes();
 
   /**
    * Options passed to {@link #newClientTransport}. Although it is safe to save this object if

--- a/core/src/main/java/io/grpc/internal/DnsNameResolverProvider.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolverProvider.java
@@ -84,7 +84,7 @@ public final class DnsNameResolverProvider extends NameResolverProvider {
   }
 
   @Override
-  protected Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
+  public Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
     return Collections.singleton(InetSocketAddress.class);
   }
 }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -722,19 +722,19 @@ final class ManagedChannelImpl extends ManagedChannel implements
     if (targetUri != null) {
       // For "localhost:8080" this would likely cause provider to be null, because "localhost" is
       // parsed as the scheme. Will hit the next case and try "dns:///localhost:8080".
-      provider = nameResolverRegistry.get(targetUri.getScheme());
+      provider = nameResolverRegistry.getProviderForScheme(targetUri.getScheme());
     }
 
     if (provider == null && !URI_PATTERN.matcher(target).matches()) {
       // It doesn't look like a URI target. Maybe it's an authority string. Try with the default
-      // scheme from the factory.
+      // scheme from the registry.
       try {
         targetUri = new URI(nameResolverRegistry.getDefaultScheme(), "", "/" + target, null);
       } catch (URISyntaxException e) {
         // Should not be possible.
         throw new IllegalArgumentException(e);
       }
-      provider = nameResolverRegistry.get(targetUri.getScheme());
+      provider = nameResolverRegistry.getProviderForScheme(targetUri.getScheme());
     }
 
     if (provider == null) {

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -714,12 +714,14 @@ final class ManagedChannelImpl extends ManagedChannel implements
       throw new IllegalArgumentException(String.format(
           "cannot find a NameResolver for %s", target));
     }
-    Collection<Class<? extends SocketAddress>> nameResolverSocketAddressTypes
-        = nameResolverProvider.getProducedSocketAddressTypes();
-    if (!channelTransportSocketAddressTypes.containsAll(nameResolverSocketAddressTypes)) {
-      throw new IllegalArgumentException(String.format(
-          "Address types of NameResolver '%s' for '%s' not supported by transport",
-          nameResolverProvider.getDefaultScheme(), target));
+    if (channelTransportSocketAddressTypes != null) {
+      Collection<Class<? extends SocketAddress>> nameResolverSocketAddressTypes
+          = nameResolverProvider.getProducedSocketAddressTypes();
+      if (!channelTransportSocketAddressTypes.containsAll(nameResolverSocketAddressTypes)) {
+        throw new IllegalArgumentException(String.format(
+            "Address types of NameResolver '%s' for '%s' not supported by transport",
+            nameResolverProvider.getDefaultScheme(), target));
+      }
     }
     // Finding a NameResolver. Try using the target string as the URI. If that fails, try prepending
     // "dns:///".

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -708,8 +708,8 @@ final class ManagedChannelImpl extends ManagedChannel implements
   private static NameResolver getNameResolver(
       String target, NameResolverRegistry nameResolverRegistry, NameResolver.Args nameResolverArgs,
       Collection<Class<? extends SocketAddress>> channelTransportSocketAddressTypes) {
-    NameResolverProvider nameResolverProvider = NameResolverRegistry
-        .getNameResolverProvider(nameResolverRegistry, target);
+    NameResolverProvider nameResolverProvider = nameResolverRegistry
+        .getNameResolverProvider(target);
     if (nameResolverProvider == null) {
       throw new IllegalArgumentException(String.format(
           "cannot find a NameResolver for %s", target));

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -35,6 +35,7 @@ import io.grpc.InternalGlobalInterceptors;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.NameResolver;
+import io.grpc.NameResolverProvider;
 import io.grpc.NameResolverRegistry;
 import io.grpc.ProxyDetector;
 import java.lang.reflect.InvocationTargetException;
@@ -44,6 +45,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -133,10 +135,7 @@ public final class ManagedChannelImplBuilder
   ObjectPool<? extends Executor> offloadExecutorPool = DEFAULT_EXECUTOR_POOL;
 
   private final List<ClientInterceptor> interceptors = new ArrayList<>();
-  final NameResolverRegistry nameResolverRegistry = NameResolverRegistry.getDefaultRegistry();
-
-  // Access via getter, which may perform authority override as needed
-  NameResolver.Factory nameResolverFactory = nameResolverRegistry.asFactory();
+  NameResolverRegistry nameResolverRegistry = NameResolverRegistry.getDefaultRegistry();
 
   final String target;
   @Nullable
@@ -284,7 +283,7 @@ public final class ManagedChannelImplBuilder
 
   /**
    * Returns a target string for the SocketAddress. It is only used as a placeholder, because
-   * DirectAddressNameResolverFactory will not actually try to use it. However, it must be a valid
+   * DirectAddressNameResolverProvider will not actually try to use it. However, it must be a valid
    * URI.
    */
   @VisibleForTesting
@@ -327,7 +326,10 @@ public final class ManagedChannelImplBuilder
     this.clientTransportFactoryBuilder = Preconditions
         .checkNotNull(clientTransportFactoryBuilder, "clientTransportFactoryBuilder");
     this.directServerAddress = directServerAddress;
-    this.nameResolverFactory = new DirectAddressNameResolverFactory(directServerAddress, authority);
+    NameResolverRegistry reg = new NameResolverRegistry();
+    reg.register(new DirectAddressNameResolverProvider(directServerAddress,
+        authority));
+    this.nameResolverRegistry = reg;
 
     if (channelBuilderDefaultPortProvider != null) {
       this.channelBuilderDefaultPortProvider = channelBuilderDefaultPortProvider;
@@ -379,10 +381,17 @@ public final class ManagedChannelImplBuilder
         "directServerAddress is set (%s), which forbids the use of NameResolverFactory",
         directServerAddress);
     if (resolverFactory != null) {
-      this.nameResolverFactory = resolverFactory;
+      NameResolverRegistry reg = new NameResolverRegistry();
+      reg.register(new NameResolverFactoryToProviderFacade(resolverFactory));
+      this.nameResolverRegistry = reg;
     } else {
-      this.nameResolverFactory = nameResolverRegistry.asFactory();
+      this.nameResolverRegistry = NameResolverRegistry.getDefaultRegistry();
     }
+    return this;
+  }
+
+  ManagedChannelImplBuilder nameResolverRegistry(NameResolverRegistry resolverRegistry) {
+    this.nameResolverRegistry = resolverRegistry;
     return this;
   }
 
@@ -728,13 +737,16 @@ public final class ManagedChannelImplBuilder
     return channelBuilderDefaultPortProvider.getDefaultPort();
   }
 
-  private static class DirectAddressNameResolverFactory extends NameResolver.Factory {
+  private static class DirectAddressNameResolverProvider extends NameResolverProvider {
     final SocketAddress address;
     final String authority;
+    final Collection<Class<? extends SocketAddress>> producedSocketAddressTypes;
 
-    DirectAddressNameResolverFactory(SocketAddress address, String authority) {
+    DirectAddressNameResolverProvider(SocketAddress address, String authority) {
       this.address = address;
       this.authority = authority;
+      this.producedSocketAddressTypes
+          = Collections.singleton(address.getClass());
     }
 
     @Override
@@ -762,6 +774,21 @@ public final class ManagedChannelImplBuilder
     @Override
     public String getDefaultScheme() {
       return DIRECT_ADDRESS_SCHEME;
+    }
+
+    @Override
+    protected boolean isAvailable() {
+      return true;
+    }
+
+    @Override
+    protected int priority() {
+      return 5;
+    }
+
+    @Override
+    public Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
+      return producedSocketAddressTypes;
     }
   }
 

--- a/core/src/main/java/io/grpc/internal/NameResolverFactoryToProviderFacade.java
+++ b/core/src/main/java/io/grpc/internal/NameResolverFactoryToProviderFacade.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import io.grpc.NameResolver;
+import io.grpc.NameResolver.Args;
+import io.grpc.NameResolverProvider;
+import java.net.URI;
+
+public class NameResolverFactoryToProviderFacade extends NameResolverProvider {
+
+  private NameResolver.Factory factory;
+
+  NameResolverFactoryToProviderFacade(NameResolver.Factory factory) {
+    this.factory = factory;
+  }
+
+  @Override
+  public NameResolver newNameResolver(URI targetUri, Args args) {
+    return factory.newNameResolver(targetUri, args);
+  }
+
+  @Override
+  public String getDefaultScheme() {
+    return factory.getDefaultScheme();
+  }
+
+  @Override
+  protected boolean isAvailable() {
+    return true;
+  }
+
+  @Override
+  protected int priority() {
+    return 5;
+  }
+}

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
@@ -382,6 +382,21 @@ public class ManagedChannelImplBuilderTest {
   }
 
   @Test
+  public void transportAddressTypeCompatibilityCheckSkipped() {
+    when(mockClientTransportFactory.getScheduledExecutorService())
+        .thenReturn(clock.getScheduledExecutorService());
+    when(mockClientTransportFactoryBuilder.buildClientTransportFactory())
+        .thenReturn(mockClientTransportFactory);
+    when(mockClientTransportFactory.getSupportedSocketAddressTypes())
+        .thenReturn(null);
+
+    builder = new ManagedChannelImplBuilder(DUMMY_AUTHORITY_VALID,
+        mockClientTransportFactoryBuilder, new FixedPortProvider(DUMMY_PORT));
+    // should not fail
+    ManagedChannel unused = grpcCleanupRule.register(builder.build());
+  }
+
+  @Test
   public void overrideAuthority_default() {
     assertNull(builder.authorityOverride);
   }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -39,7 +40,9 @@ import io.grpc.InternalGlobalInterceptors;
 import io.grpc.ManagedChannel;
 import io.grpc.MethodDescriptor;
 import io.grpc.NameResolver;
+import io.grpc.NameResolverRegistry;
 import io.grpc.StaticTestingClassLoader;
+import io.grpc.inprocess.InProcessSocketAddress;
 import io.grpc.internal.ManagedChannelImplBuilder.ChannelBuilderDefaultPortProvider;
 import io.grpc.internal.ManagedChannelImplBuilder.ClientTransportFactoryBuilder;
 import io.grpc.internal.ManagedChannelImplBuilder.FixedPortProvider;
@@ -196,25 +199,30 @@ public class ManagedChannelImplBuilderTest {
   }
 
   @Test
-  public void nameResolverFactory_default() {
-    assertNotNull(builder.nameResolverFactory);
+  public void nameResolverRegistry_default() {
+    assertNotNull(builder.nameResolverRegistry);
   }
 
   @Test
   @SuppressWarnings("deprecation")
   public void nameResolverFactory_normal() {
     NameResolver.Factory nameResolverFactory = mock(NameResolver.Factory.class);
+    doReturn("testscheme").when(nameResolverFactory).getDefaultScheme();
     assertEquals(builder, builder.nameResolverFactory(nameResolverFactory));
-    assertEquals(nameResolverFactory, builder.nameResolverFactory);
+    assertNotNull(builder.nameResolverRegistry);
+    assertEquals("testscheme", builder.nameResolverRegistry.asFactory().getDefaultScheme());
   }
 
   @Test
   @SuppressWarnings("deprecation")
   public void nameResolverFactory_null() {
-    NameResolver.Factory defaultValue = builder.nameResolverFactory;
-    builder.nameResolverFactory(mock(NameResolver.Factory.class));
-    assertEquals(builder, builder.nameResolverFactory(null));
-    assertEquals(defaultValue, builder.nameResolverFactory);
+    NameResolverRegistry defaultValue = builder.nameResolverRegistry;
+    NameResolver.Factory nameResolverFactory = mock(NameResolver.Factory.class);
+    doReturn("testscheme").when(nameResolverFactory).getDefaultScheme();
+    builder.nameResolverFactory(nameResolverFactory);
+    assertNotEquals(defaultValue, builder.nameResolverRegistry);
+    builder.nameResolverFactory(null);
+    assertEquals(defaultValue, builder.nameResolverRegistry);
   }
 
   @Test(expected = IllegalStateException.class)
@@ -327,6 +335,8 @@ public class ManagedChannelImplBuilderTest {
         .thenReturn(clock.getScheduledExecutorService());
     when(mockClientTransportFactoryBuilder.buildClientTransportFactory())
         .thenReturn(mockClientTransportFactory);
+    when(mockClientTransportFactory.getSupportedSocketAddressTypes())
+        .thenReturn(Collections.singleton(InetSocketAddress.class));
 
     builder = new ManagedChannelImplBuilder(DUMMY_AUTHORITY_VALID,
         mockClientTransportFactoryBuilder, new FixedPortProvider(DUMMY_PORT));
@@ -341,12 +351,34 @@ public class ManagedChannelImplBuilderTest {
         .thenReturn(clock.getScheduledExecutorService());
     when(mockClientTransportFactoryBuilder.buildClientTransportFactory())
         .thenReturn(mockClientTransportFactory);
+    when(mockClientTransportFactory.getSupportedSocketAddressTypes())
+        .thenReturn(Collections.singleton(InetSocketAddress.class));
 
     builder = new ManagedChannelImplBuilder(DUMMY_TARGET,
         mockClientTransportFactoryBuilder, new FixedPortProvider(DUMMY_PORT))
         .overrideAuthority(overrideAuthority);
     ManagedChannel channel = grpcCleanupRule.register(builder.build());
     assertEquals(overrideAuthority, channel.authority());
+  }
+
+  @Test
+  public void transportDoesNotSupportAddressTypes() {
+    when(mockClientTransportFactory.getScheduledExecutorService())
+        .thenReturn(clock.getScheduledExecutorService());
+    when(mockClientTransportFactoryBuilder.buildClientTransportFactory())
+        .thenReturn(mockClientTransportFactory);
+    when(mockClientTransportFactory.getSupportedSocketAddressTypes())
+        .thenReturn(Collections.singleton(InProcessSocketAddress.class));
+
+    builder = new ManagedChannelImplBuilder(DUMMY_AUTHORITY_VALID,
+        mockClientTransportFactoryBuilder, new FixedPortProvider(DUMMY_PORT));
+    try {
+      ManagedChannel unused = grpcCleanupRule.register(builder.build());
+      fail("Should fail");
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessageThat().isEqualTo(
+          "Address types of NameResolver 'dns' for 'valid:1234' not supported by transport");
+    }
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
@@ -24,17 +24,22 @@ import static org.mockito.Mockito.mock;
 
 import io.grpc.ChannelLogger;
 import io.grpc.NameResolver;
+import io.grpc.NameResolver.Args;
 import io.grpc.NameResolver.ServiceConfigParser;
+import io.grpc.NameResolverProvider;
+import io.grpc.NameResolverRegistry;
 import io.grpc.ProxyDetector;
 import io.grpc.SynchronizationContext;
+import io.grpc.inprocess.InProcessSocketAddress;
 import java.lang.Thread.UncaughtExceptionHandler;
+import java.net.InetSocketAddress;
 import java.net.URI;
+import java.util.Collections;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link ManagedChannelImpl#getNameResolver(
- * String, String,NameResolver.Factory, NameResolver.Args)}. */
+/** Unit tests for ManagedChannelImpl#getNameResolver(). */
 @RunWith(JUnit4.class)
 public class ManagedChannelImplGetNameResolverTest {
   private static final NameResolver.Args NAMERESOLVER_ARGS = NameResolver.Args.newBuilder()
@@ -68,9 +73,10 @@ public class ManagedChannelImplGetNameResolverTest {
     String target = "foo.googleapis.com:8080";
     String overrideAuthority = "override.authority";
     URI expectedUri = new URI("defaultscheme", "", "/foo.googleapis.com:8080", null);
-    NameResolver.Factory nameResolverFactory = new FakeNameResolverFactory(expectedUri.getScheme());
+    NameResolverRegistry nameResolverRegistry = getTestRegistry(expectedUri.getScheme());
     NameResolver nameResolver = ManagedChannelImpl.getNameResolver(
-        target, overrideAuthority, nameResolverFactory, NAMERESOLVER_ARGS);
+        target, overrideAuthority, nameResolverRegistry, NAMERESOLVER_ARGS,
+        Collections.singleton(InetSocketAddress.class));
     assertThat(nameResolver.getServiceAuthority()).isEqualTo(overrideAuthority);
   }
 
@@ -116,10 +122,21 @@ public class ManagedChannelImplGetNameResolverTest {
   }
 
   @Test
-  public void validTargetNoResovler() {
-    NameResolver.Factory nameResolverFactory = new NameResolver.Factory() {
+  public void validTargetNoResolver() {
+    NameResolverRegistry nameResolverRegistry = new NameResolverRegistry();
+    NameResolverProvider nameResolverProvider = new NameResolverProvider() {
       @Override
-      public NameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
+      protected boolean isAvailable() {
+        return true;
+      }
+
+      @Override
+      protected int priority() {
+        return 5;
+      }
+
+      @Override
+      public NameResolver newNameResolver(URI targetUri, Args args) {
         return null;
       }
 
@@ -128,41 +145,81 @@ public class ManagedChannelImplGetNameResolverTest {
         return "defaultscheme";
       }
     };
+    nameResolverRegistry.register(nameResolverProvider);
     try {
       ManagedChannelImpl.getNameResolver(
-          "foo.googleapis.com:8080", null, nameResolverFactory, NAMERESOLVER_ARGS);
+          "foo.googleapis.com:8080", null, nameResolverRegistry, NAMERESOLVER_ARGS,
+          Collections.singleton(InetSocketAddress.class));
       fail("Should fail");
     } catch (IllegalArgumentException e) {
       // expected
     }
   }
 
+  @Test
+  public void validTargetNoProvider() {
+    NameResolverRegistry nameResolverRegistry = new NameResolverRegistry();
+    try {
+      ManagedChannelImpl.getNameResolver(
+          "foo.googleapis.com:8080", null, nameResolverRegistry, NAMERESOLVER_ARGS,
+          Collections.singleton(InetSocketAddress.class));
+      fail("Should fail");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void validTargetProviderAddrTypesNotSupported() {
+    NameResolverRegistry nameResolverRegistry = getTestRegistry("testscheme");
+    try {
+      ManagedChannelImpl.getNameResolver(
+          "testscheme:///foo.googleapis.com:8080", null, nameResolverRegistry, NAMERESOLVER_ARGS,
+          Collections.singleton(InProcessSocketAddress.class));
+      fail("Should fail");
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessageThat().isEqualTo(
+          "Address types of NameResolver 'testscheme' for "
+              + "'testscheme:///foo.googleapis.com:8080' not supported by transport");
+    }
+  }
+
+
   private void testValidTarget(String target, String expectedUriString, URI expectedUri) {
-    NameResolver.Factory nameResolverFactory = new FakeNameResolverFactory(expectedUri.getScheme());
+    NameResolverRegistry nameResolverRegistry = getTestRegistry(expectedUri.getScheme());
     FakeNameResolver nameResolver
         = (FakeNameResolver) ((RetryingNameResolver) ManagedChannelImpl.getNameResolver(
-            target, null, nameResolverFactory, NAMERESOLVER_ARGS)).getRetriedNameResolver();
+        target, null, nameResolverRegistry, NAMERESOLVER_ARGS,
+        Collections.singleton(InetSocketAddress.class))).getRetriedNameResolver();
     assertNotNull(nameResolver);
     assertEquals(expectedUri, nameResolver.uri);
     assertEquals(expectedUriString, nameResolver.uri.toString());
   }
 
   private void testInvalidTarget(String target) {
-    NameResolver.Factory nameResolverFactory = new FakeNameResolverFactory("dns");
+    NameResolverRegistry nameResolverRegistry = getTestRegistry("dns");
 
     try {
       FakeNameResolver nameResolver = (FakeNameResolver) ManagedChannelImpl.getNameResolver(
-          target, null, nameResolverFactory, NAMERESOLVER_ARGS);
+          target, null, nameResolverRegistry, NAMERESOLVER_ARGS,
+          Collections.singleton(InetSocketAddress.class));
       fail("Should have failed, but got resolver with " + nameResolver.uri);
     } catch (IllegalArgumentException e) {
       // expected
     }
   }
 
-  private static class FakeNameResolverFactory extends NameResolver.Factory {
+  private static NameResolverRegistry getTestRegistry(String expectedScheme) {
+    NameResolverRegistry nameResolverRegistry = new NameResolverRegistry();
+    FakeNameResolverProvider nameResolverProvider = new FakeNameResolverProvider(expectedScheme);
+    nameResolverRegistry.register(nameResolverProvider);
+    return nameResolverRegistry;
+  }
+
+  private static class FakeNameResolverProvider extends NameResolverProvider {
     final String expectedScheme;
 
-    FakeNameResolverFactory(String expectedScheme) {
+    FakeNameResolverProvider(String expectedScheme) {
       this.expectedScheme = expectedScheme;
     }
 
@@ -177,6 +234,16 @@ public class ManagedChannelImplGetNameResolverTest {
     @Override
     public String getDefaultScheme() {
       return expectedScheme;
+    }
+
+    @Override
+    protected boolean isAvailable() {
+      return true;
+    }
+
+    @Override
+    protected int priority() {
+      return 5;
     }
   }
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -66,6 +66,7 @@ import io.grpc.StringMarshaller;
 import io.grpc.internal.FakeClock.ScheduledTask;
 import io.grpc.internal.ManagedChannelImplBuilder.UnsupportedClientTransportFactoryBuilder;
 import io.grpc.internal.TestUtils.MockClientTransportInfo;
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.util.ArrayList;
@@ -160,8 +161,12 @@ public class ManagedChannelImplIdlenessTest {
     when(mockNameResolverFactory
         .newNameResolver(any(URI.class), any(NameResolver.Args.class)))
         .thenReturn(mockNameResolver);
+    when(mockNameResolverFactory.getDefaultScheme())
+        .thenReturn("mockscheme");
     when(mockTransportFactory.getScheduledExecutorService())
         .thenReturn(timer.getScheduledExecutorService());
+    when(mockTransportFactory.getSupportedSocketAddressTypes())
+        .thenReturn(Collections.singleton(InetSocketAddress.class));
 
     ManagedChannelImplBuilder builder = new ManagedChannelImplBuilder("fake://target",
         new UnsupportedClientTransportFactoryBuilder(), null);

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -168,7 +168,7 @@ public class ManagedChannelImplIdlenessTest {
     when(mockTransportFactory.getSupportedSocketAddressTypes())
         .thenReturn(Collections.singleton(InetSocketAddress.class));
 
-    ManagedChannelImplBuilder builder = new ManagedChannelImplBuilder("fake://target",
+    ManagedChannelImplBuilder builder = new ManagedChannelImplBuilder("mockscheme:///target",
         new UnsupportedClientTransportFactoryBuilder(), null);
 
     builder

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -1724,7 +1724,7 @@ public class ManagedChannelImplTest {
     // Verify that resolving oob channel does not
     oob = helper.createResolvingOobChannelBuilder("oobauthority")
         .nameResolverFactory(
-            new FakeNameResolverFactory.Builder(URI.create("oobauthority")).build())
+            new FakeNameResolverFactory.Builder(URI.create("fake:///oobauthority")).build())
         .defaultLoadBalancingPolicy(MOCK_POLICY_NAME)
         .idleTimeout(ManagedChannelImplBuilder.IDLE_MODE_MAX_TIMEOUT_DAYS, TimeUnit.DAYS)
         .disableRetry() // irrelevant to what we test, disable retry to make verification easy
@@ -2617,7 +2617,7 @@ public class ManagedChannelImplTest {
       }
 
       @Override public String getDefaultScheme() {
-        return "fakescheme";
+        return "fake";
       }
     });
     createChannel();
@@ -3833,7 +3833,7 @@ public class ManagedChannelImplTest {
 
         @Override
         public String getDefaultScheme() {
-          return "fakescheme";
+          return "fake";
         }
       };
     channelBuilder.nameResolverFactory(factory).proxyDetector(neverProxy);

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -122,6 +122,7 @@ import io.grpc.stub.ClientCalls;
 import io.grpc.testing.TestMethodDescriptors;
 import io.grpc.util.ForwardingSubchannel;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.util.ArrayList;
@@ -287,6 +288,8 @@ public class ManagedChannelImplTest {
       ClientInterceptor... interceptors) {
     checkState(channel == null);
 
+    when(mockTransportFactory.getSupportedSocketAddressTypes()).thenReturn(Collections.singleton(
+        InetSocketAddress.class));
     channel = new ManagedChannelImpl(
         channelBuilder, mockTransportFactory, new FakeBackoffPolicyProvider(),
         balancerRpcExecutorPool, timer.getStopwatchSupplier(), Arrays.asList(interceptors),
@@ -472,6 +475,8 @@ public class ManagedChannelImplTest {
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(ImmutableList.of(addressGroup)).build();
     channelBuilder.nameResolverFactory(nameResolverFactory);
+    when(mockTransportFactory.getSupportedSocketAddressTypes()).thenReturn(Collections.singleton(
+        InetSocketAddress.class));
     channel = new ManagedChannelImpl(
         channelBuilder, mockTransportFactory, new FakeBackoffPolicyProvider(),
         balancerRpcExecutorPool, timer.getStopwatchSupplier(),
@@ -534,6 +539,8 @@ public class ManagedChannelImplTest {
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(ImmutableList.of(addressGroup)).build();
     channelBuilder.nameResolverFactory(nameResolverFactory);
+    when(mockTransportFactory.getSupportedSocketAddressTypes()).thenReturn(Collections.singleton(
+        InetSocketAddress.class));
     channel = new ManagedChannelImpl(
         channelBuilder, mockTransportFactory, new FakeBackoffPolicyProvider(),
         balancerRpcExecutorPool, timer.getStopwatchSupplier(),
@@ -2041,11 +2048,11 @@ public class ManagedChannelImplTest {
   }
 
   @Test
-  public void lbHelper_getNameResolverRegistry() {
+  public void lbHelper_getNonDefaultNameResolverRegistry() {
     createChannel();
 
     assertThat(helper.getNameResolverRegistry())
-        .isSameInstanceAs(NameResolverRegistry.getDefaultRegistry());
+        .isNotSameInstanceAs(NameResolverRegistry.getDefaultRegistry());
   }
 
   @Test
@@ -3744,6 +3751,8 @@ public class ManagedChannelImplTest {
           }
         },
         null);
+    when(mockTransportFactory.getSupportedSocketAddressTypes()).thenReturn(Collections.singleton(
+        InetSocketAddress.class));
     customBuilder.executorPool = executorPool;
     customBuilder.channelz = channelz;
     ManagedChannel mychannel = customBuilder.nameResolverFactory(factory).build();

--- a/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
+++ b/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
@@ -48,6 +48,7 @@ import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.Status;
 import io.grpc.internal.ManagedChannelImplBuilder.FixedPortProvider;
 import io.grpc.internal.ManagedChannelImplBuilder.UnsupportedClientTransportFactoryBuilder;
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.util.ArrayList;
@@ -158,6 +159,8 @@ public class ServiceConfigErrorHandlingTest {
   private void createChannel(ClientInterceptor... interceptors) {
     checkState(channel == null);
 
+    when(mockTransportFactory.getSupportedSocketAddressTypes()).thenReturn(Collections.singleton(
+        InetSocketAddress.class));
     channel =
         new ManagedChannelImpl(
             channelBuilder,

--- a/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
@@ -284,6 +284,11 @@ public final class CronetChannelBuilder
         SharedResourceHolder.release(GrpcUtil.TIMER_SERVICE, timeoutService);
       }
     }
+
+    @Override
+    public Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
+      return Collections.singleton(InetSocketAddress.class);
+    }
   }
 
   /**

--- a/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
@@ -42,6 +42,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.Collections;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Nullable;

--- a/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
@@ -42,6 +42,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;

--- a/googleapis/src/main/java/io/grpc/googleapis/GoogleCloudToProdNameResolverProvider.java
+++ b/googleapis/src/main/java/io/grpc/googleapis/GoogleCloudToProdNameResolverProvider.java
@@ -74,7 +74,7 @@ public final class GoogleCloudToProdNameResolverProvider extends NameResolverPro
   }
 
   @Override
-  protected Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
+  public Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
     return Collections.singleton(InetSocketAddress.class);
   }
 

--- a/grpclb/src/main/java/io/grpc/grpclb/SecretGrpclbNameResolverProvider.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/SecretGrpclbNameResolverProvider.java
@@ -94,7 +94,7 @@ final class SecretGrpclbNameResolverProvider {
     }
 
     @Override
-    protected Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
+    public Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
       return Collections.singleton(InetSocketAddress.class);
     }
   }

--- a/inprocess/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/inprocess/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -33,6 +33,8 @@ import io.grpc.internal.ManagedChannelImplBuilder;
 import io.grpc.internal.ManagedChannelImplBuilder.ClientTransportFactoryBuilder;
 import io.grpc.internal.SharedResourceHolder;
 import java.net.SocketAddress;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
@@ -282,6 +284,11 @@ public final class InProcessChannelBuilder extends
       if (useSharedTimer) {
         SharedResourceHolder.release(GrpcUtil.TIMER_SERVICE, timerService);
       }
+    }
+
+    @Override
+    public Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
+      return Collections.singleton(InProcessSocketAddress.class);
     }
   }
 }

--- a/inprocess/src/main/java/io/grpc/inprocess/InProcessNameResolver.java
+++ b/inprocess/src/main/java/io/grpc/inprocess/InProcessNameResolver.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.inprocess;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Preconditions;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.NameResolver;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+final class InProcessNameResolver extends NameResolver {
+  private Listener2 listener;
+  private final String authority;
+
+  InProcessNameResolver(String authority, String targetPath) {
+    checkArgument(authority == null, "non-null authority not supported");
+    this.authority = targetPath;
+  }
+
+  @Override
+  public String getServiceAuthority() {
+    return this.authority;
+  }
+
+  @Override
+  public void start(Listener2 listener) {
+    Preconditions.checkState(this.listener == null, "already started");
+    this.listener = checkNotNull(listener, "listener");
+    resolve();
+  }
+
+  @Override
+  public void refresh() {
+    resolve();
+  }
+
+  private void resolve() {
+    ResolutionResult.Builder resolutionResultBuilder = ResolutionResult.newBuilder();
+    List<EquivalentAddressGroup> servers = new ArrayList<>(1);
+    servers.add(new EquivalentAddressGroup(new InProcessSocketAddress(authority)));
+    resolutionResultBuilder.setAddresses(Collections.unmodifiableList(servers));
+    listener.onResult(resolutionResultBuilder.build());
+  }
+
+  @Override
+  public void shutdown() {}
+}

--- a/inprocess/src/main/java/io/grpc/inprocess/InProcessNameResolverProvider.java
+++ b/inprocess/src/main/java/io/grpc/inprocess/InProcessNameResolverProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The gRPC Authors
+ * Copyright 2023 The gRPC Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,27 +14,26 @@
  * limitations under the License.
  */
 
-package io.grpc.netty;
+package io.grpc.inprocess;
 
 import com.google.common.base.Preconditions;
 import io.grpc.Internal;
 import io.grpc.NameResolver;
 import io.grpc.NameResolverProvider;
-import io.netty.channel.unix.DomainSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
 
 @Internal
-public final class UdsNameResolverProvider extends NameResolverProvider {
+public final class InProcessNameResolverProvider extends NameResolverProvider {
 
-  private static final String SCHEME = "unix";
+  private static final String SCHEME = "inprocess";
 
   @Override
-  public UdsNameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
+  public InProcessNameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
     if (SCHEME.equals(targetUri.getScheme())) {
-      return new UdsNameResolver(targetUri.getAuthority(), getTargetPathFromUri(targetUri));
+      return new InProcessNameResolver(targetUri.getAuthority(), getTargetPathFromUri(targetUri));
     } else {
       return null;
     }
@@ -66,6 +65,6 @@ public final class UdsNameResolverProvider extends NameResolverProvider {
 
   @Override
   public Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
-    return Collections.singleton(DomainSocketAddress.class);
+    return Collections.singleton(InProcessSocketAddress.class);
   }
 }

--- a/inprocess/src/main/resources/META-INF/services/io.grpc.NameResolverProvider
+++ b/inprocess/src/main/resources/META-INF/services/io.grpc.NameResolverProvider
@@ -1,0 +1,1 @@
+io.grpc.inprocess.InProcessNameResolverProvider

--- a/inprocess/src/test/java/io/grpc/inprocess/InProcessNameResolverProviderTest.java
+++ b/inprocess/src/test/java/io/grpc/inprocess/InProcessNameResolverProviderTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2023 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.inprocess;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.verify;
+
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.NameResolver;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+/** Unit tests for {@link InProcessNameResolverProvider}. */
+@RunWith(JUnit4.class)
+public class InProcessNameResolverProviderTest {
+
+  @Rule
+  public final MockitoRule mocks = MockitoJUnit.rule();
+
+  @Mock
+  private NameResolver.Listener2 mockListener;
+
+  @Captor
+  private ArgumentCaptor<NameResolver.ResolutionResult> resultCaptor;
+
+  InProcessNameResolverProvider inProcessNameResolverProvider = new InProcessNameResolverProvider();
+
+
+  @Test
+  public void testRelativePath() {
+    InProcessNameResolver inProcessNameResolver =
+        inProcessNameResolverProvider.newNameResolver(URI.create("inprocess:proc.proc"), null);
+    assertThat(inProcessNameResolver).isNotNull();
+    inProcessNameResolver.start(mockListener);
+    verify(mockListener).onResult(resultCaptor.capture());
+    NameResolver.ResolutionResult result = resultCaptor.getValue();
+    List<EquivalentAddressGroup> list = result.getAddresses();
+    assertThat(list).isNotNull();
+    assertThat(list).hasSize(1);
+    EquivalentAddressGroup eag = list.get(0);
+    assertThat(eag).isNotNull();
+    List<SocketAddress> addresses = eag.getAddresses();
+    assertThat(addresses).hasSize(1);
+    assertThat(addresses.get(0)).isInstanceOf(InProcessSocketAddress.class);
+    InProcessSocketAddress domainSocketAddress = (InProcessSocketAddress) addresses.get(0);
+    assertThat(domainSocketAddress.getName()).isEqualTo("proc.proc");
+  }
+
+  @Test
+  public void testAbsolutePath() {
+    InProcessNameResolver inProcessNameResolver =
+        inProcessNameResolverProvider.newNameResolver(URI.create("inprocess:/proc.proc"), null);
+    assertThat(inProcessNameResolver).isNotNull();
+    inProcessNameResolver.start(mockListener);
+    verify(mockListener).onResult(resultCaptor.capture());
+    NameResolver.ResolutionResult result = resultCaptor.getValue();
+    List<EquivalentAddressGroup> list = result.getAddresses();
+    assertThat(list).isNotNull();
+    assertThat(list).hasSize(1);
+    EquivalentAddressGroup eag = list.get(0);
+    assertThat(eag).isNotNull();
+    List<SocketAddress> addresses = eag.getAddresses();
+    assertThat(addresses).hasSize(1);
+    assertThat(addresses.get(0)).isInstanceOf(InProcessSocketAddress.class);
+    InProcessSocketAddress domainSocketAddress = (InProcessSocketAddress) addresses.get(0);
+    assertThat(domainSocketAddress.getName()).isEqualTo("/proc.proc");
+  }
+
+  @Test
+  public void testAbsoluteAlternatePath() {
+    InProcessNameResolver udsNameResolver =
+        inProcessNameResolverProvider.newNameResolver(URI.create("inprocess:///proc.proc"), null);
+    assertThat(udsNameResolver).isNotNull();
+    udsNameResolver.start(mockListener);
+    verify(mockListener).onResult(resultCaptor.capture());
+    NameResolver.ResolutionResult result = resultCaptor.getValue();
+    List<EquivalentAddressGroup> list = result.getAddresses();
+    assertThat(list).isNotNull();
+    assertThat(list).hasSize(1);
+    EquivalentAddressGroup eag = list.get(0);
+    assertThat(eag).isNotNull();
+    List<SocketAddress> addresses = eag.getAddresses();
+    assertThat(addresses).hasSize(1);
+    assertThat(addresses.get(0)).isInstanceOf(InProcessSocketAddress.class);
+    InProcessSocketAddress domainSocketAddress = (InProcessSocketAddress) addresses.get(0);
+    assertThat(domainSocketAddress.getName()).isEqualTo("/proc.proc");
+  }
+
+  @Test
+  public void testWrongScheme() {
+    assertNull(inProcessNameResolverProvider.newNameResolver(URI.create(
+        "badscheme://localhost/proc.proc"), null));
+  }
+
+  @Test
+  public void testPathWithAuthority() {
+    try {
+      inProcessNameResolverProvider.newNameResolver(
+          URI.create("inprocess://localhost/proc.proc"), null);
+      fail("exception expected");
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessageThat().isEqualTo(
+          "non-null authority not supported");
+    }
+  }
+}

--- a/inprocess/src/test/java/io/grpc/inprocess/InProcessNameResolverTest.java
+++ b/inprocess/src/test/java/io/grpc/inprocess/InProcessNameResolverTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.inprocess;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.verify;
+
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.NameResolver;
+import java.net.SocketAddress;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+/** Unit tests for {@link InProcessNameResolver}. */
+@RunWith(JUnit4.class)
+public class InProcessNameResolverTest {
+
+  @Rule
+  public final MockitoRule mocks = MockitoJUnit.rule();
+
+  @Mock
+  private NameResolver.Listener2 mockListener;
+
+  @Captor
+  private ArgumentCaptor<NameResolver.ResolutionResult> resultCaptor;
+
+  private InProcessNameResolver inProcessNameResolver;
+
+  @Test
+  public void testValidTargetPath() {
+    inProcessNameResolver = new InProcessNameResolver(null, "proc.proc");
+    inProcessNameResolver.start(mockListener);
+    verify(mockListener).onResult(resultCaptor.capture());
+    NameResolver.ResolutionResult result = resultCaptor.getValue();
+    List<EquivalentAddressGroup> list = result.getAddresses();
+    assertThat(list).isNotNull();
+    assertThat(list).hasSize(1);
+    EquivalentAddressGroup eag = list.get(0);
+    assertThat(eag).isNotNull();
+    List<SocketAddress> addresses = eag.getAddresses();
+    assertThat(addresses).hasSize(1);
+    assertThat(addresses.get(0)).isInstanceOf(InProcessSocketAddress.class);
+    InProcessSocketAddress socketAddress = (InProcessSocketAddress) addresses.get(0);
+    assertThat(socketAddress.getName()).isEqualTo("proc.proc");
+    assertThat(inProcessNameResolver.getServiceAuthority()).isEqualTo("proc.proc");
+  }
+
+  @Test
+  public void testNonNullAuthority() {
+    try {
+      inProcessNameResolver = new InProcessNameResolver("authority", "proc.proc");
+      fail("exception expected");
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessageThat().isEqualTo("non-null authority not supported");
+    }
+  }
+}

--- a/inprocess/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
+++ b/inprocess/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
@@ -174,7 +174,7 @@ public class InProcessTransportTest extends AbstractTransportTest {
       fail("Call should fail.");
     } catch (ExecutionException ex) {
       StatusRuntimeException s = (StatusRuntimeException)ex.getCause();
-      assertEquals(s.getStatus().getCode(), Code.UNIMPLEMENTED);
+      assertEquals(Code.UNIMPLEMENTED, s.getStatus().getCode());
     }
   }
 }

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
@@ -57,7 +57,7 @@ public class Http2NettyLocalChannelTest extends AbstractInteropTest {
     NettyChannelBuilder builder = NettyChannelBuilder
         .forAddress(new LocalAddress("in-process-1"))
         .negotiationType(NegotiationType.PLAINTEXT)
-        .channelType(LocalChannel.class)
+        .channelType(LocalChannel.class, LocalAddress.class)
         .eventLoopGroup(eventLoopGroup)
         .flowControlWindow(AbstractInteropTest.TEST_FLOW_CONTROL_WINDOW)
         .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE);

--- a/interop-testing/src/test/java/io/grpc/testing/integration/RetryTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/RetryTest.java
@@ -191,7 +191,7 @@ public class RetryTest {
     rawServiceConfig.put("methodConfig", Arrays.<Object>asList(methodConfig));
     channel = cleanupRule.register(
         NettyChannelBuilder.forAddress(localAddress)
-            .channelType(LocalChannel.class)
+            .channelType(LocalChannel.class, LocalAddress.class)
             .eventLoopGroup(group)
             .usePlaintext()
             .enableRetry()

--- a/netty/src/main/java/io/grpc/netty/InternalNettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/InternalNettyChannelBuilder.java
@@ -23,6 +23,7 @@ import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.SharedResourcePool;
 import io.grpc.internal.TransportTracer;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import java.net.InetSocketAddress;
 
 /**
  * Internal {@link NettyChannelBuilder} accessor.  This is intended for usage internal to the gRPC
@@ -100,7 +101,7 @@ public final class InternalNettyChannelBuilder {
    * io.netty.channel.EventLoopGroup}.
    */
   public static void useNioTransport(NettyChannelBuilder builder) {
-    builder.channelType(NioSocketChannel.class);
+    builder.channelType(NioSocketChannel.class, InetSocketAddress.class);
     builder
         .eventLoopGroupPool(SharedResourcePool.forResource(Utils.NIO_WORKER_EVENT_LOOP_GROUP));
   }

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -264,7 +264,6 @@ public final class NettyChannelBuilder extends
    * your application won't start.
    */
   @CanIgnoreReturnValue
-  @SuppressWarnings("unchecked")
   public NettyChannelBuilder channelType(Class<? extends Channel> channelType) {
     checkNotNull(channelType, "channelType");
     try {
@@ -272,8 +271,8 @@ public final class NettyChannelBuilder extends
       checkNotNull(method, "method for remoteAddress");
       Class<?> returnType = method.getReturnType();
       checkState(SocketAddress.class.isAssignableFrom(returnType),
-          "Unexpected return type:" + returnType.getSimpleName());
-      this.transportSocketType = (Class<? extends SocketAddress>) returnType;
+          "Unexpected return type: %s", returnType.getSimpleName());
+      this.transportSocketType = returnType.asSubclass(SocketAddress.class);
     } catch (NoSuchMethodException e) {
       throw new RuntimeException(e);
     }

--- a/netty/src/main/java/io/grpc/netty/NettyChannelProvider.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelProvider.java
@@ -19,10 +19,8 @@ package io.grpc.netty;
 import io.grpc.ChannelCredentials;
 import io.grpc.Internal;
 import io.grpc.ManagedChannelProvider;
-import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Collection;
-import java.util.Collections;
 
 /** Provider for {@link NettyChannelBuilder} instances. */
 @Internal
@@ -59,6 +57,6 @@ public final class NettyChannelProvider extends ManagedChannelProvider {
 
   @Override
   protected Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
-    return Collections.singleton(InetSocketAddress.class);
+    return NettyChannelBuilder.getSupportedSocketAddressTypes();
   }
 }

--- a/netty/src/main/java/io/grpc/netty/UdsNettyChannelProvider.java
+++ b/netty/src/main/java/io/grpc/netty/UdsNettyChannelProvider.java
@@ -16,6 +16,7 @@
 
 package io.grpc.netty;
 
+import com.google.common.base.Preconditions;
 import io.grpc.ChannelCredentials;
 import io.grpc.Internal;
 import io.grpc.ManagedChannelProvider;
@@ -51,11 +52,12 @@ public final class UdsNettyChannelProvider extends ManagedChannelProvider {
 
   @Override
   public NewChannelBuilderResult newChannelBuilder(String target, ChannelCredentials creds) {
+    Preconditions.checkState(isAvailable());
     NewChannelBuilderResult result = new NettyChannelProvider().newChannelBuilder(target, creds);
     if (result.getChannelBuilder() != null) {
       ((NettyChannelBuilder) result.getChannelBuilder())
           .eventLoopGroupPool(SharedResourcePool.forResource(Utils.DEFAULT_WORKER_EVENT_LOOP_GROUP))
-          .channelType(Utils.EPOLL_DOMAIN_CLIENT_CHANNEL_TYPE);
+          .channelType(Utils.EPOLL_DOMAIN_CLIENT_CHANNEL_TYPE, DomainSocketAddress.class);
     }
     return result;
   }

--- a/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
@@ -80,9 +80,14 @@ public class NettyChannelBuilderTest {
     overrideAuthorityIsReadableHelper(builder, "override:5678");
   }
 
+  private static SocketAddress getTestSocketAddress() {
+    return new InetSocketAddress("1.1.1.1", 80);
+  }
+
   @Test
   public void overrideAuthorityIsReadableForSocketAddress() throws Exception {
-    NettyChannelBuilder builder = NettyChannelBuilder.forAddress(new SocketAddress(){});
+    NettyChannelBuilder builder = NettyChannelBuilder.forAddress(
+        getTestSocketAddress());
     overrideAuthorityIsReadableHelper(builder, "override:5678");
   }
 
@@ -99,7 +104,7 @@ public class NettyChannelBuilderTest {
 
   @Test
   public void failOverrideInvalidAuthority() {
-    NettyChannelBuilder builder = new NettyChannelBuilder(new SocketAddress(){});
+    NettyChannelBuilder builder = new NettyChannelBuilder(getTestSocketAddress());
 
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Invalid authority:");
@@ -109,7 +114,7 @@ public class NettyChannelBuilderTest {
 
   @Test
   public void disableCheckAuthorityAllowsInvalidAuthority() {
-    NettyChannelBuilder builder = new NettyChannelBuilder(new SocketAddress(){})
+    NettyChannelBuilder builder = new NettyChannelBuilder(getTestSocketAddress())
         .disableCheckAuthority();
 
     Object unused = builder.overrideAuthority("[invalidauthority")
@@ -119,7 +124,7 @@ public class NettyChannelBuilderTest {
 
   @Test
   public void enableCheckAuthorityFailOverrideInvalidAuthority() {
-    NettyChannelBuilder builder = new NettyChannelBuilder(new SocketAddress(){})
+    NettyChannelBuilder builder = new NettyChannelBuilder(getTestSocketAddress())
         .disableCheckAuthority()
         .enableCheckAuthority();
 
@@ -139,14 +144,14 @@ public class NettyChannelBuilderTest {
 
   @Test
   public void sslContextCanBeNull() {
-    NettyChannelBuilder builder = new NettyChannelBuilder(new SocketAddress(){});
+    NettyChannelBuilder builder = new NettyChannelBuilder(getTestSocketAddress());
     builder.sslContext(null);
   }
 
   @Test
   public void failIfSslContextIsNotClient() {
     SslContext sslContext = mock(SslContext.class);
-    NettyChannelBuilder builder = new NettyChannelBuilder(new SocketAddress(){});
+    NettyChannelBuilder builder = new NettyChannelBuilder(getTestSocketAddress());
 
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Server SSL context can not be used for client channel");
@@ -168,7 +173,7 @@ public class NettyChannelBuilderTest {
   @Test
   public void failNegotiationTypeWithChannelCredentials_socketAddress() {
     NettyChannelBuilder builder = NettyChannelBuilder.forAddress(
-        new SocketAddress(){}, InsecureChannelCredentials.create());
+        getTestSocketAddress(), InsecureChannelCredentials.create());
 
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("Cannot change security when using ChannelCredentials");

--- a/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
@@ -32,6 +32,7 @@ import io.grpc.netty.ProtocolNegotiators.PlaintextProtocolNegotiatorClientFactor
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFactory;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.handler.ssl.SslContext;
 import java.net.InetSocketAddress;
@@ -270,7 +271,7 @@ public class NettyChannelBuilderTest {
   @Test
   public void assertEventLoopAndChannelType_onlyTypeProvided() {
     NettyChannelBuilder builder = NettyChannelBuilder.forTarget("fakeTarget");
-    builder.channelType(LocalChannel.class);
+    builder.channelType(LocalChannel.class, LocalAddress.class);
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("Both EventLoopGroup and ChannelType should be provided");
 
@@ -303,7 +304,7 @@ public class NettyChannelBuilderTest {
   public void assertEventLoopAndChannelType_bothProvided() {
     NettyChannelBuilder builder = NettyChannelBuilder.forTarget("fakeTarget");
     builder.eventLoopGroup(mock(EventLoopGroup.class));
-    builder.channelType(LocalChannel.class);
+    builder.channelType(LocalChannel.class, LocalAddress.class);
 
     builder.assertEventLoopAndChannelType();
   }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -60,6 +60,8 @@ import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
 import java.util.concurrent.Executor;
@@ -722,6 +724,10 @@ public final class OkHttpChannelBuilder extends
     return trustManagerFactory.getTrustManagers();
   }
 
+  static Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
+    return Collections.singleton(InetSocketAddress.class);
+  }
+
   static final class SslSocketFactoryResult {
     /** {@code null} implies plaintext if {@code error == null}. */
     public final SSLSocketFactory factory;
@@ -897,6 +903,11 @@ public final class OkHttpChannelBuilder extends
 
       executorPool.returnObject(executor);
       scheduledExecutorServicePool.returnObject(scheduledExecutorService);
+    }
+
+    @Override
+    public Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
+      return OkHttpChannelBuilder.getSupportedSocketAddressTypes();
     }
   }
 }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelProvider.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelProvider.java
@@ -20,10 +20,8 @@ import io.grpc.ChannelCredentials;
 import io.grpc.Internal;
 import io.grpc.InternalServiceProviders;
 import io.grpc.ManagedChannelProvider;
-import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Collection;
-import java.util.Collections;
 
 /**
  * Provider for {@link OkHttpChannelBuilder} instances.
@@ -64,6 +62,6 @@ public final class OkHttpChannelProvider extends ManagedChannelProvider {
 
   @Override
   protected Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
-    return Collections.singleton(InetSocketAddress.class);
+    return OkHttpChannelBuilder.getSupportedSocketAddressTypes();
   }
 }

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
@@ -105,7 +105,7 @@ public final class XdsNameResolverProvider extends NameResolverProvider {
   }
 
   @Override
-  protected Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
+  public Collection<Class<? extends SocketAddress>> getProducedSocketAddressTypes() {
     return Collections.singleton(InetSocketAddress.class);
   }
 


### PR DESCRIPTION
fix ManagedChannelImpl to use NameResolverRegistry instead of NameResolverFactory fix the ManagedChannelImplBuilder and remove nameResolverFactory