### PR TITLE
util: Align AdvancedTlsX509{Key and Trust}Manager

### DIFF
--- a/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
+++ b/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
@@ -339,8 +339,8 @@ public class AdvancedTlsTest {
     AdvancedTlsX509TrustManager serverTrustManager = AdvancedTlsX509TrustManager.newBuilder()
         .setVerification(Verification.CERTIFICATE_ONLY_VERIFICATION)
         .build();
-    Closeable serverTrustShutdown = serverTrustManager.updateTrustCredentials(caCertFile,100,
-        TimeUnit.MILLISECONDS, executor);
+    Closeable serverTrustShutdown = serverTrustManager.updateTrustCredentials(caCertFile,
+        100, TimeUnit.MILLISECONDS, executor);
     ServerCredentials serverCredentials = TlsServerCredentials.newBuilder()
         .keyManager(serverKeyManager).trustManager(serverTrustManager)
         .clientAuth(ClientAuth.REQUIRE).build();
@@ -349,12 +349,12 @@ public class AdvancedTlsTest {
     // Create a client to connect.
     AdvancedTlsX509KeyManager clientKeyManager = new AdvancedTlsX509KeyManager();
     Closeable clientKeyShutdown = clientKeyManager.updateIdentityCredentials(clientCert0File,
-        clientKey0File,100, TimeUnit.MILLISECONDS, executor);
+        clientKey0File, 100, TimeUnit.MILLISECONDS, executor);
     AdvancedTlsX509TrustManager clientTrustManager = AdvancedTlsX509TrustManager.newBuilder()
         .setVerification(Verification.CERTIFICATE_AND_HOST_NAME_VERIFICATION)
         .build();
-    Closeable clientTrustShutdown = clientTrustManager.updateTrustCredentials(caCertFile,100,
-        TimeUnit.MILLISECONDS, executor);
+    Closeable clientTrustShutdown = clientTrustManager.updateTrustCredentials(caCertFile,
+        100, TimeUnit.MILLISECONDS, executor);
     ChannelCredentials channelCredentials = TlsChannelCredentials.newBuilder()
         .keyManager(clientKeyManager).trustManager(clientTrustManager).build();
     channel = Grpc.newChannelBuilderForAddress("localhost", server.getPort(), channelCredentials)
@@ -431,8 +431,8 @@ public class AdvancedTlsTest {
         .build();
     // We pass in a key as the trust certificates to intentionally create an exception.
     assertThrows(GeneralSecurityException.class,
-        () -> trustManager.updateTrustCredentials(serverKey0File,100,
-            TimeUnit.MILLISECONDS, executor));
+        () -> trustManager.updateTrustCredentials(serverKey0File, 100, TimeUnit.MILLISECONDS,
+            executor));
   }
 
   @Test

--- a/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
+++ b/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
@@ -431,8 +431,8 @@ public class AdvancedTlsTest {
         .build();
     // We pass in a key as the trust certificates to intentionally create an exception.
     assertThrows(GeneralSecurityException.class,
-        () -> trustManager.updateTrustCredentialsFromFile(serverKey0File,
-          100, TimeUnit.MILLISECONDS, executor));
+        () -> trustManager.updateTrustCredentials(serverKey0File,100,
+            TimeUnit.MILLISECONDS, executor));
   }
 
   @Test

