### PR TITLE
binder: Add missing Android API annotations

### DIFF
--- a/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkState;
 
 import android.content.Context;
 import android.os.UserHandle;
+import androidx.annotation.RequiresApi;
 import androidx.core.content.ContextCompat;
 import com.google.errorprone.annotations.DoNotCall;
 import io.grpc.ChannelCredentials;
@@ -296,6 +297,7 @@ public final class BinderChannelBuilder
    * @return this
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/10173")
+  @RequiresApi(30)
   public BinderChannelBuilder bindAsUser(UserHandle targetUserHandle) {
     this.targetUserHandle = targetUserHandle;
     return this;

--- a/binder/src/main/java/io/grpc/binder/BinderChannelCredentials.java
+++ b/binder/src/main/java/io/grpc/binder/BinderChannelCredentials.java
@@ -19,6 +19,7 @@ package io.grpc.binder;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import android.content.ComponentName;
+import androidx.annotation.RequiresApi;
 import io.grpc.ChannelCredentials;
 import io.grpc.ExperimentalApi;
 import javax.annotation.Nullable;
@@ -43,6 +44,7 @@ public final class BinderChannelCredentials extends ChannelCredentials {
    *     DevicePolicyManager.bindDeviceAdminServiceAsUser API.
    * @return a BinderChannelCredentials
    */
+  @RequiresApi(26)
   public static BinderChannelCredentials forDevicePolicyAdmin(
       ComponentName devicePolicyAdminComponentName) {
     return new BinderChannelCredentials(devicePolicyAdminComponentName);


### PR DESCRIPTION
Fixes: #10840 