### PR TITLE
opentelemetry: Add explicit histogram buckets for per-call metrics

### DIFF
--- a/opentelemetry/src/main/java/io/grpc/opentelemetry/GrpcOpenTelemetry.java
+++ b/opentelemetry/src/main/java/io/grpc/opentelemetry/GrpcOpenTelemetry.java
@@ -18,6 +18,8 @@ package io.grpc.opentelemetry;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.grpc.internal.GrpcUtil.IMPLEMENTATION_VERSION;
+import static io.grpc.opentelemetry.internal.OpenTelemetryConstants.LATENCY_BUCKETS;
+import static io.grpc.opentelemetry.internal.OpenTelemetryConstants.SIZE_BUCKETS;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
@@ -172,6 +174,7 @@ public final class GrpcOpenTelemetry {
               .setUnit("s")
               .setDescription(
                   "Time taken by gRPC to complete an RPC from application's perspective")
+              .setExplicitBucketBoundariesAdvice(LATENCY_BUCKETS)
               .build());
     }
 
@@ -189,6 +192,7 @@ public final class GrpcOpenTelemetry {
                   "grpc.client.attempt.duration")
               .setUnit("s")
               .setDescription("Time taken to complete a client call attempt")
+              .setExplicitBucketBoundariesAdvice(LATENCY_BUCKETS)
               .build());
     }
 
@@ -200,6 +204,7 @@ public final class GrpcOpenTelemetry {
               .setUnit("By")
               .setDescription("Compressed message bytes sent per client call attempt")
               .ofLongs()
+              .setExplicitBucketBoundariesAdvice(SIZE_BUCKETS)
               .build());
     }
 
@@ -211,6 +216,7 @@ public final class GrpcOpenTelemetry {
               .setUnit("By")
               .setDescription("Compressed message bytes received per call attempt")
               .ofLongs()
+              .setExplicitBucketBoundariesAdvice(SIZE_BUCKETS)
               .build());
     }
 
@@ -228,6 +234,7 @@ public final class GrpcOpenTelemetry {
               .setUnit("s")
               .setDescription(
                   "Time taken to complete a call from server transport's perspective")
+              .setExplicitBucketBoundariesAdvice(LATENCY_BUCKETS)
               .build());
     }
 
@@ -239,6 +246,7 @@ public final class GrpcOpenTelemetry {
               .setUnit("By")
               .setDescription("Compressed message bytes sent per server call")
               .ofLongs()
+              .setExplicitBucketBoundariesAdvice(SIZE_BUCKETS)
               .build());
     }
 
@@ -250,6 +258,7 @@ public final class GrpcOpenTelemetry {
               .setUnit("By")
               .setDescription("Compressed message bytes received per server call")
               .ofLongs()
+              .setExplicitBucketBoundariesAdvice(SIZE_BUCKETS)
               .build());
     }
 

