### PR TITLE
kokoro: Remove unavailable API levels 21-23

### DIFF
--- a/buildscripts/kokoro/android-interop.sh
+++ b/buildscripts/kokoro/android-interop.sh
@@ -32,6 +32,9 @@ GRADLE_FLAGS="-Pandroid.useAndroidX=true"
 ./gradlew $GRADLE_FLAGS :grpc-android-interop-testing:assembleDebugAndroidTest
 ./gradlew $GRADLE_FLAGS :grpc-binder:assembleDebugAndroidTest
 
+# To see currently-available virtual devices:
+#   gcloud firebase test android models list --filter=form=virtual
+
 # Run interop instrumentation tests on Firebase Test Lab
 gcloud firebase test android run \
   --type instrumentation \
@@ -46,9 +49,6 @@ gcloud firebase test android run \
   --device model=MediumPhone.arm,version=26,locale=en,orientation=portrait \
   --device model=Nexus6P,version=25,locale=en,orientation=portrait \
   --device model=Nexus6P,version=24,locale=en,orientation=portrait \
-  --device model=Nexus6P,version=23,locale=en,orientation=portrait \
-  --device model=Nexus6,version=22,locale=en,orientation=portrait \
-  --device model=Nexus6,version=21,locale=en,orientation=portrait
 
 # Run binderchannel instrumentation tests on Firebase Test Lab
 gcloud firebase test android run \
@@ -62,6 +62,3 @@ gcloud firebase test android run \
   --device model=MediumPhone.arm,version=26,locale=en,orientation=portrait \
   --device model=Nexus6P,version=25,locale=en,orientation=portrait \
   --device model=Nexus6P,version=24,locale=en,orientation=portrait \
-  --device model=Nexus6P,version=23,locale=en,orientation=portrait \
-  --device model=Nexus6,version=22,locale=en,orientation=portrait \
-  --device model=Nexus6,version=21,locale=en,orientation=portrait


### PR DESCRIPTION
There are no longer any devices (virtual or otherwise) that support API level 21, 22, or 23. Google Play services is still supporting API level 21 (although there is a pattern of notifying of dropped levels in July, and dropping them in August).

CC @jdcormie 