### PR TITLE
roboelectric: Remove references to kitkat

### DIFF
--- a/binder/src/main/java/io/grpc/binder/SecurityPolicies.java
+++ b/binder/src/main/java/io/grpc/binder/SecurityPolicies.java
@@ -203,12 +203,13 @@ public final class SecurityPolicies {
    * Creates {@link SecurityPolicy} which checks if the app is a profile owner app. See
    * {@link DevicePolicyManager}.
    */
+  @androidx.annotation.RequiresApi(21)
   public static SecurityPolicy isProfileOwner(Context applicationContext) {
     DevicePolicyManager devicePolicyManager =
         (DevicePolicyManager) applicationContext.getSystemService(Context.DEVICE_POLICY_SERVICE);
     return anyPackageWithUidSatisfies(
         applicationContext,
-        pkg -> VERSION.SDK_INT >= 21 && devicePolicyManager.isProfileOwnerApp(pkg),
+        pkg -> devicePolicyManager.isProfileOwnerApp(pkg),
         "Rejected by profile owner policy. No packages found for UID.",
         "Rejected by profile owner policy");
   }

--- a/binder/src/test/java/io/grpc/binder/SecurityPoliciesTest.java
+++ b/binder/src/test/java/io/grpc/binder/SecurityPoliciesTest.java
@@ -330,7 +330,6 @@ public final class SecurityPoliciesTest {
   }
 
   @Test
-  @Config(sdk = 19)
   public void testIsDeviceOwner_succeedsForDeviceOwner() throws Exception {
     PackageInfo info =
         newBuilder().setPackageName(OTHER_UID_PACKAGE_NAME).setSignatures(SIG2).build();
@@ -345,7 +344,6 @@ public final class SecurityPoliciesTest {
   }
 
   @Test
-  @Config(sdk = 19)
   public void testIsDeviceOwner_failsForNotDeviceOwner() throws Exception {
     PackageInfo info =
         newBuilder().setPackageName(OTHER_UID_PACKAGE_NAME).setSignatures(SIG2).build();
@@ -358,7 +356,6 @@ public final class SecurityPoliciesTest {
   }
 
   @Test
-  @Config(sdk = 19)
   public void testIsDeviceOwner_failsWhenNoPackagesForUid() throws Exception {
     policy = SecurityPolicies.isDeviceOwner(appContext);
 
@@ -400,19 +397,6 @@ public final class SecurityPoliciesTest {
     policy = SecurityPolicies.isProfileOwner(appContext);
 
     assertThat(policy.checkAuthorization(OTHER_UID).getCode()).isEqualTo(Status.UNAUTHENTICATED.getCode());
-  }
-
-  @Test
-  @Config(sdk = 19)
-  public void testIsProfileOwner_failsForSdkLevelTooLow() throws Exception {
-    PackageInfo info =
-        newBuilder().setPackageName(OTHER_UID_PACKAGE_NAME).setSignatures(SIG2).build();
-
-    installPackages(OTHER_UID, info);
-
-    policy = SecurityPolicies.isProfileOwner(appContext);
-
-    assertThat(policy.checkAuthorization(OTHER_UID).getCode()).isEqualTo(Status.PERMISSION_DENIED.getCode());
   }
 
   @Test


### PR DESCRIPTION
In addition to removing a test that only applies to KitKat, switch other uses of '19' to Config.OLDEST_SDK when possible to test older SDK versions.

ref cl/609823012