### PR TITLE
util: Simplify MultiChildLB.getChildLbState()

### DIFF
--- a/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
@@ -238,12 +238,6 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
 
   @VisibleForTesting
   public final ChildLbState getChildLbState(Object key) {
-    if (key == null) {
-      return null;
-    }
-    if (key instanceof EquivalentAddressGroup) {
-      key = new Endpoint((EquivalentAddressGroup) key);
-    }
     return childLbStates.get(key);
   }
 

--- a/xds/src/test/java/io/grpc/xds/LeastRequestLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/LeastRequestLoadBalancerTest.java
@@ -252,7 +252,7 @@ public class LeastRequestLoadBalancerTest {
 
   private LeastRequestLbState getChildLbState(PickResult pickResult) {
     EquivalentAddressGroup eag = pickResult.getSubchannel().getAddresses();
-    return (LeastRequestLbState) loadBalancer.getChildLbState(eag);
+    return (LeastRequestLbState) loadBalancer.getChildLbStateEag(eag);
   }
 
   @Test


### PR DESCRIPTION
Tests were converted to use getChildLbStateEag() if the argument was an EAG, so the instanceof was no longer necessary.