### PR TITLE
api: Return a noop MetricRecorder from Helper by default

### DIFF
--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -1243,7 +1243,7 @@ public abstract class LoadBalancer {
      */
     @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11110")
     public MetricRecorder getMetricRecorder() {
-      throw new UnsupportedOperationException();
+      return new MetricRecorder() {};
     }
   }
 


### PR DESCRIPTION
Since 06df25b65d, WRR has been calling this method, and it will get an exception. We don't want WRR to be broken until we have MetricRecorder fully plumbed.

CC @DNVindhya 