### PR TITLE
Upgrade distroless base images

### DIFF
--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'java'
 
     id "com.google.protobuf" version "0.9.4"
-    id 'com.google.cloud.tools.jib' version '3.1.4' // For releasing to Docker Hub
+    id 'com.google.cloud.tools.jib' version '3.3.2' // For releasing to Docker Hub
 }
 
 repositories {
@@ -58,7 +58,7 @@ mainClassName = 'io.grpc.examples.hostname.HostnameServer'
 
 // For releasing to Docker Hub
 jib {
-  from.image = "gcr.io/distroless/java:8"
+  from.image = "gcr.io/distroless/java17-debian12"
   container.ports = ['50051']
   outputPaths {
     tar = 'build/example-hostname.tar'

--- a/istio-interop-testing/build.gradle
+++ b/istio-interop-testing/build.gradle
@@ -56,7 +56,7 @@ tasks.named("compileJava").configure {
 
 // For releasing to Docker Hub
 jib {
-    from.image = "gcr.io/distroless/java:8"
+    from.image = "gcr.io/distroless/java17-debian12"
     container {
         ports = ['50051']
         mainClass="io.grpc.testing.istio.EchoTestServer"


### PR DESCRIPTION
gcr.io/distroless/java:8 is no longer being updated. Java 8 isn't a distroless option any more. Java 11 and 17 are options, but only Java 17 with Debian 12. The main alternative is to stick with Java 8 and use something like docker.io/library/eclipse-temurin:8-jre . But there doesn't seem to be much need to use an old JDK for these containers.

jib needed updating to support the oci manifest format used in the updated image.