### PR TITLE
Drop support for Bazel 5

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -76,7 +76,7 @@ jobs:
   bazel:
     runs-on: ubuntu-latest
     env:
-      USE_BAZEL_VERSION: 5.0.0
+      USE_BAZEL_VERSION: 6.0.0
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Protobuf 25.0 drops support for Bazel 5. Bazel 7 is coming out very soon, at which point we'd drop Bazel 5 anyway.