### PR TITLE
xds: fix flaky xds test due to verification race

### DIFF
--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
@@ -3010,10 +3010,10 @@ public abstract class XdsClientImplTestBase {
         + "Cluster cluster.googleapis.com2: unspecified cluster discovery type";
     call.verifyRequestNack(CDS, Arrays.asList(CDS_RESOURCE, anotherCdsResource), VERSION_1, "0001",
         NODE, Arrays.asList(errorMsg));
-    verify(anotherWatcher).onResourceDoesNotExist(eq(anotherCdsResource));
     barrier.await();
     latch.await(10, TimeUnit.SECONDS);
     verify(cdsResourceWatcher, times(2)).onChanged(any());
+    verify(anotherWatcher).onResourceDoesNotExist(eq(anotherCdsResource));
     verify(anotherWatcher).onError(any());
   }
 


### PR DESCRIPTION
result:
https://fusion2.corp.google.com/invocations/362bff0d-922f-440b-b5ea-bc0a58da1004/targets/%2F%2Fthird_party%2Fjava_src%2Fgrpc%2Fxds:src%2Ftest%2Fjava%2Fio%2Fgrpc%2Fxds%2FXdsClientImplV3Test/tests


cc. @danielzhaotongliu 