### PR TITLE
interop-testing: Custom credentials in stress test

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
@@ -204,7 +204,7 @@ public class StressTestClient {
               + "\n  --use_test_ca=true|false       Whether to trust our fake CA. Requires"
               + " --use_tls=true"
               + "\n                                 to have effect. Default: " + c.useTestCa
-              + "\n  --custom_credentials_type   Custom credentials type to use. Default "
+              + "\n  --custom_credentials_type      Custom credentials type to use. Default "
               + c.customCredentialsType
               + "\n  --test_duration_secs=SECONDS   '-1' for no limit. Default: " + c.durationSecs
               + "\n  --num_channels_per_server=INT  Number of connections to each server address."

--- a/interop-testing/src/test/java/io/grpc/testing/integration/StressTestClientTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/StressTestClientTest.java
@@ -67,7 +67,7 @@ public class StressTestClientTest {
     assertEquals(1, client.stubsPerChannel());
     assertEquals(8081, client.metricsPort());
     assertEquals(-1, client.metricsLogRateSecs());
-    assertNull((client.customCredentialsType()));
+    assertNull(client.customCredentialsType());
   }
 
   @Test

--- a/interop-testing/src/test/java/io/grpc/testing/integration/StressTestClientTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/StressTestClientTest.java
@@ -19,6 +19,7 @@ package io.grpc.testing.integration;
 import static com.google.common.collect.Sets.newHashSet;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
@@ -65,6 +66,8 @@ public class StressTestClientTest {
     assertEquals(1, client.channelsPerServer());
     assertEquals(1, client.stubsPerChannel());
     assertEquals(8081, client.metricsPort());
+    assertEquals(-1, client.metricsLogRateSecs());
+    assertNull((client.customCredentialsType()));
   }
 
   @Test

--- a/interop-testing/src/test/java/io/grpc/testing/integration/StressTestClientTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/StressTestClientTest.java
@@ -80,6 +80,7 @@ public class StressTestClientTest {
         "--server_host_override=foo.test.google.fr",
         "--use_tls=true",
         "--use_test_ca=true",
+        "--custom_credentials_type=google_default_credentials",
         "--metrics_log_rate_secs=60"
     });
 
@@ -100,6 +101,7 @@ public class StressTestClientTest {
     assertEquals(10, client.channelsPerServer());
     assertEquals(5, client.stubsPerChannel());
     assertEquals(9090, client.metricsPort());
+    assertEquals("google_default_credentials", client.customCredentialsType());
     assertEquals(60, client.metricsLogRateSecs());
   }
 


### PR DESCRIPTION
Adds support for specifying either google default or compute engine "custom" credentials on the command line. This works like it does in TestServiceClient.

Another feature from TestServiceClient is also included - the channel builder is created differently when the server port is 0. This avoids some ipv6 address parsing shenanigans.