### PR TITLE
xds: Delegate more RingHashLB address updates to MultiChildLB

### DIFF
--- a/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
@@ -241,7 +241,7 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
     return new AcceptResolvedAddrRetVal(Status.OK, getRemovedChildren(newChildren.keySet()));
   }
 
-  protected final void addMissingChildren(Map<Object, ChildLbState> newChildren) {
+  private void addMissingChildren(Map<Object, ChildLbState> newChildren) {
     // Do adds and identify reused children
     for (Map.Entry<Object, ChildLbState> entry : newChildren.entrySet()) {
       final Object key = entry.getKey();
@@ -251,7 +251,7 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
     }
   }
 
-  protected final void updateChildrenWithResolvedAddresses(ResolvedAddresses resolvedAddresses,
+  private void updateChildrenWithResolvedAddresses(ResolvedAddresses resolvedAddresses,
                                                      Map<Object, ChildLbState> newChildren) {
     for (Map.Entry<Object, ChildLbState> entry : newChildren.entrySet()) {
       Object childConfig = entry.getValue().getConfig();
@@ -266,7 +266,7 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
   /**
    * Identifies which children have been removed (are not part of the newChildKeys).
    */
-  protected final List<ChildLbState> getRemovedChildren(Set<Object> newChildKeys) {
+  private List<ChildLbState> getRemovedChildren(Set<Object> newChildKeys) {
     List<ChildLbState> removedChildren = new ArrayList<>();
     // Do removals
     for (Object key : ImmutableList.copyOf(childLbStates.keySet())) {


### PR DESCRIPTION
Since 04474970 RingHashLB has not used
acceptResolvedAddressesInternal(). At the time that was needed because deactivated children were part of MultiChildLB. But in 9de8e443, the logic of RingHashLB and MultiChildLB.acceptResolvedAddressesInternal() converged, so it can now swap back to using the base class for more logic.