--- a/opentelemetry/src/main/java/io/grpc/opentelemetry/internal/OpenTelemetryConstants.java
+++ b/opentelemetry/src/main/java/io/grpc/opentelemetry/internal/OpenTelemetryConstants.java
@@ -18,6 +18,7 @@ package io.grpc.opentelemetry.internal;
 
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.api.common.AttributeKey;
+import java.util.List;
 
 public final class OpenTelemetryConstants {
 
@@ -32,7 +33,7 @@ public final class OpenTelemetryConstants {
   public static final AttributeKey<String> LOCALITY_KEY =
       AttributeKey.stringKey("grpc.lb.locality");
 
-  public static final ImmutableList<Double> LATENCY_BUCKETS =
+  public static final List<Double> LATENCY_BUCKETS =
       ImmutableList.of(
           0d,     0.00001d, 0.00005d, 0.0001d, 0.0003d, 0.0006d, 0.0008d, 0.001d, 0.002d,
           0.003d, 0.004d,   0.005d,   0.006d,  0.008d,  0.01d,   0.013d,  0.016d, 0.02d,
@@ -40,7 +41,7 @@ public final class OpenTelemetryConstants {
           0.2d,   0.25d,    0.3d,     0.4d,    0.5d,    0.65d,   0.8d,    1d,     2d,
           5d,     10d,      20d,      50d,     100d);
 
-  public static final ImmutableList<Long> SIZE_BUCKETS =
+  public static final List<Long> SIZE_BUCKETS =
       ImmutableList.of(
           0L, 1024L, 2048L, 4096L, 16384L, 65536L, 262144L, 1048576L, 4194304L, 16777216L,
           67108864L, 268435456L, 1073741824L, 4294967296L);

--- a/opentelemetry/src/main/java/io/grpc/opentelemetry/internal/OpenTelemetryConstants.java
+++ b/opentelemetry/src/main/java/io/grpc/opentelemetry/internal/OpenTelemetryConstants.java
@@ -16,7 +16,9 @@
 
 package io.grpc.opentelemetry.internal;
 
+import com.google.common.collect.ImmutableList;
 import io.opentelemetry.api.common.AttributeKey;
+import java.util.List;
 
 public final class OpenTelemetryConstants {
 
@@ -30,6 +32,19 @@ public final class OpenTelemetryConstants {
 
   public static final AttributeKey<String> LOCALITY_KEY =
       AttributeKey.stringKey("grpc.lb.locality");
+
+  public static final List<Double> LATENCY_BUCKETS =
+      ImmutableList.of(
+          0d,     0.00001d, 0.00005d, 0.0001d, 0.0003d, 0.0006d, 0.0008d, 0.001d, 0.002d,
+          0.003d, 0.004d,   0.005d,   0.006d,  0.008d,  0.01d,   0.013d,  0.016d, 0.02d,
+          0.025d, 0.03d,    0.04d,    0.05d,   0.065d,  0.08d,   0.1d,    0.13d,  0.16d,
+          0.2d,   0.25d,    0.3d,     0.4d,    0.5d,    0.65d,   0.8d,    1d,     2d,
+          5d,     10d,      20d,      50d,     100d);
+
+  public static final List<Long> SIZE_BUCKETS =
+      ImmutableList.of(
+          0L, 1024L, 2048L, 4096L, 16384L, 65536L, 262144L, 1048576L, 4194304L, 16777216L,
+          67108864L, 268435456L, 1073741824L, 4294967296L);
 
   private OpenTelemetryConstants() {
   }

--- a/opentelemetry/src/main/java/io/grpc/opentelemetry/internal/OpenTelemetryConstants.java
+++ b/opentelemetry/src/main/java/io/grpc/opentelemetry/internal/OpenTelemetryConstants.java
@@ -18,7 +18,6 @@ package io.grpc.opentelemetry.internal;
 
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.api.common.AttributeKey;
-import java.util.List;
 
 public final class OpenTelemetryConstants {
 
@@ -33,7 +32,7 @@ public final class OpenTelemetryConstants {
   public static final AttributeKey<String> LOCALITY_KEY =
       AttributeKey.stringKey("grpc.lb.locality");
 
-  public static final List<Double> LATENCY_BUCKETS =
+  public static final ImmutableList<Double> LATENCY_BUCKETS =
       ImmutableList.of(
           0d,     0.00001d, 0.00005d, 0.0001d, 0.0003d, 0.0006d, 0.0008d, 0.001d, 0.002d,
           0.003d, 0.004d,   0.005d,   0.006d,  0.008d,  0.01d,   0.013d,  0.016d, 0.02d,
@@ -41,7 +40,7 @@ public final class OpenTelemetryConstants {
           0.2d,   0.25d,    0.3d,     0.4d,    0.5d,    0.65d,   0.8d,    1d,     2d,
           5d,     10d,      20d,      50d,     100d);
 
-  public static final List<Long> SIZE_BUCKETS =
+  public static final ImmutableList<Long> SIZE_BUCKETS =
       ImmutableList.of(
           0L, 1024L, 2048L, 4096L, 16384L, 65536L, 262144L, 1048576L, 4194304L, 16777216L,
           67108864L, 268435456L, 1073741824L, 4294967296L);

--- a/opentelemetry/src/test/java/io/grpc/opentelemetry/OpenTelemetryMetricsModuleTest.java
+++ b/opentelemetry/src/test/java/io/grpc/opentelemetry/OpenTelemetryMetricsModuleTest.java
@@ -451,10 +451,7 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(0.03 + 0.1 + 0.024)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS)
-                                        .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0))),
+                                        .hasBucketBoundaries(LATENCY_BUCKETS))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -470,9 +467,7 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(1028L)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(SIZE_BUCKETS)
-                                        .hasBucketCounts(0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0))),
+                                        .hasBucketBoundaries(SIZE_BUCKETS))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -490,9 +485,7 @@ public class OpenTelemetryMetricsModuleTest {
                                             .hasCount(1)
                                             .hasSum(0)
                                             .hasAttributes(clientAttributes)
-                                            .hasBucketBoundaries(SIZE_BUCKETS)
-                                            .hasBucketCounts(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                                0, 0))));
+                                            .hasBucketBoundaries(SIZE_BUCKETS))));
 
 
     // faking retry
@@ -543,19 +536,13 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(0.1)
                                         .hasAttributes(clientAttributes1)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS)
-                                        .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0),
+                                        .hasBucketBoundaries(LATENCY_BUCKETS),
                                 point ->
                                     point
                                         .hasCount(1)
                                         .hasSum(0.154)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS)
-                                        .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
-                                    0, 0, 0, 0, 0, 0, 0, 0, 0))),
+                                        .hasBucketBoundaries(LATENCY_BUCKETS))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -573,17 +560,13 @@ public class OpenTelemetryMetricsModuleTest {
                                             .hasCount(1)
                                             .hasSum(0)
                                             .hasAttributes(clientAttributes1)
-                                            .hasBucketBoundaries(SIZE_BUCKETS)
-                                            .hasBucketCounts(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                                0, 0),
+                                            .hasBucketBoundaries(SIZE_BUCKETS),
                                     point ->
                                         point
                                             .hasCount(1)
                                             .hasSum(0)
                                             .hasAttributes(clientAttributes)
-                                            .hasBucketBoundaries(SIZE_BUCKETS)
-                                            .hasBucketCounts(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                                0, 0))),
+                                            .hasBucketBoundaries(SIZE_BUCKETS))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -599,17 +582,13 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(1028L)
                                         .hasAttributes(clientAttributes1)
-                                        .hasBucketBoundaries(SIZE_BUCKETS)
-                                        .hasBucketCounts(0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0),
+                                        .hasBucketBoundaries(SIZE_BUCKETS),
                                 point ->
                                     point
                                         .hasCount(1)
                                         .hasSum(1028L)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(SIZE_BUCKETS)
