### PR TITLE
rls: Fix a local and remote race

### DIFF
--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -749,10 +749,10 @@ final class CachingRlsLbClient {
         if (!call.isDone()) {
           logger.log(ChannelLogLevel.DEBUG,
               "Transition to pending RLS call not done, adding a pending cache entry");
+          linkedHashLruCache.invalidate(request);
           PendingCacheEntry pendingEntry = new PendingCacheEntry(request, call, backoffPolicy);
           pendingCallCache.put(request, pendingEntry);
           call.addListener(pendingEntry::handleDoneFuture, synchronizationContext);
-          linkedHashLruCache.invalidate(request);
         } else {
           try {
             logger.log(ChannelLogLevel.DEBUG,


### PR DESCRIPTION
The local race passes `rlsPicker` to the channel before CachingRlsLbClient is finished constructing. `RlsPicker` can use multiple of the fields not yet initialized. This seems not to be happening in practice, because it appears like it would break things very loudly (e.g., NPE).

The remote race seems incredibly hard to hit, because it requires an RPC to complete before the pending data tracking the RPC is added to a map. But with if a system is at 100% CPU utilization, maybe it can be hit. If it is hit, all RPCs needing the impacted cache entry will forever be buffered.

CC @temawi 