### PR TITLE
interop-testing: Avoid Netty-specific APIs to creating channels

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/Http2Client.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/Http2Client.java
@@ -23,18 +23,16 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
+import io.grpc.ChannelCredentials;
+import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.integration.Messages.Payload;
 import io.grpc.testing.integration.Messages.SimpleRequest;
 import io.grpc.testing.integration.Messages.SimpleResponse;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -353,15 +351,8 @@ public final class Http2Client {
   }
 
   private ManagedChannel createChannel() {
-    InetAddress address;
-    try {
-      address = InetAddress.getByName(serverHost);
-    } catch (UnknownHostException ex) {
-      throw new RuntimeException(ex);
-    }
-    return NettyChannelBuilder.forAddress(new InetSocketAddress(address, serverPort))
-        .negotiationType(NegotiationType.PLAINTEXT)
-        .build();
+    ChannelCredentials creds = InsecureChannelCredentials.create();
+    return NettyChannelBuilder.forAddress(serverHost, serverPort, creds).build();
   }
 
   private static String validTestCasesHelpText() {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
@@ -20,10 +20,10 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertTrue;
 
 import io.grpc.ChannelCredentials;
+import io.grpc.Grpc;
 import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.alts.ComputeEngineChannelCredentials;
-import io.grpc.netty.NettyChannelBuilder;
 import java.util.ArrayList;
 import java.util.logging.Logger;
 
@@ -289,7 +289,7 @@ public final class XdsFederationTestClient {
         default:
           throw new IllegalArgumentException("Unknown custom credentials: " + credentialsType);
       }
-      return NettyChannelBuilder.forTarget(serverUri, channelCredentials)
+      return Grpc.newChannelBuilder(serverUri, channelCredentials)
           .keepAliveTime(3600, SECONDS)
           .keepAliveTimeout(20, SECONDS);
     }


### PR DESCRIPTION
We prefer to test using the stable APIs, as they are what our users should be using. Http2Client continues using NettyChannelBuilder because it is intended to test grpc-netty.