### PR TITLE
Enable new PickFirst LB

### DIFF
--- a/core/src/main/java/io/grpc/internal/PickFirstLoadBalancerProvider.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLoadBalancerProvider.java
@@ -37,7 +37,7 @@ public final class PickFirstLoadBalancerProvider extends LoadBalancerProvider {
   private static final String SHUFFLE_ADDRESS_LIST_KEY = "shuffleAddressList";
 
   private static boolean enableNewPickFirst =
-      GrpcUtil.getFlag("GRPC_EXPERIMENTAL_ENABLE_NEW_PICK_FIRST", false);
+      GrpcUtil.getFlag("GRPC_EXPERIMENTAL_ENABLE_NEW_PICK_FIRST", true);
 
   public static boolean isEnabledHappyEyeballs() {
 


### PR DESCRIPTION
All known bugs have been fixed and merged.  Re-enabling usage of PickFirstLeafLoadBalancer by default.
Note that Happy Eyeballs is not enabled by default.