### PR TITLE
Make AsyncSecurityPolicy.checkAuthorizationAsync public.

### DIFF
--- a/binder/src/androidTest/java/io/grpc/binder/BinderSecurityTest.java
+++ b/binder/src/androidTest/java/io/grpc/binder/BinderSecurityTest.java
@@ -188,7 +188,7 @@ public final class BinderSecurityTest {
         ServerSecurityPolicy.newBuilder()
             .servicePolicy("foo", new AsyncSecurityPolicy() {
               @Override
-              ListenableFuture<Status> checkAuthorizationAsync(int uid) {
+              public ListenableFuture<Status> checkAuthorizationAsync(int uid) {
                 return Futures.immediateFailedFuture(originalException);
               }
             })
@@ -207,7 +207,7 @@ public final class BinderSecurityTest {
         ServerSecurityPolicy.newBuilder()
             .servicePolicy("foo", new AsyncSecurityPolicy() {
               @Override
-              ListenableFuture<Status> checkAuthorizationAsync(int uid) {
+              public ListenableFuture<Status> checkAuthorizationAsync(int uid) {
                 if (firstAttempt.getAndSet(false)) {
                   return Futures.immediateFailedFuture(new IllegalStateException());
                 }
@@ -229,7 +229,7 @@ public final class BinderSecurityTest {
         ServerSecurityPolicy.newBuilder()
             .servicePolicy("foo", new AsyncSecurityPolicy() {
               @Override
-              ListenableFuture<Status> checkAuthorizationAsync(int uid) {
+              public ListenableFuture<Status> checkAuthorizationAsync(int uid) {
                 if (firstAttempt.getAndSet(false)) {
                   return Futures.immediateCancelledFuture();
                 }

--- a/binder/src/main/java/io/grpc/binder/AsyncSecurityPolicy.java
+++ b/binder/src/main/java/io/grpc/binder/AsyncSecurityPolicy.java
@@ -67,5 +67,5 @@ public final Status checkAuthorization(int uid) {
    * @return A {@link ListenableFuture} for a gRPC {@link Status} object, with OK indicating
    *     authorized.
    */
-  abstract ListenableFuture<Status> checkAuthorizationAsync(int uid);
+  public abstract ListenableFuture<Status> checkAuthorizationAsync(int uid);
 }


### PR DESCRIPTION
I initially omitted the visibility modifier because this class began as an interface. Since it moved to an abstract class, we must make it public so it can be overriden by subclasses in the integrator's packages.

Part of #10566.