### PR TITLE
cronet : Update library + Move to StableAPIs in Cronet

### DIFF
--- a/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
@@ -84,7 +84,7 @@ public final class CronetChannelBuilder extends ForwardingChannelBuilder2<Cronet
 
   private final CronetEngine cronetEngine;
   private final ManagedChannelImplBuilder managedChannelImplBuilder;
-  private TransportTracer.Factory transportTracerFactory = TransportTracer.getDefaultFactory();
+  private final TransportTracer.Factory transportTracerFactory = TransportTracer.getDefaultFactory();
 
   private boolean alwaysUsePut = false;
 
@@ -132,7 +132,7 @@ public final class CronetChannelBuilder extends ForwardingChannelBuilder2<Cronet
    * Sets the maximum message size allowed to be received on the channel. If not called,
    * defaults to {@link io.grpc.internal.GrpcUtil#DEFAULT_MAX_MESSAGE_SIZE}.
    */
-  public final CronetChannelBuilder maxMessageSize(int maxMessageSize) {
+  public CronetChannelBuilder maxMessageSize(int maxMessageSize) {
     checkArgument(maxMessageSize >= 0, "maxMessageSize must be >= 0");
     this.maxMessageSize = maxMessageSize;
     return this;
@@ -141,7 +141,7 @@ public final class CronetChannelBuilder extends ForwardingChannelBuilder2<Cronet
   /**
    * Sets the Cronet channel to always use PUT instead of POST. Defaults to false.
    */
-  public final CronetChannelBuilder alwaysUsePut(boolean enable) {
+  public CronetChannelBuilder alwaysUsePut(boolean enable) {
     this.alwaysUsePut = enable;
     return this;
   }
@@ -163,7 +163,7 @@ public final class CronetChannelBuilder extends ForwardingChannelBuilder2<Cronet
    *     application.
    * @return the builder to facilitate chaining.
    */
-  final CronetChannelBuilder setTrafficStatsTag(int tag) {
+  CronetChannelBuilder setTrafficStatsTag(int tag) {
     trafficStatsTagSet = true;
     trafficStatsTag = tag;
     return this;
@@ -184,7 +184,7 @@ public final class CronetChannelBuilder extends ForwardingChannelBuilder2<Cronet
    * @param uid the UID to attribute socket traffic caused by this channel.
    * @return the builder to facilitate chaining.
    */
-  final CronetChannelBuilder setTrafficStatsUid(int uid) {
+  CronetChannelBuilder setTrafficStatsUid(int uid) {
     trafficStatsUidSet = true;
     trafficStatsUid = uid;
     return this;
@@ -200,7 +200,7 @@ public final class CronetChannelBuilder extends ForwardingChannelBuilder2<Cronet
    *
    * @since 1.12.0
    */
-  public final CronetChannelBuilder scheduledExecutorService(
+  public CronetChannelBuilder scheduledExecutorService(
       ScheduledExecutorService scheduledExecutorService) {
     this.scheduledExecutorService =
         checkNotNull(scheduledExecutorService, "scheduledExecutorService");

--- a/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
@@ -173,7 +173,7 @@ public final class CronetChannelBuilder extends ForwardingChannelBuilder2<Cronet
    * Sets specific UID to use when accounting socket traffic caused by this channel. See {@link
    * android.net.TrafficStats} for more information. Designed for use when performing an operation
    * on behalf of another application. Caller must hold {@link
-   * android.Manifest.permission#MODIFY_NETWORK_ACCOUNTING} permission. By default traffic is
+   * android.Manifest.permission#UPDATE_DEVICE_STATS} permission. By default traffic is
    * attributed to UID of caller.
    *
    * <p><b>NOTE:</b>Setting a UID disallows sharing of sockets with channels with other UIDs, which

--- a/cronet/src/main/java/io/grpc/cronet/CronetClientStream.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetClientStream.java
@@ -247,7 +247,7 @@ class CronetClientStream extends AbstractClientStream {
   class TransportState extends Http2ClientStreamTransportState {
     private final Object lock;
     @GuardedBy("lock")
-    private Collection<PendingData> pendingData = new ArrayList<PendingData>();
+    private final Collection<PendingData> pendingData = new ArrayList<>();
     @GuardedBy("lock")
     private boolean streamReady;
     @GuardedBy("lock")

--- a/cronet/src/main/java/io/grpc/cronet/CronetClientStream.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetClientStream.java
@@ -42,7 +42,7 @@ import io.grpc.internal.TransportTracer;
 import io.grpc.internal.WritableBuffer;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -372,10 +372,10 @@ class CronetClientStream extends AbstractClientStream {
     // String and byte array.
     byte[][] serializedHeaders = TransportFrameUtil.toHttp2Headers(headers);
     for (int i = 0; i < serializedHeaders.length; i += 2) {
-      String key = new String(serializedHeaders[i], Charset.forName("UTF-8"));
+      String key = new String(serializedHeaders[i], StandardCharsets.UTF_8);
       // TODO(ericgribkoff): log an error or throw an exception
       if (isApplicationHeader(key)) {
-        String value = new String(serializedHeaders[i + 1], Charset.forName("UTF-8"));
+        String value = new String(serializedHeaders[i + 1], StandardCharsets.UTF_8);
         builder.addHeader(key, value);
       }
     }
@@ -552,8 +552,8 @@ class CronetClientStream extends AbstractClientStream {
 
       byte[][] headerValues = new byte[headerList.size()][];
       for (int i = 0; i < headerList.size(); i += 2) {
-        headerValues[i] = headerList.get(i).getBytes(Charset.forName("UTF-8"));
-        headerValues[i + 1] = headerList.get(i + 1).getBytes(Charset.forName("UTF-8"));
+        headerValues[i] = headerList.get(i).getBytes(StandardCharsets.UTF_8);
+        headerValues[i + 1] = headerList.get(i + 1).getBytes(StandardCharsets.UTF_8);
       }
       Metadata metadata =
           InternalMetadata.newMetadata(TransportFrameUtil.toRawSerializedHeaders(headerValues));

--- a/cronet/src/main/java/io/grpc/cronet/InternalCronetChannelBuilder.java
+++ b/cronet/src/main/java/io/grpc/cronet/InternalCronetChannelBuilder.java
@@ -47,7 +47,7 @@ public final class InternalCronetChannelBuilder {
    * Sets specific UID to use when accounting socket traffic caused by this channel. See {@link
    * android.net.TrafficStats} for more information. Designed for use when performing an operation
    * on behalf of another application. Caller must hold {@link
-   * android.Manifest.permission#MODIFY_NETWORK_ACCOUNTING} permission. By default traffic is
+   * android.Manifest.permission#UPDATE_DEVICE_STATS} permission. By default traffic is
    * attributed to UID of caller.
    *
    * <p><b>NOTE:</b>Setting a UID disallows sharing of sockets with channels with other UIDs, which

--- a/cronet/src/test/java/io/grpc/cronet/CronetChannelBuilderTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetChannelBuilderTest.java
@@ -35,7 +35,7 @@ import io.grpc.internal.SharedResourceHolder;
 import io.grpc.testing.TestMethodDescriptors;
 import java.net.InetSocketAddress;
 import java.util.concurrent.ScheduledExecutorService;
-import org.chromium.net.ExperimentalCronetEngine;
+import org.chromium.net.CronetEngine;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,7 +50,7 @@ import org.robolectric.annotation.Config;
 public final class CronetChannelBuilderTest {
   @Rule public final MockitoRule mocks = MockitoJUnit.rule();
 
-  @Mock private ExperimentalCronetEngine mockEngine;
+  @Mock private CronetEngine mockEngine;
   @Mock private ChannelLogger channelLogger;
 
   private final ClientStreamTracer[] tracers =

--- a/cronet/src/test/java/io/grpc/cronet/CronetClientStreamTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientStreamTest.java
@@ -80,12 +80,7 @@ public final class CronetClientStreamTest {
   @Mock private BidirectionalStream.Builder builder;
   private final Object lock = new Object();
   private final TransportTracer transportTracer = TransportTracer.getDefaultFactory().create();
-  private final Executor executor = new Executor() {
-      @Override
-      public void execute(Runnable r) {
-        r.run();
-      }
-    };
+  private final Executor executor = Runnable::run;
   CronetClientStream clientStream;
 
   private MethodDescriptor.Marshaller<Void> marshaller = TestMethodDescriptors.voidMarshaller();
@@ -171,7 +166,7 @@ public final class CronetClientStreamTest {
     String[] requests = new String[5];
     WritableBuffer[] buffers = new WritableBuffer[5];
     for (int i = 0; i < 5; ++i) {
-      requests[i] = new String("request" + String.valueOf(i));
+      requests[i] = "request" + i;
       buffers[i] = allocator.allocate(requests[i].length());
       buffers[i].write(requests[i].getBytes(Charset.forName("UTF-8")), 0, requests[i].length());
       // The 3rd and 5th writeFrame calls have flush=true.
@@ -206,27 +201,19 @@ public final class CronetClientStreamTest {
   }
 
   private static List<Map.Entry<String, String>> responseHeader(String status) {
-    Map<String, String> headers = new HashMap<String, String>();
+    Map<String, String> headers = new HashMap<>();
     headers.put(":status", status);
     headers.put("content-type", "application/grpc");
     headers.put("test-key", "test-value");
-    List<Map.Entry<String, String>> headerList = new ArrayList<Map.Entry<String, String>>(3);
-    for (Map.Entry<String, String> entry : headers.entrySet()) {
-      headerList.add(entry);
-    }
-    return headerList;
+    return new ArrayList<>(headers.entrySet());
   }
 
   private static List<Map.Entry<String, String>> trailers(int status) {
-    Map<String, String> trailers = new HashMap<String, String>();
+    Map<String, String> trailers = new HashMap<>();
     trailers.put("grpc-status", String.valueOf(status));
     trailers.put("content-type", "application/grpc");
     trailers.put("test-trailer-key", "test-trailer-value");
-    List<Map.Entry<String, String>> trailerList = new ArrayList<Map.Entry<String, String>>(3);
-    for (Map.Entry<String, String> entry : trailers.entrySet()) {
-      trailerList.add(entry);
-    }
-    return trailerList;
+    return new ArrayList<>(trailers.entrySet());
   }
 
   private static ByteBuffer createMessageFrame(byte[] bytes) {

--- a/cronet/src/test/java/io/grpc/cronet/CronetClientStreamTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientStreamTest.java
@@ -18,6 +18,7 @@ package io.grpc.cronet;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -46,7 +47,7 @@ import io.grpc.testing.TestMethodDescriptors;
 import java.io.ByteArrayInputStream;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -102,7 +103,7 @@ public final class CronetClientStreamTest {
     @Override
     @SuppressWarnings("GuardedBy")
     public void run() {
-      assertTrue(stream != null);
+      assertNotNull(stream);
       stream.transportState().start(factory);
     }
   }
@@ -168,7 +169,7 @@ public final class CronetClientStreamTest {
     for (int i = 0; i < 5; ++i) {
       requests[i] = "request" + i;
       buffers[i] = allocator.allocate(requests[i].length());
-      buffers[i].write(requests[i].getBytes(Charset.forName("UTF-8")), 0, requests[i].length());
+      buffers[i].write(requests[i].getBytes(StandardCharsets.UTF_8), 0, requests[i].length());
       // The 3rd and 5th writeFrame calls have flush=true.
       clientStream.abstractClientStreamSink().writeFrame(buffers[i], false, i == 2 || i == 4, 1);
     }
@@ -253,7 +254,7 @@ public final class CronetClientStreamTest {
     callback.onReadCompleted(
         cronetStream,
         info,
-        createMessageFrame(new String("response1").getBytes(Charset.forName("UTF-8"))),
+        createMessageFrame("response1".getBytes(StandardCharsets.UTF_8)),
         false);
     // Haven't request any message, so no callback is called here.
     verify(clientListener, times(0)).messagesAvailable(isA(MessageProducer.class));
@@ -283,9 +284,9 @@ public final class CronetClientStreamTest {
     verify(cronetStream, times(0)).write(isA(ByteBuffer.class), isA(Boolean.class));
     // Send the first data frame.
     CronetWritableBufferAllocator allocator = new CronetWritableBufferAllocator();
-    String request = new String("request");
+    String request = "request";
     WritableBuffer writableBuffer = allocator.allocate(request.length());
-    writableBuffer.write(request.getBytes(Charset.forName("UTF-8")), 0, request.length());
+    writableBuffer.write(request.getBytes(StandardCharsets.UTF_8), 0, request.length());
     clientStream.abstractClientStreamSink().writeFrame(writableBuffer, false, true, 1);
     ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
     verify(cronetStream, times(1)).write(bufferCaptor.capture(), isA(Boolean.class));
@@ -304,7 +305,7 @@ public final class CronetClientStreamTest {
     callback.onReadCompleted(
         cronetStream,
         info,
-        createMessageFrame(new String("response").getBytes(Charset.forName("UTF-8"))),
+        createMessageFrame("response".getBytes(StandardCharsets.UTF_8)),
         false);
     verify(clientListener, times(1)).messagesAvailable(isA(MessageProducer.class));
     verify(cronetStream, times(2)).read(isA(ByteBuffer.class));
@@ -680,7 +681,7 @@ public final class CronetClientStreamTest {
         .newBidirectionalStreamBuilder(
             isA(String.class), isA(BidirectionalStream.Callback.class), isA(Executor.class));
 
-    byte[] msg = "request".getBytes(Charset.forName("UTF-8"));
+    byte[] msg = "request".getBytes(StandardCharsets.UTF_8);
     stream.writeMessage(new ByteArrayInputStream(msg));
     // We still haven't built the stream or sent anything.
     verify(cronetStream, times(0)).write(isA(ByteBuffer.class), isA(Boolean.class));

--- a/cronet/src/test/java/io/grpc/cronet/CronetClientStreamTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientStreamTest.java
@@ -54,7 +54,6 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 import org.chromium.net.BidirectionalStream;
 import org.chromium.net.CronetException;
-import org.chromium.net.ExperimentalBidirectionalStream;
 import org.chromium.net.UrlResponseInfo;
 import org.chromium.net.impl.UrlResponseInfoImpl;
 import org.junit.Before;
@@ -76,9 +75,9 @@ public final class CronetClientStreamTest {
   @Mock private CronetClientTransport transport;
   private Metadata metadata = new Metadata();
   @Mock private StreamBuilderFactory factory;
-  @Mock private ExperimentalBidirectionalStream cronetStream;
+  @Mock private BidirectionalStream cronetStream;
   @Mock private ClientStreamListener clientListener;
-  @Mock private ExperimentalBidirectionalStream.Builder builder;
+  @Mock private BidirectionalStream.Builder builder;
   private final Object lock = new Object();
   private final TransportTracer transportTracer = TransportTracer.getDefaultFactory().create();
   private final Executor executor = new Executor() {
@@ -681,8 +680,8 @@ public final class CronetClientStreamTest {
             true,
             false);
     callback.setStream(stream);
-    ExperimentalBidirectionalStream.Builder getBuilder =
-        mock(ExperimentalBidirectionalStream.Builder.class);
+    BidirectionalStream.Builder getBuilder =
+        mock(BidirectionalStream.Builder.class);
     when(getFactory.newBidirectionalStreamBuilder(
             any(String.class), any(BidirectionalStream.Callback.class), any(Executor.class)))
         .thenReturn(getBuilder);
@@ -738,8 +737,8 @@ public final class CronetClientStreamTest {
             true,
             true);
     callback.setStream(stream);
-    ExperimentalBidirectionalStream.Builder builder =
-        mock(ExperimentalBidirectionalStream.Builder.class);
+    BidirectionalStream.Builder builder =
+        mock(BidirectionalStream.Builder.class);
     when(factory.newBidirectionalStreamBuilder(
             any(String.class), any(BidirectionalStream.Callback.class), any(Executor.class)))
         .thenReturn(builder);
@@ -770,8 +769,8 @@ public final class CronetClientStreamTest {
             true,
             true);
     callback.setStream(stream);
-    ExperimentalBidirectionalStream.Builder builder =
-        mock(ExperimentalBidirectionalStream.Builder.class);
+    BidirectionalStream.Builder builder =
+        mock(BidirectionalStream.Builder.class);
     when(factory.newBidirectionalStreamBuilder(
             any(String.class), any(BidirectionalStream.Callback.class), any(Executor.class)))
         .thenReturn(builder);
@@ -810,8 +809,8 @@ public final class CronetClientStreamTest {
             false,
             false);
     callback.setStream(stream);
-    ExperimentalBidirectionalStream.Builder builder =
-        mock(ExperimentalBidirectionalStream.Builder.class);
+    BidirectionalStream.Builder builder =
+        mock(BidirectionalStream.Builder.class);
     when(factory.newBidirectionalStreamBuilder(
             any(String.class), any(BidirectionalStream.Callback.class), any(Executor.class)))
         .thenReturn(builder);

--- a/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
@@ -71,12 +71,7 @@ public final class CronetClientTransportTest {
   private MethodDescriptor<Void, Void> descriptor = TestMethodDescriptors.voidMethod();
   @Mock private ManagedClientTransport.Listener clientTransportListener;
   @Mock private BidirectionalStream.Builder builder;
-  private final Executor executor = new Executor() {
-      @Override
-      public void execute(Runnable r) {
-        r.run();
-      }
-    };
+  private final Executor executor = Runnable::run;
 
   @Before
   public void setUp() {

--- a/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
@@ -17,7 +17,7 @@
 package io.grpc.cronet;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -91,7 +91,7 @@ public final class CronetClientTransportTest {
             false,
             false);
     Runnable callback = transport.start(clientTransportListener);
-    assertTrue(callback != null);
+    assertNotNull(callback);
     callback.run();
     verify(clientTransportListener).transportReady();
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,10 +23,8 @@ auto-value-annotations = "com.google.auto.value:auto-value-annotations:1.10.4"
 checkstyle = "com.puppycrawl.tools:checkstyle:10.12.5"
 commons-math3 = "org.apache.commons:commons-math3:3.6.1"
 conscrypt = "org.conscrypt:conscrypt-openjdk-uber:2.5.2"
-# Update notes / 2023-07-19 sergiitk:
-#     Cronet (API and Embedded) upgrade is blocked by https://github.com/grpc/grpc-java/issues/10396.
-cronet-api = "org.chromium.net:cronet-api:108.5359.79"
-cronet-embedded = "org.chromium.net:cronet-embedded:108.5359.79"
+cronet-api = "org.chromium.net:cronet-api:119.6045.31"
+cronet-embedded = "org.chromium.net:cronet-embedded:119.6045.31"
 errorprone-annotations = "com.google.errorprone:error_prone_annotations:2.23.0"
 errorprone-core = "com.google.errorprone:error_prone_core:2.23.0"
 google-api-protos = "com.google.api.grpc:proto-google-common-protos:2.29.0"


### PR DESCRIPTION
In this Pull Request
1. Cronet is updated to `119.6045.31` from `108.5359.79`, In which Experimental API's are deprecated and moved to Stable Interfaces.
2. grpc-cronet Moved Experimental API's to Stable Interfaces
3. Removed use of reflection as Experimental API's are no longer in use (which are introdced in #6111)

Minor Changes
1. Updated JavaDoc : Android Permission from [`MODIFY_NETWORK_ACCOUNTING` (deprecated)](https://android.googlesource.com/platform/frameworks/base/+/master/core/res/AndroidManifest.xml#6416) to `UPDATE_DEVICE_STATS`
2. Update to JAVA-8 API's to improve code readability
3. Moved from `Charset.forName("UTF-8")` to `StandardCharsets.UTF_8` Standard

Fixes #10396 (@sergiitk)