### PR TITLE
grpc-java supports onReadyThreshold property setting

### DIFF
--- a/api/src/main/java/io/grpc/CallOptions.java
+++ b/api/src/main/java/io/grpc/CallOptions.java
@@ -512,6 +512,7 @@ public final class CallOptions {
     builder.waitForReady = other.waitForReady;
     builder.maxInboundMessageSize = other.maxInboundMessageSize;
     builder.maxOutboundMessageSize = other.maxOutboundMessageSize;
+    builder.onReadyThreshold = other.onReadyThreshold;
     return builder;
   }
 
@@ -527,6 +528,7 @@ public final class CallOptions {
         .add("waitForReady", isWaitForReady())
         .add("maxInboundMessageSize", maxInboundMessageSize)
         .add("maxOutboundMessageSize", maxOutboundMessageSize)
+        .add("onReadyThreshold", onReadyThreshold)
         .add("streamTracerFactories", streamTracerFactories)
         .toString();
   }

--- a/api/src/test/java/io/grpc/CallOptionsTest.java
+++ b/api/src/test/java/io/grpc/CallOptionsTest.java
@@ -82,6 +82,16 @@ public class CallOptionsTest {
   }
 
   @Test
+  public void withOnReadyThreshold() {
+    int onReadyThreshold = 1024;
+    CallOptions callOptions = CallOptions.DEFAULT.withOnReadyThreshold(onReadyThreshold);
+    callOptions = callOptions.withWaitForReady();
+    assertThat(callOptions.getOnReadyThreshold()).isEqualTo(onReadyThreshold);
+    callOptions = callOptions.clearOnReadyThreshold();
+    assertThat(callOptions.getOnReadyThreshold()).isNull();
+  }
+
+  @Test
   public void allWiths() {
     assertThat(allSet.getAuthority()).isSameInstanceAs(sampleAuthority);
     assertThat(allSet.getDeadline()).isSameInstanceAs(sampleDeadline);

--- a/stub/src/main/java/io/grpc/stub/AbstractStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractStub.java
@@ -253,6 +253,16 @@ public abstract class AbstractStub<S extends AbstractStub<S>> {
   }
 
   /**
+   * Returns a new stub that limits the maximum number of bytes per stream in the queue.
+   *
+   * @since 1.1.0
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11021")
+  public final S withOnReadyThreshold(int numBytes) {
+    return build(channel, callOptions.withOnReadyThreshold(numBytes));
+  }
+
+  /**
    * A factory class for stub.
    *
    * @since 1.26.0

--- a/stub/src/test/java/io/grpc/stub/BaseAbstractStubTest.java
+++ b/stub/src/test/java/io/grpc/stub/BaseAbstractStubTest.java
@@ -16,6 +16,7 @@
 
 package io.grpc.stub;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -89,5 +90,17 @@ abstract class BaseAbstractStubTest<T extends AbstractStub<T>> {
     callOptions = stub.getCallOptions();
 
     assertEquals(callOptions.getExecutor(), executor);
+  }
+
+  @Test
+  public void withOnReadyThreshold() {
+    T stub = create(channel);
+    CallOptions callOptions = stub.getCallOptions();
+    assertNull(callOptions.getOnReadyThreshold());
+
+    int onReadyThreshold = 1024;
+    stub = stub.withOnReadyThreshold(onReadyThreshold);
+    callOptions = stub.getCallOptions();
+    assertThat(callOptions.getOnReadyThreshold()).isEqualTo(onReadyThreshold);
   }
 }


### PR DESCRIPTION
#### issues
https://github.com/grpc/grpc-java/issues/11289
#### modify
1. Support setting onReadyThreshold through AbstractStub
2. Add copy of the onReadyThreshold property when copying CallOptions(fix bug)