-                                        .hasBucketCounts(0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0))));
+                                        .hasBucketBoundaries(SIZE_BUCKETS))));
 
     // fake transparent retry
     fakeClock.forwardTime(10, TimeUnit.MILLISECONDS);
@@ -650,19 +629,13 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(0.1)
                                         .hasAttributes(clientAttributes1)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS)
-                                        .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0),
+                                        .hasBucketBoundaries(LATENCY_BUCKETS),
                                 point ->
                                     point
                                         .hasCount(2)
                                         .hasSum(0.154 + 0.032)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS)
-                                        .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0))),
+                                        .hasBucketBoundaries(LATENCY_BUCKETS))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -680,17 +653,13 @@ public class OpenTelemetryMetricsModuleTest {
                                             .hasCount(1)
                                             .hasSum(0)
                                             .hasAttributes(clientAttributes1)
-                                            .hasBucketBoundaries(SIZE_BUCKETS)
-                                            .hasBucketCounts(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                                0, 0),
+                                            .hasBucketBoundaries(SIZE_BUCKETS),
                                     point ->
                                         point
                                             .hasCount(2)
                                             .hasSum(0 + 0)
                                             .hasAttributes(clientAttributes)
-                                            .hasBucketBoundaries(SIZE_BUCKETS)
-                                            .hasBucketCounts(2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                                0, 0))),
+                                            .hasBucketBoundaries(SIZE_BUCKETS))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -706,17 +675,13 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(1028L)
                                         .hasAttributes(clientAttributes1)
-                                        .hasBucketBoundaries(SIZE_BUCKETS)
-                                        .hasBucketCounts(0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0),
+                                        .hasBucketBoundaries(SIZE_BUCKETS),
                                 point ->
                                     point
                                         .hasCount(2)
                                         .hasSum(1028L + 0)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(SIZE_BUCKETS)
-                                        .hasBucketCounts(1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0))));
+                                        .hasBucketBoundaries(SIZE_BUCKETS))));
 
     // fake another transparent retry
     fakeClock.forwardTime(10, MILLISECONDS);
@@ -770,25 +735,19 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(1028L)
                                         .hasAttributes(clientAttributes1)
-                                        .hasBucketBoundaries(SIZE_BUCKETS)
-                                        .hasBucketCounts(0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0),
+                                        .hasBucketBoundaries(SIZE_BUCKETS),
                                 point ->
                                     point
                                         .hasCount(2)
                                         .hasSum(1028L + 0)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(SIZE_BUCKETS)
-                                        .hasBucketCounts(1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0),
+                                        .hasBucketBoundaries(SIZE_BUCKETS),
                                 point ->
                                     point
                                         .hasCount(1)
                                         .hasSum(1028L)
                                         .hasAttributes(clientAttributes2)
-                                        .hasBucketBoundaries(SIZE_BUCKETS)
-                                        .hasBucketCounts(0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0))),
+                                        .hasBucketBoundaries(SIZE_BUCKETS))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -804,10 +763,7 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasSum(0.03 + 0.1 + 0.024 + 1 + 0.1 + 0.01 + 0.032 + 0.01
                                             + 0.024)
                                         .hasAttributes(clientAttributes2)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS)
-                                        .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 1, 0, 0, 0, 0, 0, 0))),
+                                        .hasBucketBoundaries(LATENCY_BUCKETS))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -822,28 +778,19 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(0.100)
                                         .hasAttributes(clientAttributes1)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS)
-                                        .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0),
+                                        .hasBucketBoundaries(LATENCY_BUCKETS),
                                 point ->
                                     point
                                         .hasCount(2)
                                         .hasSum(0.154 + 0.032)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS)
-                                        .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0),
+                                        .hasBucketBoundaries(LATENCY_BUCKETS),
                                 point ->
                                     point
                                         .hasCount(1)
                                         .hasSum(0.024)
                                         .hasAttributes(clientAttributes2)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS)
-                                        .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0))),
+                                        .hasBucketBoundaries(LATENCY_BUCKETS))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -861,25 +808,19 @@ public class OpenTelemetryMetricsModuleTest {
                                             .hasCount(1)
                                             .hasSum(0)
                                             .hasAttributes(clientAttributes1)
-                                            .hasBucketBoundaries(SIZE_BUCKETS)
-                                            .hasBucketCounts(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                                0, 0),
+                                            .hasBucketBoundaries(SIZE_BUCKETS),
                                     point ->
                                         point
                                             .hasCount(2)
                                             .hasSum(0 + 0)
                                             .hasAttributes(clientAttributes)
-                                            .hasBucketBoundaries(SIZE_BUCKETS)
-                                            .hasBucketCounts(2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                                0, 0),
+                                            .hasBucketBoundaries(SIZE_BUCKETS),
                                     point ->
                                         point
                                             .hasCount(1)
                                             .hasSum(33D)
                                             .hasAttributes(clientAttributes2)
-                                            .hasBucketBoundaries(SIZE_BUCKETS)
-                                            .hasBucketCounts(0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                                0, 0))));
+                                            .hasBucketBoundaries(SIZE_BUCKETS))));
   }
 
   @Test
