### PR TITLE
android-interop-testing: Fix tester activity layout

### DIFF
--- a/android-interop-testing/src/main/res/layout/activity_tester.xml
+++ b/android-interop-testing/src/main/res/layout/activity_tester.xml
@@ -37,12 +37,15 @@
         android:layout_height="wrap_content"
         android:onClick="enableUds"
         android:textColor="@color/focus"
-        android:text="Use UDS (SSL not supported)"/>
+        android:text="Use UDS (SSL not supported)"
+        tools:ignore="OnClick"
+        />
     <EditText
         android:id="@+id/uds_proxy_edit_text"
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
         android:enabled="false"
+        android:inputType="text"
         android:hint="Enter Unix Domain Socket Abstract Namespace Address"
         />
   </LinearLayout>


### PR DESCRIPTION
Add missing inputType and lint ignore rule.