### PR TITLE
Handle slow security policies without blocking gRPC threads.

### DIFF
--- a/binder/src/androidTest/java/io/grpc/binder/internal/BinderTransportTest.java
+++ b/binder/src/androidTest/java/io/grpc/binder/internal/BinderTransportTest.java
@@ -72,7 +72,7 @@ public final class BinderTransportTest extends AbstractTransportTest {
         streamTracerFactories,
         BinderInternal.createPolicyChecker(SecurityPolicies.serverInternalOnly()),
         InboundParcelablePolicy.DEFAULT,
-        /* closeableExecutor=*/ null);
+        /* shutdownListener=*/ () -> {});
 
     HostServices.configureService(addr,
         HostServices.serviceParamsBuilder()

--- a/binder/src/androidTest/java/io/grpc/binder/internal/BinderTransportTest.java
+++ b/binder/src/androidTest/java/io/grpc/binder/internal/BinderTransportTest.java
@@ -71,7 +71,8 @@ public final class BinderTransportTest extends AbstractTransportTest {
         executorServicePool,
         streamTracerFactories,
         BinderInternal.createPolicyChecker(SecurityPolicies.serverInternalOnly()),
-        InboundParcelablePolicy.DEFAULT);
+        InboundParcelablePolicy.DEFAULT,
+        /* closeableExecutor=*/ null);
 
     HostServices.configureService(addr,
         HostServices.serviceParamsBuilder()

--- a/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
@@ -77,7 +77,7 @@ public final class BinderServerBuilder
   private ServerSecurityPolicy securityPolicy;
   private InboundParcelablePolicy inboundParcelablePolicy;
   private boolean isBuilt;
-  @Nullable private Closeable closeableExecutor = null;
+  @Nullable private BinderTransportSecurity.ShutdownListener shutdownListener = null;
 
   private BinderServerBuilder(
       AndroidComponentAddress listenAddress,
@@ -92,7 +92,8 @@ public final class BinderServerBuilder
           streamTracerFactories,
           BinderInternal.createPolicyChecker(securityPolicy),
           inboundParcelablePolicy,
-          closeableExecutor);
+          // 'shutdownListener' should have been set by build()
+          checkNotNull(shutdownListener));
       BinderInternal.setIBinder(binderReceiver, server.getHostBinder());
       return server;
     });
@@ -181,7 +182,7 @@ public final class BinderServerBuilder
     ObjectPool<? extends Executor> executorPool = serverImplBuilder.getExecutorPool();
     Executor executor = executorPool.getObject();
     BinderTransportSecurity.installAuthInterceptor(this, executor);
-    closeableExecutor = () -> executorPool.returnObject(executor);
+    shutdownListener = () -> executorPool.returnObject(executor);
     return super.build();
   }
 }

--- a/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
@@ -33,8 +33,13 @@ import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.ServerImplBuilder;
 import io.grpc.internal.ObjectPool;
 import io.grpc.internal.SharedResourcePool;
+
+import java.io.Closeable;
 import java.io.File;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
