### PR TITLE
Detect transport executors with no remaining threads

### DIFF
--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 
 task javadocs(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
-    classpath += files(android.getBootClasspath())
+    // classpath += files(android.getBootClasspath())
     classpath += files({
         android.libraryVariants.collect { variant ->
             variant.javaCompileProvider.get().classpath

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 
 task javadocs(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
-    // classpath += files(android.getBootClasspath())
+    classpath += files(android.getBootClasspath())
     classpath += files({
         android.libraryVariants.collect { variant ->
             variant.javaCompileProvider.get().classpath

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -502,6 +502,7 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
     // This runs con-concurrently with handshake and works as a hack checking enough threads are
     // available to start the transport.
     executor.execute(new Runnable() {
+      @SuppressWarnings("WaitNotInLoop")
       @Override
       public void run() {
         long waitStartTime = System.nanoTime();
@@ -513,7 +514,6 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
           }
         }
         long waitEndTime = System.nanoTime();
-        System.out.println(waitEndTime - waitStartTime);
         if (waitEndTime - waitStartTime >= 100000000) { // never got notified
           startGoAway(0, ErrorCode.INTERNAL_ERROR, Status.UNAVAILABLE
               .withDescription("Timed out waiting for second handshake thread. "

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -520,8 +520,8 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
         // network is not available during startup while another thread holding lock to send the
         // initial preface.
         try {
-          barrier.await(1000, TimeUnit.MILLISECONDS);
           latch.await();
+          barrier.await(1000, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
         } catch (TimeoutException | BrokenBarrierException e) {

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -1736,6 +1736,7 @@ public class OkHttpClientTransportTest {
         EAG_ATTRS,
         NO_PROXY,
         tooManyPingsRunnable);
+    //hi
 
     ManagedClientTransport.Listener listener = mock(ManagedClientTransport.Listener.class);
     clientTransport.start(listener);

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -251,25 +251,12 @@ public class OkHttpClientTransportTest {
   public void testTransportExecutorWithTooFewThreads() throws Exception {
     ExecutorService fixedPoolExecutor = Executors.newFixedThreadPool(1);
     channelBuilder.transportExecutor(fixedPoolExecutor);
-    InetSocketAddress address = InetSocketAddress.createUnresolved("hostname", 31415);
-    clientTransport = new OkHttpClientTransport(
-        channelBuilder.buildTransportFactory(),
-        address,
-        "hostname",
-        null,
-        EAG_ATTRS,
-        NO_PROXY,
-        tooManyPingsRunnable);
-
-    // Start the transport
-    clientTransport.start(transportListener);
+    initTransport();
     ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
     verify(transportListener, timeout(TIME_OUT_MS)).transportShutdown(statusCaptor.capture());
-
-    // Verify that the description of the captured Status is as expected
     Status capturedStatus = statusCaptor.getValue();
-    System.out.println(capturedStatus);
-    assertEquals("Handshake timed out due to insufficient threads",
+    assertEquals("Timed out waiting for second handshake thread. "
+        + "The transport executor pool may have run out of threads",
         capturedStatus.getDescription());
   }
 

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -251,7 +251,16 @@ public class OkHttpClientTransportTest {
   public void testTransportExecutorWithTooFewThreads() throws Exception {
     ExecutorService fixedPoolExecutor = Executors.newFixedThreadPool(1);
     channelBuilder.transportExecutor(fixedPoolExecutor);
-    initTransport();
+    InetSocketAddress address = InetSocketAddress.createUnresolved("hostname", 31415);
+    clientTransport = new OkHttpClientTransport(
+        channelBuilder.buildTransportFactory(),
+        address,
+        "hostname",
+        null,
+        EAG_ATTRS,
+        NO_PROXY,
+        tooManyPingsRunnable);
+    clientTransport.start(transportListener);
     ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
     verify(transportListener, timeout(TIME_OUT_MS)).transportShutdown(statusCaptor.capture());
     Status capturedStatus = statusCaptor.getValue();
@@ -1736,7 +1745,6 @@ public class OkHttpClientTransportTest {
         EAG_ATTRS,
         NO_PROXY,
         tooManyPingsRunnable);
-    //hi
 
     ManagedClientTransport.Listener listener = mock(ManagedClientTransport.Listener.class);
     clientTransport.start(listener);


### PR DESCRIPTION
Created a way to detect insufficient threads to start the transport for read and write simultaneously. 

Fixes #11271 