### PR TITLE
opentelemetry: Rename and stabilize API OpenTelemetryModule (1.64.x backport)

### DIFF
--- a/opentelemetry/src/main/java/io/grpc/opentelemetry/GrpcOpenTelemetry.java
+++ b/opentelemetry/src/main/java/io/grpc/opentelemetry/GrpcOpenTelemetry.java
@@ -24,7 +24,6 @@ import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.grpc.ExperimentalApi;
 import io.grpc.InternalConfigurator;
 import io.grpc.InternalConfiguratorRegistry;
 import io.grpc.InternalManagedChannelBuilder;
@@ -45,13 +44,12 @@ import java.util.Map;
 /**
  *  The entrypoint for OpenTelemetry metrics functionality in gRPC.
  *
- *  <p>OpenTelemetryModule uses {@link io.opentelemetry.api.OpenTelemetry} APIs for instrumentation.
+ *  <p>GrpcOpenTelemetry uses {@link io.opentelemetry.api.OpenTelemetry} APIs for instrumentation.
  *  When no SDK is explicitly added no telemetry data will be collected. See
  *  {@link io.opentelemetry.sdk.OpenTelemetrySdk} for information on how to construct the SDK.
  *
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/10591")
-public final class OpenTelemetryModule {
+public final class GrpcOpenTelemetry {
 
   private static final Supplier<Stopwatch> STOPWATCH_SUPPLIER = new Supplier<Stopwatch>() {
     @Override
@@ -74,7 +72,7 @@ public final class OpenTelemetryModule {
     return new Builder();
   }
 
-  private OpenTelemetryModule(Builder builder) {
+  private GrpcOpenTelemetry(Builder builder) {
     this.openTelemetrySdk = checkNotNull(builder.openTelemetrySdk, "openTelemetrySdk");
     this.meterProvider = checkNotNull(openTelemetrySdk.getMeterProvider(), "meterProvider");
     this.meter = this.meterProvider
@@ -125,7 +123,7 @@ public final class OpenTelemetryModule {
   }
 
   /**
-   * Registers OpenTelemetryModule globally, applying its configuration to all subsequently created
+   * Registers GrpcOpenTelemetry globally, applying its configuration to all subsequently created
    * gRPC channels and servers.
    */
   public void registerGlobal() {
@@ -133,12 +131,12 @@ public final class OpenTelemetryModule {
         new InternalConfigurator() {
           @Override
           public void configureChannelBuilder(ManagedChannelBuilder<?> channelBuilder) {
-            OpenTelemetryModule.this.configureChannelBuilder(channelBuilder);
+            GrpcOpenTelemetry.this.configureChannelBuilder(channelBuilder);
           }
 
           @Override
           public void configureServerBuilder(ServerBuilder<?> serverBuilder) {
-            OpenTelemetryModule.this.configureServerBuilder(serverBuilder);
+            GrpcOpenTelemetry.this.configureServerBuilder(serverBuilder);
           }
         }));
   }
