### PR TITLE
xds: Googleapis proto sync to 2023-01-10

### DIFF
--- a/xds/third_party/googleapis/import.sh
+++ b/xds/third_party/googleapis/import.sh
@@ -16,7 +16,7 @@
 # Update VERSION then execute this script
 
 set -e
-VERSION=ca1372c6d7bcb199638ebfdb40d2b2660bab7b88
+VERSION=114a745b2841a044e98cdbb19358ed29fcf4a5f1
 DOWNLOAD_URL="https://github.com/googleapis/googleapis/archive/${VERSION}.tar.gz"
 DOWNLOAD_BASE_DIR="googleapis-${VERSION}"
 SOURCE_PROTO_BASE_DIR="${DOWNLOAD_BASE_DIR}"

--- a/xds/third_party/googleapis/src/main/proto/google/api/expr/v1alpha1/checked.proto
+++ b/xds/third_party/googleapis/src/main/proto/google/api/expr/v1alpha1/checked.proto
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -57,6 +57,15 @@ message CheckedExpr {
   // The source info derived from input that generated the parsed `expr` and
   // any optimizations made during the type-checking pass.
   SourceInfo source_info = 5;
+
+  // The expr version indicates the major / minor version number of the `expr`
+  // representation.
+  //
+  // The most common reason for a version change will be to indicate to the CEL
+  // runtimes that transformations have been performed on the expr during static
+  // analysis. In some cases, this will save the runtime the work of applying
+  // the same or similar transformations prior to evaluation.
+  string expr_version = 6;
 
   // The checked expression. Semantically equivalent to the parsed `expr`, but
   // may have structural differences.
@@ -228,15 +237,14 @@ message Decl {
   }
 
   // Function declaration specifies one or more overloads which indicate the
-  // function's parameter types and return type, and may optionally specify a
-  // function definition in terms of CEL expressions.
+  // function's parameter types and return type.
   //
   // Functions have no observable side-effects (there may be side-effects like
   // logging which are not observable from CEL).
   message FunctionDecl {
     // An overload indicates a function's parameter types and return type, and
-    // may optionally include a function body described in terms of [Expr][google.api.expr.v1alpha1.Expr]
-    // values.
+    // may optionally include a function body described in terms of
+    // [Expr][google.api.expr.v1alpha1.Expr] values.
     //
     // Functions overloads are declared in either a function or method
     // call-style. For methods, the `params[0]` is the expected type of the
@@ -248,11 +256,13 @@ message Decl {
       // Required. Globally unique overload name of the function which reflects
       // the function name and argument types.
       //
-      // This will be used by a [Reference][google.api.expr.v1alpha1.Reference] to indicate the `overload_id` that
-      // was resolved for the function `name`.
+      // This will be used by a [Reference][google.api.expr.v1alpha1.Reference]
+      // to indicate the `overload_id` that was resolved for the function
+      // `name`.
       string overload_id = 1;
 
-      // List of function parameter [Type][google.api.expr.v1alpha1.Type] values.
+      // List of function parameter [Type][google.api.expr.v1alpha1.Type]
+      // values.
       //
       // Param types are disjoint after generic type parameters have been
       // replaced with the type `DYN`. Since the `DYN` type is compatible with
@@ -275,7 +285,7 @@ message Decl {
       Type result_type = 4;
 
       // Whether the function is to be used in a method call-style `x.f(...)`
-      // of a function call-style `f(x, ...)`.
+      // or a function call-style `f(x, ...)`.
       //
       // For methods, the first parameter declaration, `params[0]` is the
       // expected type of the target receiver.
@@ -294,9 +304,11 @@ message Decl {
   // Declarations are organized in containers and this represents the full path
   // to the declaration in its container, as in `google.api.expr.Decl`.
   //
-  // Declarations used as [FunctionDecl.Overload][google.api.expr.v1alpha1.Decl.FunctionDecl.Overload] parameters may or may not
-  // have a name depending on whether the overload is function declaration or a
-  // function definition containing a result [Expr][google.api.expr.v1alpha1.Expr].
+  // Declarations used as
+  // [FunctionDecl.Overload][google.api.expr.v1alpha1.Decl.FunctionDecl.Overload]
+  // parameters may or may not have a name depending on whether the overload is
+  // function declaration or a function definition containing a result
+  // [Expr][google.api.expr.v1alpha1.Expr].
   string name = 1;
 
   // Required. The declaration kind.
@@ -321,7 +333,8 @@ message Reference {
   // presented candidates must happen at runtime because of dynamic types. The
   // type checker attempts to narrow down this list as much as possible.
   //
-  // Empty if this is not a reference to a [Decl.FunctionDecl][google.api.expr.v1alpha1.Decl.FunctionDecl].
+  // Empty if this is not a reference to a
+  // [Decl.FunctionDecl][google.api.expr.v1alpha1.Decl.FunctionDecl].
   repeated string overload_id = 3;
 
   // For references to constants, this may contain the value of the

--- a/xds/third_party/googleapis/src/main/proto/google/api/expr/v1alpha1/syntax.proto
+++ b/xds/third_party/googleapis/src/main/proto/google/api/expr/v1alpha1/syntax.proto
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -99,11 +99,19 @@ message Expr {
 
   // A list creation expression.
   //
-  // Lists may either be homogenous, e.g. `[1, 2, 3]`, or heterogenous, e.g.
+  // Lists may either be homogenous, e.g. `[1, 2, 3]`, or heterogeneous, e.g.
   // `dyn([1, 'hello', 2.0])`
   message CreateList {
     // The elements part of the list.
     repeated Expr elements = 1;
+
+    // The indices within the elements list which are marked as optional
+    // elements.
+    //
+    // When an optional-typed value is present, the value it contains
+    // is included in the list. If the optional-typed value is absent, the list
+    // element is omitted from the CreateList result.
+    repeated int32 optional_indices = 2;
   }
 
   // A map or message creation expression.
@@ -129,7 +137,14 @@ message Expr {
       }
 
       // Required. The value assigned to the key.
+      //
+      // If the optional_entry field is true, the expression must resolve to an
+      // optional-typed value. If the optional value is present, the key will be
+      // set; however, if the optional value is absent, the key will be unset.
       Expr value = 4;
+
+      // Whether the key-value pair is optional.
+      bool optional_entry = 5;
     }
 
     // The type name of the message to be created, empty when creating map
@@ -287,15 +302,16 @@ message SourceInfo {
   // `acme/app/AnvilPolicy.cel`.
   string location = 2;
 
-  // Monotonically increasing list of character offsets where newlines appear.
+  // Monotonically increasing list of code point offsets where newlines
+  // `\n` appear.
   //
   // The line number of a given position is the index `i` where for a given
   // `id` the `line_offsets[i] < id_positions[id] < line_offsets[i+1]`. The
   // column may be derivd from `id_positions[id] - line_offsets[i]`.
   repeated int32 line_offsets = 3;
 
-  // A map from the parse node id (e.g. `Expr.id`) to the character offset
-  // within source.
+  // A map from the parse node id (e.g. `Expr.id`) to the code point offset
+  // within the source.
   map<int64, int32> positions = 4;
 
   // A map from the parse node id where a macro replacement was made to the
@@ -314,7 +330,7 @@ message SourcePosition {
   // The soucre location name (e.g. file name).
   string location = 1;
 
-  // The character offset.
+  // The UTF-8 code unit offset.
   int32 offset = 2;
 
   // The 1-based index of the starting line in the source text


### PR DESCRIPTION
Sync googleapis protos to googleapis/googleapis@114a745b2841a044e98cdbb19358ed29fcf4a5f1 for consistency with Envoy and cncf/xds.

The same version is used in [envoy](https://github.com/envoyproxy/envoy/blob/62e7c593748b2ceb3b80a3398e0a937a92edf95d/api/bazel/repository_locations.bzl#L69) and [cncf/xds](https://github.com/cncf/xds/blob/0fa0005c9caaaae56e586ec2c6c26ef93704d29f/bazel/repository_locations.bzl#L23) since Jan 2023.
Function-wise, this is a noop.