### PR TITLE
android: For UDS, use fake IP instead of localhost

### DIFF
--- a/android/src/main/java/io/grpc/android/UdsChannelBuilder.java
+++ b/android/src/main/java/io/grpc/android/UdsChannelBuilder.java
@@ -68,12 +68,15 @@ public final class UdsChannelBuilder {
       throw new UnsupportedOperationException("OkHttpChannelBuilder not found on the classpath");
     }
     try {
-      // Target 'dns:///localhost' is unused, but necessary as an argument for OkHttpChannelBuilder.
+      // Target 'dns:///127.0.0.1' is unused, but necessary as an argument for OkHttpChannelBuilder.
+      // An IP address is used instead of localhost to avoid a DNS lookup (see #11442). This should
+      // work even if IPv4 is unavailable, as the DNS resolver doesn't need working IPv4 to parse an
+      // IPv4 address. Unavailable IPv4 fails when we connect(), not at resolution time.
       // TLS is unsupported because Conscrypt assumes the platform Socket implementation to improve
       // performance by using the file descriptor directly.
       Object o = OKHTTP_CHANNEL_BUILDER_CLASS
           .getMethod("forTarget", String.class, ChannelCredentials.class)
-          .invoke(null, "dns:///localhost", InsecureChannelCredentials.create());
+          .invoke(null, "dns:///127.0.0.1", InsecureChannelCredentials.create());
       ManagedChannelBuilder<?> builder = OKHTTP_CHANNEL_BUILDER_CLASS.cast(o);
       OKHTTP_CHANNEL_BUILDER_CLASS
           .getMethod("socketFactory", SocketFactory.class)


### PR DESCRIPTION
This avoids a DNS lookup, which can be slow and fail.

Fixes #11442