### PR TITLE
Introduce channel Attributes; Use them to pass the binder target user to the NameResolver

### DIFF
--- a/api/src/main/java/io/grpc/Grpc.java
+++ b/api/src/main/java/io/grpc/Grpc.java
@@ -66,6 +66,15 @@ public final class Grpc {
   public @interface TransportAttr {}
 
   /**
+   * Annotation for Channel attributes. It follows the annotation semantics defined by {@link
+   * Attributes}.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/00000000")
+  @Retention(RetentionPolicy.SOURCE)
+  @Documented
+  public @interface ChannelAttr {}
+
+  /**
    * Creates a channel builder with a target string and credentials. The target can be either a
    * valid {@link NameResolver}-compliant URI, or an authority string.
    *

--- a/api/src/main/java/io/grpc/NameResolver.java
+++ b/api/src/main/java/io/grpc/NameResolver.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.errorprone.annotations.InlineMe;
+import io.grpc.Grpc.ChannelAttr;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -281,6 +282,7 @@ public abstract class NameResolver {
     private final ProxyDetector proxyDetector;
     private final SynchronizationContext syncContext;
     private final ServiceConfigParser serviceConfigParser;
+    @ChannelAttr @Nullable private final Attributes channelAttributes;
     @Nullable private final ScheduledExecutorService scheduledExecutorService;
     @Nullable private final ChannelLogger channelLogger;
     @Nullable private final Executor executor;
@@ -291,6 +293,7 @@ public abstract class NameResolver {
         ProxyDetector proxyDetector,
         SynchronizationContext syncContext,
         ServiceConfigParser serviceConfigParser,
+        @ChannelAttr Attributes channelAttributes,
         @Nullable ScheduledExecutorService scheduledExecutorService,
         @Nullable ChannelLogger channelLogger,
         @Nullable Executor executor,
@@ -299,6 +302,7 @@ public abstract class NameResolver {
       this.proxyDetector = checkNotNull(proxyDetector, "proxyDetector not set");
       this.syncContext = checkNotNull(syncContext, "syncContext not set");
       this.serviceConfigParser = checkNotNull(serviceConfigParser, "serviceConfigParser not set");
+      this.channelAttributes = checkNotNull(channelAttributes, "channelAttributes not set");
       this.scheduledExecutorService = scheduledExecutorService;
       this.channelLogger = channelLogger;
       this.executor = executor;
@@ -361,6 +365,12 @@ public abstract class NameResolver {
      */
     public ServiceConfigParser getServiceConfigParser() {
       return serviceConfigParser;
+    }
+
+    /** Returns {@link Attributes} of the associated Channel. */
+    @ChannelAttr
+    public Attributes getChannelAttributes() {
+      return channelAttributes;
     }
 
     /**
@@ -452,6 +462,7 @@ public abstract class NameResolver {
       private ProxyDetector proxyDetector;
       private SynchronizationContext syncContext;
       private ServiceConfigParser serviceConfigParser;
+      private Attributes channelAttributes = Attributes.EMPTY;
       private ScheduledExecutorService scheduledExecutorService;
       private ChannelLogger channelLogger;
       private Executor executor;
@@ -510,6 +521,12 @@ public abstract class NameResolver {
         return this;
       }
 
+      /** See {@link Args#getChannelAttributes}. This is a required field, default empty. */
+      public Builder setChannelAttributes(@ChannelAttr Attributes channelAttributes) {
+        this.channelAttributes = checkNotNull(channelAttributes);
+        return this;
+      }
+
       /**
        * See {@link Args#getChannelLogger}.
        *
@@ -548,10 +565,16 @@ public abstract class NameResolver {
        * @since 1.21.0
        */
       public Args build() {
-        return
-            new Args(
-                defaultPort, proxyDetector, syncContext, serviceConfigParser,
-                scheduledExecutorService, channelLogger, executor, overrideAuthority);
+        return new Args(
+            defaultPort,
+            proxyDetector,
+            syncContext,
+            serviceConfigParser,
+            channelAttributes,
+            scheduledExecutorService,
+            channelLogger,
+            executor,
+            overrideAuthority);
       }
     }
   }

