### PR TITLE
examples: Add bzlmod support

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -97,7 +97,17 @@ jobs:
     - name: Run bazel build
       run: bazelisk build //... --enable_bzlmod=false
 
+    - name: Run example bazel build
+      run: bazelisk build //... --enable_bzlmod=false
+      working-directory: ./examples
+
     - name: Run bazel build (bzlmod)
       env:
         USE_BAZEL_VERSION: 7.0.0
       run: bazelisk build //... --enable_bzlmod=true
+
+    - name: Run example bazel build (bzlmod)
+      env:
+        USE_BAZEL_VERSION: 7.0.0
+      run: bazelisk build //... --enable_bzlmod=true
+      working-directory: ./examples

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "grpc-java",
     compatibility_level = 0,
     repo_name = "io_grpc_grpc_java",
-    version = "0",
+    version = "1.66.0-SNAPSHOT",  # CURRENT_GRPC_VERSION
 )
 
 # GRPC_DEPS_START

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,8 +18,10 @@ them before continuing, and set them again when resuming.
 ```bash
 MAJOR=1 MINOR=7 PATCH=0 # Set appropriately for new release
 VERSION_FILES=(
+  MODULE.bazel
   build.gradle
   core/src/main/java/io/grpc/internal/GrpcUtil.java
+  examples/MODULE.bazel
   examples/build.gradle
   examples/pom.xml
   examples/android/clientcache/app/build.gradle

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -1,0 +1,24 @@
+bazel_dep(name = "grpc-java", repo_name = "io_grpc_grpc_java", version = "1.66.0-SNAPSHOT")  # CURRENT_GRPC_VERSION
+bazel_dep(name = "grpc-proto", repo_name = "io_grpc_grpc_proto", version = "0.0.0-20240627-ec30f58")
+bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "23.1")
+bazel_dep(name = "rules_jvm_external", version = "6.0")
+bazel_dep(name = "rules_proto", version = "5.3.0-21.7")
+
+# Do not use this override in your own MODULE.bazel. Use a version from BCR
+local_path_override(
+    module_name = "grpc-java",
+    path = "..",
+)
+
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+
+use_repo(maven, "maven")
+
+maven.install(
+    artifacts = [
+        "com.google.api.grpc:grpc-google-cloud-pubsub-v1:0.1.24",
+        "com.google.api.grpc:proto-google-cloud-pubsub-v1:0.1.24",
+    ],
+    repositories = ["https://repo.maven.apache.org/maven2/"],
+    strict_visibility = True,
+)

--- a/examples/WORKSPACE.bzlmod
+++ b/examples/WORKSPACE.bzlmod
@@ -1,0 +1,1 @@
+# When using bzlmod this makes sure nothing from the legacy WORKSPACE is loaded


### PR DESCRIPTION
This also updates the version number of the grpc-java module as part of the release process.