### PR TITLE
kokoro: Avoid use of TMPDIR

### DIFF
--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -76,7 +76,7 @@ fi
 
 # Save a copy of set_github_status.py (it may differ from the base commit)
 
-SET_GITHUB_STATUS="$TMPDIR/set_github_status.py"
+SET_GITHUB_STATUS="$(mktemp -d)/set_github_status.py"
 cp "$BASE_DIR/github/grpc-java/buildscripts/set_github_status.py" "$SET_GITHUB_STATUS"
 
 


### PR DESCRIPTION
For the same pool, the CI has TMPDIR set but PRESUBMIT does not. We should be using mktemp anyway, so swap to it, and it'll use TMPDIR if set.

CC @sergiitk 