### PR TITLE
interop-testing: Logging of stress test metrics

### DIFF
--- a/interop-testing/src/test/java/io/grpc/testing/integration/StressTestClientTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/StressTestClientTest.java
@@ -79,7 +79,8 @@ public class StressTestClientTest {
         "--metrics_port=9090",
         "--server_host_override=foo.test.google.fr",
         "--use_tls=true",
-        "--use_test_ca=true"
+        "--use_test_ca=true",
+        "--metrics_log_rate_secs=60"
     });
 
     List<InetSocketAddress> addresses = Arrays.asList(new InetSocketAddress("localhost", 8080),
@@ -99,6 +100,7 @@ public class StressTestClientTest {
     assertEquals(10, client.channelsPerServer());
     assertEquals(5, client.stubsPerChannel());
     assertEquals(9090, client.metricsPort());
+    assertEquals(60, client.metricsLogRateSecs());
   }
 
   @Test


### PR DESCRIPTION
Introduces a flag to enable the logging of collected metrics. In some cases it can be more practical to analyze the metrics from a log file after the fact, instead of connecting to the metrics server to collect the metrics as the client is running.