### PR TITLE
Add Metric Instrument Registry

### DIFF
--- a/api/src/main/java/io/grpc/DoubleCounterMetricInstrument.java
+++ b/api/src/main/java/io/grpc/DoubleCounterMetricInstrument.java
@@ -23,15 +23,8 @@ import java.util.List;
  */
 @Internal
 public final class DoubleCounterMetricInstrument extends PartialMetricInstrument {
-  private final boolean enableByDefault;
-
   DoubleCounterMetricInstrument(long index, String name, String description, String unit,
       List<String> requiredLabelKeys, List<String> optionalLabelKeys, boolean enableByDefault) {
-    super(index, name, description, unit, requiredLabelKeys, optionalLabelKeys);
-    this.enableByDefault = enableByDefault;
-  }
-
-  public boolean isEnableByDefault() {
-    return enableByDefault;
+    super(index, name, description, unit, requiredLabelKeys, optionalLabelKeys, enableByDefault);
   }
 }

--- a/api/src/main/java/io/grpc/DoubleCounterMetricInstrument.java
+++ b/api/src/main/java/io/grpc/DoubleCounterMetricInstrument.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import java.util.List;
+
+/**
+ * Represents a double-valued counter metric instrument.
+ */
+@Internal
+public class DoubleCounterMetricInstrument extends PartialMetricInstrument  implements
+    MetricInstrument {
+  private final boolean isEnabledByDefault;
+
+  DoubleCounterMetricInstrument(long index, String name, String description, String unit,
+      List<String> requiredLabelKeys, List<String> optionalLabelKeys,
+      boolean isEnabledByDefault) {
+    super(index, name, description, unit, requiredLabelKeys, optionalLabelKeys);
+    this.isEnabledByDefault = isEnabledByDefault;
+  }
+
+  @Override
+  public long getIndex() {
+    return index;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public String getUnit() {
+    return unit;
+  }
+
+  @Override
+  public List<String> getRequiredLabelKeys() {
+    return requiredLabelKeys;
+  }
+
+  @Override
+  public List<String> getOptionalLabelKeys() {
+    return optionalLabelKeys;
+  }
+
+  public boolean getEnabledByDefault() {
+    return isEnabledByDefault;
+  }
+}

--- a/api/src/main/java/io/grpc/DoubleCounterMetricInstrument.java
+++ b/api/src/main/java/io/grpc/DoubleCounterMetricInstrument.java
@@ -22,48 +22,16 @@ import java.util.List;
  * Represents a double-valued counter metric instrument.
  */
 @Internal
-public class DoubleCounterMetricInstrument extends PartialMetricInstrument  implements
-    MetricInstrument {
-  private final boolean isEnabledByDefault;
+public final class DoubleCounterMetricInstrument extends PartialMetricInstrument {
+  private final boolean enableByDefault;
 
   DoubleCounterMetricInstrument(long index, String name, String description, String unit,
-      List<String> requiredLabelKeys, List<String> optionalLabelKeys,
-      boolean isEnabledByDefault) {
+      List<String> requiredLabelKeys, List<String> optionalLabelKeys, boolean enableByDefault) {
     super(index, name, description, unit, requiredLabelKeys, optionalLabelKeys);
-    this.isEnabledByDefault = isEnabledByDefault;
+    this.enableByDefault = enableByDefault;
   }
 
-  @Override
-  public long getIndex() {
-    return index;
-  }
-
-  @Override
-  public String getName() {
-    return name;
-  }
-
-  @Override
-  public String getDescription() {
-    return description;
-  }
-
-  @Override
-  public String getUnit() {
-    return unit;
-  }
-
-  @Override
-  public List<String> getRequiredLabelKeys() {
-    return requiredLabelKeys;
-  }
-
-  @Override
-  public List<String> getOptionalLabelKeys() {
-    return optionalLabelKeys;
-  }
-
-  public boolean getEnabledByDefault() {
-    return isEnabledByDefault;
+  public boolean isEnableByDefault() {
+    return enableByDefault;
   }
 }

--- a/api/src/main/java/io/grpc/DoubleHistogramMetricInstrument.java
+++ b/api/src/main/java/io/grpc/DoubleHistogramMetricInstrument.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import java.util.List;
+
+/**
+ * Represents a double-valued histogram metric instrument.
+ */
+@Internal
+public class DoubleHistogramMetricInstrument extends PartialMetricInstrument implements
+    MetricInstrument {
+  private final boolean isEnabledByDefault;
+  private final List<Double> bucketBoundaries;
+
+  DoubleHistogramMetricInstrument(long index, String name, String description, String unit,
+      List<Double> bucketBoundaries, List<String> requiredLabelKeys, List<String> optionalLabelKeys,
+      boolean isEnabledByDefault) {
+    super(index, name, description, unit, requiredLabelKeys, optionalLabelKeys);
+    this.isEnabledByDefault = isEnabledByDefault;
+    this.bucketBoundaries = bucketBoundaries;
+  }
+
+  @Override
+  public long getIndex() {
+    return index;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public String getUnit() {
+    return unit;
+  }
+
+  @Override
+  public List<String> getRequiredLabelKeys() {
+    return requiredLabelKeys;
+  }
+
+  @Override
+  public List<String> getOptionalLabelKeys() {
+    return optionalLabelKeys;
+  }
+
+  public boolean getEnabledByDefault() {
+    return isEnabledByDefault;
+  }
+
+  public List<Double> getBucketBoundaries() {
+    return bucketBoundaries;
+  }
+}
+

--- a/api/src/main/java/io/grpc/DoubleHistogramMetricInstrument.java
+++ b/api/src/main/java/io/grpc/DoubleHistogramMetricInstrument.java
@@ -22,55 +22,23 @@ import java.util.List;
  * Represents a double-valued histogram metric instrument.
  */
 @Internal
-public class DoubleHistogramMetricInstrument extends PartialMetricInstrument implements
-    MetricInstrument {
-  private final boolean isEnabledByDefault;
+public final class DoubleHistogramMetricInstrument extends PartialMetricInstrument {
+  private final boolean enableByDefault;
   private final List<Double> bucketBoundaries;
 
   DoubleHistogramMetricInstrument(long index, String name, String description, String unit,
       List<Double> bucketBoundaries, List<String> requiredLabelKeys, List<String> optionalLabelKeys,
-      boolean isEnabledByDefault) {
+      boolean enableByDefault) {
     super(index, name, description, unit, requiredLabelKeys, optionalLabelKeys);
-    this.isEnabledByDefault = isEnabledByDefault;
+    this.enableByDefault = enableByDefault;
     this.bucketBoundaries = bucketBoundaries;
   }
 
-  @Override
-  public long getIndex() {
-    return index;
-  }
-
-  @Override
-  public String getName() {
-    return name;
-  }
-
-  @Override
-  public String getDescription() {
-    return description;
-  }
-
-  @Override
-  public String getUnit() {
-    return unit;
-  }
-
-  @Override
-  public List<String> getRequiredLabelKeys() {
-    return requiredLabelKeys;
-  }
-
-  @Override
-  public List<String> getOptionalLabelKeys() {
-    return optionalLabelKeys;
-  }
-
-  public boolean getEnabledByDefault() {
-    return isEnabledByDefault;
+  public boolean isEnableByDefault() {
+    return enableByDefault;
   }
 
   public List<Double> getBucketBoundaries() {
     return bucketBoundaries;
   }
 }
-

--- a/api/src/main/java/io/grpc/DoubleHistogramMetricInstrument.java
+++ b/api/src/main/java/io/grpc/DoubleHistogramMetricInstrument.java
@@ -23,19 +23,13 @@ import java.util.List;
  */
 @Internal
 public final class DoubleHistogramMetricInstrument extends PartialMetricInstrument {
-  private final boolean enableByDefault;
   private final List<Double> bucketBoundaries;
 
   DoubleHistogramMetricInstrument(long index, String name, String description, String unit,
       List<Double> bucketBoundaries, List<String> requiredLabelKeys, List<String> optionalLabelKeys,
       boolean enableByDefault) {
-    super(index, name, description, unit, requiredLabelKeys, optionalLabelKeys);
-    this.enableByDefault = enableByDefault;
+    super(index, name, description, unit, requiredLabelKeys, optionalLabelKeys, enableByDefault);
     this.bucketBoundaries = bucketBoundaries;
-  }
-
-  public boolean isEnableByDefault() {
-    return enableByDefault;
   }
 
   public List<Double> getBucketBoundaries() {

--- a/api/src/main/java/io/grpc/LongCounterMetricInstrument.java
+++ b/api/src/main/java/io/grpc/LongCounterMetricInstrument.java
@@ -23,15 +23,8 @@ import java.util.List;
  */
 @Internal
 public final class LongCounterMetricInstrument extends PartialMetricInstrument {
-  private final boolean enableByDefault;
-
   LongCounterMetricInstrument(long index, String name, String description, String unit,
       List<String> requiredLabelKeys, List<String> optionalLabelKeys, boolean enableByDefault) {
-    super(index, name, description, unit, requiredLabelKeys, optionalLabelKeys);
-    this.enableByDefault = enableByDefault;
-  }
-
-  public boolean isEnableByDefault() {
-    return enableByDefault;
+    super(index, name, description, unit, requiredLabelKeys, optionalLabelKeys, enableByDefault);
   }
 }

--- a/api/src/main/java/io/grpc/LongCounterMetricInstrument.java
+++ b/api/src/main/java/io/grpc/LongCounterMetricInstrument.java
@@ -22,47 +22,16 @@ import java.util.List;
  * Represents a long-valued counter metric instrument.
  */
 @Internal
-class LongCounterMetricInstrument extends PartialMetricInstrument implements MetricInstrument {
-  private final boolean isEnabledByDefault;
+public final class LongCounterMetricInstrument extends PartialMetricInstrument {
+  private final boolean enableByDefault;
 
   LongCounterMetricInstrument(long index, String name, String description, String unit,
-      List<String> requiredLabelKeys,
-      List<String> optionalLabelKeys, boolean isEnabledByDefault) {
+      List<String> requiredLabelKeys, List<String> optionalLabelKeys, boolean enableByDefault) {
     super(index, name, description, unit, requiredLabelKeys, optionalLabelKeys);
-    this.isEnabledByDefault = isEnabledByDefault;
+    this.enableByDefault = enableByDefault;
   }
 
-  @Override
-  public long getIndex() {
-    return index;
-  }
-
-  @Override
-  public String getName() {
-    return name;
-  }
-
-  @Override
-  public String getDescription() {
-    return description;
-  }
-
-  @Override
-  public String getUnit() {
-    return unit;
-  }
-
-  @Override
-  public List<String> getRequiredLabelKeys() {
-    return requiredLabelKeys;
-  }
-
-  @Override
-  public List<String> getOptionalLabelKeys() {
-    return optionalLabelKeys;
-  }
-
-  public boolean getEnabledByDefault() {
-    return isEnabledByDefault;
+  public boolean isEnableByDefault() {
+    return enableByDefault;
   }
 }

--- a/api/src/main/java/io/grpc/LongCounterMetricInstrument.java
+++ b/api/src/main/java/io/grpc/LongCounterMetricInstrument.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import java.util.List;
+
+/**
+ * Represents a long-valued counter metric instrument.
+ */
+@Internal
+class LongCounterMetricInstrument extends PartialMetricInstrument implements MetricInstrument {
+  private final boolean isEnabledByDefault;
+
+  LongCounterMetricInstrument(long index, String name, String description, String unit,
+      List<String> requiredLabelKeys,
+      List<String> optionalLabelKeys, boolean isEnabledByDefault) {
+    super(index, name, description, unit, requiredLabelKeys, optionalLabelKeys);
+    this.isEnabledByDefault = isEnabledByDefault;
+  }
+
+  @Override
+  public long getIndex() {
+    return index;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public String getUnit() {
+    return unit;
+  }
+
+  @Override
+  public List<String> getRequiredLabelKeys() {
+    return requiredLabelKeys;
+  }
+
+  @Override
+  public List<String> getOptionalLabelKeys() {
+    return optionalLabelKeys;
+  }
+
+  public boolean getEnabledByDefault() {
+    return isEnabledByDefault;
+  }
+}

--- a/api/src/main/java/io/grpc/LongGaugeMetricInstrument.java
+++ b/api/src/main/java/io/grpc/LongGaugeMetricInstrument.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import java.util.List;
+
+/**
+ * Represents a long-valued gauge metric instrument.
+ */
+@Internal
+public class LongGaugeMetricInstrument extends PartialMetricInstrument implements MetricInstrument {
+  private final boolean isEnabledByDefault;
+
+  LongGaugeMetricInstrument(long index, String name, String description, String unit,
+      List<String> requiredLabelKeys, List<String> optionalLabelKeys, boolean isEnabledByDefault) {
+    super(index, name, description, unit, requiredLabelKeys, optionalLabelKeys);
+    this.isEnabledByDefault = isEnabledByDefault;
+  }
+
+  @Override
+  public long getIndex() {
+    return index;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public String getUnit() {
+    return unit;
+  }
+
+  @Override
+  public List<String> getRequiredLabelKeys() {
+    return requiredLabelKeys;
+  }
+
+  @Override
+  public List<String> getOptionalLabelKeys() {
+    return optionalLabelKeys;
+  }
+
+  public boolean getEnabledByDefault() {
+    return isEnabledByDefault;
+  }
+}

--- a/api/src/main/java/io/grpc/LongGaugeMetricInstrument.java
+++ b/api/src/main/java/io/grpc/LongGaugeMetricInstrument.java
@@ -22,46 +22,16 @@ import java.util.List;
  * Represents a long-valued gauge metric instrument.
  */
 @Internal
-public class LongGaugeMetricInstrument extends PartialMetricInstrument implements MetricInstrument {
-  private final boolean isEnabledByDefault;
+public final class LongGaugeMetricInstrument extends PartialMetricInstrument {
+  private final boolean enableByDefault;
 
   LongGaugeMetricInstrument(long index, String name, String description, String unit,
-      List<String> requiredLabelKeys, List<String> optionalLabelKeys, boolean isEnabledByDefault) {
+      List<String> requiredLabelKeys, List<String> optionalLabelKeys, boolean enableByDefault) {
     super(index, name, description, unit, requiredLabelKeys, optionalLabelKeys);
-    this.isEnabledByDefault = isEnabledByDefault;
+    this.enableByDefault = enableByDefault;
   }
 
-  @Override
-  public long getIndex() {
-    return index;
-  }
-
-  @Override
-  public String getName() {
-    return name;
-  }
-
-  @Override
-  public String getDescription() {
-    return description;
-  }
-
-  @Override
-  public String getUnit() {
-    return unit;
-  }
-
-  @Override
-  public List<String> getRequiredLabelKeys() {
-    return requiredLabelKeys;
-  }
-
-  @Override
-  public List<String> getOptionalLabelKeys() {
-    return optionalLabelKeys;
-  }
-
-  public boolean getEnabledByDefault() {
-    return isEnabledByDefault;
+  public boolean isEnableByDefault() {
+    return enableByDefault;
   }
 }

--- a/api/src/main/java/io/grpc/LongGaugeMetricInstrument.java
+++ b/api/src/main/java/io/grpc/LongGaugeMetricInstrument.java
@@ -23,15 +23,8 @@ import java.util.List;
  */
 @Internal
 public final class LongGaugeMetricInstrument extends PartialMetricInstrument {
-  private final boolean enableByDefault;
-
   LongGaugeMetricInstrument(long index, String name, String description, String unit,
       List<String> requiredLabelKeys, List<String> optionalLabelKeys, boolean enableByDefault) {
-    super(index, name, description, unit, requiredLabelKeys, optionalLabelKeys);
-    this.enableByDefault = enableByDefault;
-  }
-
-  public boolean isEnableByDefault() {
-    return enableByDefault;
+    super(index, name, description, unit, requiredLabelKeys, optionalLabelKeys, enableByDefault);
   }
 }

--- a/api/src/main/java/io/grpc/LongHistogramMetricInstrument.java
+++ b/api/src/main/java/io/grpc/LongHistogramMetricInstrument.java
@@ -22,55 +22,23 @@ import java.util.List;
  * Represents a long-valued histogram metric instrument.
  */
 @Internal
-class LongHistogramMetricInstrument extends PartialMetricInstrument implements
-    MetricInstrument {
-  private final boolean isEnabledByDefault;
+public final class LongHistogramMetricInstrument extends PartialMetricInstrument {
+  private final boolean enableByDefault;
   private final List<Long> bucketBoundaries;
 
   LongHistogramMetricInstrument(long index, String name, String description, String unit,
       List<Long> bucketBoundaries, List<String> requiredLabelKeys, List<String> optionalLabelKeys,
-      boolean isEnabledByDefault) {
+      boolean enableByDefault) {
     super(index, name, description, unit, requiredLabelKeys, optionalLabelKeys);
-    this.isEnabledByDefault = isEnabledByDefault;
+    this.enableByDefault = enableByDefault;
     this.bucketBoundaries = bucketBoundaries;
   }
 
-  @Override
-  public long getIndex() {
-    return index;
-  }
-
-  @Override
-  public String getName() {
-    return name;
-  }
-
-  @Override
-  public String getDescription() {
-    return description;
-  }
-
-  @Override
-  public String getUnit() {
-    return unit;
-  }
-
-  @Override
-  public List<String> getRequiredLabelKeys() {
-    return requiredLabelKeys;
-  }
-
-  @Override
-  public List<String> getOptionalLabelKeys() {
-    return optionalLabelKeys;
-  }
-
-  public boolean getEnabledByDefault() {
-    return isEnabledByDefault;
+  public boolean isEnableByDefault() {
+    return enableByDefault;
   }
 
   public List<Long> getBucketBoundaries() {
     return bucketBoundaries;
   }
 }
-

--- a/api/src/main/java/io/grpc/LongHistogramMetricInstrument.java
+++ b/api/src/main/java/io/grpc/LongHistogramMetricInstrument.java
@@ -23,19 +23,13 @@ import java.util.List;
  */
 @Internal
 public final class LongHistogramMetricInstrument extends PartialMetricInstrument {
-  private final boolean enableByDefault;
   private final List<Long> bucketBoundaries;
 
   LongHistogramMetricInstrument(long index, String name, String description, String unit,
       List<Long> bucketBoundaries, List<String> requiredLabelKeys, List<String> optionalLabelKeys,
       boolean enableByDefault) {
-    super(index, name, description, unit, requiredLabelKeys, optionalLabelKeys);
-    this.enableByDefault = enableByDefault;
+    super(index, name, description, unit, requiredLabelKeys, optionalLabelKeys, enableByDefault);
     this.bucketBoundaries = bucketBoundaries;
-  }
-
-  public boolean isEnableByDefault() {
-    return enableByDefault;
   }
 
   public List<Long> getBucketBoundaries() {

--- a/api/src/main/java/io/grpc/LongHistogramMetricInstrument.java
+++ b/api/src/main/java/io/grpc/LongHistogramMetricInstrument.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import java.util.List;
+
+/**
+ * Represents a long-valued histogram metric instrument.
+ */
+@Internal
+class LongHistogramMetricInstrument extends PartialMetricInstrument implements
+    MetricInstrument {
+  private final boolean isEnabledByDefault;
+  private final List<Long> bucketBoundaries;
+
+  LongHistogramMetricInstrument(long index, String name, String description, String unit,
+      List<Long> bucketBoundaries, List<String> requiredLabelKeys, List<String> optionalLabelKeys,
+      boolean isEnabledByDefault) {
+    super(index, name, description, unit, requiredLabelKeys, optionalLabelKeys);
+    this.isEnabledByDefault = isEnabledByDefault;
+    this.bucketBoundaries = bucketBoundaries;
+  }
+
+  @Override
+  public long getIndex() {
+    return index;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public String getUnit() {
+    return unit;
+  }
+
+  @Override
+  public List<String> getRequiredLabelKeys() {
+    return requiredLabelKeys;
+  }
+
+  @Override
+  public List<String> getOptionalLabelKeys() {
+    return optionalLabelKeys;
+  }
+
+  public boolean getEnabledByDefault() {
+    return isEnabledByDefault;
+  }
+
+  public List<Long> getBucketBoundaries() {
+    return bucketBoundaries;
+  }
+}
+

--- a/api/src/main/java/io/grpc/MetricInstrument.java
+++ b/api/src/main/java/io/grpc/MetricInstrument.java
@@ -64,4 +64,12 @@ public interface MetricInstrument {
    * @return a list of optional label keys.
    */
   public List<String> getOptionalLabelKeys();
+
+  /**
+   * Indicates whether this metric instrument is enabled by default.
+   *
+   * @return {@code true} if this metric instrument is enabled by default,
+   *         {@code false} otherwise.
+   */
+  public boolean isEnableByDefault();
 }

--- a/api/src/main/java/io/grpc/MetricInstrument.java
+++ b/api/src/main/java/io/grpc/MetricInstrument.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+/**
+ * Represents a metric instrument. Metric instrument contains information used to describe a metric.
+ */
+@Internal
+public interface MetricInstrument {
+  /**
+   * Returns the unique index of this metric instrument.
+   *
+   * @return the index of the metric instrument.
+   */
+  public long getIndex();
+
+  /**
+   * Returns the name of the metric.
+   *
+   * @return the name of the metric.
+   */
+  public String getName();
+
+  /**
+   * Returns a description of the metric.
+   *
+   * @return a description of the metric.
+   */
+  public String getDescription();
+
+  /**
+   * Returns the unit of measurement for the metric.
+   *
+   * @return the unit of measurement.
+   */
+  public String getUnit();
+}

--- a/api/src/main/java/io/grpc/MetricInstrument.java
+++ b/api/src/main/java/io/grpc/MetricInstrument.java
@@ -16,6 +16,8 @@
 
 package io.grpc;
 
+import java.util.List;
+
 /**
  * Represents a metric instrument. Metric instrument contains information used to describe a metric.
  */
@@ -48,4 +50,18 @@ public interface MetricInstrument {
    * @return the unit of measurement.
    */
   public String getUnit();
+
+  /**
+   * Returns a list of required label keys for this metric instrument.
+   *
+   * @return a list of required label keys.
+   */
+  public List<String> getRequiredLabelKeys();
+
+  /**
+   * Returns a list of optional label keys for this metric instrument.
+   *
+   * @return a list of optional label keys.
+   */
+  public List<String> getOptionalLabelKeys();
 }

--- a/api/src/main/java/io/grpc/MetricInstrumentRegistry.java
+++ b/api/src/main/java/io/grpc/MetricInstrumentRegistry.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2024 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+/**
+ * A registry for globally registered metric instruments.
+ */
+@Internal
+public final class MetricInstrumentRegistry {
+  private static MetricInstrumentRegistry instance;
+  private final List<MetricInstrument> metricInstruments;
+  private final Set<String> registeredMetricNames;
+
+  private MetricInstrumentRegistry() {
+    this.metricInstruments = new CopyOnWriteArrayList<>();
+    this.registeredMetricNames = new CopyOnWriteArraySet<>();
+  }
+
+  /**
+   * Returns the default metric instrument registry.
+   */
+  public static synchronized MetricInstrumentRegistry getDefaultRegistry() {
+    if (instance == null) {
+      instance = new MetricInstrumentRegistry();
+    }
+    return instance;
+  }
+
+  /**
+   * Returns a list of registered metric instruments.
+   */
+  public List<MetricInstrument> getMetricInstruments() {
+    return metricInstruments;
+  }
+
+  /**
+   * Registers a new Double Counter metric instrument.
+   *
+   * @param name the name of the metric
+   * @param description a description of the metric
+   * @param unit the unit of measurement for the metric
+   * @param requiredLabelKeys a list of required label keys
+   * @param optionalLabelKeys a list of optional label keys
+   * @param isEnabledByDefault whether the metric should be enabled by default
+   * @return the newly created DoubleCounterMetricInstrument
+   * @throws IllegalStateException if a metric with the same name already exists
+   */
+  // TODO(dnvindhya): Evaluate locks over synchronized methods and update if needed
+  public synchronized DoubleCounterMetricInstrument registerDoubleCounter(String name,
+      String description, String unit, List<String> requiredLabelKeys,
+      List<String> optionalLabelKeys, boolean isEnabledByDefault) {
+    if (registeredMetricNames.contains(name)) {
+      throw new IllegalStateException("Metric with name " + name + " already exists");
+    }
+    long instrumentIndex = metricInstruments.size();
+    DoubleCounterMetricInstrument instrument = new DoubleCounterMetricInstrument(
+        instrumentIndex, name, description, unit, requiredLabelKeys, optionalLabelKeys,
+        isEnabledByDefault);
+    metricInstruments.add(instrument);
+    registeredMetricNames.add(name);
+    return instrument;
+  }
+
+  /**
+   * Registers a new Long Counter metric instrument.
+   *
+   * @param name the name of the metric
+   * @param description a description of the metric
+   * @param unit the unit of measurement for the metric
+   * @param requiredLabelKeys a list of required label keys
+   * @param optionalLabelKeys a list of optional label keys
+   * @param isEnabledByDefault whether the metric should be enabled by default
+   * @return the newly created LongCounterMetricInstrument
+   * @throws IllegalStateException if a metric with the same name already exists
+   */
+  public synchronized LongCounterMetricInstrument registerLongCounter(String name,
+      String description, String unit, List<String> requiredLabelKeys,
+      List<String> optionalLabelKeys, boolean isEnabledByDefault) {
+    if (registeredMetricNames.contains(name)) {
+      throw new IllegalStateException("Metric with name " + name + " already exists");
+    }
+    // Acquire lock?
+    long instrumentIndex = metricInstruments.size();
+    LongCounterMetricInstrument instrument = new LongCounterMetricInstrument(
+        instrumentIndex, name, description, unit, requiredLabelKeys, optionalLabelKeys,
+        isEnabledByDefault);
+    metricInstruments.add(instrument);
+    registeredMetricNames.add(name);
+    return instrument;
+  }
+
+  /**
+   * Registers a new Double Histogram metric instrument.
+   *
+   * @param name the name of the metric
+   * @param description a description of the metric
+   * @param unit the unit of measurement for the metric
+   * @param bucketBoundaries recommended set of explicit bucket boundaries for the histogram
+   * @param requiredLabelKeys a list of required label keys
+   * @param optionalLabelKeys a list of optional label keys
+   * @param isEnabledByDefault whether the metric should be enabled by default
+   * @return the newly created DoubleHistogramMetricInstrument
+   * @throws IllegalStateException if a metric with the same name already exists
+   */
+  public synchronized DoubleHistogramMetricInstrument registerDoubleHistogram(String name,
+      String description, String unit, List<Double> bucketBoundaries,
+      List<String> requiredLabelKeys, List<String> optionalLabelKeys, boolean isEnabledByDefault) {
+    if (registeredMetricNames.contains(name)) {
+      throw new IllegalStateException("Metric with name " + name + " already exists");
+    }
+    long indexToInsertInstrument = metricInstruments.size();
+    DoubleHistogramMetricInstrument instrument = new DoubleHistogramMetricInstrument(
+        indexToInsertInstrument, name, description, unit, bucketBoundaries, requiredLabelKeys,
+        optionalLabelKeys,
+        isEnabledByDefault);
+    metricInstruments.add(instrument);
+    registeredMetricNames.add(name);
+    return instrument;
+  }
+
+  /**
+   * Registers a new Long Histogram metric instrument.
+   *
+   * @param name the name of the metric
+   * @param description a description of the metric
+   * @param unit the unit of measurement for the metric
+   * @param bucketBoundaries recommended set of explicit bucket boundaries for the histogram
+   * @param requiredLabelKeys a list of required label keys
+   * @param optionalLabelKeys a list of optional label keys
+   * @param isEnabledByDefault whether the metric should be enabled by default
+   * @return the newly created LongHistogramMetricInstrument
+   * @throws IllegalStateException if a metric with the same name already exists
+   */
+  public synchronized LongHistogramMetricInstrument registerLongHistogram(String name,
+      String description, String unit, List<Long> bucketBoundaries, List<String> requiredLabelKeys,
+      List<String> optionalLabelKeys, boolean isEnabledByDefault) {
+    if (registeredMetricNames.contains(name)) {
+      throw new IllegalStateException("Metric with name " + name + " already exists");
+    }
+    long indexToInsertInstrument = metricInstruments.size();
+    LongHistogramMetricInstrument instrument = new LongHistogramMetricInstrument(
+        indexToInsertInstrument, name, description, unit, bucketBoundaries, requiredLabelKeys,
+        optionalLabelKeys,
+        isEnabledByDefault);
+    metricInstruments.add(instrument);
+    registeredMetricNames.add(name);
+    return instrument;
+  }
+
+
+  /**
+   * Registers a new Long Gauge metric instrument.
+   *
+   * @param name the name of the metric
+   * @param description a description of the metric
+   * @param unit the unit of measurement for the metric
+   * @param requiredLabelKeys a list of required label keys
+   * @param optionalLabelKeys a list of optional label keys
+   * @param isEnabledByDefault whether the metric should be enabled by default
+   * @return the newly created LongGaugeMetricInstrument
+   * @throws IllegalStateException if a metric with the same name already exists
+   */
+  public synchronized LongGaugeMetricInstrument registerLongGauge(String name, String description,
+      String unit, List<String> requiredLabelKeys, List<String> optionalLabelKeys, boolean
+      isEnabledByDefault) {
+    if (registeredMetricNames.contains(name)) {
+      throw new IllegalStateException("Metric with name " + name + " already exists");
+    }
+    long indexToInsertInstrument = metricInstruments.size();
+    LongGaugeMetricInstrument instrument = new LongGaugeMetricInstrument(
+        indexToInsertInstrument, name, description, unit, requiredLabelKeys, optionalLabelKeys,
+        isEnabledByDefault);
+    metricInstruments.add(instrument);
+    registeredMetricNames.add(name);
+    return instrument;
+  }
+
+}

--- a/api/src/main/java/io/grpc/MetricInstrumentRegistry.java
+++ b/api/src/main/java/io/grpc/MetricInstrumentRegistry.java
@@ -16,6 +16,7 @@
 
 package io.grpc;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -49,7 +50,7 @@ public final class MetricInstrumentRegistry {
    * Returns a list of registered metric instruments.
    */
   public List<MetricInstrument> getMetricInstruments() {
-    return metricInstruments;
+    return Collections.unmodifiableList(metricInstruments);
   }
 
   /**
@@ -60,21 +61,21 @@ public final class MetricInstrumentRegistry {
    * @param unit the unit of measurement for the metric
    * @param requiredLabelKeys a list of required label keys
    * @param optionalLabelKeys a list of optional label keys
-   * @param isEnabledByDefault whether the metric should be enabled by default
+   * @param enableByDefault whether the metric should be enabled by default
    * @return the newly created DoubleCounterMetricInstrument
    * @throws IllegalStateException if a metric with the same name already exists
    */
   // TODO(dnvindhya): Evaluate locks over synchronized methods and update if needed
   public synchronized DoubleCounterMetricInstrument registerDoubleCounter(String name,
       String description, String unit, List<String> requiredLabelKeys,
-      List<String> optionalLabelKeys, boolean isEnabledByDefault) {
+      List<String> optionalLabelKeys, boolean enableByDefault) {
     if (registeredMetricNames.contains(name)) {
       throw new IllegalStateException("Metric with name " + name + " already exists");
     }
     long instrumentIndex = metricInstruments.size();
     DoubleCounterMetricInstrument instrument = new DoubleCounterMetricInstrument(
         instrumentIndex, name, description, unit, requiredLabelKeys, optionalLabelKeys,
-        isEnabledByDefault);
+        enableByDefault);
     metricInstruments.add(instrument);
     registeredMetricNames.add(name);
     return instrument;
@@ -88,13 +89,13 @@ public final class MetricInstrumentRegistry {
    * @param unit the unit of measurement for the metric
    * @param requiredLabelKeys a list of required label keys
    * @param optionalLabelKeys a list of optional label keys
-   * @param isEnabledByDefault whether the metric should be enabled by default
+   * @param enableByDefault whether the metric should be enabled by default
    * @return the newly created LongCounterMetricInstrument
    * @throws IllegalStateException if a metric with the same name already exists
    */
   public synchronized LongCounterMetricInstrument registerLongCounter(String name,
       String description, String unit, List<String> requiredLabelKeys,
-      List<String> optionalLabelKeys, boolean isEnabledByDefault) {
+      List<String> optionalLabelKeys, boolean enableByDefault) {
     if (registeredMetricNames.contains(name)) {
       throw new IllegalStateException("Metric with name " + name + " already exists");
     }
@@ -102,7 +103,7 @@ public final class MetricInstrumentRegistry {
     long instrumentIndex = metricInstruments.size();
     LongCounterMetricInstrument instrument = new LongCounterMetricInstrument(
         instrumentIndex, name, description, unit, requiredLabelKeys, optionalLabelKeys,
-        isEnabledByDefault);
+        enableByDefault);
     metricInstruments.add(instrument);
     registeredMetricNames.add(name);
     return instrument;
@@ -117,13 +118,13 @@ public final class MetricInstrumentRegistry {
    * @param bucketBoundaries recommended set of explicit bucket boundaries for the histogram
    * @param requiredLabelKeys a list of required label keys
    * @param optionalLabelKeys a list of optional label keys
-   * @param isEnabledByDefault whether the metric should be enabled by default
+   * @param enableByDefault whether the metric should be enabled by default
    * @return the newly created DoubleHistogramMetricInstrument
    * @throws IllegalStateException if a metric with the same name already exists
    */
   public synchronized DoubleHistogramMetricInstrument registerDoubleHistogram(String name,
       String description, String unit, List<Double> bucketBoundaries,
-      List<String> requiredLabelKeys, List<String> optionalLabelKeys, boolean isEnabledByDefault) {
+      List<String> requiredLabelKeys, List<String> optionalLabelKeys, boolean enableByDefault) {
     if (registeredMetricNames.contains(name)) {
       throw new IllegalStateException("Metric with name " + name + " already exists");
     }
@@ -131,7 +132,7 @@ public final class MetricInstrumentRegistry {
     DoubleHistogramMetricInstrument instrument = new DoubleHistogramMetricInstrument(
         indexToInsertInstrument, name, description, unit, bucketBoundaries, requiredLabelKeys,
         optionalLabelKeys,
-        isEnabledByDefault);
+        enableByDefault);
     metricInstruments.add(instrument);
     registeredMetricNames.add(name);
     return instrument;
@@ -146,13 +147,13 @@ public final class MetricInstrumentRegistry {
    * @param bucketBoundaries recommended set of explicit bucket boundaries for the histogram
    * @param requiredLabelKeys a list of required label keys
    * @param optionalLabelKeys a list of optional label keys
-   * @param isEnabledByDefault whether the metric should be enabled by default
+   * @param enableByDefault whether the metric should be enabled by default
    * @return the newly created LongHistogramMetricInstrument
    * @throws IllegalStateException if a metric with the same name already exists
    */
   public synchronized LongHistogramMetricInstrument registerLongHistogram(String name,
       String description, String unit, List<Long> bucketBoundaries, List<String> requiredLabelKeys,
-      List<String> optionalLabelKeys, boolean isEnabledByDefault) {
+      List<String> optionalLabelKeys, boolean enableByDefault) {
     if (registeredMetricNames.contains(name)) {
       throw new IllegalStateException("Metric with name " + name + " already exists");
     }
@@ -160,7 +161,7 @@ public final class MetricInstrumentRegistry {
     LongHistogramMetricInstrument instrument = new LongHistogramMetricInstrument(
         indexToInsertInstrument, name, description, unit, bucketBoundaries, requiredLabelKeys,
         optionalLabelKeys,
-        isEnabledByDefault);
+        enableByDefault);
     metricInstruments.add(instrument);
     registeredMetricNames.add(name);
     return instrument;
@@ -175,23 +176,22 @@ public final class MetricInstrumentRegistry {
    * @param unit the unit of measurement for the metric
    * @param requiredLabelKeys a list of required label keys
    * @param optionalLabelKeys a list of optional label keys
-   * @param isEnabledByDefault whether the metric should be enabled by default
+   * @param enableByDefault whether the metric should be enabled by default
    * @return the newly created LongGaugeMetricInstrument
    * @throws IllegalStateException if a metric with the same name already exists
    */
   public synchronized LongGaugeMetricInstrument registerLongGauge(String name, String description,
       String unit, List<String> requiredLabelKeys, List<String> optionalLabelKeys, boolean
-      isEnabledByDefault) {
+      enableByDefault) {
     if (registeredMetricNames.contains(name)) {
       throw new IllegalStateException("Metric with name " + name + " already exists");
     }
     long indexToInsertInstrument = metricInstruments.size();
     LongGaugeMetricInstrument instrument = new LongGaugeMetricInstrument(
         indexToInsertInstrument, name, description, unit, requiredLabelKeys, optionalLabelKeys,
-        isEnabledByDefault);
+        enableByDefault);
     metricInstruments.add(instrument);
     registeredMetricNames.add(name);
     return instrument;
   }
-
 }

--- a/api/src/main/java/io/grpc/PartialMetricInstrument.java
+++ b/api/src/main/java/io/grpc/PartialMetricInstrument.java
@@ -16,6 +16,7 @@
 
 package io.grpc;
 
+import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 /**
@@ -23,7 +24,7 @@ import java.util.List;
  * provides common fields and functionality for metric instruments.
  */
 @Internal
-abstract class PartialMetricInstrument {
+abstract class PartialMetricInstrument implements MetricInstrument {
   protected final long index;
   protected final String name;
   protected final String description;
@@ -47,21 +48,37 @@ abstract class PartialMetricInstrument {
     this.name = name;
     this.description = description;
     this.unit = unit;
-    this.requiredLabelKeys = requiredLabelKeys;
-    this.optionalLabelKeys = optionalLabelKeys;
+    this.requiredLabelKeys = ImmutableList.copyOf(requiredLabelKeys);
+    this.optionalLabelKeys = ImmutableList.copyOf(optionalLabelKeys);
   }
 
-  /**
-   * Returns a list of required label keys for this metric instrument.
-   *
-   * @return a list of required label keys.
-   */
-  abstract List<String> getRequiredLabelKeys();
+  @Override
+  public long getIndex() {
+    return index;
+  }
 
-  /**
-   * Returns a list of optional label keys for this metric instrument.
-   *
-   * @return a list of optional label keys.
-   */
-  abstract List<String> getOptionalLabelKeys();
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public String getUnit() {
+    return unit;
+  }
+
+  @Override
+  public List<String> getRequiredLabelKeys() {
+    return requiredLabelKeys;
+  }
+
+  @Override
+  public List<String> getOptionalLabelKeys() {
+    return optionalLabelKeys;
+  }
 }

--- a/api/src/main/java/io/grpc/PartialMetricInstrument.java
+++ b/api/src/main/java/io/grpc/PartialMetricInstrument.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import java.util.List;
+
+/**
+ * A partial implementation of the {@link MetricInstrument} interface. This class
+ * provides common fields and functionality for metric instruments.
+ */
+@Internal
+abstract class PartialMetricInstrument {
+  protected final long index;
+  protected final String name;
+  protected final String description;
+  protected final String unit;
+  protected final List<String> requiredLabelKeys;
+  protected final List<String> optionalLabelKeys;
+
+  /**
+   * Constructs a new PartialMetricInstrument with the specified attributes.
+   *
+   * @param index             the unique index of this metric instrument
+   * @param name              the name of the metric
+   * @param description       a description of the metric
+   * @param unit              the unit of measurement for the metric
+   * @param requiredLabelKeys a list of required label keys for the metric
+   * @param optionalLabelKeys a list of optional label keys for the metric
+   */
+  protected PartialMetricInstrument(long index, String name, String description, String unit,
+      List<String> requiredLabelKeys, List<String> optionalLabelKeys) {
+    this.index = index;
+    this.name = name;
+    this.description = description;
+    this.unit = unit;
+    this.requiredLabelKeys = requiredLabelKeys;
+    this.optionalLabelKeys = optionalLabelKeys;
+  }
+
+  /**
+   * Returns a list of required label keys for this metric instrument.
+   *
+   * @return a list of required label keys.
+   */
+  abstract List<String> getRequiredLabelKeys();
+
+  /**
+   * Returns a list of optional label keys for this metric instrument.
+   *
+   * @return a list of optional label keys.
+   */
+  abstract List<String> getOptionalLabelKeys();
+}

--- a/api/src/main/java/io/grpc/PartialMetricInstrument.java
+++ b/api/src/main/java/io/grpc/PartialMetricInstrument.java
@@ -31,6 +31,7 @@ abstract class PartialMetricInstrument implements MetricInstrument {
   protected final String unit;
   protected final List<String> requiredLabelKeys;
   protected final List<String> optionalLabelKeys;
+  protected final boolean enableByDefault;
 
   /**
    * Constructs a new PartialMetricInstrument with the specified attributes.
@@ -41,15 +42,17 @@ abstract class PartialMetricInstrument implements MetricInstrument {
    * @param unit              the unit of measurement for the metric
    * @param requiredLabelKeys a list of required label keys for the metric
    * @param optionalLabelKeys a list of optional label keys for the metric
+   * @param enableByDefault   whether the metric should be enabled by default
    */
   protected PartialMetricInstrument(long index, String name, String description, String unit,
-      List<String> requiredLabelKeys, List<String> optionalLabelKeys) {
+      List<String> requiredLabelKeys, List<String> optionalLabelKeys, boolean enableByDefault) {
     this.index = index;
     this.name = name;
     this.description = description;
     this.unit = unit;
     this.requiredLabelKeys = ImmutableList.copyOf(requiredLabelKeys);
     this.optionalLabelKeys = ImmutableList.copyOf(optionalLabelKeys);
+    this.enableByDefault = enableByDefault;
   }
 
   @Override
@@ -80,5 +83,10 @@ abstract class PartialMetricInstrument implements MetricInstrument {
   @Override
   public List<String> getOptionalLabelKeys() {
     return optionalLabelKeys;
+  }
+
+  @Override
+  public boolean isEnableByDefault() {
+    return enableByDefault;
   }
 }


### PR DESCRIPTION
This PR adds Metric Instrument Registry which provides APIs to register gRPC specific metric instruments. Metric instruments has the necessary information needed to create a metric (e.g. OpenTelemetry based metric).

This is one of the initial PRs (of many) for gRPC metrics architecture / framework described in [gRFC A79](https://github.com/grpc/proposal/blob/master/A79-non-per-call-metrics-architecture.md).

Unit tests will be added in a follow up PR.