### PR TITLE
stub: stabilize StreamObservers by removing the experimentalApi annotation

### DIFF
--- a/stub/src/main/java/io/grpc/stub/StreamObservers.java
+++ b/stub/src/main/java/io/grpc/stub/StreamObservers.java
@@ -17,14 +17,12 @@
 package io.grpc.stub;
 
 import com.google.common.base.Preconditions;
-import io.grpc.ExperimentalApi;
 import java.util.Iterator;
 
 /**
  * Utility functions for working with {@link StreamObserver} and it's common subclasses like
  * {@link CallStreamObserver}.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/4694")
 public final class StreamObservers {
   /**
    * Copy the values of an {@link Iterator} to the target {@link CallStreamObserver} while properly


### PR DESCRIPTION
fixes #4694
