### PR TITLE
util: MultiChildLB children know if they are active

### DIFF
--- a/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
@@ -425,7 +425,7 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
       @Override
       public void updateBalancingState(final ConnectivityState newState,
           final SubchannelPicker newPicker) {
-        if (!childLbStates.containsKey(key)) {
+        if (currentState == SHUTDOWN) {
           return;
         }
 

--- a/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
@@ -262,9 +262,7 @@ class ClusterManagerLoadBalancer extends MultiChildLoadBalancer {
       @Override
       public void updateBalancingState(final ConnectivityState newState,
                                        final SubchannelPicker newPicker) {
-        // If we are already in the process of resolving addresses, the overall balancing state
-        // will be updated at the end of it, and we don't need to trigger that update here.
-        if (getChildLbState(getKey()) == null) {
+        if (getCurrentState() == ConnectivityState.SHUTDOWN) {
           return;
         }
 
@@ -272,6 +270,8 @@ class ClusterManagerLoadBalancer extends MultiChildLoadBalancer {
         // when the child instance exits deactivated state.
         setCurrentState(newState);
         setCurrentPicker(newPicker);
+        // If we are already in the process of resolving addresses, the overall balancing state
+        // will be updated at the end of it, and we don't need to trigger that update here.
         if (deletionTimer == null && !resolvingAddresses) {
           updateOverallBalancingState();
         }


### PR DESCRIPTION
No need to look up in the map to see if they are still a child.