### PR TITLE
xds: Add xDS node ID in few control plane errors

### DIFF
--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
@@ -206,7 +206,7 @@ final class CdsLoadBalancer2 extends LoadBalancer {
               }
               loopStatus = Status.UNAVAILABLE.withDescription(String.format(
                   "CDS error: circular aggregate clusters directly under %s for "
-                      + "root cluster %s, named %s xDS node ID: %s",
+                      + "root cluster %s, named %s, xDS node ID: %s",
                   clusterState.name, root.name, namesCausingLoops,
                   xdsClient.getBootstrapInfo().node().getId()));
             }
@@ -225,10 +225,9 @@ final class CdsLoadBalancer2 extends LoadBalancer {
           childLb.shutdown();
           childLb = null;
         }
-        Status unavailable =
-            Status.UNAVAILABLE.withDescription(
-                "CDS error: found 0 leaf (logical DNS or EDS) clusters for root cluster "
-                    + root.name + " xDS node ID: " + xdsClient.getBootstrapInfo().node().getId());
+        Status unavailable = Status.UNAVAILABLE.withDescription(String.format(
+            "CDS error: found 0 leaf (logical DNS or EDS) clusters for root cluster %s"
+                + " xDS node ID: %s", root.name, xdsClient.getBootstrapInfo().node().getId()));
         helper.updateBalancingState(
             TRANSIENT_FAILURE, new FixedResultPicker(PickResult.withError(unavailable)));
         return;
