### PR TITLE
Allow configuration of the queued byte threshold at which a Stream is considered not ready

### DIFF
--- a/api/src/main/java/io/grpc/CallOptions.java
+++ b/api/src/main/java/io/grpc/CallOptions.java
@@ -208,15 +208,15 @@ public final class CallOptions {
   }
 
   /**
-   * Specifies how many bytes must be queued before the call will leave the
-   * <a href="https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md">
-   * 'wait for ready'</a> state.
+   * Specifies how many bytes must be queued before the call is
+   * considered not ready to send more messages.
    *
    * @param numBytes The number of bytes that must be queued. Must be a
    *                 positive integer.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11021")
   public CallOptions withOnReadyThreshold(int numBytes) {
+    checkArgument(numBytes > 0, "numBytes must be positive: %s", numBytes);
     Builder builder = toBuilder(this);
     builder.onReadyThreshold = numBytes;
     return builder.build();

--- a/api/src/main/java/io/grpc/CallOptions.java
+++ b/api/src/main/java/io/grpc/CallOptions.java
@@ -79,6 +79,8 @@ public final class CallOptions {
   private final Integer maxInboundMessageSize;
   @Nullable
   private final Integer maxOutboundMessageSize;
+  @Nullable
+  private final Integer onReadyThreshold;
 
   private CallOptions(Builder builder) {
     this.deadline = builder.deadline;
@@ -91,6 +93,7 @@ public final class CallOptions {
     this.waitForReady = builder.waitForReady;
     this.maxInboundMessageSize = builder.maxInboundMessageSize;
     this.maxOutboundMessageSize = builder.maxOutboundMessageSize;
+    this.onReadyThreshold = builder.onReadyThreshold;
   }
 
   static class Builder {
@@ -105,6 +108,7 @@ public final class CallOptions {
     Boolean waitForReady;
     Integer maxInboundMessageSize;
     Integer maxOutboundMessageSize;
+    Integer onReadyThreshold;
 
     private CallOptions build() {
       return new CallOptions(this);
@@ -201,6 +205,46 @@ public final class CallOptions {
     Builder builder = toBuilder(this);
     builder.waitForReady = Boolean.FALSE;
     return builder.build();
+  }
+
+  /**
+   * Specifies how many bytes must be queued before the call will leave the
+   * <a href="https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md">
+   * 'wait for ready'</a> state.
+   *
+   * @param numBytes The number of bytes that must be queued. Must be a
+   *                 positive integer.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11021")
+  public CallOptions withOnReadyThreshold(int numBytes) {
+    Builder builder = toBuilder(this);
+    builder.onReadyThreshold = numBytes;
+    return builder.build();
+  }
+
+  /**
+   * Resets to the default number of bytes that must be queued before the
+   * call will leave the <a href="https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md">
+   * 'wait for ready'</a> state.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11021")
+  public CallOptions clearOnReadyThreshold() {
+    Builder builder = toBuilder(this);
+    builder.onReadyThreshold = null;
+    return builder.build();
+  }
+
+  /**
+   * Returns to the default number of bytes that must be queued before the
+   * call will leave the <a href="https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md">
+   * 'wait for ready'</a> state.
+   *
+   * @return null if the default threshold is used.
+   */
+  @Nullable
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11021")
+  public Integer getOnReadyThreshold() {
+    return onReadyThreshold;
   }
 
   /**

--- a/api/src/main/java/io/grpc/PartialForwardingServerCall.java
+++ b/api/src/main/java/io/grpc/PartialForwardingServerCall.java
@@ -58,6 +58,20 @@ abstract class PartialForwardingServerCall<ReqT, RespT> extends ServerCall<ReqT,
     delegate().setMessageCompression(enabled);
   }
 
+  /**
+   * A hint to the call that specifies how many bytes must be queued before
+   * {@link #isReady()} will return true. A call may ignore this property if
+   * unsupported. This must be set before any messages are sent.
+   *
+   * @param numBytes The number of bytes that must be queued. Must be a
+   *                 positive integer.
+   */
+  @Override
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11021")
+  public void setOnReadyThreshold(int numBytes) {
+    delegate().setOnReadyThreshold(numBytes);
+  }
+
   @Override
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
   public void setCompression(String compressor) {

--- a/api/src/main/java/io/grpc/PartialForwardingServerCall.java
+++ b/api/src/main/java/io/grpc/PartialForwardingServerCall.java
@@ -58,14 +58,6 @@ abstract class PartialForwardingServerCall<ReqT, RespT> extends ServerCall<ReqT,
     delegate().setMessageCompression(enabled);
   }
 
