### PR TITLE
Change many api deps to implementation deps

### DIFF
--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -10,8 +10,9 @@ plugins {
 description = "gRPC: ALTS"
 
 dependencies {
-    api project(':grpc-core')
+    api project(':grpc-api')
     implementation project(':grpc-auth'),
+            project(':grpc-core'),
             project(':grpc-grpclb'),
             project(':grpc-protobuf'),
             project(':grpc-stub'),
@@ -27,6 +28,7 @@ dependencies {
 
     testImplementation project(':grpc-testing'),
             testFixtures(project(':grpc-core')),
+            project(':grpc-inprocess'),
             project(':grpc-testing-proto'),
             libraries.guava,
             libraries.junit,

--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-base:18.0.1'
 
     implementation project(':grpc-android'),
+            project(':grpc-core'),
             project(':grpc-auth'),
             project(':grpc-census'),
             project(':grpc-okhttp'),

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,7 +35,8 @@ repositories {
 }
 
 dependencies {
-    api project(':grpc-core')
+    api project(':grpc-api')
+    implementation project(':grpc-core')
     implementation libraries.guava
     testImplementation project('::grpc-okhttp')
     testImplementation libraries.androidx.test.core

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     testFixturesImplementation libraries.guava,
             libraries.junit,
             libraries.mockito.core
+    testImplementation project(':grpc-core')
     testImplementation project(':grpc-testing')
     testImplementation libraries.guava.testlib
 

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -19,6 +19,7 @@ dependencies {
             libraries.google.auth.credentials
     implementation libraries.guava
     testImplementation project(':grpc-testing'),
+            project(':grpc-core'),
             libraries.google.auth.oauth2Http
     signature libraries.signature.java
     signature libraries.signature.android

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -26,6 +26,7 @@ tasks.named("jar").configure {
 
 dependencies {
     implementation project(':grpc-core'),
+            project(':grpc-inprocess'),
             project(':grpc-netty'),
             project(':grpc-okhttp'),
             project(':grpc-stub'),

--- a/binder/build.gradle
+++ b/binder/build.gradle
@@ -35,8 +35,9 @@ repositories {
 }
 
 dependencies {
-    api project(':grpc-core')
+    api project(':grpc-api')
 
+    implementation project(':grpc-core')
     implementation libraries.androidx.annotation
     implementation libraries.androidx.core
     implementation libraries.androidx.lifecycle.common
@@ -51,6 +52,7 @@ dependencies {
     testImplementation libraries.guava.testlib
     testImplementation libraries.truth
     testImplementation project(':grpc-testing')
+    testImplementation project(':grpc-inprocess')
     testImplementation testFixtures(project(':grpc-core'))
 
     androidTestAnnotationProcessor libraries.auto.value

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -33,6 +33,7 @@ dependencies {
             libraries.truth,
             project(':grpc-testing')
     testImplementation testFixtures(project(':grpc-api')),
+            project(':grpc-inprocess'),
             project(':grpc-testing')
     testImplementation libraries.guava.testlib
 

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -43,8 +43,9 @@ android {
 }
 
 dependencies {
-    api project(':grpc-core'),
+    api project(':grpc-api'),
             libraries.cronet.api
+    implementation project(':grpc-core')
     implementation libraries.guava
     testImplementation project(':grpc-testing')
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
     testImplementation "io.grpc:grpc-testing:${grpcVersion}"
+    testImplementation "io.grpc:grpc-inprocess:${grpcVersion}"
     testImplementation "junit:junit:4.13.2"
     testImplementation "org.mockito:mockito-core:4.4.0"
 }

--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "io.grpc:grpc-testing:${grpcVersion}"
+    testImplementation "io.grpc:grpc-inprocess:${grpcVersion}"
 }
 
 protobuf {

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
     testImplementation "io.grpc:grpc-testing:${grpcVersion}"
+    testImplementation "io.grpc:grpc-inprocess:${grpcVersion}"
     testImplementation "junit:junit:4.13.2"
     testImplementation "org.mockito:mockito-core:4.4.0"
 }

--- a/examples/example-oauth/build.gradle
+++ b/examples/example-oauth/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
     testImplementation "io.grpc:grpc-testing:${grpcVersion}"
+    testImplementation "io.grpc:grpc-inprocess:${grpcVersion}"
     testImplementation "junit:junit:4.13.2"
     testImplementation "org.mockito:mockito-core:4.4.0"
 }

--- a/inprocess/build.gradle
+++ b/inprocess/build.gradle
@@ -14,8 +14,9 @@ tasks.named("jar").configure {
 }
 
 dependencies {
-    api project(':grpc-core')
+    api project(':grpc-api')
 
+    implementation project(':grpc-core')
     implementation libraries.guava
     testImplementation project(':grpc-testing'),
             testFixtures(project(':grpc-core'))

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -24,6 +24,7 @@ dependencies {
             project(':grpc-rls'),
             project(':grpc-services'),
             project(':grpc-testing'),
+            project(':grpc-protobuf-lite'),
             project(path: ':grpc-xds', configuration: 'shadow'),
             libraries.hdrhistogram,
             libraries.truth,
@@ -49,6 +50,8 @@ dependencies {
             project(':grpc-rls')
     testImplementation testFixtures(project(':grpc-api')),
             testFixtures(project(':grpc-core')),
+            project(':grpc-inprocess'),
+            project(':grpc-core'),
             libraries.mockito.core,
             libraries.okhttp
     alpnagent libraries.jetty.alpn.agent

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -20,9 +20,10 @@ tasks.named("jar").configure {
 }
 
 dependencies {
-    api project(':grpc-core'),
+    api project(':grpc-api'),
             libraries.netty.codec.http2
-    implementation libs.netty.handler.proxy,
+    implementation project(':grpc-core'),
+            libs.netty.handler.proxy,
             libraries.guava,
             libraries.errorprone.annotations,
             libraries.perfmark.api,

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -15,8 +15,9 @@ tasks.named("jar").configure {
 }
 
 dependencies {
-    api project(':grpc-core')
+    api project(':grpc-api')
     implementation project(':grpc-util'),
+            project(':grpc-core'),
             libraries.okio,
             libraries.guava,
             libraries.perfmark.api

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -27,7 +27,7 @@ dependencies {
         exclude group: 'com.google.api', module: 'api-common'
     }
 
-    api (project(':grpc-protobuf-lite')) {
+    implementation (project(':grpc-protobuf-lite')) {
         exclude group: 'com.google.protobuf', module: 'protobuf-javalite'
     }
 

--- a/rls/build.gradle
+++ b/rls/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     compileOnly libraries.javax.annotation
     testImplementation libraries.truth,
             project(':grpc-grpclb'),
+            project(':grpc-inprocess'),
             project(':grpc-testing'),
             project(':grpc-testing-proto'),
             testFixtures(project(':grpc-core'))

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -23,10 +23,10 @@ tasks.named("jar").configure {
 }
 
 dependencies {
-    api project(':grpc-protobuf'),
-            project(':grpc-stub'),
-            project(':grpc-util')
+    api project(':grpc-stub')
     implementation project(':grpc-core'),
+            project(':grpc-protobuf'),
+            project(':grpc-util'),
             libraries.protobuf.java.util,
             libraries.guava.jre // JRE required by protobuf-java-util
 
@@ -35,6 +35,7 @@ dependencies {
             libraries.gson  // to fix checkUpperBoundDeps error here
     compileOnly libraries.javax.annotation
     testImplementation project(':grpc-testing'),
+            project(':grpc-inprocess'),
             libraries.netty.transport.epoll, // for DomainSocketAddress
             testFixtures(project(':grpc-core')),
             testFixtures(project(':grpc-api'))

--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -19,6 +19,7 @@ dependencies {
         libraries.guava
     implementation libraries.errorprone.annotations
     testImplementation libraries.truth,
+            project(':grpc-inprocess'),
             project(':grpc-testing'),
             testFixtures(project(':grpc-api'))
     signature libraries.signature.java

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -9,10 +9,11 @@ plugins {
 description = "gRPC: Testing"
 
 dependencies {
-    api project(':grpc-inprocess'),
-            project(':grpc-util'),
+    api project(':grpc-util'),
             project(':grpc-stub'),
             libraries.junit
+    implementation project(':grpc-inprocess')
+    implementation project(':grpc-core')
     // Only io.grpc.internal.testing.StatsTestUtils depends on opencensus_api, for internal use.
     compileOnly libraries.opencensus.api
     runtimeOnly project(":grpc-api")   // Pull in newer version than census-api

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     compileOnly sourceSets.thirdparty.output
     implementation project(':grpc-stub'),
             project(':grpc-core'),
+            project(':grpc-util'),
             project(':grpc-services'),
             project(':grpc-auth'),
             project(path: ':grpc-alts', configuration: 'shadow'),
@@ -58,6 +59,7 @@ dependencies {
     def nettyDependency = implementation project(':grpc-netty')
 
     testImplementation project(':grpc-rls')
+    testImplementation project(':grpc-inprocess')
     testImplementation testFixtures(project(':grpc-core')),
             testFixtures(project(':grpc-api')),
             testFixtures(project(':grpc-util'))


### PR DESCRIPTION
These look pretty fair now, mostly only exposing grpc-api and annotations as api dependencies.

-----

As noticed at https://github.com/grpc/grpc-java/pull/10755#issuecomment-1858032345

CC @temawi 