### PR TITLE
Expose the getOrCreate method via the InternalSharedXdsClientPoolProvider

### DIFF
--- a/xds/src/main/java/io/grpc/xds/InternalSharedXdsClientPoolProvider.java
+++ b/xds/src/main/java/io/grpc/xds/InternalSharedXdsClientPoolProvider.java
@@ -17,6 +17,7 @@
 package io.grpc.xds;
 
 import io.grpc.Internal;
+import io.grpc.internal.ObjectPool;
 import java.util.Map;
 
 /**
@@ -29,5 +30,9 @@ public final class InternalSharedXdsClientPoolProvider {
 
   public static void setDefaultProviderBootstrapOverride(Map<String, ?> bootstrap) {
     SharedXdsClientPoolProvider.getDefaultProvider().setBootstrapOverride(bootstrap);
+  }
+
+  public static ObjectPool<XdsClient> getOrCreate() throws XdsInitializationException {
+    return SharedXdsClientPoolProvider.getDefaultProvider().getOrCreate();
   }
 }


### PR DESCRIPTION
This is needed for internal users to both set the bootstrap and interact with the XdsClient via the shared object pool

@YifeiZhuang