### PR TITLE
CONTRIBUTING.md: Update commit guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,43 +30,36 @@ style configurations are commonly useful. For IntelliJ 14, copy the style to
 `~/.IdeaIC14/config/codestyles/`, start IntelliJ, go to File > Settings > Code
 Style, and set the Scheme to `GoogleStyle`.
 
-## Maintaining clean commit history
-
-We have few conventions for keeping history clean and making code reviews easier
-for reviewers:
-
-* First line of commit messages should be in format of
-
-  `package-name: summary of change`
-
-  where the summary finishes the sentence: `This commit improves gRPC to ____________.`
-
-  for example:
-
-  `core,netty,interop-testing: add capacitive duractance to turbo encabulators`
-
-* Every time you receive a feedback on your pull request, push changes that
-  address it as a separate one or multiple commits with a descriptive commit
-  message (try avoid using vauge `addressed pr feedback` type of messages).
-
-  Project maintainers are obligated to squash those commits into one when
-  merging.
-
 ## Guidelines for Pull Requests
 How to get your contributions merged smoothly and quickly.
  
 - Create **small PRs** that are narrowly focused on **addressing a single concern**. We often times receive PRs that are trying to fix several things at a time, but only one fix is considered acceptable, nothing gets merged and both author's & review's time is wasted. Create more PRs to address different concerns and everyone will be happy.
  
-- For speculative changes, consider opening an issue and discussing it first. If you are suggesting a behavioral or API change, consider starting with a [gRFC proposal](https://github.com/grpc/proposal). 
- 
-- Provide a good **PR description** as a record of **what** change is being made and **why** it was made. Link to a github issue if it exists.
- 
-- Don't fix code style and formatting unless you are already changing that line to address an issue. PRs with irrelevant changes won't be merged. If you do want to fix formatting or style, do that in a separate PR.
- 
-- Unless your PR is trivial, you should expect there will be reviewer comments that you'll need to address before merging. We expect you to be reasonably responsive to those comments, otherwise the PR will be closed after 2-3 weeks of inactivity.
- 
-- Maintain **clean commit history** and use **meaningful commit messages**. See [maintaining clean commit history](#maintaining-clean-commit-history) for details.
- 
+- For speculative changes, consider opening an issue and discussing it to avoid
+  wasting time on an inappropriate approach. If you are suggesting a behavioral
+  or API change, consider starting with a [gRFC
+  proposal](https://github.com/grpc/proposal).
+
+- Follow [typical Git commit message](https://cbea.ms/git-commit/#seven-rules)
+  structure. Have a good **commit description** as a record of **what** and
+  **why** the change is being made. Link to a GitHub issue if it exists. The
+  commit description makes a good PR description and is auto-copied by GitHub if
+  you have a single commit when creating the PR.
+
+  If your change is mostly for a single module (other module changes are
+  trivial), prefix your commit summary with the module name changed. Instead of
+  "Add HTTP/2 faster-than-light support to gRPC Netty" it is more terse as
+  "netty: Add faster-than-light support".
+
+- Don't fix code style and formatting unless you are already changing that line
+  to address an issue. If you do want to fix formatting or style, do that in a
+  separate PR.
+
+- Unless your PR is trivial, you should expect there will be reviewer comments
+  that you'll need to address before merging. Make review changes as additional
+  commits so the reviewer can review just the changes; do not squash reviewed
+  commits unless the reviewer agrees. PRs are squashed when merging.
+
 - Keep your PR up to date with upstream/master (if there are merge conflicts, we can't really merge your change).
 
 - **All tests need to be passing** before your change can be merged. We recommend you **run tests locally** before creating your PR to catch breakages early on. Also, `./gradlew build` (`gradlew build` on Windows) **must not introduce any new warnings**.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ How to get your contributions merged smoothly and quickly.
   commit description makes a good PR description and is auto-copied by GitHub if
   you have a single commit when creating the PR.
 
-  If your change is mostly for a single module (other module changes are
+  If your change is mostly for a single module (e.g., other module changes are
   trivial), prefix your commit summary with the module name changed. Instead of
   "Add HTTP/2 faster-than-light support to gRPC Netty" it is more terse as
   "netty: Add faster-than-light support".

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ How to get your contributions merged smoothly and quickly.
   separate PR.
 
 - Unless your PR is trivial, you should expect there will be reviewer comments
-  that you'll need to address before merging. Make review changes as additional
+  that you'll need to address before merging. Address comments with additional
   commits so the reviewer can review just the changes; do not squash reviewed
   commits unless the reviewer agrees. PRs are squashed when merging.
 


### PR DESCRIPTION
It came up in #11073, and I saw it could use a little updating. Notably, I'm linking to a guide to what Git commit messages should look like. I also tried to make the language less heavy-handed and demanding.

-----

I do think there's more that can be done, but I think this is a step in the right direction. It's obvious the IntelliJ style mention is out-of-date, for example.