### PR TITLE
xds: Import RLQS protos

### DIFF
--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -20,6 +20,7 @@ sourceSets {
             srcDir 'third_party/envoy/src/main/proto'
             srcDir 'third_party/protoc-gen-validate/src/main/proto'
             srcDir 'third_party/xds/src/main/proto'
+            srcDir 'third_party/cel-spec/src/main/proto'
             srcDir 'third_party/googleapis/src/main/proto'
             srcDir 'third_party/istio/src/main/proto'
         }
@@ -185,6 +186,7 @@ tasks.named("shadowJar").configure {
     relocate 'com.google.api.expr', "${prefixName}.shaded.com.google.api.expr"
     relocate 'com.google.security', "${prefixName}.shaded.com.google.security"
     // TODO: missing java_package option in .proto
+    relocate 'dev.cel.expr', "${prefixName}.shaded.dev.cel.expr"
     relocate 'envoy.annotations', "${prefixName}.shaded.envoy.annotations"
     relocate 'io.envoyproxy', "${prefixName}.shaded.io.envoyproxy"
     relocate 'io.grpc.netty', 'io.grpc.netty.shaded.io.grpc.netty'
@@ -212,6 +214,7 @@ tasks.named("jacocoTestReport").configure {
                 '**/com/github/xds/**',
                 '**/com/google/api/expr/**',
                 '**/com/google/security/**',
+                '**/cel/expr/**',
                 '**/envoy/annotations/**',
                 '**/io/envoyproxy/**',
                 '**/udpa/annotations/**',

--- a/xds/src/generated/thirdparty/grpc/io/envoyproxy/envoy/service/rate_limit_quota/v3/RateLimitQuotaServiceGrpc.java
+++ b/xds/src/generated/thirdparty/grpc/io/envoyproxy/envoy/service/rate_limit_quota/v3/RateLimitQuotaServiceGrpc.java
@@ -1,0 +1,303 @@
+package io.envoyproxy.envoy.service.rate_limit_quota.v3;
+
+import static io.grpc.MethodDescriptor.generateFullMethodName;
+
+/**
+ * <pre>
+ * Defines the Rate Limit Quota Service (RLQS).
+ * </pre>
+ */
+@javax.annotation.Generated(
+    value = "by gRPC proto compiler",
+    comments = "Source: envoy/service/rate_limit_quota/v3/rlqs.proto")
+@io.grpc.stub.annotations.GrpcGenerated
+public final class RateLimitQuotaServiceGrpc {
+
+  private RateLimitQuotaServiceGrpc() {}
+
+  public static final java.lang.String SERVICE_NAME = "envoy.service.rate_limit_quota.v3.RateLimitQuotaService";
+
+  // Static method descriptors that strictly reflect the proto.
+  private static volatile io.grpc.MethodDescriptor<io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaUsageReports,
+      io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaResponse> getStreamRateLimitQuotasMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "StreamRateLimitQuotas",
+      requestType = io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaUsageReports.class,
+      responseType = io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+  public static io.grpc.MethodDescriptor<io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaUsageReports,
+      io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaResponse> getStreamRateLimitQuotasMethod() {
+    io.grpc.MethodDescriptor<io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaUsageReports, io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaResponse> getStreamRateLimitQuotasMethod;
+    if ((getStreamRateLimitQuotasMethod = RateLimitQuotaServiceGrpc.getStreamRateLimitQuotasMethod) == null) {
+      synchronized (RateLimitQuotaServiceGrpc.class) {
+        if ((getStreamRateLimitQuotasMethod = RateLimitQuotaServiceGrpc.getStreamRateLimitQuotasMethod) == null) {
+          RateLimitQuotaServiceGrpc.getStreamRateLimitQuotasMethod = getStreamRateLimitQuotasMethod =
+              io.grpc.MethodDescriptor.<io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaUsageReports, io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "StreamRateLimitQuotas"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaUsageReports.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaResponse.getDefaultInstance()))
+              .setSchemaDescriptor(new RateLimitQuotaServiceMethodDescriptorSupplier("StreamRateLimitQuotas"))
+              .build();
+        }
+      }
+    }
+    return getStreamRateLimitQuotasMethod;
+  }
+
+  /**
+   * Creates a new async stub that supports all call types for the service
+   */
+  public static RateLimitQuotaServiceStub newStub(io.grpc.Channel channel) {
+    io.grpc.stub.AbstractStub.StubFactory<RateLimitQuotaServiceStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<RateLimitQuotaServiceStub>() {
+        @java.lang.Override
+        public RateLimitQuotaServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new RateLimitQuotaServiceStub(channel, callOptions);
+        }
+      };
+    return RateLimitQuotaServiceStub.newStub(factory, channel);
+  }
+
+  /**
+   * Creates a new blocking-style stub that supports unary and streaming output calls on the service
+   */
+  public static RateLimitQuotaServiceBlockingStub newBlockingStub(
+      io.grpc.Channel channel) {
+    io.grpc.stub.AbstractStub.StubFactory<RateLimitQuotaServiceBlockingStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<RateLimitQuotaServiceBlockingStub>() {
+        @java.lang.Override
+        public RateLimitQuotaServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new RateLimitQuotaServiceBlockingStub(channel, callOptions);
+        }
+      };
+    return RateLimitQuotaServiceBlockingStub.newStub(factory, channel);
+  }
+
+  /**
+   * Creates a new ListenableFuture-style stub that supports unary calls on the service
+   */
+  public static RateLimitQuotaServiceFutureStub newFutureStub(
+      io.grpc.Channel channel) {
+    io.grpc.stub.AbstractStub.StubFactory<RateLimitQuotaServiceFutureStub> factory =
+      new io.grpc.stub.AbstractStub.StubFactory<RateLimitQuotaServiceFutureStub>() {
+        @java.lang.Override
+        public RateLimitQuotaServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+          return new RateLimitQuotaServiceFutureStub(channel, callOptions);
+        }
+      };
+    return RateLimitQuotaServiceFutureStub.newStub(factory, channel);
+  }
+
+  /**
+   * <pre>
+   * Defines the Rate Limit Quota Service (RLQS).
+   * </pre>
+   */
+  public interface AsyncService {
+
+    /**
+     * <pre>
+     * Main communication channel: the data plane sends usage reports to the RLQS server,
+     * and the server asynchronously responding with the assignments.
+     * </pre>
+     */
+    default io.grpc.stub.StreamObserver<io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaUsageReports> streamRateLimitQuotas(
+        io.grpc.stub.StreamObserver<io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaResponse> responseObserver) {
+      return io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall(getStreamRateLimitQuotasMethod(), responseObserver);
+    }
+  }
+
+  /**
+   * Base class for the server implementation of the service RateLimitQuotaService.
+   * <pre>
+   * Defines the Rate Limit Quota Service (RLQS).
+   * </pre>
+   */
+  public static abstract class RateLimitQuotaServiceImplBase
+      implements io.grpc.BindableService, AsyncService {
+
+    @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
+      return RateLimitQuotaServiceGrpc.bindService(this);
+    }
+  }
+
+  /**
+   * A stub to allow clients to do asynchronous rpc calls to service RateLimitQuotaService.
+   * <pre>
+   * Defines the Rate Limit Quota Service (RLQS).
+   * </pre>
+   */
+  public static final class RateLimitQuotaServiceStub
+      extends io.grpc.stub.AbstractAsyncStub<RateLimitQuotaServiceStub> {
+    private RateLimitQuotaServiceStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+      super(channel, callOptions);
+    }
+
+    @java.lang.Override
+    protected RateLimitQuotaServiceStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+      return new RateLimitQuotaServiceStub(channel, callOptions);
+    }
+
+    /**
+     * <pre>
+     * Main communication channel: the data plane sends usage reports to the RLQS server,
+     * and the server asynchronously responding with the assignments.
+     * </pre>
+     */
+    public io.grpc.stub.StreamObserver<io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaUsageReports> streamRateLimitQuotas(
+        io.grpc.stub.StreamObserver<io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaResponse> responseObserver) {
+      return io.grpc.stub.ClientCalls.asyncBidiStreamingCall(
+          getChannel().newCall(getStreamRateLimitQuotasMethod(), getCallOptions()), responseObserver);
+    }
+  }
+
+  /**
+   * A stub to allow clients to do synchronous rpc calls to service RateLimitQuotaService.
+   * <pre>
+   * Defines the Rate Limit Quota Service (RLQS).
+   * </pre>
+   */
+  public static final class RateLimitQuotaServiceBlockingStub
+      extends io.grpc.stub.AbstractBlockingStub<RateLimitQuotaServiceBlockingStub> {
+    private RateLimitQuotaServiceBlockingStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+      super(channel, callOptions);
+    }
+
+    @java.lang.Override
+    protected RateLimitQuotaServiceBlockingStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+      return new RateLimitQuotaServiceBlockingStub(channel, callOptions);
+    }
+  }
+
+  /**
+   * A stub to allow clients to do ListenableFuture-style rpc calls to service RateLimitQuotaService.
+   * <pre>
+   * Defines the Rate Limit Quota Service (RLQS).
+   * </pre>
+   */
+  public static final class RateLimitQuotaServiceFutureStub
+      extends io.grpc.stub.AbstractFutureStub<RateLimitQuotaServiceFutureStub> {
+    private RateLimitQuotaServiceFutureStub(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+      super(channel, callOptions);
+    }
+
+    @java.lang.Override
+    protected RateLimitQuotaServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+      return new RateLimitQuotaServiceFutureStub(channel, callOptions);
+    }
+  }
+
+  private static final int METHODID_STREAM_RATE_LIMIT_QUOTAS = 0;
+
+  private static final class MethodHandlers<Req, Resp> implements
+      io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
+      io.grpc.stub.ServerCalls.ServerStreamingMethod<Req, Resp>,
+      io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
+      io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
+    private final AsyncService serviceImpl;
+    private final int methodId;
+
+    MethodHandlers(AsyncService serviceImpl, int methodId) {
+      this.serviceImpl = serviceImpl;
+      this.methodId = methodId;
+    }
+
+    @java.lang.Override
+    @java.lang.SuppressWarnings("unchecked")
+    public void invoke(Req request, io.grpc.stub.StreamObserver<Resp> responseObserver) {
+      switch (methodId) {
+        default:
+          throw new AssertionError();
+      }
+    }
+
+    @java.lang.Override
+    @java.lang.SuppressWarnings("unchecked")
+    public io.grpc.stub.StreamObserver<Req> invoke(
+        io.grpc.stub.StreamObserver<Resp> responseObserver) {
+      switch (methodId) {
+        case METHODID_STREAM_RATE_LIMIT_QUOTAS:
+          return (io.grpc.stub.StreamObserver<Req>) serviceImpl.streamRateLimitQuotas(
+              (io.grpc.stub.StreamObserver<io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaResponse>) responseObserver);
+        default:
+          throw new AssertionError();
+      }
+    }
+  }
+
+  public static final io.grpc.ServerServiceDefinition bindService(AsyncService service) {
+    return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
+        .addMethod(
+          getStreamRateLimitQuotasMethod(),
+          io.grpc.stub.ServerCalls.asyncBidiStreamingCall(
+            new MethodHandlers<
+              io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaUsageReports,
+              io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaResponse>(
+                service, METHODID_STREAM_RATE_LIMIT_QUOTAS)))
+        .build();
+  }
+
+  private static abstract class RateLimitQuotaServiceBaseDescriptorSupplier
+      implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+    RateLimitQuotaServiceBaseDescriptorSupplier() {}
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
+      return io.envoyproxy.envoy.service.rate_limit_quota.v3.RlqsProto.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().findServiceByName("RateLimitQuotaService");
+    }
+  }
+
+  private static final class RateLimitQuotaServiceFileDescriptorSupplier
+      extends RateLimitQuotaServiceBaseDescriptorSupplier {
+    RateLimitQuotaServiceFileDescriptorSupplier() {}
+  }
+
+  private static final class RateLimitQuotaServiceMethodDescriptorSupplier
+      extends RateLimitQuotaServiceBaseDescriptorSupplier
+      implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+    private final java.lang.String methodName;
+
+    RateLimitQuotaServiceMethodDescriptorSupplier(java.lang.String methodName) {
+      this.methodName = methodName;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor() {
+      return getServiceDescriptor().findMethodByName(methodName);
+    }
+  }
+
+  private static volatile io.grpc.ServiceDescriptor serviceDescriptor;
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    io.grpc.ServiceDescriptor result = serviceDescriptor;
+    if (result == null) {
+      synchronized (RateLimitQuotaServiceGrpc.class) {
+        result = serviceDescriptor;
+        if (result == null) {
+          serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
+              .setSchemaDescriptor(new RateLimitQuotaServiceFileDescriptorSupplier())
+              .addMethod(getStreamRateLimitQuotasMethod())
+              .build();
+        }
+      }
+    }
+    return result;
+  }
+}

