### PR TITLE
core: touch() buffer when detach()ing (1.66.x backport)

### DIFF
--- a/core/src/main/java/io/grpc/internal/ReadableBuffers.java
+++ b/core/src/main/java/io/grpc/internal/ReadableBuffers.java
@@ -415,6 +415,7 @@ public final class ReadableBuffers {
     public InputStream detach() {
       ReadableBuffer detachedBuffer = buffer;
       buffer = buffer.readBytes(0);
+      detachedBuffer.touch();
       return new BufferInputStream(detachedBuffer);
     }
 


### PR DESCRIPTION
Detachable lets a buffer outlive its original lifetime. The new lifetime is application-controlled. If the application fails to read/close the stream, then the leak detector wouldn't make clear what code was responsible for the buffer's lifetime. With this touch, we'll be able to see detach() was called and thus know the application needs debugging.

Realized when looking at b/364531464, although I think the issue is unrelated.

Backport of #11510