+
+import javax.annotation.Nullable;
 
 /**
  * Builder for a server that services requests from an Android Service.
@@ -72,6 +77,7 @@ public final class BinderServerBuilder
   private ServerSecurityPolicy securityPolicy;
   private InboundParcelablePolicy inboundParcelablePolicy;
   private boolean isBuilt;
+  @Nullable private Closeable closeableExecutor = null;
 
   private BinderServerBuilder(
       AndroidComponentAddress listenAddress,
@@ -85,7 +91,8 @@ public final class BinderServerBuilder
           schedulerPool,
           streamTracerFactories,
           BinderInternal.createPolicyChecker(securityPolicy),
-          inboundParcelablePolicy);
+          inboundParcelablePolicy,
+          closeableExecutor);
       BinderInternal.setIBinder(binderReceiver, server.getHostBinder());
       return server;
     });
@@ -171,7 +178,10 @@ public final class BinderServerBuilder
     checkState(!isBuilt, "BinderServerBuilder can only be used to build one server instance.");
     isBuilt = true;
     // We install the security interceptor last, so it's closest to the transport.
-    BinderTransportSecurity.installAuthInterceptor(this, serverImplBuilder.getExecutorPool());
+    ObjectPool<? extends Executor> executorPool = serverImplBuilder.getExecutorPool();
+    Executor executor = executorPool.getObject();
+    BinderTransportSecurity.installAuthInterceptor(this, executor);
+    closeableExecutor = () -> executorPool.returnObject(executor);
     return super.build();
   }
 }

--- a/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderServerBuilder.java
@@ -171,7 +171,7 @@ public final class BinderServerBuilder
     checkState(!isBuilt, "BinderServerBuilder can only be used to build one server instance.");
     isBuilt = true;
     // We install the security interceptor last, so it's closest to the transport.
-    BinderTransportSecurity.installAuthInterceptor(this);
+    BinderTransportSecurity.installAuthInterceptor(this, serverImplBuilder.getExecutorPool());
     return super.build();
   }
 }

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransportSecurity.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransportSecurity.java
@@ -132,7 +132,7 @@ public final class BinderTransportSecurity {
         return newServerCallListenerForDoneAuthResult(authStatusFuture, call, headers, next);
       }
 
-      return new PendingAuthListener<>(authStatusFuture, executorPool, call, headers, next);
+      return PendingAuthListener.create(authStatusFuture, executorPool, call, headers, next);
     }
   }
 

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransportSecurity.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransportSecurity.java
@@ -165,6 +165,13 @@ public final class BinderTransportSecurity {
           return authorization;
         }
       }
+      // Under high load, this may trigger a large number of concurrent authorization checks that
+      // perform essentially the same work and have the potential of exhausting the resources they
+      // depend on. This was a non-issue in the past with synchronous policy checks due to the
+      // fixed-size nature of the thread pool this method runs under.
+      //
+      // TODO(10669): evaluate if there should be at most a single pending authorization check per
+      //  (uid, serviceName) pair at any given time.
       ListenableFuture<Status> authorization =
           serverPolicyChecker.checkAuthorizationForServiceAsync(uid, serviceName);
       if (useCache) {

--- a/binder/src/main/java/io/grpc/binder/internal/PendingAuthListener.java
+++ b/binder/src/main/java/io/grpc/binder/internal/PendingAuthListener.java
@@ -23,104 +23,104 @@ import javax.annotation.Nullable;
  */
 final class PendingAuthListener<ReqT, RespT> extends ServerCall.Listener<ReqT> {
 
-    private final ConcurrentLinkedQueue<ListenerConsumer<ReqT>> pendingSteps =
-        new ConcurrentLinkedQueue<>();
-    private final AtomicReference<Listener<ReqT>> delegateRef = new AtomicReference<>(null);
+  private final ConcurrentLinkedQueue<ListenerConsumer<ReqT>> pendingSteps =
+      new ConcurrentLinkedQueue<>();
+  private final AtomicReference<Listener<ReqT>> delegateRef = new AtomicReference<>(null);
 
-    /**
-     * @param authStatusFuture a ListenableFuture holding the result status of the authorization
-     *                         policy from a {@link io.grpc.binder.SecurityPolicy} or a
-     *                         {@link io.grpc.binder.AsyncSecurityPolicy}. The call only progresses
-     *                         if {@link Status#isOk()} is true.
-     * @param executorPool     a pool that can provide at least one Executor under which the result
-     *                         of {@code authStatusFuture} can be handled, progressing the gRPC
-     *                         stages.
-     * @param call             the 'call' parameter from {@link io.grpc.ServerInterceptor}
-     * @param headers          the 'headers' parameter from {@link io.grpc.ServerInterceptor}
-     * @param next             the 'next' parameter from {@link io.grpc.ServerInterceptor}
-     */
-    PendingAuthListener(
-            ListenableFuture<Status> authStatusFuture,
-            ObjectPool<? extends Executor> executorPool,
-            ServerCall<ReqT, RespT> call,
-            Metadata headers,
-            ServerCallHandler<ReqT, RespT> next) {
-        Executor executor = executorPool.getObject();
+  /**
+   * @param authStatusFuture a ListenableFuture holding the result status of the authorization
+   *                         policy from a {@link io.grpc.binder.SecurityPolicy} or a
+   *                         {@link io.grpc.binder.AsyncSecurityPolicy}. The call only progresses
+   *                         if {@link Status#isOk()} is true.
+   * @param executorPool     a pool that can provide at least one Executor under which the result
+   *                         of {@code authStatusFuture} can be handled, progressing the gRPC
+   *                         stages.
+   * @param call             the 'call' parameter from {@link io.grpc.ServerInterceptor}
+   * @param headers          the 'headers' parameter from {@link io.grpc.ServerInterceptor}
+   * @param next             the 'next' parameter from {@link io.grpc.ServerInterceptor}
+   */
+  PendingAuthListener(
+      ListenableFuture<Status> authStatusFuture,
+      ObjectPool<? extends Executor> executorPool,
+      ServerCall<ReqT, RespT> call,
+      Metadata headers,
+      ServerCallHandler<ReqT, RespT> next) {
+    Executor executor = executorPool.getObject();
+    Futures.addCallback(
+        authStatusFuture,
+        new FutureCallback<Status>() {
+          @Override
+          public void onSuccess(Status authStatus) {
+            if (authStatus.isOk()) {
+              delegateRef.set(next.startCall(call, headers));
+              maybeRunPendingSteps();
+            } else {
+              call.close(authStatus, new Metadata());
+            }
+            executorPool.returnObject(executor);
+          }
 
-        Futures.addCallback(authStatusFuture,
-            new FutureCallback<Status>() {
-                @Override
-                public void onSuccess(Status authStatus) {
-                    if (authStatus.isOk()) {
-                        delegateRef.set(next.startCall(call, headers));
-                        maybeRunPendingSteps();
-                    } else {
-                        call.close(authStatus, new Metadata());
-                    }
-                    executorPool.returnObject(executor);
-                }
-
-                @Override
-                public void onFailure(Throwable t) {
-                    call.close(
-                        Status.INTERNAL.withCause(t).withDescription("Authorization future failed"),
-                        new Metadata());
-                    executorPool.returnObject(executor);
-                }
-            }, executor);
+          @Override
+          public void onFailure(Throwable t) {
+            call.close(
+                Status.INTERNAL.withCause(t).withDescription("Authorization future failed"),
+                new Metadata());
+            executorPool.returnObject(executor);
+            }
+          }, executor);
     }
 
-    /**
-     * Runs any enqueued step in this ServerCall listener as long as the authorization check is
-     * complete. Otherwise, no-op and returns immediately.
-     */
-    private void maybeRunPendingSteps() {
-        @Nullable Listener<ReqT> delegate = delegateRef.get();
-        if (delegate == null) {
-            return;
-        }
-
-        ListenerConsumer<ReqT> nextStep;
-        while ((nextStep = pendingSteps.poll()) != null) {
-            nextStep.accept(delegate);
-        }
+  /**
+   * Runs any enqueued step in this ServerCall listener as long as the authorization check is
+   * complete. Otherwise, no-op and returns immediately.
+   */
+  private void maybeRunPendingSteps() {
+    @Nullable Listener<ReqT> delegate = delegateRef.get();
+    if (delegate == null) {
+      return;
     }
 
-    @Override
-    public void onCancel() {
-        pendingSteps.offer(Listener::onCancel);
-        maybeRunPendingSteps();
+      ListenerConsumer<ReqT> nextStep;
+      while ((nextStep = pendingSteps.poll()) != null) {
+        nextStep.accept(delegate);
+      }
     }
 
-    @Override
-    public void onComplete() {
-        pendingSteps.offer(Listener::onComplete);
-        maybeRunPendingSteps();
-    }
+  @Override
+  public void onCancel() {
+    pendingSteps.offer(Listener::onCancel);
+    maybeRunPendingSteps();
+  }
 
-    @Override
-    public void onHalfClose() {
-        pendingSteps.offer(Listener::onHalfClose);
-        maybeRunPendingSteps();
-    }
+  @Override
+  public void onComplete() {
+    pendingSteps.offer(Listener::onComplete);
+    maybeRunPendingSteps();
+  }
 
-    @Override
-    public void onMessage(ReqT message) {
-        pendingSteps.offer(delegate -> delegate.onMessage(message));
-        maybeRunPendingSteps();
-    }
+  @Override
+  public void onHalfClose() {
+    pendingSteps.offer(Listener::onHalfClose);
+    maybeRunPendingSteps();
+  }
 
-    @Override
-    public void onReady() {
-        pendingSteps.offer(Listener::onReady);
-        maybeRunPendingSteps();
-    }
+  @Override
+  public void onMessage(ReqT message) {
+    pendingSteps.offer(delegate -> delegate.onMessage(message));
+    maybeRunPendingSteps();
+  }
 
-    /**
-     * Similar to Java8's {@link java.util.function.Consumer}, but redeclared in order to support
-     * Android SDK 21.
-     */
-    private interface ListenerConsumer<ReqT> {
-        void accept(Listener<ReqT> listener);
-    }
+  @Override
+  public void onReady() {
+    pendingSteps.offer(Listener::onReady);
+    maybeRunPendingSteps();
+  }
+
+  /**
+   * Similar to Java8's {@link java.util.function.Consumer}, but redeclared in order to support
+   * Android SDK 21.
+   */
+  private interface ListenerConsumer<ReqT> {
+    void accept(Listener<ReqT> listener);
+  }
 }

--- a/binder/src/main/java/io/grpc/binder/internal/PendingAuthListener.java
+++ b/binder/src/main/java/io/grpc/binder/internal/PendingAuthListener.java
@@ -83,7 +83,7 @@ final class PendingAuthListener<ReqT, RespT> extends ServerCall.Listener<ReqT> {
     ServerCall.Listener<ReqT> delegate;
     try {
       delegate = next.startCall(call, headers);
-    } catch (Exception e) {
+    } catch (RuntimeException e) {
       call.close(
           Status
               .INTERNAL

--- a/binder/src/main/java/io/grpc/binder/internal/PendingAuthListener.java
+++ b/binder/src/main/java/io/grpc/binder/internal/PendingAuthListener.java
@@ -1,0 +1,97 @@
+package io.grpc.binder.internal;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.Status;
+import io.grpc.internal.ObjectPool;
+
+import java.util.concurrent.Executor;
+
+/**
+ * A {@link ServerCall.Listener} that can be returned by a {@link io.grpc.ServerInterceptor} to
+ * asynchronously advance the gRPC pending resolving a possibly asynchronous security policy check.
+ */
+final class PendingAuthListener<ReqT, RespT> extends ServerCall.Listener<ReqT> {
+
+    private final ListenableFuture<Listener<ReqT>> authStatusFuture;
+    private final Executor sequentialExecutor;
+    private final ObjectPool<? extends Executor> executorPool;
+    private final Executor executor;
+
+    /**
+     * @param authStatusFuture a ListenableFuture holding the result status of the authorization
+     *                         policy from a {@link io.grpc.binder.SecurityPolicy} or a
+     *                         {@link io.grpc.binder.AsyncSecurityPolicy}. The call only progresses
+     *                         if {@link Status#isOk()} is true.
+     * @param executorPool     a pool that can provide at least one Executor under which the result
+     *                         of {@code authStatusFuture} can be handled, progressing the gRPC
+     *                         stages.
+     * @param call             the 'call' parameter from {@link io.grpc.ServerInterceptor}
+     * @param headers          the 'headers' parameter from {@link io.grpc.ServerInterceptor}
+     * @param next             the 'next' parameter from {@link io.grpc.ServerInterceptor}
+     */
+    PendingAuthListener(
+            ListenableFuture<Status> authStatusFuture,
+            ObjectPool<? extends Executor> executorPool,
+            ServerCall<ReqT, RespT> call, Metadata headers,
+            ServerCallHandler<ReqT, RespT> next) {
+        this.executorPool = executorPool;
+        this.executor = executorPool.getObject();
+        this.authStatusFuture = Futures.transform(authStatusFuture, authStatus -> {
+            if (authStatus.isOk()) {
+                return next.startCall(call, headers);
+            }
+            call.close(authStatus, new Metadata());
+            throw new IllegalStateException("Auth failed", authStatus.asException());
+        }, executor);
+        this.sequentialExecutor = MoreExecutors.newSequentialExecutor(executor);
+    }
+
+    @Override
+    public void onCancel() {
+        ListenableFuture<?> unused = Futures.transform(authStatusFuture, delegate -> {
+            delegate.onCancel();
+            executorPool.returnObject(executor);
+            return null;
+        }, sequentialExecutor);
+    }
+
+    @Override
+    public void onComplete() {
+        ListenableFuture<?> unused = Futures.transform(authStatusFuture, delegate -> {
+            delegate.onComplete();
+            executorPool.returnObject(executor);
+            return null;
+        }, sequentialExecutor);
+    }
+
+    @Override
+    public void onHalfClose() {
+        ListenableFuture<?> unused = Futures.transform(authStatusFuture, delegate -> {
+            delegate.onHalfClose();
+            return null;
+        }, sequentialExecutor);
+    }
+
+    @Override
+    public void onMessage(ReqT message) {
+        ListenableFuture<?> unused = Futures.transform(authStatusFuture, delegate -> {
+            delegate.onMessage(message);
+            return null;
+        }, sequentialExecutor);
+    }
+
+    @Override
+    public void onReady() {
+        ListenableFuture<?> unused = Futures.transform(authStatusFuture, delegate -> {
+            delegate.onReady();
+            return null;
+        }, sequentialExecutor);
+    }
+}

--- a/binder/src/test/java/io/grpc/binder/ServerSecurityPolicyTest.java
+++ b/binder/src/test/java/io/grpc/binder/ServerSecurityPolicyTest.java
@@ -55,49 +55,55 @@ public final class ServerSecurityPolicyTest {
   @Test
   public void testDefaultInternalOnly() throws Exception {
     policy = new ServerSecurityPolicy();
-    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE1)).isEqualTo(Code.OK);
-    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE2)).isEqualTo(Code.OK);
+    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE1))
+        .isEqualTo(Status.OK.getCode());
+    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE2))
+        .isEqualTo(Status.OK.getCode());
   }
 
   @Test
   public void testDefaultInternalOnly_legacyApi() {
     policy = new ServerSecurityPolicy();
-    assertThat(policy.checkAuthorizationForService(MY_UID, SERVICE1).getCode()).isEqualTo(Code.OK);
-    assertThat(policy.checkAuthorizationForService(MY_UID, SERVICE2).getCode()).isEqualTo(Code.OK);
+    assertThat(policy.checkAuthorizationForService(MY_UID, SERVICE1).getCode())
+        .isEqualTo(Status.OK.getCode());
+    assertThat(policy.checkAuthorizationForService(MY_UID, SERVICE2).getCode())
+        .isEqualTo(Status.OK.getCode());
   }
 
   @Test
   public void testInternalOnly_AnotherUid() throws Exception {
     policy = new ServerSecurityPolicy();
     assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE1))
