### PR TITLE
stub: Deprecate StreamObservers

### DIFF
--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
@@ -26,7 +26,6 @@ import io.grpc.benchmarks.proto.Messages;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
-import io.grpc.stub.StreamObservers;
 import io.grpc.testing.TlsTesting;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
@@ -282,6 +281,7 @@ public class AsyncServer {
     }
 
     @Override
+    @SuppressWarnings("deprecation") // For StreamObservers, ideally we refactor this class out.
     public void streamingFromServer(
         final Messages.SimpleRequest request,
         final StreamObserver<Messages.SimpleResponse> observer) {
@@ -291,7 +291,7 @@ public class AsyncServer {
           (ServerCallStreamObserver<Messages.SimpleResponse>) observer;
       // If the client cancels, copyWithFlowControl takes care of calling
       // responseObserver.onCompleted() for us
-      StreamObservers.copyWithFlowControl(
+      io.grpc.stub.StreamObservers.copyWithFlowControl(
           new Iterator<Messages.SimpleResponse>() {
             @Override
             public boolean hasNext() {
@@ -312,6 +312,7 @@ public class AsyncServer {
     }
 
     @Override
+    @SuppressWarnings("deprecation") // For StreamObservers, ideally we refactor this class out.
     public StreamObserver<Messages.SimpleRequest> streamingBothWays(
         final StreamObserver<Messages.SimpleResponse> observer) {
       // receive data forever and send data forever until client cancels or we shut down.
@@ -319,7 +320,7 @@ public class AsyncServer {
           (ServerCallStreamObserver<Messages.SimpleResponse>) observer;
       // If the client cancels, copyWithFlowControl takes care of calling
       // responseObserver.onCompleted() for us
-      StreamObservers.copyWithFlowControl(
+      io.grpc.stub.StreamObservers.copyWithFlowControl(
           new Iterator<Messages.SimpleResponse>() {
             @Override
             public boolean hasNext() {

--- a/stub/src/main/java/io/grpc/stub/StreamObservers.java
+++ b/stub/src/main/java/io/grpc/stub/StreamObservers.java
@@ -23,7 +23,10 @@ import java.util.Iterator;
 /**
  * Utility functions for working with {@link StreamObserver} and it's common subclasses like
  * {@link CallStreamObserver}.
+ *
+ * @deprecated Of questionable utility and generally not used.
  */
+@Deprecated
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4694")
 public final class StreamObservers {
   /**


### PR DESCRIPTION
This class is of questionable utility and generally not used.

Fixes #4694