### PR TITLE
xds: Plumb locality in xds_cluster_impl and weighted_target

### DIFF
--- a/xds/src/main/java/io/grpc/xds/InternalXdsAttributes.java
+++ b/xds/src/main/java/io/grpc/xds/InternalXdsAttributes.java
@@ -78,6 +78,13 @@ public final class InternalXdsAttributes {
       Attributes.Key.create("io.grpc.xds.InternalXdsAttributes.locality");
 
   /**
+   * The name of the locality that this EquivalentAddressGroup is in.
+   */
+  @EquivalentAddressGroup.Attr
+  static final Attributes.Key<String> ATTR_LOCALITY_NAME =
+      Attributes.Key.create("io.grpc.xds.InternalXdsAttributes.localityName");
+
+  /**
    * Endpoint weight for load balancing purposes.
    */
   @EquivalentAddressGroup.Attr

--- a/xds/src/main/java/io/grpc/xds/WeightedTargetLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedTargetLoadBalancer.java
@@ -23,6 +23,7 @@ import static io.grpc.ConnectivityState.READY;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 
 import com.google.common.collect.ImmutableMap;
+import io.grpc.Attributes;
 import io.grpc.ConnectivityState;
 import io.grpc.InternalLogId;
 import io.grpc.LoadBalancer;
@@ -42,6 +43,8 @@ import javax.annotation.Nullable;
 
 /** Load balancer for weighted_target policy. */
 final class WeightedTargetLoadBalancer extends LoadBalancer {
+  public static final Attributes.Key<String> CHILD_NAME =
+      Attributes.Key.create("io.grpc.xds.WeightedTargetLoadBalancer.CHILD_NAME");
 
   private final XdsLogger logger;
   private final Map<String, GracefulSwitchLoadBalancer> childBalancers = new HashMap<>();
@@ -95,6 +98,9 @@ final class WeightedTargetLoadBalancer extends LoadBalancer {
           resolvedAddresses.toBuilder()
               .setAddresses(AddressFilter.filter(resolvedAddresses.getAddresses(), targetName))
               .setLoadBalancingPolicyConfig(targets.get(targetName).policySelection.getConfig())
+              .setAttributes(resolvedAddresses.getAttributes().toBuilder()
+                .set(CHILD_NAME, targetName)
+                .build())
               .build());
     }
 

--- a/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancer.java
@@ -31,7 +31,6 @@ import io.grpc.internal.ServiceConfigUtil.PolicySelection;
 import io.grpc.util.GracefulSwitchLoadBalancer;
 import io.grpc.xds.WeightedTargetLoadBalancerProvider.WeightedPolicySelection;
 import io.grpc.xds.WeightedTargetLoadBalancerProvider.WeightedTargetConfig;
-import io.grpc.xds.client.Locality;
 import io.grpc.xds.client.XdsLogger;
 import io.grpc.xds.client.XdsLogger.XdsLogLevel;
 import java.util.HashMap;
@@ -73,10 +72,10 @@ final class WrrLocalityLoadBalancer extends LoadBalancer {
         = (WrrLocalityConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
 
     // A map of locality weights is built up from the locality weight attributes in each address.
-    Map<Locality, Integer> localityWeights = new HashMap<>();
+    Map<String, Integer> localityWeights = new HashMap<>();
     for (EquivalentAddressGroup eag : resolvedAddresses.getAddresses()) {
       Attributes eagAttrs = eag.getAttributes();
-      Locality locality = eagAttrs.get(InternalXdsAttributes.ATTR_LOCALITY);
+      String locality = eagAttrs.get(InternalXdsAttributes.ATTR_LOCALITY_NAME);
       Integer localityWeight = eagAttrs.get(InternalXdsAttributes.ATTR_LOCALITY_WEIGHT);
 
       if (locality == null) {
@@ -106,8 +105,8 @@ final class WrrLocalityLoadBalancer extends LoadBalancer {
     // Weighted target LB expects a WeightedPolicySelection for each locality as it will create a
     // child LB for each.
     Map<String, WeightedPolicySelection> weightedPolicySelections = new HashMap<>();
-    for (Locality locality : localityWeights.keySet()) {
-      weightedPolicySelections.put(locality.toString(),
+    for (String locality : localityWeights.keySet()) {
+      weightedPolicySelections.put(locality,
           new WeightedPolicySelection(localityWeights.get(locality),
               wrrLocalityConfig.childPolicy));
     }

--- a/xds/src/test/java/io/grpc/xds/WeightedTargetLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedTargetLoadBalancerTest.java
@@ -220,6 +220,8 @@ public class WeightedTargetLoadBalancerTest {
       ResolvedAddresses resolvedAddresses = resolvedAddressesCaptor.getValue();
       assertThat(resolvedAddresses.getLoadBalancingPolicyConfig()).isEqualTo(configs[i]);
       assertThat(resolvedAddresses.getAttributes().get(fakeKey)).isEqualTo(fakeValue);
+      assertThat(resolvedAddresses.getAttributes().get(WeightedTargetLoadBalancer.CHILD_NAME))
+          .isEqualTo("target" + i);
       assertThat(Iterables.getOnlyElement(resolvedAddresses.getAddresses()).getAddresses())
           .containsExactly(socketAddresses[i]);
     }


### PR DESCRIPTION
As part of gRFC A78:

> To support the locality label in the WRR metrics, we will extend the
> `weighted_target` LB policy (see A28) to define a resolver attribute
> that indicates the name of its child. This attribute will be passed
> down to each of its children with the appropriate value, so that any
> LB policy that sits underneath the `weighted_target` policy will be
> able to use it.

xds_cluster_impl is involved because it uses the child names in the AddressFilter, which must match the names used by weighted_target. Instead of using Locality.toString() in multiple policies and assuming the policies agree, we now have xds_cluster_impl decide the locality's name and pass it down explicitly. This allows us to change the name format to match gRFC A78:

> If locality information is available, the value of this label will be
> of the form `{region="${REGION}", zone="${ZONE}",
> sub_zone="${SUB_ZONE}"}`, where `${REGION}`, `${ZONE}`, and
> `${SUB_ZONE}` are replaced with the actual values. If no locality
> information is available, the label will be set to the empty string.

----

CC @DNVindhya, @temawi. The API exposed to WRR will be `WeightedTargetLoadBalancer.CHILD_NAME`