--- a/binder/src/main/java/io/grpc/binder/ApiConstants.java
+++ b/binder/src/main/java/io/grpc/binder/ApiConstants.java
@@ -39,8 +39,8 @@ public final class ApiConstants {
    * <p>In multi-user Android, the target user for an Intent is unfortunately not part of the intent
    * itself. Instead, it's passed around as a separate argument wherever that Intent is needed.
    * Following suit, this implementation of the binder transport accepts the target Android user as
-   * a parameter to BinderChannelBuilder -- it's not in the target URI or the SocketAddress.
-   * Instead, downstream plugins such as {@link io.grpc.NameResolver}s and {@link
+   * a parameter to BinderChannelBuilder -- unfortunately it's not in the target URI or the
+   * SocketAddress. Instead, downstream plugins such as {@link io.grpc.NameResolver}s and {@link
    * io.grpc.LoadBalancer}s can use this attribute to obtain the Channel's target UserHandle. If the
    * attribute is not set, the Channel's target is the Android user hosting the current process (the
    * default).

--- a/binder/src/main/java/io/grpc/binder/ApiConstants.java
+++ b/binder/src/main/java/io/grpc/binder/ApiConstants.java
@@ -17,7 +17,10 @@
 package io.grpc.binder;
 
 import android.content.Intent;
+import android.os.UserHandle;
+import io.grpc.Attributes;
 import io.grpc.ExperimentalApi;
+import io.grpc.Grpc.ChannelAttr;
 
 /** Constant parts of the gRPC binder transport public API. */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/8022")
@@ -29,4 +32,20 @@ public final class ApiConstants {
    * themselves in a {@link android.app.Service#onBind(Intent)} call.
    */
   public static final String ACTION_BIND = "grpc.io.action.BIND";
+
+  /**
+   * The target Android user of a binder Channel.
+   *
+   * <p>In multi-user Android, the target user for an Intent is unfortunately not part of the intent
+   * itself. Instead, it's passed around as a separate argument wherever that Intent is needed.
+   * Following suit, this implementation of the binder transport accepts the target Android user as
+   * a parameter to BinderChannelBuilder -- it's not in the target URI or the SocketAddress.
+   * Instead, downstream plugins such as {@link io.grpc.NameResolver}s and {@link
+   * io.grpc.LoadBalancer}s can use this attribute to obtain the Channel's target UserHandle. If the
+   * attribute is not set, the Channel's target is the Android user hosting the current process (the
+   * default).
+   */
+  @ChannelAttr
+  public static final Attributes.Key<UserHandle> CHANNEL_ATTR_TARGET_USER =
+      Attributes.Key.create("io.grpc.binder.CHANNEL_ATTR_TARGET_USER");
 }

--- a/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
@@ -23,6 +23,7 @@ import android.content.Context;
 import android.os.UserHandle;
 import androidx.annotation.RequiresApi;
 import com.google.errorprone.annotations.DoNotCall;
+import io.grpc.Attributes;
 import io.grpc.ExperimentalApi;
 import io.grpc.ForwardingChannelBuilder;
 import io.grpc.ManagedChannel;
@@ -159,6 +160,7 @@ public final class BinderChannelBuilder extends ForwardingChannelBuilder<BinderC
 
   private final ManagedChannelImplBuilder managedChannelImplBuilder;
   private final BinderClientTransportFactory.Builder transportFactoryBuilder;
+  private final Attributes.Builder channelAttrBuilder = Attributes.newBuilder();
 
   private boolean strictLifecycleManagement;
 
@@ -250,6 +252,7 @@ public final class BinderChannelBuilder extends ForwardingChannelBuilder<BinderC
   @RequiresApi(30)
   public BinderChannelBuilder bindAsUser(UserHandle targetUserHandle) {
     transportFactoryBuilder.setTargetUserHandle(targetUserHandle);
+    channelAttrBuilder.set(ApiConstants.CHANNEL_ATTR_TARGET_USER, targetUserHandle);
     return this;
   }
 
@@ -284,6 +287,7 @@ public final class BinderChannelBuilder extends ForwardingChannelBuilder<BinderC
   public ManagedChannel build() {
     transportFactoryBuilder.setOffloadExecutorPool(
         managedChannelImplBuilder.getOffloadExecutorPool());
+    managedChannelImplBuilder.setChannelAttributes(channelAttrBuilder.build());
     return super.build();
   }
 }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -590,6 +590,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
     this.authorityOverride = builder.authorityOverride;
     this.nameResolverArgs =
         NameResolver.Args.newBuilder()
+            .setChannelAttributes(builder.channelAttributes)
             .setDefaultPort(builder.getDefaultPort())
             .setProxyDetector(proxyDetector)
             .setSynchronizationContext(syncContext)

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -35,6 +35,7 @@ import io.grpc.ClientTransportFilter;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
 import io.grpc.EquivalentAddressGroup;
+import io.grpc.Grpc.ChannelAttr;
 import io.grpc.InternalChannelz;
 import io.grpc.InternalConfiguratorRegistry;
 import io.grpc.ManagedChannel;
@@ -196,6 +197,8 @@ public final class ManagedChannelImplBuilder
 
   @Nullable
   ProxyDetector proxyDetector;
+
+  @ChannelAttr Attributes channelAttributes = Attributes.EMPTY;
 
   private boolean authorityCheckerDisabled;
   private boolean statsEnabled = true;
@@ -664,6 +667,14 @@ public final class ManagedChannelImplBuilder
   }
 
   /**
+   * Makes the specified Attributes available to downstream plugins such as resolvers and load
+   * balancers.
+   */
+  public void setChannelAttributes(@ChannelAttr Attributes channelAttributes) {
+    this.channelAttributes = channelAttributes;
+  }
+
+  /**
    * Verifies the authority is valid.
    */
   @VisibleForTesting
