### PR TITLE
opentelemetry: Missing locality should be empty string (1.64.x backport)

### DIFF
--- a/opentelemetry/src/main/java/io/grpc/opentelemetry/OpenTelemetryMetricsModule.java
+++ b/opentelemetry/src/main/java/io/grpc/opentelemetry/OpenTelemetryMetricsModule.java
@@ -213,7 +213,7 @@ final class OpenTelemetryMetricsModule {
       if (module.localityEnabled) {
         String savedLocality = locality;
         if (savedLocality == null) {
-          savedLocality = "unknown";
+          savedLocality = "";
         }
         builder.put(LOCALITY_KEY, savedLocality);
       }

--- a/opentelemetry/src/test/java/io/grpc/opentelemetry/OpenTelemetryMetricsModuleTest.java
+++ b/opentelemetry/src/test/java/io/grpc/opentelemetry/OpenTelemetryMetricsModuleTest.java
@@ -974,7 +974,7 @@ public class OpenTelemetryMetricsModuleTest {
 
     io.opentelemetry.api.common.Attributes clientAttributesWithLocality
         = clientAttributes.toBuilder()
-        .put(LOCALITY_KEY, "unknown")
+        .put(LOCALITY_KEY, "")
         .build();
 
     assertThat(openTelemetryTesting.getMetrics())


### PR DESCRIPTION
From gRFC A78:

> If no locality information is available, the label will be set to the
> empty string.

Backport of #11172