### PR TITLE
xds: fix xdsNameResolver virtual host lookup using authority [1.62.x backport]

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -696,7 +696,7 @@ final class XdsNameResolver extends NameResolver {
     // called in syncContext
     private void updateRoutes(List<VirtualHost> virtualHosts, long httpMaxStreamDurationNano,
         @Nullable List<NamedFilterConfig> filterConfigs) {
-      String authority = overrideAuthority != null ? overrideAuthority : ldsResourceName;
+      String authority = overrideAuthority != null ? overrideAuthority : encodedServiceAuthority;
       VirtualHost virtualHost = RoutingUtils.findVirtualHostForHostName(virtualHosts, authority);
       if (virtualHost == null) {
         String error = "Failed to find virtual host matching hostname: " + authority;

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -333,6 +333,18 @@ public class XdsNameResolverTest {
         RouteAction.forCluster(
             cluster2, Collections.emptyList(), TimeUnit.SECONDS.toNanos(20L), null),
         ImmutableMap.of());
+    bootstrapInfo = BootstrapInfo.builder()
+        .servers(ImmutableList.of(ServerInfo.create(
+            "td.googleapis.com", InsecureChannelCredentials.create())))
+        .clientDefaultListenerResourceNameTemplate("test-%s")
+        .node(Node.newBuilder().build())
+        .build();
+    resolver = new XdsNameResolver(null, AUTHORITY, null,
+        serviceConfigParser, syncContext, scheduler,
+        xdsClientPoolFactory, mockRandom, FilterRegistry.getDefaultRegistry(), null);
+    // use different ldsResourceName and service authority. The virtualhost lookup should use
+    // service authority.
+    expectedLdsResourceName = "test-" + expectedLdsResourceName;
 
     resolver.start(mockListener);
     FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();


### PR DESCRIPTION

backport of https://github.com/grpc/grpc-java/pull/10960