@@ -291,10 +290,8 @@ final class CdsLoadBalancer2 extends LoadBalancer {
 
     private void handleClusterDiscoveryError(Status error) {
       String description = error.getDescription() == null ? "" : error.getDescription() + " ";
-      Status errorWithNodeId = Status.fromCode(error.getCode())
-          .withDescription(
-              description + " xDS node ID: " + xdsClient.getBootstrapInfo().node().getId())
-          .withCause(error.getCause());
+      Status errorWithNodeId = error.withDescription(
+              description + "xDS node ID: " + xdsClient.getBootstrapInfo().node().getId());
       if (childLb != null) {
         childLb.handleNameResolutionError(errorWithNodeId);
       } else {

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -815,10 +815,12 @@ final class XdsNameResolver extends NameResolver {
       // the config selector handles the error message itself. Once the LB API allows providing
       // failure information for addresses yet still providing a service config, the config seector
       // could be avoided.
+      String errorWithNodeId =
+          error + "xDS node ID: " + xdsClient.getBootstrapInfo().node().getId();
       listener.onResult(ResolutionResult.newBuilder()
           .setAttributes(Attributes.newBuilder()
             .set(InternalConfigSelector.KEY,
-              new FailingConfigSelector(Status.UNAVAILABLE.withDescription(error)))
+              new FailingConfigSelector(Status.UNAVAILABLE.withDescription(errorWithNodeId)))
             .build())
           .setServiceConfig(emptyServiceConfig)
           .build());
@@ -876,7 +878,8 @@ final class XdsNameResolver extends NameResolver {
         if (RouteDiscoveryState.this != routeDiscoveryState) {
           return;
         }
-        String error = "RDS resource does not exist: " + resourceName;
+        String error = "RDS resource does not exist: " + resourceName + " xDS node ID: "
+            + xdsClient.getBootstrapInfo().node().getId();
         logger.log(XdsLogLevel.INFO, error);
         cleanUpRoutes(error);
       }

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -816,7 +816,7 @@ final class XdsNameResolver extends NameResolver {
       // failure information for addresses yet still providing a service config, the config seector
       // could be avoided.
       String errorWithNodeId =
-          error + "xDS node ID: " + xdsClient.getBootstrapInfo().node().getId();
+          error + ", xDS node ID: " + xdsClient.getBootstrapInfo().node().getId();
       listener.onResult(ResolutionResult.newBuilder()
           .setAttributes(Attributes.newBuilder()
             .set(InternalConfigSelector.KEY,
@@ -878,8 +878,7 @@ final class XdsNameResolver extends NameResolver {
         if (RouteDiscoveryState.this != routeDiscoveryState) {
           return;
         }
-        String error = "RDS resource does not exist: " + resourceName + " xDS node ID: "
-            + xdsClient.getBootstrapInfo().node().getId();
+        String error = "RDS resource does not exist: " + resourceName;
         logger.log(XdsLogLevel.INFO, error);
         cleanUpRoutes(error);
       }

--- a/xds/src/main/java/io/grpc/xds/XdsServerWrapper.java
+++ b/xds/src/main/java/io/grpc/xds/XdsServerWrapper.java
@@ -425,9 +425,8 @@ final class XdsServerWrapper extends Server {
         return;
       }
       StatusException statusException = Status.UNAVAILABLE.withDescription(
-              "Listener " + resourceName + " unavailable" + " xDS node ID: "
-                  + xdsClient.getBootstrapInfo().node().getId())
-          .asException();
+          String.format("Listener %s unavailable, xDS node ID: %s", resourceName,
+              xdsClient.getBootstrapInfo().node().getId())).asException();
       handleConfigNotFound(statusException);
     }
 
@@ -437,10 +436,8 @@ final class XdsServerWrapper extends Server {
         return;
       }
       String description = error.getDescription() == null ? "" : error.getDescription() + " ";
-      Status errorWithNodeId = Status.fromCode(error.getCode())
-          .withDescription(
-              description + "xDS node ID: " + xdsClient.getBootstrapInfo().node().getId())
-          .withCause(error.getCause());
+      Status errorWithNodeId = error.withDescription(
+          description + "xDS node ID: " + xdsClient.getBootstrapInfo().node().getId());
       logger.log(Level.FINE, "Error from XdsClient", errorWithNodeId);
       if (!isServing) {
         listener.onNotServing(errorWithNodeId.asException());
@@ -672,10 +669,8 @@ final class XdsServerWrapper extends Server {
               return;
             }
             String description = error.getDescription() == null ? "" : error.getDescription() + " ";
-            Status errorWithNodeId = Status.fromCode(error.getCode())
-                .withDescription(
-                    description + "xDS node ID: " + xdsClient.getBootstrapInfo().node().getId())
-                .withCause(error.getCause());
+            Status errorWithNodeId = error.withDescription(
+                    description + "xDS node ID: " + xdsClient.getBootstrapInfo().node().getId());
             logger.log(Level.WARNING, "Error loading RDS resource {0} from XdsClient: {1}.",
                     new Object[]{resourceName, errorWithNodeId});
             maybeUpdateSelector();

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
@@ -525,7 +525,7 @@ public class CdsLoadBalancer2Test {
     Status unavailable = Status.UNAVAILABLE.withDescription(
         "CDS error: circular aggregate clusters directly under cluster-02.googleapis.com for root"
             + " cluster cluster-foo.googleapis.com, named [cluster-01.googleapis.com,"
-            + " cluster-02.googleapis.com]" + ", xDS node ID: " + NODE_ID);
+            + " cluster-02.googleapis.com], xDS node ID: " + NODE_ID);
     assertPicker(pickerCaptor.getValue(), unavailable, null);
   }
 
@@ -567,7 +567,7 @@ public class CdsLoadBalancer2Test {
     Status unavailable = Status.UNAVAILABLE.withDescription(
         "CDS error: circular aggregate clusters directly under cluster-02.googleapis.com for root"
             + " cluster cluster-foo.googleapis.com, named [cluster-01.googleapis.com,"
-            + " cluster-02.googleapis.com]" + ", xDS node ID: " + NODE_ID);
+            + " cluster-02.googleapis.com], xDS node ID: " + NODE_ID);
     assertPicker(pickerCaptor.getValue(), unavailable, null);
   }
 
@@ -635,7 +635,7 @@ public class CdsLoadBalancer2Test {
         eq(ConnectivityState.TRANSIENT_FAILURE), pickerCaptor.capture());
     Status expectedError = Status.UNAVAILABLE.withDescription(
         "Unable to load CDS cluster-foo.googleapis.com. xDS server returned: "
-        + "RESOURCE_EXHAUSTED: OOM" + " xDS node ID: " + NODE_ID);
+        + "RESOURCE_EXHAUSTED: OOM xDS node ID: " + NODE_ID);
     assertPicker(pickerCaptor.getValue(), expectedError, null);
     assertThat(childBalancers).isEmpty();
   }
@@ -666,7 +666,7 @@ public class CdsLoadBalancer2Test {
   @Test
   public void handleNameResolutionErrorFromUpstream_beforeChildLbCreated_returnErrorPicker() {
     Status upstreamError = Status.UNAVAILABLE.withDescription(
-        "unreachable" + " xDS node ID: " + NODE_ID);
+        "unreachable xDS node ID: " + NODE_ID);
     loadBalancer.handleNameResolutionError(upstreamError);
     verify(helper).updateBalancingState(
         eq(ConnectivityState.TRANSIENT_FAILURE), pickerCaptor.capture());

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
@@ -525,7 +525,7 @@ public class CdsLoadBalancer2Test {
     Status unavailable = Status.UNAVAILABLE.withDescription(
         "CDS error: circular aggregate clusters directly under cluster-02.googleapis.com for root"
             + " cluster cluster-foo.googleapis.com, named [cluster-01.googleapis.com,"
-            + " cluster-02.googleapis.com]" + " xDS node ID: " + NODE_ID);
+            + " cluster-02.googleapis.com]" + ", xDS node ID: " + NODE_ID);
     assertPicker(pickerCaptor.getValue(), unavailable, null);
   }
 
@@ -567,7 +567,7 @@ public class CdsLoadBalancer2Test {
     Status unavailable = Status.UNAVAILABLE.withDescription(
         "CDS error: circular aggregate clusters directly under cluster-02.googleapis.com for root"
             + " cluster cluster-foo.googleapis.com, named [cluster-01.googleapis.com,"
-            + " cluster-02.googleapis.com]" + " xDS node ID: " + NODE_ID);
+            + " cluster-02.googleapis.com]" + ", xDS node ID: " + NODE_ID);
     assertPicker(pickerCaptor.getValue(), unavailable, null);
   }
 
@@ -635,7 +635,7 @@ public class CdsLoadBalancer2Test {
         eq(ConnectivityState.TRANSIENT_FAILURE), pickerCaptor.capture());
     Status expectedError = Status.UNAVAILABLE.withDescription(
         "Unable to load CDS cluster-foo.googleapis.com. xDS server returned: "
-        + "RESOURCE_EXHAUSTED: OOM" + "  xDS node ID: " + NODE_ID);
+        + "RESOURCE_EXHAUSTED: OOM" + " xDS node ID: " + NODE_ID);
     assertPicker(pickerCaptor.getValue(), expectedError, null);
     assertThat(childBalancers).isEmpty();
   }


### PR DESCRIPTION
This PR adds xDS node ID in control plane errors to enable cross-referencing with control plane logs when debugging (b/364405814). 

CC @fengli79 