--- a/xds/third_party/cel-spec/LICENSE
+++ b/xds/third_party/cel-spec/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/xds/third_party/cel-spec/import.sh
+++ b/xds/third_party/cel-spec/import.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Copyright 2024 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Update VERSION then execute this script
+
+set -e
+VERSION="v0.15.0"
+DOWNLOAD_URL="https://github.com/google/cel-spec/archive/refs/tags/${VERSION}.tar.gz"
+DOWNLOAD_BASE_DIR="cel-spec-${VERSION#v}"
+SOURCE_PROTO_BASE_DIR="${DOWNLOAD_BASE_DIR}/proto"
+TARGET_PROTO_BASE_DIR="src/main/proto"
+# Sorted alphabetically.
+FILES=(
+cel/expr/checked.proto
+cel/expr/syntax.proto
+)
+
+pushd `git rev-parse --show-toplevel`/xds/third_party/cel-spec > /dev/null
+
+# put the repo in a tmp directory
+tmpdir="$(mktemp -d)"
+trap "rm -rf ${tmpdir}" EXIT
+curl -Ls "${DOWNLOAD_URL}" | tar xz -C "${tmpdir}"
+
+cp -p "${tmpdir}/${DOWNLOAD_BASE_DIR}/LICENSE" LICENSE
+
+rm -rf "${TARGET_PROTO_BASE_DIR}"
+mkdir -p "${TARGET_PROTO_BASE_DIR}"
+pushd "${TARGET_PROTO_BASE_DIR}" > /dev/null
+
+# copy proto files to project directory
+TOTAL=${#FILES[@]}
+COPIED=0
+for file in "${FILES[@]}"
+do
+  mkdir -p "$(dirname "${file}")"
+  cp -p "${tmpdir}/${SOURCE_PROTO_BASE_DIR}/${file}" "${file}" && (( ++COPIED ))
+done
+popd > /dev/null
+
+popd > /dev/null
+
+echo "Imported ${COPIED} files."
+if (( COPIED != TOTAL )); then
+  echo "Failed importing $(( TOTAL - COPIED )) files." 1>&2
+  exit 1
+fi

--- a/xds/third_party/cel-spec/src/main/proto/cel/expr/checked.proto
+++ b/xds/third_party/cel-spec/src/main/proto/cel/expr/checked.proto
@@ -1,0 +1,344 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package cel.expr;
+
+import "cel/expr/syntax.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/struct.proto";
+
+option cc_enable_arenas = true;
+option go_package = "cel.dev/expr";
+option java_multiple_files = true;
+option java_outer_classname = "DeclProto";
+option java_package = "dev.cel.expr";
+
+// Protos for representing CEL declarations and typed checked expressions.
+
+// A CEL expression which has been successfully type checked.
+message CheckedExpr {
+  // A map from expression ids to resolved references.
+  //
+  // The following entries are in this table:
+  //
+  // - An Ident or Select expression is represented here if it resolves to a
+  //   declaration. For instance, if `a.b.c` is represented by
+  //   `select(select(id(a), b), c)`, and `a.b` resolves to a declaration,
+  //   while `c` is a field selection, then the reference is attached to the
+  //   nested select expression (but not to the id or or the outer select).
+  //   In turn, if `a` resolves to a declaration and `b.c` are field selections,
+  //   the reference is attached to the ident expression.
+  // - Every Call expression has an entry here, identifying the function being
+  //   called.
+  // - Every CreateStruct expression for a message has an entry, identifying
+  //   the message.
+  map<int64, Reference> reference_map = 2;
+
+  // A map from expression ids to types.
+  //
+  // Every expression node which has a type different than DYN has a mapping
+  // here. If an expression has type DYN, it is omitted from this map to save
+  // space.
+  map<int64, Type> type_map = 3;
+
+  // The source info derived from input that generated the parsed `expr` and
+  // any optimizations made during the type-checking pass.
+  SourceInfo source_info = 5;
+
+  // The expr version indicates the major / minor version number of the `expr`
+  // representation.
+  //
+  // The most common reason for a version change will be to indicate to the CEL
+  // runtimes that transformations have been performed on the expr during static
+  // analysis. In some cases, this will save the runtime the work of applying
+  // the same or similar transformations prior to evaluation.
+  string expr_version = 6;
+
+  // The checked expression. Semantically equivalent to the parsed `expr`, but
+  // may have structural differences.
+  Expr expr = 4;
+}
+
+// Represents a CEL type.
+message Type {
+  // List type with typed elements, e.g. `list<example.proto.MyMessage>`.
+  message ListType {
+    // The element type.
+    Type elem_type = 1;
+  }
+
+  // Map type with parameterized key and value types, e.g. `map<string, int>`.
+  message MapType {
+    // The type of the key.
+    Type key_type = 1;
+
+    // The type of the value.
+    Type value_type = 2;
+  }
+
+  // Function type with result and arg types.
+  message FunctionType {
+    // Result type of the function.
+    Type result_type = 1;
+
+    // Argument types of the function.
+    repeated Type arg_types = 2;
+  }
+
+  // Application defined abstract type.
+  message AbstractType {
+    // The fully qualified name of this abstract type.
+    string name = 1;
+
+    // Parameter types for this abstract type.
+    repeated Type parameter_types = 2;
+  }
+
+  // CEL primitive types.
+  enum PrimitiveType {
+    // Unspecified type.
+    PRIMITIVE_TYPE_UNSPECIFIED = 0;
+
+    // Boolean type.
+    BOOL = 1;
+
+    // Int64 type.
+    //
+    // 32-bit integer values are widened to int64.
+    INT64 = 2;
+
+    // Uint64 type.
+    //
+    // 32-bit unsigned integer values are widened to uint64.
+    UINT64 = 3;
+
+    // Double type.
+    //
+    // 32-bit float values are widened to double values.
+    DOUBLE = 4;
+
+    // String type.
+    STRING = 5;
+
+    // Bytes type.
+    BYTES = 6;
+  }
+
+  // Well-known protobuf types treated with first-class support in CEL.
+  enum WellKnownType {
+    // Unspecified type.
+    WELL_KNOWN_TYPE_UNSPECIFIED = 0;
+
+    // Well-known protobuf.Any type.
+    //
+    // Any types are a polymorphic message type. During type-checking they are
+    // treated like `DYN` types, but at runtime they are resolved to a specific
+    // message type specified at evaluation time.
+    ANY = 1;
+
+    // Well-known protobuf.Timestamp type, internally referenced as `timestamp`.
+    TIMESTAMP = 2;
+
+    // Well-known protobuf.Duration type, internally referenced as `duration`.
+    DURATION = 3;
+  }
+
+  // The kind of type.
+  oneof type_kind {
+    // Dynamic type.
+    google.protobuf.Empty dyn = 1;
+
+    // Null value.
+    google.protobuf.NullValue null = 2;
+
+    // Primitive types: `true`, `1u`, `-2.0`, `'string'`, `b'bytes'`.
+    PrimitiveType primitive = 3;
+
+    // Wrapper of a primitive type, e.g. `google.protobuf.Int64Value`.
+    PrimitiveType wrapper = 4;
+
+    // Well-known protobuf type such as `google.protobuf.Timestamp`.
+    WellKnownType well_known = 5;
+
+    // Parameterized list with elements of `list_type`, e.g. `list<timestamp>`.
+    ListType list_type = 6;
+
+    // Parameterized map with typed keys and values.
+    MapType map_type = 7;
+
+    // Function type.
+    FunctionType function = 8;
+
+    // Protocol buffer message type.
+    //
+    // The `message_type` string specifies the qualified message type name. For
+    // example, `google.type.PhoneNumber`.
+    string message_type = 9;
+
+    // Type param type.
+    //
+    // The `type_param` string specifies the type parameter name, e.g. `list<E>`
+    // would be a `list_type` whose element type was a `type_param` type
+    // named `E`.
+    string type_param = 10;
+
+    // Type type.
+    //
+    // The `type` value specifies the target type. e.g. int is type with a
+    // target type of `Primitive.INT64`.
+    Type type = 11;
+
+    // Error type.
+    //
+    // During type-checking if an expression is an error, its type is propagated
+    // as the `ERROR` type. This permits the type-checker to discover other
+    // errors present in the expression.
+    google.protobuf.Empty error = 12;
+
+    // Abstract, application defined type.
+    //
+    // An abstract type has no accessible field names, and it can only be
+    // inspected via helper / member functions.
+    AbstractType abstract_type = 14;
+  }
+}
+
+// Represents a declaration of a named value or function.
+//
+// A declaration is part of the contract between the expression, the agent
+// evaluating that expression, and the caller requesting evaluation.
+message Decl {
+  // Identifier declaration which specifies its type and optional `Expr` value.
+  //
+  // An identifier without a value is a declaration that must be provided at
+  // evaluation time. An identifier with a value should resolve to a constant,
+  // but may be used in conjunction with other identifiers bound at evaluation
+  // time.
+  message IdentDecl {
+    // Required. The type of the identifier.
+    Type type = 1;
+
+    // The constant value of the identifier. If not specified, the identifier
+    // must be supplied at evaluation time.
+    Constant value = 2;
+
+    // Documentation string for the identifier.
+    string doc = 3;
+  }
+
+  // Function declaration specifies one or more overloads which indicate the
+  // function's parameter types and return type.
+  //
+  // Functions have no observable side-effects (there may be side-effects like
+  // logging which are not observable from CEL).
+  message FunctionDecl {
+    // An overload indicates a function's parameter types and return type, and
+    // may optionally include a function body described in terms of
+    // [Expr][cel.expr.Expr] values.
+    //
+    // Functions overloads are declared in either a function or method
+    // call-style. For methods, the `params[0]` is the expected type of the
+    // target receiver.
+    //
+    // Overloads must have non-overlapping argument types after erasure of all
+    // parameterized type variables (similar as type erasure in Java).
+    message Overload {
+      // Required. Globally unique overload name of the function which reflects
+      // the function name and argument types.
+      //
+      // This will be used by a [Reference][cel.expr.Reference] to
+      // indicate the `overload_id` that was resolved for the function `name`.
+      string overload_id = 1;
+
+      // List of function parameter [Type][cel.expr.Type] values.
+      //
+      // Param types are disjoint after generic type parameters have been
+      // replaced with the type `DYN`. Since the `DYN` type is compatible with
+      // any other type, this means that if `A` is a type parameter, the
+      // function types `int<A>` and `int<int>` are not disjoint. Likewise,
+      // `map<string, string>` is not disjoint from `map<K, V>`.
+      //
+      // When the `result_type` of a function is a generic type param, the
+      // type param name also appears as the `type` of on at least one params.
+      repeated Type params = 2;
+
+      // The type param names associated with the function declaration.
+      //
+      // For example, `function ex<K,V>(K key, map<K, V> map) : V` would yield
+      // the type params of `K, V`.
+      repeated string type_params = 3;
+
+      // Required. The result type of the function. For example, the operator
+      // `string.isEmpty()` would have `result_type` of `kind: BOOL`.
+      Type result_type = 4;
+
+      // Whether the function is to be used in a method call-style `x.f(...)`
+      // of a function call-style `f(x, ...)`.
+      //
+      // For methods, the first parameter declaration, `params[0]` is the
+      // expected type of the target receiver.
+      bool is_instance_function = 5;
+
+      // Documentation string for the overload.
+      string doc = 6;
+    }
+
+    // Required. List of function overloads, must contain at least one overload.
+    repeated Overload overloads = 1;
+  }
+
+  // The fully qualified name of the declaration.
+  //
+  // Declarations are organized in containers and this represents the full path
+  // to the declaration in its container, as in `cel.expr.Decl`.
+  //
+  // Declarations used as
+  // [FunctionDecl.Overload][cel.expr.Decl.FunctionDecl.Overload]
+  // parameters may or may not have a name depending on whether the overload is
+  // function declaration or a function definition containing a result
+  // [Expr][cel.expr.Expr].
+  string name = 1;
+
+  // Required. The declaration kind.
+  oneof decl_kind {
+    // Identifier declaration.
+    IdentDecl ident = 2;
+
+    // Function declaration.
+    FunctionDecl function = 3;
+  }
+}
+
+// Describes a resolved reference to a declaration.
+message Reference {
+  // The fully qualified name of the declaration.
+  string name = 1;
+
+  // For references to functions, this is a list of `Overload.overload_id`
+  // values which match according to typing rules.
+  //
+  // If the list has more than one element, overload resolution among the
+  // presented candidates must happen at runtime because of dynamic types. The
+  // type checker attempts to narrow down this list as much as possible.
+  //
+  // Empty if this is not a reference to a
+  // [Decl.FunctionDecl][cel.expr.Decl.FunctionDecl].
+  repeated string overload_id = 3;
+
+  // For references to constants, this may contain the value of the
+  // constant if known at compile time.
+  Constant value = 4;
+}

--- a/xds/third_party/cel-spec/src/main/proto/cel/expr/syntax.proto
+++ b/xds/third_party/cel-spec/src/main/proto/cel/expr/syntax.proto
@@ -1,0 +1,393 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package cel.expr;
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+
+option cc_enable_arenas = true;
+option go_package = "cel.dev/expr";
+option java_multiple_files = true;
+option java_outer_classname = "SyntaxProto";
+option java_package = "dev.cel.expr";
+
+// A representation of the abstract syntax of the Common Expression Language.
+
+// An expression together with source information as returned by the parser.
+message ParsedExpr {
+  // The parsed expression.
+  Expr expr = 2;
+
+  // The source info derived from input that generated the parsed `expr`.
+  SourceInfo source_info = 3;
+}
+
+// An abstract representation of a common expression.
+//
+// Expressions are abstractly represented as a collection of identifiers,
+// select statements, function calls, literals, and comprehensions. All
+// operators with the exception of the '.' operator are modelled as function
+// calls. This makes it easy to represent new operators into the existing AST.
+//
+// All references within expressions must resolve to a
+// [Decl][cel.expr.Decl] provided at type-check for an expression to be
+// valid. A reference may either be a bare identifier `name` or a qualified
+// identifier `google.api.name`. References may either refer to a value or a
+// function declaration.
+//
+// For example, the expression `google.api.name.startsWith('expr')` references
+// the declaration `google.api.name` within a
+// [Expr.Select][cel.expr.Expr.Select] expression, and the function
+// declaration `startsWith`.
+message Expr {
+  // An identifier expression. e.g. `request`.
+  message Ident {
+    // Required. Holds a single, unqualified identifier, possibly preceded by a
+    // '.'.
+    //
+    // Qualified names are represented by the
+    // [Expr.Select][cel.expr.Expr.Select] expression.
+    string name = 1;
+  }
+
+  // A field selection expression. e.g. `request.auth`.
+  message Select {
+    // Required. The target of the selection expression.
+    //
+    // For example, in the select expression `request.auth`, the `request`
+    // portion of the expression is the `operand`.
+    Expr operand = 1;
+
+    // Required. The name of the field to select.
+    //
+    // For example, in the select expression `request.auth`, the `auth` portion
+    // of the expression would be the `field`.
+    string field = 2;
+
+    // Whether the select is to be interpreted as a field presence test.
+    //
+    // This results from the macro `has(request.auth)`.
+    bool test_only = 3;
+  }
+
+  // A call expression, including calls to predefined functions and operators.
+  //
+  // For example, `value == 10`, `size(map_value)`.
+  message Call {
+    // The target of an method call-style expression. For example, `x` in
+    // `x.f()`.
+    Expr target = 1;
+
+    // Required. The name of the function or method being called.
+    string function = 2;
+
+    // The arguments.
+    repeated Expr args = 3;
+  }
+
+  // A list creation expression.
+  //
+  // Lists may either be homogenous, e.g. `[1, 2, 3]`, or heterogeneous, e.g.
+  // `dyn([1, 'hello', 2.0])`
+  message CreateList {
+    // The elements part of the list.
+    repeated Expr elements = 1;
+
+    // The indices within the elements list which are marked as optional
+    // elements.
+    //
+    // When an optional-typed value is present, the value it contains
+    // is included in the list. If the optional-typed value is absent, the list
+    // element is omitted from the CreateList result.
+    repeated int32 optional_indices = 2;
+  }
+
+  // A map or message creation expression.
+  //
+  // Maps are constructed as `{'key_name': 'value'}`. Message construction is
+  // similar, but prefixed with a type name and composed of field ids:
+  // `types.MyType{field_id: 'value'}`.
+  message CreateStruct {
+    // Represents an entry.
+    message Entry {
+      // Required. An id assigned to this node by the parser which is unique
+      // in a given expression tree. This is used to associate type
+      // information and other attributes to the node.
+      int64 id = 1;
+
+      // The `Entry` key kinds.
+      oneof key_kind {
+        // The field key for a message creator statement.
+        string field_key = 2;
+
+        // The key expression for a map creation statement.
+        Expr map_key = 3;
+      }
+
+      // Required. The value assigned to the key.
+      //
+      // If the optional_entry field is true, the expression must resolve to an
+      // optional-typed value. If the optional value is present, the key will be
+      // set; however, if the optional value is absent, the key will be unset.
+      Expr value = 4;
+
+      // Whether the key-value pair is optional.
+      bool optional_entry = 5;
+    }
+
+    // The type name of the message to be created, empty when creating map
+    // literals.
+    string message_name = 1;
+
+    // The entries in the creation expression.
+    repeated Entry entries = 2;
+  }
+
+  // A comprehension expression applied to a list or map.
+  //
+  // Comprehensions are not part of the core syntax, but enabled with macros.
+  // A macro matches a specific call signature within a parsed AST and replaces
+  // the call with an alternate AST block. Macro expansion happens at parse
+  // time.
+  //
+  // The following macros are supported within CEL:
+  //
+  // Aggregate type macros may be applied to all elements in a list or all keys
+  // in a map:
+  //
+  // *  `all`, `exists`, `exists_one` -  test a predicate expression against
+  //    the inputs and return `true` if the predicate is satisfied for all,
+  //    any, or only one value `list.all(x, x < 10)`.
+  // *  `filter` - test a predicate expression against the inputs and return
+  //    the subset of elements which satisfy the predicate:
+  //    `payments.filter(p, p > 1000)`.
+  // *  `map` - apply an expression to all elements in the input and return the
+  //    output aggregate type: `[1, 2, 3].map(i, i * i)`.
+  //
+  // The `has(m.x)` macro tests whether the property `x` is present in struct
+  // `m`. The semantics of this macro depend on the type of `m`. For proto2
+  // messages `has(m.x)` is defined as 'defined, but not set`. For proto3, the
+  // macro tests whether the property is set to its default. For map and struct
+  // types, the macro tests whether the property `x` is defined on `m`.
+  //
+  // Comprehension evaluation can be best visualized as the following
+  // pseudocode:
+  //
+  // ```
+  // let `accu_var` = `accu_init`
+  // for (let `iter_var` in `iter_range`) {
+  //   if (!`loop_condition`) {
+  //     break
+  //   }
+  //   `accu_var` = `loop_step`
+  // }
+  // return `result`
+  // ```
+  message Comprehension {
+    // The name of the iteration variable.
+    string iter_var = 1;
+
+    // The range over which var iterates.
+    Expr iter_range = 2;
+
+    // The name of the variable used for accumulation of the result.
+    string accu_var = 3;
+
+    // The initial value of the accumulator.
+    Expr accu_init = 4;
+
+    // An expression which can contain iter_var and accu_var.
+    //
+    // Returns false when the result has been computed and may be used as
+    // a hint to short-circuit the remainder of the comprehension.
+    Expr loop_condition = 5;
+
+    // An expression which can contain iter_var and accu_var.
+    //
+    // Computes the next value of accu_var.
+    Expr loop_step = 6;
+
+    // An expression which can contain accu_var.
+    //
+    // Computes the result.
+    Expr result = 7;
+  }
+
+  // Required. An id assigned to this node by the parser which is unique in a
+  // given expression tree. This is used to associate type information and other
+  // attributes to a node in the parse tree.
+  int64 id = 2;
+
+  // Required. Variants of expressions.
+  oneof expr_kind {
+    // A constant expression.
+    Constant const_expr = 3;
+
+    // An identifier expression.
+    Ident ident_expr = 4;
+
+    // A field selection expression, e.g. `request.auth`.
+    Select select_expr = 5;
+
+    // A call expression, including calls to predefined functions and operators.
+    Call call_expr = 6;
+
+    // A list creation expression.
+    CreateList list_expr = 7;
+
+    // A map or message creation expression.
+    CreateStruct struct_expr = 8;
+
+    // A comprehension expression.
+    Comprehension comprehension_expr = 9;
+  }
+}
+
+// Represents a primitive literal.
+//
+// Named 'Constant' here for backwards compatibility.
+//
+// This is similar as the primitives supported in the well-known type
+// `google.protobuf.Value`, but richer so it can represent CEL's full range of
+// primitives.
+//
+// Lists and structs are not included as constants as these aggregate types may
+// contain [Expr][cel.expr.Expr] elements which require evaluation and
+// are thus not constant.
+//
+// Examples of constants include: `"hello"`, `b'bytes'`, `1u`, `4.2`, `-2`,
+// `true`, `null`.
+message Constant {
+  // Required. The valid constant kinds.
+  oneof constant_kind {
+    // null value.
+    google.protobuf.NullValue null_value = 1;
+
+    // boolean value.
+    bool bool_value = 2;
+
+    // int64 value.
+    int64 int64_value = 3;
+
+    // uint64 value.
+    uint64 uint64_value = 4;
+
+    // double value.
+    double double_value = 5;
+
+    // string value.
+    string string_value = 6;
+
+    // bytes value.
+    bytes bytes_value = 7;
+
+    // protobuf.Duration value.
+    //
+    // Deprecated: duration is no longer considered a builtin cel type.
+    google.protobuf.Duration duration_value = 8 [deprecated = true];
+
+    // protobuf.Timestamp value.
+    //
+    // Deprecated: timestamp is no longer considered a builtin cel type.
+    google.protobuf.Timestamp timestamp_value = 9 [deprecated = true];
+  }
+}
+
+// Source information collected at parse time.
+message SourceInfo {
+  // The syntax version of the source, e.g. `cel1`.
+  string syntax_version = 1;
+
+  // The location name. All position information attached to an expression is
+  // relative to this location.
+  //
+  // The location could be a file, UI element, or similar. For example,
+  // `acme/app/AnvilPolicy.cel`.
+  string location = 2;
+
+  // Monotonically increasing list of code point offsets where newlines
+  // `\n` appear.
+  //
+  // The line number of a given position is the index `i` where for a given
+  // `id` the `line_offsets[i] < id_positions[id] < line_offsets[i+1]`. The
+  // column may be derived from `id_positions[id] - line_offsets[i]`.
+  repeated int32 line_offsets = 3;
+
+  // A map from the parse node id (e.g. `Expr.id`) to the code point offset
+  // within the source.
+  map<int64, int32> positions = 4;
+
+  // A map from the parse node id where a macro replacement was made to the
+  // call `Expr` that resulted in a macro expansion.
+  //
+  // For example, `has(value.field)` is a function call that is replaced by a
+  // `test_only` field selection in the AST. Likewise, the call
+  // `list.exists(e, e > 10)` translates to a comprehension expression. The key
+  // in the map corresponds to the expression id of the expanded macro, and the
+  // value is the call `Expr` that was replaced.
+  map<int64, Expr> macro_calls = 5;
+
+  // A list of tags for extensions that were used while parsing or type checking
+  // the source expression. For example, optimizations that require special
+  // runtime support may be specified.
+  //
+  // These are used to check feature support between components in separate
+  // implementations. This can be used to either skip redundant work or
+  // report an error if the extension is unsupported.
+  repeated Extension extensions = 6;
+
+  // An extension that was requested for the source expression.
+  message Extension {
+    // Version
+    message Version {
+      // Major version changes indicate different required support level from
+      // the required components.
+      int64 major = 1;
+      // Minor version changes must not change the observed behavior from
+      // existing implementations, but may be provided informationally.
+      int64 minor = 2;
+    }
+
+    // CEL component specifier.
+    enum Component {
+      // Unspecified, default.
+      COMPONENT_UNSPECIFIED = 0;
+      // Parser. Converts a CEL string to an AST.
+      COMPONENT_PARSER = 1;
+      // Type checker. Checks that references in an AST are defined and types
+      // agree.
+      COMPONENT_TYPE_CHECKER = 2;
+      // Runtime. Evaluates a parsed and optionally checked CEL AST against a
+      // context.
+      COMPONENT_RUNTIME = 3;
+    }
+
+    // Identifier for the extension. Example: constant_folding
+    string id = 1;
+
+    // If set, the listed components must understand the extension for the
+    // expression to evaluate correctly.
+    //
+    // This field has set semantics, repeated values should be deduplicated.
+    repeated Component affected_components = 2;
+
+    // Version info. May be skipped if it isn't meaningful for the extension.
+    // (for example constant_folding might always be v0.0).
+    Version version = 3;
+  }
+}

--- a/xds/third_party/envoy/import.sh
+++ b/xds/third_party/envoy/import.sh
@@ -74,6 +74,7 @@ envoy/data/accesslog/v3/accesslog.proto
 envoy/extensions/clusters/aggregate/v3/cluster.proto
 envoy/extensions/filters/common/fault/v3/fault.proto
 envoy/extensions/filters/http/fault/v3/fault.proto
+envoy/extensions/filters/http/rate_limit_quota/v3/rate_limit_quota.proto
 envoy/extensions/filters/http/rbac/v3/rbac.proto
 envoy/extensions/filters/http/router/v3/router.proto
 envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -95,6 +96,7 @@ envoy/service/rate_limit_quota/v3/rlqs.proto
 envoy/service/status/v3/csds.proto
 envoy/type/http/v3/path_transformation.proto
 envoy/type/matcher/v3/filter_state.proto
+envoy/type/matcher/v3/http_inputs.proto
 envoy/type/matcher/v3/metadata.proto
 envoy/type/matcher/v3/node.proto
 envoy/type/matcher/v3/number.proto
@@ -106,6 +108,7 @@ envoy/type/matcher/v3/value.proto
 envoy/type/metadata/v3/metadata.proto
 envoy/type/tracing/v3/custom_tag.proto
 envoy/type/v3/http.proto
+envoy/type/v3/http_status.proto
 envoy/type/v3/percent.proto
 envoy/type/v3/range.proto
 envoy/type/v3/ratelimit_strategy.proto

--- a/xds/third_party/envoy/import.sh
+++ b/xds/third_party/envoy/import.sh
@@ -91,6 +91,7 @@ envoy/extensions/transport_sockets/tls/v3/tls.proto
 envoy/service/discovery/v3/ads.proto
 envoy/service/discovery/v3/discovery.proto
 envoy/service/load_stats/v3/lrs.proto
+envoy/service/rate_limit_quota/v3/rlqs.proto
 envoy/service/status/v3/csds.proto
 envoy/type/http/v3/path_transformation.proto
 envoy/type/matcher/v3/filter_state.proto
@@ -107,7 +108,10 @@ envoy/type/tracing/v3/custom_tag.proto
 envoy/type/v3/http.proto
 envoy/type/v3/percent.proto
 envoy/type/v3/range.proto
+envoy/type/v3/ratelimit_strategy.proto
+envoy/type/v3/ratelimit_unit.proto
 envoy/type/v3/semantic_version.proto
+envoy/type/v3/token_bucket.proto
 )
 
 pushd "$(git rev-parse --show-toplevel)/xds/third_party/envoy" > /dev/null

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/http/rate_limit_quota/v3/rate_limit_quota.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/http/rate_limit_quota/v3/rate_limit_quota.proto
@@ -1,0 +1,423 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.http.rate_limit_quota.v3;
+
+import "envoy/config/core/v3/base.proto";
+import "envoy/config/core/v3/extension.proto";
+import "envoy/config/core/v3/grpc_service.proto";
+import "envoy/type/v3/http_status.proto";
+import "envoy/type/v3/ratelimit_strategy.proto";
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/wrappers.proto";
+import "google/rpc/status.proto";
+
+import "xds/annotations/v3/status.proto";
+import "xds/type/matcher/v3/matcher.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.http.rate_limit_quota.v3";
+option java_outer_classname = "RateLimitQuotaProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/rate_limit_quota/v3;rate_limit_quotav3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+option (xds.annotations.v3.file_status).work_in_progress = true;
+
+// [#protodoc-title: Rate Limit Quota]
+// Rate Limit Quota :ref:`configuration overview <config_http_filters_rate_limit_quota>`.
+// [#extension: envoy.filters.http.rate_limit_quota]
+
+// Configures the Rate Limit Quota filter.
+//
+// Can be overridden in the per-route and per-host configurations.
+// The more specific definition completely overrides the less specific definition.
+// [#next-free-field: 7]
+message RateLimitQuotaFilterConfig {
+  // Configures the gRPC Rate Limit Quota Service (RLQS) RateLimitQuotaService.
+  config.core.v3.GrpcService rlqs_server = 1 [(validate.rules).message = {required: true}];
+
+  // The application domain to use when calling the service. This enables sharing the quota
+  // server between different applications without fear of overlap.
+  // E.g., "envoy".
+  string domain = 2 [(validate.rules).string = {min_len: 1}];
+
+  // The match tree to use for grouping incoming requests into buckets.
+  //
+  // Example:
+  //
+  // .. validated-code-block:: yaml
+  //   :type-name: xds.type.matcher.v3.Matcher
+  //
+  //   matcher_list:
+  //     matchers:
+  //     # Assign requests with header['env'] set to 'staging' to the bucket { name: 'staging' }
+  //     - predicate:
+  //         single_predicate:
+  //           input:
+  //             typed_config:
+  //               '@type': type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+  //               header_name: env
+  //           value_match:
+  //             exact: staging
+  //       on_match:
+  //         action:
+  //           typed_config:
+  //             '@type': type.googleapis.com/envoy.extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings
+  //             bucket_id_builder:
+  //               bucket_id_builder:
+  //                 name:
+  //                   string_value: staging
+  //
+  //     # Assign requests with header['user_group'] set to 'admin' to the bucket { acl: 'admin_users' }
+  //     - predicate:
+  //         single_predicate:
+  //           input:
+  //             typed_config:
+  //               '@type': type.googleapis.com/xds.type.matcher.v3.HttpAttributesCelMatchInput
+  //           custom_match:
+  //             typed_config:
+  //               '@type': type.googleapis.com/xds.type.matcher.v3.CelMatcher
+  //               expr_match:
+  //                 # Shortened for illustration purposes. Here should be parsed CEL expression:
+  //                 # request.headers['user_group'] == 'admin'
+  //                 parsed_expr: {}
+  //       on_match:
+  //         action:
+  //           typed_config:
+  //             '@type': type.googleapis.com/envoy.extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings
+  //             bucket_id_builder:
+  //               bucket_id_builder:
+  //                 acl:
+  //                   string_value: admin_users
+  //
+  //   # Catch-all clause for the requests not matched by any of the matchers.
+  //   # In this example, deny all requests.
+  //   on_no_match:
+  //     action:
+  //       typed_config:
+  //         '@type': type.googleapis.com/envoy.extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings
+  //         no_assignment_behavior:
+  //           fallback_rate_limit:
+  //             blanket_rule: DENY_ALL
+  //
+  // .. attention::
+  //  The first matched group wins. Once the request is matched into a bucket, matcher
+  //  evaluation ends.
+  //
+  // Use ``on_no_match`` field to assign the catch-all bucket. If a request is not matched
+  // into any bucket, and there's no  ``on_no_match`` field configured, the request will be
+  // ALLOWED by default. It will NOT be reported to the RLQS server.
+  //
+  // Refer to :ref:`Unified Matcher API <envoy_v3_api_msg_.xds.type.matcher.v3.Matcher>`
+  // documentation for more information on the matcher trees.
+  xds.type.matcher.v3.Matcher bucket_matchers = 3 [(validate.rules).message = {required: true}];
+
+  // If set, this will enable -- but not necessarily enforce -- the rate limit for the given
+  // fraction of requests.
+  //
+  // Defaults to 100% of requests.
+  config.core.v3.RuntimeFractionalPercent filter_enabled = 4;
+
+  // If set, this will enforce the rate limit decisions for the given fraction of requests.
+  // For requests that are not enforced the filter will still obtain the quota and include it
+  // in the load computation, however the request will always be allowed regardless of the outcome
+  // of quota application. This allows validation or testing of the rate limiting service
+  // infrastructure without disrupting existing traffic.
+  //
+  // Note: this only applies to the fraction of enabled requests.
+  //
+  // Defaults to 100% of requests.
+  config.core.v3.RuntimeFractionalPercent filter_enforced = 5;
+
+  // Specifies a list of HTTP headers that should be added to each request that
+  // has been rate limited and is also forwarded upstream. This can only occur when the
+  // filter is enabled but not enforced.
+  repeated config.core.v3.HeaderValueOption request_headers_to_add_when_not_enforced = 6
+      [(validate.rules).repeated = {max_items: 10}];
+}
+
+// Per-route and per-host configuration overrides. The more specific definition completely
+// overrides the less specific definition.
+message RateLimitQuotaOverride {
+  // The application domain to use when calling the service. This enables sharing the quota
+  // server between different applications without fear of overlap.
+  // E.g., "envoy".
+  //
+  // If empty, inherits the value from the less specific definition.
+  string domain = 1;
+
+  // The match tree to use for grouping incoming requests into buckets.
+  //
+  // If set, fully overrides the bucket matchers provided on the less specific definition.
+  // If not set, inherits the value from the less specific definition.
+  //
+  // See usage example: :ref:`RateLimitQuotaFilterConfig.bucket_matchers
+  // <envoy_v3_api_field_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaFilterConfig.bucket_matchers>`.
+  xds.type.matcher.v3.Matcher bucket_matchers = 2;
+}
+
+// Rate Limit Quota Bucket Settings to apply on the successful ``bucket_matchers`` match.
+//
+// Specify this message in the :ref:`Matcher.OnMatch.action
+// <envoy_v3_api_field_.xds.type.matcher.v3.Matcher.OnMatch.action>` field of the
+// ``bucket_matchers`` matcher tree to assign the matched requests to the Quota Bucket.
+// Usage example: :ref:`RateLimitQuotaFilterConfig.bucket_matchers
+// <envoy_v3_api_field_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaFilterConfig.bucket_matchers>`.
+// [#next-free-field: 6]
+message RateLimitQuotaBucketSettings {
+  // Configures the behavior after the first request has been matched to the bucket, and before the
+  // the RLQS server returns the first quota assignment.
+  message NoAssignmentBehavior {
+    oneof no_assignment_behavior {
+      option (validate.required) = true;
+
+      // Apply pre-configured rate limiting strategy until the server sends the first assignment.
+      type.v3.RateLimitStrategy fallback_rate_limit = 1;
+    }
+  }
+
+  // Specifies the behavior when the bucket's assignment has expired, and cannot be refreshed for
+  // any reason.
+  message ExpiredAssignmentBehavior {
+    // Reuse the last known quota assignment, effectively extending it for the duration
+    // specified in the :ref:`expired_assignment_behavior_timeout
+    // <envoy_v3_api_field_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings.ExpiredAssignmentBehavior.expired_assignment_behavior_timeout>`
+    // field.
+    message ReuseLastAssignment {
+    }
+
+    // Limit the time :ref:`ExpiredAssignmentBehavior
+    // <envoy_v3_api_msg_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings.ExpiredAssignmentBehavior>`
+    // is applied. If the server doesn't respond within this duration:
+    //
+    // 1. Selected ``ExpiredAssignmentBehavior`` is no longer applied.
+    // 2. The bucket is abandoned. The process of abandoning the bucket is described in the
+    //    :ref:`AbandonAction <envoy_v3_api_msg_service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction.AbandonAction>`
+    //    message.
+    // 3. If a new request is matched into the bucket that has become abandoned,
+    //    the data plane restarts the subscription to the bucket. The process of restarting the
+    //    subscription is described in the :ref:`AbandonAction
+    //    <envoy_v3_api_msg_service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction.AbandonAction>`
+    //    message.
+    //
+    // If not set, defaults to zero, and the bucket is abandoned immediately.
+    google.protobuf.Duration expired_assignment_behavior_timeout = 1
+        [(validate.rules).duration = {gt {}}];
+
+    oneof expired_assignment_behavior {
+      option (validate.required) = true;
+
+      // Apply the rate limiting strategy to all requests matched into the bucket until the RLQS
+      // server sends a new assignment, or the :ref:`expired_assignment_behavior_timeout
+      // <envoy_v3_api_field_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings.ExpiredAssignmentBehavior.expired_assignment_behavior_timeout>`
+      // runs out.
+      type.v3.RateLimitStrategy fallback_rate_limit = 2;
+
+      // Reuse the last ``active`` assignment until the RLQS server sends a new assignment, or the
+      // :ref:`expired_assignment_behavior_timeout
+      // <envoy_v3_api_field_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings.ExpiredAssignmentBehavior.expired_assignment_behavior_timeout>`
+      // runs out.
+      ReuseLastAssignment reuse_last_assignment = 3;
+    }
+  }
+
+  // Customize the deny response to the requests over the rate limit.
+  message DenyResponseSettings {
+    // HTTP response code to deny for HTTP requests (gRPC excluded).
+    // Defaults to 429 (:ref:`StatusCode.TooManyRequests<envoy_v3_api_enum_value_type.v3.StatusCode.TooManyRequests>`).
+    type.v3.HttpStatus http_status = 1;
+
+    // HTTP response body used to deny for HTTP requests (gRPC excluded).
+    // If not set, an empty body is returned.
+    google.protobuf.BytesValue http_body = 2;
+
+    // Configure the deny response for gRPC requests over the rate limit.
+    // Allows to specify the `RPC status code
+    // <https://cloud.google.com/natural-language/docs/reference/rpc/google.rpc#google.rpc.Code>`_,
+    // and the error message.
+    // Defaults to the Status with the RPC Code ``UNAVAILABLE`` and empty message.
+    //
+    // To identify gRPC requests, Envoy checks that the ``Content-Type`` header is
+    // ``application/grpc``, or one of the various ``application/grpc+`` values.
+    //
+    // .. note::
+    //   The HTTP code for a gRPC response is always 200.
+    google.rpc.Status grpc_status = 3;
+
+    // Specifies a list of HTTP headers that should be added to each response for requests that
+    // have been rate limited. Applies both to plain HTTP, and gRPC requests.
+    // The headers are added even when the rate limit quota was not enforced.
+    repeated config.core.v3.HeaderValueOption response_headers_to_add = 4
+        [(validate.rules).repeated = {max_items: 10}];
+  }
+
+  // ``BucketIdBuilder`` makes it possible to build :ref:`BucketId
+  // <envoy_v3_api_msg_service.rate_limit_quota.v3.BucketId>` with values substituted
+  // from the dynamic properties associated with each individual request. See usage examples in
+  // the docs to :ref:`bucket_id_builder
+  // <envoy_v3_api_field_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings.bucket_id_builder>`
+  // field.
+  message BucketIdBuilder {
+    // Produces the value of the :ref:`BucketId
+    // <envoy_v3_api_msg_service.rate_limit_quota.v3.BucketId>` map.
+    message ValueBuilder {
+      oneof value_specifier {
+        option (validate.required) = true;
+
+        // Static string value — becomes the value in the :ref:`BucketId
+        // <envoy_v3_api_msg_service.rate_limit_quota.v3.BucketId>` map as is.
+        string string_value = 1;
+
+        // Dynamic value — evaluated for each request. Must produce a string output, which becomes
+        // the value in the :ref:`BucketId <envoy_v3_api_msg_service.rate_limit_quota.v3.BucketId>`
+        // map. For example, extensions with the ``envoy.matching.http.input`` category can be used.
+        config.core.v3.TypedExtensionConfig custom_value = 2;
+      }
+    }
+
+    // The map translated into the ``BucketId`` map.
+    //
+    // The ``string key`` of this map and becomes the key of ``BucketId`` map as is.
+    //
+    // The ``ValueBuilder value`` for the key can be:
+    //
+    // * static ``StringValue string_value`` — becomes the value in the ``BucketId`` map as is.
+    // * dynamic ``TypedExtensionConfig custom_value`` — evaluated for each request. Must produce
+    //   a string output, which becomes the value in the the ``BucketId`` map.
+    //
+    // See usage examples in the docs to :ref:`bucket_id_builder
+    // <envoy_v3_api_field_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings.bucket_id_builder>`
+    // field.
+    map<string, ValueBuilder> bucket_id_builder = 1 [(validate.rules).map = {min_pairs: 1}];
+  }
+
+  // ``BucketId`` builder.
+  //
+  // :ref:`BucketId <envoy_v3_api_msg_service.rate_limit_quota.v3.BucketId>` is a map from
+  // the string key to the string value which serves as bucket identifier common for on
+  // the control plane and the data plane.
+  //
+  // While ``BucketId`` is always static, ``BucketIdBuilder`` allows to populate map values
+  // with the dynamic properties associated with the each individual request.
+  //
+  // Example 1: static fields only
+  //
+  // ``BucketIdBuilder``:
+  //
+  // .. validated-code-block:: yaml
+  //   :type-name: envoy.extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings.BucketIdBuilder
+  //
+  //   bucket_id_builder:
+  //     name:
+  //       string_value: my_bucket
+  //     hello:
+  //       string_value: world
+  //
+  // Produces the following ``BucketId`` for all requests:
+  //
+  // .. validated-code-block:: yaml
+  //   :type-name: envoy.service.rate_limit_quota.v3.BucketId
+  //
+  //   bucket:
+  //     name: my_bucket
+  //     hello: world
+  //
+  // Example 2: static and dynamic fields
+  //
+  // .. validated-code-block:: yaml
+  //   :type-name: envoy.extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings.BucketIdBuilder
+  //
+  //   bucket_id_builder:
+  //     name:
+  //       string_value: my_bucket
+  //     env:
+  //       custom_value:
+  //         typed_config:
+  //           '@type': type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+  //           header_name: environment
+  //
+  // In this example, the value of ``BucketId`` key ``env`` is substituted from the ``environment``
+  // request header.
+  //
+  // This is equivalent to the following ``pseudo-code``:
+  //
+  // .. code-block:: yaml
+  //
+  //    name: 'my_bucket'
+  //    env: $header['environment']
+  //
+  // For example, the request with the HTTP header ``env`` set to ``staging`` will produce
+  // the following ``BucketId``:
+  //
+  // .. validated-code-block:: yaml
+  //   :type-name: envoy.service.rate_limit_quota.v3.BucketId
+  //
+  //   bucket:
+  //     name: my_bucket
+  //     env: staging
+  //
+  // For the request with the HTTP header ``environment`` set to ``prod``, will produce:
+  //
+  // .. validated-code-block:: yaml
+  //   :type-name: envoy.service.rate_limit_quota.v3.BucketId
+  //
+  //   bucket:
+  //     name: my_bucket
+  //     env: prod
+  //
+  // .. note::
+  //   The order of ``BucketId`` keys do not matter. Buckets ``{ a: 'A', b: 'B' }`` and
+  //   ``{ b: 'B', a: 'A' }`` are identical.
+  //
+  // If not set, requests will NOT be reported to the server, and will always limited
+  // according to :ref:`no_assignment_behavior
+  // <envoy_v3_api_field_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings.no_assignment_behavior>`
+  // configuration.
+  BucketIdBuilder bucket_id_builder = 1;
+
+  // The interval at which the data plane (RLQS client) is to report quota usage for this bucket.
+  //
+  // When the first request is matched to a bucket with no assignment, the data plane is to report
+  // the request immediately in the :ref:`RateLimitQuotaUsageReports
+  // <envoy_v3_api_msg_service.rate_limit_quota.v3.RateLimitQuotaUsageReports>` message.
+  // For the RLQS server, this signals that the data plane is now subscribed to
+  // the quota assignments in this bucket, and will start sending the assignment as described in
+  // the :ref:`RLQS documentation <envoy_v3_api_file_envoy/service/rate_limit_quota/v3/rlqs.proto>`.
+  //
+  // After sending the initial report, the data plane is to continue reporting the bucket usage with
+  // the internal specified in this field.
+  //
+  // If for any reason RLQS client doesn't receive the initial assignment for the reported bucket,
+  // the data plane will eventually consider the bucket abandoned and stop sending the usage
+  // reports. This is explained in more details at :ref:`Rate Limit Quota Service (RLQS)
+  // <envoy_v3_api_file_envoy/service/rate_limit_quota/v3/rlqs.proto>`.
+  //
+  // [#comment: 100000000 nanoseconds = 0.1 seconds]
+  google.protobuf.Duration reporting_interval = 2 [(validate.rules).duration = {
+    required: true
+    gt {nanos: 100000000}
+  }];
+
+  // Customize the deny response to the requests over the rate limit.
+  // If not set, the filter will be configured as if an empty message is set,
+  // and will behave according to the defaults specified in :ref:`DenyResponseSettings
+  // <envoy_v3_api_msg_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings.DenyResponseSettings>`.
+  DenyResponseSettings deny_response_settings = 3;
+
+  // Configures the behavior in the "no assignment" state: after the first request has been
+  // matched to the bucket, and before the the RLQS server returns the first quota assignment.
+  //
+  // If not set, the default behavior is to allow all requests.
+  NoAssignmentBehavior no_assignment_behavior = 4;
+
+  // Configures the behavior in the "expired assignment" state: the bucket's assignment has expired,
+  // and cannot be refreshed.
+  //
+  // If not set, the bucket is abandoned when its ``active`` assignment expires.
+  // The process of abandoning the bucket, and restarting the subscription is described in the
+  // :ref:`AbandonAction <envoy_v3_api_msg_service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction.AbandonAction>`
+  // message.
+  ExpiredAssignmentBehavior expired_assignment_behavior = 5;
+}

