### PR TITLE
core: Detect NameResolverProviders passed as Factories

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -382,7 +382,11 @@ public final class ManagedChannelImplBuilder
         directServerAddress);
     if (resolverFactory != null) {
       NameResolverRegistry reg = new NameResolverRegistry();
-      reg.register(new NameResolverFactoryToProviderFacade(resolverFactory));
+      if (resolverFactory instanceof NameResolverProvider) {
+        reg.register((NameResolverProvider) resolverFactory);
+      } else {
+        reg.register(new NameResolverFactoryToProviderFacade(resolverFactory));
+      }
       this.nameResolverRegistry = reg;
     } else {
       this.nameResolverRegistry = NameResolverRegistry.getDefaultRegistry();


### PR DESCRIPTION
This may help some to move closer to Providers. It especially helps cases where `NameResolverFactory`s aren't returning `InetSocketAddress`, as it allows them to override `getProducedSocketAddressTypes()`, which will now fail starting in 15fc70be.