### PR TITLE
security: Stabilize AdvancedTlsX509KeyManager.

### DIFF
--- a/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
+++ b/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
@@ -45,14 +45,11 @@ import io.grpc.util.AdvancedTlsX509TrustManager.Verification;
 import io.grpc.util.CertificateUtils;
 import java.io.Closeable;
 import java.io.File;
-import java.io.IOException;
 import java.net.Socket;
 import java.security.GeneralSecurityException;
-import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.security.spec.InvalidKeySpecException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -65,13 +62,13 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class AdvancedTlsTest {
-  public static final String SERVER_0_KEY_FILE = "server0.key";
-  public static final String SERVER_0_PEM_FILE = "server0.pem";
-  public static final String CLIENT_0_KEY_FILE = "client.key";
-  public static final String CLIENT_0_PEM_FILE = "client.pem";
-  public static final String CA_PEM_FILE = "ca.pem";
-  public static final String SERVER_BAD_KEY_FILE = "badserver.key";
-  public static final String SERVER_BAD_PEM_FILE = "badserver.pem";
+  private static final String SERVER_0_KEY_FILE = "server0.key";
+  private static final String SERVER_0_PEM_FILE = "server0.pem";
+  private static final String CLIENT_0_KEY_FILE = "client.key";
+  private static final String CLIENT_0_PEM_FILE = "client.pem";
+  private static final String CA_PEM_FILE = "ca.pem";
+  private static final String SERVER_BAD_KEY_FILE = "badserver.key";
+  private static final String SERVER_BAD_PEM_FILE = "badserver.pem";
 
   private ScheduledExecutorService executor;
   private Server server;
@@ -92,7 +89,7 @@ public class AdvancedTlsTest {
 
   @Before
   public void setUp()
-      throws NoSuchAlgorithmException, IOException, CertificateException, InvalidKeySpecException {
+      throws Exception {
     executor = Executors.newSingleThreadScheduledExecutor();
     caCertFile = TestUtils.loadCert(CA_PEM_FILE);
     serverKey0File = TestUtils.loadCert(SERVER_0_KEY_FILE);

--- a/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
+++ b/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
@@ -282,11 +282,11 @@ public class AdvancedTlsTest {
             new SslSocketAndEnginePeerVerifier() {
               @Override
               public void verifyPeerCertificate(X509Certificate[] peerCertChain, String authType,
-                  Socket socket) throws CertificateException { }
+                  Socket socket) { }
 
               @Override
               public void verifyPeerCertificate(X509Certificate[] peerCertChain, String authType,
-                  SSLEngine engine) throws CertificateException { }
+                  SSLEngine engine) { }
             })
         .build();
     serverTrustManager.updateTrustCredentials(caCert);
@@ -307,11 +307,11 @@ public class AdvancedTlsTest {
             new SslSocketAndEnginePeerVerifier() {
               @Override
               public void verifyPeerCertificate(X509Certificate[] peerCertChain, String authType,
-                  Socket socket) throws CertificateException { }
+                  Socket socket) { }
 
               @Override
               public void verifyPeerCertificate(X509Certificate[] peerCertChain, String authType,
-                  SSLEngine engine) throws CertificateException { }
+                  SSLEngine engine) { }
             })
         .build();
     clientTrustManager.updateTrustCredentials(caCert);
@@ -416,7 +416,7 @@ public class AdvancedTlsTest {
   }
 
   @Test
