### PR TITLE
lb: acceptResolvedAddresses() to return Status

### DIFF
--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -162,20 +162,21 @@ public abstract class LoadBalancer {
    * @return {@code true} if the resolved addresses were accepted. {@code false} if rejected.
    * @since 1.49.0
    */
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     if (resolvedAddresses.getAddresses().isEmpty()
         && !canHandleEmptyAddressListFromNameResolution()) {
-      handleNameResolutionError(Status.UNAVAILABLE.withDescription(
-          "NameResolver returned no usable address. addrs=" + resolvedAddresses.getAddresses()
-              + ", attrs=" + resolvedAddresses.getAttributes()));
-      return false;
+      Status unavailableStatus = Status.UNAVAILABLE.withDescription(
+              "NameResolver returned no usable address. addrs=" + resolvedAddresses.getAddresses()
+                      + ", attrs=" + resolvedAddresses.getAttributes());
+      handleNameResolutionError(unavailableStatus);
+      return unavailableStatus;
     } else {
       if (recursionCount++ == 0) {
         handleResolvedAddresses(resolvedAddresses);
       }
       recursionCount = 0;
 
-      return true;
+      return Status.OK;
     }
   }
 

--- a/api/src/test/java/io/grpc/LoadBalancerTest.java
+++ b/api/src/test/java/io/grpc/LoadBalancerTest.java
@@ -240,9 +240,9 @@ public class LoadBalancerTest {
 
     LoadBalancer balancer = new LoadBalancer() {
         @Override
-        public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+        public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
           resultCapture.set(resolvedAddresses);
-          return true;
+          return Status.OK;
         }
 
         @Override

--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
@@ -70,8 +70,8 @@ public final class AutoConfiguredLoadBalancerFactory {
     }
 
     @Override
-    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-      return true;
+    public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+      return Status.OK;
     }
 
     @Override
@@ -102,7 +102,7 @@ public final class AutoConfiguredLoadBalancerFactory {
      * Returns non-OK status if the delegate rejects the resolvedAddresses (e.g. if it does not
      * support an empty list).
      */
-    boolean tryAcceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    Status tryAcceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       PolicySelection policySelection =
           (PolicySelection) resolvedAddresses.getLoadBalancingPolicyConfig();
 
@@ -116,7 +116,7 @@ public final class AutoConfiguredLoadBalancerFactory {
           delegate.shutdown();
           delegateProvider = null;
           delegate = new NoopLoadBalancer();
-          return true;
+          return Status.OK;
         }
         policySelection =
             new PolicySelection(defaultProvider, /* config= */ null);

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1805,7 +1805,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
                 // GrpcUtil.getTransportFromPickResult().
                 onError(configOrError.getError());
                 if (resolutionResultListener != null) {
-                  resolutionResultListener.resolutionAttempted(false);
+                  resolutionResultListener.resolutionAttempted(configOrError.getError());
                 }
                 return;
               } else {
@@ -1851,7 +1851,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
             }
             Attributes attributes = attrBuilder.build();
 
-            boolean lastAddressesAccepted = helper.lb.tryAcceptResolvedAddresses(
+            Status addressAcceptanceStatus = helper.lb.tryAcceptResolvedAddresses(
                 ResolvedAddresses.newBuilder()
                     .setAddresses(servers)
                     .setAttributes(attributes)
@@ -1859,7 +1859,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
                     .build());
             // If a listener is provided, let it know if the addresses were accepted.
             if (resolutionResultListener != null) {
-              resolutionResultListener.resolutionAttempted(lastAddressesAccepted);
+              resolutionResultListener.resolutionAttempted(addressAcceptanceStatus);
             }
           }
         }

--- a/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
@@ -62,20 +62,23 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     List<EquivalentAddressGroup> servers = resolvedAddresses.getAddresses();
     if (servers.isEmpty()) {
-      handleNameResolutionError(Status.UNAVAILABLE.withDescription(
-          "NameResolver returned no usable address. addrs=" + resolvedAddresses.getAddresses()
-          + ", attrs=" + resolvedAddresses.getAttributes()));
-      return false;
+      Status unavailableStatus = Status.UNAVAILABLE.withDescription(
+              "NameResolver returned no usable address. addrs=" + resolvedAddresses.getAddresses()
+                      + ", attrs=" + resolvedAddresses.getAttributes());
+      handleNameResolutionError(unavailableStatus);
+      return unavailableStatus;
     }
     for (EquivalentAddressGroup eag : servers) {
       if (eag == null) {
-        handleNameResolutionError(Status.UNAVAILABLE.withDescription(
+        Status unavailableStatus = Status.UNAVAILABLE.withDescription(
             "NameResolver returned address list with null endpoint. addrs="
-            + resolvedAddresses.getAddresses() + ", attrs=" + resolvedAddresses.getAttributes()));
-        return false;
+                + resolvedAddresses.getAddresses() + ", attrs="
+                + resolvedAddresses.getAttributes());
+        handleNameResolutionError(unavailableStatus);
+        return unavailableStatus;
       }
     }
     // We can optionally be configured to shuffle the address list. This can help better distribute
@@ -102,7 +105,7 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
       SocketAddress previousAddress = addressIndex.getCurrentAddress();
       addressIndex.updateGroups(newImmutableAddressGroups);
       if (addressIndex.seekTo(previousAddress)) {
-        return true;
+        return Status.OK;
       }
       addressIndex.reset();
     } else {
@@ -144,7 +147,7 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
       requestConnection();
     }
 
