### PR TITLE
core: remove GrpcUtil.getHost

### DIFF
--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -48,10 +48,8 @@ import io.grpc.internal.StreamListener.MessageProducer;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
-import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -631,25 +629,6 @@ public final class GrpcUtil {
         return Stopwatch.createUnstarted();
       }
     };
-
-  /**
-   * Returns the host via {@link InetSocketAddress#getHostString} if it is possible,
-   * i.e. in jdk >= 7.
-   * Otherwise, return it via {@link InetSocketAddress#getHostName} which may incur a DNS lookup.
-   */
-  public static String getHost(InetSocketAddress addr) {
-    try {
-      Method getHostStringMethod = InetSocketAddress.class.getMethod("getHostString");
-      return (String) getHostStringMethod.invoke(addr);
-    } catch (NoSuchMethodException e) {
-      // noop
-    } catch (IllegalAccessException e) {
-      // noop
-    } catch (InvocationTargetException e) {
-      // noop
-    }
-    return addr.getHostName();
-  }
 
   /**
    * Marshals a nanoseconds representation of the timeout to and from a string representation,

--- a/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
+++ b/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
@@ -202,14 +202,7 @@ class ProxyDetectorImpl implements ProxyDetector {
 
   private ProxiedSocketAddress detectProxy(InetSocketAddress targetAddr) throws IOException {
     URI uri;
-    String host;
-    try {
-      host = GrpcUtil.getHost(targetAddr);
-    } catch (Throwable t) {
-      // Workaround for Android API levels < 19 if getHostName causes a NetworkOnMainThreadException
-      log.log(Level.WARNING, "Failed to get host for proxy lookup, proceeding without proxy", t);
-      return null;
-    }
+    String host = targetAddr.getHostString();
     try {
       uri =
           new URI(
@@ -247,13 +240,14 @@ class ProxyDetectorImpl implements ProxyDetector {
     // The prompt string should be the realm as returned by the server.
     // We don't have it because we are avoiding the full handshake.
     String promptString = "";
-    PasswordAuthentication auth = authenticationProvider.requestPasswordAuthentication(
-        GrpcUtil.getHost(proxyAddr),
-        proxyAddr.getAddress(),
-        proxyAddr.getPort(),
-        PROXY_SCHEME,
-        promptString,
-        null);
+    PasswordAuthentication auth =
+        authenticationProvider.requestPasswordAuthentication(
+            proxyAddr.getHostString(),
+            proxyAddr.getAddress(),
+            proxyAddr.getPort(),
+            PROXY_SCHEME,
+            promptString,
+            null);
 
     final InetSocketAddress resolvedProxyAddr;
     if (proxyAddr.isUnresolved()) {


### PR DESCRIPTION
This utility is not relevant on supported JDK versions anymore.
