### PR TITLE
Revert "Enable new PickFirst LB"

### DIFF
--- a/core/src/main/java/io/grpc/internal/PickFirstLoadBalancerProvider.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLoadBalancerProvider.java
@@ -37,7 +37,7 @@ public final class PickFirstLoadBalancerProvider extends LoadBalancerProvider {
   private static final String SHUFFLE_ADDRESS_LIST_KEY = "shuffleAddressList";
 
   private static boolean enableNewPickFirst =
-      GrpcUtil.getFlag("GRPC_EXPERIMENTAL_ENABLE_NEW_PICK_FIRST", true);
+      GrpcUtil.getFlag("GRPC_EXPERIMENTAL_ENABLE_NEW_PICK_FIRST", false);
 
   public static boolean isEnabledHappyEyeballs() {
 


### PR DESCRIPTION
Reverts grpc/grpc-java#11348

Traffic increase still present in Android (GMS) as reported in b/356143949