@@ -938,9 +879,7 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(0)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(SIZE_BUCKETS)
-                                        .hasBucketCounts(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0))),
+                                        .hasBucketBoundaries(SIZE_BUCKETS))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -955,10 +894,7 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(3D)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS)
-                                        .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 1, 0, 0, 0, 0, 0))),
+                                        .hasBucketBoundaries(LATENCY_BUCKETS))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -973,10 +909,7 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(0)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS)
-                                        .hasBucketCounts(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0))),
+                                        .hasBucketBoundaries(LATENCY_BUCKETS))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -994,9 +927,7 @@ public class OpenTelemetryMetricsModuleTest {
                                             .hasCount(1)
                                             .hasSum(0)
                                             .hasAttributes(clientAttributes)
-                                            .hasBucketBoundaries(SIZE_BUCKETS)
-                                            .hasBucketCounts(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                                0, 0))));
+                                            .hasBucketBoundaries(SIZE_BUCKETS))));
 
   }
 

--- a/opentelemetry/src/test/java/io/grpc/opentelemetry/OpenTelemetryMetricsModuleTest.java
+++ b/opentelemetry/src/test/java/io/grpc/opentelemetry/OpenTelemetryMetricsModuleTest.java
@@ -97,6 +97,15 @@ public class OpenTelemetryMetricsModuleTest {
       = "grpc.server.call.sent_total_compressed_message_size";
   private static final String SERVER_CALL_RECV_TOTAL_COMPRESSED_MESSAGE_SIZE
       = "grpc.server.call.rcvd_total_compressed_message_size";
+  private static final double[] LATENCY_BUCKETS =
+      {   0d,     0.00001d, 0.00005d, 0.0001d, 0.0003d, 0.0006d, 0.0008d, 0.001d, 0.002d,
+          0.003d, 0.004d,   0.005d,   0.006d,  0.008d,  0.01d,   0.013d,  0.016d, 0.02d,
+          0.025d, 0.03d,    0.04d,    0.05d,   0.065d,  0.08d,   0.1d,    0.13d,  0.16d,
+          0.2d,   0.25d,    0.3d,     0.4d,    0.5d,    0.65d,   0.8d,    1d,     2d,
+          5d,     10d,      20d,      50d,     100d };
+  private static final double[] SIZE_BUCKETS =
+      { 0L, 1024L, 2048L, 4096L, 16384L, 65536L, 262144L, 1048576L, 4194304L, 16777216L,
+      67108864L, 268435456L, 1073741824L, 4294967296L };
 
   private static final class StringInputStream extends InputStream {
     final String string;
@@ -301,7 +310,11 @@ public class OpenTelemetryMetricsModuleTest {
                                     point
                                         .hasCount(1)
                                         .hasSum(0.03 + 0.1 + 0.016 + 0.024)
-                                        .hasAttributes(clientAttributes))),
+                                        .hasAttributes(clientAttributes)
+                                        .hasBucketBoundaries(LATENCY_BUCKETS)
+                                        .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -316,7 +329,10 @@ public class OpenTelemetryMetricsModuleTest {
                                     point
                                         .hasCount(1)
                                         .hasSum(1028L + 99)
-                                        .hasAttributes(clientAttributes))),
+                                        .hasAttributes(clientAttributes)
+                                        .hasBucketBoundaries(SIZE_BUCKETS)
+                                        .hasBucketCounts(0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -333,7 +349,9 @@ public class OpenTelemetryMetricsModuleTest {
                                         point
                                             .hasCount(1)
                                             .hasSum(154)
-                                            .hasAttributes(clientAttributes))),
+                                            .hasAttributes(clientAttributes)
+                                            .hasBucketCounts(0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                0, 0))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -347,7 +365,11 @@ public class OpenTelemetryMetricsModuleTest {
                                     point
                                         .hasCount(1)
                                         .hasSum(0.03 + 0.1 + 0.016 + 0.024)
-                                        .hasAttributes(clientAttributes))));
+                                        .hasAttributes(clientAttributes)
+                                        .hasBucketBoundaries(LATENCY_BUCKETS)
+                                        .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0))));
   }
 
   // This test is only unit-testing the metrics recording logic. The retry behavior is faked.
@@ -428,7 +450,11 @@ public class OpenTelemetryMetricsModuleTest {
                                     point
                                         .hasCount(1)
                                         .hasSum(0.03 + 0.1 + 0.024)
-                                        .hasAttributes(clientAttributes))),
+                                        .hasAttributes(clientAttributes)
+                                        .hasBucketBoundaries(LATENCY_BUCKETS)
+                                        .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -443,7 +469,10 @@ public class OpenTelemetryMetricsModuleTest {
                                     point
                                         .hasCount(1)
                                         .hasSum(1028L)
-                                        .hasAttributes(clientAttributes))),
+                                        .hasAttributes(clientAttributes)
+                                        .hasBucketBoundaries(SIZE_BUCKETS)
+                                        .hasBucketCounts(0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -460,7 +489,10 @@ public class OpenTelemetryMetricsModuleTest {
                                         point
                                             .hasCount(1)
                                             .hasSum(0)
-                                            .hasAttributes(clientAttributes))));
+                                            .hasAttributes(clientAttributes)
+                                            .hasBucketBoundaries(SIZE_BUCKETS)
+                                            .hasBucketCounts(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                0, 0))));
 
 
     // faking retry
@@ -510,12 +542,20 @@ public class OpenTelemetryMetricsModuleTest {
                                     point
                                         .hasCount(1)
                                         .hasSum(0.1)
-                                        .hasAttributes(clientAttributes1),
+                                        .hasAttributes(clientAttributes1)
+                                        .hasBucketBoundaries(LATENCY_BUCKETS)
+                                        .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0),
                                 point ->
                                     point
                                         .hasCount(1)
                                         .hasSum(0.154)
