### PR TITLE
Add `load()` statements for the Bazel builtin top-level java symbols

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,6 +49,7 @@ bazel_dep(name = "googleapis", repo_name = "com_google_googleapis", version = "0
 bazel_dep(name = "grpc", repo_name = "com_github_grpc_grpc", version = "1.56.3.bcr.1")
 bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "23.1")
 bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_java", version = "5.3.5")
 bazel_dep(name = "rules_go", repo_name = "io_bazel_rules_go", version = "0.46.0")
 bazel_dep(name = "rules_jvm_external", version = "6.0")
 bazel_dep(name = "rules_proto", version = "5.3.0-21.7")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,6 +3,12 @@ workspace(name = "io_grpc_grpc_java")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
+    name = "rules_java",
+    url = "https://github.com/bazelbuild/rules_java/releases/download/5.3.5/rules_java-5.3.5.tar.gz",
+    sha256 = "c73336802d0b4882e40770666ad055212df4ea62cfa6edf9cb0f9d29828a0934",
+)
+
+http_archive(
     name = "rules_jvm_external",
     sha256 = "d31e369b854322ca5098ea12c69d7175ded971435e55c18dd9dd5f29cc5249ac",
     strip_prefix = "rules_jvm_external-5.3",

--- a/java_grpc_library.bzl
+++ b/java_grpc_library.bzl
@@ -1,5 +1,7 @@
 """Build rule for java_grpc_library."""
 
+load("@rules_java//java:defs.bzl", "java_common", "JavaInfo", "JavaPluginInfo")
+
 _JavaRpcToolchainInfo = provider(
     fields = [
         "java_toolchain",


### PR DESCRIPTION
Loads are being added in preparation for moving the symbols out of Bazel and into `rules_java`.

ref cl/623147910