### PR TITLE
xds: Plumb the Cluster's filterMetadata to RPCs

### DIFF
--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
@@ -176,13 +176,15 @@ final class CdsLoadBalancer2 extends LoadBalancer {
                     clusterState.result.lrsServerInfo(),
                     clusterState.result.maxConcurrentRequests(),
                     clusterState.result.upstreamTlsContext(),
+                    clusterState.result.filterMetadata(),
                     clusterState.result.outlierDetection());
               } else {  // logical DNS
                 instance = DiscoveryMechanism.forLogicalDns(
                     clusterState.name, clusterState.result.dnsHostName(),
                     clusterState.result.lrsServerInfo(),
                     clusterState.result.maxConcurrentRequests(),
-                    clusterState.result.upstreamTlsContext());
+                    clusterState.result.upstreamTlsContext(),
+                    clusterState.result.filterMetadata());
               }
               instances.add(instance);
             }

--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -21,6 +21,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.Struct;
 import io.grpc.Attributes;
 import io.grpc.ClientStreamTracer;
 import io.grpc.ClientStreamTracer.StreamInfo;
@@ -54,6 +56,7 @@ import io.grpc.xds.orca.OrcaPerRequestUtil.OrcaPerRequestReportListener;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
@@ -140,6 +143,7 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
     childLbHelper.updateDropPolicies(config.dropCategories);
     childLbHelper.updateMaxConcurrentRequests(config.maxConcurrentRequests);
     childLbHelper.updateSslContextProviderSupplier(config.tlsContext);
+    childLbHelper.updateFilterMetadata(config.filterMetadata);
 
     childSwitchLb.switchTo(config.childPolicy.getProvider());
     childSwitchLb.handleResolvedAddresses(
@@ -189,6 +193,7 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
     private long maxConcurrentRequests = DEFAULT_PER_CLUSTER_MAX_CONCURRENT_REQUESTS;
     @Nullable
     private SslContextProviderSupplier sslContextProviderSupplier;
+    private Map<String, Struct> filterMetadata = ImmutableMap.of();
     @Nullable
     private final ServerInfo lrsServerInfo;
 
@@ -201,8 +206,8 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
     public void updateBalancingState(ConnectivityState newState, SubchannelPicker newPicker) {
       currentState = newState;
       currentPicker =  newPicker;
-      SubchannelPicker picker =
-          new RequestLimitingSubchannelPicker(newPicker, dropPolicies, maxConcurrentRequests);
+      SubchannelPicker picker = new RequestLimitingSubchannelPicker(
+          newPicker, dropPolicies, maxConcurrentRequests, filterMetadata);
       delegate().updateBalancingState(newState, picker);
     }
 
@@ -311,20 +316,29 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
               : null;
     }
 