@@ -268,7 +266,7 @@ public final class OpenTelemetryModule {
 
 
   /**
-   * Builder for configuring {@link OpenTelemetryModule}.
+   * Builder for configuring {@link GrpcOpenTelemetry}.
    */
   public static class Builder {
     private OpenTelemetry openTelemetrySdk = OpenTelemetry.noop();
@@ -328,11 +326,11 @@ public final class OpenTelemetryModule {
     }
 
     /**
-     * Returns a new {@link OpenTelemetryModule} built with the configuration of this {@link
+     * Returns a new {@link GrpcOpenTelemetry} built with the configuration of this {@link
      * Builder}.
      */
-    public OpenTelemetryModule build() {
-      return new OpenTelemetryModule(this);
+    public GrpcOpenTelemetry build() {
+      return new GrpcOpenTelemetry(this);
     }
   }
 }

--- a/opentelemetry/src/test/java/io/grpc/opentelemetry/GrpcOpenTelemetryTest.java
+++ b/opentelemetry/src/test/java/io/grpc/opentelemetry/GrpcOpenTelemetryTest.java
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class OpenTelemetryModuleTest {
+public class GrpcOpenTelemetryTest {
   private final InMemoryMetricReader inMemoryMetricReader = InMemoryMetricReader.create();
   private final SdkMeterProvider meterProvider =
       SdkMeterProvider.builder().registerMetricReader(inMemoryMetricReader).build();
@@ -42,7 +42,7 @@ public class OpenTelemetryModuleTest {
     OpenTelemetrySdk sdk =
         OpenTelemetrySdk.builder().setMeterProvider(meterProvider).build();
 
-    OpenTelemetryModule openTelemetryModule = OpenTelemetryModule.newBuilder()
+    GrpcOpenTelemetry openTelemetryModule = GrpcOpenTelemetry.newBuilder()
         .sdk(sdk)
         .addOptionalLabel("version")
         .build();
@@ -58,7 +58,7 @@ public class OpenTelemetryModuleTest {
 
   @Test
   public void builderDefaults() {
-    OpenTelemetryModule module = OpenTelemetryModule.newBuilder().build();
+    GrpcOpenTelemetry module = GrpcOpenTelemetry.newBuilder().build();
 
     assertThat(module.getOpenTelemetryInstance()).isNotNull();
     assertThat(module.getOpenTelemetryInstance()).isSameInstanceAs(noopOpenTelemetry);
@@ -77,11 +77,11 @@ public class OpenTelemetryModuleTest {
 
   @Test
   public void enableDisableMetrics() {
-    OpenTelemetryModule.Builder builder = OpenTelemetryModule.newBuilder();
+    GrpcOpenTelemetry.Builder builder = GrpcOpenTelemetry.newBuilder();
     builder.enableMetrics(Arrays.asList("metric1", "metric4"));
     builder.disableMetrics(Arrays.asList("metric2", "metric3"));
 
-    OpenTelemetryModule module = builder.build();
+    GrpcOpenTelemetry module = builder.build();
 
     assertThat(module.getEnableMetrics().get("metric1")).isTrue();
     assertThat(module.getEnableMetrics().get("metric4")).isTrue();
@@ -91,12 +91,12 @@ public class OpenTelemetryModuleTest {
 
   @Test
   public void disableAllMetrics() {
-    OpenTelemetryModule.Builder builder = OpenTelemetryModule.newBuilder();
+    GrpcOpenTelemetry.Builder builder = GrpcOpenTelemetry.newBuilder();
     builder.enableMetrics(Arrays.asList("metric1", "metric4"));
     builder.disableMetrics(Arrays.asList("metric2", "metric3"));
     builder.disableAllMetrics();
 
-    OpenTelemetryModule module = builder.build();
+    GrpcOpenTelemetry module = builder.build();
 
     assertThat(module.getEnableMetrics()).isEmpty();
   }

--- a/opentelemetry/src/test/java/io/grpc/opentelemetry/OpenTelemetryMetricsModuleTest.java
+++ b/opentelemetry/src/test/java/io/grpc/opentelemetry/OpenTelemetryMetricsModuleTest.java
@@ -158,7 +158,7 @@ public class OpenTelemetryMetricsModuleTest {
 
   @Test
   public void testClientInterceptors() {
-    OpenTelemetryMetricsResource resource = OpenTelemetryModule.createMetricInstruments(testMeter,
+    OpenTelemetryMetricsResource resource = GrpcOpenTelemetry.createMetricInstruments(testMeter,
         enabledMetricsMap, disableDefaultMetrics);
     OpenTelemetryMetricsModule module = newOpenTelemetryMetricsModule(resource);
     grpcServerRule.getServiceRegistry().addService(
@@ -214,7 +214,7 @@ public class OpenTelemetryMetricsModuleTest {
   @Test
   public void clientBasicMetrics() {
     String target = "target:///";
-    OpenTelemetryMetricsResource resource = OpenTelemetryModule.createMetricInstruments(testMeter,
+    OpenTelemetryMetricsResource resource = GrpcOpenTelemetry.createMetricInstruments(testMeter,
         enabledMetricsMap, disableDefaultMetrics);
     OpenTelemetryMetricsModule module = newOpenTelemetryMetricsModule(resource);
     OpenTelemetryMetricsModule.CallAttemptsTracerFactory callAttemptsTracerFactory =
@@ -353,7 +353,7 @@ public class OpenTelemetryMetricsModuleTest {
   @Test
   public void recordAttemptMetrics() {
     String target = "dns:///example.com";
-    OpenTelemetryMetricsResource resource = OpenTelemetryModule.createMetricInstruments(testMeter,
+    OpenTelemetryMetricsResource resource = GrpcOpenTelemetry.createMetricInstruments(testMeter,
         enabledMetricsMap, disableDefaultMetrics);
     OpenTelemetryMetricsModule module = newOpenTelemetryMetricsModule(resource);
     OpenTelemetryMetricsModule.CallAttemptsTracerFactory callAttemptsTracerFactory =
@@ -778,7 +778,7 @@ public class OpenTelemetryMetricsModuleTest {
   @Test
   public void clientStreamNeverCreatedStillRecordMetrics() {
     String target = "dns:///foo.example.com";
-    OpenTelemetryMetricsResource resource = OpenTelemetryModule.createMetricInstruments(testMeter,
+    OpenTelemetryMetricsResource resource = GrpcOpenTelemetry.createMetricInstruments(testMeter,
         enabledMetricsMap, disableDefaultMetrics);
     OpenTelemetryMetricsModule module = newOpenTelemetryMetricsModule(resource);
     OpenTelemetryMetricsModule.CallAttemptsTracerFactory callAttemptsTracerFactory =
@@ -882,7 +882,7 @@ public class OpenTelemetryMetricsModuleTest {
   @Test
   public void clientLocalityMetrics_present() {
     String target = "target:///";
-    OpenTelemetryMetricsResource resource = OpenTelemetryModule.createMetricInstruments(testMeter,
+    OpenTelemetryMetricsResource resource = GrpcOpenTelemetry.createMetricInstruments(testMeter,
         enabledMetricsMap, disableDefaultMetrics);
     OpenTelemetryMetricsModule module = new OpenTelemetryMetricsModule(
         fakeClock.getStopwatchSupplier(), resource, Arrays.asList("grpc.lb.locality"));
@@ -950,7 +950,7 @@ public class OpenTelemetryMetricsModuleTest {
   @Test
   public void clientLocalityMetrics_missing() {
     String target = "target:///";
-    OpenTelemetryMetricsResource resource = OpenTelemetryModule.createMetricInstruments(testMeter,
+    OpenTelemetryMetricsResource resource = GrpcOpenTelemetry.createMetricInstruments(testMeter,
         enabledMetricsMap, disableDefaultMetrics);
     OpenTelemetryMetricsModule module = new OpenTelemetryMetricsModule(
         fakeClock.getStopwatchSupplier(), resource, Arrays.asList("grpc.lb.locality"));
@@ -1013,7 +1013,7 @@ public class OpenTelemetryMetricsModuleTest {
 
   @Test
   public void serverBasicMetrics() {
-    OpenTelemetryMetricsResource resource = OpenTelemetryModule.createMetricInstruments(testMeter,
+    OpenTelemetryMetricsResource resource = GrpcOpenTelemetry.createMetricInstruments(testMeter,
         enabledMetricsMap, disableDefaultMetrics);
     OpenTelemetryMetricsModule module = newOpenTelemetryMetricsModule(resource);
     ServerStreamTracer.Factory tracerFactory = module.getServerTracerFactory();


### PR DESCRIPTION
OpenTelemetryModule is renamed to GrpcOpenTelemetry. The Builder is now `final`, although that should only impact mocks as it had a private constructor.

Fixes #10591

Backport of #11173