### PR TITLE
chore: make once-set fields of `AbstractClientStream` `final`

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream.java
@@ -92,8 +92,8 @@ public abstract class AbstractClientStream extends AbstractStream
 
   private final TransportTracer transportTracer;
   private final Framer framer;
-  private boolean shouldBeCountedForInUse;
-  private boolean useGet;
+  private final boolean shouldBeCountedForInUse;
+  private final boolean useGet;
   private Metadata headers;
   /**
    * Whether cancel() has been called. This is not strictly necessary, but removes the delay between


### PR DESCRIPTION
# Description

This makes `shouldBeCountedForInUse` and `useGet` `private` fields of `AbstractClientStream` `final` since they already are effectively.
