### PR TITLE
protobuf: Stabilize ProtoUtils.metadataMarshaller()

### DIFF
--- a/protobuf/src/main/java/io/grpc/protobuf/ProtoUtils.java
+++ b/protobuf/src/main/java/io/grpc/protobuf/ProtoUtils.java
@@ -85,7 +85,6 @@ public final class ProtoUtils {
    *
    * @since 1.13.0
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4477")
   public static <T extends Message> Metadata.BinaryMarshaller<T> metadataMarshaller(T instance) {
     return ProtoLiteUtils.metadataMarshaller(instance);
   }


### PR DESCRIPTION
This method has been around since 2018 and is now considered stable.

Closes #4477