### PR TITLE
kokoro: Avoid using Kokoro's env_vars setting

### DIFF
--- a/buildscripts/kokoro/macos.cfg
+++ b/buildscripts/kokoro/macos.cfg
@@ -4,14 +4,6 @@
 build_file: "grpc-java/buildscripts/kokoro/macos.sh"
 timeout_mins: 45
 
-# We had problems with random tests timing out because it took seconds to do
-# trivial (ns) operations. The Mac machines have 2 cores with 4 logical
-# threads, so Gradle should be using 4 workers by default.
-env_vars {
-  key: "GRADLE_FLAGS"
-  value: "--max-workers=2"
-}
-
 # We always build mvn artifacts.
 action {
   define_artifacts {

--- a/buildscripts/kokoro/macos.sh
+++ b/buildscripts/kokoro/macos.sh
@@ -7,6 +7,11 @@ fi
 
 readonly GRPC_JAVA_DIR="$(cd "$(dirname "$0")"/../.. && pwd)"
 
+# We had problems with random tests timing out because it took seconds to do
+# trivial (ns) operations. The Kokoro Mac machines have 2 cores with 4 logical
+# threads, so Gradle should be using 4 workers by default.
+export GRADLE_FLAGS="${GRADLE_FLAGS:-} --max-workers=2"
+
 . "$GRPC_JAVA_DIR"/buildscripts/kokoro/kokoro.sh
 trap spongify_logs EXIT
 


### PR DESCRIPTION
It makes it hard to run ephemeral jobs, and we don't actually need it here because we aren't changing the setting with manual runs.