-                                        .hasAttributes(clientAttributes))),
+                                        .hasAttributes(clientAttributes)
+                                        .hasBucketBoundaries(LATENCY_BUCKETS)
+                                        .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+                                    0, 0, 0, 0, 0, 0, 0, 0, 0))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -532,12 +572,18 @@ public class OpenTelemetryMetricsModuleTest {
                                         point
                                             .hasCount(1)
                                             .hasSum(0)
-                                            .hasAttributes(clientAttributes1),
+                                            .hasAttributes(clientAttributes1)
+                                            .hasBucketBoundaries(SIZE_BUCKETS)
+                                            .hasBucketCounts(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                0, 0),
                                     point ->
                                         point
                                             .hasCount(1)
                                             .hasSum(0)
-                                            .hasAttributes(clientAttributes))),
+                                            .hasAttributes(clientAttributes)
+                                            .hasBucketBoundaries(SIZE_BUCKETS)
+                                            .hasBucketCounts(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                0, 0))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -552,12 +598,18 @@ public class OpenTelemetryMetricsModuleTest {
                                     point
                                         .hasCount(1)
                                         .hasSum(1028L)
-                                        .hasAttributes(clientAttributes1),
+                                        .hasAttributes(clientAttributes1)
+                                        .hasBucketBoundaries(SIZE_BUCKETS)
+                                        .hasBucketCounts(0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0),
                                 point ->
                                     point
                                         .hasCount(1)
                                         .hasSum(1028L)
-                                        .hasAttributes(clientAttributes))));
+                                        .hasAttributes(clientAttributes)
+                                        .hasBucketBoundaries(SIZE_BUCKETS)
+                                        .hasBucketCounts(0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0))));
 
     // fake transparent retry
     fakeClock.forwardTime(10, TimeUnit.MILLISECONDS);
@@ -597,12 +649,20 @@ public class OpenTelemetryMetricsModuleTest {
                                     point
                                         .hasCount(1)
                                         .hasSum(0.1)
-                                        .hasAttributes(clientAttributes1),
+                                        .hasAttributes(clientAttributes1)
+                                        .hasBucketBoundaries(LATENCY_BUCKETS)
+                                        .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0),
                                 point ->
                                     point
                                         .hasCount(2)
                                         .hasSum(0.154 + 0.032)
-                                        .hasAttributes(clientAttributes))),
+                                        .hasAttributes(clientAttributes)
+                                        .hasBucketBoundaries(LATENCY_BUCKETS)
+                                        .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -619,12 +679,18 @@ public class OpenTelemetryMetricsModuleTest {
                                         point
                                             .hasCount(1)
                                             .hasSum(0)
-                                            .hasAttributes(clientAttributes1),
+                                            .hasAttributes(clientAttributes1)
+                                            .hasBucketBoundaries(SIZE_BUCKETS)
+                                            .hasBucketCounts(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                0, 0),
                                     point ->
                                         point
                                             .hasCount(2)
                                             .hasSum(0 + 0)
-                                            .hasAttributes(clientAttributes))),
+                                            .hasAttributes(clientAttributes)
+                                            .hasBucketBoundaries(SIZE_BUCKETS)
+                                            .hasBucketCounts(2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                0, 0))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -639,12 +705,18 @@ public class OpenTelemetryMetricsModuleTest {
                                     point
                                         .hasCount(1)
                                         .hasSum(1028L)
-                                        .hasAttributes(clientAttributes1),
+                                        .hasAttributes(clientAttributes1)
+                                        .hasBucketBoundaries(SIZE_BUCKETS)
+                                        .hasBucketCounts(0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0),
                                 point ->
                                     point
                                         .hasCount(2)
                                         .hasSum(1028L + 0)
-                                        .hasAttributes(clientAttributes))));
+                                        .hasAttributes(clientAttributes)
+                                        .hasBucketBoundaries(SIZE_BUCKETS)
+                                        .hasBucketCounts(1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0))));
 
     // fake another transparent retry
     fakeClock.forwardTime(10, MILLISECONDS);
@@ -697,17 +769,26 @@ public class OpenTelemetryMetricsModuleTest {
                                     point
                                         .hasCount(1)
                                         .hasSum(1028L)
-                                        .hasAttributes(clientAttributes1),
+                                        .hasAttributes(clientAttributes1)
+                                        .hasBucketBoundaries(SIZE_BUCKETS)
+                                        .hasBucketCounts(0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0),
                                 point ->
                                     point
                                         .hasCount(2)
                                         .hasSum(1028L + 0)
-                                        .hasAttributes(clientAttributes),
+                                        .hasAttributes(clientAttributes)
+                                        .hasBucketBoundaries(SIZE_BUCKETS)
+                                        .hasBucketCounts(1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0),
                                 point ->
                                     point
                                         .hasCount(1)
                                         .hasSum(1028L)
-                                        .hasAttributes(clientAttributes2))),
+                                        .hasAttributes(clientAttributes2)
+                                        .hasBucketBoundaries(SIZE_BUCKETS)
+                                        .hasBucketCounts(0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -722,7 +803,11 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(0.03 + 0.1 + 0.024 + 1 + 0.1 + 0.01 + 0.032 + 0.01
                                             + 0.024)
-                                        .hasAttributes(clientAttributes2))),
+                                        .hasAttributes(clientAttributes2)
+                                        .hasBucketBoundaries(LATENCY_BUCKETS)
+                                        .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 1, 0, 0, 0, 0, 0, 0))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -736,17 +821,29 @@ public class OpenTelemetryMetricsModuleTest {
                                     point
                                         .hasCount(1)
                                         .hasSum(0.100)
-                                        .hasAttributes(clientAttributes1),
+                                        .hasAttributes(clientAttributes1)
+                                        .hasBucketBoundaries(LATENCY_BUCKETS)
+                                        .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0),
                                 point ->
                                     point
                                         .hasCount(2)
                                         .hasSum(0.154 + 0.032)