-        .isEqualTo(Code.PERMISSION_DENIED);
+        .isEqualTo(Status.PERMISSION_DENIED.getCode());
     assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE2))
-        .isEqualTo(Code.PERMISSION_DENIED);
+        .isEqualTo(Status.PERMISSION_DENIED.getCode());
   }
 
   @Test
   public void testInternalOnly_AnotherUid_legacyApi() {
     policy = new ServerSecurityPolicy();
     assertThat(policy.checkAuthorizationForService(OTHER_UID, SERVICE1).getCode())
-        .isEqualTo(Code.PERMISSION_DENIED);
+        .isEqualTo(Status.PERMISSION_DENIED.getCode());
     assertThat(policy.checkAuthorizationForService(OTHER_UID, SERVICE2).getCode())
-        .isEqualTo(Code.PERMISSION_DENIED);
+        .isEqualTo(Status.PERMISSION_DENIED.getCode());
   }
 
   @Test
   public void testBuilderDefault() throws Exception {
     policy = ServerSecurityPolicy.newBuilder().build();
-    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE1)).isEqualTo(Code.OK);
+    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE1))
+        .isEqualTo(Status.OK.getCode());
     assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE1))
-        .isEqualTo(Code.PERMISSION_DENIED);
+        .isEqualTo(Status.PERMISSION_DENIED.getCode());
   }
 
   @Test
   public void testBuilderDefault_legacyApi() {
     policy = ServerSecurityPolicy.newBuilder().build();
-    assertThat(policy.checkAuthorizationForService(MY_UID, SERVICE1).getCode()).isEqualTo(Code.OK);
+    assertThat(policy.checkAuthorizationForService(MY_UID, SERVICE1).getCode())
+        .isEqualTo(Status.OK.getCode());
     assertThat(policy.checkAuthorizationForService(OTHER_UID, SERVICE1).getCode())
-        .isEqualTo(Code.PERMISSION_DENIED);
+        .isEqualTo(Status.PERMISSION_DENIED.getCode());
   }
 
   @Test
