### PR TITLE
Plumb target to OpenTelemetry per-call metrics

### DIFF
--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder2.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder2.java
@@ -95,6 +95,12 @@ public abstract class ForwardingChannelBuilder2<T extends ManagedChannelBuilder<
   }
 
   @Override
+  protected T interceptWithTarget(InterceptorFactory factory) {
+    delegate().interceptWithTarget(factory);
+    return thisT();
+  }
+
+  @Override
   public T addTransportFilter(ClientTransportFilter transportFilter) {
     delegate().addTransportFilter(transportFilter);
     return thisT();

--- a/api/src/main/java/io/grpc/InternalManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/InternalManagedChannelBuilder.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+/**
+ * Internal accessors for {@link ManagedChannelBuilder}.
+ */
+public final class InternalManagedChannelBuilder {
+  private InternalManagedChannelBuilder() {}
+
+  public static <T extends ManagedChannelBuilder<T>> T interceptWithTarget(
+      ManagedChannelBuilder<T> builder, InternalInterceptorFactory factory) {
+    return builder.interceptWithTarget(factory);
+  }
+
+  public interface InternalInterceptorFactory extends ManagedChannelBuilder.InterceptorFactory {}
+}

--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -160,6 +160,21 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   public abstract T intercept(ClientInterceptor... interceptors);
 
   /**
+   * Internal-only: Adds a factory that will construct an interceptor based on the channel's target.
+   * This can be used to work around nameResolverFactory() changing the target string.
+   */
+  @Internal
+  protected T interceptWithTarget(InterceptorFactory factory) {
+    throw new UnsupportedOperationException();
+  }
+
+  /** Internal-only. */
+  @Internal
+  protected interface InterceptorFactory {
+    ClientInterceptor newInterceptor(String target);
+  }
+
+  /**
    * Adds a {@link ClientTransportFilter}. The order of filters being added is the order they will
    * be executed
    *

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for ManagedChannelImpl#getNameResolverProvider(). */
+/** Unit tests for ManagedChannelImplBuilder#getNameResolverProvider(). */
 @RunWith(JUnit4.class)
 public class ManagedChannelImplGetNameResolverTest {
   @Test
@@ -95,7 +95,7 @@ public class ManagedChannelImplGetNameResolverTest {
   public void validTargetNoProvider() {
     NameResolverRegistry nameResolverRegistry = new NameResolverRegistry();
     try {
-      ManagedChannelImpl.getNameResolverProvider(
+      ManagedChannelImplBuilder.getNameResolverProvider(
           "foo.googleapis.com:8080", nameResolverRegistry,
           Collections.singleton(InetSocketAddress.class));
       fail("Should fail");
@@ -108,7 +108,7 @@ public class ManagedChannelImplGetNameResolverTest {
   public void validTargetProviderAddrTypesNotSupported() {
     NameResolverRegistry nameResolverRegistry = getTestRegistry("testscheme");
     try {
-      ManagedChannelImpl.getNameResolverProvider(
+      ManagedChannelImplBuilder.getNameResolverProvider(
           "testscheme:///foo.googleapis.com:8080", nameResolverRegistry,
           Collections.singleton(InProcessSocketAddress.class));
       fail("Should fail");
@@ -121,8 +121,9 @@ public class ManagedChannelImplGetNameResolverTest {
 
   private void testValidTarget(String target, String expectedUriString, URI expectedUri) {
     NameResolverRegistry nameResolverRegistry = getTestRegistry(expectedUri.getScheme());
-    ManagedChannelImpl.ResolvedNameResolver resolved = ManagedChannelImpl.getNameResolverProvider(
-        target, nameResolverRegistry, Collections.singleton(InetSocketAddress.class));
+    ManagedChannelImplBuilder.ResolvedNameResolver resolved =
+        ManagedChannelImplBuilder.getNameResolverProvider(
+            target, nameResolverRegistry, Collections.singleton(InetSocketAddress.class));
     assertThat(resolved.provider).isInstanceOf(FakeNameResolverProvider.class);
     assertThat(resolved.targetUri).isEqualTo(expectedUri);
     assertThat(resolved.targetUri.toString()).isEqualTo(expectedUriString);
@@ -132,8 +133,9 @@ public class ManagedChannelImplGetNameResolverTest {
     NameResolverRegistry nameResolverRegistry = getTestRegistry("dns");
 
     try {
-      ManagedChannelImpl.ResolvedNameResolver resolved = ManagedChannelImpl.getNameResolverProvider(
-          target, nameResolverRegistry, Collections.singleton(InetSocketAddress.class));
+      ManagedChannelImplBuilder.ResolvedNameResolver resolved =
+          ManagedChannelImplBuilder.getNameResolverProvider(
+              target, nameResolverRegistry, Collections.singleton(InetSocketAddress.class));
       FakeNameResolverProvider nameResolverProvider = (FakeNameResolverProvider) resolved.provider;
       fail("Should have failed, but got resolver provider " + nameResolverProvider);
     } catch (IllegalArgumentException e) {

--- a/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
+++ b/core/src/test/java/io/grpc/internal/ServiceConfigErrorHandlingTest.java
@@ -45,6 +45,7 @@ import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.NameResolver;
 import io.grpc.NameResolver.ConfigOrError;
+import io.grpc.NameResolverProvider;
 import io.grpc.Status;
 import io.grpc.internal.ManagedChannelImplBuilder.FixedPortProvider;
 import io.grpc.internal.ManagedChannelImplBuilder.UnsupportedClientTransportFactoryBuilder;
@@ -161,10 +162,14 @@ public class ServiceConfigErrorHandlingTest {
 
     when(mockTransportFactory.getSupportedSocketAddressTypes()).thenReturn(Collections.singleton(
         InetSocketAddress.class));
+    NameResolverProvider nameResolverProvider =
+        channelBuilder.nameResolverRegistry.getProviderForScheme(expectedUri.getScheme());
     channel =
         new ManagedChannelImpl(
             channelBuilder,
             mockTransportFactory,
+            expectedUri,
+            nameResolverProvider,
             new FakeBackoffPolicyProvider(),
             balancerRpcExecutorPool,
             timer.getStopwatchSupplier(),

--- a/opentelemetry/src/main/java/io/grpc/opentelemetry/OpenTelemetryMetricsModule.java
+++ b/opentelemetry/src/main/java/io/grpc/opentelemetry/OpenTelemetryMetricsModule.java
@@ -19,6 +19,7 @@ package io.grpc.opentelemetry;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.grpc.opentelemetry.internal.OpenTelemetryConstants.METHOD_KEY;
 import static io.grpc.opentelemetry.internal.OpenTelemetryConstants.STATUS_KEY;
+import static io.grpc.opentelemetry.internal.OpenTelemetryConstants.TARGET_KEY;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
@@ -97,8 +98,8 @@ final class OpenTelemetryMetricsModule {
   /**
    * Returns the client interceptor that facilitates OpenTelemetry metrics reporting.
    */
-  ClientInterceptor getClientInterceptor() {
-    return new MetricsClientInterceptor();
+  ClientInterceptor getClientInterceptor(String target) {
+    return new MetricsClientInterceptor(target);
   }
 
   static String recordMethodName(String fullMethodName, boolean isGeneratedMethod) {
@@ -135,6 +136,7 @@ final class OpenTelemetryMetricsModule {
     final CallAttemptsTracerFactory attemptsState;
     final OpenTelemetryMetricsModule module;
     final StreamInfo info;
+    final String target;
     final String fullMethodName;
     volatile long outboundWireSize;
     volatile long inboundWireSize;
@@ -142,10 +144,11 @@ final class OpenTelemetryMetricsModule {
     Code statusCode;
 
     ClientTracer(CallAttemptsTracerFactory attemptsState, OpenTelemetryMetricsModule module,
-        StreamInfo info, String fullMethodName) {
+        StreamInfo info, String target, String fullMethodName) {
       this.attemptsState = attemptsState;
       this.module = module;
       this.info = info;
+      this.target = target;
       this.fullMethodName = fullMethodName;
       this.stopwatch = module.stopwatchSupplier.get().start();
     }
@@ -189,9 +192,9 @@ final class OpenTelemetryMetricsModule {
     }
 
     void recordFinishedAttempt() {
-      // TODO(dnvindhya) : add target as an attribute
       io.opentelemetry.api.common.Attributes attribute =
           io.opentelemetry.api.common.Attributes.of(METHOD_KEY, fullMethodName,
+              TARGET_KEY, target,
               STATUS_KEY, statusCode.toString());
 
       if (module.resource.clientAttemptCountCounter() != null ) {
@@ -212,6 +215,7 @@ final class OpenTelemetryMetricsModule {
   @VisibleForTesting
   static final class CallAttemptsTracerFactory extends ClientStreamTracer.Factory {
     private final OpenTelemetryMetricsModule module;
+    private final String target;
     private final Stopwatch attemptStopwatch;
     private final Stopwatch callStopWatch;
     @GuardedBy("lock")
@@ -226,15 +230,17 @@ final class OpenTelemetryMetricsModule {
     @GuardedBy("lock")
     private boolean finishedCallToBeRecorded;
 
-    CallAttemptsTracerFactory(OpenTelemetryMetricsModule module, String fullMethodName) {
+    CallAttemptsTracerFactory(
+        OpenTelemetryMetricsModule module, String target, String fullMethodName) {
       this.module = checkNotNull(module, "module");
+      this.target = checkNotNull(target, "target");
       this.fullMethodName = checkNotNull(fullMethodName, "fullMethodName");
       this.attemptStopwatch = module.stopwatchSupplier.get();
       this.callStopWatch = module.stopwatchSupplier.get().start();
 
-      // TODO(dnvindhya) : add target as an attribute
-      io.opentelemetry.api.common.Attributes attribute =
-          io.opentelemetry.api.common.Attributes.of(METHOD_KEY, fullMethodName);
+      io.opentelemetry.api.common.Attributes attribute = io.opentelemetry.api.common.Attributes.of(
+          METHOD_KEY, fullMethodName,
+          TARGET_KEY, target);
 
       // Record here in case mewClientStreamTracer() would never be called.
       if (module.resource.clientAttemptCountCounter() != null) {
@@ -257,9 +263,9 @@ final class OpenTelemetryMetricsModule {
       // CallAttemptsTracerFactory constructor. attemptsPerCall will be non-zero after the first
       // attempt, as first attempt cannot be a transparent retry.
       if (attemptsPerCall.get() > 0) {
-        // TODO(dnvindhya): Add target as an attribute
         io.opentelemetry.api.common.Attributes attribute =
-            io.opentelemetry.api.common.Attributes.of(METHOD_KEY, fullMethodName);
+            io.opentelemetry.api.common.Attributes.of(METHOD_KEY, fullMethodName,
+                TARGET_KEY, target);
         if (module.resource.clientAttemptCountCounter() != null) {
           module.resource.clientAttemptCountCounter().add(1, attribute);
         }
@@ -267,7 +273,7 @@ final class OpenTelemetryMetricsModule {
       if (!info.isTransparentRetry()) {
         attemptsPerCall.incrementAndGet();
       }
-      return new ClientTracer(this, module, info, fullMethodName);
+      return new ClientTracer(this, module, info, target, fullMethodName);
     }
 
     // Called whenever each attempt is ended.
@@ -309,15 +315,15 @@ final class OpenTelemetryMetricsModule {
 
     void recordFinishedCall() {
       if (attemptsPerCall.get() == 0) {
-        ClientTracer tracer = new ClientTracer(this, module, null, fullMethodName);
+        ClientTracer tracer = new ClientTracer(this, module, null, target, fullMethodName);
         tracer.attemptNanos = attemptStopwatch.elapsed(TimeUnit.NANOSECONDS);
         tracer.statusCode = status.getCode();
         tracer.recordFinishedAttempt();
       }
       callLatencyNanos = callStopWatch.elapsed(TimeUnit.NANOSECONDS);
-      // TODO(dnvindhya): record target as an attribute
       io.opentelemetry.api.common.Attributes attribute =
           io.opentelemetry.api.common.Attributes.of(METHOD_KEY, fullMethodName,
+              TARGET_KEY, target,
               STATUS_KEY, status.getCode().toString());
 
       if (module.resource.clientCallDurationCounter() != null) {
@@ -459,6 +465,12 @@ final class OpenTelemetryMetricsModule {
 
   @VisibleForTesting
   final class MetricsClientInterceptor implements ClientInterceptor {
+    private final String target;
+
+    MetricsClientInterceptor(String target) {
+      this.target = checkNotNull(target, "target");
+    }
+
     @Override
     public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
         MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
@@ -466,7 +478,7 @@ final class OpenTelemetryMetricsModule {
       // which is true for all generated methods. Otherwise, programatically
       // created methods result in high cardinality metrics.
       final CallAttemptsTracerFactory tracerFactory = new CallAttemptsTracerFactory(
-          OpenTelemetryMetricsModule.this, recordMethodName(method.getFullMethodName(),
+          OpenTelemetryMetricsModule.this, target, recordMethodName(method.getFullMethodName(),
           method.isSampledToLocalTracing()));
       ClientCall<ReqT, RespT> call =
           next.newCall(method, callOptions.withStreamTracerFactory(tracerFactory));

--- a/opentelemetry/src/main/java/io/grpc/opentelemetry/OpenTelemetryModule.java
+++ b/opentelemetry/src/main/java/io/grpc/opentelemetry/OpenTelemetryModule.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableMap;
 import io.grpc.ExperimentalApi;
 import io.grpc.InternalConfigurator;
 import io.grpc.InternalConfiguratorRegistry;
+import io.grpc.InternalManagedChannelBuilder;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.MetricSink;
 import io.grpc.ServerBuilder;
@@ -146,7 +147,8 @@ public final class OpenTelemetryModule {
    */
   public void configureChannelBuilder(ManagedChannelBuilder<?> builder) {
     builder.addMetricSink(sink);
-    builder.intercept(openTelemetryMetricsModule.getClientInterceptor());
+    InternalManagedChannelBuilder.interceptWithTarget(
+        builder, openTelemetryMetricsModule::getClientInterceptor);
   }
 
   /**


### PR DESCRIPTION
You'll probably want to look at the two commits separately. I am sending them in one PR because the second commit shows "what the heck Eric is doing." Each commit has a useful commit message.

I can't say I'm wild about this solution at the current state, but there are some options for getting us out of this strangeness. We need to have a team discussion, and the only thing we guarantee here that might be hard to undo is "when you configure a channel with opentelemetry, that dictates the interceptor order." Which seems appropriate for all solutions.

I don't expect anyone is particularly more/less suited to review this, so sending it to Terry since he's seen some of the other metric stuff. But @larry-safran, if you are interested, feel free to take a look.

CC @DNVindhya 