### PR TITLE
netty/shaded: Add missing evaluationDependsOn

### DIFF
--- a/netty/shaded/build.gradle
+++ b/netty/shaded/build.gradle
@@ -17,6 +17,8 @@ description = "gRPC: Netty Shaded"
 
 sourceSets { testShadow {} }
 
+evaluationDependsOn(':grpc-netty')
+
 dependencies {
     implementation project(':grpc-netty')
     runtimeOnly libraries.netty.tcnative,


### PR DESCRIPTION
`project(':grpc-netty').configurations` requires the grpc-netty project to be configured, which requires evaluationDependsOn. Without evaluationDependsOn, project loading order is arbitrary and you can get random errors after small configuration changes.