-  /**
-   * A hint to the call that specifies how many bytes must be queued before
-   * {@link #isReady()} will return true. A call may ignore this property if
-   * unsupported. This must be set before any messages are sent.
-   *
-   * @param numBytes The number of bytes that must be queued. Must be a
-   *                 positive integer.
-   */
   @Override
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11021")
   public void setOnReadyThreshold(int numBytes) {

--- a/api/src/main/java/io/grpc/ServerCall.java
+++ b/api/src/main/java/io/grpc/ServerCall.java
@@ -16,6 +16,8 @@
 
 package io.grpc;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import javax.annotation.Nullable;
 
 /**
@@ -211,15 +213,15 @@ public abstract class ServerCall<ReqT, RespT> {
 
   /**
    * A hint to the call that specifies how many bytes must be queued before
-   * {@link #isReady()} will return true. A call may ignore this property if
-   * unsupported. This must be set before any messages are sent.
+   * {@link #isReady()} will return false. A call may ignore this property if
+   * unsupported. This may only be set before any messages are sent.
    *
    * @param numBytes The number of bytes that must be queued. Must be a
    *                 positive integer.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11021")
   public void setOnReadyThreshold(int numBytes) {
-    // noop
+    checkArgument(numBytes > 0, "numBytes must be positive: %s", numBytes);
   }
 
   /**

--- a/api/src/main/java/io/grpc/ServerCall.java
+++ b/api/src/main/java/io/grpc/ServerCall.java
@@ -210,6 +210,19 @@ public abstract class ServerCall<ReqT, RespT> {
   }
 
   /**
+   * A hint to the call that specifies how many bytes must be queued before
+   * {@link #isReady()} will return true. A call may ignore this property if
+   * unsupported. This must be set before any messages are sent.
+   *
+   * @param numBytes The number of bytes that must be queued. Must be a
+   *                 positive integer.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11021")
+  public void setOnReadyThreshold(int numBytes) {
+    // noop
+  }
+
+  /**
    * Returns the level of security guarantee in communications
    *
    * <p>Determining the level of security offered by the transport for RPCs on server-side.

--- a/binder/src/main/java/io/grpc/binder/internal/MultiMessageServerStream.java
+++ b/binder/src/main/java/io/grpc/binder/internal/MultiMessageServerStream.java
@@ -65,6 +65,11 @@ final class MultiMessageServerStream implements ServerStream {
   }
 
   @Override
+  public void setOnReadyThreshold(int numBytes) {
+    // No-op
+  }
+
+  @Override
   public boolean isReady() {
     return outbound.isReady();
   }

--- a/binder/src/main/java/io/grpc/binder/internal/SingleMessageServerStream.java
+++ b/binder/src/main/java/io/grpc/binder/internal/SingleMessageServerStream.java
@@ -68,6 +68,11 @@ final class SingleMessageServerStream implements ServerStream {
   }
 
   @Override
+  public void setOnReadyThreshold(int numBytes) {
+    // No-op
+  }
+
+  @Override
   public boolean isReady() {
     return outbound.isReady();
   }

--- a/core/src/main/java/io/grpc/internal/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream.java
@@ -243,9 +243,13 @@ public abstract class AbstractClientStream extends AbstractStream
     protected TransportState(
         int maxMessageSize,
         StatsTraceContext statsTraceCtx,
-        TransportTracer transportTracer) {
+        TransportTracer transportTracer,
+        CallOptions options) {
       super(maxMessageSize, statsTraceCtx, transportTracer);
       this.statsTraceCtx = checkNotNull(statsTraceCtx, "statsTraceCtx");
+      if (options.getOnReadyThreshold() != null) {
+        this.setOnReadyThreshold(options.getOnReadyThreshold());
+      }
     }
 
     private void setFullStreamDecompression(boolean fullStreamDecompression) {

--- a/core/src/main/java/io/grpc/internal/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerStream.java
@@ -187,7 +187,6 @@ public abstract class AbstractServerStream extends AbstractStream
    *                 positive integer.
    */
   @Override
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11021")
   public void setOnReadyThreshold(int numBytes) {
     super.setOnReadyThreshold(numBytes);
   }

--- a/core/src/main/java/io/grpc/internal/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerStream.java
@@ -180,8 +180,8 @@ public abstract class AbstractServerStream extends AbstractStream
 
   /**
    * A hint to the stream that specifies how many bytes must be queued before
-   * {@link StreamListener#onReady()} will be called. A stream may ignore this property if
-   * unsupported. This must be set before any messages are sent.
+   * {@link #isReady()} will return false. A stream may ignore this property
+   * if unsupported. This may only be set before any messages are sent.
    *
    * @param numBytes The number of bytes that must be queued. Must be a
    *                 positive integer.

--- a/core/src/main/java/io/grpc/internal/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerStream.java
@@ -19,6 +19,7 @@ package io.grpc.internal;
 import com.google.common.base.Preconditions;
 import io.grpc.Attributes;
 import io.grpc.Decompressor;
+import io.grpc.ExperimentalApi;
 import io.grpc.InternalStatus;
 import io.grpc.Metadata;
 import io.grpc.Status;
@@ -178,6 +179,20 @@ public abstract class AbstractServerStream extends AbstractStream
   }
 
   /**
+   * A hint to the stream that specifies how many bytes must be queued before
+   * {@link StreamListener#onReady()} will be called. A stream may ignore this property if
+   * unsupported. This must be set before any messages are sent.
+   *
+   * @param numBytes The number of bytes that must be queued. Must be a
+   *                 positive integer.
+   */
+  @Override
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11021")
+  public void setOnReadyThreshold(int numBytes) {
+    super.setOnReadyThreshold(numBytes);
+  }
+
+  /**
    * This should only be called from the transport thread (except for private interactions with
    * {@code AbstractServerStream}).
    */
@@ -242,6 +257,8 @@ public abstract class AbstractServerStream extends AbstractStream
         deframerClosedTask = null;
       }
     }
