### PR TITLE
bazel: protobuf_javalite typo in IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS (1.59.x backport)

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -60,7 +60,7 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
 IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS = {
     "com.google.protobuf:protobuf-java": "@com_google_protobuf//:protobuf_java",
     "com.google.protobuf:protobuf-java-util": "@com_google_protobuf//:protobuf_java_util",
-    "com.google.protobuf:protobuf-javalite": "@com_google_protobuf_javalite//:protobuf_java_lite",
+    "com.google.protobuf:protobuf-javalite": "@com_google_protobuf_javalite//:protobuf_javalite",
     "io.grpc:grpc-alts": "@io_grpc_grpc_java//alts",
     "io.grpc:grpc-api": "@io_grpc_grpc_java//api",
     "io.grpc:grpc-auth": "@io_grpc_grpc_java//auth",


### PR DESCRIPTION
Related to #6544 and #6976

Backport of #10592