### PR TITLE
opentelemetry: Add optional grpc.lb.locality to per-call metrics

### DIFF
--- a/opentelemetry/src/main/java/io/grpc/opentelemetry/OpenTelemetryModule.java
+++ b/opentelemetry/src/main/java/io/grpc/opentelemetry/OpenTelemetryModule.java
@@ -84,8 +84,9 @@ public final class OpenTelemetryModule {
     this.enableMetrics = ImmutableMap.copyOf(builder.enableMetrics);
     this.disableDefault = builder.disableAll;
     this.resource = createMetricInstruments(meter, enableMetrics, disableDefault);
-    this.openTelemetryMetricsModule = new OpenTelemetryMetricsModule(STOPWATCH_SUPPLIER, resource);
     this.optionalLabels = ImmutableList.copyOf(builder.optionalLabels);
+    this.openTelemetryMetricsModule =
+        new OpenTelemetryMetricsModule(STOPWATCH_SUPPLIER, resource, optionalLabels);
     this.sink = new OpenTelemetryMetricSink(meter, enableMetrics, disableDefault, optionalLabels);
   }
 

--- a/opentelemetry/src/main/java/io/grpc/opentelemetry/internal/OpenTelemetryConstants.java
+++ b/opentelemetry/src/main/java/io/grpc/opentelemetry/internal/OpenTelemetryConstants.java
@@ -28,6 +28,9 @@ public final class OpenTelemetryConstants {
 
   public static final AttributeKey<String> TARGET_KEY = AttributeKey.stringKey("grpc.target");
 
+  public static final AttributeKey<String> LOCALITY_KEY =
+      AttributeKey.stringKey("grpc.lb.locality");
+
   private OpenTelemetryConstants() {
   }
 }


### PR DESCRIPTION
The optional label API was added in 4c78a974 and xds_cluster_impl was plumbed in 077dcbf9.

From gRFC A78:

> ### Optional xDS Locality Label
>
> When xDS is used, it is desirable for some metrics to include an optional
> label indicating which xDS locality the metrics are associated with.
> We want to provide this optional label for the metrics in both the
> existing per-call metrics defined in [A66] and in the new metrics for
> the WRR LB policy, described below.
>
> If locality information is available, the value of this label will be of
> the form `{region="${REGION}", zone="${ZONE}", sub_zone="${SUB_ZONE}"}`,
> where `${REGION}`, `${ZONE}`, and `${SUB_ZONE}` are replaced with the
> actual values.  If no locality information is available, the label will
> be set to the empty string.
>
> #### Per-Call Metrics
>
> To support the locality label in the per-call metrics, we will provide
> a mechanism for LB picker to add optional labels to the call attempt
> tracer.  We will then use this mechanism in the `xds_cluster_impl`
> policy's picker to set the locality label. ...
>
> This label will be available on the following per-call metrics:
> - `grpc.client.attempt.duration`
> - `grpc.client.attempt.sent_total_compressed_message_size`
> - `grpc.client.attempt.rcvd_total_compressed_message_size`

CC @DNVindhya 