### PR TITLE
bazel: Don't use artifact() for protobuf deps

### DIFF
--- a/protobuf-lite/BUILD.bazel
+++ b/protobuf-lite/BUILD.bazel
@@ -12,8 +12,8 @@ java_library(
         artifact("com.google.guava:guava"),
         artifact("com.google.j2objc:j2objc-annotations"),
     ] + select({
-        ":android": [artifact("com.google.protobuf:protobuf-javalite")],
-        "//conditions:default": [artifact("com.google.protobuf:protobuf-java")],
+        ":android": ["@com_google_protobuf//:protobuf_javalite"],
+        "//conditions:default": ["@com_google_protobuf//:protobuf_java"],
     }),
 )
 


### PR DESCRIPTION
We don't include protobuf in IO_GRPC_GRPC_JAVA_ARTIFACTS, so there might not actually be an alias available for it to @com_google_protobuf. While we could add it, it is easier to use the @com_google_protobuf references directly.

This was preventing `bazel query 'deps(//...)' from succeeding, because it couldn't find javalite.