### PR TITLE
Modified netty-shaded resources to enable successful compilation into a native image.

### DIFF
--- a/netty/shaded/build.gradle
+++ b/netty/shaded/build.gradle
@@ -148,25 +148,16 @@ class NettyResourceTransformer implements Transformer {
 
     @Override
     void transform(TransformerContext context) {
-        String updatedPath = context.path.replace("io.netty", "io.grpc.netty.shaded.io.netty")
-        String updatedContent = context.is.getText().replace("io.netty", "io.grpc.netty.shaded.io.netty")
-        resources.put(updatedPath, updatedContent)
+        // don't include any file under META-INF/native-image/io.netty
     }
 
     @Override
     boolean hasTransformedResource() {
-        resources.size() > 0
+        return false
     }
 
     @Override
     void modifyOutputStream(ZipOutputStream outputStream, boolean preserveFileTimestamps) {
-        for (resourceEntry in resources) {
-            ZipEntry entry = new ZipEntry(resourceEntry.key)
-            entry.time = TransformerContext.getEntryTimestamp(preserveFileTimestamps, entry.time)
-
-            outputStream.putNextEntry(entry)
-            outputStream.write(resourceEntry.value.getBytes())
-            outputStream.closeEntry()
-        }
+        
     }
 }

--- a/netty/shaded/src/testShadow/java/io/grpc/netty/shaded/ShadingTest.java
+++ b/netty/shaded/src/testShadow/java/io/grpc/netty/shaded/ShadingTest.java
@@ -41,8 +41,6 @@ import io.grpc.testing.protobuf.SimpleServiceGrpc.SimpleServiceBlockingStub;
 import io.grpc.testing.protobuf.SimpleServiceGrpc.SimpleServiceImplBase;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Scanner;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Test;
@@ -80,12 +78,7 @@ public final class ShadingTest {
         .getResourceAsStream(
             "META-INF/native-image/io.grpc.netty.shaded.io.netty/netty-transport/"
                 + "reflection-config.json");
-    assertThat(inputStream).isNotNull();
-
-    Scanner s = new Scanner(inputStream, StandardCharsets.UTF_8.name()).useDelimiter("\\A");
-    String reflectionConfig = s.hasNext() ? s.next() : "";
-
-    assertThat(reflectionConfig).contains("io.grpc.netty.shaded.io.netty");
+    assertThat(inputStream).isNull();
   }
 
   @Test


### PR DESCRIPTION
This modification will delete all configuration files under the META-INF/native-image/io.netty folder. During testing, these configuration files will prevent successful compilation of the native image.
Fixes #10601 
