### PR TITLE
binder: Add a connection timeout

### DIFF
--- a/binder/src/androidTest/java/io/grpc/binder/internal/BinderClientTransportTest.java
+++ b/binder/src/androidTest/java/io/grpc/binder/internal/BinderClientTransportTest.java
@@ -22,12 +22,10 @@ import android.content.Context;
 import android.os.DeadObjectException;
 import android.os.Parcel;
 import android.os.RemoteException;
-import androidx.core.content.ContextCompat;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.protobuf.Empty;
-import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ClientStreamTracer;
 import io.grpc.Metadata;
@@ -37,12 +35,8 @@ import io.grpc.ServerServiceDefinition;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.binder.AndroidComponentAddress;
-import io.grpc.binder.BindServiceFlags;
-import io.grpc.binder.BinderChannelCredentials;
 import io.grpc.binder.BinderServerBuilder;
 import io.grpc.binder.HostServices;
-import io.grpc.binder.InboundParcelablePolicy;
-import io.grpc.binder.SecurityPolicies;
 import io.grpc.binder.SecurityPolicy;
 import io.grpc.binder.internal.OneWayBinderProxies.BlackHoleOneWayBinderProxy;
 import io.grpc.binder.internal.OneWayBinderProxies.BlockingBinderDecorator;
@@ -61,13 +55,11 @@ import java.io.InputStream;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import org.junit.After;
@@ -171,7 +163,7 @@ public final class BinderClientTransportTest {
     }
 
     public BinderClientTransportBuilder setConnectTimeoutMillis(int timeoutMillis) {
-      factoryBuilder.setConnectTimeoutMillis(timeoutMillis);
+      factoryBuilder.setReadyTimeoutMillis(timeoutMillis);
       return this;
     }
 

