### PR TITLE
util: MultiChildLoadBalance.shutdown() log to FINE (backport #10898 to 1.62)

### DIFF
--- a/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
@@ -297,7 +297,7 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
 
   @Override
   public void shutdown() {
-    logger.log(Level.INFO, "Shutdown");
+    logger.log(Level.FINE, "Shutdown");
     for (ChildLbState state : childLbStates.values()) {
       state.shutdown();
     }


### PR DESCRIPTION
The log level of this method is set to INFO, which is too spammy. Bring it down to the FINE level.