-    return true;
+    return Status.OK;
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/PickFirstLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLoadBalancer.java
@@ -50,13 +50,14 @@ final class PickFirstLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     List<EquivalentAddressGroup> servers = resolvedAddresses.getAddresses();
     if (servers.isEmpty()) {
-      handleNameResolutionError(Status.UNAVAILABLE.withDescription(
-          "NameResolver returned no usable address. addrs=" + resolvedAddresses.getAddresses()
-              + ", attrs=" + resolvedAddresses.getAttributes()));
-      return false;
+      Status unavailableStatus = Status.UNAVAILABLE.withDescription(
+              "NameResolver returned no usable address. addrs=" + resolvedAddresses.getAddresses()
+                      + ", attrs=" + resolvedAddresses.getAttributes());
+      handleNameResolutionError(unavailableStatus);
+      return unavailableStatus;
     }
 
     // We can optionally be configured to shuffle the address list. This can help better distribute
@@ -92,7 +93,7 @@ final class PickFirstLoadBalancer extends LoadBalancer {
       subchannel.updateAddresses(servers);
     }
 
-    return true;
+    return Status.OK;
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/RetryingNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/RetryingNameResolver.java
@@ -114,8 +114,8 @@ final class RetryingNameResolver extends ForwardingNameResolver {
    * the Listener2.onResult() API can be changed to return a boolean for this purpose.
    */
   class ResolutionResultListener {
-    public void resolutionAttempted(boolean successful) {
-      if (successful) {
+    public void resolutionAttempted(Status successStatus) {
+      if (successStatus.isOk()) {
         retryScheduler.reset();
       } else {
         retryScheduler.schedule(new DelayedNameResolverRefresh());

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -230,7 +230,7 @@ public class DnsNameResolverTest {
       ResolutionResult result = invocation.getArgument(0);
       syncContext.execute(
           () -> result.getAttributes().get(RetryingNameResolver.RESOLUTION_RESULT_LISTENER_KEY)
-              .resolutionAttempted(true));
+              .resolutionAttempted(Status.OK));
       return null;
     }).when(mockListener).onResult(isA(ResolutionResult.class));
   }
@@ -591,7 +591,7 @@ public class DnsNameResolverTest {
     doAnswer(invocation -> {
       ResolutionResult result = invocation.getArgument(0);
       result.getAttributes().get(RetryingNameResolver.RESOLUTION_RESULT_LISTENER_KEY)
-          .resolutionAttempted(false);
+          .resolutionAttempted(Status.UNAVAILABLE);
       return null;
     }).when(mockListener).onResult(isA(ResolutionResult.class));
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -154,7 +154,8 @@ public class ManagedChannelImplIdlenessTest {
   @Before
   @SuppressWarnings("deprecation") // For NameResolver.Listener
   public void setUp() {
-    when(mockLoadBalancer.acceptResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(true);
+    when(mockLoadBalancer.acceptResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(
+        Status.OK);
     LoadBalancerRegistry.getDefaultRegistry().register(mockLoadBalancerProvider);
     when(mockNameResolver.getServiceAuthority()).thenReturn(AUTHORITY);
     when(mockNameResolverFactory

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -316,7 +316,8 @@ public class ManagedChannelImplTest {
 
   @Before
   public void setUp() throws Exception {
-    when(mockLoadBalancer.acceptResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(true);
+    when(mockLoadBalancer.acceptResolvedAddresses(isA(ResolvedAddresses.class))).thenReturn(
+        Status.OK);
     LoadBalancerRegistry.getDefaultRegistry().register(mockLoadBalancerProvider);
     expectedUri = new URI(TARGET);
     transports = TestUtils.captureTransports(mockTransportFactory);

--- a/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
@@ -562,8 +562,8 @@ public class PickFirstLeafLoadBalancerTest {
     loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     assertFalse(loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-        .setAddresses(Arrays.<EquivalentAddressGroup>asList()).setAttributes(affinity).build()));
+        ResolvedAddresses.newBuilder().setAddresses(Arrays.<EquivalentAddressGroup>asList())
+            .setAttributes(affinity).build()).isOk());
     assertEquals(TRANSIENT_FAILURE, loadBalancer.getCurrentState());
   }
 
@@ -573,7 +573,7 @@ public class PickFirstLeafLoadBalancerTest {
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
     List<EquivalentAddressGroup> eags = Arrays.asList((EquivalentAddressGroup) null);
     assertFalse(loadBalancer.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder().setAddresses(eags).setAttributes(affinity).build()));
+        ResolvedAddresses.newBuilder().setAddresses(eags).setAttributes(affinity).build()).isOk());
     assertEquals(TRANSIENT_FAILURE, loadBalancer.getCurrentState());
   }
 

--- a/core/src/test/java/io/grpc/internal/RetryingNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/RetryingNameResolverTest.java
@@ -90,7 +90,7 @@ public class RetryingNameResolverTest {
         .get(RetryingNameResolver.RESOLUTION_RESULT_LISTENER_KEY);
     assertThat(resolutionResultListener).isNotNull();
 
-    resolutionResultListener.resolutionAttempted(true);
+    resolutionResultListener.resolutionAttempted(Status.OK);
     verify(mockRetryScheduler).reset();
   }
 
@@ -108,7 +108,7 @@ public class RetryingNameResolverTest {
         .get(RetryingNameResolver.RESOLUTION_RESULT_LISTENER_KEY);
     assertThat(resolutionResultListener).isNotNull();
 
-    resolutionResultListener.resolutionAttempted(false);
+    resolutionResultListener.resolutionAttempted(Status.UNAVAILABLE);
     verify(mockRetryScheduler).schedule(isA(Runnable.class));
   }
 

--- a/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
+++ b/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
@@ -192,7 +192,7 @@ public class ServiceConfigErrorHandlingTest {
 
   @Before
   public void setUp() throws Exception {
-    mockLoadBalancer.setAcceptAddresses(true);
+    mockLoadBalancer.setAddressAcceptanceStatus(Status.OK);
     LoadBalancerRegistry.getDefaultRegistry().register(mockLoadBalancerProvider);
     expectedUri = new URI(TARGET);
     when(mockTransportFactory.getScheduledExecutorService())
@@ -280,7 +280,7 @@ public class ServiceConfigErrorHandlingTest {
     nameResolverFactory.servers.clear();
 
     // 2nd resolution
-    mockLoadBalancer.setAcceptAddresses(false);
+    mockLoadBalancer.setAddressAcceptanceStatus(Status.UNAVAILABLE);
     nameResolverFactory.allResolved();
 
     // 2nd service config without addresses
@@ -649,7 +649,7 @@ public class ServiceConfigErrorHandlingTest {
 
   private static class FakeLoadBalancer extends LoadBalancer {
 
-    private boolean acceptAddresses = true;
+    private Status addressAcceptanceStatus = Status.OK;
 
     @Nullable
     private Helper helper;
@@ -659,12 +659,12 @@ public class ServiceConfigErrorHandlingTest {
     }
 
     @Override
-    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-      return acceptAddresses;
+    public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+      return addressAcceptanceStatus;
     }
 
-    public void setAcceptAddresses(boolean acceptAddresses) {
-      this.acceptAddresses = acceptAddresses;
+    public void setAddressAcceptanceStatus(Status addressAcceptanceStatus) {
+      this.addressAcceptanceStatus = addressAcceptanceStatus;
     }
 
     @Override

--- a/examples/src/main/java/io/grpc/examples/customloadbalance/ShufflingPickFirstLoadBalancer.java
+++ b/examples/src/main/java/io/grpc/examples/customloadbalance/ShufflingPickFirstLoadBalancer.java
@@ -63,13 +63,14 @@ class ShufflingPickFirstLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     List<EquivalentAddressGroup> servers = new ArrayList<>(resolvedAddresses.getAddresses());
     if (servers.isEmpty()) {
-      handleNameResolutionError(Status.UNAVAILABLE.withDescription(
+      Status unavailableStatus = Status.UNAVAILABLE.withDescription(
           "NameResolver returned no usable address. addrs=" + resolvedAddresses.getAddresses()
-              + ", attrs=" + resolvedAddresses.getAttributes()));
-      return false;
+              + ", attrs=" + resolvedAddresses.getAttributes());
+      handleNameResolutionError(unavailableStatus);
+      return unavailableStatus;
     }
 
     Config config
@@ -97,7 +98,7 @@ class ShufflingPickFirstLoadBalancer extends LoadBalancer {
       subchannel.updateAddresses(servers);
     }
 
-    return true;
+    return Status.OK;
   }
 
   @Override

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -76,16 +76,17 @@ class GrpclbLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     Attributes attributes = resolvedAddresses.getAttributes();
     List<EquivalentAddressGroup> newLbAddresses = attributes.get(GrpclbConstants.ATTR_LB_ADDRS);
     if (newLbAddresses == null) {
       newLbAddresses = Collections.emptyList();
     }
     if (newLbAddresses.isEmpty() && resolvedAddresses.getAddresses().isEmpty()) {
-      handleNameResolutionError(
-          Status.UNAVAILABLE.withDescription("No backend or balancer addresses found"));
-      return false;
+      Status unavailableStatus = Status.UNAVAILABLE.withDescription(
+          "No backend or balancer addresses found");
+      handleNameResolutionError(unavailableStatus);
+      return unavailableStatus;
     }
     List<EquivalentAddressGroup> overrideAuthorityLbAddresses =
         new ArrayList<>(newLbAddresses.size());
@@ -115,7 +116,7 @@ class GrpclbLoadBalancer extends LoadBalancer {
     grpclbState.handleAddresses(Collections.unmodifiableList(overrideAuthorityLbAddresses),
         newBackendServers);
 
-    return true;
+    return Status.OK;
   }
 
   @Override

--- a/rls/src/main/java/io/grpc/rls/LbPolicyConfiguration.java
+++ b/rls/src/main/java/io/grpc/rls/LbPolicyConfiguration.java
@@ -303,7 +303,7 @@ final class LbPolicyConfiguration {
             @Override
             public void run() {
               if (!lb.acceptResolvedAddresses(
-                  childLbResolvedAddressFactory.create(lbConfig.getConfig()))) {
+                  childLbResolvedAddressFactory.create(lbConfig.getConfig())).isOk()) {
                 helper.refreshNameResolution();
               }
               lb.requestConnection();

--- a/rls/src/main/java/io/grpc/rls/RlsLoadBalancer.java
+++ b/rls/src/main/java/io/grpc/rls/RlsLoadBalancer.java
@@ -49,7 +49,7 @@ final class RlsLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(ChannelLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     LbPolicyConfiguration lbPolicyConfiguration =
         (LbPolicyConfiguration) resolvedAddresses.getLoadBalancingPolicyConfig();
@@ -78,7 +78,7 @@ final class RlsLoadBalancer extends LoadBalancer {
       //  not required.
       this.lbPolicyConfiguration = lbPolicyConfiguration;
     }
-    return true;
+    return Status.OK;
   }
 
   @Override

--- a/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
+++ b/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
@@ -703,7 +703,7 @@ public class CachingRlsLbClientTest {
       LoadBalancer loadBalancer = new LoadBalancer() {
 
         @Override
-        public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+        public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
           Map<?, ?> config = (Map<?, ?>) resolvedAddresses.getLoadBalancingPolicyConfig();
           if (DEFAULT_TARGET.equals(config.get("target"))) {
             helper.updateBalancingState(
@@ -727,7 +727,7 @@ public class CachingRlsLbClientTest {
                 });
           }
 
-          return true;
+          return Status.OK;
         }
 
         @Override

--- a/rls/src/test/java/io/grpc/rls/LbPolicyConfigurationTest.java
+++ b/rls/src/test/java/io/grpc/rls/LbPolicyConfigurationTest.java
@@ -36,6 +36,7 @@ import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.NameResolver.ConfigOrError;
+import io.grpc.Status;
 import io.grpc.SynchronizationContext;
 import io.grpc.rls.ChildLoadBalancerHelper.ChildLoadBalancerHelperProvider;
 import io.grpc.rls.LbPolicyConfiguration.ChildLbStatusListener;
@@ -95,6 +96,7 @@ public class LbPolicyConfigurationTest {
     doReturn(lb).when(lbProvider).newLoadBalancer(any(Helper.class));
     doReturn(ConfigOrError.fromConfig(new Object()))
         .when(lbProvider).parseLoadBalancingPolicyConfig(ArgumentMatchers.<Map<String, ?>>any());
+    doReturn(Status.OK).when(lb).acceptResolvedAddresses(any(ResolvedAddresses.class));
   }
 
   @Test
@@ -123,7 +125,7 @@ public class LbPolicyConfigurationTest {
 
   @Test
   public void childPolicyWrapper_addressesRejected() {
-    when(lb.acceptResolvedAddresses(any(ResolvedAddresses.class))).thenReturn(false);
+    when(lb.acceptResolvedAddresses(any(ResolvedAddresses.class))).thenReturn(Status.UNAVAILABLE);
     factory.createOrGet("target");
     verify(helper).refreshNameResolution();
   }

--- a/util/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
@@ -95,7 +95,7 @@ public final class OutlierDetectionLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(ChannelLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     OutlierDetectionLoadBalancerConfig config
         = (OutlierDetectionLoadBalancerConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
@@ -149,7 +149,7 @@ public final class OutlierDetectionLoadBalancer extends LoadBalancer {
     switchLb.handleResolvedAddresses(
         resolvedAddresses.toBuilder().setLoadBalancingPolicyConfig(config.childPolicy.getConfig())
             .build());
-    return true;
+    return Status.OK;
   }
 
   @Override

--- a/util/src/test/java/io/grpc/util/OutlierDetectionLoadBalancerTest.java
+++ b/util/src/test/java/io/grpc/util/OutlierDetectionLoadBalancerTest.java
@@ -1207,7 +1207,7 @@ public class OutlierDetectionLoadBalancerTest {
     }
 
     @Override
-    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       subchannelList = new ArrayList<>();
       for (EquivalentAddressGroup eag: resolvedAddresses.getAddresses()) {
         Subchannel subchannel = helper.createSubchannel(CreateSubchannelArgs.newBuilder()
@@ -1216,7 +1216,7 @@ public class OutlierDetectionLoadBalancerTest {
         subchannel.start(mock(SubchannelStateListener.class));
         deliverSubchannelState(READY);
       }
-      return true;
+      return Status.OK;
     }
 
     @Override

--- a/util/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
+++ b/util/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
@@ -114,7 +114,7 @@ public class RoundRobinLoadBalancerTest {
     loadBalancer = new RoundRobinLoadBalancer(mockHelper);
   }
 
-  private boolean acceptAddresses(List<EquivalentAddressGroup> eagList, Attributes attrs) {
+  private Status acceptAddresses(List<EquivalentAddressGroup> eagList, Attributes attrs) {
     return loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(eagList).setAttributes(attrs).build());
   }
@@ -126,8 +126,8 @@ public class RoundRobinLoadBalancerTest {
 
   @Test
   public void pickAfterResolved() throws Exception {
-    boolean addressesAccepted = acceptAddresses(servers, affinity);
-    assertThat(addressesAccepted).isTrue();
+    Status addressesAcceptanceStatus = acceptAddresses(servers, affinity);
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     final Subchannel readySubchannel = subchannels.values().iterator().next();
     deliverSubchannelState(readySubchannel, ConnectivityStateInfo.forNonError(READY));
 
@@ -181,8 +181,8 @@ public class RoundRobinLoadBalancerTest {
 
     InOrder inOrder = inOrder(mockHelper);
 
-    boolean addressesAccepted = acceptAddresses(currentServers, affinity);
-    assertThat(addressesAccepted).isTrue();
+    Status addressesAcceptanceStatus = acceptAddresses(currentServers, affinity);
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
 
     inOrder.verify(mockHelper).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
 
@@ -205,9 +205,9 @@ public class RoundRobinLoadBalancerTest {
     // This time with Attributes
     List<EquivalentAddressGroup> latestServers = Lists.newArrayList(oldEag2, newEag);
 
-    addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(latestServers).setAttributes(affinity).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
 
     verify(newSubchannel, times(1)).requestConnection();
     verify(oldSubchannel, times(1)).updateAddresses(Arrays.asList(oldEag2));
@@ -233,8 +233,8 @@ public class RoundRobinLoadBalancerTest {
   @Test
   public void pickAfterStateChange() throws Exception {
     InOrder inOrder = inOrder(mockHelper);
-    boolean addressesAccepted = acceptAddresses(servers, Attributes.EMPTY);
-    assertThat(addressesAccepted).isTrue();
+    Status addressesAcceptanceStatus = acceptAddresses(servers, Attributes.EMPTY);
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
 
     // TODO figure out if this method testing the right things
 
@@ -270,8 +270,8 @@ public class RoundRobinLoadBalancerTest {
   @Test
   public void ignoreShutdownSubchannelStateChange() {
     InOrder inOrder = inOrder(mockHelper);
-    boolean addressesAccepted = acceptAddresses(servers, Attributes.EMPTY);
-    assertThat(addressesAccepted).isTrue();
+    Status addressesAcceptanceStatus = acceptAddresses(servers, Attributes.EMPTY);
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     inOrder.verify(mockHelper).updateBalancingState(eq(CONNECTING), isA(EmptyPicker.class));
 
     loadBalancer.shutdown();
@@ -289,8 +289,8 @@ public class RoundRobinLoadBalancerTest {
   @Test
   public void stayTransientFailureUntilReady() {
     InOrder inOrder = inOrder(mockHelper);
-    boolean addressesAccepted = acceptAddresses(servers, Attributes.EMPTY);
-    assertThat(addressesAccepted).isTrue();
+    Status addressesAcceptanceStatus = acceptAddresses(servers, Attributes.EMPTY);
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
 
     inOrder.verify(mockHelper).updateBalancingState(eq(CONNECTING), isA(EmptyPicker.class));
 
@@ -326,8 +326,8 @@ public class RoundRobinLoadBalancerTest {
   @Test
   public void refreshNameResolutionWhenSubchannelConnectionBroken() {
     InOrder inOrder = inOrder(mockHelper);
-    boolean addressesAccepted = acceptAddresses(servers, Attributes.EMPTY);
-    assertThat(addressesAccepted).isTrue();
+    Status addressesAcceptanceStatus = acceptAddresses(servers, Attributes.EMPTY);
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
 
     verify(mockHelper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
     inOrder.verify(mockHelper).updateBalancingState(eq(CONNECTING), isA(EmptyPicker.class));
@@ -393,9 +393,9 @@ public class RoundRobinLoadBalancerTest {
 
   @Test
   public void nameResolutionErrorWithActiveChannels() throws Exception {
-    boolean addressesAccepted = acceptAddresses(servers, affinity);
+    Status addressesAcceptanceStatus = acceptAddresses(servers, affinity);
     final Subchannel readySubchannel = subchannels.values().iterator().next();
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     deliverSubchannelState(readySubchannel, ConnectivityStateInfo.forNonError(READY));
     loadBalancer.resolvingAddresses = true;
     loadBalancer.handleNameResolutionError(Status.NOT_FOUND.withDescription("nameResolutionError"));
@@ -420,8 +420,8 @@ public class RoundRobinLoadBalancerTest {
 
   @Test
   public void subchannelStateIsolation() throws Exception {
-    boolean addressesAccepted = acceptAddresses(servers, Attributes.EMPTY);
-    assertThat(addressesAccepted).isTrue();
+    Status addressesAcceptanceStatus = acceptAddresses(servers, Attributes.EMPTY);
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
 
     Iterator<Subchannel> subchannelIterator = subchannels.values().iterator();
     Subchannel sc1 = subchannelIterator.next();
@@ -505,7 +505,7 @@ public class RoundRobinLoadBalancerTest {
         ResolvedAddresses.newBuilder()
             .setAddresses(Collections.emptyList())
             .setAttributes(affinity)
-            .build())).isFalse();
+            .build()).isOk()).isFalse();
   }
 
   private List<Subchannel> getList(SubchannelPicker picker) {

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
@@ -82,9 +82,9 @@ final class CdsLoadBalancer2 extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     if (this.resolvedAddresses != null) {
-      return true;
+      return Status.OK;
     }
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     this.resolvedAddresses = resolvedAddresses;
@@ -94,7 +94,7 @@ final class CdsLoadBalancer2 extends LoadBalancer {
     logger.log(XdsLogLevel.INFO, "Config: {0}", config);
     cdsLbState = new CdsLbState(config.name);
     cdsLbState.start();
-    return true;
+    return Status.OK;
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -101,7 +101,7 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     Attributes attributes = resolvedAddresses.getAttributes();
     if (xdsClientPool == null) {
@@ -135,7 +135,7 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
             .setAttributes(attributes)
             .setLoadBalancingPolicyConfig(config.childPolicy.getConfig())
             .build());
-    return true;
+    return Status.OK;
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
@@ -112,7 +112,7 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     if (xdsClientPool == null) {
       xdsClientPool = resolvedAddresses.getAttributes().get(InternalXdsAttributes.XDS_CLIENT_POOL);
@@ -126,7 +126,7 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
       this.config = config;
       delegate.handleResolvedAddresses(resolvedAddresses);
     }
-    return true;
+    return Status.OK;
   }
 
   @Override
@@ -170,7 +170,7 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
     }
 
     @Override
-    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       this.resolvedAddresses = resolvedAddresses;
       ClusterResolverConfig config =
           (ClusterResolverConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
@@ -189,7 +189,7 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
         clusterStates.put(instance.cluster, state);
         state.start();
       }
-      return true;
+      return Status.OK;
     }
 
     @Override

--- a/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancer.java
@@ -82,7 +82,7 @@ final class LeastRequestLoadBalancer extends MultiChildLoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     // Need to update choiceCount before calling super so that the updateBalancingState call has the
     // new value.  However, if the update fails we need to revert it.
     int oldChoiceCount = choiceCount;
@@ -92,13 +92,13 @@ final class LeastRequestLoadBalancer extends MultiChildLoadBalancer {
       choiceCount = config.choiceCount;
     }
 
-    boolean successfulUpdate = super.acceptResolvedAddresses(resolvedAddresses);
+    Status addressAcceptanceStatus = super.acceptResolvedAddresses(resolvedAddresses);
 
-    if (!successfulUpdate) {
+    if (!addressAcceptanceStatus.isOk()) {
       choiceCount = oldChoiceCount;
     }
 
-    return successfulUpdate;
+    return addressAcceptanceStatus;
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/PriorityLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/PriorityLoadBalancer.java
@@ -85,7 +85,7 @@ final class PriorityLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     this.resolvedAddresses = resolvedAddresses;
     PriorityLbConfig config = (PriorityLbConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
@@ -111,7 +111,7 @@ final class PriorityLoadBalancer extends LoadBalancer {
     }
     handlingResolvedAddresses = false;
     tryNextPriority();
-    return true;
+    return Status.OK;
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -104,23 +104,24 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     if (resolvedAddresses.getLoadBalancingPolicyConfig() == null) {
-      handleNameResolutionError(Status.UNAVAILABLE.withDescription(
+      Status unavailableStatus = Status.UNAVAILABLE.withDescription(
               "NameResolver returned no WeightedRoundRobinLoadBalancerConfig. addrs="
                       + resolvedAddresses.getAddresses()
-                      + ", attrs=" + resolvedAddresses.getAttributes()));
-      return false;
+                      + ", attrs=" + resolvedAddresses.getAttributes());
+      handleNameResolutionError(unavailableStatus);
+      return unavailableStatus;
     }
     config =
             (WeightedRoundRobinLoadBalancerConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
-    boolean accepted = super.acceptResolvedAddresses(resolvedAddresses);
+    Status addressAcceptanceStatus = super.acceptResolvedAddresses(resolvedAddresses);
     if (weightUpdateTimer != null && weightUpdateTimer.isPending()) {
       weightUpdateTimer.cancel();
     }
     updateWeightTask.run();
     afterAcceptAddresses();
-    return accepted;
+    return addressAcceptanceStatus;
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/WeightedTargetLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedTargetLoadBalancer.java
@@ -59,7 +59,7 @@ final class WeightedTargetLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     try {
       resolvingAddresses = true;
       return acceptResolvedAddressesInternal(resolvedAddresses);
@@ -68,7 +68,7 @@ final class WeightedTargetLoadBalancer extends LoadBalancer {
     }
   }
 
-  public boolean acceptResolvedAddressesInternal(ResolvedAddresses resolvedAddresses) {
+  public Status acceptResolvedAddressesInternal(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     Object lbConfig = resolvedAddresses.getLoadBalancingPolicyConfig();
     checkNotNull(lbConfig, "missing weighted_target lb config");
@@ -107,7 +107,7 @@ final class WeightedTargetLoadBalancer extends LoadBalancer {
     childBalancers.keySet().retainAll(targets.keySet());
     childHelpers.keySet().retainAll(targets.keySet());
     updateOverallBalancingState();
-    return true;
+    return Status.OK;
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancer.java
@@ -62,7 +62,7 @@ final class WrrLocalityLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+  public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
 
     // The configuration with the child policy is combined with the locality weights
@@ -78,15 +78,18 @@ final class WrrLocalityLoadBalancer extends LoadBalancer {
       Integer localityWeight = eagAttrs.get(InternalXdsAttributes.ATTR_LOCALITY_WEIGHT);
 
       if (locality == null) {
-        helper.updateBalancingState(TRANSIENT_FAILURE, new FixedResultPicker(PickResult.withError(
-            Status.UNAVAILABLE.withDescription("wrr_locality error: no locality provided"))));
-        return false;
+        Status unavailableStatus = Status.UNAVAILABLE.withDescription(
+            "wrr_locality error: no locality provided");
+        helper.updateBalancingState(TRANSIENT_FAILURE,
+            new FixedResultPicker(PickResult.withError(unavailableStatus)));
+        return unavailableStatus;
       }
       if (localityWeight == null) {
-        helper.updateBalancingState(TRANSIENT_FAILURE, new FixedResultPicker(PickResult.withError(
-            Status.UNAVAILABLE.withDescription(
-                "wrr_locality error: no weight provided for locality " + locality))));
-        return false;
+        Status unavailableStatus = Status.UNAVAILABLE.withDescription(
+                "wrr_locality error: no weight provided for locality " + locality);
+        helper.updateBalancingState(TRANSIENT_FAILURE,
+            new FixedResultPicker(PickResult.withError(unavailableStatus)));
+        return unavailableStatus;
       }
 
       if (!localityWeights.containsKey(locality)) {
@@ -113,7 +116,7 @@ final class WrrLocalityLoadBalancer extends LoadBalancer {
             .setLoadBalancingPolicyConfig(new WeightedTargetConfig(weightedPolicySelections))
             .build());
 
-    return true;
+    return Status.OK;
   }
 
   @Override

--- a/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
@@ -741,11 +741,11 @@ public class ClusterImplLoadBalancerTest {
     }
 
     @Override
-    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       addresses = resolvedAddresses.getAddresses();
       config = resolvedAddresses.getLoadBalancingPolicyConfig();
       attributes = resolvedAddresses.getAttributes();
-      return true;
+      return Status.OK;
     }
 
     @Override

--- a/xds/src/test/java/io/grpc/xds/ClusterManagerLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterManagerLoadBalancerTest.java
@@ -361,14 +361,14 @@ public class ClusterManagerLoadBalancerTest {
     }
 
     @Override
-    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       config = resolvedAddresses.getLoadBalancingPolicyConfig();
 
       if (failing) {
         helper.updateBalancingState(
             TRANSIENT_FAILURE, new FixedResultPicker(PickResult.withError(Status.INTERNAL)));
       }
-      return true;
+      return Status.OK;
     }
 
     @Override

--- a/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
@@ -1335,10 +1335,10 @@ public class ClusterResolverLoadBalancerTest {
     }
 
     @Override
-    public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       addresses = resolvedAddresses.getAddresses();
       config = resolvedAddresses.getLoadBalancingPolicyConfig();
-      return true;
+      return Status.OK;
     }
 
     @Override

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
@@ -157,10 +157,10 @@ public class RingHashLoadBalancerTest {
   public void subchannelLazyConnectUntilPicked() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1);  // one server
-    boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     verify(helper).createSubchannel(any(CreateSubchannelArgs.class));
     Subchannel subchannel = Iterables.getOnlyElement(subchannels.values());
     verify(subchannel, never()).requestConnection();
@@ -189,10 +189,10 @@ public class RingHashLoadBalancerTest {
   public void subchannelNotAutoReconnectAfterReenteringIdle() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1);  // one server
-    boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     Subchannel subchannel = Iterables.getOnlyElement(subchannels.values());
     InOrder inOrder = Mockito.inOrder(helper, subchannel);
     inOrder.verify(helper).updateBalancingState(eq(IDLE), pickerCaptor.capture());
@@ -220,10 +220,10 @@ public class RingHashLoadBalancerTest {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1);
     InOrder inOrder = Mockito.inOrder(helper);
-    boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     inOrder.verify(helper, times(2)).createSubchannel(any(CreateSubchannelArgs.class));
     inOrder.verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
 
@@ -282,10 +282,10 @@ public class RingHashLoadBalancerTest {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1, 1);
     InOrder inOrder = Mockito.inOrder(helper);
-    boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     inOrder.verify(helper, times(4)).createSubchannel(any(CreateSubchannelArgs.class));
     inOrder.verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
 
@@ -341,10 +341,10 @@ public class RingHashLoadBalancerTest {
   public void subchannelStayInTransientFailureUntilBecomeReady() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
     verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
     reset(helper);
@@ -384,10 +384,10 @@ public class RingHashLoadBalancerTest {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
     InOrder inOrder = Mockito.inOrder(helper);
-    boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
     verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
 
@@ -401,10 +401,10 @@ public class RingHashLoadBalancerTest {
     verifyConnection(1);
 
     servers = createWeightedServerAddrs(1,1);
-    addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     inOrder.verify(helper)
         .updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
     verifyConnection(1);
@@ -430,10 +430,10 @@ public class RingHashLoadBalancerTest {
   public void ignoreShutdownSubchannelStateChange() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
     verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
 
@@ -451,10 +451,10 @@ public class RingHashLoadBalancerTest {
   public void deterministicPickWithHostsPartiallyRemoved() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1, 1, 1);
-    boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     InOrder inOrder = Mockito.inOrder(helper);
     inOrder.verify(helper, times(5)).createSubchannel(any(CreateSubchannelArgs.class));
     inOrder.verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
@@ -480,10 +480,10 @@ public class RingHashLoadBalancerTest {
       Attributes attr = addr.getAttributes().toBuilder().set(CUSTOM_KEY, "custom value").build();
       updatedServers.add(new EquivalentAddressGroup(addr.getAddresses(), attr));
     }
-    addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(updatedServers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     verify(subchannels.get(Collections.singletonList(servers.get(0))))
         .updateAddresses(Collections.singletonList(updatedServers.get(0)));
     verify(subchannels.get(Collections.singletonList(servers.get(1))))
@@ -498,10 +498,10 @@ public class RingHashLoadBalancerTest {
   public void deterministicPickWithNewHostsAdded() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1);  // server0 and server1
-    boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     InOrder inOrder = Mockito.inOrder(helper);
     inOrder.verify(helper, times(2)).createSubchannel(any(CreateSubchannelArgs.class));
     inOrder.verify(helper).updateBalancingState(eq(IDLE), pickerCaptor.capture());
@@ -523,10 +523,10 @@ public class RingHashLoadBalancerTest {
     assertThat(subchannel.getAddresses()).isEqualTo(servers.get(1));
 
     servers = createWeightedServerAddrs(1, 1, 1, 1, 1);  // server2, server3, server4 added
-    addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     inOrder.verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
     inOrder.verify(helper).updateBalancingState(eq(READY), pickerCaptor.capture());
     assertThat(pickerCaptor.getValue().pickSubchannel(args).getSubchannel())
@@ -539,10 +539,10 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
     verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));  // initial IDLE
     reset(helper);
@@ -601,10 +601,10 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
     verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));  // initial IDLE
     reset(helper);
@@ -668,10 +668,10 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
     verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
 
@@ -707,10 +707,10 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
     verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
 
@@ -739,10 +739,10 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
     verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
 
@@ -771,10 +771,10 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
     verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
     // ring:
@@ -807,10 +807,10 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
     verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
     // ring:
@@ -846,10 +846,10 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
     verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
     // ring:
@@ -889,10 +889,10 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
     verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
     // ring:
@@ -934,10 +934,10 @@ public class RingHashLoadBalancerTest {
     // Map each server address to exactly one ring entry.
     RingHashConfig config = new RingHashConfig(3, 3);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 1, 1);
-    boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
     verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
 
@@ -971,49 +971,49 @@ public class RingHashLoadBalancerTest {
     RingHashConfig config = new RingHashConfig(10000, 100000);  // large ring
     List<EquivalentAddressGroup> servers =
         createWeightedServerAddrs(Integer.MAX_VALUE, 10, 100); // MAX:10:100
-    boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
 
     // Try value between max signed and max unsigned int
     servers = createWeightedServerAddrs(Integer.MAX_VALUE + 100L, 100); // (MAX+100):100
-    addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
 
     // Try a negative value
     servers = createWeightedServerAddrs(10, -20, 100); // 10:-20:100
-    addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isFalse();
+    assertThat(addressesAcceptanceStatus.isOk()).isFalse();
 
     // Try an individual value larger than max unsigned int
     long maxUnsigned = UnsignedInteger.MAX_VALUE.longValue();
     servers = createWeightedServerAddrs(maxUnsigned + 10, 10, 100); // uMAX+10:10:100
-    addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isFalse();
+    assertThat(addressesAcceptanceStatus.isOk()).isFalse();
 
     // Try a sum of values larger than max unsigned int
     servers = createWeightedServerAddrs(Integer.MAX_VALUE, Integer.MAX_VALUE, 100); // MAX:MAX:100
-    addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isFalse();
+    assertThat(addressesAcceptanceStatus.isOk()).isFalse();
   }
 
   @Test
   public void hostSelectionProportionalToWeights() {
     RingHashConfig config = new RingHashConfig(10000, 100000);  // large ring
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1, 10, 100); // 1:10:100
-    boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
     verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
 
@@ -1059,10 +1059,10 @@ public class RingHashLoadBalancerTest {
   public void nameResolutionErrorWithActiveSubchannels() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createWeightedServerAddrs(1);
-    boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isTrue();
+    assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     verify(helper).createSubchannel(any(CreateSubchannelArgs.class));
     verify(helper).updateBalancingState(eq(IDLE), pickerCaptor.capture());
 
@@ -1083,10 +1083,10 @@ public class RingHashLoadBalancerTest {
   public void duplicateAddresses() {
     RingHashConfig config = new RingHashConfig(10, 100);
     List<EquivalentAddressGroup> servers = createRepeatedServerAddrs(1, 2, 3);
-    boolean addressesAccepted = loadBalancer.acceptResolvedAddresses(
+    Status addressesAcceptanceStatus = loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(config).build());
-    assertThat(addressesAccepted).isFalse();
+    assertThat(addressesAcceptanceStatus.isOk()).isFalse();
     verify(helper).updateBalancingState(eq(TRANSIENT_FAILURE), pickerCaptor.capture());
 
     PickSubchannelArgs args = new PickSubchannelArgsImpl(

--- a/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
@@ -467,7 +467,7 @@ public class WeightedRoundRobinLoadBalancerTest {
   public void emptyConfig() {
     assertThat(wrr.acceptResolvedAddresses(ResolvedAddresses.newBuilder()
             .setAddresses(servers).setLoadBalancingPolicyConfig(null)
-            .setAttributes(affinity).build())).isFalse();
+            .setAttributes(affinity).build()).isOk()).isFalse();
     verify(helper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
     verify(helper).updateBalancingState(eq(ConnectivityState.TRANSIENT_FAILURE), any());
     assertThat(fakeClock.getPendingTasks()).isEmpty();


### PR DESCRIPTION
Instead of a `boolean`, `LoadBalancer.acceptResolvedAddresses()` now return a Status object. `Status.OK` represents accepted addresses and others non-acceptance. This allows the LB to provide more information about why a set of addresses were not acceptable.

The status will later be sent to the name resolver as well to allow it to also better react to to bad addresses.