### PR TITLE
xds: Increase timeouts in XdsClientFederationTest

### DIFF
--- a/xds/src/test/java/io/grpc/xds/XdsClientFederationTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientFederationTest.java
@@ -102,11 +102,11 @@ public class XdsClientFederationTest {
     xdsClient.watchXdsResource(XdsListenerResource.getInstance(),
         "xdstp://server-one/envoy.config.listener.v3.Listener/test-server", mockDirectPathWatcher);
 
-    verify(mockWatcher, timeout(2000)).onChanged(
+    verify(mockWatcher, timeout(10000)).onChanged(
         LdsUpdate.forApiListener(
             HttpConnectionManager.forRdsName(0, "route-config.googleapis.com", ImmutableList.of(
                 new NamedFilterConfig("terminal-filter", RouterFilter.ROUTER_CONFIG)))));
-    verify(mockDirectPathWatcher, timeout(2000)).onChanged(
+    verify(mockDirectPathWatcher, timeout(10000)).onChanged(
         LdsUpdate.forApiListener(
             HttpConnectionManager.forRdsName(0, "route-config.googleapis.com", ImmutableList.of(
                 new NamedFilterConfig("terminal-filter", RouterFilter.ROUTER_CONFIG)))));


### PR DESCRIPTION
`isolatedResourceDeletions()` has failed with a timeout waiting on onChanged when running under TSAN. TSAN can slow things down, so let's increase the timeout to ensure it isn't just timeout flake.