### PR TITLE
xds: Envoy proto sync to 2024-01-24

### DIFF
--- a/xds/third_party/envoy/import.sh
+++ b/xds/third_party/envoy/import.sh
@@ -17,7 +17,7 @@
 
 set -e
 # import VERSION from the google internal copybara_version.txt for Envoy
-VERSION=0478eba2a495027bf6ac8e787c42e2f5b9eb553b
+VERSION=147e6b9523d8d2ae0d9d2205254d6e633644c6fe
 DOWNLOAD_URL="https://github.com/envoyproxy/envoy/archive/${VERSION}.tar.gz"
 DOWNLOAD_BASE_DIR="envoy-${VERSION}"
 SOURCE_PROTO_BASE_DIR="${DOWNLOAD_BASE_DIR}/api"
@@ -79,6 +79,7 @@ envoy/config/core/v3/event_service_config.proto
 envoy/config/core/v3/extension.proto
 envoy/config/core/v3/grpc_service.proto
 envoy/config/core/v3/health_check.proto
+envoy/config/core/v3/http_service.proto
 envoy/config/core/v3/http_uri.proto
 envoy/config/core/v3/protocol.proto
 envoy/config/core/v3/proxy_protocol.proto
@@ -124,6 +125,7 @@ envoy/config/trace/v3/opentelemetry.proto
 envoy/config/trace/v3/service.proto
 envoy/config/trace/v3/trace.proto
 envoy/config/trace/v3/zipkin.proto
+envoy/data/accesslog/v3/accesslog.proto
 envoy/extensions/clusters/aggregate/v3/cluster.proto
 envoy/extensions/filters/common/fault/v3/fault.proto
 envoy/extensions/filters/http/fault/v3/fault.proto

--- a/xds/third_party/envoy/src/main/proto/envoy/admin/v3/config_dump.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/admin/v3/config_dump.proto
@@ -33,6 +33,7 @@ message ConfigDump {
   // * ``bootstrap``: :ref:`BootstrapConfigDump <envoy_v3_api_msg_admin.v3.BootstrapConfigDump>`
   // * ``clusters``: :ref:`ClustersConfigDump <envoy_v3_api_msg_admin.v3.ClustersConfigDump>`
   // * ``ecds_filter_http``: :ref:`EcdsConfigDump <envoy_v3_api_msg_admin.v3.EcdsConfigDump>`
+  // * ``ecds_filter_quic_listener``: :ref:`EcdsConfigDump <envoy_v3_api_msg_admin.v3.EcdsConfigDump>`
   // * ``ecds_filter_tcp_listener``: :ref:`EcdsConfigDump <envoy_v3_api_msg_admin.v3.EcdsConfigDump>`
   // * ``endpoints``:  :ref:`EndpointsConfigDump <envoy_v3_api_msg_admin.v3.EndpointsConfigDump>`
   // * ``listeners``: :ref:`ListenersConfigDump <envoy_v3_api_msg_admin.v3.ListenersConfigDump>`

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/scoped_route.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/scoped_route.proto
@@ -39,7 +39,7 @@ option (udpa.annotations.file_status).package_version_status = FROZEN;
 //       fragments:
 //         - header_value_extractor:
 //             name: X-Route-Selector
-//             element_separator: ,
+//             element_separator: ","
 //             element:
 //               separator: =
 //               key: vip

--- a/xds/third_party/envoy/src/main/proto/envoy/config/accesslog/v3/accesslog.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/accesslog/v3/accesslog.proto
@@ -4,6 +4,7 @@ package envoy.config.accesslog.v3;
 
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/route/v3/route_components.proto";
+import "envoy/data/accesslog/v3/accesslog.proto";
 import "envoy/type/matcher/v3/metadata.proto";
 import "envoy/type/v3/percent.proto";
 
@@ -43,7 +44,7 @@ message AccessLog {
   }
 }
 
-// [#next-free-field: 13]
+// [#next-free-field: 14]
 message AccessLogFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.accesslog.v2.AccessLogFilter";
@@ -87,6 +88,9 @@ message AccessLogFilter {
 
     // Metadata Filter
     MetadataFilter metadata_filter = 12;
+
+    // Log Type Filter
+    LogTypeFilter log_type_filter = 13;
   }
 }
 
@@ -250,6 +254,8 @@ message ResponseFlagFilter {
         in: "UPE"
         in: "NC"
         in: "OM"
+        in: "DF"
+        in: "DO"
       }
     }
   }];
@@ -308,6 +314,17 @@ message MetadataFilter {
   // Default result if the key does not exist in dynamic metadata: if unset or
   // true, then log; if false, then don't log.
   google.protobuf.BoolValue match_if_key_not_found = 2;
+}
+
+// Filters based on access log type.
+message LogTypeFilter {
+  // Logs only records which their type is one of the types defined in this field.
+  repeated data.accesslog.v3.AccessLogType types = 1
+      [(validate.rules).repeated = {items {enum {defined_only: true}}}];
+
+  // If this field is set to true, the filter will instead block all records
+  // with a access log type in types field, and allow all other records.
+  bool exclude = 2;
 }
 
 // Extension filter is statically registered at runtime.

--- a/xds/third_party/envoy/src/main/proto/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/bootstrap/v3/bootstrap.proto
@@ -41,7 +41,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // <config_overview_bootstrap>` for more detail.
 
 // Bootstrap :ref:`configuration overview <config_overview_bootstrap>`.
