### PR TITLE
api: Hide internal metric APIs (1.64.x backport)

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -55,7 +55,11 @@ dependencies {
 tasks.named("javadoc").configure {
     source sourceSets.context.allSource
     // We want io.grpc.Internal, but not io.grpc.Internal*
+    exclude 'io/grpc/*MetricInstrument.java'
+    exclude 'io/grpc/*MetricInstrumentRegistry.java'
     exclude 'io/grpc/Internal?*.java'
+    exclude 'io/grpc/MetricRecorder.java'
+    exclude 'io/grpc/MetricSink.java'
 }
 
 tasks.named("sourcesJar").configure {

--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder2.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder2.java
@@ -258,7 +258,7 @@ public abstract class ForwardingChannelBuilder2<T extends ManagedChannelBuilder<
   }
 
   @Override
-  public T addMetricSink(MetricSink metricSink) {
+  protected T addMetricSink(MetricSink metricSink) {
     delegate().addMetricSink(metricSink);
     return thisT();
   }

--- a/api/src/main/java/io/grpc/InternalManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/InternalManagedChannelBuilder.java
@@ -19,12 +19,18 @@ package io.grpc;
 /**
  * Internal accessors for {@link ManagedChannelBuilder}.
  */
+@Internal
 public final class InternalManagedChannelBuilder {
   private InternalManagedChannelBuilder() {}
 
   public static <T extends ManagedChannelBuilder<T>> T interceptWithTarget(
       ManagedChannelBuilder<T> builder, InternalInterceptorFactory factory) {
     return builder.interceptWithTarget(factory);
+  }
+
+  public static <T extends ManagedChannelBuilder<T>> T addMetricSink(
+      ManagedChannelBuilder<T> builder, MetricSink metricSink) {
+    return builder.addMetricSink(metricSink);
   }
 
   public interface InternalInterceptorFactory extends ManagedChannelBuilder.InterceptorFactory {}

--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -1255,7 +1255,7 @@ public abstract class LoadBalancer {
      *
      * @since 1.64.0
      */
-    @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11110")
+    @Internal
     public MetricRecorder getMetricRecorder() {
       return new MetricRecorder() {};
     }

--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -628,8 +628,8 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * @return this
    * @since 1.64.0
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11110")
-  public T addMetricSink(MetricSink metricSink) {
+  @Internal
+  protected T addMetricSink(MetricSink metricSink) {
     throw new UnsupportedOperationException();
   }
 

--- a/api/src/main/java/io/grpc/MetricSink.java
+++ b/api/src/main/java/io/grpc/MetricSink.java
@@ -23,7 +23,7 @@ import java.util.Set;
 /**
  * An internal interface representing a receiver or aggregator of gRPC metrics data.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/11110")
+@Internal
 public interface MetricSink {
 
   /**

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -687,7 +687,7 @@ public final class ManagedChannelImplBuilder
   }
 
   @Override
-  public ManagedChannelImplBuilder addMetricSink(MetricSink metricSink) {
+  protected ManagedChannelImplBuilder addMetricSink(MetricSink metricSink) {
     metricSinks.add(checkNotNull(metricSink, "metric sink"));
     return this;
   }

--- a/opentelemetry/src/main/java/io/grpc/opentelemetry/GrpcOpenTelemetry.java
+++ b/opentelemetry/src/main/java/io/grpc/opentelemetry/GrpcOpenTelemetry.java
@@ -145,7 +145,7 @@ public final class GrpcOpenTelemetry {
    * Configures the given {@link ManagedChannelBuilder} with OpenTelemetry metrics instrumentation.
    */
   public void configureChannelBuilder(ManagedChannelBuilder<?> builder) {
-    builder.addMetricSink(sink);
+    InternalManagedChannelBuilder.addMetricSink(builder, sink);
     InternalManagedChannelBuilder.interceptWithTarget(
         builder, openTelemetryMetricsModule::getClientInterceptor);
   }

--- a/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
+++ b/rls/src/test/java/io/grpc/rls/RlsLoadBalancerTest.java
@@ -42,6 +42,7 @@ import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.ForwardingChannelBuilder2;
+import io.grpc.InternalManagedChannelBuilder;
 import io.grpc.LoadBalancer.CreateSubchannelArgs;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.PickDetailsConsumer;
@@ -310,10 +311,11 @@ public class RlsLoadBalancerTest {
         .start());
     MetricSink metrics = mock(MetricSink.class, delegatesTo(new NoopMetricSink()));
     ManagedChannel channel = grpcCleanupRule.register(
-        InProcessChannelBuilder.forName("fake-bigtable.googleapis.com")
-        .defaultServiceConfig(parseJson(getServiceConfigJsonStr()))
-        .addMetricSink(metrics)
-        .directExecutor()
+        InternalManagedChannelBuilder.addMetricSink(
+            InProcessChannelBuilder.forName("fake-bigtable.googleapis.com")
+            .defaultServiceConfig(parseJson(getServiceConfigJsonStr()))
+            .directExecutor(),
+        metrics)
         .build());
 
     StreamRecorder<Void> recorder = StreamRecorder.create();

--- a/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
@@ -44,6 +44,7 @@ import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.DoubleHistogramMetricInstrument;
 import io.grpc.EquivalentAddressGroup;
+import io.grpc.InternalManagedChannelBuilder;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.CreateSubchannelArgs;
 import io.grpc.LoadBalancer.Helper;
@@ -1268,11 +1269,13 @@ public class WeightedRoundRobinLoadBalancerTest {
         .start());
     MetricSink metrics = mock(MetricSink.class, delegatesTo(new NoopMetricSink()));
     Channel channel = grpcCleanupRule.register(
-        InProcessChannelBuilder.forName(serverName)
-        .defaultServiceConfig(Collections.singletonMap(
-            "loadBalancingConfig", Arrays.asList(Collections.singletonMap(
-                "weighted_round_robin", Collections.emptyMap()))))
-        .addMetricSink(metrics)
+        InternalManagedChannelBuilder.addMetricSink(
+            InProcessChannelBuilder.forName(serverName)
+            .defaultServiceConfig(Collections.singletonMap(
+                "loadBalancingConfig", Arrays.asList(Collections.singletonMap(
+                    "weighted_round_robin", Collections.emptyMap()))))
+            .directExecutor(),
+        metrics)
         .directExecutor()
         .build());
 


### PR DESCRIPTION
Some APIs were marked experimental but had internal APIs in their surface. These were all changed to internal. And then the internal APIs were mostly hidden from generated documentation.

All these APIs will eventually become public and maybe even stable. But they need some iteration before we're ready for others to start using them.

Backport of #11174