### PR TITLE
Change GAE interop tests to use java11 runtime

### DIFF
--- a/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/NettyClientInteropServlet.java
+++ b/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/NettyClientInteropServlet.java
@@ -16,9 +16,6 @@
 
 package io.grpc.testing.integration;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import io.grpc.Grpc;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.TlsChannelCredentials;
@@ -134,7 +131,6 @@ public final class NettyClientInteropServlet extends HttpServlet {
       ManagedChannelBuilder<?> builder =
           Grpc.newChannelBuilder(INTEROP_TEST_ADDRESS, TlsChannelCredentials.create())
               .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE);
-      assertTrue(builder instanceof NettyChannelBuilder);
       ((NettyChannelBuilder) builder)
           .flowControlWindow(AbstractInteropTest.TEST_FLOW_CONTROL_WINDOW);
       return builder;

--- a/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/NettyClientInteropServlet.java
+++ b/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/NettyClientInteropServlet.java
@@ -131,10 +131,6 @@ public final class NettyClientInteropServlet extends HttpServlet {
   public static final class Tester extends AbstractInteropTest {
     @Override
     protected ManagedChannelBuilder<?> createChannelBuilder() {
-      assertEquals(
-          "jdk8 required",
-          "1.8",
-          System.getProperty("java.specification.version"));
       ManagedChannelBuilder<?> builder =
           Grpc.newChannelBuilder(INTEROP_TEST_ADDRESS, TlsChannelCredentials.create())
               .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE);

--- a/gae-interop-testing/gae-jdk8/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/gae-interop-testing/gae-jdk8/src/main/webapp/WEB-INF/appengine-web.xml
@@ -13,8 +13,7 @@
 -->
 <!-- [START config] -->
 <appengine-web-app xmlns='http://appengine.google.com/ns/1.0'>
-  <threadsafe>true</threadsafe>
   <service>java-gae-interop-test</service>
-  <runtime>java8</runtime>
+  <runtime>java11</runtime>
 </appengine-web-app>
 <!-- [END config] -->


### PR DESCRIPTION
The Java 8 runtime is end of support. Leaving this a gae-jdk8 for now. The gae-jdk8 was because AppEngine changed dramatically from Java 7 to Java 8. Nowadays the versions are more in line with OpenJDK and not very different from each other.

Fixes #10925