@@ -107,11 +113,14 @@ public final class ServerSecurityPolicyTest {
             .servicePolicy(SERVICE2, policy((uid) -> Status.OK))
             .build();
 
-    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE1)).isEqualTo(Code.OK);
+    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE1))
+        .isEqualTo(Status.OK.getCode());
     assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE1))
-        .isEqualTo(Code.PERMISSION_DENIED);
-    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE2)).isEqualTo(Code.OK);
-    assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE2)).isEqualTo(Code.OK);
+        .isEqualTo(Status.PERMISSION_DENIED.getCode());
+    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE2))
+        .isEqualTo(Status.OK.getCode());
+    assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE2))
+        .isEqualTo(Status.OK.getCode());
   }
 
 
@@ -122,12 +131,14 @@ public final class ServerSecurityPolicyTest {
             .servicePolicy(SERVICE2, policy((uid) -> Status.OK))
             .build();
 
-    assertThat(policy.checkAuthorizationForService(MY_UID, SERVICE1).getCode()).isEqualTo(Code.OK);
+    assertThat(policy.checkAuthorizationForService(MY_UID, SERVICE1).getCode())
+        .isEqualTo(Status.OK.getCode());
     assertThat(policy.checkAuthorizationForService(OTHER_UID, SERVICE1).getCode())
-        .isEqualTo(Code.PERMISSION_DENIED);
-    assertThat(policy.checkAuthorizationForService(MY_UID, SERVICE2).getCode()).isEqualTo(Code.OK);
+        .isEqualTo(Status.PERMISSION_DENIED.getCode());
+    assertThat(policy.checkAuthorizationForService(MY_UID, SERVICE2).getCode())
+        .isEqualTo(Status.OK.getCode());
     assertThat(policy.checkAuthorizationForService(OTHER_UID, SERVICE2).getCode())
-        .isEqualTo(Code.OK);
+        .isEqualTo(Status.OK.getCode());
   }
 
   @Test
