### PR TITLE
buildscripts: Migrate PSM Interop to Artifact Registry (v1.63.x backport)

### DIFF
--- a/buildscripts/kokoro/psm-security.sh
+++ b/buildscripts/kokoro/psm-security.sh
@@ -5,8 +5,8 @@ set -eo pipefail
 readonly GITHUB_REPOSITORY_NAME="grpc-java"
 readonly TEST_DRIVER_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/${TEST_DRIVER_REPO_OWNER:-grpc}/psm-interop/${TEST_DRIVER_BRANCH:-main}/.kokoro/psm_interop_kokoro_lib.sh"
 ## xDS test server/client Docker images
-readonly SERVER_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/java-server"
-readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/java-client"
+readonly SERVER_IMAGE_NAME="us-docker.pkg.dev/grpc-testing/psm-interop/java-server"
+readonly CLIENT_IMAGE_NAME="us-docker.pkg.dev/grpc-testing/psm-interop/java-client"
 readonly FORCE_IMAGE_BUILD="${FORCE_IMAGE_BUILD:-0}"
 readonly BUILD_APP_PATH="interop-testing/build/install/grpc-interop-testing"
 

--- a/buildscripts/kokoro/xds_k8s_lb.sh
+++ b/buildscripts/kokoro/xds_k8s_lb.sh
@@ -5,8 +5,8 @@ set -eo pipefail
 readonly GITHUB_REPOSITORY_NAME="grpc-java"
 readonly TEST_DRIVER_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/${TEST_DRIVER_REPO_OWNER:-grpc}/psm-interop/${TEST_DRIVER_BRANCH:-main}/.kokoro/psm_interop_kokoro_lib.sh"
 ## xDS test server/client Docker images
-readonly SERVER_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/java-server"
-readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/java-client"
+readonly SERVER_IMAGE_NAME="us-docker.pkg.dev/grpc-testing/psm-interop/java-server"
+readonly CLIENT_IMAGE_NAME="us-docker.pkg.dev/grpc-testing/psm-interop/java-client"
 readonly FORCE_IMAGE_BUILD="${FORCE_IMAGE_BUILD:-0}"
 readonly BUILD_APP_PATH="interop-testing/build/install/grpc-interop-testing"
 

--- a/buildscripts/kokoro/xds_url_map.sh
+++ b/buildscripts/kokoro/xds_url_map.sh
@@ -5,8 +5,8 @@ set -eo pipefail
 readonly GITHUB_REPOSITORY_NAME="grpc-java"
 readonly TEST_DRIVER_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/${TEST_DRIVER_REPO_OWNER:-grpc}/psm-interop/${TEST_DRIVER_BRANCH:-main}/.kokoro/psm_interop_kokoro_lib.sh"
 ## xDS test client Docker images
-readonly SERVER_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/java-server"
-readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/java-client"
+readonly SERVER_IMAGE_NAME="us-docker.pkg.dev/grpc-testing/psm-interop/java-server"
+readonly CLIENT_IMAGE_NAME="us-docker.pkg.dev/grpc-testing/psm-interop/java-client"
 readonly FORCE_IMAGE_BUILD="${FORCE_IMAGE_BUILD:-0}"
 readonly BUILD_APP_PATH="interop-testing/build/install/grpc-interop-testing"
 

--- a/buildscripts/xds-k8s/cloudbuild.yaml
+++ b/buildscripts/xds-k8s/cloudbuild.yaml
@@ -16,8 +16,8 @@ steps:
     - '.'
 
 substitutions:
-  _SERVER_IMAGE_NAME: gcr.io/grpc-testing/xds-interop/java-server
-  _CLIENT_IMAGE_NAME: gcr.io/grpc-testing/xds-interop/java-client
+  _SERVER_IMAGE_NAME: us-docker.pkg.dev/grpc-testing/psm-interop/java-server
+  _CLIENT_IMAGE_NAME: us-docker.pkg.dev/grpc-testing/psm-interop/java-client
 
 images:
   - '${_SERVER_IMAGE_NAME}:${COMMIT_SHA}'


### PR DESCRIPTION
Backport of #11079 to v1.63.x.
---
From Container Registry (gcr.io) to Artifact Registry (pkg.dev).