### PR TITLE
util: Remove child policy config from MultiChildLB state

### DIFF
--- a/util/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
@@ -96,9 +96,8 @@ final class RoundRobinLoadBalancer extends MultiChildLoadBalancer {
   }
 
   @Override
-  protected ChildLbState createChildLbState(Object key, Object policyConfig,
-      ResolvedAddresses resolvedAddresses) {
-    return new ChildLbState(key, pickFirstLbProvider, policyConfig) {
+  protected ChildLbState createChildLbState(Object key) {
+    return new ChildLbState(key, pickFirstLbProvider) {
       @Override
       protected ChildLbStateHelper createChildHelper() {
         return new ChildLbStateHelper() {

--- a/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
@@ -70,8 +70,7 @@ class ClusterManagerLoadBalancer extends MultiChildLoadBalancer {
   }
 
   @Override
-  protected ResolvedAddresses getChildAddresses(Object key, ResolvedAddresses resolvedAddresses,
-      Object unusedChildConfig) {
+  protected ResolvedAddresses getChildAddresses(Object key, ResolvedAddresses resolvedAddresses) {
     ClusterManagerConfig config = (ClusterManagerConfig)
         resolvedAddresses.getLoadBalancingPolicyConfig();
     Object childConfig = config.childPolicies.get(key);
@@ -87,7 +86,7 @@ class ClusterManagerLoadBalancer extends MultiChildLoadBalancer {
       for (String key : config.childPolicies.keySet()) {
         ChildLbState child = getChildLbState(key);
         if (child == null) {
-          child = new ClusterManagerLbState(key, GracefulSwitchLoadBalancerFactory.INSTANCE, null);
+          child = new ClusterManagerLbState(key, GracefulSwitchLoadBalancerFactory.INSTANCE);
         }
         newChildPolicies.put(key, child);
       }
@@ -204,9 +203,8 @@ class ClusterManagerLoadBalancer extends MultiChildLoadBalancer {
     @Nullable
     ScheduledHandle deletionTimer;
 
-    public ClusterManagerLbState(Object key, LoadBalancer.Factory policyFactory,
-        Object childConfig) {
-      super(key, policyFactory, childConfig);
+    public ClusterManagerLbState(Object key, LoadBalancer.Factory policyFactory) {
+      super(key, policyFactory);
     }
 
     @Override

--- a/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancer.java
@@ -126,9 +126,8 @@ final class LeastRequestLoadBalancer extends MultiChildLoadBalancer {
   }
 
   @Override
-  protected ChildLbState createChildLbState(Object key, Object policyConfig,
-      ResolvedAddresses unused) {
-    return new LeastRequestLbState(key, pickFirstLbProvider, policyConfig);
+  protected ChildLbState createChildLbState(Object key) {
+    return new LeastRequestLbState(key, pickFirstLbProvider);
   }
 
   private void updateBalancingState(ConnectivityState state, SubchannelPicker picker) {
@@ -320,9 +319,8 @@ final class LeastRequestLoadBalancer extends MultiChildLoadBalancer {
   protected class LeastRequestLbState extends ChildLbState {
     private final AtomicInteger activeRequests = new AtomicInteger(0);
 
-    public LeastRequestLbState(Object key, LoadBalancerProvider policyProvider,
-        Object childConfig) {
-      super(key, policyProvider, childConfig);
+    public LeastRequestLbState(Object key, LoadBalancerProvider policyProvider) {
+      super(key, policyProvider);
     }
 
     int getActiveRequests() {

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -219,9 +219,8 @@ final class RingHashLoadBalancer extends MultiChildLoadBalancer {
   }
 
   @Override
-  protected ChildLbState createChildLbState(Object key, Object policyConfig,
-      ResolvedAddresses resolvedAddresses) {
-    return new ChildLbState(key, lazyLbFactory, null);
+  protected ChildLbState createChildLbState(Object key) {
+    return new ChildLbState(key, lazyLbFactory);
   }
 
   private Status validateAddrList(List<EquivalentAddressGroup> addrList) {

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -148,10 +148,8 @@ final class WeightedRoundRobinLoadBalancer extends MultiChildLoadBalancer {
   }
 
   @Override
-  protected ChildLbState createChildLbState(Object key, Object policyConfig,
-      ResolvedAddresses unused) {
-    ChildLbState childLbState = new WeightedChildLbState(key, pickFirstLbProvider, policyConfig);
-    return childLbState;
+  protected ChildLbState createChildLbState(Object key) {
+    return new WeightedChildLbState(key, pickFirstLbProvider);
   }
 
   @Override
@@ -289,9 +287,8 @@ final class WeightedRoundRobinLoadBalancer extends MultiChildLoadBalancer {
 
     private OrcaReportListener orcaReportListener;
 
-    public WeightedChildLbState(
-        Object key, LoadBalancerProvider policyProvider, Object childConfig) {
-      super(key, policyProvider, childConfig);
+    public WeightedChildLbState(Object key, LoadBalancerProvider policyProvider) {
+      super(key, policyProvider);
     }
 
     @Override


### PR DESCRIPTION
The child policy config should be refreshed every address update, so it shouldn't be stored in the ChildLbState. In addition, none of the current usages actually used what was stored in the ChildLbState in a meaningful way (it was always null).

ResolvedAddresses was also removed from createChildLbState(), as nothing in it should be needed for creation; it varies over time and the values passed at creation are immutable.