### PR TITLE
Add instrumentation tags to opencensus metrics

### DIFF
--- a/census/build.gradle
+++ b/census/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     runtimeOnly project(":grpc-context")
     implementation libraries.guava,
             project(":grpc-context"), // Override opencensus dependency with our newer version
+            project(":grpc-core"),
             libraries.opencensus.api,
             libraries.opencensus.contrib.grpc.metrics
 

--- a/census/src/main/java/io/grpc/census/CensusStatsModule.java
+++ b/census/src/main/java/io/grpc/census/CensusStatsModule.java
@@ -18,6 +18,10 @@ package io.grpc.census;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.grpc.census.internal.ObservabilityCensusConstants.API_LATENCY_PER_CALL;
+import static io.grpc.census.internal.ObservabilityCensusConstants.INSTRUMENTATION_SOURCE;
+import static io.grpc.census.internal.ObservabilityCensusConstants.INSTRUMENTATION_VERSION;
+import static io.grpc.census.internal.ObservabilityCensusConstants.LIBRARY_NAME;
+import static io.grpc.census.internal.ObservabilityCensusConstants.LIBRARY_VERSION;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
@@ -396,6 +400,8 @@ final class CensusStatsModule {
               .tagger
               .toBuilder(startCtx)
               .putLocal(RpcMeasureConstants.GRPC_CLIENT_STATUS, statusTag)
+              .putLocal(INSTRUMENTATION_SOURCE, LIBRARY_NAME)
+              .putLocal(INSTRUMENTATION_VERSION, LIBRARY_VERSION)
               .build());
     }
   }
@@ -447,6 +453,8 @@ final class CensusStatsModule {
       TagValue methodTag = TagValue.create(fullMethodName);
       startCtx = module.tagger.toBuilder(parentCtx)
           .putLocal(RpcMeasureConstants.GRPC_CLIENT_METHOD, methodTag)
+          .putLocal(INSTRUMENTATION_SOURCE, LIBRARY_NAME)
+          .putLocal(INSTRUMENTATION_VERSION, LIBRARY_VERSION)
           .build();
       if (module.recordStartedRpcs) {
         // Record here in case newClientStreamTracer() would never be called.
@@ -556,6 +564,8 @@ final class CensusStatsModule {
               .toBuilder(parentCtx)
               .putLocal(RpcMeasureConstants.GRPC_CLIENT_METHOD, methodTag)
               .putLocal(RpcMeasureConstants.GRPC_CLIENT_STATUS, statusTag)
+              .putLocal(INSTRUMENTATION_SOURCE, LIBRARY_NAME)
+              .putLocal(INSTRUMENTATION_VERSION, LIBRARY_VERSION)
               .build());
     }
   }
@@ -765,6 +775,8 @@ final class CensusStatsModule {
               .tagger
               .toBuilder(parentCtx)
               .putLocal(RpcMeasureConstants.GRPC_SERVER_STATUS, statusTag)
+              .putLocal(INSTRUMENTATION_SOURCE, LIBRARY_NAME)
+              .putLocal(INSTRUMENTATION_VERSION, LIBRARY_VERSION)
               .build());
     }
 
@@ -787,6 +799,8 @@ final class CensusStatsModule {
           tagger
               .toBuilder(parentCtx)
               .putLocal(RpcMeasureConstants.GRPC_SERVER_METHOD, methodTag)
+              .putLocal(INSTRUMENTATION_SOURCE, LIBRARY_NAME)
+              .putLocal(INSTRUMENTATION_VERSION, LIBRARY_VERSION)
               .build();
       return new ServerTracer(CensusStatsModule.this, parentCtx);
     }

--- a/census/src/main/java/io/grpc/census/internal/ObservabilityCensusConstants.java
+++ b/census/src/main/java/io/grpc/census/internal/ObservabilityCensusConstants.java
@@ -27,11 +27,15 @@ import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER
 
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.CallOptions;
+import io.grpc.internal.GrpcUtil;
+import io.grpc.internal.GrpcUtil.GrpcBuildVersion;
 import io.opencensus.contrib.grpc.metrics.RpcViewConstants;
 import io.opencensus.stats.Aggregation;
 import io.opencensus.stats.Measure;
 import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.View;