+    private void updateFilterMetadata(Map<String, Struct> filterMetadata) {
+      this.filterMetadata = ImmutableMap.copyOf(filterMetadata);
+    }
+
     private class RequestLimitingSubchannelPicker extends SubchannelPicker {
       private final SubchannelPicker delegate;
       private final List<DropOverload> dropPolicies;
       private final long maxConcurrentRequests;
+      private final Map<String, Struct> filterMetadata;
 
       private RequestLimitingSubchannelPicker(SubchannelPicker delegate,
-          List<DropOverload> dropPolicies, long maxConcurrentRequests) {
+          List<DropOverload> dropPolicies, long maxConcurrentRequests,
+          Map<String, Struct> filterMetadata) {
         this.delegate = delegate;
         this.dropPolicies = dropPolicies;
         this.maxConcurrentRequests = maxConcurrentRequests;
+        this.filterMetadata = checkNotNull(filterMetadata, "filterMetadata");
       }
 
       @Override
       public PickResult pickSubchannel(PickSubchannelArgs args) {
+        args.getCallOptions().getOption(ClusterImplLoadBalancerProvider.FILTER_METADATA_CONSUMER)
+            .accept(filterMetadata);
         for (DropOverload dropOverload : dropPolicies) {
           int rand = random.nextInt(1_000_000);
           if (rand < dropOverload.dropsPerMillion()) {

--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancerProvider.java
@@ -19,6 +19,9 @@ package io.grpc.xds;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.Struct;
+import io.grpc.CallOptions;
 import io.grpc.Internal;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
@@ -34,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
 /**
@@ -43,6 +47,11 @@ import javax.annotation.Nullable;
  */
 @Internal
 public final class ClusterImplLoadBalancerProvider extends LoadBalancerProvider {
+  /**
+   * Consumer of filter metadata from the cluster used by the call. Consumer may not modify map.
+   */
+  public static final CallOptions.Key<Consumer<Map<String, Struct>>> FILTER_METADATA_CONSUMER =
+      CallOptions.Key.createWithDefault("io.grpc.xds.internalFilterMetadataConsumer", (m) -> { });
 
   @Override
   public boolean isAvailable() {
@@ -89,16 +98,18 @@ public final class ClusterImplLoadBalancerProvider extends LoadBalancerProvider 
     final List<DropOverload> dropCategories;
     // Provides the direct child policy and its config.
     final PolicySelection childPolicy;
+    final Map<String, Struct> filterMetadata;
 
     ClusterImplConfig(String cluster, @Nullable String edsServiceName,
         @Nullable ServerInfo lrsServerInfo, @Nullable Long maxConcurrentRequests,
         List<DropOverload> dropCategories, PolicySelection childPolicy,
-        @Nullable UpstreamTlsContext tlsContext) {
+        @Nullable UpstreamTlsContext tlsContext, Map<String, Struct> filterMetadata) {
       this.cluster = checkNotNull(cluster, "cluster");
       this.edsServiceName = edsServiceName;
       this.lrsServerInfo = lrsServerInfo;
       this.maxConcurrentRequests = maxConcurrentRequests;
       this.tlsContext = tlsContext;
+      this.filterMetadata = ImmutableMap.copyOf(filterMetadata);
       this.dropCategories = Collections.unmodifiableList(
           new ArrayList<>(checkNotNull(dropCategories, "dropCategories")));
       this.childPolicy = checkNotNull(childPolicy, "childPolicy");

--- a/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancerProvider.java
@@ -19,6 +19,8 @@ package io.grpc.xds;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.Struct;
 import io.grpc.Internal;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
@@ -129,6 +131,7 @@ public final class ClusterResolverLoadBalancerProvider extends LoadBalancerProvi
       final String dnsHostName;
       @Nullable
       final OutlierDetection outlierDetection;
+      final Map<String, Struct> filterMetadata;
 
       enum Type {
         EDS,
@@ -138,7 +141,7 @@ public final class ClusterResolverLoadBalancerProvider extends LoadBalancerProvi
       private DiscoveryMechanism(String cluster, Type type, @Nullable String edsServiceName,
           @Nullable String dnsHostName, @Nullable ServerInfo lrsServerInfo,
           @Nullable Long maxConcurrentRequests, @Nullable UpstreamTlsContext tlsContext,
-          @Nullable OutlierDetection outlierDetection) {
+          Map<String, Struct> filterMetadata, @Nullable OutlierDetection outlierDetection) {
         this.cluster = checkNotNull(cluster, "cluster");
         this.type = checkNotNull(type, "type");
         this.edsServiceName = edsServiceName;
@@ -146,28 +149,29 @@ public final class ClusterResolverLoadBalancerProvider extends LoadBalancerProvi
         this.lrsServerInfo = lrsServerInfo;
         this.maxConcurrentRequests = maxConcurrentRequests;
         this.tlsContext = tlsContext;
+        this.filterMetadata = ImmutableMap.copyOf(checkNotNull(filterMetadata, "filterMetadata"));
         this.outlierDetection = outlierDetection;
       }
 
       static DiscoveryMechanism forEds(String cluster, @Nullable String edsServiceName,
           @Nullable ServerInfo lrsServerInfo, @Nullable Long maxConcurrentRequests,
-          @Nullable UpstreamTlsContext tlsContext,
+          @Nullable UpstreamTlsContext tlsContext, Map<String, Struct> filterMetadata,
           OutlierDetection outlierDetection) {
         return new DiscoveryMechanism(cluster, Type.EDS, edsServiceName, null, lrsServerInfo,
-            maxConcurrentRequests, tlsContext, outlierDetection);
+            maxConcurrentRequests, tlsContext, filterMetadata, outlierDetection);
       }
 
       static DiscoveryMechanism forLogicalDns(String cluster, String dnsHostName,
           @Nullable ServerInfo lrsServerInfo, @Nullable Long maxConcurrentRequests,
-          @Nullable UpstreamTlsContext tlsContext) {
+          @Nullable UpstreamTlsContext tlsContext, Map<String, Struct> filterMetadata) {
         return new DiscoveryMechanism(cluster, Type.LOGICAL_DNS, null, dnsHostName,
-            lrsServerInfo, maxConcurrentRequests, tlsContext, null);
+            lrsServerInfo, maxConcurrentRequests, tlsContext, filterMetadata, null);
       }
 
       @Override
       public int hashCode() {
         return Objects.hash(cluster, type, lrsServerInfo, maxConcurrentRequests, tlsContext,
-            edsServiceName, dnsHostName);
+            edsServiceName, dnsHostName, outlierDetection, filterMetadata);
       }
 
       @Override
@@ -185,7 +189,9 @@ public final class ClusterResolverLoadBalancerProvider extends LoadBalancerProvi
             && Objects.equals(dnsHostName, that.dnsHostName)
             && Objects.equals(lrsServerInfo, that.lrsServerInfo)
             && Objects.equals(maxConcurrentRequests, that.maxConcurrentRequests)
-            && Objects.equals(tlsContext, that.tlsContext);
+            && Objects.equals(tlsContext, that.tlsContext)
+            && Objects.equals(filterMetadata, that.filterMetadata)
+            && Objects.equals(outlierDetection, that.outlierDetection);
       }
 
       @Override
@@ -198,7 +204,8 @@ public final class ClusterResolverLoadBalancerProvider extends LoadBalancerProvi
                 .add("dnsHostName", dnsHostName)
                 .add("lrsServerInfo", lrsServerInfo)
                 // Exclude tlsContext as its string representation is cumbersome.
-                .add("maxConcurrentRequests", maxConcurrentRequests);
+                .add("maxConcurrentRequests", maxConcurrentRequests)
+                .add("filterMetadata", filterMetadata);
         return toStringHelper.toString();
       }
     }

--- a/xds/src/main/java/io/grpc/xds/InternalGrpcBootstrapperImpl.java
+++ b/xds/src/main/java/io/grpc/xds/InternalGrpcBootstrapperImpl.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import io.grpc.Internal;
+import io.grpc.xds.client.XdsInitializationException;
+import java.io.IOException;
+
+/**
+ * Internal accessors for GrpcBootstrapperImpl.
+ */
+@Internal
+public final class InternalGrpcBootstrapperImpl {
+  private InternalGrpcBootstrapperImpl() {} // prevent instantiation
+
+  public static String getJsonContent() throws XdsInitializationException, IOException {
+    return new GrpcBootstrapperImpl().getJsonContent();
+  }
+}

--- a/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
@@ -177,7 +177,8 @@ public class ClusterImplLoadBalancerTest {
     Object weightedTargetConfig = new Object();
     ClusterImplConfig config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         null, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null);
+        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
+        Collections.emptyMap());
     EquivalentAddressGroup endpoint = makeAddress("endpoint-addr", locality);
     deliverAddressesAndConfig(Collections.singletonList(endpoint), config);
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(downstreamBalancers);
@@ -202,7 +203,8 @@ public class ClusterImplLoadBalancerTest {
     ClusterImplConfig configWithWeightedTarget = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME,
         LRS_SERVER_INFO,
         null, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null);
+        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
+        Collections.emptyMap());
     EquivalentAddressGroup endpoint = makeAddress("endpoint-addr", locality);
     deliverAddressesAndConfig(Collections.singletonList(endpoint), configWithWeightedTarget);
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(downstreamBalancers);
@@ -215,7 +217,8 @@ public class ClusterImplLoadBalancerTest {
     ClusterImplConfig configWithWrrLocality = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME,
         LRS_SERVER_INFO,
         null, Collections.<DropOverload>emptyList(),
-        new PolicySelection(wrrLocalityProvider, wrrLocalityConfig), null);
+        new PolicySelection(wrrLocalityProvider, wrrLocalityConfig), null,
+        Collections.emptyMap());
     deliverAddressesAndConfig(Collections.singletonList(endpoint), configWithWrrLocality);
     childBalancer = Iterables.getOnlyElement(downstreamBalancers);
     assertThat(childBalancer.name).isEqualTo(XdsLbPolicies.WRR_LOCALITY_POLICY_NAME);
