### PR TITLE
okhttp: Don't warn about missing Conscrypt

### DIFF
--- a/okhttp/third_party/okhttp/main/java/io/grpc/okhttp/internal/Platform.java
+++ b/okhttp/third_party/okhttp/main/java/io/grpc/okhttp/internal/Platform.java
@@ -283,7 +283,7 @@ public class Platform {
 
   /**
    * Select the first recognized security provider according to the preference order returned by
-   * {@link Security#getProviders}. If a recognized provider is not found then warn but continue.
+   * {@link Security#getProviders}.
    */
   private static Provider getAndroidSecurityProvider() {
     Provider[] providers = Security.getProviders();
@@ -295,7 +295,6 @@ public class Platform {
         }
       }
     }
-    logger.log(Level.WARNING, "Unable to find Conscrypt");
     return null;
   }
 


### PR DESCRIPTION
When running on the JDK, it is quite normal for Conscrypt not to be present. We'll end up using the JDK 9 ALPN API and everything will be fine. On Android, it would be extremely rare for someone to completely remove the default Android security providers, so the warning was almost never going to trigger on that platform anyway.

Fixes #11576. Alternative to #11567