### PR TITLE
netty: fix tsan data race in attributes

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -131,7 +131,7 @@ class NettyClientHandler extends AbstractNettyHandler {
 
   private WriteQueue clientWriteQueue;
   private Http2Ping ping;
-  private Attributes attributes;
+  private volatile Attributes attributes;
   private InternalChannelz.Security securityInfo;
   private Status abruptGoAwayStatus;
   private Status channelInactiveReason;


### PR DESCRIPTION
`attribute` is not thread safe, fix forward cl/596040220

Original [tsan](https://fusion2.corp.google.com/ci/tap/zatar.tsan/activity/596040220/invocations/b5346bf3-4f67-4037-9340-fa8abe1a15d8/targets/%2F%2Fjavatests%2Fcom%2Fgoogle%2Fsecurity%2Fzatar%2Ffederation:MtlsCredentialsFactoryTest/history;cell=596040220/b5346bf3-4f67-4037-9340-fa8abe1a15d8/tests)

After fix [tsan](https://fusion2.corp.google.com/invocations/9ba9d310-2942-4f9a-92a3-58ae87a9b364/targets/%2F%2Fjavatests%2Fcom%2Fgoogle%2Fsecurity%2Fzatar%2Ffederation:MtlsCredentialsFactoryTest/tests)


The issue is introduced by #10646
cl/596040220
