### PR TITLE
examples: support retry policy example for bazel build

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -248,3 +248,20 @@ java_grpc_library(
     deps = ["@io_grpc_grpc_proto//:health_java_proto"],
 )
 
+java_binary(
+    name = "retrying-hello-world-client",
+    testonly = 1,
+    main_class = "io.grpc.examples.retrying.RetryingHelloWorldClient",
+    runtime_deps = [
+        ":examples",
+    ],
+)
+
+java_binary(
+    name = "retrying-hello-world-server",
+    testonly = 1,
+    main_class = "io.grpc.examples.retrying.RetryingHelloWorldServer",
+    runtime_deps = [
+        ":examples",
+    ],
+)


### PR DESCRIPTION
According to the docs, I can use bazel to build examples, but retry-example is not supported in bazel config. So If you'll try to build this example with bazel, you'll get an error:
```
examples git:(master) ✗ bazel build :retrying-hello-world-server :retrying-hello-world-client
ERROR: Skipping ':retrying-hello-world-client': no such target '//:retrying-hello-world-client': target 'retrying-hello-world-client' not declared in package '' defined by /Users/rostik404/projects/grpc-java/examples/BUILD.bazel
ERROR: no such target '//:retrying-hello-world-client': target 'retrying-hello-world-client' not declared in package '' defined by /Users/rostik404/projects/grpc-java/examples/BUILD.bazel
INFO: Elapsed time: 0.331s
INFO: 0 processes.
ERROR: Build did NOT complete successfully
```