### PR TITLE
servlet: introduce ServletServerBuilder.buildServlet()

### DIFF
--- a/servlet/src/main/java/io/grpc/servlet/GrpcServlet.java
+++ b/servlet/src/main/java/io/grpc/servlet/GrpcServlet.java
@@ -16,7 +16,6 @@
 
 package io.grpc.servlet;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.grpc.BindableService;
 import io.grpc.ExperimentalApi;
 import java.io.IOException;
@@ -40,7 +39,6 @@ public class GrpcServlet extends HttpServlet {
 
   private final ServletAdapter servletAdapter;
 
-  @VisibleForTesting
   GrpcServlet(ServletAdapter servletAdapter) {
     this.servletAdapter = servletAdapter;
   }

--- a/servlet/src/main/java/io/grpc/servlet/ServletServerBuilder.java
+++ b/servlet/src/main/java/io/grpc/servlet/ServletServerBuilder.java
@@ -101,6 +101,13 @@ public final class ServletServerBuilder extends ForwardingServerBuilder<ServletS
     return new ServletAdapter(buildAndStart(), streamTracerFactories, maxInboundMessageSize);
   }
 
+  /**
+   * Creates a {@link GrpcServlet}.
+   */
+  public GrpcServlet buildServlet() {
+    return new GrpcServlet(buildServletAdapter());
+  }
+
   private ServerTransportListener buildAndStart() {
     Server server;
     try {


### PR DESCRIPTION
I am trying to use gRPC in the existing Spring Boot application, servlets are registered programmatically there.
The code is supposed to look like the following:

```java
@Bean
public ServletRegistrationBean<GrpcServlet> myServiceServlet(MyServiceImpl serviceImpl) {
    GrpcServlet servlet = new ServletServerBuilder()
            .addService(serviceImpl)
            .intercept(TransmitStatusRuntimeExceptionInterceptor.instance())
            .buildServlet();
    return new ServletRegistrationBean<>(servlet, "/" + MyServiceGrpc.SERVICE_NAME + "/*");
}
```
