### PR TITLE
examples: For Bazel, remove compat repo for maven_install

### DIFF
--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -40,13 +40,8 @@ maven_install(
         "com.google.api.grpc:grpc-google-cloud-pubsub-v1:0.1.24",
         "com.google.api.grpc:proto-google-cloud-pubsub-v1:0.1.24",
     ] + IO_GRPC_GRPC_JAVA_ARTIFACTS + PROTOBUF_MAVEN_ARTIFACTS,
-    generate_compat_repositories = True,
     override_targets = IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS,
     repositories = [
         "https://repo.maven.apache.org/maven2/",
     ],
 )
-
-load("@maven//:compat.bzl", "compat_repositories")
-
-compat_repositories()


### PR DESCRIPTION
It hasn't been needed since 0064991. In that commit the main WORKSPACE was cleaned up, but not the examples.