@@ -929,5 +940,15 @@ public final class ManagedChannelImplBuilder
    */
   public ObjectPool<? extends Executor> getOffloadExecutorPool() {
     return this.offloadExecutorPool;
+  }
+
+  /** Returns the NameResolverRegistry. */
+  public NameResolverRegistry getNameResolverRegistry() {
+    return nameResolverRegistry;
+  }
+
+  /** Returns the target string. */
+  public String getTarget() {
+    return target;
   }
 }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -941,14 +941,4 @@ public final class ManagedChannelImplBuilder
   public ObjectPool<? extends Executor> getOffloadExecutorPool() {
     return this.offloadExecutorPool;
   }
-
-  /** Returns the NameResolverRegistry. */
-  public NameResolverRegistry getNameResolverRegistry() {
-    return nameResolverRegistry;
-  }
-
-  /** Returns the target string. */
-  public String getTarget() {
-    return target;
-  }
 }

--- a/testing/src/main/java/io/grpc/internal/testing/FakeNameResolverProvider.java
+++ b/testing/src/main/java/io/grpc/internal/testing/FakeNameResolverProvider.java
@@ -25,12 +25,16 @@ import java.net.SocketAddress;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
 
 /** A name resolver to always resolve the given URI into the given address. */
 public final class FakeNameResolverProvider extends NameResolverProvider {
 
   private final URI targetUri;
   private final SocketAddress address;
+  private final BlockingDeque<FakeNameResolver> resolversCreated = new LinkedBlockingDeque<>();
 
   public FakeNameResolverProvider(String targetUri, SocketAddress address) {
     this.targetUri = URI.create(targetUri);
@@ -40,7 +44,9 @@ public final class FakeNameResolverProvider extends NameResolverProvider {
   @Override
   public NameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
     if (targetUri.equals(this.targetUri)) {
-      return new FakeNameResolver(address);
+      FakeNameResolver result = new FakeNameResolver(address, args);
+      resolversCreated.add(result);
+      return result;
     }
     return null;
   }
@@ -65,15 +71,26 @@ public final class FakeNameResolverProvider extends NameResolverProvider {
     return Collections.singleton(address.getClass());
   }
 
+  /**
+   * Returns the next FakeNameResolver created by this provider, or null if none were created before
+   * the timeout lapsed.
+   */
+  public FakeNameResolver pollNextResolverCreated(long timeout, TimeUnit unit)
+      throws InterruptedException {
+    return resolversCreated.poll(timeout, unit);
+  }
+
   /** A single name resolver. */
-  private static final class FakeNameResolver extends NameResolver {
+  public static final class FakeNameResolver extends NameResolver {
     private static final String AUTHORITY = "fake-authority";
 
     private final SocketAddress address;
+    private final Args args;
     private volatile boolean shutdown;
 
-    private FakeNameResolver(SocketAddress address) {
+    private FakeNameResolver(SocketAddress address, Args args) {
       this.address = address;
+      this.args = args;
     }
 
     @Override
@@ -96,6 +113,10 @@ public final class FakeNameResolverProvider extends NameResolverProvider {
     @Override
     public void shutdown() {
       shutdown = true;
+    }
+
+    public Args getArgs() {
+      return this.args;
     }
   }
 }


### PR DESCRIPTION
In multi-user Android, the target user for an Intent is unfortunately not part of the intent
itself. Instead, it's passed around as a separate argument wherever that Intent is needed.
Following suit, the binder grpc transport accepts the target Android user as
a parameter to BinderChannelBuilder -- unfortunately it's not in the target URI or the direct SocketAddress, despite being part of the server's location.
 
But downstream plugins such as NameResolvers need access to this UserHandle too. This change introduces a new Channel Attributes mechanism and uses it to expose the Channel's target user (for use in an upcoming NameResolverProvider).