### PR TITLE
netty: Release SendGrpcFrameCommand when stream is missing (1.63.x backport)

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -749,6 +749,7 @@ class NettyServerHandler extends AbstractNettyHandler {
       int streamId = cmd.stream().id();
       Http2Stream stream = connection().stream(streamId);
       if (stream == null) {
+        cmd.release();
         streamGone(streamId, promise);
         return;
       }


### PR DESCRIPTION
`sendGrpcFrame` owns the buffer in `SendGrpcFrameCommand`. If the frame is not handed off to netty, it needs to be released in the method.

https://github.com/grpc/grpc-java/issues/11115

Backport of #11116