### PR TITLE
Add grpc-util as compile dependency to grpc-xds

### DIFF
--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -50,6 +50,7 @@ dependencies {
             project(':grpc-core'),
             project(':grpc-services'),
             project(':grpc-auth'),
+            project(':grpc-util'),
             project(path: ':grpc-alts', configuration: 'shadow'),
             libraries.gson,
             libraries.re2j,


### PR DESCRIPTION
In https://github.com/grpc/grpc-java/pull/10362 grpc-util was added as a new module and some classes from grpc-core were extracted to grpc-util. While grpc-xds relies on classes in grpc-util, the PR didn't add any compile dependency on grpc-util in the gradle build config. As maven users, we suffer from this because the grpc-xds pom also does not contain a compile time dependency on grpc-util: [grpc-xds-1.59.1.pom](https://repo1.maven.org/maven2/io/grpc/grpc-xds/1.59.1/grpc-xds-1.59.1.pom).