### PR TITLE
Upgrade dependencies

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,7 +19,7 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "com.google.guava:failureaccess:1.0.1",
     "com.google.guava:guava:33.2.1-android",
     "com.google.re2j:re2j:1.7",
-    "com.google.truth:truth:1.4.3",
+    "com.google.truth:truth:1.4.2",
     "com.squareup.okhttp:okhttp:2.7.5",
     "com.squareup.okio:okio:2.10.0",  # 3.0+ needs swapping to -jvm; need work to avoid flag-day
     "io.netty:netty-buffer:4.1.100.Final",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,17 +9,17 @@ module(
 IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "com.google.android:annotations:4.1.1.4",
     "com.google.api.grpc:proto-google-common-protos:2.29.0",
-    "com.google.auth:google-auth-library-credentials:1.22.0",
-    "com.google.auth:google-auth-library-oauth2-http:1.22.0",
-    "com.google.auto.value:auto-value-annotations:1.10.4",
-    "com.google.auto.value:auto-value:1.10.4",
+    "com.google.auth:google-auth-library-credentials:1.23.0",
+    "com.google.auth:google-auth-library-oauth2-http:1.23.0",
+    "com.google.auto.value:auto-value-annotations:1.11.0",
+    "com.google.auto.value:auto-value:1.11.0",
     "com.google.code.findbugs:jsr305:3.0.2",
-    "com.google.code.gson:gson:2.10.1",
-    "com.google.errorprone:error_prone_annotations:2.23.0",
+    "com.google.code.gson:gson:2.11.0",
+    "com.google.errorprone:error_prone_annotations:2.28.0",
     "com.google.guava:failureaccess:1.0.1",
-    "com.google.guava:guava:32.1.3-android",
+    "com.google.guava:guava:33.2.1-android",
     "com.google.re2j:re2j:1.7",
-    "com.google.truth:truth:1.1.5",
+    "com.google.truth:truth:1.4.3",
     "com.squareup.okhttp:okhttp:2.7.5",
     "com.squareup.okio:okio:2.10.0",  # 3.0+ needs swapping to -jvm; need work to avoid flag-day
     "io.netty:netty-buffer:4.1.100.Final",
@@ -38,10 +38,10 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "io.netty:netty-transport:4.1.100.Final",
     "io.opencensus:opencensus-api:0.31.0",
     "io.opencensus:opencensus-contrib-grpc-metrics:0.31.0",
-    "io.perfmark:perfmark-api:0.26.0",
+    "io.perfmark:perfmark-api:0.27.0",
     "junit:junit:4.13.2",
     "org.apache.tomcat:annotations-api:6.0.53",
-    "org.codehaus.mojo:animal-sniffer-annotations:1.23",
+    "org.codehaus.mojo:animal-sniffer-annotations:1.24",
 ]
 # GRPC_DEPS_END
 

--- a/authz/src/test/java/io/grpc/authz/AuthorizationPolicyTranslatorTest.java
+++ b/authz/src/test/java/io/grpc/authz/AuthorizationPolicyTranslatorTest.java
@@ -45,9 +45,8 @@ public class AuthorizationPolicyTranslatorTest {
       AuthorizationPolicyTranslator.translate(policy);
       fail("exception expected");
     } catch (IOException ioe) {
-      assertThat(ioe).hasMessageThat().isEqualTo(
-          "Use JsonReader.setLenient(true) to accept malformed JSON"
-          + " at line 1 column 18 path $.name");
+      assertThat(ioe).hasMessageThat().contains("malformed JSON");
+      assertThat(ioe).hasMessageThat().contains("at line 1 column 18 path $.name");
     }
   }
 

