### PR TITLE
okhttp: remove irrelevant logs for non-android platform

### DIFF
--- a/okhttp/third_party/okhttp/main/java/io/grpc/okhttp/internal/Platform.java
+++ b/okhttp/third_party/okhttp/main/java/io/grpc/okhttp/internal/Platform.java
@@ -295,7 +295,9 @@ public class Platform {
         }
       }
     }
-    logger.log(Level.WARNING, "Unable to find Conscrypt");
+    if (PLATFORM instanceof Android) {
+      logger.log(Level.WARNING, "Unable to find Conscrypt");
+    }
     return null;
   }
 


### PR DESCRIPTION
We are using the io.grpc:grpc-okhttp library on the backend, and it appears that this warning is irrelevant for non-Android platforms. However, this false-positive warning triggers log alarms, which is very unfortunate.