### PR TITLE
Remove deactivation and GracefulSwitchLb from MultiChildLb

### DIFF
--- a/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
@@ -238,7 +238,7 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
 
     // Raactivate deactivated children
     for (ChildLbState reusedChild : reusedChildren) {
-      reusedChild.reactivate(reusedChild.getPolicyProvider());
+      reusedChild.reactivate(reusedChild.getPolicyFactory());
     }
 
     updateChildrenWithResolvedAddresses(resolvedAddresses, newChildren);
@@ -388,20 +388,20 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
     private final Object config;
 
     private final GracefulSwitchLoadBalancer lb;
-    private final LoadBalancerProvider policyProvider;
+    private final LoadBalancer.Factory policyFactory;
     private ConnectivityState currentState;
     private SubchannelPicker currentPicker;
     private boolean deactivated;
 
-    public ChildLbState(Object key, LoadBalancerProvider policyProvider, Object childConfig,
+    public ChildLbState(Object key, LoadBalancer.Factory policyFactory, Object childConfig,
         SubchannelPicker initialPicker) {
-      this(key, policyProvider, childConfig, initialPicker, null, false);
+      this(key, policyFactory, childConfig, initialPicker, null, false);
     }
 
-    public ChildLbState(Object key, LoadBalancerProvider policyProvider, Object childConfig,
+    public ChildLbState(Object key, LoadBalancer.Factory policyFactory, Object childConfig,
           SubchannelPicker initialPicker, ResolvedAddresses resolvedAddrs, boolean deactivated) {
       this.key = key;
-      this.policyProvider = policyProvider;
+      this.policyFactory = policyFactory;
       this.deactivated = deactivated;
       this.currentPicker = initialPicker;
       this.config = childConfig;
@@ -409,7 +409,7 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
       this.currentState = deactivated ? IDLE : CONNECTING;
       this.resolvedAddresses = resolvedAddrs;
       if (!deactivated) {
-        lb.switchTo(policyProvider);
+        lb.switchTo(policyFactory);
       }
     }
 
@@ -442,7 +442,7 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
      * This base implementation does nothing but reset the flag.  If you really want to both
      * deactivate and reactivate you should override them both.
      */
-    protected void reactivate(LoadBalancerProvider policyProvider) {
+    protected void reactivate(LoadBalancer.Factory policyFactory) {
       deactivated = false;
     }
 
@@ -478,8 +478,8 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
       return currentPicker;
     }
 
-    protected final LoadBalancerProvider getPolicyProvider() {
-      return policyProvider;
+    protected final LoadBalancer.Factory getPolicyFactory() {
+      return policyFactory;
     }
 
     protected final Subchannel getSubchannels(PickSubchannelArgs args) {

--- a/util/src/test/java/io/grpc/util/MultiChildLoadBalancerTest.java
+++ b/util/src/test/java/io/grpc/util/MultiChildLoadBalancerTest.java
@@ -358,9 +358,6 @@ public class MultiChildLoadBalancerTest {
       ConnectivityState overallState = null;
       final Map<Object, SubchannelPicker> childPickers = new HashMap<>();
       for (ChildLbState childLbState : getChildLbStates()) {
-        if (childLbState.isDeactivated()) {
-          continue;
-        }
         childPickers.put(childLbState.getKey(), childLbState.getCurrentPicker());
         overallState = aggregateState(overallState, childLbState.getCurrentState());
       }

--- a/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
@@ -210,13 +210,13 @@ class ClusterManagerLoadBalancer extends MultiChildLoadBalancer {
     }
 
     @Override
-    protected void reactivate(LoadBalancerProvider policyProvider) {
+    protected void reactivate(Factory policyFactory) {
       if (deletionTimer != null && deletionTimer.isPending()) {
         deletionTimer.cancel();
         logger.log(XdsLogLevel.DEBUG, "Child balancer {0} reactivated", getKey());
       }
 
-      super.reactivate(policyProvider);
+      super.reactivate(policyFactory);
     }
 
     @Override

--- a/xds/src/main/java/io/grpc/xds/LazyLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/LazyLoadBalancer.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2024 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import com.google.common.base.Preconditions;
+import io.grpc.ConnectivityState;
+import io.grpc.LoadBalancer;
+import io.grpc.Status;
+import io.grpc.util.ForwardingLoadBalancer;
+
+/**
+ * A load balancer that starts in IDLE instead of CONNECTING. Once it starts connecting, it
+ * instantiates its delegate.
+ */
+final class LazyLoadBalancer extends ForwardingLoadBalancer {
+  private LoadBalancer delegate;
+
+  public LazyLoadBalancer(Helper helper, LoadBalancer.Factory delegateFactory) {
+    this.delegate = new LazyDelegate(helper, delegateFactory);
+  }
+
+  @Override
+  protected LoadBalancer delegate() {
+    return delegate;
+  }
+
+  @Override
+  public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    return delegate.acceptResolvedAddresses(resolvedAddresses);
+  }
+
+  private final class LazyDelegate extends LoadBalancer {
+    private final Helper helper;
+    private final LoadBalancer.Factory delegateFactory;
+    private ResolvedAddresses addresses;
+    private Status error;
+    private boolean updatedBalancingState;
+
+    public LazyDelegate(Helper helper, LoadBalancer.Factory delegateFactory) {
+      this.helper = Preconditions.checkNotNull(helper, "helper");
+      this.delegateFactory = Preconditions.checkNotNull(delegateFactory, "delegateFactory");
+    }
+
+    private LoadBalancer activate() {
+      if (delegate != this) {
+        return delegate;
+      }
+      delegate = delegateFactory.newLoadBalancer(helper);
+      if (addresses != null) {
+        delegate.acceptResolvedAddresses(addresses);
+      }
+      if (error != null) {
+        delegate.handleNameResolutionError(error);
+      }
+      return delegate;
+    }
+
+    @Override
+    public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+      this.addresses = resolvedAddresses;
+      this.error = null;
+      initializeBalancingState();
+      return Status.OK;
+    }
+
+    @Override
+    public void handleNameResolutionError(Status error) {
+      // Preserve addresses, because even old addresses may be used by the real policy
+      this.error = error;
+      initializeBalancingState();
+    }
+
+    private void initializeBalancingState() {
+      if (updatedBalancingState) {
+        return;
+      }
+      helper.updateBalancingState(ConnectivityState.IDLE, new LazyPicker());
+      updatedBalancingState = true;
+    }
+
+    @Override
+    public void requestConnection() {
+      activate().requestConnection();
+    }
+
+    @Override
+    public void shutdown() {
+    }
+
+    private final class LazyPicker extends SubchannelPicker {
+      @Override
+      public PickResult pickSubchannel(PickSubchannelArgs args) {
+        helper.getSynchronizationContext().execute(LazyDelegate.this::activate);
+        return PickResult.withNoResult();
+      }
+
+      @Override
+      public void requestConnection() {
+        helper.getSynchronizationContext().execute(LazyDelegate.this::requestConnection);
+      }
+    }
+  }
+
+  public static final class Factory extends LoadBalancer.Factory {
+    private final LoadBalancer.Factory delegate;
+
+    public Factory(LoadBalancer.Factory delegate) {
+      this.delegate = Preconditions.checkNotNull(delegate, "delegate");
+    }
+
+    @Override public LoadBalancer newLoadBalancer(Helper helper) {
+      return new LazyLoadBalancer(helper, delegate);
+    }
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -99,8 +99,7 @@ final class RingHashLoadBalancer extends MultiChildLoadBalancer {
         return addressValidityStatus;
       }
 
-      // We don't care about reuse because we don't want to activate them
-      addMissingChildrenAndIdReuse(newChildren);
+      addMissingChildren(newChildren);
       updateChildrenWithResolvedAddresses(resolvedAddresses, newChildren);
 
       // Now do the ringhash specific logic with weights and building the ring


### PR DESCRIPTION
I can leave the three commits as separate when merging. The changes to MultiChildLb itself are pretty easy. Most of the review will be in the two earlier commits which remove the dependency on these features.

I think this exposes some other potential cleanups, but I didn't want to bring in too much.