### PR TITLE
servlet: Move deps to version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,10 +40,18 @@ guava-testlib = "com.google.guava:guava-testlib:32.1.3-android"
 # May be different from the -android version.
 guava-jre = "com.google.guava:guava:32.1.3-jre"
 hdrhistogram = "org.hdrhistogram:HdrHistogram:2.1.12"
-javax-annotation = "org.apache.tomcat:annotations-api:6.0.53"
 j2objc-annotations = " com.google.j2objc:j2objc-annotations:2.8"
+jakarta-servlet-api = "jakarta.servlet:jakarta.servlet-api:5.0.0"
+javax-annotation = "org.apache.tomcat:annotations-api:6.0.53"
+javax-servlet-api = "javax.servlet:javax.servlet-api:4.0.1"
+jetty-client = "org.eclipse.jetty:jetty-client:10.0.7"
+jetty-http2-server = "org.eclipse.jetty.http2:http2-server:11.0.7"
+jetty-http2-server10 = "org.eclipse.jetty.http2:http2-server:10.0.7"
+jetty-servlet = "org.eclipse.jetty:jetty-servlet:11.0.7"
+jetty-servlet10 = "org.eclipse.jetty:jetty-servlet:10.0.7"
 jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
 junit = "junit:junit:4.13.2"
+lincheck = "org.jetbrains.kotlinx:lincheck:2.14.1"
 # Update notes / 2023-07-19 sergiitk:
 #    Couldn't update to 5.4.0, updated to the last in 4.x line. Version 5.x breaks some tests.
 #    Error log: https://github.com/grpc/grpc-java/pull/10359#issuecomment-1632834435
@@ -78,7 +86,11 @@ re2j = "com.google.re2j:re2j:1.7"
 robolectric = "org.robolectric:robolectric:4.11.1"
 signature-android = "net.sf.androidscents.signature:android-api-level-19:4.4.2_r4"
 signature-java = "org.codehaus.mojo.signature:java18:1.0"
+tomcat-embed-core = "org.apache.tomcat.embed:tomcat-embed-core:10.0.14"
+tomcat-embed-core9 = "org.apache.tomcat.embed:tomcat-embed-core:9.0.56"
 truth = "com.google.truth:truth:1.1.5"
+undertow-servlet = "io.undertow:undertow-servlet:2.2.14.Final"
+undertow-servlet-jakartaee9 = "io.undertow:undertow-servlet-jakartaee9:2.2.13.Final"
 
 # Do not update: Pinned to the last version supporting Java 8.
 # See https://checkstyle.sourceforge.io/releasenotes.html#Release_10.1

--- a/servlet/build.gradle
+++ b/servlet/build.gradle
@@ -5,8 +5,6 @@ plugins {
 
 description = "gRPC: Servlet"
 
-def jettyVersion = '10.0.7'
-
 sourceSets {
     // Testing threading is more of a brute-force test and is very slow. No need to run it as part
     // of normal suite.
@@ -36,19 +34,19 @@ tasks.named("jar").configure {
 
 dependencies {
     api project(':grpc-api')
-    compileOnly 'javax.servlet:javax.servlet-api:4.0.1',
+    compileOnly libraries.javax.servlet.api,
             libraries.javax.annotation // java 9, 10 needs it
 
     implementation project(':grpc-util'),
             project(':grpc-core'),
             libraries.guava
 
-    testImplementation 'javax.servlet:javax.servlet-api:4.0.1'
+    testImplementation libraries.javax.servlet.api
 
     threadingTestImplementation project(':grpc-servlet'),
         libraries.truth,
-	'javax.servlet:javax.servlet-api:4.0.1',
-        'org.jetbrains.kotlinx:lincheck:2.14.1'
+	libraries.javax.servlet.api,
+        libraries.lincheck
 
     itImplementation project(':grpc-servlet'),
             project(':grpc-netty'),
@@ -60,13 +58,13 @@ dependencies {
         exclude group: 'io.grpc', module: 'grpc-xds'
     }
 
-    undertowTestImplementation 'io.undertow:undertow-servlet:2.2.14.Final'
+    undertowTestImplementation libraries.undertow.servlet
 
-    tomcatTestImplementation 'org.apache.tomcat.embed:tomcat-embed-core:9.0.56'
+    tomcatTestImplementation libraries.tomcat.embed.core9
 
-    jettyTestImplementation "org.eclipse.jetty:jetty-servlet:${jettyVersion}",
-            "org.eclipse.jetty.http2:http2-server:${jettyVersion}",
-            "org.eclipse.jetty:jetty-client:${jettyVersion}",
+    jettyTestImplementation libraries.jetty.servlet10,
+            libraries.jetty.http2.server10,
+            libraries.jetty.client,
             project(':grpc-testing'),
             libraries.truth,
             libraries.protobuf.java

--- a/servlet/jakarta/build.gradle
+++ b/servlet/jakarta/build.gradle
@@ -77,7 +77,7 @@ tasks.named("jar").configure {
 
 dependencies {
     api project(':grpc-api')
-    compileOnly 'jakarta.servlet:jakarta.servlet-api:5.0.0',
+    compileOnly libraries.jakarta.servlet.api,
             libraries.javax.annotation
 
     implementation project(':grpc-util'),
@@ -94,12 +94,12 @@ dependencies {
         exclude group: 'io.grpc', module: 'grpc-xds'
     }
 
-    tomcatTestImplementation 'org.apache.tomcat.embed:tomcat-embed-core:10.0.14'
+    tomcatTestImplementation libraries.tomcat.embed.core
 
-    jettyTestImplementation "org.eclipse.jetty:jetty-servlet:11.0.7",
-            "org.eclipse.jetty.http2:http2-server:11.0.7"
+    jettyTestImplementation libraries.jetty.servlet,
+            libraries.jetty.http2.server
 
-    undertowTestImplementation 'io.undertow:undertow-servlet-jakartaee9:2.2.13.Final'
+    undertowTestImplementation libraries.undertow.servlet.jakartaee9
 }
 
 // Set up individual classpaths for each test, to avoid any mismatch,


### PR DESCRIPTION
This allows the checkForUpdates task to notice the dependencies and suggest updates.

I plan to upgrade some of the servers after this change in hopes it reduces test flakiness.