### PR TITLE
xds: Check for validity of xdsClient in ClusterImplLbHelper (v1.67.x backport)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -236,7 +236,8 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
           delegate().start(new SubchannelStateListener() {
             @Override
             public void onSubchannelState(ConnectivityStateInfo newState) {
-              if (newState.getState().equals(ConnectivityState.READY)) {
+              // Do nothing if LB has been shutdown
+              if (xdsClient != null && newState.getState().equals(ConnectivityState.READY)) {
                 // Get locality based on the connected address attributes
                 ClusterLocality updatedClusterLocality = createClusterLocalityFromAttributes(
                     subchannel.getConnectedAddressAttributes());


### PR DESCRIPTION
This PR adds null check for xdsClient in onSubChannelState. 
This avoids NPE for xdsClient when LB is shutdown and onSubChannelState is called later as part of listener callback. As shutdown is racy and eventually consistent, this check would avoid calculating locality after LB is shutdown.

b/369220083

Backport of #11553

CC @apolcyn 