### PR TITLE
interop-testing: Fix disabling of stream tracers

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
@@ -472,10 +472,10 @@ public class StressTestClient {
       Thread.currentThread().setName(gaugeName);
 
       Tester tester = new Tester();
-      tester.setUp();
       // The client stream tracers that AbstractInteropTest installs by default would fill up the
       // heap in no time in a long running stress test with many requests.
       tester.setEnableClientStreamTracers(false);
+      tester.setUp();
 
       WeightedTestCaseSelector testCaseSelector = new WeightedTestCaseSelector(testCaseWeightPairs);
       Long endTime = durationSec == null ? null : System.nanoTime() + SECONDS.toNanos(durationSecs);


### PR DESCRIPTION
The client stream tracers need to be disabled before setUp() is called.