### PR TITLE
rls: add counter metrics

### DIFF
--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -693,6 +693,13 @@ public abstract class LoadBalancer {
       return drop;
     }
 
+    /**
+     * Returns {@code true} if the pick was not created with {@link #withNoResult()}.
+     */
+    public boolean hasResult() {
+      return !(subchannel == null && status.isOk());
+    }
+
     @Override
     public String toString() {
       return MoreObjects.toStringHelper(this)

--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -1012,7 +1012,7 @@ final class CachingRlsLbClient {
     }
 
     private String determineMetricsPickResult(PickResult pickResult) {
-      if (pickResult.getStatus().equals(Status.OK)) {
+      if (pickResult.getStatus().isOk()) {
         return "complete";
       } else if (pickResult.isDrop()) {
         return "drop";

--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -969,9 +969,11 @@ final class CachingRlsLbClient {
         logger.log(ChannelLogLevel.DEBUG, "Returning PickResult");
         PickResult pickResult = picker.pickSubchannel(args);
         // TODO: include the "grpc.target" label once target is available here.
-        helper.getMetricRecorder().addLongCounter(TARGET_PICKS_COUNTER, 1,
-            Lists.newArrayList("", lookupService, childPolicyWrapper.getTarget(),
-                determineMetricsPickResult(pickResult)), Lists.newArrayList());
+        if (pickResult.hasResult()) {
+          helper.getMetricRecorder().addLongCounter(TARGET_PICKS_COUNTER, 1,
+              Lists.newArrayList("", lookupService, childPolicyWrapper.getTarget(),
+                  determineMetricsPickResult(pickResult)), Lists.newArrayList());
+        }
         return pickResult;
       } else if (response.hasError()) {
         logger.log(ChannelLogLevel.DEBUG, "RLS response has errors");
@@ -1004,10 +1006,12 @@ final class CachingRlsLbClient {
         return PickResult.withNoResult();
       }
       PickResult pickResult = picker.pickSubchannel(args);
-      // TODO: include the grpc.target label once target is available here.
-      helper.getMetricRecorder().addLongCounter(DEFAULT_TARGET_PICKS_COUNTER, 1,
-          Lists.newArrayList("", lookupService, fallbackChildPolicyWrapper.getTarget(),
-              determineMetricsPickResult(pickResult)), Lists.newArrayList());
+      if (pickResult.hasResult()) {
+        // TODO: include the grpc.target label once target is available here.
+        helper.getMetricRecorder().addLongCounter(DEFAULT_TARGET_PICKS_COUNTER, 1,
+            Lists.newArrayList("", lookupService, fallbackChildPolicyWrapper.getTarget(),
+                determineMetricsPickResult(pickResult)), Lists.newArrayList());
+      }
       return pickResult;
     }
 

--- a/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
+++ b/rls/src/test/java/io/grpc/rls/CachingRlsLbClientTest.java
@@ -49,6 +49,7 @@ import io.grpc.LoadBalancerProvider;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
+import io.grpc.MetricRecorder;
 import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.Status;
 import io.grpc.Status.Code;
@@ -120,6 +121,8 @@ public class CachingRlsLbClientTest {
   private EvictionListener<RouteLookupRequest, CacheEntry> evictionListener;
   @Mock
   private SocketAddress socketAddress;
+  @Mock
+  private MetricRecorder mockMetricRecorder;
 
   private final SynchronizationContext syncContext =
       new SynchronizationContext(new UncaughtExceptionHandler() {
@@ -887,6 +890,11 @@ public class CachingRlsLbClientTest {
     @Override
     public ChannelLogger getChannelLogger() {
       return mock(ChannelLogger.class);
+    }
+
+    @Override
+    public MetricRecorder getMetricRecorder() {
+      return mockMetricRecorder;
     }
   }
 

--- a/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
@@ -204,13 +204,12 @@ public class RlsLoadBalancerTest {
     picker.pickSubchannel(fakeSearchMethodArgs); // Will create the subchannel
     FakeSubchannel subchannel = subchannels.peek();
     assertThat(subchannel).isNotNull();
-    verifyLongCounterAdd("grpc.lb.rls.target_picks", 1, 1, "wilderness", "complete");
 
     // Ensure happy path is unaffected
     subchannel.updateState(ConnectivityStateInfo.forNonError(ConnectivityState.READY));
     res = picker.pickSubchannel(fakeSearchMethodArgs);
     assertThat(res.getStatus().getCode()).isEqualTo(Status.Code.OK);
-    verifyLongCounterAdd("grpc.lb.rls.target_picks", 2, 1, "wilderness", "complete");
+    verifyLongCounterAdd("grpc.lb.rls.target_picks", 1, 1, "wilderness", "complete");
 
     // Check on conversion
     Throwable cause = new Throwable("cause");
@@ -242,9 +241,7 @@ public class RlsLoadBalancerTest {
         .updateBalancingState(eq(ConnectivityState.CONNECTING), any(SubchannelPicker.class));
     inOrder.verify(helper, atLeast(0)).getSynchronizationContext();
     inOrder.verify(helper, atLeast(0)).getScheduledExecutorService();
-    inOrder.verify(helper).getMetricRecorder();
     inOrder.verifyNoMoreInteractions();
-    verifyLongCounterAdd("grpc.lb.rls.target_picks", 1, 1, "wilderness", "complete");
 
     assertThat(res.getStatus().isOk()).isTrue();
     assertThat(subchannels).hasSize(1);
@@ -258,7 +255,7 @@ public class RlsLoadBalancerTest {
     res = picker.pickSubchannel(searchSubchannelArgs);
     assertThat(subchannelIsReady(res.getSubchannel())).isTrue();
     assertThat(res.getSubchannel()).isSameInstanceAs(searchSubchannel);
-    verifyLongCounterAdd("grpc.lb.rls.target_picks", 2, 1, "wilderness", "complete");
+    verifyLongCounterAdd("grpc.lb.rls.target_picks", 1, 1, "wilderness", "complete");
 
     // rescue should be pending status although the overall channel state is READY
     res = picker.pickSubchannel(rescueSubchannelArgs);
@@ -327,18 +324,18 @@ public class RlsLoadBalancerTest {
     assertThat(subchannelIsReady(fallbackSubchannel)).isTrue();
     inOrder.verify(helper).getMetricRecorder();
     inOrder.verifyNoMoreInteractions();
-    verifyLongCounterAdd("grpc.lb.rls.default_target_picks", 2, 1, "defaultTarget", "complete");
+    verifyLongCounterAdd("grpc.lb.rls.default_target_picks", 1, 1, "defaultTarget", "complete");
     verifyNoMoreInteractions(mockMetricRecorder);
 
     Subchannel subchannel = picker.pickSubchannel(searchSubchannelArgs).getSubchannel();
     assertThat(subchannelIsReady(subchannel)).isTrue();
     assertThat(subchannel).isSameInstanceAs(fallbackSubchannel);
-    verifyLongCounterAdd("grpc.lb.rls.default_target_picks", 3, 1, "defaultTarget", "complete");
+    verifyLongCounterAdd("grpc.lb.rls.default_target_picks", 2, 1, "defaultTarget", "complete");
 
     subchannel = picker.pickSubchannel(searchSubchannelArgs).getSubchannel();
     assertThat(subchannelIsReady(subchannel)).isTrue();
     assertThat(subchannel).isSameInstanceAs(fallbackSubchannel);
-    verifyLongCounterAdd("grpc.lb.rls.default_target_picks", 4, 1, "defaultTarget", "complete");
+    verifyLongCounterAdd("grpc.lb.rls.default_target_picks", 3, 1, "defaultTarget", "complete");
 
     // Make sure that when RLS starts communicating that default stops being used
     fakeThrottler.nextResult = false;
@@ -349,7 +346,7 @@ public class RlsLoadBalancerTest {
         (FakeSubchannel) markReadyAndGetPickResult(inOrder, searchSubchannelArgs).getSubchannel();
     assertThat(searchSubchannel).isNotNull();
     assertThat(searchSubchannel).isNotSameInstanceAs(fallbackSubchannel);
-    verifyLongCounterAdd("grpc.lb.rls.target_picks", 2, 1, "wilderness", "complete");
+    verifyLongCounterAdd("grpc.lb.rls.target_picks", 1, 1, "wilderness", "complete");
 
     // create rescue subchannel
     picker.pickSubchannel(rescueSubchannelArgs);
@@ -394,10 +391,8 @@ public class RlsLoadBalancerTest {
         .updateBalancingState(eq(ConnectivityState.CONNECTING), any(SubchannelPicker.class));
     inOrder.verify(helper, atLeast(0)).getSynchronizationContext();
     inOrder.verify(helper, atLeast(0)).getScheduledExecutorService();
-    inOrder.verify(helper).getMetricRecorder();
     inOrder.verifyNoMoreInteractions();
     assertThat(res.getStatus().isOk()).isTrue();
-    verifyLongCounterAdd("grpc.lb.rls.target_picks", 1, 1, "wilderness", "complete");
 
     assertThat(subchannels).hasSize(1);
     FakeSubchannel searchSubchannel =
@@ -432,7 +427,7 @@ public class RlsLoadBalancerTest {
         new PickSubchannelArgsImpl(fakeSearchMethod, headers, CallOptions.DEFAULT));
     assertThat(res.getStatus().isOk()).isFalse();
     assertThat(subchannelIsReady(res.getSubchannel())).isFalse();
-    verifyLongCounterAdd("grpc.lb.rls.target_picks", 2, 1, "wilderness", "complete");
+    verifyLongCounterAdd("grpc.lb.rls.target_picks", 1, 1, "wilderness", "complete");
 
     res = picker.pickSubchannel(
         new PickSubchannelArgsImpl(fakeRescueMethod, headers, CallOptions.DEFAULT));

--- a/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
@@ -20,15 +20,19 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.google.common.base.Converter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ChannelCredentials;
@@ -44,14 +48,17 @@ import io.grpc.LoadBalancer.ResolvedAddresses;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.LoadBalancer.SubchannelStateListener;
+import io.grpc.LongCounterMetricInstrument;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.Marshaller;
 import io.grpc.MethodDescriptor.MethodType;
+import io.grpc.MetricRecorder;
 import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.Status;
+import io.grpc.Status.Code;
 import io.grpc.SynchronizationContext;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
@@ -84,6 +91,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.AdditionalAnswers;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
@@ -106,6 +114,8 @@ public class RlsLoadBalancerTest {
           throw new RuntimeException(e);
         }
       });
+  @Mock
+  private MetricRecorder mockMetricRecorder;
   private final FakeHelper helperDelegate = new FakeHelper();
   private final Helper helper =
       mock(Helper.class, AdditionalAnswers.delegatesTo(helperDelegate));
@@ -194,11 +204,13 @@ public class RlsLoadBalancerTest {
     picker.pickSubchannel(fakeSearchMethodArgs); // Will create the subchannel
     FakeSubchannel subchannel = subchannels.peek();
     assertThat(subchannel).isNotNull();
+    verifyLongCounterAdd("grpc.lb.rls.target_picks", 1, 1, "wilderness", "complete");
 
     // Ensure happy path is unaffected
     subchannel.updateState(ConnectivityStateInfo.forNonError(ConnectivityState.READY));
     res = picker.pickSubchannel(fakeSearchMethodArgs);
     assertThat(res.getStatus().getCode()).isEqualTo(Status.Code.OK);
+    verifyLongCounterAdd("grpc.lb.rls.target_picks", 2, 1, "wilderness", "complete");
 
     // Check on conversion
     Throwable cause = new Throwable("cause");
@@ -209,6 +221,7 @@ public class RlsLoadBalancerTest {
     assertThat(serverStatus.getDescription()).contains("RLS server returned: ");
     assertThat(serverStatus.getDescription()).endsWith("ABORTED: base desc");
     assertThat(serverStatus.getDescription()).contains("RLS server conv.test");
+    verifyNoMoreInteractions(mockMetricRecorder);
   }
 
   @Test
@@ -229,7 +242,10 @@ public class RlsLoadBalancerTest {
         .updateBalancingState(eq(ConnectivityState.CONNECTING), any(SubchannelPicker.class));
     inOrder.verify(helper, atLeast(0)).getSynchronizationContext();
     inOrder.verify(helper, atLeast(0)).getScheduledExecutorService();
+    inOrder.verify(helper).getMetricRecorder();
     inOrder.verifyNoMoreInteractions();
+    verifyLongCounterAdd("grpc.lb.rls.target_picks", 1, 1, "wilderness", "complete");
+
     assertThat(res.getStatus().isOk()).isTrue();
     assertThat(subchannels).hasSize(1);
     FakeSubchannel searchSubchannel = subchannels.getLast();
@@ -242,6 +258,7 @@ public class RlsLoadBalancerTest {
     res = picker.pickSubchannel(searchSubchannelArgs);
     assertThat(subchannelIsReady(res.getSubchannel())).isTrue();
     assertThat(res.getSubchannel()).isSameInstanceAs(searchSubchannel);
+    verifyLongCounterAdd("grpc.lb.rls.target_picks", 2, 1, "wilderness", "complete");
 
     // rescue should be pending status although the overall channel state is READY
     res = picker.pickSubchannel(rescueSubchannelArgs);
@@ -266,6 +283,29 @@ public class RlsLoadBalancerTest {
     res = picker.pickSubchannel(searchSubchannelArgs);
     assertThat(res.getStatus().getCode()).isEqualTo(Status.Code.UNAVAILABLE);
     assertThat(subchannelIsReady(res.getSubchannel())).isFalse();
+    verifyLongCounterAdd("grpc.lb.rls.target_picks", 1, 1, "wilderness", "fail");
+
+    verifyNoMoreInteractions(mockMetricRecorder);
+  }
+
+  @Test
+  public void lb_working_withoutDefaultTarget_noRlsResponse() throws Exception {
+    defaultTarget = "";
+    fakeThrottler.nextResult = true;
+
+    deliverResolvedAddresses();
+    InOrder inOrder = inOrder(helper);
+    inOrder.verify(helper)
+        .updateBalancingState(eq(ConnectivityState.CONNECTING), pickerCaptor.capture());
+    SubchannelPicker picker = pickerCaptor.getValue();
+
+    // With no RLS response and no fallback, we should see a failure
+    PickResult res = picker.pickSubchannel(searchSubchannelArgs); // create subchannel
+    assertThat(res.getStatus().getCode()).isEqualTo(Code.UNAVAILABLE);
+    inOrder.verify(helper).getMetricRecorder();
+    inOrder.verifyNoMoreInteractions();
+    verifyFailedPicksCounterAdd(1, 1);
+    verifyNoMoreInteractions(mockMetricRecorder);
   }
 
   @Test
@@ -285,15 +325,20 @@ public class RlsLoadBalancerTest {
         (FakeSubchannel) markReadyAndGetPickResult(inOrder, searchSubchannelArgs).getSubchannel();
     assertThat(fallbackSubchannel).isNotNull();
     assertThat(subchannelIsReady(fallbackSubchannel)).isTrue();
+    inOrder.verify(helper).getMetricRecorder();
     inOrder.verifyNoMoreInteractions();
+    verifyLongCounterAdd("grpc.lb.rls.default_target_picks", 2, 1, "defaultTarget", "complete");
+    verifyNoMoreInteractions(mockMetricRecorder);
 
     Subchannel subchannel = picker.pickSubchannel(searchSubchannelArgs).getSubchannel();
     assertThat(subchannelIsReady(subchannel)).isTrue();
     assertThat(subchannel).isSameInstanceAs(fallbackSubchannel);
+    verifyLongCounterAdd("grpc.lb.rls.default_target_picks", 3, 1, "defaultTarget", "complete");
 
     subchannel = picker.pickSubchannel(searchSubchannelArgs).getSubchannel();
     assertThat(subchannelIsReady(subchannel)).isTrue();
     assertThat(subchannel).isSameInstanceAs(fallbackSubchannel);
+    verifyLongCounterAdd("grpc.lb.rls.default_target_picks", 4, 1, "defaultTarget", "complete");
 
     // Make sure that when RLS starts communicating that default stops being used
     fakeThrottler.nextResult = false;
@@ -304,6 +349,7 @@ public class RlsLoadBalancerTest {
         (FakeSubchannel) markReadyAndGetPickResult(inOrder, searchSubchannelArgs).getSubchannel();
     assertThat(searchSubchannel).isNotNull();
     assertThat(searchSubchannel).isNotSameInstanceAs(fallbackSubchannel);
+    verifyLongCounterAdd("grpc.lb.rls.target_picks", 2, 1, "wilderness", "complete");
 
     // create rescue subchannel
     picker.pickSubchannel(rescueSubchannelArgs);
@@ -312,6 +358,7 @@ public class RlsLoadBalancerTest {
     assertThat(rescueSubchannel).isNotNull();
     assertThat(rescueSubchannel).isNotSameInstanceAs(fallbackSubchannel);
     assertThat(rescueSubchannel).isNotSameInstanceAs(searchSubchannel);
+    verifyLongCounterAdd("grpc.lb.rls.target_picks", 1, 1, "civilization", "complete");
 
     // all channels are failed
     rescueSubchannel.updateState(ConnectivityStateInfo.forTransientFailure(Status.UNAVAILABLE));
@@ -322,6 +369,9 @@ public class RlsLoadBalancerTest {
         searchSubchannelArgs);
     assertThat(res.getStatus().getCode()).isEqualTo(Status.Code.UNAVAILABLE);
     assertThat(res.getSubchannel()).isNull();
+    verifyLongCounterAdd("grpc.lb.rls.target_picks", 1, 1, "wilderness", "fail");
+
+    verifyNoMoreInteractions(mockMetricRecorder);
   }
 
   @Test
@@ -344,12 +394,15 @@ public class RlsLoadBalancerTest {
         .updateBalancingState(eq(ConnectivityState.CONNECTING), any(SubchannelPicker.class));
     inOrder.verify(helper, atLeast(0)).getSynchronizationContext();
     inOrder.verify(helper, atLeast(0)).getScheduledExecutorService();
+    inOrder.verify(helper).getMetricRecorder();
     inOrder.verifyNoMoreInteractions();
     assertThat(res.getStatus().isOk()).isTrue();
+    verifyLongCounterAdd("grpc.lb.rls.target_picks", 1, 1, "wilderness", "complete");
 
     assertThat(subchannels).hasSize(1);
     FakeSubchannel searchSubchannel =
         (FakeSubchannel) markReadyAndGetPickResult(inOrder, searchSubchannelArgs).getSubchannel();
+    inOrder.verify(helper).getMetricRecorder();
     inOrder.verifyNoMoreInteractions();
     assertThat(subchannelIsReady(searchSubchannel)).isTrue();
     assertThat(subchannels.getLast()).isSameInstanceAs(searchSubchannel);
@@ -379,12 +432,14 @@ public class RlsLoadBalancerTest {
         new PickSubchannelArgsImpl(fakeSearchMethod, headers, CallOptions.DEFAULT));
     assertThat(res.getStatus().isOk()).isFalse();
     assertThat(subchannelIsReady(res.getSubchannel())).isFalse();
+    verifyLongCounterAdd("grpc.lb.rls.target_picks", 2, 1, "wilderness", "complete");
 
     res = picker.pickSubchannel(
         new PickSubchannelArgsImpl(fakeRescueMethod, headers, CallOptions.DEFAULT));
     assertThat(subchannelIsReady(res.getSubchannel())).isTrue();
     assertThat(res.getSubchannel().getAddresses()).isEqualTo(rescueSubchannel.getAddresses());
     assertThat(res.getSubchannel().getAttributes()).isEqualTo(rescueSubchannel.getAttributes());
+    verifyLongCounterAdd("grpc.lb.rls.target_picks", 1, 1, "civilization", "complete");
 
     // all channels are failed
     rescueSubchannel.updateState(ConnectivityStateInfo.forTransientFailure(Status.NOT_FOUND));
@@ -392,6 +447,8 @@ public class RlsLoadBalancerTest {
         .updateBalancingState(eq(ConnectivityState.TRANSIENT_FAILURE), pickerCaptor.capture());
     inOrder.verify(helper, atLeast(0)).refreshNameResolution();
     inOrder.verifyNoMoreInteractions();
+    verifyLongCounterAdd("grpc.lb.rls.target_picks", 1, 1, "wilderness", "fail");
+    verifyNoMoreInteractions(mockMetricRecorder);
   }
 
   @Test
@@ -424,7 +481,9 @@ public class RlsLoadBalancerTest {
     assertThat(subchannelIsReady(res.getSubchannel())).isTrue();
     assertThat(res.getSubchannel().getAddresses()).isEqualTo(searchSubchannel.getAddresses());
     assertThat(res.getSubchannel().getAttributes()).isEqualTo(searchSubchannel.getAttributes());
+    verifyLongCounterAdd("grpc.lb.rls.target_picks", 1, 1, "wilderness", "complete");
 
+    inOrder.verify(helper).getMetricRecorder();
     inOrder.verifyNoMoreInteractions();
 
     rlsLb.handleNameResolutionError(Status.UNAVAILABLE);
@@ -436,6 +495,7 @@ public class RlsLoadBalancerTest {
         new PickSubchannelArgsImpl(fakeSearchMethod, headers, CallOptions.DEFAULT));
     assertThat(res.getStatus().isOk()).isFalse();
     assertThat(subchannelIsReady(res.getSubchannel())).isFalse();
+    verifyNoMoreInteractions(mockMetricRecorder);
   }
 
   private PickResult markReadyAndGetPickResult(InOrder inOrder,
@@ -502,6 +562,36 @@ public class RlsLoadBalancerTest {
         + "  \"defaultTarget\": \"" + defaultTarget + "\",\n"
         + "  \"requestProcessingStrategy\": \"SYNC_LOOKUP_DEFAULT_TARGET_ON_ERROR\"\n"
         + "}";
+  }
+
+  // Verifies that the MetricRecorder has been called to record a long counter value of 1 for the
+  // given metric name, the given number of times
+  private void verifyLongCounterAdd(String name, int times, long value,
+      String dataPlaneTargetLabel, String pickResult) {
+    // TODO: support the "grpc.target" label once available.
+    verify(mockMetricRecorder, times(times)).addLongCounter(
+        argThat(new ArgumentMatcher<LongCounterMetricInstrument>() {
+          @Override
+          public boolean matches(LongCounterMetricInstrument longCounterInstrument) {
+            return longCounterInstrument.getName().equals(name);
+          }
+        }), eq(value),
+        eq(Lists.newArrayList("", "localhost:8972", dataPlaneTargetLabel, pickResult)),
+        eq(Lists.newArrayList()));
+  }
+
+  // This one is for verifying the failed_pick metric specifically.
+  private void verifyFailedPicksCounterAdd(int times, long value) {
+    // TODO: support the "grpc.target" label once available.
+    verify(mockMetricRecorder, times(times)).addLongCounter(
+        argThat(new ArgumentMatcher<LongCounterMetricInstrument>() {
+          @Override
+          public boolean matches(LongCounterMetricInstrument longCounterInstrument) {
+            return longCounterInstrument.getName().equals("grpc.lb.rls.failed_picks");
+          }
+        }), eq(value),
+        eq(Lists.newArrayList("", "localhost:8972")),
+        eq(Lists.newArrayList()));
   }
 
   private final class FakeHelper extends Helper {
@@ -591,6 +681,11 @@ public class RlsLoadBalancerTest {
     @Override
     public ChannelLogger getChannelLogger() {
       return mock(ChannelLogger.class);
+    }
+
+    @Override
+    public MetricRecorder getMetricRecorder() {
+      return mockMetricRecorder;
     }
   }
 


### PR DESCRIPTION
Adds the following metrics to the RlsLoadBalancer:
- grpc.lb.rls.default_target_picks
- grpc.lb.rls.target_picks
- grpc.lb.rls.failed_picks

Still missing the labels, that will be added in a later PR.