### PR TITLE
xds: move tlsContextManager

### DIFF
--- a/xds/src/main/java/io/grpc/xds/SharedXdsClientPoolProvider.java
+++ b/xds/src/main/java/io/grpc/xds/SharedXdsClientPoolProvider.java
@@ -28,7 +28,6 @@ import io.grpc.internal.SharedResourceHolder;
 import io.grpc.internal.TimeProvider;
 import io.grpc.xds.Bootstrapper.BootstrapInfo;
 import io.grpc.xds.XdsNameResolverProvider.XdsClientPoolFactory;
-import io.grpc.xds.internal.security.TlsContextManagerImpl;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
@@ -130,8 +129,7 @@ final class SharedXdsClientPoolProvider implements XdsClientPoolFactory {
               scheduler,
               new ExponentialBackoffPolicy.Provider(),
               GrpcUtil.STOPWATCH_SUPPLIER,
-              TimeProvider.SYSTEM_TIME_PROVIDER,
-              new TlsContextManagerImpl(bootstrapInfo));
+              TimeProvider.SYSTEM_TIME_PROVIDER);
         }
         refCount++;
         return xdsClient;

--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -47,6 +47,7 @@ import io.grpc.xds.XdsClient.ResourceStore;
 import io.grpc.xds.XdsClient.TimerLaunch;
 import io.grpc.xds.XdsClient.XdsResponseHandler;
 import io.grpc.xds.XdsLogger.XdsLogLevel;
+import io.grpc.xds.internal.security.TlsContextManagerImpl;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
@@ -116,8 +117,7 @@ final class XdsClientImpl extends XdsClient
       ScheduledExecutorService timeService,
       BackoffPolicy.Provider backoffPolicyProvider,
       Supplier<Stopwatch> stopwatchSupplier,
-      TimeProvider timeProvider,
-      TlsContextManager tlsContextManager) {
+      TimeProvider timeProvider) {
     this.xdsTransportFactory = xdsTransportFactory;
     this.bootstrapInfo = bootstrapInfo;
     this.context = context;
@@ -125,7 +125,7 @@ final class XdsClientImpl extends XdsClient
     this.backoffPolicyProvider = backoffPolicyProvider;
     this.stopwatchSupplier = stopwatchSupplier;
     this.timeProvider = timeProvider;
-    this.tlsContextManager = checkNotNull(tlsContextManager, "tlsContextManager");
+    this.tlsContextManager = new TlsContextManagerImpl(bootstrapInfo);
     logId = InternalLogId.allocate("xds-client", null);
     logger = XdsLogger.withLogId(logId);
     logger.log(XdsLogLevel.INFO, "Created");

--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
@@ -287,8 +287,6 @@ public abstract class XdsClientImplTestBase {
   private ResourceWatcher<CdsUpdate> cdsResourceWatcher;
   @Mock
   private ResourceWatcher<EdsUpdate> edsResourceWatcher;
-  @Mock
-  private TlsContextManager tlsContextManager;
 
   private ManagedChannel channel;
   private ManagedChannel channelForCustomAuthority;
@@ -374,8 +372,7 @@ public abstract class XdsClientImplTestBase {
             fakeClock.getScheduledExecutorService(),
             backoffPolicyProvider,
             fakeClock.getStopwatchSupplier(),
-            timeProvider,
-            tlsContextManager);
+            timeProvider);
 
     assertThat(resourceDiscoveryCalls).isEmpty();
     assertThat(loadReportCalls).isEmpty();
@@ -3749,8 +3746,7 @@ public abstract class XdsClientImplTestBase {
         fakeClock.getScheduledExecutorService(),
         backoffPolicyProvider,
         fakeClock.getStopwatchSupplier(),
-        timeProvider,
-        tlsContextManager);
+        timeProvider);
   }
 
   private  BootstrapInfo buildBootStrap(String serverUri) {


### PR DESCRIPTION
Minor refactor to the tlsContextManager to not expose itself on the xdsClientImpl constructor.
This is to allow stubby team can use xds easily.
 