### PR TITLE
api: Remove test dependency on grpclb

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -44,8 +44,7 @@ dependencies {
     testFixturesImplementation libraries.guava,
             libraries.junit,
             libraries.mockito.core
-    testImplementation project(':grpc-testing'),
-            project(':grpc-grpclb')
+    testImplementation project(':grpc-testing')
     testImplementation libraries.guava.testlib
     jmh project(':grpc-core')
 

--- a/api/src/test/java/io/grpc/LoadBalancerRegistryTest.java
+++ b/api/src/test/java/io/grpc/LoadBalancerRegistryTest.java
@@ -19,7 +19,6 @@ package io.grpc;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
-import io.grpc.grpclb.GrpclbLoadBalancerProvider;
 import io.grpc.internal.PickFirstLoadBalancerProvider;
 import java.util.List;
 import org.junit.Test;
@@ -41,7 +40,7 @@ public class LoadBalancerRegistryTest {
   @Test
   public void stockProviders() {
     LoadBalancerRegistry defaultRegistry = LoadBalancerRegistry.getDefaultRegistry();
-    assertThat(defaultRegistry.providers()).hasSize(4);
+    assertThat(defaultRegistry.providers()).hasSize(3);
 
     LoadBalancerProvider pickFirst = defaultRegistry.getProvider("pick_first");
     assertThat(pickFirst).isInstanceOf(PickFirstLoadBalancerProvider.class);
@@ -57,10 +56,6 @@ public class LoadBalancerRegistryTest {
     assertThat(outlierDetection.getClass().getName()).isEqualTo(
         "io.grpc.util.OutlierDetectionLoadBalancerProvider");
     assertThat(roundRobin.getPriority()).isEqualTo(5);
-
-    LoadBalancerProvider grpclb = defaultRegistry.getProvider("grpclb");
-    assertThat(grpclb).isInstanceOf(GrpclbLoadBalancerProvider.class);
-    assertThat(grpclb.getPriority()).isEqualTo(5);
   }
 
   @Test

--- a/api/src/test/java/io/grpc/NameResolverRegistryTest.java
+++ b/api/src/test/java/io/grpc/NameResolverRegistryTest.java
@@ -204,9 +204,9 @@ public class NameResolverRegistryTest {
     Map<String, NameResolverProvider> providers =
             NameResolverRegistry.getDefaultRegistry().providers();
     assertThat(providers).hasSize(1);
-    // 2 name resolvers from grpclb and core, higher priority one is returned.
-    assertThat(providers.get("dns").getClass().getName())
-        .isEqualTo("io.grpc.grpclb.SecretGrpclbNameResolverProvider$Provider");
+    // 2 name resolvers from core
+    assertThat(providers.get("dns"))
+        .isInstanceOf(io.grpc.internal.DnsNameResolverProvider.class);
     assertThat(NameResolverRegistry.getDefaultRegistry().asFactory().getDefaultScheme())
         .isEqualTo("dns");
   }

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerProviderTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerProviderTest.java
@@ -18,6 +18,7 @@ package io.grpc.grpclb;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import io.grpc.LoadBalancerRegistry;
 import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.Status;
 import io.grpc.grpclb.GrpclbState.Mode;
@@ -30,6 +31,17 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class GrpclbLoadBalancerProviderTest {
   private final GrpclbLoadBalancerProvider provider = new GrpclbLoadBalancerProvider();
+
+  @Test
+  public void provider_isRegistered() {
+    LoadBalancerRegistry registry = LoadBalancerRegistry.getDefaultRegistry();
+    assertThat(registry.getProvider("grpclb")).isInstanceOf(GrpclbLoadBalancerProvider.class);
+  }
+
+  @Test
+  public void provider_getPriority() {
+    assertThat(provider.getPriority()).isEqualTo(5);
+  }
 
   @Test
   public void retrieveModeFromLbConfig_pickFirst() throws Exception {

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbNameResolverTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbNameResolverTest.java
@@ -32,6 +32,7 @@ import io.grpc.NameResolver;
 import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.NameResolver.ResolutionResult;
 import io.grpc.NameResolver.ServiceConfigParser;
+import io.grpc.NameResolverRegistry;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.SynchronizationContext;
@@ -119,6 +120,13 @@ public class GrpclbNameResolverTest {
             /* isAndroid */false);
     hostName = resolver.getHost();
     assertThat(hostName).isEqualTo(NAME);
+  }
+
+  @Test
+  public void provider_isRegistered() {
+    NameResolverRegistry registry = NameResolverRegistry.getDefaultRegistry();
+    assertThat(registry.getProviderForScheme("dns").getClass().getName())
+        .isEqualTo("io.grpc.grpclb.SecretGrpclbNameResolverProvider$Provider");
   }
 
   @Test


### PR DESCRIPTION
It was just unnecessary, and is isn't great having lower-level tests depend on higher-level packages.