### PR TITLE
buildscripts: Use Java 11 on Windows CI

### DIFF
--- a/buildscripts/kokoro/windows.bat
+++ b/buildscripts/kokoro/windows.bat
@@ -15,10 +15,6 @@ set ESCWORKSPACE=%WORKSPACE:\=\\%
 rename "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" vswhere-disabled.exe
 
 
-@rem Clear JAVA_HOME to prevent a different Java version from being used
-set JAVA_HOME=
-set PATH=C:\Program Files\java\jdk1.8.0_152\bin;%PATH%
-
 cmd.exe /C "%WORKSPACE%\buildscripts\kokoro\windows32.bat" || exit /b 1
 cmd.exe /C "%WORKSPACE%\buildscripts\kokoro\windows64.bat" || exit /b 1
 

--- a/buildscripts/kokoro/windows32.bat
+++ b/buildscripts/kokoro/windows32.bat
@@ -15,7 +15,7 @@ set ESCWORKSPACE=%WORKSPACE:\=\\%
 
 @rem Clear JAVA_HOME to prevent a different Java version from being used
 set JAVA_HOME=
-set PATH=C:\Program Files\java\jdk1.8.0_152\bin;%PATH%
+set PATH=C:\Program Files\OpenJDK\openjdk-11.0.12_7\bin;%PATH%
 
 mkdir grpc-java-helper32
 cd grpc-java-helper32

--- a/buildscripts/kokoro/windows64.bat
+++ b/buildscripts/kokoro/windows64.bat
@@ -14,7 +14,7 @@ set ESCWORKSPACE=%WORKSPACE:\=\\%
 
 @rem Clear JAVA_HOME to prevent a different Java version from being used
 set JAVA_HOME=
-set PATH=C:\Program Files\java\jdk1.8.0_152\bin;%PATH%
+set PATH=C:\Program Files\OpenJDK\openjdk-11.0.12_7\bin;%PATH%
 
 mkdir grpc-java-helper64
 cd grpc-java-helper64


### PR DESCRIPTION
This version of Java is old, but not as old as the Java 8 version.