### PR TITLE
util:Remove Unused experimental API ManagedChannelBuilder.enableFullStreamDecompression

### DIFF
--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -129,12 +129,6 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
   }
 
   @Override
-  public T enableFullStreamDecompression() {
-    delegate().enableFullStreamDecompression();
-    return thisT();
-  }
-
-  @Override
   public T decompressorRegistry(DecompressorRegistry registry) {
     delegate().decompressorRegistry(registry);
     return thisT();

--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder2.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder2.java
@@ -132,12 +132,6 @@ public abstract class ForwardingChannelBuilder2<T extends ManagedChannelBuilder<
   }
 
   @Override
-  public T enableFullStreamDecompression() {
-    delegate().enableFullStreamDecompression();
-    return thisT();
-  }
-
-  @Override
   public T decompressorRegistry(DecompressorRegistry registry) {
     delegate().decompressorRegistry(registry);
     return thisT();

--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -259,22 +259,6 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   }
 
   /**
-   * Enables full-stream decompression of inbound streams. This will cause the channel's outbound
-   * headers to advertise support for GZIP compressed streams, and gRPC servers which support the
-   * feature may respond with a GZIP compressed stream.
-   *
-   * <p>EXPERIMENTAL: This method is here to enable an experimental feature, and may be changed or
-   * removed once the feature is stable.
-   *
-   * @throws UnsupportedOperationException if unsupported
-   * @since 1.7.0
-   */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/3399")
-  public T enableFullStreamDecompression() {
-    throw new UnsupportedOperationException();
-  }
-
-  /**
    * Set the decompression registry for use in the channel. This is an advanced API call and
    * shouldn't be used unless you are using custom message encoding. The default supported
    * decompressors are in {@link DecompressorRegistry#getDefaultInstance}.

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -410,12 +410,6 @@ public final class ManagedChannelImplBuilder
   }
 
   @Override
-  public ManagedChannelImplBuilder enableFullStreamDecompression() {
-    this.fullStreamDecompression = true;
-    return this;
-  }
-
-  @Override
   public ManagedChannelImplBuilder decompressorRegistry(DecompressorRegistry registry) {
     if (registry != null) {
       this.decompressorRegistry = registry;

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
@@ -258,12 +258,6 @@ public class ManagedChannelImplBuilderTest {
   }
 
   @Test
-  public void fullStreamDecompression_enabled() {
-    assertEquals(builder, builder.enableFullStreamDecompression());
-    assertTrue(builder.fullStreamDecompression);
-  }
-
-  @Test
   public void decompressorRegistry_default() {
     assertNotNull(builder.decompressorRegistry);
   }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -88,7 +88,6 @@ public class TestServiceClient {
   private String defaultServiceAccount;
   private String serviceAccountKeyFile;
   private String oauthScope;
-  private boolean fullStreamDecompression;
   private int localHandshakerPort = -1;
   private Map<String, ?> serviceConfig = null;
   private int soakIterations = 10;
@@ -159,8 +158,6 @@ public class TestServiceClient {
         serviceAccountKeyFile = value;
       } else if ("oauth_scope".equals(key)) {
         oauthScope = value;
-      } else if ("full_stream_decompression".equals(key)) {
-        fullStreamDecompression = Boolean.parseBoolean(value);
       } else if ("local_handshaker_port".equals(key)) {
         localHandshakerPort = Integer.parseInt(value);
       } else if ("service_config_json".equals(key)) {
@@ -226,8 +223,6 @@ public class TestServiceClient {
           + "\n  --service_account_key_file  Path to service account json key file."
             + c.serviceAccountKeyFile
           + "\n  --oauth_scope               Scope for OAuth tokens. Default " + c.oauthScope
-          + "\n  --full_stream_decompression Enable full-stream decompression. Default "
-            + c.fullStreamDecompression
           + "\n --service_config_json=SERVICE_CONFIG_JSON"
           + "\n                              Disables service config lookups and sets the provided "
           + "\n                              string as the default service config."
@@ -638,9 +633,6 @@ public class TestServiceClient {
         if (serverHostOverride != null) {
           nettyBuilder.overrideAuthority(serverHostOverride);
         }
-        if (fullStreamDecompression) {
-          nettyBuilder.enableFullStreamDecompression();
-        }
         // Disable the default census stats interceptor, use testing interceptor instead.
         InternalNettyChannelBuilder.setStatsEnabled(nettyBuilder, false);
         if (serviceConfig != null) {
@@ -663,9 +655,6 @@ public class TestServiceClient {
         // Force the hostname to match the cert the server uses.
         okBuilder.overrideAuthority(
             GrpcUtil.authorityFromHostAndPort(serverHostOverride, serverPort));
-      }
-      if (fullStreamDecompression) {
-        okBuilder.enableFullStreamDecompression();
       }
       // Disable the default census stats interceptor, use testing interceptor instead.
       InternalOkHttpChannelBuilder.setStatsEnabled(okBuilder, false);


### PR DESCRIPTION
Remove unused experimental method. This is a no-op, since it was never implemented on the server side.

Fixes #3399 