### PR TITLE
Plumb optional labels from LB to ClientStreamTracer

### DIFF
--- a/api/src/main/java/io/grpc/ClientStreamTracer.java
+++ b/api/src/main/java/io/grpc/ClientStreamTracer.java
@@ -80,6 +80,13 @@ public abstract class ClientStreamTracer extends StreamTracer {
   }
 
   /**
+   * Information providing context to the call became available.
+   */
+  @Internal
+  public void addOptionalLabel(String key, String value) {
+  }
+
+  /**
    * Factory class for {@link ClientStreamTracer}.
    */
   public abstract static class Factory {

--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -490,6 +490,29 @@ public abstract class LoadBalancer {
      * @since 1.2.0
      */
     public abstract MethodDescriptor<?, ?> getMethodDescriptor();
+
+    /**
+     * Gets an object that can be informed about what sort of pick was made.
+     */
+    @Internal
+    public PickDetailsConsumer getPickDetailsConsumer() {
+      return new PickDetailsConsumer() {};
+    }
+  }
+
+  /** Receives information about the pick being chosen. */
+  @Internal
+  public interface PickDetailsConsumer {
+    /**
+     * Optional labels that provide context of how the pick was routed. Particularly helpful for
+     * per-RPC metrics.
+     *
+     * @throws NullPointerException if key or value is {@code null}
+     */
+    default void addOptionalLabel(String key, String value) {
+      checkNotNull(key, "key");
+      checkNotNull(value, "value");
+    }
   }
 
   /**

--- a/api/src/testFixtures/java/io/grpc/PickSubchannelArgsMatcher.java
+++ b/api/src/testFixtures/java/io/grpc/PickSubchannelArgsMatcher.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import com.google.common.base.Preconditions;
+import io.grpc.CallOptions;
+import io.grpc.LoadBalancer.PickSubchannelArgs;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import org.mockito.ArgumentMatcher;
+import org.mockito.ArgumentMatchers;
+
+/**
+ * Mockito Matcher for {@link PickSubchannelArgs}.
+ */
+public final class PickSubchannelArgsMatcher implements ArgumentMatcher<PickSubchannelArgs> {
+  private final MethodDescriptor<?, ?> method;
+  private final Metadata headers;
+  private final CallOptions callOptions;
+
+  public PickSubchannelArgsMatcher(
+      MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
+    this.method = Preconditions.checkNotNull(method, "method");
+    this.headers = Preconditions.checkNotNull(headers, "headers");
+    this.callOptions = Preconditions.checkNotNull(callOptions, "callOptions");
+  }
+
+  @Override
+  public boolean matches(PickSubchannelArgs args) {
+    return args != null
+        && method.equals(args.getMethodDescriptor())
+        && headers.equals(args.getHeaders())
+        && callOptions.equals(args.getCallOptions());
+  }
+
+  @Override
+  public final String toString() {
+    return "[method=" + method + " headers=" + headers + " callOptions=" + callOptions + "]";
+  }
+
+  public static PickSubchannelArgs eqPickSubchannelArgs(
+      MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
+    return ArgumentMatchers.argThat(new PickSubchannelArgsMatcher(method, headers, callOptions));
+  }
+}

--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -137,7 +137,8 @@ final class DelayedClientTransport implements ManagedClientTransport {
       MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions,
       ClientStreamTracer[] tracers) {
     try {
-      PickSubchannelArgs args = new PickSubchannelArgsImpl(method, headers, callOptions);
+      PickSubchannelArgs args = new PickSubchannelArgsImpl(
+          method, headers, callOptions, new PickDetailsConsumerImpl(tracers));
       SubchannelPicker picker = null;
       long pickerVersion = -1;
       while (true) {

--- a/core/src/main/java/io/grpc/internal/ForwardingClientStreamTracer.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingClientStreamTracer.java
@@ -55,6 +55,11 @@ public abstract class ForwardingClientStreamTracer extends ClientStreamTracer {
   }
 
   @Override
+  public void addOptionalLabel(String key, String value) {
+    delegate().addOptionalLabel(key, value);
+  }
+
+  @Override
   public void streamClosed(Status status) {
     delegate().streamClosed(status);
   }

--- a/core/src/main/java/io/grpc/internal/PickDetailsConsumerImpl.java
+++ b/core/src/main/java/io/grpc/internal/PickDetailsConsumerImpl.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import com.google.common.base.Preconditions;
+import io.grpc.ClientStreamTracer;
+import io.grpc.LoadBalancer.PickDetailsConsumer;
+
+/**
+ * Adapter for tracers into details consumers.
+ */
+final class PickDetailsConsumerImpl implements PickDetailsConsumer {
+  private final ClientStreamTracer[] tracers;
+
+  /** Construct a consumer with unchanging tracers array. */
+  public PickDetailsConsumerImpl(ClientStreamTracer[] tracers) {
+    this.tracers = Preconditions.checkNotNull(tracers, "tracers");
+  }
+
+  @Override
+  public void addOptionalLabel(String key, String value) {
+    Preconditions.checkNotNull(key, "key");
+    Preconditions.checkNotNull(value, "value");
+    for (ClientStreamTracer tracer : tracers) {
+      tracer.addOptionalLabel(key, value);
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/internal/PickSubchannelArgsImpl.java
+++ b/core/src/main/java/io/grpc/internal/PickSubchannelArgsImpl.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Objects;
 import io.grpc.CallOptions;
+import io.grpc.LoadBalancer.PickDetailsConsumer;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -29,15 +30,18 @@ public final class PickSubchannelArgsImpl extends PickSubchannelArgs {
   private final CallOptions callOptions;
   private final Metadata headers;
   private final MethodDescriptor<?, ?> method;
+  private final PickDetailsConsumer pickDetailsConsumer;
 
   /**
    * Creates call args object for given method with its call options, metadata.
    */
   public PickSubchannelArgsImpl(
-      MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
+      MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions,
+      PickDetailsConsumer pickDetailsConsumer) {
     this.method = checkNotNull(method, "method");
     this.headers = checkNotNull(headers, "headers");
     this.callOptions = checkNotNull(callOptions, "callOptions");
+    this.pickDetailsConsumer = checkNotNull(pickDetailsConsumer, "pickDetailsConsumer");
   }
 
   @Override
@@ -56,6 +60,11 @@ public final class PickSubchannelArgsImpl extends PickSubchannelArgs {
   }
 
   @Override
+  public PickDetailsConsumer getPickDetailsConsumer() {
+    return pickDetailsConsumer;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;
@@ -66,12 +75,13 @@ public final class PickSubchannelArgsImpl extends PickSubchannelArgs {
     PickSubchannelArgsImpl that = (PickSubchannelArgsImpl) o;
     return Objects.equal(callOptions, that.callOptions)
         && Objects.equal(headers, that.headers)
-        && Objects.equal(method, that.method);
+        && Objects.equal(method, that.method)
+        && Objects.equal(pickDetailsConsumer, that.pickDetailsConsumer);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(callOptions, headers, method);
+    return Objects.hashCode(callOptions, headers, method, pickDetailsConsumer);
   }
 
   @Override

--- a/core/src/test/java/io/grpc/internal/ManagedChannelServiceConfigTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelServiceConfigTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableMap;
 import io.grpc.CallOptions;
 import io.grpc.InternalConfigSelector;
 import io.grpc.InternalConfigSelector.Result;
+import io.grpc.LoadBalancer.PickDetailsConsumer;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.internal.ManagedChannelServiceConfig.MethodInfo;
@@ -209,7 +210,8 @@ public class ManagedChannelServiceConfigTest {
     InternalConfigSelector configSelector = serviceConfig.getDefaultConfigSelector();
     MethodDescriptor<?, ?> method = methodForName("service1", "method1");
     Result result = configSelector.selectConfig(
-        new PickSubchannelArgsImpl(method, new Metadata(), CallOptions.DEFAULT));
+        new PickSubchannelArgsImpl(
+            method, new Metadata(), CallOptions.DEFAULT, new PickDetailsConsumer() {}));
     MethodInfo methodInfoFromDefaultConfigSelector =
         ((ManagedChannelServiceConfig) result.getConfig()).getMethodConfig(method);
     assertThat(methodInfoFromDefaultConfigSelector)

--- a/interop-testing/src/test/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProviderTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProviderTest.java
@@ -100,7 +100,7 @@ public class RpcBehaviorLoadBalancerProviderTest {
   @Test
   public void pickerAddsRpcBehaviorMetadata() {
     PickSubchannelArgsImpl args = new PickSubchannelArgsImpl(TestMethodDescriptors.voidMethod(),
-        new Metadata(), CallOptions.DEFAULT);
+        new Metadata(), CallOptions.DEFAULT, new LoadBalancer.PickDetailsConsumer() {});
     new RpcBehaviorPicker(mockPicker, "error-code-15").pickSubchannel(args);
 
     assertThat(args.getHeaders()

--- a/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
+++ b/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
@@ -43,6 +43,7 @@ import io.grpc.EquivalentAddressGroup;
 import io.grpc.ForwardingChannelBuilder2;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancer.PickDetailsConsumer;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.LoadBalancerProvider;
@@ -383,7 +384,8 @@ public class CachingRlsLbClientTest {
                 .setFullMethodName("doesn/exists")
                 .build(),
             headers,
-            CallOptions.DEFAULT));
+            CallOptions.DEFAULT,
+            new PickDetailsConsumer() {}));
     assertThat(pickResult.getStatus().getCode()).isEqualTo(Code.UNAVAILABLE);
     assertThat(pickResult.getStatus().getDescription()).contains("fallback not available");
     assertThat(fakeThrottler.getNumThrottled()).isEqualTo(1);
@@ -438,7 +440,8 @@ public class CachingRlsLbClientTest {
             TestMethodDescriptors.voidMethod().toBuilder().setFullMethodName("service1/create")
                 .build(),
             headers,
-            CallOptions.DEFAULT));
+            CallOptions.DEFAULT,
+            new PickDetailsConsumer() {}));
   }
 
   @Test
@@ -521,7 +524,8 @@ public class CachingRlsLbClientTest {
             .setFullMethodName("doesn/exists")
             .build(),
         headers,
-        CallOptions.DEFAULT);
+        CallOptions.DEFAULT,
+        new PickDetailsConsumer() {});
     return invalidArgs;
   }
 

--- a/util/src/main/java/io/grpc/util/ForwardingClientStreamTracer.java
+++ b/util/src/main/java/io/grpc/util/ForwardingClientStreamTracer.java
@@ -54,6 +54,11 @@ public abstract class ForwardingClientStreamTracer extends ClientStreamTracer {
   }
 
   @Override
+  public void addOptionalLabel(String key, String value) {
+    delegate().addOptionalLabel(key, value);
+  }
+
+  @Override
   public void streamClosed(Status status) {
     delegate().streamClosed(status);
   }

--- a/xds/src/test/java/io/grpc/xds/ClusterManagerLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterManagerLoadBalancerTest.java
@@ -37,6 +37,7 @@ import io.grpc.ConnectivityState;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancer.PickDetailsConsumer;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
 import io.grpc.LoadBalancer.ResolvedAddresses;
@@ -310,7 +311,8 @@ public class ClusterManagerLoadBalancerTest {
                 .build(),
             new Metadata(),
             CallOptions.DEFAULT.withOption(
-                XdsNameResolver.CLUSTER_SELECTION_KEY, clusterName));
+                XdsNameResolver.CLUSTER_SELECTION_KEY, clusterName),
+            new PickDetailsConsumer() {});
     return picker.pickSubchannel(args);
   }
 

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
@@ -50,6 +50,7 @@ import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer.CreateSubchannelArgs;
 import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancer.PickDetailsConsumer;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
 import io.grpc.LoadBalancer.ResolvedAddresses;
