### PR TITLE
Add gauge metric API and Otel implementation (1.64.x backport)

### DIFF
--- a/api/src/main/java/io/grpc/CallbackMetricInstrument.java
+++ b/api/src/main/java/io/grpc/CallbackMetricInstrument.java
@@ -16,16 +16,8 @@
 
 package io.grpc;
 
-import java.util.List;
-
 /**
- * Represents a long-valued gauge metric instrument.
+ * Tagging interface for MetricInstruments that can be used with batch callbacks.
  */
 @Internal
-public final class LongGaugeMetricInstrument extends PartialMetricInstrument
-    implements CallbackMetricInstrument {
-  public LongGaugeMetricInstrument(int index, String name, String description, String unit,
-      List<String> requiredLabelKeys, List<String> optionalLabelKeys, boolean enableByDefault) {
-    super(index, name, description, unit, requiredLabelKeys, optionalLabelKeys, enableByDefault);
-  }
-}
+public interface CallbackMetricInstrument extends MetricInstrument {}

--- a/api/src/main/java/io/grpc/MetricRecorder.java
+++ b/api/src/main/java/io/grpc/MetricRecorder.java
@@ -67,4 +67,43 @@ public interface MetricRecorder {
    */
   default void recordLongHistogram(LongHistogramMetricInstrument metricInstrument, long value,
       List<String> requiredLabelValues, List<String> optionalLabelValues) {}
+
+  /**
+   * Registers a callback to produce metric values for only the listed instruments. The returned
+   * registration must be closed when no longer needed, which will remove the callback.
+   *
+   * @param callback The callback to call to record.
+   * @param metricInstruments The metric instruments the callback will record against.
+   */
+  default Registration registerBatchCallback(BatchCallback callback,
+      CallbackMetricInstrument... metricInstruments) {
+    return () -> { };
+  }
+
+  /** Callback to record gauge values. */
+  interface BatchCallback {
+    /** Records instrument values into {@code recorder}. */
+    void accept(BatchRecorder recorder);
+  }
+
+  /** Recorder for instrument values produced by a batch callback. */
+  interface BatchRecorder {
+    /**
+     * Record a long gauge value.
+     *
+     * @param value The value to record.
+     * @param requiredLabelValues A list of required label values for the metric.
+     * @param optionalLabelValues A list of additional, optional label values for the metric.
+     */
+    void recordLongGauge(LongGaugeMetricInstrument metricInstrument, long value,
+        List<String> requiredLabelValues, List<String> optionalLabelValues);
+  }
+
+  /** A handle to a registration, that allows unregistration. */
+  interface Registration extends AutoCloseable {
+    // Redefined to not throw an exception.
+    /** Unregister. */
+    @Override
+    void close();
+  }
 }

--- a/api/src/main/java/io/grpc/MetricSink.java
+++ b/api/src/main/java/io/grpc/MetricSink.java
@@ -99,5 +99,30 @@ public interface MetricSink {
       List<String> requiredLabelValues, List<String> optionalLabelValues) {
   }
 
+  /**
+   * Record a long gauge value.
+   *
+   * @param value The value to record.
+   * @param requiredLabelValues A list of required label values for the metric.
+   * @param optionalLabelValues A list of additional, optional label values for the metric.
+   */
+  default void recordLongGauge(LongGaugeMetricInstrument metricInstrument, long value,
+      List<String> requiredLabelValues, List<String> optionalLabelValues){
+  }
+
+  /**
+   * Registers a callback to produce metric values for only the listed instruments. The returned
+   * registration must be closed when no longer needed, which will remove the callback.
+   *
+   * @param callback The callback to call to record.
+   * @param metricInstruments The metric instruments the callback will record against.
+   */
+  default Registration registerBatchCallback(Runnable callback,
+      CallbackMetricInstrument... metricInstruments) {
+    return () -> { };
+  }
+
+  interface Registration extends MetricRecorder.Registration {}
+
   void updateMeasures(List<MetricInstrument> instruments);
 }


### PR DESCRIPTION
This is needed by gRFC A78 for xds metrics, and for RLS metrics. Since gauges need to acquire a lock (or other synchronization) in the callback, the callback allows batching multiple gauges together to avoid acquiring-and-requiring such locks.

Unlike other metrics, gauges are reported on-demand to the MetricSink. This means not all sinks will receive the same data, as the sinks will ask for the gauges at different times.

Backport of #11154