### PR TITLE
opentelemetry: Publish grpc opentelemetry (v1.64.x backport)

### DIFF
--- a/opentelemetry/build.gradle
+++ b/opentelemetry/build.gradle
@@ -1,5 +1,8 @@
 plugins {
     id "java-library"
+    id "maven-publish"
+
+    id "ru.vyarus.animalsniffer"
 }
 
 description = 'gRPC: OpenTelemetry'
@@ -17,6 +20,9 @@ dependencies {
             "org.assertj:assertj-core:3.24.2"
 
     annotationProcessor libraries.auto.value
+
+    signature libraries.signature.java
+    signature libraries.signature.android
 }
 
 tasks.named("jar").configure {

--- a/opentelemetry/src/main/java/io/grpc/opentelemetry/GrpcOpenTelemetry.java
+++ b/opentelemetry/src/main/java/io/grpc/opentelemetry/GrpcOpenTelemetry.java
@@ -46,7 +46,7 @@ import java.util.Map;
  *
  *  <p>GrpcOpenTelemetry uses {@link io.opentelemetry.api.OpenTelemetry} APIs for instrumentation.
  *  When no SDK is explicitly added no telemetry data will be collected. See
- *  {@link io.opentelemetry.sdk.OpenTelemetrySdk} for information on how to construct the SDK.
+ *  {@code io.opentelemetry.sdk.OpenTelemetrySdk} for information on how to construct the SDK.
  *
  */
 public final class GrpcOpenTelemetry {
@@ -279,7 +279,7 @@ public final class GrpcOpenTelemetry {
     /**
      * Sets the {@link io.opentelemetry.api.OpenTelemetry} entrypoint to use. This can be used to
      * configure OpenTelemetry by returning the instance created by a
-     * {@link io.opentelemetry.sdk.OpenTelemetrySdkBuilder}.
+     * {@code io.opentelemetry.sdk.OpenTelemetrySdkBuilder}.
      */
     public Builder sdk(OpenTelemetry sdk) {
       this.openTelemetrySdk = sdk;


### PR DESCRIPTION
This PR enables publishing for grpc-opentelemetry module.

Backport of #11187.