### PR TITLE
s2a: Enable publishing.

### DIFF
--- a/s2a/build.gradle
+++ b/s2a/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "java-library"
+    id "maven-publish"
 
     id "com.github.johnrengelman.shadow"
     id "com.google.osdetector"


### PR DESCRIPTION
There are a few comments which we will get to in followup CL's:
https://github.com/grpc/grpc-java/pull/11540
https://github.com/grpc/grpc-java/pull/11534
https://github.com/grpc/grpc-java/pull/11539
https://github.com/grpc/grpc-java/pull/11113#discussion_r1762063248

I think all major comments / refactoring after https://github.com/grpc/grpc-java/pull/11113 have been addressed. Are we ok to enable publishing of s2a?