--- a/authz/src/test/java/io/grpc/authz/AuthorizationServerInterceptorTest.java
+++ b/authz/src/test/java/io/grpc/authz/AuthorizationServerInterceptorTest.java
@@ -35,9 +35,8 @@ public class AuthorizationServerInterceptorTest {
       AuthorizationServerInterceptor.create(policy);
       fail("exception expected");
     } catch (IOException ioe) {
-      assertThat(ioe).hasMessageThat().isEqualTo(
-          "Use JsonReader.setLenient(true) to accept malformed JSON"
-          + " at line 1 column 18 path $.name");
+      assertThat(ioe).hasMessageThat().contains("malformed JSON");
+      assertThat(ioe).hasMessageThat().contains("at line 1 column 18 path $.name");
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -474,7 +474,13 @@ def isAcceptableVersion(ModuleComponentIdentifier candidate) {
         return true
     if (group == 'io.netty' && version.contains('Final'))
         return true
+    if (group == 'io.undertow' && version.contains('Final'))
+        return true
     if (module == 'android-api-level-19')
+        return true
+    if (module == 'opentelemetry-exporter-prometheus')
+        return true
+    if (module == 'opentelemetry-gcp-resources')
         return true
     return version ==~ /^[0-9]+(\.[0-9]+)+$/
 }

--- a/buildSrc/src/main/java/io/grpc/gradle/CheckForUpdatesTask.java
+++ b/buildSrc/src/main/java/io/grpc/gradle/CheckForUpdatesTask.java
@@ -28,8 +28,10 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.VersionCatalog;
 import org.gradle.api.artifacts.VersionCatalogsExtension;
+import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
+import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
@@ -88,8 +90,14 @@ public abstract class CheckForUpdatesTask extends DefaultTask {
   public void checkForUpdates() {
     for (Library lib : libraries) {
       String name = lib.getName();
-      ModuleVersionIdentifier oldId = ((ResolvedDependencyResult) lib.getOldResult().get()
-          .getDependencies().iterator().next()).getSelected().getModuleVersion();
+      DependencyResult oldResult = lib.getOldResult().get().getDependencies().iterator().next();
+      if (oldResult instanceof UnresolvedDependencyResult) {
+        System.out.println(String.format(
+            "- Current version of libs.%s not resolved", name));
+        continue;
+      }
+      ModuleVersionIdentifier oldId =
+          ((ResolvedDependencyResult) oldResult).getSelected().getModuleVersion();
       ModuleVersionIdentifier newId = ((ResolvedDependencyResult) lib.getNewResult().get()
           .getDependencies().iterator().next()).getSelected().getModuleVersion();
       if (oldId != newId) {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -24,7 +24,7 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.66.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.25.1'
+def protobufVersion = '3.25.3'
 def protocVersion = protobufVersion
 
 dependencies {

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -25,7 +25,7 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.66.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.25.1'
+def protocVersion = '3.25.3'
 
 dependencies {
     // grpc-alts transitively depends on grpc-netty-shaded, grpc-protobuf, and grpc-stub

--- a/examples/example-debug/build.gradle
+++ b/examples/example-debug/build.gradle
@@ -26,7 +26,7 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.66.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.25.1'
+def protobufVersion = '3.25.3'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-debug/pom.xml
+++ b/examples/example-debug/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.66.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protoc.version>3.25.1</protoc.version>
+    <protoc.version>3.25.3</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -34,15 +34,15 @@
   <dependencies>
     <dependency>
       <groupId>io.grpc</groupId>
+      <artifactId>grpc-services</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-services</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.tomcat</groupId>
@@ -54,11 +54,6 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
       <scope>runtime</scope>
-    </dependency>
-    <dependency> <!-- prevent downgrade of version in protobuf-java-util from grpc-services -->
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>32.1.3-jre</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -25,7 +25,7 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.66.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.25.1'
+def protobufVersion = '3.25.3'
 def protocVersion = protobufVersion
 
 
@@ -34,7 +34,7 @@ dependencies {
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-auth:${grpcVersion}"
     compileOnly "org.apache.tomcat:annotations-api:6.0.53"
-    implementation "com.google.auth:google-auth-library-oauth2-http:1.4.0"
+    implementation "com.google.auth:google-auth-library-oauth2-http:1.23.0"
     implementation "com.google.api.grpc:grpc-google-cloud-pubsub-v1:0.1.24"
     runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
 }

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.66.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.25.1</protobuf.version>
+    <protobuf.version>3.25.3</protobuf.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>1.4.0</version>
+      <version>1.23.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>

--- a/examples/example-gcp-csm-observability/build.gradle
+++ b/examples/example-gcp-csm-observability/build.gradle
@@ -26,9 +26,9 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.66.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.25.1'
-def openTelemetryVersion = '1.39.0'
-def openTelemetryPrometheusVersion = '1.39.0-alpha'
+def protocVersion = '3.25.3'
+def openTelemetryVersion = '1.40.0'
+def openTelemetryPrometheusVersion = '1.40.0-alpha'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-gcp-observability/build.gradle
+++ b/examples/example-gcp-observability/build.gradle
@@ -26,7 +26,7 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.66.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.25.1'
+def protocVersion = '3.25.3'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -24,7 +24,7 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.66.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.25.1'
+def protobufVersion = '3.25.3'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-hostname/pom.xml
+++ b/examples/example-hostname/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.66.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protoc.version>3.25.1</protoc.version>
+    <protoc.version>3.25.3</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -34,15 +34,15 @@
   <dependencies>
     <dependency>
       <groupId>io.grpc</groupId>
+      <artifactId>grpc-services</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-services</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.tomcat</groupId>
@@ -54,11 +54,6 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
       <scope>runtime</scope>
-    </dependency>
-    <dependency> <!-- prevent downgrade of version in protobuf-java-util from grpc-services -->
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>32.1.3-jre</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -24,7 +24,7 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.66.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.25.1'
+def protobufVersion = '3.25.3'
 def protocVersion = protobufVersion
 
 dependencies {

--- a/examples/example-jwt-auth/pom.xml
+++ b/examples/example-jwt-auth/pom.xml
@@ -14,8 +14,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.66.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.25.1</protobuf.version>
-    <protoc.version>3.25.1</protoc.version>
+    <protobuf.version>3.25.3</protobuf.version>
+    <protoc.version>3.25.3</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/examples/example-oauth/build.gradle
+++ b/examples/example-oauth/build.gradle
@@ -24,14 +24,14 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.66.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.25.1'
+def protobufVersion = '3.25.3'
 def protocVersion = protobufVersion
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-auth:${grpcVersion}"
-    implementation "com.google.auth:google-auth-library-oauth2-http:1.18.0"
+    implementation "com.google.auth:google-auth-library-oauth2-http:1.23.0"
 
     compileOnly "org.apache.tomcat:annotations-api:6.0.53"
 

--- a/examples/example-oauth/pom.xml
+++ b/examples/example-oauth/pom.xml
@@ -14,8 +14,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.66.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.25.1</protobuf.version>
-    <protoc.version>3.25.1</protoc.version>
+    <protobuf.version>3.25.3</protobuf.version>
+    <protoc.version>3.25.3</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>1.18.0</version>
+      <version>1.23.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.tomcat</groupId>

--- a/examples/example-opentelemetry/build.gradle
+++ b/examples/example-opentelemetry/build.gradle
@@ -25,9 +25,9 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.66.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.25.1'
-def openTelemetryVersion = '1.39.0'
-def openTelemetryPrometheusVersion = '1.39.0-alpha'
+def protocVersion = '3.25.3'
+def openTelemetryVersion = '1.40.0'
+def openTelemetryPrometheusVersion = '1.40.0-alpha'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-orca/build.gradle
+++ b/examples/example-orca/build.gradle
@@ -19,7 +19,7 @@ java {
 }
 
 def grpcVersion = '1.66.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.25.1'
+def protocVersion = '3.25.3'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-reflection/build.gradle
+++ b/examples/example-reflection/build.gradle
@@ -19,7 +19,7 @@ java {
 }
 
 def grpcVersion = '1.66.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.25.1'
+def protocVersion = '3.25.3'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-servlet/build.gradle
+++ b/examples/example-servlet/build.gradle
@@ -17,7 +17,7 @@ java {
 }
 
 def grpcVersion = '1.66.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.25.1'
+def protocVersion = '3.25.3'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}",

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -25,7 +25,7 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.66.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.25.1'
+def protocVersion = '3.25.3'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.66.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protoc.version>3.25.1</protoc.version>
+    <protoc.version>3.25.3</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/examples/example-xds/build.gradle
+++ b/examples/example-xds/build.gradle
@@ -24,7 +24,7 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.66.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.25.1'
+def protocVersion = '3.25.3'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.66.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.25.1</protobuf.version>
-    <protoc.version>3.25.1</protoc.version>
+    <protobuf.version>3.25.3</protobuf.version>
+    <protoc.version>3.25.3</protoc.version>
     <!-- required for JDK 8 -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -35,6 +35,10 @@
   <dependencies>
     <dependency>
       <groupId>io.grpc</groupId>
+      <artifactId>grpc-services</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
       <scope>runtime</scope>
     </dependency>
@@ -44,21 +48,12 @@
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
-      <artifactId>grpc-services</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
       <version>${protobuf.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>32.1.3-jre</version> <!-- prevent downgrade of version in protobuf-java-util -->
     </dependency>
     <dependency>
       <groupId>org.apache.tomcat</groupId>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -93,7 +93,9 @@ signature-android = "net.sf.androidscents.signature:android-api-level-19:4.4.2_r
 signature-java = "org.codehaus.mojo.signature:java18:1.0"
 tomcat-embed-core = "org.apache.tomcat.embed:tomcat-embed-core:10.1.25"
 tomcat-embed-core9 = "org.apache.tomcat.embed:tomcat-embed-core:9.0.89"
-truth = "com.google.truth:truth:1.4.3"
+# 1.4.3+ causes "unknown enum constant ElementType.MODULE" warning.
+# https://github.com/google/truth/issues/1320
+truth = "com.google.truth:truth:1.4.2"
 undertow-servlet = "io.undertow:undertow-servlet:2.2.32.Final"
 undertow-servlet-jakartaee9 = "io.undertow:undertow-servlet:2.3.14.Final"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,58 +1,60 @@
 [versions]
-googleauth = "1.22.0"
 netty = '4.1.100.Final'
 # Keep the following references of tcnative version in sync whenever it's updated:
 #   SECURITY.md
 nettytcnative = '2.0.61.Final'
 opencensus = "0.31.1"
-protobuf = "3.25.1"
+# Not upgrading to 4.x as it is not yet ABI compatible.
+# https://github.com/protocolbuffers/protobuf/issues/17247
+protobuf = "3.25.3"
 
 [libraries]
 android-annotations = "com.google.android:annotations:4.1.1.4"
-androidx-annotation = "androidx.annotation:annotation:1.7.0"
-androidx-core = "androidx.core:core:1.12.0"
-androidx-lifecycle-common = "androidx.lifecycle:lifecycle-common:2.6.2"
-androidx-lifecycle-service = "androidx.lifecycle:lifecycle-service:2.6.2"
-androidx-test-core = "androidx.test:core:1.5.0"
-androidx-test-ext-junit = "androidx.test.ext:junit:1.1.5"
-androidx-test-rules = "androidx.test:rules:1.5.0"
-animalsniffer = "org.codehaus.mojo:animal-sniffer:1.23"
-animalsniffer-annotations = "org.codehaus.mojo:animal-sniffer-annotations:1.23"
-assertj-core = "org.assertj:assertj-core:3.24.2"
-auto-value = "com.google.auto.value:auto-value:1.10.4"
-auto-value-annotations = "com.google.auto.value:auto-value-annotations:1.10.4"
+androidx-annotation = "androidx.annotation:annotation:1.8.0"
+androidx-core = "androidx.core:core:1.13.1"
+androidx-lifecycle-common = "androidx.lifecycle:lifecycle-common:2.8.3"
+androidx-lifecycle-service = "androidx.lifecycle:lifecycle-service:2.8.3"
+androidx-test-core = "androidx.test:core:1.6.1"
+androidx-test-ext-junit = "androidx.test.ext:junit:1.2.1"
+androidx-test-rules = "androidx.test:rules:1.6.1"
+animalsniffer = "org.codehaus.mojo:animal-sniffer:1.24"
+animalsniffer-annotations = "org.codehaus.mojo:animal-sniffer-annotations:1.24"
+assertj-core = "org.assertj:assertj-core:3.26.0"
+auto-value = "com.google.auto.value:auto-value:1.11.0"
+auto-value-annotations = "com.google.auto.value:auto-value-annotations:1.11.0"
 checkstyle = "com.puppycrawl.tools:checkstyle:10.17.0"
 commons-math3 = "org.apache.commons:commons-math3:3.6.1"
 conscrypt = "org.conscrypt:conscrypt-openjdk-uber:2.5.2"
 cronet-api = "org.chromium.net:cronet-api:119.6045.31"
 cronet-embedded = "org.chromium.net:cronet-embedded:119.6045.31"
-errorprone-annotations = "com.google.errorprone:error_prone_annotations:2.23.0"
+errorprone-annotations = "com.google.errorprone:error_prone_annotations:2.28.0"
 errorprone-core = "com.google.errorprone:error_prone_core:2.23.0"
-google-api-protos = "com.google.api.grpc:proto-google-common-protos:2.29.0"
-google-auth-credentials = { module = "com.google.auth:google-auth-library-credentials", version.ref = "googleauth" }
-google-auth-oauth2Http = { module = "com.google.auth:google-auth-library-oauth2-http", version.ref = "googleauth" }
+google-api-protos = "com.google.api.grpc:proto-google-common-protos:2.41.0"
+google-auth-credentials = "com.google.auth:google-auth-library-credentials:1.23.0"
+google-auth-oauth2Http = "com.google.auth:google-auth-library-oauth2-http:1.23.0"
 # Release notes: https://cloud.google.com/logging/docs/release-notes
-google-cloud-logging = "com.google.cloud:google-cloud-logging:3.15.14"
-gson = "com.google.code.gson:gson:2.10.1"
-guava = "com.google.guava:guava:32.1.3-android"
+google-cloud-logging = "com.google.cloud:google-cloud-logging:3.19.0"
+gson = "com.google.code.gson:gson:2.11.0"
+guava = "com.google.guava:guava:33.2.1-android"
 guava-betaChecker = "com.google.guava:guava-beta-checker:1.0"
-guava-testlib = "com.google.guava:guava-testlib:32.1.3-android"
+guava-testlib = "com.google.guava:guava-testlib:33.2.1-android"
 # JRE version is needed for projects where its a transitive dependency, f.e. gcp-observability.
 # May be different from the -android version.
-guava-jre = "com.google.guava:guava:32.1.3-jre"
-hdrhistogram = "org.hdrhistogram:HdrHistogram:2.1.12"
-j2objc-annotations = " com.google.j2objc:j2objc-annotations:2.8"
+guava-jre = "com.google.guava:guava:33.2.1-jre"
+hdrhistogram = "org.hdrhistogram:HdrHistogram:2.2.2"
+j2objc-annotations = " com.google.j2objc:j2objc-annotations:3.0.0"
 jakarta-servlet-api = "jakarta.servlet:jakarta.servlet-api:5.0.0"
 javax-annotation = "org.apache.tomcat:annotations-api:6.0.53"
 javax-servlet-api = "javax.servlet:javax.servlet-api:4.0.1"
 jetty-client = "org.eclipse.jetty:jetty-client:10.0.20"
-jetty-http2-server = "org.eclipse.jetty.http2:http2-server:11.0.20"
+jetty-http2-server = "org.eclipse.jetty.http2:http2-server:11.0.22"
 jetty-http2-server10 = "org.eclipse.jetty.http2:http2-server:10.0.20"
-jetty-servlet = "org.eclipse.jetty:jetty-servlet:11.0.20"
+jetty-servlet = "org.eclipse.jetty:jetty-servlet:11.0.22"
 jetty-servlet10 = "org.eclipse.jetty:jetty-servlet:10.0.20"
 jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
 junit = "junit:junit:4.13.2"
-lincheck = "org.jetbrains.kotlinx:lincheck:2.14.1"
+# 2.17+ require Java 11+ (not mentioned in release notes)
+lincheck = "org.jetbrains.kotlinx:lincheck:2.16"
 # Update notes / 2023-07-19 sergiitk:
 #    Couldn't update to 5.4.0, updated to the last in 4.x line. Version 5.x breaks some tests.
 #    Error log: https://github.com/grpc/grpc-java/pull/10359#issuecomment-1632834435
@@ -75,25 +77,25 @@ opencensus-contrib-grpc-metrics = { module = "io.opencensus:opencensus-contrib-g
 opencensus-exporter-stats-stackdriver = { module = "io.opencensus:opencensus-exporter-stats-stackdriver", version.ref = "opencensus" }
 opencensus-exporter-trace-stackdriver = { module = "io.opencensus:opencensus-exporter-trace-stackdriver", version.ref = "opencensus" }
 opencensus-impl = { module = "io.opencensus:opencensus-impl", version.ref = "opencensus" }
-opentelemetry-api = "io.opentelemetry:opentelemetry-api:1.39.0"
-opentelemetry-exporter-prometheus = "io.opentelemetry:opentelemetry-exporter-prometheus:1.39.0-alpha"
+opentelemetry-api = "io.opentelemetry:opentelemetry-api:1.40.0"
+opentelemetry-exporter-prometheus = "io.opentelemetry:opentelemetry-exporter-prometheus:1.40.0-alpha"
 opentelemetry-gcp-resources = "io.opentelemetry.contrib:opentelemetry-gcp-resources:1.36.0-alpha"
-opentelemetry-sdk-extension-autoconfigure = "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.39.0"
-opentelemetry-sdk-testing = "io.opentelemetry:opentelemetry-sdk-testing:1.39.0"
-perfmark-api = "io.perfmark:perfmark-api:0.26.0"
+opentelemetry-sdk-extension-autoconfigure = "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.40.0"
+opentelemetry-sdk-testing = "io.opentelemetry:opentelemetry-sdk-testing:1.40.0"
+perfmark-api = "io.perfmark:perfmark-api:0.27.0"
 protobuf-java = { module = "com.google.protobuf:protobuf-java", version.ref = "protobuf" }
 protobuf-java-util = { module = "com.google.protobuf:protobuf-java-util", version.ref = "protobuf" }
 protobuf-javalite = { module = "com.google.protobuf:protobuf-javalite", version.ref = "protobuf" }
 protobuf-protoc = { module = "com.google.protobuf:protoc", version.ref = "protobuf" }
 re2j = "com.google.re2j:re2j:1.7"
-robolectric = "org.robolectric:robolectric:4.11.1"
+robolectric = "org.robolectric:robolectric:4.13"
 signature-android = "net.sf.androidscents.signature:android-api-level-19:4.4.2_r4"
 signature-java = "org.codehaus.mojo.signature:java18:1.0"
-tomcat-embed-core = "org.apache.tomcat.embed:tomcat-embed-core:10.1.23"
+tomcat-embed-core = "org.apache.tomcat.embed:tomcat-embed-core:10.1.25"
 tomcat-embed-core9 = "org.apache.tomcat.embed:tomcat-embed-core:9.0.89"
-truth = "com.google.truth:truth:1.1.5"
+truth = "com.google.truth:truth:1.4.3"
 undertow-servlet = "io.undertow:undertow-servlet:2.2.32.Final"
-undertow-servlet-jakartaee9 = "io.undertow:undertow-servlet:2.3.13.Final"
+undertow-servlet-jakartaee9 = "io.undertow:undertow-servlet:2.3.14.Final"
 
 # Do not update: Pinned to the last version supporting Java 8.
 # See https://checkstyle.sourceforge.io/releasenotes.html#Release_10.1

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -23,7 +23,7 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "com.google.guava:failureaccess:1.0.1",
     "com.google.guava:guava:33.2.1-android",
     "com.google.re2j:re2j:1.7",
-    "com.google.truth:truth:1.4.3",
+    "com.google.truth:truth:1.4.2",
     "com.squareup.okhttp:okhttp:2.7.5",
     "com.squareup.okio:okio:2.10.0",  # 3.0+ needs swapping to -jvm; need work to avoid flag-day
     "io.netty:netty-buffer:4.1.100.Final",

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -13,17 +13,17 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "com.google.android:annotations:4.1.1.4",
     "com.google.api.grpc:proto-google-common-protos:2.29.0",
-    "com.google.auth:google-auth-library-credentials:1.22.0",
-    "com.google.auth:google-auth-library-oauth2-http:1.22.0",
-    "com.google.auto.value:auto-value-annotations:1.10.4",
-    "com.google.auto.value:auto-value:1.10.4",
+    "com.google.auth:google-auth-library-credentials:1.23.0",
+    "com.google.auth:google-auth-library-oauth2-http:1.23.0",
+    "com.google.auto.value:auto-value-annotations:1.11.0",
+    "com.google.auto.value:auto-value:1.11.0",
     "com.google.code.findbugs:jsr305:3.0.2",
-    "com.google.code.gson:gson:2.10.1",
-    "com.google.errorprone:error_prone_annotations:2.23.0",
+    "com.google.code.gson:gson:2.11.0",
+    "com.google.errorprone:error_prone_annotations:2.28.0",
     "com.google.guava:failureaccess:1.0.1",
-    "com.google.guava:guava:32.1.3-android",
+    "com.google.guava:guava:33.2.1-android",
     "com.google.re2j:re2j:1.7",
-    "com.google.truth:truth:1.1.5",
+    "com.google.truth:truth:1.4.3",
     "com.squareup.okhttp:okhttp:2.7.5",
     "com.squareup.okio:okio:2.10.0",  # 3.0+ needs swapping to -jvm; need work to avoid flag-day
     "io.netty:netty-buffer:4.1.100.Final",
@@ -42,10 +42,10 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "io.netty:netty-transport:4.1.100.Final",
     "io.opencensus:opencensus-api:0.31.0",
     "io.opencensus:opencensus-contrib-grpc-metrics:0.31.0",
-    "io.perfmark:perfmark-api:0.26.0",
+    "io.perfmark:perfmark-api:0.27.0",
     "junit:junit:4.13.2",
     "org.apache.tomcat:annotations-api:6.0.53",
-    "org.codehaus.mojo:animal-sniffer-annotations:1.23",
+    "org.codehaus.mojo:animal-sniffer-annotations:1.24",
 ]
 # GRPC_DEPS_END
 


### PR DESCRIPTION
The GSON upgrade slightly changed an error string, so the test was updated to be less of a change detector.

Some OpenTelemetry dependencies are alpha versions, so needed an adjustment in build.gradle to accept the versions. Similarly, Undertow includes Final in its version numbers which needs to be accepted.