### PR TITLE
Plumb target to load balancer

### DIFF
--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -1186,6 +1186,13 @@ public abstract class LoadBalancer {
     public abstract String getAuthority();
 
     /**
+     * Returns the target string of the channel, guaranteed to include its scheme.
+     */
+    public String getChannelTarget() {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
      * Returns the ChannelCredentials used to construct the channel, without bearer tokens.
      *
      * @since 1.35.0

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
@@ -17,21 +17,12 @@
 package io.grpc.internal;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
 
-import io.grpc.ChannelLogger;
 import io.grpc.NameResolver;
-import io.grpc.NameResolver.Args;
-import io.grpc.NameResolver.ServiceConfigParser;
 import io.grpc.NameResolverProvider;
 import io.grpc.NameResolverRegistry;
-import io.grpc.ProxyDetector;
-import io.grpc.SynchronizationContext;
 import io.grpc.inprocess.InProcessSocketAddress;
-import java.lang.Thread.UncaughtExceptionHandler;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.Collections;
@@ -39,18 +30,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for ManagedChannelImpl#getNameResolver(). */
+/** Unit tests for ManagedChannelImpl#getNameResolverProvider(). */
 @RunWith(JUnit4.class)
 public class ManagedChannelImplGetNameResolverTest {
-  private static final NameResolver.Args NAMERESOLVER_ARGS = NameResolver.Args.newBuilder()
-      .setDefaultPort(447)
-      .setProxyDetector(mock(ProxyDetector.class))
-      .setSynchronizationContext(new SynchronizationContext(mock(UncaughtExceptionHandler.class)))
-      .setServiceConfigParser(mock(ServiceConfigParser.class))
-      .setChannelLogger(mock(ChannelLogger.class))
-      .setScheduledExecutorService(new FakeClock().getScheduledExecutorService())
-      .build();
-
   @Test
   public void invalidUriTarget() {
     testInvalidTarget("defaultscheme:///[invalid]");
@@ -66,18 +48,6 @@ public class ManagedChannelImplGetNameResolverTest {
   public void validAuthorityTarget() throws Exception {
     testValidTarget("foo.googleapis.com:8080", "defaultscheme:///foo.googleapis.com:8080",
         new URI("defaultscheme", "", "/foo.googleapis.com:8080", null));
-  }
-
-  @Test
-  public void validAuthorityTarget_overrideAuthority() throws Exception {
-    String target = "foo.googleapis.com:8080";
-    String overrideAuthority = "override.authority";
-    URI expectedUri = new URI("defaultscheme", "", "/foo.googleapis.com:8080", null);
-    NameResolverRegistry nameResolverRegistry = getTestRegistry(expectedUri.getScheme());
-    NameResolver nameResolver = ManagedChannelImpl.getNameResolver(
-        target, overrideAuthority, nameResolverRegistry, NAMERESOLVER_ARGS,
-        Collections.singleton(InetSocketAddress.class));
-    assertThat(nameResolver.getServiceAuthority()).isEqualTo(overrideAuthority);
   }
 
   @Test
@@ -122,46 +92,11 @@ public class ManagedChannelImplGetNameResolverTest {
   }
 
   @Test
-  public void validTargetNoResolver() {
-    NameResolverRegistry nameResolverRegistry = new NameResolverRegistry();
-    NameResolverProvider nameResolverProvider = new NameResolverProvider() {
-      @Override
-      protected boolean isAvailable() {
-        return true;
-      }
-
-      @Override
-      protected int priority() {
-        return 5;
-      }
-
-      @Override
-      public NameResolver newNameResolver(URI targetUri, Args args) {
-        return null;
-      }
-
-      @Override
-      public String getDefaultScheme() {
-        return "defaultscheme";
-      }
-    };
-    nameResolverRegistry.register(nameResolverProvider);
-    try {
-      ManagedChannelImpl.getNameResolver(
-          "foo.googleapis.com:8080", null, nameResolverRegistry, NAMERESOLVER_ARGS,
-          Collections.singleton(InetSocketAddress.class));
-      fail("Should fail");
-    } catch (IllegalArgumentException e) {
-      // expected
-    }
-  }
-
-  @Test
   public void validTargetNoProvider() {
     NameResolverRegistry nameResolverRegistry = new NameResolverRegistry();
     try {
-      ManagedChannelImpl.getNameResolver(
-          "foo.googleapis.com:8080", null, nameResolverRegistry, NAMERESOLVER_ARGS,
+      ManagedChannelImpl.getNameResolverProvider(
+          "foo.googleapis.com:8080", nameResolverRegistry,
           Collections.singleton(InetSocketAddress.class));
       fail("Should fail");
     } catch (IllegalArgumentException e) {
@@ -173,8 +108,8 @@ public class ManagedChannelImplGetNameResolverTest {
   public void validTargetProviderAddrTypesNotSupported() {
     NameResolverRegistry nameResolverRegistry = getTestRegistry("testscheme");
     try {
-      ManagedChannelImpl.getNameResolver(
-          "testscheme:///foo.googleapis.com:8080", null, nameResolverRegistry, NAMERESOLVER_ARGS,
+      ManagedChannelImpl.getNameResolverProvider(
+          "testscheme:///foo.googleapis.com:8080", nameResolverRegistry,
           Collections.singleton(InProcessSocketAddress.class));
       fail("Should fail");
     } catch (IllegalArgumentException e) {
@@ -184,26 +119,23 @@ public class ManagedChannelImplGetNameResolverTest {
     }
   }
 
-
   private void testValidTarget(String target, String expectedUriString, URI expectedUri) {
     NameResolverRegistry nameResolverRegistry = getTestRegistry(expectedUri.getScheme());
-    FakeNameResolver nameResolver
-        = (FakeNameResolver) ((RetryingNameResolver) ManagedChannelImpl.getNameResolver(
-        target, null, nameResolverRegistry, NAMERESOLVER_ARGS,
-        Collections.singleton(InetSocketAddress.class))).getRetriedNameResolver();
-    assertNotNull(nameResolver);
-    assertEquals(expectedUri, nameResolver.uri);
-    assertEquals(expectedUriString, nameResolver.uri.toString());
+    ManagedChannelImpl.ResolvedNameResolver resolved = ManagedChannelImpl.getNameResolverProvider(
+        target, nameResolverRegistry, Collections.singleton(InetSocketAddress.class));
+    assertThat(resolved.provider).isInstanceOf(FakeNameResolverProvider.class);
+    assertThat(resolved.targetUri).isEqualTo(expectedUri);
+    assertThat(resolved.targetUri.toString()).isEqualTo(expectedUriString);
   }
 
   private void testInvalidTarget(String target) {
     NameResolverRegistry nameResolverRegistry = getTestRegistry("dns");
 
     try {
-      FakeNameResolver nameResolver = (FakeNameResolver) ManagedChannelImpl.getNameResolver(
-          target, null, nameResolverRegistry, NAMERESOLVER_ARGS,
-          Collections.singleton(InetSocketAddress.class));
-      fail("Should have failed, but got resolver with " + nameResolver.uri);
+      ManagedChannelImpl.ResolvedNameResolver resolved = ManagedChannelImpl.getNameResolverProvider(
+          target, nameResolverRegistry, Collections.singleton(InetSocketAddress.class));
+      FakeNameResolverProvider nameResolverProvider = (FakeNameResolverProvider) resolved.provider;
+      fail("Should have failed, but got resolver provider " + nameResolverProvider);
     } catch (IllegalArgumentException e) {
       // expected
     }

--- a/util/src/main/java/io/grpc/util/ForwardingLoadBalancerHelper.java
+++ b/util/src/main/java/io/grpc/util/ForwardingLoadBalancerHelper.java
@@ -107,6 +107,11 @@ public abstract class ForwardingLoadBalancerHelper extends LoadBalancer.Helper {
   }
 
   @Override
+  public String getChannelTarget() {
+    return delegate().getChannelTarget();
+  }
+
+  @Override
   public ChannelCredentials getChannelCredentials() {
     return delegate().getChannelCredentials();
   }


### PR DESCRIPTION
gRFC A78 has WRR and pick-first include a `grpc.target` label, defined in A66:

> `grpc.target` : Canonicalized target URI used when creating gRPC
> Channel, e.g. "dns:///pubsub.googleapis.com:443",
> "xds:///helloworld-gke:8000". Canonicalized target URI is the form
> with the scheme included if the user didn't mention the scheme
> (`scheme://[authority]/path`). For channels such as inprocess channels
> where a target URI is not available, implementations can synthesize a
> target URI.

CC @DNVindhya 