+import io.opencensus.tags.TagKey;
+import io.opencensus.tags.TagValue;
 import io.opencensus.trace.SpanContext;
 import java.util.Arrays;
 
@@ -46,6 +50,16 @@ public final class ObservabilityCensusConstants {
 
   public static CallOptions.Key<SpanContext> CLIENT_TRACE_SPAN_CONTEXT_KEY
       = CallOptions.Key.createWithDefault("Client span context for tracing", SpanContext.INVALID);
+
+  public static final TagKey INSTRUMENTATION_SOURCE = TagKey.create("instrumentation_source");
+
+  public static final TagKey INSTRUMENTATION_VERSION = TagKey.create("instrumentation_version");
+
+  public static final TagValue LIBRARY_NAME = TagValue.create("grpc-java");
+
+  static GrpcBuildVersion buildVersion = GrpcUtil.getGrpcBuildVersion();
+  public static final TagValue LIBRARY_VERSION = TagValue.create(
+      "v" + buildVersion.getImplementationVersion());
 
   static final Aggregation AGGREGATION_WITH_BYTES_HISTOGRAM =
       RpcViewConstants.GRPC_CLIENT_SENT_BYTES_PER_RPC_VIEW.getAggregation();
@@ -65,7 +79,8 @@ public final class ObservabilityCensusConstants {
           "Time taken by gRPC to complete an RPC from application's perspective",
           API_LATENCY_PER_CALL,
           AGGREGATION_WITH_MILLIS_HISTOGRAM,
-          Arrays.asList(GRPC_CLIENT_METHOD, GRPC_CLIENT_STATUS));
+          Arrays.asList(GRPC_CLIENT_METHOD, GRPC_CLIENT_STATUS,
+              INSTRUMENTATION_SOURCE, INSTRUMENTATION_VERSION));
 
   public static final View GRPC_CLIENT_SENT_COMPRESSED_MESSAGE_BYTES_PER_RPC_VIEW =
       View.create(
@@ -73,7 +88,8 @@ public final class ObservabilityCensusConstants {
           "Compressed message bytes sent per client RPC attempt",
           GRPC_CLIENT_SENT_BYTES_PER_RPC,
           AGGREGATION_WITH_BYTES_HISTOGRAM,
-          Arrays.asList(GRPC_CLIENT_METHOD, GRPC_CLIENT_STATUS));
+          Arrays.asList(GRPC_CLIENT_METHOD, GRPC_CLIENT_STATUS,
+              INSTRUMENTATION_SOURCE, INSTRUMENTATION_VERSION));
 
   public static final View GRPC_CLIENT_RECEIVED_COMPRESSED_MESSAGE_BYTES_PER_RPC_VIEW =
       View.create(
@@ -81,7 +97,8 @@ public final class ObservabilityCensusConstants {
           "Compressed message bytes received per client RPC attempt",
           GRPC_CLIENT_RECEIVED_BYTES_PER_RPC,
           AGGREGATION_WITH_BYTES_HISTOGRAM,
-          Arrays.asList(GRPC_CLIENT_METHOD, GRPC_CLIENT_STATUS));
+          Arrays.asList(GRPC_CLIENT_METHOD, GRPC_CLIENT_STATUS,
+              INSTRUMENTATION_SOURCE, INSTRUMENTATION_VERSION));
 
   public static final View GRPC_SERVER_SENT_COMPRESSED_MESSAGE_BYTES_PER_RPC_VIEW =
       View.create(
@@ -89,7 +106,8 @@ public final class ObservabilityCensusConstants {
           "Compressed message bytes sent per server RPC",
           GRPC_SERVER_SENT_BYTES_PER_RPC,
           AGGREGATION_WITH_BYTES_HISTOGRAM,
-          Arrays.asList(GRPC_SERVER_METHOD, GRPC_SERVER_STATUS));
+          Arrays.asList(GRPC_SERVER_METHOD, GRPC_SERVER_STATUS,
+              INSTRUMENTATION_SOURCE, INSTRUMENTATION_VERSION));
 
   public static final View GRPC_SERVER_RECEIVED_COMPRESSED_MESSAGE_BYTES_PER_RPC_VIEW =
       View.create(
@@ -97,7 +115,8 @@ public final class ObservabilityCensusConstants {
           "Compressed message bytes received per server RPC",
           GRPC_SERVER_RECEIVED_BYTES_PER_RPC,
           AGGREGATION_WITH_BYTES_HISTOGRAM,
-          Arrays.asList(GRPC_SERVER_METHOD, GRPC_SERVER_STATUS));
+          Arrays.asList(GRPC_SERVER_METHOD, GRPC_SERVER_STATUS,
+              INSTRUMENTATION_SOURCE, INSTRUMENTATION_VERSION));
 
   private ObservabilityCensusConstants() {}
 }

