### PR TITLE
alts,census,gcp-observability: Explicitly set grpc-context as an implementation dependency

### DIFF
--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     api project(':grpc-api')
     implementation project(':grpc-auth'),
             project(':grpc-core'),
+            project(":grpc-context"), // Override google-auth dependency with our newer version
             project(':grpc-grpclb'),
             project(':grpc-protobuf'),
             project(':grpc-stub'),

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -15,12 +15,12 @@ tasks.named("jar").configure {
 }
 
 dependencies {
-    api project(':grpc-api'),
-            project(":grpc-context"), // Override google-auth dependency with our newer version
+    api project(':grpc-api')
             libraries.google.auth.credentials
     implementation libraries.guava
     testImplementation project(':grpc-testing'),
             project(':grpc-core'),
+            project(":grpc-context"), // Override google-auth dependency with our newer version
             libraries.google.auth.oauth2Http
     signature libraries.signature.java
     signature libraries.signature.android

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -16,6 +16,7 @@ tasks.named("jar").configure {
 
 dependencies {
     api project(':grpc-api'),
+            project(":grpc-context"), // Override google-auth dependency with our newer version
             libraries.google.auth.credentials
     implementation libraries.guava
     testImplementation project(':grpc-testing'),

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -15,7 +15,7 @@ tasks.named("jar").configure {
 }
 
 dependencies {
-    api project(':grpc-api')
+    api project(':grpc-api'),
             libraries.google.auth.credentials
     implementation libraries.guava
     testImplementation project(':grpc-testing'),

--- a/census/build.gradle
+++ b/census/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     // force dependent jars to depend on latest grpc-context
     runtimeOnly project(":grpc-context")
     implementation libraries.guava,
+            project(":grpc-context"), // Override opencensus dependency with our newer version
             libraries.opencensus.api,
             libraries.opencensus.contrib.grpc.metrics
 

--- a/gcp-observability/build.gradle
+++ b/gcp-observability/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation project(':grpc-protobuf'),
             project(':grpc-stub'),
             project(':grpc-census'),
+            project(":grpc-context"), // Override opencensus dependency with our newer version
             libraries.opencensus.contrib.grpc.metrics
     // Avoid gradle using project dependencies without configuration: shadow
     implementation (libraries.google.cloud.logging) {

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -15,7 +15,8 @@ dependencies {
     implementation project(':grpc-inprocess')
     implementation project(':grpc-core')
     // Only io.grpc.internal.testing.StatsTestUtils depends on opencensus_api, for internal use.
-    compileOnly libraries.opencensus.api
+    compileOnly libraries.opencensus.api,
+            project(":grpc-context") // Override opencensus dependency with our newer version
     runtimeOnly project(":grpc-api")   // Pull in newer version than census-api
 
     testImplementation libraries.mockito.core


### PR DESCRIPTION
Override google-auth `io.grpc:grpc-context` dependency with our own `project(":grpc-context")`.

This fixes the issue with classes depending on `grpc-alts` implementation receiving very (!) old `io.grpc:grpc-context:1.27.2` as a transitive dependency of `com.google.auth`.   
Projects `grpc-census` `grpc-gcp-observability` are affected in the similar way, except `io.grpc:grpc-context:1.59.1` is pulled as  a transitive dependency of `io.opencensus`. 

### Before
```
❯ ./gradlew -q :grpc-xds:dependencyInsight --configuration=compileClasspath --dependency=io.grpc:grpc-context
*** Skipping the build of codegen and compilation of proto files because skipCodegen=true
  * Skipping the build of Android projects because skipAndroid=true
io.grpc:grpc-context:1.27.2
  Variant compile:
    | Attribute Name                 | Provided | Requested    |
    |--------------------------------|----------|--------------|
    | org.gradle.status              | release  |              |
    | org.gradle.category            | library  | library      |
    | org.gradle.libraryelements     | jar      | classes      |
    | org.gradle.usage               | java-api | java-api     |
    | org.gradle.dependency.bundling |          | external     |
    | org.gradle.jvm.environment     |          | standard-jvm |
    | org.gradle.jvm.version         |          | 8            |

io.grpc:grpc-context:1.27.2
\--- io.opencensus:opencensus-api:0.31.1
     +--- com.google.http-client:google-http-client:1.43.3
     |    +--- com.google.auth:google-auth-library-oauth2-http:1.22.0
     |    |    \--- project :grpc-alts
     |    |         \--- compileClasspath
     |    \--- com.google.http-client:google-http-client-gson:1.43.3
     |         \--- com.google.auth:google-auth-library-oauth2-http:1.22.0 (*)
     \--- io.opencensus:opencensus-contrib-http-util:0.31.1
          \--- com.google.http-client:google-http-client:1.43.3 (*)

(*) - Indicates repeated occurrences of a transitive dependency subtree. Gradle expands transitive dependency subtrees only once per project; repeat occurrences only display the root of the subtree, followed by this annotation.
```

### After
```
❯ ./gradlew -q :grpc-xds:dependencyInsight --configuration=compileClasspath --dependency=io.grpc:grpc-context
*** Skipping the build of codegen and compilation of proto files because skipCodegen=true
  * Skipping the build of Android projects because skipAndroid=true
project :grpc-context
  Variant apiElements:
    | Attribute Name                 | Provided | Requested    |
    |--------------------------------|----------|--------------|
    | org.gradle.category            | library  | library      |
    | org.gradle.dependency.bundling | external | external     |
    | org.gradle.jvm.version         | 8        | 8            |
    | org.gradle.libraryelements     | jar      | classes      |
    | org.gradle.usage               | java-api | java-api     |
    | org.gradle.jvm.environment     |          | standard-jvm |
   Selection reasons:
      - By conflict resolution: between versions 1.63.0-SNAPSHOT and 1.27.2

project :grpc-context
\--- project :grpc-alts
     \--- compileClasspath

io.grpc:grpc-context:1.27.2 -> project :grpc-context
\--- io.opencensus:opencensus-api:0.31.1
     +--- com.google.http-client:google-http-client:1.43.3
     |    +--- com.google.auth:google-auth-library-oauth2-http:1.22.0
     |    |    \--- project :grpc-alts
     |    |         \--- compileClasspath
     |    \--- com.google.http-client:google-http-client-gson:1.43.3
     |         \--- com.google.auth:google-auth-library-oauth2-http:1.22.0 (*)
     \--- io.opencensus:opencensus-contrib-http-util:0.31.1
          \--- com.google.http-client:google-http-client:1.43.3 (*)

(*) - Indicates repeated occurrences of a transitive dependency subtree. Gradle expands transitive dependency subtrees only once per project; repeat occurrences only display the root of the subtree, followed by this annotation.
```