### PR TITLE
xds: Avoid nonexistent DNS resolution in XdsClientImplV3Test

### DIFF
--- a/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientImplTestBase.java
@@ -3726,9 +3726,12 @@ public abstract class XdsClientImplTestBase {
   }
 
   @Test
-  public void sendToNonexistentHost() throws Exception {
+  public void sendToNonexistentServer() throws Exception {
     // Setup xdsClient to fail on stream creation
-    XdsClientImpl client = createXdsClient("some.garbage");
+    // The Windows CI takes ~11 seconds to resolve "doesnotexist.invalid.". That seems broken, since
+    // it should take no I/O, but let's limit ourselves to IP literals and hostnames in the hosts
+    // file. Assume localhost doesn't speak HTTP/2 on the finger port
+    XdsClientImpl client = createXdsClient("localhost:79");
     client.watchXdsResource(XdsListenerResource.getInstance(), LDS_RESOURCE, ldsResourceWatcher);
     verify(ldsResourceWatcher, Mockito.timeout(5000).times(1)).onError(ArgumentMatchers.any());
     assertThat(fakeClock.numPendingTasks()).isEqualTo(1); //retry


### PR DESCRIPTION
The DNS lookups are taking considerable time on the Windows CI (~11s),
which causes the test to time out:

```
Wanted but not invoked:
ldsResourceWatcher.onError(<any>);
-> at io.grpc.xds.XdsClientImplTestBase.sendToNonexistentHost(XdsClientImplTestBase.java:3733)
Actually, there were zero interactions with this mock.

	at io.grpc.xds.XdsClientImplTestBase.sendToNonexistentHost(XdsClientImplTestBase.java:3733)
```

The ARM build, which uses an emulator, has had this test succeed, so the
failure seems unrelated to CPU usage. We want to avoid external I/O
anyway during tests, so removing the DNS lookup is good.

The TSAN comment referenced XdsClientImplTestBase.sendToNonexistentHost,
but the test no longer calls fakeClock.forwardTime so the comment was
out-of-date. Change the comment to make clear the race involved.