### PR TITLE
xds: fix NPE in wrr in TF state

### DIFF
--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -378,6 +378,9 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
       WeightedChildLbState wChild = (WeightedChildLbState) childLbState;
       PickResult pickResult = childLbState.getCurrentPicker().pickSubchannel(args);
       Subchannel subchannel = pickResult.getSubchannel();
+      if (subchannel == null) {
+        return pickResult;
+      }
       if (!enableOobLoadReport) {
         return PickResult.withSubchannel(subchannel,
             OrcaPerRequestUtil.getInstance().newOrcaClientStreamTracerFactory(


### PR DESCRIPTION
The issues was introduced from 1.60 
Before #10584 the WRR picker is only created for READY states, therefore the pick result is always A subchannel. 
After #10584 the WRR picker is created for TF case, thus we may get a pick result that is empty. 

fix b/287153892