### PR TITLE
xds: Use empty string when disabling server hostname verification

### DIFF
--- a/xds/src/main/java/io/grpc/xds/internal/security/trust/XdsX509TrustManager.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/trust/XdsX509TrustManager.java
@@ -229,7 +229,7 @@ final class XdsX509TrustManager extends X509ExtendedTrustManager implements X509
       SSLSocket sslSocket = (SSLSocket) socket;
       SSLParameters sslParams = sslSocket.getSSLParameters();
       if (sslParams != null) {
-        sslParams.setEndpointIdentificationAlgorithm(null);
+        sslParams.setEndpointIdentificationAlgorithm("");
         sslSocket.setSSLParameters(sslParams);
       }
     }
@@ -242,7 +242,7 @@ final class XdsX509TrustManager extends X509ExtendedTrustManager implements X509
       throws CertificateException {
     SSLParameters sslParams = sslEngine.getSSLParameters();
     if (sslParams != null) {
-      sslParams.setEndpointIdentificationAlgorithm(null);
+      sslParams.setEndpointIdentificationAlgorithm("");
       sslEngine.setSSLParameters(sslParams);
     }
     delegate.checkServerTrusted(chain, authType, sslEngine);

--- a/xds/src/test/java/io/grpc/xds/internal/security/trust/XdsX509TrustManagerTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/security/trust/XdsX509TrustManagerTest.java
@@ -534,6 +534,7 @@ public class XdsX509TrustManagerTest {
         CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     trustManager.checkServerTrusted(serverCerts, "ECDHE_ECDSA", sslEngine);
     verify(sslEngine, times(1)).getHandshakeSession();
+    assertThat(sslEngine.getSSLParameters().getEndpointIdentificationAlgorithm()).isEmpty();
   }
 
   @Test
@@ -561,6 +562,7 @@ public class XdsX509TrustManagerTest {
     trustManager.checkServerTrusted(serverCerts, "ECDHE_ECDSA", sslSocket);
     verify(sslSocket, times(1)).isConnected();
     verify(sslSocket, times(1)).getHandshakeSession();
+    assertThat(sslSocket.getSSLParameters().getEndpointIdentificationAlgorithm()).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
Setting a null endpoint identification algorithm gets ignored in Sun's
SSLEngine implementation.

Fixes #10810.