--- a/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
+++ b/netty/src/test/java/io/grpc/netty/AdvancedTlsTest.java
@@ -339,8 +339,8 @@ public class AdvancedTlsTest {
     AdvancedTlsX509TrustManager serverTrustManager = AdvancedTlsX509TrustManager.newBuilder()
         .setVerification(Verification.CERTIFICATE_ONLY_VERIFICATION)
         .build();
-    Closeable serverTrustShutdown = serverTrustManager.updateTrustCredentialsFromFile(caCertFile,
-        100, TimeUnit.MILLISECONDS, executor);
+    Closeable serverTrustShutdown = serverTrustManager.updateTrustCredentials(caCertFile,100,
+        TimeUnit.MILLISECONDS, executor);
     ServerCredentials serverCredentials = TlsServerCredentials.newBuilder()
         .keyManager(serverKeyManager).trustManager(serverTrustManager)
         .clientAuth(ClientAuth.REQUIRE).build();
@@ -353,8 +353,8 @@ public class AdvancedTlsTest {
     AdvancedTlsX509TrustManager clientTrustManager = AdvancedTlsX509TrustManager.newBuilder()
         .setVerification(Verification.CERTIFICATE_AND_HOST_NAME_VERIFICATION)
         .build();
-    Closeable clientTrustShutdown = clientTrustManager.updateTrustCredentialsFromFile(caCertFile,
-        100, TimeUnit.MILLISECONDS, executor);
+    Closeable clientTrustShutdown = clientTrustManager.updateTrustCredentials(caCertFile,100,
+        TimeUnit.MILLISECONDS, executor);
     ChannelCredentials channelCredentials = TlsChannelCredentials.newBuilder()
         .keyManager(clientKeyManager).trustManager(clientTrustManager).build();
     channel = Grpc.newChannelBuilderForAddress("localhost", server.getPort(), channelCredentials)
@@ -385,7 +385,7 @@ public class AdvancedTlsTest {
     AdvancedTlsX509TrustManager serverTrustManager = AdvancedTlsX509TrustManager.newBuilder()
         .setVerification(Verification.CERTIFICATE_ONLY_VERIFICATION)
         .build();
-    serverTrustManager.updateTrustCredentialsFromFile(caCertFile);
+    serverTrustManager.updateTrustCredentials(caCertFile);
     ServerCredentials serverCredentials = TlsServerCredentials.newBuilder()
         .keyManager(serverKeyManager).trustManager(serverTrustManager)
         .clientAuth(ClientAuth.REQUIRE).build();
@@ -397,7 +397,7 @@ public class AdvancedTlsTest {
     AdvancedTlsX509TrustManager clientTrustManager = AdvancedTlsX509TrustManager.newBuilder()
         .setVerification(Verification.CERTIFICATE_AND_HOST_NAME_VERIFICATION)
         .build();
-    clientTrustManager.updateTrustCredentialsFromFile(caCertFile);
+    clientTrustManager.updateTrustCredentials(caCertFile);
     ChannelCredentials channelCredentials = TlsChannelCredentials.newBuilder()
         .keyManager(clientKeyManager).trustManager(clientTrustManager).build();
     channel = Grpc.newChannelBuilderForAddress("localhost", server.getPort(), channelCredentials)

--- a/util/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
+++ b/util/src/main/java/io/grpc/util/AdvancedTlsX509KeyManager.java
@@ -116,7 +116,7 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
    * @param key  the private key that is going to be used
    */
   public void updateIdentityCredentials(X509Certificate[] certs, PrivateKey key) {
-    this.keyInfo = new KeyInfo(checkNotNull(key, "key"), checkNotNull(certs, "certs"));
+    this.keyInfo = new KeyInfo(checkNotNull(certs, "certs"), checkNotNull(key, "key"));
   }
 
   /**
@@ -216,26 +216,26 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
 
   private static class KeyInfo {
     // The private key and the cert chain we will use to send to peers to prove our identity.
-    final PrivateKey key;
     final X509Certificate[] certs;
+    final PrivateKey key;
 
-    public KeyInfo(PrivateKey key, X509Certificate[] certs) {
-      this.key = key;
+    public KeyInfo(X509Certificate[] certs, PrivateKey key) {
       this.certs = certs;
+      this.key = key;
     }
   }
 
   private class LoadFilePathExecution implements Runnable {
     File keyFile;
     File certFile;
-    long currentKeyTime;
     long currentCertTime;
+    long currentKeyTime;
 
     public LoadFilePathExecution(File certFile, File keyFile) {
       this.certFile = certFile;
       this.keyFile = keyFile;
-      this.currentKeyTime = 0;
       this.currentCertTime = 0;
+      this.currentKeyTime = 0;
     }
 
     @Override
@@ -244,11 +244,11 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
         UpdateResult newResult = readAndUpdate(this.certFile, this.keyFile, this.currentKeyTime,
             this.currentCertTime);
         if (newResult.success) {
-          this.currentKeyTime = newResult.keyTime;
           this.currentCertTime = newResult.certTime;
+          this.currentKeyTime = newResult.keyTime;
         }
       } catch (IOException | GeneralSecurityException e) {
-        log.log(Level.SEVERE, String.format("Failed refreshing private key and certificate"
+        log.log(Level.SEVERE, String.format("Failed refreshing certificate and private key"
                 + " chain from files. Using previous ones (certFile lastModified = %s, keyFile "
                 + "lastModified = %s)", certFile.lastModified(), keyFile.lastModified()), e);
       }
@@ -257,13 +257,13 @@ public final class AdvancedTlsX509KeyManager extends X509ExtendedKeyManager {
 
   private static class UpdateResult {
     boolean success;
-    long keyTime;
     long certTime;
+    long keyTime;
 
-    public UpdateResult(boolean success, long keyTime, long certTime) {
+    public UpdateResult(boolean success, long certTime, long keyTime) {
       this.success = success;
-      this.keyTime = keyTime;
       this.certTime = certTime;
+      this.keyTime = keyTime;
     }
   }
 

--- a/util/src/main/java/io/grpc/util/AdvancedTlsX509TrustManager.java
+++ b/util/src/main/java/io/grpc/util/AdvancedTlsX509TrustManager.java
@@ -220,6 +220,20 @@ public final class AdvancedTlsX509TrustManager extends X509ExtendedTrustManager 
   }
 
   /**
+   * Updates the trust certificates from a local file path.
+   *
+   * @param trustCertFile  the file on disk holding the trust certificates
+   */
+  public void updateTrustCredentials(File trustCertFile) throws IOException,
+      GeneralSecurityException {
+    long updatedTime = readAndUpdate(trustCertFile, 0);
+    if (updatedTime == 0) {
+      throw new GeneralSecurityException(
+          "Files were unmodified before their initial update. Probably a bug.");
+    }
+  }
+
+  /**
    * Schedules a {@code ScheduledExecutorService} to read trust certificates from a local file path
    * periodically, and updates the cached trust certs if there is an update. You must close the
    * returned Closeable before calling this method again or other update methods
@@ -278,20 +292,6 @@ public final class AdvancedTlsX509TrustManager extends X509ExtendedTrustManager 
   public Closeable updateTrustCredentialsFromFile(File trustCertFile, long period, TimeUnit unit,
       ScheduledExecutorService executor) throws IOException, GeneralSecurityException {
     return updateTrustCredentials(trustCertFile, period, unit, executor);
-  }
-
-  /**
-   * Updates the trust certificates from a local file path.
-   *
-   * @param trustCertFile  the file on disk holding the trust certificates
-   */
-  public void updateTrustCredentials(File trustCertFile) throws IOException,
-      GeneralSecurityException {
-    long updatedTime = readAndUpdate(trustCertFile, 0);
-    if (updatedTime == 0) {
-      throw new GeneralSecurityException(
-          "Files were unmodified before their initial update. Probably a bug.");
-    }
   }
 
   /**

--- a/util/src/test/java/io/grpc/util/AdvancedTlsX509KeyManagerTest.java
+++ b/util/src/test/java/io/grpc/util/AdvancedTlsX509KeyManagerTest.java
@@ -76,7 +76,7 @@ public class AdvancedTlsX509KeyManagerTest {
   }
 
   @Test
-  public void credentialSetting() throws Exception {
+  public void updateTrustCredentials_replacesIssuers() throws Exception {
     // Overall happy path checking of public API.
     AdvancedTlsX509KeyManager serverKeyManager = new AdvancedTlsX509KeyManager();
     serverKeyManager.updateIdentityCredentials(serverCert0, serverKey0);
@@ -89,6 +89,10 @@ public class AdvancedTlsX509KeyManagerTest {
 
     serverKeyManager.updateIdentityCredentials(serverCert0File, serverKey0File,1,
         TimeUnit.MINUTES, executor);
+    assertEquals(serverKey0, serverKeyManager.getPrivateKey(ALIAS));
+    assertArrayEquals(serverCert0, serverKeyManager.getCertificateChain(ALIAS));
+
+    serverKeyManager.updateIdentityCredentials(serverCert0, serverKey0);
     assertEquals(serverKey0, serverKeyManager.getPrivateKey(ALIAS));
     assertArrayEquals(serverCert0, serverKeyManager.getCertificateChain(ALIAS));
   }

--- a/util/src/test/java/io/grpc/util/AdvancedTlsX509TrustManagerTest.java
+++ b/util/src/test/java/io/grpc/util/AdvancedTlsX509TrustManagerTest.java
@@ -72,17 +72,17 @@ public class AdvancedTlsX509TrustManagerTest {
   public void updateTrustCredentials_replacesIssuers() throws Exception {
     // Overall happy path checking of public API.
     AdvancedTlsX509TrustManager trustManager = AdvancedTlsX509TrustManager.newBuilder().build();
-    trustManager.updateTrustCredentialsFromFile(serverCert0File);
+    trustManager.updateTrustCredentials(serverCert0File);
     assertArrayEquals(serverCert0, trustManager.getAcceptedIssuers());
 
     trustManager.updateTrustCredentials(caCert);
     assertArrayEquals(caCert, trustManager.getAcceptedIssuers());
 
-    trustManager.updateTrustCredentialsFromFile(serverCert0File, 1, TimeUnit.MINUTES,
+    trustManager.updateTrustCredentials(serverCert0File, 1, TimeUnit.MINUTES,
         executor);
     assertArrayEquals(serverCert0, trustManager.getAcceptedIssuers());
 
-    trustManager.updateTrustCredentialsFromFile(serverCert0File);
+    trustManager.updateTrustCredentials(serverCert0File);
     assertArrayEquals(serverCert0, trustManager.getAcceptedIssuers());
   }
 
@@ -101,23 +101,15 @@ public class AdvancedTlsX509TrustManagerTest {
     AdvancedTlsX509TrustManager trustManager = AdvancedTlsX509TrustManager.newBuilder().build();
 
     NullPointerException npe = assertThrows(NullPointerException.class, () -> trustManager
-        .updateTrustCredentials(null));
-    assertEquals("trustCerts", npe.getMessage());
-
-    npe = assertThrows(NullPointerException.class, () -> trustManager
-        .updateTrustCredentialsFromFile(null));
+        .updateTrustCredentials(null, 1, null, null));
     assertEquals("trustCertFile", npe.getMessage());
 
     npe = assertThrows(NullPointerException.class, () -> trustManager
-        .updateTrustCredentialsFromFile(null, 1, null, null));
-    assertEquals("trustCertFile", npe.getMessage());
-
-    npe = assertThrows(NullPointerException.class, () -> trustManager
-        .updateTrustCredentialsFromFile(caCertFile, 1, null, null));
+        .updateTrustCredentials(caCertFile, 1, null, null));
     assertEquals("unit", npe.getMessage());
 
     npe = assertThrows(NullPointerException.class, () -> trustManager
-        .updateTrustCredentialsFromFile(caCertFile, 1, TimeUnit.MINUTES, null));
+        .updateTrustCredentials(caCertFile, 1, TimeUnit.MINUTES, null));
     assertEquals("executor", npe.getMessage());
 
     Logger log = Logger.getLogger(AdvancedTlsX509TrustManager.class.getName());
@@ -125,8 +117,7 @@ public class AdvancedTlsX509TrustManagerTest {
     log.addHandler(handler);
     log.setUseParentHandlers(false);
     log.setLevel(Level.FINE);
-    trustManager.updateTrustCredentialsFromFile(serverCert0File, -1, TimeUnit.SECONDS,
-        executor);
+    trustManager.updateTrustCredentials(serverCert0File, -1, TimeUnit.SECONDS, executor);
     log.removeHandler(handler);
     try {
       LogRecord logRecord = Iterables.find(handler.getRecords(),


### PR DESCRIPTION
- Swap key/cert arguments of internal private classes in KeyManager
- Deprecate *FromFile methods in TrustManager in favor of overloaded updateTrustCredentials
- Unit test for https://github.com/grpc/grpc-java/pull/11352