### PR TITLE
util: Make grpc-core an implementation dependency

### DIFF
--- a/rls/build.gradle
+++ b/rls/build.gradle
@@ -16,6 +16,7 @@ tasks.named("jar").configure {
 
 dependencies {
     implementation project(':grpc-util'),
+            project(':grpc-core'),
             project(':grpc-protobuf'),
             project(':grpc-stub'),
             libraries.auto.value.annotations,

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -26,7 +26,8 @@ dependencies {
     api project(':grpc-protobuf'),
             project(':grpc-stub'),
             project(':grpc-util')
-    implementation libraries.protobuf.java.util,
+    implementation project(':grpc-core'),
+            libraries.protobuf.java.util,
             libraries.guava.jre // JRE required by protobuf-java-util
 
     runtimeOnly libraries.errorprone.annotations,

--- a/servlet/build.gradle
+++ b/servlet/build.gradle
@@ -40,6 +40,7 @@ dependencies {
             libraries.javax.annotation // java 9, 10 needs it
 
     implementation project(':grpc-util'),
+            project(':grpc-core'),
             libraries.guava
 
     testImplementation 'javax.servlet:javax.servlet-api:4.0.1'

--- a/servlet/jakarta/build.gradle
+++ b/servlet/jakarta/build.gradle
@@ -81,6 +81,7 @@ dependencies {
             libraries.javax.annotation
 
     implementation project(':grpc-util'),
+            project(':grpc-core'),
             libraries.guava
 
     itImplementation project(':grpc-servlet-jakarta'),

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -16,9 +16,10 @@ tasks.named("jar").configure {
 }
 
 dependencies {
-    api project(':grpc-core')
+    api project(':grpc-api')
 
-    implementation libraries.animalsniffer.annotations,
+    implementation project(':grpc-core'),
+            libraries.animalsniffer.annotations,
             libraries.guava
     testImplementation libraries.guava.testlib,
             testFixtures(project(':grpc-api')),


### PR DESCRIPTION
This prevents grpc-core from being exposed on the classpath when compiling code using grpc-util.