### PR TITLE
Revert "StatusException/StatusRuntimeException hide stack trace in a simpler way"

### DIFF
--- a/api/src/main/java/io/grpc/StatusException.java
+++ b/api/src/main/java/io/grpc/StatusException.java
@@ -27,6 +27,7 @@ public class StatusException extends Exception {
   private static final long serialVersionUID = -660954903976144640L;
   private final Status status;
   private final Metadata trailers;
+  private final boolean fillInStackTrace;
 
   /**
    * Constructs an exception with both a status.  See also {@link Status#asException()}.
@@ -48,10 +49,21 @@ public class StatusException extends Exception {
   }
 
   StatusException(Status status, @Nullable Metadata trailers, boolean fillInStackTrace) {
-    super(Status.formatThrowableMessage(status), status.getCause(),
-            /* enableSuppression */ true, /* writableStackTrace */fillInStackTrace);
+    super(Status.formatThrowableMessage(status), status.getCause());
     this.status = status;
     this.trailers = trailers;
+    this.fillInStackTrace = fillInStackTrace;
+    fillInStackTrace();
+  }
+
+  @Override
+  public synchronized Throwable fillInStackTrace() {
+    // Let's observe final variables in two states!  This works because Throwable will invoke this
+    // method before fillInStackTrace is set, thus doing nothing.  After the constructor has set
+    // fillInStackTrace, this method will properly fill it in.  Additionally, sub classes may call
+    // this normally, because fillInStackTrace will either be set, or this method will be
+    // overriden.
+    return fillInStackTrace ? super.fillInStackTrace() : this;
   }
 
   /**


### PR DESCRIPTION
Internal linters caught an error in calling super in the constructor: `Call requires API level 24 (current min is 19): new java.lang.Exception`.

Reverts grpc/grpc-java#11064.
Internal ref cl/621317657.