### PR TITLE
xds: Remove useless ExperimentalApi for WRR

### DIFF
--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -30,7 +30,6 @@ import io.grpc.ConnectivityStateInfo;
 import io.grpc.Deadline.Ticker;
 import io.grpc.DoubleHistogramMetricInstrument;
 import io.grpc.EquivalentAddressGroup;
-import io.grpc.ExperimentalApi;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.LongCounterMetricInstrument;
@@ -89,7 +88,6 @@ import java.util.logging.Logger;
  *  </pre>
  *  See related documentation: https://cloud.google.com/service-mesh/legacy/load-balancing-apis/proxyless-configure-advanced-traffic-management#custom-lb-config
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/9885")
 final class WeightedRoundRobinLoadBalancer extends MultiChildLoadBalancer {
 
   private static final LongCounterMetricInstrument RR_FALLBACK_COUNTER;

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancerProvider.java
@@ -18,7 +18,6 @@ package io.grpc.xds;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.Deadline;
-import io.grpc.ExperimentalApi;
 import io.grpc.Internal;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
@@ -32,7 +31,6 @@ import java.util.Map;
 /**
  * Provides a {@link WeightedRoundRobinLoadBalancer}.
  * */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/9885")
 @Internal
 public final class WeightedRoundRobinLoadBalancerProvider extends LoadBalancerProvider {
 


### PR DESCRIPTION
A package-private class isn't visible and `@Internal` is stronger than experimental. The only way users should use WRR is via the weight_round_robin string, and that's already not suffixed with _experimental.

Closes #9885