--- a/xds/third_party/envoy/src/main/proto/envoy/service/rate_limit_quota/v3/rlqs.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/service/rate_limit_quota/v3/rlqs.proto
@@ -1,0 +1,258 @@
+syntax = "proto3";
+
+package envoy.service.rate_limit_quota.v3;
+
+import "envoy/type/v3/ratelimit_strategy.proto";
+
+import "google/protobuf/duration.proto";
+
+import "xds/annotations/v3/status.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.service.rate_limit_quota.v3";
+option java_outer_classname = "RlqsProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/rate_limit_quota/v3;rate_limit_quotav3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+option (xds.annotations.v3.file_status).work_in_progress = true;
+
+// [#protodoc-title: Rate Limit Quota Service (RLQS)]
+
+// The Rate Limit Quota Service (RLQS) is a Envoy global rate limiting service that allows to
+// delegate rate limit decisions to a remote service. The service will aggregate the usage reports
+// from multiple data plane instances, and distribute Rate Limit Assignments to each instance
+// based on its business logic. The logic is outside of the scope of the protocol API.
+//
+// The protocol is designed as a streaming-first API. It utilizes watch-like subscription model.
+// The data plane groups requests into Quota Buckets as directed by the filter config,
+// and periodically reports them to the RLQS server along with the Bucket identifier, :ref:`BucketId
+// <envoy_v3_api_msg_service.rate_limit_quota.v3.BucketId>`. Once RLQS server has collected enough
+// reports to make a decision, it'll send back the assignment with the rate limiting instructions.
+//
+// The first report sent by the data plane is interpreted by the RLQS server as a "watch" request,
+// indicating that the data plane instance is interested in receiving further updates for the
+// ``BucketId``. From then on, RLQS server may push assignments to this instance at will, even if
+// the instance is not sending usage reports. It's the responsibility of the RLQS server
+// to determine when the data plane instance didn't send ``BucketId`` reports for too long,
+// and to respond with the :ref:`AbandonAction
+// <envoy_v3_api_msg_service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction.AbandonAction>`,
+// indicating that the server has now stopped sending quota assignments for the ``BucketId`` bucket,
+// and the data plane instance should :ref:`abandon
+// <envoy_v3_api_field_service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction.abandon_action>`
+// it.
+//
+// If for any reason the RLQS client doesn't receive the initial assignment for the reported bucket,
+// in order to prevent memory exhaustion, the data plane will limit the time such bucket
+// is retained. The exact time to wait for the initial assignment is chosen by the filter,
+// and may vary based on the implementation.
+// Once the duration ends, the data plane will stop reporting bucket usage, reject any enqueued
+// requests, and purge the bucket from the memory. Subsequent requests matched into the bucket
+// will re-initialize the bucket in the "no assignment" state, restarting the reports.
+//
+// Refer to Rate Limit Quota :ref:`configuration overview <config_http_filters_rate_limit_quota>`
+// for further details.
+
+// Defines the Rate Limit Quota Service (RLQS).
+service RateLimitQuotaService {
+  // Main communication channel: the data plane sends usage reports to the RLQS server,
+  // and the server asynchronously responding with the assignments.
+  rpc StreamRateLimitQuotas(stream RateLimitQuotaUsageReports)
+      returns (stream RateLimitQuotaResponse) {
+  }
+}
+
+message RateLimitQuotaUsageReports {
+  // The usage report for a bucket.
+  //
+  // .. note::
+  //   Note that the first report sent for a ``BucketId`` indicates to the RLQS server that
+  //   the RLQS client is subscribing for the future assignments for this ``BucketId``.
+  message BucketQuotaUsage {
+    // ``BucketId`` for which request quota usage is reported.
+    BucketId bucket_id = 1 [(validate.rules).message = {required: true}];
+
+    // Time elapsed since the last report.
+    google.protobuf.Duration time_elapsed = 2 [(validate.rules).duration = {
+      required: true
+      gt {}
+    }];
+
+    // Requests the data plane has allowed through.
+    uint64 num_requests_allowed = 3;
+
+    // Requests throttled.
+    uint64 num_requests_denied = 4;
+  }
+
+  // All quota requests must specify the domain. This enables sharing the quota
+  // server between different applications without fear of overlap.
+  // E.g., "envoy".
+  //
+  // Should only be provided in the first report, all subsequent messages on the same
+  // stream are considered to be in the same domain. In case the domain needs to be
+  // changes, close the stream, and reopen a new one with the different domain.
+  string domain = 1 [(validate.rules).string = {min_len: 1}];
+
+  // A list of quota usage reports. The list is processed by the RLQS server in the same order
+  // it's provided by the client.
+  repeated BucketQuotaUsage bucket_quota_usages = 2 [(validate.rules).repeated = {min_items: 1}];
+}
+
+message RateLimitQuotaResponse {
+  // Commands the data plane to apply one of the actions to the bucket with the
+  // :ref:`bucket_id <envoy_v3_api_field_service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction.bucket_id>`.
+  message BucketAction {
+    // Quota assignment for the bucket. Configures the rate limiting strategy and the duration
+    // for the given :ref:`bucket_id
+    // <envoy_v3_api_field_service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction.bucket_id>`.
+    //
+    // **Applying the first assignment to the bucket**
+    //
+    // Once the data plane receives the ``QuotaAssignmentAction``, it must send the current usage
+    // report for the bucket, and start rate limiting requests matched into the bucket
+    // using the strategy configured in the :ref:`rate_limit_strategy
+    // <envoy_v3_api_field_service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction.QuotaAssignmentAction.rate_limit_strategy>`
+    // field. The assignment becomes bucket's ``active`` assignment.
+    //
+    // **Expiring the assignment**
+    //
+    // The duration of the assignment defined in the :ref:`assignment_time_to_live
+    // <envoy_v3_api_field_service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction.QuotaAssignmentAction.assignment_time_to_live>`
+    // field. When the duration runs off, the assignment is ``expired``, and no longer ``active``.
+    // The data plane should stop applying the rate limiting strategy to the bucket, and transition
+    // the bucket to the "expired assignment" state. This activates the behavior configured in the
+    // :ref:`expired_assignment_behavior <envoy_v3_api_field_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings.expired_assignment_behavior>`
+    // field.
+    //
+    // **Replacing the assignment**
+    //
+    // * If the rate limiting strategy is different from bucket's ``active`` assignment, or
+    //   the current bucket assignment is ``expired``, the data plane must immediately
+    //   end the current assignment, report the bucket usage, and apply the new assignment.
+    //   The new assignment becomes bucket's ``active`` assignment.
+    // * If the rate limiting strategy is the same as the bucket's ``active`` (not ``expired``)
+    //   assignment, the data plane should extend the duration of the ``active`` assignment
+    //   for the duration of the new assignment provided in the :ref:`assignment_time_to_live
+    //   <envoy_v3_api_field_service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction.QuotaAssignmentAction.assignment_time_to_live>`
+    //   field. The ``active`` assignment is considered unchanged.
+    message QuotaAssignmentAction {
+      // A duration after which the assignment is be considered ``expired``. The process of the
+      // expiration is described :ref:`above
+      // <envoy_v3_api_msg_service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction.QuotaAssignmentAction>`.
+      //
+      // * If unset, the assignment has no expiration date.
+      // * If set to ``0``, the assignment expires immediately, forcing the client into the
+      //   :ref:`"expired assignment"
+      //   <envoy_v3_api_field_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings.ExpiredAssignmentBehavior.expired_assignment_behavior_timeout>`
+      //   state. This may be used by the RLQS server in cases when it needs clients to proactively
+      //   fall back to the pre-configured :ref:`ExpiredAssignmentBehavior
+      //   <envoy_v3_api_msg_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings.ExpiredAssignmentBehavior>`,
+      //   f.e. before the server going into restart.
+      //
+      // .. attention::
+      //   Note that :ref:`expiring
+      //   <envoy_v3_api_msg_service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction.QuotaAssignmentAction>`
+      //   the assignment is not the same as :ref:`abandoning
+      //   <envoy_v3_api_msg_service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction.AbandonAction>`
+      //   the assignment. While expiring the assignment just transitions the bucket to
+      //   the "expired assignment" state; abandoning the assignment completely erases
+      //   the bucket from the data plane memory, and stops the usage reports.
+      google.protobuf.Duration assignment_time_to_live = 2 [(validate.rules).duration = {gte {}}];
+
+      // Configures the local rate limiter for the request matched to the bucket.
+      // If not set, allow all requests.
+      type.v3.RateLimitStrategy rate_limit_strategy = 3;
+    }
+
+    // Abandon action for the bucket. Indicates that the RLQS server will no longer be
+    // sending updates for the given :ref:`bucket_id
+    // <envoy_v3_api_field_service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction.bucket_id>`.
+    //
+    // If no requests are reported for a bucket, after some time the server considers the bucket
+    // inactive. The server stops tracking the bucket, and instructs the the data plane to abandon
+    // the bucket via this message.
+    //
+    // **Abandoning the assignment**
+    //
+    // The data plane is to erase the bucket (including its usage data) from the memory.
+    // It should stop tracking the bucket, and stop reporting its usage. This effectively resets
+    // the data plane to the state prior to matching the first request into the bucket.
+    //
+    // **Restarting the subscription**
+    //
+    // If a new request is matched into a bucket previously abandoned, the data plane must behave
+    // as if it has never tracked the bucket, and it's the first request matched into it:
+    //
+    // 1. The process of :ref:`subscription and reporting
+    //    <envoy_v3_api_field_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings.reporting_interval>`
+    //    starts from the beginning.
+    //
+    // 2. The bucket transitions to the :ref:`"no assignment"
+    //    <envoy_v3_api_field_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings.no_assignment_behavior>`
+    //    state.
+    //
+    // 3. Once the new assignment is received, it's applied per
+    //    "Applying the first assignment to the bucket" section of the :ref:`QuotaAssignmentAction
+    //    <envoy_v3_api_msg_service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction.QuotaAssignmentAction>`.
+    message AbandonAction {
+    }
+
+    // ``BucketId`` for which request the action is applied.
+    BucketId bucket_id = 1 [(validate.rules).message = {required: true}];
+
+    oneof bucket_action {
+      option (validate.required) = true;
+
+      // Apply the quota assignment to the bucket.
+      //
+      // Commands the data plane to apply a rate limiting strategy to the bucket.
+      // The process of applying and expiring the rate limiting strategy is detailed in the
+      // :ref:`QuotaAssignmentAction
+      // <envoy_v3_api_msg_service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction.QuotaAssignmentAction>`
+      // message.
+      QuotaAssignmentAction quota_assignment_action = 2;
+
+      // Abandon the bucket.
+      //
+      // Commands the data plane to abandon the bucket.
+      // The process of abandoning the bucket is described in the :ref:`AbandonAction
+      // <envoy_v3_api_msg_service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction.AbandonAction>`
+      // message.
+      AbandonAction abandon_action = 3;
+    }
+  }
+
+  // An ordered list of actions to be applied to the buckets. The actions are applied in the
+  // given order, from top to bottom.
+  repeated BucketAction bucket_action = 1 [(validate.rules).repeated = {min_items: 1}];
+}
+
+// The identifier for the bucket. Used to match the bucket between the control plane (RLQS server),
+// and the data plane (RLQS client), f.e.:
+//
+// * the data plane sends a usage report for requests matched into the bucket with ``BucketId``
+//   to the control plane
+// * the control plane sends an assignment for the bucket with ``BucketId`` to the data plane
+//   Bucket ID.
+//
+// Example:
+//
+// .. validated-code-block:: yaml
+//   :type-name: envoy.service.rate_limit_quota.v3.BucketId
+//
+//   bucket:
+//     name: my_bucket
+//     env: staging
+//
+// .. note::
+//   The order of ``BucketId`` keys do not matter. Buckets ``{ a: 'A', b: 'B' }`` and
+//   ``{ b: 'B', a: 'A' }`` are identical.
+message BucketId {
+  map<string, string> bucket = 1 [(validate.rules).map = {
+    min_pairs: 1
+    keys {string {min_len: 1}}
+    values {string {min_len: 1}}
+  }];
+}

