### PR TITLE
okhttp: Ignore known conscrypt socket close issue (1.61.x backport)

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -1098,6 +1098,7 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
     }
 
     @Override
+    @SuppressWarnings("Finally")
     public void run() {
       String threadName = Thread.currentThread().getName();
       Thread.currentThread().setName("OkHttpClientTransport");
@@ -1130,6 +1131,15 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
           frameReader.close();
         } catch (IOException ex) {
           log.log(Level.INFO, "Exception closing frame reader", ex);
+        } catch (RuntimeException e) {
+          // This same check is done in okhttp proper:
+          // https://github.com/square/okhttp/blob/3cc0f4917cbda03cb31617f8ead1e0aeb19de2fb/okhttp/src/main/kotlin/okhttp3/internal/-UtilJvm.kt#L270
+
+          // Conscrypt in Android 10 and 11 may throw closing an SSLSocket. This is safe to ignore.
+          // https://issuetracker.google.com/issues/177450597
+          if (!"bio == null".equals(e.getMessage())) {
+            throw e;
+          }
         }
         listener.transportTerminated();
         Thread.currentThread().setName(threadName);


### PR DESCRIPTION
Backport of #10811

This stops an exception from being thrown when a known Conscrypt synchronization issue happens.

Note that lack of coverage on the PR is because this issue only happens infrequently in highly concurrent systems and a unit test would not be able to catch it.

Fixes: #10800  