-// [#next-free-field: 38]
+// [#next-free-field: 41]
 message Bootstrap {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.bootstrap.v2.Bootstrap";
@@ -99,6 +99,48 @@ message Bootstrap {
     // the :ref:`ads <envoy_v3_api_field_config.core.v3.ConfigSource.ads>` field set will be
     // streamed on the ADS channel.
     core.v3.ApiConfigSource ads_config = 3;
+  }
+
+  message ApplicationLogConfig {
+    message LogFormat {
+      oneof log_format {
+        option (validate.required) = true;
+
+        // Flush application logs in JSON format. The configured JSON struct can
+        // support all the format flags specified in the :option:`--log-format`
+        // command line options section, except for the ``%v`` and ``%_`` flags.
+        google.protobuf.Struct json_format = 1;
+
+        // Flush application log in a format defined by a string. The text format
+        // can support all the format flags specified in the :option:`--log-format`
+        // command line option section.
+        string text_format = 2;
+      }
+    }
+
+    // Optional field to set the application logs format. If this field is set, it will override
+    // the default log format. Setting both this field and :option:`--log-format` command line
+    // option is not allowed, and will cause a bootstrap error.
+    LogFormat log_format = 1;
+  }
+
+  message DeferredStatOptions {
+    // When the flag is enabled, Envoy will lazily initialize a subset of the stats (see below).
+    // This will save memory and CPU cycles when creating the objects that own these stats, if those
+    // stats are never referenced throughout the lifetime of the process. However, it will incur additional
+    // memory overhead for these objects, and a small increase of CPU usage when a at least one of the stats
+    // is updated for the first time.
+    // Groups of stats that will be lazily initialized:
+    // - Cluster traffic stats: a subgroup of the :ref:`cluster statistics <config_cluster_manager_cluster_stats>`
+    // that are used when requests are routed to the cluster.
+    bool enable_deferred_creation_stats = 1;
+  }
+
+  message GrpcAsyncClientManagerConfig {
+    // Optional field to set the expiration time for the cached gRPC client object.
+    // The minimal value is 5s and the default is 50s.
+    google.protobuf.Duration max_cached_entry_idle_duration = 1
+        [(validate.rules).duration = {gte {seconds: 5}}];
   }
 
   reserved 10, 11;
@@ -162,6 +204,9 @@ message Bootstrap {
 
   // Optional set of stats sinks.
   repeated metrics.v3.StatsSink stats_sinks = 6;
+
+  // Options to control behaviors of deferred creation compatible stats.
+  DeferredStatOptions deferred_stat_options = 39;
 
   // Configuration for internal processing of stats.
   metrics.v3.StatsConfig stats_config = 13;
@@ -360,6 +405,12 @@ message Bootstrap {
   // Envoy only supports ListenerManager for this field and Envoy Mobile
   // supports ApiListenerManager.
   core.v3.TypedExtensionConfig listener_manager = 37;
+
+  // Optional application log configuration.
+  ApplicationLogConfig application_log_config = 38;
+
+  // Optional gRPC async manager config.
+  GrpcAsyncClientManagerConfig grpc_async_client_manager_config = 40;
 }
 
 // Administration interface :ref:`operations documentation
@@ -397,6 +448,7 @@ message Admin {
 }
 
 // Cluster manager :ref:`architecture overview <arch_overview_cluster_manager>`.
+// [#next-free-field: 6]
 message ClusterManager {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.bootstrap.v2.ClusterManager";
@@ -437,6 +489,11 @@ message ClusterManager {
   // <envoy_v3_api_field_config.core.v3.ApiConfigSource.api_type>` :ref:`GRPC
   // <envoy_v3_api_enum_value_config.core.v3.ApiConfigSource.ApiType.GRPC>`.
   core.v3.ApiConfigSource load_stats_config = 4;
+
+  // Whether the ClusterManager will create clusters on the worker threads
+  // inline during requests. This will save memory and CPU cycles in cases where
+  // there are lots of inactive clusters and > 1 worker thread.
+  bool enable_deferred_cluster_creation = 5;
 }
 
 // Allows you to specify different watchdog configs for different subsystems.

--- a/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/cluster.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/cluster.proto
@@ -13,6 +13,7 @@ import "envoy/config/core/v3/health_check.proto";
 import "envoy/config/core/v3/protocol.proto";
 import "envoy/config/core/v3/resolver.proto";
 import "envoy/config/endpoint/v3/endpoint.proto";
+import "envoy/type/metadata/v3/metadata.proto";
 import "envoy/type/v3/percent.proto";
 
 import "google/protobuf/any.proto";
@@ -551,6 +552,10 @@ message Cluster {
     // The port to override for the original dst address. This port
     // will take precedence over filter state and header override ports
     google.protobuf.UInt32Value upstream_port_override = 3 [(validate.rules).uint32 = {lte: 65535}];
+
+    // The dynamic metadata key to override destination address.
+    // First the request metadata is considered, then the connection one.
+    type.metadata.v3.MetadataKey metadata_key = 4;
   }
 
   // Common configuration for all load balancer implementations.
@@ -719,7 +724,7 @@ message Cluster {
     google.protobuf.DoubleValue per_upstream_preconnect_ratio = 1
         [(validate.rules).double = {lte: 3.0 gte: 1.0}];
 
-    // Indicates how many many streams (rounded up) can be anticipated across a cluster for each
+    // Indicates how many streams (rounded up) can be anticipated across a cluster for each
     // stream, useful for low QPS services. This is currently supported for a subset of
     // deterministic non-hash-based load-balancing algorithms (weighted round robin, random).
     // Unlike ``per_upstream_preconnect_ratio`` this preconnects across the upstream instances in a
@@ -1252,4 +1257,19 @@ message TrackClusterStats {
   // <config_cluster_manager_cluster_stats_request_response_sizes>`  tracking header and body sizes
   // of requests and responses will be published.
   bool request_response_sizes = 2;
+
+  // If true, some stats will be emitted per-endpoint, similar to the stats in admin ``/clusters``
+  // output.
+  //
+  // This does not currently output correct stats during a hot-restart.
+  //
+  // This is not currently implemented by all stat sinks.
+  //
+  // These stats do not honor filtering or tag extraction rules in :ref:`StatsConfig
+  // <envoy_v3_api_msg_config.metrics.v3.StatsConfig>` (but fixed-value tags are supported). Admin
+  // endpoint filtering is supported.
+  //
+  // This may not be used at the same time as
+  // :ref:`load_stats_config <envoy_v3_api_field_config.bootstrap.v3.ClusterManager.load_stats_config>`.
+  bool per_endpoint_stats = 3;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/filter.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/filter.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.config.cluster.v3;
 
+import "envoy/config/core/v3/config_source.proto";
+
 import "google/protobuf/any.proto";
 
 import "udpa/annotations/status.proto";
@@ -14,8 +16,8 @@ option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3;clusterv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
-// [#protodoc-title: Upstream filters]
-// Upstream filters apply to the connections to the upstream cluster hosts.
+// [#protodoc-title: Upstream network filters]
+// Upstream network filters apply to the connections to the upstream cluster hosts.
 
 message Filter {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.cluster.Filter";
@@ -26,6 +28,13 @@ message Filter {
   // Filter specific configuration which depends on the filter being
   // instantiated. See the supported filters for further documentation.
   // Note that Envoy's :ref:`downstream network
-  // filters <config_network_filters>` are not valid upstream filters.
+  // filters <config_network_filters>` are not valid upstream network filters.
+  // Only one of typed_config or config_discovery can be used.
   google.protobuf.Any typed_config = 2;
+
+  // Configuration source specifier for an extension configuration discovery
+  // service. In case of a failure and without the default configuration, the
+  // listener closes the connections.
+  // Only one of typed_config or config_discovery can be used.
+  core.v3.ExtensionConfigSource config_discovery = 3;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/outlier_detection.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/outlier_detection.proto
@@ -19,7 +19,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // See the :ref:`architecture overview <arch_overview_outlier_detection>` for
 // more information on outlier detection.
-// [#next-free-field: 23]
+// [#next-free-field: 24]
 message OutlierDetection {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.cluster.OutlierDetection";
@@ -161,4 +161,10 @@ message OutlierDetection {
   // See :ref:`max_ejection_time_jitter<envoy_v3_api_field_config.cluster.v3.OutlierDetection.base_ejection_time>`
   // Defaults to 0s.
   google.protobuf.Duration max_ejection_time_jitter = 22;
+
+  // If active health checking is enabled and a host is ejected by outlier detection, a successful active health check
+  // unejects the host by default and considers it as healthy. Unejection also clears all the outlier detection counters.
+  // To change this default behavior set this config to ``false`` where active health checking will not uneject the host.
+  // Defaults to true.
+  google.protobuf.BoolValue successful_active_health_check_uneject_host = 23;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/address.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/address.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package envoy.config.core.v3;
 
+import "envoy/config/core/v3/extension.proto";
 import "envoy/config/core/v3/socket_option.proto";
 
 import "google/protobuf/wrappers.proto";
@@ -130,7 +131,7 @@ message ExtraSourceAddress {
   SocketOptionsOverride socket_options = 2;
 }
 
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message BindConfig {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.core.BindConfig";
 
@@ -150,20 +151,22 @@ message BindConfig {
   // precompiled binaries.
   repeated SocketOption socket_options = 3;
 
-  // Extra source addresses appended to the address specified in the `source_address`
-  // field. This enables to specify multiple source addresses. Currently, only one extra
-  // address can be supported, and the extra address should have a different IP version
-  // with the address in the `source_address` field. The address which has the same IP
-  // version with the target host's address IP version will be used as bind address. If more
-  // than one extra address specified, only the first address matched IP version will be
-  // returned. If there is no same IP version address found, the address in the `source_address`
-  // will be returned.
+  // Extra source addresses appended to the address specified in the ``source_address``
+  // field. This enables to specify multiple source addresses.
+  // The source address selection is determined by :ref:`local_address_selector
+  // <envoy_v3_api_field_config.core.v3.BindConfig.local_address_selector>`.
   repeated ExtraSourceAddress extra_source_addresses = 5;
 
   // Deprecated by
   // :ref:`extra_source_addresses <envoy_v3_api_field_config.core.v3.BindConfig.extra_source_addresses>`
   repeated SocketAddress additional_source_addresses = 4
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+
+  // Custom local address selector to override the default (i.e.
+  // :ref:`DefaultLocalAddressSelector
+  // <envoy_v3_api_msg_config.upstream.local_address_selector.v3.DefaultLocalAddressSelector>`).
+  // [#extension-category: envoy.upstream.local_address_selector]
+  TypedExtensionConfig local_address_selector = 6;
 }
 
 // Addresses specify either a logical or physical address and port, which are

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/base.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/base.proto
@@ -324,8 +324,18 @@ message HeaderValue {
   // The same :ref:`format specifier <config_access_log_format>` as used for
   // :ref:`HTTP access logging <config_access_log>` applies here, however
   // unknown header values are replaced with the empty string instead of ``-``.
+  // Header value is encoded as string. This does not work for non-utf8 characters.
+  // Only one of ``value`` or ``raw_value`` can be set.
   string value = 2 [
-    (validate.rules).string = {max_bytes: 16384 well_known_regex: HTTP_HEADER_VALUE strict: false}
+    (validate.rules).string = {max_bytes: 16384 well_known_regex: HTTP_HEADER_VALUE strict: false},
+    (udpa.annotations.field_migrate).oneof_promotion = "value_type"
+  ];
+
+  // Header value is encoded as bytes which can support non-utf8 characters.
+  // Only one of ``value`` or ``raw_value`` can be set.
+  bytes raw_value = 3 [
+    (validate.rules).bytes = {min_len: 0 max_len: 16384},
+    (udpa.annotations.field_migrate).oneof_promotion = "value_type"
   ];
 }
 
@@ -336,9 +346,12 @@ message HeaderValueOption {
 
   // Describes the supported actions types for header append action.
   enum HeaderAppendAction {
-    // This action will append the specified value to the existing values if the header
-    // already exists. If the header doesn't exist then this will add the header with
-    // specified key and value.
+    // If the header already exists, this action will result in:
+    //
+    // - Comma-concatenated for predefined inline headers.
+    // - Duplicate header added in the ``HeaderMap`` for other headers.
+    //
+    // If the header doesn't exist then this will add new header with specified key and value.
     APPEND_IF_EXISTS_OR_ADD = 0;
 
     // This action will add the header if it doesn't already exist. If the header
@@ -349,6 +362,10 @@ message HeaderValueOption {
     // the header already exists. If the header doesn't exist then this will add the header
     // with specified key and value.
     OVERWRITE_IF_EXISTS_OR_ADD = 2;
+
+    // This action will overwrite the specified value by discarding any existing values if
+    // the header already exists. If the header doesn't exist then this will be no-op.
+    OVERWRITE_IF_EXISTS = 3;
   }
 
   // Header name/value pair that this option applies to.

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/config_source.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/config_source.proto
@@ -152,7 +152,8 @@ message RateLimitSettings {
   google.protobuf.UInt32Value max_tokens = 1;
 
   // Rate at which tokens will be filled per second. If not set, a default fill rate of 10 tokens
-  // per second will be used.
+  // per second will be used. The minimal fill rate is once per year. Lower
+  // fill rates will be set to once per year.
   google.protobuf.DoubleValue fill_rate = 2 [(validate.rules).double = {gt: 0.0}];
 }
 

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/health_check.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/health_check.proto
@@ -4,6 +4,7 @@ package envoy.config.core.v3;
 
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/event_service_config.proto";
+import "envoy/config/core/v3/extension.proto";
 import "envoy/type/matcher/v3/string.proto";
 import "envoy/type/v3/http.proto";
 import "envoy/type/v3/range.proto";
@@ -13,6 +14,7 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -60,7 +62,7 @@ message HealthStatusSet {
       [(validate.rules).repeated = {items {enum {defined_only: true}}}];
 }
 
-// [#next-free-field: 25]
+// [#next-free-field: 26]
 message HealthCheck {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.core.HealthCheck";
 
@@ -366,9 +368,19 @@ message HealthCheck {
   // The default value for "healthy edge interval" is the same as the default interval.
   google.protobuf.Duration healthy_edge_interval = 16 [(validate.rules).duration = {gt {}}];
 
+  // .. attention::
+  // This field is deprecated in favor of the extension
+  // :ref:`event_logger <envoy_v3_api_field_config.core.v3.HealthCheck.event_logger>` and
+  // :ref:`event_log_path <envoy_v3_api_field_extensions.health_check.event_sinks.file.v3.HealthCheckEventFileSink.event_log_path>`
+  // in the file sink extension.
+  //
   // Specifies the path to the :ref:`health check event log <arch_overview_health_check_logging>`.
-  // If empty, no event log will be written.
-  string event_log_path = 17;
+  string event_log_path = 17
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+
+  // A list of event log sinks to process the health check event.
+  // [#extension-category: envoy.health_check.event_sinks]
+  repeated TypedExtensionConfig event_logger = 25;
 
   // [#not-implemented-hide:]
   // The gRPC service for the health check event service.

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/http_service.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/http_service.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+
+package envoy.config.core.v3;
+
+import "envoy/config/core/v3/base.proto";
+import "envoy/config/core/v3/http_uri.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.config.core.v3";
+option java_outer_classname = "HttpServiceProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/core/v3;corev3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: HTTP services]
+
+// HTTP service configuration.
+message HttpService {
+  // The service's HTTP URI. For example:
+  //
+  // .. code-block:: yaml
+  //
+  //    http_uri:
+  //      uri: https://www.myserviceapi.com/v1/data
+  //      cluster: www.myserviceapi.com|443
+  //
+  HttpUri http_uri = 1;
+
+  // Specifies a list of HTTP headers that should be added to each request
+  // handled by this virtual host.
+  repeated HeaderValueOption request_headers_to_add = 2
+      [(validate.rules).repeated = {max_items: 1000}];
+}

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/http_uri.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/http_uri.proto
@@ -52,6 +52,7 @@ message HttpUri {
   // Sets the maximum duration in milliseconds that a response can take to arrive upon request.
   google.protobuf.Duration timeout = 3 [(validate.rules).duration = {
     required: true
+    lt {seconds: 4294967296}
     gte {}
   }];
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/protocol.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/protocol.proto
@@ -56,7 +56,7 @@ message QuicKeepAliveSettings {
 }
 
 // QUIC protocol options which apply to both downstream and upstream connections.
-// [#next-free-field: 6]
+// [#next-free-field: 8]
 message QuicProtocolOptions {
   // Maximum number of streams that the client can negotiate per connection. 100
   // if not specified.
@@ -85,7 +85,7 @@ message QuicProtocolOptions {
       [(validate.rules).uint32 = {lte: 25165824 gte: 1}];
 
   // The number of timeouts that can occur before port migration is triggered for QUIC clients.
-  // This defaults to 1. If set to 0, port migration will not occur on path degrading.
+  // This defaults to 4. If set to 0, port migration will not occur on path degrading.
   // Timeout here refers to QUIC internal path degrading timeout mechanism, such as PTO.
   // This has no effect on server sessions.
   google.protobuf.UInt32Value num_timeouts_to_trigger_port_migration = 4
@@ -94,6 +94,14 @@ message QuicProtocolOptions {
   // Probes the peer at the configured interval to solicit traffic, i.e. ACK or PATH_RESPONSE, from the peer to push back connection idle timeout.
   // If absent, use the default keepalive behavior of which a client connection sends PINGs every 15s, and a server connection doesn't do anything.
   QuicKeepAliveSettings connection_keepalive = 5;
+
+  // A comma-separated list of strings representing QUIC connection options defined in
+  // `QUICHE <https://github.com/google/quiche/blob/main/quiche/quic/core/crypto/crypto_protocol.h>`_ and to be sent by upstream connections.
+  string connection_options = 6;
+
+  // A comma-separated list of strings representing QUIC client connection options defined in
+  // `QUICHE <https://github.com/google/quiche/blob/main/quiche/quic/core/crypto/crypto_protocol.h>`_ and to be sent by upstream connections.
+  string client_connection_options = 7;
 }
 
 message UpstreamHttpProtocolOptions {
@@ -104,12 +112,14 @@ message UpstreamHttpProtocolOptions {
   // upstream connections based on the downstream HTTP host/authority header or any other arbitrary
   // header when :ref:`override_auto_sni_header <envoy_v3_api_field_config.core.v3.UpstreamHttpProtocolOptions.override_auto_sni_header>`
   // is set, as seen by the :ref:`router filter <config_http_filters_router>`.
+  // Does nothing if a filter before the http router filter sets the corresponding metadata.
   bool auto_sni = 1;
 
   // Automatic validate upstream presented certificate for new upstream connections based on the
   // downstream HTTP host/authority header or any other arbitrary header when :ref:`override_auto_sni_header <envoy_v3_api_field_config.core.v3.UpstreamHttpProtocolOptions.override_auto_sni_header>`
   // is set, as seen by the :ref:`router filter <config_http_filters_router>`.
   // This field is intended to be set with ``auto_sni`` field.
+  // Does nothing if a filter before the http router filter sets the corresponding metadata.
   bool auto_san_validation = 2;
 
   // An optional alternative to the host/authority header to be used for setting the SNI value.
@@ -119,6 +129,7 @@ message UpstreamHttpProtocolOptions {
   // is not found or the value is empty, host/authority header will be used instead.
   // This field is intended to be set with ``auto_sni`` and/or ``auto_san_validation`` fields.
   // If none of these fields are set then setting this would be a no-op.
+  // Does nothing if a filter before the http router filter sets the corresponding metadata.
   string override_auto_sni_header = 3
       [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME ignore_empty: true}];
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/substitution_format_string.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/substitution_format_string.proto
@@ -19,9 +19,15 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Substitution format string]
 
+// Optional configuration options to be used with json_format.
+message JsonFormatOptions {
+  // The output JSON string properties will be sorted.
+  bool sort_properties = 1;
+}
+
 // Configuration to use multiple :ref:`command operators <config_access_log_command_operators>`
 // to generate a new string in either plain text or JSON format.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message SubstitutionFormatString {
   oneof format {
     option (validate.required) = true;
@@ -113,4 +119,7 @@ message SubstitutionFormatString {
   // See the formatters extensions documentation for details.
   // [#extension-category: envoy.formatter]
   repeated TypedExtensionConfig formatters = 6;
+
+  // If json_format is used, the options will be applied to the output JSON string.
+  JsonFormatOptions json_format_options = 7;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/config/endpoint/v3/endpoint.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/endpoint/v3/endpoint.proto
@@ -35,12 +35,11 @@ message ClusterLoadAssignment {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.ClusterLoadAssignment";
 
   // Load balancing policy settings.
-  // [#next-free-field: 6]
+  // [#next-free-field: 7]
   message Policy {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.ClusterLoadAssignment.Policy";
 
-    // [#not-implemented-hide:]
     message DropOverload {
       option (udpa.annotations.versioning).previous_message_type =
           "envoy.api.v2.ClusterLoadAssignment.Policy.DropOverload";
@@ -75,7 +74,9 @@ message ClusterLoadAssignment {
     //    "throttle"_drop = 60%
     //    "lb"_drop = 20%  // 50% of the remaining 'actual' load, which is 40%.
     //    actual_outgoing_load = 20% // remaining after applying all categories.
-    // [#not-implemented-hide:]
+    //
+    // Envoy supports only one element and will NACK if more than one element is present.
+    // Other xDS-capable data planes will not necessarily have this limitation.
     repeated DropOverload drop_overloads = 2;
 
     // Priority levels and localities are considered overprovisioned with this
@@ -99,6 +100,16 @@ message ClusterLoadAssignment {
     // are considered stale and should be marked unhealthy.
     // Defaults to 0 which means endpoints never go stale.
     google.protobuf.Duration endpoint_stale_after = 4 [(validate.rules).duration = {gt {}}];
+
+    // If true, use the :ref:`load balancing weight
+    // <envoy_v3_api_field_config.endpoint.v3.LbEndpoint.load_balancing_weight>` of healthy and unhealthy
+    // hosts to determine the health of the priority level. If false, use the number of healthy and unhealthy hosts
+    // to determine the health of the priority level, or in other words assume each host has a weight of 1 for
+    // this calculation.
+    //
+    // Note: this is not currently implemented for
+    // :ref:`locality weighted load balancing <arch_overview_load_balancing_locality_weighted_lb>`.
+    bool weighted_priority_health = 6;
   }
 
   // Name of the cluster. This will be the :ref:`service_name

--- a/xds/third_party/envoy/src/main/proto/envoy/config/endpoint/v3/endpoint_components.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/endpoint/v3/endpoint_components.proto
@@ -57,6 +57,11 @@ message Endpoint {
     bool disable_active_health_check = 4;
   }
 
+  message AdditionalAddress {
+    // Additional address that is associated with the endpoint.
+    core.v3.Address address = 1;
+  }
+
   // The upstream host address.
   //
   // .. attention::
@@ -82,6 +87,13 @@ message Endpoint {
   // that require a hostname, like
   // :ref:`auto_host_rewrite <envoy_v3_api_field_config.route.v3.RouteAction.auto_host_rewrite>`.
   string hostname = 3;
+
+  // An ordered list of addresses that together with ``address`` comprise the
+  // list of addresses for an endpoint. The address given in the ``address`` is
+  // prepended to this list. It is assumed that the list must already be
+  // sorted by preference order of the addresses. This will only be supported
+  // for STATIC and EDS clusters.
+  repeated AdditionalAddress additional_addresses = 4;
 }
 
 // An Endpoint that Envoy can route traffic to.
@@ -182,9 +194,9 @@ message LocalityLbEndpoints {
   // default to the highest priority (0).
   //
   // Under usual circumstances, Envoy will only select endpoints for the highest
-  // priority (0). In the event all endpoints for a particular priority are
+  // priority (0). In the event that enough endpoints for a particular priority are
   // unavailable/unhealthy, Envoy will fail over to selecting endpoints for the
-  // next highest priority group.
+  // next highest priority group. Read more at :ref:`priority levels <arch_overview_load_balancing_priority_levels>`.
   //
   // Priorities should range from 0 (highest) to N (lowest) without skipping.
   uint32 priority = 5 [(validate.rules).uint32 = {lte: 128}];

--- a/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/listener.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/listener.proto
@@ -53,7 +53,7 @@ message ListenerCollection {
   repeated xds.core.v3.CollectionEntry entries = 1;
 }
 
-// [#next-free-field: 34]
+// [#next-free-field: 35]
 message Listener {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Listener";
 
@@ -199,7 +199,12 @@ message Listener {
   // before a connection is created.
   // UDP Listener filters can be specified when the protocol in the listener socket address in
   // :ref:`protocol <envoy_v3_api_field_config.core.v3.SocketAddress.protocol>` is :ref:`UDP
-  // <envoy_v3_api_enum_value_config.core.v3.SocketAddress.Protocol.UDP>`.
+  // <envoy_v3_api_enum_value_config.core.v3.SocketAddress.Protocol.UDP>` and no
+  // :ref:`quic_options <envoy_v3_api_field_config.listener.v3.UdpListenerConfig.quic_options>` is specified in :ref:`udp_listener_config <envoy_v3_api_field_config.listener.v3.Listener.udp_listener_config>`.
+  // QUIC listener filters can be specified when :ref:`quic_options
+  // <envoy_v3_api_field_config.listener.v3.UdpListenerConfig.quic_options>` is
+  // specified in :ref:`udp_listener_config <envoy_v3_api_field_config.listener.v3.Listener.udp_listener_config>`.
+  // They are processed sequentially right before connection creation. And like TCP Listener filters, they can be used to manipulate the connection metadata and socket. But the difference is that they can't be used to pause connection creation.
   repeated ListenerFilter listener_filters = 9;
 
   // The timeout to wait for all listener filters to complete operation. If the timeout is reached,
@@ -244,7 +249,7 @@ message Listener {
   // Additional socket options that may not be present in Envoy source code or
   // precompiled binaries. The socket options can be updated for a listener when
   // :ref:`enable_reuse_port <envoy_v3_api_field_config.listener.v3.Listener.enable_reuse_port>`
-  // is `true`. Otherwise, if socket options change during a listener update the update will be rejected
+  // is ``true``. Otherwise, if socket options change during a listener update the update will be rejected
   // to make it clear that the options were not updated.
   repeated core.v3.SocketOption socket_options = 13;
 
@@ -338,6 +343,17 @@ message Listener {
   // The maximum length a tcp listener's pending connections queue can grow to. If no value is
   // provided net.core.somaxconn will be used on Linux and 128 otherwise.
   google.protobuf.UInt32Value tcp_backlog_size = 24;
+
+  // The maximum number of connections to accept from the kernel per socket
+  // event. Envoy may decide to close these connections after accepting them
+  // from the kernel e.g. due to load shedding, or other policies.
+  // If there are more than max_connections_to_accept_per_socket_event
+  // connections pending accept, connections over this threshold will be
+  // accepted in later event loop iterations.
+  // If no value is provided Envoy will accept all connections pending accept
+  // from the kernel.
+  google.protobuf.UInt32Value max_connections_to_accept_per_socket_event = 34
+      [(validate.rules).uint32 = {gt: 0}];
 
   // Whether the listener should bind to the port. A listener that doesn't
   // bind can only receive connections redirected from other listeners that set

--- a/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/listener_components.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/listener_components.proto
@@ -45,7 +45,6 @@ message Filter {
     // Configuration source specifier for an extension configuration discovery
     // service. In case of a failure and without the default configuration, the
     // listener closes the connections.
-    // [#not-implemented-hide:]
     core.v3.ExtensionConfigSource config_discovery = 5;
   }
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/config/metrics/v3/stats.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/metrics/v3/stats.proto
@@ -121,8 +121,8 @@ message StatsMatcher {
   // limited by either an exclusion or an inclusion list of :ref:`StringMatcher
   // <envoy_v3_api_msg_type.matcher.v3.StringMatcher>` protos:
   //
-  // * If ``reject_all`` is set to `true`, no stats will be instantiated. If ``reject_all`` is set to
-  //   `false`, all stats will be instantiated.
+  // * If ``reject_all`` is set to ``true``, no stats will be instantiated. If ``reject_all`` is set to
+  //   ``false``, all stats will be instantiated.
   //
   // * If an exclusion list is supplied, any stat name matching *any* of the StringMatchers in the
   //   list will not instantiate.

--- a/xds/third_party/envoy/src/main/proto/envoy/config/rbac/v3/rbac.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/rbac/v3/rbac.proto
@@ -321,10 +321,10 @@ message Principal {
     // A CIDR block that describes the downstream IP.
     // This address will honor proxy protocol, but will not honor XFF.
     //
-    // This field is deprecated; either use :ref:`direct_remote_ip
-    // <envoy_v3_api_field_config.rbac.v3.Principal.direct_remote_ip>` for the same
+    // This field is deprecated; either use :ref:`remote_ip
+    // <envoy_v3_api_field_config.rbac.v3.Principal.remote_ip>` for the same
     // behavior, or use
-    // :ref:`remote_ip <envoy_v3_api_field_config.rbac.v3.Principal.remote_ip>`.
+    // :ref:`direct_remote_ip <envoy_v3_api_field_config.rbac.v3.Principal.direct_remote_ip>`.
     core.v3.CidrRange source_ip = 5
         [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 

--- a/xds/third_party/envoy/src/main/proto/envoy/config/route/v3/route.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/route/v3/route.proto
@@ -23,7 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // * Routing :ref:`architecture overview <arch_overview_http_routing>`
 // * HTTP :ref:`router filter <config_http_filters_router>`
 
-// [#next-free-field: 17]
+// [#next-free-field: 18]
 message RouteConfiguration {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.RouteConfiguration";
 
@@ -82,14 +82,11 @@ message RouteConfiguration {
     (validate.rules).repeated = {items {string {well_known_regex: HTTP_HEADER_NAME strict: false}}}
   ];
 
-  // By default, headers that should be added/removed are evaluated from most to least specific:
-  //
-  // * route level
-  // * virtual host level
-  // * connection manager level
-  //
-  // To allow setting overrides at the route or virtual host level, this order can be reversed
-  // by setting this option to true. Defaults to false.
+  // Headers mutations at all levels are evaluated, if specified. By default, the order is from most
+  // specific (i.e. route entry level) to least specific (i.e. route configuration level). Later header
+  // mutations may override earlier mutations.
+  // This order can be reversed by setting this field to true. In other words, most specific level mutation
+  // is evaluated last.
   //
   bool most_specific_header_mutations_wins = 10;
 
@@ -142,19 +139,22 @@ message RouteConfiguration {
   // For users who want to only match path on the "<path>" portion, this option should be true.
   bool ignore_path_parameters_in_path_matching = 15;
 
-  // The typed_per_filter_config field can be used to provide RouteConfiguration level per filter config.
-  // The key should match the :ref:`filter config name
+  // This field can be used to provide RouteConfiguration level per filter config. The key should match the
+  // :ref:`filter config name
   // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.name>`.
-  // The canonical filter name (e.g., ``envoy.filters.http.buffer`` for the HTTP buffer filter) can also
-  // be used for the backwards compatibility. If there is no entry referred by the filter config name, the
-  // entry referred by the canonical filter name will be provided to the filters as fallback.
-  //
-  // Use of this field is filter specific;
-  // see the :ref:`HTTP filter documentation <config_http_filters>` for if and how it is utilized.
+  // See :ref:`Http filter route specific config <arch_overview_http_filters_per_filter_config>`
+  // for details.
   // [#comment: An entry's value may be wrapped in a
   // :ref:`FilterConfig<envoy_v3_api_msg_config.route.v3.FilterConfig>`
   // message to specify additional options.]
   map<string, google.protobuf.Any> typed_per_filter_config = 16;
+
+  // The metadata field can be used to provide additional information
+  // about the route configuration. It can be used for configuration, stats, and logging.
+  // The metadata should go under the filter namespace that will need it.
+  // For instance, if the metadata is intended for the Router filter,
+  // the filter name should be specified as ``envoy.filters.http.router``.
+  core.v3.Metadata metadata = 17;
 }
 
 message Vhds {

--- a/xds/third_party/envoy/src/main/proto/envoy/config/route/v3/route_components.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/route/v3/route_components.proto
@@ -41,7 +41,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // host header. This allows a single listener to service multiple top level domain path trees. Once
 // a virtual host is selected based on the domain, the routes are processed in order to see which
 // upstream cluster to route to or whether to perform a redirect.
-// [#next-free-field: 24]
+// [#next-free-field: 25]
 message VirtualHost {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.VirtualHost";
 
@@ -153,15 +153,11 @@ message VirtualHost {
   //   to configure the CORS HTTP filter.
   CorsPolicy cors = 8 [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
-  // The per_filter_config field can be used to provide virtual host-specific configurations for filters.
-  // The key should match the :ref:`filter config name
+  // This field can be used to provide virtual host level per filter config. The key should match the
+  // :ref:`filter config name
   // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.name>`.
-  // The canonical filter name (e.g., ``envoy.filters.http.buffer`` for the HTTP buffer filter) can also
-  // be used for the backwards compatibility. If there is no entry referred by the filter config name, the
-  // entry referred by the canonical filter name will be provided to the filters as fallback.
-  //
-  // Use of this field is filter specific;
-  // see the :ref:`HTTP filter documentation <config_http_filters>` for if and how it is utilized.
+  // See :ref:`Http filter route specific config <arch_overview_http_filters_per_filter_config>`
+  // for details.
   // [#comment: An entry's value may be wrapped in a
   // :ref:`FilterConfig<envoy_v3_api_msg_config.route.v3.FilterConfig>`
   // message to specify additional options.]
@@ -219,6 +215,13 @@ message VirtualHost {
   // It takes precedence over the route config mirror policy entirely.
   // That is, policies are not merged, the most specific non-empty one becomes the mirror policies.
   repeated RouteAction.RequestMirrorPolicy request_mirror_policies = 22;
+
+  // The metadata field can be used to provide additional information
+  // about the virtual host. It can be used for configuration, stats, and logging.
+  // The metadata should go under the filter namespace that will need it.
+  // For instance, if the metadata is intended for the Router filter,
+  // the filter name should be specified as ``envoy.filters.http.router``.
+  core.v3.Metadata metadata = 24;
 }
 
 // A filter-defined action type.
@@ -292,15 +295,11 @@ message Route {
   // Decorator for the matched route.
   Decorator decorator = 5;
 
-  // The per_filter_config field can be used to provide route-specific configurations for filters.
-  // The key should match the :ref:`filter config name
+  // This field can be used to provide route specific per filter config. The key should match the
+  // :ref:`filter config name
   // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.name>`.
-  // The canonical filter name (e.g., ``envoy.filters.http.buffer`` for the HTTP buffer filter) can also
-  // be used for the backwards compatibility. If there is no entry referred by the filter config name, the
-  // entry referred by the canonical filter name will be provided to the filters as fallback.
-  //
-  // Use of this field is filter specific;
-  // see the :ref:`HTTP filter documentation <config_http_filters>` for if and how it is utilized.
+  // See :ref:`Http filter route specific config <arch_overview_http_filters_per_filter_config>`
+  // for details.
   // [#comment: An entry's value may be wrapped in a
   // :ref:`FilterConfig<envoy_v3_api_msg_config.route.v3.FilterConfig>`
   // message to specify additional options.]
@@ -451,16 +450,11 @@ message WeightedCluster {
       items {string {well_known_regex: HTTP_HEADER_NAME strict: false}}
     }];
 
-    // The per_filter_config field can be used to provide weighted cluster-specific configurations
-    // for filters.
-    // The key should match the :ref:`filter config name
+    // This field can be used to provide weighted cluster specific per filter config. The key should match the
+    // :ref:`filter config name
     // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.name>`.
-    // The canonical filter name (e.g., ``envoy.filters.http.buffer`` for the HTTP buffer filter) can also
-    // be used for the backwards compatibility. If there is no entry referred by the filter config name, the
-    // entry referred by the canonical filter name will be provided to the filters as fallback.
-    //
-    // Use of this field is filter specific;
-    // see the :ref:`HTTP filter documentation <config_http_filters>` for if and how it is utilized.
+    // See :ref:`Http filter route specific config <arch_overview_http_filters_per_filter_config>`
+    // for details.
     // [#comment: An entry's value may be wrapped in a
     // :ref:`FilterConfig<envoy_v3_api_msg_config.route.v3.FilterConfig>`
     // message to specify additional options.]
@@ -537,10 +531,20 @@ message RouteMatch {
 
     // If specified, the route will match against whether or not a certificate is validated.
     // If not specified, certificate validation status (true or false) will not be considered when route matching.
+    //
+    // .. warning::
+    //
+    //    Client certificate validation is not currently performed upon TLS session resumption. For
+    //    a resumed TLS session the route will match only when ``validated`` is false, regardless of
+    //    whether the client TLS certificate is valid.
+    //
+    //    The only known workaround for this issue is to disable TLS session resumption entirely, by
+    //    setting both :ref:`disable_stateless_session_resumption <envoy_v3_api_field_extensions.transport_sockets.tls.v3.DownstreamTlsContext.disable_stateless_session_resumption>`
+    //    and :ref:`disable_stateful_session_resumption <envoy_v3_api_field_extensions.transport_sockets.tls.v3.DownstreamTlsContext.disable_stateful_session_resumption>` on the DownstreamTlsContext.
     google.protobuf.BoolValue validated = 2;
   }
 
-  // An extensible message for matching CONNECT requests.
+  // An extensible message for matching CONNECT or CONNECT-UDP requests.
   message ConnectMatcher {
   }
 
@@ -573,11 +577,10 @@ message RouteMatch {
     // stripping. This needs more thought.]
     type.matcher.v3.RegexMatcher safe_regex = 10 [(validate.rules).message = {required: true}];
 
-    // If this is used as the matcher, the matcher will only match CONNECT requests.
-    // Note that this will not match HTTP/2 upgrade-style CONNECT requests
-    // (WebSocket and the like) as they are normalized in Envoy as HTTP/1.1 style
-    // upgrades.
-    // This is the only way to match CONNECT requests for HTTP/1.1. For HTTP/2,
+    // If this is used as the matcher, the matcher will only match CONNECT or CONNECT-UDP requests.
+    // Note that this will not match other Extended CONNECT requests (WebSocket and the like) as
+    // they are normalized in Envoy as HTTP/1.1 style upgrades.
+    // This is the only way to match CONNECT requests for HTTP/1.1. For HTTP/2 and HTTP/3,
     // where Extended CONNECT requests may have a path, the path matchers will work if
     // there is a path present.
     // Note that CONNECT support is currently considered alpha in Envoy.
@@ -632,7 +635,8 @@ message RouteMatch {
   // match. The router will check the query string from the ``path`` header
   // against all the specified query parameters. If the number of specified
   // query parameters is nonzero, they all must match the ``path`` header's
-  // query string for a match to occur.
+  // query string for a match to occur. In the event query parameters are
+  // repeated, only the first value for each key will be considered.
   //
   // .. note::
   //
@@ -833,6 +837,18 @@ message RouteAction {
       type.matcher.v3.RegexMatchAndSubstitute regex_rewrite = 2;
     }
 
+    // CookieAttribute defines an API for adding additional attributes for a HTTP cookie.
+    message CookieAttribute {
+      // The name of the cookie attribute.
+      string name = 1
+          [(validate.rules).string =
+               {min_len: 1 max_bytes: 16384 well_known_regex: HTTP_HEADER_NAME strict: false}];
+
+      // The optional value of the cookie attribute.
+      string value = 2 [(validate.rules).string =
+                            {max_bytes: 16384 well_known_regex: HTTP_HEADER_VALUE strict: false}];
+    }
+
     // Envoy supports two types of cookie affinity:
     //
     // 1. Passive. Envoy takes a cookie that's present in the cookies header and
@@ -864,6 +880,9 @@ message RouteAction {
       // The name of the path for the cookie. If no path is specified here, no path
       // will be set for the cookie.
       string path = 3;
+
+      // Additional attributes for the cookie. They will be used when generating a new cookie.
+      repeated CookieAttribute attributes = 4;
     }
 
     message ConnectionProperties {
@@ -880,7 +899,8 @@ message RouteAction {
 
       // The name of the URL query parameter that will be used to obtain the hash
       // key. If the parameter is not present, no hash will be produced. Query
-      // parameter names are case-sensitive.
+      // parameter names are case-sensitive. If query parameters are repeated, only
+      // the first value will be considered.
       string name = 1 [(validate.rules).string = {min_len: 1}];
     }
 
@@ -1135,7 +1155,9 @@ message RouteAction {
     // Indicates that during forwarding, the host header will be swapped with
     // the hostname of the upstream host chosen by the cluster manager. This
     // option is applicable only when the destination cluster for a route is of
-    // type ``strict_dns`` or ``logical_dns``. Setting this to true with other cluster types
+    // type ``strict_dns`` or ``logical_dns``,
+    // or when :ref:`hostname <envoy_v3_api_field_config.endpoint.v3.Endpoint.hostname>`
+    // field is not empty. Setting this to true with other cluster types
     // has no effect. Using this option will append the
     // :ref:`config_http_conn_man_headers_x-forwarded-host` header if
     // :ref:`append_x_forwarded_host <envoy_v3_api_field_config.route.v3.RouteAction.append_x_forwarded_host>`
@@ -1188,7 +1210,8 @@ message RouteAction {
   // :ref:`host_rewrite_header <envoy_v3_api_field_config.route.v3.RouteAction.host_rewrite_header>`, or
   // :ref:`host_rewrite_path_regex <envoy_v3_api_field_config.route.v3.RouteAction.host_rewrite_path_regex>`)
   // causes the original value of the host header, if any, to be appended to the
-  // :ref:`config_http_conn_man_headers_x-forwarded-host` HTTP header.
+  // :ref:`config_http_conn_man_headers_x-forwarded-host` HTTP header if it is different to the last value appended.
+  // This can be disabled by setting the runtime guard ``envoy_reloadable_features_append_xfh_idempotent`` to false.
   bool append_x_forwarded_host = 38;
 
   // Specifies the upstream timeout for the route. If not specified, the default is 15s. This
@@ -2342,6 +2365,7 @@ message QueryParameterMatcher {
 }
 
 // HTTP Internal Redirect :ref:`architecture overview <arch_overview_internal_redirects>`.
+// [#next-free-field: 6]
 message InternalRedirectPolicy {
   // An internal redirect is not handled, unless the number of previous internal redirects that a
   // downstream request has encountered is lower than this value.
@@ -2367,6 +2391,14 @@ message InternalRedirectPolicy {
   // Allow internal redirect to follow a target URI with a different scheme than the value of
   // x-forwarded-proto. The default is false.
   bool allow_cross_scheme_redirect = 4;
+
+  // Specifies a list of headers, by name, to copy from the internal redirect into the subsequent
+  // request. If a header is specified here but not present in the redirect, it will be cleared in
+  // the subsequent request.
+  repeated string response_headers_to_copy = 5 [(validate.rules).repeated = {
+    unique: true
+    items {string {well_known_regex: HTTP_HEADER_NAME strict: false}}
+  }];
 }
 
 // A simple wrapper for an HTTP filter config. This is intended to be used as a wrapper for the
@@ -2375,7 +2407,6 @@ message InternalRedirectPolicy {
 // :ref:`Route.typed_per_filter_config<envoy_v3_api_field_config.route.v3.Route.typed_per_filter_config>`,
 // or :ref:`WeightedCluster.ClusterWeight.typed_per_filter_config<envoy_v3_api_field_config.route.v3.WeightedCluster.ClusterWeight.typed_per_filter_config>`
 // to add additional flags to the filter.
-// [#not-implemented-hide:]
 message FilterConfig {
   // The filter config.
   google.protobuf.Any config = 1;
@@ -2386,6 +2417,8 @@ message FilterConfig {
   bool is_optional = 2;
 
   // If true, the filter is disabled in the route or virtual host and the ``config`` field is ignored.
+  // See :ref:`route based filter chain <arch_overview_http_filters_route_based_filter_chain>`
+  // for more details.
   //
   // .. note::
   //

--- a/xds/third_party/envoy/src/main/proto/envoy/config/route/v3/scoped_route.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/route/v3/scoped_route.proto
@@ -44,7 +44,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //       fragments:
 //         - header_value_extractor:
 //             name: X-Route-Selector
-//             element_separator: ,
+//             element_separator: ","
 //             element:
 //               separator: =
 //               key: vip

--- a/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/dynamic_ot.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/dynamic_ot.proto
@@ -4,6 +4,7 @@ package envoy.config.trace.v3;
 
 import "google/protobuf/struct.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -29,9 +30,14 @@ message DynamicOtConfig {
 
   // Dynamic library implementing the `OpenTracing API
   // <https://github.com/opentracing/opentracing-cpp>`_.
-  string library = 1 [(validate.rules).string = {min_len: 1}];
+  string library = 1 [
+    deprecated = true,
+    (validate.rules).string = {min_len: 1},
+    (envoy.annotations.deprecated_at_minor_version) = "3.0"
+  ];
 
   // The configuration to use when creating a tracer from the given dynamic
   // library.
-  google.protobuf.Struct config = 2;
+  google.protobuf.Struct config = 2
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/opencensus.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/opencensus.proto
@@ -48,29 +48,35 @@ message OpenCensusConfig {
   reserved 7;
 
   // Configures tracing, e.g. the sampler, max number of annotations, etc.
-  opencensus.proto.trace.v1.TraceConfig trace_config = 1;
+  opencensus.proto.trace.v1.TraceConfig trace_config = 1
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // Enables the stdout exporter if set to true. This is intended for debugging
   // purposes.
-  bool stdout_exporter_enabled = 2;
+  bool stdout_exporter_enabled = 2
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // Enables the Stackdriver exporter if set to true. The project_id must also
   // be set.
-  bool stackdriver_exporter_enabled = 3;
+  bool stackdriver_exporter_enabled = 3
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // The Cloud project_id to use for Stackdriver tracing.
-  string stackdriver_project_id = 4;
+  string stackdriver_project_id = 4
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // (optional) By default, the Stackdriver exporter will connect to production
   // Stackdriver. If stackdriver_address is non-empty, it will instead connect
   // to this address, which is in the gRPC format:
   // https://github.com/grpc/grpc/blob/master/doc/naming.md
-  string stackdriver_address = 10;
+  string stackdriver_address = 10
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // (optional) The gRPC server that hosts Stackdriver tracing service. Only
   // Google gRPC is supported. If :ref:`target_uri <envoy_v3_api_field_config.core.v3.GrpcService.GoogleGrpc.target_uri>`
   // is not provided, the default production Stackdriver address will be used.
-  core.v3.GrpcService stackdriver_grpc_service = 13;
+  core.v3.GrpcService stackdriver_grpc_service = 13
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // Enables the Zipkin exporter if set to true. The url and service name must
   // also be set. This is deprecated, prefer to use Envoy's :ref:`native Zipkin
@@ -86,21 +92,26 @@ message OpenCensusConfig {
 
   // Enables the OpenCensus Agent exporter if set to true. The ocagent_address or
   // ocagent_grpc_service must also be set.
-  bool ocagent_exporter_enabled = 11;
+  bool ocagent_exporter_enabled = 11
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // The address of the OpenCensus Agent, if its exporter is enabled, in gRPC
   // format: https://github.com/grpc/grpc/blob/master/doc/naming.md
   // [#comment:TODO: deprecate this field]
-  string ocagent_address = 12;
+  string ocagent_address = 12
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // (optional) The gRPC server hosted by the OpenCensus Agent. Only Google gRPC is supported.
   // This is only used if the ocagent_address is left empty.
-  core.v3.GrpcService ocagent_grpc_service = 14;
+  core.v3.GrpcService ocagent_grpc_service = 14
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // List of incoming trace context headers we will accept. First one found
   // wins.
-  repeated TraceContext incoming_trace_context = 8;
+  repeated TraceContext incoming_trace_context = 8
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // List of outgoing trace context headers we will produce.
-  repeated TraceContext outgoing_trace_context = 9;
+  repeated TraceContext outgoing_trace_context = 9
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/opentelemetry.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/opentelemetry.proto
@@ -2,8 +2,11 @@ syntax = "proto3";
 
 package envoy.config.trace.v3;
 
+import "envoy/config/core/v3/extension.proto";
 import "envoy/config/core/v3/grpc_service.proto";
+import "envoy/config/core/v3/http_service.proto";
 
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 
 option java_package = "io.envoyproxy.envoy.config.trace.v3";
@@ -16,13 +19,42 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // Configuration for the OpenTelemetry tracer.
 //  [#extension: envoy.tracers.opentelemetry]
+// [#next-free-field: 6]
 message OpenTelemetryConfig {
   // The upstream gRPC cluster that will receive OTLP traces.
   // Note that the tracer drops traces if the server does not read data fast enough.
-  // This field can be left empty to disable reporting traces to the collector.
-  core.v3.GrpcService grpc_service = 1;
+  // This field can be left empty to disable reporting traces to the gRPC service.
+  // Only one of ``grpc_service``, ``http_service`` may be used.
+  core.v3.GrpcService grpc_service = 1
+      [(udpa.annotations.field_migrate).oneof_promotion = "otlp_exporter"];
+
+  // The upstream HTTP cluster that will receive OTLP traces.
+  // This field can be left empty to disable reporting traces to the HTTP service.
+  // Only one of ``grpc_service``, ``http_service`` may be used.
+  //
+  // .. note::
+  //
+  //   Note: The ``request_headers_to_add`` property in the OTLP HTTP exporter service
+  //   does not support the :ref:`format specifier <config_access_log_format>` as used for
+  //   :ref:`HTTP access logging <config_access_log>`.
+  //   The values configured are added as HTTP headers on the OTLP export request
+  //   without any formatting applied.
+  core.v3.HttpService http_service = 3
+      [(udpa.annotations.field_migrate).oneof_promotion = "otlp_exporter"];
 
   // The name for the service. This will be populated in the ResourceSpan Resource attributes.
   // If it is not provided, it will default to "unknown_service:envoy".
   string service_name = 2;
+
+  // An ordered list of resource detectors
+  // [#extension-category: envoy.tracers.opentelemetry.resource_detectors]
+  repeated core.v3.TypedExtensionConfig resource_detectors = 4;
+
+  // Specifies the sampler to be used by the OpenTelemetry tracer.
+  // The configured sampler implements the Sampler interface defined by the OpenTelemetry specification.
+  // This field can be left empty. In this case, the default Envoy sampling decision is used.
+  //
+  // See: `OpenTelemetry sampler specification <https://opentelemetry.io/docs/specs/otel/trace/sdk/#sampler>`_
+  // [#extension-category: envoy.tracers.opentelemetry.samplers]
+  core.v3.TypedExtensionConfig sampler = 5;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/zipkin.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/zipkin.proto
@@ -75,7 +75,7 @@ message ZipkinConfig {
   //
   // * The Envoy Proxy is used as gateway or ingress.
   // * The Envoy Proxy is used as sidecar but inbound traffic capturing or outbound traffic capturing is disabled.
-  // * Any case that the `start_child_span of router <envoy_v3_api_field_extensions.filters.http.router.v3.Router.start_child_span>` is set to true.
+  // * Any case that the :ref:`start_child_span of router <envoy_v3_api_field_extensions.filters.http.router.v3.Router.start_child_span>` is set to true.
   //
   // .. attention::
   //

--- a/xds/third_party/envoy/src/main/proto/envoy/data/accesslog/v3/accesslog.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/data/accesslog/v3/accesslog.proto
@@ -1,0 +1,541 @@
+syntax = "proto3";
+
+package envoy.data.accesslog.v3;
+
+import "envoy/config/core/v3/address.proto";
+import "envoy/config/core/v3/base.proto";
+
+import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
+
+import "envoy/annotations/deprecation.proto";
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.data.accesslog.v3";
+option java_outer_classname = "AccesslogProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/data/accesslog/v3;accesslogv3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: gRPC access logs]
+// Envoy access logs describe incoming interaction with Envoy over a fixed
+// period of time, and typically cover a single request/response exchange,
+// (e.g. HTTP), stream (e.g. over HTTP/gRPC), or proxied connection (e.g. TCP).
+// Access logs contain fields defined in protocol-specific protobuf messages.
+//
+// Except where explicitly declared otherwise, all fields describe
+// *downstream* interaction between Envoy and a connected client.
+// Fields describing *upstream* interaction will explicitly include ``upstream``
+// in their name.
+
+enum AccessLogType {
+  NotSet = 0;
+  TcpUpstreamConnected = 1;
+  TcpPeriodic = 2;
+  TcpConnectionEnd = 3;
+  DownstreamStart = 4;
+  DownstreamPeriodic = 5;
+  DownstreamEnd = 6;
+  UpstreamPoolReady = 7;
+  UpstreamPeriodic = 8;
+  UpstreamEnd = 9;
+  DownstreamTunnelSuccessfullyEstablished = 10;
+  UdpTunnelUpstreamConnected = 11;
+  UdpPeriodic = 12;
+  UdpSessionEnd = 13;
+}
+
+message TCPAccessLogEntry {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.data.accesslog.v2.TCPAccessLogEntry";
+
+  // Common properties shared by all Envoy access logs.
+  AccessLogCommon common_properties = 1;
+
+  // Properties of the TCP connection.
+  ConnectionProperties connection_properties = 2;
+}
+
+message HTTPAccessLogEntry {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.data.accesslog.v2.HTTPAccessLogEntry";
+
+  // HTTP version
+  enum HTTPVersion {
+    PROTOCOL_UNSPECIFIED = 0;
+    HTTP10 = 1;
+    HTTP11 = 2;
+    HTTP2 = 3;
+    HTTP3 = 4;
+  }
+
+  // Common properties shared by all Envoy access logs.
+  AccessLogCommon common_properties = 1;
+
+  HTTPVersion protocol_version = 2;
+
+  // Description of the incoming HTTP request.
+  HTTPRequestProperties request = 3;
+
+  // Description of the outgoing HTTP response.
+  HTTPResponseProperties response = 4;
+}
+
+// Defines fields for a connection
+message ConnectionProperties {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.data.accesslog.v2.ConnectionProperties";
+
+  // Number of bytes received from downstream.
+  uint64 received_bytes = 1;
+
+  // Number of bytes sent to downstream.
+  uint64 sent_bytes = 2;
+}
+
+// Defines fields that are shared by all Envoy access logs.
+// [#next-free-field: 34]
+message AccessLogCommon {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.data.accesslog.v2.AccessLogCommon";
+
+  // [#not-implemented-hide:]
+  // This field indicates the rate at which this log entry was sampled.
+  // Valid range is (0.0, 1.0].
+  double sample_rate = 1 [(validate.rules).double = {lte: 1.0 gt: 0.0}];
+
+  // This field is the remote/origin address on which the request from the user was received.
+  // Note: This may not be the physical peer. E.g, if the remote address is inferred from for
+  // example the x-forwarder-for header, proxy protocol, etc.
+  config.core.v3.Address downstream_remote_address = 2;
+
+  // This field is the local/destination address on which the request from the user was received.
+  config.core.v3.Address downstream_local_address = 3;
+
+  // If the connection is secure,S this field will contain TLS properties.
+  TLSProperties tls_properties = 4;
+
+  // The time that Envoy started servicing this request. This is effectively the time that the first
+  // downstream byte is received.
+  google.protobuf.Timestamp start_time = 5;
+
+  // Interval between the first downstream byte received and the last
+  // downstream byte received (i.e. time it takes to receive a request).
+  google.protobuf.Duration time_to_last_rx_byte = 6;
+
+  // Interval between the first downstream byte received and the first upstream byte sent. There may
+  // by considerable delta between ``time_to_last_rx_byte`` and this value due to filters.
+  // Additionally, the same caveats apply as documented in ``time_to_last_downstream_tx_byte`` about
+  // not accounting for kernel socket buffer time, etc.
+  google.protobuf.Duration time_to_first_upstream_tx_byte = 7;
+
+  // Interval between the first downstream byte received and the last upstream byte sent. There may
+  // by considerable delta between ``time_to_last_rx_byte`` and this value due to filters.
+  // Additionally, the same caveats apply as documented in ``time_to_last_downstream_tx_byte`` about
+  // not accounting for kernel socket buffer time, etc.
+  google.protobuf.Duration time_to_last_upstream_tx_byte = 8;
+
+  // Interval between the first downstream byte received and the first upstream
+  // byte received (i.e. time it takes to start receiving a response).
+  google.protobuf.Duration time_to_first_upstream_rx_byte = 9;
+
+  // Interval between the first downstream byte received and the last upstream
+  // byte received (i.e. time it takes to receive a complete response).
+  google.protobuf.Duration time_to_last_upstream_rx_byte = 10;
+
+  // Interval between the first downstream byte received and the first downstream byte sent.
+  // There may be a considerable delta between the ``time_to_first_upstream_rx_byte`` and this field
+  // due to filters. Additionally, the same caveats apply as documented in
+  // ``time_to_last_downstream_tx_byte`` about not accounting for kernel socket buffer time, etc.
+  google.protobuf.Duration time_to_first_downstream_tx_byte = 11;
+
+  // Interval between the first downstream byte received and the last downstream byte sent.
+  // Depending on protocol, buffering, windowing, filters, etc. there may be a considerable delta
+  // between ``time_to_last_upstream_rx_byte`` and this field. Note also that this is an approximate
+  // time. In the current implementation it does not include kernel socket buffer time. In the
+  // current implementation it also does not include send window buffering inside the HTTP/2 codec.
+  // In the future it is likely that work will be done to make this duration more accurate.
+  google.protobuf.Duration time_to_last_downstream_tx_byte = 12;
+
+  // The upstream remote/destination address that handles this exchange. This does not include
+  // retries.
+  config.core.v3.Address upstream_remote_address = 13;
+
+  // The upstream local/origin address that handles this exchange. This does not include retries.
+  config.core.v3.Address upstream_local_address = 14;
+
+  // The upstream cluster that ``upstream_remote_address`` belongs to.
+  string upstream_cluster = 15;
+
+  // Flags indicating occurrences during request/response processing.
+  ResponseFlags response_flags = 16;
+
+  // All metadata encountered during request processing, including endpoint
+  // selection.
+  //
+  // This can be used to associate IDs attached to the various configurations
+  // used to process this request with the access log entry. For example, a
+  // route created from a higher level forwarding rule with some ID can place
+  // that ID in this field and cross reference later. It can also be used to
+  // determine if a canary endpoint was used or not.
+  config.core.v3.Metadata metadata = 17;
+
+  // If upstream connection failed due to transport socket (e.g. TLS handshake), provides the
+  // failure reason from the transport socket. The format of this field depends on the configured
+  // upstream transport socket. Common TLS failures are in
+  // :ref:`TLS trouble shooting <arch_overview_ssl_trouble_shooting>`.
+  string upstream_transport_failure_reason = 18;
+
+  // The name of the route
+  string route_name = 19;
+
+  // This field is the downstream direct remote address on which the request from the user was
+  // received. Note: This is always the physical peer, even if the remote address is inferred from
+  // for example the x-forwarder-for header, proxy protocol, etc.
+  config.core.v3.Address downstream_direct_remote_address = 20;
+
+  // Map of filter state in stream info that have been configured to be logged. If the filter
+  // state serialized to any message other than ``google.protobuf.Any`` it will be packed into
+  // ``google.protobuf.Any``.
+  map<string, google.protobuf.Any> filter_state_objects = 21;
+
+  // A list of custom tags, which annotate logs with additional information.
+  // To configure this value, users should configure
+  // :ref:`custom_tags <envoy_v3_api_field_extensions.access_loggers.grpc.v3.CommonGrpcAccessLogConfig.custom_tags>`.
+  map<string, string> custom_tags = 22;
+
+  // For HTTP: Total duration in milliseconds of the request from the start time to the last byte out.
+  // For TCP: Total duration in milliseconds of the downstream connection.
+  // This is the total duration of the request (i.e., when the request's ActiveStream is destroyed)
+  // and may be longer than ``time_to_last_downstream_tx_byte``.
+  google.protobuf.Duration duration = 23;
+
+  // For HTTP: Number of times the request is attempted upstream. Note that the field is omitted when the request was never attempted upstream.
+  // For TCP: Number of times the connection request is attempted upstream. Note that the field is omitted when the connect request was never attempted upstream.
+  uint32 upstream_request_attempt_count = 24;
+
+  // Connection termination details may provide additional information about why the connection was terminated by Envoy for L4 reasons.
+  string connection_termination_details = 25;
+
+  // Optional unique id of stream (TCP connection, long-live HTTP2 stream, HTTP request) for logging and tracing.
+  // This could be any format string that could be used to identify one stream.
+  string stream_id = 26;
+
+  // If this log entry is final log entry that flushed after the stream completed or
+  // intermediate log entry that flushed periodically during the stream.
+  // There may be multiple intermediate log entries and only one final log entry for each
+  // long-live stream (TCP connection, long-live HTTP2 stream).
+  // And if it is necessary, unique ID or identifier can be added to the log entry
+  // :ref:`stream_id <envoy_v3_api_field_data.accesslog.v3.AccessLogCommon.stream_id>` to
+  // correlate all these intermediate log entries and final log entry.
+  //
+  // .. attention::
+  //
+  //   This field is deprecated in favor of ``access_log_type`` for better indication of the
+  //   type of the access log record.
+  bool intermediate_log_entry = 27
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+
+  // If downstream connection in listener failed due to transport socket (e.g. TLS handshake), provides the
+  // failure reason from the transport socket. The format of this field depends on the configured downstream
+  // transport socket. Common TLS failures are in :ref:`TLS trouble shooting <arch_overview_ssl_trouble_shooting>`.
+  string downstream_transport_failure_reason = 28;
+
+  // For HTTP: Total number of bytes sent to the downstream by the http stream.
+  // For TCP: Total number of bytes sent to the downstream by the tcp proxy.
+  uint64 downstream_wire_bytes_sent = 29;
+
+  // For HTTP: Total number of bytes received from the downstream by the http stream. Envoy over counts sizes of received HTTP/1.1 pipelined requests by adding up bytes of requests in the pipeline to the one currently being processed.
+  // For TCP: Total number of bytes received from the downstream by the tcp proxy.
+  uint64 downstream_wire_bytes_received = 30;
+
+  // For HTTP: Total number of bytes sent to the upstream by the http stream. This value accumulates during upstream retries.
+  // For TCP: Total number of bytes sent to the upstream by the tcp proxy.
+  uint64 upstream_wire_bytes_sent = 31;
+
+  // For HTTP: Total number of bytes received from the upstream by the http stream.
+  // For TCP: Total number of bytes sent to the upstream by the tcp proxy.
+  uint64 upstream_wire_bytes_received = 32;
+
+  // The type of the access log, which indicates when the log was recorded.
+  // See :ref:`ACCESS_LOG_TYPE <config_access_log_format_access_log_type>` for the available values.
+  // In case the access log was recorded by a flow which does not correspond to one of the supported
+  // values, then the default value will be ``NotSet``.
+  // For more information about how access log behaves and when it is being recorded,
+  // please refer to :ref:`access logging <arch_overview_access_logs>`.
+  AccessLogType access_log_type = 33;
+}
+
+// Flags indicating occurrences during request/response processing.
+// [#next-free-field: 28]
+message ResponseFlags {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.data.accesslog.v2.ResponseFlags";
+
+  message Unauthorized {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.data.accesslog.v2.ResponseFlags.Unauthorized";
+
+    // Reasons why the request was unauthorized
+    enum Reason {
+      REASON_UNSPECIFIED = 0;
+
+      // The request was denied by the external authorization service.
+      EXTERNAL_SERVICE = 1;
+    }
+
+    Reason reason = 1;
+  }
+
+  // Indicates local server healthcheck failed.
+  bool failed_local_healthcheck = 1;
+
+  // Indicates there was no healthy upstream.
+  bool no_healthy_upstream = 2;
+
+  // Indicates an there was an upstream request timeout.
+  bool upstream_request_timeout = 3;
+
+  // Indicates local codec level reset was sent on the stream.
+  bool local_reset = 4;
+
+  // Indicates remote codec level reset was received on the stream.
+  bool upstream_remote_reset = 5;
+
+  // Indicates there was a local reset by a connection pool due to an initial connection failure.
+  bool upstream_connection_failure = 6;
+
+  // Indicates the stream was reset due to an upstream connection termination.
+  bool upstream_connection_termination = 7;
+
+  // Indicates the stream was reset because of a resource overflow.
+  bool upstream_overflow = 8;
+
+  // Indicates no route was found for the request.
+  bool no_route_found = 9;
+
+  // Indicates that the request was delayed before proxying.
+  bool delay_injected = 10;
+
+  // Indicates that the request was aborted with an injected error code.
+  bool fault_injected = 11;
+
+  // Indicates that the request was rate-limited locally.
+  bool rate_limited = 12;
+
+  // Indicates if the request was deemed unauthorized and the reason for it.
+  Unauthorized unauthorized_details = 13;
+
+  // Indicates that the request was rejected because there was an error in rate limit service.
+  bool rate_limit_service_error = 14;
+
+  // Indicates the stream was reset due to a downstream connection termination.
+  bool downstream_connection_termination = 15;
+
+  // Indicates that the upstream retry limit was exceeded, resulting in a downstream error.
+  bool upstream_retry_limit_exceeded = 16;
+
+  // Indicates that the stream idle timeout was hit, resulting in a downstream 408.
+  bool stream_idle_timeout = 17;
+
+  // Indicates that the request was rejected because an envoy request header failed strict
+  // validation.
+  bool invalid_envoy_request_headers = 18;
+
+  // Indicates there was an HTTP protocol error on the downstream request.
+  bool downstream_protocol_error = 19;
+
+  // Indicates there was a max stream duration reached on the upstream request.
+  bool upstream_max_stream_duration_reached = 20;
+
+  // Indicates the response was served from a cache filter.
+  bool response_from_cache_filter = 21;
+
+  // Indicates that a filter configuration is not available.
+  bool no_filter_config_found = 22;
+
+  // Indicates that request or connection exceeded the downstream connection duration.
+  bool duration_timeout = 23;
+
+  // Indicates there was an HTTP protocol error in the upstream response.
+  bool upstream_protocol_error = 24;
+
+  // Indicates no cluster was found for the request.
+  bool no_cluster_found = 25;
+
+  // Indicates overload manager terminated the request.
+  bool overload_manager = 26;
+
+  // Indicates a DNS resolution failed.
+  bool dns_resolution_failure = 27;
+}
+
+// Properties of a negotiated TLS connection.
+// [#next-free-field: 8]
+message TLSProperties {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.data.accesslog.v2.TLSProperties";
+
+  enum TLSVersion {
+    VERSION_UNSPECIFIED = 0;
+    TLSv1 = 1;
+    TLSv1_1 = 2;
+    TLSv1_2 = 3;
+    TLSv1_3 = 4;
+  }
+
+  message CertificateProperties {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.data.accesslog.v2.TLSProperties.CertificateProperties";
+
+    message SubjectAltName {
+      option (udpa.annotations.versioning).previous_message_type =
+          "envoy.data.accesslog.v2.TLSProperties.CertificateProperties.SubjectAltName";
+
+      oneof san {
+        string uri = 1;
+
+        // [#not-implemented-hide:]
+        string dns = 2;
+      }
+    }
+
+    // SANs present in the certificate.
+    repeated SubjectAltName subject_alt_name = 1;
+
+    // The subject field of the certificate.
+    string subject = 2;
+
+    // The issuer field of the certificate.
+    string issuer = 3;
+  }
+
+  // Version of TLS that was negotiated.
+  TLSVersion tls_version = 1;
+
+  // TLS cipher suite negotiated during handshake. The value is a
+  // four-digit hex code defined by the IANA TLS Cipher Suite Registry
+  // (e.g. ``009C`` for ``TLS_RSA_WITH_AES_128_GCM_SHA256``).
+  //
+  // Here it is expressed as an integer.
+  google.protobuf.UInt32Value tls_cipher_suite = 2;
+
+  // SNI hostname from handshake.
+  string tls_sni_hostname = 3;
+
+  // Properties of the local certificate used to negotiate TLS.
+  CertificateProperties local_certificate_properties = 4;
+
+  // Properties of the peer certificate used to negotiate TLS.
+  CertificateProperties peer_certificate_properties = 5;
+
+  // The TLS session ID.
+  string tls_session_id = 6;
+
+  // The ``JA3`` fingerprint when ``JA3`` fingerprinting is enabled.
+  string ja3_fingerprint = 7;
+}
+
+// [#next-free-field: 16]
+message HTTPRequestProperties {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.data.accesslog.v2.HTTPRequestProperties";
+
+  // The request method (RFC 7231/2616).
+  config.core.v3.RequestMethod request_method = 1 [(validate.rules).enum = {defined_only: true}];
+
+  // The scheme portion of the incoming request URI.
+  string scheme = 2;
+
+  // HTTP/2 ``:authority`` or HTTP/1.1 ``Host`` header value.
+  string authority = 3;
+
+  // The port of the incoming request URI
+  // (unused currently, as port is composed onto authority).
+  google.protobuf.UInt32Value port = 4;
+
+  // The path portion from the incoming request URI.
+  string path = 5;
+
+  // Value of the ``User-Agent`` request header.
+  string user_agent = 6;
+
+  // Value of the ``Referer`` request header.
+  string referer = 7;
+
+  // Value of the ``X-Forwarded-For`` request header.
+  string forwarded_for = 8;
+
+  // Value of the ``X-Request-Id`` request header
+  //
+  // This header is used by Envoy to uniquely identify a request.
+  // It will be generated for all external requests and internal requests that
+  // do not already have a request ID.
+  string request_id = 9;
+
+  // Value of the ``X-Envoy-Original-Path`` request header.
+  string original_path = 10;
+
+  // Size of the HTTP request headers in bytes.
+  //
+  // This value is captured from the OSI layer 7 perspective, i.e. it does not
+  // include overhead from framing or encoding at other networking layers.
+  uint64 request_headers_bytes = 11;
+
+  // Size of the HTTP request body in bytes.
+  //
+  // This value is captured from the OSI layer 7 perspective, i.e. it does not
+  // include overhead from framing or encoding at other networking layers.
+  uint64 request_body_bytes = 12;
+
+  // Map of additional headers that have been configured to be logged.
+  map<string, string> request_headers = 13;
+
+  // Number of header bytes sent to the upstream by the http stream, including protocol overhead.
+  //
+  // This value accumulates during upstream retries.
+  uint64 upstream_header_bytes_sent = 14;
+
+  // Number of header bytes received from the downstream by the http stream, including protocol overhead.
+  uint64 downstream_header_bytes_received = 15;
+}
+
+// [#next-free-field: 9]
+message HTTPResponseProperties {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.data.accesslog.v2.HTTPResponseProperties";
+
+  // The HTTP response code returned by Envoy.
+  google.protobuf.UInt32Value response_code = 1;
+
+  // Size of the HTTP response headers in bytes.
+  //
+  // This value is captured from the OSI layer 7 perspective, i.e. it does not
+  // include protocol overhead or overhead from framing or encoding at other networking layers.
+  uint64 response_headers_bytes = 2;
+
+  // Size of the HTTP response body in bytes.
+  //
+  // This value is captured from the OSI layer 7 perspective, i.e. it does not
+  // include overhead from framing or encoding at other networking layers.
+  uint64 response_body_bytes = 3;
+
+  // Map of additional headers configured to be logged.
+  map<string, string> response_headers = 4;
+
+  // Map of trailers configured to be logged.
+  map<string, string> response_trailers = 5;
+
+  // The HTTP response code details.
+  string response_code_details = 6;
+
+  // Number of header bytes received from the upstream by the http stream, including protocol overhead.
+  uint64 upstream_header_bytes_received = 7;
+
+  // Number of header bytes sent to the downstream by the http stream, including protocol overhead.
+  uint64 downstream_header_bytes_sent = 8;
+}

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/http/fault/v3/fault.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/http/fault/v3/fault.proto
@@ -6,6 +6,7 @@ import "envoy/config/route/v3/route_components.proto";
 import "envoy/extensions/filters/common/fault/v3/fault.proto";
 import "envoy/type/v3/percent.proto";
 
+import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";
@@ -55,7 +56,7 @@ message FaultAbort {
   type.v3.FractionalPercent percentage = 3;
 }
 
-// [#next-free-field: 16]
+// [#next-free-field: 17]
 message HTTPFault {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.fault.v2.HTTPFault";
@@ -148,4 +149,11 @@ message HTTPFault {
   // If set to false, dynamic stats storage will be allocated for the downstream cluster name.
   // Default value is false.
   bool disable_downstream_cluster_stats = 15;
+
+  // When an abort or delay fault is executed, the metadata struct provided here will be added to the
+  // request's dynamic metadata under the namespace corresponding to the name of the fault filter.
+  // This data can be logged as part of Access Logs using the :ref:`command operator
+  // <config_access_log_command_operators>` %DYNAMIC_METADATA(NAMESPACE)%, where NAMESPACE is the name of
+  // the fault filter.
+  google.protobuf.Struct filter_metadata = 16;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/http/router/v3/router.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/http/router/v3/router.proto
@@ -8,6 +8,7 @@ import "envoy/extensions/filters/network/http_connection_manager/v3/http_connect
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -52,7 +53,13 @@ message Router {
   // useful in scenarios where other filters (auth, ratelimit, etc.) make
   // outbound calls and have child spans rooted at the same ingress
   // parent. Defaults to false.
-  bool start_child_span = 2;
+  //
+  // .. attention::
+  //   This field is deprecated by the
+  //   :ref:`spawn_upstream_span <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.Tracing.spawn_upstream_span>`.
+  //   Please use that ``spawn_upstream_span`` field to control the span creation.
+  bool start_child_span = 2
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // Configuration for HTTP upstream logs emitted by the router. Upstream logs
   // are configured in the same way as access logs, but each log entry represents
@@ -115,16 +122,16 @@ message Router {
   // .. note::
   //   Upstream HTTP filters are currently in alpha.
   //
-  // Optional HTTP filters for the upstream filter chain.
+  // Optional HTTP filters for the upstream HTTP filter chain.
   //
   // These filters will be applied for all requests that pass through the router.
   // They will also be applied to shadowed requests.
-  // Upstream filters cannot change route or cluster.
-  // Upstream filters specified on the cluster will override these filters.
+  // Upstream HTTP filters cannot change route or cluster.
+  // Upstream HTTP filters specified on the cluster will override these filters.
   //
-  // If using upstream filters, please be aware that local errors sent by
-  // upstream filters will not trigger retries, and local errors sent by
-  // upstream filters will count as a final response if hedging is configured.
+  // If using upstream HTTP filters, please be aware that local errors sent by
+  // upstream HTTP filters will not trigger retries, and local errors sent by
+  // upstream HTTP filters will count as a final response if hedging is configured.
   // [#extension-category: envoy.filters.http.upstream]
   repeated network.http_connection_manager.v3.HttpFilter upstream_http_filters = 8;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -130,7 +130,7 @@ message HttpConnectionManager {
     UNESCAPE_AND_FORWARD = 4;
   }
 
-  // [#next-free-field: 10]
+  // [#next-free-field: 11]
   message Tracing {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager.Tracing";
@@ -195,6 +195,27 @@ message HttpConnectionManager {
     //   Such a constraint is inherent to OpenCensus itself. It cannot be overcome without changes
     //   on OpenCensus side.
     config.trace.v3.Tracing.Http provider = 9;
+
+    // Create separate tracing span for each upstream request if true. And if this flag is set to true,
+    // the tracing provider will assume that Envoy will be independent hop in the trace chain and may
+    // set span type to client or server based on this flag.
+    // This will deprecate the
+    // :ref:`start_child_span <envoy_v3_api_field_extensions.filters.http.router.v3.Router.start_child_span>`
+    // in the router.
+    //
+    // Users should set appropriate value based on their tracing provider and actual scenario:
+    //
+    // * If Envoy is used as sidecar and users want to make the sidecar and its application as only one
+    //   hop in the trace chain, this flag should be set to false. And please also make sure the
+    //   :ref:`start_child_span <envoy_v3_api_field_extensions.filters.http.router.v3.Router.start_child_span>`
+    //   in the router is not set to true.
+    // * If Envoy is used as gateway or independent proxy, or users want to make the sidecar and its
+    //   application as different hops in the trace chain, this flag should be set to true.
+    // * If tracing provider that has explicit requirements on span creation (like SkyWalking),
+    //   this flag should be set to true.
+    //
+    // The default value is false for now for backward compatibility.
+    google.protobuf.BoolValue spawn_upstream_span = 10;
   }
 
   message InternalAddressConfig {
@@ -361,7 +382,7 @@ message HttpConnectionManager {
     // on stream close, when the HTTP request is complete. If this field is set, the HCM will flush access
     // logs periodically at the specified interval. This is especially useful in the case of long-lived
     // requests, such as CONNECT and Websockets. Final access logs can be detected via the
-    // `requestComplete()` method of `StreamInfo` in access log filters, or thru the `%DURATION%` substitution
+    // ``requestComplete()`` method of ``StreamInfo`` in access log filters, or through the ``%DURATION%`` substitution
     // string.
     // The interval must be at least 1 millisecond.
     google.protobuf.Duration access_log_flush_interval = 1
@@ -372,6 +393,11 @@ message HttpConnectionManager {
     // This log record, if enabled, does not depend on periodic log records or request completion log.
     // Details related to upstream cluster, such as upstream host, will not be available for this log.
     bool flush_access_log_on_new_request = 2;
+
+    // If true, the HCM will flush an access log when a tunnel is successfully established. For example,
+    // this could be when an upstream has successfully returned 101 Switching Protocols, or when the proxy
+    // has returned 200 to a CONNECT request.
+    bool flush_log_on_tunnel_successfully_established = 3;
   }
 
   reserved 27, 11;
@@ -857,12 +883,12 @@ message HttpConnectionManager {
   // [#extension-category: envoy.http.header_validators]
   config.core.v3.TypedExtensionConfig typed_header_validation_config = 50;
 
-  // Append the `x-forwarded-port` header with the port value client used to connect to Envoy. It
-  // will be ignored if the `x-forwarded-port` header has been set by any trusted proxy in front of Envoy.
+  // Append the ``x-forwarded-port`` header with the port value client used to connect to Envoy. It
+  // will be ignored if the ``x-forwarded-port`` header has been set by any trusted proxy in front of Envoy.
   bool append_x_forwarded_port = 51;
 
-  // Whether the HCM will add ProxyProtocolFilterState to the Connection lifetime filter state. Defaults to `true`.
-  // This should be set to `false` in cases where Envoy's view of the downstream address may not correspond to the
+  // Whether the HCM will add ProxyProtocolFilterState to the Connection lifetime filter state. Defaults to ``true``.
+  // This should be set to ``false`` in cases where Envoy's view of the downstream address may not correspond to the
   // actual client address, for example, if there's another proxy in front of the Envoy.
   google.protobuf.BoolValue add_proxy_protocol_connection_state = 53;
 }
@@ -1028,7 +1054,9 @@ message ScopedRoutes {
         // .. note::
         //
         //   If the header appears multiple times only the first value is used.
-        string name = 1 [(validate.rules).string = {min_len: 1}];
+        string name = 1 [
+          (validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_NAME strict: false}
+        ];
 
         // The element separator (e.g., ';' separates 'a;b;c;d').
         // Default: empty string. This causes the entirety of the header field to be extracted.
@@ -1104,7 +1132,7 @@ message ScopedRds {
   string srds_resources_locator = 2;
 }
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message HttpFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.http_connection_manager.v2.HttpFilter";
@@ -1140,8 +1168,15 @@ message HttpFilter {
   // If true, clients that do not support this filter may ignore the
   // filter but otherwise accept the config.
   // Otherwise, clients that do not support this filter must reject the config.
-  // This is also same with typed per filter config.
   bool is_optional = 6;
+
+  // If true, the filter is disabled by default and must be explicitly enabled by setting
+  // per filter configuration in the route configuration.
+  // See :ref:`route based filter chain <arch_overview_http_filters_route_based_filter_chain>`
+  // for more details.
+  //
+  // Terminal filters (e.g. ``envoy.filters.http.router``) cannot be marked as disabled.
+  bool disabled = 7;
 }
 
 message RequestIDExtension {

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
@@ -6,6 +6,7 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";
+import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.load_balancing_policies.client_side_weighted_round_robin.v3";
 option java_outer_classname = "ClientSideWeightedRoundRobinProto";
@@ -21,14 +22,15 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // This policy differs from the built-in ROUND_ROBIN policy in terms of
 // how the endpoint weights are determined. In the ROUND_ROBIN policy,
 // the endpoint weights are sent by the control plane via EDS. However,
-// in this policy, the endpoint weights are instead determined via
-// qps (queries per second), eps (errors per second), and CPU utilization
-// metrics sent by the endpoint using the Open Request Cost Aggregation (ORCA)
-// protocol. A query counts towards qps when successful, otherwise towards both
-// qps and eps. What counts as an error is up to the endpoint to define.
-// A config parameter error_utilization_penalty controls the penalty to adjust
-// endpoint weights using eps and qps. The weight of a given endpoint is
-// computed as: qps / (cpu_utilization + eps/qps * error_utilization_penalty)
+// in this policy, the endpoint weights are instead determined via qps (queries
+// per second), eps (errors per second), and utilization metrics sent by the
+// endpoint using the Open Request Cost Aggregation (ORCA) protocol. Utilization
+// is determined by using the ORCA application_utilization field, if set, or
+// else falling back to the cpu_utilization field. All queries count toward qps,
+// regardless of result. Only failed queries count toward eps. A config
+// parameter error_utilization_penalty controls the penalty to adjust endpoint
+// weights using eps and qps. The weight of a given endpoint is computed as:
+//   qps / (utilization + eps/qps * error_utilization_penalty)
 //
 // See the :ref:`load balancing architecture overview<arch_overview_load_balancing_types>` for more information.
 //
@@ -58,10 +60,12 @@ message ClientSideWeightedRoundRobin {
   // blackout_period applies. Defaults to 3 minutes.
   google.protobuf.Duration weight_expiration_period = 4;
 
-  // How often endpoint weights are recalculated. Default is 1 second.
+  // How often endpoint weights are recalculated. Values less than 100ms are
+  // capped at 100ms. Default is 1 second.
   google.protobuf.Duration weight_update_period = 5;
 
   // The multiplier used to adjust endpoint weights with the error rate
-  // calculated as eps/qps. Default is 1.0.
-  google.protobuf.FloatValue error_utilization_penalty = 6;
+  // calculated as eps/qps. Configuration is rejected if this value is negative.
+  // Default is 1.0.
+  google.protobuf.FloatValue error_utilization_penalty = 6 [(validate.rules).float = {gte: 0.0}];
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/load_balancing_policies/least_request/v3/least_request.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/load_balancing_policies/least_request/v3/least_request.proto
@@ -22,6 +22,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // This configuration allows the built-in LEAST_REQUEST LB policy to be configured via the LB policy
 // extension point. See the :ref:`load balancing architecture overview
 // <arch_overview_load_balancing_types>` for more information.
+// [#next-free-field: 6]
 message LeastRequest {
   // The number of random healthy hosts from which the host with the fewest active requests will
   // be chosen. Defaults to 2 so that we perform two-choice selection if the field is not set.
@@ -30,18 +31,18 @@ message LeastRequest {
   // The following formula is used to calculate the dynamic weights when hosts have different load
   // balancing weights:
   //
-  // `weight = load_balancing_weight / (active_requests + 1)^active_request_bias`
+  // ``weight = load_balancing_weight / (active_requests + 1)^active_request_bias``
   //
   // The larger the active request bias is, the more aggressively active requests will lower the
   // effective weight when all host weights are not equal.
   //
-  // `active_request_bias` must be greater than or equal to 0.0.
+  // ``active_request_bias`` must be greater than or equal to 0.0.
   //
-  // When `active_request_bias == 0.0` the Least Request Load Balancer doesn't consider the number
+  // When ``active_request_bias == 0.0`` the Least Request Load Balancer doesn't consider the number
   // of active requests at the time it picks a host and behaves like the Round Robin Load
   // Balancer.
   //
-  // When `active_request_bias > 0.0` the Least Request Load Balancer scales the load balancing
+  // When ``active_request_bias > 0.0`` the Least Request Load Balancer scales the load balancing
   // weight by the number of active requests at the time it does a pick.
   //
   // The value is cached for performance reasons and refreshed whenever one of the Load Balancer's
@@ -58,4 +59,10 @@ message LeastRequest {
 
   // Configuration for local zone aware load balancing or locality weighted load balancing.
   common.v3.LocalityLbConfig locality_lb_config = 4;
+
+  // [#not-implemented-hide:]
+  // Configuration for performing full scan on the list of hosts.
+  // If this configuration is set, when selecting the host a full scan on the list hosts will be
+  // used to select the one with least requests instead of using random choices.
+  google.protobuf.BoolValue enable_full_scan = 5;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/load_balancing_policies/ring_hash/v3/ring_hash.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/load_balancing_policies/ring_hash/v3/ring_hash.proto
@@ -46,17 +46,18 @@ message RingHash {
   // provided host) the better the request distribution will reflect the desired weights. Defaults
   // to 1024 entries, and limited to 8M entries. See also
   // :ref:`maximum_ring_size<envoy_v3_api_field_config.cluster.v3.Cluster.RingHashLbConfig.maximum_ring_size>`.
-  google.protobuf.UInt64Value minimum_ring_size = 2 [(validate.rules).uint64 = {lte: 8388608}];
+  google.protobuf.UInt64Value minimum_ring_size = 2
+      [(validate.rules).uint64 = {lte: 8388608 gte: 1}];
 
   // Maximum hash ring size. Defaults to 8M entries, and limited to 8M entries, but can be lowered
   // to further constrain resource use. See also
   // :ref:`minimum_ring_size<envoy_v3_api_field_config.cluster.v3.Cluster.RingHashLbConfig.minimum_ring_size>`.
   google.protobuf.UInt64Value maximum_ring_size = 3 [(validate.rules).uint64 = {lte: 8388608}];
 
-  // If set to `true`, the cluster will use hostname instead of the resolved
+  // If set to ``true``, the cluster will use hostname instead of the resolved
   // address as the key to consistently hash to an upstream host. Only valid for StrictDNS clusters with hostnames which resolve to a single IP address.
   //
-  // ..note::
+  // .. note::
   //   This is deprecated and please use :ref:`consistent_hashing_lb_config
   //   <envoy_v3_api_field_extensions.load_balancing_policies.ring_hash.v3.RingHash.consistent_hashing_lb_config>` instead.
   bool use_hostname_for_hashing = 4
@@ -68,7 +69,7 @@ message RingHash {
   // Minimum is 100.
   //
   // This is implemented based on the method described in the paper https://arxiv.org/abs/1608.01350. For the specified
-  // `hash_balance_factor`, requests to any upstream host are capped at `hash_balance_factor/100` times the average number of requests
+  // ``hash_balance_factor``, requests to any upstream host are capped at ``hash_balance_factor/100`` times the average number of requests
   // across the cluster. When a request arrives for an upstream host that is currently serving at its max capacity, linear probing
   // is used to identify an eligible host. Further, the linear probe is implemented using a random jump in hosts ring/table to identify
   // the eligible host (this technique is as described in the paper https://arxiv.org/abs/1908.08762 - the random jump avoids the
@@ -76,10 +77,10 @@ message RingHash {
   //
   // If weights are specified on the hosts, they are respected.
   //
-  // This is an O(N) algorithm, unlike other load balancers. Using a lower `hash_balance_factor` results in more hosts
+  // This is an O(N) algorithm, unlike other load balancers. Using a lower ``hash_balance_factor`` results in more hosts
   // being probed, so use a higher value if you require better performance.
   //
-  // ..note::
+  // .. note::
   //   This is deprecated and please use :ref:`consistent_hashing_lb_config
   //   <envoy_v3_api_field_extensions.load_balancing_policies.ring_hash.v3.RingHash.consistent_hashing_lb_config>` instead.
   google.protobuf.UInt32Value hash_balance_factor = 5 [

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -178,6 +178,11 @@ message PrivateKeyProvider {
   oneof config_type {
     google.protobuf.Any typed_config = 3 [(udpa.annotations.sensitive) = true];
   }
+
+  // If the private key provider isn't available (eg. the required hardware capability doesn't existed),
+  // Envoy will fallback to the BoringSSL default implementation when the ``fallback`` is true.
+  // The default value is ``false``.
+  bool fallback = 4;
 }
 
 // [#next-free-field: 9]
@@ -505,6 +510,11 @@ message CertificateValidationContext {
   // from that chain. This default behavior can be altered by setting
   // :ref:`only_verify_leaf_cert_crl <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.only_verify_leaf_cert_crl>` to
   // true.
+  //
+  // If ``crl`` is a filesystem path, a watch will be added to the parent
+  // directory for any file moves to support rotation. This currently only
+  // applies to dynamic secrets, when the ``CertificateValidationContext`` is
+  // delivered via SDS.
   config.core.v3.DataSource crl = 7;
 
   // If specified, Envoy will not reject expired certificates.
@@ -526,12 +536,10 @@ message CertificateValidationContext {
   bool only_verify_leaf_cert_crl = 14;
 
   // Defines maximum depth of a certificate chain accepted in verification, the default limit is 100, though this can be system-dependent.
-  // This number does not include the leaf, so a depth of 1 allows the leaf and one CA certificate. If a trusted issuer appears in the chain,
-  // but in a depth larger than configured, the certificate validation will fail.
-  // See `BoringSSL SSL_CTX_set_verify_depth <https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_CTX_set_verify_depth>`
-  // If you use OpenSSL, its behavior is different from BoringSSL, this will define a limit on the number of certificates between the end-entity and trust-anchor certificates.
-  // Neither the end-entity nor the trust-anchor certificates count against depth.
-  // See `OpenSSL SSL set_verify_depth <https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_verify_depth.html>`_.
+  // This number does not include the leaf but includes the trust anchor, so a depth of 1 allows the leaf and one CA certificate. If a trusted issuer
+  // appears in the chain, but in a depth larger than configured, the certificate validation will fail.
+  // This matches the semantics of ``SSL_CTX_set_verify_depth`` in OpenSSL 1.0.x and older versions of BoringSSL. It differs from ``SSL_CTX_set_verify_depth``
+  // in OpenSSL 1.1.x and newer versions of BoringSSL in that the trust anchor is included.
   // Trusted issues are specified by setting :ref:`trusted_ca <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`
   google.protobuf.UInt32Value max_verify_depth = 16 [(validate.rules).uint32 = {lte: 100}];
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -25,6 +25,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#extension: envoy.transport_sockets.tls]
 // The TLS contexts below provide the transport socket configuration for upstream/downstream TLS.
 
+// [#next-free-field: 6]
 message UpstreamTlsContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.auth.UpstreamTlsContext";
@@ -53,9 +54,16 @@ message UpstreamTlsContext {
   //
   // Defaults to 1, setting this to 0 disables session resumption.
   google.protobuf.UInt32Value max_session_keys = 4;
+
+  // This field is used to control the enforcement, whereby the handshake will fail if the keyUsage extension
+  // is present and incompatible with the TLS usage. Currently, the default value is false (i.e., enforcement off)
+  // but it is expected to be changed to true by default in a future release.
+  // ``ssl.was_key_usage_invalid`` in :ref:`listener metrics <config_listener_stats>` will be set for certificate
+  // configurations that would fail if this option were set to true.
+  google.protobuf.BoolValue enforce_rsa_key_usage = 5;
 }
 
-// [#next-free-field: 10]
+// [#next-free-field: 11]
 message DownstreamTlsContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.auth.DownstreamTlsContext";
@@ -110,6 +118,10 @@ message DownstreamTlsContext {
     // implication that sessions cannot be resumed across hot restarts or on different hosts.
     bool disable_stateless_session_resumption = 7;
   }
+
+  // If set to true, the TLS server will not maintain a session cache of TLS sessions. (This is
+  // relevant only for TLSv1.2 and earlier.)
+  bool disable_stateful_session_resumption = 10;
 
   // If specified, ``session_timeout`` will change the maximum lifetime (in seconds) of the TLS session.
   // Currently this value is used as a hint for the `TLS session ticket lifetime (for TLSv1.2) <https://tools.ietf.org/html/rfc5077#section-5.6>`_.

--- a/xds/third_party/envoy/src/main/proto/envoy/service/status/v3/csds.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/service/status/v3/csds.proto
@@ -85,6 +85,11 @@ message ClientStatusRequest {
 
   // The node making the csds request.
   config.core.v3.Node node = 2;
+
+  // If true, the server will not include the resource contents in the response
+  // (i.e., the generic_xds_configs.xds_config field will not be populated).
+  // [#not-implemented-hide:]
+  bool exclude_resource_contents = 3;
 }
 
 // Detailed config (per xDS) with status.
@@ -180,6 +185,11 @@ message ClientConfig {
   // Represents generic xDS config and the exact config structure depends on
   // the type URL (like Cluster if it is CDS)
   repeated GenericXdsConfig generic_xds_configs = 3;
+
+  // For xDS clients, the scope in which the data is used.
+  // For example, gRPC indicates the data plane target or that the data is
+  // associated with gRPC server(s).
+  string client_scope = 4;
 }
 
 message ClientStatusResponse {

--- a/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/regex.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/regex.proto
@@ -57,11 +57,8 @@ message RegexMatcher {
 
   oneof engine_type {
     // Google's RE2 regex engine.
-    GoogleRE2 google_re2 = 1 [
-      deprecated = true,
-      (validate.rules).message = {required: true},
-      (envoy.annotations.deprecated_at_minor_version) = "3.0"
-    ];
+    GoogleRE2 google_re2 = 1
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
   }
 
   // The regex match string. The string must be supported by the configured engine. The regex is matched

--- a/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/value.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/value.proto
@@ -19,7 +19,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // Specifies the way to match a ProtobufWkt::Value. Primitive values and ListValue are supported.
 // StructValue is not supported and is always not matched.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message ValueMatcher {
   option (udpa.annotations.versioning).previous_message_type = "envoy.type.matcher.ValueMatcher";
 
@@ -56,6 +56,9 @@ message ValueMatcher {
     // If specified, a match occurs if and only if the target value is a list value and
     // is matched to this field.
     ListMatcher list_match = 6;
+
+    // If specified, a match occurs if and only if any of the alternatives in the match accept the value.
+    OrMatcher or_match = 7;
   }
 }
 
@@ -69,4 +72,9 @@ message ListMatcher {
     // If specified, at least one of the values in the list must match the value specified.
     ValueMatcher one_of = 1;
   }
+}
+
+// Specifies a list of alternatives for the match.
+message OrMatcher {
+  repeated ValueMatcher value_matchers = 1 [(validate.rules).repeated = {min_items: 2}];
 }


### PR DESCRIPTION
`envoyproxy/envoy`: Sync protos to the latest imported version https://github.com/envoyproxy/envoy/commit/147e6b9523d8d2ae0d9d2205254d6e633644c6fe (commit 2024-01-24, cl/604403196). 

Should be a noop, just a routine xDS proto update to make upcoming RLQS-related imports simpler.