### PR TITLE
buildscripts: Don't set JDK 8 on OS X from unix.sh

### DIFF
--- a/buildscripts/kokoro/macos.sh
+++ b/buildscripts/kokoro/macos.sh
@@ -16,6 +16,6 @@ export GRADLE_FLAGS="${GRADLE_FLAGS:-} --max-workers=2"
 trap spongify_logs EXIT
 
 export -n JAVA_HOME
-export PATH="$(/usr/libexec/java_home -v"1.8.0"):${PATH}"
+export PATH="$(/usr/libexec/java_home -v"1.8.0")/bin:${PATH}"
 
 "$GRPC_JAVA_DIR"/buildscripts/kokoro/unix.sh

--- a/buildscripts/kokoro/macos.sh
+++ b/buildscripts/kokoro/macos.sh
@@ -15,4 +15,6 @@ export GRADLE_FLAGS="${GRADLE_FLAGS:-} --max-workers=2"
 . "$GRPC_JAVA_DIR"/buildscripts/kokoro/kokoro.sh
 trap spongify_logs EXIT
 
+export PATH="$(/usr/libexec/java_home -v"1.8.0"):${PATH}"
+
 "$GRPC_JAVA_DIR"/buildscripts/kokoro/unix.sh

--- a/buildscripts/kokoro/macos.sh
+++ b/buildscripts/kokoro/macos.sh
@@ -15,6 +15,7 @@ export GRADLE_FLAGS="${GRADLE_FLAGS:-} --max-workers=2"
 . "$GRPC_JAVA_DIR"/buildscripts/kokoro/kokoro.sh
 trap spongify_logs EXIT
 
+export -n JAVA_HOME
 export PATH="$(/usr/libexec/java_home -v"1.8.0"):${PATH}"
 
 "$GRPC_JAVA_DIR"/buildscripts/kokoro/unix.sh

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -23,11 +23,6 @@ readonly GRPC_JAVA_DIR="$(cd "$(dirname "$0")"/../.. && pwd)"
 # cd to the root dir of grpc-java
 cd $(dirname $0)/../..
 
-# TODO(zpencer): always make sure we are using Oracle jdk8
-if [[ -f /usr/libexec/java_home ]]; then
-    JAVA_HOME=$(/usr/libexec/java_home -v"1.8.0")
-fi
-
 # ARCH is x86_64 unless otherwise specified.
 ARCH="${ARCH:-x86_64}"
 


### PR DESCRIPTION
We build on many different JDK versions these days, so we should be able to use whatever the environment has available, for the most part. Any specialized configuration should be much earlier, like macos.sh.