### PR TITLE
Make setOnReadyThreshold() a noop method instead of abstract.

### DIFF
--- a/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
@@ -77,7 +77,7 @@ public abstract class ServerCallStreamObserver<RespT> extends CallStreamObserver
    *                 positive integer.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11021")
-  public abstract void setOnReadyThreshold(int numBytes) {
+  public void setOnReadyThreshold(int numBytes) {
     checkArgument(numBytes > 0, "numBytes must be positive: %s", numBytes);
   }
 
@@ -144,7 +144,7 @@ public abstract class ServerCallStreamObserver<RespT> extends CallStreamObserver
    * @param onReadyHandler to call when peer is ready to receive more messages.
    */
   @Override
-  public void setOnReadyHandler(Runnable onReadyHandler);
+  public abstract void setOnReadyHandler(Runnable onReadyHandler);
 
   /**
    * Requests the peer to produce {@code count} more messages to be delivered to the 'inbound'

--- a/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
@@ -77,7 +77,9 @@ public abstract class ServerCallStreamObserver<RespT> extends CallStreamObserver
    *                 positive integer.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11021")
-  public abstract void setOnReadyThreshold(int numBytes);
+  public abstract void setOnReadyThreshold(int numBytes) {
+    checkArgument(numBytes > 0, "numBytes must be positive: %s", numBytes);
+  }
 
   /**
    * Sets the compression algorithm to use for the call. May only be called before sending any
@@ -142,9 +144,7 @@ public abstract class ServerCallStreamObserver<RespT> extends CallStreamObserver
    * @param onReadyHandler to call when peer is ready to receive more messages.
    */
   @Override
-  public void setOnReadyHandler(Runnable onReadyHandler) {
-    checkArgument(numBytes > 0, "numBytes must be positive: %s", numBytes);
-  }
+  public void setOnReadyHandler(Runnable onReadyHandler);
 
   /**
    * Requests the peer to produce {@code count} more messages to be delivered to the 'inbound'

--- a/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
@@ -16,6 +16,8 @@
 
 package io.grpc.stub;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import io.grpc.ExperimentalApi;
 
 /**
@@ -140,7 +142,9 @@ public abstract class ServerCallStreamObserver<RespT> extends CallStreamObserver
    * @param onReadyHandler to call when peer is ready to receive more messages.
    */
   @Override
-  public abstract void setOnReadyHandler(Runnable onReadyHandler);
+  public void setOnReadyHandler(Runnable onReadyHandler) {
+    checkArgument(numBytes > 0, "numBytes must be positive: %s", numBytes);
+  }
 
   /**
    * Requests the peer to produce {@code count} more messages to be delivered to the 'inbound'


### PR DESCRIPTION
This change fixes existing users broke by https://github.com/grpc/grpc-java/pull/10977