### PR TITLE
Change PickFirstLeafLoadBalancer to only have 1 subchannel at a time

### DIFF
--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -122,6 +122,12 @@ public abstract class LoadBalancer {
       LoadBalancer.CreateSubchannelArgs.Key.create("internal:health-check-consumer-listener");
 
   @Internal
+  public static final LoadBalancer.CreateSubchannelArgs.Key<Boolean>
+      DISABLE_SUBCHANNEL_RECONNECT_KEY =
+      LoadBalancer.CreateSubchannelArgs.Key.createWithDefault(
+          "internal:disable-subchannel-reconnect", Boolean.FALSE);
+
+  @Internal
   public static final Attributes.Key<Boolean>
       HAS_HEALTH_PRODUCER_LISTENER_KEY =
       Attributes.Key.create("internal:has-health-check-producer-listener");
@@ -823,6 +829,13 @@ public abstract class LoadBalancer {
           .add("attrs", attrs)
           .add("customOptions", Arrays.deepToString(customOptions))
           .toString();
+    }
+
+    @Internal
+    public Object[][] getOptions() {
+      Object[][] retVal = new Object[customOptions.length][2];
+      System.arraycopy(retVal, 0, customOptions, 0, customOptions.length);
+      return retVal;
     }
 
     @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")

--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -831,13 +831,6 @@ public abstract class LoadBalancer {
           .toString();
     }
 
-    @Internal
-    public Object[][] getOptions() {
-      Object[][] retVal = new Object[customOptions.length][2];
-      System.arraycopy(retVal, 0, customOptions, 0, customOptions.length);
-      return retVal;
-    }
-
     @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
     public static final class Builder {
 

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -45,6 +45,7 @@ import io.grpc.InternalChannelz.ChannelStats;
 import io.grpc.InternalInstrumented;
 import io.grpc.InternalLogId;
 import io.grpc.InternalWithLogId;
+import io.grpc.LoadBalancer;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
@@ -77,6 +78,7 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
   private final CallTracer callsTracer;
   private final ChannelTracer channelTracer;
   private final ChannelLogger channelLogger;
+  private final boolean recconectDisabled;
 
   private final List<ClientTransportFilter> transportFilters;
 
@@ -159,13 +161,15 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
 
   private volatile Attributes connectedAddressAttributes;
 
-  InternalSubchannel(List<EquivalentAddressGroup> addressGroups, String authority, String userAgent,
-      BackoffPolicy.Provider backoffPolicyProvider,
-      ClientTransportFactory transportFactory, ScheduledExecutorService scheduledExecutor,
-      Supplier<Stopwatch> stopwatchSupplier, SynchronizationContext syncContext, Callback callback,
-      InternalChannelz channelz, CallTracer callsTracer, ChannelTracer channelTracer,
-      InternalLogId logId, ChannelLogger channelLogger,
-      List<ClientTransportFilter> transportFilters) {
+  InternalSubchannel(LoadBalancer.CreateSubchannelArgs args, String authority, String userAgent,
+                     BackoffPolicy.Provider backoffPolicyProvider,
+                     ClientTransportFactory transportFactory,
+                     ScheduledExecutorService scheduledExecutor,
+                     Supplier<Stopwatch> stopwatchSupplier, SynchronizationContext syncContext,
+                     Callback callback, InternalChannelz channelz, CallTracer callsTracer,
+                     ChannelTracer channelTracer, InternalLogId logId,
+                     ChannelLogger channelLogger, List<ClientTransportFilter> transportFilters) {
+    List<EquivalentAddressGroup> addressGroups = args.getAddresses();
     Preconditions.checkNotNull(addressGroups, "addressGroups");
     Preconditions.checkArgument(!addressGroups.isEmpty(), "addressGroups is empty");
     checkListHasNoNulls(addressGroups, "addressGroups contains null entry");
@@ -187,6 +191,7 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
     this.logId = Preconditions.checkNotNull(logId, "logId");
     this.channelLogger = Preconditions.checkNotNull(channelLogger, "channelLogger");
     this.transportFilters = transportFilters;
+    this.recconectDisabled = args.getOption(LoadBalancer.DISABLE_SUBCHANNEL_RECONNECT_KEY);
   }
 
   ChannelLogger getChannelLogger() {
@@ -196,7 +201,7 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
   @Override
   public ClientTransport obtainActiveTransport() {
     ClientTransport savedTransport = activeTransport;
-    if (savedTransport != null) {
+    if (savedTransport != null && state.getState() != IDLE) {
       return savedTransport;
     }
     syncContext.execute(new Runnable() {
@@ -289,6 +294,11 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
     }
 
     gotoState(ConnectivityStateInfo.forTransientFailure(status));
+
+    if (recconectDisabled) {
+      return;
+    }
+
     if (reconnectPolicy == null) {
       reconnectPolicy = backoffPolicyProvider.get();
     }

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -78,7 +78,7 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
   private final CallTracer callsTracer;
   private final ChannelTracer channelTracer;
   private final ChannelLogger channelLogger;
-  private final boolean reconectDisabled;
+  private final boolean reconnectDisabled;
 
   private final List<ClientTransportFilter> transportFilters;
 
@@ -191,7 +191,7 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
     this.logId = Preconditions.checkNotNull(logId, "logId");
     this.channelLogger = Preconditions.checkNotNull(channelLogger, "channelLogger");
     this.transportFilters = transportFilters;
-    this.reconectDisabled = args.getOption(LoadBalancer.DISABLE_SUBCHANNEL_RECONNECT_KEY);
+    this.reconnectDisabled = args.getOption(LoadBalancer.DISABLE_SUBCHANNEL_RECONNECT_KEY);
   }
 
   ChannelLogger getChannelLogger() {
@@ -295,7 +295,7 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
 
     gotoState(ConnectivityStateInfo.forTransientFailure(status));
 
-    if (reconectDisabled) {
+    if (reconnectDisabled) {
       return;
     }
 
@@ -347,7 +347,7 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
     if (state.getState() != newState.getState()) {
       Preconditions.checkState(state.getState() != SHUTDOWN,
           "Cannot transition out of SHUTDOWN to " + newState);
-      if (reconectDisabled && newState.getState() == TRANSIENT_FAILURE) {
+      if (reconnectDisabled && newState.getState() == TRANSIENT_FAILURE) {
         state = ConnectivityStateInfo.forNonError(IDLE);
       } else {
         state = newState;

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1475,7 +1475,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
       }
 
       final InternalSubchannel internalSubchannel = new InternalSubchannel(
-          addressGroup,
+          CreateSubchannelArgs.newBuilder().setAddresses(addressGroup).build(),
           authority, userAgent, backoffPolicyProvider, oobTransportFactory,
           oobTransportFactory.getScheduledExecutorService(), stopwatchSupplier, syncContext,
           // All callback methods are run from syncContext
@@ -1907,7 +1907,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
       }
 
       final InternalSubchannel internalSubchannel = new InternalSubchannel(
-          args.getAddresses(),
+          args,
           authority(),
           userAgent,
           backoffPolicyProvider,

--- a/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
@@ -462,6 +462,7 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
           requestConnection();
         } else {
           if (!addressIndex.isValid()) {
+            subchannelData.subchannel.shutdown(); // shutdown the previous subchannel
             scheduleBackoff();
           } else {
             subchannelData.subchannel.shutdown(); // shutdown the previous subchannel

--- a/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
@@ -460,7 +460,8 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
             scheduleBackoff();
           } else {
             subchannelData.subchannel.requestConnection();
-            subchannelData.updateState(CONNECTING);}
+            subchannelData.updateState(CONNECTING);
+          }
         }
         break;
       default:

--- a/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
@@ -292,7 +292,7 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
           }
         }
 
-        if (!firstPass || isPassComplete()) {
+        if (isPassComplete()) {
           rawConnectivityState = TRANSIENT_FAILURE;
           updateBalancingState(TRANSIENT_FAILURE,
               new Picker(PickResult.withError(stateInfo.getStatus())));

--- a/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
+++ b/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
@@ -310,10 +310,57 @@ public class InternalSubchannelTest {
     verify(mockBackoffPolicy2, times(backoff2Consulted)).nextBackoffNanos();
   }
 
+  @Test public void twoAddressesReconnectDisabled() {
+    SocketAddress addr1 = mock(SocketAddress.class);
+    SocketAddress addr2 = mock(SocketAddress.class);
+    createInternalSubchannel(true,
+        new EquivalentAddressGroup(Arrays.asList(addr1, addr2)));
+    assertEquals(IDLE, internalSubchannel.getState());
+
+    assertNull(internalSubchannel.obtainActiveTransport());
+    assertExactCallbackInvokes("onStateChange:CONNECTING");
+    assertEquals(CONNECTING, internalSubchannel.getState());
+    verify(mockTransportFactory).newClientTransport(eq(addr1), any(), any());
+    // Let this one fail without success
+    transports.poll().listener.transportShutdown(Status.UNAVAILABLE);
+    // Still in CONNECTING
+    assertNull(internalSubchannel.obtainActiveTransport());
+    assertNoCallbackInvoke();
+    assertEquals(CONNECTING, internalSubchannel.getState());
+
+    // Second attempt will start immediately. Still no back-off policy.
+    verify(mockBackoffPolicyProvider, times(0)).get();
+    verify(mockTransportFactory, times(1))
+        .newClientTransport(
+            eq(addr2),
+            eq(createClientTransportOptions()),
+            isA(TransportLogger.class));
+    assertNull(internalSubchannel.obtainActiveTransport());
+    // Fail this one too
+    assertNoCallbackInvoke();
+    transports.poll().listener.transportShutdown(Status.UNAVAILABLE);
+    // All addresses have failed, but we aren't controlling retries.
+    assertEquals(IDLE, internalSubchannel.getState());
+    assertExactCallbackInvokes("onStateChange:" + UNAVAILABLE_STATE);
+    // Backoff reset and first back-off interval begins
+    verify(mockBackoffPolicy1, never()).nextBackoffNanos();
+    verify(mockBackoffPolicyProvider, never()).get();
+    assertTrue("Nothing should have been scheduled", fakeClock.getPendingTasks().isEmpty());
+
+    // Should follow orders and create an active transport.
+    internalSubchannel.obtainActiveTransport();
+    assertExactCallbackInvokes("onStateChange:CONNECTING");
+    assertEquals(CONNECTING, internalSubchannel.getState());
+
+    // Shouldn't have anything scheduled, so shouldn't do anything
+    assertTrue("Nothing should have been scheduled 2", fakeClock.getPendingTasks().isEmpty());
+  }
+
   @Test public void twoAddressesReconnect() {
     SocketAddress addr1 = mock(SocketAddress.class);
     SocketAddress addr2 = mock(SocketAddress.class);
-    createInternalSubchannel(addr1, addr2);
+    createInternalSubchannel(false,
+        new EquivalentAddressGroup(Arrays.asList(addr1, addr2)));
     assertEquals(IDLE, internalSubchannel.getState());
     // Invocation counters
     int transportsAddr1 = 0;
@@ -1378,12 +1425,22 @@ public class InternalSubchannelTest {
   }
 
   private void createInternalSubchannel(EquivalentAddressGroup ... addrs) {
+    createInternalSubchannel(false, addrs);
+  }
+
+  private void createInternalSubchannel(boolean reconnectDisabled, EquivalentAddressGroup ... addrs) {
     List<EquivalentAddressGroup> addressGroups = Arrays.asList(addrs);
     InternalLogId logId = InternalLogId.allocate("Subchannel", /*details=*/ AUTHORITY);
     ChannelTracer subchannelTracer = new ChannelTracer(logId, 10,
         fakeClock.getTimeProvider().currentTimeNanos(), "Subchannel");
+    LoadBalancer.CreateSubchannelArgs.Builder argBuilder =
+        LoadBalancer.CreateSubchannelArgs.newBuilder().setAddresses(addressGroups);
+    if (reconnectDisabled) {
+      argBuilder.addOption(LoadBalancer.DISABLE_SUBCHANNEL_RECONNECT_KEY, reconnectDisabled);
+    }
+    LoadBalancer.CreateSubchannelArgs createSubchannelArgs = argBuilder.build();
     internalSubchannel = new InternalSubchannel(
-        LoadBalancer.CreateSubchannelArgs.newBuilder().setAddresses(addressGroups).build(),
+        createSubchannelArgs,
         AUTHORITY, USER_AGENT,
         mockBackoffPolicyProvider, mockTransportFactory, fakeClock.getScheduledExecutorService(),
         fakeClock.getStopwatchSupplier(), syncContext, mockInternalSubchannelCallback,

--- a/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
+++ b/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
@@ -1428,7 +1428,8 @@ public class InternalSubchannelTest {
     createInternalSubchannel(false, addrs);
   }
 
-  private void createInternalSubchannel(boolean reconnectDisabled, EquivalentAddressGroup ... addrs) {
+  private void createInternalSubchannel(boolean reconnectDisabled,
+                                        EquivalentAddressGroup ... addrs) {
     List<EquivalentAddressGroup> addressGroups = Arrays.asList(addrs);
     InternalLogId logId = InternalLogId.allocate("Subchannel", /*details=*/ AUTHORITY);
     ChannelTracer subchannelTracer = new ChannelTracer(logId, 10,

--- a/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
+++ b/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
@@ -46,6 +46,7 @@ import io.grpc.EquivalentAddressGroup;
 import io.grpc.InternalChannelz;
 import io.grpc.InternalLogId;
 import io.grpc.InternalWithLogId;
+import io.grpc.LoadBalancer;
 import io.grpc.Status;
 import io.grpc.SynchronizationContext;
 import io.grpc.internal.InternalSubchannel.CallTracingTransport;
@@ -1381,7 +1382,9 @@ public class InternalSubchannelTest {
     InternalLogId logId = InternalLogId.allocate("Subchannel", /*details=*/ AUTHORITY);
     ChannelTracer subchannelTracer = new ChannelTracer(logId, 10,
         fakeClock.getTimeProvider().currentTimeNanos(), "Subchannel");
-    internalSubchannel = new InternalSubchannel(addressGroups, AUTHORITY, USER_AGENT,
+    internalSubchannel = new InternalSubchannel(
+        LoadBalancer.CreateSubchannelArgs.newBuilder().setAddresses(addressGroups).build(),
+        AUTHORITY, USER_AGENT,
         mockBackoffPolicyProvider, mockTransportFactory, fakeClock.getScheduledExecutorService(),
         fakeClock.getStopwatchSupplier(), syncContext, mockInternalSubchannelCallback,
         channelz, CallTracer.getDefaultFactory().create(),

--- a/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
@@ -2606,7 +2606,7 @@ public class PickFirstLeafLoadBalancerTest {
       listeners[i].onSubchannelState(ConnectivityStateInfo.forTransientFailure(error));
     }
     assertEquals(TRANSIENT_FAILURE, loadBalancer.getConcludedConnectivityState());
-    assertFalse("Index should be at end", loadBalancer.indexIntrospector.isValid());
+    assertFalse("Index should be at end", loadBalancer.isIndexValid());
 
     forwardTimeByBackoffDelay(); // should trigger retry
     for (int i = 0; i < subchannels.length; i++) {
@@ -2618,7 +2618,7 @@ public class PickFirstLeafLoadBalancerTest {
     forwardTimeByBackoffDelay(); // should trigger retry again
     for (int i = 0; i < subchannels.length; i++) {
       inOrder.verify(subchannels[i]).requestConnection();
-      assertEquals(i, loadBalancer.indexIntrospector.getGroupIndex());
+      assertEquals(i, loadBalancer.getGroupIndex());
       listeners[i].onSubchannelState(ConnectivityStateInfo.forTransientFailure(error)); // cascade
     }
   }

--- a/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
@@ -32,7 +32,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;

--- a/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
@@ -2764,7 +2764,7 @@ public class PickFirstLeafLoadBalancerTest {
   }
 
   private void forwardTimeByBackoffDelay() {
-    backoffMillis *= 1.8; // backoff factor for ExponentialBackoffProvider is 1.6 with Jitter .2
+    backoffMillis = (long) (backoffMillis * 1.8); // backoff factor default is 1.6 with Jitter .2
     fakeClock.forwardTime(backoffMillis, TimeUnit.MILLISECONDS);
   }
 

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
@@ -150,7 +150,7 @@ public class RingHashLoadBalancerTest {
     assertThat(result.getStatus().isOk()).isTrue();
     assertThat(result.getSubchannel()).isNull();
     Subchannel subchannel = Iterables.getOnlyElement(subchannels.values());
-    int expectedTimes = PickFirstLoadBalancerProvider.isEnabledHappyEyeballs() ? 1 : 2;
+    int expectedTimes = PickFirstLoadBalancerProvider.isEnabledHappyEyeballs() ? 2 : 1;
     verify(subchannel, times(expectedTimes)).requestConnection();
     verify(helper).updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
     verify(helper).createSubchannel(any(CreateSubchannelArgs.class));
@@ -184,7 +184,7 @@ public class RingHashLoadBalancerTest {
     pickerCaptor.getValue().pickSubchannel(args);
     Subchannel subchannel = subchannels.get(Collections.singletonList(childLbState.getEag()));
     InOrder inOrder = Mockito.inOrder(helper, subchannel);
-    int expectedTimes = PickFirstLoadBalancerProvider.isEnabledHappyEyeballs() ? 1 : 2;
+    int expectedTimes = PickFirstLoadBalancerProvider.isEnabledHappyEyeballs() ? 2 : 1;
     inOrder.verify(subchannel, times(expectedTimes)).requestConnection();
     deliverSubchannelState(subchannel, CSI_READY);
     inOrder.verify(helper).updateBalancingState(eq(READY), any(SubchannelPicker.class));
@@ -443,7 +443,7 @@ public class RingHashLoadBalancerTest {
     PickResult result = pickerCaptor.getValue().pickSubchannel(args);
     assertThat(result.getStatus().isOk()).isTrue();
     assertThat(result.getSubchannel()).isNull();  // buffer request
-    int expectedTimes = PickFirstLoadBalancerProvider.isEnabledHappyEyeballs() ? 1 : 2;
+    int expectedTimes = PickFirstLoadBalancerProvider.isEnabledHappyEyeballs() ? 2 : 1;
     // verify kicked off connection to server2
     verify(getSubChannel(servers.get(1)), times(expectedTimes)).requestConnection();
     assertThat(subchannels.size()).isEqualTo(2);  // no excessive connection

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
@@ -150,8 +150,8 @@ public class RingHashLoadBalancerTest {
     assertThat(result.getStatus().isOk()).isTrue();
     assertThat(result.getSubchannel()).isNull();
     Subchannel subchannel = Iterables.getOnlyElement(subchannels.values());
-    int expectedTimes = PickFirstLoadBalancerProvider.isEnabledHappyEyeballs()
-                            || !PickFirstLoadBalancerProvider.isEnabledNewPickFirst() ? 2 : 1;
+    int expectedTimes = PickFirstLoadBalancerProvider.isEnabledNewPickFirst()
+                            && !PickFirstLoadBalancerProvider.isEnabledHappyEyeballs() ? 1 : 2;
     verify(subchannel, times(expectedTimes)).requestConnection();
     verify(helper).updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
     verify(helper).createSubchannel(any(CreateSubchannelArgs.class));

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
@@ -150,7 +150,8 @@ public class RingHashLoadBalancerTest {
     assertThat(result.getStatus().isOk()).isTrue();
     assertThat(result.getSubchannel()).isNull();
     Subchannel subchannel = Iterables.getOnlyElement(subchannels.values());
-    int expectedTimes = PickFirstLoadBalancerProvider.isEnabledHappyEyeballs() ? 2 : 1;
+    int expectedTimes = PickFirstLoadBalancerProvider.isEnabledHappyEyeballs()
+                            || !PickFirstLoadBalancerProvider.isEnabledNewPickFirst() ? 2 : 1;
     verify(subchannel, times(expectedTimes)).requestConnection();
     verify(helper).updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
     verify(helper).createSubchannel(any(CreateSubchannelArgs.class));
@@ -184,7 +185,8 @@ public class RingHashLoadBalancerTest {
     pickerCaptor.getValue().pickSubchannel(args);
     Subchannel subchannel = subchannels.get(Collections.singletonList(childLbState.getEag()));
     InOrder inOrder = Mockito.inOrder(helper, subchannel);
-    int expectedTimes = PickFirstLoadBalancerProvider.isEnabledHappyEyeballs() ? 2 : 1;
+    int expectedTimes = PickFirstLoadBalancerProvider.isEnabledHappyEyeballs()
+                            || !PickFirstLoadBalancerProvider.isEnabledNewPickFirst() ? 2 : 1;
     inOrder.verify(subchannel, times(expectedTimes)).requestConnection();
     deliverSubchannelState(subchannel, CSI_READY);
     inOrder.verify(helper).updateBalancingState(eq(READY), any(SubchannelPicker.class));
@@ -443,8 +445,10 @@ public class RingHashLoadBalancerTest {
     PickResult result = pickerCaptor.getValue().pickSubchannel(args);
     assertThat(result.getStatus().isOk()).isTrue();
     assertThat(result.getSubchannel()).isNull();  // buffer request
-    int expectedTimes = PickFirstLoadBalancerProvider.isEnabledHappyEyeballs() ? 2 : 1;
     // verify kicked off connection to server2
+    int expectedTimes = PickFirstLoadBalancerProvider.isEnabledHappyEyeballs()
+                            || !PickFirstLoadBalancerProvider.isEnabledNewPickFirst() ? 2 : 1;
+
     verify(getSubChannel(servers.get(1)), times(expectedTimes)).requestConnection();
     assertThat(subchannels.size()).isEqualTo(2);  // no excessive connection
 


### PR DESCRIPTION
Hide behind environment variable GRPC_SERIALIZE_RETRIES

This is for testing with GMS core to see if they use the new PF with only 1 subchannel at a time trying to reconnect whether that eliminates their 6% data increase.