### PR TITLE
Upgrade and fix import issues with envoy_api

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -45,6 +45,7 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
 ]
 # GRPC_DEPS_END
 
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "googleapis", repo_name = "com_google_googleapis", version = "0.0.0-20240326-1c8d509c5")
 bazel_dep(name = "grpc", repo_name = "com_github_grpc_grpc", version = "1.56.3.bcr.1")
 bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "23.1")

--- a/buildscripts/data-plane-api-no-envoy.patch
+++ b/buildscripts/data-plane-api-no-envoy.patch
@@ -1,0 +1,32 @@
+diff --git a/bazel/pgv.patch b/bazel/pgv.patch
+new file mode 100644
+index 00000000..81e25abf
+--- /dev/null
++++ b/bazel/pgv.patch
+@@ -0,0 +1,13 @@
++--- a/templates/cc/register.go	2023-06-22 14:25:05.776175085 +0000
+++++ b/templates/cc/register.go	2023-06-22 14:26:33.008090583 +0000
++@@ -116,6 +116,10 @@
++ func (fns CCFuncs) methodName(name interface{}) string {
++ 	nameStr := fmt.Sprintf("%s", name)
++ 	switch nameStr {
+++	case "concept":
+++		return "concept_"
+++	case "requires":
+++		return "requires_"
++ 	case "const":
++ 		return "const_"
++ 	case "inline":
+diff --git a/bazel/repositories.bzl b/bazel/repositories.bzl
+index 3e24566a..7813b0ab 100644
+--- a/bazel/repositories.bzl
++++ b/bazel/repositories.bzl
+@@ -19,7 +19,7 @@ def api_dependencies():
+     external_http_archive(
+         name = "com_envoyproxy_protoc_gen_validate",
+         patch_args = ["-p1"],
+-        patches = ["@envoy//bazel:pgv.patch"],
++        patches = ["@envoy_api//bazel:pgv.patch"],
+     )
+     external_http_archive(
+         name = "com_google_googleapis",

--- a/buildscripts/data-plane-api-no-envoy.patch
+++ b/buildscripts/data-plane-api-no-envoy.patch
@@ -1,6 +1,24 @@
+From 786c93ccaae9891338f098a5aba60e9987d78bd3 Mon Sep 17 00:00:00 2001
+From: "update-envoy[bot]"
+ <135279899+update-envoy[bot]@users.noreply.github.com>
+Date: Mon, 17 Jun 2024 02:25:24 +0000
+Subject: [PATCH] bazel: `@envoy_api` should not depend on `@envoy` (#34759)
+
+The extra dependency was introduced in 65273b2a9b. pgv.patch is only
+used by envoy_api, so just moving the file avoids the dependency.
+
+Signed-off-by: Eric Anderson <ejona@google.com>
+
+Mirrored from https://github.com/envoyproxy/envoy @ 9fde867399cc7fcf97815995f8466f62172b26f6
+---
+ bazel/pgv.patch        | 13 +++++++++++++
+ bazel/repositories.bzl |  2 +-
+ 2 files changed, 14 insertions(+), 1 deletion(-)
+ create mode 100644 bazel/pgv.patch
+
 diff --git a/bazel/pgv.patch b/bazel/pgv.patch
 new file mode 100644
-index 00000000..81e25abf
+index 000000000..81e25abfe
 --- /dev/null
 +++ b/bazel/pgv.patch
 @@ -0,0 +1,13 @@
@@ -18,7 +36,7 @@ index 00000000..81e25abf
 + 		return "const_"
 + 	case "inline":
 diff --git a/bazel/repositories.bzl b/bazel/repositories.bzl
-index 3e24566a..7813b0ab 100644
+index 3e24566a9..7813b0abd 100644
 --- a/bazel/repositories.bzl
 +++ b/bazel/repositories.bzl
 @@ -19,7 +19,7 @@ def api_dependencies():

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -142,12 +142,14 @@ def grpc_java_repositories(bzlmod = False):
     if not native.existing_rule("envoy_api"):
         http_archive(
             name = "envoy_api",
-            sha256 = "fff067a5d6d776fc88549b5dd4773a6f8f0187b26a859de8b29bd4226a28ee63",
-            strip_prefix = "data-plane-api-9d6ffa70677c4dbf23f6ed569676206c4e2edff4",
+            sha256 = "c4c9c43903e413924b0cb08e9747f3c3a0727ad221a3c446a326db32def18c60",
+            strip_prefix = "data-plane-api-1611a7304794e13efe2d26f8480a2d2473a528c5",
             urls = [
-                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/envoyproxy/data-plane-api/archive/9d6ffa70677c4dbf23f6ed569676206c4e2edff4.tar.gz",
-                "https://github.com/envoyproxy/data-plane-api/archive/9d6ffa70677c4dbf23f6ed569676206c4e2edff4.tar.gz",
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/envoyproxy/data-plane-api/archive/1611a7304794e13efe2d26f8480a2d2473a528c5.tar.gz",
+                "https://github.com/envoyproxy/data-plane-api/archive/1611a7304794e13efe2d26f8480a2d2473a528c5.tar.gz",
             ],
+            patch_args = ["-p1"],
+            patches = ["@io_grpc_grpc_java//:buildscripts/data-plane-api-no-envoy.patch"],
         )
 
 def com_google_protobuf():

--- a/xds/third_party/envoy/import.sh
+++ b/xds/third_party/envoy/import.sh
@@ -137,7 +137,7 @@ COPIED=0
 for file in "${FILES[@]}"
 do
   mkdir -p "$(dirname "${file}")"
-  cp -p "${tmpdir}/${SOURCE_PROTO_BASE_DIR}/${file}" "${file}" && (( COPIED++ ))
+  cp -p "${tmpdir}/${SOURCE_PROTO_BASE_DIR}/${file}" "${file}" && (( ++COPIED ))
 done
 popd > /dev/null
 


### PR DESCRIPTION
Bazel was not updated as part of feab4e54. Also, `(( X++ ))` exits 1 if X is zero. The patch to data-plane-api is being upstreamed in https://github.com/envoyproxy/envoy/pull/34759

CC @larry-safran 