-                                        .hasAttributes(clientAttributes),
+                                        .hasAttributes(clientAttributes)
+                                        .hasBucketBoundaries(LATENCY_BUCKETS)
+                                        .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0),
                                 point ->
                                     point
                                         .hasCount(1)
                                         .hasSum(0.024)
-                                        .hasAttributes(clientAttributes2))),
+                                        .hasAttributes(clientAttributes2)
+                                        .hasBucketBoundaries(LATENCY_BUCKETS)
+                                        .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -763,17 +860,26 @@ public class OpenTelemetryMetricsModuleTest {
                                         point
                                             .hasCount(1)
                                             .hasSum(0)
-                                            .hasAttributes(clientAttributes1),
+                                            .hasAttributes(clientAttributes1)
+                                            .hasBucketBoundaries(SIZE_BUCKETS)
+                                            .hasBucketCounts(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                0, 0),
                                     point ->
                                         point
                                             .hasCount(2)
                                             .hasSum(0 + 0)
-                                            .hasAttributes(clientAttributes),
+                                            .hasAttributes(clientAttributes)
+                                            .hasBucketBoundaries(SIZE_BUCKETS)
+                                            .hasBucketCounts(2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                0, 0),
                                     point ->
                                         point
                                             .hasCount(1)
                                             .hasSum(33D)
-                                            .hasAttributes(clientAttributes2))));
+                                            .hasAttributes(clientAttributes2)
+                                            .hasBucketBoundaries(SIZE_BUCKETS)
+                                            .hasBucketCounts(0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                0, 0))));
   }
 
   @Test
@@ -831,7 +937,10 @@ public class OpenTelemetryMetricsModuleTest {
                                     point
                                         .hasCount(1)
                                         .hasSum(0)
-                                        .hasAttributes(clientAttributes))),
+                                        .hasAttributes(clientAttributes)
+                                        .hasBucketBoundaries(SIZE_BUCKETS)
+                                        .hasBucketCounts(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -845,7 +954,11 @@ public class OpenTelemetryMetricsModuleTest {
                                     point
                                         .hasCount(1)
                                         .hasSum(3D)
-                                        .hasAttributes(clientAttributes))),
+                                        .hasAttributes(clientAttributes)
+                                        .hasBucketBoundaries(LATENCY_BUCKETS)
+                                        .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 1, 0, 0, 0, 0, 0))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -859,7 +972,11 @@ public class OpenTelemetryMetricsModuleTest {
                                     point
                                         .hasCount(1)
                                         .hasSum(0)
-                                        .hasAttributes(clientAttributes))),
+                                        .hasAttributes(clientAttributes)
+                                        .hasBucketBoundaries(LATENCY_BUCKETS)
+                                        .hasBucketCounts(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -876,7 +993,10 @@ public class OpenTelemetryMetricsModuleTest {
                                         point
                                             .hasCount(1)
                                             .hasSum(0)
-                                            .hasAttributes(clientAttributes))));
+                                            .hasAttributes(clientAttributes)
+                                            .hasBucketBoundaries(SIZE_BUCKETS)
+                                            .hasBucketCounts(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                0, 0))));
 
   }
 
@@ -1077,7 +1197,10 @@ public class OpenTelemetryMetricsModuleTest {
                                     point
                                         .hasCount(1)
                                         .hasSum(1028L + 99)
-                                        .hasAttributes(serverAttributes))),
+                                        .hasAttributes(serverAttributes)
+                                        .hasBucketBoundaries(SIZE_BUCKETS)
+                                        .hasBucketCounts(0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -1105,7 +1228,11 @@ public class OpenTelemetryMetricsModuleTest {
                                     point
                                         .hasCount(1)
                                         .hasSum(0.1 + 0.016 + 0.024)
-                                        .hasAttributes(serverAttributes))),
+                                        .hasAttributes(serverAttributes)
+                                        .hasBucketBoundaries(LATENCY_BUCKETS)
+                                        .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -1122,7 +1249,10 @@ public class OpenTelemetryMetricsModuleTest {
                                         point
                                             .hasCount(1)
                                             .hasSum(34L + 154)
-                                            .hasAttributes(serverAttributes))));
+                                            .hasAttributes(serverAttributes)
+                                            .hasBucketBoundaries(SIZE_BUCKETS)
+                                            .hasBucketCounts(0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                0, 0))));
 
   }
 