--- a/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/http_inputs.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/matcher/v3/http_inputs.proto
@@ -1,0 +1,71 @@
+syntax = "proto3";
+
+package envoy.type.matcher.v3;
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.type.matcher.v3";
+option java_outer_classname = "HttpInputsProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3;matcherv3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Common HTTP inputs]
+
+// Match input indicates that matching should be done on a specific request header.
+// The resulting input string will be all headers for the given key joined by a comma,
+// e.g. if the request contains two 'foo' headers with value 'bar' and 'baz', the input
+// string will be 'bar,baz'.
+// [#comment:TODO(snowp): Link to unified matching docs.]
+// [#extension: envoy.matching.inputs.request_headers]
+message HttpRequestHeaderMatchInput {
+  // The request header to match on.
+  string header_name = 1
+      [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false}];
+}
+
+// Match input indicates that matching should be done on a specific request trailer.
+// The resulting input string will be all headers for the given key joined by a comma,
+// e.g. if the request contains two 'foo' headers with value 'bar' and 'baz', the input
+// string will be 'bar,baz'.
+// [#comment:TODO(snowp): Link to unified matching docs.]
+// [#extension: envoy.matching.inputs.request_trailers]
+message HttpRequestTrailerMatchInput {
+  // The request trailer to match on.
+  string header_name = 1
+      [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false}];
+}
+
+// Match input indicating that matching should be done on a specific response header.
+// The resulting input string will be all headers for the given key joined by a comma,
+// e.g. if the response contains two 'foo' headers with value 'bar' and 'baz', the input
+// string will be 'bar,baz'.
+// [#comment:TODO(snowp): Link to unified matching docs.]
+// [#extension: envoy.matching.inputs.response_headers]
+message HttpResponseHeaderMatchInput {
+  // The response header to match on.
+  string header_name = 1
+      [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false}];
+}
+
+// Match input indicates that matching should be done on a specific response trailer.
+// The resulting input string will be all headers for the given key joined by a comma,
+// e.g. if the request contains two 'foo' headers with value 'bar' and 'baz', the input
+// string will be 'bar,baz'.
+// [#comment:TODO(snowp): Link to unified matching docs.]
+// [#extension: envoy.matching.inputs.response_trailers]
+message HttpResponseTrailerMatchInput {
+  // The response trailer to match on.
+  string header_name = 1
+      [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false}];
+}
+
+// Match input indicates that matching should be done on a specific query parameter.
+// The resulting input string will be the first query parameter for the value
+// 'query_param'.
+// [#extension: envoy.matching.inputs.query_params]
+message HttpRequestQueryParamMatchInput {
+  // The query parameter to match on.
+  string query_param = 1 [(validate.rules).string = {min_len: 1}];
+}

