### PR TITLE
util: Remove minor convenience functions from MultiChildLB

### DIFF
--- a/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
@@ -173,26 +173,9 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
   @Override
   public void handleNameResolutionError(Status error) {
     if (currentConnectivityState != READY)  {
-      helper.updateBalancingState(TRANSIENT_FAILURE, getErrorPicker(error));
+      helper.updateBalancingState(
+          TRANSIENT_FAILURE, new FixedResultPicker(PickResult.withError(error)));
     }
-  }
-
-  /**
-   * Handle the name resolution error only for the specified child.
-   *
-   * <p/>Override if you need special handling.
-   */
-  protected void handleNameResolutionError(ChildLbState child, Status error) {
-    child.lb.handleNameResolutionError(error);
-  }
-
-  /**
-   * Creates a new picker representing an error status.
-   *
-   * <p/>Override to produce a custom picker when there are errors.
-   */
-  protected SubchannelPicker getErrorPicker(Status error)  {
-    return new FixedResultPicker(PickResult.withError(error));
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
@@ -183,11 +183,12 @@ class ClusterManagerLoadBalancer extends MultiChildLoadBalancer {
     for (ChildLbState state : getChildLbStates()) {
       if (((ClusterManagerLbState) state).deletionTimer == null) {
         gotoTransientFailure = false;
-        handleNameResolutionError(state, error);
+        state.getLb().handleNameResolutionError(error);
       }
     }
     if (gotoTransientFailure) {
-      getHelper().updateBalancingState(TRANSIENT_FAILURE, getErrorPicker(error));
+      getHelper().updateBalancingState(
+          TRANSIENT_FAILURE, new FixedResultPicker(PickResult.withError(error)));
     }
   }
 


### PR DESCRIPTION
These were once needed to be overridden (e.g., by RoundRobinLB), but now nothing overrides them and MultiChildLB doesn't even call one of them.