### PR TITLE
xds: WRRPicker must not access unsynchronized data in ChildLbState

### DIFF
--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -261,6 +261,7 @@ final class WeightedRoundRobinLoadBalancer extends MultiChildLoadBalancer {
               ImmutableList.of(locality));
       newWeights[i] = newWeight > 0 ? (float) newWeight : 0.0f;
     }
+
     if (staleEndpoints.get() > 0) {
       helper.getMetricRecorder()
           .addLongCounter(ENDPOINT_WEIGHT_STALE_COUNTER, staleEndpoints.get(),
@@ -272,7 +273,6 @@ final class WeightedRoundRobinLoadBalancer extends MultiChildLoadBalancer {
           .addLongCounter(ENDPOINT_WEIGHT_NOT_YET_USEABLE_COUNTER, notYetUsableEndpoints.get(),
               ImmutableList.of(helper.getChannelTarget()), ImmutableList.of(locality));
     }
-
     boolean weightsEffective = picker.updateWeight(newWeights);
     if (!weightsEffective) {
       helper.getMetricRecorder()
@@ -472,6 +472,9 @@ final class WeightedRoundRobinLoadBalancer extends MultiChildLoadBalancer {
 
   @VisibleForTesting
   static final class WeightedRoundRobinPicker extends SubchannelPicker {
+    // Parallel lists (column-based storage instead of normal row-based storage of List<Struct>).
+    // The ith element of children corresponds to the ith element of pickers, listeners, and even
+    // updateWeight(float[]).
     private final List<ChildLbState> children; // May only be accessed from sync context
     private final List<SubchannelPicker> pickers;
     private final List<OrcaPerRequestReportListener> reportListeners;

--- a/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
@@ -244,7 +244,7 @@ public class WeightedRoundRobinLoadBalancerTest {
     String weightedPickerStr = weightedPicker.toString();
     assertThat(weightedPickerStr).contains("enableOobLoadReport=false");
     assertThat(weightedPickerStr).contains("errorUtilizationPenalty=1.0");
-    assertThat(weightedPickerStr).contains("list=");
+    assertThat(weightedPickerStr).contains("pickers=");
 
     WeightedChildLbState weightedChild1 = (WeightedChildLbState) getChild(weightedPicker, 0);
     WeightedChildLbState weightedChild2 = (WeightedChildLbState) getChild(weightedPicker, 1);


### PR DESCRIPTION
There was no point to using subchannels as keys to subchannelToReportListenerMap, as the listener is per-child. That meant the keys would be guaranteed to be known ahead-of-time and the unsynchronized getOrCreateOrcaListener() during picking was unnecessary.

The picker still stores ChildLbStates to make sure that updating weights uses the correct children, but the picker itself no longer references ChildLbStates except in the constructor. That means weight calculation is moved into the LB policy, as child.getWeight() is unsynchronized, and the picker no longer needs a reference to helper.