--- a/xds/third_party/envoy/src/main/proto/envoy/type/v3/http_status.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/v3/http_status.proto
@@ -1,0 +1,143 @@
+syntax = "proto3";
+
+package envoy.type.v3;
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.type.v3";
+option java_outer_classname = "HttpStatusProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/v3;typev3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: HTTP status codes]
+
+// HTTP response codes supported in Envoy.
+// For more details: https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+enum StatusCode {
+  // Empty - This code not part of the HTTP status code specification, but it is needed for proto
+  // `enum` type.
+  Empty = 0;
+
+  Continue = 100;
+
+  OK = 200;
+
+  Created = 201;
+
+  Accepted = 202;
+
+  NonAuthoritativeInformation = 203;
+
+  NoContent = 204;
+
+  ResetContent = 205;
+
+  PartialContent = 206;
+
+  MultiStatus = 207;
+
+  AlreadyReported = 208;
+
+  IMUsed = 226;
+
+  MultipleChoices = 300;
+
+  MovedPermanently = 301;
+
+  Found = 302;
+
+  SeeOther = 303;
+
+  NotModified = 304;
+
+  UseProxy = 305;
+
+  TemporaryRedirect = 307;
+
+  PermanentRedirect = 308;
+
+  BadRequest = 400;
+
+  Unauthorized = 401;
+
+  PaymentRequired = 402;
+
+  Forbidden = 403;
+
+  NotFound = 404;
+
+  MethodNotAllowed = 405;
+
+  NotAcceptable = 406;
+
+  ProxyAuthenticationRequired = 407;
+
+  RequestTimeout = 408;
+
+  Conflict = 409;
+
+  Gone = 410;
+
+  LengthRequired = 411;
+
+  PreconditionFailed = 412;
+
+  PayloadTooLarge = 413;
+
+  URITooLong = 414;
+
+  UnsupportedMediaType = 415;
+
+  RangeNotSatisfiable = 416;
+
+  ExpectationFailed = 417;
+
+  MisdirectedRequest = 421;
+
+  UnprocessableEntity = 422;
+
+  Locked = 423;
+
+  FailedDependency = 424;
+
+  UpgradeRequired = 426;
+
+  PreconditionRequired = 428;
+
+  TooManyRequests = 429;
+
+  RequestHeaderFieldsTooLarge = 431;
+
+  InternalServerError = 500;
+
+  NotImplemented = 501;
+
+  BadGateway = 502;
+
+  ServiceUnavailable = 503;
+
+  GatewayTimeout = 504;
+
+  HTTPVersionNotSupported = 505;
+
+  VariantAlsoNegotiates = 506;
+
+  InsufficientStorage = 507;
+
+  LoopDetected = 508;
+
+  NotExtended = 510;
+
+  NetworkAuthenticationRequired = 511;
+}
+
+// HTTP status.
+message HttpStatus {
+  option (udpa.annotations.versioning).previous_message_type = "envoy.type.HttpStatus";
+
+  // Supplies HTTP response code.
+  StatusCode code = 1 [(validate.rules).enum = {defined_only: true not_in: 0}];
+}

