### PR TITLE
Reduce the flakiness of the OkHttp tests (though not eliminate).

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpServerTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpServerTransport.java
@@ -174,8 +174,8 @@ final class OkHttpServerTransport implements ServerTransport,
       }
       synchronized (lock) {
         this.socket = result.socket;
-        this.attributes = result.attributes;
       }
+      this.attributes = result.attributes;
 
       int maxQueuedControlFrames = 10000;
       AsyncSink asyncSink = AsyncSink.sink(serializingExecutor, this, maxQueuedControlFrames);

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -115,6 +115,7 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.net.SocketFactory;
 import okio.Buffer;
@@ -294,7 +295,9 @@ public class OkHttpClientTransportTest {
     Buffer buffer = createMessageFrame(message);
     frameHandler().data(false, 3, buffer, (int) buffer.size(),
         (int) buffer.size());
-    assertWithMessage("log messages: " + logs.stream().map(LogRecord::getMessage).toArray())
+
+    assertWithMessage("log messages: " +
+        logs.stream().map(LogRecord::getMessage).collect(Collectors.toList()))
         .that(logs).hasSize(1);
     log = logs.remove(0);
     assertThat(log.getMessage()).startsWith(Direction.INBOUND + " DATA: streamId=" + 3);

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -18,6 +18,7 @@ package io.grpc.okhttp;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static io.grpc.internal.ClientStreamListener.RpcProgress.MISCARRIED;
 import static io.grpc.internal.ClientStreamListener.RpcProgress.PROCESSED;
 import static io.grpc.internal.ClientStreamListener.RpcProgress.REFUSED;
@@ -293,7 +294,7 @@ public class OkHttpClientTransportTest {
     Buffer buffer = createMessageFrame(message);
     frameHandler().data(false, 3, buffer, (int) buffer.size(),
         (int) buffer.size());
-    assertThat(logs).hasSize(1);
+    assertWithMessage("log messages: " + logs).that(logs).hasSize(1);
     log = logs.remove(0);
     assertThat(log.getMessage()).startsWith(Direction.INBOUND + " DATA: streamId=" + 3);
     assertThat(log.getLevel()).isEqualTo(Level.FINE);

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -296,8 +296,8 @@ public class OkHttpClientTransportTest {
     frameHandler().data(false, 3, buffer, (int) buffer.size(),
         (int) buffer.size());
 
-    assertWithMessage("log messages: " +
-        logs.stream().map(LogRecord::getMessage).collect(Collectors.toList()))
+    assertWithMessage("log messages: "
+        + logs.stream().map(LogRecord::getMessage).collect(Collectors.toList()))
         .that(logs).hasSize(1);
     log = logs.remove(0);
     assertThat(log.getMessage()).startsWith(Direction.INBOUND + " DATA: streamId=" + 3);

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -294,7 +294,8 @@ public class OkHttpClientTransportTest {
     Buffer buffer = createMessageFrame(message);
     frameHandler().data(false, 3, buffer, (int) buffer.size(),
         (int) buffer.size());
-    assertWithMessage("log messages: " + logs).that(logs).hasSize(1);
+    assertWithMessage("log messages: " + logs.stream().map(LogRecord::getMessage).toArray())
+        .that(logs).hasSize(1);
     log = logs.remove(0);
     assertThat(log.getMessage()).startsWith(Direction.INBOUND + " DATA: streamId=" + 3);
     assertThat(log.getLevel()).isEqualTo(Level.FINE);

--- a/okhttp/src/test/java/io/grpc/okhttp/TlsTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/TlsTest.java
@@ -117,6 +117,7 @@ public class TlsTest {
     ManagedChannel channel = grpcCleanupRule.register(clientChannel(server, channelCreds));
 
     SimpleServiceGrpc.newBlockingStub(channel).unaryRpc(SimpleRequest.getDefaultInstance());
+    server.shutdown();
   }
 
   @Test
@@ -144,6 +145,7 @@ public class TlsTest {
     ManagedChannel channel = grpcCleanupRule.register(clientChannel(server, channelCreds));
 
     assertRpcFails(channel);
+    server.shutdown();
   }
 
   @Test
@@ -168,6 +170,7 @@ public class TlsTest {
     ManagedChannel channel = grpcCleanupRule.register(clientChannel(server, channelCreds));
 
     SimpleServiceGrpc.newBlockingStub(channel).unaryRpc(SimpleRequest.getDefaultInstance());
+    server.shutdown();
   }
 
   @Test
@@ -192,6 +195,7 @@ public class TlsTest {
     ManagedChannel channel = grpcCleanupRule.register(clientChannel(server, channelCreds));
 
     assertRpcFails(channel);
+    server.shutdown();
   }
 
   @Test
@@ -208,6 +212,7 @@ public class TlsTest {
     ManagedChannel channel = grpcCleanupRule.register(clientChannel(server, channelCreds));
 
     assertRpcFails(channel);
+    server.shutdown();
   }
 
   @Test
@@ -231,6 +236,7 @@ public class TlsTest {
         .build());
 
     assertRpcFails(channel);
+    server.shutdown();
   }
 
   @Test
@@ -255,6 +261,7 @@ public class TlsTest {
           .build());
 
     SimpleServiceGrpc.newBlockingStub(channel).unaryRpc(SimpleRequest.getDefaultInstance());
+    server.shutdown();
   }
 
   @Test
@@ -280,6 +287,7 @@ public class TlsTest {
 
     Status status = assertRpcFails(channel);
     assertThat(status.getCause()).isInstanceOf(SSLPeerUnverifiedException.class);
+    server.shutdown();
   }
 
   private static Server server(ServerCredentials creds) throws IOException {


### PR DESCRIPTION
Doing server.shutdown() after the TlsTest tests, because OkHttpServer.acceptConnections is looping creating transports which TSAN gets unhappy when they conflict with cleanup.  Doing a shutdown at the end of each test, so that loop can break before the rule's cleanup, pretty much eliminated those incidents.

```
WARNING: ThreadSanitizer: data race (pid=3197)
  Read of size 1 at 0x00008dff1726 by thread T71:
    #0 sun.security.ssl.SSLSocketImpl$AppOutputStream.write([BII)V SSLSocketImpl.java:1300 
    #1 okio.OutputStreamSink.write(Lokio/Buffer;J)V JvmOkio.kt:56 
    #2 okio.AsyncTimeout$sink$1.write(Lokio/Buffer;J)V AsyncTimeout.kt:102 
    #3 io.grpc.okhttp.AsyncSink$2.doRun()V AsyncSink.java:177 
    #4 io.grpc.okhttp.AsyncSink$WriteRunnable.run()V AsyncSink.java:232 
    #5 io.grpc.internal.SerializingExecutor.run()V SerializingExecutor.java:133 

  Previous write of size 1 at 0x00008dff1726 by thread T74:
    #0 sun.security.ssl.TransportContext.fatal(Lsun/security/ssl/Alert;Ljava/lang/String;ZLjava/lang/Throwable;)Ljavax/net/ssl/SSLException; TransportContext.java:433 
    #1 sun.security.ssl.TransportContext.fatal(Lsun/security/ssl/Alert;Ljava/lang/String;Ljava/lang/Throwable;)Ljavax/net/ssl/SSLException; TransportContext.java:303 
    #2 sun.security.ssl.TransportContext.fatal(Lsun/security/ssl/Alert;Ljava/lang/Throwable;)Ljavax/net/ssl/SSLException; TransportContext.java:298 
    #3 sun.security.ssl.SSLSocketImpl.handleException(Ljava/lang/Exception;)V SSLSocketImpl.java:1686 
    #4 sun.security.ssl.SSLSocketImpl$AppInputStream.read([BII)I SSLSocketImpl.java:1086 
    #5 okio.InputStreamSource.read(Lokio/Buffer;J)J JvmOkio.kt:93 
    #6 okio.AsyncTimeout$source$1.read(Lokio/Buffer;J)J AsyncTimeout.kt:128 
    #7 okio.RealBufferedSource.request(J)Z RealBufferedSource.kt:209 
    #8 okio.RealBufferedSource.require(J)V RealBufferedSource.kt:202 
    #9 okio.RealBufferedSource.readByteString(J)Lokio/ByteString; RealBufferedSource.kt:218 
    #10 io.grpc.okhttp.internal.framed.Http2$Reader.readConnectionPreface()V Http2.java:111 
    #11 io.grpc.okhttp.OkHttpServerTransport$FrameHandler.run()V OkHttpServerTransport.java:569 
```
```
  Write of size 1 at 0x0000cdc2a7d9 by thread T94:
    #0 java.net.Socket.shutdownOutput()V Socket.java:1575 
    #1 sun.security.ssl.BaseSSLSocketImpl.shutdownOutput()V BaseSSLSocketImpl.java:234 
    #2 sun.security.ssl.SSLSocketImpl.handleClosedNotifyAlert(Z)V SSLSocketImpl.java:762 
    #3 sun.security.ssl.SSLSocketImpl.closeNotify(Z)V SSLSocketImpl.java:738 
    #4 sun.security.ssl.TransportContext.closeNotify(Z)V TransportContext.java:269 
    #5 sun.security.ssl.TransportContext.passiveInboundClose()V TransportContext.java:544 
    #6 sun.security.ssl.TransportContext.closeInbound()V TransportContext.java:506 
    #7 sun.security.ssl.Alert$AlertConsumer.consume(Lsun/security/ssl/ConnectionContext;Ljava/nio/ByteBuffer;)V Alert.java:245 
    #8 sun.security.ssl.TransportContext.dispatch(Lsun/security/ssl/Plaintext;)V TransportContext.java:186 
    #9 sun.security.ssl.SSLTransport.decode(Lsun/security/ssl/TransportContext;[Ljava/nio/ByteBuffer;II[Ljava/nio/ByteBuffer;II)Lsun/security/ssl/Plaintext; SSLTransport.java:172 
    #10 sun.security.ssl.SSLSocketImpl.decode(Ljava/nio/ByteBuffer;)Lsun/security/ssl/Plaintext; SSLSocketImpl.java:1514 
    #11 sun.security.ssl.SSLSocketImpl.readApplicationRecord(Ljava/nio/ByteBuffer;)Ljava/nio/ByteBuffer; SSLSocketImpl.java:1481 
    #12 sun.security.ssl.SSLSocketImpl$AppInputStream.read([BII)I SSLSocketImpl.java:1070 
    #13 okio.InputStreamSource.read(Lokio/Buffer;J)J JvmOkio.kt:93 
    #14 okio.AsyncTimeout$source$1.read(Lokio/Buffer;J)J AsyncTimeout.kt:128 
    #15 okio.RealBufferedSource.request(J)Z RealBufferedSource.kt:209 
    #16 okio.RealBufferedSource.require(J)V RealBufferedSource.kt:202 
    #17 io.grpc.okhttp.internal.framed.Http2$Reader.nextFrame(Lio/grpc/okhttp/internal/framed/FrameReader$Handler;)Z Http2.java:120 
    #18 io.grpc.okhttp.OkHttpServerTransport$FrameHandler.run()V OkHttpServerTransport.java:583 

  Previous read of size 1 at 0x0000cdc2a7d9 by thread T92:
    #0 java.net.Socket.isOutputShutdown()Z Socket.java:1659 
    #1 sun.security.ssl.BaseSSLSocketImpl.isOutputShutdown()Z BaseSSLSocketImpl.java:260 
    #2 sun.security.ssl.SSLSocketImpl.isOutputShutdown()Z SSLSocketImpl.java:886 
    #3 sun.security.ssl.SSLSocketImpl.close()V SSLSocketImpl.java:584 
    #4 sun.security.ssl.SSLSocketImpl$AppOutputStream.close()V SSLSocketImpl.java:1334 
    #5 okio.OutputStreamSink.close()V JvmOkio.kt:71 
    #6 okio.AsyncTimeout$sink$1.close()V AsyncTimeout.kt:112 
    #7 io.grpc.okhttp.AsyncSink$3.run()V AsyncSink.java:209 
```