### PR TITLE
README.md: Correct gradle protobuf reference from 3.22.3 to 3.24.0 (v1.58.x backport)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ plugins {
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:3.22.3"
+    artifact = "com.google.protobuf:protoc:3.24.0"
   }
   plugins {
     grpc {
@@ -190,7 +190,7 @@ plugins {
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:3.22.3"
+    artifact = "com.google.protobuf:protoc:3.24.0"
   }
   plugins {
     grpc {


### PR DESCRIPTION
Backport of #10772 to v1.58.x.
---
1. The bump to `3.23.4` was incorrectly done to the master README in https://github.com/grpc/grpc-java/pull/10359.
2. This was reverted in https://github.com/grpc/grpc-java/pull/10430.
3. Then protobuf was upgraded again in 1.58.0, from `3.23.4` to `3.24.0` (f8baa9ca1)
4. 1.58.0 release updated it to `3.24.0` for maven, but kept at `3.22.3` for gradle (75af7abf4).