--- a/opentelemetry/src/test/java/io/grpc/opentelemetry/OpenTelemetryMetricsModuleTest.java
+++ b/opentelemetry/src/test/java/io/grpc/opentelemetry/OpenTelemetryMetricsModuleTest.java
@@ -97,13 +97,13 @@ public class OpenTelemetryMetricsModuleTest {
       = "grpc.server.call.sent_total_compressed_message_size";
   private static final String SERVER_CALL_RECV_TOTAL_COMPRESSED_MESSAGE_SIZE
       = "grpc.server.call.rcvd_total_compressed_message_size";
-  private static final double[] LATENCY_BUCKETS =
+  private static final double[] latencyBuckets =
       {   0d,     0.00001d, 0.00005d, 0.0001d, 0.0003d, 0.0006d, 0.0008d, 0.001d, 0.002d,
           0.003d, 0.004d,   0.005d,   0.006d,  0.008d,  0.01d,   0.013d,  0.016d, 0.02d,
           0.025d, 0.03d,    0.04d,    0.05d,   0.065d,  0.08d,   0.1d,    0.13d,  0.16d,
           0.2d,   0.25d,    0.3d,     0.4d,    0.5d,    0.65d,   0.8d,    1d,     2d,
           5d,     10d,      20d,      50d,     100d };
-  private static final double[] SIZE_BUCKETS =
+  private static final double[] sizeBuckets =
       { 0L, 1024L, 2048L, 4096L, 16384L, 65536L, 262144L, 1048576L, 4194304L, 16777216L,
       67108864L, 268435456L, 1073741824L, 4294967296L };
 
@@ -311,7 +311,7 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(0.03 + 0.1 + 0.016 + 0.024)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS)
+                                        .hasBucketBoundaries(latencyBuckets)
                                         .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
                                             0, 0, 0, 0, 0, 0, 0, 0, 0))),
@@ -330,7 +330,7 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(1028L + 99)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(SIZE_BUCKETS)
+                                        .hasBucketBoundaries(sizeBuckets)
                                         .hasBucketCounts(0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                             0))),
             metric ->
@@ -366,7 +366,7 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(0.03 + 0.1 + 0.016 + 0.024)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS)
+                                        .hasBucketBoundaries(latencyBuckets)
                                         .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
                                             0, 0, 0, 0, 0, 0, 0, 0, 0))));
@@ -451,7 +451,7 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(0.03 + 0.1 + 0.024)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS))),
+                                        .hasBucketBoundaries(latencyBuckets))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -467,7 +467,7 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(1028L)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(SIZE_BUCKETS))),
+                                        .hasBucketBoundaries(sizeBuckets))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -485,7 +485,7 @@ public class OpenTelemetryMetricsModuleTest {
                                             .hasCount(1)
                                             .hasSum(0)
                                             .hasAttributes(clientAttributes)
-                                            .hasBucketBoundaries(SIZE_BUCKETS))));
+                                            .hasBucketBoundaries(sizeBuckets))));
 
 
     // faking retry
@@ -536,13 +536,13 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(0.1)
                                         .hasAttributes(clientAttributes1)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS),
+                                        .hasBucketBoundaries(latencyBuckets),
                                 point ->
                                     point
                                         .hasCount(1)
                                         .hasSum(0.154)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS))),
+                                        .hasBucketBoundaries(latencyBuckets))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -560,13 +560,13 @@ public class OpenTelemetryMetricsModuleTest {
                                             .hasCount(1)
                                             .hasSum(0)
                                             .hasAttributes(clientAttributes1)
-                                            .hasBucketBoundaries(SIZE_BUCKETS),
+                                            .hasBucketBoundaries(sizeBuckets),
                                     point ->
                                         point
                                             .hasCount(1)
                                             .hasSum(0)
                                             .hasAttributes(clientAttributes)
-                                            .hasBucketBoundaries(SIZE_BUCKETS))),
+                                            .hasBucketBoundaries(sizeBuckets))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -582,13 +582,13 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(1028L)
                                         .hasAttributes(clientAttributes1)
-                                        .hasBucketBoundaries(SIZE_BUCKETS),
+                                        .hasBucketBoundaries(sizeBuckets),
                                 point ->
                                     point
                                         .hasCount(1)
                                         .hasSum(1028L)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(SIZE_BUCKETS))));
+                                        .hasBucketBoundaries(sizeBuckets))));
 
     // fake transparent retry
     fakeClock.forwardTime(10, TimeUnit.MILLISECONDS);
@@ -629,13 +629,13 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(0.1)
                                         .hasAttributes(clientAttributes1)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS),
+                                        .hasBucketBoundaries(latencyBuckets),
                                 point ->
                                     point
                                         .hasCount(2)
                                         .hasSum(0.154 + 0.032)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS))),
+                                        .hasBucketBoundaries(latencyBuckets))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -653,13 +653,13 @@ public class OpenTelemetryMetricsModuleTest {
                                             .hasCount(1)
                                             .hasSum(0)
                                             .hasAttributes(clientAttributes1)
-                                            .hasBucketBoundaries(SIZE_BUCKETS),
+                                            .hasBucketBoundaries(sizeBuckets),
                                     point ->
                                         point
                                             .hasCount(2)
                                             .hasSum(0 + 0)
                                             .hasAttributes(clientAttributes)
-                                            .hasBucketBoundaries(SIZE_BUCKETS))),
+                                            .hasBucketBoundaries(sizeBuckets))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -675,13 +675,13 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(1028L)
                                         .hasAttributes(clientAttributes1)
-                                        .hasBucketBoundaries(SIZE_BUCKETS),
+                                        .hasBucketBoundaries(sizeBuckets),
                                 point ->
                                     point
                                         .hasCount(2)
                                         .hasSum(1028L + 0)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(SIZE_BUCKETS))));
