### PR TITLE
gcp-csm-o11y: Use xds's shadow configuration

### DIFF
--- a/gcp-csm-observability/build.gradle
+++ b/gcp-csm-observability/build.gradle
@@ -17,7 +17,7 @@ dependencies {
             project(':grpc-core'),
             project(':grpc-opentelemetry'),
             project(':grpc-protobuf'),
-            project(':grpc-xds'),
+            project(path: ':grpc-xds', configuration: 'shadow'),
             libraries.guava.jre, // jre version pulled in via xds
             libraries.protobuf.java,
             libraries.opentelemetry.gcp.resources,


### PR DESCRIPTION
This prevents mixing shaded and non-shaded class files. We do the same thing in all the other projects that depend on xds.