### PR TITLE
xds, rls: Experimental metrics are disabled by default (v1.64.x backport)

### DIFF
--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -136,25 +136,31 @@ final class CachingRlsLbClient {
     MetricInstrumentRegistry metricInstrumentRegistry
         = MetricInstrumentRegistry.getDefaultRegistry();
     DEFAULT_TARGET_PICKS_COUNTER = metricInstrumentRegistry.registerLongCounter(
-        "grpc.lb.rls.default_target_picks", "Number of LB picks sent to the default target", "pick",
+        "grpc.lb.rls.default_target_picks",
+        "EXPERIMENTAL. Number of LB picks sent to the default target", "{pick}",
         Arrays.asList("grpc.target", "grpc.lb.rls.server_target",
-            "grpc.lb.rls.data_plane_target", "grpc.lb.pick_result"), Collections.emptyList(), true);
+            "grpc.lb.rls.data_plane_target", "grpc.lb.pick_result"), Collections.emptyList(),
+        false);
     TARGET_PICKS_COUNTER = metricInstrumentRegistry.registerLongCounter("grpc.lb.rls.target_picks",
-        "Number of LB picks sent to each RLS target", "pick",
-        Arrays.asList("grpc.target", "grpc.lb.rls.server_target",
-            "grpc.lb.rls.data_plane_target", "grpc.lb.pick_result"), Collections.emptyList(), true);
+        "EXPERIMENTAL. Number of LB picks sent to each RLS target. Note that if the default "
+            + "target is also returned by the RLS server, RPCs sent to that target from the cache "
+            + "will be counted in this metric, not in grpc.rls.default_target_picks.", "{pick}",
+        Arrays.asList("grpc.target", "grpc.lb.rls.server_target", "grpc.lb.rls.data_plane_target",
+            "grpc.lb.pick_result"), Collections.emptyList(),
+        false);
     FAILED_PICKS_COUNTER = metricInstrumentRegistry.registerLongCounter("grpc.lb.rls.failed_picks",
-        "Number of LB picks failed due to either a failed RLS request or the RLS channel being "
-            + "throttled", "pick", Arrays.asList("grpc.target", "grpc.lb.rls.server_target"),
-        Collections.emptyList(), true);
+        "EXPERIMENTAL. Number of LB picks failed due to either a failed RLS request or the "
+            + "RLS channel being throttled", "{pick}",
+        Arrays.asList("grpc.target", "grpc.lb.rls.server_target"),
+        Collections.emptyList(), false);
     CACHE_ENTRIES_GAUGE = metricInstrumentRegistry.registerLongGauge("grpc.lb.rls.cache_entries",
-        "Number of entries in the RLS cache", "entry",
-        Arrays.asList("grpc.target", "grpc.lb.rls.server_target", "grpc.lb.rls.instance_id"),
-        Collections.emptyList(), true);
+        "EXPERIMENTAL. Number of entries in the RLS cache", "{entry}",
+        Arrays.asList("grpc.target", "grpc.lb.rls.server_target", "grpc.lb.rls.instance_uuid"),
+        Collections.emptyList(), false);
     CACHE_SIZE_GAUGE = metricInstrumentRegistry.registerLongGauge("grpc.lb.rls.cache_size",
-        "The current size of the RLS cache", "byte",
-        Arrays.asList("grpc.target", "grpc.lb.rls.server_target", "grpc.lb.rls.instance_id"),
-        Collections.emptyList(), true);
+        "EXPERIMENTAL. The current size of the RLS cache", "By",
+        Arrays.asList("grpc.target", "grpc.lb.rls.server_target", "grpc.lb.rls.instance_uuid"),
+        Collections.emptyList(), false);
   }
 
   private CachingRlsLbClient(Builder builder) {

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -89,24 +89,26 @@ final class WeightedRoundRobinLoadBalancer extends RoundRobinLoadBalancer {
     MetricInstrumentRegistry metricInstrumentRegistry
         = MetricInstrumentRegistry.getDefaultRegistry();
     RR_FALLBACK_COUNTER = metricInstrumentRegistry.registerLongCounter("grpc.lb.wrr.rr_fallback",
-        "Number of scheduler updates in which there were not enough endpoints with valid "
-            + "weight, which caused the WRR policy to fall back to RR behavior", "update",
-        Lists.newArrayList("grpc.target"), Lists.newArrayList("grpc.lb.locality"), true);
+        "EXPERIMENTAL. Number of scheduler updates in which there were not enough endpoints "
+            + "with valid weight, which caused the WRR policy to fall back to RR behavior",
+        "{update}", Lists.newArrayList("grpc.target"), Lists.newArrayList("grpc.lb.locality"),
+        false);
     ENDPOINT_WEIGHT_NOT_YET_USEABLE_COUNTER = metricInstrumentRegistry.registerLongCounter(
-        "grpc.lb.wrr.endpoint_weight_not_yet_usable",
-        "Number of endpoints from each scheduler update that don't yet have usable weight "
-            + "information", "endpoint", Lists.newArrayList("grpc.target"),
-        Lists.newArrayList("grpc.lb.locality"), true);
+        "grpc.lb.wrr.endpoint_weight_not_yet_usable", "EXPERIMENTAL. Number of endpoints "
+            + "from each scheduler update that don't yet have usable weight information",
+        "{endpoint}", Lists.newArrayList("grpc.target"), Lists.newArrayList("grpc.lb.locality"),
+        false);
     ENDPOINT_WEIGHT_STALE_COUNTER = metricInstrumentRegistry.registerLongCounter(
         "grpc.lb.wrr.endpoint_weight_stale",
-        "Number of endpoints from each scheduler update whose latest weight is older than the "
-            + "expiration period", "endpoint", Lists.newArrayList("grpc.target"),
-        Lists.newArrayList("grpc.lb.locality"), true);
+        "EXPERIMENTAL. Number of endpoints from each scheduler update whose latest weight is "
+            + "older than the expiration period", "{endpoint}", Lists.newArrayList("grpc.target"),
+        Lists.newArrayList("grpc.lb.locality"), false);
     ENDPOINT_WEIGHTS_HISTOGRAM = metricInstrumentRegistry.registerDoubleHistogram(
-        "grpc.lb.wrr.endpoint_weights", "The histogram buckets will be endpoint weight ranges.",
-        "weight", Lists.newArrayList(), Lists.newArrayList("grpc.target"),
+        "grpc.lb.wrr.endpoint_weights",
+        "EXPERIMENTAL. The histogram buckets will be endpoint weight ranges.",
+        "{weight}", Lists.newArrayList(), Lists.newArrayList("grpc.target"),
         Lists.newArrayList("grpc.lb.locality"),
-        true);
+        false);
   }
 
   public WeightedRoundRobinLoadBalancer(Helper helper, Ticker ticker) {


### PR DESCRIPTION
This PR 

- Updates WRR and RLS metrics to be experimental and therefore disabled by default.

    From gRFC A78:

    > Metric Stability
    >
    > All metrics added in this proposal will start as experimental and therefore off by default.

- Adds "Experimental." in the beginning of metric description. 
- Updates metric units  to include `{}`, as strings inside `{}` are suffixed to metric name in some [metric conversions](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.33.0/specification/compatibility/prometheus_and_openmetrics.md#metric-metadata).

Backport of #11196
