### PR TITLE
services: restore //services:binarylog bazel target

### DIFF
--- a/services/BUILD.bazel
+++ b/services/BUILD.bazel
@@ -10,6 +10,7 @@ java_library(
     name = "services_maven",
     exports = [
         ":admin",
+        ":binarylog",
         ":channelz",
         ":health",
         ":healthlb",

--- a/services/BUILD.bazel
+++ b/services/BUILD.bazel
@@ -77,11 +77,11 @@ java_library(
     deps = [
         "//api",
         "//context",
-        "@com_google_code_findbugs_jsr305//jar",
-        "@com_google_guava_guava//jar",
         "@com_google_protobuf//:protobuf_java",
         "@com_google_protobuf//:protobuf_java_util",
         "@io_grpc_grpc_proto//:binarylog_java_proto",
+        artifact("com.google.code.findbugs:jsr305"),
+        artifact("com.google.guava:guava"),
     ],
 )
 

--- a/services/BUILD.bazel
+++ b/services/BUILD.bazel
@@ -63,6 +63,28 @@ java_library(
 )
 
 java_library(
+    name = "binarylog",
+    srcs = [
+        "src/main/java/io/grpc/protobuf/services/BinaryLogProvider.java",
+        "src/main/java/io/grpc/protobuf/services/BinaryLogProviderImpl.java",
+        "src/main/java/io/grpc/protobuf/services/BinaryLogSink.java",
+        "src/main/java/io/grpc/protobuf/services/BinaryLogs.java",
+        "src/main/java/io/grpc/protobuf/services/BinlogHelper.java",
+        "src/main/java/io/grpc/protobuf/services/InetAddressUtil.java",
+        "src/main/java/io/grpc/protobuf/services/TempFileSink.java",
+    ],
+    deps = [
+        "//api",
+        "//context",
+        "@com_google_code_findbugs_jsr305//jar",
+        "@com_google_guava_guava//jar",
+        "@com_google_protobuf//:protobuf_java",
+        "@com_google_protobuf//:protobuf_java_util",
+        "@io_grpc_grpc_proto//:binarylog_java_proto",
+    ],
+)
+
+java_library(
     name = "channelz",
     srcs = [
         "src/main/java/io/grpc/protobuf/services/ChannelzProtoUtil.java",


### PR DESCRIPTION
The target was wrongly deleted in 75492c8 / #10832.
See details in https://github.com/grpc/grpc-java/issues/4017#issuecomment-2159516522.