### PR TITLE
Fix tests and warnings on Java 17

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        jre: [8, 11]
+        jre: [8, 11, 17]
       fail-fast: false # Should swap to true if we grow a large matrix
 
     steps:

--- a/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
+++ b/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
@@ -135,7 +135,6 @@ class ProxyDetectorImpl implements ProxyDetector {
             Level.WARNING,
             "failed to create URL for Authenticator: {0} {1}", new Object[] {protocol, host});
       }
-      // TODO(spencerfang): consider using java.security.AccessController here
       return Authenticator.requestPasswordAuthentication(
           host, addr, port, protocol, prompt, scheme, url, Authenticator.RequestorType.PROXY);
     }
@@ -144,7 +143,6 @@ class ProxyDetectorImpl implements ProxyDetector {
       new Supplier<ProxySelector>() {
         @Override
         public ProxySelector get() {
-          // TODO(spencerfang): consider using java.security.AccessController here
           return ProxySelector.getDefault();
         }
       };

--- a/netty/src/main/java/io/grpc/netty/JettyTlsUtil.java
+++ b/netty/src/main/java/io/grpc/netty/JettyTlsUtil.java
@@ -17,8 +17,6 @@
 package io.grpc.netty;
 
 import java.lang.reflect.Method;
-import java.security.AccessController;
-import java.security.PrivilegedExceptionAction;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 
@@ -42,13 +40,7 @@ final class JettyTlsUtil {
         SSLContext context = SSLContext.getInstance("TLS");
         context.init(null, null, null);
         SSLEngine engine = context.createSSLEngine();
-        Method getApplicationProtocol =
-            AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
-              @Override
-              public Method run() throws Exception {
-                return SSLEngine.class.getMethod("getApplicationProtocol");
-              }
-            });
+        Method getApplicationProtocol = SSLEngine.class.getMethod("getApplicationProtocol");
         getApplicationProtocol.invoke(engine);
         return null;
       } catch (Throwable t) {

--- a/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
+++ b/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
@@ -68,6 +68,7 @@ import io.grpc.netty.ProtocolNegotiators.HostPort;
 import io.grpc.netty.ProtocolNegotiators.ServerTlsHandler;
 import io.grpc.netty.ProtocolNegotiators.WaitUntilActiveHandler;
 import io.grpc.testing.TlsTesting;
+import io.grpc.util.CertificateUtils;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
@@ -107,16 +108,13 @@ import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.proxy.ProxyConnectException;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
-import io.netty.handler.ssl.util.SelfSignedCertificate;
 import java.io.File;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.security.KeyStore;
-import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.ArrayDeque;
 import java.util.Arrays;
@@ -478,19 +476,26 @@ public class ProtocolNegotiatorsTest {
 
   @Test
   public void from_tls_managers() throws Exception {
-    SelfSignedCertificate cert = new SelfSignedCertificate(TestUtils.TEST_SERVER_HOST);
     KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
     keyStore.load(null);
-    keyStore.setKeyEntry("mykey", cert.key(), new char[0], new Certificate[] {cert.cert()});
+    try (InputStream server1Chain = TlsTesting.loadCert("server1.pem");
+         InputStream server1Key = TlsTesting.loadCert("server1.key")) {
+      X509Certificate[] chain = CertificateUtils.getX509Certificates(server1Chain);
+      keyStore.setKeyEntry("key", CertificateUtils.getPrivateKey(server1Key), new char[0], chain);
+    }
     KeyManagerFactory keyManagerFactory =
         KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
     keyManagerFactory.init(keyStore, new char[0]);
 
     KeyStore certStore = KeyStore.getInstance(KeyStore.getDefaultType());
     certStore.load(null);
-    certStore.setCertificateEntry("mycert", cert.cert());
     TrustManagerFactory trustManagerFactory =
         TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+    try (InputStream ca = TlsTesting.loadCert("ca.pem")) {
+      for (X509Certificate cert : CertificateUtils.getX509Certificates(ca)) {
+        certStore.setCertificateEntry(cert.getSubjectX500Principal().getName("RFC2253"), cert);
+      }
+    }
     trustManagerFactory.init(certStore);
 
     ServerCredentials serverCreds = TlsServerCredentials.newBuilder()
@@ -504,8 +509,7 @@ public class ProtocolNegotiatorsTest {
         .build();
     InternalChannelz.Tls tls = expectSuccessfulHandshake(channelCreds, serverCreds);
     assertThat(((X509Certificate) tls.remoteCert).getSubjectX500Principal().getName())
-        .isEqualTo("CN=" + TestUtils.TEST_SERVER_HOST);
-    cert.delete();
+        .isEqualTo("CN=*.test.google.com,O=Example\\, Co.,L=Chicago,ST=Illinois,C=US");
   }
 
   @Test
@@ -1214,11 +1218,15 @@ public class ProtocolNegotiatorsTest {
 
   @Test
   public void clientTlsHandler_firesNegotiation() throws Exception {
-    SelfSignedCertificate cert = new SelfSignedCertificate("authority");
-    SslContext clientSslContext =
-        GrpcSslContexts.configure(SslContextBuilder.forClient().trustManager(cert.cert())).build();
-    SslContext serverSslContext =
-        GrpcSslContexts.configure(SslContextBuilder.forServer(cert.key(), cert.cert())).build();
+    SslContext clientSslContext;
+    try (InputStream ca = TlsTesting.loadCert("ca.pem")) {
+      clientSslContext = GrpcSslContexts.forClient().trustManager(ca).build();
+    }
+    SslContext serverSslContext;
+    try (InputStream server1Key = TlsTesting.loadCert("server1.key");
+        InputStream server1Chain = TlsTesting.loadCert("server1.pem")) {
+      serverSslContext = GrpcSslContexts.forServer(server1Chain, server1Key).build();
+    }
     FakeGrpcHttp2ConnectionHandler gh = FakeGrpcHttp2ConnectionHandler.newHandler();
     ClientTlsProtocolNegotiator pn = new ClientTlsProtocolNegotiator(clientSslContext, null);
     WriteBufferingAndExceptionHandler clientWbaeh =
@@ -1404,7 +1412,7 @@ public class ProtocolNegotiatorsTest {
 
     @Override
     public String getAuthority() {
-      return "authority";
+      return "foo.test.google.fr";
     }
   }
 

--- a/okhttp/third_party/okhttp/main/java/io/grpc/okhttp/internal/Platform.java
+++ b/okhttp/third_party/okhttp/main/java/io/grpc/okhttp/internal/Platform.java
@@ -28,11 +28,8 @@ import java.lang.reflect.Proxy;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketException;
-import java.security.AccessController;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.security.Provider;
 import java.security.Security;
 import java.util.ArrayList;
@@ -218,40 +215,20 @@ public class Platform {
       SSLContext context = SSLContext.getInstance("TLS", sslProvider);
       context.init(null, null, null);
       SSLEngine engine = context.createSSLEngine();
-      Method getEngineApplicationProtocol =
-          AccessController.doPrivileged(
-              new PrivilegedExceptionAction<Method>() {
-                @Override
-                public Method run() throws Exception {
-                  return SSLEngine.class.getMethod("getApplicationProtocol");
-                }
-              });
+      Method getEngineApplicationProtocol = SSLEngine.class.getMethod("getApplicationProtocol");
       getEngineApplicationProtocol.invoke(engine);
 
       Method setApplicationProtocols =
-          AccessController.doPrivileged(
-              new PrivilegedExceptionAction<Method>() {
-                @Override
-                public Method run() throws Exception {
-                  return SSLParameters.class.getMethod("setApplicationProtocols", String[].class);
-                }
-              });
-      Method getApplicationProtocol =
-          AccessController.doPrivileged(
-              new PrivilegedExceptionAction<Method>() {
-                @Override
-                public Method run() throws Exception {
-                  return SSLSocket.class.getMethod("getApplicationProtocol");
-                }
-              });
+          SSLParameters.class.getMethod("setApplicationProtocols", String[].class);
+      Method getApplicationProtocol = SSLSocket.class.getMethod("getApplicationProtocol");
       return new JdkAlpnPlatform(sslProvider, setApplicationProtocols, getApplicationProtocol);
     } catch (NoSuchAlgorithmException ignored) {
       // On older Java
     } catch (KeyManagementException ignored) {
       // On older Java
-    } catch (PrivilegedActionException ignored) {
-      // On older Java
     } catch (IllegalAccessException ignored) {
+      // On older Java
+    } catch (NoSuchMethodException ignored) {
       // On older Java
     } catch (InvocationTargetException ignored) {
       // On older Java

--- a/xds/src/test/java/io/grpc/xds/SharedCallCounterMapTest.java
+++ b/xds/src/test/java/io/grpc/xds/SharedCallCounterMapTest.java
@@ -54,6 +54,7 @@ public class SharedCallCounterMapTest {
     final CounterReference ref = counters.get(CLUSTER).get(EDS_SERVICE_NAME);
     counter = null;
     GcFinalization.awaitDone(new FinalizationPredicate() {
+      @SuppressWarnings("deprecation") // Use refersTo(null) once we require Java 17+
       @Override
       public boolean isDone() {
         return ref.isEnqueued();
@@ -71,6 +72,7 @@ public class SharedCallCounterMapTest {
     assertThat(counter.get()).isEqualTo(0);
     counter = null;
     GcFinalization.awaitDone(new FinalizationPredicate() {
+      @SuppressWarnings("deprecation") // Use refersTo(null) once we require Java 17+
       @Override
       public boolean isDone() {
         return ref.isEnqueued();


### PR DESCRIPTION
SelfSignedCertificate is not available on Java 17 because OpenJdkSelfSignedCertGenerator is not available. This only impacted tests.

AccessController is being removed, and these locations are doing simple reflection which is unlikely to require it even when a security policy is in effect. There's other places we do reflection without the AccessController, so either no security policies care or the users can update their policies to allow it.