### PR TITLE
opentelemetry: Fix checking wrong metric for null (1.64.x backport)

### DIFF
--- a/opentelemetry/src/main/java/io/grpc/opentelemetry/OpenTelemetryMetricsModule.java
+++ b/opentelemetry/src/main/java/io/grpc/opentelemetry/OpenTelemetryMetricsModule.java
@@ -194,7 +194,7 @@ final class OpenTelemetryMetricsModule {
           io.opentelemetry.api.common.Attributes.of(METHOD_KEY, fullMethodName,
               STATUS_KEY, statusCode.toString());
 
-      if (module.resource.clientAttemptCountCounter() != null ) {
+      if (module.resource.clientAttemptDurationCounter() != null ) {
         module.resource.clientAttemptDurationCounter()
             .record(attemptNanos * SECONDS_PER_NANO, attribute);
       }


### PR DESCRIPTION
CC @DNVindhya 

Backport of #11155