@@ -135,19 +146,22 @@ public final class ServerSecurityPolicyTest {
     policy =
         ServerSecurityPolicy.newBuilder()
             .servicePolicy(SERVICE2, asyncPolicy(uid -> {
-              // Add some extra future transformation to confirm that a chain
-              // of futures gets properly handled.
-              ListenableFuture<Void> dependency = Futures.immediateVoidFuture();
-              return Futures
-                      .transform(dependency, unused -> Status.OK, MoreExecutors.directExecutor());
+                // Add some extra future transformation to confirm that a chain
+                // of futures gets properly handled.
+                ListenableFuture<Void> dependency = Futures.immediateVoidFuture();
+                return Futures
+                        .transform(dependency, unused -> Status.OK, MoreExecutors.directExecutor());
             }))
             .build();
 
-    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE1)).isEqualTo(Code.OK);
+    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE1))
+        .isEqualTo(Status.OK.getCode());
     assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE1))
-        .isEqualTo(Code.PERMISSION_DENIED);
-    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE2)).isEqualTo(Code.OK);
-    assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE2)).isEqualTo(Code.OK);
+        .isEqualTo(Status.PERMISSION_DENIED.getCode());
+    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE2))
+        .isEqualTo(Status.OK.getCode());
+    assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE2))
+        .isEqualTo(Status.OK.getCode());
   }
 
   @Test
@@ -156,7 +170,8 @@ public final class ServerSecurityPolicyTest {
         ServerSecurityPolicy.newBuilder()
             .servicePolicy(SERVICE1, asyncPolicy(uid ->
                 Futures
-                    .immediateFailedFuture(new IllegalStateException("something went wrong"))
+                    .immediateFailedFuture(
+                        new IllegalStateException("something went wrong"))
             ))
             .build();
 
@@ -185,22 +200,22 @@ public final class ServerSecurityPolicyTest {
         MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor());
     CountDownLatch unsatisfiedLatch = new CountDownLatch(1);
     ListenableFuture<Status> toBeInterruptedFuture = listeningExecutorService.submit(() -> {
-      unsatisfiedLatch.await();  // waits forever
-      return null;
+        unsatisfiedLatch.await();  // waits forever
+        return null;
     });
 
     CyclicBarrier barrier = new CyclicBarrier(2);
     Thread testThread = Thread.currentThread();
     new Thread(() -> {
-      awaitOrFail(barrier);
-      testThread.interrupt();
+        awaitOrFail(barrier);
+        testThread.interrupt();
     }).start();
 
     policy =
         ServerSecurityPolicy.newBuilder()
             .servicePolicy(SERVICE1, asyncPolicy(unused -> {
-              awaitOrFail(barrier);
-              return toBeInterruptedFuture;
+                awaitOrFail(barrier);
+                return toBeInterruptedFuture;
             }))
             .build();
     ListenableFuture<Status> statusFuture =
@@ -221,19 +236,19 @@ public final class ServerSecurityPolicyTest {
 
     // Uses the specified policy for service1.
     assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE1))
-        .isEqualTo(Code.INTERNAL);
+        .isEqualTo(Status.INTERNAL.getCode());
     assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE1))
-        .isEqualTo(Code.INTERNAL);
+        .isEqualTo(Status.INTERNAL.getCode());
 
     // Uses the specified policy for service2.
     assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE2))
-        .isEqualTo(Code.PERMISSION_DENIED);
-    assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE2)).isEqualTo(Code.OK);
+        .isEqualTo(Status.PERMISSION_DENIED.getCode());
+    assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE2)).isEqualTo(Status.OK.getCode());
 
     // Falls back to the default.
-    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE3)).isEqualTo(Code.OK);
+    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE3)).isEqualTo(Status.OK.getCode());
     assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE3))
