### PR TITLE
binder: Make transport notification methods package-private

### DIFF
--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -258,8 +258,10 @@ public abstract class BinderTransport
     return !flowController.isTransmitWindowFull();
   }
 
+  @GuardedBy("this")
   abstract void notifyShutdown(Status shutdownStatus);
 
+  @GuardedBy("this")
   abstract void notifyTerminated();
 
   void releaseExecutors() {
@@ -702,13 +704,13 @@ public abstract class BinderTransport
 
     @Override
     @GuardedBy("this")
-    public void notifyShutdown(Status status) {
+    void notifyShutdown(Status status) {
       clientTransportListener.transportShutdown(status);
     }
 
     @Override
     @GuardedBy("this")
-    public void notifyTerminated() {
+    void notifyTerminated() {
       if (numInUseStreams.getAndSet(0) > 0) {
         clientTransportListener.transportInUse(false);
       }
@@ -871,13 +873,13 @@ public abstract class BinderTransport
 
     @Override
     @GuardedBy("this")
-    public void notifyShutdown(Status status) {
+    void notifyShutdown(Status status) {
       // Nothing to do.
     }
 
     @Override
     @GuardedBy("this")
-    public void notifyTerminated() {
+    void notifyTerminated() {
       if (serverTransportListener != null) {
         serverTransportListener.transportTerminated();
       }


### PR DESCRIPTION
These are overrides of BinderTransport itself, so not used elsewhere. They are essentially private. It was scary seeing `@GuardedBy` for a public method. I copied the annotation to the base class to make sure ErrorProne could verify the calls.

(I noticed then when reviewing #11255)