### PR TITLE
api: Add ClientStreamTracer.inboundHeaders(Metadata)

### DIFF
--- a/api/src/main/java/io/grpc/ClientStreamTracer.java
+++ b/api/src/main/java/io/grpc/ClientStreamTracer.java
@@ -70,10 +70,23 @@ public abstract class ClientStreamTracer extends StreamTracer {
   }
 
   /**
-   * Trailing metadata has been received from the server.
+   * Headers has been received from the server. This method does not pass ownership to {@code
+   * headers}, so implementations must not access the metadata after returning. Modifications to the
+   * metadata within this method will be seen by interceptors and the application.
    *
-   * @param trailers the mutable trailing metadata.  Modifications to it will be seen by
-   *                 interceptors and the application.
+   * @param headers the received header metadata
+   */
+  public void inboundHeaders(Metadata headers) {
+    inboundHeaders();
+  }
+
+  /**
+   * Trailing metadata has been received from the server. This method does not pass ownership to
+   * {@code trailers}, so implementations must not access the metadata after returning.
+   * Modifications to the metadata within this method will be seen by interceptors and the
+   * application.
+   *
+   * @param trailers the received trailing metadata
    * @since 1.17.0
    */
   public void inboundTrailers(Metadata trailers) {

--- a/binder/src/main/java/io/grpc/binder/internal/Inbound.java
+++ b/binder/src/main/java/io/grpc/binder/internal/Inbound.java
@@ -579,7 +579,7 @@ abstract class Inbound<L extends StreamListener> implements StreamListener.Messa
     @GuardedBy("this")
     protected void handlePrefix(int flags, Parcel parcel) throws StatusException {
       Metadata headers = MetadataHelper.readMetadata(parcel, attributes);
-      statsTraceContext.clientInboundHeaders();
+      statsTraceContext.clientInboundHeaders(headers);
       listener.headersRead(headers);
     }
 

--- a/core/src/main/java/io/grpc/internal/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream.java
@@ -304,7 +304,7 @@ public abstract class AbstractClientStream extends AbstractStream
      */
     protected void inboundHeadersReceived(Metadata headers) {
       checkState(!statusReported, "Received headers on closed stream");
-      statsTraceCtx.clientInboundHeaders();
+      statsTraceCtx.clientInboundHeaders(headers);
 
       boolean compressedStream = false;
       String streamEncoding = headers.get(CONTENT_ENCODING_KEY);

--- a/core/src/main/java/io/grpc/internal/ForwardingClientStreamTracer.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingClientStreamTracer.java
@@ -50,6 +50,11 @@ public abstract class ForwardingClientStreamTracer extends ClientStreamTracer {
   }
 
   @Override
+  public void inboundHeaders(Metadata headers) {
+    delegate().inboundHeaders(headers);
+  }
+
+  @Override
   public void inboundTrailers(Metadata trailers) {
     delegate().inboundTrailers(trailers);
   }

--- a/core/src/main/java/io/grpc/internal/StatsTraceContext.java
+++ b/core/src/main/java/io/grpc/internal/StatsTraceContext.java
@@ -101,9 +101,9 @@ public final class StatsTraceContext {
    *
    * <p>Called from abstract stream implementations.
    */
-  public void clientInboundHeaders() {
+  public void clientInboundHeaders(Metadata headers) {
     for (StreamTracer tracer : tracers) {
-      ((ClientStreamTracer) tracer).inboundHeaders();
+      ((ClientStreamTracer) tracer).inboundHeaders(headers);
     }
   }
 

--- a/inprocess/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/inprocess/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -571,7 +571,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
             return;
           }
 
-          clientStream.statsTraceCtx.clientInboundHeaders();
+          clientStream.statsTraceCtx.clientInboundHeaders(headers);
           syncContext.executeLater(() -> clientStreamListener.headersRead(headers));
         }
         syncContext.drain();

--- a/util/src/main/java/io/grpc/util/ForwardingClientStreamTracer.java
+++ b/util/src/main/java/io/grpc/util/ForwardingClientStreamTracer.java
@@ -49,6 +49,11 @@ public abstract class ForwardingClientStreamTracer extends ClientStreamTracer {
   }
 
   @Override
+  public void inboundHeaders(Metadata headers) {
+    delegate().inboundHeaders(headers);
+  }
+
+  @Override
   public void inboundTrailers(Metadata trailers) {
     delegate().inboundTrailers(trailers);
   }


### PR DESCRIPTION
This will be used by the metadata exchange of CSM. When recording per-attempt metrics, we really need per-attempt data and can't leverage ClientInterceptors.

CC @DNVindhya 