### PR TITLE
kokoro: Build android-interop-testing and binder separately

### DIFF
--- a/buildscripts/kokoro/android-interop.sh
+++ b/buildscripts/kokoro/android-interop.sh
@@ -30,7 +30,8 @@ GRADLE_FLAGS="-Pandroid.useAndroidX=true"
 
 ./gradlew $GRADLE_FLAGS \
   :grpc-android-interop-testing:assembleDebug \
-  :grpc-android-interop-testing:assembleDebugAndroidTest \
+  :grpc-android-interop-testing:assembleDebugAndroidTest
+./gradlew $GRADLE_FLAGS \
   :grpc-binder:assembleDebugAndroidTest
 
 # Run interop instrumentation tests on Firebase Test Lab


### PR DESCRIPTION
This avoids an OOM. We could probably configure things to run them together, but that generally takes trial-and-error.