### PR TITLE
examples: Remove unused imports from CSM Observability example (v1.65.x backport)

### DIFF
--- a/examples/example-gcp-csm-observability/build.gradle
+++ b/examples/example-gcp-csm-observability/build.gradle
@@ -36,7 +36,6 @@ dependencies {
     implementation "io.grpc:grpc-gcp-csm-observability:${grpcVersion}"
     implementation "io.opentelemetry:opentelemetry-sdk:${openTelemetryVersion}"
     implementation "io.opentelemetry:opentelemetry-sdk-metrics:${openTelemetryVersion}"
-    implementation "io.opentelemetry:opentelemetry-exporter-logging:${openTelemetryVersion}"
     implementation "io.opentelemetry:opentelemetry-exporter-prometheus:${openTelemetryPrometheusVersion}"
     compileOnly "org.apache.tomcat:annotations-api:6.0.53"
     runtimeOnly "io.grpc:grpc-xds:${grpcVersion}"

--- a/examples/example-gcp-csm-observability/src/main/java/io/grpc/examples/csmobservability/CsmObservabilityClient.java
+++ b/examples/example-gcp-csm-observability/src/main/java/io/grpc/examples/csmobservability/CsmObservabilityClient.java
@@ -20,13 +20,11 @@ import io.grpc.Channel;
 import io.grpc.Grpc;
 import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.grpc.gcp.csm.observability.CsmObservability;
-import io.opentelemetry.exporter.logging.LoggingMetricExporter;
 import io.opentelemetry.exporter.prometheus.PrometheusHttpServer;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
@@ -69,7 +67,9 @@ public class CsmObservabilityClient {
    */
   public static void main(String[] args) throws Exception {
     String user = "world";
+    // Use xDS to establish contact with the server "helloworld:50051".
     String target = "xds:///helloworld:50051";
+    // The port on which prometheus metrics will be exposed.
     int prometheusPort = 9464;
     AtomicBoolean sendRpcs = new AtomicBoolean(true);
     if (args.length > 0) {

--- a/examples/example-gcp-csm-observability/src/main/java/io/grpc/examples/csmobservability/CsmObservabilityServer.java
+++ b/examples/example-gcp-csm-observability/src/main/java/io/grpc/examples/csmobservability/CsmObservabilityServer.java
@@ -38,9 +38,9 @@ import java.util.logging.Logger;
 public class CsmObservabilityServer {
   private static final Logger logger = Logger.getLogger(CsmObservabilityServer.class.getName());
 
-  private Server gRPCServer;
+  private Server server;
   private void start(int port) throws IOException {
-    gRPCServer = Grpc.newServerBuilderForPort(port, InsecureServerCredentials.create())
+    server = Grpc.newServerBuilderForPort(port, InsecureServerCredentials.create())
         .addService(new GreeterImpl())
         .build()
         .start();
@@ -48,14 +48,17 @@ public class CsmObservabilityServer {
   }
 
   private void stop() throws InterruptedException {
-    if (gRPCServer != null) {
-      gRPCServer.shutdown().awaitTermination(30, TimeUnit.SECONDS);
+    if (server != null) {
+      server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
     }
   }
 
+  /**
+   * Await termination on the main thread since the grpc library uses daemon threads.
+   */
   private void blockUntilShutdown() throws InterruptedException {
-    if (gRPCServer != null) {
-      gRPCServer.awaitTermination();
+    if (server != null) {
+      server.awaitTermination();
     }
   }
 
@@ -63,8 +66,9 @@ public class CsmObservabilityServer {
    * Main launches the server from the command line.
    */
   public static void main(String[] args) throws IOException, InterruptedException {
-    /* The port on which the server should run. */
+    // The port on which the server should run.
     int port = 50051;
+    // The port on which prometheus metrics will be exposed.
     int prometheusPort = 9464;
 
     if (args.length > 0) {


### PR DESCRIPTION
Backport of #11307.
