### PR TITLE
xds: include the target label to WRR metrics

### DIFF
--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -430,31 +430,33 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
       for (int i = 0; i < children.size(); i++) {
         double newWeight = ((WeightedChildLbState) children.get(i)).getWeight(staleEndpoints,
             notYetUsableEndpoints);
-        // TODO: add target and locality labels once available
+        // TODO: add locality label once available
         helper.getMetricRecorder()
-            .recordDoubleHistogram(ENDPOINT_WEIGHTS_HISTOGRAM, newWeight, ImmutableList.of(""),
+            .recordDoubleHistogram(ENDPOINT_WEIGHTS_HISTOGRAM, newWeight,
+                ImmutableList.of(helper.getChannelTarget()),
                 ImmutableList.of(""));
         newWeights[i] = newWeight > 0 ? (float) newWeight : 0.0f;
       }
       if (staleEndpoints.get() > 0) {
-        // TODO: add target and locality labels once available
+        // TODO: add locality label once available
         helper.getMetricRecorder()
             .addLongCounter(ENDPOINT_WEIGHT_STALE_COUNTER, staleEndpoints.get(),
-                ImmutableList.of(""),
+                ImmutableList.of(helper.getChannelTarget()),
                 ImmutableList.of(""));
       }
       if (notYetUsableEndpoints.get() > 0) {
-        // TODO: add target and locality labels once available
+        // TODO: add locality label once available
         helper.getMetricRecorder()
             .addLongCounter(ENDPOINT_WEIGHT_NOT_YET_USEABLE_COUNTER, notYetUsableEndpoints.get(),
-                ImmutableList.of(""), ImmutableList.of(""));
+                ImmutableList.of(helper.getChannelTarget()), ImmutableList.of(""));
       }
 
       this.scheduler = new StaticStrideScheduler(newWeights, sequence);
       if (this.scheduler.usesRoundRobin()) {
-        // TODO: add target and locality labels once available
+        // TODO: locality label once available
         helper.getMetricRecorder()
-            .addLongCounter(RR_FALLBACK_COUNTER, 1, ImmutableList.of(""), ImmutableList.of(""));
+            .addLongCounter(RR_FALLBACK_COUNTER, 1, ImmutableList.of(helper.getChannelTarget()),
+                ImmutableList.of(""));
       }
     }
 

--- a/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
@@ -144,6 +144,8 @@ public class WeightedRoundRobinLoadBalancerTest {
           }
       });
 
+  private String channelTarget = "channel-target";
+
   public WeightedRoundRobinLoadBalancerTest() {
     testHelperInstance = new TestHelper();
     helper = mock(Helper.class, delegatesTo(testHelperInstance));
@@ -1238,7 +1240,7 @@ public class WeightedRoundRobinLoadBalancerTest {
           public boolean matches(LongCounterMetricInstrument longCounterInstrument) {
             return longCounterInstrument.getName().equals(name);
           }
-        }), eq(value), eq(Lists.newArrayList("")), eq(Lists.newArrayList("")));
+        }), eq(value), eq(Lists.newArrayList(channelTarget)), eq(Lists.newArrayList("")));
   }
 
   // Verifies that the MetricRecorder has been called to record a given double histogram value the
@@ -1250,7 +1252,7 @@ public class WeightedRoundRobinLoadBalancerTest {
           public boolean matches(DoubleHistogramMetricInstrument doubleHistogramInstrument) {
             return doubleHistogramInstrument.getName().equals(name);
           }
-        }), eq(value), eq(Lists.newArrayList("")), eq(Lists.newArrayList("")));
+        }), eq(value), eq(Lists.newArrayList(channelTarget)), eq(Lists.newArrayList("")));
   }
 
   private int getNumFilteredPendingTasks() {
@@ -1325,6 +1327,11 @@ public class WeightedRoundRobinLoadBalancerTest {
     @Override
     public MetricRecorder getMetricRecorder() {
       return mockMetricRecorder;
+    }
+
+    @Override
+    public String getChannelTarget() {
+      return channelTarget;
     }
   }
 }


### PR DESCRIPTION
The channel target is now available via the `Helper`, let's record it as a label with the various metrics we track in `WeightedRoundRobinLoadBalancer`.