### PR TITLE
alts: Re-enable deprecation warnings

### DIFF
--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -49,10 +49,6 @@ configureProtoCompilation()
 import net.ltgt.gradle.errorprone.CheckSeverity
 
 [tasks.named("compileJava"), tasks.named("compileTestJava")]*.configure {
-    // protobuf calls valueof. Will be fixed in next release (google/protobuf#4046)
-    options.compilerArgs += [
-        "-Xlint:-deprecation"
-    ]
     // ALTS returns a lot of futures that we mostly don't care about.
     options.errorprone.check("FutureReturnValueIgnored", CheckSeverity.OFF)
 }


### PR DESCRIPTION
google/protobuf#4046 was fixed a long time ago. Recently noticed when working on ForwardingChannelBuilder(2).