### PR TITLE
util: SocketAddress.toString() cannot be used for equality

### DIFF
--- a/util/src/test/java/io/grpc/util/MultiChildLoadBalancerTest.java
+++ b/util/src/test/java/io/grpc/util/MultiChildLoadBalancerTest.java
@@ -21,7 +21,6 @@ import static io.grpc.ConnectivityState.CONNECTING;
 import static io.grpc.ConnectivityState.READY;
 import static io.grpc.ConnectivityState.SHUTDOWN;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.AdditionalAnswers.delegatesTo;
@@ -34,6 +33,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.google.common.collect.Lists;
+import com.google.common.testing.EqualsTester;
 import io.grpc.Attributes;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
@@ -244,37 +244,28 @@ public class MultiChildLoadBalancerTest {
 
   @Test
   public void testEndpoint_equals() {
-    assertEquals(
-        createEndpoint(Attributes.EMPTY, "addr1"),
-        createEndpoint(Attributes.EMPTY, "addr1"));
-
-    assertEquals(
-        createEndpoint(Attributes.EMPTY, "addr1", "addr2"),
-        createEndpoint(Attributes.EMPTY, "addr2", "addr1"));
-
-    assertEquals(
-        createEndpoint(Attributes.EMPTY, "addr1", "addr2"),
-        createEndpoint(affinity, "addr2", "addr1"));
-
-    assertEquals(
-        createEndpoint(Attributes.EMPTY, "addr1", "addr2").hashCode(),
-        createEndpoint(affinity, "addr2", "addr1").hashCode());
-
-  }
-
-  @Test
-  public void testEndpoint_notEquals() {
-    assertNotEquals(
-        createEndpoint(Attributes.EMPTY, "addr1", "addr2"),
-        createEndpoint(Attributes.EMPTY, "addr1", "addr3"));
-
-    assertNotEquals(
-        createEndpoint(Attributes.EMPTY, "addr1"),
-        createEndpoint(Attributes.EMPTY, "addr1", "addr2"));
-
-    assertNotEquals(
-        createEndpoint(Attributes.EMPTY, "addr1", "addr2"),
-        createEndpoint(Attributes.EMPTY, "addr1"));
+    new EqualsTester()
+        .addEqualityGroup(
+            createEndpoint(Attributes.EMPTY, "addr1"),
+            createEndpoint(Attributes.EMPTY, "addr1"))
+        .addEqualityGroup(
+            createEndpoint(Attributes.EMPTY, "addr1", "addr2"),
+            createEndpoint(Attributes.EMPTY, "addr2", "addr1"),
+            createEndpoint(affinity, "addr1", "addr2"))
+        .addEqualityGroup(
+            createEndpoint(Attributes.EMPTY, "addr1", "addr3"))
+        .addEqualityGroup(
+            createEndpoint(Attributes.EMPTY, "addr1", "addr2", "addr3", "addr4", "addr5", "addr6",
+              "addr7", "addr8", "addr9", "addr10"),
+            createEndpoint(Attributes.EMPTY, "addr2", "addr1", "addr3", "addr4", "addr5", "addr6",
+              "addr7", "addr8", "addr9", "addr10"))
+        .addEqualityGroup(
+            createEndpoint(Attributes.EMPTY, "addr1", "addr2", "addr3", "addr4", "addr5", "addr6",
+              "addr7", "addr8", "addr9", "addr11"))
+        .addEqualityGroup(
+            createEndpoint(Attributes.EMPTY, "addr1", "addr2", "addr3", "addr4", "addr5", "addr6",
+              "addr7", "addr8", "addr9", "addr10", "addr11"))
+        .testEquals();
   }
 
   private String addressesOnlyString(EquivalentAddressGroup eag) {

--- a/util/src/testFixtures/java/io/grpc/util/AbstractTestHelper.java
+++ b/util/src/testFixtures/java/io/grpc/util/AbstractTestHelper.java
@@ -276,7 +276,7 @@ public abstract class AbstractTestHelper extends ForwardingLoadBalancerHelper {
     }
   }
 
-  public static class FakeSocketAddress extends SocketAddress {
+  public static final class FakeSocketAddress extends SocketAddress {
     private static final long serialVersionUID = 0L;
     final String name;
 
@@ -287,6 +287,20 @@ public abstract class AbstractTestHelper extends ForwardingLoadBalancerHelper {
     @Override
     public String toString() {
       return "FakeSocketAddress-" + name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof FakeSocketAddress)) {
+        return false;
+      }
+      FakeSocketAddress that = (FakeSocketAddress) o;
+      return this.name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+      return name.hashCode();
     }
   }
 }


### PR DESCRIPTION
Some addresses are equal even though their toString is different (InetSocketAddress ignores the hostname when it has an address). And some addresses are not equal even though their toString might be the same (AnonymousInProcessSocketAddress doesn't override toString()).

InetSocketAddress/InetAddress do not cache the toString() result. Thus, even in the worst case that uses a HashSet, this should use less memory than the earlier approach, as no strings are formatted. It probably also significantly improves performance in the reasonably common case when an Endpoint is created just for looking up a key, because the string creation in the constructor isn't then amorized.
updateChildrenWithResolvedAddresses(), for example, creates n^2 Endpoint objects for lookups.