### PR TITLE
TCP_USER_TIMEOUT property setting issue fixed

### DIFF
--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -20,6 +20,7 @@ dependencies {
             libraries.netty.codec.http2
     implementation project(':grpc-core'),
             libs.netty.handler.proxy,
+            libs.netty.transport.epoll,
             libraries.guava,
             libraries.errorprone.annotations,
             libraries.perfmark.api,

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -20,7 +20,6 @@ dependencies {
             libraries.netty.codec.http2
     implementation project(':grpc-core'),
             libs.netty.handler.proxy,
-            libs.netty.transport.epoll,
             libraries.guava,
             libraries.errorprone.annotations,
             libraries.perfmark.api,

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -281,15 +281,17 @@ class NettyClientTransport implements ConnectionClientTransport {
     channel = regFuture.channel();
     // For non-epoll based channel, the option will be ignored.
     try {
-      boolean isEpollChannel = Class.forName("io.netty.channel.epoll.AbstractEpollChannel").isInstance(channel);
-      if (keepAliveTimeNanos != KEEPALIVE_TIME_NANOS_DISABLED && isEpollChannel) {
+      if (keepAliveTimeNanos != KEEPALIVE_TIME_NANOS_DISABLED &&
+              Class.forName("io.netty.channel.epoll.AbstractEpollChannel").isInstance(channel)) {
         ChannelOption<Integer> tcpUserTimeout = Utils.maybeGetTcpUserTimeoutOption();
         if (tcpUserTimeout != null) {
-          channel.config().setOption(tcpUserTimeout, (int) TimeUnit.NANOSECONDS.toMillis(keepAliveTimeoutNanos));
+          int tcpUserTimeoutMs = (int) TimeUnit.NANOSECONDS.toMillis(keepAliveTimeoutNanos);
+          channel.config().setOption(tcpUserTimeout, tcpUserTimeoutMs);
         }
       }
     } catch (ClassNotFoundException ignored) {
-      // JVM did not load AbstractEpollChannel, so the current channel will not be of epoll type, so there is no need to set TCP_USER_TIMEOUT
+      // JVM did not load AbstractEpollChannel, so the current channel will not be of epoll type,
+      // so there is no need to set TCP_USER_TIMEOUT
     }
     // Start the write queue as soon as the channel is constructed
     handler.startWriteQueue(channel);

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -289,7 +289,7 @@ class NettyClientTransport implements ConnectionClientTransport {
         }
       }
     } catch (ClassNotFoundException ignored) {
-
+      // JVM did not load AbstractEpollChannel, so the current channel will not be of epoll type, so there is no need to set TCP_USER_TIMEOUT
     }
     // Start the write queue as soon as the channel is constructed
     handler.startWriteQueue(channel);

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -281,8 +281,8 @@ class NettyClientTransport implements ConnectionClientTransport {
     channel = regFuture.channel();
     // For non-epoll based channel, the option will be ignored.
     try {
-      if (keepAliveTimeNanos != KEEPALIVE_TIME_NANOS_DISABLED &&
-              Class.forName("io.netty.channel.epoll.AbstractEpollChannel").isInstance(channel)) {
+      if (keepAliveTimeNanos != KEEPALIVE_TIME_NANOS_DISABLED
+              && Class.forName("io.netty.channel.epoll.AbstractEpollChannel").isInstance(channel)) {
         ChannelOption<Integer> tcpUserTimeout = Utils.maybeGetTcpUserTimeoutOption();
         if (tcpUserTimeout != null) {
           int tcpUserTimeoutMs = (int) TimeUnit.NANOSECONDS.toMillis(keepAliveTimeoutNanos);


### PR DESCRIPTION
In NettyClientTransport, the TCP_USER_TIMEOUT attribute can be set only if the channel is of the AbstractEpollStreamChannel.

Fixes #11517