### PR TITLE
netty: Handle write queue promise failures

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerStream.java
@@ -278,6 +278,7 @@ public abstract class AbstractServerStream extends AbstractStream
      */
     public final void transportReportStatus(final Status status) {
       Preconditions.checkArgument(!status.isOk(), "status must not be OK");
+      onStreamDeallocated();
       if (deframerClosed) {
         deframerClosedTask = null;
         closeListener(status);
@@ -300,6 +301,7 @@ public abstract class AbstractServerStream extends AbstractStream
      * #transportReportStatus}.
      */
     public void complete() {
+      onStreamDeallocated();
       if (deframerClosed) {
         deframerClosedTask = null;
         closeListener(Status.OK);
@@ -335,7 +337,6 @@ public abstract class AbstractServerStream extends AbstractStream
           getTransportTracer().reportStreamClosed(closedStatus.isOk());
         }
         listenerClosed = true;
-        onStreamDeallocated();
         listener().closed(newStatus);
       }
     }

--- a/core/src/main/java/io/grpc/internal/AbstractStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractStream.java
@@ -291,6 +291,12 @@ public abstract class AbstractStream implements Stream {
       }
     }
 
+    protected boolean isStreamDeallocated() {
+      synchronized (onReadyLock) {
+        return deallocated;
+      }
+    }
+
     /**
      * Event handler to be called by the subclass when a number of bytes are being queued for
      * sending to the remote endpoint.

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -183,17 +183,32 @@ class NettyClientStream extends AbstractClientStream {
         // Add the bytes to outbound flow control.
         onSendingBytes(numBytes);
         writeQueue.enqueue(new SendGrpcFrameCommand(transportState(), bytebuf, endOfStream), flush)
-            .addListener(new ChannelFutureListener() {
-              @Override
-              public void operationComplete(ChannelFuture future) throws Exception {
-                // If the future succeeds when http2stream is null, the stream has been cancelled
-                // before it began and Netty is purging pending writes from the flow-controller.
-                if (future.isSuccess() && transportState().http2Stream() != null) {
-                  // Remove the bytes from outbound flow control, optionally notifying
-                  // the client that they can send more bytes.
-                  transportState().onSentBytes(numBytes);
-                  NettyClientStream.this.getTransportTracer().reportMessageSent(numMessages);
-                }
+            .addListener((ChannelFutureListener) future -> {
+              // If the future succeeds when http2stream is null, the stream has been cancelled
+              // before it began and Netty is purging pending writes from the flow-controller.
+              if (future.isSuccess() && transportState().http2Stream() == null) {
+                return;
+              }
+
+              if (future.isSuccess()) {
+                // Remove the bytes from outbound flow control, optionally notifying
+                // the client that they can send more bytes.
+                transportState().onSentBytes(numBytes);
+                NettyClientStream.this.getTransportTracer().reportMessageSent(numMessages);
+                // } else {
+              } else if (isReady()) {
+                // Future failed, release blocking.
+                // Normally we don't need to do anything here because the cause of a failed future
+                // while writing DATA frames would be an IO error and the stream is already closed.
+                // However, we still need to handle this case to cover for any issues in Netty
+                // that may lead to the "Stream does not exist" protocol error.
+                // See io.netty.handler.codec.http2.StreamBufferingEncoder#writeData.
+                // Note: isReady() check protects from spamming stream resets by scheduling multiple
+                // CancelClientStreamCommand commands. Initial transportReportStatus() with
+                // stopDelivery=true calls onStreamDeallocated(), which sets a flag to make
+                // the transport state not ready.
+                transportState().http2ProcessingFailed(
+                    transportState().statusFromFailedFuture(future), true, new Metadata());
               }
             });
       } else {

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -183,7 +183,7 @@ class NettyClientStream extends AbstractClientStream {
         // Add the bytes to outbound flow control.
         onSendingBytes(numBytes);
         writeQueue.enqueue(new SendGrpcFrameCommand(transportState(), bytebuf, endOfStream), flush)
-            .addListener((ChannelFutureListener) future -> {
+            .addListener((ChannelFuture future) -> {
               // If the future succeeds when http2stream is null, the stream has been cancelled
               // before it began and Netty is purging pending writes from the flow-controller.
               if (future.isSuccess() && transportState().http2Stream() == null) {

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -195,7 +195,6 @@ class NettyClientStream extends AbstractClientStream {
                 // the client that they can send more bytes.
                 transportState().onSentBytes(numBytes);
                 NettyClientStream.this.getTransportTracer().reportMessageSent(numMessages);
-                // } else {
               } else if (isReady()) {
                 // Future failed, release blocking.
                 // Normally we don't need to do anything here because the cause of a failed future

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -296,7 +296,7 @@ class NettyClientStream extends AbstractClientStream {
       handler.getWriteQueue().enqueue(new CancelClientStreamCommand(this, status), true);
     }
 
-    protected void onWriteFrameData(ChannelFuture future, int numMessages, int numBytes) {
+    private void onWriteFrameData(ChannelFuture future, int numMessages, int numBytes) {
       // If the future succeeds when http2stream is null, the stream has been cancelled
       // before it began and Netty is purging pending writes from the flow-controller.
       if (future.isSuccess() && http2Stream() == null) {

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -502,8 +502,7 @@ class NettyServerHandler extends AbstractNettyHandler {
             state,
             attributes,
             authority,
-            statsTraceCtx,
-            transportTracer);
+            statsTraceCtx);
         transportListener.streamCreated(stream, method, metadata);
         state.onStreamAllocated();
         http2Stream.setProperty(streamKey, state);

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -210,6 +210,7 @@ class NettyServerStream extends AbstractServerStream {
       if (future.isSuccess() || isStreamDeallocated()) {
         return;
       }
+
       // Future failed, fail RPC.
       // Normally we don't need to do anything here because the cause of a failed future
       // while writing DATA frames would be an IO error and the stream is already closed.

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -147,6 +147,8 @@ class NettyServerStream extends AbstractServerStream {
           SendResponseHeadersCommand.createTrailers(transportState(), http2Trailers, status);
       writeQueue.enqueue(trailersCommand, true)
           .addListener((ChannelFuture future) -> handleWriteFutureFailures(future));
+      // .addListener((ChannelFuture future) -> transportState().handleWriteFutureFailures(future));
+      // .addListener((ChannelFutureListener) transportState()::handleWriteFutureFailures);
     }
 
     @Override
@@ -163,6 +165,7 @@ class NettyServerStream extends AbstractServerStream {
       }
     }
 
+    // TODO(sergiitk): move to the TransportState.
     private void handleWriteFutureFailures(ChannelFuture future) {
       // isReady() check protects from spamming stream resets by scheduling multiple
       // CancelServerStreamCommand commands. Initial transportReportStatus()

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -96,7 +96,7 @@ class NettyServerStream extends AbstractServerStream {
         Http2Headers http2headers = Utils.convertServerHeaders(headers);
         SendResponseHeadersCommand headersCommand =
             SendResponseHeadersCommand.createHeaders(transportState(), http2headers);
-        writeQueue.enqueue(headersCommand, true)
+        writeQueue.enqueue(headersCommand, flush)
             .addListener((ChannelFutureListener) transportState()::handleWriteFutureFailures);
       }
     }

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -212,8 +212,8 @@ class NettyServerStream extends AbstractServerStream {
       }
 
       // Future failed, fail RPC.
-      // Normally we don't need to do anything here because the cause of a failed future
-      // while writing DATA frames would be an IO error and the stream is already closed.
+      // Normally we don't need to do anything on frame write failures because the cause of
+      // the failed future would be an IO error that closed the stream.
       // However, we still need handle any unexpected failures raised in Netty.
       http2ProcessingFailed(Utils.statusFromThrowable(future.cause()));
     }

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -214,8 +214,6 @@ class NettyServerStream extends AbstractServerStream {
       // Normally we don't need to do anything here because the cause of a failed future
       // while writing DATA frames would be an IO error and the stream is already closed.
       // However, we still need handle any unexpected failures raised in Netty.
-      // TODO(sergiitk): check if something similar to
-      //    io.grpc.netty.NettyClientTransport#statusFromFailedFuture is needed.
       http2ProcessingFailed(Utils.statusFromThrowable(future.cause()));
     }
 

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -104,9 +104,8 @@ class NettyServerStream extends AbstractServerStream {
       Http2Headers http2headers = Utils.convertServerHeaders(headers);
       SendResponseHeadersCommand headersCommand =
           SendResponseHeadersCommand.createHeaders(transportState(), http2headers);
-      // TODO(sergiitk): special handling for goaway?
       writeQueue.enqueue(headersCommand, flush)
-          .addListener((ChannelFutureListener) this::handleWriteFutureFailures);
+          .addListener((ChannelFuture future) -> handleWriteFutureFailures(future));
     }
 
     private void writeFrameInternal(WritableBuffer frame, boolean flush, final int numMessages) {
@@ -147,7 +146,7 @@ class NettyServerStream extends AbstractServerStream {
       SendResponseHeadersCommand trailersCommand =
           SendResponseHeadersCommand.createTrailers(transportState(), http2Trailers, status);
       writeQueue.enqueue(trailersCommand, true)
-          .addListener((ChannelFutureListener) this::handleWriteFutureFailures);
+          .addListener((ChannelFuture future) -> handleWriteFutureFailures(future));
     }
 
     @Override

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -195,9 +195,8 @@ class NettyServerStream extends AbstractServerStream {
     private void onWriteFrameData(ChannelFuture future, int numMessages, int numBytes) {
       // Remove the bytes from outbound flow control, optionally notifying
       // the client that they can send more bytes.
-      // TODO(sergiitk): should onSentBytes be called only on success?
-      onSentBytes(numBytes);
       if (future.isSuccess()) {
+        onSentBytes(numBytes);
         getTransportTracer().reportMessageSent(numMessages);
       } else {
         handleWriteFutureFailures(future);

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -34,6 +34,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -62,6 +63,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.util.AsciiString;
 import java.io.BufferedInputStream;
@@ -407,6 +409,36 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
     ArgumentCaptor<Status> captor = ArgumentCaptor.forClass(Status.class);
     verify(listener).closed(captor.capture(), same(PROCESSED), any(Metadata.class));
     assertEquals(Status.Code.INTERNAL, captor.getValue().getCode());
+  }
+
+
+  @Test
+  public void writeMessagePromiseFailed() {
+    // Force stream creation.
+    int streamId = Integer.MAX_VALUE;
+    ByteArrayInputStream msg = new ByteArrayInputStream(smallMessage());
+
+    Http2Exception connectionError = Http2Exception.connectionError(
+        io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR,
+        "Stream does not exist %d",
+        streamId);
+    ChannelPromise failedPromise = new DefaultChannelPromise(channel).setFailure(connectionError);
+
+    when(writeQueue.enqueue(any(QueuedCommand.class), anyBoolean())).thenReturn(failedPromise);
+
+    stream().transportState().setId(streamId);
+    stream.writeMessage(msg);
+    stream.flush();
+
+    ArgumentCaptor<CancelClientStreamCommand> commandCaptor =
+        ArgumentCaptor.forClass(CancelClientStreamCommand.class);
+
+    verify(writeQueue, atLeastOnce()).enqueue(commandCaptor.capture(), eq(true));
+
+    CancelClientStreamCommand cancelCommand = commandCaptor.getValue();
+    assertThat(cancelCommand).isInstanceOf(CancelClientStreamCommand.class);
+    assertThat(cancelCommand.reason().getCode()).isEqualTo(Status.INTERNAL.getCode());
+    assertThat(cancelCommand.reason().getCause()).isEqualTo(connectionError);
   }
 
   @Test

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -251,7 +251,6 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
     assertThat(cancelReason.getCode()).isEqualTo(Status.INTERNAL.getCode());
     assertThat(cancelReason.getCause()).isEqualTo(h2Error);
     // Verify listener closed.
-    // TODO(sergiitk): should we expect REFUSED/MISCARRIED instead?
     verify(listener).closed(same(cancelReason), eq(PROCESSED), any(Metadata.class));
   }
 

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -46,7 +46,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.Streams;
 import com.google.common.io.BaseEncoding;
 import io.grpc.CallOptions;
 import io.grpc.InternalStatus;
@@ -83,7 +82,6 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.invocation.Invocation;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -215,44 +213,13 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
   @Test
   public void writeFrameFutureFailedShouldCancelRpc() {
     Http2Exception h2Error = connectionError(PROTOCOL_ERROR, "Stream does not exist %d", STREAM_ID);
-    ChannelPromise failedFuture = new DefaultChannelPromise(channel).setFailure(h2Error);
-
-    // For a single-frame message SendGrpcFrameCommand command is sent once with endStream=true.
-    when(writeQueue.enqueue(any(SendGrpcFrameCommand.class), eq(true))).thenReturn(failedFuture);
-
-    // Write a single-frame message.
-    stream().transportState().setId(STREAM_ID);
-    stream.writeMessage(new ByteArrayInputStream(smallMessage()));
-    stream.flush();
-
-    // Correctness check: verify we're really testing a single-frame writeMessage flow.
-    InOrder inOrder = Mockito.inOrder(writeQueue);
-    inOrder.verify(writeQueue).enqueue(any(CreateStreamCommand.class), eq(false));
-    inOrder.verify(writeQueue).enqueue(any(SendGrpcFrameCommand.class), eq(true));
-    inOrder.verify(writeQueue).enqueue(any(CancelClientStreamCommand.class), eq(true));
-    inOrder.verifyNoMoreInteractions();
-
-    // Get CancelClientStreamCommand, we know it's the last one.
-    Invocation invocation =
-        Streams.findLast(Mockito.mockingDetails(writeQueue).getInvocations().stream()).get();
-    CancelClientStreamCommand cancelCommand = invocation.getArgument(0);
-
-    Status cancelReason = cancelCommand.reason();
-    assertThat(cancelReason.getCode()).isEqualTo(Status.INTERNAL.getCode());
-    assertThat(cancelReason.getCause()).isEqualTo(h2Error);
-    // Verify listener closed.
-    // TODO(sergiitk): should we expect REFUSED/MISCARRIED instead?
-    verify(listener).closed(same(cancelReason), eq(PROCESSED), any(Metadata.class));
-  }
-
-  @Test
-  public void writeMultiFrameFutureFailedShouldCancelRpc() {
-    Http2Exception h2Error = connectionError(PROTOCOL_ERROR, "Stream does not exist %d", STREAM_ID);
     // Fail all SendGrpcFrameCommands command sent to the queue.
     when(writeQueue.enqueue(any(SendGrpcFrameCommand.class), anyBoolean())).thenReturn(
         new DefaultChannelPromise(channel).setFailure(h2Error));
 
-    // Place multiple messages: to ensure multiple frames written to the queue.
+    // Write multiple messages to ensure multiple SendGrpcFrameCommand are enqueued. We set up all
+    // of them to fail, which allows us to assert that only a single cancel is sent, and the stream
+    // isn't spammed with multiple RST_STREAM.
     stream().transportState().setId(STREAM_ID);
     stream.writeMessage(new ByteArrayInputStream(smallMessage()));
     stream.writeMessage(new ByteArrayInputStream(largeMessage()));

--- a/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
@@ -24,13 +24,14 @@ import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -45,7 +46,6 @@ import io.grpc.internal.ServerStreamListener;
 import io.grpc.internal.StatsTraceContext;
 import io.grpc.internal.StreamListener;
 import io.grpc.internal.TransportTracer;
-import io.grpc.netty.WriteQueue.QueuedCommand;
 import io.netty.buffer.EmptyByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.DefaultChannelPromise;
@@ -55,14 +55,18 @@ import io.netty.util.AsciiString;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Queue;
+import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
+import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -134,24 +138,58 @@ public class NettyServerStreamTest extends NettyStreamTestBase<NettyServerStream
   @Test
   public void writeFrameFutureFailedShouldCancelRpc() {
     Http2Exception h2Error = connectionError(PROTOCOL_ERROR, "Stream does not exist %d", STREAM_ID);
-    when(writeQueue.enqueue(any(SendGrpcFrameCommand.class), eq(true))).thenReturn(
+    when(writeQueue.enqueue(any(SendGrpcFrameCommand.class), anyBoolean())).thenReturn(
         new DefaultChannelPromise(channel).setFailure(h2Error));
 
-    // Single-frame message.
+    // Write multiple messages to ensure multiple SendGrpcFrameCommand are enqueued. We set up all
+    // of them to fail, which allows us to assert that only a single cancel is sent, and the stream
+    // isn't spammed with multiple RST_STREAM.
     stream.writeMessage(new ByteArrayInputStream(smallMessage()));
+    stream.writeMessage(new ByteArrayInputStream(largeMessage()));
     stream.flush();
-    verifyWriteFutureFailure(h2Error, SendGrpcFrameCommand.class);
+
+    verifyWriteFutureFailure(h2Error);
+    // Verify CancelServerStreamCommand enqueued once, right after first SendGrpcFrameCommand.
+    InOrder inOrder = Mockito.inOrder(writeQueue);
+    inOrder.verify(writeQueue).enqueue(any(SendGrpcFrameCommand.class), eq(false));
+    // Verify that failed SendGrpcFrameCommand results in immediate CancelServerStreamCommand.
+    inOrder.verify(writeQueue).enqueue(any(CancelServerStreamCommand.class), eq(true));
+    // Verify that any other failures do not produce another CancelServerStreamCommand in the queue.
+    inOrder.verify(writeQueue, atLeast(1)).enqueue(any(SendGrpcFrameCommand.class), eq(false));
+    inOrder.verify(writeQueue).enqueue(any(SendGrpcFrameCommand.class), eq(true));
+    inOrder.verifyNoMoreInteractions();
   }
 
   @Test
   public void writeHeadersFutureFailedShouldCancelRpc() {
     Http2Exception h2Error = connectionError(PROTOCOL_ERROR, "Stream does not exist %d", STREAM_ID);
-    when(writeQueue.enqueue(any(SendResponseHeadersCommand.class), eq(true))).thenReturn(
+    Class<SendResponseHeadersCommand> headersCommandClass = SendResponseHeadersCommand.class;
+    when(writeQueue.enqueue(any(headersCommandClass), anyBoolean())).thenReturn(
         new DefaultChannelPromise(channel).setFailure(h2Error));
 
-    stream().writeHeaders(new Metadata(), true);
+    // Prepare different headers to make it easier to distinguish in the error message.
+    Metadata headers1 = new Metadata();
+    headers1.put(Metadata.Key.of("writeHeaders", Metadata.ASCII_STRING_MARSHALLER), "1");
+    Metadata headers2 = new Metadata();
+    headers2.put(Metadata.Key.of("writeHeaders", Metadata.ASCII_STRING_MARSHALLER), "2");
+    Metadata headers3 = new Metadata();
+    headers3.put(Metadata.Key.of("writeHeaders", Metadata.ASCII_STRING_MARSHALLER), "3");
+
+    // Note that the second (flush) argument of NettyServerStream.Sink#writeHeaders(Metadata,
+    // boolean) is ignored, and SendResponseHeadersCommand is always enqueued with flush=true.
+    stream().writeHeaders(headers1, true);
+    stream().writeHeaders(headers2, true);
+    stream().writeHeaders(headers3, true);
     stream.flush();
-    verifyWriteFutureFailure(h2Error, SendResponseHeadersCommand.class);
+
+    verifyWriteFutureFailure(h2Error);
+    // Verify CancelServerStreamCommand enqueued once, right after first SendResponseHeadersCommand.
+    InOrder inOrder = Mockito.inOrder(writeQueue);
+    inOrder.verify(writeQueue).enqueue(any(headersCommandClass), anyBoolean());
+    inOrder.verify(writeQueue).enqueue(any(CancelServerStreamCommand.class), eq(true));
+    inOrder.verify(writeQueue, atLeast(1)).enqueue(any(headersCommandClass), anyBoolean());
+    inOrder.verifyNoMoreInteractions();
+
   }
 
   @Test
@@ -161,30 +199,35 @@ public class NettyServerStreamTest extends NettyStreamTestBase<NettyServerStream
         new DefaultChannelPromise(channel).setFailure(h2Error));
 
     stream().close(Status.OK, trailers);
-    verifyWriteFutureFailure(h2Error, SendResponseHeadersCommand.class);
+
+    verifyWriteFutureFailure(h2Error);
+    verify(writeQueue).enqueue(any(CancelServerStreamCommand.class), eq(true));
   }
 
-  private void verifyWriteFutureFailure(
-      Http2Exception h2Error, Class<? extends QueuedCommand> failedCommand) {
-    verify(writeQueue, times(1)).enqueue(any(failedCommand), eq(true));
-    verify(writeQueue, times(1)).enqueue(any(CancelServerStreamCommand.class), eq(true));
-    verifyNoMoreInteractions(writeQueue);
-
-    ArgumentCaptor<QueuedCommand> commandCaptor = ArgumentCaptor.forClass(QueuedCommand.class);
-    verify(writeQueue, atLeastOnce()).enqueue(commandCaptor.capture(), eq(true));
-
-    // Check the last call to be CancelClientStreamCommand.
-    QueuedCommand command = commandCaptor.getValue();
-    assertWithMessage("Expected last command on the stream to be CancelServerStreamCommand")
-        .that(command)
-        .isInstanceOf(CancelServerStreamCommand.class);
-    CancelServerStreamCommand cancelCommand = (CancelServerStreamCommand) command;
-    // Check connection error info is propagated via Status.
-    Status cancelReason = cancelCommand.reason();
+  private void verifyWriteFutureFailure(Http2Exception h2Error) {
+    // Check the error that caused the future write failure propagated via Status.
+    Status cancelReason = findCancelServerStreamCommand().reason();
     assertThat(cancelReason.getCode()).isEqualTo(Status.INTERNAL.getCode());
     assertThat(cancelReason.getCause()).isEqualTo(h2Error);
-    // Listener closed.
+    // Verify the listener has closed.
     verify(serverListener).closed(same(cancelReason));
+  }
+
+  private CancelServerStreamCommand findCancelServerStreamCommand() {
+    // Ensure there's no CancelServerStreamCommand enqueued with flush=false.
+    verify(writeQueue, never()).enqueue(any(CancelServerStreamCommand.class), eq(false));
+
+    List<CancelServerStreamCommand> commands = Mockito.mockingDetails(writeQueue).getInvocations()
+        .stream()
+        // Get enqueue() innovations only.
+        .filter(invocation -> invocation.getMethod().getName().equals("enqueue"))
+        // Find the cancel commands.
+        .filter(invocation -> invocation.getArgument(0) instanceof CancelServerStreamCommand)
+        .map(invocation -> invocation.getArgument(0, CancelServerStreamCommand.class))
+        .collect(Collectors.toList());
+
+    assertWithMessage("Expected exactly one CancelClientStreamCommand").that(commands).hasSize(1);
+    return commands.get(0);
   }
 
   @Test

--- a/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
@@ -353,7 +353,7 @@ public class NettyServerStreamTest extends NettyStreamTestBase<NettyServerStream
         handler, channel.eventLoop(), http2Stream, DEFAULT_MAX_MESSAGE_SIZE, statsTraceCtx,
         transportTracer, "method");
     NettyServerStream stream = new NettyServerStream(channel, state, Attributes.EMPTY,
-        "test-authority", statsTraceCtx, transportTracer);
+        "test-authority", statsTraceCtx);
     stream.transportState().setListener(serverListener);
     state.onStreamAllocated();
     verify(serverListener, atLeastOnce()).onReady();

--- a/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
@@ -175,10 +175,9 @@ public class NettyServerStreamTest extends NettyStreamTestBase<NettyServerStream
     Metadata headers3 = new Metadata();
     headers3.put(Metadata.Key.of("writeHeaders", Metadata.ASCII_STRING_MARSHALLER), "3");
 
-    // Note that the second (flush) argument of NettyServerStream.Sink#writeHeaders(Metadata,
-    // boolean) is ignored, and SendResponseHeadersCommand is always enqueued with flush=true.
-    stream().writeHeaders(headers1, true);
-    stream().writeHeaders(headers2, true);
+    // Note writeHeaders flush argument shouldn't matter for this test.
+    stream().writeHeaders(headers1, false);
+    stream().writeHeaders(headers2, false);
     stream().writeHeaders(headers3, true);
     stream.flush();
 
@@ -189,7 +188,6 @@ public class NettyServerStreamTest extends NettyStreamTestBase<NettyServerStream
     inOrder.verify(writeQueue).enqueue(any(CancelServerStreamCommand.class), eq(true));
     inOrder.verify(writeQueue, atLeast(1)).enqueue(any(headersCommandClass), anyBoolean());
     inOrder.verifyNoMoreInteractions();
-
   }
 
   @Test


### PR DESCRIPTION
Handles Netty write frame failures caused by issues in the Netty itself.

Normally we don't need to do anything on frame write failures because the cause of a failed future would be an IO error that resulted in the stream closure.  Prior to this PR we treated these issues as a noop, except the initial headers write on the client side.

However, a case like netty/netty#13805 (a bug in generating next stream id) resulted in an unclosed stream on our side.
This PR adds write frame future failure handlers that ensures the stream is cancelled, and the cause is propagated via Status.

Fixes #10849