### PR TITLE
api:Provide a default implementation for new method added to ManagedTranport.Listener to support ClientTransportFilters

### DIFF
--- a/api/src/test/java/io/grpc/ContextTest.java
+++ b/api/src/test/java/io/grpc/ContextTest.java
@@ -706,7 +706,7 @@ public class ContextTest {
 
   @Test
   public void innerDeadlineCompletesBeforeOuter() throws Exception {
-    Context base = Context.current().withDeadline(Deadline.after(2, TimeUnit.SECONDS), scheduler);
+    Context base = Context.current().withDeadline(Deadline.after(3, TimeUnit.SECONDS), scheduler);
     Context child = base.withDeadline(Deadline.after(1, TimeUnit.SECONDS), scheduler);
     child.addListener(cancellationListener, MoreExecutors.directExecutor());
     assertFalse(base.isCancelled());

--- a/api/src/test/java/io/grpc/ContextTest.java
+++ b/api/src/test/java/io/grpc/ContextTest.java
@@ -719,7 +719,7 @@ public class ContextTest {
 
     deadlineLatch = new CountDownLatch(1);
     base.addListener(cancellationListener, MoreExecutors.directExecutor());
-    assertTrue(deadlineLatch.await(2, TimeUnit.SECONDS));
+    assertTrue(deadlineLatch.await(4, TimeUnit.SECONDS));
     assertTrue(base.isCancelled());
     assertTrue(base.cancellationCause() instanceof TimeoutException);
     assertNotSame(base.cancellationCause(), child.cancellationCause());

--- a/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
@@ -110,6 +110,8 @@ public interface ManagedClientTransport extends ClientTransport {
      * Called just before {@link #transportReady} to allow direct modification of transport
      * Attributes.
      */
-    Attributes filterTransport(Attributes attributes);
+    default Attributes filterTransport(Attributes attributes) {
+      return attributes;
+    }
   }
 }

--- a/core/src/test/java/io/grpc/internal/ManagedClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedClientTransportTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import io.grpc.Attributes;
+import io.grpc.Status;
+import junit.framework.TestCase;
+import org.junit.Test;
+
+public class ManagedClientTransportTest extends TestCase {
+
+  @Test
+  public void testListener() {
+    ManagedClientTransport.Listener listener = new ManagedClientTransport.Listener() {
+      @Override
+      public void transportShutdown(Status s) {}
+
+      @Override
+      public void transportTerminated() {}
+
+      @Override
+      public void transportReady() {}
+
+      @Override
+      public void transportInUse(boolean inUse) {}
+    };
+
+    // Test that the listener methods do not throw.
+    listener.transportShutdown(Status.OK);
+    listener.transportTerminated();
+    listener.transportReady();
+    listener.transportInUse(true);
+
+
+    assertNull(listener.filterTransport(null));
+
+    Attributes attributes = Attributes.newBuilder()
+        .set(Attributes.Key.create("yolo"), "To be, or not to be?")
+        .set(Attributes.Key.create("foo"), "bar!")
+        .set(Attributes.Key.create("bar"), "foo?")
+        .build();
+    assertEquals(attributes, listener.filterTransport(attributes));
+  }
+}

--- a/core/src/test/java/io/grpc/internal/ManagedClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedClientTransportTest.java
@@ -16,12 +16,17 @@
 
 package io.grpc.internal;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import io.grpc.Attributes;
 import io.grpc.Status;
-import junit.framework.TestCase;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
-public class ManagedClientTransportTest extends TestCase {
+@RunWith(JUnit4.class)
+public class ManagedClientTransportTest {
 
   @Test
   public void testListener() {

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
@@ -3010,7 +3010,7 @@ public abstract class XdsClientImplTestBase {
         + "Cluster cluster.googleapis.com2: unspecified cluster discovery type";
     call.verifyRequestNack(CDS, Arrays.asList(CDS_RESOURCE, anotherCdsResource), VERSION_1, "0001",
         NODE, Arrays.asList(errorMsg));
-    verify(anotherWatcher).onResourceDoesNotExist(eq(anotherCdsResource));
+    verify(anotherWatcher, Mockito.timeout(2000)).onResourceDoesNotExist(eq(anotherCdsResource));
     barrier.await();
     latch.await(10, TimeUnit.SECONDS);
     verify(cdsResourceWatcher, times(2)).onChanged(any());


### PR DESCRIPTION
Avoids breaking backward compatibility which was done by #10646.