### PR TITLE
buildSrc: Avoid duplicating group in checkForUpdates

### DIFF
--- a/buildSrc/src/main/java/io/grpc/gradle/CheckForUpdatesTask.java
+++ b/buildSrc/src/main/java/io/grpc/gradle/CheckForUpdatesTask.java
@@ -94,8 +94,8 @@ public abstract class CheckForUpdatesTask extends DefaultTask {
           .getDependencies().iterator().next()).getSelected().getModuleVersion();
       if (oldId != newId) {
         System.out.println(String.format(
-            "libs.%s = %s:%s %s -> %s",
-            name, newId.getGroup(), newId.getModule(), oldId.getVersion(), newId.getVersion()));
+            "libs.%s = %s %s -> %s",
+            name, newId.getModule(), oldId.getVersion(), newId.getVersion()));
       }
     }
   }


### PR DESCRIPTION
getModule() returns a ModuleIdentifier, not a string. And the identifier's toString() includes the module's group.