### PR TITLE
buildscripts: Break up android-interop gradle builds

### DIFF
--- a/buildscripts/kokoro/android-interop.sh
+++ b/buildscripts/kokoro/android-interop.sh
@@ -28,11 +28,9 @@ unset JAVA_HOME
 
 GRADLE_FLAGS="-Pandroid.useAndroidX=true"
 
-./gradlew $GRADLE_FLAGS \
-  :grpc-android-interop-testing:assembleDebug \
-  :grpc-android-interop-testing:assembleDebugAndroidTest
-./gradlew $GRADLE_FLAGS \
-  :grpc-binder:assembleDebugAndroidTest
+./gradlew $GRADLE_FLAGS :grpc-android-interop-testing:assembleDebug
+./gradlew $GRADLE_FLAGS :grpc-android-interop-testing:assembleDebugAndroidTest
+./gradlew $GRADLE_FLAGS :grpc-binder:assembleDebugAndroidTest
 
 # Run interop instrumentation tests on Firebase Test Lab
 gcloud firebase test android run \


### PR DESCRIPTION
Splits the :grpc-android-interop-testing:assembleDebug and :grpc-android-interop-testing:assembleDebugAndroidTest build targets with hopes of avoiding OOMs.