### PR TITLE
compiler: Upgrade from CentOS 7 to AlmaLinux 8 (1.63.x backport)

### DIFF
--- a/buildscripts/grpc-java-artifacts/Dockerfile
+++ b/buildscripts/grpc-java-artifacts/Dockerfile
@@ -1,17 +1,15 @@
-FROM centos:7.9.2009
+FROM almalinux:8
 
 RUN yum install -y \
             autoconf \
             automake \
+            diffutils \
             gcc-c++ \
-            gcc-c++.i686 \
             glibc-devel \
             glibc-devel.i686 \
             java-11-openjdk-devel \
             libstdc++-devel \
             libstdc++-devel.i686 \
-            libstdc++-static \
-            libstdc++-static.i686 \
             libtool \
             make \
             tar \

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -117,7 +117,6 @@ model {
                     // Link other (system) libraries dynamically.
                     // Clang under OSX doesn't support these options.
                     linker.args "-Wl,-Bstatic", "-lprotoc", "-lprotobuf", "-static-libgcc",
-                            "-static-libstdc++",
                             "-Wl,-Bdynamic", "-lpthread", "-s"
                 }
                 addEnvArgs("LDFLAGS", linker.args)

--- a/compiler/check-artifact.sh
+++ b/compiler/check-artifact.sh
@@ -113,23 +113,14 @@ checkDependencies ()
     dump_cmd='objdump -x '"$1"' | fgrep "DLL Name"'
     white_list="KERNEL32\.dll\|msvcrt\.dll\|USER32\.dll"
   elif [[ "$OS" == linux ]]; then
-    dump_cmd='ldd '"$1"
+    dump_cmd='objdump -x '"$1"' | grep "NEEDED"'
+    white_list="libpthread\.so\.0\|libstdc++\.so\.6\|libc\.so\.6"
     if [[ "$ARCH" == x86_32 ]]; then
-      white_list="linux-gate\.so\.1\|libpthread\.so\.0\|libm\.so\.6\|libc\.so\.6\|ld-linux\.so\.2"
+      white_list="${white_list}\|libm\.so\.6"
     elif [[ "$ARCH" == x86_64 ]]; then
-      white_list="linux-vdso\.so\.1\|libpthread\.so\.0\|libm\.so\.6\|libc\.so\.6\|ld-linux-x86-64\.so\.2"
+      white_list="${white_list}\|libm\.so\.6"
     elif [[ "$ARCH" == aarch_64 ]]; then
-      dump_cmd='aarch64-linux-gnu-objdump -x '"$1"' |grep "NEEDED"'
-      white_list="linux-vdso\.so\.1\|libpthread\.so\.0\|libm\.so\.6\|libc\.so\.6\|ld-linux-aarch64\.so\.1"
-    elif [[ "$ARCH" == loongarch_64 ]]; then
-      dump_cmd='objdump -x '"$1"' | grep NEEDED'
-      white_list="linux-vdso\.so\.1\|libpthread\.so\.0\|libm\.so\.6\|libc\.so\.6\|ld\.so\.1"
-    elif [[ "$ARCH" == ppcle_64 ]]; then
-      dump_cmd='powerpc64le-linux-gnu-objdump -x '"$1"' |grep "NEEDED"'
-      white_list="linux-vdso64\.so\.1\|libpthread\.so\.0\|libm\.so\.6\|libc\.so\.6\|ld64\.so\.2"
-    elif [[ "$ARCH" == s390_64 ]]; then
-      dump_cmd='s390x-linux-gnu-objdump -x '"$1"' |grep "NEEDED"'
-      white_list="linux-vdso64\.so\.1\|libpthread\.so\.0\|libm\.so\.6\|libc\.so\.6\|ld64\.so\.1"
+      white_list="${white_list}\|ld-linux-aarch64\.so\.1"
     fi
   elif [[ "$OS" == osx ]]; then
     dump_cmd='otool -L '"$1"' | fgrep dylib'


### PR DESCRIPTION
CentOS 7 became end-of-life on July 1st and is no longer working. We now dynamically link against libstdc++, as RHEL 8 doesn't support static linking: https://access.redhat.com/articles/rhel8-abi-compatibility

We now use objdump in check-artifact for all linux architectures. This avoids using a mix of objdump and ldd. ldd shows transitive dependencies, which is less convenient.

Backport of #11354