### PR TITLE
core: Delete AbstractTransportTest.clientShutdownBeforeStartRunnable

### DIFF
--- a/core/src/testFixtures/java/io/grpc/internal/AbstractTransportTest.java
+++ b/core/src/testFixtures/java/io/grpc/internal/AbstractTransportTest.java
@@ -351,26 +351,6 @@ public abstract class AbstractTransportTest {
   }
 
   @Test
-  public void clientShutdownBeforeStartRunnable() throws Exception {
-    server.start(serverListener);
-    client = newClientTransport(server);
-    Runnable runnable = client.start(mockClientTransportListener);
-    // Shutdown before calling 'runnable'
-    client.shutdown(Status.UNAVAILABLE.withDescription("shutdown called"));
-    runIfNotNull(runnable);
-    verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportTerminated();
-    // We should verify that clients don't call transportReady() after transportTerminated(), but
-    // transports do this today and nothing cares. ServerImpl, on the other hand, doesn't appreciate
-    // the out-of-order calls.
-    MockServerTransportListener serverTransportListener
-        = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
-    assertTrue(serverTransportListener.waitForTermination(TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    // Allow any status as some transports (e.g., Netty) don't communicate the original status when
-    // shutdown while handshaking. It won't be used anyway, so no big deal.
-    verify(mockClientTransportListener).transportShutdown(any(Status.class));
-  }
-
-  @Test
   public void clientStartAndStopOnceConnected() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);

--- a/servlet/src/jettyTest/java/io/grpc/servlet/JettyTransportTest.java
+++ b/servlet/src/jettyTest/java/io/grpc/servlet/JettyTransportTest.java
@@ -262,9 +262,4 @@ public class JettyTransportTest extends AbstractTransportTest {
   @Ignore("https://github.com/jetty/jetty.project/issues/11822")
   @Test
   public void clientChecksInboundMetadataSize_trailer() {}
-
-  @Override
-  @Ignore("Not yet investigated, but has been seen for multiple servlet containers")
-  @Test
-  public void clientShutdownBeforeStartRunnable() {}
 }

--- a/servlet/src/tomcatTest/java/io/grpc/servlet/TomcatTransportTest.java
+++ b/servlet/src/tomcatTest/java/io/grpc/servlet/TomcatTransportTest.java
@@ -274,9 +274,4 @@ public class TomcatTransportTest extends AbstractTransportTest {
   @Ignore("regression since bumping grpc v1.46 to v1.53")
   @Test
   public void messageProducerOnlyProducesRequestedMessages() {}
-
-  @Override
-  @Ignore("Not yet investigated, but has been seen for multiple servlet containers")
-  @Test
-  public void clientShutdownBeforeStartRunnable() {}
 }

--- a/servlet/src/undertowTest/java/io/grpc/servlet/UndertowTransportTest.java
+++ b/servlet/src/undertowTest/java/io/grpc/servlet/UndertowTransportTest.java
@@ -308,9 +308,4 @@ public class UndertowTransportTest extends AbstractTransportTest {
   @Ignore("regression since bumping grpc v1.46 to v1.53")
   @Test
   public void messageProducerOnlyProducesRequestedMessages() {}
-
-  @Override
-  @Ignore("Not yet investigated, but has been seen for multiple servlet containers")
-  @Test
-  public void clientShutdownBeforeStartRunnable() {}
 }


### PR DESCRIPTION
The test was added in e4e7f3a06 when InProcess stopped returning a Runnable from start(). In #11256 we realized (indirectly) that there's no point in using the Runnable any more.

This test failed with Binder (which seems to have been using the Runnable unnecessarily), and InProcess, Netty, and OkHttp don't use the Runnable. Instead of fixing it, we'll just move toward stopping using Runnable.

I'm not removing the Runnable usage from Binder in this commit because this test is currently causing CI failures and I don't want to do a behavior change when fixing it.

CC @larry-safran 