--- a/xds/third_party/envoy/src/main/proto/envoy/type/v3/ratelimit_strategy.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/v3/ratelimit_strategy.proto
@@ -1,0 +1,79 @@
+syntax = "proto3";
+
+package envoy.type.v3;
+
+import "envoy/type/v3/ratelimit_unit.proto";
+import "envoy/type/v3/token_bucket.proto";
+
+import "xds/annotations/v3/status.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.type.v3";
+option java_outer_classname = "RatelimitStrategyProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/v3;typev3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+option (xds.annotations.v3.file_status).work_in_progress = true;
+
+// [#protodoc-title: Rate Limit Strategies]
+
+message RateLimitStrategy {
+  // Choose between allow all and deny all.
+  enum BlanketRule {
+    ALLOW_ALL = 0;
+    DENY_ALL = 1;
+  }
+
+  // Best-effort limit of the number of requests per time unit.
+  //
+  // Allows to specify the desired requests per second (RPS, QPS), requests per minute (QPM, RPM),
+  // etc., without specifying a rate limiting algorithm implementation.
+  //
+  // ``RequestsPerTimeUnit`` strategy does not demand any specific rate limiting algorithm to be
+  // used (in contrast to the :ref:`TokenBucket <envoy_v3_api_msg_type.v3.TokenBucket>`,
+  // for example). It implies that the implementation details of rate limiting algorithm are
+  // irrelevant as long as the configured number of "requests per time unit" is achieved.
+  //
+  // Note that the ``TokenBucket`` is still a valid implementation of the ``RequestsPerTimeUnit``
+  // strategy, and may be chosen to enforce the rate limit. However, there's no guarantee it will be
+  // the ``TokenBucket`` in particular, and not the Leaky Bucket, the Sliding Window, or any other
+  // rate limiting algorithm that fulfills the requirements.
+  message RequestsPerTimeUnit {
+    // The desired number of requests per :ref:`time_unit
+    // <envoy_v3_api_field_type.v3.RateLimitStrategy.RequestsPerTimeUnit.time_unit>` to allow.
+    // If set to ``0``, deny all (equivalent to ``BlanketRule.DENY_ALL``).
+    //
+    // .. note::
+    //   Note that the algorithm implementation determines the course of action for the requests
+    //   over the limit. As long as the ``requests_per_time_unit`` converges on the desired value,
+    //   it's allowed to treat this field as a soft-limit: allow bursts, redistribute the allowance
+    //   over time, etc.
+    //
+    uint64 requests_per_time_unit = 1;
+
+    // The unit of time. Ignored when :ref:`requests_per_time_unit
+    // <envoy_v3_api_field_type.v3.RateLimitStrategy.RequestsPerTimeUnit.requests_per_time_unit>`
+    // is ``0`` (deny all).
+    RateLimitUnit time_unit = 2 [(validate.rules).enum = {defined_only: true}];
+  }
+
+  oneof strategy {
+    option (validate.required) = true;
+
+    // Allow or Deny the requests.
+    // If unset, allow all.
+    BlanketRule blanket_rule = 1 [(validate.rules).enum = {defined_only: true}];
+
+    // Best-effort limit of the number of requests per time unit, f.e. requests per second.
+    // Does not prescribe any specific rate limiting algorithm, see :ref:`RequestsPerTimeUnit
+    // <envoy_v3_api_msg_type.v3.RateLimitStrategy.RequestsPerTimeUnit>` for details.
+    RequestsPerTimeUnit requests_per_time_unit = 2;
+
+    // Limit the requests by consuming tokens from the Token Bucket.
+    // Allow the same number of requests as the number of tokens available in
+    // the token bucket.
+    TokenBucket token_bucket = 3;
+  }
+}

