### PR TITLE
Adding missing synchronization in runnable

### DIFF
--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -327,7 +327,9 @@ public abstract class BinderTransport
                 inbound.closeAbnormal(shutdownStatus);
               }
             }
-            notifyTerminated();
+            synchronized (this) {
+              notifyTerminated();
+            } 
             releaseExecutors();
           });
     }


### PR DESCRIPTION
Call to awaitTermination() should be access guarded but it is not when called from inside the runnable. This PR fixes that.