### PR TITLE
interop-testing: allow disabling of stream tracers

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -313,6 +313,11 @@ public abstract class AbstractInteropTest {
 
   private final LinkedBlockingQueue<TestClientStreamTracer> clientStreamTracers =
       new LinkedBlockingQueue<>();
+  private boolean enableClientStreamTracers = true;
+
+  void setEnableClientStreamTracers(boolean enableClientStreamTracers) {
+    this.enableClientStreamTracers = enableClientStreamTracers;
+  }
 
   private final ClientStreamTracer.Factory clientStreamTracerFactory =
       new ClientStreamTracer.Factory() {
@@ -343,9 +348,14 @@ public abstract class AbstractInteropTest {
     startServer(serverBuilder);
     channel = createChannel();
 
-    blockingStub =
-        TestServiceGrpc.newBlockingStub(channel).withInterceptors(tracerSetupInterceptor);
-    asyncStub = TestServiceGrpc.newStub(channel).withInterceptors(tracerSetupInterceptor);
+    if (enableClientStreamTracers) {
+      blockingStub =
+          TestServiceGrpc.newBlockingStub(channel).withInterceptors(tracerSetupInterceptor);
+      asyncStub = TestServiceGrpc.newStub(channel).withInterceptors(tracerSetupInterceptor);
+    } else {
+      blockingStub = TestServiceGrpc.newBlockingStub(channel);
+      asyncStub = TestServiceGrpc.newStub(channel);
+    }
 
     ClientInterceptor[] additionalInterceptors = getAdditionalInterceptors();
     if (additionalInterceptors != null) {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
@@ -466,6 +466,10 @@ public class StressTestClient {
 
       Tester tester = new Tester();
       tester.setUp();
+      // The client stream tracers that AbstractInteropTest installs by default would fill up the
+      // heap in no time in a long running stress test with many requests.
+      tester.setEnableClientStreamTracers(false);
+
       WeightedTestCaseSelector testCaseSelector = new WeightedTestCaseSelector(testCaseWeightPairs);
       Long endTime = durationSec == null ? null : System.nanoTime() + SECONDS.toNanos(durationSecs);
       long lastMetricsCollectionTime = initLastMetricsCollectionTime();


### PR DESCRIPTION
This adds the ability to disable the installation of stream tracers in each test call in AbstractInteropTest. The tracers are stored in a list and used to make assertions by normal tests, but a long running stress test will accumulate too many entries in this list and the heap gets quickly filled up.