### PR TITLE
Minor - add missing instruction

### DIFF
--- a/examples/example-reflection/README.md
+++ b/examples/example-reflection/README.md
@@ -45,7 +45,7 @@ Output
 
 ### List all the methods of a service
   ```
-  $ grpcurl -plaintext localhost:50051 helloworld.Greeter
+  $ grpcurl -plaintext localhost:50051 list helloworld.Greeter
   ```
 Output
   ```


### PR DESCRIPTION
The "list" instruction was missing, so the command didn't work properly. I added it to the readme, so other people won't have to debug it as I did