### PR TITLE
Name old undertow servlet lib with version number

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -96,8 +96,8 @@ tomcat-embed-core9 = "org.apache.tomcat.embed:tomcat-embed-core:9.0.89"
 # 1.4.3+ causes "unknown enum constant ElementType.MODULE" warning.
 # https://github.com/google/truth/issues/1320
 truth = "com.google.truth:truth:1.4.2"
-undertow-servlet = "io.undertow:undertow-servlet:2.2.32.Final"
-undertow-servlet-jakartaee9 = "io.undertow:undertow-servlet:2.3.14.Final"
+undertow-servlet22 = "io.undertow:undertow-servlet:2.2.32.Final"
+undertow-servlet = "io.undertow:undertow-servlet:2.3.14.Final"
 
 # Do not update: Pinned to the last version supporting Java 8.
 # See https://checkstyle.sourceforge.io/releasenotes.html#Release_10.1

--- a/servlet/build.gradle
+++ b/servlet/build.gradle
@@ -57,7 +57,7 @@ dependencies {
         exclude group: 'io.grpc', module: 'grpc-xds'
     }
 
-    undertowTestImplementation libraries.undertow.servlet
+    undertowTestImplementation libraries.undertow.servlet22
 
     tomcatTestImplementation libraries.tomcat.embed.core9
 

--- a/servlet/jakarta/build.gradle
+++ b/servlet/jakarta/build.gradle
@@ -99,7 +99,7 @@ dependencies {
     jettyTestImplementation libraries.jetty.servlet,
             libraries.jetty.http2.server
 
-    undertowTestImplementation libraries.undertow.servlet.jakartaee9
+    undertowTestImplementation libraries.undertow.servlet
 }
 
 // Set up individual classpaths for each test, to avoid any mismatch,


### PR DESCRIPTION
This makes it clearer it isn't intended to be upgraded. We do this already for the other servlet containers (e.g., jetty-servlet10).