### PR TITLE
util:MultiChildLoadBalancer cleanup

### DIFF
--- a/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
@@ -80,24 +80,6 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
   protected abstract void updateOverallBalancingState();
 
   /**
-   * Creates a picker representing the state before any connections have been established.
-   *
-   * <p/>Override to produce a custom picker.
-   */
-  protected SubchannelPicker getInitialPicker() {
-    return new FixedResultPicker(PickResult.withNoResult());
-  }
-
-  /**
-   * Creates a new picker representing an error status.
-   *
-   * <p/>Override to produce a custom picker when there are errors.
-   */
-  protected SubchannelPicker getErrorPicker(Status error)  {
-    return new FixedResultPicker(PickResult.withError(error));
-  }
-
-  /**
    * Override to utilize parsing of the policy configuration or alternative helper/lb generation.
    */
   protected Map<Object, ChildLbState> createChildLbMap(ResolvedAddresses resolvedAddresses) {
@@ -203,6 +185,24 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
    */
   protected void handleNameResolutionError(ChildLbState child, Status error) {
     child.lb.handleNameResolutionError(error);
+  }
+
+  /**
+   * Creates a picker representing the state before any connections have been established.
+   *
+   * <p/>Override to produce a custom picker.
+   */
+  protected SubchannelPicker getInitialPicker() {
+    return new FixedResultPicker(PickResult.withNoResult());
+  }
+
+  /**
+   * Creates a new picker representing an error status.
+   *
+   * <p/>Override to produce a custom picker when there are errors.
+   */
+  protected SubchannelPicker getErrorPicker(Status error)  {
+    return new FixedResultPicker(PickResult.withError(error));
   }
 
   @Override

--- a/util/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -49,11 +48,6 @@ public class RoundRobinLoadBalancer extends MultiChildLoadBalancer {
 
   public RoundRobinLoadBalancer(Helper helper) {
     super(helper);
-  }
-
-  @Override
-  protected SubchannelPicker getSubchannelPicker(Map<Object, SubchannelPicker> childPickers) {
-    throw new UnsupportedOperationException(); // local updateOverallBalancingState doesn't use this
   }
 
   /**

--- a/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancer.java
@@ -41,10 +41,8 @@ import io.grpc.Status;
 import io.grpc.util.MultiChildLoadBalancer;
 import io.grpc.xds.ThreadSafeRandom.ThreadSafeRandomImpl;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nonnull;
 
@@ -73,12 +71,6 @@ final class LeastRequestLoadBalancer extends MultiChildLoadBalancer {
   LeastRequestLoadBalancer(Helper helper, ThreadSafeRandom random) {
     super(helper);
     this.random = checkNotNull(random, "random");
-  }
-
-  @Override
-  protected SubchannelPicker getSubchannelPicker(Map<Object, SubchannelPicker> childPickers) {
-    throw new UnsupportedOperationException(
-        "LeastRequestLoadBalancer uses its ChildLbStates, not these child pickers directly");
   }
 
   @Override
@@ -163,18 +155,6 @@ final class LeastRequestLoadBalancer extends MultiChildLoadBalancer {
   @VisibleForTesting
   void setResolvingAddresses(boolean newValue) {
     super.resolvingAddresses = newValue;
-  }
-
-  // Expose for tests in this package.
-  @Override
-  protected Collection<ChildLbState> getChildLbStates() {
-    return super.getChildLbStates();
-  }
-
-  // Expose for tests in this package.
-  @Override
-  protected ChildLbState getChildLbState(Object key) {
-    return super.getChildLbState(key);
   }
 
   // Expose for tests in this package.

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -85,7 +85,6 @@ final class RingHashLoadBalancer extends MultiChildLoadBalancer {
       return addressValidityStatus;
     }
 
-    AcceptResolvedAddrRetVal acceptRetVal;
     try {
       resolvingAddresses = true;
       // Subclass handles any special manipulation to create appropriate types of ChildLbStates
@@ -145,7 +144,7 @@ final class RingHashLoadBalancer extends MultiChildLoadBalancer {
       // clusters and resolver can remove them in service config.
       updateOverallBalancingState();
 
-      shutdownRemoved(removedChildren(newChildren.keySet()));
+      shutdownRemoved(getRemovedChildren(newChildren.keySet()));
     } finally {
       this.resolvingAddresses = false;
     }

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -38,12 +38,10 @@ import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.Status;
 import io.grpc.SynchronizationContext;
-import io.grpc.util.GracefulSwitchLoadBalancer;
 import io.grpc.util.MultiChildLoadBalancer;
 import io.grpc.xds.XdsLogger.XdsLogLevel;
 import java.net.SocketAddress;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -446,11 +444,6 @@ final class RingHashLoadBalancer extends MultiChildLoadBalancer {
 
   }
 
-  @Override
-  protected SubchannelPicker getSubchannelPicker(Map<Object, SubchannelPicker> childPickers) {
-    throw new UnsupportedOperationException("Not used by RingHash");
-  }
-
   /**
    * An unmodifiable view of a subchannel with state not subject to its real connectivity
    * state changes.
@@ -505,23 +498,6 @@ final class RingHashLoadBalancer extends MultiChildLoadBalancer {
     }
   }
 
-  static Set<EquivalentAddressGroup> getStrippedChildEags(Collection<ChildLbState> states) {
-    return states.stream()
-        .map(ChildLbState::getEag)
-        .map(RingHashLoadBalancer::stripAttrs)
-        .collect(Collectors.toSet());
-  }
-
-  @Override
-  protected Collection<ChildLbState> getChildLbStates() {
-    return super.getChildLbStates();
-  }
-
-  @Override
-  protected ChildLbState getChildLbStateEag(EquivalentAddressGroup eag) {
-    return super.getChildLbStateEag(eag);
-  }
-
   class RingHashChildLbState extends MultiChildLoadBalancer.ChildLbState {
 
     public RingHashChildLbState(Endpoint key, ResolvedAddresses resolvedAddresses) {
@@ -548,12 +524,6 @@ final class RingHashLoadBalancer extends MultiChildLoadBalancer {
     @Override
     protected void shutdown() {
       super.shutdown();
-    }
-
-    // Need to expose this to the LB class
-    @Override
-    protected GracefulSwitchLoadBalancer getLb() {
-      return super.getLb();
     }
 
   }

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -148,12 +148,6 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
         config.enableOobLoadReport, config.errorUtilizationPenalty, sequence);
   }
 
-  // Expose for tests in this package.
-  @Override
-  protected ChildLbState getChildLbStateEag(EquivalentAddressGroup eag) {
-    return super.getChildLbStateEag(eag);
-  }
-
   @VisibleForTesting
   final class WeightedChildLbState extends ChildLbState {
 

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -115,7 +115,7 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
     }
     config =
             (WeightedRoundRobinLoadBalancerConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
-    AcceptResolvedAddressRetVal acceptRetVal;
+    AcceptResolvedAddrRetVal acceptRetVal;
     try {
       resolvingAddresses = true;
       acceptRetVal = acceptResolvedAddressesInternal(resolvedAddresses);


### PR DESCRIPTION
A number of simple cleanups of the MultiChildLoadBalancer class (with associated updates in the petiole policies).

- Add javadoc including the word `override` for all of the methods that are candidates for overriding
- Add `final` to all of the methods that are exposed for use by subclasses, but not expected to be extended
- Getters that were being overridden just to let tests in another package access them have been made `public final`.
- Refactored the code so that the 2 methods acting as flags could be removed leaving cleaner opportunities for construction
- Reordered methods so that those likely to be overridden were at the top of the class
- Removed some unneeded methods