-        .isEqualTo(Code.PERMISSION_DENIED);
+        .isEqualTo(Status.PERMISSION_DENIED.getCode());
   }
   @Test
   public void testPerServiceNoDefault_legacyApi() {
@@ -246,58 +261,64 @@ public final class ServerSecurityPolicyTest {
 
     // Uses the specified policy for service1.
     assertThat(policy.checkAuthorizationForService(MY_UID, SERVICE1).getCode())
-        .isEqualTo(Code.INTERNAL);
+        .isEqualTo(Status.INTERNAL.getCode());
     assertThat(policy.checkAuthorizationForService(OTHER_UID, SERVICE1).getCode())
-        .isEqualTo(Code.INTERNAL);
+        .isEqualTo(Status.INTERNAL.getCode());
 
     // Uses the specified policy for service2.
     assertThat(policy.checkAuthorizationForService(MY_UID, SERVICE2).getCode())
-        .isEqualTo(Code.PERMISSION_DENIED);
+        .isEqualTo(Status.PERMISSION_DENIED.getCode());
     assertThat(policy.checkAuthorizationForService(OTHER_UID, SERVICE2).getCode())
-        .isEqualTo(Code.OK);
+        .isEqualTo(Status.OK.getCode());
 
     // Falls back to the default.
     assertThat(policy.checkAuthorizationForService(MY_UID, SERVICE3).getCode())
-        .isEqualTo(Code.OK);
+        .isEqualTo(Status.OK.getCode());
     assertThat(policy.checkAuthorizationForService(OTHER_UID, SERVICE3).getCode())
-        .isEqualTo(Code.PERMISSION_DENIED);
+        .isEqualTo(Status.PERMISSION_DENIED.getCode());
   }
 
   @Test
   public void testPerServiceNoDefaultAsync() throws Exception {
     policy =
-        ServerSecurityPolicy.newBuilder()
-            .servicePolicy(
-                SERVICE1,
-                asyncPolicy((uid) -> Futures.immediateFuture(Status.INTERNAL)))
-            .servicePolicy(
-                SERVICE2, asyncPolicy((uid) -> {
-                  // Add some extra future transformation to confirm that a chain
-                  // of futures gets properly handled.
-                  ListenableFuture<Boolean> anotherUidFuture =
-                      Futures.immediateFuture(uid == OTHER_UID);
-                  return Futures
-                      .transform(
-                          anotherUidFuture,
-                          anotherUid -> anotherUid ? Status.OK : Status.PERMISSION_DENIED,
-                          MoreExecutors.directExecutor());
-                }))
-                .build();
+            ServerSecurityPolicy.newBuilder()
+                    .servicePolicy(
+                            SERVICE1,
+                            asyncPolicy((uid) -> Futures.immediateFuture(Status.INTERNAL)))
+                    .servicePolicy(
+                            SERVICE2, asyncPolicy((uid) -> {
+                              // Add some extra future transformation to confirm that a chain
+                              // of futures gets properly handled.
+                              ListenableFuture<Boolean> anotherUidFuture =
+                                      Futures.immediateFuture(uid == OTHER_UID);
+                              return Futures
+                                      .transform(
+                                              anotherUidFuture,
+                                              anotherUid ->
+                                                      anotherUid
+                                                              ? Status.OK
+                                                              : Status.PERMISSION_DENIED,
+                                              MoreExecutors.directExecutor());
+                            }))
+                    .build();
 
     // Uses the specified policy for service1.
-    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE1)).isEqualTo(Code.INTERNAL);
+    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE1))
+            .isEqualTo(Status.INTERNAL.getCode());
     assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE1))
-        .isEqualTo(Code.INTERNAL);
+            .isEqualTo(Status.INTERNAL.getCode());
 
     // Uses the specified policy for service2.
     assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE2))
-        .isEqualTo(Code.PERMISSION_DENIED);
-    assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE2)).isEqualTo(Code.OK);
+            .isEqualTo(Status.PERMISSION_DENIED.getCode());
+    assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE2))
+            .isEqualTo(Status.OK.getCode());
 
     // Falls back to the default.
-    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE3)).isEqualTo(Code.OK);
+    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE3))
+            .isEqualTo(Status.OK.getCode());
     assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE3))
