### PR TITLE
Implement Http2Headers.isEmpty (1.59.x backport)

### DIFF
--- a/netty/src/main/java/io/grpc/netty/AbstractHttp2Headers.java
+++ b/netty/src/main/java/io/grpc/netty/AbstractHttp2Headers.java
@@ -37,7 +37,7 @@ abstract class AbstractHttp2Headers implements Http2Headers {
 
   @Override
   public boolean isEmpty() {
-    throw new UnsupportedOperationException();
+    return size() == 0;
   }
 
   @Override


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-java/issues/10665

Using `grpc-netty` with Netty 4.1.101.Final results in the following error:

```
io.grpc.StatusRuntimeException: UNKNOWN
	at app//io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:275)
	at app//io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:256)
	at app//io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:169)
	// Remaining stacktrace omitted
Caused by: java.lang.UnsupportedOperationException
	at io.grpc.netty.AbstractHttp2Headers.isEmpty(AbstractHttp2Headers.java:40)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:419)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:352)
	at io.netty.handler.codec.http2.Http2InboundFrameLogger$1.onHeadersRead(Http2InboundFrameLogger.java:56)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader$2.processFragment(DefaultHttp2FrameReader.java:476)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readHeadersFrame(DefaultHttp2FrameReader.java:484)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.processPayloadState(DefaultHttp2FrameReader.java:253)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readFrame(DefaultHttp2FrameReader.java:159)
	at io.netty.handler.codec.http2.Http2InboundFrameLogger.readFrame(Http2InboundFrameLogger.java:41)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder.decodeFrame(DefaultHttp2ConnectionDecoder.java:188)
	at io.netty.handler.codec.http2.Http2ConnectionHandler$FrameDecoder.decode(Http2ConnectionHandler.java:393)
	at io.netty.handler.codec.http2.Http2ConnectionHandler.decode(Http2ConnectionHandler.java:453)
	// Remaining stacktrace omitted
```

In https://github.com/netty/netty/commit/2657079302ef7a63a002feccc1492418c0e6934a, Netty introduced code that calls `Http2Headers.isEmpty`. However the gRPC `Http2Headers` implementations do not implement this method. I assume this is simply an oversight.

`AbstractHttp2Headers` feels a fairly brittle. There are a number of methods here that are not implemented by the concrete implementations. Future Netty versions could begin calling these methods and cause similar failures. I wonder if it might be better to eliminate `AbstractHttp2Headers` to ensure that any unsupported methods are unsupported intentionally rather that accidentally. It seems like this isn't the first time there have been issues like this, see https://github.com/grpc/grpc-java/issues/7953.

Backport of #10663