### PR TITLE
Allow users to start watching xDS resources outside of io.grpc.xds pa…

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -26,6 +26,7 @@ import com.google.common.net.UrlEscapers;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.Any;
+import io.grpc.ExperimentalApi;
 import io.grpc.Status;
 import io.grpc.xds.Bootstrapper.ServerInfo;
 import io.grpc.xds.LoadStatsManager2.ClusterDropStats;
@@ -115,7 +116,8 @@ public abstract class XdsClient {
   /**
    * Watcher interface for a single requested xDS resource.
    */
-  interface ResourceWatcher<T extends ResourceUpdate> {
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/10862")
+  public interface ResourceWatcher<T extends ResourceUpdate> {
 
     /**
      * Called when the resource discovery RPC encounters some transient error.

--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -125,7 +125,7 @@ public abstract class XdsClient {
      * <p>Note that we expect that the implementer to:
      * - Comply with the guarantee to not generate certain statuses by the library:
      *   https://grpc.github.io/grpc/core/md_doc_statuscodes.html. If the code needs to be
-     *   propagated to the channel, override it with {@link Status.Code#UNAVAILABLE}.
+     *   propagated to the channel, override it with {@link io.grpc.Status.Code#UNAVAILABLE}.
      * - Keep {@link Status} description in one form or another, as it contains valuable debugging
      *   information.
      */
@@ -308,23 +308,25 @@ public abstract class XdsClient {
   /**
    * Registers a data watcher for the given Xds resource.
    */
-  <T extends ResourceUpdate> void watchXdsResource(XdsResourceType<T> type, String resourceName,
-                                                   ResourceWatcher<T> watcher,
-                                                   Executor executor) {
+  public <T extends ResourceUpdate> void watchXdsResource(XdsResourceType<T> type,
+      String resourceName,
+      ResourceWatcher<T> watcher,
+      Executor executor) {
     throw new UnsupportedOperationException();
   }
 
-  <T extends ResourceUpdate> void watchXdsResource(XdsResourceType<T> type, String resourceName,
-                                                   ResourceWatcher<T> watcher) {
+  public <T extends ResourceUpdate> void watchXdsResource(XdsResourceType<T> type,
+      String resourceName,
+      ResourceWatcher<T> watcher) {
     watchXdsResource(type, resourceName, watcher, MoreExecutors.directExecutor());
   }
 
   /**
    * Unregisters the given resource watcher.
    */
-  <T extends ResourceUpdate> void cancelXdsResourceWatch(XdsResourceType<T> type,
-                                                         String resourceName,
-                                                         ResourceWatcher<T> watcher) {
+  public <T extends ResourceUpdate> void cancelXdsResourceWatch(XdsResourceType<T> type,
+      String resourceName,
+      ResourceWatcher<T> watcher) {
     throw new UnsupportedOperationException();
   }
 

--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -78,7 +78,7 @@ public abstract class XdsClient {
     return true;
   }
 
-  static String canonifyResourceName(String resourceName) {
+  public static String canonifyResourceName(String resourceName) {
     checkNotNull(resourceName, "resourceName");
     if (!resourceName.startsWith(XDSTP_SCHEME)) {
       return resourceName;
@@ -102,7 +102,7 @@ public abstract class XdsClient {
     return resourceName.replace(rawQuery, canonifiedQuery);
   }
 
-  static String percentEncodePath(String input) {
+  public static String percentEncodePath(String input) {
     Iterable<String> pathSegs = Splitter.on('/').split(input);
     List<String> encodedSegs = new ArrayList<>();
     for (String pathSeg : pathSegs) {

--- a/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientImpl.java
@@ -286,9 +286,10 @@ final class XdsClientImpl extends XdsClient
   }
 
   @Override
-  <T extends ResourceUpdate> void watchXdsResource(XdsResourceType<T> type, String resourceName,
-                                                   ResourceWatcher<T> watcher,
-                                                   Executor watcherExecutor) {
+  public <T extends ResourceUpdate> void watchXdsResource(XdsResourceType<T> type,
+      String resourceName,
+      ResourceWatcher<T> watcher,
+      Executor watcherExecutor) {
     syncContext.execute(new Runnable() {
       @Override
       @SuppressWarnings("unchecked")
@@ -313,9 +314,9 @@ final class XdsClientImpl extends XdsClient
   }
 
   @Override
-  <T extends ResourceUpdate> void cancelXdsResourceWatch(XdsResourceType<T> type,
-                                                         String resourceName,
-                                                         ResourceWatcher<T> watcher) {
+  public <T extends ResourceUpdate> void cancelXdsResourceWatch(XdsResourceType<T> type,
+      String resourceName,
+      ResourceWatcher<T> watcher) {
     syncContext.execute(new Runnable() {
       @Override
       @SuppressWarnings("unchecked")

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
@@ -789,8 +789,9 @@ public class CdsLoadBalancer2Test {
 
     @Override
     @SuppressWarnings("unchecked")
-    <T extends ResourceUpdate> void watchXdsResource(XdsResourceType<T> type, String resourceName,
-                          ResourceWatcher<T> watcher, Executor syncContext) {
+    public <T extends ResourceUpdate> void watchXdsResource(XdsResourceType<T> type,
+        String resourceName,
+        ResourceWatcher<T> watcher, Executor syncContext) {
       assertThat(type.typeName()).isEqualTo("CDS");
       watchers.computeIfAbsent(resourceName, k -> new ArrayList<>())
           .add((ResourceWatcher<CdsUpdate>)watcher);
@@ -798,9 +799,9 @@ public class CdsLoadBalancer2Test {
 
     @Override
     @SuppressWarnings("unchecked")
-    <T extends ResourceUpdate> void cancelXdsResourceWatch(XdsResourceType<T> type,
-                                                           String resourceName,
-                                                           ResourceWatcher<T> watcher) {
+    public <T extends ResourceUpdate> void cancelXdsResourceWatch(XdsResourceType<T> type,
+        String resourceName,
+        ResourceWatcher<T> watcher) {
       assertThat(type.typeName()).isEqualTo("CDS");
       assertThat(watchers).containsKey(resourceName);
       List<ResourceWatcher<CdsUpdate>> watcherList = watchers.get(resourceName);

--- a/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
@@ -1184,9 +1184,10 @@ public class ClusterResolverLoadBalancerTest {
 
     @Override
     @SuppressWarnings("unchecked")
-    <T extends ResourceUpdate> void watchXdsResource(XdsResourceType<T> type, String resourceName,
-                                                     ResourceWatcher<T> watcher,
-                                                     Executor syncContext) {
+    public <T extends ResourceUpdate> void watchXdsResource(XdsResourceType<T> type,
+            String resourceName,
+            ResourceWatcher<T> watcher,
+            Executor syncContext) {
       assertThat(type.typeName()).isEqualTo("EDS");
       assertThat(watchers).doesNotContainKey(resourceName);
       watchers.put(resourceName, (ResourceWatcher<EdsUpdate>) watcher);
@@ -1194,9 +1195,9 @@ public class ClusterResolverLoadBalancerTest {
 
     @Override
     @SuppressWarnings("unchecked")
-    <T extends ResourceUpdate> void cancelXdsResourceWatch(XdsResourceType<T> type,
-                                                           String resourceName,
-                                                           ResourceWatcher<T> watcher) {
+    public <T extends ResourceUpdate> void cancelXdsResourceWatch(XdsResourceType<T> type,
+            String resourceName,
+            ResourceWatcher<T> watcher) {
       assertThat(type.typeName()).isEqualTo("EDS");
       assertThat(watchers).containsKey(resourceName);
       watchers.remove(resourceName);

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -1915,10 +1915,10 @@ public class XdsNameResolverTest {
 
     @Override
     @SuppressWarnings("unchecked")
-    <T extends ResourceUpdate> void watchXdsResource(XdsResourceType<T> resourceType,
-                                                     String resourceName,
-                                                     ResourceWatcher<T> watcher,
-                                                     Executor syncContext) {
+    public <T extends ResourceUpdate> void watchXdsResource(XdsResourceType<T> resourceType,
+            String resourceName,
+            ResourceWatcher<T> watcher,
+            Executor syncContext) {
 
       switch (resourceType.typeName()) {
         case "LDS":
@@ -1939,9 +1939,9 @@ public class XdsNameResolverTest {
     }
 
     @Override
-    <T extends ResourceUpdate> void cancelXdsResourceWatch(XdsResourceType<T> type,
-                                                           String resourceName,
-                                                           ResourceWatcher<T> watcher) {
+    public <T extends ResourceUpdate> void cancelXdsResourceWatch(XdsResourceType<T> type,
+            String resourceName,
+            ResourceWatcher<T> watcher) {
       switch (type.typeName()) {
         case "LDS":
           assertThat(ldsResource).isNotNull();

--- a/xds/src/test/java/io/grpc/xds/XdsServerTestHelper.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerTestHelper.java
@@ -181,10 +181,10 @@ public class XdsServerTestHelper {
 
     @Override
     @SuppressWarnings("unchecked")
-    <T extends ResourceUpdate> void watchXdsResource(XdsResourceType<T> resourceType,
-                                                     String resourceName,
-                                                     ResourceWatcher<T> watcher,
-                                                     Executor syncContext) {
+    public <T extends ResourceUpdate> void watchXdsResource(XdsResourceType<T> resourceType,
+        String resourceName,
+        ResourceWatcher<T> watcher,
+        Executor syncContext) {
       switch (resourceType.typeName()) {
         case "LDS":
           assertThat(ldsWatcher).isNull();
@@ -201,9 +201,9 @@ public class XdsServerTestHelper {
     }
 
     @Override
-    <T extends ResourceUpdate> void cancelXdsResourceWatch(XdsResourceType<T> type,
-                                                           String resourceName,
-                                ResourceWatcher<T> watcher) {
+    public <T extends ResourceUpdate> void cancelXdsResourceWatch(XdsResourceType<T> type,
+        String resourceName,
+        ResourceWatcher<T> watcher) {
       switch (type.typeName()) {
         case "LDS":
           assertThat(ldsWatcher).isNotNull();


### PR DESCRIPTION
Mark couple of helper functions in XdsClient as public. This will allow users who define and control custom xDS resources to reuse common methods