### PR TITLE
Make Ring Hash LB a petiole policy

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,7 +14,6 @@ android {
     }
     compileSdkVersion 34
     defaultConfig {
-        consumerProguardFiles "proguard-rules.txt"
         minSdkVersion 21
         targetSdkVersion 33
         versionCode 1

--- a/android/proguard-rules.txt
+++ b/android/proguard-rules.txt
@@ -1,6 +1,0 @@
--keepclassmembers class io.grpc.okhttp.OkHttpChannelBuilder {
-  io.grpc.okhttp.OkHttpChannelBuilder forTarget(java.lang.String);
-  io.grpc.okhttp.OkHttpChannelBuilder scheduledExecutorService(java.util.concurrent.ScheduledExecutorService);
-  io.grpc.okhttp.OkHttpChannelBuilder sslSocketFactory(javax.net.ssl.SSLSocketFactory);
-  io.grpc.okhttp.OkHttpChannelBuilder transportExecutor(java.util.concurrent.Executor);
-}

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
@@ -26,7 +26,6 @@ import io.grpc.benchmarks.proto.Messages;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
-import io.grpc.stub.StreamObservers;
 import io.grpc.testing.TlsTesting;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
@@ -282,6 +281,7 @@ public class AsyncServer {
     }
 
     @Override
+    @SuppressWarnings("deprecation") // For StreamObservers, ideally we refactor this class out.
     public void streamingFromServer(
         final Messages.SimpleRequest request,
         final StreamObserver<Messages.SimpleResponse> observer) {
@@ -291,7 +291,7 @@ public class AsyncServer {
           (ServerCallStreamObserver<Messages.SimpleResponse>) observer;
       // If the client cancels, copyWithFlowControl takes care of calling
       // responseObserver.onCompleted() for us
-      StreamObservers.copyWithFlowControl(
+      io.grpc.stub.StreamObservers.copyWithFlowControl(
           new Iterator<Messages.SimpleResponse>() {
             @Override
             public boolean hasNext() {
@@ -312,6 +312,7 @@ public class AsyncServer {
     }
 
     @Override
+    @SuppressWarnings("deprecation") // For StreamObservers, ideally we refactor this class out.
     public StreamObserver<Messages.SimpleRequest> streamingBothWays(
         final StreamObserver<Messages.SimpleResponse> observer) {
       // receive data forever and send data forever until client cancels or we shut down.
@@ -319,7 +320,7 @@ public class AsyncServer {
           (ServerCallStreamObserver<Messages.SimpleResponse>) observer;
       // If the client cancels, copyWithFlowControl takes care of calling
       // responseObserver.onCompleted() for us
-      StreamObservers.copyWithFlowControl(
+      io.grpc.stub.StreamObservers.copyWithFlowControl(
           new Iterator<Messages.SimpleResponse>() {
             @Override
             public boolean hasNext() {

--- a/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
@@ -51,7 +51,7 @@ import javax.annotation.Nullable;
  * list and sticking to the first that works.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/10383")
-public final class PickFirstLeafLoadBalancer extends LoadBalancer {
+final class PickFirstLeafLoadBalancer extends LoadBalancer {
   private final Helper helper;
   private final Map<SocketAddress, SubchannelData> subchannels = new HashMap<>();
   private Index addressIndex;
@@ -160,7 +160,6 @@ public final class PickFirstLeafLoadBalancer extends LoadBalancer {
     // for time being.
     updateBalancingState(TRANSIENT_FAILURE, new Picker(PickResult.withError(error)));
   }
-
 
   void processSubchannelState(Subchannel subchannel, ConnectivityStateInfo stateInfo) {
     ConnectivityState newState = stateInfo.getState();

--- a/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
@@ -51,7 +51,7 @@ import javax.annotation.Nullable;
  * list and sticking to the first that works.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/10383")
-final class PickFirstLeafLoadBalancer extends LoadBalancer {
+public final class PickFirstLeafLoadBalancer extends LoadBalancer {
   private final Helper helper;
   private final Map<SocketAddress, SubchannelData> subchannels = new HashMap<>();
   private Index addressIndex;
@@ -160,6 +160,7 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
     // for time being.
     updateBalancingState(TRANSIENT_FAILURE, new Picker(PickResult.withError(error)));
   }
+
 
   void processSubchannelState(Subchannel subchannel, ConnectivityStateInfo stateInfo) {
     ConnectivityState newState = stateInfo.getState();

--- a/core/src/main/java/io/grpc/internal/PickFirstLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLoadBalancer.java
@@ -102,6 +102,7 @@ final class PickFirstLoadBalancer extends LoadBalancer {
       subchannel.shutdown();
       subchannel = null;
     }
+
     // NB(lukaszx0) Whether we should propagate the error unconditionally is arguable. It's fine
     // for time being.
     updateBalancingState(TRANSIENT_FAILURE, new Picker(PickResult.withError(error)));

--- a/core/src/main/java/io/grpc/internal/PickFirstLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLoadBalancer.java
@@ -40,7 +40,7 @@ import javax.annotation.Nullable;
  * io.grpc.NameResolver}.  The channel's default behavior is used, which is walking down the address
  * list and sticking to the first that works.
  */
-public final class PickFirstLoadBalancer extends LoadBalancer {
+final class PickFirstLoadBalancer extends LoadBalancer {
   private final Helper helper;
   private Subchannel subchannel;
   private ConnectivityState currentState = IDLE;

--- a/core/src/main/java/io/grpc/internal/PickFirstLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLoadBalancer.java
@@ -40,7 +40,7 @@ import javax.annotation.Nullable;
  * io.grpc.NameResolver}.  The channel's default behavior is used, which is walking down the address
  * list and sticking to the first that works.
  */
-final class PickFirstLoadBalancer extends LoadBalancer {
+public final class PickFirstLoadBalancer extends LoadBalancer {
   private final Helper helper;
   private Subchannel subchannel;
   private ConnectivityState currentState = IDLE;

--- a/stub/src/main/java/io/grpc/stub/StreamObservers.java
+++ b/stub/src/main/java/io/grpc/stub/StreamObservers.java
@@ -23,7 +23,10 @@ import java.util.Iterator;
 /**
  * Utility functions for working with {@link StreamObserver} and it's common subclasses like
  * {@link CallStreamObserver}.
+ *
+ * @deprecated Of questionable utility and generally not used.
  */
+@Deprecated
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4694")
 public final class StreamObservers {
   /**

--- a/util/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
@@ -181,4 +181,8 @@ public final class GracefulSwitchLoadBalancer extends ForwardingLoadBalancer {
     pendingLb.shutdown();
     currentLb.shutdown();
   }
+
+  public String delegateType() {
+    return delegate().getClass().getSimpleName();
+  }
 }

--- a/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
@@ -73,10 +73,6 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
   protected abstract SubchannelPicker getSubchannelPicker(
       Map<Object, SubchannelPicker> childPickers);
 
-  protected static EquivalentAddressGroup stripAttrs(EquivalentAddressGroup eag) {
-    return new EquivalentAddressGroup(eag.getAddresses());
-  }
-
   protected SubchannelPicker getInitialPicker() {
     return EMPTY_PICKER;
   }
@@ -94,19 +90,9 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
     return childLbStates.values();
   }
 
-  protected ChildLbState getChildLbState(EquivalentAddressGroup eag) {
-    if (eag == null) {
-      return null;
-    }
-    return childLbStates.get(stripAttrs(eag));
-  }
-
   protected ChildLbState getChildLbState(Object key) {
     if (key == null) {
       return null;
-    }
-    if (key instanceof EquivalentAddressGroup) {
-      key = new Endpoint((EquivalentAddressGroup) key);
     }
     return childLbStates.get(key);
   }

--- a/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
@@ -127,7 +127,8 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
       if (existingChildLbState != null) {
         childLbMap.put(endpoint, existingChildLbState);
       } else {
-        childLbMap.put(endpoint, createChildLbState(endpoint, null, getInitialPicker()));
+        childLbMap.put(endpoint,
+            createChildLbState(endpoint, null, getInitialPicker(), resolvedAddresses));
       }
     }
     return childLbMap;
@@ -137,7 +138,7 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
    * Override to create an instance of a subclass.
    */
   protected ChildLbState createChildLbState(Object key, Object policyConfig,
-      SubchannelPicker initialPicker) {
+      SubchannelPicker initialPicker, ResolvedAddresses resolvedAddresses) {
     return new ChildLbState(key, pickFirstLbProvider, policyConfig, initialPicker);
   }
 

--- a/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
@@ -94,6 +94,9 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
     if (key == null) {
       return null;
     }
+    if (key instanceof EquivalentAddressGroup) {
+      key = new Endpoint((EquivalentAddressGroup) key);
+    }
     return childLbStates.get(key);
   }
 

--- a/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
@@ -157,7 +157,7 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
         return false;
       }
 
-      // Update the picker and
+      // Update the picker and our connectivity state
       updateOverallBalancingState();
 
       // shutdown removed children

--- a/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
@@ -26,7 +26,6 @@ import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import io.grpc.Attributes;
 import io.grpc.ConnectivityState;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.Internal;
@@ -71,7 +70,6 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
     logger.log(Level.FINE, "Created");
   }
 
-<<<<<<< HEAD
   protected abstract SubchannelPicker getSubchannelPicker(
       Map<Object, SubchannelPicker> childPickers);
 
@@ -79,19 +77,6 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
     return new EquivalentAddressGroup(eag.getAddresses());
   }
 
-=======
-  protected static EquivalentAddressGroup stripAttrs(EquivalentAddressGroup eag) {
-    if (eag.getAttributes() == Attributes.EMPTY) {
-      return eag;
-    } else {
-      return new EquivalentAddressGroup(eag.getAddresses());
-    }
-  }
-
-  protected abstract SubchannelPicker getSubchannelPicker(
-      Map<Object, SubchannelPicker> childPickers);
-
->>>>>>> 87585d87f (Responded to a number of the code review comments.)
   protected SubchannelPicker getInitialPicker() {
     return EMPTY_PICKER;
   }
@@ -109,15 +94,6 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
     return childLbStates.values();
   }
 
-  /**
-   * Generally, the only reason to override this is to expose it to a test of a LB in a
-   * different package.
-    */
-  @VisibleForTesting
-  protected Collection<ChildLbState> getChildLbStates() {
-    return childLbStates.values();
-  }
-
   protected ChildLbState getChildLbState(EquivalentAddressGroup eag) {
     if (eag == null) {
       return null;
@@ -125,54 +101,6 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
     return childLbStates.get(stripAttrs(eag));
   }
 
-  /**
-   * Override to utilize parsing of the policy configuration or alternative helper/lb generation.
-   */
-  protected Map<Object, ChildLbState> createChildLbMap(ResolvedAddresses resolvedAddresses) {
-    Map<Object, ChildLbState> childLbMap = new HashMap<>();
-    List<EquivalentAddressGroup> addresses = resolvedAddresses.getAddresses();
-    Object policyConfig = resolvedAddresses.getLoadBalancingPolicyConfig();
-    for (EquivalentAddressGroup eag : addresses) {
-      EquivalentAddressGroup strippedEag = stripAttrs(eag); // keys need to be just addresses
-      ChildLbState childLbState = new ChildLbState(strippedEag, pickFirstLbProvider, policyConfig,
-          getInitialPicker());
-      childLbMap.put(strippedEag, childLbState);
-    }
-    return childLbMap;
-  }
-
-  @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-    try {
-      resolvingAddresses = true;
-      return acceptResolvedAddressesInternal(resolvedAddresses);
-    } finally {
-      resolvingAddresses = false;
-    }
-  }
-
-  protected ResolvedAddresses getChildAddresses(Object key, ResolvedAddresses resolvedAddresses,
-      Object childConfig) {
-    checkArgument(key instanceof EquivalentAddressGroup, "key is wrong type");
-
-    // Retrieve the non-stripped version
-    EquivalentAddressGroup eag = null;
-    for (EquivalentAddressGroup equivalentAddressGroup : resolvedAddresses.getAddresses()) {
-      if (stripAttrs(equivalentAddressGroup).equals(key)) {
-        eag = equivalentAddressGroup;
-        break;
-      }
-    }
-
-    checkNotNull(eag, key.toString() + " no longer present in load balancer children");
-
-    return resolvedAddresses.toBuilder()
-        .setAddresses(Collections.singletonList(eag))
-        .setLoadBalancingPolicyConfig(childConfig)
-        .build();
-  }
-
-<<<<<<< HEAD
   protected ChildLbState getChildLbState(Object key) {
     if (key == null) {
       return null;
@@ -229,9 +157,6 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
       resolvingAddresses = false;
     }
   }
-=======
-
->>>>>>> 87585d87f (Responded to a number of the code review comments.)
 
   /**
    * Override this if your keys are not of type Endpoint.
@@ -525,7 +450,6 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
       logger.log(Level.FINE, "Child balancer {0} deleted", key);
     }
 
-<<<<<<< HEAD
     /**
      * ChildLbStateHelper is the glue between ChildLbState and the helpers associated with the
      * petiole policy above and the PickFirstLoadBalancer's helper below.
@@ -533,8 +457,6 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
      * <p>The ChildLbState updates happen during updateBalancingState.  Otherwise, it is doing
      * simple forwarding.
      */
-=======
->>>>>>> 87585d87f (Responded to a number of the code review comments.)
     private final class ChildLbStateHelper extends ForwardingLoadBalancerHelper {
 
       @Override

--- a/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
@@ -205,7 +205,7 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
       ResolvedAddresses childAddresses = getChildAddresses(key, resolvedAddresses, childConfig);
       childLbStates.get(key).setResolvedAddresses(childAddresses); // update child state
       childLb.handleResolvedAddresses(childAddresses); // update child LB
-      if (childLb != entry.getValue().getLb()) {
+      if (childLb != entry.getValue().lb) {
         entry.getValue().shutdown(); // Reused old LB
       }
     }
@@ -388,11 +388,6 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
 
     public boolean isDeactivated() {
       return deactivated;
-    }
-
-    @VisibleForTesting
-    LoadBalancer getLb() {
-      return this.lb;
     }
 
     protected void setDeactivated() {

--- a/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
@@ -93,6 +93,10 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
     return childLbStates.values();
   }
 
+  /**
+   * Generally, the only reason to override this is to expose it to a test of a LB in a
+   * different package.
+   */
   protected ChildLbState getChildLbState(Object key) {
     if (key == null) {
       return null;

--- a/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
@@ -26,6 +26,7 @@ import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.grpc.ConnectivityState;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.Internal;
@@ -57,11 +58,9 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
   private final Map<Object, ChildLbState> childLbStates = new LinkedHashMap<>();
   private final Helper helper;
   // Set to true if currently in the process of handling resolved addresses.
-  @VisibleForTesting
   protected boolean resolvingAddresses;
 
-  protected final PickFirstLoadBalancerProvider pickFirstLbProvider =
-      new PickFirstLoadBalancerProvider();
+  protected final LoadBalancerProvider pickFirstLbProvider = new PickFirstLoadBalancerProvider();
 
   protected ConnectivityState currentConnectivityState;
 
@@ -85,6 +84,10 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
    * Generally, the only reason to override this is to expose it to a test of a LB in a different
    * package.
    */
+  protected ImmutableMap<Object, ChildLbState> getImmutableChildMap() {
+    return ImmutableMap.copyOf(childLbStates);
+  }
+
   @VisibleForTesting
   protected Collection<ChildLbState> getChildLbStates() {
     return childLbStates.values();
@@ -120,7 +123,8 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
       if (existingChildLbState != null) {
         childLbMap.put(endpoint, existingChildLbState);
       } else {
-        childLbMap.put(endpoint, createChildLbState(endpoint, null, getInitialPicker()));
+        childLbMap.put(endpoint,
+            createChildLbState(endpoint, null, getInitialPicker(), resolvedAddresses));
       }
     }
     return childLbMap;
@@ -130,7 +134,7 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
    * Override to create an instance of a subclass.
    */
   protected ChildLbState createChildLbState(Object key, Object policyConfig,
-      SubchannelPicker initialPicker) {
+      SubchannelPicker initialPicker, ResolvedAddresses resolvedAddresses) {
     return new ChildLbState(key, pickFirstLbProvider, policyConfig, initialPicker);
   }
 
@@ -141,7 +145,20 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
   public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     try {
       resolvingAddresses = true;
-      return acceptResolvedAddressesInternal(resolvedAddresses);
+
+      // process resolvedAddresses to update children
+      AcceptResolvedAddressRetVal acceptRetVal =
+          acceptResolvedAddressesInternal(resolvedAddresses);
+      if (!acceptRetVal.status.isOk()) {
+        return acceptRetVal.status;
+      }
+
+      // Update the picker and our connectivity state
+      updateOverallBalancingState();
+
+      // shutdown removed children
+      shutdownRemoved(acceptRetVal.removedChildren);
+      return acceptRetVal.status;
     } finally {
       resolvingAddresses = false;
     }
@@ -156,15 +173,18 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
    */
   protected ResolvedAddresses getChildAddresses(Object key, ResolvedAddresses resolvedAddresses,
       Object childConfig) {
+    Endpoint endpointKey;
     if (key instanceof EquivalentAddressGroup) {
-      key = new Endpoint((EquivalentAddressGroup) key);
+      endpointKey = new Endpoint((EquivalentAddressGroup) key);
+    } else {
+      checkArgument(key instanceof Endpoint, "key is wrong type");
+      endpointKey = (Endpoint) key;
     }
-    checkArgument(key instanceof Endpoint, "key is wrong type");
 
     // Retrieve the non-stripped version
     EquivalentAddressGroup eagToUse = null;
     for (EquivalentAddressGroup currEag : resolvedAddresses.getAddresses()) {
-      if (key.equals(new Endpoint(currEag))) {
+      if (endpointKey.equals(new Endpoint(currEag))) {
         eagToUse = currEag;
         break;
       }
@@ -178,7 +198,13 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
         .build();
   }
 
-  private Status acceptResolvedAddressesInternal(ResolvedAddresses resolvedAddresses) {
+  /**
+   *   This does the work to update the child map and calculate which children have been removed.
+   *   You must call {@link #updateOverallBalancingState} to update the picker
+   *   and call {@link #shutdownRemoved(List)} to shutdown the endpoints that have been removed.
+   */
+  protected AcceptResolvedAddressRetVal acceptResolvedAddressesInternal(
+      ResolvedAddresses resolvedAddresses) {
     logger.log(Level.FINE, "Received resolution result: {0}", resolvedAddresses);
     Map<Object, ChildLbState> newChildren = createChildLbMap(resolvedAddresses);
 
@@ -186,7 +212,7 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
       Status unavailableStatus = Status.UNAVAILABLE.withDescription(
               "NameResolver returned no usable address. " + resolvedAddresses);
       handleNameResolutionError(unavailableStatus);
-      return unavailableStatus;
+      return new AcceptResolvedAddressRetVal(unavailableStatus, null);
     }
 
     // Do adds and updates
@@ -199,36 +225,43 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
       } else {
         // Reuse the existing one
         ChildLbState existingChildLbState = childLbStates.get(key);
-        if (existingChildLbState.isDeactivated()) {
+        if (existingChildLbState.isDeactivated() && reactivateChildOnReuse()) {
           existingChildLbState.reactivate(childPolicyProvider);
         }
       }
 
-      LoadBalancer childLb = childLbStates.get(key).lb;
+      ChildLbState childLbState = childLbStates.get(key);
       ResolvedAddresses childAddresses = getChildAddresses(key, resolvedAddresses, childConfig);
-      childLbStates.get(key).setResolvedAddresses(childAddresses); // update child state
-      childLb.handleResolvedAddresses(childAddresses); // update child LB
-      if (childLb != entry.getValue().lb) {
-        entry.getValue().shutdown(); // Reused old LB
+      childLbStates.get(key).setResolvedAddresses(childAddresses); // update child
+      if (!childLbState.deactivated) {
+        childLbState.lb.handleResolvedAddresses(childAddresses); // update child LB
       }
     }
 
+    List<ChildLbState> removedChildren = new ArrayList<>();
     // Do removals
     for (Object key : ImmutableList.copyOf(childLbStates.keySet())) {
       if (!newChildren.containsKey(key)) {
-        childLbStates.get(key).deactivate();
+        ChildLbState childLbState = childLbStates.get(key);
+        childLbState.deactivate();
+        removedChildren.add(childLbState);
       }
     }
-    // Must update channel picker before return so that new RPCs will not be routed to deleted
-    // clusters and resolver can remove them in service config.
-    updateOverallBalancingState();
-    return Status.OK;
+    return new AcceptResolvedAddressRetVal(Status.OK, removedChildren);
+  }
+
+  protected void shutdownRemoved(List<ChildLbState> removedChildren) {
+    // Do shutdowns after updating picker to reduce the chance of failing an RPC by picking a
+    // subchannel that has been shutdown.
+    for (ChildLbState childLbState : removedChildren) {
+      childLbState.shutdown();
+    }
   }
 
   @Override
   public void handleNameResolutionError(Status error) {
     if (currentConnectivityState != READY)  {
-      updateHelperBalancingState(TRANSIENT_FAILURE, getErrorPicker(error));
+      helper.updateBalancingState(TRANSIENT_FAILURE, getErrorPicker(error));
     }
   }
 
@@ -238,9 +271,19 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
 
   /**
    * If true, then when a subchannel state changes to idle, the corresponding child will
-   * have requestConnection called on its LB.
+   * have requestConnection called on its LB. Also causes the PickFirstLB to be created when
+   * the child is created or reused.
    */
   protected boolean reconnectOnIdle() {
+    return true;
+  }
+
+  /**
+   * If true, then when {@link #acceptResolvedAddresses} sees a key that was already part of the
+   * child map which is deactivated, it will call reactivate on the child.
+   * If false, it will leave it deactivated.
+   */
+  protected boolean reactivateChildOnReuse() {
     return true;
   }
 
@@ -263,15 +306,11 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
       childPickers.put(childLbState.key, childLbState.currentPicker);
       overallState = aggregateState(overallState, childLbState.currentState);
     }
+
     if (overallState != null) {
       helper.updateBalancingState(overallState, getSubchannelPicker(childPickers));
       currentConnectivityState = overallState;
     }
-  }
-
-  protected final void updateHelperBalancingState(ConnectivityState newState,
-      SubchannelPicker newPicker) {
-    helper.updateBalancingState(newState, newPicker);
   }
 
   @Nullable
@@ -330,20 +369,31 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
     private final Object key;
     private ResolvedAddresses resolvedAddresses;
     private final Object config;
+
     private final GracefulSwitchLoadBalancer lb;
-    private LoadBalancerProvider policyProvider;
-    private ConnectivityState currentState = CONNECTING;
+    private final LoadBalancerProvider policyProvider;
+    private ConnectivityState currentState;
     private SubchannelPicker currentPicker;
     private boolean deactivated;
 
     public ChildLbState(Object key, LoadBalancerProvider policyProvider, Object childConfig,
         SubchannelPicker initialPicker) {
+      this(key, policyProvider, childConfig, initialPicker, null, false);
+    }
+
+    public ChildLbState(Object key, LoadBalancerProvider policyProvider, Object childConfig,
+          SubchannelPicker initialPicker, ResolvedAddresses resolvedAddrs, boolean deactivated) {
       this.key = key;
       this.policyProvider = policyProvider;
-      lb = new GracefulSwitchLoadBalancer(new ChildLbStateHelper());
-      lb.switchTo(policyProvider);
-      currentPicker = initialPicker;
-      config = childConfig;
+      this.deactivated = deactivated;
+      this.currentPicker = initialPicker;
+      this.config = childConfig;
+      this.lb = new GracefulSwitchLoadBalancer(new ChildLbStateHelper());
+      this.currentState = deactivated ? IDLE : CONNECTING;
+      this.resolvedAddresses = resolvedAddrs;
+      if (!deactivated) {
+        lb.switchTo(policyProvider);
+      }
     }
 
     @Override
@@ -361,6 +411,10 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
 
     Object getConfig() {
       return config;
+    }
+
+    protected GracefulSwitchLoadBalancer getLb() {
+      return lb;
     }
 
     public LoadBalancerProvider getPolicyProvider() {
@@ -397,34 +451,41 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
       deactivated = true;
     }
 
+    protected void markReactivated() {
+      deactivated = false;
+    }
+
     protected void setResolvedAddresses(ResolvedAddresses newAddresses) {
       checkNotNull(newAddresses, "Missing address list for child");
       resolvedAddresses = newAddresses;
     }
 
+    /**
+     * The default implementation. This not only marks the lb policy as not active, it also removes
+     * this child from the map of children maintained by the petiole policy.
+     *
+     * <p>Note that this does not explicitly shutdown this child.  That will generally be done by
+     * acceptResolvedAddresses on the LB, but can also be handled by an override such as is done
+     * in <a href=" https://github.com/grpc/grpc-java/blob/master/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java">ClusterManagerLoadBalancer</a>.
+     *
+     * <p>If you plan to reactivate, you will probably want to override this to not call
+     * childLbStates.remove() and handle that cleanup another way.
+     */
     protected void deactivate() {
       if (deactivated) {
         return;
       }
 
-      shutdown();
-      childLbStates.remove(key);
+      childLbStates.remove(key); // This means it can't be reactivated again
       deactivated = true;
       logger.log(Level.FINE, "Child balancer {0} deactivated", key);
     }
 
+    /**
+     * This base implementation does nothing but reset the flag.  If you really want to both
+     * deactivate and reactivate you should override them both.
+     */
     protected void reactivate(LoadBalancerProvider policyProvider) {
-      if (!this.policyProvider.getPolicyName().equals(policyProvider.getPolicyName())) {
-        Object[] objects = {
-            key, this.policyProvider.getPolicyName(),policyProvider.getPolicyName()};
-        logger.log(Level.FINE, "Child balancer {0} switching policy from {1} to {2}", objects);
-        lb.switchTo(policyProvider);
-        this.policyProvider = policyProvider;
-      } else {
-        logger.log(Level.FINE, "Child balancer {0} reactivated", key);
-        lb.acceptResolvedAddresses(resolvedAddresses);
-      }
-
       deactivated = false;
     }
 
@@ -441,6 +502,10 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
      * <p>The ChildLbState updates happen during updateBalancingState.  Otherwise, it is doing
      * simple forwarding.
      */
+    protected ResolvedAddresses getResolvedAddresses() {
+      return resolvedAddresses;
+    }
+
     private final class ChildLbStateHelper extends ForwardingLoadBalancerHelper {
 
       @Override
@@ -480,7 +545,7 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
     final String[] addrs;
     final int hashCode;
 
-    Endpoint(EquivalentAddressGroup eag) {
+    public Endpoint(EquivalentAddressGroup eag) {
       checkNotNull(eag, "eag");
 
       addrs = new String[eag.getAddresses().size()];
@@ -523,4 +588,15 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
       return Arrays.toString(addrs);
     }
   }
+
+  protected static class AcceptResolvedAddressRetVal {
+    public final Status status;
+    public final List<ChildLbState> removedChildren;
+
+    public AcceptResolvedAddressRetVal(Status status, List<ChildLbState> removedChildren) {
+      this.status = status;
+      this.removedChildren = removedChildren;
+    }
+  }
+
 }

--- a/util/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
@@ -16,7 +16,6 @@
 
 package io.grpc.util;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static io.grpc.ConnectivityState.CONNECTING;
 import static io.grpc.ConnectivityState.IDLE;
 import static io.grpc.ConnectivityState.READY;
@@ -113,6 +112,22 @@ public class RoundRobinLoadBalancer extends MultiChildLoadBalancer {
     return new ReadyPicker(pickerList, startIndex);
   }
 
+<<<<<<< HEAD
+=======
+  /**
+   * Filters out non-ready and deactivated child load balancers (subchannels).
+   */
+  private List<ChildLbState> getReadyChildren() {
+    List<ChildLbState> activeChildren = new ArrayList<>();
+    for (ChildLbState child : getChildLbStates()) {
+      if (!child.isDeactivated() && child.getCurrentState() == READY) {
+        activeChildren.add(child);
+      }
+    }
+    return activeChildren;
+  }
+
+>>>>>>> 87585d87f (Responded to a number of the code review comments.)
   public abstract static class RoundRobinPicker extends SubchannelPicker {
     public abstract boolean isEquivalentTo(RoundRobinPicker picker);
   }

--- a/util/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
@@ -16,6 +16,7 @@
 
 package io.grpc.util;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.grpc.ConnectivityState.CONNECTING;
 import static io.grpc.ConnectivityState.IDLE;
 import static io.grpc.ConnectivityState.READY;
@@ -25,9 +26,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
-import io.grpc.Attributes;
 import io.grpc.ConnectivityState;
-import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.Internal;
 import io.grpc.LoadBalancer;
@@ -48,10 +47,6 @@ import javax.annotation.Nonnull;
  */
 @Internal
 public class RoundRobinLoadBalancer extends MultiChildLoadBalancer {
-  @VisibleForTesting
-  static final Attributes.Key<Ref<ConnectivityStateInfo>> STATE_INFO =
-      Attributes.Key.create("state-info");
-
   private final Random random;
   protected RoundRobinPicker currentPicker = new EmptyPicker(EMPTY_OK);
 
@@ -132,7 +127,7 @@ public class RoundRobinLoadBalancer extends MultiChildLoadBalancer {
     private volatile int index;
 
     public ReadyPicker(List<SubchannelPicker> list, int startIndex) {
-      Preconditions.checkArgument(!list.isEmpty(), "empty list");
+      checkArgument(!list.isEmpty(), "empty list");
       this.subchannelPickers = list;
       this.index = startIndex - 1;
     }

--- a/util/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
@@ -16,6 +16,7 @@
 
 package io.grpc.util;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.grpc.ConnectivityState.CONNECTING;
 import static io.grpc.ConnectivityState.IDLE;
 import static io.grpc.ConnectivityState.READY;
@@ -112,22 +113,6 @@ public class RoundRobinLoadBalancer extends MultiChildLoadBalancer {
     return new ReadyPicker(pickerList, startIndex);
   }
 
-<<<<<<< HEAD
-=======
-  /**
-   * Filters out non-ready and deactivated child load balancers (subchannels).
-   */
-  private List<ChildLbState> getReadyChildren() {
-    List<ChildLbState> activeChildren = new ArrayList<>();
-    for (ChildLbState child : getChildLbStates()) {
-      if (!child.isDeactivated() && child.getCurrentState() == READY) {
-        activeChildren.add(child);
-      }
-    }
-    return activeChildren;
-  }
-
->>>>>>> 87585d87f (Responded to a number of the code review comments.)
   public abstract static class RoundRobinPicker extends SubchannelPicker {
     public abstract boolean isEquivalentTo(RoundRobinPicker picker);
   }

--- a/util/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
+++ b/util/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
@@ -345,7 +345,7 @@ public class RoundRobinLoadBalancerTest {
       // Simulate receiving go-away so READY subchannels transit to IDLE.
       deliverSubchannelState(sc, ConnectivityStateInfo.forNonError(IDLE));
       inOrder.verify(mockHelper).refreshNameResolution();
-      verify(sc, times(1)).requestConnection();
+      verify(sc, times(2)).requestConnection();
       inOrder.verify(mockHelper).updateBalancingState(eq(CONNECTING), isA(EmptyPicker.class));
     }
 
@@ -454,7 +454,7 @@ public class RoundRobinLoadBalancerTest {
     // The IDLE subchannel is dropped from the picker, but a reconnection is requested
     assertEquals(READY, stateIterator.next());
     assertThat(getList(pickers.next())).containsExactly(sc1, sc3);
-    verify(sc2, times(1)).requestConnection();
+    verify(sc2, times(2)).requestConnection();
     // The failing subchannel is dropped from the picker, with no requested reconnect
     assertEquals(READY, stateIterator.next());
     assertThat(getList(pickers.next())).containsExactly(sc1);

--- a/util/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
+++ b/util/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
@@ -345,7 +345,7 @@ public class RoundRobinLoadBalancerTest {
       // Simulate receiving go-away so READY subchannels transit to IDLE.
       deliverSubchannelState(sc, ConnectivityStateInfo.forNonError(IDLE));
       inOrder.verify(mockHelper).refreshNameResolution();
-      verify(sc, times(2)).requestConnection();
+      verify(sc, times(1)).requestConnection();
       inOrder.verify(mockHelper).updateBalancingState(eq(CONNECTING), isA(EmptyPicker.class));
     }
 
@@ -454,7 +454,7 @@ public class RoundRobinLoadBalancerTest {
     // The IDLE subchannel is dropped from the picker, but a reconnection is requested
     assertEquals(READY, stateIterator.next());
     assertThat(getList(pickers.next())).containsExactly(sc1, sc3);
-    verify(sc2, times(2)).requestConnection();
+    verify(sc2, times(1)).requestConnection();
     // The failing subchannel is dropped from the picker, with no requested reconnect
     assertEquals(READY, stateIterator.next());
     assertThat(getList(pickers.next())).containsExactly(sc1);

--- a/util/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
+++ b/util/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
@@ -197,15 +197,9 @@ public class RoundRobinLoadBalancerTest {
     verify(oldSubchannel, times(1)).requestConnection();
 
     assertThat(loadBalancer.getChildLbStates().size()).isEqualTo(2);
-<<<<<<< HEAD
     assertThat(loadBalancer.getChildLbStateEag(removedEag).getCurrentPicker().pickSubchannel(null)
         .getSubchannel()).isEqualTo(removedSubchannel);
     assertThat(loadBalancer.getChildLbStateEag(oldEag1).getCurrentPicker().pickSubchannel(null)
-=======
-    assertThat(loadBalancer.getChildLbState(removedEag).getCurrentPicker().pickSubchannel(null)
-        .getSubchannel()).isEqualTo(removedSubchannel);
-    assertThat(loadBalancer.getChildLbState(oldEag1).getCurrentPicker().pickSubchannel(null)
->>>>>>> 87585d87f (Responded to a number of the code review comments.)
         .getSubchannel()).isEqualTo(oldSubchannel);
 
     // This time with Attributes
@@ -222,15 +216,9 @@ public class RoundRobinLoadBalancerTest {
     deliverSubchannelState(newSubchannel, ConnectivityStateInfo.forNonError(READY));
 
     assertThat(loadBalancer.getChildLbStates().size()).isEqualTo(2);
-<<<<<<< HEAD
     assertThat(loadBalancer.getChildLbStateEag(newEag).getCurrentPicker()
         .pickSubchannel(null).getSubchannel()).isEqualTo(newSubchannel);
     assertThat(loadBalancer.getChildLbStateEag(oldEag2).getCurrentPicker()
-=======
-    assertThat(loadBalancer.getChildLbState(newEag).getCurrentPicker()
-        .pickSubchannel(null).getSubchannel()).isEqualTo(newSubchannel);
-    assertThat(loadBalancer.getChildLbState(oldEag2).getCurrentPicker()
->>>>>>> 87585d87f (Responded to a number of the code review comments.)
         .pickSubchannel(null).getSubchannel()).isEqualTo(oldSubchannel);
 
     verify(mockHelper, times(6)).createSubchannel(any(CreateSubchannelArgs.class));

--- a/util/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
+++ b/util/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
@@ -74,6 +74,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
@@ -350,6 +351,19 @@ public class RoundRobinLoadBalancerTest {
     }
 
     verifyNoMoreInteractions(mockHelper);
+  }
+
+  @Test
+  public void removingAddressShutsdownSubchannel() {
+    acceptAddresses(servers, affinity);
+    final Subchannel subchannel2 = subchannels.get(Collections.singletonList(servers.get(2)));
+
+    InOrder inOrder = Mockito.inOrder(mockHelper, subchannel2);
+    // send LB only the first 2 addresses
+    List<EquivalentAddressGroup> svs2 = Arrays.asList(servers.get(0), servers.get(1));
+    acceptAddresses(svs2, affinity);
+    inOrder.verify(mockHelper).updateBalancingState(eq(CONNECTING), any());
+    inOrder.verify(subchannel2).shutdown();
   }
 
   @Test

--- a/util/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
+++ b/util/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
@@ -197,9 +197,15 @@ public class RoundRobinLoadBalancerTest {
     verify(oldSubchannel, times(1)).requestConnection();
 
     assertThat(loadBalancer.getChildLbStates().size()).isEqualTo(2);
+<<<<<<< HEAD
     assertThat(loadBalancer.getChildLbStateEag(removedEag).getCurrentPicker().pickSubchannel(null)
         .getSubchannel()).isEqualTo(removedSubchannel);
     assertThat(loadBalancer.getChildLbStateEag(oldEag1).getCurrentPicker().pickSubchannel(null)
+=======
+    assertThat(loadBalancer.getChildLbState(removedEag).getCurrentPicker().pickSubchannel(null)
+        .getSubchannel()).isEqualTo(removedSubchannel);
+    assertThat(loadBalancer.getChildLbState(oldEag1).getCurrentPicker().pickSubchannel(null)
+>>>>>>> 87585d87f (Responded to a number of the code review comments.)
         .getSubchannel()).isEqualTo(oldSubchannel);
 
     // This time with Attributes
@@ -216,9 +222,15 @@ public class RoundRobinLoadBalancerTest {
     deliverSubchannelState(newSubchannel, ConnectivityStateInfo.forNonError(READY));
 
     assertThat(loadBalancer.getChildLbStates().size()).isEqualTo(2);
+<<<<<<< HEAD
     assertThat(loadBalancer.getChildLbStateEag(newEag).getCurrentPicker()
         .pickSubchannel(null).getSubchannel()).isEqualTo(newSubchannel);
     assertThat(loadBalancer.getChildLbStateEag(oldEag2).getCurrentPicker()
+=======
+    assertThat(loadBalancer.getChildLbState(newEag).getCurrentPicker()
+        .pickSubchannel(null).getSubchannel()).isEqualTo(newSubchannel);
+    assertThat(loadBalancer.getChildLbState(oldEag2).getCurrentPicker()
+>>>>>>> 87585d87f (Responded to a number of the code review comments.)
         .pickSubchannel(null).getSubchannel()).isEqualTo(oldSubchannel);
 
     verify(mockHelper, times(6)).createSubchannel(any(CreateSubchannelArgs.class));

--- a/util/src/testFixtures/java/io/grpc/util/AbstractTestHelper.java
+++ b/util/src/testFixtures/java/io/grpc/util/AbstractTestHelper.java
@@ -26,7 +26,6 @@ import io.grpc.ChannelLogger;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
-import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.CreateSubchannelArgs;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.Subchannel;

--- a/util/src/testFixtures/java/io/grpc/util/AbstractTestHelper.java
+++ b/util/src/testFixtures/java/io/grpc/util/AbstractTestHelper.java
@@ -26,6 +26,7 @@ import io.grpc.ChannelLogger;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.CreateSubchannelArgs;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.Subchannel;

--- a/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
@@ -162,6 +162,11 @@ class ClusterManagerLoadBalancer extends MultiChildLoadBalancer {
     return false;
   }
 
+  @Override
+  protected boolean shutdownInAcceptResolvedAddresses() {
+    return false;
+  }
+
   /**
    * This differs from the base class in the use of the deletion timer.  When it is deactivated,
    * rather than immediately calling shutdown it starts a timer.  If shutdown or reactivate

--- a/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
@@ -98,21 +98,21 @@ class ClusterManagerLoadBalancer extends MultiChildLoadBalancer {
    * to be done by the timer.
    */
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     try {
       resolvingAddresses = true;
 
       // process resolvedAddresses to update children
       AcceptResolvedAddressRetVal acceptRetVal =
           acceptResolvedAddressesInternal(resolvedAddresses);
-      if (!acceptRetVal.valid) {
-        return false;
+      if (!acceptRetVal.status.isOk()) {
+        return acceptRetVal.status;
       }
 
       // Update the picker
       updateOverallBalancingState();
 
-      return true;
+      return acceptRetVal.status;
     } finally {
       resolvingAddresses = false;
     }

--- a/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
@@ -98,21 +98,21 @@ class ClusterManagerLoadBalancer extends MultiChildLoadBalancer {
    * to be done by the timer.
    */
   @Override
-  public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     try {
       resolvingAddresses = true;
 
       // process resolvedAddresses to update children
       AcceptResolvedAddressRetVal acceptRetVal =
           acceptResolvedAddressesInternal(resolvedAddresses);
-      if (!acceptRetVal.status.isOk()) {
-        return acceptRetVal.status;
+      if (!acceptRetVal.valid) {
+        return false;
       }
 
       // Update the picker
       updateOverallBalancingState();
 
-      return acceptRetVal.status;
+      return true;
     } finally {
       resolvingAddresses = false;
     }
@@ -159,11 +159,6 @@ class ClusterManagerLoadBalancer extends MultiChildLoadBalancer {
 
   @Override
   protected boolean reconnectOnIdle() {
-    return false;
-  }
-
-  @Override
-  protected boolean shutdownInAcceptResolvedAddresses() {
     return false;
   }
 

--- a/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancer.java
@@ -145,13 +145,13 @@ final class LeastRequestLoadBalancer extends MultiChildLoadBalancer {
 
   @Override
   protected ChildLbState createChildLbState(Object key, Object policyConfig,
-      SubchannelPicker initialPicker) {
+      SubchannelPicker initialPicker, ResolvedAddresses unused) {
     return new LeastRequestLbState(key, pickFirstLbProvider, policyConfig, initialPicker);
   }
 
   private void updateBalancingState(ConnectivityState state, LeastRequestPicker picker) {
     if (state != currentConnectivityState || !picker.isEquivalentTo(currentPicker)) {
-      super.updateHelperBalancingState(state, picker);
+      getHelper().updateBalancingState(state, picker);
       currentConnectivityState = state;
       currentPicker = picker;
     }

--- a/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancer.java
@@ -145,7 +145,7 @@ final class LeastRequestLoadBalancer extends MultiChildLoadBalancer {
 
   @Override
   protected ChildLbState createChildLbState(Object key, Object policyConfig,
-      SubchannelPicker initialPicker) {
+      SubchannelPicker initialPicker, ResolvedAddresses unused) {
     return new LeastRequestLbState(key, pickFirstLbProvider, policyConfig, initialPicker);
   }
 

--- a/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancer.java
@@ -145,7 +145,7 @@ final class LeastRequestLoadBalancer extends MultiChildLoadBalancer {
 
   @Override
   protected ChildLbState createChildLbState(Object key, Object policyConfig,
-      SubchannelPicker initialPicker, ResolvedAddresses unused) {
+      SubchannelPicker initialPicker) {
     return new LeastRequestLbState(key, pickFirstLbProvider, policyConfig, initialPicker);
   }
 

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -194,6 +194,7 @@ final class RingHashLoadBalancer extends MultiChildLoadBalancer {
           break;
         case TRANSIENT_FAILURE:
           numTF++;
+          break;
         default:
           // ignore it
       }

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -271,6 +271,11 @@ final class RingHashLoadBalancer extends MultiChildLoadBalancer {
     return false;
   }
 
+  @Override
+  protected boolean shutdownInAcceptResolvedAddresses() {
+    return false;
+  }
+
   /**
    * Create RingHashChildLbState objects with resolvedAddresses filled in.
    * @return Map of {@link Endpoint} -> {@link RingHashChildLbState}
@@ -584,18 +589,6 @@ final class RingHashLoadBalancer extends MultiChildLoadBalancer {
 
     public RingHashChildLbState(Endpoint key, ResolvedAddresses resolvedAddresses) {
       super(key, pickFirstLbProvider, null, EMPTY_PICKER, resolvedAddresses, true);
-    }
-
-    @Override
-    protected void deactivate() {
-      if (isDeactivated()) {
-        return;
-      }
-
-      // Remove yourself, but don't shutdown yet
-      removeChild(getKey());
-      setDeactivated();
-      logger.log(XdsLogLevel.DEBUG, "Child balancer {0} deactivated", getKey());
     }
 
     @Override

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -156,7 +156,11 @@ final class RingHashLoadBalancer extends MultiChildLoadBalancer {
         connectionAttemptIterator.next();
       }
 
-      updateLbStateAndShutdownRemoved(acceptRetVal.removedChildren);
+      // Must update channel picker before return so that new RPCs will not be routed to deleted
+      // clusters and resolver can remove them in service config.
+      updateOverallBalancingState();
+
+      shutdownRemoved(acceptRetVal.removedChildren);
     } finally {
       this.resolvingAddresses = false;
     }

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -155,12 +155,8 @@ final class RingHashLoadBalancer extends MultiChildLoadBalancer {
    * <p>Aggregation rules (in order of dominance):
    * <ol>
    *   <li>If there is at least one subchannel in READY state, overall state is READY</li>
-   *   <li>If there are <em>2 or more</em> subchannels in TRANSIENT_FAILURE, overall state is
-   *   TRANSIENT_FAILURE</li>
    *   <li>If there is at least one subchannel in CONNECTING state, overall state is
    *   CONNECTING</li>
-   *   <li> If there is one subchannel in TRANSIENT_FAILURE state and there is
-   *    more than one subchannel, report CONNECTING </li>
    *   <li>If there is at least one subchannel in IDLE state, overall state is IDLE</li>
    *   <li>Otherwise, overall state is TRANSIENT_FAILURE</li>
    * </ol>

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -97,7 +97,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
 
   @Override
   protected ChildLbState createChildLbState(Object key, Object policyConfig,
-      SubchannelPicker initialPicker) {
+      SubchannelPicker initialPicker, ResolvedAddresses resolvedAddresses) {
     ChildLbState childLbState = new WeightedChildLbState(key, pickFirstLbProvider, policyConfig,
         initialPicker);
     return childLbState;

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -128,7 +128,12 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
       updateWeightTask.run();
 
       createAndApplyOrcaListeners();
-      updateLbStateAndShutdownRemoved(acceptRetVal.removedChildren);
+
+      // Must update channel picker before return so that new RPCs will not be routed to deleted
+      // clusters and resolver can remove them in service config.
+      updateOverallBalancingState();
+
+      shutdownRemoved(acceptRetVal.removedChildren);
     } finally {
       resolvingAddresses = false;
     }

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -96,25 +96,11 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
   }
 
   @Override
-<<<<<<< HEAD
   protected ChildLbState createChildLbState(Object key, Object policyConfig,
       SubchannelPicker initialPicker) {
     ChildLbState childLbState = new WeightedChildLbState(key, pickFirstLbProvider, policyConfig,
         initialPicker);
     return childLbState;
-=======
-  protected Map<Object, ChildLbState> createChildLbMap(ResolvedAddresses resolvedAddresses) {
-    Map<Object, ChildLbState> childLbMap = new HashMap<>();
-    List<EquivalentAddressGroup> addresses = resolvedAddresses.getAddresses();
-    Object policyConfig = resolvedAddresses.getLoadBalancingPolicyConfig();
-    for (EquivalentAddressGroup eag : addresses) {
-      EquivalentAddressGroup key = stripAttrs(eag);
-      ChildLbState childLbState = new WeightedChildLbState(key, pickFirstLbProvider, policyConfig,
-          getInitialPicker());
-      childLbMap.put(key, childLbState);
-    }
-    return childLbMap;
->>>>>>> 87585d87f (Responded to a number of the code review comments.)
   }
 
   @Override
@@ -146,13 +132,8 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
 
   // Expose for tests in this package.
   @Override
-<<<<<<< HEAD
   protected ChildLbState getChildLbStateEag(EquivalentAddressGroup eag) {
     return super.getChildLbStateEag(eag);
-=======
-  protected ChildLbState getChildLbState(EquivalentAddressGroup eag) {
-    return super.getChildLbState(eag);
->>>>>>> 87585d87f (Responded to a number of the code review comments.)
   }
 
   @VisibleForTesting
@@ -293,11 +274,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
     public Subchannel createSubchannel(CreateSubchannelArgs args) {
       checkElementIndex(0, args.getAddresses().size(), "Empty address group");
       WeightedChildLbState childLbState =
-<<<<<<< HEAD
           (WeightedChildLbState) wrr.getChildLbStateEag(args.getAddresses().get(0));
-=======
-          (WeightedChildLbState) wrr.getChildLbState(args.getAddresses().get(0));
->>>>>>> 87585d87f (Responded to a number of the code review comments.)
       return wrr.new WrrSubchannel(delegate().createSubchannel(args), childLbState);
     }
   }

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -96,11 +96,25 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
   }
 
   @Override
+<<<<<<< HEAD
   protected ChildLbState createChildLbState(Object key, Object policyConfig,
       SubchannelPicker initialPicker) {
     ChildLbState childLbState = new WeightedChildLbState(key, pickFirstLbProvider, policyConfig,
         initialPicker);
     return childLbState;
+=======
+  protected Map<Object, ChildLbState> createChildLbMap(ResolvedAddresses resolvedAddresses) {
+    Map<Object, ChildLbState> childLbMap = new HashMap<>();
+    List<EquivalentAddressGroup> addresses = resolvedAddresses.getAddresses();
+    Object policyConfig = resolvedAddresses.getLoadBalancingPolicyConfig();
+    for (EquivalentAddressGroup eag : addresses) {
+      EquivalentAddressGroup key = stripAttrs(eag);
+      ChildLbState childLbState = new WeightedChildLbState(key, pickFirstLbProvider, policyConfig,
+          getInitialPicker());
+      childLbMap.put(key, childLbState);
+    }
+    return childLbMap;
+>>>>>>> 87585d87f (Responded to a number of the code review comments.)
   }
 
   @Override
@@ -132,8 +146,13 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
 
   // Expose for tests in this package.
   @Override
+<<<<<<< HEAD
   protected ChildLbState getChildLbStateEag(EquivalentAddressGroup eag) {
     return super.getChildLbStateEag(eag);
+=======
+  protected ChildLbState getChildLbState(EquivalentAddressGroup eag) {
+    return super.getChildLbState(eag);
+>>>>>>> 87585d87f (Responded to a number of the code review comments.)
   }
 
   @VisibleForTesting
@@ -274,7 +293,11 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
     public Subchannel createSubchannel(CreateSubchannelArgs args) {
       checkElementIndex(0, args.getAddresses().size(), "Empty address group");
       WeightedChildLbState childLbState =
+<<<<<<< HEAD
           (WeightedChildLbState) wrr.getChildLbStateEag(args.getAddresses().get(0));
+=======
+          (WeightedChildLbState) wrr.getChildLbState(args.getAddresses().get(0));
+>>>>>>> 87585d87f (Responded to a number of the code review comments.)
       return wrr.new WrrSubchannel(delegate().createSubchannel(args), childLbState);
     }
   }

--- a/xds/src/test/java/io/grpc/xds/LeastRequestLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/LeastRequestLoadBalancerTest.java
@@ -233,9 +233,7 @@ public class LeastRequestLoadBalancerTest {
   }
 
   private Subchannel getSubchannel(ChildLbState childLbState) {
-    List<EquivalentAddressGroup> eagList =
-        Arrays.asList((EquivalentAddressGroup) childLbState.getKey());
-    return subchannels.get(eagList);
+    return subchannels.get(Collections.singletonList(childLbState.getEag()));
   }
 
   private static List<Object> getChildEags(LeastRequestLoadBalancer loadBalancer) {
@@ -588,7 +586,7 @@ public class LeastRequestLoadBalancerTest {
     deliverSubchannelState(sc2, ConnectivityStateInfo.forNonError(IDLE));
     deliverSubchannelState(sc3, ConnectivityStateInfo.forTransientFailure(Status.UNAVAILABLE));
 
-    verify(helper, times(3))
+    verify(helper, times(6))
         .updateBalancingState(stateCaptor.capture(), pickerCaptor.capture());
     Iterator<ConnectivityState> stateIterator = stateCaptor.getAllValues().iterator();
     Iterator<SubchannelPicker> pickers = pickerCaptor.getAllValues().iterator();

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
@@ -22,18 +22,21 @@ import static io.grpc.ConnectivityState.IDLE;
 import static io.grpc.ConnectivityState.READY;
 import static io.grpc.ConnectivityState.SHUTDOWN;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
+import static io.grpc.xds.RingHashLoadBalancerTest.InitializationFlags.DO_NOT_RESET_HELPER;
+import static io.grpc.xds.RingHashLoadBalancerTest.InitializationFlags.DO_NOT_VERIFY;
+import static io.grpc.xds.RingHashLoadBalancerTest.InitializationFlags.RESET_SUBCHANNEL_MOCKS;
+import static io.grpc.xds.RingHashLoadBalancerTest.InitializationFlags.STAY_IN_CONNECTING;
+import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.clearInvocations;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Iterables;
 import com.google.common.primitives.UnsignedInteger;
@@ -48,13 +51,15 @@ import io.grpc.LoadBalancer.PickSubchannelArgs;
 import io.grpc.LoadBalancer.ResolvedAddresses;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer.SubchannelPicker;
-import io.grpc.LoadBalancer.SubchannelStateListener;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.SynchronizationContext;
 import io.grpc.internal.PickSubchannelArgsImpl;
 import io.grpc.testing.TestMethodDescriptors;
+import io.grpc.util.AbstractTestHelper;
+import io.grpc.util.MultiChildLoadBalancer.ChildLbState;
+import io.grpc.xds.RingHashLoadBalancer.RingHashChildLbState;
 import io.grpc.xds.RingHashLoadBalancer.RingHashConfig;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.net.SocketAddress;
@@ -74,12 +79,9 @@ import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InOrder;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-import org.mockito.stubbing.Answer;
 
 /** Unit test for {@link io.grpc.LoadBalancer}. */
 @RunWith(JUnit4.class)
@@ -97,49 +99,18 @@ public class RingHashLoadBalancerTest {
         }
       });
   private final Map<List<EquivalentAddressGroup>, Subchannel> subchannels = new HashMap<>();
-  private final Map<Subchannel, SubchannelStateListener> subchannelStateListeners =
-      new HashMap<>();
   private final Deque<Subchannel> connectionRequestedQueue = new ArrayDeque<>();
   private final XxHash64 hashFunc = XxHash64.INSTANCE;
-  @Mock
-  private Helper helper;
+  private final TestHelper testHelperInst = new TestHelper();
+  private final Helper helper = mock(Helper.class, delegatesTo(testHelperInst));
   @Captor
   private ArgumentCaptor<SubchannelPicker> pickerCaptor;
   private RingHashLoadBalancer loadBalancer;
 
   @Before
   public void setUp() {
-    when(helper.getAuthority()).thenReturn(AUTHORITY);
-    when(helper.getSynchronizationContext()).thenReturn(syncContext);
-    when(helper.createSubchannel(any(CreateSubchannelArgs.class))).thenAnswer(
-        new Answer<Subchannel>() {
-          @Override
-          public Subchannel answer(InvocationOnMock invocation) throws Throwable {
-            CreateSubchannelArgs args = (CreateSubchannelArgs) invocation.getArguments()[0];
-            final Subchannel subchannel = mock(Subchannel.class);
-            when(subchannel.getAllAddresses()).thenReturn(args.getAddresses());
-            when(subchannel.getAttributes()).thenReturn(args.getAttributes());
-            subchannels.put(args.getAddresses(), subchannel);
-            doAnswer(new Answer<Void>() {
-              @Override
-              public Void answer(InvocationOnMock invocation) throws Throwable {
-                subchannelStateListeners.put(
-                    subchannel, (SubchannelStateListener) invocation.getArguments()[0]);
-                return null;
-              }
-            }).when(subchannel).start(any(SubchannelStateListener.class));
-            doAnswer(new Answer<Void>() {
-              @Override
-              public Void answer(InvocationOnMock invocation) throws Throwable {
-                connectionRequestedQueue.offer(subchannel);
-                return null;
-              }
-            }).when(subchannel).requestConnection();
-            return subchannel;
-          }
-        });
     loadBalancer = new RingHashLoadBalancer(helper);
-    // Skip uninterested interactions.
+    // Consume calls not relevant for tests that would otherwise fail verifyNoMoreInteractions
     verify(helper).getAuthority();
     verify(helper).getSynchronizationContext();
   }
@@ -161,21 +132,20 @@ public class RingHashLoadBalancerTest {
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     assertThat(addressesAcceptanceStatus.isOk()).isTrue();
-    verify(helper).createSubchannel(any(CreateSubchannelArgs.class));
-    Subchannel subchannel = Iterables.getOnlyElement(subchannels.values());
-    verify(subchannel, never()).requestConnection();
     verify(helper).updateBalancingState(eq(IDLE), pickerCaptor.capture());
+    assertThat(subchannels.size()).isEqualTo(0);
 
     // Picking subchannel triggers connection.
-    PickSubchannelArgs args = new PickSubchannelArgsImpl(
-        TestMethodDescriptors.voidMethod(), new Metadata(),
-        CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, hashFunc.hashVoid()));
+    PickSubchannelArgs args = getDefaultPickSubchannelArgs(hashFunc.hashVoid());
     PickResult result = pickerCaptor.getValue().pickSubchannel(args);
     assertThat(result.getStatus().isOk()).isTrue();
     assertThat(result.getSubchannel()).isNull();
+    Subchannel subchannel = Iterables.getOnlyElement(subchannels.values());
     verify(subchannel).requestConnection();
-    deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(CONNECTING));
     verify(helper).updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
+    verify(helper).createSubchannel(any(CreateSubchannelArgs.class));
+    deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(CONNECTING));
+    verify(helper, times(2)).updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
 
     // Subchannel becomes ready, triggers pick again.
     deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(READY));
@@ -193,16 +163,19 @@ public class RingHashLoadBalancerTest {
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     assertThat(addressesAcceptanceStatus.isOk()).isTrue();
-    Subchannel subchannel = Iterables.getOnlyElement(subchannels.values());
-    InOrder inOrder = Mockito.inOrder(helper, subchannel);
-    inOrder.verify(helper).updateBalancingState(eq(IDLE), pickerCaptor.capture());
-    inOrder.verify(subchannel, never()).requestConnection();
+    verify(helper).updateBalancingState(eq(IDLE), pickerCaptor.capture());
+
+    RingHashChildLbState childLbState =
+        (RingHashChildLbState) loadBalancer.getChildLbStates().iterator().next();
+    assertThat(childLbState.isDeactivated()).isTrue();
 
     // Picking subchannel triggers connection.
-    PickSubchannelArgs args = new PickSubchannelArgsImpl(
-        TestMethodDescriptors.voidMethod(), new Metadata(),
-        CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, hashFunc.hashVoid()));
+    PickSubchannelArgs args = getDefaultPickSubchannelArgs(hashFunc.hashVoid());
     pickerCaptor.getValue().pickSubchannel(args);
+    assertThat(childLbState.isDeactivated()).isFalse();
+    assertThat(childLbState.getLb().delegateType()).isEqualTo("PickFirstLoadBalancer");
+    Subchannel subchannel = subchannels.get(Collections.singletonList(childLbState.getEag()));
+    InOrder inOrder = Mockito.inOrder(helper, subchannel);
     inOrder.verify(subchannel).requestConnection();
     deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(READY));
     inOrder.verify(helper).updateBalancingState(eq(READY), any(SubchannelPicker.class));
@@ -220,12 +193,8 @@ public class RingHashLoadBalancerTest {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1);
     InOrder inOrder = Mockito.inOrder(helper);
-    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
-    inOrder.verify(helper, times(2)).createSubchannel(any(CreateSubchannelArgs.class));
-    inOrder.verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
+
+    initializeLbSubchannels(config, servers);
 
     // one in CONNECTING, one in IDLE
     deliverSubchannelState(
@@ -263,7 +232,7 @@ public class RingHashLoadBalancerTest {
         ConnectivityStateInfo.forNonError(IDLE));
     inOrder.verify(helper).refreshNameResolution();
     inOrder.verify(helper).updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
-    verifyConnection(1);
+    verifyConnection(0);
 
     verifyNoMoreInteractions(helper);
   }
@@ -278,164 +247,57 @@ public class RingHashLoadBalancerTest {
   }
 
   @Test
-  public void aggregateSubchannelStates_twoOrMoreSubchannelsInTransientFailure() {
+  public void aggregateSubchannelStates_allSubchannelsInTransientFailure() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1, 1);
-    InOrder inOrder = Mockito.inOrder(helper);
-    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
-    inOrder.verify(helper, times(4)).createSubchannel(any(CreateSubchannelArgs.class));
-    inOrder.verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
 
-    // one in TRANSIENT_FAILURE, three in IDLE
-    deliverSubchannelState(
-        subchannels.get(Collections.singletonList(servers.get(0))),
-        ConnectivityStateInfo.forTransientFailure(
-            Status.UNAVAILABLE.withDescription("not found")));
+    List<Subchannel> subChannelList = initializeLbSubchannels(config, servers, STAY_IN_CONNECTING);
+
+    // reset inOrder to include all the childLBs now that they have been created
+    clearInvocations(helper);
+    InOrder inOrder = Mockito.inOrder(helper,
+        subChannelList.get(0), subChannelList.get(1), subChannelList.get(2), subChannelList.get(3));
+
+    // one in TRANSIENT_FAILURE, three in CONNECTING
+    deliverNotFound(subChannelList, 0);
     inOrder.verify(helper).refreshNameResolution();
     inOrder.verify(helper).updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
-    verifyConnection(1);
 
-    // two in TRANSIENT_FAILURE, two in IDLE
-    deliverSubchannelState(
-        subchannels.get(Collections.singletonList(servers.get(1))),
-        ConnectivityStateInfo.forTransientFailure(
-            Status.UNAVAILABLE.withDescription("also not found")));
+    // two in TRANSIENT_FAILURE, two in CONNECTING
+    deliverNotFound(subChannelList, 1);
     inOrder.verify(helper).refreshNameResolution();
     inOrder.verify(helper)
         .updateBalancingState(eq(TRANSIENT_FAILURE), any(SubchannelPicker.class));
-    verifyConnection(1);
 
-    // two in TRANSIENT_FAILURE, one in CONNECTING, one in IDLE
-    // The overall state is dominated by the two in TRANSIENT_FAILURE.
-    deliverSubchannelState(
-        subchannels.get(Collections.singletonList(servers.get(2))),
-        ConnectivityStateInfo.forNonError(CONNECTING));
-    inOrder.verify(helper)
-        .updateBalancingState(eq(TRANSIENT_FAILURE), any(SubchannelPicker.class));
-    verifyConnection(0);
-
-    // three in TRANSIENT_FAILURE, one in CONNECTING
-    deliverSubchannelState(
-        subchannels.get(Collections.singletonList(servers.get(3))),
-        ConnectivityStateInfo.forTransientFailure(
-            Status.UNAVAILABLE.withDescription("connection lost")));
+    // All 4 in TF switch to TF
+    deliverNotFound(subChannelList, 2);
     inOrder.verify(helper).refreshNameResolution();
     inOrder.verify(helper)
         .updateBalancingState(eq(TRANSIENT_FAILURE), any(SubchannelPicker.class));
-    verifyConnection(0);
+    deliverNotFound(subChannelList, 3);
+    inOrder.verify(helper).refreshNameResolution();
+    inOrder.verify(helper)
+        .updateBalancingState(eq(TRANSIENT_FAILURE), any(SubchannelPicker.class));
+
+    // reset subchannel to CONNECTING - shouldn't change anything since PF hides the state change
+    deliverSubchannelState(subChannelList.get(2), ConnectivityStateInfo.forNonError(CONNECTING));
+    inOrder.verify(helper, never())
+        .updateBalancingState(eq(TRANSIENT_FAILURE), any(SubchannelPicker.class));
+    inOrder.verify(subChannelList.get(2), never()).requestConnection();
 
     // three in TRANSIENT_FAILURE, one in READY
-    deliverSubchannelState(
-        subchannels.get(Collections.singletonList(servers.get(2))),
-        ConnectivityStateInfo.forNonError(READY));
+    deliverSubchannelState(subChannelList.get(2), ConnectivityStateInfo.forNonError(READY));
     inOrder.verify(helper).updateBalancingState(eq(READY), any(SubchannelPicker.class));
-    verifyConnection(0);
+    inOrder.verify(subChannelList.get(2), never()).requestConnection();
 
     verifyNoMoreInteractions(helper);
-  }
-
-  @Test
-  public void subchannelStayInTransientFailureUntilBecomeReady() {
-    RingHashConfig config = new RingHashConfig(10, 100);
-    List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
-    verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
-    verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
-    reset(helper);
-
-    // Simulate picks have taken place and subchannels have requested connection.
-    for (Subchannel subchannel : subchannels.values()) {
-      deliverSubchannelState(subchannel, ConnectivityStateInfo.forTransientFailure(
-          Status.UNAUTHENTICATED.withDescription("Permission denied")));
-    }
-    verify(helper, times(3)).refreshNameResolution();
-
-    // Stays in IDLE when until there are two or more subchannels in TRANSIENT_FAILURE.
-    verify(helper).updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
-    verify(helper, times(2))
-        .updateBalancingState(eq(TRANSIENT_FAILURE), any(SubchannelPicker.class));
-    verifyConnection(3);
-
-    verifyNoMoreInteractions(helper);
-    reset(helper);
-    // Simulate underlying subchannel auto reconnect after backoff.
-    for (Subchannel subchannel : subchannels.values()) {
-      deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(CONNECTING));
-    }
-    verify(helper, times(3))
-        .updateBalancingState(eq(TRANSIENT_FAILURE), any(SubchannelPicker.class));
-    verifyConnection(3);
-    verifyNoMoreInteractions(helper);
-
-    // Simulate one subchannel enters READY.
-    deliverSubchannelState(
-        subchannels.values().iterator().next(), ConnectivityStateInfo.forNonError(READY));
-    verify(helper).updateBalancingState(eq(READY), any(SubchannelPicker.class));
-  }
-
-  @Test
-  public void updateConnectionIterator() {
-    RingHashConfig config = new RingHashConfig(10, 100);
-    List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    InOrder inOrder = Mockito.inOrder(helper);
-    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
-    verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
-    verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
-
-    deliverSubchannelState(
-        subchannels.get(Collections.singletonList(servers.get(0))),
-        ConnectivityStateInfo.forTransientFailure(
-            Status.UNAVAILABLE.withDescription("connection lost")));
-    inOrder.verify(helper).refreshNameResolution();
-    inOrder.verify(helper)
-        .updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
-    verifyConnection(1);
-
-    servers = createWeightedServerAddrs(1,1);
-    addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
-    inOrder.verify(helper)
-        .updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
-    verifyConnection(1);
-
-    deliverSubchannelState(
-        subchannels.get(Collections.singletonList(servers.get(1))),
-        ConnectivityStateInfo.forTransientFailure(
-            Status.UNAVAILABLE.withDescription("connection lost")));
-    inOrder.verify(helper).refreshNameResolution();
-    inOrder.verify(helper)
-        .updateBalancingState(eq(TRANSIENT_FAILURE), any(SubchannelPicker.class));
-    verifyConnection(1);
-
-    deliverSubchannelState(
-        subchannels.get(Collections.singletonList(servers.get(0))),
-        ConnectivityStateInfo.forNonError(CONNECTING));
-    inOrder.verify(helper)
-        .updateBalancingState(eq(TRANSIENT_FAILURE), any(SubchannelPicker.class));
-    verifyConnection(1);
   }
 
   @Test
   public void ignoreShutdownSubchannelStateChange() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
-    verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
-    verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
+    initializeLbSubchannels(config, servers);
 
     loadBalancer.shutdown();
     for (Subchannel sc : subchannels.values()) {
@@ -451,13 +313,8 @@ public class RingHashLoadBalancerTest {
   public void deterministicPickWithHostsPartiallyRemoved() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1, 1, 1);
-    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
+    initializeLbSubchannels(config, servers);
     InOrder inOrder = Mockito.inOrder(helper);
-    inOrder.verify(helper, times(5)).createSubchannel(any(CreateSubchannelArgs.class));
-    inOrder.verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
 
     // Bring all subchannels to READY so that next pick always succeeds.
     for (Subchannel subchannel : subchannels.values()) {
@@ -466,10 +323,8 @@ public class RingHashLoadBalancerTest {
     }
 
     // Simulate rpc hash hits one ring entry exactly for server1.
-    long rpcHash = hashFunc.hashAsciiString("[FakeSocketAddress-server1]_0");
-    PickSubchannelArgs args = new PickSubchannelArgsImpl(
-        TestMethodDescriptors.voidMethod(), new Metadata(),
-        CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, rpcHash));
+    long rpcHash = hashFunc.hashAsciiString("FakeSocketAddress-server1_0");
+    PickSubchannelArgs args = getDefaultPickSubchannelArgs(rpcHash);
     pickerCaptor.getValue().pickSubchannel(args);
     PickResult result = pickerCaptor.getValue().pickSubchannel(args);
     Subchannel subchannel = result.getSubchannel();
@@ -480,14 +335,14 @@ public class RingHashLoadBalancerTest {
       Attributes attr = addr.getAttributes().toBuilder().set(CUSTOM_KEY, "custom value").build();
       updatedServers.add(new EquivalentAddressGroup(addr.getAddresses(), attr));
     }
-    addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
+    Subchannel subchannel0_old = subchannels.get(Collections.singletonList(servers.get(0)));
+    Subchannel subchannel1_old = subchannels.get(Collections.singletonList(servers.get(1)));
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(updatedServers).setLoadBalancingPolicyConfig(config).build());
     assertThat(addressesAcceptanceStatus.isOk()).isTrue();
-    verify(subchannels.get(Collections.singletonList(servers.get(0))))
-        .updateAddresses(Collections.singletonList(updatedServers.get(0)));
-    verify(subchannels.get(Collections.singletonList(servers.get(1))))
-        .updateAddresses(Collections.singletonList(updatedServers.get(1)));
+    verify(subchannel0_old).updateAddresses(Collections.singletonList(updatedServers.get(0)));
+    verify(subchannel1_old).updateAddresses(Collections.singletonList(updatedServers.get(1)));
     inOrder.verify(helper).updateBalancingState(eq(READY), pickerCaptor.capture());
     assertThat(pickerCaptor.getValue().pickSubchannel(args).getSubchannel())
         .isSameInstanceAs(subchannel);
@@ -498,13 +353,9 @@ public class RingHashLoadBalancerTest {
   public void deterministicPickWithNewHostsAdded() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1);  // server0 and server1
-    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
+    initializeLbSubchannels(config, servers, DO_NOT_VERIFY, DO_NOT_RESET_HELPER);
+
     InOrder inOrder = Mockito.inOrder(helper);
-    inOrder.verify(helper, times(2)).createSubchannel(any(CreateSubchannelArgs.class));
-    inOrder.verify(helper).updateBalancingState(eq(IDLE), pickerCaptor.capture());
 
     // Bring all subchannels to READY so that next pick always succeeds.
     for (Subchannel subchannel : subchannels.values()) {
@@ -513,66 +364,68 @@ public class RingHashLoadBalancerTest {
     }
 
     // Simulate rpc hash hits one ring entry exactly for server1.
-    long rpcHash = hashFunc.hashAsciiString("[FakeSocketAddress-server1]_0");
-    PickSubchannelArgs args = new PickSubchannelArgsImpl(
-        TestMethodDescriptors.voidMethod(), new Metadata(),
-        CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, rpcHash));
+    long rpcHash = hashFunc.hashAsciiString("FakeSocketAddress-server1_0");
+    PickSubchannelArgs args = getDefaultPickSubchannelArgs(rpcHash);
     pickerCaptor.getValue().pickSubchannel(args);
     PickResult result = pickerCaptor.getValue().pickSubchannel(args);
     Subchannel subchannel = result.getSubchannel();
     assertThat(subchannel.getAddresses()).isEqualTo(servers.get(1));
 
     servers = createWeightedServerAddrs(1, 1, 1, 1, 1);  // server2, server3, server4 added
-    addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
-    inOrder.verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
-    inOrder.verify(helper).updateBalancingState(eq(READY), pickerCaptor.capture());
-    assertThat(pickerCaptor.getValue().pickSubchannel(args).getSubchannel())
-        .isSameInstanceAs(subchannel);
-    verifyNoMoreInteractions(helper);
-  }
-
-  @Test
-  public void skipFailingHosts_pickNextNonFailingHostInFirstTwoHosts() {
-    // Map each server address to exactly one ring entry.
-    RingHashConfig config = new RingHashConfig(3, 3);
-    List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
     Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     assertThat(addressesAcceptanceStatus.isOk()).isTrue();
-    verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
-    verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));  // initial IDLE
+    assertThat(loadBalancer.getChildLbStates().size()).isEqualTo(5);
+    inOrder.verify(helper).updateBalancingState(eq(READY), pickerCaptor.capture());
+    assertThat(pickerCaptor.getValue().pickSubchannel(args).getSubchannel())
+        .isSameInstanceAs(subchannel);
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  private Subchannel getSubChannel(EquivalentAddressGroup eag) {
+    return subchannels.get(Collections.singletonList(eag));
+  }
+
+  @Test
+  public void skipFailingHosts_pickNextNonFailingHost() {
+    // Map each server address to exactly one ring entry.
+    RingHashConfig config = new RingHashConfig(3, 3);
+    List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
+    Status addressesAcceptanceStatus =
+        loadBalancer.acceptResolvedAddresses(
+            ResolvedAddresses.newBuilder()
+                .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
+
+    // Create subchannel for the first address
+    ((RingHashChildLbState)loadBalancer.getChildLbStateEag(servers.get(0))).activate();
+    verifyConnection(1);
+
     reset(helper);
     // ring:
-    //   "[FakeSocketAddress-server1]_0"
-    //   "[FakeSocketAddress-server0]_0"
-    //   "[FakeSocketAddress-server2]_0"
+    //   "FakeSocketAddress-server0_0"
+    //   "FakeSocketAddress-server1_0"
+    //   "FakeSocketAddress-server2_0"
 
-    long rpcHash = hashFunc.hashAsciiString("[FakeSocketAddress-server0]_0");
+    long rpcHash = hashFunc.hashAsciiString("FakeSocketAddress-server0_0");
     PickSubchannelArgs args = getDefaultPickSubchannelArgs(rpcHash);
 
     // Bring down server0 to force trying server2.
     deliverSubchannelState(
-        subchannels.get(Collections.singletonList(servers.get(0))),
+        getSubChannel(servers.get(0)),
         ConnectivityStateInfo.forTransientFailure(
             Status.UNAVAILABLE.withDescription("unreachable")));
     verify(helper).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
-    verifyConnection(1);
 
     PickResult result = pickerCaptor.getValue().pickSubchannel(args);
     assertThat(result.getStatus().isOk()).isTrue();
     assertThat(result.getSubchannel()).isNull();  // buffer request
-    verify(subchannels.get(Collections.singletonList(servers.get(2))))
-        .requestConnection();  // kick off connection to server2
-    verify(subchannels.get(Collections.singletonList(servers.get(1))), never())
-        .requestConnection();  // no excessive connection
+    verify(getSubChannel(servers.get(1))).requestConnection();  // kicked off connection to server2
+    assertThat(subchannels.size()).isEqualTo(2);  // no excessive connection
 
     reset(helper);
-    deliverSubchannelState(
-        subchannels.get(Collections.singletonList(servers.get(2))),
+    deliverSubchannelState(getSubChannel(servers.get(1)),
         ConnectivityStateInfo.forNonError(CONNECTING));
     verify(helper).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
 
@@ -580,14 +433,12 @@ public class RingHashLoadBalancerTest {
     assertThat(result.getStatus().isOk()).isTrue();
     assertThat(result.getSubchannel()).isNull();  // buffer request
 
-    deliverSubchannelState(
-        subchannels.get(Collections.singletonList(servers.get(2))),
-        ConnectivityStateInfo.forNonError(READY));
+    deliverSubchannelState(getSubChannel(servers.get(1)), ConnectivityStateInfo.forNonError(READY));
     verify(helper).updateBalancingState(eq(READY), pickerCaptor.capture());
 
     result = pickerCaptor.getValue().pickSubchannel(args);
     assertThat(result.getStatus().isOk()).isTrue();
-    assertThat(result.getSubchannel().getAddresses()).isEqualTo(servers.get(2));
+    assertThat(result.getSubchannel().getAddresses()).isEqualTo(servers.get(1));
   }
 
   private PickSubchannelArgsImpl getDefaultPickSubchannelArgs(long rpcHash) {
@@ -596,55 +447,59 @@ public class RingHashLoadBalancerTest {
         CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, rpcHash));
   }
 
+  private PickSubchannelArgsImpl getDefaultPickSubchannelArgsForServer(int serverid) {
+    long rpcHash = hashFunc.hashAsciiString("FakeSocketAddress-server" + serverid + "_0");
+    return getDefaultPickSubchannelArgs(rpcHash);
+  }
+
   @Test
   public void skipFailingHosts_firstTwoHostsFailed_pickNextFirstReady() {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
-    verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
-    verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));  // initial IDLE
-    reset(helper);
-    // ring:
-    //   "[FakeSocketAddress-server1]_0"
-    //   "[FakeSocketAddress-server0]_0"
-    //   "[FakeSocketAddress-server2]_0"
 
-    long rpcHash = hashFunc.hashAsciiString("[FakeSocketAddress-server0]_0");
-    PickSubchannelArgs args = new PickSubchannelArgsImpl(
-        TestMethodDescriptors.voidMethod(), new Metadata(),
-        CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, rpcHash));
+    initializeLbSubchannels(config, servers);
+
+    // ring:
+    //   "FakeSocketAddress-server0_0"
+    //   "FakeSocketAddress-server1_0"
+    //   "FakeSocketAddress-server2_0"
+
+    long rpcHash = hashFunc.hashAsciiString("FakeSocketAddress-server1_0");
+    PickSubchannelArgs args = getDefaultPickSubchannelArgs(rpcHash);
 
     // Bring down server0 and server2 to force trying server1.
     deliverSubchannelState(
-        subchannels.get(Collections.singletonList(servers.get(0))),
+        subchannels.get(Collections.singletonList(servers.get(1))),
         ConnectivityStateInfo.forTransientFailure(
             Status.UNAVAILABLE.withDescription("unreachable")));
     deliverSubchannelState(
         subchannels.get(Collections.singletonList(servers.get(2))),
         ConnectivityStateInfo.forTransientFailure(
             Status.PERMISSION_DENIED.withDescription("permission denied")));
-    verify(helper).updateBalancingState(eq(TRANSIENT_FAILURE), pickerCaptor.capture());
-    verifyConnection(2); // LB attempts to recover by itself
+    verify(helper).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
+    verifyConnection(0);
+    PickResult result = pickerCaptor.getValue().pickSubchannel(args); // activate last subchannel
+    assertThat(result.getStatus().isOk()).isTrue();
+    verifyConnection(1);
 
-    PickResult result = pickerCaptor.getValue().pickSubchannel(args);
+    deliverSubchannelState(
+        subchannels.get(Collections.singletonList(servers.get(0))),
+        ConnectivityStateInfo.forTransientFailure(
+            Status.PERMISSION_DENIED.withDescription("permission denied again")));
+    verify(helper, times(2)).updateBalancingState(eq(TRANSIENT_FAILURE), pickerCaptor.capture());
+    result = pickerCaptor.getValue().pickSubchannel(args);
     assertThat(result.getStatus().isOk()).isFalse();  // fail the RPC
     assertThat(result.getStatus().getCode())
         .isEqualTo(Code.UNAVAILABLE);  // with error status for the original server hit by hash
     assertThat(result.getStatus().getDescription()).isEqualTo("unreachable");
-    verify(subchannels.get(Collections.singletonList(servers.get(1))))
-        .requestConnection(); // kickoff connection to server3 (next first non-failing)
-    verify(subchannels.get(Collections.singletonList(servers.get(0)))).requestConnection();
-    verify(subchannels.get(Collections.singletonList(servers.get(2)))).requestConnection();
 
     // Now connecting to server1.
     deliverSubchannelState(
         subchannels.get(Collections.singletonList(servers.get(1))),
         ConnectivityStateInfo.forNonError(CONNECTING));
-    verify(helper, times(2)).updateBalancingState(eq(TRANSIENT_FAILURE), pickerCaptor.capture());
+
+    reset(helper);
 
     result = pickerCaptor.getValue().pickSubchannel(args);
     assertThat(result.getStatus().isOk()).isFalse();  // fail the RPC
@@ -658,9 +513,29 @@ public class RingHashLoadBalancerTest {
         ConnectivityStateInfo.forNonError(READY));
     verify(helper).updateBalancingState(eq(READY), pickerCaptor.capture());
 
-    result = pickerCaptor.getValue().pickSubchannel(args);
+    SubchannelPicker picker = pickerCaptor.getValue();
+    result = picker.pickSubchannel(args);
     assertThat(result.getStatus().isOk()).isTrue();  // succeed
     assertThat(result.getSubchannel().getAddresses()).isEqualTo(servers.get(1));  // with server1
+    assertThat(picker.pickSubchannel(getDefaultPickSubchannelArgsForServer(0))).isEqualTo(result);
+    assertThat(picker.pickSubchannel(getDefaultPickSubchannelArgsForServer(2))).isEqualTo(result);
+  }
+
+  @Test
+  public void removingAddressShutdownSubchannel() {
+    // Map each server address to exactly one ring entry.
+    RingHashConfig config = new RingHashConfig(3, 3);
+    List<EquivalentAddressGroup> svs1 = createWeightedServerAddrs(1, 1, 1);
+    List<Subchannel> subchannels1 = initializeLbSubchannels(config, svs1, STAY_IN_CONNECTING);
+
+    List<EquivalentAddressGroup> svs2 = createWeightedServerAddrs(1, 1);
+    InOrder inOrder = Mockito.inOrder(helper, subchannels1.get(2));
+    // send LB the missing address
+    loadBalancer.acceptResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setAddresses(svs2).setLoadBalancingPolicyConfig(config).build());
+    inOrder.verify(helper).updateBalancingState(eq(CONNECTING), any());
+    inOrder.verify(subchannels1.get(2)).shutdown();
   }
 
   @Test
@@ -668,12 +543,7 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
-    verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
-    verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
+    initializeLbSubchannels(config, servers);
 
     // Bring all subchannels to TRANSIENT_FAILURE.
     for (Subchannel subchannel : subchannels.values()) {
@@ -683,23 +553,16 @@ public class RingHashLoadBalancerTest {
     }
     verify(helper, atLeastOnce())
         .updateBalancingState(eq(TRANSIENT_FAILURE), pickerCaptor.capture());
-    verifyConnection(3);
+    verifyConnection(0);
 
     // Picking subchannel triggers connection. RPC hash hits server0.
-    PickSubchannelArgs args = new PickSubchannelArgsImpl(
-        TestMethodDescriptors.voidMethod(), new Metadata(),
-        CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, hashFunc.hashVoid()));
+    PickSubchannelArgs args = getDefaultPickSubchannelArgsForServer(0);
     PickResult result = pickerCaptor.getValue().pickSubchannel(args);
     assertThat(result.getStatus().isOk()).isFalse();
     assertThat(result.getStatus().getCode()).isEqualTo(Code.UNAVAILABLE);
     assertThat(result.getStatus().getDescription())
         .isEqualTo("[FakeSocketAddress-server0] unreachable");
-    verify(subchannels.get(Collections.singletonList(servers.get(0))))
-        .requestConnection();
-    verify(subchannels.get(Collections.singletonList(servers.get(1))))
-        .requestConnection();
-    verify(subchannels.get(Collections.singletonList(servers.get(2))))
-        .requestConnection();
+    verifyConnection(0); // TF has already started taking care of this, pick doesn't need to
   }
 
   @Test
@@ -707,31 +570,20 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
-    verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
-    verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
+    initializeLbSubchannels(config, servers);
 
+    // Go to TF does nothing, though PF will try to reconnect after backoff
     deliverSubchannelState(subchannels.get(Collections.singletonList(servers.get(1))),
         ConnectivityStateInfo.forTransientFailure(
-        Status.UNAVAILABLE.withDescription("unreachable")));
+            Status.UNAVAILABLE.withDescription("unreachable")));
     verify(helper).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
-    verifyConnection(1);
+    verifyConnection(0);
 
     // Picking subchannel triggers connection. RPC hash hits server0.
-    PickSubchannelArgs args = new PickSubchannelArgsImpl(
-        TestMethodDescriptors.voidMethod(), new Metadata(),
-        CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, hashFunc.hashVoid()));
+    PickSubchannelArgs args = getDefaultPickSubchannelArgs(hashFunc.hashVoid());
     PickResult result = pickerCaptor.getValue().pickSubchannel(args);
     assertThat(result.getStatus().isOk()).isTrue();
-    verify(subchannels.get(Collections.singletonList(servers.get(0))))
-        .requestConnection();
-    verify(subchannels.get(Collections.singletonList(servers.get(1))), never())
-        .requestConnection();
-    verify(subchannels.get(Collections.singletonList(servers.get(2))), never())
-        .requestConnection();
+    verifyConnection(1);
   }
 
   @Test
@@ -739,12 +591,7 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
-    verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
-    verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
+    initializeLbSubchannels(config, servers);
 
     deliverSubchannelState(subchannels.get(Collections.singletonList(servers.get(0))),
         ConnectivityStateInfo.forNonError(CONNECTING));
@@ -753,9 +600,7 @@ public class RingHashLoadBalancerTest {
     verify(helper, times(2)).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
 
     // Picking subchannel triggers connection.
-    PickSubchannelArgs args = new PickSubchannelArgsImpl(
-        TestMethodDescriptors.voidMethod(), new Metadata(),
-        CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, hashFunc.hashVoid()));
+    PickSubchannelArgs args = getDefaultPickSubchannelArgs(hashFunc.hashVoid());
     PickResult result = pickerCaptor.getValue().pickSubchannel(args);
     assertThat(result.getStatus().isOk()).isTrue();
     verify(subchannels.get(Collections.singletonList(servers.get(0))), never())
@@ -771,35 +616,30 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
-    verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
-    verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
-    // ring:
-    //   "[FakeSocketAddress-server1]_0"
-    //   "[FakeSocketAddress-server0]_0"
-    //   "[FakeSocketAddress-server2]_0"
 
-    deliverSubchannelState(subchannels.get(Collections.singletonList(servers.get(0))),
+    List<Subchannel> subchannelList =
+        initializeLbSubchannels(config, servers, RESET_SUBCHANNEL_MOCKS);
+
+    // ring:
+    //   "FakeSocketAddress-server1_0"
+    //   "FakeSocketAddress-server0_0"
+    //   "FakeSocketAddress-server2_0"
+
+    deliverSubchannelState(subchannelList.get(0),
         ConnectivityStateInfo.forTransientFailure(
             Status.UNAVAILABLE.withDescription("unreachable")));
     verify(helper).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
-    verifyConnection(1);
+    verifyConnection(0);
 
-    // Picking subchannel triggers connection.
-    PickSubchannelArgs args = new PickSubchannelArgsImpl(
-        TestMethodDescriptors.voidMethod(), new Metadata(),
-        CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, hashFunc.hashVoid()));
-    PickResult result = pickerCaptor.getValue().pickSubchannel(args);
+    // Per GRFC A61 Picking subchannel should no longer request connections that were failing
+    PickSubchannelArgs args = getDefaultPickSubchannelArgs(hashFunc.hashVoid());
+    SubchannelPicker picker1 = pickerCaptor.getValue();
+    PickResult result = picker1.pickSubchannel(args);
     assertThat(result.getStatus().isOk()).isTrue();
-    verify(subchannels.get(Collections.singletonList(servers.get(0))))
-        .requestConnection();
-    verify(subchannels.get(Collections.singletonList(servers.get(2))))
-        .requestConnection();
-    verify(subchannels.get(Collections.singletonList(servers.get(1))), never())
-        .requestConnection();
+    assertThat(result.getSubchannel()).isNull();
+    verify(subchannelList.get(0), never()).requestConnection(); // In TF
+    verify(subchannelList.get(1)).requestConnection();
+    verify(subchannelList.get(2), never()).requestConnection(); // Not one of the first 2
   }
 
   @Test
@@ -807,38 +647,31 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
-    verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
-    verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
+
+    initializeLbSubchannels(config, servers);
+
     // ring:
-    //   "[FakeSocketAddress-server1]_0"
-    //   "[FakeSocketAddress-server0]_0"
-    //   "[FakeSocketAddress-server2]_0"
+    //   "FakeSocketAddress-server1_0"
+    //   "FakeSocketAddress-server0_0"
+    //   "FakeSocketAddress-server2_0"
 
     Subchannel firstSubchannel = subchannels.get(Collections.singletonList(servers.get(0)));
-    deliverSubchannelState(firstSubchannel,
-        ConnectivityStateInfo.forTransientFailure(Status.UNAVAILABLE.withDescription(
-            firstSubchannel.getAddresses().getAddresses() + "unreachable")));
+    deliverSubchannelUnreachable(firstSubchannel);
+    verifyConnection(0);
+
     deliverSubchannelState(subchannels.get(Collections.singletonList(servers.get(2))),
         ConnectivityStateInfo.forNonError(CONNECTING));
     verify(helper, times(2)).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
-    verifyConnection(1);
+    verifyConnection(0);
 
-    // Picking subchannel triggers connection.
-    PickSubchannelArgs args = new PickSubchannelArgsImpl(
-        TestMethodDescriptors.voidMethod(), new Metadata(),
-        CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, hashFunc.hashVoid()));
+    // Picking subchannel when idle triggers connection.
+    deliverSubchannelState(subchannels.get(Collections.singletonList(servers.get(2))),
+        ConnectivityStateInfo.forNonError(IDLE));
+    verifyConnection(0);
+    PickSubchannelArgs args = getDefaultPickSubchannelArgs(hashFunc.hashVoid());
     PickResult result = pickerCaptor.getValue().pickSubchannel(args);
     assertThat(result.getStatus().isOk()).isTrue();
-    verify(subchannels.get(Collections.singletonList(servers.get(0))))
-        .requestConnection();
-    verify(subchannels.get(Collections.singletonList(servers.get(2))), never())
-        .requestConnection();
-    verify(subchannels.get(Collections.singletonList(servers.get(1))), never())
-        .requestConnection();
+    verifyConnection(1);
   }
 
   @Test
@@ -846,42 +679,26 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
-    verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
-    verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
+
+    initializeLbSubchannels(config, servers);
+
     // ring:
-    //   "[FakeSocketAddress-server1]_0"
-    //   "[FakeSocketAddress-server0]_0"
-    //   "[FakeSocketAddress-server2]_0"
+    //   "FakeSocketAddress-server1_0"
+    //   "FakeSocketAddress-server0_0"
+    //   "FakeSocketAddress-server2_0"
 
     Subchannel firstSubchannel = subchannels.get(Collections.singletonList(servers.get(0)));
-    deliverSubchannelState(firstSubchannel,
-        ConnectivityStateInfo.forTransientFailure(Status.UNAVAILABLE.withDescription(
-            firstSubchannel.getAddresses().getAddresses() + " unreachable")));
-    deliverSubchannelState(subchannels.get(Collections.singletonList(servers.get(2))),
-        ConnectivityStateInfo.forTransientFailure(
-            Status.UNAVAILABLE.withDescription("unreachable")));
+    deliverSubchannelUnreachable(firstSubchannel);
+    deliverSubchannelUnreachable(subchannels.get(Collections.singletonList(servers.get(2))));
     verify(helper).updateBalancingState(eq(TRANSIENT_FAILURE), pickerCaptor.capture());
-    verifyConnection(2);
+    verifyConnection(0);
 
     // Picking subchannel triggers connection.
-    PickSubchannelArgs args = new PickSubchannelArgsImpl(
-        TestMethodDescriptors.voidMethod(), new Metadata(),
-        CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, hashFunc.hashVoid()));
+    PickSubchannelArgs args = getDefaultPickSubchannelArgs(hashFunc.hashVoid());
     PickResult result = pickerCaptor.getValue().pickSubchannel(args);
-    assertThat(result.getStatus().isOk()).isFalse();
-    assertThat(result.getStatus().getCode()).isEqualTo(Code.UNAVAILABLE);
-    assertThat(result.getStatus().getDescription())
-        .isEqualTo("[FakeSocketAddress-server0] unreachable");
-    verify(subchannels.get(Collections.singletonList(servers.get(0))))
-        .requestConnection();
-    verify(subchannels.get(Collections.singletonList(servers.get(2))))
-        .requestConnection();
-    verify(subchannels.get(Collections.singletonList(servers.get(1))))
-        .requestConnection();
+    assertThat(result.getStatus().isOk()).isTrue();
+    verify(subchannels.get(Collections.singletonList(servers.get(1)))).requestConnection();
+    verifyConnection(1);
   }
 
   @Test
@@ -889,44 +706,29 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
-    verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
-    verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
+
+    initializeLbSubchannels(config, servers);
+
     // ring:
-    //   "[FakeSocketAddress-server1]_0"
-    //   "[FakeSocketAddress-server0]_0"
-    //   "[FakeSocketAddress-server2]_0"
+    //   "FakeSocketAddress-server1_0"
+    //   "FakeSocketAddress-server0_0"
+    //   "FakeSocketAddress-server2_0"
 
     Subchannel firstSubchannel = subchannels.get(Collections.singletonList(servers.get(0)));
-    deliverSubchannelState(firstSubchannel,
-        ConnectivityStateInfo.forTransientFailure(Status.UNAVAILABLE.withDescription(
-            firstSubchannel.getAddresses().getAddresses() + " unreachable")));
-    deliverSubchannelState(subchannels.get(Collections.singletonList(servers.get(2))),
-        ConnectivityStateInfo.forTransientFailure(
-            Status.UNAVAILABLE.withDescription("unreachable")));
+
+    deliverSubchannelUnreachable(firstSubchannel);
+    deliverSubchannelUnreachable(subchannels.get(Collections.singletonList(servers.get(2))));
     deliverSubchannelState(subchannels.get(Collections.singletonList(servers.get(1))),
         ConnectivityStateInfo.forNonError(CONNECTING));
-    verify(helper, times(2)).updateBalancingState(eq(TRANSIENT_FAILURE), pickerCaptor.capture());
-    verifyConnection(2);
+    verify(helper, atLeastOnce())
+        .updateBalancingState(eq(TRANSIENT_FAILURE), pickerCaptor.capture());
+    verifyConnection(0);
 
-    // Picking subchannel triggers connection.
-    PickSubchannelArgs args = new PickSubchannelArgsImpl(
-        TestMethodDescriptors.voidMethod(), new Metadata(),
-        CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, hashFunc.hashVoid()));
+    // Picking subchannel should not trigger connection per gRFC A61.
+    PickSubchannelArgs args = getDefaultPickSubchannelArgs(hashFunc.hashVoid());
     PickResult result = pickerCaptor.getValue().pickSubchannel(args);
-    assertThat(result.getStatus().isOk()).isFalse();
-    assertThat(result.getStatus().getCode()).isEqualTo(Code.UNAVAILABLE);
-    assertThat(result.getStatus().getDescription())
-        .isEqualTo("[FakeSocketAddress-server0] unreachable");
-    verify(subchannels.get(Collections.singletonList(servers.get(0))))
-        .requestConnection();
-    verify(subchannels.get(Collections.singletonList(servers.get(2))))
-        .requestConnection();
-    verify(subchannels.get(Collections.singletonList(servers.get(1))), never())
-        .requestConnection();
+    assertThat(result.getStatus().isOk()).isTrue();
+    verifyConnection(0);
   }
 
   @Test
@@ -934,35 +736,29 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
-    verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
-    verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
+
+    initializeLbSubchannels(config, servers);
 
     // Bring one subchannel to TRANSIENT_FAILURE.
     Subchannel firstSubchannel = subchannels.get(Collections.singletonList(servers.get(0)));
-    deliverSubchannelState(firstSubchannel,
-        ConnectivityStateInfo.forTransientFailure(
-        Status.UNAVAILABLE.withDescription(
-            firstSubchannel.getAddresses().getAddresses() + " unreachable")));
+    deliverSubchannelUnreachable(firstSubchannel);
 
-    verify(helper).updateBalancingState(eq(CONNECTING), any());
-    verifyConnection(1);
+    verify(helper).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
+    verifyConnection(0);
+
+    reset(helper);
     deliverSubchannelState(firstSubchannel, ConnectivityStateInfo.forNonError(IDLE));
-    verify(helper, times(2)).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
+    // Should not have called updateBalancingState on the helper again because PickFirst is
+    // shielding the higher level from the state change.
+    verify(helper, never()).updateBalancingState(any(), any());
     verifyConnection(1);
 
-    // Picking subchannel triggers connection. RPC hash hits server0.
-    PickSubchannelArgs args = new PickSubchannelArgsImpl(
-        TestMethodDescriptors.voidMethod(), new Metadata(),
-        CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, hashFunc.hashVoid()));
+    // Picking subchannel triggers connection on second address. RPC hash hits server0.
+    PickSubchannelArgs args = getDefaultPickSubchannelArgs(hashFunc.hashVoid());
     PickResult result = pickerCaptor.getValue().pickSubchannel(args);
     assertThat(result.getStatus().isOk()).isTrue();
-    verify(subchannels.get(Collections.singletonList(servers.get(0)))).requestConnection();
-    verify(subchannels.get(Collections.singletonList(servers.get(2)))).requestConnection();
-    verify(subchannels.get(Collections.singletonList(servers.get(1))), never())
+    verify(subchannels.get(Collections.singletonList(servers.get(1)))).requestConnection();
+    verify(subchannels.get(Collections.singletonList(servers.get(2))), never())
         .requestConnection();
   }
 
@@ -971,14 +767,12 @@ public class RingHashLoadBalancerTest {
     RingHashConfig config = new RingHashConfig(10000, 100000);  // large ring
     List<EquivalentAddressGroup> servers =
         createWeightedServerAddrs(Integer.MAX_VALUE, 10, 100); // MAX:10:100
-    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
+
+    initializeLbSubchannels(config, servers);
 
     // Try value between max signed and max unsigned int
     servers = createWeightedServerAddrs(Integer.MAX_VALUE + 100L, 100); // (MAX+100):100
-    addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
     assertThat(addressesAcceptanceStatus.isOk()).isTrue();
@@ -1010,12 +804,8 @@ public class RingHashLoadBalancerTest {
   public void hostSelectionProportionalToWeights() {
     RingHashConfig config = new RingHashConfig(10000, 100000);  // large ring
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 10, 100); // 1:10:100
-    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
-    verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
-    verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
+
+    initializeLbSubchannels(config, servers);
 
     // Bring all subchannels to READY.
     Map<EquivalentAddressGroup, Integer> pickCounts = new HashMap<>();
@@ -1028,9 +818,7 @@ public class RingHashLoadBalancerTest {
 
     for (int i = 0; i < 10000; i++) {
       long hash = hashFunc.hashInt(i);
-      PickSubchannelArgs args = new PickSubchannelArgsImpl(
-          TestMethodDescriptors.voidMethod(), new Metadata(),
-          CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, hash));
+      PickSubchannelArgs args = getDefaultPickSubchannelArgs(hash);
       Subchannel pickedSubchannel = picker.pickSubchannel(args).getSubchannel();
       EquivalentAddressGroup addr = pickedSubchannel.getAddresses();
       pickCounts.put(addr, pickCounts.get(addr) + 1);
@@ -1059,21 +847,19 @@ public class RingHashLoadBalancerTest {
   public void nameResolutionErrorWithActiveSubchannels() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1);
-    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
+
+    initializeLbSubchannels(config, servers, DO_NOT_VERIFY, DO_NOT_RESET_HELPER);
     verify(helper).createSubchannel(any(CreateSubchannelArgs.class));
-    verify(helper).updateBalancingState(eq(IDLE), pickerCaptor.capture());
+    verify(helper, times(2)).updateBalancingState(eq(IDLE), pickerCaptor.capture());
 
     // Picking subchannel triggers subchannel creation and connection.
-    PickSubchannelArgs args = new PickSubchannelArgsImpl(
-        TestMethodDescriptors.voidMethod(), new Metadata(),
-        CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, hashFunc.hashVoid()));
+    PickSubchannelArgs args = getDefaultPickSubchannelArgs(hashFunc.hashVoid());
     pickerCaptor.getValue().pickSubchannel(args);
+    verify(helper, never()).updateBalancingState(eq(READY), any(SubchannelPicker.class));
     deliverSubchannelState(
         Iterables.getOnlyElement(subchannels.values()), ConnectivityStateInfo.forNonError(READY));
     verify(helper).updateBalancingState(eq(READY), any(SubchannelPicker.class));
+    reset(helper);
 
     loadBalancer.handleNameResolutionError(Status.NOT_FOUND.withDescription("target not found"));
     verifyNoMoreInteractions(helper);
@@ -1083,15 +869,12 @@ public class RingHashLoadBalancerTest {
   public void duplicateAddresses() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createRepeatedServerAddrs(1, 2, 3);
-    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAcceptanceStatus.isOk()).isFalse();
+
+    initializeLbSubchannels(config, servers, DO_NOT_VERIFY);
+
     verify(helper).updateBalancingState(eq(TRANSIENT_FAILURE), pickerCaptor.capture());
 
-    PickSubchannelArgs args = new PickSubchannelArgsImpl(
-        TestMethodDescriptors.voidMethod(), new Metadata(),
-        CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, hashFunc.hashVoid()));
+    PickSubchannelArgs args = getDefaultPickSubchannelArgs(hashFunc.hashVoid());
     PickResult result = pickerCaptor.getValue().pickSubchannel(args);
     assertThat(result.getStatus().isOk()).isFalse();  // fail the RPC
     assertThat(result.getStatus().getCode())
@@ -1103,8 +886,105 @@ public class RingHashLoadBalancerTest {
     assertThat(description).contains("Address: FakeSocketAddress-server2, count: 3");
   }
 
+  private List<Subchannel> initializeLbSubchannels(RingHashConfig config,
+      List<EquivalentAddressGroup> servers, InitializationFlags... initFlags) {
+
+    boolean doVerifies = true;
+    boolean resetSubchannels = false;
+    boolean returnToIdle = true;
+    boolean resetHelper = true;
+    for (InitializationFlags flag : initFlags) {
+      switch (flag) {
+        case DO_NOT_VERIFY:
+          doVerifies = false;
+          break;
+        case RESET_SUBCHANNEL_MOCKS:
+          resetSubchannels = true;
+          break;
+        case STAY_IN_CONNECTING:
+          returnToIdle = false;
+          break;
+        case DO_NOT_RESET_HELPER:
+          resetHelper = false;
+          break;
+        default:
+          throw new IllegalArgumentException("Unrecognized flag: " + flag);
+      }
+    }
+
+    Status addressesAcceptanceStatus =
+        loadBalancer.acceptResolvedAddresses(
+            ResolvedAddresses.newBuilder()
+                .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
+
+    if (doVerifies) {
+      assertThat(addressesAcceptanceStatus.isOk()).isTrue();
+      verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
+    }
+
+    if (!addressesAcceptanceStatus.isOk()) {
+      return new ArrayList<>();
+    }
+
+    // Activate them all to create the child LB and subchannel
+    for (ChildLbState childLbState : loadBalancer.getChildLbStates()) {
+      ((RingHashChildLbState)childLbState).activate();
+    }
+
+    if (doVerifies) {
+      verify(helper, times(servers.size())).createSubchannel(any(CreateSubchannelArgs.class));
+      verify(helper, times(servers.size()))
+          .updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
+      verifyConnection(servers.size());
+    }
+
+    if (returnToIdle) {
+      for (Subchannel subchannel : subchannels.values()) {
+        deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(IDLE));
+      }
+      if (doVerifies) {
+        verify(helper, times(2 * servers.size() - 1))
+            .updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
+        verify(helper, times(2)).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
+      }
+    }
+
+
+    // Get a list of subchannels in the same order as servers
+    List<Subchannel> subchannelList = new ArrayList<>();
+    for (EquivalentAddressGroup server : servers) {
+      List<EquivalentAddressGroup> singletonList = Collections.singletonList(server);
+      Subchannel subchannel = subchannels.get(singletonList);
+      subchannelList.add(subchannel);
+      if (resetSubchannels) {
+        reset(subchannel);
+      }
+    }
+
+    if (resetHelper) {
+      reset(helper);
+    }
+
+    return subchannelList;
+  }
+
   private void deliverSubchannelState(Subchannel subchannel, ConnectivityStateInfo state) {
-    subchannelStateListeners.get(subchannel).onSubchannelState(state);
+    testHelperInst.deliverSubchannelState(subchannel, state);
+  }
+
+  private void deliverNotFound(List<Subchannel> subChannelList, int index) {
+    deliverSubchannelState(
+        subChannelList.get(index),
+        ConnectivityStateInfo.forTransientFailure(
+            Status.UNAVAILABLE.withDescription("also not found")));
+  }
+
+  protected void deliverSubchannelUnreachable(Subchannel subchannel) {
+    deliverSubchannelState(subchannel,
+        ConnectivityStateInfo.forTransientFailure(
+            Status.UNAVAILABLE.withDescription(
+                subchannel.getAddresses().getAddresses() + "unreachable")));
+
   }
 
   private static List<EquivalentAddressGroup> createWeightedServerAddrs(long... weights) {
@@ -1155,5 +1035,52 @@ public class RingHashLoadBalancerTest {
     public String toString() {
       return "FakeSocketAddress-" +  name;
     }
+  }
+
+  private class TestHelper extends AbstractTestHelper {
+
+    @Override
+    public Map<List<EquivalentAddressGroup>, Subchannel> getSubchannelMap() {
+      return subchannels;
+    }
+
+    @Override
+    public String getAuthority() {
+      return AUTHORITY;
+    }
+
+    @Override
+    public SynchronizationContext getSynchronizationContext() {
+      return syncContext;
+    }
+
+    private Subchannel getMockSubchannel(Subchannel realSubchannel) {
+      return realToMockSubChannelMap.get(realSubchannel);
+    }
+
+    @Override
+    protected AbstractTestHelper.TestSubchannel createRealSubchannel(CreateSubchannelArgs args) {
+      return new RingHashTestSubchannel(args);
+    }
+
+    private class RingHashTestSubchannel extends AbstractTestHelper.TestSubchannel {
+
+      RingHashTestSubchannel(CreateSubchannelArgs args) {
+        super(args);
+      }
+
+      @Override
+      public void requestConnection() {
+        connectionRequestedQueue.offer(getMockSubchannel(this));
+      }
+
+    }
+  }
+
+  enum InitializationFlags {
+    DO_NOT_VERIFY,
+    RESET_SUBCHANNEL_MOCKS,
+    STAY_IN_CONNECTING,
+    DO_NOT_RESET_HELPER
   }
 }

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
@@ -25,7 +25,10 @@ import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 import static io.grpc.xds.RingHashLoadBalancerTest.InitializationFlags.DO_NOT_RESET_HELPER;
 import static io.grpc.xds.RingHashLoadBalancerTest.InitializationFlags.DO_NOT_VERIFY;
 import static io.grpc.xds.RingHashLoadBalancerTest.InitializationFlags.RESET_SUBCHANNEL_MOCKS;
+<<<<<<< HEAD
 import static io.grpc.xds.RingHashLoadBalancerTest.InitializationFlags.STAY_IN_CONNECTING;
+=======
+>>>>>>> c5829f334 (Complete fixing implementation and tests so that all tests pass as expected.)
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -886,8 +889,8 @@ public class RingHashLoadBalancerTest {
     assertThat(description).contains("Address: FakeSocketAddress-server2, count: 3");
   }
 
-  private List<Subchannel> initializeLbSubchannels(RingHashConfig config,
-      List<EquivalentAddressGroup> servers, InitializationFlags... initFlags) {
+  private List<Subchannel> initializeLbSubchannels(RingHashConfig config, List<EquivalentAddressGroup> servers,
+      InitializationFlags... initFlags) {
 
     boolean doVerifies = true;
     boolean resetSubchannels = false;

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
@@ -111,8 +111,7 @@ public class RingHashLoadBalancerTest {
   @Before
   public void setUp() {
     loadBalancer = new RingHashLoadBalancer(helper, new Random(0));
-    // Skip uninterested interactions.
-    System.out.println(helper.getClass());
+    // Consume calls not relevant for tests that would otherwise fail verifyNoMoreInteractions
     verify(helper).getAuthority();
     verify(helper).getSynchronizationContext();
   }

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
@@ -589,6 +589,7 @@ public class RingHashLoadBalancerTest {
         subchannels.get(Collections.singletonList(servers.get(0))),
         ConnectivityStateInfo.forTransientFailure(
             Status.PERMISSION_DENIED.withDescription("permission denied again")));
+    verify(helper, times(2)).updateBalancingState(eq(TRANSIENT_FAILURE), pickerCaptor.capture());
     result = pickerCaptor.getValue().pickSubchannel(args);
     assertThat(result.getStatus().isOk()).isFalse();  // fail the RPC
     assertThat(result.getStatus().getCode())

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
@@ -720,7 +720,8 @@ public class RingHashLoadBalancerTest {
     deliverSubchannelUnreachable(subchannels.get(Collections.singletonList(servers.get(2))));
     deliverSubchannelState(subchannels.get(Collections.singletonList(servers.get(1))),
         ConnectivityStateInfo.forNonError(CONNECTING));
-    verify(helper, atLeastOnce()).updateBalancingState(eq(TRANSIENT_FAILURE), pickerCaptor.capture());
+    verify(helper, atLeastOnce())
+        .updateBalancingState(eq(TRANSIENT_FAILURE), pickerCaptor.capture());
     verifyConnection(0);
 
     // Picking subchannel should not trigger connection per gRFC A61.

--- a/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
@@ -681,7 +681,11 @@ public class WeightedRoundRobinLoadBalancerTest {
       EquivalentAddressGroup addresses = getAddresses(pickResult);
       pickCount.merge(addresses, 1, Integer::sum);
       assertThat(pickResult.getStreamTracerFactory()).isNotNull();
+<<<<<<< HEAD
       WeightedChildLbState childLbState = (WeightedChildLbState) wrr.getChildLbStateEag(addresses);
+=======
+      WeightedChildLbState childLbState = (WeightedChildLbState) wrr.getChildLbState(addresses);
+>>>>>>> 87585d87f (Responded to a number of the code review comments.)
       childLbState.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
           InternalCallMetricRecorder.createMetricReport(
               0.1, 0, 0.1, qpsByChannel.get(addresses), 0,
@@ -699,7 +703,11 @@ public class WeightedRoundRobinLoadBalancerTest {
       EquivalentAddressGroup addresses = getAddresses(pickResult);
       pickCount.merge(addresses, 1, Integer::sum);
       assertThat(pickResult.getStreamTracerFactory()).isNotNull();
+<<<<<<< HEAD
       WeightedChildLbState childLbState = (WeightedChildLbState) wrr.getChildLbStateEag(addresses);
+=======
+      WeightedChildLbState childLbState = (WeightedChildLbState) wrr.getChildLbState(addresses);
+>>>>>>> 87585d87f (Responded to a number of the code review comments.)
       childLbState.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
           InternalCallMetricRecorder.createMetricReport(
               0.1, 0, 0.1, qpsByChannel.get(addresses), 0,

--- a/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
@@ -17,6 +17,7 @@
 package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.grpc.ConnectivityState.CONNECTING;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
@@ -59,6 +60,7 @@ import io.grpc.xds.WeightedRoundRobinLoadBalancer.WeightedRoundRobinLoadBalancer
 import io.grpc.xds.WeightedRoundRobinLoadBalancer.WeightedRoundRobinPicker;
 import java.net.SocketAddress;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -78,7 +80,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -176,7 +180,7 @@ public class WeightedRoundRobinLoadBalancerTest {
             .forNonError(ConnectivityState.READY));
     Subchannel connectingSubchannel = it.next();
     getSubchannelStateListener(connectingSubchannel).onSubchannelState(ConnectivityStateInfo
-            .forNonError(ConnectivityState.CONNECTING));
+            .forNonError(CONNECTING));
     verify(helper, times(2)).updateBalancingState(
             eq(ConnectivityState.READY), pickerCaptor.capture());
     assertThat(pickerCaptor.getAllValues().size()).isEqualTo(2);
@@ -477,7 +481,7 @@ public class WeightedRoundRobinLoadBalancerTest {
             .setAttributes(affinity).build()));
     verify(helper, times(6)).createSubchannel(
             any(CreateSubchannelArgs.class));
-    verify(helper).updateBalancingState(eq(ConnectivityState.CONNECTING), pickerCaptor.capture());
+    verify(helper).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
     assertThat(pickerCaptor.getValue().getClass().getName())
         .isEqualTo("io.grpc.util.RoundRobinLoadBalancer$EmptyPicker");
     assertThat(fakeClock.forwardTime(11, TimeUnit.SECONDS)).isEqualTo(1);
@@ -554,7 +558,7 @@ public class WeightedRoundRobinLoadBalancerTest {
         .forNonError(ConnectivityState.READY));
     Subchannel connectingSubchannel = it.next();
     getSubchannelStateListener(connectingSubchannel).onSubchannelState(ConnectivityStateInfo
-        .forNonError(ConnectivityState.CONNECTING));
+        .forNonError(CONNECTING));
     verify(helper, times(2)).updateBalancingState(
         eq(ConnectivityState.READY), pickerCaptor.capture());
     assertThat(pickerCaptor.getAllValues().size()).isEqualTo(2);
@@ -1062,6 +1066,24 @@ public class WeightedRoundRobinLoadBalancerTest {
     assertThat(sss.pick()).isEqualTo(2);
     assertThat(sequence.get()).isEqualTo(9);
   }
+
+  @Test
+  public void removingAddressShutsdownSubchannel() {
+    syncContext.execute(() -> wrr.acceptResolvedAddresses(ResolvedAddresses.newBuilder()
+        .setAddresses(servers).setLoadBalancingPolicyConfig(weightedConfig)
+        .setAttributes(affinity).build()));
+    final Subchannel subchannel2 = subchannels.get(Collections.singletonList(servers.get(2)));
+
+    InOrder inOrder = Mockito.inOrder(helper, subchannel2);
+    // send LB only the first 2 addresses
+    List<EquivalentAddressGroup> svs2 = Arrays.asList(servers.get(0), servers.get(1));
+    syncContext.execute(() -> wrr.acceptResolvedAddresses(ResolvedAddresses.newBuilder()
+        .setAddresses(svs2).setLoadBalancingPolicyConfig(weightedConfig)
+        .setAttributes(affinity).build()));
+    inOrder.verify(helper).updateBalancingState(eq(CONNECTING), any());
+    inOrder.verify(subchannel2).shutdown();
+  }
+
 
   private static final class VerifyingScheduler {
     private final StaticStrideScheduler delegate;

--- a/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
@@ -681,11 +681,7 @@ public class WeightedRoundRobinLoadBalancerTest {
       EquivalentAddressGroup addresses = getAddresses(pickResult);
       pickCount.merge(addresses, 1, Integer::sum);
       assertThat(pickResult.getStreamTracerFactory()).isNotNull();
-<<<<<<< HEAD
       WeightedChildLbState childLbState = (WeightedChildLbState) wrr.getChildLbStateEag(addresses);
-=======
-      WeightedChildLbState childLbState = (WeightedChildLbState) wrr.getChildLbState(addresses);
->>>>>>> 87585d87f (Responded to a number of the code review comments.)
       childLbState.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
           InternalCallMetricRecorder.createMetricReport(
               0.1, 0, 0.1, qpsByChannel.get(addresses), 0,
@@ -703,11 +699,7 @@ public class WeightedRoundRobinLoadBalancerTest {
       EquivalentAddressGroup addresses = getAddresses(pickResult);
       pickCount.merge(addresses, 1, Integer::sum);
       assertThat(pickResult.getStreamTracerFactory()).isNotNull();
-<<<<<<< HEAD
       WeightedChildLbState childLbState = (WeightedChildLbState) wrr.getChildLbStateEag(addresses);
-=======
-      WeightedChildLbState childLbState = (WeightedChildLbState) wrr.getChildLbState(addresses);
->>>>>>> 87585d87f (Responded to a number of the code review comments.)
       childLbState.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
           InternalCallMetricRecorder.createMetricReport(
               0.1, 0, 0.1, qpsByChannel.get(addresses), 0,


### PR DESCRIPTION
Implementation of A61 for Ring Hash

Major changes to behavior:
-   Lazy create PickFirstLoadBalancers rather than lazily connect subchannels
-   When picking, look for first entry in ring not in TF rather than focus on first 2 entries in the ring after hash