### PR TITLE
Revert "Start 1.63.3 development cycle"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ subprojects {
     apply plugin: "net.ltgt.errorprone"
 
     group = "io.grpc"
-    version = "1.63.3-SNAPSHOT" // CURRENT_GRPC_VERSION
+    version = "1.63.2-SNAPSHOT" // CURRENT_GRPC_VERSION
 
     repositories {
         maven { // The google mirror is less flaky than mavenCentral()

--- a/compiler/src/test/golden/TestDeprecatedService.java.txt
+++ b/compiler/src/test/golden/TestDeprecatedService.java.txt
@@ -8,7 +8,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.63.3-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.63.2-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
 @io.grpc.stub.annotations.GrpcGenerated
 @java.lang.Deprecated

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -8,7 +8,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.63.3-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.63.2-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
 @io.grpc.stub.annotations.GrpcGenerated
 public final class TestServiceGrpc {

--- a/compiler/src/testLite/golden/TestDeprecatedService.java.txt
+++ b/compiler/src/testLite/golden/TestDeprecatedService.java.txt
@@ -8,7 +8,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.63.3-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.63.2-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
 @io.grpc.stub.annotations.GrpcGenerated
 @java.lang.Deprecated

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -8,7 +8,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.63.3-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.63.2-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
 @io.grpc.stub.annotations.GrpcGenerated
 public final class TestServiceGrpc {

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -221,7 +221,7 @@ public final class GrpcUtil {
 
   public static final Splitter ACCEPT_ENCODING_SPLITTER = Splitter.on(',').trimResults();
 
-  public static final String IMPLEMENTATION_VERSION = "1.63.3-SNAPSHOT"; // CURRENT_GRPC_VERSION
+  public static final String IMPLEMENTATION_VERSION = "1.63.2-SNAPSHOT"; // CURRENT_GRPC_VERSION
 
   /**
    * The default timeout in nanos for a keepalive ping request.

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -34,7 +34,7 @@ android {
 protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.25.1' }
     plugins {
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -54,12 +54,12 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.0'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'org.apache.tomcat:annotations-api:6.0.53'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.google.truth:truth:1.1.5'
-    testImplementation 'io.grpc:grpc-testing:1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-testing:1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 }

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -32,7 +32,7 @@ android {
 protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.25.1' }
     plugins {
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -52,8 +52,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.0'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'org.apache.tomcat:annotations-api:6.0.53'
 }

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -32,7 +32,7 @@ android {
 protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.25.1' }
     plugins {
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -52,8 +52,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.0'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'org.apache.tomcat:annotations-api:6.0.53'
 }

--- a/examples/android/strictmode/app/build.gradle
+++ b/examples/android/strictmode/app/build.gradle
@@ -33,7 +33,7 @@ android {
 protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.25.1' }
     plugins {
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -53,8 +53,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.0'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'org.apache.tomcat:annotations-api:6.0.53'
 }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -23,7 +23,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.25.1'
 def protocVersion = protobufVersion
 

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -24,7 +24,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.1'
 
 dependencies {

--- a/examples/example-debug/build.gradle
+++ b/examples/example-debug/build.gradle
@@ -25,7 +25,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.25.1'
 
 dependencies {

--- a/examples/example-debug/pom.xml
+++ b/examples/example-debug/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.63.3-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.63.2-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-debug</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.63.3-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.63.2-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protoc.version>3.25.1</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -24,7 +24,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.25.1'
 def protocVersion = protobufVersion
 

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.63.3-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.63.2-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-gauth</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.63.3-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.63.2-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.25.1</protobuf.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/examples/example-gcp-observability/build.gradle
+++ b/examples/example-gcp-observability/build.gradle
@@ -25,7 +25,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.1'
 
 dependencies {

--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -23,7 +23,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.25.1'
 
 dependencies {

--- a/examples/example-hostname/pom.xml
+++ b/examples/example-hostname/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.63.3-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.63.2-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-hostname</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.63.3-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.63.2-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protoc.version>3.25.1</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -23,7 +23,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.25.1'
 def protocVersion = protobufVersion
 

--- a/examples/example-jwt-auth/pom.xml
+++ b/examples/example-jwt-auth/pom.xml
@@ -7,13 +7,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.63.3-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.63.2-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-jwt-auth</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.63.3-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.63.2-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.25.1</protobuf.version>
     <protoc.version>3.25.1</protoc.version>
     <!-- required for jdk9 -->

--- a/examples/example-oauth/build.gradle
+++ b/examples/example-oauth/build.gradle
@@ -23,7 +23,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.25.1'
 def protocVersion = protobufVersion
 

--- a/examples/example-oauth/pom.xml
+++ b/examples/example-oauth/pom.xml
@@ -7,13 +7,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.63.3-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.63.2-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-oauth</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.63.3-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.63.2-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.25.1</protobuf.version>
     <protoc.version>3.25.1</protoc.version>
     <!-- required for jdk9 -->

--- a/examples/example-orca/build.gradle
+++ b/examples/example-orca/build.gradle
@@ -18,7 +18,7 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-def grpcVersion = '1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.1'
 
 dependencies {

--- a/examples/example-reflection/build.gradle
+++ b/examples/example-reflection/build.gradle
@@ -18,7 +18,7 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-def grpcVersion = '1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.1'
 
 dependencies {

--- a/examples/example-servlet/build.gradle
+++ b/examples/example-servlet/build.gradle
@@ -16,7 +16,7 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-def grpcVersion = '1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.1'
 
 dependencies {

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -24,7 +24,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.1'
 
 dependencies {

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.63.3-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.63.2-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-tls</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.63.3-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.63.2-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protoc.version>3.25.1</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/examples/example-xds/build.gradle
+++ b/examples/example-xds/build.gradle
@@ -23,7 +23,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.63.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.63.2-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.1'
 
 dependencies {

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.63.3-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.63.2-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>examples</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.63.3-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.63.2-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.25.1</protobuf.version>
     <protoc.version>3.25.1</protoc.version>
     <!-- required for JDK 8 -->


### PR DESCRIPTION
This should never have been done and makes the normal patch release process broken.