### PR TITLE
api: fix javadoc of CallCredentials.applyRequestMetadata

### DIFF
--- a/api/src/main/java/io/grpc/CallCredentials.java
+++ b/api/src/main/java/io/grpc/CallCredentials.java
@@ -43,7 +43,7 @@ public abstract class CallCredentials {
    * <p>It is called for each individual RPC, within the {@link Context} of the call, before the
    * stream is about to be created on a transport. Implementations should not block in this
    * method. If metadata is not immediately available, e.g., needs to be fetched from network, the
-   * implementation may give the {@code applier} to an asynchronous task which will eventually call
+   * implementation may give the {@code appExecutor} an asynchronous task which will eventually call
    * the {@code applier}. The RPC proceeds only after the {@code applier} is called.
    *
    * @param requestInfo request-related information


### PR DESCRIPTION
The current Javadoc for the method `CallCredentials.applyRequestMetadata` seems unclear or possibly contains an error. It currently states:

> the implementation may give the `applier` to an asynchronous task which will eventually call the `applier`.

I believe this should be clarified to:

> the implementation may give the `appExecutor` an asynchronous task which will eventually call the `applier`.

This change better explains the usage of `appExecutor` in this method.