### PR TITLE
core: Remove "can't call transport listener from start()" restriction

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
@@ -39,9 +39,7 @@ public interface ManagedClientTransport extends ClientTransport {
   /**
    * Starts transport. This method may only be called once.
    *
-   * <p>Implementations must not call {@code listener} from within {@link #start}; implementations
-   * are expected to notify listener on a separate thread or when the returned {@link Runnable} is
-   * run. This method and the returned {@code Runnable} should not throw any exceptions.
+   * <p>This method and the returned {@code Runnable} should not throw any exceptions.
    *
    * @param listener non-{@code null} listener of transport events
    * @return a {@link Runnable} that is executed after-the-fact by the original caller, typically


### PR DESCRIPTION
This hasn't been needed since f8f569e07, when InternalSubchannel stopped calling start() with a lock held. Note that also means no transport needs to return a Runnable (but some still are).

I had noticed in e4e7f3a06 that it was safe for InProcess to call the listener directly within start(), but I didn't notice this Javadoc that said it wasn't allowed.

CC @jdcormie 