@@ -239,7 +242,8 @@ public class ClusterImplLoadBalancerTest {
     Object weightedTargetConfig = new Object();
     ClusterImplConfig config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         null, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null);
+        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
+        Collections.emptyMap());
     EquivalentAddressGroup endpoint = makeAddress("endpoint-addr", locality);
     deliverAddressesAndConfig(Collections.singletonList(endpoint), config);
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(downstreamBalancers);
@@ -258,7 +262,8 @@ public class ClusterImplLoadBalancerTest {
         buildWeightedTargetConfig(ImmutableMap.of(locality, 10));
     ClusterImplConfig config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         null, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null);
+        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
+        Collections.emptyMap());
     EquivalentAddressGroup endpoint = makeAddress("endpoint-addr", locality);
     deliverAddressesAndConfig(Collections.singletonList(endpoint), config);
     FakeLoadBalancer leafBalancer = Iterables.getOnlyElement(downstreamBalancers);
@@ -284,7 +289,8 @@ public class ClusterImplLoadBalancerTest {
         buildWeightedTargetConfig(ImmutableMap.of(locality, 10));
     ClusterImplConfig config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         null, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null);
+        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
+        Collections.emptyMap());
     EquivalentAddressGroup endpoint = makeAddress("endpoint-addr", locality);
     deliverAddressesAndConfig(Collections.singletonList(endpoint), config);
     FakeLoadBalancer leafBalancer = Iterables.getOnlyElement(downstreamBalancers);