-        .isEqualTo(Code.PERMISSION_DENIED);
+            .isEqualTo(Status.PERMISSION_DENIED.getCode());
   }
 
   /**
@@ -333,12 +354,12 @@ public final class ServerSecurityPolicyTest {
 
   private static void awaitOrFail(CyclicBarrier barrier) {
     try {
-      barrier.await();
+        barrier.await();
     } catch (BrokenBarrierException e) {
-      fail(e.getMessage());
+        fail(e.getMessage());
     } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      fail(e.getMessage());
+        Thread.currentThread().interrupt();
+        fail(e.getMessage());
     }
   }
 }

--- a/binder/src/test/java/io/grpc/binder/ServerSecurityPolicyTest.java
+++ b/binder/src/test/java/io/grpc/binder/ServerSecurityPolicyTest.java
@@ -55,43 +55,49 @@ public final class ServerSecurityPolicyTest {
   @Test
   public void testDefaultInternalOnly() throws Exception {
     policy = new ServerSecurityPolicy();
-    checkAsyncPolicy(policy, MY_UID, SERVICE1, Code.OK);
-    checkAsyncPolicy(policy, MY_UID, SERVICE2, Code.OK);
+    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE1)).isEqualTo(Code.OK);
+    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE2)).isEqualTo(Code.OK);
   }
 
   @Test
-  public void testDefaultInternalOnly_legacyApi() throws Exception {
+  public void testDefaultInternalOnly_legacyApi() {
     policy = new ServerSecurityPolicy();
-    checkLegacySynchronousPolicy(policy, MY_UID, SERVICE1, Code.OK);
-    checkLegacySynchronousPolicy(policy, MY_UID, SERVICE2, Code.OK);
+    assertThat(policy.checkAuthorizationForService(MY_UID, SERVICE1).getCode()).isEqualTo(Code.OK);
+    assertThat(policy.checkAuthorizationForService(MY_UID, SERVICE2).getCode()).isEqualTo(Code.OK);
   }
 
   @Test
   public void testInternalOnly_AnotherUid() throws Exception {
     policy = new ServerSecurityPolicy();
-    checkAsyncPolicy(policy, OTHER_UID, SERVICE1, Code.PERMISSION_DENIED);
-    checkAsyncPolicy(policy, OTHER_UID, SERVICE2, Code.PERMISSION_DENIED);
+    assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE1))
+        .isEqualTo(Code.PERMISSION_DENIED);
+    assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE2))
+        .isEqualTo(Code.PERMISSION_DENIED);
   }
 
   @Test
-  public void testInternalOnly_AnotherUid_legacyApi() throws Exception {
+  public void testInternalOnly_AnotherUid_legacyApi() {
     policy = new ServerSecurityPolicy();
-    checkLegacySynchronousPolicy(policy, OTHER_UID, SERVICE1, Code.PERMISSION_DENIED);
-    checkLegacySynchronousPolicy(policy, OTHER_UID, SERVICE2, Code.PERMISSION_DENIED);
+    assertThat(policy.checkAuthorizationForService(OTHER_UID, SERVICE1).getCode())
+        .isEqualTo(Code.PERMISSION_DENIED);
+    assertThat(policy.checkAuthorizationForService(OTHER_UID, SERVICE2).getCode())
+        .isEqualTo(Code.PERMISSION_DENIED);
   }
 
   @Test
   public void testBuilderDefault() throws Exception {
     policy = ServerSecurityPolicy.newBuilder().build();
-    checkAsyncPolicy(policy, MY_UID, SERVICE1, Code.OK);
-    checkAsyncPolicy(policy, OTHER_UID, SERVICE1, Code.PERMISSION_DENIED);
+    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE1)).isEqualTo(Code.OK);
+    assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE1))
+        .isEqualTo(Code.PERMISSION_DENIED);
   }
 
   @Test
-  public void testBuilderDefault_legacyApi() throws Exception {
+  public void testBuilderDefault_legacyApi() {
     policy = ServerSecurityPolicy.newBuilder().build();
-    checkLegacySynchronousPolicy(policy, MY_UID, SERVICE1, Code.OK);
-    checkLegacySynchronousPolicy(policy, OTHER_UID, SERVICE1, Code.PERMISSION_DENIED);
+    assertThat(policy.checkAuthorizationForService(MY_UID, SERVICE1).getCode()).isEqualTo(Code.OK);
+    assertThat(policy.checkAuthorizationForService(OTHER_UID, SERVICE1).getCode())
+        .isEqualTo(Code.PERMISSION_DENIED);
   }
 
   @Test
@@ -101,24 +107,27 @@ public final class ServerSecurityPolicyTest {
             .servicePolicy(SERVICE2, policy((uid) -> Status.OK))
             .build();
 
-    checkAsyncPolicy(policy, MY_UID, SERVICE1, Code.OK);
-    checkAsyncPolicy(policy, OTHER_UID, SERVICE1, Code.PERMISSION_DENIED);
-    checkAsyncPolicy(policy, MY_UID, SERVICE2, Code.OK);
-    checkAsyncPolicy(policy, OTHER_UID, SERVICE2, Code.OK);
+    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE1)).isEqualTo(Code.OK);
+    assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE1))
+        .isEqualTo(Code.PERMISSION_DENIED);
+    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE2)).isEqualTo(Code.OK);
+    assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE2)).isEqualTo(Code.OK);
   }
 
 
   @Test
-  public void testPerService_legacyApi() throws Exception {
+  public void testPerService_legacyApi() {
     policy =
         ServerSecurityPolicy.newBuilder()
             .servicePolicy(SERVICE2, policy((uid) -> Status.OK))
             .build();
 
-    checkLegacySynchronousPolicy(policy, MY_UID, SERVICE1, Code.OK);
-    checkLegacySynchronousPolicy(policy, OTHER_UID, SERVICE1, Code.PERMISSION_DENIED);
-    checkLegacySynchronousPolicy(policy, MY_UID, SERVICE2, Code.OK);
-    checkLegacySynchronousPolicy(policy, OTHER_UID, SERVICE2, Code.OK);
+    assertThat(policy.checkAuthorizationForService(MY_UID, SERVICE1).getCode()).isEqualTo(Code.OK);
+    assertThat(policy.checkAuthorizationForService(OTHER_UID, SERVICE1).getCode())
+        .isEqualTo(Code.PERMISSION_DENIED);
+    assertThat(policy.checkAuthorizationForService(MY_UID, SERVICE2).getCode()).isEqualTo(Code.OK);
+    assertThat(policy.checkAuthorizationForService(OTHER_UID, SERVICE2).getCode())
+        .isEqualTo(Code.OK);
   }
 
   @Test
@@ -134,10 +143,11 @@ public final class ServerSecurityPolicyTest {
             }))
             .build();
 
-    checkAsyncPolicy(policy, MY_UID, SERVICE1, Code.OK);
-    checkAsyncPolicy(policy, OTHER_UID, SERVICE1, Code.PERMISSION_DENIED);
-    checkAsyncPolicy(policy, MY_UID, SERVICE2, Code.OK);
-    checkAsyncPolicy(policy, OTHER_UID, SERVICE2, Code.OK);
+    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE1)).isEqualTo(Code.OK);
+    assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE1))
+        .isEqualTo(Code.PERMISSION_DENIED);
+    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE2)).isEqualTo(Code.OK);
+    assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE2)).isEqualTo(Code.OK);
   }
 
   @Test
@@ -210,19 +220,23 @@ public final class ServerSecurityPolicyTest {
             .build();
 
     // Uses the specified policy for service1.
-    checkAsyncPolicy(policy, MY_UID, SERVICE1, Code.INTERNAL);
-    checkAsyncPolicy(policy, OTHER_UID, SERVICE1, Code.INTERNAL);
+    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE1))
+        .isEqualTo(Code.INTERNAL);
+    assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE1))
+        .isEqualTo(Code.INTERNAL);
 
     // Uses the specified policy for service2.
-    checkAsyncPolicy(policy, MY_UID, SERVICE2, Code.PERMISSION_DENIED);
-    checkAsyncPolicy(policy, OTHER_UID, SERVICE2, Code.OK);
+    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE2))
+        .isEqualTo(Code.PERMISSION_DENIED);
+    assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE2)).isEqualTo(Code.OK);
 
     // Falls back to the default.
-    checkAsyncPolicy(policy, MY_UID, SERVICE3, Code.OK);
-    checkAsyncPolicy(policy, OTHER_UID, SERVICE3, Code.PERMISSION_DENIED);
+    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE3)).isEqualTo(Code.OK);
+    assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE3))
+        .isEqualTo(Code.PERMISSION_DENIED);
   }
   @Test
-  public void testPerServiceNoDefault_legacyApi() throws Exception {
+  public void testPerServiceNoDefault_legacyApi() {
     policy =
         ServerSecurityPolicy.newBuilder()
             .servicePolicy(SERVICE1, policy((uid) -> Status.INTERNAL))
@@ -231,16 +245,22 @@ public final class ServerSecurityPolicyTest {
             .build();
 
     // Uses the specified policy for service1.
-    checkLegacySynchronousPolicy(policy, MY_UID, SERVICE1, Code.INTERNAL);
-    checkLegacySynchronousPolicy(policy, OTHER_UID, SERVICE1, Code.INTERNAL);
+    assertThat(policy.checkAuthorizationForService(MY_UID, SERVICE1).getCode())
+        .isEqualTo(Code.INTERNAL);
+    assertThat(policy.checkAuthorizationForService(OTHER_UID, SERVICE1).getCode())
+        .isEqualTo(Code.INTERNAL);
 
     // Uses the specified policy for service2.
-    checkLegacySynchronousPolicy(policy, MY_UID, SERVICE2, Code.PERMISSION_DENIED);
-    checkLegacySynchronousPolicy(policy, OTHER_UID, SERVICE2, Code.OK);
+    assertThat(policy.checkAuthorizationForService(MY_UID, SERVICE2).getCode())
+        .isEqualTo(Code.PERMISSION_DENIED);
+    assertThat(policy.checkAuthorizationForService(OTHER_UID, SERVICE2).getCode())
+        .isEqualTo(Code.OK);
 
     // Falls back to the default.
-    checkLegacySynchronousPolicy(policy, MY_UID, SERVICE3, Code.OK);
-    checkLegacySynchronousPolicy(policy, OTHER_UID, SERVICE3, Code.PERMISSION_DENIED);
+    assertThat(policy.checkAuthorizationForService(MY_UID, SERVICE3).getCode())
+        .isEqualTo(Code.OK);
+    assertThat(policy.checkAuthorizationForService(OTHER_UID, SERVICE3).getCode())
+        .isEqualTo(Code.PERMISSION_DENIED);
   }
 
   @Test
@@ -265,45 +285,32 @@ public final class ServerSecurityPolicyTest {
                 .build();
 
     // Uses the specified policy for service1.
-    checkAsyncPolicy(policy, MY_UID, SERVICE1, Code.INTERNAL);
-    checkAsyncPolicy(policy, OTHER_UID, SERVICE1, Code.INTERNAL);
+    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE1)).isEqualTo(Code.INTERNAL);
+    assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE1))
+        .isEqualTo(Code.INTERNAL);
 
     // Uses the specified policy for service2.
-    checkAsyncPolicy(policy, MY_UID, SERVICE2, Code.PERMISSION_DENIED);
-    checkAsyncPolicy(policy, OTHER_UID, SERVICE2, Code.OK);
+    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE2))
+        .isEqualTo(Code.PERMISSION_DENIED);
+    assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE2)).isEqualTo(Code.OK);
 
     // Falls back to the default.
-    checkAsyncPolicy(policy, MY_UID, SERVICE3, Code.OK);
-    checkAsyncPolicy(policy, OTHER_UID, SERVICE3, Code.PERMISSION_DENIED);
+    assertThat(checkAuthorizationForServiceAsync(policy, MY_UID, SERVICE3)).isEqualTo(Code.OK);
+    assertThat(checkAuthorizationForServiceAsync(policy, OTHER_UID, SERVICE3))
+        .isEqualTo(Code.PERMISSION_DENIED);
   }
 
   /**
-   * Checks the resulting status of a {@link io.grpc.binder.ServerSecurityPolicy} built with a
-   * using the legacy {@link ServerSecurityPolicy#checkAuthorizationForService} API for backward
-   * compatibility.
+   * Shortcut for invoking {@link ServerSecurityPolicy#checkAuthorizationForServiceAsync} without
+   * dealing with concurrency details. Returns a {link @Status.Code} for convenience.
    */
