### PR TITLE
interop-testing: Fix total calls log statement

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
@@ -92,7 +92,7 @@ public class StressTestClient {
       client.runStressTest();
       client.startMetricsLogging();
       client.blockUntilStressTestComplete();
-      log.log(Level.INFO, "Total calls made: {0}", client.getTotalCallCount());
+      log.log(Level.INFO, "Total calls made: " + client.getTotalCallCount());
     } catch (Exception e) {
       log.log(Level.WARNING, "The stress test client encountered an error!", e);
     } finally {


### PR DESCRIPTION
We don't want local specific formatting of the number, so let's just concatenate.