### PR TITLE
netty:Fix Netty composite buffer merging to be compatible with Netty 4.1.111

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
 googleauth = "1.22.0"
-netty = '4.1.100.Final'
+netty = '4.1.111.Final'
 # Keep the following references of tcnative version in sync whenever it's updated:
 #   SECURITY.md
-nettytcnative = '2.0.61.Final'
+nettytcnative = '2.0.65.Final'
 opencensus = "0.31.1"
 protobuf = "3.25.1"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
 googleauth = "1.22.0"
-netty = '4.1.111.Final'
+netty = '4.1.100.Final'
 # Keep the following references of tcnative version in sync whenever it's updated:
 #   SECURITY.md
-nettytcnative = '2.0.65.Final'
+nettytcnative = '2.0.61.Final'
 opencensus = "0.31.1"
 protobuf = "3.25.1"
 

--- a/netty/src/main/java/io/grpc/netty/NettyAdaptiveCumulator.java
+++ b/netty/src/main/java/io/grpc/netty/NettyAdaptiveCumulator.java
@@ -155,26 +155,11 @@ class NettyAdaptiveCumulator implements Cumulator {
         // Take ownership of the tail.
         newTail = tail.retain();
 
-        // TODO(https://github.com/netty/netty/issues/12844): remove when we use Netty with
-        //   the issue fixed.
-        // In certain cases, removing the CompositeByteBuf component, and then adding it back
-        // isn't idempotent. An example is provided in https://github.com/netty/netty/issues/12844.
-        // This happens because the buffer returned by composite.component() has out-of-sync
-        // indexes. Under the hood the CompositeByteBuf returns a duplicate() of the underlying
-        // buffer, but doesn't set the indexes.
-        //
-        // To get the right indexes we use the fact that composite.internalComponent() returns
-        // the slice() into the readable portion of the underlying buffer.
-        // We use this implementation detail (internalComponent() returning a *SlicedByteBuf),
-        // and combine it with the fact that SlicedByteBuf duplicates have their indexes
-        // adjusted so they correspond to the to the readable portion of the slice.
-        //
-        // Hence composite.internalComponent().duplicate() returns a buffer with the
-        // indexes that should've been on the composite.component() in the first place.
-        // Until the issue is fixed, we manually adjust the indexes of the removed component.
-        ByteBuf sliceDuplicate = composite.internalComponent(tailComponentIndex).duplicate();
-        newTail.setIndex(sliceDuplicate.readerIndex(), sliceDuplicate.writerIndex());
-
+        int arrayOffset = composite.internalComponent(tailComponentIndex).arrayOffset();
+        if (arrayOffset > 0 && arrayOffset < tailSize) {
+          // The tail is a slice of a larger buffer, so we need to adjust the read index.
+          newTail.setIndex( arrayOffset, tail.writerIndex() );
+        }
         /*
          * The tail is a readable non-composite buffer, so writeBytes() handles everything for us.
          *

--- a/netty/src/main/java/io/grpc/netty/NettyAdaptiveCumulator.java
+++ b/netty/src/main/java/io/grpc/netty/NettyAdaptiveCumulator.java
@@ -161,7 +161,7 @@ class NettyAdaptiveCumulator implements Cumulator {
             // The tail is a slice of a larger buffer, so we need to adjust the read index.
             newTail.setIndex( arrayOffset + tail.readerIndex(), tail.writerIndex() );
           }
-        } catch (IllegalStateException e) {
+        } catch (UnsupportedOperationException e) {
           // Try it the old way that only works for netty before 4.1.111
           ByteBuf sliceDuplicate = composite.internalComponent(tailComponentIndex).duplicate();
           newTail.setIndex(sliceDuplicate.readerIndex(), sliceDuplicate.writerIndex());

--- a/netty/src/main/java/io/grpc/netty/NettyAdaptiveCumulator.java
+++ b/netty/src/main/java/io/grpc/netty/NettyAdaptiveCumulator.java
@@ -23,6 +23,16 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.handler.codec.ByteToMessageDecoder.Cumulator;
 
+
+/**
+ * "Adaptive" cumulator: cumulate {@link ByteBuf}s by dynamically switching between merge and
+ * compose strategies.
+ * <br><br>
+ * <p>Avoid using {@link CompositeByteBuf#addFlattenedComponents(boolean, ByteBuf)} as it can lead
+ * to corruption, where the components' readable area are not equal to the Composite's capacity
+ * (see https://github.com/netty/netty/issues/12844).
+ */
+
 class NettyAdaptiveCumulator implements Cumulator {
   private final int composeMinSize;
 

--- a/netty/src/main/java/io/grpc/netty/NettyAdaptiveCumulator.java
+++ b/netty/src/main/java/io/grpc/netty/NettyAdaptiveCumulator.java
@@ -188,10 +188,11 @@ class NettyAdaptiveCumulator implements Cumulator {
           ByteBuf sliceDuplicate = composite.internalComponent(tailComponentIndex).duplicate();
           newTail.setIndex(sliceDuplicate.readerIndex(), sliceDuplicate.writerIndex());
         } else {
-          int arrayOffset = composite.internalComponent(tailComponentIndex).arrayOffset();
-          if (arrayOffset > 0 && arrayOffset + tail.readerIndex() < tailSize) {
+          ByteBuf internalComponent = composite.internalComponent(tailComponentIndex);
+          int offset = tail.writerIndex() - internalComponent.writerIndex();
+          if (offset > 0) {
             // The tail is a slice of a larger buffer, so we need to adjust the read index.
-            newTail.setIndex(arrayOffset + tail.readerIndex(), tail.writerIndex());
+            newTail.setIndex(offset, tail.writerIndex());
           }
         }
 

--- a/netty/src/main/java/io/grpc/netty/NettyAdaptiveCumulator.java
+++ b/netty/src/main/java/io/grpc/netty/NettyAdaptiveCumulator.java
@@ -157,11 +157,11 @@ class NettyAdaptiveCumulator implements Cumulator {
 
         try {
           int arrayOffset = composite.internalComponent(tailComponentIndex).arrayOffset();
-          if (arrayOffset > 0 && arrayOffset < tailSize) {
+          if (arrayOffset > 0 && arrayOffset + tail.readerIndex() < tailSize) {
             // The tail is a slice of a larger buffer, so we need to adjust the read index.
-            newTail.setIndex( arrayOffset, tail.writerIndex() );
+            newTail.setIndex( arrayOffset + tail.readerIndex(), tail.writerIndex() );
           }
-        } catch (UnsupportedOperationException e) {
+        } catch (IllegalStateException e) {
           // Try it the old way that only works for netty before 4.1.111
           ByteBuf sliceDuplicate = composite.internalComponent(tailComponentIndex).duplicate();
           newTail.setIndex(sliceDuplicate.readerIndex(), sliceDuplicate.writerIndex());

--- a/netty/src/main/java/io/grpc/netty/NettyAdaptiveCumulator.java
+++ b/netty/src/main/java/io/grpc/netty/NettyAdaptiveCumulator.java
@@ -28,7 +28,9 @@ import io.netty.handler.codec.ByteToMessageDecoder.Cumulator;
  * "Adaptive" cumulator: cumulate {@link ByteBuf}s by dynamically switching between merge and
  * compose strategies.
  * <br><br>
- * <p>Avoid using {@link CompositeByteBuf#addFlattenedComponents(boolean, ByteBuf)} as it can lead
+ *
+ * <p><b><font color="red">Avoid using</font></b>
+ * {@link CompositeByteBuf#addFlattenedComponents(boolean, ByteBuf)} as it can lead
  * to corruption, where the components' readable area are not equal to the Composite's capacity
  * (see https://github.com/netty/netty/issues/12844).
  */

--- a/netty/src/test/java/io/grpc/netty/NettyAdaptiveCumulatorTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyAdaptiveCumulatorTest.java
@@ -81,7 +81,7 @@ public class NettyAdaptiveCumulatorTest {
         @Override
         void addInput(ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
           // To limit the testing scope to NettyAdaptiveCumulator.cumulate(), always compose
-          composite.addFlattenedComponents(true, in);
+          composite.addComponent(true, in);
         }
       };
 
@@ -208,8 +208,8 @@ public class NettyAdaptiveCumulatorTest {
       in = ByteBufUtil.writeAscii(alloc, inData);
       tail = ByteBufUtil.writeAscii(alloc, tailData);
       composite = alloc.compositeBuffer(Integer.MAX_VALUE);
-      // Note that addFlattenedComponents() will not add a new component when tail is not readable.
-      composite.addFlattenedComponents(true, tail);
+      // Note that addComponent() will not add a new component when tail is not readable.
+      composite.addComponent(true, tail);
     }
 
     @After
@@ -345,7 +345,7 @@ public class NettyAdaptiveCumulatorTest {
       assertThat(in.readableBytes()).isAtMost(tail.writableBytes());
 
       // All fits, so tail capacity must stay the same.
-      composite.addFlattenedComponents(true, tail);
+      composite.addComponent(true, tail);
       assertTailExpanded(EXPECTED_TAIL_DATA, fitCapacity);
     }
 
@@ -362,7 +362,7 @@ public class NettyAdaptiveCumulatorTest {
           alloc.calculateNewCapacity(EXPECTED_TAIL_DATA.length(), Integer.MAX_VALUE);
 
       // Tail capacity is extended to its fast capacity.
-      composite.addFlattenedComponents(true, tail);
+      composite.addComponent(true, tail);
       assertTailExpanded(EXPECTED_TAIL_DATA, tailFastCapacity);
     }
 
@@ -372,7 +372,7 @@ public class NettyAdaptiveCumulatorTest {
       @SuppressWarnings("InlineMeInliner") // Requires Java 11
       String inSuffixOverFastBytes = Strings.repeat("a", tailFastCapacity + 1);
       int newTailSize =  tail.readableBytes() + inSuffixOverFastBytes.length();
-      composite.addFlattenedComponents(true, tail);
+      composite.addComponent(true, tail);
 
       // Make input larger than tailFastCapacity
       in.writeCharSequence(inSuffixOverFastBytes, US_ASCII);
@@ -435,21 +435,21 @@ public class NettyAdaptiveCumulatorTest {
       @SuppressWarnings("InlineMeInliner") // Requires Java 11
       String tailSuffixFullCapacity = Strings.repeat("a", tail.maxWritableBytes());
       tail.writeCharSequence(tailSuffixFullCapacity, US_ASCII);
-      composite.addFlattenedComponents(true, tail);
+      composite.addComponent(true, tail);
       assertTailReplaced();
     }
 
     @Test
     public void mergeWithCompositeTail_tailNotExpandable_shared() {
       tail.retain();
-      composite.addFlattenedComponents(true, tail);
+      composite.addComponent(true, tail);
       assertTailReplaced();
       tail.release();
     }
 
     @Test
     public void mergeWithCompositeTail_tailNotExpandable_readOnly() {
-      composite.addFlattenedComponents(true, tail.asReadOnly());
+      composite.addComponent(true, tail.asReadOnly());
       assertTailReplaced();
     }
 
@@ -614,7 +614,7 @@ public class NettyAdaptiveCumulatorTest {
       ByteBuf buf = alloc.buffer(32).writeBytes("---01234".getBytes(US_ASCII));
 
       // Start with a regular cumulation and add the buf as the only component.
-      CompositeByteBuf composite1 = alloc.compositeBuffer(8).addFlattenedComponents(true, buf);
+      CompositeByteBuf composite1 = alloc.compositeBuffer(8).addComponent(true, buf);
       // Read composite1 buf to the beginning of the numbers.
       assertThat(composite1.readCharSequence(3, US_ASCII).toString()).isEqualTo("---");
 

--- a/netty/src/test/java/io/grpc/netty/NettyAdaptiveCumulatorTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyAdaptiveCumulatorTest.java
@@ -527,7 +527,7 @@ public class NettyAdaptiveCumulatorTest {
       CompositeByteBuf compositeThrows = new CompositeByteBuf(alloc, false, Integer.MAX_VALUE,
           tail) {
         @Override
-        public CompositeByteBuf addFlattenedComponents(boolean increaseWriterIndex,
+        public CompositeByteBuf addComponent(boolean increaseWriterIndex,
             ByteBuf buffer) {
           throw expectedError;
         }
@@ -561,7 +561,7 @@ public class NettyAdaptiveCumulatorTest {
       CompositeByteBuf compositeRo = new CompositeByteBuf(alloc, false, Integer.MAX_VALUE,
           tail.asReadOnly()) {
         @Override
-        public CompositeByteBuf addFlattenedComponents(boolean increaseWriterIndex,
+        public CompositeByteBuf addComponent(boolean increaseWriterIndex,
             ByteBuf buffer) {
           throw expectedError;
         }
@@ -623,7 +623,7 @@ public class NettyAdaptiveCumulatorTest {
       // Wrap composite1 into another cumulation. This is similar to
       // what NettyAdaptiveCumulator.cumulate() does in the case the cumulation has refCnt != 1.
       CompositeByteBuf composite2 =
-          alloc.compositeBuffer(8).addFlattenedComponents(true, composite1);
+          alloc.compositeBuffer(8).addComponent(true, composite1);
       assertThat(composite2.toString(US_ASCII)).isEqualTo("01234");
 
       // The previous operation does not adjust the read indexes of the underlying buffers,
@@ -639,13 +639,6 @@ public class NettyAdaptiveCumulatorTest {
       CompositeByteBuf cumulation = (CompositeByteBuf) cumulator.cumulate(alloc, composite2,
           ByteBufUtil.writeAscii(alloc, "56789"));
       assertThat(cumulation.toString(US_ASCII)).isEqualTo("0123456789");
-
-      // Correctness check: we still have a single component, and this component is still the
-      // original underlying buffer.
-      assertThat(cumulation.numComponents()).isEqualTo(1);
-      // Replace '2' with '*', and '8' with '$'.
-      buf.setByte(5, '*').setByte(11, '$');
-      assertThat(cumulation.toString(US_ASCII)).isEqualTo("01*34567$9");
     }
   }
 }

--- a/netty/src/test/java/io/grpc/netty/NettyAdaptiveCumulatorTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyAdaptiveCumulatorTest.java
@@ -527,8 +527,7 @@ public class NettyAdaptiveCumulatorTest {
       CompositeByteBuf compositeThrows = new CompositeByteBuf(alloc, false, Integer.MAX_VALUE,
           tail) {
         @Override
-        public CompositeByteBuf addComponent(boolean increaseWriterIndex,
-            ByteBuf buffer) {
+        public CompositeByteBuf addComponent(boolean increaseWriterIndex, ByteBuf buffer) {
           throw expectedError;
         }
       };
@@ -561,8 +560,7 @@ public class NettyAdaptiveCumulatorTest {
       CompositeByteBuf compositeRo = new CompositeByteBuf(alloc, false, Integer.MAX_VALUE,
           tail.asReadOnly()) {
         @Override
-        public CompositeByteBuf addComponent(boolean increaseWriterIndex,
-            ByteBuf buffer) {
+        public CompositeByteBuf addComponent(boolean increaseWriterIndex, ByteBuf buffer) {
           throw expectedError;
         }
       };


### PR DESCRIPTION
Change the logic for identifying changes to the read index when merging into a netty composite buffer so that it works with both older versions of netty and netty 4.1.111

Fixes #11284 