@@ -368,7 +374,8 @@ public class ClusterImplLoadBalancerTest {
         buildWeightedTargetConfig(ImmutableMap.of(locality, 10));
     ClusterImplConfig config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         null, Collections.singletonList(DropOverload.create("throttle", 500_000)),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null);
+        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
+        Collections.emptyMap());
     EquivalentAddressGroup endpoint = makeAddress("endpoint-addr", locality);
     deliverAddressesAndConfig(Collections.singletonList(endpoint), config);
     when(mockRandom.nextInt(anyInt())).thenReturn(499_999, 999_999, 1_000_000);
@@ -397,7 +404,8 @@ public class ClusterImplLoadBalancerTest {
     //  Config update updates drop policies.
     config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO, null,
         Collections.singletonList(DropOverload.create("lb", 1_000_000)),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null);
+        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
+        Collections.emptyMap());
     loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder()
             .setAddresses(Collections.singletonList(endpoint))
@@ -444,7 +452,8 @@ public class ClusterImplLoadBalancerTest {
         buildWeightedTargetConfig(ImmutableMap.of(locality, 10));
     ClusterImplConfig config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         maxConcurrentRequests, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null);
+        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
+        Collections.emptyMap());
     EquivalentAddressGroup endpoint = makeAddress("endpoint-addr", locality);
     deliverAddressesAndConfig(Collections.singletonList(endpoint), config);
     assertThat(downstreamBalancers).hasSize(1);  // one leaf balancer
@@ -486,7 +495,8 @@ public class ClusterImplLoadBalancerTest {
     maxConcurrentRequests = 101L;
     config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         maxConcurrentRequests, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null);
+        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
+        Collections.emptyMap());
     deliverAddressesAndConfig(Collections.singletonList(endpoint), config);
 
     result = currentPicker.pickSubchannel(pickSubchannelArgs);
@@ -532,7 +542,8 @@ public class ClusterImplLoadBalancerTest {
         buildWeightedTargetConfig(ImmutableMap.of(locality, 10));
     ClusterImplConfig config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         null, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null);
+        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
+        Collections.emptyMap());
     EquivalentAddressGroup endpoint = makeAddress("endpoint-addr", locality);
     deliverAddressesAndConfig(Collections.singletonList(endpoint), config);
     assertThat(downstreamBalancers).hasSize(1);  // one leaf balancer
