### PR TITLE
core: Improve language for leaked channel error

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelOrphanWrapper.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelOrphanWrapper.java
@@ -157,10 +157,9 @@ final class ManagedChannelOrphanWrapper extends ForwardingManagedChannel {
           Level level = Level.SEVERE;
           if (logger.isLoggable(level)) {
             String fmt =
-                "*~*~*~ Previous channel {0} was not shutdown properly!!! ~*~*~*"
+                "*~*~*~ Previous channel {0} was garbage collected without being shut down! ~*~*~*"
                     + System.getProperty("line.separator")
-                    + "    Make sure to call shutdown()/shutdownNow() and wait "
-                    + "until awaitTermination() returns true.";
+                    + "    Make sure to call shutdown()/shutdownNow()";
             LogRecord lr = new LogRecord(level, fmt);
             lr.setLoggerName(logger.getName());
             lr.setParameters(new Object[] {ref.channelStr});


### PR DESCRIPTION
Originally you had to confirm that awaitTermination() returned true, but that was annoying and useless, especially after calling shutdownNow(). The behavior was changed in ce2ae1fb because the awaitTermination() detection logic could prevent the channel from getting garbage collected.

Fixes #10732

CC @Jasper-M