### PR TITLE
Add ClientTransportFilter

### DIFF
--- a/api/src/main/java/io/grpc/ClientTransportFilter.java
+++ b/api/src/main/java/io/grpc/ClientTransportFilter.java
@@ -21,30 +21,31 @@ package io.grpc;
  * to modify the channels or transport life-cycle event behavior, but they can be useful hooks
  * for transport observability. Multiple filters may be registered to the client.
  *
- * @since 1.60.0
+ * @since 1.61.0
  */
 @ExperimentalApi("https://gitub.com/grpc/grpc-java/issues/10652")
-public interface ClientTransportHook {
+public abstract class ClientTransportFilter {
   /**
    * Called when a transport is ready to accept traffic (when a connection has been established).
    * The default implementation is a no-op.
-   */
-  void transportReady(Attributes transportAttrs);
-
-  /**
-   * Called when a transport is shutting down. Shutdown could have been caused by an error or normal
-   * operation.
-   * This is called prior to {@link #transportTerminated}.
-   * Default implementation is a no-op.
    *
-   * @param s the reason for the shutdown.
+   * @param transportAttrs current transport attributes
+   *
+   * @return new transport attributes. Default implementation returns the passed-in attributes
+   * intact.
    */
-  void transportShutdown(Status s, Attributes transportAttrs);
+  public Attributes transportReady(Attributes transportAttrs){
+    return transportAttrs;
+  }
 
   /**
    * Called when a transport completed shutting down. All resources have been released.
    * All streams have either been closed or transferred off this transport.
    * Default implementation is a no-op
+   *
+   * @param transportAttrs the effective transport attributes, which is what is returned by {@link
+   * #transportReady} of the last executed filter.
    */
-  void transportTerminated(Attributes transportAttrs);
+  public void transportTerminated(Attributes transportAttrs) {
+  }
 }

--- a/api/src/main/java/io/grpc/ClientTransportFilter.java
+++ b/api/src/main/java/io/grpc/ClientTransportFilter.java
@@ -1,0 +1,39 @@
+package io.grpc;
+
+/**
+ * Listens on the client transport life-cycle events. These filters do not have the capability
+ * to modify the channels or transport life-cycle event behavior, but they can be useful hooks
+ * for transport observability. Multiple filters may be registered to the client.
+ */
+@ExperimentalApi("https://gitub.com/grpc/grpc-java/issues/TODO")
+public abstract class ClientTransportFilter {
+  /**
+   * Called when a transport is ready to accept traffic (when a connection has been established).
+   * The default implementation is a no-op.
+   */
+  public void transportReady() {
+
+  }
+
+  /**
+   * Called when a transport is shutting down. Shutdown could have been caused by an error or normal
+   * operation.
+   * This is called prior to {@link #transportTerminated}.
+   * Default implementation is a no-op.
+   *
+   * @param s the reason for the shutdown.
+   */
+  public void transportShutdown(Status s) {
+
+  }
+
+  /**
+   * Called when a transport completed shutting down. All resources have been released.
+   * All streams have either been closed or transferred off this transport.
+   * Default implementation is a no-op
+   */
+  public void transportTerminated() {
+
+  }
+
+}

--- a/api/src/main/java/io/grpc/ClientTransportFilter.java
+++ b/api/src/main/java/io/grpc/ClientTransportFilter.java
@@ -22,14 +22,12 @@ package io.grpc;
  * for transport observability. Multiple filters may be registered to the client.
  */
 @ExperimentalApi("https://gitub.com/grpc/grpc-java/issues/TODO")
-public abstract class ClientTransportFilter {
+public interface ClientTransportFilter {
   /**
    * Called when a transport is ready to accept traffic (when a connection has been established).
    * The default implementation is a no-op.
    */
-  public void transportReady() {
-
-  }
+  void transportReady(Attributes transportAttrs);
 
   /**
    * Called when a transport is shutting down. Shutdown could have been caused by an error or normal
@@ -39,17 +37,12 @@ public abstract class ClientTransportFilter {
    *
    * @param s the reason for the shutdown.
    */
-  public void transportShutdown(Status s) {
-
-  }
+  void transportShutdown(Status s, Attributes transportAttrs);
 
   /**
    * Called when a transport completed shutting down. All resources have been released.
    * All streams have either been closed or transferred off this transport.
    * Default implementation is a no-op
    */
-  public void transportTerminated() {
-
-  }
-
+  void transportTerminated(Attributes transportAttrs);
 }

--- a/api/src/main/java/io/grpc/ClientTransportFilter.java
+++ b/api/src/main/java/io/grpc/ClientTransportFilter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.grpc;
 
 /**

--- a/api/src/main/java/io/grpc/ClientTransportFilter.java
+++ b/api/src/main/java/io/grpc/ClientTransportFilter.java
@@ -32,7 +32,7 @@ public abstract class ClientTransportFilter {
    * @param transportAttrs current transport attributes
    *
    * @return new transport attributes. Default implementation returns the passed-in attributes
-   * intact.
+   *     intact.
    */
   public Attributes transportReady(Attributes transportAttrs) {
     return transportAttrs;

--- a/api/src/main/java/io/grpc/ClientTransportFilter.java
+++ b/api/src/main/java/io/grpc/ClientTransportFilter.java
@@ -34,7 +34,7 @@ public abstract class ClientTransportFilter {
    * @return new transport attributes. Default implementation returns the passed-in attributes
    * intact.
    */
-  public Attributes transportReady(Attributes transportAttrs){
+  public Attributes transportReady(Attributes transportAttrs) {
     return transportAttrs;
   }
 

--- a/api/src/main/java/io/grpc/ClientTransportHook.java
+++ b/api/src/main/java/io/grpc/ClientTransportHook.java
@@ -23,7 +23,7 @@ package io.grpc;
  *
  * @since 1.60.0
  */
-@ExperimentalApi("https://gitub.com/grpc/grpc-java/issues/TODO")
+@ExperimentalApi("https://gitub.com/grpc/grpc-java/issues/10652")
 public interface ClientTransportHook {
   /**
    * Called when a transport is ready to accept traffic (when a connection has been established).

--- a/api/src/main/java/io/grpc/ClientTransportHook.java
+++ b/api/src/main/java/io/grpc/ClientTransportHook.java
@@ -20,6 +20,8 @@ package io.grpc;
  * Listens on the client transport life-cycle events. These filters do not have the capability
  * to modify the channels or transport life-cycle event behavior, but they can be useful hooks
  * for transport observability. Multiple filters may be registered to the client.
+ *
+ * @since 1.60.0
  */
 @ExperimentalApi("https://gitub.com/grpc/grpc-java/issues/TODO")
 public interface ClientTransportHook {

--- a/api/src/main/java/io/grpc/ClientTransportHook.java
+++ b/api/src/main/java/io/grpc/ClientTransportHook.java
@@ -22,7 +22,7 @@ package io.grpc;
  * for transport observability. Multiple filters may be registered to the client.
  */
 @ExperimentalApi("https://gitub.com/grpc/grpc-java/issues/TODO")
-public interface ClientTransportFilter {
+public interface ClientTransportHook {
   /**
    * Called when a transport is ready to accept traffic (when a connection has been established).
    * The default implementation is a no-op.

--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -92,6 +92,12 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
   }
 
   @Override
+  public T addTransportFilter(ClientTransportFilter transportFilter) {
+    delegate().addTransportFilter(transportFilter);
+    return thisT();
+  }
+
+  @Override
   public T userAgent(String userAgent) {
     delegate().userAgent(userAgent);
     return thisT();

--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -92,12 +92,6 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
   }
 
   @Override
-  public T addTransportFilter(ClientTransportFilter transportFilter) {
-    delegate().addTransportFilter(transportFilter);
-    return thisT();
-  }
-
-  @Override
   public T userAgent(String userAgent) {
     delegate().userAgent(userAgent);
     return thisT();

--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder2.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder2.java
@@ -95,8 +95,8 @@ public abstract class ForwardingChannelBuilder2<T extends ManagedChannelBuilder<
   }
 
   @Override
-  public T addTransportFilter(ClientTransportFilter transportFilter) {
-    delegate().addTransportFilter(transportFilter);
+  public T addTransportHook(ClientTransportHook transportHook) {
+    delegate().addTransportHook(transportHook);
     return thisT();
   }
 

--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder2.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder2.java
@@ -95,8 +95,8 @@ public abstract class ForwardingChannelBuilder2<T extends ManagedChannelBuilder<
   }
 
   @Override
-  public T addTransportHook(ClientTransportHook transportHook) {
-    delegate().addTransportHook(transportHook);
+  public T addTransportFilter(ClientTransportFilter transportFilter) {
+    delegate().addTransportFilter(transportFilter);
     return thisT();
   }
 

--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder2.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder2.java
@@ -95,6 +95,12 @@ public abstract class ForwardingChannelBuilder2<T extends ManagedChannelBuilder<
   }
 
   @Override
+  public T addTransportFilter(ClientTransportFilter transportFilter) {
+    delegate().addTransportFilter(transportFilter);
+    return thisT();
+  }
+
+  @Override
   public T userAgent(String userAgent) {
     delegate().userAgent(userAgent);
     return thisT();

--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -167,7 +167,7 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * @since 1.60.0
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/TODO")
-  public T addTransportFilter(ClientTransportFilter filter){
+  public T addTransportFilter(ClientTransportFilter filter) {
     throw new UnsupportedOperationException();
   }
 

--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -160,14 +160,14 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   public abstract T intercept(ClientInterceptor... interceptors);
 
   /**
-   * Adds a {@link ClientTransportFilter}. The order of filters being added is the order they will
+   * Adds a {@link ClientTransportHook}. The order of filters being added is the order they will
    * be executed
    *
    * @return this
    * @since 1.60.0
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/TODO")
-  public T addTransportFilter(ClientTransportFilter filter) {
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/10647")
+  public T addTransportHook(ClientTransportHook hook) {
     throw new UnsupportedOperationException();
   }
 

--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -160,14 +160,14 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   public abstract T intercept(ClientInterceptor... interceptors);
 
   /**
-   * Adds a {@link ClientTransportHook}. The order of filters being added is the order they will
+   * Adds a {@link ClientTransportFilter}. The order of filters being added is the order they will
    * be executed
    *
    * @return this
    * @since 1.60.0
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/10652")
-  public T addTransportHook(ClientTransportHook hook) {
+  public T addTransportFilter(ClientTransportFilter filter) {
     throw new UnsupportedOperationException();
   }
 

--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -160,6 +160,18 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   public abstract T intercept(ClientInterceptor... interceptors);
 
   /**
+   * Adds a {@link ClientTransportFilter}. The order of filters being added is the order they will
+   * be executed
+   *
+   * @return this
+   * @since 1.60.0
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/TODO")
+  public T addTransportFilter(ClientTransportFilter filter){
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Provides a custom {@code User-Agent} for the application.
    *
    * <p>It's an optional parameter. The library will provide a user agent independent of this

--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -166,7 +166,7 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * @return this
    * @since 1.60.0
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/10647")
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/10652")
   public T addTransportHook(ClientTransportHook hook) {
     throw new UnsupportedOperationException();
   }

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -758,7 +758,8 @@ public abstract class BinderTransport
             // triggers), could have shut us down.
             if (!isShutdown()) {
               setState(TransportState.READY);
-              clientTransportListener.filterTransport(attributes);
+              attributes = clientTransportListener.filterTransport(attributes);
+```
               clientTransportListener.transportReady();
             }
           }

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -758,6 +758,7 @@ public abstract class BinderTransport
             // triggers), could have shut us down.
             if (!isShutdown()) {
               setState(TransportState.READY);
+              clientTransportListener.filterTransport(attributes);
               clientTransportListener.transportReady();
             }
           }

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -759,7 +759,6 @@ public abstract class BinderTransport
             if (!isShutdown()) {
               setState(TransportState.READY);
               attributes = clientTransportListener.filterTransport(attributes);
-```
               clientTransportListener.transportReady();
             }
           }

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -35,7 +35,7 @@ import io.grpc.CallOptions;
 import io.grpc.ChannelLogger;
 import io.grpc.ChannelLogger.ChannelLogLevel;
 import io.grpc.ClientStreamTracer;
-import io.grpc.ClientTransportFilter;
+import io.grpc.ClientTransportHook;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
@@ -78,7 +78,7 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
   private final ChannelTracer channelTracer;
   private final ChannelLogger channelLogger;
 
-  private final List<ClientTransportFilter> transportFilters;
+  private final List<ClientTransportHook> transportHooks;
 
   /**
    * All field must be mutated in the syncContext.
@@ -163,7 +163,7 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
       Supplier<Stopwatch> stopwatchSupplier, SynchronizationContext syncContext, Callback callback,
       InternalChannelz channelz, CallTracer callsTracer, ChannelTracer channelTracer,
       InternalLogId logId, ChannelLogger channelLogger,
-      List<ClientTransportFilter> transportFilters) {
+      List<ClientTransportHook> transportHooks) {
     Preconditions.checkNotNull(addressGroups, "addressGroups");
     Preconditions.checkArgument(!addressGroups.isEmpty(), "addressGroups is empty");
     checkListHasNoNulls(addressGroups, "addressGroups contains null entry");
@@ -184,7 +184,7 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
     this.channelTracer = Preconditions.checkNotNull(channelTracer, "channelTracer");
     this.logId = Preconditions.checkNotNull(logId, "logId");
     this.channelLogger = Preconditions.checkNotNull(channelLogger, "channelLogger");
-    this.transportFilters = transportFilters;
+    this.transportHooks = transportHooks;
   }
 
   ChannelLogger getChannelLogger() {
@@ -547,8 +547,8 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
     @Override
     public void transportReady() {
       channelLogger.log(ChannelLogLevel.INFO, "READY");
-      for (ClientTransportFilter filter : transportFilters) {
-        filter.transportReady(transport.getAttributes());
+      for (ClientTransportHook hook : transportHooks) {
+        hook.transportReady(transport.getAttributes());
       }
       syncContext.execute(new Runnable() {
         @Override
@@ -578,8 +578,8 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
       channelLogger.log(
           ChannelLogLevel.INFO, "{0} SHUTDOWN with {1}", transport.getLogId(), printShortStatus(s));
       shutdownInitiated = true;
-      for (ClientTransportFilter filter : transportFilters) {
-        filter.transportShutdown(s, transport.getAttributes());
+      for (ClientTransportHook hook : transportHooks) {
+        hook.transportShutdown(s, transport.getAttributes());
       }
       syncContext.execute(new Runnable() {
         @Override
@@ -618,8 +618,8 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
       channelLogger.log(ChannelLogLevel.INFO, "{0} Terminated", transport.getLogId());
       channelz.removeClientSocket(transport);
       handleTransportInUseState(transport, false);
-      for (ClientTransportFilter filter : transportFilters) {
-        filter.transportTerminated(transport.getAttributes());
+      for (ClientTransportHook hook : transportHooks) {
+        hook.transportTerminated(transport.getAttributes());
       }
       syncContext.execute(new Runnable() {
         @Override

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -548,7 +548,7 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
     public void transportReady() {
       channelLogger.log(ChannelLogLevel.INFO, "READY");
       for (ClientTransportFilter filter : transportFilters) {
-        filter.transportReady();
+        filter.transportReady(transport.getAttributes());
       }
       syncContext.execute(new Runnable() {
         @Override
@@ -579,7 +579,7 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
           ChannelLogLevel.INFO, "{0} SHUTDOWN with {1}", transport.getLogId(), printShortStatus(s));
       shutdownInitiated = true;
       for (ClientTransportFilter filter : transportFilters) {
-        filter.transportShutdown(s);
+        filter.transportShutdown(s, transport.getAttributes());
       }
       syncContext.execute(new Runnable() {
         @Override
@@ -619,7 +619,7 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
       channelz.removeClientSocket(transport);
       handleTransportInUseState(transport, false);
       for (ClientTransportFilter filter : transportFilters) {
-        filter.transportTerminated();
+        filter.transportTerminated(transport.getAttributes());
       }
       syncContext.execute(new Runnable() {
         @Override

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -162,7 +162,8 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
       ClientTransportFactory transportFactory, ScheduledExecutorService scheduledExecutor,
       Supplier<Stopwatch> stopwatchSupplier, SynchronizationContext syncContext, Callback callback,
       InternalChannelz channelz, CallTracer callsTracer, ChannelTracer channelTracer,
-      InternalLogId logId, ChannelLogger channelLogger, List<ClientTransportFilter> transportFilters) {
+      InternalLogId logId, ChannelLogger channelLogger,
+      List<ClientTransportFilter> transportFilters) {
     Preconditions.checkNotNull(addressGroups, "addressGroups");
     Preconditions.checkArgument(!addressGroups.isEmpty(), "addressGroups is empty");
     checkListHasNoNulls(addressGroups, "addressGroups contains null entry");

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -548,7 +548,7 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
     public Attributes filterTransport(Attributes attributes) {
       for (ClientTransportFilter filter : transportFilters) {
         attributes = Preconditions.checkNotNull(filter.transportReady(attributes),
-        "Filter %s returned null", filter);
+            "Filter %s returned null", filter);
       }
       return attributes;
     }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -664,7 +664,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
       channel = builder.binlog.wrapChannel(channel);
     }
     this.interceptorChannel = ClientInterceptors.intercept(channel, interceptors);
-    this.transportFilters = builder.transportFilters;
+    this.transportFilters = new ArrayList<>(builder.transportFilters);
     this.stopwatchSupplier = checkNotNull(stopwatchSupplier, "stopwatchSupplier");
     if (builder.idleTimeoutMillis == IDLE_TIMEOUT_MILLIS_DISABLE) {
       this.idleTimeoutMillis = builder.idleTimeoutMillis;

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -585,13 +585,13 @@ final class ManagedChannelImpl extends ManagedChannel implements
   private final Rescheduler idleTimer;
 
   ManagedChannelImpl(
-    ManagedChannelImplBuilder builder,
-    ClientTransportFactory clientTransportFactory,
-    BackoffPolicy.Provider backoffPolicyProvider,
-    ObjectPool<? extends Executor> balancerRpcExecutorPool,
-    Supplier<Stopwatch> stopwatchSupplier,
-    List<ClientInterceptor> interceptors,
-    final TimeProvider timeProvider) {
+      ManagedChannelImplBuilder builder,
+      ClientTransportFactory clientTransportFactory,
+      BackoffPolicy.Provider backoffPolicyProvider,
+      ObjectPool<? extends Executor> balancerRpcExecutorPool,
+      Supplier<Stopwatch> stopwatchSupplier,
+      List<ClientInterceptor> interceptors,
+      final TimeProvider timeProvider) {
     this.target = checkNotNull(builder.target, "target");
     this.logId = InternalLogId.allocate("Channel", target);
     this.timeProvider = checkNotNull(timeProvider, "timeProvider");

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -42,7 +42,7 @@ import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
 import io.grpc.ClientStreamTracer;
-import io.grpc.ClientTransportFilter;
+import io.grpc.ClientTransportHook;
 import io.grpc.CompressorRegistry;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
@@ -211,7 +211,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
    */
   private final Channel interceptorChannel;
 
-  private final List<ClientTransportFilter> transportFilters;
+  private final List<ClientTransportHook> transportHooks;
   @Nullable private final String userAgent;
 
   // Only null after channel is terminated. Must be assigned from the syncContext.
@@ -664,7 +664,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
       channel = builder.binlog.wrapChannel(channel);
     }
     this.interceptorChannel = ClientInterceptors.intercept(channel, interceptors);
-    this.transportFilters = new ArrayList<>(builder.transportFilters);
+    this.transportHooks = new ArrayList<>(builder.transportHooks);
     this.stopwatchSupplier = checkNotNull(stopwatchSupplier, "stopwatchSupplier");
     if (builder.idleTimeoutMillis == IDLE_TIMEOUT_MILLIS_DISABLE) {
       this.idleTimeoutMillis = builder.idleTimeoutMillis;
@@ -1571,7 +1571,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
           subchannelTracer,
           subchannelLogId,
           subchannelLogger,
-          transportFilters);
+          transportHooks);
       oobChannelTracer.reportEvent(new ChannelTrace.Event.Builder()
           .setDescription("Child Subchannel created")
           .setSeverity(ChannelTrace.Event.Severity.CT_INFO)
@@ -1996,7 +1996,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
           subchannelTracer,
           subchannelLogId,
           subchannelLogger,
-          transportFilters);
+          transportHooks);
 
       channelTracer.reportEvent(new ChannelTrace.Event.Builder()
           .setDescription("Child Subchannel started")

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -42,7 +42,7 @@ import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
 import io.grpc.ClientStreamTracer;
-import io.grpc.ClientTransportHook;
+import io.grpc.ClientTransportFilter;
 import io.grpc.CompressorRegistry;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
@@ -211,7 +211,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
    */
   private final Channel interceptorChannel;
 
-  private final List<ClientTransportHook> transportHooks;
+  private final List<ClientTransportFilter> transportFilters;
   @Nullable private final String userAgent;
 
   // Only null after channel is terminated. Must be assigned from the syncContext.
@@ -664,7 +664,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
       channel = builder.binlog.wrapChannel(channel);
     }
     this.interceptorChannel = ClientInterceptors.intercept(channel, interceptors);
-    this.transportHooks = new ArrayList<>(builder.transportHooks);
+    this.transportFilters = new ArrayList<>(builder.transportFilters);
     this.stopwatchSupplier = checkNotNull(stopwatchSupplier, "stopwatchSupplier");
     if (builder.idleTimeoutMillis == IDLE_TIMEOUT_MILLIS_DISABLE) {
       this.idleTimeoutMillis = builder.idleTimeoutMillis;
@@ -1571,7 +1571,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
           subchannelTracer,
           subchannelLogId,
           subchannelLogger,
-          transportHooks);
+          transportFilters);
       oobChannelTracer.reportEvent(new ChannelTrace.Event.Builder()
           .setDescription("Child Subchannel created")
           .setSeverity(ChannelTrace.Event.Severity.CT_INFO)
@@ -1996,7 +1996,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
           subchannelTracer,
           subchannelLogId,
           subchannelLogger,
-          transportHooks);
+          transportFilters);
 
       channelTracer.reportEvent(new ChannelTrace.Event.Builder()
           .setDescription("Child Subchannel started")
@@ -2152,6 +2152,11 @@ final class ManagedChannelImpl extends ManagedChannel implements
     @Override
     public void transportReady() {
       // Don't care
+    }
+
+    @Override
+    public Attributes filterTransport(Attributes attributes) {
+      return attributes;
     }
 
     @Override

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -28,7 +28,7 @@ import io.grpc.BinaryLog;
 import io.grpc.CallCredentials;
 import io.grpc.ChannelCredentials;
 import io.grpc.ClientInterceptor;
-import io.grpc.ClientTransportFilter;
+import io.grpc.ClientTransportHook;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
 import io.grpc.EquivalentAddressGroup;
@@ -139,7 +139,7 @@ public final class ManagedChannelImplBuilder
   private final List<ClientInterceptor> interceptors = new ArrayList<>();
   NameResolverRegistry nameResolverRegistry = NameResolverRegistry.getDefaultRegistry();
 
-  final List<ClientTransportFilter> transportFilters = new ArrayList<>();
+  final List<ClientTransportHook> transportHooks = new ArrayList<>();
 
   final String target;
   @Nullable
@@ -379,8 +379,8 @@ public final class ManagedChannelImplBuilder
   }
 
   @Override
-  public ManagedChannelImplBuilder addTransportFilter(ClientTransportFilter filter) {
-    transportFilters.add(checkNotNull(filter, "filter"));
+  public ManagedChannelImplBuilder addTransportHook(ClientTransportHook hook) {
+    transportHooks.add(checkNotNull(hook, "transport hook"));
     return this;
   }
 

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -28,7 +28,7 @@ import io.grpc.BinaryLog;
 import io.grpc.CallCredentials;
 import io.grpc.ChannelCredentials;
 import io.grpc.ClientInterceptor;
-import io.grpc.ClientTransportHook;
+import io.grpc.ClientTransportFilter;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
 import io.grpc.EquivalentAddressGroup;
@@ -139,7 +139,7 @@ public final class ManagedChannelImplBuilder
   private final List<ClientInterceptor> interceptors = new ArrayList<>();
   NameResolverRegistry nameResolverRegistry = NameResolverRegistry.getDefaultRegistry();
 
-  final List<ClientTransportHook> transportHooks = new ArrayList<>();
+  final List<ClientTransportFilter> transportFilters = new ArrayList<>();
 
   final String target;
   @Nullable
@@ -379,8 +379,8 @@ public final class ManagedChannelImplBuilder
   }
 
   @Override
-  public ManagedChannelImplBuilder addTransportHook(ClientTransportHook hook) {
-    transportHooks.add(checkNotNull(hook, "transport hook"));
+  public ManagedChannelImplBuilder addTransportFilter(ClientTransportFilter hook) {
+    transportFilters.add(checkNotNull(hook, "transport filter"));
     return this;
   }
 

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -17,6 +17,7 @@
 package io.grpc.internal;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -27,6 +28,7 @@ import io.grpc.BinaryLog;
 import io.grpc.CallCredentials;
 import io.grpc.ChannelCredentials;
 import io.grpc.ClientInterceptor;
+import io.grpc.ClientTransportFilter;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
 import io.grpc.EquivalentAddressGroup;
@@ -136,6 +138,8 @@ public final class ManagedChannelImplBuilder
 
   private final List<ClientInterceptor> interceptors = new ArrayList<>();
   NameResolverRegistry nameResolverRegistry = NameResolverRegistry.getDefaultRegistry();
+
+  final List<ClientTransportFilter> transportFilters = new ArrayList<>();
 
   final String target;
   @Nullable
@@ -267,11 +271,10 @@ public final class ManagedChannelImplBuilder
       String target, @Nullable ChannelCredentials channelCreds, @Nullable CallCredentials callCreds,
       ClientTransportFactoryBuilder clientTransportFactoryBuilder,
       @Nullable ChannelBuilderDefaultPortProvider channelBuilderDefaultPortProvider) {
-    this.target = Preconditions.checkNotNull(target, "target");
+    this.target = checkNotNull(target, "target");
     this.channelCredentials = channelCreds;
     this.callCredentials = callCreds;
-    this.clientTransportFactoryBuilder = Preconditions
-        .checkNotNull(clientTransportFactoryBuilder, "clientTransportFactoryBuilder");
+    this.clientTransportFactoryBuilder = checkNotNull(clientTransportFactoryBuilder, "clientTransportFactoryBuilder");
     this.directServerAddress = null;
 
     if (channelBuilderDefaultPortProvider != null) {
@@ -323,8 +326,7 @@ public final class ManagedChannelImplBuilder
     this.target = makeTargetStringForDirectAddress(directServerAddress);
     this.channelCredentials = channelCreds;
     this.callCredentials = callCreds;
-    this.clientTransportFactoryBuilder = Preconditions
-        .checkNotNull(clientTransportFactoryBuilder, "clientTransportFactoryBuilder");
+    this.clientTransportFactoryBuilder = checkNotNull(clientTransportFactoryBuilder, "clientTransportFactoryBuilder");
     this.directServerAddress = directServerAddress;
     NameResolverRegistry reg = new NameResolverRegistry();
     reg.register(new DirectAddressNameResolverProvider(directServerAddress,
@@ -372,6 +374,12 @@ public final class ManagedChannelImplBuilder
   @Override
   public ManagedChannelImplBuilder intercept(ClientInterceptor... interceptors) {
     return intercept(Arrays.asList(interceptors));
+  }
+
+  @Override
+  public ManagedChannelImplBuilder addTransportFilter(ClientTransportFilter filter) {
+    transportFilters.add(checkNotNull(filter, "filter"));
+    return this;
   }
 
   @Deprecated

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -274,7 +274,8 @@ public final class ManagedChannelImplBuilder
     this.target = checkNotNull(target, "target");
     this.channelCredentials = channelCreds;
     this.callCredentials = callCreds;
-    this.clientTransportFactoryBuilder = checkNotNull(clientTransportFactoryBuilder, "clientTransportFactoryBuilder");
+    this.clientTransportFactoryBuilder = checkNotNull(clientTransportFactoryBuilder,
+        "clientTransportFactoryBuilder");
     this.directServerAddress = null;
 
     if (channelBuilderDefaultPortProvider != null) {
@@ -326,7 +327,8 @@ public final class ManagedChannelImplBuilder
     this.target = makeTargetStringForDirectAddress(directServerAddress);
     this.channelCredentials = channelCreds;
     this.callCredentials = callCreds;
-    this.clientTransportFactoryBuilder = checkNotNull(clientTransportFactoryBuilder, "clientTransportFactoryBuilder");
+    this.clientTransportFactoryBuilder = checkNotNull(clientTransportFactoryBuilder,
+        "clientTransportFactoryBuilder");
     this.directServerAddress = directServerAddress;
     NameResolverRegistry reg = new NameResolverRegistry();
     reg.register(new DirectAddressNameResolverProvider(directServerAddress,

--- a/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
@@ -106,6 +106,10 @@ public interface ManagedClientTransport extends ClientTransport {
      */
     void transportInUse(boolean inUse);
 
+    /**
+     * Called just before {@link #transportReady} to allow direct modification of transport
+     * Attributes.
+     */
     Attributes filterTransport(Attributes attributes);
   }
 }

--- a/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
@@ -16,6 +16,7 @@
 
 package io.grpc.internal;
 
+import io.grpc.Attributes;
 import io.grpc.Status;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
@@ -104,5 +105,7 @@ public interface ManagedClientTransport extends ClientTransport {
      * at least one stream.
      */
     void transportInUse(boolean inUse);
+
+    Attributes filterTransport(Attributes attributes);
   }
 }

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -131,6 +131,11 @@ final class OobChannel extends ManagedChannel implements InternalInstrumented<Ch
         }
 
         @Override
+        public Attributes filterTransport(Attributes attributes){
+          return attributes;
+        }
+
+        @Override
         public void transportInUse(boolean inUse) {
           // Don't care
         }

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -131,7 +131,7 @@ final class OobChannel extends ManagedChannel implements InternalInstrumented<Ch
         }
 
         @Override
-        public Attributes filterTransport(Attributes attributes){
+        public Attributes filterTransport(Attributes attributes) {
           return attributes;
         }
 

--- a/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
+++ b/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
@@ -54,6 +54,7 @@ import io.grpc.internal.InternalSubchannel.TransportLogger;
 import io.grpc.internal.TestUtils.MockClientTransportInfo;
 import java.net.SocketAddress;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
@@ -1360,7 +1361,8 @@ public class InternalSubchannelTest {
         channelz, CallTracer.getDefaultFactory().create(),
         subchannelTracer,
         logId,
-        new ChannelLoggerImpl(subchannelTracer, fakeClock.getTimeProvider()));
+        new ChannelLoggerImpl(subchannelTracer, fakeClock.getTimeProvider()),
+        Collections.emptyList());
   }
 
   private void assertNoCallbackInvoke() {

--- a/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
+++ b/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
@@ -1362,7 +1362,7 @@ public class InternalSubchannelTest {
         subchannelTracer,
         logId,
         new ChannelLoggerImpl(subchannelTracer, fakeClock.getTimeProvider()),
-        Collections.emptyList());
+          Collections.emptyList());
   }
 
   private void assertNoCallbackInvoke() {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -72,7 +72,7 @@ import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
 import io.grpc.ClientStreamTracer;
 import io.grpc.ClientStreamTracer.StreamInfo;
-import io.grpc.ClientTransportFilter;
+import io.grpc.ClientTransportHook;
 import io.grpc.CompositeChannelCredentials;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
@@ -4248,7 +4248,7 @@ public class ManagedChannelImplTest {
     final AtomicInteger readyCallbackCalled = new AtomicInteger(0);
     final AtomicInteger shutdownCallbackCalled = new AtomicInteger(0);
     final AtomicInteger terminationCallbackCalled = new AtomicInteger(0);
-    ClientTransportFilter transportFilter = new ClientTransportFilter() {
+    ClientTransportHook transportHook = new ClientTransportHook() {
       @Override
       public void transportReady(Attributes transportAttrs) {
         readyCallbackCalled.incrementAndGet();
@@ -4265,7 +4265,7 @@ public class ManagedChannelImplTest {
       }
     };
 
-    channelBuilder.addTransportFilter(transportFilter);
+    channelBuilder.addTransportHook(transportHook);
     assertEquals(0, readyCallbackCalled.get());
 
     createChannel();

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -108,7 +108,6 @@ import io.grpc.ProxiedSocketAddress;
 import io.grpc.ProxyDetector;
 import io.grpc.SecurityLevel;
 import io.grpc.ServerMethodDefinition;
-import io.grpc.ServerTransportFilter;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StringMarshaller;
@@ -4244,7 +4243,7 @@ public class ManagedChannelImplTest {
   }
 
   @Test
-  public void transportFilters() throws Exception{
+  public void transportFilters() throws Exception {
 
     final AtomicInteger readyCallbackCalled = new AtomicInteger(0);
     final AtomicInteger shutdownCallbackCalled = new AtomicInteger(0);
@@ -4254,10 +4253,12 @@ public class ManagedChannelImplTest {
       public void transportReady() {
         readyCallbackCalled.incrementAndGet();
       }
+
       @Override
       public void transportShutdown(Status s) {
         shutdownCallbackCalled.incrementAndGet();
       }
+
       @Override
       public void transportTerminated() {
         terminationCallbackCalled.incrementAndGet();
@@ -4269,10 +4270,10 @@ public class ManagedChannelImplTest {
 
     createChannel();
     final Subchannel subchannel =
-      createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+        createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
     requestConnectionSafely(helper, subchannel);
     verify(mockTransportFactory)
-      .newClientTransport(
+        .newClientTransport(
         any(SocketAddress.class), any(ClientTransportOptions.class), any(ChannelLogger.class));
     MockClientTransportInfo transportInfo = transports.poll();
     ManagedClientTransport.Listener transportListener = transportInfo.listener;

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -4243,7 +4243,7 @@ public class ManagedChannelImplTest {
   }
 
   @Test
-  public void transportFilters() throws Exception {
+  public void transportFilters() {
 
     final AtomicInteger readyCallbackCalled = new AtomicInteger(0);
     final AtomicInteger shutdownCallbackCalled = new AtomicInteger(0);

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -4246,7 +4246,6 @@ public class ManagedChannelImplTest {
   public void transportFilters() {
 
     final AtomicInteger readyCallbackCalled = new AtomicInteger(0);
-    final AtomicInteger shutdownCallbackCalled = new AtomicInteger(0);
     final AtomicInteger terminationCallbackCalled = new AtomicInteger(0);
     ClientTransportFilter transportFilter = new ClientTransportFilter() {
       @Override
@@ -4277,7 +4276,6 @@ public class ManagedChannelImplTest {
     transportListener.filterTransport(Attributes.EMPTY);
     transportListener.transportReady();
     assertEquals(1, readyCallbackCalled.get());
-    assertEquals(0, shutdownCallbackCalled.get());
     assertEquals(0, terminationCallbackCalled.get());
 
     transportListener.transportShutdown(Status.OK);

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -72,6 +72,7 @@ import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
 import io.grpc.ClientStreamTracer;
 import io.grpc.ClientStreamTracer.StreamInfo;
+import io.grpc.ClientTransportFilter;
 import io.grpc.CompositeChannelCredentials;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
@@ -107,6 +108,7 @@ import io.grpc.ProxiedSocketAddress;
 import io.grpc.ProxyDetector;
 import io.grpc.SecurityLevel;
 import io.grpc.ServerMethodDefinition;
+import io.grpc.ServerTransportFilter;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StringMarshaller;
@@ -139,6 +141,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
@@ -4238,6 +4241,53 @@ public class ManagedChannelImplTest {
         resolvedOobChannel.shutdownNow();
       }
     }
+  }
+
+  @Test
+  public void transportFilters() throws Exception{
+
+    final AtomicInteger readyCallbackCalled = new AtomicInteger(0);
+    final AtomicInteger shutdownCallbackCalled = new AtomicInteger(0);
+    final AtomicInteger terminationCallbackCalled = new AtomicInteger(0);
+    ClientTransportFilter transportFilter = new ClientTransportFilter() {
+      @Override
+      public void transportReady() {
+        readyCallbackCalled.incrementAndGet();
+      }
+      @Override
+      public void transportShutdown(Status s) {
+        shutdownCallbackCalled.incrementAndGet();
+      }
+      @Override
+      public void transportTerminated() {
+        terminationCallbackCalled.incrementAndGet();
+      }
+    };
+
+    channelBuilder.addTransportFilter(transportFilter);
+    assertEquals(0, readyCallbackCalled.get());
+
+    createChannel();
+    final Subchannel subchannel =
+      createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+    requestConnectionSafely(helper, subchannel);
+    verify(mockTransportFactory)
+      .newClientTransport(
+        any(SocketAddress.class), any(ClientTransportOptions.class), any(ChannelLogger.class));
+    MockClientTransportInfo transportInfo = transports.poll();
+    ManagedClientTransport.Listener transportListener = transportInfo.listener;
+
+    transportListener.transportReady();
+    assertEquals(1, readyCallbackCalled.get());
+    assertEquals(0, shutdownCallbackCalled.get());
+    assertEquals(0, terminationCallbackCalled.get());
+
+    transportListener.transportShutdown(Status.OK);
+    assertEquals(1, shutdownCallbackCalled.get());
+    assertEquals(0, terminationCallbackCalled.get());
+
+    transportListener.transportTerminated();
+    assertEquals(1, terminationCallbackCalled.get());
   }
 
   private static final class FakeBackoffPolicyProvider implements BackoffPolicy.Provider {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -4250,17 +4250,17 @@ public class ManagedChannelImplTest {
     final AtomicInteger terminationCallbackCalled = new AtomicInteger(0);
     ClientTransportFilter transportFilter = new ClientTransportFilter() {
       @Override
-      public void transportReady() {
+      public void transportReady(Attributes transportAttrs) {
         readyCallbackCalled.incrementAndGet();
       }
 
       @Override
-      public void transportShutdown(Status s) {
+      public void transportShutdown(Status s, Attributes transportAttrs) {
         shutdownCallbackCalled.incrementAndGet();
       }
 
       @Override
-      public void transportTerminated() {
+      public void transportTerminated(Attributes transportAttrs) {
         terminationCallbackCalled.incrementAndGet();
       }
     };

--- a/core/src/testFixtures/java/io/grpc/internal/AbstractTransportTest.java
+++ b/core/src/testFixtures/java/io/grpc/internal/AbstractTransportTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
@@ -219,6 +220,7 @@ public abstract class AbstractTransportTest {
   @Before
   public void setUp() {
     server = newServer(Arrays.asList(serverStreamTracerFactory));
+    when(mockClientTransportListener.filterTransport(any())).thenAnswer(i -> i.getArguments()[0]);
   }
 
   @After
@@ -2136,6 +2138,7 @@ public abstract class AbstractTransportTest {
       ManagedClientTransport clientTransport,
       ManagedClientTransport.Listener listener) {
     runIfNotNull(clientTransport.start(listener));
+    verify(listener, timeout(TIMEOUT_MS)).filterTransport(any());
     verify(listener, timeout(TIMEOUT_MS)).transportReady();
   }
 

--- a/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
@@ -169,6 +169,7 @@ class CronetClientTransport implements ConnectionClientTransport {
     return new Runnable() {
       @Override
       public void run() {
+        attrs = CronetClientTransport.this.listener.filterTransport(attrs);
         // Listener callbacks should not be called simultaneously
         CronetClientTransport.this.listener.transportReady();
       }

--- a/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
@@ -61,7 +61,7 @@ class CronetClientTransport implements ConnectionClientTransport {
   private final int maxMessageSize;
   private final boolean alwaysUsePut;
   private final TransportTracer transportTracer;
-  private final Attributes attrs;
+  private Attributes attrs;
   private final boolean useGetForSafeMethods;
   private final boolean usePutForIdempotentMethods;
   // Indicates the transport is in go-away state: no new streams will be processed,

--- a/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
@@ -80,6 +80,8 @@ public final class CronetClientTransportTest {
 
   @Before
   public void setUp() {
+    when(clientTransportListener.filterTransport(any()))
+        .thenAnswer(i -> i.getArgument(0, Attributes.class));
     transport =
         new CronetClientTransport(
             streamFactory,

--- a/inprocess/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/inprocess/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -106,7 +106,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
           new IdentityHashMap<InProcessStream, Boolean>());
   @GuardedBy("this")
   private List<ServerStreamTracer.Factory> serverStreamTracerFactories;
-  private final Attributes attributes;
+  private Attributes attributes;
 
   private Thread.UncaughtExceptionHandler uncaughtExceptionHandler =
       new Thread.UncaughtExceptionHandler() {
@@ -213,6 +213,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
               .set(Grpc.TRANSPORT_ATTR_LOCAL_ADDR, address)
               .build();
           serverStreamAttributes = serverTransportListener.transportReady(serverTransportAttrs);
+          attributes = clientTransportListener.filterTransport(attributes);
           clientTransportListener.transportReady();
         }
       }

--- a/netty/src/main/java/io/grpc/netty/ClientTransportLifecycleManager.java
+++ b/netty/src/main/java/io/grpc/netty/ClientTransportLifecycleManager.java
@@ -42,7 +42,7 @@ final class ClientTransportLifecycleManager {
       return attributes;
     }
     transportReady = true;
-    attributes = listener.filterTransport(Attributes.EMPTY);
+    attributes = listener.filterTransport(attributes);
     listener.transportReady();
     return attributes;
   }

--- a/netty/src/main/java/io/grpc/netty/ClientTransportLifecycleManager.java
+++ b/netty/src/main/java/io/grpc/netty/ClientTransportLifecycleManager.java
@@ -17,6 +17,7 @@
 package io.grpc.netty;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.grpc.Attributes;
 import io.grpc.Status;
 import io.grpc.internal.ManagedClientTransport;
 
@@ -36,12 +37,14 @@ final class ClientTransportLifecycleManager {
     this.listener = listener;
   }
 
-  public void notifyReady() {
+  public Attributes notifyReady(Attributes attributes) {
     if (transportReady || transportShutdown) {
-      return;
+      return attributes;
     }
     transportReady = true;
+    attributes = listener.filterTransport(Attributes.EMPTY);
     listener.transportReady();
+    return attributes;
   }
 
   /**

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -913,7 +913,7 @@ class NettyClientHandler extends AbstractNettyHandler {
     public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) {
       if (firstSettings) {
         firstSettings = false;
-        lifecycleManager.notifyReady();
+        attributes = lifecycleManager.notifyReady(attributes);
       }
     }
 

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -35,6 +35,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import com.google.common.base.Ticker;
 import com.google.common.io.ByteStreams;
@@ -105,6 +107,7 @@ import javax.annotation.Nullable;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -142,6 +145,11 @@ public class NettyClientTransportTest {
   private InetSocketAddress address;
   private String authority;
   private NettyServer server;
+
+  @Before
+  public void setup() {
+    when(clientTransportListener.filterTransport(any())).thenAnswer(i -> i.getArguments()[0]);
+  }
 
   @After
   public void teardown() throws Exception {

--- a/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertEquals;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.ChannelLogger;
-import io.grpc.EquivalentAddressGroup.Attr;
 import io.grpc.ServerStreamTracer;
 import io.grpc.Status;
 import io.grpc.internal.AbstractTransportTest;

--- a/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
@@ -20,7 +20,9 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.util.concurrent.SettableFuture;
+import io.grpc.Attributes;
 import io.grpc.ChannelLogger;
+import io.grpc.EquivalentAddressGroup.Attr;
 import io.grpc.ServerStreamTracer;
 import io.grpc.Status;
 import io.grpc.internal.AbstractTransportTest;
@@ -143,6 +145,11 @@ public class NettyTransportTest extends AbstractTransportTest {
       public void transportInUse(boolean inUse) {
         Throwable t = new Throwable("transport should have failed and shutdown but didnt");
         future.setException(t);
+      }
+
+      @Override
+      public Attributes filterTransport(Attributes attributes) {
+        return attributes;
       }
     });
     if (runnable != null) {

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -1283,6 +1283,7 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
           outboundWindowSizeIncreased = outboundFlow.initialOutboundWindowSize(initialWindowSize);
         }
         if (firstSettings) {
+          attributes = listener.filterTransport(attributes);
           listener.transportReady();
           firstSettings = false;
         }


### PR DESCRIPTION
**Problem**
We're trying to add some stats on the number of connections opened, closed, and active on the client side for grpc-java. On the server side, ServerTransportFilter acts as a reasonable hook for this, but there doesn't seem to be anything comparable on the client side that I can find (if there is, please direct me to it!).

Closes #10647

**Solution**
Add a ClientTransportFilter. Similarly to ServerTransportFilter this will provide an observability hook and allows direct modification of the transport's attributes. 
To wire this in, this PR also adds a `filterTransport` method to `ManagedClientTransport.Listener` which handles modifying the transport's attributes. This is called just before `transportReady`