### PR TITLE
Fix OkHTTP client transport leak (1.63.x backport)

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -953,8 +953,8 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
         }
         if (!startPendingStreams()) {
           stopIfNecessary();
-          maybeClearInUse(stream);
         }
+        maybeClearInUse(stream);
       }
     }
   }


### PR DESCRIPTION
Fixes #11053: make sure to remove finished stream in okhttp client transport even if a pending stream was started.

Backport of #11054

CC @hypnoce