### PR TITLE
Fix AdvancedTlsX509TrustManager to handle client side validation of socket

### DIFF
--- a/util/src/main/java/io/grpc/util/AdvancedTlsX509TrustManager.java
+++ b/util/src/main/java/io/grpc/util/AdvancedTlsX509TrustManager.java
@@ -196,7 +196,11 @@ public final class AdvancedTlsX509TrustManager extends X509ExtendedTrustManager 
           currentDelegateManager.checkServerTrusted(chain, authType, sslSocket);
         }
       } else {
-        currentDelegateManager.checkClientTrusted(chain, authType, sslEngine);
+        if (sslEngine != null) {
+          currentDelegateManager.checkClientTrusted(chain, authType, sslEngine);
+        } else {
+          currentDelegateManager.checkClientTrusted(chain, authType, socket);
+        }
       }
     }
     // Perform the additional peer cert check.


### PR DESCRIPTION
There's a missing if-statement to check SSLEngine vs socket before calling currentDelegateManager.checkClientTrusted