### PR TITLE
core: add description to Status.UNKNOWN in ServerImpl's #internalClose

### DIFF
--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -810,7 +810,7 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
      */
     private void internalClose(Throwable t, String task) {
       // TODO(ejona86): this is not thread-safe :)
-      String description = "Internal Application Error @ task " + task;
+      String description = "Application Error @ task " + task;
       stream.close(Status.UNKNOWN.withDescription(description).withCause(t), new Metadata());
     }
 

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -808,9 +808,9 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
     /**
      * Like {@link ServerCall#close(Status, Metadata)}, but thread-safe for internal use.
      */
-    private void internalClose(Throwable t, String task) {
+    private void internalClose(Throwable t) {
       // TODO(ejona86): this is not thread-safe :)
-      String description = "Application Error @ task " + task;
+      String description = "Application error processing RPC";
       stream.close(Status.UNKNOWN.withDescription(description).withCause(t), new Metadata());
     }
 
@@ -827,13 +827,13 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
 
           @Override
           public void runInContext() {
-            String taskName = "ServerCallListener(app).messagesAvailable";
-            try (TaskCloseable ignore = PerfMark.traceTask(taskName)) {
+            try (TaskCloseable ignore =
+                     PerfMark.traceTask("ServerCallListener(app).messagesAvailable")) {
               PerfMark.attachTag(tag);
               PerfMark.linkIn(link);
               getListener().messagesAvailable(producer);
             } catch (Throwable t) {
-              internalClose(t, taskName);
+              internalClose(t);
               throw t;
             }
           }
@@ -855,13 +855,12 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
 
           @Override
           public void runInContext() {
-            String taskName = "ServerCallListener(app).halfClosed";
-            try (TaskCloseable ignore = PerfMark.traceTask(taskName)) {
+            try (TaskCloseable ignore = PerfMark.traceTask("ServerCallListener(app).halfClosed")) {
               PerfMark.attachTag(tag);
               PerfMark.linkIn(link);
               getListener().halfClosed();
             } catch (Throwable t) {
-              internalClose(t, taskName);
+              internalClose(t);
               throw t;
             }
           }
@@ -929,13 +928,12 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
 
           @Override
           public void runInContext() {
-            String taskName = "ServerCallListener(app).onReady";
-            try (TaskCloseable ignore = PerfMark.traceTask(taskName)) {
+            try (TaskCloseable ignore = PerfMark.traceTask("ServerCallListener(app).onReady")) {
               PerfMark.attachTag(tag);
               PerfMark.linkIn(link);
               getListener().onReady();
             } catch (Throwable t) {
-              internalClose(t, taskName);
+              internalClose(t);
               throw t;
             }
           }

--- a/interop-testing/src/test/java/io/grpc/testing/integration/MoreInProcessTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/MoreInProcessTest.java
@@ -251,7 +251,7 @@ public class MoreInProcessTest {
     assertTrue(finishLatch.await(900, TimeUnit.MILLISECONDS));
     Status actualStatus = Status.fromThrowable(throwableRef.get());
     Status expectedStatus = Status.UNKNOWN.withDescription(
-        "Internal Application Error @ task ServerCallListener(app).messagesAvailable");
+        "Application Error @ task ServerCallListener(app).messagesAvailable");
     assertEquals(expectedStatus.getCode(), actualStatus.getCode());
     assertEquals(expectedStatus.getDescription(), actualStatus.getDescription());
     assertNull(actualStatus.getCause());

--- a/interop-testing/src/test/java/io/grpc/testing/integration/MoreInProcessTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/MoreInProcessTest.java
@@ -250,8 +250,7 @@ public class MoreInProcessTest {
 
     assertTrue(finishLatch.await(900, TimeUnit.MILLISECONDS));
     Status actualStatus = Status.fromThrowable(throwableRef.get());
-    Status expectedStatus = Status.UNKNOWN.withDescription(
-        "Application Error @ task ServerCallListener(app).messagesAvailable");
+    Status expectedStatus = Status.UNKNOWN.withDescription("Application error processing RPC");
     assertEquals(expectedStatus.getCode(), actualStatus.getCode());
     assertEquals(expectedStatus.getDescription(), actualStatus.getDescription());
     assertNull(actualStatus.getCause());

--- a/interop-testing/src/test/java/io/grpc/testing/integration/MoreInProcessTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/MoreInProcessTest.java
@@ -249,7 +249,12 @@ public class MoreInProcessTest {
         .onNext(StreamingInputCallRequest.getDefaultInstance());
 
     assertTrue(finishLatch.await(900, TimeUnit.MILLISECONDS));
-    assertEquals(Status.UNKNOWN, Status.fromThrowable(throwableRef.get()));
+    Status actualStatus = Status.fromThrowable(throwableRef.get());
+    Status expectedStatus = Status.UNKNOWN.withDescription(
+        "Internal Application Error @ task ServerCallListener(app).messagesAvailable");
+    assertEquals(expectedStatus.getCode(), actualStatus.getCode());
+    assertEquals(expectedStatus.getDescription(), actualStatus.getDescription());
+    assertNull(actualStatus.getCause());
     assertNull(responseRef.get());
   }
 }


### PR DESCRIPTION
This is currently the only place where we return Status.UNKNOWN with no description, which makes is harder to debug and differentiate from statuses originated from non-grpc sources.

This PR enriches ServerImpl's #internalClose `Status.UNKNOWN` with description `Application error processing RPC`.