-  public void onFileReloadingKeyManagerBadInitialContentTest() throws Exception {
+  public void onFileReloadingKeyManagerBadInitialContentTest() {
     AdvancedTlsX509KeyManager keyManager = new AdvancedTlsX509KeyManager();
     // We swap the order of key and certificates to intentionally create an exception.
     assertThrows(GeneralSecurityException.class,
@@ -436,7 +436,7 @@ public class AdvancedTlsTest {
   }
 
   @Test
-  public void keyManagerAliasesTest() throws Exception {
+  public void keyManagerAliasesTest() {
     AdvancedTlsX509KeyManager km = new AdvancedTlsX509KeyManager();
     assertArrayEquals(
         new String[] {"default"}, km.getClientAliases("", null));

--- a/util/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
+++ b/util/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
@@ -39,8 +39,7 @@ import javax.net.ssl.X509ExtendedKeyManager;
  * AdvancedTlsX509KeyManager is an {@code X509ExtendedKeyManager} that allows users to configure
  * advanced TLS features, such as private key and certificate chain reloading.
  * We expect only one of {@link AdvancedTlsX509KeyManager#updateIdentityCredentials},
- * {@link AdvancedTlsX509KeyManager#updateIdentityCredentialsFromFile
- * (File, File, long, TimeUnit, ScheduledExecutorService)},
+ * {@link AdvancedTlsX509KeyManager#updateIdentityCredentialsFromFile(File, File)},
  * {@link AdvancedTlsX509KeyManager#updateIdentityCredentialsFromFile
  * (File, File, long, TimeUnit, ScheduledExecutorService)} methods to be called after instantiation
  * of this class.

--- a/util/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
+++ b/util/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
@@ -130,8 +130,7 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
       throw new GeneralSecurityException(
           "Files were unmodified before their initial update. Probably a bug.");
     }
-    if (checkNotNull(unit, "unit").toMinutes(period) <
-        MINIMUM_REFRESH_PERIOD_IN_MINUTES) {
+    if (checkNotNull(unit, "unit").toMinutes(period) < MINIMUM_REFRESH_PERIOD_IN_MINUTES) {
       log.log(Level.FINE,
           "Provided refresh period of {0} {1} is too small. Default value of {2} minute(s) "
           + "will be used.", new Object[] {period, unit.name(), MINIMUM_REFRESH_PERIOD_IN_MINUTES});

--- a/util/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
+++ b/util/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
@@ -132,7 +132,7 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
           "Files were unmodified before their initial update. Probably a bug.");
     }
     if (checkNotNull(unit, "unit").toMinutes(period) < MINIMUM_REFRESH_PERIOD) {
-      log.log(Level.INFO,
+      log.log(Level.FINE,
           "Provided refresh period of {0} {1} is too small. Default value of {2} minute(s) "
           + "will be used.", new Object[] {period, unit.name(), MINIMUM_REFRESH_PERIOD});
       period = MINIMUM_REFRESH_PERIOD;

--- a/util/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
+++ b/util/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
@@ -38,11 +38,6 @@ import javax.net.ssl.X509ExtendedKeyManager;
 /**
  * AdvancedTlsX509KeyManager is an {@code X509ExtendedKeyManager} that allows users to configure
  * advanced TLS features, such as private key and certificate chain reloading.
- * We expect only one of {@link AdvancedTlsX509KeyManager#updateIdentityCredentials},
- * {@link AdvancedTlsX509KeyManager#updateIdentityCredentialsFromFile(File, File)},
- * {@link AdvancedTlsX509KeyManager#updateIdentityCredentialsFromFile
- * (File, File, long, TimeUnit, ScheduledExecutorService)} methods to be called after instantiation
- * of this class.
  */
 public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
   private static final Logger log = Logger.getLogger(AdvancedTlsX509KeyManager.class.getName());
@@ -111,7 +106,9 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
   /**
    * Schedules a {@code ScheduledExecutorService} to read private key and certificate chains from
    * the local file paths periodically, and update the cached identity credentials if they are both
-   * updated. Please make sure to close the returned Closeable before calling this method again.
+   * updated. You must close the returned Closeable before calling this method again or other update
+   * methods ({@link AdvancedTlsX509KeyManager#updateIdentityCredentials}, {@link
+   * AdvancedTlsX509KeyManager#updateIdentityCredentialsFromFile(File, File)}).
    * Before scheduling the task, the method synchronously executes {@code  readAndUpdate} once. The
    * minimum refresh period of 1 minute is enforced.
    *

--- a/util/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
+++ b/util/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
@@ -48,7 +48,7 @@ import javax.net.ssl.X509ExtendedKeyManager;
 public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
   private static final Logger log = Logger.getLogger(AdvancedTlsX509KeyManager.class.getName());
   // Minimum allowed period for refreshing files with credential information.
-  private static final int MINIMUM_REFRESH_PERIOD = 1 ;
+  private static final int MINIMUM_REFRESH_PERIOD_IN_MINUTES = 1 ;
   // The credential information to be sent to peers to prove our identity.
   private volatile KeyInfo keyInfo;
 
@@ -131,11 +131,12 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
       throw new GeneralSecurityException(
           "Files were unmodified before their initial update. Probably a bug.");
     }
-    if (checkNotNull(unit, "unit").toMinutes(period) < MINIMUM_REFRESH_PERIOD) {
+    if (checkNotNull(unit, "unit").toMinutes(period) <
+        MINIMUM_REFRESH_PERIOD_IN_MINUTES) {
       log.log(Level.FINE,
           "Provided refresh period of {0} {1} is too small. Default value of {2} minute(s) "
-          + "will be used.", new Object[] {period, unit.name(), MINIMUM_REFRESH_PERIOD});
-      period = MINIMUM_REFRESH_PERIOD;
+          + "will be used.", new Object[] {period, unit.name(), MINIMUM_REFRESH_PERIOD_IN_MINUTES});
+      period = MINIMUM_REFRESH_PERIOD_IN_MINUTES;
       unit = TimeUnit.MINUTES;
     }
     final ScheduledFuture<?> future =

--- a/util/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
+++ b/util/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
@@ -112,7 +112,8 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
   /**
    * Schedules a {@code ScheduledExecutorService} to read private key and certificate chains from
    * the local file paths periodically, and update the cached identity credentials if they are both
-   * updated. Please make sure to close the returned Closebale before calling this method again.
+   * updated. Please make sure to close the returned Closeable before calling this method again.
+   * Before scheduling the task, the method synchronously executes {@code  readAndUpdate} once.
    *
    * @param keyFile  the file on disk holding the private key
    * @param certFile  the file on disk holding the certificate chain
@@ -130,8 +131,9 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
           "Files were unmodified before their initial update. Probably a bug.");
     }
     if (checkNotNull(unit, "unit").toMinutes(period) < MINIMUM_REFRESH_PERIOD) {
-      log.log(Level.INFO, "Provided refresh period of {} {} is too small. Default value of {} "
-          + "minute(s) will be used.", new Object[] {period, unit.name(), MINIMUM_REFRESH_PERIOD});
+      log.log(Level.INFO, "Provided refresh period of {0} {1} is too small. Default value of "
+          + "{2} minute(s) will be used.", new Object[] {period, unit.name(),
+          MINIMUM_REFRESH_PERIOD});
       period = MINIMUM_REFRESH_PERIOD;
       unit = TimeUnit.MINUTES;
     }

--- a/util/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
+++ b/util/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
@@ -113,7 +113,8 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
    * Schedules a {@code ScheduledExecutorService} to read private key and certificate chains from
    * the local file paths periodically, and update the cached identity credentials if they are both
    * updated. Please make sure to close the returned Closeable before calling this method again.
-   * Before scheduling the task, the method synchronously executes {@code  readAndUpdate} once.
+   * Before scheduling the task, the method synchronously executes {@code  readAndUpdate} once. The
+   * minimum refresh period of 1 minute is enforced.
    *
    * @param keyFile  the file on disk holding the private key
    * @param certFile  the file on disk holding the certificate chain

--- a/util/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
+++ b/util/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
@@ -48,7 +48,7 @@ import javax.net.ssl.X509ExtendedKeyManager;
 public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
   private static final Logger log = Logger.getLogger(AdvancedTlsX509KeyManager.class.getName());
   // Minimum allowed period for refreshing files with credential information.
-  public static final int MINIMUM_REFRESH_PERIOD = 1 ;
+  private static final int MINIMUM_REFRESH_PERIOD = 1 ;
   // The credential information to be sent to peers to prove our identity.
   private volatile KeyInfo keyInfo;
 

--- a/util/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
+++ b/util/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
@@ -132,9 +132,9 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
           "Files were unmodified before their initial update. Probably a bug.");
     }
     if (checkNotNull(unit, "unit").toMinutes(period) < MINIMUM_REFRESH_PERIOD) {
-      log.log(Level.INFO, "Provided refresh period of {0} {1} is too small. Default value of "
-          + "{2} minute(s) will be used.", new Object[] {period, unit.name(),
-          MINIMUM_REFRESH_PERIOD});
+      log.log(Level.INFO,
+          "Provided refresh period of {0} {1} is too small. Default value of {2} minute(s) "
+          + "will be used.", new Object[] {period, unit.name(), MINIMUM_REFRESH_PERIOD});
       period = MINIMUM_REFRESH_PERIOD;
       unit = TimeUnit.MINUTES;
     }

--- a/util/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
+++ b/util/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
@@ -48,7 +48,7 @@ import javax.net.ssl.X509ExtendedKeyManager;
 public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
   private static final Logger log = Logger.getLogger(AdvancedTlsX509KeyManager.class.getName());
   // Minimum allowed period for refreshing files with credential information.
-  public final static int MINIMUM_REFRESH_PERIOD = 1 ;
+  public static final int MINIMUM_REFRESH_PERIOD = 1 ;
   // The credential information to be sent to peers to prove our identity.
   private volatile KeyInfo keyInfo;
 
@@ -130,9 +130,8 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
           "Files were unmodified before their initial update. Probably a bug.");
     }
     if (checkNotNull(unit, "unit").toMinutes(period) < MINIMUM_REFRESH_PERIOD) {
-      log.log(Level.INFO, "Provided refresh period of {} {} is too small. "
-          + "Default value of {} minute(s) will be used.", new Object[] {period, unit.name(),
-          MINIMUM_REFRESH_PERIOD});
+      log.log(Level.INFO, "Provided refresh period of {} {} is too small. Default value of {} "
+          + "minute(s) will be used.", new Object[] {period, unit.name(), MINIMUM_REFRESH_PERIOD});
       period = MINIMUM_REFRESH_PERIOD;
       unit = TimeUnit.MINUTES;
     }

--- a/util/src/test/java/io/grpc/util/AdvancedTlsX509KeyManagerTest.java
+++ b/util/src/test/java/io/grpc/util/AdvancedTlsX509KeyManagerTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import com.google.common.util.concurrent.MoreExecutors;
+import io.grpc.internal.FakeClock;
 import io.grpc.internal.testing.TestUtils;
 import io.grpc.testing.TlsTesting;
 import java.io.File;
@@ -30,14 +30,12 @@ import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -65,9 +63,8 @@ public class AdvancedTlsX509KeyManagerTest {
   private X509Certificate[] clientCert0;
 
   @Before
-  public void setUp()
-      throws Exception {
-    executor = Executors.newSingleThreadScheduledExecutor();
+  public void setUp() throws Exception {
+    executor = new FakeClock().getScheduledExecutorService();
     serverKey0File = TestUtils.loadCert(SERVER_0_KEY_FILE);
     serverCert0File = TestUtils.loadCert(SERVER_0_PEM_FILE);
     clientKey0File = TestUtils.loadCert(CLIENT_0_KEY_FILE);
@@ -76,11 +73,6 @@ public class AdvancedTlsX509KeyManagerTest {
     serverCert0 = CertificateUtils.getX509Certificates(TlsTesting.loadCert(SERVER_0_PEM_FILE));
     clientKey0 = CertificateUtils.getPrivateKey(TlsTesting.loadCert(CLIENT_0_KEY_FILE));
     clientCert0 = CertificateUtils.getX509Certificates(TlsTesting.loadCert(CLIENT_0_PEM_FILE));
-  }
-
-  @After
-  public void tearDown() {
-    MoreExecutors.shutdownAndAwaitTermination(executor, 5, TimeUnit.SECONDS);
   }
 
   @Test

--- a/util/src/test/java/io/grpc/util/AdvancedTlsX509KeyManagerTest.java
+++ b/util/src/test/java/io/grpc/util/AdvancedTlsX509KeyManagerTest.java
@@ -26,18 +26,15 @@ import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.internal.testing.TestUtils;
 import io.grpc.testing.TlsTesting;
 import java.io.File;
-import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
-import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.security.spec.InvalidKeySpecException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Handler;
+import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import org.junit.After;
@@ -49,11 +46,11 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link AdvancedTlsX509KeyManager}. */
 @RunWith(JUnit4.class)
 public class AdvancedTlsX509KeyManagerTest {
-  public static final String SERVER_0_KEY_FILE = "server0.key";
-  public static final String SERVER_0_PEM_FILE = "server0.pem";
-  public static final String CLIENT_0_KEY_FILE = "client.key";
-  public static final String CLIENT_0_PEM_FILE = "client.pem";
-  public static final String ALIAS = "default";
+  private static final String SERVER_0_KEY_FILE = "server0.key";
+  private static final String SERVER_0_PEM_FILE = "server0.pem";
+  private static final String CLIENT_0_KEY_FILE = "client.key";
+  private static final String CLIENT_0_PEM_FILE = "client.pem";
+  private static final String ALIAS = "default";
 
   private ScheduledExecutorService executor;
 
@@ -69,7 +66,7 @@ public class AdvancedTlsX509KeyManagerTest {
 
   @Before
   public void setUp()
-      throws NoSuchAlgorithmException, IOException, CertificateException, InvalidKeySpecException {
+      throws Exception {
     executor = Executors.newSingleThreadScheduledExecutor();
     serverKey0File = TestUtils.loadCert(SERVER_0_KEY_FILE);
     serverCert0File = TestUtils.loadCert(SERVER_0_PEM_FILE);
@@ -138,6 +135,7 @@ public class AdvancedTlsX509KeyManagerTest {
     TestHandler handler = new TestHandler();
     log.addHandler(handler);
     log.setUseParentHandlers(false);
+    log.setLevel(Level.FINE);
     serverKeyManager.updateIdentityCredentialsFromFile(serverKey0File, serverCert0File, -1,
             TimeUnit.SECONDS, executor);
     log.removeHandler(handler);

--- a/util/src/test/java/io/grpc/util/AdvancedTlsX509KeyManagerTest.java
+++ b/util/src/test/java/io/grpc/util/AdvancedTlsX509KeyManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The gRPC Authors
+ * Copyright 2024 The gRPC Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.when;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.internal.testing.TestUtils;
@@ -38,7 +37,6 @@ import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.ConsoleHandler;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -156,6 +154,7 @@ public class AdvancedTlsX509KeyManagerTest {
   private static class TestHandler extends Handler {
     private final List<LogRecord> records = new ArrayList<>();
 
+    @Override
     public void publish(LogRecord record) {
       records.add(record);
     }

--- a/util/src/test/java/io/grpc/util/AdvancedTlsX509KeyManagerTest.java
+++ b/util/src/test/java/io/grpc/util/AdvancedTlsX509KeyManagerTest.java
@@ -140,7 +140,6 @@ public class AdvancedTlsX509KeyManagerTest {
     TestHandler handler = new TestHandler();
     log.addHandler(handler);
     log.setUseParentHandlers(false);
-    log.addHandler(new ConsoleHandler());
     serverKeyManager.updateIdentityCredentialsFromFile(serverKey0File, serverCert0File, -1,
             TimeUnit.SECONDS, executor);
     log.removeHandler(handler);

--- a/util/src/test/java/io/grpc/util/AdvancedTlsX509KeyManagerTest.java
+++ b/util/src/test/java/io/grpc/util/AdvancedTlsX509KeyManagerTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2021 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.util;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import io.grpc.internal.testing.TestUtils;
+import io.grpc.testing.TlsTesting;
+import java.io.File;
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.security.spec.InvalidKeySpecException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link AdvancedTlsX509KeyManager}. */
+@RunWith(JUnit4.class)
+public class AdvancedTlsX509KeyManagerTest {
+  public static final String SERVER_0_KEY_FILE = "server0.key";
+  public static final String SERVER_0_PEM_FILE = "server0.pem";
+  public static final String CLIENT_0_KEY_FILE = "client.key";
+  public static final String CLIENT_0_PEM_FILE = "client.pem";
+  public static final String ALIAS = "default";
+
+  private ScheduledExecutorService executor;
+
+  private File serverKey0File;
+  private File serverCert0File;
+  private File clientKey0File;
+  private File clientCert0File;
+
+  private PrivateKey serverKey0;
+  private X509Certificate[] serverCert0;
+  private PrivateKey clientKey0;
+  private X509Certificate[] clientCert0;
+
+  @Before
+  public void setUp()
+      throws NoSuchAlgorithmException, IOException, CertificateException, InvalidKeySpecException {
+    executor = Executors.newSingleThreadScheduledExecutor();
+    serverKey0File = TestUtils.loadCert(SERVER_0_KEY_FILE);
+    serverCert0File = TestUtils.loadCert(SERVER_0_PEM_FILE);
+    clientKey0File = TestUtils.loadCert(CLIENT_0_KEY_FILE);
+    clientCert0File = TestUtils.loadCert(CLIENT_0_PEM_FILE);
+    serverKey0 = CertificateUtils.getPrivateKey(TlsTesting.loadCert(SERVER_0_KEY_FILE));
+    serverCert0 = CertificateUtils.getX509Certificates(TlsTesting.loadCert(SERVER_0_PEM_FILE));
+    clientKey0 = CertificateUtils.getPrivateKey(TlsTesting.loadCert(CLIENT_0_KEY_FILE));
+    clientCert0 = CertificateUtils.getX509Certificates(TlsTesting.loadCert(CLIENT_0_PEM_FILE));
+  }
+
+  @After
+  public void tearDown() {
+    MoreExecutors.shutdownAndAwaitTermination(executor, 5, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void CredentialSettingTest() throws Exception {
+    // Overall happy path checking of public API.
+    AdvancedTlsX509KeyManager serverKeyManager = new AdvancedTlsX509KeyManager();
+    serverKeyManager.updateIdentityCredentials(serverKey0, serverCert0);
+    assertEquals(serverKey0, serverKeyManager.getPrivateKey(ALIAS));
+    assertArrayEquals(serverCert0, serverKeyManager.getCertificateChain(ALIAS));
+
+    serverKeyManager.updateIdentityCredentialsFromFile(clientKey0File, clientCert0File);
+    assertEquals(clientKey0, serverKeyManager.getPrivateKey(ALIAS));
+    assertArrayEquals(clientCert0, serverKeyManager.getCertificateChain(ALIAS));
+
+    serverKeyManager.updateIdentityCredentialsFromFile(serverKey0File, serverCert0File, 1,
+        TimeUnit.MINUTES, executor);
+    assertEquals(serverKey0, serverKeyManager.getPrivateKey(ALIAS));
+    assertArrayEquals(serverCert0, serverKeyManager.getCertificateChain(ALIAS));
+  }
+
+  @Test
+  public void CredentialSettingParameterValidityTest() throws Exception {
+    // Checking edge cases of public API parameter setting.
+    AdvancedTlsX509KeyManager serverKeyManager = new AdvancedTlsX509KeyManager();
+    NullPointerException npe = assertThrows(NullPointerException.class, () -> serverKeyManager.
+        updateIdentityCredentials(null, serverCert0));
+    assertEquals("key", npe.getMessage());
+
+    npe = assertThrows(NullPointerException.class, () -> serverKeyManager.
+        updateIdentityCredentials(serverKey0, null));
+    assertEquals("certs", npe.getMessage());
+
+    npe = assertThrows(NullPointerException.class, () -> serverKeyManager.
+        updateIdentityCredentialsFromFile(null, serverCert0File));
+    assertEquals("keyFile", npe.getMessage());
+
+    npe = assertThrows(NullPointerException.class, () -> serverKeyManager.
+        updateIdentityCredentialsFromFile(serverKey0File, null));
+    assertEquals("certFile", npe.getMessage());
+
+    npe = assertThrows(NullPointerException.class, () -> serverKeyManager.
+        updateIdentityCredentialsFromFile(serverKey0File, serverCert0File, 1, null,
+            executor));
+    assertEquals("unit", npe.getMessage());
+
+    npe = assertThrows(NullPointerException.class, () -> serverKeyManager.
+        updateIdentityCredentialsFromFile(serverKey0File, serverCert0File, 1,
+            TimeUnit.MINUTES, null));
+    assertEquals("executor", npe.getMessage());
+
+    Logger log = Logger.getLogger(AdvancedTlsX509KeyManager.class.getName());
+    TestHandler handler = new TestHandler();
+    log.addHandler(handler);
+    log.setUseParentHandlers(false);
+    log.addHandler(new ConsoleHandler());
+    serverKeyManager.updateIdentityCredentialsFromFile(serverKey0File, serverCert0File, -1,
+            TimeUnit.SECONDS, executor);
+    log.removeHandler(handler);
+    for (LogRecord record : handler.getRecords()) {
+      if (record.getMessage().contains("Default value of ")) {
+        assertTrue(true);
+        return;
+      }
+    }
+    fail("Log message related to setting default values not found");
+  }
+
+
+  private static class TestHandler extends Handler {
+    private final List<LogRecord> records = new ArrayList<>();
+
+    public void publish(LogRecord record) {
+      records.add(record);
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void close() throws SecurityException {
+    }
+
+    public List<LogRecord> getRecords() {
+      return records;
+    }
+  }
+
+}

--- a/util/src/test/java/io/grpc/util/AdvancedTlsX509KeyManagerTest.java
+++ b/util/src/test/java/io/grpc/util/AdvancedTlsX509KeyManagerTest.java
@@ -87,7 +87,7 @@ public class AdvancedTlsX509KeyManagerTest {
   }
 
   @Test
-  public void CredentialSettingTest() throws Exception {
+  public void credentialSetting() throws Exception {
     // Overall happy path checking of public API.
     AdvancedTlsX509KeyManager serverKeyManager = new AdvancedTlsX509KeyManager();
     serverKeyManager.updateIdentityCredentials(serverKey0, serverCert0);
@@ -105,32 +105,32 @@ public class AdvancedTlsX509KeyManagerTest {
   }
 
   @Test
-  public void CredentialSettingParameterValidityTest() throws Exception {
+  public void credentialSettingParameterValidity() throws Exception {
     // Checking edge cases of public API parameter setting.
     AdvancedTlsX509KeyManager serverKeyManager = new AdvancedTlsX509KeyManager();
-    NullPointerException npe = assertThrows(NullPointerException.class, () -> serverKeyManager.
-        updateIdentityCredentials(null, serverCert0));
+    NullPointerException npe = assertThrows(NullPointerException.class, () -> serverKeyManager
+        .updateIdentityCredentials(null, serverCert0));
     assertEquals("key", npe.getMessage());
 
-    npe = assertThrows(NullPointerException.class, () -> serverKeyManager.
-        updateIdentityCredentials(serverKey0, null));
+    npe = assertThrows(NullPointerException.class, () -> serverKeyManager
+        .updateIdentityCredentials(serverKey0, null));
     assertEquals("certs", npe.getMessage());
 
-    npe = assertThrows(NullPointerException.class, () -> serverKeyManager.
-        updateIdentityCredentialsFromFile(null, serverCert0File));
+    npe = assertThrows(NullPointerException.class, () -> serverKeyManager
+        .updateIdentityCredentialsFromFile(null, serverCert0File));
     assertEquals("keyFile", npe.getMessage());
 
-    npe = assertThrows(NullPointerException.class, () -> serverKeyManager.
-        updateIdentityCredentialsFromFile(serverKey0File, null));
+    npe = assertThrows(NullPointerException.class, () -> serverKeyManager
+        .updateIdentityCredentialsFromFile(serverKey0File, null));
     assertEquals("certFile", npe.getMessage());
 
-    npe = assertThrows(NullPointerException.class, () -> serverKeyManager.
-        updateIdentityCredentialsFromFile(serverKey0File, serverCert0File, 1, null,
+    npe = assertThrows(NullPointerException.class, () -> serverKeyManager
+        .updateIdentityCredentialsFromFile(serverKey0File, serverCert0File, 1, null,
             executor));
     assertEquals("unit", npe.getMessage());
 
-    npe = assertThrows(NullPointerException.class, () -> serverKeyManager.
-        updateIdentityCredentialsFromFile(serverKey0File, serverCert0File, 1,
+    npe = assertThrows(NullPointerException.class, () -> serverKeyManager
+        .updateIdentityCredentialsFromFile(serverKey0File, serverCert0File, 1,
             TimeUnit.MINUTES, null));
     assertEquals("executor", npe.getMessage());
 


### PR DESCRIPTION
This PR is a part of 'Stabilize Advanced TLS' effort.
Clean up, improve javadoc, de-experimentalize of AdvancedTlsX509KeyManager, add a unit test (e2e already exists).