### PR TITLE
Restore old behavior of NettyAdaptiveCumulator, but avoid using that class if Netty is on version 4.1.111 or later

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyAdaptiveCumulator.java
+++ b/netty/src/main/java/io/grpc/netty/NettyAdaptiveCumulator.java
@@ -27,12 +27,6 @@ import io.netty.handler.codec.ByteToMessageDecoder.Cumulator;
 /**
  * "Adaptive" cumulator: cumulate {@link ByteBuf}s by dynamically switching between merge and
  * compose strategies.
- * <br><br>
- *
- * <p><b><font color="red">Avoid using</font></b>
- * {@link CompositeByteBuf#addFlattenedComponents(boolean, ByteBuf)} as it can lead
- * to corruption, where the components' readable area are not equal to the Composite's capacity
- * (see https://github.com/netty/netty/issues/12844).
  */
 
 class NettyAdaptiveCumulator implements Cumulator {
@@ -95,7 +89,8 @@ class NettyAdaptiveCumulator implements Cumulator {
           composite.capacity(composite.writerIndex());
         }
       } else {
-        composite = alloc.compositeBuffer(Integer.MAX_VALUE).addComponent(true, cumulation);
+        composite = alloc.compositeBuffer(Integer.MAX_VALUE)
+            .addFlattenedComponents(true, cumulation);
       }
       addInput(alloc, composite, in);
       in = null;
@@ -115,7 +110,7 @@ class NettyAdaptiveCumulator implements Cumulator {
   @VisibleForTesting
   void addInput(ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
     if (shouldCompose(composite, in, composeMinSize)) {
-      composite.addComponent(true, in);
+      composite.addFlattenedComponents(true, in);
     } else {
       // The total size of the new data and the last component are below the threshold. Merge them.
       mergeWithCompositeTail(alloc, composite, in);
@@ -161,12 +156,31 @@ class NettyAdaptiveCumulator implements Cumulator {
     ByteBuf tail = composite.component(tailComponentIndex);
     ByteBuf newTail = null;
     try {
-      if (tail.refCnt() == 1 && !tail.isReadOnly() && newTailSize <= tail.maxCapacity()
-          && !isCompositeOrWrappedComposite(tail)) {
+      if (tail.refCnt() == 1 && !tail.isReadOnly() && newTailSize <= tail.maxCapacity()) {
         // Ideal case: the tail isn't shared, and can be expanded to the required capacity.
 
         // Take ownership of the tail.
         newTail = tail.retain();
+
+        // TODO(https://github.com/netty/netty/issues/12844): remove when we use Netty with
+        //   the issue fixed.
+        // In certain cases, removing the CompositeByteBuf component, and then adding it back
+        // isn't idempotent. An example is provided in https://github.com/netty/netty/issues/12844.
+        // This happens because the buffer returned by composite.component() has out-of-sync
+        // indexes. Under the hood the CompositeByteBuf returns a duplicate() of the underlying
+        // buffer, but doesn't set the indexes.
+        //
+        // To get the right indexes we use the fact that composite.internalComponent() returns
+        // the slice() into the readable portion of the underlying buffer.
+        // We use this implementation detail (internalComponent() returning a *SlicedByteBuf),
+        // and combine it with the fact that SlicedByteBuf duplicates have their indexes
+        // adjusted so they correspond to the to the readable portion of the slice.
+        //
+        // Hence composite.internalComponent().duplicate() returns a buffer with the
+        // indexes that should've been on the composite.component() in the first place.
+        // Until the issue is fixed, we manually adjust the indexes of the removed component.
+        ByteBuf sliceDuplicate = composite.internalComponent(tailComponentIndex).duplicate();
+        newTail.setIndex(sliceDuplicate.readerIndex(), sliceDuplicate.writerIndex());
 
         /*
          * The tail is a readable non-composite buffer, so writeBytes() handles everything for us.
@@ -183,11 +197,7 @@ class NettyAdaptiveCumulator implements Cumulator {
         newTail.writeBytes(in);
 
       } else {
-        // The tail satisfies one or more criteria:
-        // - Shared
-        // - Not expandable
-        // - Composite
-        // - Wrapped Composite
+        // The tail is shared, or not expandable. Replace it with a new buffer of desired capacity.
         newTail = alloc.buffer(alloc.calculateNewCapacity(newTailSize, Integer.MAX_VALUE));
         newTail.setBytes(0, composite, tailStart, tailSize)
             .setBytes(tailSize, in, in.readerIndex(), inputSize)
@@ -200,7 +210,7 @@ class NettyAdaptiveCumulator implements Cumulator {
       // Remove the old tail, reset writer index.
       composite.removeComponent(tailComponentIndex).setIndex(0, tailStart);
       // Add back the new tail.
-      composite.addComponent(true, newTail);
+      composite.addFlattenedComponents(true, newTail);
       // New tail's ownership transferred to the composite buf.
       newTail = null;
       composite.readerIndex(prevReader);
@@ -214,13 +224,5 @@ class NettyAdaptiveCumulator implements Cumulator {
         newTail.release();
       }
     }
-  }
-
-  private static boolean isCompositeOrWrappedComposite(ByteBuf tail) {
-    ByteBuf cur = tail;
-    while (cur.unwrap() != null) {
-      cur = cur.unwrap();
-    }
-    return cur instanceof CompositeByteBuf;
   }
 }


### PR DESCRIPTION
The fix to support Netty 4.1.111 caused a problem in a Google internal test which led to #11366 which would have completely broken Netty 4.1.111 installations.  This eliminates the problems that caused a desire to revert.  

A long term fix should be developed to keep the performance advantages provided by NettyAdaptiveCumulator with no down sides.