### PR TITLE
Revert "Fix retries that timeout hanging forever."

### DIFF
--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -195,10 +195,7 @@ abstract class RetriableStream<ReqT> implements ClientStream {
             }
           }
           if (retryFuture != null) {
-            boolean cancelled = retryFuture.cancel(false);
-            if (cancelled) {
-              inFlightSubStreams.decrementAndGet();
-            }
+            retryFuture.cancel(false);
           }
           if (hedgingFuture != null) {
             hedgingFuture.cancel(false);


### PR DESCRIPTION
Reverts grpc/grpc-java#10855

Failure of //javatests/com/google/geo/automotive/testing/drive/sim/controller/fixtures:DriveSimControllerRuleTest is blocking copybara imports to g3.