### PR TITLE
Upgrade dependencies post v1.61.0 release

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,9 +22,11 @@ animalsniffer = "org.codehaus.mojo:animal-sniffer:1.23"
 animalsniffer-annotations = "org.codehaus.mojo:animal-sniffer-annotations:1.23"
 auto-value = "com.google.auto.value:auto-value:1.10.4"
 auto-value-annotations = "com.google.auto.value:auto-value-annotations:1.10.4"
-checkstyle = "com.puppycrawl.tools:checkstyle:10.12.5"
+checkstyle = "com.puppycrawl.tools:checkstyle:10.12.7"
 commons-math3 = "org.apache.commons:commons-math3:3.6.1"
 conscrypt = "org.conscrypt:conscrypt-openjdk-uber:2.5.2"
+# Update notes / 2023-07-19 sergiitk:
+#     Upgrade is blocked by https://github.com/grpc/grpc-java/issues/10396.
 cronet-api = "org.chromium.net:cronet-api:108.5359.79"
 cronet-embedded = "org.chromium.net:cronet-embedded:108.5359.79"
 errorprone-annotations = "com.google.errorprone:error_prone_annotations:2.23.0"


### PR DESCRIPTION
### Dependency updates

#### Update successfully to the latest
- [ ] `checkstyle`  10.12.5 -> 10.12.7

#### Updated to non-latest
- 

#### Not updated
- Cronet -- upgrade blocked by ticket https://github.com/grpc/grpc-java/issues/10396
  - [x] ~`cronet.api`  108.5359.79 -> 113.5672.61~
  - [x] ~`cronet.embedded`  108.5359.79 -> 113.5672.61~

### Contributor's

### Contributor's log
<details>
<summary>checkForUpdates results (at the time of PR creation)</summary>

Important: this is not an actual list of updated dependencies.

```
libs.androidx.annotation = androidx.annotation:androidx.annotation:annotation 1.7.0 -> 1.7.1
libs.androidx.lifecycle.common = androidx.lifecycle:androidx.lifecycle:lifecycle-common 2.6.2 -> 2.7.0
libs.androidx.lifecycle.service = androidx.lifecycle:androidx.lifecycle:lifecycle-service 2.6.2 -> 2.7.0
libs.checkstyle = com.puppycrawl.tools:com.puppycrawl.tools:checkstyle 10.12.5 -> 10.12.7
libs.checkstylejava8 = com.puppycrawl.tools:com.puppycrawl.tools:checkstyle 9.3 -> 10.12.7
libs.cronet.api = org.chromium.net:org.chromium.net:cronet-api 108.5359.79 -> 113.5672.61
libs.cronet.embedded = org.chromium.net:org.chromium.net:cronet-embedded 108.5359.79 -> 113.5672.61
libs.errorprone.annotations = com.google.errorprone:com.google.errorprone:error_prone_annotations 2.23.0 -> 2.24.1
libs.errorprone.core = com.google.errorprone:com.google.errorprone:error_prone_core 2.23.0 -> 2.24.1
libs.errorprone.corejava8 = com.google.errorprone:com.google.errorprone:error_prone_core 2.10.0 -> 2.24.1
libs.google.api.protos = com.google.api.grpc:com.google.api.grpc:proto-google-common-protos 2.29.0 -> 2.30.0
libs.google.auth.credentials = com.google.auth:com.google.auth:google-auth-library-credentials 1.4.0 -> 1.22.0
libs.google.auth.oauth2Http = com.google.auth:com.google.auth:google-auth-library-oauth2-http 1.4.0 -> 1.22.0
libs.google.cloud.logging = com.google.cloud:com.google.cloud:google-cloud-logging 3.15.14 -> 3.15.15
libs.guava = com.google.guava:com.google.guava:guava 32.1.3-android -> 33.0.0-jre
libs.guava.jre = com.google.guava:com.google.guava:guava 32.1.3-jre -> 33.0.0-jre
libs.guava.testlib = com.google.guava:com.google.guava:guava-testlib 32.1.3-android -> 33.0.0-jre
libs.mockito.android = org.mockito:org.mockito:mockito-android 4.4.0 -> 5.9.0
libs.mockito.core = org.mockito:org.mockito:mockito-core 4.4.0 -> 5.9.0
libs.netty.codec.http2 = io.netty:io.netty:netty-codec-http2 4.1.100.Final -> 4.1.105.Final
libs.netty.handler.proxy = io.netty:io.netty:netty-handler-proxy 4.1.100.Final -> 4.1.105.Final
libs.netty.tcnative = io.netty:io.netty:netty-tcnative-boringssl-static 2.0.61.Final -> 2.0.62.Final
libs.netty.tcnative.classes = io.netty:io.netty:netty-tcnative-classes 2.0.61.Final -> 2.0.62.Final
libs.netty.transport.epoll = io.netty:io.netty:netty-transport-native-epoll 4.1.100.Final -> 4.1.105.Final
libs.netty.unix.common = io.netty:io.netty:netty-transport-native-unix-common 4.1.100.Final -> 4.1.105.Final
libs.okio = com.squareup.okio:com.squareup.okio:okio 3.4.0 -> 3.7.0
libs.opentelemetry.api = io.opentelemetry:io.opentelemetry:opentelemetry-api 1.32.0 -> 1.34.1
libs.opentelemetry.sdk.testing = io.opentelemetry:io.opentelemetry:opentelemetry-sdk-testing 1.32.0 -> 1.34.1
libs.perfmark.api = io.perfmark:io.perfmark:perfmark-api 0.26.0 -> 0.27.0
libs.protobuf.java = com.google.protobuf:com.google.protobuf:protobuf-java 3.25.1 -> 3.25.2
libs.protobuf.java.util = com.google.protobuf:com.google.protobuf:protobuf-java-util 3.25.1 -> 3.25.2
libs.protobuf.javalite = com.google.protobuf:com.google.protobuf:protobuf-javalite 3.25.1 -> 3.25.2
libs.protobuf.protoc = com.google.protobuf:com.google.protobuf:protoc 3.25.1 -> 3.25.2
libs.truth = com.google.truth:com.google.truth:truth 1.1.5 -> 1.2.0
```
</details>