### PR TITLE
PoC: client channels

### DIFF
--- a/netty/src/main/java/io/grpc/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/netty/Utils.java
@@ -229,7 +229,6 @@ class Utils {
     Preconditions.checkNotNull(method, "method");
 
     // Discard any application supplied duplicates of the reserved headers
-    headers.discardAll(CONTENT_TYPE_KEY);
     headers.discardAll(GrpcUtil.TE_HEADER);
     headers.discardAll(GrpcUtil.USER_AGENT_KEY);
 
@@ -244,7 +243,6 @@ class Utils {
 
   public static Http2Headers convertServerHeaders(Metadata headers) {
     // Discard any application supplied duplicates of the reserved headers
-    headers.discardAll(CONTENT_TYPE_KEY);
     headers.discardAll(GrpcUtil.TE_HEADER);
     headers.discardAll(GrpcUtil.USER_AGENT_KEY);
 

--- a/netty/src/test/java/io/grpc/clientchannel/ByteBufMarshaller.java
+++ b/netty/src/test/java/io/grpc/clientchannel/ByteBufMarshaller.java
@@ -1,0 +1,95 @@
+package io.grpc.clientchannel;
+
+import io.grpc.*;
+import io.netty.buffer.*;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+class ByteBufMarshaller implements MethodDescriptor.Marshaller<ByteBuf> {
+
+    static ByteBufMarshaller INSTANCE = new ByteBufMarshaller();
+
+    @Override
+    public InputStream stream(ByteBuf value) {
+        return new DrainableInputStream(value);
+    }
+
+    @Override
+    public ByteBuf parse(InputStream stream) {
+        try {
+            // See https://github.com/GoogleCloudPlatform/grpc-gcp-java/pull/77
+            if (stream instanceof KnownLength) {
+                int size = ((KnownLength) stream).available();
+
+                if (size == 0) {
+                    return Unpooled.EMPTY_BUFFER;
+                }
+
+                if (stream instanceof Detachable) {
+                    Detachable detachable = (Detachable) stream;
+                    stream = detachable.detach();
+                }
+
+                if (stream instanceof HasByteBuffer && ((HasByteBuffer) stream).byteBufferSupported()) {
+                    HasByteBuffer hasByteBuffer = (HasByteBuffer) stream;
+                    stream.mark(size);
+
+                    ByteBuf firstBuffer = Unpooled.wrappedBuffer((hasByteBuffer.getByteBuffer()));
+                    stream.skip(firstBuffer.readableBytes());
+
+                    try {
+                        // Skip composite buffer if the result fits into a single buffer
+                        if (stream.available() <= 0) {
+                            return firstBuffer;
+                        }
+
+                        CompositeByteBuf compositeBuffer = Unpooled.compositeBuffer(32);
+                        compositeBuffer.addComponent(true, firstBuffer);
+
+                        while (stream.available() != 0) {
+                            ByteBuffer buffer = ((HasByteBuffer) stream).getByteBuffer();
+                            ByteBuf byteBuf = Unpooled.wrappedBuffer(buffer);
+                            compositeBuffer.addComponent(true, byteBuf);
+                            stream.skip(buffer.remaining());
+                        }
+
+                        return compositeBuffer;
+                    } finally {
+                        stream.reset();
+                    }
+                }
+            }
+
+            ByteBuf buf = Unpooled.buffer(stream.available());
+            buf.writeBytes(stream, stream.available());
+
+            return buf;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    class DrainableInputStream extends ByteBufInputStream implements Drainable {
+
+        private final ByteBuf buffer;
+
+        public DrainableInputStream(ByteBuf buffer) {
+            super(buffer);
+            this.buffer = buffer;
+        }
+
+        @Override
+        public int drainTo(OutputStream target) {
+            int capacity = buffer.readableBytes();
+            try {
+                buffer.getBytes(buffer.readerIndex(), target, capacity);
+                buffer.release();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            return capacity;
+        }
+    }
+}

--- a/netty/src/test/java/io/grpc/clientchannel/ClientChannelService.java
+++ b/netty/src/test/java/io/grpc/clientchannel/ClientChannelService.java
@@ -1,0 +1,159 @@
+package io.grpc.clientchannel;
+
+import io.grpc.*;
+import io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.NettyServerBuilder;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.local.LocalAddress;
+import io.netty.channel.local.LocalServerChannel;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+public abstract class ClientChannelService implements BindableService {
+
+    static String TUNNEL_SERVICE = "io.grpc.Tunnel";
+
+    static MethodDescriptor<ByteBuf, ByteBuf> NEW_TUNNEL_METHOD = MethodDescriptor
+            .newBuilder(ByteBufMarshaller.INSTANCE, ByteBufMarshaller.INSTANCE)
+            .setFullMethodName(TUNNEL_SERVICE + "/new")
+            .setType(MethodDescriptor.MethodType.BIDI_STREAMING)
+            .build();
+
+    public static void registerServer(
+            ManagedChannel networkChannel,
+            Metadata headers,
+            Consumer<ServerBuilder<?>> serverBuilderConsumer
+    ) {
+        ClientCall<ByteBuf, ByteBuf> serverCall = networkChannel.newCall(NEW_TUNNEL_METHOD, CallOptions.DEFAULT);
+
+        DefaultEventLoopGroup eventLoopGroup = new DefaultEventLoopGroup();
+
+        TunnelChannel channel = new TunnelChannel(serverCall::sendMessage);
+
+        NettyServerBuilder nettyServerBuilder = NettyServerBuilder
+                .forAddress(new LocalAddress("clientchannel-" + System.nanoTime()))
+                .workerEventLoopGroup(eventLoopGroup)
+                .bossEventLoopGroup(eventLoopGroup);
+        serverBuilderConsumer.accept(nettyServerBuilder);
+
+        Server server = nettyServerBuilder
+                .withOption(ChannelOption.SO_KEEPALIVE, null)
+                .withOption(ChannelOption.AUTO_READ, true)
+                .withOption(ChannelOption.AUTO_CLOSE, false)
+                .channelFactory(() -> {
+                    return new LocalServerChannel() {
+                        @Override
+                        protected void doBeginRead() {
+                            pipeline().fireChannelRead(channel);
+                        }
+                    };
+                })
+                .build();
+
+        try {
+            server.start();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        serverCall.start(
+                new ClientCall.Listener<ByteBuf>() {
+
+                    @Override
+                    public void onReady() {
+                        serverCall.request(Integer.MAX_VALUE);
+                    }
+
+                    @Override
+                    public void onMessage(ByteBuf bytes) {
+                        if (bytes.readableBytes() > 0) {
+                            channel.pipeline().fireChannelRead(bytes);
+                        }
+                    }
+
+                    @Override
+                    public void onClose(Status status, Metadata trailers) {
+                        server.shutdown();
+                    }
+                },
+                headers
+        );
+    }
+
+    abstract protected void onChannel(ManagedChannel channel, Metadata headers);
+
+    @Override
+    public ServerServiceDefinition bindService() {
+        return ServerServiceDefinition
+                .builder(TUNNEL_SERVICE)
+                .addMethod(NEW_TUNNEL_METHOD, new TunnelHandler(this))
+                .build();
+    }
+
+    static class TunnelHandler implements ServerCallHandler<ByteBuf, ByteBuf> {
+
+        private final ClientChannelService tunnelClientChannelService;
+
+        private final AtomicLong id = new AtomicLong();
+
+        public TunnelHandler(ClientChannelService tunnelClientChannelService) {
+            this.tunnelClientChannelService = tunnelClientChannelService;
+        }
+
+        @Override
+        public ServerCall.Listener<ByteBuf> startCall(ServerCall<ByteBuf, ByteBuf> call, Metadata headers) {
+            try {
+                call.sendHeaders(new Metadata());
+                call.request(Integer.MAX_VALUE);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            TunnelChannel nettyChannel = new TunnelChannel(call::sendMessage);
+            DefaultEventLoopGroup eventLoopGroup = new DefaultEventLoopGroup();
+
+            ManagedChannel grpcChannel = NettyChannelBuilder
+                    .forAddress(new LocalAddress("tunnel-" + id.incrementAndGet()))
+                    .eventLoopGroup(eventLoopGroup)
+                    .directExecutor()
+                    .channelFactory(() -> nettyChannel)
+                    .withOption(ChannelOption.SO_KEEPALIVE, null)
+                    .withOption(ChannelOption.AUTO_READ, false)
+                    .withOption(ChannelOption.AUTO_CLOSE, false)
+                    .usePlaintext()
+                    .build();
+
+            tunnelClientChannelService.onChannel(grpcChannel, headers);
+
+            return new ServerCall.Listener<ByteBuf>() {
+
+                @Override
+                public void onMessage(ByteBuf byteBuf) {
+                    if (byteBuf.readableBytes() > 0) {
+                        nettyChannel.pipeline().fireChannelRead(byteBuf);
+                    }
+                }
+
+                @Override
+                public void onHalfClose() {
+                    onCancel();
+                }
+
+                @Override
+                public void onComplete() {
+                    onCancel();
+                }
+
+                @Override
+                public void onCancel() {
+                    grpcChannel.shutdown();
+                    eventLoopGroup.shutdownGracefully();
+                }
+            };
+        }
+    }
+}

--- a/netty/src/test/java/io/grpc/clientchannel/ClientChannelService.java
+++ b/netty/src/test/java/io/grpc/clientchannel/ClientChannelService.java
@@ -15,6 +15,8 @@ import java.util.function.Consumer;
 
 public abstract class ClientChannelService implements BindableService {
 
+    public static final Metadata.Key<String> CONTENT_TYPE_KEY = Metadata.Key.of("content-type", Metadata.ASCII_STRING_MARSHALLER);
+
     static String TUNNEL_SERVICE = "io.grpc.Tunnel";
 
     static MethodDescriptor<ByteBuf, ByteBuf> NEW_TUNNEL_METHOD = MethodDescriptor
@@ -61,6 +63,8 @@ public abstract class ClientChannelService implements BindableService {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
+
+            headers.put(CONTENT_TYPE_KEY, "application/grpc+raw");
 
             serverCall.start(
                     new ClientCall.Listener<ByteBuf>() {

--- a/netty/src/test/java/io/grpc/clientchannel/TunnelChannel.java
+++ b/netty/src/test/java/io/grpc/clientchannel/TunnelChannel.java
@@ -1,0 +1,94 @@
+package io.grpc.clientchannel;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.*;
+import io.netty.util.ReferenceCountUtil;
+
+import java.net.SocketAddress;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+class TunnelChannel extends AbstractChannel {
+
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private final Consumer<ByteBuf> call;
+
+    public TunnelChannel(Consumer<ByteBuf> call) {
+        super(null);
+        this.call = call;
+    }
+
+    @Override
+    protected void doWrite(ChannelOutboundBuffer in) {
+        Object msg;
+        while ((msg = in.current()) != null) {
+            ReferenceCountUtil.retain(msg);
+            call.accept(((ByteBuf) msg).touch());
+            in.remove();
+        }
+    }
+
+    @Override
+    protected AbstractUnsafe newUnsafe() {
+        return new AbstractUnsafe() {
+            @Override
+            public void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+                promise.setSuccess();
+            }
+        };
+    }
+
+    @Override
+    public boolean isOpen() {
+        return !closed.get();
+    }
+
+    @Override
+    public boolean isActive() {
+        return isOpen();
+    }
+
+    @Override
+    protected void doClose() {
+        closed.set(true);
+    }
+
+    //////////////////////////////////
+
+    @Override
+    protected void doBeginRead() {
+
+    }
+
+    @Override
+    protected boolean isCompatible(EventLoop loop) {
+        return true;
+    }
+
+    @Override
+    public ChannelConfig config() {
+        return new DefaultChannelConfig(this);
+    }
+
+    @Override
+    public ChannelMetadata metadata() {
+        return new ChannelMetadata(false);
+    }
+
+    @Override
+    protected void doBind(SocketAddress localAddress) {}
+
+    @Override
+    protected void doDisconnect() {}
+
+    @Override
+    protected SocketAddress localAddress0() {
+        return null;
+    }
+
+    @Override
+    protected SocketAddress remoteAddress0() {
+        return null;
+    }
+}

--- a/netty/src/test/java/io/grpc/clientchannel/example/TunnelClient.java
+++ b/netty/src/test/java/io/grpc/clientchannel/example/TunnelClient.java
@@ -1,6 +1,5 @@
 package io.grpc.clientchannel.example;
 
-import io.grpc.ConnectivityState;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
 import io.grpc.clientchannel.ClientChannelService;
@@ -16,10 +15,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class TunnelClient {
 
-    public static Metadata.Key<String> PREFIX_HEADER = Metadata.Key.of("zone", Metadata.ASCII_STRING_MARSHALLER);
+    public static Metadata.Key<String> PREFIX_HEADER = Metadata.Key.of("prefix", Metadata.ASCII_STRING_MARSHALLER);
 
     public static void main(String[] args) throws Exception {
-        io.grpc.ManagedChannel networkChannel = ManagedChannelBuilder.forAddress("localhost", 50051).usePlaintext().build();
+        io.grpc.ManagedChannel networkChannel = ManagedChannelBuilder
+                .forAddress("localhost", 50051)
+                .usePlaintext()
+                .build();
 
         Metadata headers = new Metadata();
         headers.put(PREFIX_HEADER, "Value: ");
@@ -29,7 +31,7 @@ public class TunnelClient {
                 headers,
                 b -> {
                     MutableHandlerRegistry registry = new MutableHandlerRegistry();
-                    registry.addService(new VMDriverService());
+                    registry.addService(new SimpleService());
 
                     b.fallbackHandlerRegistry(registry);
                 }
@@ -38,7 +40,7 @@ public class TunnelClient {
         Thread.currentThread().join();
     }
 
-    private static class VMDriverService extends SimpleServiceGrpc.SimpleServiceImplBase {
+    static class SimpleService extends SimpleServiceGrpc.SimpleServiceImplBase {
 
         @Override
         public void serverStreamingRpc(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {

--- a/netty/src/test/java/io/grpc/clientchannel/example/TunnelClient.java
+++ b/netty/src/test/java/io/grpc/clientchannel/example/TunnelClient.java
@@ -1,0 +1,66 @@
+package io.grpc.clientchannel.example;
+
+import io.grpc.ConnectivityState;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.clientchannel.ClientChannelService;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.protobuf.SimpleRequest;
+import io.grpc.testing.protobuf.SimpleResponse;
+import io.grpc.testing.protobuf.SimpleServiceGrpc;
+import io.grpc.util.MutableHandlerRegistry;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TunnelClient {
+
+    public static Metadata.Key<String> PREFIX_HEADER = Metadata.Key.of("zone", Metadata.ASCII_STRING_MARSHALLER);
+
+    public static void main(String[] args) throws Exception {
+        io.grpc.ManagedChannel networkChannel = ManagedChannelBuilder.forAddress("localhost", 50051).usePlaintext().build();
+
+        networkChannel.getState(true);
+
+        networkChannel.notifyWhenStateChanged(ConnectivityState.READY, () -> {
+            Metadata headers = new Metadata();
+            headers.put(PREFIX_HEADER, "Value: ");
+
+            ClientChannelService.registerServer(
+                    networkChannel,
+                    headers,
+                    b -> {
+                        MutableHandlerRegistry registry = new MutableHandlerRegistry();
+                        registry.addService(new VMDriverService());
+
+                        b.fallbackHandlerRegistry(registry);
+                    }
+            );
+        });
+
+        Thread.currentThread().join();
+    }
+
+    private static class VMDriverService extends SimpleServiceGrpc.SimpleServiceImplBase {
+
+        @Override
+        public void serverStreamingRpc(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            AtomicInteger counter = new AtomicInteger(5);
+            Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(
+                    () -> {
+                        int i = counter.getAndDecrement();
+                        if (i > 0) {
+                            responseObserver.onNext(SimpleResponse.newBuilder().setResponseMessage("Hello " + request.getRequestMessage() + " " + i).build());
+                        } else {
+                            responseObserver.onCompleted();
+                            throw new RuntimeException("Completed");
+                        }
+                    },
+                    0,
+                    1,
+                    TimeUnit.SECONDS
+            );
+        }
+    }
+}

--- a/netty/src/test/java/io/grpc/clientchannel/example/TunnelServer.java
+++ b/netty/src/test/java/io/grpc/clientchannel/example/TunnelServer.java
@@ -1,0 +1,55 @@
+package io.grpc.clientchannel.example;
+
+import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.clientchannel.ClientChannelService;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.protobuf.SimpleRequest;
+import io.grpc.testing.protobuf.SimpleResponse;
+import io.grpc.testing.protobuf.SimpleServiceGrpc;
+import io.grpc.testing.protobuf.SimpleServiceGrpc.SimpleServiceStub;
+
+import static io.grpc.clientchannel.example.TunnelClient.PREFIX_HEADER;
+
+public class TunnelServer {
+
+    public static void main(String[] args) throws Exception {
+        Server server = ServerBuilder
+            .forPort(50051)
+            .addService(
+                new ClientChannelService() {
+                    @Override
+                    protected void onChannel(ManagedChannel channel, Metadata headers) {
+                        String prefix = headers.get(PREFIX_HEADER);
+                        SimpleServiceStub stub = SimpleServiceGrpc.newStub(channel);
+
+                        stub.serverStreamingRpc(
+                                SimpleRequest.newBuilder().setRequestMessage("foo").build(),
+                                new StreamObserver<SimpleResponse>() {
+                                    @Override
+                                    public void onNext(SimpleResponse value) {
+                                        System.out.println(prefix + value.getResponseMessage());
+                                    }
+
+                                    @Override
+                                    public void onError(Throwable t) {
+                                        t.printStackTrace();
+                                    }
+
+                                    @Override
+                                    public void onCompleted() {
+                                        System.out.println("Completed");
+                                    }
+                                }
+                        );
+                    }
+                }
+            )
+            .build()
+            .start();
+
+        server.awaitTermination();
+    }
+}


### PR DESCRIPTION
This PR (based off #3987) proposes a potential implementation for Client Channels that allow server call services on connected clients.

The current implementation uses a bi-directional call as a transport by implementing an in-memory Netty channel due to the complexity of the underlying representation. A custom `Marshaller` is used for zero copy operations, to prevent additional buffers from being created. That is achieved with a custom `Drainable` implementation and a `HasByteBuffer` consumer.

The final version should of course be using a custom implementation of both `ManagedChannel` and `InternalServer`.

See https://github.com/grpc/grpc/issues/14101 for the main discussion.