### PR TITLE
xds: cncf/xds proto sync to 2024-07-24

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -87,13 +87,22 @@ IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS = {
 
 def grpc_java_repositories(bzlmod = False):
     """Imports dependencies for grpc-java."""
+    if not native.existing_rule("dev_cel"):
+        http_archive(
+            name = "dev_cel",
+            strip_prefix = "cel-spec-0.15.0",
+            sha256 = "3ee09eb69dbe77722e9dee23dc48dc2cd9f765869fcf5ffb1226587c81791a0b",
+            urls = [
+                "https://github.com/google/cel-spec/archive/refs/tags/v0.15.0.tar.gz",
+            ],
+        )
     if not native.existing_rule("com_github_cncf_xds"):
         http_archive(
             name = "com_github_cncf_xds",
-            strip_prefix = "xds-e9ce68804cb4e64cab5a52e3c8baf840d4ff87b7",
-            sha256 = "0d33b83f8c6368954e72e7785539f0d272a8aba2f6e2e336ed15fd1514bc9899",
+            strip_prefix = "xds-024c85f92f20cab567a83acc50934c7f9711d124",
+            sha256 = "5f403aa681711500ca8e62387be3e37d971977db6e88616fc21862a406430649",
             urls = [
-                "https://github.com/cncf/xds/archive/e9ce68804cb4e64cab5a52e3c8baf840d4ff87b7.tar.gz",
+                "https://github.com/cncf/xds/archive/024c85f92f20cab567a83acc50934c7f9711d124.tar.gz",
             ],
         )
     if not bzlmod and not native.existing_rule("com_github_grpc_grpc"):

--- a/xds/third_party/xds/import.sh
+++ b/xds/third_party/xds/import.sh
@@ -17,7 +17,7 @@
 
 set -e
 # import VERSION from one of the google internal CLs
-VERSION=e9ce68804cb4e64cab5a52e3c8baf840d4ff87b7
+VERSION=024c85f92f20cab567a83acc50934c7f9711d124
 DOWNLOAD_URL="https://github.com/cncf/xds/archive/${VERSION}.tar.gz"
 DOWNLOAD_BASE_DIR="xds-${VERSION}"
 SOURCE_PROTO_BASE_DIR="${DOWNLOAD_BASE_DIR}"

--- a/xds/third_party/xds/src/main/proto/udpa/annotations/migrate.proto
+++ b/xds/third_party/xds/src/main/proto/udpa/annotations/migrate.proto
@@ -8,7 +8,7 @@ package udpa.annotations;
 
 import "google/protobuf/descriptor.proto";
 
-option go_package = "github.com/cncf/xds/go/annotations";
+option go_package = "github.com/cncf/xds/go/udpa/annotations";
 
 // Magic number in this file derived from top 28bit of SHA256 digest of
 // "udpa.annotation.migrate".

--- a/xds/third_party/xds/src/main/proto/udpa/annotations/security.proto
+++ b/xds/third_party/xds/src/main/proto/udpa/annotations/security.proto
@@ -10,7 +10,7 @@ import "udpa/annotations/status.proto";
 
 import "google/protobuf/descriptor.proto";
 
-option go_package = "github.com/cncf/xds/go/annotations";
+option go_package = "github.com/cncf/xds/go/udpa/annotations";
 
 // All annotations in this file are experimental and subject to change. Their
 // only consumer today is the Envoy APIs and SecuritAnnotationValidator protoc

--- a/xds/third_party/xds/src/main/proto/udpa/annotations/sensitive.proto
+++ b/xds/third_party/xds/src/main/proto/udpa/annotations/sensitive.proto
@@ -8,7 +8,7 @@ package udpa.annotations;
 
 import "google/protobuf/descriptor.proto";
 
-option go_package = "github.com/cncf/xds/go/annotations";
+option go_package = "github.com/cncf/xds/go/udpa/annotations";
 
 extend google.protobuf.FieldOptions {
   // Magic number is the 28 most significant bits in the sha256sum of "udpa.annotations.sensitive".

--- a/xds/third_party/xds/src/main/proto/udpa/annotations/status.proto
+++ b/xds/third_party/xds/src/main/proto/udpa/annotations/status.proto
@@ -8,7 +8,7 @@ package udpa.annotations;
 
 import "google/protobuf/descriptor.proto";
 
-option go_package = "github.com/cncf/xds/go/annotations";
+option go_package = "github.com/cncf/xds/go/udpa/annotations";
 
 // Magic number in this file derived from top 28bit of SHA256 digest of
 // "udpa.annotation.status".

--- a/xds/third_party/xds/src/main/proto/udpa/annotations/versioning.proto
+++ b/xds/third_party/xds/src/main/proto/udpa/annotations/versioning.proto
@@ -8,7 +8,7 @@ package udpa.annotations;
 
 import "google/protobuf/descriptor.proto";
 
-option go_package = "github.com/cncf/xds/go/annotations";
+option go_package = "github.com/cncf/xds/go/udpa/annotations";
 
 extend google.protobuf.MessageOptions {
   // Magic number derived from 0x78 ('x') 0x44 ('D') 0x53 ('S')

--- a/xds/third_party/xds/src/main/proto/xds/type/matcher/v3/string.proto
+++ b/xds/third_party/xds/src/main/proto/xds/type/matcher/v3/string.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package xds.type.matcher.v3;
 
+import "xds/core/v3/extension.proto";
 import "xds/type/matcher/v3/regex.proto";
 
 import "validate/validate.proto";
@@ -14,7 +15,7 @@ option go_package = "github.com/cncf/xds/go/xds/type/matcher/v3";
 // [#protodoc-title: String matcher]
 
 // Specifies the way to match a string.
-// [#next-free-field: 8]
+// [#next-free-field: 9]
 message StringMatcher {
   oneof match_pattern {
     option (validate.required) = true;
@@ -52,6 +53,10 @@ message StringMatcher {
     //
     // * *abc* matches the value *xyz.abc.def*
     string contains = 7 [(validate.rules).string = {min_len: 1}];
+
+    // Use an extension as the matcher type.
+    // [#extension-category: envoy.string_matcher]
+    xds.core.v3.TypedExtensionConfig custom = 8;
   }
 
   // If true, indicates the exact/prefix/suffix matching should be case insensitive. This has no


### PR DESCRIPTION
`cncf/xds`: Sync protos to the latest imported version https://github.com/envoyproxy/envoy/commit/024c85f92f20cab567a83acc50934c7f9711d124 (commit 2024-07-23, cl/655545156).

Should be a noop, just a routine xDS proto update to make upcoming RLQS-related imports simpler, see related #11401.

Note that CEL is only added as a bazel dependency as now it's required to build cncf/xds. Actual third-party source import will be done in the follow up PR, where RLQS dependencies are added to the import scripts.