### PR TITLE
Mark couple of helper functions in XdsClient as public. 

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -77,7 +77,10 @@ public abstract class XdsClient {
     return true;
   }
 
-  static String canonifyResourceName(String resourceName) {
+  /*
+   * Convert the XDSTP resource name to its canonical version.
+   */
+  public static String canonifyResourceName(String resourceName) {
     checkNotNull(resourceName, "resourceName");
     if (!resourceName.startsWith(XDSTP_SCHEME)) {
       return resourceName;
@@ -101,7 +104,10 @@ public abstract class XdsClient {
     return resourceName.replace(rawQuery, canonifiedQuery);
   }
 
-  static String percentEncodePath(String input) {
+  /*
+   * Percent encode the input using the url path segment escaper.
+   */
+  public static String percentEncodePath(String input) {
     Iterable<String> pathSegs = Splitter.on('/').split(input);
     List<String> encodedSegs = new ArrayList<>();
     for (String pathSeg : pathSegs) {

--- a/xds/src/main/java/io/grpc/xds/XdsClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClient.java
@@ -82,6 +82,7 @@ public abstract class XdsClient {
   /*
    * Convert the XDSTP resource name to its canonical version.
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/10862")
   public static String canonifyResourceName(String resourceName) {
     checkNotNull(resourceName, "resourceName");
     if (!resourceName.startsWith(XDSTP_SCHEME)) {
@@ -109,6 +110,7 @@ public abstract class XdsClient {
   /*
    * Percent encode the input using the url path segment escaper.
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/10862")
   public static String percentEncodePath(String input) {
     Iterable<String> pathSegs = Splitter.on('/').split(input);
     List<String> encodedSegs = new ArrayList<>();


### PR DESCRIPTION
This will allow users who define and control custom xDS resources to reuse common methods.

@YifeiZhuang