### PR TITLE
all: Add grpc-inprocess

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -12,6 +12,7 @@ def subprojects = [
     project(':grpc-auth'),
     project(':grpc-core'),
     project(':grpc-grpclb'),
+    project(':grpc-inprocess'),
     project(':grpc-netty'),
     project(':grpc-okhttp'),
     project(':grpc-protobuf'),


### PR DESCRIPTION
This should have been added when inprocess was moved out of core. This includes inprocess in the Javadoc and code coverage reporting.