--- a/xds/third_party/envoy/src/main/proto/envoy/type/v3/ratelimit_unit.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/v3/ratelimit_unit.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+package envoy.type.v3;
+
+import "udpa/annotations/status.proto";
+
+option java_package = "io.envoyproxy.envoy.type.v3";
+option java_outer_classname = "RatelimitUnitProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/v3;typev3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Ratelimit Time Unit]
+
+// Identifies the unit of of time for rate limit.
+enum RateLimitUnit {
+  // The time unit is not known.
+  UNKNOWN = 0;
+
+  // The time unit representing a second.
+  SECOND = 1;
+
+  // The time unit representing a minute.
+  MINUTE = 2;
+
+  // The time unit representing an hour.
+  HOUR = 3;
+
+  // The time unit representing a day.
+  DAY = 4;
+
+  // The time unit representing a month.
+  MONTH = 5;
+
+  // The time unit representing a year.
+  YEAR = 6;
+}

--- a/xds/third_party/envoy/src/main/proto/envoy/type/v3/token_bucket.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/v3/token_bucket.proto
@@ -1,0 +1,39 @@
+syntax = "proto3";
+
+package envoy.type.v3;
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/wrappers.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.type.v3";
+option java_outer_classname = "TokenBucketProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/type/v3;typev3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Token bucket]
+
+// Configures a token bucket, typically used for rate limiting.
+message TokenBucket {
+  option (udpa.annotations.versioning).previous_message_type = "envoy.type.TokenBucket";
+
+  // The maximum tokens that the bucket can hold. This is also the number of tokens that the bucket
+  // initially contains.
+  uint32 max_tokens = 1 [(validate.rules).uint32 = {gt: 0}];
+
+  // The number of tokens added to the bucket during each fill interval. If not specified, defaults
+  // to a single token.
+  google.protobuf.UInt32Value tokens_per_fill = 2 [(validate.rules).uint32 = {gt: 0}];
+
+  // The fill interval that tokens are added to the bucket. During each fill interval
+  // ``tokens_per_fill`` are added to the bucket. The bucket will never contain more than
+  // ``max_tokens`` tokens.
+  google.protobuf.Duration fill_interval = 3 [(validate.rules).duration = {
+    required: true
+    gt {}
+  }];
+}

