### PR TITLE
core: Remove direct test dependency on inprocess

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -32,7 +32,6 @@ dependencies {
             libraries.truth,
             project(':grpc-testing')
     testImplementation testFixtures(project(':grpc-api')),
-            project(':grpc-inprocess'),
             project(':grpc-testing')
     testImplementation libraries.guava.testlib
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
@@ -366,7 +366,7 @@ public class ManagedChannelImplBuilderTest {
     when(mockClientTransportFactoryBuilder.buildClientTransportFactory())
         .thenReturn(mockClientTransportFactory);
     when(mockClientTransportFactory.getSupportedSocketAddressTypes())
-        .thenReturn(Collections.singleton(SpecialSocketAddress.class));
+        .thenReturn(Collections.singleton(CustomSocketAddress.class));
 
     builder = new ManagedChannelImplBuilder(DUMMY_AUTHORITY_VALID,
         mockClientTransportFactoryBuilder, new FixedPortProvider(DUMMY_PORT));
@@ -782,5 +782,5 @@ public class ManagedChannelImplBuilderTest {
     assertFalse(uriPattern.matcher(" a:/").matches()); // space not matched
   }
 
-  private static class SpecialSocketAddress extends SocketAddress {}
+  private static class CustomSocketAddress extends SocketAddress {}
 }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
@@ -46,7 +46,6 @@ import io.grpc.MetricSink;
 import io.grpc.NameResolver;
 import io.grpc.NameResolverRegistry;
 import io.grpc.StaticTestingClassLoader;
-import io.grpc.inprocess.InProcessSocketAddress;
 import io.grpc.internal.ManagedChannelImplBuilder.ChannelBuilderDefaultPortProvider;
 import io.grpc.internal.ManagedChannelImplBuilder.ClientTransportFactoryBuilder;
 import io.grpc.internal.ManagedChannelImplBuilder.FixedPortProvider;
@@ -367,7 +366,7 @@ public class ManagedChannelImplBuilderTest {
     when(mockClientTransportFactoryBuilder.buildClientTransportFactory())
         .thenReturn(mockClientTransportFactory);
     when(mockClientTransportFactory.getSupportedSocketAddressTypes())
-        .thenReturn(Collections.singleton(InProcessSocketAddress.class));
+        .thenReturn(Collections.singleton(SpecialSocketAddress.class));
 
     builder = new ManagedChannelImplBuilder(DUMMY_AUTHORITY_VALID,
         mockClientTransportFactoryBuilder, new FixedPortProvider(DUMMY_PORT));
@@ -782,4 +781,6 @@ public class ManagedChannelImplBuilderTest {
     assertFalse(uriPattern.matcher("a,:/").matches()); // ',' not matched
     assertFalse(uriPattern.matcher(" a:/").matches()); // space not matched
   }
+
+  private static class SpecialSocketAddress extends SocketAddress {}
 }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
@@ -110,7 +110,7 @@ public class ManagedChannelImplGetNameResolverTest {
     try {
       ManagedChannelImplBuilder.getNameResolverProvider(
           "testscheme:///foo.googleapis.com:8080", nameResolverRegistry,
-          Collections.singleton(SpecialSocketAddress.class));
+          Collections.singleton(CustomSocketAddress.class));
       fail("Should fail");
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessageThat().isEqualTo(
@@ -197,5 +197,5 @@ public class ManagedChannelImplGetNameResolverTest {
     @Override public void shutdown() {}
   }
 
-  private static class SpecialSocketAddress extends SocketAddress {}
+  private static class CustomSocketAddress extends SocketAddress {}
 }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
@@ -22,8 +22,8 @@ import static org.junit.Assert.fail;
 import io.grpc.NameResolver;
 import io.grpc.NameResolverProvider;
 import io.grpc.NameResolverRegistry;
-import io.grpc.inprocess.InProcessSocketAddress;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.net.URI;
 import java.util.Collections;
 import org.junit.Test;
@@ -110,7 +110,7 @@ public class ManagedChannelImplGetNameResolverTest {
     try {
       ManagedChannelImplBuilder.getNameResolverProvider(
           "testscheme:///foo.googleapis.com:8080", nameResolverRegistry,
-          Collections.singleton(InProcessSocketAddress.class));
+          Collections.singleton(SpecialSocketAddress.class));
       fail("Should fail");
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessageThat().isEqualTo(
@@ -196,4 +196,6 @@ public class ManagedChannelImplGetNameResolverTest {
 
     @Override public void shutdown() {}
   }
+
+  private static class SpecialSocketAddress extends SocketAddress {}
 }


### PR DESCRIPTION
An inprocess class was just being abused. Note that grpc-testing depends on inprocess, so there is still an indirect dependency on inprocess present.