### PR TITLE
protobuf-lite: ProtoLiteUtils experimental comment

### DIFF
--- a/protobuf-lite/src/main/java/io/grpc/protobuf/lite/ProtoLiteUtils.java
+++ b/protobuf-lite/src/main/java/io/grpc/protobuf/lite/ProtoLiteUtils.java
@@ -40,7 +40,7 @@ import java.lang.ref.WeakReference;
  * Utility methods for using protobuf with grpc.
  *
  * <p>Note that this class will remain experimental for the foreseeable future as the proto lite
- * API, which this class depends on, is noy guaranteed to be stable. This is explained in protobuf
+ * API, which this class depends on, is not guaranteed to be stable. This is explained in protobuf
  * documentation at: https://github.com/protocolbuffers/protobuf/blob/main/java/lite.md
  */
 @ExperimentalApi("Will remain experimental as protobuf lite API is not stable")

--- a/protobuf-lite/src/main/java/io/grpc/protobuf/lite/ProtoLiteUtils.java
+++ b/protobuf-lite/src/main/java/io/grpc/protobuf/lite/ProtoLiteUtils.java
@@ -38,8 +38,12 @@ import java.lang.ref.WeakReference;
 
 /**
  * Utility methods for using protobuf with grpc.
+ *
+ * <p>Note that this class will remain experimental for the foreseeable future as the proto lite
+ * API, which this class depends on, is noy guaranteed to be stable. This is explained in protobuf
+ * documentation at: https://github.com/protocolbuffers/protobuf/blob/main/java/lite.md
  */
-@ExperimentalApi("Experimental until Lite is stable in protobuf")
+@ExperimentalApi("Will remain experimental as protobuf lite API is not stable")
 public final class ProtoLiteUtils {
 
   // default visibility to avoid synthetic accessors


### PR DESCRIPTION
Add a comment clarifying that the ProtoLiteUtils class will remain experimental.