-  private static void checkLegacySynchronousPolicy(
+  private static Status.Code checkAuthorizationForServiceAsync(
           ServerSecurityPolicy policy,
           int callerUid,
-          String service,
-          Status.Code expectedCode) throws ExecutionException{
-    // Legacy API; checked for backward compatibility
-    assertThat(policy.checkAuthorizationForService(callerUid, service).getCode())
-        .isEqualTo(expectedCode);
-  }
-
-  /**
-   * Checks the resulting status of a {@link io.grpc.binder.ServerSecurityPolicy} using the new,
-   * asynchronous API ({@link ServerSecurityPolicy#checkAuthorizationForServiceAsync}).
-   */
-  private static void checkAsyncPolicy(
-          ServerSecurityPolicy policy,
-          int callerUid,
-          String service,
-          Status.Code expectedCode) throws ExecutionException{
+          String service) throws ExecutionException {
     ListenableFuture<Status> statusFuture =
         policy.checkAuthorizationForServiceAsync(callerUid, service);
-    assertThat(Uninterruptibles.getUninterruptibly(statusFuture).getCode()).isEqualTo(expectedCode);
+    return Uninterruptibles.getUninterruptibly(statusFuture).getCode();
   }
 
   private static SecurityPolicy policy(Function<Integer, Status> func) {


### PR DESCRIPTION
- Introduce PendingAuthListener to handle a ListenableFuture<Status>, progressing the gRPC through each stage in sequence once the future completes and is OK.
- Move unit tests away from `checkAuthorizationForService` and into `checkAuthorizationForServiceAsync` since that should be the only method called in production now.
- Some tests in `ServerSecurityPolicyTest` had their expectations updated; they previously called synchornous APIs that transformed failed `ListenableFuture<Status>` into one or another status. Now, we call the sync API, so those transformations do not happen anymore, thus the test needs to deal with failed futures directly.
- I couldn't figure out if this PR needs extra tests. AFAICT `BinderSecurityTest` should already cover the new codepaths, but please let me know otherwise.

This should be the last PR to address #10566.