### PR TITLE
interop-testing: Remove unused implementation deps

### DIFF
--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -13,12 +13,9 @@ dependencies {
     implementation project(path: ':grpc-alts', configuration: 'shadow'),
             project(':grpc-auth'),
             project(':grpc-census'),
-            project(':grpc-core'),
             project(':grpc-gcp-csm-observability'),
-            project(':grpc-googleapis'),
             project(':grpc-netty'),
             project(':grpc-okhttp'),
-            project(':grpc-rls'),
             project(':grpc-services'),
             project(':grpc-testing'),
             project(':grpc-protobuf-lite'),
@@ -45,6 +42,7 @@ dependencies {
             libraries.netty.tcnative,
             libraries.netty.tcnative.classes,
             libraries.opentelemetry.exporter.prometheus, // For xds interop client
+            project(':grpc-googleapis'),
             project(':grpc-grpclb'),
             project(':grpc-rls')
     testImplementation testFixtures(project(':grpc-api')),


### PR DESCRIPTION
googleapis and rls can still be used at runtime.