+
+
 
     @Override
     protected ServerStreamListener listener() {

--- a/core/src/main/java/io/grpc/internal/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerStream.java
@@ -19,7 +19,6 @@ package io.grpc.internal;
 import com.google.common.base.Preconditions;
 import io.grpc.Attributes;
 import io.grpc.Decompressor;
-import io.grpc.ExperimentalApi;
 import io.grpc.InternalStatus;
 import io.grpc.Metadata;
 import io.grpc.Status;

--- a/core/src/main/java/io/grpc/internal/AbstractStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractStream.java
@@ -79,8 +79,9 @@ public abstract class AbstractStream implements Stream {
 
   /**
    * A hint to the stream that specifies how many bytes must be queued before
-   * {@link StreamListener#onReady()} will be called. A stream may ignore this property if
-   * unsupported. This must be set before any messages are sent.
+   * {@link #isReady()} will return false. A stream may ignore this property if
+   * unsupported. This may only be set during stream initialization before
+   * any messages are set.
    *
    * @param numBytes The number of bytes that must be queued. Must be a
    *                 positive integer.
@@ -196,8 +197,8 @@ public abstract class AbstractStream implements Stream {
 
     /**
      * A hint to the stream that specifies how many bytes must be queued before
-     * {@link StreamListener#onReady()} will be called. A stream may ignore this property if
-     * unsupported. This must be set before any messages are sent.
+     * {@link #isReady()} will return false. A stream may ignore this property if
+     * unsupported. This may only be set before any messages are sent.
      *
      * @param numBytes The number of bytes that must be queued. Must be a
      *                 positive integer.

--- a/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java
+++ b/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java
@@ -18,6 +18,7 @@ package io.grpc.internal;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
+import io.grpc.CallOptions;
 import io.grpc.InternalMetadata;
 import io.grpc.InternalStatus;
 import io.grpc.Metadata;
@@ -67,8 +68,9 @@ public abstract class Http2ClientStreamTransportState extends AbstractClientStre
   protected Http2ClientStreamTransportState(
       int maxMessageSize,
       StatsTraceContext statsTraceCtx,
-      TransportTracer transportTracer) {
-    super(maxMessageSize, statsTraceCtx, transportTracer);
+      TransportTracer transportTracer,
+      CallOptions options) {
+    super(maxMessageSize, statsTraceCtx, transportTracer, options);
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -34,7 +34,6 @@ import io.grpc.Compressor;
 import io.grpc.CompressorRegistry;
 import io.grpc.Context;
 import io.grpc.DecompressorRegistry;
-import io.grpc.ExperimentalApi;
 import io.grpc.InternalDecompressorRegistry;
 import io.grpc.InternalStatus;
 import io.grpc.Metadata;

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -34,6 +34,7 @@ import io.grpc.Compressor;
 import io.grpc.CompressorRegistry;
 import io.grpc.Context;
 import io.grpc.DecompressorRegistry;
+import io.grpc.ExperimentalApi;
 import io.grpc.InternalDecompressorRegistry;
 import io.grpc.InternalStatus;
 import io.grpc.Metadata;
@@ -182,6 +183,20 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
   @Override
   public void setMessageCompression(boolean enable) {
     stream.setMessageCompression(enable);
+  }
+
+  /**
+   * A hint to the call that specifies how many bytes must be queued before
+   * {@link #isReady()} will return true. A call may ignore this property if
+   * unsupported. This must be set before any messages are sent.
+   *
+   * @param numBytes The number of bytes that must be queued. Must be a
+   *                 positive integer.
+   */
+  @Override
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11021")
+  public void setOnReadyThreshold(int numBytes) {
+    stream.setOnReadyThreshold(numBytes);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -185,14 +185,6 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
     stream.setMessageCompression(enable);
   }
 
-  /**
-   * A hint to the call that specifies how many bytes must be queued before
-   * {@link #isReady()} will return true. A call may ignore this property if
-   * unsupported. This must be set before any messages are sent.
-   *
-   * @param numBytes The number of bytes that must be queued. Must be a
-   *                 positive integer.
-   */
   @Override
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11021")
   public void setOnReadyThreshold(int numBytes) {

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -186,7 +186,6 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
   }
 
   @Override
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11021")
   public void setOnReadyThreshold(int numBytes) {
     stream.setOnReadyThreshold(numBytes);
   }

--- a/core/src/main/java/io/grpc/internal/ServerStream.java
+++ b/core/src/main/java/io/grpc/internal/ServerStream.java
@@ -18,7 +18,6 @@ package io.grpc.internal;
 
 import io.grpc.Attributes;
 import io.grpc.Decompressor;
-import io.grpc.ExperimentalApi;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import javax.annotation.Nullable;

--- a/core/src/main/java/io/grpc/internal/ServerStream.java
+++ b/core/src/main/java/io/grpc/internal/ServerStream.java
@@ -18,6 +18,7 @@ package io.grpc.internal;
 
 import io.grpc.Attributes;
 import io.grpc.Decompressor;
+import io.grpc.ExperimentalApi;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import javax.annotation.Nullable;
@@ -96,4 +97,15 @@ public interface ServerStream extends Stream {
    * The HTTP/2 stream id, or {@code -1} if not supported.
    */
   int streamId();
+
+  /**
+   * A hint to the stream that specifies how many bytes must be queued before
+   * {@link StreamListener#onReady()} will be called. A stream may ignore this property if
+   * unsupported. This must be set before any messages are sent.
+   *
+   * @param numBytes The number of bytes that must be queued. Must be a
+   *                 positive integer.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11021")
+  void setOnReadyThreshold(int numBytes);
 }

--- a/core/src/main/java/io/grpc/internal/ServerStream.java
+++ b/core/src/main/java/io/grpc/internal/ServerStream.java
@@ -107,6 +107,5 @@ public interface ServerStream extends Stream {
    * @param numBytes The number of bytes that must be queued. Must be a
    *                 positive integer.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11021")
   void setOnReadyThreshold(int numBytes);
 }

--- a/core/src/main/java/io/grpc/internal/ServerStream.java
+++ b/core/src/main/java/io/grpc/internal/ServerStream.java
@@ -100,8 +100,9 @@ public interface ServerStream extends Stream {
 
   /**
    * A hint to the stream that specifies how many bytes must be queued before
-   * {@link StreamListener#onReady()} will be called. A stream may ignore this property if
-   * unsupported. This must be set before any messages are sent.
+   * {@link #isReady()} will return false. A stream may ignore this property if
+   * unsupported. This may only be set during stream initialization before
+   * any messages are set.
    *
    * @param numBytes The number of bytes that must be queued. Must be a
    *                 positive integer.

--- a/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
@@ -617,7 +617,7 @@ public class AbstractClientStreamTest {
     }
 
     public BaseTransportState(StatsTraceContext statsTraceCtx, TransportTracer transportTracer) {
-      super(DEFAULT_MAX_MESSAGE_SIZE, statsTraceCtx, transportTracer);
+      super(DEFAULT_MAX_MESSAGE_SIZE, statsTraceCtx, transportTracer, CallOptions.DEFAULT);
     }
 
     @Override

--- a/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.internal.ClientStreamListener.RpcProgress.PROCESSED;
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -482,6 +483,41 @@ public class AbstractClientStreamTest {
     assertThat(insight.toString()).isEqualTo("[remote_addr=fake_server_addr]");
   }
 
+  @Test
+  public void overrideOnReadyThreshold() {
+    AbstractClientStream.Sink sink = mock(AbstractClientStream.Sink.class);
+    BaseTransportState state = new BaseTransportState(statsTraceCtx, transportTracer);
+    AbstractClientStream stream = new BaseAbstractClientStream(
+        allocator,
+        state,
+        sink,
+        statsTraceCtx,
+        transportTracer,
+        CallOptions.DEFAULT.withOnReadyThreshold(10),
+        true);
+    ClientStreamListener listener = new NoopClientStreamListener();
+    stream.start(listener);
+    state.onStreamAllocated();
+
+    // Stream should be ready. 0 bytes are queued.
+    assertTrue(stream.isReady());
+
+    // Queue some bytes above the custom threshold and check that the stream is not ready.
+    stream.onSendingBytes(100);
+    assertFalse(stream.isReady());
+
+    // Simulate a flush and verify ready now.
+    stream.transportState().onSentBytes(91);
+    assertTrue(stream.isReady());
+  }
+
+  @Test
+  public void resetOnReadyThreshold() {
+    CallOptions options = CallOptions.DEFAULT.withOnReadyThreshold(10);
+    assertEquals(Integer.valueOf(10), options.getOnReadyThreshold());
+    assertNull(options.clearOnReadyThreshold().getOnReadyThreshold());
+  }
+
   /**
    * No-op base class for testing.
    */
@@ -517,9 +553,23 @@ public class AbstractClientStreamTest {
         StatsTraceContext statsTraceCtx,
         TransportTracer transportTracer,
         boolean useGet) {
-      super(allocator, statsTraceCtx, transportTracer, new Metadata(), CallOptions.DEFAULT, useGet);
+      this(allocator, state, sink, statsTraceCtx, transportTracer, CallOptions.DEFAULT, useGet);
+    }
+
+    public BaseAbstractClientStream(
+        WritableBufferAllocator allocator,
+        TransportState state,
+        Sink sink,
+        StatsTraceContext statsTraceCtx,
+        TransportTracer transportTracer,
+        CallOptions callOptions,
+        boolean useGet) {
+      super(allocator, statsTraceCtx, transportTracer, new Metadata(), callOptions, useGet);
       this.state = state;
       this.sink = sink;
+      if (callOptions.getOnReadyThreshold() != null) {
+        this.transportState().setOnReadyThreshold(callOptions.getOnReadyThreshold());
+      }
     }
 
     @Override

--- a/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
@@ -18,6 +18,7 @@ package io.grpc.internal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -369,6 +370,15 @@ public class AbstractServerStreamTest {
     assertEquals(
         Status.Code.INTERNAL, metadataCaptor.getValue().get(InternalStatus.CODE_KEY).getCode());
     assertEquals("bad", metadataCaptor.getValue().get(InternalStatus.MESSAGE_KEY));
+  }
+
+  @Test
+  public void changeOnReadyThreshold() {
+    stream.setListener(new ServerStreamListenerBase());
+    stream.transportState().onStreamAllocated();
+    stream.setOnReadyThreshold(Integer.MAX_VALUE);
+    stream.onSendingBytes(Integer.MAX_VALUE - 1);
+    assertTrue(stream.isReady());
   }
 
   private static class ServerStreamListenerBase implements ServerStreamListener {

--- a/core/src/test/java/io/grpc/internal/Http2ClientStreamTransportStateTest.java
+++ b/core/src/test/java/io/grpc/internal/Http2ClientStreamTransportStateTest.java
@@ -361,6 +361,7 @@ public class Http2ClientStreamTransportStateTest {
     public BaseTransportState(TransportTracer transportTracer, CallOptions options) {
       super(DEFAULT_MAX_MESSAGE_SIZE, StatsTraceContext.NOOP, transportTracer, options);
     }
+
     public BaseTransportState(TransportTracer transportTracer) {
       this(transportTracer, CallOptions.DEFAULT);
     }

--- a/core/src/test/java/io/grpc/internal/Http2ClientStreamTransportStateTest.java
+++ b/core/src/test/java/io/grpc/internal/Http2ClientStreamTransportStateTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import io.grpc.CallOptions;
 import io.grpc.InternalMetadata;
 import io.grpc.Metadata;
 import io.grpc.Status;
@@ -349,7 +350,7 @@ public class Http2ClientStreamTransportStateTest {
 
   private static class BaseTransportState extends Http2ClientStreamTransportState {
     public BaseTransportState(TransportTracer transportTracer) {
-      super(DEFAULT_MAX_MESSAGE_SIZE, StatsTraceContext.NOOP, transportTracer);
+      super(DEFAULT_MAX_MESSAGE_SIZE, StatsTraceContext.NOOP, transportTracer, CallOptions.DEFAULT);
     }
 
     @Override

--- a/core/src/test/java/io/grpc/internal/Http2ClientStreamTransportStateTest.java
+++ b/core/src/test/java/io/grpc/internal/Http2ClientStreamTransportStateTest.java
@@ -348,9 +348,21 @@ public class Http2ClientStreamTransportStateTest {
     assertEquals(Code.UNKNOWN, statusCaptor.getValue().getCode());
   }
 
+  @Test
+  public void transportStateWithOnReadyThreshold() {
+    BaseTransportState state = new BaseTransportState(transportTracer,
+        CallOptions.DEFAULT.withOnReadyThreshold(Integer.MAX_VALUE));
+    assertEquals(Integer.MAX_VALUE, state.onReadyThreshold);
+  }
+
   private static class BaseTransportState extends Http2ClientStreamTransportState {
+    private int onReadyThreshold;
+
+    public BaseTransportState(TransportTracer transportTracer, CallOptions options) {
+      super(DEFAULT_MAX_MESSAGE_SIZE, StatsTraceContext.NOOP, transportTracer, options);
+    }
     public BaseTransportState(TransportTracer transportTracer) {
-      super(DEFAULT_MAX_MESSAGE_SIZE, StatsTraceContext.NOOP, transportTracer, CallOptions.DEFAULT);
+      this(transportTracer, CallOptions.DEFAULT);
     }
 
     @Override
@@ -367,6 +379,12 @@ public class Http2ClientStreamTransportStateTest {
     @Override
     public void runOnTransportThread(Runnable r) {
       r.run();
+    }
+
+    @Override
+    void setOnReadyThreshold(int numBytes) {
+      onReadyThreshold = numBytes;
+      super.setOnReadyThreshold(numBytes);
     }
   }
 }

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -148,6 +148,12 @@ public class ServerCallImplTest {
   }
 
   @Test
+  public void setOnReadyThreshold() {
+    call.setOnReadyThreshold(10);
+    verify(stream).setOnReadyThreshold(10);
+  }
+
+  @Test
   public void sendHeader_firstCall() {
     Metadata headers = new Metadata();
 

--- a/cronet/src/main/java/io/grpc/cronet/CronetClientStream.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetClientStream.java
@@ -124,7 +124,8 @@ class CronetClientStream extends AbstractClientStream {
     this.delayRequestHeader = (method.getType() == MethodDescriptor.MethodType.UNARY);
     this.annotation = callOptions.getOption(CRONET_ANNOTATION_KEY);
     this.annotations = callOptions.getOption(CRONET_ANNOTATIONS_KEY);
-    this.state = new TransportState(maxMessageSize, statsTraceCtx, lock, transportTracer);
+    this.state = new TransportState(maxMessageSize, statsTraceCtx, lock, transportTracer,
+            callOptions);
 
     // Tests expect the "plain" deframer behavior, not MigratingDeframer
     // https://github.com/grpc/grpc-java/issues/7140
@@ -270,8 +271,8 @@ class CronetClientStream extends AbstractClientStream {
 
     public TransportState(
         int maxMessageSize, StatsTraceContext statsTraceCtx, Object lock,
-        TransportTracer transportTracer) {
-      super(maxMessageSize, statsTraceCtx, transportTracer);
+        TransportTracer transportTracer, CallOptions options) {
+      super(maxMessageSize, statsTraceCtx, transportTracer, options);
       this.lock = Preconditions.checkNotNull(lock, "lock");
     }
 

--- a/inprocess/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/inprocess/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -699,16 +699,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
         return -1;
       }
 
-      /**
-       * A hint to the stream that specifies how many bytes must be queued before
-       * {@link StreamListener#onReady()} will be called. A stream may ignore this property if
-       * unsupported. This must be set before any messages are sent.
-       *
-       * @param numBytes The number of bytes that must be queued. Must be a
-       *                 positive integer.
-       */
       @Override
-      @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11021")
       public void setOnReadyThreshold(int numBytes) {
         // noop
       }

--- a/inprocess/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/inprocess/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -31,6 +31,7 @@ import io.grpc.Compressor;
 import io.grpc.Deadline;
 import io.grpc.Decompressor;
 import io.grpc.DecompressorRegistry;
+import io.grpc.ExperimentalApi;
 import io.grpc.Grpc;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalLogId;
@@ -696,6 +697,20 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
       @Override
       public int streamId() {
         return -1;
+      }
+
+      /**
+       * A hint to the stream that specifies how many bytes must be queued before
+       * {@link StreamListener#onReady()} will be called. A stream may ignore this property if
+       * unsupported. This must be set before any messages are sent.
+       *
+       * @param numBytes The number of bytes that must be queued. Must be a
+       *                 positive integer.
+       */
+      @Override
+      @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11021")
+      public void setOnReadyThreshold(int numBytes) {
+        // noop
       }
     }
 

--- a/inprocess/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/inprocess/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -31,7 +31,6 @@ import io.grpc.Compressor;
 import io.grpc.Deadline;
 import io.grpc.Decompressor;
 import io.grpc.DecompressorRegistry;
-import io.grpc.ExperimentalApi;
 import io.grpc.Grpc;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalLogId;

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -92,9 +92,6 @@ class NettyClientStream extends AbstractClientStream {
     this.authority = checkNotNull(authority, "authority");
     this.scheme = checkNotNull(scheme, "scheme");
     this.userAgent = userAgent;
-    if (callOptions.getOnReadyThreshold() != null) {
-      this.setOnReadyThreshold(callOptions.getOnReadyThreshold());
-    }
   }
 
   @Override
@@ -240,8 +237,9 @@ class NettyClientStream extends AbstractClientStream {
         int maxMessageSize,
         StatsTraceContext statsTraceCtx,
         TransportTracer transportTracer,
-        String methodName) {
-      super(maxMessageSize, statsTraceCtx, transportTracer);
+        String methodName,
+        CallOptions options) {
+      super(maxMessageSize, statsTraceCtx, transportTracer, options);
       this.methodName = checkNotNull(methodName, "methodName");
       this.handler = checkNotNull(handler, "handler");
       this.eventLoop = checkNotNull(eventLoop, "eventLoop");

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -92,6 +92,9 @@ class NettyClientStream extends AbstractClientStream {
     this.authority = checkNotNull(authority, "authority");
     this.scheme = checkNotNull(scheme, "scheme");
     this.userAgent = userAgent;
+    if (callOptions.getOnReadyThreshold() != null) {
+      this.setOnReadyThreshold(callOptions.getOnReadyThreshold());
+    }
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -188,7 +188,8 @@ class NettyClientTransport implements ConnectionClientTransport {
             maxMessageSize,
             statsTraceCtx,
             transportTracer,
-            method.getFullMethodName()) {
+            method.getFullMethodName(),
+            callOptions) {
           @Override
           protected Status statusFromFailedFuture(ChannelFuture f) {
             return NettyClientTransport.this.statusFromFailedFuture(f);

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -1000,7 +1000,8 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
           maxMessageSize,
           StatsTraceContext.NOOP,
           transportTracer,
-          "methodName");
+          "methodName",
+          CallOptions.DEFAULT);
     }
 
     @Override

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -69,7 +69,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.LinkedList;
 import java.util.Queue;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -506,32 +505,6 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
             AsciiString.of("/testService/test?" + BaseEncoding.base64().encode(msg)));
   }
 
-
-  @Test
-  public void overrideOnReadyThreshold() throws Exception {
-    AtomicInteger mutableReadyThreshold = new AtomicInteger(0);
-    when(handler.getWriteQueue()).thenReturn(writeQueue);
-    NettyClientStream unused = new NettyClientStream(
-        new TransportStateImpl(handler, DEFAULT_MAX_MESSAGE_SIZE),
-        methodDescriptor,
-        new Metadata(),
-        channel,
-        AsciiString.of("localhost"),
-        AsciiString.of("http"),
-        AsciiString.of("agent"),
-        StatsTraceContext.NOOP,
-        transportTracer,
-        CallOptions.DEFAULT.withOnReadyThreshold(Integer.MAX_VALUE),
-        false) {
-      @Override
-      protected void setOnReadyThreshold(int numBytes) {
-        mutableReadyThreshold.set(numBytes);
-        super.setOnReadyThreshold(numBytes);
-      }
-    };
-    assertEquals(Integer.MAX_VALUE, mutableReadyThreshold.get());
-  }
-
   @Override
   protected NettyClientStream createStream() {
     when(handler.getWriteQueue()).thenReturn(writeQueue);
@@ -590,7 +563,8 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
           maxMessageSize,
           StatsTraceContext.NOOP,
           transportTracer,
-          "methodName");
+          "methodName",
+          CallOptions.DEFAULT);
     }
 
     @Override

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -100,6 +100,9 @@ class OkHttpClientStream extends AbstractClientStream {
             transport,
             initialWindowSize,
             method.getFullMethodName());
+    if (callOptions.getOnReadyThreshold() != null) {
+      this.setOnReadyThreshold(callOptions.getOnReadyThreshold());
+    }
   }
 
   @Override

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -99,10 +99,8 @@ class OkHttpClientStream extends AbstractClientStream {
             outboundFlow,
             transport,
             initialWindowSize,
-            method.getFullMethodName());
-    if (callOptions.getOnReadyThreshold() != null) {
-      this.setOnReadyThreshold(callOptions.getOnReadyThreshold());
-    }
+            method.getFullMethodName(),
+            callOptions);
   }
 
   @Override
@@ -225,8 +223,9 @@ class OkHttpClientStream extends AbstractClientStream {
         OutboundFlowController outboundFlow,
         OkHttpClientTransport transport,
         int initialWindowSize,
-        String methodName) {
-      super(maxMessageSize, statsTraceCtx, OkHttpClientStream.this.getTransportTracer());
+        String methodName,
+        CallOptions options) {
+      super(maxMessageSize, statsTraceCtx, OkHttpClientStream.this.getTransportTracer(), options);
       this.lock = checkNotNull(lock, "lock");
       this.frameWriter = frameWriter;
       this.outboundFlow = outboundFlow;

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
@@ -44,7 +44,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
 import org.junit.Rule;
@@ -259,33 +258,6 @@ public class OkHttpClientStreamTest {
     assertThat(headersCaptor.getValue()).contains(
         new Header(Header.TARGET_PATH, "/" + getMethod.getFullMethodName() + "?"
             + BaseEncoding.base64().encode(msg)));
-  }
-
-  @Test
-  public void overrideOnReadyThreshold() {
-    AtomicInteger mutableReadyThreshold = new AtomicInteger(0);
-    new OkHttpClientStream(
-        methodDescriptor,
-        new Metadata(),
-        frameWriter,
-        transport,
-        flowController,
-        lock,
-        MAX_MESSAGE_SIZE,
-        INITIAL_WINDOW_SIZE,
-        "localhost",
-        "userAgent",
-        StatsTraceContext.NOOP,
-        transportTracer,
-        CallOptions.DEFAULT.withOnReadyThreshold(Integer.MAX_VALUE),
-        false) {
-      @Override
-      protected void setOnReadyThreshold(int numBytes) {
-        mutableReadyThreshold.set(numBytes);
-        super.setOnReadyThreshold(numBytes);
-      }
-    };
-    assertEquals(Integer.MAX_VALUE, mutableReadyThreshold.get());
   }
 
   // TODO(carl-mastrangelo): extract this out into a testing/ directory and remove other definitions

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
@@ -44,6 +44,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
 import org.junit.Rule;
@@ -258,6 +259,33 @@ public class OkHttpClientStreamTest {
     assertThat(headersCaptor.getValue()).contains(
         new Header(Header.TARGET_PATH, "/" + getMethod.getFullMethodName() + "?"
             + BaseEncoding.base64().encode(msg)));
+  }
+
+  @Test
+  public void overrideOnReadyThreshold() {
+    AtomicInteger mutableReadyThreshold = new AtomicInteger(0);
+    new OkHttpClientStream(
+        methodDescriptor,
+        new Metadata(),
+        frameWriter,
+        transport,
+        flowController,
+        lock,
+        MAX_MESSAGE_SIZE,
+        INITIAL_WINDOW_SIZE,
+        "localhost",
+        "userAgent",
+        StatsTraceContext.NOOP,
+        transportTracer,
+        CallOptions.DEFAULT.withOnReadyThreshold(Integer.MAX_VALUE),
+        false) {
+      @Override
+      protected void setOnReadyThreshold(int numBytes) {
+        mutableReadyThreshold.set(numBytes);
+        super.setOnReadyThreshold(numBytes);
+      }
+    };
+    assertEquals(Integer.MAX_VALUE, mutableReadyThreshold.get());
   }
 
   // TODO(carl-mastrangelo): extract this out into a testing/ directory and remove other definitions

--- a/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
@@ -67,8 +67,9 @@ public abstract class ServerCallStreamObserver<RespT> extends CallStreamObserver
 
   /**
    * A hint to the call that specifies how many bytes must be queued before
-   * {@link #isReady()} will return true. A call may ignore this property if
-   * unsupported. This must be set before any messages are sent.
+   * {@link #isReady()} will return false. A call may ignore this property if
+   * unsupported. This may only be set during stream initialization before
+   * any messages are set.
    *
    * @param numBytes The number of bytes that must be queued. Must be a
    *                 positive integer.

--- a/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
@@ -64,6 +64,18 @@ public abstract class ServerCallStreamObserver<RespT> extends CallStreamObserver
    */
   public abstract void setOnCancelHandler(Runnable onCancelHandler);
 
+
+  /**
+   * A hint to the call that specifies how many bytes must be queued before
+   * {@link #isReady()} will return true. A call may ignore this property if
+   * unsupported. This must be set before any messages are sent.
+   *
+   * @param numBytes The number of bytes that must be queued. Must be a
+   *                 positive integer.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11021")
+  public abstract void setOnReadyThreshold(int numBytes);
+
   /**
    * Sets the compression algorithm to use for the call. May only be called before sending any
    * messages. Default gRPC servers support the "gzip" compressor.

--- a/stub/src/main/java/io/grpc/stub/ServerCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCalls.java
@@ -395,7 +395,7 @@ public final class ServerCalls {
       call.close(Status.OK, new Metadata());
       completed = true;
     }
-
+    
     @Override
     public boolean isReady() {
       return call.isReady();
@@ -420,6 +420,14 @@ public final class ServerCalls {
           + "during the initial call to the application, before the service returns its "
           + "StreamObserver");
       this.onCancelHandler = onCancelHandler;
+    }
+
+    @Override
+    public void setOnReadyThreshold(int numBytes) {
+      checkState(!frozen, "Cannot alter setOnReadyThreshold after initialization. May only be "
+          + "called during the initial call to the application, before the service returns its "
+          + "StreamObserver");
+      call.setOnReadyThreshold(numBytes);
     }
 
     @Override

--- a/util/src/main/java/io/grpc/util/TransmitStatusRuntimeExceptionInterceptor.java
+++ b/util/src/main/java/io/grpc/util/TransmitStatusRuntimeExceptionInterceptor.java
@@ -219,14 +219,6 @@ public final class TransmitStatusRuntimeExceptionInterceptor implements ServerIn
       });
     }
 
-    /**
-     * A hint to the call that specifies how many bytes must be queued before
-     * {@link #isReady()} will return true. A call may ignore this property if
-     * unsupported. This must be set before any messages are sent.
-     *
-     * @param numBytes The number of bytes that must be queued. Must be a
-     *                 positive integer.
-     */
     @Override
     @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11021")
     public void setOnReadyThreshold(final int numBytes) {

--- a/util/src/main/java/io/grpc/util/TransmitStatusRuntimeExceptionInterceptor.java
+++ b/util/src/main/java/io/grpc/util/TransmitStatusRuntimeExceptionInterceptor.java
@@ -219,6 +219,25 @@ public final class TransmitStatusRuntimeExceptionInterceptor implements ServerIn
       });
     }
 
+    /**
+     * A hint to the call that specifies how many bytes must be queued before
+     * {@link #isReady()} will return true. A call may ignore this property if
+     * unsupported. This must be set before any messages are sent.
+     *
+     * @param numBytes The number of bytes that must be queued. Must be a
+     *                 positive integer.
+     */
+    @Override
+    @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11021")
+    public void setOnReadyThreshold(final int numBytes) {
+      serializingExecutor.execute(new Runnable() {
+        @Override
+        public void run() {
+          SerializingServerCall.super.setOnReadyThreshold(numBytes);
+        }
+      });
+    }
+
     @Override
     public void setCompression(final String compressor) {
       serializingExecutor.execute(new Runnable() {


### PR DESCRIPTION
- on clients this is exposed by setting a CallOption
- on servers this is configured by calling a method on ServerCall or ServerStreamListener