### PR TITLE
fix flaky xds test due to verification race (#10798) (v1.61.x backport)

### DIFF
--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
@@ -3010,10 +3010,10 @@ public abstract class XdsClientImplTestBase {
         + "Cluster cluster.googleapis.com2: unspecified cluster discovery type";
     call.verifyRequestNack(CDS, Arrays.asList(CDS_RESOURCE, anotherCdsResource), VERSION_1, "0001",
         NODE, Arrays.asList(errorMsg));
-    verify(anotherWatcher).onResourceDoesNotExist(eq(anotherCdsResource));
     barrier.await();
     latch.await(10, TimeUnit.SECONDS);
     verify(cdsResourceWatcher, times(2)).onChanged(any());
+    verify(anotherWatcher).onResourceDoesNotExist(eq(anotherCdsResource));
     verify(anotherWatcher).onError(any());
   }
 


### PR DESCRIPTION
backport of #10798