### PR TITLE
auth: Add support for Retryable interface

### DIFF
--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.auth.Credentials;
 import com.google.auth.RequestMetadataCallback;
+import com.google.auth.Retryable;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.BaseEncoding;
 import io.grpc.InternalMayRequireSpecificExecutor;
@@ -28,7 +29,6 @@ import io.grpc.MethodDescriptor;
 import io.grpc.SecurityLevel;
 import io.grpc.Status;
 import io.grpc.StatusException;
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URI;
@@ -143,8 +143,8 @@ final class GoogleAuthLibraryCallCredentials extends io.grpc.CallCredentials
 
       @Override
       public void onFailure(Throwable e) {
-        if (e instanceof IOException) {
-          // Since it's an I/O failure, let the call be retried with UNAVAILABLE.
+        if (e instanceof Retryable && ((Retryable) e).isRetryable()) {
+          // Let the call be retried with UNAVAILABLE.
           applier.fail(Status.UNAVAILABLE
               .withDescription("Credentials failed to obtain metadata")
               .withCause(e));

--- a/auth/src/test/java/io/grpc/auth/GoogleAuthLibraryCallCredentialsTest.java
+++ b/auth/src/test/java/io/grpc/auth/GoogleAuthLibraryCallCredentialsTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.auth.Credentials;
 import com.google.auth.RequestMetadataCallback;
+import com.google.auth.Retryable;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
@@ -191,8 +192,9 @@ public class GoogleAuthLibraryCallCredentialsTest {
   }
 
   @Test
-  public void credentialsFailsWithIoException() throws Exception {
-    Exception exception = new IOException("Broken");
+  public void credentialsFailsWithRetryableRetryableException() throws Exception {
+    boolean retryable = true;
+    Exception exception = new RetryableException(retryable);
     when(credentials.getRequestMetadata(eq(expectedUri))).thenThrow(exception);
 
     GoogleAuthLibraryCallCredentials callCredentials =
@@ -203,6 +205,23 @@ public class GoogleAuthLibraryCallCredentialsTest {
     verify(applier).fail(statusCaptor.capture());
     Status status = statusCaptor.getValue();
     assertEquals(Status.Code.UNAVAILABLE, status.getCode());
+    assertEquals(exception, status.getCause());
+  }
+
+  @Test
+  public void credentialsFailsWithUnretryableRetryableException() throws Exception {
+    boolean retryable = false;
+    Exception exception = new RetryableException(retryable);
+    when(credentials.getRequestMetadata(eq(expectedUri))).thenThrow(exception);
+
+    GoogleAuthLibraryCallCredentials callCredentials =
+        new GoogleAuthLibraryCallCredentials(credentials);
+    callCredentials.applyRequestMetadata(new RequestInfoImpl(), executor, applier);
+
+    verify(credentials).getRequestMetadata(eq(expectedUri));
+    verify(applier).fail(statusCaptor.capture());
+    Status status = statusCaptor.getValue();
+    assertEquals(Status.Code.UNAUTHENTICATED, status.getCode());
     assertEquals(exception, status.getCause());
   }
 
@@ -456,6 +475,23 @@ public class GoogleAuthLibraryCallCredentialsTest {
     @Override
     public Attributes getTransportAttrs() {
       return Attributes.EMPTY;
+    }
+  }
+
+  private static class RetryableException extends IOException implements Retryable {
+    private final boolean retryable;
+
+    public RetryableException(boolean retryable) {
+      super("Broken");
+      this.retryable = retryable;
+    }
+
+    @Override public boolean isRetryable() {
+      return retryable;
+    }
+
+    @Override public int getRetryCount() {
+      return 0;
     }
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,5 @@
 [versions]
-# Compatibility problem with internal version getting onto 1.5.3.
-# https://github.com/grpc/grpc-java/pull/9118
-googleauth = "1.4.0"
+googleauth = "1.22.0"
 netty = '4.1.100.Final'
 # Keep the following references of tcnative version in sync whenever it's updated:
 #   SECURITY.md

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -12,8 +12,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "com.google.android:annotations:4.1.1.4",
     "com.google.api.grpc:proto-google-common-protos:2.29.0",
-    "com.google.auth:google-auth-library-credentials:1.4.0",
-    "com.google.auth:google-auth-library-oauth2-http:1.4.0",
+    "com.google.auth:google-auth-library-credentials:1.22.0",
+    "com.google.auth:google-auth-library-oauth2-http:1.22.0",
     "com.google.auto.value:auto-value-annotations:1.10.4",
     "com.google.auto.value:auto-value:1.10.4",
     "com.google.code.findbugs:jsr305:3.0.2",


### PR DESCRIPTION
Retryable was added in google-auth-library 1.5.3 to make clear the situations that deserve a retry of the RPC. Upgrading to that caused problems because of transitive dependency issues syncing into Google so it was reverted in 369f87be. google-auth-library 1.11.0 changed the approach to avoid the transitive dependency updates. cl/601545581 upgraded to 1.22.0 inside Google. Bump to that version and swap away from the imprecise IOException heuristic. go/auth-correct-retry

Fixes #6808

CC @TimurSadykov