### PR TITLE
buildscripts: OS X env should be in macos.sh

### DIFF
--- a/buildscripts/kokoro/macos.sh
+++ b/buildscripts/kokoro/macos.sh
@@ -15,4 +15,7 @@ export GRADLE_FLAGS="${GRADLE_FLAGS:-} --max-workers=2"
 . "$GRPC_JAVA_DIR"/buildscripts/kokoro/kokoro.sh
 trap spongify_logs EXIT
 
+export -n JAVA_HOME
+export PATH="$(/usr/libexec/java_home -v"1.8.0")/bin:${PATH}"
+
 "$GRPC_JAVA_DIR"/buildscripts/kokoro/unix.sh

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -23,11 +23,6 @@ readonly GRPC_JAVA_DIR="$(cd "$(dirname "$0")"/../.. && pwd)"
 # cd to the root dir of grpc-java
 cd $(dirname $0)/../..
 
-# TODO(zpencer): always make sure we are using Oracle jdk8
-if [[ -f /usr/libexec/java_home ]]; then
-    JAVA_HOME=$(/usr/libexec/java_home -v"1.8.0")
-fi
-
 # ARCH is x86_64 unless otherwise specified.
 ARCH="${ARCH:-x86_64}"
 


### PR DESCRIPTION
unix.sh is shared by multiple OSes and environments. Clear JAVA_HOME, since we never want to use that as PATH is more reliable, better supported, and more typical.