### PR TITLE
Fix retry race condition (1.62.x backport)

### DIFF
--- a/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
@@ -705,6 +705,7 @@ public class RetriableStreamTest {
     // cancel
     retriableStream.cancel(Status.CANCELLED);
     inOrder.verify(retriableStreamRecorder, never()).postCommit();
+    verify(masterListener, times(1)).closed(any(), any(), any());
   }
 
   @Test
@@ -733,6 +734,7 @@ public class RetriableStreamTest {
 
     verifyNoMoreInteractions(mockStream1);
     verifyNoMoreInteractions(mockStream2);
+    verify(masterListener, times(1)).closed(any(), any(), any());
   }
 
   @Test


### PR DESCRIPTION
Future.cancel can return true when the executable has started, but the future value hasn't yet been set which was causing us to do an extra decrement.  That is what was causing `DriveSimControllerRuleTest` to fail with the first attempt to fix the retry deadlock.

Backport of #11026