--- a/census/src/test/java/io/grpc/census/CensusModulesTest.java
+++ b/census/src/test/java/io/grpc/census/CensusModulesTest.java
@@ -24,6 +24,10 @@ import static io.grpc.census.CensusStatsModule.CallAttemptsTracerFactory.RETRY_D
 import static io.grpc.census.CensusStatsModule.CallAttemptsTracerFactory.TRANSPARENT_RETRIES_PER_CALL;
 import static io.grpc.census.internal.ObservabilityCensusConstants.API_LATENCY_PER_CALL;
 import static io.grpc.census.internal.ObservabilityCensusConstants.CLIENT_TRACE_SPAN_CONTEXT_KEY;
+import static io.grpc.census.internal.ObservabilityCensusConstants.INSTRUMENTATION_SOURCE;
+import static io.grpc.census.internal.ObservabilityCensusConstants.INSTRUMENTATION_VERSION;
+import static io.grpc.census.internal.ObservabilityCensusConstants.LIBRARY_NAME;
+import static io.grpc.census.internal.ObservabilityCensusConstants.LIBRARY_VERSION;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -335,10 +339,10 @@ public class CensusModulesTest {
     if (nonDefaultContext) {
       TagValue extraTag = record.tags.get(StatsTestUtils.EXTRA_TAG);
       assertEquals("extra value", extraTag.asString());
-      assertEquals(2, record.tags.size());
+      assertEquals(4, record.tags.size());
     } else {
       assertNull(record.tags.get(StatsTestUtils.EXTRA_TAG));
-      assertEquals(1, record.tags.size());
+      assertEquals(3, record.tags.size());
     }
 
     if (nonDefaultContext) {
@@ -427,7 +431,7 @@ public class CensusModulesTest {
       StatsTestUtils.MetricsRecord record = statsRecorder.pollRecord();
       assertNotNull(record);
       assertNoServerContent(record);
-      assertEquals(1, record.tags.size());
+      assertEquals(3, record.tags.size());
       TagValue methodTag = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
       assertEquals(method.getFullMethodName(), methodTag.asString());
       assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS));
@@ -537,7 +541,7 @@ public class CensusModulesTest {
         callAttemptsTracerFactory.newClientStreamTracer(STREAM_INFO,  new Metadata());
 
     StatsTestUtils.MetricsRecord record = statsRecorder.pollRecord();
-    assertEquals(1, record.tags.size());
+    assertEquals(3, record.tags.size());
     TagValue methodTag = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
     assertEquals(method.getFullMethodName(), methodTag.asString());
     assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS));
@@ -581,7 +585,7 @@ public class CensusModulesTest {
     fakeClock.forwardTime(1000, MILLISECONDS);
     tracer = callAttemptsTracerFactory.newClientStreamTracer(STREAM_INFO, new Metadata());
     record = statsRecorder.pollRecord();
-    assertEquals(1, record.tags.size());
+    assertEquals(3, record.tags.size());
     methodTag = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
     assertEquals(method.getFullMethodName(), methodTag.asString());
     assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS));
@@ -623,7 +627,7 @@ public class CensusModulesTest {
     tracer = callAttemptsTracerFactory.newClientStreamTracer(
         STREAM_INFO.toBuilder().setIsTransparentRetry(true).build(), new Metadata());
     record = statsRecorder.pollRecord();
-    assertEquals(1, record.tags.size());
+    assertEquals(3, record.tags.size());
     methodTag = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
     assertEquals(method.getFullMethodName(), methodTag.asString());
     assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS));
