### PR TITLE
Fix bazel 3d party dependency use_repo

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -60,7 +60,9 @@ use_repo(
     non_module_deps,
     "com_github_cncf_xds",
     "envoy_api",
-    "io_grpc_grpc_proto",
+    "com_google_protobuf",
+    "com_google_protobuf_javalite",
+    "io_grpc_grpc_proto"
 )
 
 grpc_repo_deps_ext = use_extension("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_repo_deps_ext")


### PR DESCRIPTION
Some dependencies from https://github.com/firov/grpc-java/blob/64ae9f057af34bfec8b532f84c2b622218af63b7/repositories.bzl#L167 are missing in use_repo, which leads to graph query problems in user repository.

```
bazel query --notool_deps --noimplicit_deps "deps(//...)" --output graph

ERROR: Evaluation of query failed: preloading transitive closure failed: no such package '@@[unknown repo 'com_google_protobuf_javalite' requested from @https://github.com/grpc-java~]//': The repository '@@[unknown repo 'com_google_protobuf_javalite' requested from @https://github.com/grpc-java~]' could not be resolved: No repository visible as '@com_google_protobuf_javalite' from repository '@https://github.com/grpc-java~'
```