@@ -461,13 +462,14 @@ public class RingHashLoadBalancerTest {
     assertThat(result.getSubchannel().getAddresses()).isEqualTo(servers.get(1));
   }
 
-  private PickSubchannelArgsImpl getDefaultPickSubchannelArgs(long rpcHash) {
+  private PickSubchannelArgs getDefaultPickSubchannelArgs(long rpcHash) {
     return new PickSubchannelArgsImpl(
         TestMethodDescriptors.voidMethod(), new Metadata(),
-        CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, rpcHash));
+        CallOptions.DEFAULT.withOption(XdsNameResolver.RPC_HASH_KEY, rpcHash),
+        new PickDetailsConsumer() {});
   }
 
-  private PickSubchannelArgsImpl getDefaultPickSubchannelArgsForServer(int serverid) {
+  private PickSubchannelArgs getDefaultPickSubchannelArgsForServer(int serverid) {
     long rpcHash = hashFunc.hashAsciiString("FakeSocketAddress-server" + serverid + "_0");
     return getDefaultPickSubchannelArgs(rpcHash);
   }


### PR DESCRIPTION
As part of gRFC A78:

> To support the locality label in the per-call metrics, we will provide
> a mechanism for LB picker to add optional labels to the call attempt
> tracer.

-----

@temawi, I'm suspecting you may be the best to review this, because you already have some context. Most lines changed are in tests. We can discuss.

(I have [another commit](https://github.com/ejona86/grpc-java/tree/xds-locality-weight-target) prepared that will follow this one (because the tests collide), to plumb locality to WRR)