--- a/binder/src/androidTest/java/io/grpc/binder/internal/BinderClientTransportTest.java
+++ b/binder/src/androidTest/java/io/grpc/binder/internal/BinderClientTransportTest.java
@@ -362,7 +362,7 @@ public final class BinderClientTransportTest {
     BlockingBinderDecorator<BlackHoleOneWayBinderProxy> decorator = new BlockingBinderDecorator<>();
     transport = new BinderClientTransportBuilder()
         .setBinderDecorator(decorator)
-        .setConnectTimeoutMillis(1_000)
+        .setConnectTimeoutMillis(1_234)
         .build();
     transport.start(transportListener).run();
     BlackHoleOneWayBinderProxy endpointBinder = new BlackHoleOneWayBinderProxy(
@@ -371,7 +371,7 @@ public final class BinderClientTransportTest {
     decorator.putNextResult(endpointBinder);
     Status transportStatus = transportListener.awaitShutdown();
     assertThat(transportStatus.getCode()).isEqualTo(Code.DEADLINE_EXCEEDED);
-    assertThat(transportStatus.getDescription()).contains("1000");
+    assertThat(transportStatus.getDescription()).contains("1234");
     transportListener.awaitTermination();
   }
 
@@ -379,12 +379,12 @@ public final class BinderClientTransportTest {
   public void testBlackHoleSecurityPolicyConnectTimeout() throws Exception {
     transport = new BinderClientTransportBuilder()
         .setSecurityPolicy(blockingSecurityPolicy)
-        .setConnectTimeoutMillis(1_000)
+        .setConnectTimeoutMillis(1_234)
         .build();
     transport.start(transportListener).run();
     Status transportStatus = transportListener.awaitShutdown();
     assertThat(transportStatus.getCode()).isEqualTo(Code.DEADLINE_EXCEEDED);
-    assertThat(transportStatus.getDescription()).contains("1000");
+    assertThat(transportStatus.getDescription()).contains("1234");
     transportListener.awaitTermination();
     blockingSecurityPolicy.provideNextCheckAuthorizationResult(Status.OK);
   }

--- a/binder/src/androidTest/java/io/grpc/binder/internal/BinderClientTransportTest.java
+++ b/binder/src/androidTest/java/io/grpc/binder/internal/BinderClientTransportTest.java
@@ -162,7 +162,7 @@ public final class BinderClientTransportTest {
       return this;
     }
 
-    public BinderClientTransportBuilder setConnectTimeoutMillis(int timeoutMillis) {
+    public BinderClientTransportBuilder setReadyTimeoutMillis(int timeoutMillis) {
       factoryBuilder.setReadyTimeoutMillis(timeoutMillis);
       return this;
     }
@@ -354,7 +354,7 @@ public final class BinderClientTransportTest {
     BlockingBinderDecorator<BlackHoleOneWayBinderProxy> decorator = new BlockingBinderDecorator<>();
     transport = new BinderClientTransportBuilder()
         .setBinderDecorator(decorator)
-        .setConnectTimeoutMillis(1_234)
+        .setReadyTimeoutMillis(1_234)
         .build();
     transport.start(transportListener).run();
     BlackHoleOneWayBinderProxy endpointBinder = new BlackHoleOneWayBinderProxy(
@@ -371,7 +371,7 @@ public final class BinderClientTransportTest {
   public void testBlackHoleSecurityPolicyConnectTimeout() throws Exception {
     transport = new BinderClientTransportBuilder()
         .setSecurityPolicy(blockingSecurityPolicy)
-        .setConnectTimeoutMillis(1_234)
+        .setReadyTimeoutMillis(1_234)
         .build();
     transport.start(transportListener).run();
     Status transportStatus = transportListener.awaitShutdown();

--- a/binder/src/androidTest/java/io/grpc/binder/internal/BinderClientTransportTest.java
+++ b/binder/src/androidTest/java/io/grpc/binder/internal/BinderClientTransportTest.java
@@ -413,7 +413,7 @@ public final class BinderClientTransportTest {
     }
 
     public void awaitTermination() throws Exception {
-      isTerminated.get(5, TimeUnit.SECONDS);
+      isTerminated.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
     }
 
     @Override
@@ -424,7 +424,7 @@ public final class BinderClientTransportTest {
     }
 
     public void awaitReady() throws Exception {
-      isReady.get(5, TimeUnit.SECONDS);
+      isReady.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
     }
 
     @Override

--- a/binder/src/androidTest/java/io/grpc/binder/internal/OneWayBinderProxies.java
+++ b/binder/src/androidTest/java/io/grpc/binder/internal/OneWayBinderProxies.java
@@ -95,6 +95,37 @@ public final class OneWayBinderProxies {
     }
   }
 
+  /**
+   * A {@link OneWayBinderProxy} decorator whose transact method can be configured to silently drop.
+   */
+  public static final class BlackHoleOneWayBinderProxy extends OneWayBinderProxy {
+
+    private final OneWayBinderProxy wrapped;
+    private boolean dropAllTransactions;
+
+    BlackHoleOneWayBinderProxy(OneWayBinderProxy wrapped) {
+      super(wrapped.getDelegate());
+      this.wrapped = wrapped;
+    }
+
+    /**
+     * Causes all future invocations of transact to be silently dropped.
+     *
+     * <p>Users are responsible for ensuring their calls "happen-before" the relevant calls to
+     * {@link #transact(int, ParcelHolder)}.
+     */
+    public void dropAllTransactions(boolean dropAllTransactions) {
+      this.dropAllTransactions = dropAllTransactions;
+    }
+
+    @Override
+    public void transact(int code, ParcelHolder data) throws RemoteException {
+      if (!dropAllTransactions) {
+        wrapped.transact(code, data);
+      }
+    }
+  }
+
   // Cannot be instantiated.
   private OneWayBinderProxies() {};
 }

--- a/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
@@ -310,9 +310,9 @@ public final class BinderChannelBuilder
     checkArgument(value > 0, "timeout is %s, but must be positive", value);
     // We convert to the largest unit to avoid overflow.
     if (unit.toDays(value) >= 30) {
-      transportFactoryBuilder.setConnectTimeoutMillis(-1);
+      transportFactoryBuilder.setReadyTimeoutMillis(-1);
     } else {
-      transportFactoryBuilder.setConnectTimeoutMillis(unit.toMillis(value));
+      transportFactoryBuilder.setReadyTimeoutMillis(unit.toMillis(value));
     }
     return this;
   }

--- a/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
@@ -293,13 +293,6 @@ public final class BinderChannelBuilder
     return this;
   }
 
-  @Override
-  public ManagedChannel build() {
-    transportFactoryBuilder.setOffloadExecutorPool(
-        managedChannelImplBuilder.getOffloadExecutorPool());
-    return super.build();
-  }
-
   /**
    * Limits how long it can take to establish a single connection behind this channel.
    *
@@ -318,5 +311,12 @@ public final class BinderChannelBuilder
       transportFactoryBuilder.setConnectTimeoutMillis(unit.toMillis(value));
     }
     return this;
+  }
+
+  @Override
+  public ManagedChannel build() {
+    transportFactoryBuilder.setOffloadExecutorPool(
+        managedChannelImplBuilder.getOffloadExecutorPool());
+    return super.build();
   }
 }

--- a/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
@@ -294,13 +294,17 @@ public final class BinderChannelBuilder
   }
 
   /**
-   * Limits how long it can take to establish a single connection behind this channel.
+   * Limits how long it can take for Channels to establish a single connection to the server.
    *
-   * <p>Connection establishment may include creating an Android binding, waiting for the server to
-   * start and return from onBind(), exchanging handshake transactions according to the wire
-   * protocol and evaluating a {@link SecurityPolicy}.
+   * <p>Establishing a connection may include (but isn't limited to):
+   * <ul>
+   * <li>creating an Android binding
+   * <li>waiting for the server process to start and return from Service#onBind()
+   * <li>exchanging handshake transactions according to the wire protocol
+   * <li>evaluating a {@link SecurityPolicy}.
+   * </ul>
    *
-   * <p>The default value is intentionally unspecified and subject to change.
+   * <p>The default timeout value is intentionally unspecified and subject to change.
    */
   public BinderChannelBuilder connectTimeout(long value, TimeUnit unit) {
     checkArgument(value > 0, "timeout is %s, but must be positive", value);

--- a/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
@@ -296,7 +296,7 @@ public final class BinderChannelBuilder
   /**
    * Limits how long it can take for Channels to establish a single connection to the server.
    *
-   * <p>Establishing a connection may include (but isn't limited to):
+   * <p>Establishing a gRPC/binder connection may include (but isn't limited to):
    * <ul>
    * <li>Creating an Android binding.
    * <li>Waiting for Android to create the server process.
@@ -305,9 +305,9 @@ public final class BinderChannelBuilder
    * <li>Evaluating a {@link SecurityPolicy} on both sides.
    * </ul>
    *
-   * <p>This setting doesn't change the need to set a deadline on every call. It merely ensures that
-   * gRPC features like load balancing and wait-for-ready work as expected despite edge cases that
-   * could otherwise stall a connection indefinitely.
+   * <p>This setting doesn't change the need for deadlines at the call level. It merely ensures that
+   * gRPC features like load balancing and wait-for-ready work as expected despite certain edge
+   * cases that could otherwise stall a Channel indefinitely.
    *
    * <p>The default timeout value is intentionally unspecified and subject to change.
    */

--- a/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
@@ -16,7 +16,6 @@
 
 package io.grpc.binder;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
@@ -290,35 +289,6 @@ public final class BinderChannelBuilder
   public BinderChannelBuilder idleTimeout(long value, TimeUnit unit) {
     checkState(!strictLifecycleManagement, "Idle timeouts are not supported when strict lifecycle management is enabled");
     super.idleTimeout(value, unit);
-    return this;
-  }
-
-  /**
-   * Limits how long it can take for Channels to establish a single connection to the server.
-   *
-   * <p>Establishing a gRPC/binder connection may include (but isn't limited to):
-   * <ul>
-   * <li>Creating an Android binding.
-   * <li>Waiting for Android to create the server process.
-   * <li>Waiting for the remote Service to be created and handle onBind().
-   * <li>Exchanging handshake transactions according to the wire protocol.
-   * <li>Evaluating a {@link SecurityPolicy} on both sides.
-   * </ul>
-   *
-   * <p>This setting doesn't change the need for deadlines at the call level. It merely ensures that
-   * gRPC features like load balancing and wait-for-ready work as expected despite certain edge
-   * cases that could otherwise stall a Channel indefinitely.
-   *
-   * <p>The default timeout value is intentionally unspecified and subject to change.
-   */
-  public BinderChannelBuilder connectTimeout(long value, TimeUnit unit) {
-    checkArgument(value > 0, "timeout is %s, but must be positive", value);
-    // We convert to the largest unit to avoid overflow.
-    if (unit.toDays(value) >= 30) {
-      transportFactoryBuilder.setReadyTimeoutMillis(-1);
-    } else {
-      transportFactoryBuilder.setReadyTimeoutMillis(unit.toMillis(value));
-    }
     return this;
   }
 

--- a/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
@@ -298,11 +298,16 @@ public final class BinderChannelBuilder
    *
    * <p>Establishing a connection may include (but isn't limited to):
    * <ul>
-   * <li>creating an Android binding
-   * <li>waiting for the server process to start and return from Service#onBind()
-   * <li>exchanging handshake transactions according to the wire protocol
-   * <li>evaluating a {@link SecurityPolicy}.
+   * <li>Creating an Android binding.
+   * <li>Waiting for Android to create the server process.
+   * <li>Waiting for the remote Service to be created and handle onBind().
+   * <li>Exchanging handshake transactions according to the wire protocol.
+   * <li>Evaluating a {@link SecurityPolicy} on both sides.
    * </ul>
+   *
+   * <p>This setting doesn't change the need to set a deadline on every call. It merely ensures that
+   * gRPC features like load balancing and wait-for-ready work as expected despite edge cases that
+   * could otherwise stall a connection indefinitely.
    *
    * <p>The default timeout value is intentionally unspecified and subject to change.
    */

--- a/binder/src/main/java/io/grpc/binder/internal/BinderClientTransportFactory.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderClientTransportFactory.java
@@ -131,7 +131,7 @@ public final class BinderClientTransportFactory implements ClientTransportFactor
     BindServiceFlags bindServiceFlags = BindServiceFlags.DEFAULTS;
     InboundParcelablePolicy inboundParcelablePolicy = InboundParcelablePolicy.DEFAULT;
     OneWayBinderProxy.Decorator binderDecorator = OneWayBinderProxy.IDENTITY_DECORATOR;
-    long connectTimeoutMillis = -1;  // TODO(jdcormie): Set an actual default here in a separate PR.
+    long connectTimeoutMillis = -1;  // TODO(jdcormie) Set an non-infinite default in a separate PR.
 
     @Override
     public BinderClientTransportFactory buildClientTransportFactory() {

--- a/binder/src/main/java/io/grpc/binder/internal/BinderClientTransportFactory.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderClientTransportFactory.java
@@ -211,8 +211,8 @@ public final class BinderClientTransportFactory implements ClientTransportFactor
      * that gRPC features like
      * <a href="https://github.com/grpc/grpc/blob/master/doc/load-balancing.md">load balancing</a>
      * and <a href="https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md">fail-fast</a>
-     * work as expected despite certain edge cases that could otherwise stall the transport
-     * indefinitely.
+     * work as expected despite certain edge cases in Android that could otherwise stall the
+     * transport indefinitely.
      *
      * <p>Optional. Use a negative value to wait indefinitely.
      */

--- a/binder/src/main/java/io/grpc/binder/internal/BinderClientTransportFactory.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderClientTransportFactory.java
@@ -57,7 +57,7 @@ public final class BinderClientTransportFactory implements ClientTransportFactor
   final BindServiceFlags bindServiceFlags;
   final InboundParcelablePolicy inboundParcelablePolicy;
   final OneWayBinderProxy.Decorator binderDecorator;
-  final long connectTimeoutMillis;
+  final long readyTimeoutMillis;
 
   ScheduledExecutorService executorService;
   Executor offloadExecutor;
@@ -75,7 +75,7 @@ public final class BinderClientTransportFactory implements ClientTransportFactor
     bindServiceFlags = checkNotNull(builder.bindServiceFlags);
     inboundParcelablePolicy = checkNotNull(builder.inboundParcelablePolicy);
     binderDecorator = checkNotNull(builder.binderDecorator);
-    connectTimeoutMillis = builder.connectTimeoutMillis;
+    readyTimeoutMillis = builder.readyTimeoutMillis;
 
     executorService = scheduledExecutorPool.getObject();
     offloadExecutor = offloadExecutorPool.getObject();
@@ -131,7 +131,7 @@ public final class BinderClientTransportFactory implements ClientTransportFactor
     BindServiceFlags bindServiceFlags = BindServiceFlags.DEFAULTS;
     InboundParcelablePolicy inboundParcelablePolicy = InboundParcelablePolicy.DEFAULT;
     OneWayBinderProxy.Decorator binderDecorator = OneWayBinderProxy.IDENTITY_DECORATOR;
-    long connectTimeoutMillis = -1;  // TODO(jdcormie) Set an non-infinite default in a separate PR.
+    long readyTimeoutMillis = -1;  // TODO(jdcormie) Set an non-infinite default in a separate PR.
 
     @Override
     public BinderClientTransportFactory buildClientTransportFactory() {
@@ -196,12 +196,12 @@ public final class BinderClientTransportFactory implements ClientTransportFactor
     }
 
     /**
-     * Limits how long it can take to for new transports to become ready after starting.
+     * Limits how long it can take to for a new transport to become ready after being started.
      *
      * <p>Optional. Use a non-positive value to wait indefinitely.
      */
-    public Builder setConnectTimeoutMillis(long connectTimeoutMillis) {
-      this.connectTimeoutMillis = connectTimeoutMillis;
+    public Builder setReadyTimeoutMillis(long readyTimeoutMillis) {
+      this.readyTimeoutMillis = readyTimeoutMillis;
       return this;
     }
   }

--- a/binder/src/main/java/io/grpc/binder/internal/BinderClientTransportFactory.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderClientTransportFactory.java
@@ -57,6 +57,7 @@ public final class BinderClientTransportFactory implements ClientTransportFactor
   final BindServiceFlags bindServiceFlags;
   final InboundParcelablePolicy inboundParcelablePolicy;
   final OneWayBinderProxy.Decorator binderDecorator;
+  final long connectTimeoutMillis;
 
   ScheduledExecutorService executorService;
   Executor offloadExecutor;
@@ -74,6 +75,7 @@ public final class BinderClientTransportFactory implements ClientTransportFactor
     bindServiceFlags = checkNotNull(builder.bindServiceFlags);
     inboundParcelablePolicy = checkNotNull(builder.inboundParcelablePolicy);
     binderDecorator = checkNotNull(builder.binderDecorator);
+    connectTimeoutMillis = builder.connectTimeoutMillis;
 
     executorService = scheduledExecutorPool.getObject();
     offloadExecutor = offloadExecutorPool.getObject();
@@ -129,6 +131,7 @@ public final class BinderClientTransportFactory implements ClientTransportFactor
     BindServiceFlags bindServiceFlags = BindServiceFlags.DEFAULTS;
     InboundParcelablePolicy inboundParcelablePolicy = InboundParcelablePolicy.DEFAULT;
     OneWayBinderProxy.Decorator binderDecorator = OneWayBinderProxy.IDENTITY_DECORATOR;
+    long connectTimeoutMillis = -1;  // TODO(jdcormie): Set an actual default here in a separate PR.
 
     @Override
     public BinderClientTransportFactory buildClientTransportFactory() {
@@ -189,6 +192,16 @@ public final class BinderClientTransportFactory implements ClientTransportFactor
      */
     public Builder setBinderDecorator(OneWayBinderProxy.Decorator binderDecorator) {
       this.binderDecorator = checkNotNull(binderDecorator, "binderDecorator");
+      return this;
+    }
+
+    /**
+     * Limits how long it can take to for new transports to become ready after starting.
+     *
+     * <p>Optional. Use a non-positive value to wait indefinitely.
+     */
+    public Builder setConnectTimeoutMillis(long connectTimeoutMillis) {
+      this.connectTimeoutMillis = connectTimeoutMillis;
       return this;
     }
   }

--- a/binder/src/main/java/io/grpc/binder/internal/BinderClientTransportFactory.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderClientTransportFactory.java
@@ -211,8 +211,8 @@ public final class BinderClientTransportFactory implements ClientTransportFactor
      * that gRPC features like
      * <a href="https://github.com/grpc/grpc/blob/master/doc/load-balancing.md">load balancing</a>
      * and <a href="https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md">fail-fast</a>
-     * work as expected despite certain edge cases in Android that could otherwise stall the
-     * transport indefinitely.
+     * work as expected despite certain edge cases that could otherwise stall the transport
+     * indefinitely.
      *
      * <p>Optional. Use a negative value to wait indefinitely.
      */

--- a/binder/src/main/java/io/grpc/binder/internal/BinderClientTransportFactory.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderClientTransportFactory.java
@@ -208,8 +208,11 @@ public final class BinderClientTransportFactory implements ClientTransportFactor
      * </ul>
      *
      * <p>This setting doesn't change the need for deadlines at the call level. It merely ensures
-     * that gRPC features like load balancing and wait-for-ready work as expected despite certain
-     * edge cases that could otherwise stall the transport indefinitely.
+     * that gRPC features like
+     * <a href="https://github.com/grpc/grpc/blob/master/doc/load-balancing.md">load balancing</a>
+     * and <a href="https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md">fail-fast</a>
+     * work as expected despite certain edge cases that could otherwise stall the transport
+     * indefinitely.
      *
      * <p>Optional. Use a negative value to wait indefinitely.
      */

--- a/binder/src/main/java/io/grpc/binder/internal/BinderClientTransportFactory.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderClientTransportFactory.java
@@ -198,6 +198,19 @@ public final class BinderClientTransportFactory implements ClientTransportFactor
     /**
      * Limits how long it can take to for a new transport to become ready after being started.
      *
+     * <p>This process includes:
+     * <ul>
+     * <li>Creating an Android binding.
+     * <li>Waiting for Android to create the server process.
+     * <li>Waiting for the remote Service to be created and handle onBind().
+     * <li>Exchanging handshake transactions according to the wire protocol.
+     * <li>Evaluating a {@link SecurityPolicy} on both sides.
+     * </ul>
+     *
+     * <p>This setting doesn't change the need for deadlines at the call level. It merely ensures
+     * that gRPC features like load balancing and wait-for-ready work as expected despite certain
+     * edge cases that could otherwise stall the transport indefinitely.
+     *
      * <p>Optional. Use a negative value to wait indefinitely.
      */
     public Builder setReadyTimeoutMillis(long readyTimeoutMillis) {

--- a/binder/src/main/java/io/grpc/binder/internal/BinderClientTransportFactory.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderClientTransportFactory.java
@@ -198,7 +198,7 @@ public final class BinderClientTransportFactory implements ClientTransportFactor
     /**
      * Limits how long it can take to for a new transport to become ready after being started.
      *
-     * <p>Optional. Use a non-positive value to wait indefinitely.
+     * <p>Optional. Use a negative value to wait indefinitely.
      */
     public Builder setReadyTimeoutMillis(long readyTimeoutMillis) {
       this.readyTimeoutMillis = readyTimeoutMillis;

--- a/binder/src/main/java/io/grpc/binder/internal/BinderClientTransportFactory.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderClientTransportFactory.java
@@ -198,7 +198,7 @@ public final class BinderClientTransportFactory implements ClientTransportFactor
     /**
      * Limits how long it can take to for a new transport to become ready after being started.
      *
-     * <p>This process includes:
+     * <p>This process currently includes:
      * <ul>
      * <li>Creating an Android binding.
      * <li>Waiting for Android to create the server process.

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -19,6 +19,7 @@ package io.grpc.binder.internal;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import android.content.Context;
 import android.os.Binder;
@@ -69,6 +70,8 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
@@ -560,13 +563,14 @@ public abstract class BinderTransport
     private final Bindable serviceBinding;
     /** Number of ongoing calls which keep this transport "in-use". */
     private final AtomicInteger numInUseStreams;
-
+    private final long connectTimeoutMillis;
     private final PingTracker pingTracker;
 
     @Nullable private ManagedClientTransport.Listener clientTransportListener;
 
     @GuardedBy("this")
     private int latestCallId = FIRST_CALL_ID;
+    private ScheduledFuture<?> connectTimeoutFuture; // != null iff timeout scheduled.
 
     /**
      * Constructs a new transport instance.
@@ -588,6 +592,7 @@ public abstract class BinderTransport
       this.offloadExecutorPool = factory.offloadExecutorPool;
       this.securityPolicy = factory.securityPolicy;
       this.offloadExecutor = offloadExecutorPool.getObject();
+      this.connectTimeoutMillis = factory.connectTimeoutMillis;
       numInUseStreams = new AtomicInteger();
       pingTracker = new PingTracker(Ticker.systemTicker(), (id) -> sendPing(id));
 
@@ -627,9 +632,22 @@ public abstract class BinderTransport
           if (inState(TransportState.NOT_STARTED)) {
             setState(TransportState.SETUP);
             serviceBinding.bind();
+            if (connectTimeoutMillis > 0) {
+              connectTimeoutFuture = getScheduledExecutorService().schedule(
+                  BinderClientTransport.this::onTimeoutExpired, connectTimeoutMillis, MILLISECONDS);
+            }
           }
         }
       };
+    }
+
+    private synchronized void onTimeoutExpired() {
+      if (inState(TransportState.SETUP)) {
+        connectTimeoutFuture = null;
+        shutdownInternal(Status.DEADLINE_EXCEEDED
+            .withDescription("Connect timeout " + connectTimeoutMillis + "ms lapsed"),
+            true);
+      }
     }
 
     @Override
@@ -712,6 +730,10 @@ public abstract class BinderTransport
       if (numInUseStreams.getAndSet(0) > 0) {
         clientTransportListener.transportInUse(false);
       }
+      if (connectTimeoutFuture != null) {
+        connectTimeoutFuture.cancel(false);
+        connectTimeoutFuture = null;
+      }
       serviceBinding.unbind();
       clientTransportListener.transportTerminated();
     }
@@ -761,6 +783,10 @@ public abstract class BinderTransport
               setState(TransportState.READY);
               attributes = clientTransportListener.filterTransport(attributes);
               clientTransportListener.transportReady();
+              if (connectTimeoutFuture != null) {
+                connectTimeoutFuture.cancel(false);
+                connectTimeoutFuture = null;
+              }
             }
           }
         }

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -569,6 +569,7 @@ public abstract class BinderTransport
 
     @GuardedBy("this")
     private int latestCallId = FIRST_CALL_ID;
+    @GuardedBy("this")
     private ScheduledFuture<?> readyTimeoutFuture; // != null iff timeout scheduled.
 
     /**


### PR DESCRIPTION
Timeout is initially infinite so that we can release/import the supporting code and the behavior change independently. 

Fixes https://github.com/grpc/grpc-java/issues/11137