### PR TITLE
xds: Have ClusterManagerLB use child map for preserving children

### DIFF
--- a/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
@@ -79,7 +79,8 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
 
   /**
    * Override to utilize parsing of the policy configuration or alternative helper/lb generation.
-   * Override this if keys are not Endpoints or if child policies have configuration.
+   * Override this if keys are not Endpoints or if child policies have configuration. Null map
+   * values preserve the child without delivering the child an update.
    */
   protected Map<Object, ResolvedAddresses> createChildAddressesMap(
       ResolvedAddresses resolvedAddresses) {
@@ -181,8 +182,10 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
         childLbState = createChildLbState(entry.getKey());
         childLbStates.put(entry.getKey(), childLbState);
       }
-      childLbState.setResolvedAddresses(entry.getValue()); // update child
-      childLbState.lb.handleResolvedAddresses(entry.getValue()); // update child LB
+      if (entry.getValue() != null) {
+        childLbState.setResolvedAddresses(entry.getValue()); // update child
+        childLbState.lb.handleResolvedAddresses(entry.getValue()); // update child LB
+      }
     }
   }
 


### PR DESCRIPTION
Instead of doing a dance of supplementing config so the later createChildAddressesMap() won't delete children, just look at the existing children and don't delete any that shouldn't be deleted.