### PR TITLE
all: Add opentelemetry (1.64.x backport)

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -15,6 +15,7 @@ def subprojects = [
     project(':grpc-inprocess'),
     project(':grpc-netty'),
     project(':grpc-okhttp'),
+    project(':grpc-opentelemetry'),
     project(':grpc-protobuf'),
     project(':grpc-protobuf-lite'),
     project(':grpc-rls'),

--- a/opentelemetry/build.gradle
+++ b/opentelemetry/build.gradle
@@ -41,3 +41,7 @@ tasks.named("compileJava").configure {
             ".*/build/generated/sources/annotationProcessor/java/.*",
             "|")
 }
+
+tasks.named("javadoc").configure {
+    exclude 'io/grpc/opentelemetry/internal/**'
+}


### PR DESCRIPTION
This adds opentelemetry to the shared javadoc (but also other things like having its tests contribute to code coverage).

Backport of #11208