### PR TITLE
Update RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -65,7 +65,7 @@ would be used to create all `v1.7` tags (e.g. `v1.7.0`, `v1.7.1`).
    ```bash
    git fetch upstream
    git checkout -b v$MAJOR.$MINOR.x \
-     $(git log --pretty=format:%H --grep "^Start $MAJOR.$((MINOR+1)).0 development cycle$" upstream/master)^
+     $(git log --pretty=format:%H --grep "^Start $MAJOR.$((MINOR+1)).0 development cycle" upstream/master)^
    git push upstream v$MAJOR.$MINOR.x
    ```
 5. Continue with Google-internal steps at go/grpc-java/releasing, but stop
@@ -132,7 +132,9 @@ Tagging the Release
      compiler/src/test{,Lite}/golden/Test{,Deprecated}Service.java.txt
    ./gradlew build
    git commit -a -m "Bump version to $MAJOR.$MINOR.$((PATCH+1))-SNAPSHOT"
+   git push -u origin release-v$MAJOR.$MINOR.$PATCH
    ```
+   Raise a PR and set the base branch of the PR to v$MAJOR.$MINOR.x of the upstream grpc-java repo.
 6. Go through PR review and push the release tag and updated release branch to
    GitHub (DO NOT click the merge button on the GitHub page):
 


### PR DESCRIPTION
1. Removing $ when looking for the commit 'Start of  development cycle...' because it produces empty result with the $. It seems how the squash was done may influence whether $ will work or not.

2. Added an explicit git push instruction at step 5 of tagging and what base branch to use, since it will cause conflict with the default base branch used of master.