### PR TITLE
all:Add GCP CSM Observability

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -12,6 +12,7 @@ def subprojects = [
     project(':grpc-auth'),
     project(':grpc-core'),
     project(':grpc-grpclb'),
+    project(':grpc-gcp-csm-observability'),
     project(':grpc-inprocess'),
     project(':grpc-netty'),
     project(':grpc-okhttp'),


### PR DESCRIPTION
This adds GCP CSM Observability to the shared javadoc (but also other things like having its tests contribute to code coverage).