### PR TITLE
Allow to send empty subscription and update version afterward (1.66.x backport)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
+++ b/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
@@ -152,8 +152,14 @@ final class ControlPlaneClient {
       startRpcStream();
     }
     Collection<String> resources = resourceStore.getSubscribedResources(serverInfo, resourceType);
-    if (resources != null) {
-      adsStream.sendDiscoveryRequest(resourceType, resources);
+    if (resources == null) {
+      resources = Collections.emptyList();
+    }
+    adsStream.sendDiscoveryRequest(resourceType, resources);
+    if (resources.isEmpty()) {
+      // The resource type no longer has subscribing resources; clean up references to it
+      versions.remove(resourceType);
+      adsStream.respNonces.remove(resourceType);
     }
   }
 

--- a/xds/src/main/java/io/grpc/xds/client/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/client/XdsClientImpl.java
@@ -281,7 +281,7 @@ public final class XdsClientImpl extends XdsClient implements XdsResponseHandler
       @SuppressWarnings("unchecked")
       public void run() {
         ResourceSubscriber<T> subscriber =
-            (ResourceSubscriber<T>) resourceSubscribers.get(type).get(resourceName);;
+            (ResourceSubscriber<T>) resourceSubscribers.get(type).get(resourceName);
         subscriber.removeWatcher(watcher);
         if (!subscriber.isWatched()) {
           subscriber.cancelResourceWatch();

--- a/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplV3Test.java
+++ b/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplV3Test.java
@@ -118,6 +118,7 @@ import org.junit.runners.Parameterized.Parameters;
 import org.mockito.ArgumentMatcher;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
+import org.mockito.verification.VerificationMode;
 
 /**
  * Tests for {@link XdsClientImpl} with protocol version v3.
@@ -205,8 +206,8 @@ public class GrpcXdsClientImplV3Test extends GrpcXdsClientImplTestBase {
     @Override
     protected void verifyRequest(
         XdsResourceType<?> type, List<String> resources, String versionInfo, String nonce,
-        EnvoyProtoData.Node node) {
-      verify(requestObserver, Mockito.timeout(2000)).onNext(argThat(new DiscoveryRequestMatcher(
+        EnvoyProtoData.Node node, VerificationMode verificationMode) {
+      verify(requestObserver, verificationMode).onNext(argThat(new DiscoveryRequestMatcher(
           node.toEnvoyProtoNode(), versionInfo, resources, type.typeUrl(), nonce, null, null)));
     }
 


### PR DESCRIPTION
Closes #11232 

As described in the original issue:

If a CDS update revoke all subscribed resources, all EDS subscriptions will be cancelled. 

### adjustResourceSubscription issue

The first observation of the `istiod` logs is,

```
>>>>> CDS PUSH
2024-06-04T08:30:16.705222Z	info	ads	CDS: PUSH for node:e2e-service-consumer-base-5dd4cb9fbf-v6gjk.default resources:0 size:0B nonce:af2f0bd1-c785-4232-b381-de703b6e3e7d version:2024-06-04T08:30:16Z/7
>>>>> EDS PUSH immediately after CDS
2024-06-04T08:30:16.705384Z	info	ads	EDS: PUSH for node:e2e-service-consumer-base-5dd4cb9fbf-v6gjk.default resources:2 size:395B empty:0 cached:0/2 nonce:cea5b0b2-82d7-4c81-99cc-744ae9a7948e version:2024-06-04T08:30:16Z/7
2024-06-04T08:30:16.705464Z	debug	grpcgen	building lds for e2e-service-consumer-base-5dd4cb9fbf-v6gjk.default with filter:
map[e2e-service-provider.default.svc.cluster.local:{map[e2e-service-provider.default.svc.cluster.local:{}] map[80:{}]}]
2024-06-04T08:30:16.705535Z	info	ads	LDS: PUSH for node:e2e-service-consumer-base-5dd4cb9fbf-v6gjk.default resources:1 size:450B nonce:29cd5728-2464-48b7-ac40-1acb5bd2bc22 version:2024-06-04T08:30:16Z/7
2024-06-04T08:30:16.706144Z	info	ads	RDS: PUSH for node:e2e-service-consumer-base-5dd4cb9fbf-v6gjk.default resources:1 size:4.8kB nonce:1866c85b-4695-4b37-91b0-d9cb844b4181 version:2024-06-04T08:30:16Z/7
2024-06-04T08:30:16.710333Z	debug	ads	ADS:CDS: REQ e2e-service-consumer-base-5dd4cb9fbf-v6gjk.default-1 resources:2 nonce:af2f0bd1-c785-4232-b381-de703b6e3e7d version:2024-06-04T08:30:16Z/7 
2024-06-04T08:30:16.710475Z	debug	ads	ADS:CDS: ACK e2e-service-consumer-base-5dd4cb9fbf-v6gjk.default-1 2024-06-04T08:30:16Z/7 af2f0bd1-c785-4232-b381-de703b6e3e7d
2024-06-04T08:30:16.713459Z	debug	ads	ADS:EDS: REQ e2e-service-consumer-base-5dd4cb9fbf-v6gjk.default-1 resources:1 nonce:2dd9df3c-e64c-4a8e-9787-429e5dcf2719 version:2024-06-04T08:30:14Z/6 
2024-06-04T08:30:16.713508Z	debug	ads	ADS:EDS: REQ e2e-service-consumer-base-5dd4cb9fbf-v6gjk.default-1 Expired nonce received 2dd9df3c-e64c-4a8e-9787-429e5dcf2719, sent cea5b0b2-82d7-4c81-99cc-744ae9a7948e
>>>>>> NO resources:0 REQ log
2024-06-04T08:30:16.718041Z	debug	ads	ADS:LDS: REQ e2e-service-consumer-base-5dd4cb9fbf-v6gjk.default-1 resources:1 nonce:29cd5728-2464-48b7-ac40-1acb5bd2bc22 version:2024-06-04T08:30:16Z/7 
2024-06-04T08:30:16.718084Z	debug	ads	ADS:LDS: ACK e2e-service-consumer-base-5dd4cb9fbf-v6gjk.default-1 2024-06-04T08:30:16Z/7 29cd5728-2464-48b7-ac40-1acb5bd2bc22
```

If EDS is empty, `adjustResourceSubscription` does not work. 

### resourceVersion update issue

If all resources are removed from a type, e.g.  EDS, `subscribedResourceTypeUrls` entry will be also removed. This will prevent nonce being updated from the upstream EDS PUSH.

Backport of #11264