### PR TITLE
[vote] Update MAINTAINERS.md. Removed @sanjaypujare from Active Maintainer list and added him to Emeritus Maintainers list. Removed the org names from Emeritus maintainers list. Please comment as "Agree" if you agree to the change, if not please comment as "Disagree". Your comment will be counted as a vote.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -14,22 +14,22 @@ for general contribution guidelines.
 - [larry-safran](https://github.com/larry-safran), Google LLC
 - [markb74](https://github.com/markb74), Google LLC
 - [ran-su](https://github.com/ran-su), Google LLC
-- [sanjaypujare](https://github.com/sanjaypujare), Google LLC
 - [sergiitk](https://github.com/sergiitk), Google LLC
 - [temawi](https://github.com/temawi), Google LLC
 - [YifeiZhuang](https://github.com/YifeiZhuang), Google LLC
 - [zhangkun83](https://github.com/zhangkun83), Google LLC
 
 ## Emeritus Maintainers (in alphabetical order)
-- [carl-mastrangelo](https://github.com/carl-mastrangelo), Google LLC
-- [creamsoup](https://github.com/creamsoup), Google LLC
-- [dapengzhang0](https://github.com/dapengzhang0), Google LLC
-- [ericgribkoff](https://github.com/ericgribkoff), Google LLC
-- [jiangtaoli2016](https://github.com/jiangtaoli2016), Google LLC
-- [jtattermusch](https://github.com/jtattermusch), Google LLC
-- [louiscryan](https://github.com/louiscryan), Google LLC
-- [nicolasnoble](https://github.com/nicolasnoble), Google LLC
-- [nmittler](https://github.com/nmittler), Google LLC
-- [srini100](https://github.com/srini100), Google LLC
-- [voidzcy](https://github.com/voidzcy), Google LLC
-- [zpencer](https://github.com/zpencer), Google LLC
+- [carl-mastrangelo](https://github.com/carl-mastrangelo)
+- [creamsoup](https://github.com/creamsoup)
+- [dapengzhang0](https://github.com/dapengzhang0)
+- [ericgribkoff](https://github.com/ericgribkoff)
+- [jiangtaoli2016](https://github.com/jiangtaoli2016)
+- [jtattermusch](https://github.com/jtattermusch)
+- [louiscryan](https://github.com/louiscryan)
+- [nicolasnoble](https://github.com/nicolasnoble)
+- [nmittler](https://github.com/nmittler)
+- [sanjaypujare](https://github.com/sanjaypujare)
+- [srini100](https://github.com/srini100)
+- [voidzcy](https://github.com/voidzcy)
+- [zpencer](https://github.com/zpencer)


### PR DESCRIPTION
[vote] Updated MAINTAINERS.md. Removed @sanjaypujare from Active Maintainers list and added him to Emeritus Maintainers list Removed the org names from Emeritus maintainers list Please comment as "Agree" if you agree to the change, if not please comment as "Disagree". Your comment will be counted as a vote.