### PR TITLE
OkHttpServer: support maxConcurrentCallsPerConnection (Fixes #11062).

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpServerBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpServerBuilder.java
@@ -74,6 +74,7 @@ public final class OkHttpServerBuilder extends ForwardingServerBuilder<OkHttpSer
   private static final long MIN_MAX_CONNECTION_IDLE_NANO = TimeUnit.SECONDS.toNanos(1L);
   static final long MAX_CONNECTION_AGE_NANOS_DISABLED = Long.MAX_VALUE;
   static final long MAX_CONNECTION_AGE_GRACE_NANOS_INFINITE = Long.MAX_VALUE;
+  static final int MAX_CONCURRENT_STREAMS = Integer.MAX_VALUE;
   private static final long MIN_MAX_CONNECTION_AGE_NANO = TimeUnit.SECONDS.toNanos(1L);
 
   private static final long AS_LARGE_AS_INFINITE = TimeUnit.DAYS.toNanos(1000L);
@@ -129,6 +130,7 @@ public final class OkHttpServerBuilder extends ForwardingServerBuilder<OkHttpSer
   long permitKeepAliveTimeInNanos = TimeUnit.MINUTES.toNanos(5);
   long maxConnectionAgeInNanos = MAX_CONNECTION_AGE_NANOS_DISABLED;
   long maxConnectionAgeGraceInNanos = MAX_CONNECTION_AGE_GRACE_NANOS_INFINITE;
+  int maxConcurrentCallsPerConnection = MAX_CONCURRENT_STREAMS;
 
   OkHttpServerBuilder(
       SocketAddress address, HandshakerSocketFactory handshakerSocketFactory) {
@@ -347,6 +349,18 @@ public final class OkHttpServerBuilder extends ForwardingServerBuilder<OkHttpSer
   public OkHttpServerBuilder maxInboundMetadataSize(int bytes) {
     Preconditions.checkArgument(bytes > 0, "maxInboundMetadataSize must be > 0");
     this.maxInboundMetadataSize = bytes;
+    return this;
+  }
+
+  /**
+   * The maximum number of concurrent calls permitted for each incoming connection. Defaults to no
+   * limit.
+   */
+  @CanIgnoreReturnValue
+  public OkHttpServerBuilder maxConcurrentCallsPerConnection(int maxConcurrentCallsPerConnection) {
+    checkArgument(maxConcurrentCallsPerConnection > 0,
+        "max must be positive: %s", maxConcurrentCallsPerConnection);
+    this.maxConcurrentCallsPerConnection = maxConcurrentCallsPerConnection;
     return this;
   }
 


### PR DESCRIPTION
* Add option in OkHttpServerBuilder
* Add value as MAX_CONCURRENT_STREAM setting in settings frame sent by the server to the client per connection
* Enforce limit by sending a RST frame with REFUSED_STREAM error

This PR is really a try since I may be not enough familiar with all gRPC internals. Let me know if I'm too far from a correct solution.