@@ -644,7 +648,7 @@ public class CensusModulesTest {
     tracer = callAttemptsTracerFactory.newClientStreamTracer(
         STREAM_INFO.toBuilder().setIsTransparentRetry(true).build(), new Metadata());
     record = statsRecorder.pollRecord();
-    assertEquals(1, record.tags.size());
+    assertEquals(3, record.tags.size());
     assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS));
     tracer.outboundHeaders();
     tracer.outboundMessage(0);
@@ -831,7 +835,7 @@ public class CensusModulesTest {
     StatsTestUtils.MetricsRecord record = statsRecorder.pollRecord();
     assertNotNull(record);
     assertNoServerContent(record);
-    assertEquals(1, record.tags.size());
+    assertEquals(3, record.tags.size());
     TagValue methodTag = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
     assertEquals(method.getFullMethodName(), methodTag.asString());
     assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS));
@@ -934,7 +938,7 @@ public class CensusModulesTest {
       StatsTestUtils.MetricsRecord clientRecord = statsRecorder.pollRecord();
       assertNotNull(clientRecord);
       assertNoServerContent(clientRecord);
-      assertEquals(2, clientRecord.tags.size());
+      assertEquals(4, clientRecord.tags.size());
       TagValue clientMethodTag = clientRecord.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
       assertEquals(method.getFullMethodName(), clientMethodTag.asString());
       TagValue clientPropagatedTag = clientRecord.tags.get(StatsTestUtils.EXTRA_TAG);
@@ -959,6 +963,8 @@ public class CensusModulesTest {
             .putLocal(
                 RpcMeasureConstants.GRPC_SERVER_METHOD,
                 TagValue.create(method.getFullMethodName()))
+            .putLocal(INSTRUMENTATION_SOURCE, LIBRARY_NAME)
+            .putLocal(INSTRUMENTATION_VERSION, LIBRARY_VERSION)
             .build(),
         io.opencensus.tags.unsafe.ContextUtils.getValue(serverContext));
 
@@ -970,7 +976,7 @@ public class CensusModulesTest {
       StatsTestUtils.MetricsRecord serverRecord = statsRecorder.pollRecord();
       assertNotNull(serverRecord);
       assertNoClientContent(serverRecord);
-      assertEquals(2, serverRecord.tags.size());
+      assertEquals(4, serverRecord.tags.size());
       TagValue serverMethodTag = serverRecord.tags.get(RpcMeasureConstants.GRPC_SERVER_METHOD);
       assertEquals(method.getFullMethodName(), serverMethodTag.asString());
       TagValue serverPropagatedTag = serverRecord.tags.get(StatsTestUtils.EXTRA_TAG);
@@ -1187,7 +1193,7 @@ public class CensusModulesTest {
       StatsTestUtils.MetricsRecord record = statsRecorder.pollRecord();
       assertNotNull(record);
       assertNoClientContent(record);
-      assertEquals(1, record.tags.size());
+      assertEquals(3, record.tags.size());
       TagValue methodTag = record.tags.get(RpcMeasureConstants.GRPC_SERVER_METHOD);
       assertEquals(method.getFullMethodName(), methodTag.asString());
       assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_SERVER_STARTED_RPCS));
@@ -1203,6 +1209,8 @@ public class CensusModulesTest {
             .putLocal(
                 RpcMeasureConstants.GRPC_SERVER_METHOD,
                 TagValue.create(method.getFullMethodName()))
+            .putLocal(INSTRUMENTATION_SOURCE, LIBRARY_NAME)
+            .putLocal(INSTRUMENTATION_VERSION, LIBRARY_VERSION)
             .build(),
         statsCtx);
 
@@ -1556,7 +1564,8 @@ public class CensusModulesTest {
     assertDistributionData(
         localStats,
         ObservabilityCensusConstants.GRPC_CLIENT_API_LATENCY_VIEW,
-        ImmutableList.of(TagValue.create(method.getFullMethodName()), TagValue.create("OK")),
+        ImmutableList.of(TagValue.create(method.getFullMethodName()), TagValue.create("OK"),
+                         LIBRARY_NAME, LIBRARY_VERSION),
         50.0, 1, 0.0,
         ImmutableList.of(
             0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 1L,


### PR DESCRIPTION
Add two tags to the A66 metrics exported by the opencensus stats module. This will be picked up by the Cloud Monitoring pipeline and allow us to build dashboard off these tags.

Similarly done in https://github.com/grpc-ecosystem/grpc-spring/pull/1081