### PR TITLE
gcp-csm-o11y: s/csm.service_namespace/csm.service_namespace_name/

### DIFF
--- a/gcp-csm-observability/src/main/java/io/grpc/gcp/csm/observability/MetadataExchanger.java
+++ b/gcp-csm-observability/src/main/java/io/grpc/gcp/csm/observability/MetadataExchanger.java
@@ -280,8 +280,8 @@ final class MetadataExchanger implements InternalOpenTelemetryPlugin {
 
       @Override
       public void addLabels(AttributesBuilder to) {
-        put(to, "csm.service_name",      serviceName);
-        put(to, "csm.service_namespace", serviceNamespace);
+        put(to, "csm.service_name",           serviceName);
+        put(to, "csm.service_namespace_name", serviceNamespace);
         Struct exchange = receivedExchange;
         if (exchange == null) {
           exchange = Struct.getDefaultInstance();

--- a/gcp-csm-observability/src/test/java/io/grpc/gcp/csm/observability/CsmObservabilityTest.java
+++ b/gcp-csm-observability/src/test/java/io/grpc/gcp/csm/observability/CsmObservabilityTest.java
@@ -114,7 +114,7 @@ public final class CsmObservabilityTest {
         .put(stringKey("csm.remote_workload_canonical_service"), "unknown")
         .put(stringKey("csm.remote_workload_type"),              "unknown")
         .put(stringKey("csm.service_name"),                      "unknown")
-        .put(stringKey("csm.service_namespace"),                 "unknown")
+        .put(stringKey("csm.service_namespace_name"),            "unknown")
         .put(stringKey("csm.workload_canonical_service"),        "unknown")
         .put(stringKey("csm.mesh_id"),                           "unknown")
         .build();
@@ -170,7 +170,7 @@ public final class CsmObservabilityTest {
         .put(stringKey("csm.remote_workload_canonical_service"), "unknown")
         .put(stringKey("csm.remote_workload_type"),              "unknown")
         .put(stringKey("csm.service_name"),                      "unknown")
-        .put(stringKey("csm.service_namespace"),                 "unknown")
+        .put(stringKey("csm.service_namespace_name"),            "unknown")
         .put(stringKey("csm.workload_canonical_service"),        "unknown")
         .put(stringKey("csm.mesh_id"),                           "unknown")
         .build();
@@ -335,7 +335,7 @@ public final class CsmObservabilityTest {
         .put(stringKey("csm.remote_workload_namespace_name"),    "namespace-1e43c")
         .put(stringKey("csm.remote_workload_name"),              "fast-server")
         .put(stringKey("csm.service_name"),                      "second-server-name")
-        .put(stringKey("csm.service_namespace"),                 "namespace-0001")
+        .put(stringKey("csm.service_namespace_name"),            "namespace-0001")
         .put(stringKey("csm.workload_canonical_service"),        "canon-service-is-a-client")
         .put(stringKey("csm.mesh_id"),                           "mymesh")
         .build();
@@ -427,7 +427,7 @@ public final class CsmObservabilityTest {
         .put(stringKey("csm.remote_workload_location"),          "us-east2-c")
         .put(stringKey("csm.remote_workload_name"),              "fast-server")
         .put(stringKey("csm.service_name"),                      "unknown")
-        .put(stringKey("csm.service_namespace"),                 "unknown")
+        .put(stringKey("csm.service_namespace_name"),            "unknown")
         .put(stringKey("csm.workload_canonical_service"),        "canon-service-is-a-client")
         .put(stringKey("csm.mesh_id"),                           "mymesh")
         .build();
@@ -517,7 +517,7 @@ public final class CsmObservabilityTest {
         .put(stringKey("csm.remote_workload_location"),          "us-east2-c")
         .put(stringKey("csm.remote_workload_name"),              "fast-server")
         .put(stringKey("csm.service_name"),                      "unknown")
-        .put(stringKey("csm.service_namespace"),                 "unknown")
+        .put(stringKey("csm.service_namespace_name"),            "unknown")
         .put(stringKey("csm.workload_canonical_service"),        "canon-service-is-a-client")
         .put(stringKey("csm.mesh_id"),                           "mymesh")
         .build();


### PR DESCRIPTION
Just a typo, maybe because service_namespace is used in filter metadata from CDS.