### PR TITLE
util: Status desc for outlier detection ejection

### DIFF
--- a/util/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
@@ -377,8 +377,9 @@ public final class OutlierDetectionLoadBalancer extends LoadBalancer {
 
     void eject() {
       ejected = true;
-      subchannelStateListener.onSubchannelState(
-          ConnectivityStateInfo.forTransientFailure(Status.UNAVAILABLE));
+      subchannelStateListener.onSubchannelState(ConnectivityStateInfo.forTransientFailure(
+          Status.UNAVAILABLE.withDescription(
+              "The subchannel has been ejected by outlier detection")));
       logger.log(ChannelLogLevel.INFO, "Subchannel ejected: {0}", this);
     }
 


### PR DESCRIPTION
Including a Status description makes it easier to debug subchannel closure issues if it's clear that a subchannel became unavailable because of an outlier detection ejection.

Fixes #10673