### PR TITLE
Replace GracefulSwitch.switchTo with normal config passing

### DIFF
--- a/util/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/GracefulSwitchLoadBalancer.java
@@ -20,11 +20,18 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.ExperimentalApi;
 import io.grpc.LoadBalancer;
+import io.grpc.LoadBalancerRegistry;
+import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.Status;
+import io.grpc.internal.ServiceConfigUtil;
+import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -33,9 +40,16 @@ import javax.annotation.concurrent.NotThreadSafe;
  * other than READY, the new policy will be swapped into place immediately.  Otherwise, the channel
  * will keep using the old policy until the new policy reports READY or the old policy exits READY.
  *
- * <p>The balancer must {@link #switchTo(LoadBalancer.Factory) switch to} a policy prior to {@link
+ * <p>The child balancer and configuration is specified using service config. Config objects are
+ * generally created by calling {@link #parseLoadBalancingPolicyConfig(List)} from a
+ * {@link io.grpc.LoadBalancerProvider#parseLoadBalancingPolicyConfig
+ * provider's parseLoadBalancingPolicyConfig()} implementation.
+ *
+ * <p>Alternatively, the balancer may {@link #switchTo(LoadBalancer.Factory) switch to} a policy
+ * prior to {@link
  * LoadBalancer#handleResolvedAddresses(ResolvedAddresses) handling resolved addresses} for the
- * first time.
+ * first time. This causes graceful switch to ignore the service config and pass through the
+ * resolved addresses directly to the child policy.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/5999")
 @NotThreadSafe // Must be accessed in SynchronizationContext
@@ -90,6 +104,7 @@ public final class GracefulSwitchLoadBalancer extends ForwardingLoadBalancer {
   private LoadBalancer pendingLb = defaultBalancer;
   private ConnectivityState pendingState;
   private SubchannelPicker pendingPicker;
+  private boolean switchToCalled;
 
   private boolean currentLbIsReady;
 
@@ -97,11 +112,43 @@ public final class GracefulSwitchLoadBalancer extends ForwardingLoadBalancer {
     this.helper = checkNotNull(helper, "helper");
   }
 
+  @Override
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    if (switchToCalled) {
+      delegate().handleResolvedAddresses(resolvedAddresses);
+      return;
+    }
+    Config config = (Config) resolvedAddresses.getLoadBalancingPolicyConfig();
+    switchToInternal(config.childFactory);
+    delegate().handleResolvedAddresses(
+        resolvedAddresses.toBuilder()
+          .setLoadBalancingPolicyConfig(config.childConfig)
+          .build());
+  }
+
+  @Override
+  public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    if (switchToCalled) {
+      return delegate().acceptResolvedAddresses(resolvedAddresses);
+    }
+    Config config = (Config) resolvedAddresses.getLoadBalancingPolicyConfig();
+    switchToInternal(config.childFactory);
+    return delegate().acceptResolvedAddresses(
+        resolvedAddresses.toBuilder()
+          .setLoadBalancingPolicyConfig(config.childConfig)
+          .build());
+  }
+
   /**
    * Gracefully switch to a new policy defined by the given factory, if the given factory isn't
    * equal to the current one.
    */
   public void switchTo(LoadBalancer.Factory newBalancerFactory) {
+    switchToCalled = true;
+    switchToInternal(newBalancerFactory);
+  }
+
+  private void switchToInternal(LoadBalancer.Factory newBalancerFactory) {
     checkNotNull(newBalancerFactory, "newBalancerFactory");
 
     if (newBalancerFactory.equals(pendingBalancerFactory)) {
@@ -184,5 +231,87 @@ public final class GracefulSwitchLoadBalancer extends ForwardingLoadBalancer {
 
   public String delegateType() {
     return delegate().getClass().getSimpleName();
+  }
+
+  /**
+   * Provided a JSON list of LoadBalancingConfigs, parse it into a config to pass to GracefulSwitch.
+   */
+  public static ConfigOrError parseLoadBalancingPolicyConfig(
+      List<Map<String, ?>> loadBalancingConfigs) {
+    return parseLoadBalancingPolicyConfig(
+        loadBalancingConfigs, LoadBalancerRegistry.getDefaultRegistry());
+  }
+
+  /**
+   * Provided a JSON list of LoadBalancingConfigs, parse it into a config to pass to GracefulSwitch.
+   */
+  public static ConfigOrError parseLoadBalancingPolicyConfig(
+      List<Map<String, ?>> loadBalancingConfigs, LoadBalancerRegistry lbRegistry) {
+    List<ServiceConfigUtil.LbConfig> childConfigCandidates =
+        ServiceConfigUtil.unwrapLoadBalancingConfigList(loadBalancingConfigs);
+    if (childConfigCandidates == null || childConfigCandidates.isEmpty()) {
+      return ConfigOrError.fromError(
+          Status.INTERNAL.withDescription("No child LB config specified"));
+    }
+    ConfigOrError selectedConfig =
+        ServiceConfigUtil.selectLbPolicyFromList(childConfigCandidates, lbRegistry);
+    if (selectedConfig.getError() != null) {
+      Status error = selectedConfig.getError();
+      return ConfigOrError.fromError(
+          Status.INTERNAL
+              .withCause(error.getCause())
+              .withDescription(error.getDescription())
+              .augmentDescription("Failed to select child config"));
+    }
+    ServiceConfigUtil.PolicySelection selection =
+        (ServiceConfigUtil.PolicySelection) selectedConfig.getConfig();
+    return ConfigOrError.fromConfig(
+        createLoadBalancingPolicyConfig(selection.getProvider(), selection.getConfig()));
+  }
+
+  /**
+   * Directly create a config to pass to GracefulSwitch. The object returned is the same as would be
+   * found in {@code ConfigOrError.getConfig()}.
+   */
+  public static Object createLoadBalancingPolicyConfig(
+      LoadBalancer.Factory childFactory, @Nullable Object childConfig) {
+    return new Config(childFactory, childConfig);
+  }
+
+  static final class Config {
+    final LoadBalancer.Factory childFactory;
+    @Nullable
+    final Object childConfig;
+
+    public Config(LoadBalancer.Factory childFactory, @Nullable Object childConfig) {
+      this.childFactory = checkNotNull(childFactory, "childFactory");
+      this.childConfig = childConfig;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Config)) {
+        return false;
+      }
+      Config that = (Config) o;
+      return Objects.equal(childFactory, that.childFactory)
+          && Objects.equal(childConfig, that.childConfig);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(childFactory, childConfig);
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper("GracefulSwitchLoadBalancer.Config")
+          .add("childFactory", childFactory)
+          .add("childConfig", childConfig)
+          .toString();
+    }
   }
 }

--- a/util/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
@@ -39,7 +39,6 @@ import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.SynchronizationContext;
 import io.grpc.SynchronizationContext.ScheduledHandle;
-import io.grpc.internal.ServiceConfigUtil.PolicySelection;
 import io.grpc.internal.TimeProvider;
 import java.net.SocketAddress;
 import java.util.ArrayList;
@@ -140,8 +139,6 @@ public final class OutlierDetectionLoadBalancer extends LoadBalancer {
       addressMap.put(e.getKey(), endpointTrackerMap.get(e.getValue()));
     }
 
-    switchLb.switchTo(config.childPolicy.getProvider());
-
     // If outlier detection is actually configured, start a timer that will periodically try to
     // detect outliers.
     if (config.outlierDetectionEnabled()) {
@@ -175,8 +172,7 @@ public final class OutlierDetectionLoadBalancer extends LoadBalancer {
     }
 
     switchLb.handleResolvedAddresses(
-        resolvedAddresses.toBuilder().setLoadBalancingPolicyConfig(config.childPolicy.getConfig())
-            .build());
+        resolvedAddresses.toBuilder().setLoadBalancingPolicyConfig(config.childConfig).build());
     return Status.OK;
   }
 
@@ -958,7 +954,7 @@ public final class OutlierDetectionLoadBalancer extends LoadBalancer {
     public final Integer maxEjectionPercent;
     public final SuccessRateEjection successRateEjection;
     public final FailurePercentageEjection failurePercentageEjection;
-    public final PolicySelection childPolicy;
+    public final Object childConfig;
 
     private OutlierDetectionLoadBalancerConfig(Long intervalNanos,
         Long baseEjectionTimeNanos,
@@ -966,14 +962,14 @@ public final class OutlierDetectionLoadBalancer extends LoadBalancer {
         Integer maxEjectionPercent,
         SuccessRateEjection successRateEjection,
         FailurePercentageEjection failurePercentageEjection,
-        PolicySelection childPolicy) {
+        Object childConfig) {
       this.intervalNanos = intervalNanos;
       this.baseEjectionTimeNanos = baseEjectionTimeNanos;
       this.maxEjectionTimeNanos = maxEjectionTimeNanos;
       this.maxEjectionPercent = maxEjectionPercent;
       this.successRateEjection = successRateEjection;
       this.failurePercentageEjection = failurePercentageEjection;
-      this.childPolicy = childPolicy;
+      this.childConfig = childConfig;
     }
 
     /** Builds a new {@link OutlierDetectionLoadBalancerConfig}. */
@@ -984,7 +980,7 @@ public final class OutlierDetectionLoadBalancer extends LoadBalancer {
       Integer maxEjectionPercent = 10;
       SuccessRateEjection successRateEjection;
       FailurePercentageEjection failurePercentageEjection;
-      PolicySelection childPolicy;
+      Object childConfig;
 
       /** The interval between outlier detection sweeps. */
       public Builder setIntervalNanos(Long intervalNanos) {
@@ -1028,19 +1024,22 @@ public final class OutlierDetectionLoadBalancer extends LoadBalancer {
         return this;
       }
 
-      /** Sets the child policy the {@link OutlierDetectionLoadBalancer} delegates to. */
-      public Builder setChildPolicy(PolicySelection childPolicy) {
-        checkState(childPolicy != null);
-        this.childPolicy = childPolicy;
+      /**
+       * Sets the graceful child switch config the {@link OutlierDetectionLoadBalancer} delegates
+       * to.
+       */
+      public Builder setChildConfig(Object childConfig) {
+        checkState(childConfig != null);
+        this.childConfig = childConfig;
         return this;
       }
 
       /** Builds a new instance of {@link OutlierDetectionLoadBalancerConfig}. */
       public OutlierDetectionLoadBalancerConfig build() {
-        checkState(childPolicy != null);
+        checkState(childConfig != null);
         return new OutlierDetectionLoadBalancerConfig(intervalNanos, baseEjectionTimeNanos,
             maxEjectionTimeNanos, maxEjectionPercent, successRateEjection,
-            failurePercentageEjection, childPolicy);
+            failurePercentageEjection, childConfig);
       }
     }
 

--- a/util/src/test/java/io/grpc/util/OutlierDetectionLoadBalancerProviderTest.java
+++ b/util/src/test/java/io/grpc/util/OutlierDetectionLoadBalancerProviderTest.java
@@ -89,7 +89,9 @@ public class OutlierDetectionLoadBalancerProviderTest {
         = (OutlierDetectionLoadBalancerConfig) configOrError.getConfig();
     assertThat(config.successRateEjection).isNotNull();
     assertThat(config.failurePercentageEjection).isNotNull();
-    assertThat(config.childPolicy.getProvider().getPolicyName()).isEqualTo("round_robin");
+    assertThat(
+        GracefulSwitchLoadBalancerAccessor.getChildProvider(config.childConfig).getPolicyName())
+        .isEqualTo("round_robin");
   }
 
   @Test
@@ -135,7 +137,9 @@ public class OutlierDetectionLoadBalancerProviderTest {
     assertThat(config.failurePercentageEjection.minimumHosts).isEqualTo(100);
     assertThat(config.failurePercentageEjection.requestVolume).isEqualTo(100);
 
-    assertThat(config.childPolicy.getProvider().getPolicyName()).isEqualTo("round_robin");
+    assertThat(
+        GracefulSwitchLoadBalancerAccessor.getChildProvider(config.childConfig).getPolicyName())
+        .isEqualTo("round_robin");
   }
 
   @SuppressWarnings("unchecked")

--- a/util/src/test/java/io/grpc/util/OutlierDetectionLoadBalancerTest.java
+++ b/util/src/test/java/io/grpc/util/OutlierDetectionLoadBalancerTest.java
@@ -55,7 +55,6 @@ import io.grpc.SynchronizationContext;
 import io.grpc.internal.FakeClock;
 import io.grpc.internal.FakeClock.ScheduledTask;
 import io.grpc.internal.PickFirstLoadBalancerProvider;
-import io.grpc.internal.ServiceConfigUtil.PolicySelection;
 import io.grpc.internal.TestUtils.StandardLoadBalancerProvider;
 import io.grpc.util.OutlierDetectionLoadBalancer.EndpointTracker;
 import io.grpc.util.OutlierDetectionLoadBalancer.OutlierDetectionLoadBalancerConfig;
@@ -245,7 +244,7 @@ public class OutlierDetectionLoadBalancerTest {
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(
         new OutlierDetectionLoadBalancerConfig.Builder()
             .setSuccessRateEjection(new SuccessRateEjection.Builder().build())
-            .setChildPolicy(new PolicySelection(mockChildLbProvider, null)).build(),
+            .setChildConfig(newChildConfig(mockChildLbProvider, null)).build(),
         new EquivalentAddressGroup(mockSocketAddress)));
     loadBalancer.handleNameResolutionError(Status.DEADLINE_EXCEEDED);
 
@@ -260,7 +259,7 @@ public class OutlierDetectionLoadBalancerTest {
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(
         new OutlierDetectionLoadBalancerConfig.Builder()
             .setSuccessRateEjection(new SuccessRateEjection.Builder().build())
-            .setChildPolicy(new PolicySelection(mockChildLbProvider, null)).build(),
+            .setChildConfig(newChildConfig(mockChildLbProvider, null)).build(),
         new EquivalentAddressGroup(mockSocketAddress)));
     loadBalancer.shutdown();
     verify(mockChildLb).shutdown();
@@ -271,9 +270,10 @@ public class OutlierDetectionLoadBalancerTest {
    */
   @Test
   public void acceptResolvedAddresses() {
+    Object childConfig = "theConfig";
     OutlierDetectionLoadBalancerConfig config = new OutlierDetectionLoadBalancerConfig.Builder()
         .setSuccessRateEjection(new SuccessRateEjection.Builder().build())
-        .setChildPolicy(new PolicySelection(mockChildLbProvider, null)).build();
+        .setChildConfig(newChildConfig(mockChildLbProvider, childConfig)).build();
     ResolvedAddresses resolvedAddresses = buildResolvedAddress(config,
         new EquivalentAddressGroup(mockSocketAddress));
 
@@ -281,8 +281,7 @@ public class OutlierDetectionLoadBalancerTest {
 
     // Handling of resolved addresses is delegated
     verify(mockChildLb).handleResolvedAddresses(
-        resolvedAddresses.toBuilder().setLoadBalancingPolicyConfig(config.childPolicy.getConfig())
-            .build());
+        resolvedAddresses.toBuilder().setLoadBalancingPolicyConfig(childConfig).build());
 
     // There is a single pending task to run the outlier detection algorithm
     assertThat(fakeClock.getPendingTasks()).hasSize(1);
@@ -301,7 +300,7 @@ public class OutlierDetectionLoadBalancerTest {
   public void childLbRecreatesSubchannels() {
     OutlierDetectionLoadBalancerConfig config = new OutlierDetectionLoadBalancerConfig.Builder()
         .setSuccessRateEjection(new SuccessRateEjection.Builder().build())
-        .setChildPolicy(new PolicySelection(fakeLbProvider, null)).build();
+        .setChildConfig(newChildConfig(fakeLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers.get(0)));
 
@@ -323,7 +322,7 @@ public class OutlierDetectionLoadBalancerTest {
   public void acceptResolvedAddresses_outlierDetectionDisabled() {
     OutlierDetectionLoadBalancerConfig config = new OutlierDetectionLoadBalancerConfig.Builder()
         .setSuccessRateEjection(new SuccessRateEjection.Builder().build())
-        .setChildPolicy(new PolicySelection(mockChildLbProvider, null)).build();
+        .setChildConfig(newChildConfig(mockChildLbProvider, null)).build();
     ResolvedAddresses resolvedAddresses = buildResolvedAddress(config,
         new EquivalentAddressGroup(mockSocketAddress));
 
@@ -334,8 +333,8 @@ public class OutlierDetectionLoadBalancerTest {
     // There is a single pending task to run the outlier detection algorithm
     assertThat(fakeClock.getPendingTasks()).hasSize(1);
 
-    config = new OutlierDetectionLoadBalancerConfig.Builder().setChildPolicy(
-        new PolicySelection(mockChildLbProvider, null)).build();
+    config = new OutlierDetectionLoadBalancerConfig.Builder().setChildConfig(
+        newChildConfig(mockChildLbProvider, null)).build();
     loadBalancer.acceptResolvedAddresses(
         buildResolvedAddress(config, new EquivalentAddressGroup(mockSocketAddress)));
 
@@ -351,7 +350,7 @@ public class OutlierDetectionLoadBalancerTest {
   public void acceptResolvedAddresses_intervalUpdate() {
     OutlierDetectionLoadBalancerConfig config = new OutlierDetectionLoadBalancerConfig.Builder()
         .setSuccessRateEjection(new SuccessRateEjection.Builder().build())
-        .setChildPolicy(new PolicySelection(mockChildLbProvider, null)).build();
+        .setChildConfig(newChildConfig(mockChildLbProvider, null)).build();
     ResolvedAddresses resolvedAddresses = buildResolvedAddress(config,
         new EquivalentAddressGroup(mockSocketAddress));
 
@@ -361,7 +360,7 @@ public class OutlierDetectionLoadBalancerTest {
     config = new OutlierDetectionLoadBalancerConfig.Builder()
         .setIntervalNanos(config.intervalNanos * 2)
         .setSuccessRateEjection(new SuccessRateEjection.Builder().build())
-        .setChildPolicy(new PolicySelection(mockChildLbProvider, null)).build();
+        .setChildConfig(newChildConfig(mockChildLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(
         buildResolvedAddress(config, new EquivalentAddressGroup(mockSocketAddress)));
@@ -396,7 +395,7 @@ public class OutlierDetectionLoadBalancerTest {
   public void delegatePick() throws Exception {
     OutlierDetectionLoadBalancerConfig config = new OutlierDetectionLoadBalancerConfig.Builder()
         .setSuccessRateEjection(new SuccessRateEjection.Builder().build())
-        .setChildPolicy(new PolicySelection(roundRobinLbProvider, null)).build();
+        .setChildConfig(newChildConfig(roundRobinLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers.get(0)));
 
@@ -424,7 +423,7 @@ public class OutlierDetectionLoadBalancerTest {
   public void delegatePickTracerFactoryPreserved() {
     OutlierDetectionLoadBalancerConfig config = new OutlierDetectionLoadBalancerConfig.Builder()
         .setSuccessRateEjection(new SuccessRateEjection.Builder().build())
-        .setChildPolicy(new PolicySelection(fakeLbProvider, null)).build();
+        .setChildConfig(newChildConfig(fakeLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers.get(0)));
 
@@ -463,7 +462,7 @@ public class OutlierDetectionLoadBalancerTest {
 
     OutlierDetectionLoadBalancerConfig config = new OutlierDetectionLoadBalancerConfig.Builder()
         .setSuccessRateEjection(new SuccessRateEjection.Builder().build())
-        .setChildPolicy(new PolicySelection(fakeLbProvider, null)).build();
+        .setChildConfig(newChildConfig(fakeLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers.get(0)));
 
@@ -496,7 +495,7 @@ public class OutlierDetectionLoadBalancerTest {
         .setMaxEjectionPercent(50)
         .setSuccessRateEjection(
             new SuccessRateEjection.Builder().setMinimumHosts(3).setRequestVolume(10).build())
-        .setChildPolicy(new PolicySelection(roundRobinLbProvider, null)).build();
+        .setChildConfig(newChildConfig(roundRobinLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -520,7 +519,7 @@ public class OutlierDetectionLoadBalancerTest {
             new SuccessRateEjection.Builder()
                 .setMinimumHosts(3)
                 .setRequestVolume(10).build())
-        .setChildPolicy(new PolicySelection(roundRobinLbProvider, null)).build();
+        .setChildConfig(newChildConfig(roundRobinLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -545,7 +544,7 @@ public class OutlierDetectionLoadBalancerTest {
             new SuccessRateEjection.Builder()
                 .setMinimumHosts(3)
                 .setRequestVolume(10).build())
-        .setChildPolicy(new PolicySelection(roundRobinLbProvider, null)).build();
+        .setChildConfig(newChildConfig(roundRobinLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -565,7 +564,7 @@ public class OutlierDetectionLoadBalancerTest {
                 .setMinimumHosts(3)
                 .setRequestVolume(10)
                 .setEnforcementPercentage(0).build())
-        .setChildPolicy(new PolicySelection(roundRobinLbProvider, null)).build();
+        .setChildConfig(newChildConfig(roundRobinLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -592,7 +591,7 @@ public class OutlierDetectionLoadBalancerTest {
             new SuccessRateEjection.Builder()
                 .setMinimumHosts(3)
                 .setRequestVolume(10).build())
-        .setChildPolicy(new PolicySelection(roundRobinLbProvider, null)).build();
+        .setChildConfig(newChildConfig(roundRobinLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -626,7 +625,7 @@ public class OutlierDetectionLoadBalancerTest {
             new SuccessRateEjection.Builder()
                 .setMinimumHosts(3)
                 .setRequestVolume(20).build())
-        .setChildPolicy(new PolicySelection(roundRobinLbProvider, null)).build();
+        .setChildConfig(newChildConfig(roundRobinLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -654,7 +653,7 @@ public class OutlierDetectionLoadBalancerTest {
             new SuccessRateEjection.Builder()
                 .setMinimumHosts(5)
                 .setRequestVolume(20).build())
-        .setChildPolicy(new PolicySelection(roundRobinLbProvider, null)).build();
+        .setChildConfig(newChildConfig(roundRobinLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -684,7 +683,7 @@ public class OutlierDetectionLoadBalancerTest {
                 .setRequestVolume(10)
                 .setEnforcementPercentage(0)
                 .build())
-        .setChildPolicy(new PolicySelection(roundRobinLbProvider, null)).build();
+        .setChildConfig(newChildConfig(roundRobinLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -709,7 +708,7 @@ public class OutlierDetectionLoadBalancerTest {
                 .setMinimumHosts(3)
                 .setRequestVolume(10)
                 .setStdevFactor(1).build())
-        .setChildPolicy(new PolicySelection(roundRobinLbProvider, null)).build();
+        .setChildConfig(newChildConfig(roundRobinLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -738,7 +737,7 @@ public class OutlierDetectionLoadBalancerTest {
                 .setMinimumHosts(3)
                 .setRequestVolume(10)
                 .setStdevFactor(1).build())
-        .setChildPolicy(new PolicySelection(roundRobinLbProvider, null)).build();
+        .setChildConfig(newChildConfig(roundRobinLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -772,7 +771,7 @@ public class OutlierDetectionLoadBalancerTest {
             new FailurePercentageEjection.Builder()
                 .setMinimumHosts(3)
                 .setRequestVolume(10).build())
-        .setChildPolicy(new PolicySelection(roundRobinLbProvider, null)).build();
+        .setChildConfig(newChildConfig(roundRobinLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -797,7 +796,7 @@ public class OutlierDetectionLoadBalancerTest {
             new FailurePercentageEjection.Builder()
                 .setMinimumHosts(3)
                 .setRequestVolume(10).build())
-        .setChildPolicy(new PolicySelection(roundRobinLbProvider, null)).build();
+        .setChildConfig(newChildConfig(roundRobinLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -821,7 +820,7 @@ public class OutlierDetectionLoadBalancerTest {
             new FailurePercentageEjection.Builder()
                 .setMinimumHosts(3)
                 .setRequestVolume(100).build()) // We won't produce this much volume...
-        .setChildPolicy(new PolicySelection(roundRobinLbProvider, null)).build();
+        .setChildConfig(newChildConfig(roundRobinLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -846,7 +845,7 @@ public class OutlierDetectionLoadBalancerTest {
             new FailurePercentageEjection.Builder()
                 .setMinimumHosts(5)
                 .setRequestVolume(20).build())
-        .setChildPolicy(new PolicySelection(roundRobinLbProvider, null)).build();
+        .setChildConfig(newChildConfig(roundRobinLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -876,7 +875,7 @@ public class OutlierDetectionLoadBalancerTest {
                 .setRequestVolume(10)
                 .setEnforcementPercentage(0)
                 .build())
-        .setChildPolicy(new PolicySelection(roundRobinLbProvider, null)).build();
+        .setChildConfig(newChildConfig(roundRobinLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -905,7 +904,7 @@ public class OutlierDetectionLoadBalancerTest {
                 .setMinimumHosts(3)
                 .setRequestVolume(1)
                 .build())
-        .setChildPolicy(new PolicySelection(roundRobinLbProvider, null)).build();
+        .setChildConfig(newChildConfig(roundRobinLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -942,7 +941,7 @@ public class OutlierDetectionLoadBalancerTest {
             new FailurePercentageEjection.Builder()
                 .setMinimumHosts(3)
                 .setRequestVolume(10).build())
-        .setChildPolicy(new PolicySelection(roundRobinLbProvider, null)).build();
+        .setChildConfig(newChildConfig(roundRobinLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -986,7 +985,7 @@ public class OutlierDetectionLoadBalancerTest {
             new FailurePercentageEjection.Builder()
                 .setMinimumHosts(3)
                 .setRequestVolume(10).build())
-        .setChildPolicy(new PolicySelection(fakeLbProvider, null)).build();
+        .setChildConfig(newChildConfig(fakeLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
     EquivalentAddressGroup manyAddEndpoint = new EquivalentAddressGroup(Arrays.asList(
@@ -1029,7 +1028,7 @@ public class OutlierDetectionLoadBalancerTest {
             new FailurePercentageEjection.Builder()
                 .setMinimumHosts(3)
                 .setRequestVolume(10).build())
-        .setChildPolicy(new PolicySelection(roundRobinLbProvider, null)).build();
+        .setChildConfig(newChildConfig(roundRobinLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -1073,7 +1072,7 @@ public class OutlierDetectionLoadBalancerTest {
             new FailurePercentageEjection.Builder()
                 .setMinimumHosts(3)
                 .setRequestVolume(10).build())
-        .setChildPolicy(new PolicySelection(fakeLbProvider, null)).build();
+        .setChildConfig(newChildConfig(fakeLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -1136,7 +1135,7 @@ public class OutlierDetectionLoadBalancerTest {
             new FailurePercentageEjection.Builder()
                 .setMinimumHosts(3)
                 .setRequestVolume(10).build())
-        .setChildPolicy(new PolicySelection(roundRobinLbProvider, null)).build();
+        .setChildConfig(newChildConfig(roundRobinLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -1163,7 +1162,7 @@ public class OutlierDetectionLoadBalancerTest {
                 .setMinimumHosts(3)
                 .setRequestVolume(10)
                 .setEnforcementPercentage(0).build()) // Configured, but not enforcing.
-        .setChildPolicy(new PolicySelection(roundRobinLbProvider, null)).build();
+        .setChildConfig(newChildConfig(roundRobinLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -1192,7 +1191,7 @@ public class OutlierDetectionLoadBalancerTest {
                 .setMinimumHosts(3)
                 .setRequestVolume(10)
                 .setEnforcementPercentage(0).build()) // Configured, but not enforcing.
-        .setChildPolicy(new PolicySelection(fakeLbProvider, null)).build();
+        .setChildConfig(newChildConfig(fakeLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -1236,7 +1235,7 @@ public class OutlierDetectionLoadBalancerTest {
             new FailurePercentageEjection.Builder()
                 .setMinimumHosts(3)
                 .setRequestVolume(10).build()) // Configured, but not enforcing.
-        .setChildPolicy(new PolicySelection(roundRobinLbProvider, null)).build();
+        .setChildConfig(newChildConfig(roundRobinLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -1265,7 +1264,7 @@ public class OutlierDetectionLoadBalancerTest {
             new FailurePercentageEjection.Builder()
                 .setMinimumHosts(3)
                 .setRequestVolume(10).build()) // Configured, but not enforcing.
-        .setChildPolicy(new PolicySelection(fakeLbProvider, null)).build();
+        .setChildConfig(newChildConfig(fakeLbProvider, null)).build();
 
     loadBalancer.acceptResolvedAddresses(buildResolvedAddress(config, servers));
 
@@ -1387,6 +1386,10 @@ public class OutlierDetectionLoadBalancerTest {
           .that(entry.getValue().subchannelsEjected())
           .isEqualTo(addresses.contains(entry.getKey()));
     }
+  }
+
+  private Object newChildConfig(LoadBalancerProvider provider, Object config) {
+    return GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(provider, config);
   }
 
   /** Round robin like fake load balancer. */

--- a/util/src/testFixtures/java/io/grpc/util/GracefulSwitchLoadBalancerAccessor.java
+++ b/util/src/testFixtures/java/io/grpc/util/GracefulSwitchLoadBalancerAccessor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.util;
+
+import io.grpc.LoadBalancerProvider;
+
+/**
+ * Accessors for white-box testing involving GracefulSwitchLoadBalancer.
+ */
+public final class GracefulSwitchLoadBalancerAccessor {
+  private GracefulSwitchLoadBalancerAccessor() {
+    // Do not instantiate
+  }
+
+  public static LoadBalancerProvider getChildProvider(Object config) {
+    return (LoadBalancerProvider) ((GracefulSwitchLoadBalancer.Config) config).childFactory;
+  }
+
+  public static Object getChildConfig(Object config) {
+    return ((GracefulSwitchLoadBalancer.Config) config).childConfig;
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -145,11 +145,10 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
     childLbHelper.updateSslContextProviderSupplier(config.tlsContext);
     childLbHelper.updateFilterMetadata(config.filterMetadata);
 
-    childSwitchLb.switchTo(config.childPolicy.getProvider());
     childSwitchLb.handleResolvedAddresses(
         resolvedAddresses.toBuilder()
             .setAttributes(attributes)
-            .setLoadBalancingPolicyConfig(config.childPolicy.getConfig())
+            .setLoadBalancingPolicyConfig(config.childConfig)
             .build());
     return Status.OK;
   }

--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancerProvider.java
@@ -29,7 +29,6 @@ import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.Status;
-import io.grpc.internal.ServiceConfigUtil.PolicySelection;
 import io.grpc.xds.Endpoints.DropOverload;
 import io.grpc.xds.EnvoyServerProtoData.UpstreamTlsContext;
 import io.grpc.xds.client.Bootstrapper.ServerInfo;
@@ -97,12 +96,12 @@ public final class ClusterImplLoadBalancerProvider extends LoadBalancerProvider 
     // Drop configurations.
     final List<DropOverload> dropCategories;
     // Provides the direct child policy and its config.
-    final PolicySelection childPolicy;
+    final Object childConfig;
     final Map<String, Struct> filterMetadata;
 
     ClusterImplConfig(String cluster, @Nullable String edsServiceName,
         @Nullable ServerInfo lrsServerInfo, @Nullable Long maxConcurrentRequests,
-        List<DropOverload> dropCategories, PolicySelection childPolicy,
+        List<DropOverload> dropCategories, Object childConfig,
         @Nullable UpstreamTlsContext tlsContext, Map<String, Struct> filterMetadata) {
       this.cluster = checkNotNull(cluster, "cluster");
       this.edsServiceName = edsServiceName;
@@ -112,7 +111,7 @@ public final class ClusterImplLoadBalancerProvider extends LoadBalancerProvider 
       this.filterMetadata = ImmutableMap.copyOf(filterMetadata);
       this.dropCategories = Collections.unmodifiableList(
           new ArrayList<>(checkNotNull(dropCategories, "dropCategories")));
-      this.childPolicy = checkNotNull(childPolicy, "childPolicy");
+      this.childConfig = checkNotNull(childConfig, "childConfig");
     }
 
     @Override
@@ -124,7 +123,7 @@ public final class ClusterImplLoadBalancerProvider extends LoadBalancerProvider 
           .add("maxConcurrentRequests", maxConcurrentRequests)
           // Exclude tlsContext as its string representation is cumbersome.
           .add("dropCategories", dropCategories)
-          .add("childPolicy", childPolicy)
+          .add("childConfig", childConfig)
           .toString();
     }
   }

--- a/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
@@ -778,7 +778,8 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
     OutlierDetectionLoadBalancerConfig.Builder configBuilder
         = new OutlierDetectionLoadBalancerConfig.Builder();
 
-    configBuilder.setChildPolicy(childPolicy);
+    configBuilder.setChildConfig(GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(
+        childPolicy.getProvider(), childPolicy.getConfig()));
 
     if (outlierDetection.intervalNanos() != null) {
       configBuilder.setIntervalNanos(outlierDetection.intervalNanos());

--- a/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancerProvider.java
@@ -27,7 +27,6 @@ import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.Status;
-import io.grpc.internal.ServiceConfigUtil.PolicySelection;
 import io.grpc.xds.EnvoyServerProtoData.OutlierDetection;
 import io.grpc.xds.EnvoyServerProtoData.UpstreamTlsContext;
 import io.grpc.xds.client.Bootstrapper.ServerInfo;
@@ -73,18 +72,17 @@ public final class ClusterResolverLoadBalancerProvider extends LoadBalancerProvi
   static final class ClusterResolverConfig {
     // Ordered list of clusters to be resolved.
     final List<DiscoveryMechanism> discoveryMechanisms;
-    // Endpoint-level load balancing policy with config
-    // (round_robin, least_request_experimental or ring_hash_experimental).
-    final PolicySelection lbPolicy;
+    // GracefulSwitch configuration
+    final Object lbConfig;
 
-    ClusterResolverConfig(List<DiscoveryMechanism> discoveryMechanisms, PolicySelection lbPolicy) {
+    ClusterResolverConfig(List<DiscoveryMechanism> discoveryMechanisms, Object lbConfig) {
       this.discoveryMechanisms = checkNotNull(discoveryMechanisms, "discoveryMechanisms");
-      this.lbPolicy = checkNotNull(lbPolicy, "lbPolicy");
+      this.lbConfig = checkNotNull(lbConfig, "lbConfig");
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(discoveryMechanisms, lbPolicy);
+      return Objects.hash(discoveryMechanisms, lbConfig);
     }
 
     @Override
@@ -97,14 +95,14 @@ public final class ClusterResolverLoadBalancerProvider extends LoadBalancerProvi
       }
       ClusterResolverConfig that = (ClusterResolverConfig) o;
       return discoveryMechanisms.equals(that.discoveryMechanisms)
-          && lbPolicy.equals(that.lbPolicy);
+          && lbConfig.equals(that.lbConfig);
     }
 
     @Override
     public String toString() {
       return MoreObjects.toStringHelper(this)
           .add("discoveryMechanisms", discoveryMechanisms)
-          .add("lbPolicy", lbPolicy)
+          .add("lbConfig", lbConfig)
           .toString();
     }
 

--- a/xds/src/main/java/io/grpc/xds/PriorityLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/PriorityLoadBalancer.java
@@ -25,11 +25,9 @@ import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 import io.grpc.ConnectivityState;
 import io.grpc.InternalLogId;
 import io.grpc.LoadBalancer;
-import io.grpc.LoadBalancerProvider;
 import io.grpc.Status;
 import io.grpc.SynchronizationContext;
 import io.grpc.SynchronizationContext.ScheduledHandle;
-import io.grpc.internal.ServiceConfigUtil.PolicySelection;
 import io.grpc.util.ForwardingLoadBalancerHelper;
 import io.grpc.util.GracefulSwitchLoadBalancer;
 import io.grpc.xds.PriorityLoadBalancerProvider.PriorityLbConfig;
@@ -208,7 +206,6 @@ final class PriorityLoadBalancer extends LoadBalancer {
     // Timer to delay shutdown and deletion of the priority. Scheduled whenever the child is
     // deactivated.
     @Nullable ScheduledHandle deletionTimer;
-    @Nullable String policy;
     ConnectivityState connectivityState = CONNECTING;
     SubchannelPicker picker = new FixedResultPicker(PickResult.withNoResult());
 
@@ -285,17 +282,10 @@ final class PriorityLoadBalancer extends LoadBalancer {
     void updateResolvedAddresses() {
       PriorityLbConfig config =
           (PriorityLbConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
-      PolicySelection childPolicySelection = config.childConfigs.get(priority).policySelection;
-      LoadBalancerProvider lbProvider = childPolicySelection.getProvider();
-      String newPolicy = lbProvider.getPolicyName();
-      if (!newPolicy.equals(policy)) {
-        policy = newPolicy;
-        lb.switchTo(lbProvider);
-      }
       lb.handleResolvedAddresses(
           resolvedAddresses.toBuilder()
               .setAddresses(AddressFilter.filter(resolvedAddresses.getAddresses(), priority))
-              .setLoadBalancingPolicyConfig(childPolicySelection.getConfig())
+              .setLoadBalancingPolicyConfig(config.childConfigs.get(priority).childConfig)
               .build());
     }
 

--- a/xds/src/main/java/io/grpc/xds/PriorityLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/PriorityLoadBalancerProvider.java
@@ -26,7 +26,6 @@ import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.Status;
-import io.grpc.internal.ServiceConfigUtil.PolicySelection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -90,18 +89,18 @@ public final class PriorityLoadBalancerProvider extends LoadBalancerProvider {
     }
 
     static final class PriorityChildConfig {
-      final PolicySelection policySelection;
+      final Object childConfig;
       final boolean ignoreReresolution;
 
-      PriorityChildConfig(PolicySelection policySelection, boolean ignoreReresolution) {
-        this.policySelection = checkNotNull(policySelection, "policySelection");
+      PriorityChildConfig(Object childConfig, boolean ignoreReresolution) {
+        this.childConfig = checkNotNull(childConfig, "childConfig");
         this.ignoreReresolution = ignoreReresolution;
       }
 
       @Override
       public String toString() {
         return MoreObjects.toStringHelper(this)
-            .add("policySelection", policySelection)
+            .add("childConfig", childConfig)
             .add("ignoreReresolution", ignoreReresolution)
             .toString();
       }

--- a/xds/src/main/java/io/grpc/xds/WeightedTargetLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedTargetLoadBalancer.java
@@ -79,17 +79,11 @@ final class WeightedTargetLoadBalancer extends LoadBalancer {
     WeightedTargetConfig weightedTargetConfig = (WeightedTargetConfig) lbConfig;
     Map<String, WeightedPolicySelection> newTargets = weightedTargetConfig.targets;
     for (String targetName : newTargets.keySet()) {
-      WeightedPolicySelection weightedChildLbConfig = newTargets.get(targetName);
       if (!targets.containsKey(targetName)) {
         ChildHelper childHelper = new ChildHelper(targetName);
         GracefulSwitchLoadBalancer childBalancer = new GracefulSwitchLoadBalancer(childHelper);
-        childBalancer.switchTo(weightedChildLbConfig.policySelection.getProvider());
         childHelpers.put(targetName, childHelper);
         childBalancers.put(targetName, childBalancer);
-      } else if (!weightedChildLbConfig.policySelection.getProvider().equals(
-          targets.get(targetName).policySelection.getProvider())) {
-        childBalancers.get(targetName)
-            .switchTo(weightedChildLbConfig.policySelection.getProvider());
       }
     }
     targets = newTargets;
@@ -97,7 +91,7 @@ final class WeightedTargetLoadBalancer extends LoadBalancer {
       childBalancers.get(targetName).handleResolvedAddresses(
           resolvedAddresses.toBuilder()
               .setAddresses(AddressFilter.filter(resolvedAddresses.getAddresses(), targetName))
-              .setLoadBalancingPolicyConfig(targets.get(targetName).policySelection.getConfig())
+              .setLoadBalancingPolicyConfig(targets.get(targetName).childConfig)
               .setAttributes(resolvedAddresses.getAttributes().toBuilder()
                 .set(CHILD_NAME, targetName)
                 .build())

--- a/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
@@ -49,7 +49,6 @@ import io.grpc.SynchronizationContext;
 import io.grpc.internal.FakeClock;
 import io.grpc.internal.ObjectPool;
 import io.grpc.internal.PickSubchannelArgsImpl;
-import io.grpc.internal.ServiceConfigUtil.PolicySelection;
 import io.grpc.protobuf.ProtoUtils;
 import io.grpc.testing.TestMethodDescriptors;
 import io.grpc.util.GracefulSwitchLoadBalancer;
@@ -178,8 +177,9 @@ public class ClusterImplLoadBalancerTest {
     Object weightedTargetConfig = new Object();
     ClusterImplConfig config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         null, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
-        Collections.emptyMap());
+        GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(
+            weightedTargetProvider, weightedTargetConfig),
+        null, Collections.emptyMap());
     EquivalentAddressGroup endpoint = makeAddress("endpoint-addr", locality);
     deliverAddressesAndConfig(Collections.singletonList(endpoint), config);
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(downstreamBalancers);
@@ -204,8 +204,9 @@ public class ClusterImplLoadBalancerTest {
     ClusterImplConfig configWithWeightedTarget = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME,
         LRS_SERVER_INFO,
         null, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
-        Collections.emptyMap());
+        GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(
+            weightedTargetProvider, weightedTargetConfig),
+        null, Collections.emptyMap());
     EquivalentAddressGroup endpoint = makeAddress("endpoint-addr", locality);
     deliverAddressesAndConfig(Collections.singletonList(endpoint), configWithWeightedTarget);
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(downstreamBalancers);
@@ -218,8 +219,9 @@ public class ClusterImplLoadBalancerTest {
     ClusterImplConfig configWithWrrLocality = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME,
         LRS_SERVER_INFO,
         null, Collections.<DropOverload>emptyList(),
-        new PolicySelection(wrrLocalityProvider, wrrLocalityConfig), null,
-        Collections.emptyMap());
+        GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(
+            wrrLocalityProvider, wrrLocalityConfig),
+        null, Collections.emptyMap());
     deliverAddressesAndConfig(Collections.singletonList(endpoint), configWithWrrLocality);
     childBalancer = Iterables.getOnlyElement(downstreamBalancers);
     assertThat(childBalancer.name).isEqualTo(XdsLbPolicies.WRR_LOCALITY_POLICY_NAME);
@@ -243,8 +245,9 @@ public class ClusterImplLoadBalancerTest {
     Object weightedTargetConfig = new Object();
     ClusterImplConfig config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         null, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
-        Collections.emptyMap());
+        GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(
+            weightedTargetProvider, weightedTargetConfig),
+        null, Collections.emptyMap());
     EquivalentAddressGroup endpoint = makeAddress("endpoint-addr", locality);
     deliverAddressesAndConfig(Collections.singletonList(endpoint), config);
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(downstreamBalancers);
@@ -263,8 +266,9 @@ public class ClusterImplLoadBalancerTest {
         buildWeightedTargetConfig(ImmutableMap.of(locality, 10));
     ClusterImplConfig config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         null, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
-        Collections.emptyMap());
+        GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(
+            weightedTargetProvider, weightedTargetConfig),
+        null, Collections.emptyMap());
     EquivalentAddressGroup endpoint = makeAddress("endpoint-addr", locality);
     deliverAddressesAndConfig(Collections.singletonList(endpoint), config);
     FakeLoadBalancer leafBalancer = Iterables.getOnlyElement(downstreamBalancers);
@@ -290,8 +294,9 @@ public class ClusterImplLoadBalancerTest {
         buildWeightedTargetConfig(ImmutableMap.of(locality, 10));
     ClusterImplConfig config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         null, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
-        Collections.emptyMap());
+        GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(
+            weightedTargetProvider, weightedTargetConfig),
+        null, Collections.emptyMap());
     EquivalentAddressGroup endpoint = makeAddress("endpoint-addr", locality);
     deliverAddressesAndConfig(Collections.singletonList(endpoint), config);
     FakeLoadBalancer leafBalancer = Iterables.getOnlyElement(downstreamBalancers);
@@ -375,8 +380,9 @@ public class ClusterImplLoadBalancerTest {
         buildWeightedTargetConfig(ImmutableMap.of(locality, 10));
     ClusterImplConfig config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         null, Collections.singletonList(DropOverload.create("throttle", 500_000)),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
-        Collections.emptyMap());
+        GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(
+            weightedTargetProvider, weightedTargetConfig),
+        null, Collections.emptyMap());
     EquivalentAddressGroup endpoint = makeAddress("endpoint-addr", locality);
     deliverAddressesAndConfig(Collections.singletonList(endpoint), config);
     when(mockRandom.nextInt(anyInt())).thenReturn(499_999, 999_999, 1_000_000);
@@ -405,8 +411,9 @@ public class ClusterImplLoadBalancerTest {
     //  Config update updates drop policies.
     config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO, null,
         Collections.singletonList(DropOverload.create("lb", 1_000_000)),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
-        Collections.emptyMap());
+        GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(
+            weightedTargetProvider, weightedTargetConfig),
+        null, Collections.emptyMap());
     loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(Collections.singletonList(endpoint))
@@ -453,8 +460,9 @@ public class ClusterImplLoadBalancerTest {
         buildWeightedTargetConfig(ImmutableMap.of(locality, 10));
     ClusterImplConfig config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         maxConcurrentRequests, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
-        Collections.emptyMap());
+        GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(
+            weightedTargetProvider, weightedTargetConfig),
+        null, Collections.emptyMap());
     EquivalentAddressGroup endpoint = makeAddress("endpoint-addr", locality);
     deliverAddressesAndConfig(Collections.singletonList(endpoint), config);
     assertThat(downstreamBalancers).hasSize(1);  // one leaf balancer
@@ -496,8 +504,9 @@ public class ClusterImplLoadBalancerTest {
     maxConcurrentRequests = 101L;
     config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         maxConcurrentRequests, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
-        Collections.emptyMap());
+        GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(
+            weightedTargetProvider, weightedTargetConfig),
+        null, Collections.emptyMap());
     deliverAddressesAndConfig(Collections.singletonList(endpoint), config);
 
     result = currentPicker.pickSubchannel(pickSubchannelArgs);
@@ -543,8 +552,9 @@ public class ClusterImplLoadBalancerTest {
         buildWeightedTargetConfig(ImmutableMap.of(locality, 10));
     ClusterImplConfig config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         null, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
-        Collections.emptyMap());
+        GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(
+            weightedTargetProvider, weightedTargetConfig),
+        null, Collections.emptyMap());
     EquivalentAddressGroup endpoint = makeAddress("endpoint-addr", locality);
     deliverAddressesAndConfig(Collections.singletonList(endpoint), config);
     assertThat(downstreamBalancers).hasSize(1);  // one leaf balancer
@@ -590,8 +600,9 @@ public class ClusterImplLoadBalancerTest {
         buildWeightedTargetConfig(ImmutableMap.of(locality, 10));
     ClusterImplConfig config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         null, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
-        Collections.emptyMap());
+        GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(
+            weightedTargetProvider, weightedTargetConfig),
+        null, Collections.emptyMap());
     // One locality with two endpoints.
     EquivalentAddressGroup endpoint1 = makeAddress("endpoint-addr1", locality);
     EquivalentAddressGroup endpoint2 = makeAddress("endpoint-addr2", locality);
@@ -628,8 +639,9 @@ public class ClusterImplLoadBalancerTest {
         buildWeightedTargetConfig(ImmutableMap.of(locality, 10));
     ClusterImplConfig config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         null, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), upstreamTlsContext,
-        Collections.emptyMap());
+        GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(
+            weightedTargetProvider, weightedTargetConfig),
+        upstreamTlsContext, Collections.emptyMap());
     // One locality with two endpoints.
     EquivalentAddressGroup endpoint1 = makeAddress("endpoint-addr1", locality);
     EquivalentAddressGroup endpoint2 = makeAddress("endpoint-addr2", locality);
@@ -652,8 +664,9 @@ public class ClusterImplLoadBalancerTest {
     // Removes UpstreamTlsContext from the config.
     config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         null, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
-        Collections.emptyMap());
+        GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(
+            weightedTargetProvider, weightedTargetConfig),
+        null, Collections.emptyMap());
     deliverAddressesAndConfig(Arrays.asList(endpoint1, endpoint2), config);
     assertThat(Iterables.getOnlyElement(downstreamBalancers)).isSameInstanceAs(leafBalancer);
     subchannel = leafBalancer.helper.createSubchannel(args);  // creates new connections
@@ -667,8 +680,9 @@ public class ClusterImplLoadBalancerTest {
         CommonTlsContextTestsUtil.buildUpstreamTlsContext("google_cloud_private_spiffe1", true);
     config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         null, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), upstreamTlsContext,
-        Collections.emptyMap());
+        GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(
+            weightedTargetProvider, weightedTargetConfig),
+        upstreamTlsContext, Collections.emptyMap());
     deliverAddressesAndConfig(Arrays.asList(endpoint1, endpoint2), config);
     assertThat(Iterables.getOnlyElement(downstreamBalancers)).isSameInstanceAs(leafBalancer);
     subchannel = leafBalancer.helper.createSubchannel(args);  // creates new connections

--- a/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
@@ -52,6 +52,7 @@ import io.grpc.internal.PickSubchannelArgsImpl;
 import io.grpc.internal.ServiceConfigUtil.PolicySelection;
 import io.grpc.protobuf.ProtoUtils;
 import io.grpc.testing.TestMethodDescriptors;
+import io.grpc.util.GracefulSwitchLoadBalancer;
 import io.grpc.xds.ClusterImplLoadBalancerProvider.ClusterImplConfig;
 import io.grpc.xds.Endpoints.DropOverload;
 import io.grpc.xds.EnvoyServerProtoData.DownstreamTlsContext;
@@ -119,8 +120,8 @@ public class ClusterImplLoadBalancerTest {
   private final FakeClock fakeClock = new FakeClock();
   private final Locality locality =
       Locality.create("test-region", "test-zone", "test-subzone");
-  private final PolicySelection roundRobin =
-      new PolicySelection(new FakeLoadBalancerProvider("round_robin"), null);
+  private final Object roundRobin = GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(
+      new FakeLoadBalancerProvider("round_robin"), null);
   private final List<FakeLoadBalancer> downstreamBalancers = new ArrayList<>();
   private final FakeTlsContextManager tlsContextManager = new FakeTlsContextManager();
   private final LoadStatsManager2 loadStatsManager =

--- a/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
@@ -286,10 +286,11 @@ public class ClusterResolverLoadBalancerTest {
     PriorityChildConfig priorityChildConfig =
         Iterables.getOnlyElement(priorityLbConfig.childConfigs.values());
     assertThat(priorityChildConfig.ignoreReresolution).isTrue();
-    assertThat(priorityChildConfig.policySelection.getProvider().getPolicyName())
+    assertThat(GracefulSwitchLoadBalancerAccessor.getChildProvider(priorityChildConfig.childConfig)
+          .getPolicyName())
         .isEqualTo(CLUSTER_IMPL_POLICY_NAME);
-    ClusterImplConfig clusterImplConfig =
-        (ClusterImplConfig) priorityChildConfig.policySelection.getConfig();
+    ClusterImplConfig clusterImplConfig = (ClusterImplConfig)
+        GracefulSwitchLoadBalancerAccessor.getChildConfig(priorityChildConfig.childConfig);
     assertClusterImplConfig(clusterImplConfig, CLUSTER1, EDS_SERVICE_NAME1, LRS_SERVER_INFO, 100L,
         tlsContext, Collections.<DropOverload>emptyList(), "ring_hash_experimental");
     RingHashConfig ringHashConfig = (RingHashConfig)
@@ -326,10 +327,11 @@ public class ClusterResolverLoadBalancerTest {
     assertThat(priorityLbConfig.priorities).containsExactly(CLUSTER1 + "[child1]");
     PriorityChildConfig priorityChildConfig =
         Iterables.getOnlyElement(priorityLbConfig.childConfigs.values());
-    assertThat(priorityChildConfig.policySelection.getProvider().getPolicyName())
+    assertThat(GracefulSwitchLoadBalancerAccessor.getChildProvider(priorityChildConfig.childConfig)
+          .getPolicyName())
         .isEqualTo(CLUSTER_IMPL_POLICY_NAME);
-    ClusterImplConfig clusterImplConfig =
-        (ClusterImplConfig) priorityChildConfig.policySelection.getConfig();
+    ClusterImplConfig clusterImplConfig = (ClusterImplConfig)
+        GracefulSwitchLoadBalancerAccessor.getChildConfig(priorityChildConfig.childConfig);
     assertClusterImplConfig(clusterImplConfig, CLUSTER1, EDS_SERVICE_NAME1, LRS_SERVER_INFO, 100L,
         tlsContext, Collections.<DropOverload>emptyList(), WRR_LOCALITY_POLICY_NAME);
     WrrLocalityConfig wrrLocalityConfig = (WrrLocalityConfig)
@@ -373,10 +375,11 @@ public class ClusterResolverLoadBalancerTest {
         Iterables.getOnlyElement(priorityLbConfig.childConfigs.values());
 
     // The child config for priority should be outlier detection.
-    assertThat(priorityChildConfig.policySelection.getProvider().getPolicyName())
+    assertThat(GracefulSwitchLoadBalancerAccessor.getChildProvider(priorityChildConfig.childConfig)
+          .getPolicyName())
         .isEqualTo("outlier_detection_experimental");
-    OutlierDetectionLoadBalancerConfig outlierDetectionConfig =
-        (OutlierDetectionLoadBalancerConfig) priorityChildConfig.policySelection.getConfig();
+    OutlierDetectionLoadBalancerConfig outlierDetectionConfig = (OutlierDetectionLoadBalancerConfig)
+        GracefulSwitchLoadBalancerAccessor.getChildConfig(priorityChildConfig.childConfig);
 
     // The outlier detection config should faithfully represent what came down from xDS.
     assertThat(outlierDetectionConfig.intervalNanos).isEqualTo(outlierDetection.intervalNanos());
@@ -480,10 +483,11 @@ public class ClusterResolverLoadBalancerTest {
 
     PriorityChildConfig priorityChildConfig1 = priorityLbConfig.childConfigs.get(priority1);
     assertThat(priorityChildConfig1.ignoreReresolution).isTrue();
-    assertThat(priorityChildConfig1.policySelection.getProvider().getPolicyName())
+    assertThat(GracefulSwitchLoadBalancerAccessor.getChildProvider(priorityChildConfig1.childConfig)
+          .getPolicyName())
         .isEqualTo(CLUSTER_IMPL_POLICY_NAME);
-    ClusterImplConfig clusterImplConfig1 =
-        (ClusterImplConfig) priorityChildConfig1.policySelection.getConfig();
+    ClusterImplConfig clusterImplConfig1 = (ClusterImplConfig)
+        GracefulSwitchLoadBalancerAccessor.getChildConfig(priorityChildConfig1.childConfig);
     assertClusterImplConfig(clusterImplConfig1, CLUSTER2, EDS_SERVICE_NAME2, LRS_SERVER_INFO, 200L,
         tlsContext, Collections.<DropOverload>emptyList(), WRR_LOCALITY_POLICY_NAME);
     WrrLocalityConfig wrrLocalityConfig1 = (WrrLocalityConfig)
@@ -494,10 +498,11 @@ public class ClusterResolverLoadBalancerTest {
 
     PriorityChildConfig priorityChildConfig2 = priorityLbConfig.childConfigs.get(priority2);
     assertThat(priorityChildConfig2.ignoreReresolution).isTrue();
-    assertThat(priorityChildConfig2.policySelection.getProvider().getPolicyName())
+    assertThat(GracefulSwitchLoadBalancerAccessor.getChildProvider(priorityChildConfig2.childConfig)
+          .getPolicyName())
         .isEqualTo(CLUSTER_IMPL_POLICY_NAME);
-    ClusterImplConfig clusterImplConfig2 =
-        (ClusterImplConfig) priorityChildConfig2.policySelection.getConfig();
+    ClusterImplConfig clusterImplConfig2 = (ClusterImplConfig)
+        GracefulSwitchLoadBalancerAccessor.getChildConfig(priorityChildConfig2.childConfig);
     assertClusterImplConfig(clusterImplConfig2, CLUSTER2, EDS_SERVICE_NAME2, LRS_SERVER_INFO, 200L,
         tlsContext, Collections.<DropOverload>emptyList(), WRR_LOCALITY_POLICY_NAME);
     WrrLocalityConfig wrrLocalityConfig2 = (WrrLocalityConfig)
@@ -508,10 +513,11 @@ public class ClusterResolverLoadBalancerTest {
 
     PriorityChildConfig priorityChildConfig3 = priorityLbConfig.childConfigs.get(priority3);
     assertThat(priorityChildConfig3.ignoreReresolution).isTrue();
-    assertThat(priorityChildConfig3.policySelection.getProvider().getPolicyName())
+    assertThat(GracefulSwitchLoadBalancerAccessor.getChildProvider(priorityChildConfig3.childConfig)
+          .getPolicyName())
         .isEqualTo(CLUSTER_IMPL_POLICY_NAME);
-    ClusterImplConfig clusterImplConfig3 =
-        (ClusterImplConfig) priorityChildConfig3.policySelection.getConfig();
+    ClusterImplConfig clusterImplConfig3 = (ClusterImplConfig)
+        GracefulSwitchLoadBalancerAccessor.getChildConfig(priorityChildConfig3.childConfig);
     assertClusterImplConfig(clusterImplConfig3, CLUSTER1, EDS_SERVICE_NAME1, LRS_SERVER_INFO, 100L,
         tlsContext, Collections.<DropOverload>emptyList(), WRR_LOCALITY_POLICY_NAME);
     WrrLocalityConfig wrrLocalityConfig3 = (WrrLocalityConfig)
@@ -779,10 +785,11 @@ public class ClusterResolverLoadBalancerTest {
     String priority = Iterables.getOnlyElement(priorityLbConfig.priorities);
     PriorityChildConfig priorityChildConfig = priorityLbConfig.childConfigs.get(priority);
     assertThat(priorityChildConfig.ignoreReresolution).isFalse();
-    assertThat(priorityChildConfig.policySelection.getProvider().getPolicyName())
+    assertThat(GracefulSwitchLoadBalancerAccessor.getChildProvider(priorityChildConfig.childConfig)
+          .getPolicyName())
         .isEqualTo(CLUSTER_IMPL_POLICY_NAME);
-    ClusterImplConfig clusterImplConfig =
-        (ClusterImplConfig) priorityChildConfig.policySelection.getConfig();
+    ClusterImplConfig clusterImplConfig = (ClusterImplConfig)
+        GracefulSwitchLoadBalancerAccessor.getChildConfig(priorityChildConfig.childConfig);
     assertClusterImplConfig(clusterImplConfig, CLUSTER_DNS, null, LRS_SERVER_INFO, 300L, null,
         Collections.<DropOverload>emptyList(), "pick_first");
     assertAddressesEqual(Arrays.asList(endpoint1, endpoint2), childBalancer.addresses);

--- a/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
@@ -413,8 +413,8 @@ public class ClusterResolverLoadBalancerTest {
         outlierDetection.failurePercentageEjection().requestVolume());
 
     // The wrapped configuration should not have been tampered with.
-    ClusterImplConfig clusterImplConfig =
-        (ClusterImplConfig) outlierDetectionConfig.childPolicy.getConfig();
+    ClusterImplConfig clusterImplConfig = (ClusterImplConfig)
+        GracefulSwitchLoadBalancerAccessor.getChildConfig(outlierDetectionConfig.childConfig);
     assertClusterImplConfig(clusterImplConfig, CLUSTER1, EDS_SERVICE_NAME1, LRS_SERVER_INFO, 100L,
         tlsContext, Collections.<DropOverload>emptyList(), WRR_LOCALITY_POLICY_NAME);
     WrrLocalityConfig wrrLocalityConfig =

--- a/xds/src/test/java/io/grpc/xds/PriorityLoadBalancerProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/PriorityLoadBalancerProviderTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.mock;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.grpc.LoadBalancerProvider;
-import io.grpc.internal.ServiceConfigUtil.PolicySelection;
+import io.grpc.util.GracefulSwitchLoadBalancer;
 import io.grpc.xds.PriorityLoadBalancerProvider.PriorityLbConfig;
 import io.grpc.xds.PriorityLoadBalancerProvider.PriorityLbConfig.PriorityChildConfig;
 import java.util.List;
@@ -45,7 +45,7 @@ public class PriorityLoadBalancerProviderTest {
         ImmutableMap.of(
             "p0",
             new PriorityChildConfig(
-                new PolicySelection(mock(LoadBalancerProvider.class), null), true));
+                newChildConfig(mock(LoadBalancerProvider.class), null), true));
     List<String> priorities = ImmutableList.of();
 
     thrown.expect(IllegalArgumentException.class);
@@ -59,10 +59,14 @@ public class PriorityLoadBalancerProviderTest {
         ImmutableMap.of(
             "p1",
             new PriorityChildConfig(
-                new PolicySelection(mock(LoadBalancerProvider.class), null), true));
+                newChildConfig(mock(LoadBalancerProvider.class), null), true));
     List<String> priorities = ImmutableList.of("p0", "p1");
 
     thrown.expect(IllegalArgumentException.class);
     new PriorityLbConfig(childConfigs, priorities);
+  }
+
+  private Object newChildConfig(LoadBalancerProvider provider, Object config) {
+    return GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(provider, config);
   }
 }

--- a/xds/src/test/java/io/grpc/xds/PriorityLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/PriorityLoadBalancerTest.java
@@ -52,8 +52,8 @@ import io.grpc.LoadBalancerProvider;
 import io.grpc.Status;
 import io.grpc.SynchronizationContext;
 import io.grpc.internal.FakeClock;
-import io.grpc.internal.ServiceConfigUtil.PolicySelection;
 import io.grpc.internal.TestUtils.StandardLoadBalancerProvider;
+import io.grpc.util.GracefulSwitchLoadBalancer;
 import io.grpc.xds.PriorityLoadBalancerProvider.PriorityLbConfig;
 import io.grpc.xds.PriorityLoadBalancerProvider.PriorityLbConfig.PriorityChildConfig;
 import java.net.InetSocketAddress;
@@ -150,13 +150,13 @@ public class PriorityLoadBalancerTest {
         Attributes.newBuilder().set(Attributes.Key.create("fakeKey"), "fakeValue").build();
     Object fooConfig0 = new Object();
     PriorityChildConfig priorityChildConfig0 =
-        new PriorityChildConfig(new PolicySelection(fooLbProvider, fooConfig0), true);
+        new PriorityChildConfig(newChildConfig(fooLbProvider, fooConfig0), true);
     Object barConfig0 = new Object();
     PriorityChildConfig priorityChildConfig1 =
-        new PriorityChildConfig(new PolicySelection(barLbProvider, barConfig0), true);
+        new PriorityChildConfig(newChildConfig(barLbProvider, barConfig0), true);
     Object fooConfig1 = new Object();
     PriorityChildConfig priorityChildConfig2 =
-        new PriorityChildConfig(new PolicySelection(fooLbProvider, fooConfig1), true);
+        new PriorityChildConfig(newChildConfig(fooLbProvider, fooConfig1), true);
     PriorityLbConfig priorityLbConfig =
         new PriorityLbConfig(
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1,
@@ -209,7 +209,7 @@ public class PriorityLoadBalancerTest {
     PriorityLbConfig newPriorityLbConfig =
         new PriorityLbConfig(
             ImmutableMap.of("p1",
-                new PriorityChildConfig(new PolicySelection(barLbProvider, newBarConfig), true)),
+                new PriorityChildConfig(newChildConfig(barLbProvider, newBarConfig), true)),
             ImmutableList.of("p1"));
     priorityLb.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
@@ -236,10 +236,10 @@ public class PriorityLoadBalancerTest {
   public void handleNameResolutionError() {
     Object fooConfig0 = new Object();
     PriorityChildConfig priorityChildConfig0 =
-        new PriorityChildConfig(new PolicySelection(fooLbProvider, fooConfig0), true);
+        new PriorityChildConfig(newChildConfig(fooLbProvider, fooConfig0), true);
     Object fooConfig1 = new Object();
     PriorityChildConfig priorityChildConfig1 =
-        new PriorityChildConfig(new PolicySelection(fooLbProvider, fooConfig1), true);
+        new PriorityChildConfig(newChildConfig(fooLbProvider, fooConfig1), true);
 
     PriorityLbConfig priorityLbConfig =
         new PriorityLbConfig(ImmutableMap.of("p0", priorityChildConfig0), ImmutableList.of("p0"));
@@ -274,13 +274,13 @@ public class PriorityLoadBalancerTest {
   @Test
   public void typicalPriorityFailOverFlow() {
     PriorityChildConfig priorityChildConfig0 =
-        new PriorityChildConfig(new PolicySelection(fooLbProvider, new Object()), true);
+        new PriorityChildConfig(newChildConfig(fooLbProvider, new Object()), true);
     PriorityChildConfig priorityChildConfig1 =
-        new PriorityChildConfig(new PolicySelection(fooLbProvider, new Object()), true);
+        new PriorityChildConfig(newChildConfig(fooLbProvider, new Object()), true);
     PriorityChildConfig priorityChildConfig2 =
-        new PriorityChildConfig(new PolicySelection(fooLbProvider, new Object()), true);
+        new PriorityChildConfig(newChildConfig(fooLbProvider, new Object()), true);
     PriorityChildConfig priorityChildConfig3 =
-        new PriorityChildConfig(new PolicySelection(fooLbProvider, new Object()), true);
+        new PriorityChildConfig(newChildConfig(fooLbProvider, new Object()), true);
     PriorityLbConfig priorityLbConfig =
         new PriorityLbConfig(
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1,
@@ -412,9 +412,9 @@ public class PriorityLoadBalancerTest {
   @Test
   public void idleToConnectingDoesNotTriggerFailOver() {
     PriorityChildConfig priorityChildConfig0 =
-        new PriorityChildConfig(new PolicySelection(fooLbProvider, new Object()), true);
+        new PriorityChildConfig(newChildConfig(fooLbProvider, new Object()), true);
     PriorityChildConfig priorityChildConfig1 =
-        new PriorityChildConfig(new PolicySelection(fooLbProvider, new Object()), true);
+        new PriorityChildConfig(newChildConfig(fooLbProvider, new Object()), true);
     PriorityLbConfig priorityLbConfig =
         new PriorityLbConfig(
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1),
@@ -448,9 +448,9 @@ public class PriorityLoadBalancerTest {
   @Test
   public void connectingResetFailOverIfSeenReadyOrIdleSinceTransientFailure() {
     PriorityChildConfig priorityChildConfig0 =
-        new PriorityChildConfig(new PolicySelection(fooLbProvider, new Object()), true);
+        new PriorityChildConfig(newChildConfig(fooLbProvider, new Object()), true);
     PriorityChildConfig priorityChildConfig1 =
-        new PriorityChildConfig(new PolicySelection(fooLbProvider, new Object()), true);
+        new PriorityChildConfig(newChildConfig(fooLbProvider, new Object()), true);
     PriorityLbConfig priorityLbConfig =
         new PriorityLbConfig(
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1),
@@ -490,9 +490,9 @@ public class PriorityLoadBalancerTest {
   @Test
   public void readyToConnectDoesNotFailOverButUpdatesPicker() {
     PriorityChildConfig priorityChildConfig0 =
-        new PriorityChildConfig(new PolicySelection(fooLbProvider, new Object()), true);
+        new PriorityChildConfig(newChildConfig(fooLbProvider, new Object()), true);
     PriorityChildConfig priorityChildConfig1 =
-        new PriorityChildConfig(new PolicySelection(fooLbProvider, new Object()), true);
+        new PriorityChildConfig(newChildConfig(fooLbProvider, new Object()), true);
     PriorityLbConfig priorityLbConfig =
         new PriorityLbConfig(
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1),
@@ -547,13 +547,13 @@ public class PriorityLoadBalancerTest {
   @Test
   public void typicalPriorityFailOverFlowWithIdleUpdate() {
     PriorityChildConfig priorityChildConfig0 =
-        new PriorityChildConfig(new PolicySelection(fooLbProvider, new Object()), true);
+        new PriorityChildConfig(newChildConfig(fooLbProvider, new Object()), true);
     PriorityChildConfig priorityChildConfig1 =
-        new PriorityChildConfig(new PolicySelection(fooLbProvider, new Object()), true);
+        new PriorityChildConfig(newChildConfig(fooLbProvider, new Object()), true);
     PriorityChildConfig priorityChildConfig2 =
-        new PriorityChildConfig(new PolicySelection(fooLbProvider, new Object()), true);
+        new PriorityChildConfig(newChildConfig(fooLbProvider, new Object()), true);
     PriorityChildConfig priorityChildConfig3 =
-        new PriorityChildConfig(new PolicySelection(fooLbProvider, new Object()), true);
+        new PriorityChildConfig(newChildConfig(fooLbProvider, new Object()), true);
     PriorityLbConfig priorityLbConfig =
         new PriorityLbConfig(
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1,
@@ -655,9 +655,9 @@ public class PriorityLoadBalancerTest {
   @Test
   public void bypassReresolutionRequestsIfConfiged() {
     PriorityChildConfig priorityChildConfig0 =
-        new PriorityChildConfig(new PolicySelection(fooLbProvider, new Object()), true);
+        new PriorityChildConfig(newChildConfig(fooLbProvider, new Object()), true);
     PriorityChildConfig priorityChildConfig1 =
-        new PriorityChildConfig(new PolicySelection(fooLbProvider, new Object()), false);
+        new PriorityChildConfig(newChildConfig(fooLbProvider, new Object()), false);
     PriorityLbConfig priorityLbConfig =
         new PriorityLbConfig(
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1),
@@ -683,9 +683,9 @@ public class PriorityLoadBalancerTest {
   @Test
   public void raceBetweenShutdownAndChildLbBalancingStateUpdate() {
     PriorityChildConfig priorityChildConfig0 =
-        new PriorityChildConfig(new PolicySelection(fooLbProvider, new Object()), true);
+        new PriorityChildConfig(newChildConfig(fooLbProvider, new Object()), true);
     PriorityChildConfig priorityChildConfig1 =
-        new PriorityChildConfig(new PolicySelection(fooLbProvider, new Object()), false);
+        new PriorityChildConfig(newChildConfig(fooLbProvider, new Object()), false);
     PriorityLbConfig priorityLbConfig =
         new PriorityLbConfig(
             ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1),
@@ -710,9 +710,9 @@ public class PriorityLoadBalancerTest {
     FakeLoadBalancerProvider fakeLbProvider = new FakeLoadBalancerProvider();
 
     PriorityChildConfig priorityChildConfig0 =
-        new PriorityChildConfig(new PolicySelection(fakeLbProvider, new Object()), true);
+        new PriorityChildConfig(newChildConfig(fakeLbProvider, new Object()), true);
     PriorityChildConfig priorityChildConfig1 =
-        new PriorityChildConfig(new PolicySelection(fakeLbProvider, new Object()), false);
+        new PriorityChildConfig(newChildConfig(fakeLbProvider, new Object()), false);
     PriorityLbConfig priorityLbConfig =
         new PriorityLbConfig(
             ImmutableMap.of("p0", priorityChildConfig0),
@@ -763,6 +763,10 @@ public class PriorityLoadBalancerTest {
     assertLatestConnectivityState(IDLE);
     PickResult pickResult = pickerCaptor.getValue().pickSubchannel(mock(PickSubchannelArgs.class));
     assertThat(pickResult).isEqualTo(PickResult.withNoResult());
+  }
+
+  private Object newChildConfig(LoadBalancerProvider provider, Object config) {
+    return GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(provider, config);
   }
 
   private static class FakeLoadBalancerProvider extends LoadBalancerProvider {

--- a/xds/src/test/java/io/grpc/xds/WeightedTargetLoadBalancerProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedTargetLoadBalancerProviderTest.java
@@ -26,7 +26,7 @@ import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.internal.JsonParser;
-import io.grpc.internal.ServiceConfigUtil.PolicySelection;
+import io.grpc.util.GracefulSwitchLoadBalancer;
 import io.grpc.xds.WeightedTargetLoadBalancerProvider.WeightedPolicySelection;
 import io.grpc.xds.WeightedTargetLoadBalancerProvider.WeightedTargetConfig;
 import java.util.Map;
@@ -128,11 +128,13 @@ public class WeightedTargetLoadBalancerProviderTest {
             "target_1",
             new WeightedPolicySelection(
                 10,
-                new PolicySelection(lbProviderFoo, fooConfig)),
+                GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(
+                    lbProviderFoo, fooConfig)),
             "target_2",
             new WeightedPolicySelection(
                 20,
-                new PolicySelection(lbProviderBar, barConfig)))));
+                GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(
+                    lbProviderBar, barConfig)))));
     assertThat(parsedConfig).isEqualTo(expectedConfig);
   }
 }

--- a/xds/src/test/java/io/grpc/xds/WeightedTargetLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedTargetLoadBalancerTest.java
@@ -49,7 +49,7 @@ import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.Status;
 import io.grpc.SynchronizationContext;
-import io.grpc.internal.ServiceConfigUtil.PolicySelection;
+import io.grpc.util.GracefulSwitchLoadBalancer;
 import io.grpc.xds.WeightedRandomPicker.WeightedChildPicker;
 import io.grpc.xds.WeightedTargetLoadBalancerProvider.WeightedPolicySelection;
 import io.grpc.xds.WeightedTargetLoadBalancerProvider.WeightedTargetConfig;
@@ -146,13 +146,13 @@ public class WeightedTargetLoadBalancerTest {
   };
 
   private final WeightedPolicySelection weightedLbConfig0 = new WeightedPolicySelection(
-      weights[0], new PolicySelection(fooLbProvider, configs[0]));
+      weights[0], newChildConfig(fooLbProvider, configs[0]));
   private final WeightedPolicySelection weightedLbConfig1 = new WeightedPolicySelection(
-      weights[1], new PolicySelection(barLbProvider, configs[1]));
+      weights[1], newChildConfig(barLbProvider, configs[1]));
   private final WeightedPolicySelection weightedLbConfig2 = new WeightedPolicySelection(
-      weights[2],  new PolicySelection(barLbProvider, configs[2]));
+      weights[2],  newChildConfig(barLbProvider, configs[2]));
   private final WeightedPolicySelection weightedLbConfig3 = new WeightedPolicySelection(
-      weights[3], new PolicySelection(fooLbProvider, configs[3]));
+      weights[3], newChildConfig(fooLbProvider, configs[3]));
 
   @Mock
   private Helper helper;
@@ -233,16 +233,16 @@ public class WeightedTargetLoadBalancerTest {
     Map<String, WeightedPolicySelection> newTargets = ImmutableMap.of(
         "target1",
         new WeightedPolicySelection(
-            newWeights[0], new PolicySelection(barLbProvider, newConfigs[0])),
+            newWeights[0], newChildConfig(barLbProvider, newConfigs[0])),
         "target2",
         new WeightedPolicySelection(
-            newWeights[1], new PolicySelection(barLbProvider, newConfigs[1])),
+            newWeights[1], newChildConfig(barLbProvider, newConfigs[1])),
         "target3",
         new WeightedPolicySelection(
-            newWeights[2], new PolicySelection(fooLbProvider, newConfigs[2])),
+            newWeights[2], newChildConfig(fooLbProvider, newConfigs[2])),
         "target4",
         new WeightedPolicySelection(
-            newWeights[3], new PolicySelection(fooLbProvider, newConfigs[3])));
+            newWeights[3], newChildConfig(fooLbProvider, newConfigs[3])));
     weightedTargetLb.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
@@ -418,9 +418,9 @@ public class WeightedTargetLoadBalancerTest {
 
     Map<String, WeightedPolicySelection> targets = ImmutableMap.of(
         "target0", new WeightedPolicySelection(
-            weights[0], new PolicySelection(fakeLbProvider, configs[0])),
+            weights[0], newChildConfig(fakeLbProvider, configs[0])),
         "target3", new WeightedPolicySelection(
-            weights[3], new PolicySelection(fakeLbProvider, configs[3])));
+            weights[3], newChildConfig(fakeLbProvider, configs[3])));
     weightedTargetLb.handleResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
@@ -432,6 +432,10 @@ public class WeightedTargetLoadBalancerTest {
     // WeightedTargetLLoadBalancer, the overall balancing state should only be updated once.
     verify(helper, times(1)).updateBalancingState(any(), any());
 
+  }
+
+  private Object newChildConfig(LoadBalancerProvider provider, Object config) {
+    return GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(provider, config);
   }
 
   private static class FakeLoadBalancerProvider extends LoadBalancerProvider {

--- a/xds/src/test/java/io/grpc/xds/WrrLocalityLoadBalancerProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/WrrLocalityLoadBalancerProviderTest.java
@@ -27,6 +27,7 @@ import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.NameResolver;
+import io.grpc.util.GracefulSwitchLoadBalancerAccessor;
 import io.grpc.xds.WrrLocalityLoadBalancer.WrrLocalityConfig;
 import java.util.Map;
 import org.junit.Test;
@@ -64,6 +65,8 @@ public class WrrLocalityLoadBalancerProviderTest {
     WrrLocalityLoadBalancerProvider provider = new WrrLocalityLoadBalancerProvider();
     NameResolver.ConfigOrError configOrError = provider.parseLoadBalancingPolicyConfig(rawConfig);
     WrrLocalityConfig config = (WrrLocalityConfig) configOrError.getConfig();
-    assertThat(config.childPolicy.getProvider().getPolicyName()).isEqualTo("round_robin");
+    LoadBalancerProvider childProvider =
+        GracefulSwitchLoadBalancerAccessor.getChildProvider(config.childConfig);
+    assertThat(childProvider.getPolicyName()).isEqualTo("round_robin");
   }
 }


### PR DESCRIPTION
This doesn't actually remove switchTo() as the API is currently public, although we may want to mark it deprecated. You may want to look at each commit separately, especially the first. The rest of the commits should look pretty similar to each other (IIRC). The tests added to GracefulSwitchLoadBalancerTest are copies of the existing tests with switchTo() replaced. You'll notice I made some changes to the existing tests before I copied them.

No rush on reviewing this. It has been sitting around on my machine since March.