### PR TITLE
bazel: Verify Maven deps in bzlmod and WORKSPACE match

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -81,6 +81,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Check versions match in MODULE.bazel and repositories.bzl
+      run: |
+        diff -u <(sed -n '/GRPC_DEPS_START/,/GRPC_DEPS_END/ {/GRPC_DEPS_/! p}' MODULE.bazel) \
+                <(sed -n '/GRPC_DEPS_START/,/GRPC_DEPS_END/ {/GRPC_DEPS_/! p}' repositories.bzl)
+
     - name: Bazel cache
       uses: actions/cache@v3
       with:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,6 +5,46 @@ module(
     version = "0",
 )
 
+# GRPC_DEPS_START
+IO_GRPC_GRPC_JAVA_ARTIFACTS = [
+    "com.google.android:annotations:4.1.1.4",
+    "com.google.api.grpc:proto-google-common-protos:2.29.0",
+    "com.google.auth:google-auth-library-credentials:1.22.0",
+    "com.google.auth:google-auth-library-oauth2-http:1.22.0",
+    "com.google.auto.value:auto-value-annotations:1.10.4",
+    "com.google.auto.value:auto-value:1.10.4",
+    "com.google.code.findbugs:jsr305:3.0.2",
+    "com.google.code.gson:gson:2.10.1",
+    "com.google.errorprone:error_prone_annotations:2.23.0",
+    "com.google.guava:failureaccess:1.0.1",
+    "com.google.guava:guava:32.1.3-android",
+    "com.google.re2j:re2j:1.7",
+    "com.google.truth:truth:1.1.5",
+    "com.squareup.okhttp:okhttp:2.7.5",
+    "com.squareup.okio:okio:2.10.0",  # 3.0+ needs swapping to -jvm; need work to avoid flag-day
+    "io.netty:netty-buffer:4.1.100.Final",
+    "io.netty:netty-codec-http2:4.1.100.Final",
+    "io.netty:netty-codec-http:4.1.100.Final",
+    "io.netty:netty-codec-socks:4.1.100.Final",
+    "io.netty:netty-codec:4.1.100.Final",
+    "io.netty:netty-common:4.1.100.Final",
+    "io.netty:netty-handler-proxy:4.1.100.Final",
+    "io.netty:netty-handler:4.1.100.Final",
+    "io.netty:netty-resolver:4.1.100.Final",
+    "io.netty:netty-tcnative-boringssl-static:2.0.61.Final",
+    "io.netty:netty-tcnative-classes:2.0.61.Final",
+    "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.100.Final",
+    "io.netty:netty-transport-native-unix-common:4.1.100.Final",
+    "io.netty:netty-transport:4.1.100.Final",
+    "io.opencensus:opencensus-api:0.31.0",
+    "io.opencensus:opencensus-contrib-grpc-metrics:0.31.0",
+    "io.perfmark:perfmark-api:0.26.0",
+    "junit:junit:4.13.2",
+    "org.apache.tomcat:annotations-api:6.0.53",
+    "org.codehaus.mojo:animal-sniffer-annotations:1.23",
+]
+# GRPC_DEPS_END
+
 bazel_dep(name = "googleapis", repo_name = "com_google_googleapis", version = "0.0.0-20240326-1c8d509c5")
 bazel_dep(name = "grpc", repo_name = "com_github_grpc_grpc", version = "1.56.3.bcr.1")
 bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "23.1")
@@ -34,43 +74,7 @@ use_repo(
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 
 maven.install(
-    artifacts = [
-        "com.google.android:annotations:4.1.1.4",
-        "com.google.api.grpc:proto-google-common-protos:2.29.0",
-        "com.google.auth:google-auth-library-credentials:1.22.0",
-        "com.google.auth:google-auth-library-oauth2-http:1.22.0",
-        "com.google.auto.value:auto-value-annotations:1.10.4",
-        "com.google.auto.value:auto-value:1.10.4",
-        "com.google.code.findbugs:jsr305:3.0.2",
-        "com.google.code.gson:gson:2.10.1",
-        "com.google.errorprone:error_prone_annotations:2.23.0",
-        "com.google.guava:failureaccess:1.0.1",
-        "com.google.guava:guava:32.1.3-android",
-        "com.google.re2j:re2j:1.7",
-        "com.google.truth:truth:1.1.5",
-        "com.squareup.okhttp:okhttp:2.7.5",
-        "com.squareup.okio:okio:2.10.0",  # 3.0+ needs swapping to -jvm; need work to avoid flag-day
-        "io.netty:netty-buffer:4.1.100.Final",
-        "io.netty:netty-codec-http2:4.1.100.Final",
-        "io.netty:netty-codec-http:4.1.100.Final",
-        "io.netty:netty-codec-socks:4.1.100.Final",
-        "io.netty:netty-codec:4.1.100.Final",
-        "io.netty:netty-common:4.1.100.Final",
-        "io.netty:netty-handler-proxy:4.1.100.Final",
-        "io.netty:netty-handler:4.1.100.Final",
-        "io.netty:netty-resolver:4.1.100.Final",
-        "io.netty:netty-tcnative-boringssl-static:2.0.61.Final",
-        "io.netty:netty-tcnative-classes:2.0.61.Final",
-        "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.100.Final",
-        "io.netty:netty-transport-native-unix-common:4.1.100.Final",
-        "io.netty:netty-transport:4.1.100.Final",
-        "io.opencensus:opencensus-api:0.31.0",
-        "io.opencensus:opencensus-contrib-grpc-metrics:0.31.0",
-        "io.perfmark:perfmark-api:0.26.0",
-        "junit:junit:4.13.2",
-        "org.apache.tomcat:annotations-api:6.0.53",
-        "org.codehaus.mojo:animal-sniffer-annotations:1.23",
-    ],
+    artifacts = IO_GRPC_GRPC_JAVA_ARTIFACTS,
     repositories = [
         "https://repo.maven.apache.org/maven2/",
     ],

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -9,6 +9,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 #         # Your own deps
 #     ] + IO_GRPC_GRPC_JAVA_ARTIFACTS,
 # )
+# GRPC_DEPS_START
 IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "com.google.android:annotations:4.1.1.4",
     "com.google.api.grpc:proto-google-common-protos:2.29.0",
@@ -46,6 +47,7 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "org.apache.tomcat:annotations-api:6.0.53",
     "org.codehaus.mojo:animal-sniffer-annotations:1.23",
 ]
+# GRPC_DEPS_END
 
 # For use with maven_install's override_targets.
 # maven_install(


### PR DESCRIPTION
The text between the GRPC_DEPS_{START,END} must be identical in formatting. Probably not a problem in general and not necessarily bad. But it is simplistic.

Eric waking up this morning:
> We need more sed.