### PR TITLE
buildscripts: Avoid vswhere crashing Gradle

### DIFF
--- a/buildscripts/kokoro/windows.bat
+++ b/buildscripts/kokoro/windows.bat
@@ -11,6 +11,8 @@ cd /d %~dp0\..\..
 
 set WORKSPACE=T:\src\github\grpc-java
 set ESCWORKSPACE=%WORKSPACE:\=\\%
+@rem vswhere is too old, so it crashes gradle. https://github.com/gradle/gradle/issues/21993
+rename "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" vswhere-disabled.exe
 
 
 @rem Clear JAVA_HOME to prevent a different Java version from being used


### PR DESCRIPTION
I'm trying to upgrade to a newer Windows Kokoro image, but the new one has an old vswhere installed that breaks Gradle. Our old image doesn't have vswhere at all. If vswhere isn't found, this rename prints some errors, but the bat script continues executing. So this change is compatible with both the older and newer image.