+                                        .hasBucketBoundaries(sizeBuckets))));
 
     // fake another transparent retry
     fakeClock.forwardTime(10, MILLISECONDS);
@@ -735,19 +735,19 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(1028L)
                                         .hasAttributes(clientAttributes1)
-                                        .hasBucketBoundaries(SIZE_BUCKETS),
+                                        .hasBucketBoundaries(sizeBuckets),
                                 point ->
                                     point
                                         .hasCount(2)
                                         .hasSum(1028L + 0)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(SIZE_BUCKETS),
+                                        .hasBucketBoundaries(sizeBuckets),
                                 point ->
                                     point
                                         .hasCount(1)
                                         .hasSum(1028L)
                                         .hasAttributes(clientAttributes2)
-                                        .hasBucketBoundaries(SIZE_BUCKETS))),
+                                        .hasBucketBoundaries(sizeBuckets))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -763,7 +763,7 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasSum(0.03 + 0.1 + 0.024 + 1 + 0.1 + 0.01 + 0.032 + 0.01
                                             + 0.024)
                                         .hasAttributes(clientAttributes2)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS))),
+                                        .hasBucketBoundaries(latencyBuckets))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -778,19 +778,19 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(0.100)
                                         .hasAttributes(clientAttributes1)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS),
+                                        .hasBucketBoundaries(latencyBuckets),
                                 point ->
                                     point
                                         .hasCount(2)
                                         .hasSum(0.154 + 0.032)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS),
+                                        .hasBucketBoundaries(latencyBuckets),
                                 point ->
                                     point
                                         .hasCount(1)
                                         .hasSum(0.024)
                                         .hasAttributes(clientAttributes2)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS))),
+                                        .hasBucketBoundaries(latencyBuckets))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -808,19 +808,19 @@ public class OpenTelemetryMetricsModuleTest {
                                             .hasCount(1)
                                             .hasSum(0)
                                             .hasAttributes(clientAttributes1)
-                                            .hasBucketBoundaries(SIZE_BUCKETS),
+                                            .hasBucketBoundaries(sizeBuckets),
                                     point ->
                                         point
                                             .hasCount(2)
                                             .hasSum(0 + 0)
                                             .hasAttributes(clientAttributes)
-                                            .hasBucketBoundaries(SIZE_BUCKETS),
+                                            .hasBucketBoundaries(sizeBuckets),
                                     point ->
                                         point
                                             .hasCount(1)
                                             .hasSum(33D)
                                             .hasAttributes(clientAttributes2)
-                                            .hasBucketBoundaries(SIZE_BUCKETS))));
+                                            .hasBucketBoundaries(sizeBuckets))));
   }
 
   @Test
@@ -879,7 +879,7 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(0)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(SIZE_BUCKETS))),
+                                        .hasBucketBoundaries(sizeBuckets))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -894,7 +894,7 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(3D)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS))),
+                                        .hasBucketBoundaries(latencyBuckets))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -909,7 +909,7 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(0)
                                         .hasAttributes(clientAttributes)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS))),
+                                        .hasBucketBoundaries(latencyBuckets))),
             metric ->
                 assertThat(metric)
                     .hasInstrumentationScope(InstrumentationScopeInfo.create(
@@ -927,7 +927,7 @@ public class OpenTelemetryMetricsModuleTest {
                                             .hasCount(1)
                                             .hasSum(0)
                                             .hasAttributes(clientAttributes)
-                                            .hasBucketBoundaries(SIZE_BUCKETS))));
+                                            .hasBucketBoundaries(sizeBuckets))));
 
   }
 
@@ -1129,7 +1129,7 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(1028L + 99)
                                         .hasAttributes(serverAttributes)
-                                        .hasBucketBoundaries(SIZE_BUCKETS)
+                                        .hasBucketBoundaries(sizeBuckets)
                                         .hasBucketCounts(0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                             0))),
             metric ->
@@ -1160,7 +1160,7 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasCount(1)
                                         .hasSum(0.1 + 0.016 + 0.024)
                                         .hasAttributes(serverAttributes)
-                                        .hasBucketBoundaries(LATENCY_BUCKETS)
+                                        .hasBucketBoundaries(latencyBuckets)
                                         .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
                                             0, 0, 0, 0, 0, 0, 0, 0, 0))),
@@ -1181,7 +1181,7 @@ public class OpenTelemetryMetricsModuleTest {
                                             .hasCount(1)
                                             .hasSum(34L + 154)
                                             .hasAttributes(serverAttributes)
-                                            .hasBucketBoundaries(SIZE_BUCKETS)
+                                            .hasBucketBoundaries(sizeBuckets)
                                             .hasBucketCounts(0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                                 0, 0))));
 


### PR DESCRIPTION
As part of gRFC [A66](https://github.com/grpc/proposal/blob/master/A66-otel-stats.md#units):

> Buckets for histograms in default views should be as follows -
> Latency : 0, 0.00001, 0.00005, 0.0001, 0.0003, 0.0006, 0.0008, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.008, 0.01, 0.013, 0.016, 0.02, 0.025, 0.03, 0.04, 0.05, 0.065, 0.08, 0.1, 0.13, 0.16, 0.2, 0.25, 0.3, 0.4, 0.5, 0.65, 0.8, 1, 2, 5, 10, 20, 50, 100
> Size : 0, 1024, 2048, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296

This PR adds histogram bucket boundaries for per-call metrics.

CC @yashykt 