### PR TITLE
Remove semi-circular dependency between core and util (1.62.x backport)

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -19,8 +19,7 @@ description = 'gRPC: Core'
 dependencies {
     api project(':grpc-api')
     // force dependent jars to depend on latest grpc-context
-    runtimeOnly project(":grpc-context"),
-            project(":grpc-util")  // need grpc-util to pull in round robin
+    runtimeOnly project(":grpc-context")
     implementation libraries.gson,
             libraries.android.annotations,
             libraries.animalsniffer.annotations,

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -28,6 +28,7 @@ dependencies {
             libraries.errorprone.annotations,
             libraries.perfmark.api,
             libraries.netty.unix.common
+    runtimeOnly project(":grpc-util")  // need grpc-util to pull in round robin
 
     // Tests depend on base class defined by core module.
     testImplementation testFixtures(project(':grpc-core')),


### PR DESCRIPTION
Add the 'fake' dependency to grpc-netty instead of grpc-core. grpc-okhttp already depends on grpc-util and probably would be fine without round_robin on Android.

There's not actually a circular dependency, but some tools can't handle the compile vs runtime distinction. Such tools are broken, but fixes have been slow and this approach works with no real downfalls.

Works around #10576 #10701

Backport of #10919