### PR TITLE
Clarify that NameResolver can only be started once.

### DIFF
--- a/api/src/main/java/io/grpc/NameResolver.java
+++ b/api/src/main/java/io/grpc/NameResolver.java
@@ -76,6 +76,8 @@ public abstract class NameResolver {
    * Starts the resolution. The method is not supposed to throw any exceptions. That might cause the
    * Channel that the name resolver is serving to crash. Errors should be propagated
    * through {@link Listener#onError}.
+   * 
+   * <p>An instance may not be started more than once, by any overload of this method. 
    *
    * @param listener used to receive updates on the target
    * @since 1.0.0
@@ -102,6 +104,8 @@ public abstract class NameResolver {
    * Starts the resolution. The method is not supposed to throw any exceptions. That might cause the
    * Channel that the name resolver is serving to crash. Errors should be propagated
    * through {@link Listener2#onError}.
+   * 
+   * <p>An instance may not be started more than once, by any overload of this method.
    *
    * @param listener used to receive updates on the target
    * @since 1.21.0

--- a/api/src/main/java/io/grpc/NameResolver.java
+++ b/api/src/main/java/io/grpc/NameResolver.java
@@ -77,7 +77,8 @@ public abstract class NameResolver {
    * Channel that the name resolver is serving to crash. Errors should be propagated
    * through {@link Listener#onError}.
    * 
-   * <p>An instance may not be started more than once, by any overload of this method. 
+   * <p>An instance may not be started more than once, by any overload of this method, even after
+   * an intervening call to {@link #shutdown}.
    *
    * @param listener used to receive updates on the target
    * @since 1.0.0
@@ -105,7 +106,8 @@ public abstract class NameResolver {
    * Channel that the name resolver is serving to crash. Errors should be propagated
    * through {@link Listener2#onError}.
    * 
-   * <p>An instance may not be started more than once, by any overload of this method.
+   * <p>An instance may not be started more than once, by any overload of this method, even after
+   * an intervening call to {@link #shutdown}.
    *
    * @param listener used to receive updates on the target
    * @since 1.21.0


### PR DESCRIPTION
On the surface this looks like a breaking API change but I'm actually just formalizing existing intolerance of multi-start exhibited by widely-used implementations: DnsNameResolver, UdsNameResolver, XdsNameResolver as well as several Google-internal ones