--- a/xds/third_party/xds/import.sh
+++ b/xds/third_party/xds/import.sh
@@ -45,9 +45,12 @@ xds/core/v3/resource_locator.proto
 xds/core/v3/resource_name.proto
 xds/data/orca/v3/orca_load_report.proto
 xds/service/orca/v3/orca.proto
+xds/type/matcher/v3/cel.proto
 xds/type/matcher/v3/matcher.proto
 xds/type/matcher/v3/regex.proto
 xds/type/matcher/v3/string.proto
+xds/type/v3/cel.proto
+xds/type/matcher/v3/http_inputs.proto
 xds/type/v3/typed_struct.proto
 )
 

--- a/xds/third_party/xds/src/main/proto/xds/type/matcher/v3/cel.proto
+++ b/xds/third_party/xds/src/main/proto/xds/type/matcher/v3/cel.proto
@@ -1,0 +1,42 @@
+syntax = "proto3";
+
+package xds.type.matcher.v3;
+
+import "xds/annotations/v3/status.proto";
+import "xds/type/v3/cel.proto";
+
+import "validate/validate.proto";
+
+option java_package = "com.github.xds.type.matcher.v3";
+option java_outer_classname = "CelProto";
+option java_multiple_files = true;
+option go_package = "github.com/cncf/xds/go/xds/type/matcher/v3";
+
+option (xds.annotations.v3.file_status).work_in_progress = true;
+
+// [#protodoc-title: Common Expression Language (CEL) matchers]
+
+// Performs a match by evaluating a `Common Expression Language
+// <https://github.com/google/cel-spec>`_ (CEL) expression against the standardized set of
+// :ref:`HTTP attributes <arch_overview_attributes>` specified via ``HttpAttributesCelMatchInput``.
+//
+// .. attention::
+//
+//   The match is ``true``, iff the result of the evaluation is a bool AND true.
+//   In all other cases, the match is ``false``, including but not limited to: non-bool types,
+//   ``false``, ``null``,`` int(1)``, etc.
+//   In case CEL expression raises an error, the result of the evaluation is interpreted "no match".
+//
+// Refer to :ref:`Unified Matcher API <envoy_v3_api_msg_.xds.type.matcher.v3.Matcher>` documentation
+// for usage details.
+//
+// [#comment:TODO(sergiitk): Link HttpAttributesMatchInput + usage example.]
+// [#comment:TODO(sergiitk): When implemented, add the extension tag.]
+message CelMatcher {
+  // Either parsed or checked representation of the CEL program.
+  type.v3.CelExpression expr_match = 1 [(validate.rules).message = {required: true}];
+
+  // Free-form description of the CEL AST, e.g. the original expression text, to be
+  // used for debugging assistance.
+  string description = 2;
+}

--- a/xds/third_party/xds/src/main/proto/xds/type/matcher/v3/http_inputs.proto
+++ b/xds/third_party/xds/src/main/proto/xds/type/matcher/v3/http_inputs.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+package xds.type.matcher.v3;
+
+import "xds/annotations/v3/status.proto";
+
+option java_package = "com.github.xds.type.matcher.v3";
+option java_outer_classname = "HttpInputsProto";
+option java_multiple_files = true;
+option go_package = "github.com/cncf/xds/go/xds/type/matcher/v3";
+
+option (xds.annotations.v3.file_status).work_in_progress = true;
+
+// [#protodoc-title: Common HTTP Inputs]
+
+// Specifies that matching should be performed on the set of :ref:`HTTP attributes
+// <arch_overview_attributes>`.
+//
+// The attributes will be exposed via `Common Expression Language
+// <https://github.com/google/cel-spec>`_ runtime to associated CEL matcher.
+//
+// Refer to :ref:`Unified Matcher API <envoy_v3_api_msg_.xds.type.matcher.v3.Matcher>` documentation
+// for usage details.
+//
+// [#comment:TODO(sergiitk): When implemented, add the extension tag.]
+message HttpAttributesCelMatchInput {
+}

--- a/xds/third_party/xds/src/main/proto/xds/type/v3/cel.proto
+++ b/xds/third_party/xds/src/main/proto/xds/type/v3/cel.proto
@@ -1,0 +1,70 @@
+syntax = "proto3";
+
+package xds.type.v3;
+
+import "google/api/expr/v1alpha1/checked.proto";
+import "google/api/expr/v1alpha1/syntax.proto";
+import "cel/expr/checked.proto";
+import "cel/expr/syntax.proto";
+import "google/protobuf/wrappers.proto";
+
+import "xds/annotations/v3/status.proto";
+
+import "validate/validate.proto";
+
+option java_package = "com.github.xds.type.v3";
+option java_outer_classname = "CelProto";
+option java_multiple_files = true;
+option go_package = "github.com/cncf/xds/go/xds/type/v3";
+
+option (xds.annotations.v3.file_status).work_in_progress = true;
+
+// [#protodoc-title: Common Expression Language (CEL)]
+
+// Either parsed or checked representation of the `Common Expression Language
+// <https://github.com/google/cel-spec>`_ (CEL) program.
+message CelExpression {
+  oneof expr_specifier {
+    // Parsed expression in abstract syntax tree (AST) form.
+    //
+    // Deprecated -- use ``cel_expr_parsed`` field instead.
+    // If ``cel_expr_parsed`` or ``cel_expr_checked`` is set, this field is not used.
+    google.api.expr.v1alpha1.ParsedExpr parsed_expr = 1  [deprecated = true];
+
+    // Parsed expression in abstract syntax tree (AST) form that has been successfully type checked.
+    //
+    // Deprecated -- use ``cel_expr_checked`` field instead.
+    // If ``cel_expr_parsed`` or ``cel_expr_checked`` is set, this field is not used.
+    google.api.expr.v1alpha1.CheckedExpr checked_expr = 2  [deprecated = true];
+  }
+
+  // Parsed expression in abstract syntax tree (AST) form.
+  //
+  // If ``cel_expr_checked`` is set, this field is not used.
+  cel.expr.ParsedExpr cel_expr_parsed = 3;
+
+  // Parsed expression in abstract syntax tree (AST) form that has been successfully type checked.
+  //
+  // If set, takes precedence over ``cel_expr_parsed``.
+  cel.expr.CheckedExpr cel_expr_checked = 4;
+}
+
+// Extracts a string by evaluating a `Common Expression Language
+// <https://github.com/google/cel-spec>`_ (CEL) expression against the standardized set of
+// :ref:`HTTP attributes <arch_overview_attributes>`.
+//
+// .. attention::
+//
+//   Besides CEL evaluation raising an error explicitly, CEL program returning a type other than
+//   the ``string``, or not returning anything, are considered an error as well.
+//
+// [#comment:TODO(sergiitk): When implemented, add the extension tag.]
+message CelExtractString {
+  // The CEL expression used to extract a string from the CEL environment.
+  // the "subject string") that should be replaced.
+  CelExpression expr_extract = 1 [(validate.rules).message = {required: true}];
+
+  // If CEL expression evaluates to an error, this value is be returned to the caller.
+  // If not set, the error is propagated to the caller.
+  google.protobuf.StringValue default_value = 2;
+}


### PR DESCRIPTION
Imports the protos of Rate Limiting Quota Service (RLQS) and Rate Limit Quota HTTP Filter.

Note: the list below only shows the new top-level protos, and excludes their direct and transitional dependencies (those from import statements).

#### RLQS Imports
- Service — envoy/service/rate_limit_quota/v3/rlqs.proto (Service): 7b8a304
- HTTP Filter — envoy/extensions/filters/http/rate_limit_quota/v3/rate_limit_quota.proto: 49c77c4

#### CEL Imports
- Initial third-party repo setup: 99a64bd
- Parsed CEL Expression: cel/expr/syntax.proto: 99a64bd
- Parsed and type-checked CEL Expression: cel/expr/checked.proto: 99a64bd


#### Required typed_config extensions
##### `bucket_matchers` predicate input
- `HttpAttributesCelMatchInput` — xds/type/matcher/v3/http_inputs.proto: 54924e0
- `HttpRequestHeaderMatchInput` — envoy/type/matcher/v3/http_inputs.proto: 49c77c4

##### `bucket_matchers` predicate custom_match
- `CelMatcher` — xds/type/matcher/v3/cel.proto: 54924e0