@@ -578,7 +589,8 @@ public class ClusterImplLoadBalancerTest {
         buildWeightedTargetConfig(ImmutableMap.of(locality, 10));
     ClusterImplConfig config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         null, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null);
+        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
+        Collections.emptyMap());
     // One locality with two endpoints.
     EquivalentAddressGroup endpoint1 = makeAddress("endpoint-addr1", locality);
     EquivalentAddressGroup endpoint2 = makeAddress("endpoint-addr2", locality);
@@ -615,7 +627,8 @@ public class ClusterImplLoadBalancerTest {
         buildWeightedTargetConfig(ImmutableMap.of(locality, 10));
     ClusterImplConfig config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         null, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), upstreamTlsContext);
+        new PolicySelection(weightedTargetProvider, weightedTargetConfig), upstreamTlsContext,
+        Collections.emptyMap());
     // One locality with two endpoints.
     EquivalentAddressGroup endpoint1 = makeAddress("endpoint-addr1", locality);
     EquivalentAddressGroup endpoint2 = makeAddress("endpoint-addr2", locality);
@@ -638,7 +651,8 @@ public class ClusterImplLoadBalancerTest {
     // Removes UpstreamTlsContext from the config.
     config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         null, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null);
+        new PolicySelection(weightedTargetProvider, weightedTargetConfig), null,
+        Collections.emptyMap());
     deliverAddressesAndConfig(Arrays.asList(endpoint1, endpoint2), config);
     assertThat(Iterables.getOnlyElement(downstreamBalancers)).isSameInstanceAs(leafBalancer);
     subchannel = leafBalancer.helper.createSubchannel(args);  // creates new connections
@@ -652,7 +666,8 @@ public class ClusterImplLoadBalancerTest {
         CommonTlsContextTestsUtil.buildUpstreamTlsContext("google_cloud_private_spiffe1", true);
     config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
         null, Collections.<DropOverload>emptyList(),
-        new PolicySelection(weightedTargetProvider, weightedTargetConfig), upstreamTlsContext);
+        new PolicySelection(weightedTargetProvider, weightedTargetConfig), upstreamTlsContext,
+        Collections.emptyMap());
     deliverAddressesAndConfig(Arrays.asList(endpoint1, endpoint2), config);
     assertThat(Iterables.getOnlyElement(downstreamBalancers)).isSameInstanceAs(leafBalancer);
     subchannel = leafBalancer.helper.createSubchannel(args);  // creates new connections

--- a/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
@@ -136,15 +136,16 @@ public class ClusterResolverLoadBalancerTest {
       FailurePercentageEjection.create(100, 100, 100, 100));
   private final DiscoveryMechanism edsDiscoveryMechanism1 =
       DiscoveryMechanism.forEds(CLUSTER1, EDS_SERVICE_NAME1, LRS_SERVER_INFO, 100L, tlsContext,
-          null);
+          Collections.emptyMap(), null);
   private final DiscoveryMechanism edsDiscoveryMechanism2 =
       DiscoveryMechanism.forEds(CLUSTER2, EDS_SERVICE_NAME2, LRS_SERVER_INFO, 200L, tlsContext,
-          null);
+          Collections.emptyMap(), null);
   private final DiscoveryMechanism edsDiscoveryMechanismWithOutlierDetection =
       DiscoveryMechanism.forEds(CLUSTER1, EDS_SERVICE_NAME1, LRS_SERVER_INFO, 100L, tlsContext,
-          outlierDetection);
+          Collections.emptyMap(), outlierDetection);
   private final DiscoveryMechanism logicalDnsDiscoveryMechanism =
-      DiscoveryMechanism.forLogicalDns(CLUSTER_DNS, DNS_HOST_NAME, LRS_SERVER_INFO, 300L, null);
+      DiscoveryMechanism.forLogicalDns(CLUSTER_DNS, DNS_HOST_NAME, LRS_SERVER_INFO, 300L, null,
+          Collections.emptyMap());
 
   private final SynchronizationContext syncContext = new SynchronizationContext(
       new Thread.UncaughtExceptionHandler() {


### PR DESCRIPTION
This will be used by CSM observability, and may get exposed to further uses in the future.

CC @DNVindhya 