### PR TITLE
Include com_google_protobuf_javalite to MODULE.bazel to fix bzlmod querying graph in end-user repo

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -60,6 +60,7 @@ use_repo(
     non_module_deps,
     "com_github_cncf_xds",
     "envoy_api",
+    "com_google_protobuf_javalite",
     "io_grpc_grpc_proto",
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -60,7 +60,6 @@ use_repo(
     non_module_deps,
     "com_github_cncf_xds",
     "envoy_api",
-    "com_google_protobuf",
     "com_google_protobuf_javalite",
     "io_grpc_grpc_proto"
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -60,7 +60,6 @@ use_repo(
     non_module_deps,
     "com_github_cncf_xds",
     "envoy_api",
-    "com_google_protobuf_javalite",
     "io_grpc_grpc_proto"
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -60,7 +60,7 @@ use_repo(
     non_module_deps,
     "com_github_cncf_xds",
     "envoy_api",
-    "io_grpc_grpc_proto"
+    "io_grpc_grpc_proto",
 )
 
 grpc_repo_deps_ext = use_extension("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_repo_deps_ext")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -60,7 +60,9 @@ use_repo(
     non_module_deps,
     "com_github_cncf_xds",
     "envoy_api",
-    "io_grpc_grpc_proto",
+    "com_google_protobuf",
+    "com_google_protobuf_javalite",
+    "io_grpc_grpc_proto"
 )
 
 grpc_repo_deps_ext = use_extension("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_repo_deps_ext")

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1,4 +1,4 @@
-∑"""External dependencies for grpc-java."""
+"""External dependencies for grpc-java."""
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1,4 +1,4 @@
-"""External dependencies for grpc-java."""
+∑"""External dependencies for grpc-java."""
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
@@ -62,7 +62,7 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
 IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS = {
     "com.google.protobuf:protobuf-java": "@com_google_protobuf//:protobuf_java",
     "com.google.protobuf:protobuf-java-util": "@com_google_protobuf//:protobuf_java_util",
-    "com.google.protobuf:protobuf-javalite": "@com_google_protobuf_javalite//:protobuf_javalite",
+    "com.google.protobuf:protobuf-javalite": "@com_google_protobuf//:protobuf_javalite",
     "io.grpc:grpc-alts": "@io_grpc_grpc_java//alts",
     "io.grpc:grpc-api": "@io_grpc_grpc_java//api",
     "io.grpc:grpc-auth": "@io_grpc_grpc_java//auth",
@@ -117,8 +117,6 @@ def grpc_java_repositories(bzlmod = False):
         )
     if not bzlmod and not native.existing_rule("com_google_protobuf"):
         com_google_protobuf()
-    if not bzlmod and not native.existing_rule("com_google_protobuf_javalite"):
-        com_google_protobuf_javalite()
     if not bzlmod and not native.existing_rule("com_google_googleapis"):
         http_archive(
             name = "com_google_googleapis",
@@ -156,15 +154,6 @@ def com_google_protobuf():
     # This statement defines the @com_google_protobuf repo.
     http_archive(
         name = "com_google_protobuf",
-        sha256 = "9bd87b8280ef720d3240514f884e56a712f2218f0d693b48050c836028940a42",
-        strip_prefix = "protobuf-25.1",
-        urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protobuf-25.1.tar.gz"],
-    )
-
-def com_google_protobuf_javalite():
-    # java_lite_proto_library rules implicitly depend on @com_google_protobuf_javalite
-    http_archive(
-        name = "com_google_protobuf_javalite",
         sha256 = "9bd87b8280ef720d3240514f884e56a712f2218f0d693b48050c836028940a42",
         strip_prefix = "protobuf-25.1",
         urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protobuf-25.1.tar.gz"],

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -62,7 +62,7 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
 IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS = {
     "com.google.protobuf:protobuf-java": "@com_google_protobuf//:protobuf_java",
     "com.google.protobuf:protobuf-java-util": "@com_google_protobuf//:protobuf_java_util",
-    "com.google.protobuf:protobuf-javalite": "@com_google_protobuf//:protobuf_javalite",
+    "com.google.protobuf:protobuf-javalite": "@com_google_protobuf_javalite//:protobuf_javalite",
     "io.grpc:grpc-alts": "@io_grpc_grpc_java//alts",
     "io.grpc:grpc-api": "@io_grpc_grpc_java//api",
     "io.grpc:grpc-auth": "@io_grpc_grpc_java//auth",
@@ -117,6 +117,8 @@ def grpc_java_repositories(bzlmod = False):
         )
     if not bzlmod and not native.existing_rule("com_google_protobuf"):
         com_google_protobuf()
+    if not native.existing_rule("com_google_protobuf_javalite"):
+        com_google_protobuf_javalite()
     if not bzlmod and not native.existing_rule("com_google_googleapis"):
         http_archive(
             name = "com_google_googleapis",
@@ -154,6 +156,15 @@ def com_google_protobuf():
     # This statement defines the @com_google_protobuf repo.
     http_archive(
         name = "com_google_protobuf",
+        sha256 = "9bd87b8280ef720d3240514f884e56a712f2218f0d693b48050c836028940a42",
+        strip_prefix = "protobuf-25.1",
+        urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protobuf-25.1.tar.gz"],
+    )
+
+def com_google_protobuf_javalite():
+    # java_lite_proto_library rules implicitly depend on @com_google_protobuf_javalite
+    http_archive(
+        name = "com_google_protobuf_javalite",
         sha256 = "9bd87b8280ef720d3240514f884e56a712f2218f0d693b48050c836028940a42",
         strip_prefix = "protobuf-25.1",
         urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protobuf-25.1.tar.gz"],


### PR DESCRIPTION
Query in end-user repository fails with:
```
bazel query --notool_deps --noimplicit_deps "deps(//...)" --output graph

ERROR: Evaluation of query failed: preloading transitive closure failed: no such package '@@[unknown repo 'com_google_protobuf_javalite' requested from @https://github.com/grpc-java~]//': The repository '@@[unknown repo 'com_google_protobuf_javalite' requested from @https://github.com/grpc-java~]' could not be resolved: No repository visible as '@com_google_protobuf_javalite' from repository '@https://github.com/grpc-java~'
```
It's because com_google_protobuf_javalite is missing in use_repo in MODULE.bazel and completely not imported in repositories.bzl when using bzlmod. I noticed that actually com_google_protobuf_javalite is an archive with protobuf repository, which we already have, so i just change remapping.