### PR TITLE
compiler: add option @generated=jakarta

### DIFF
--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -1135,13 +1135,16 @@ static void PrintService(const ServiceDescriptor* service,
         *vars,
         "@javax.annotation.Generated(\n"
         "    value = \"by gRPC proto compiler$grpc_version$\",\n"
-        "    comments = \"Source: $file_name$\")\n"
-        "@$GrpcGenerated$\n");
-  } else { // GeneratedAnnotation::OMIT
+        "    comments = \"Source: $file_name$\")\n");
+  } else if generated_annotation == GeneratedAnnotation::JAKARTA) {
     p->Print(
         *vars,
-        "@$GrpcGenerated$\n");
+        "@jakarta.annotation.Generated(\n"
+        "    value = \"by gRPC proto compiler$grpc_version$\",\n"
+        "    comments = \"Source: $file_name$\")\n");
   }
+  // Always include @GrpcGenerated
+  p->Print(*vars, "@$GrpcGenerated$\n");
 
   if (service->options().deprecated()) {
     p->Print(*vars, "@$Deprecated$\n");

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -1136,7 +1136,7 @@ static void PrintService(const ServiceDescriptor* service,
         "@javax.annotation.Generated(\n"
         "    value = \"by gRPC proto compiler$grpc_version$\",\n"
         "    comments = \"Source: $file_name$\")\n");
-  } else if generated_annotation == GeneratedAnnotation::JAKARTA) {
+  } else if (generated_annotation == GeneratedAnnotation::JAKARTA) {
     p->Print(
         *vars,
         "@jakarta.annotation.Generated(\n"

--- a/compiler/src/java_plugin/cpp/java_generator.h
+++ b/compiler/src/java_plugin/cpp/java_generator.h
@@ -58,7 +58,7 @@ enum ProtoFlavor {
 };
 
 enum GeneratedAnnotation {
-  OMIT, JAVAX
+  OMIT, JAVAX, JAKARTA
 };
 
 // Returns the package name of the gRPC services defined in the given file.

--- a/compiler/src/java_plugin/cpp/java_plugin.cpp
+++ b/compiler/src/java_plugin/cpp/java_plugin.cpp
@@ -72,6 +72,8 @@ class JavaGrpcGenerator : public protobuf::compiler::CodeGenerator {
            generated_annotation = java_grpc_generator::GeneratedAnnotation::OMIT;
          } else if (options[i].second == "javax") {
            generated_annotation = java_grpc_generator::GeneratedAnnotation::JAVAX;
+         } else if (options[i].second == "jakarta") {
+           generated_annotation = java_grpc_generator::GeneratedAnnotation::JAKARTA;
          }
       }
     }


### PR DESCRIPTION
Add (optional) support for `@jakarta.annotation.Generated` while retaining existing functionality.

An extension of #11086