### PR TITLE
xds: Update error handling for ADS stream close and failure scenarios

### DIFF
--- a/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
+++ b/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
@@ -415,7 +415,7 @@ final class ControlPlaneClient {
         // the XdsClient should consider that a connectivity error (see gRFC A57).
         if (status.isOk()) {
           newStatus = Status.UNAVAILABLE.withDescription(
-              "ADS stream failed due to connectivity error");
+              "ADS stream failed, because connection was closed before receiving a response.");
         }
       }
 

--- a/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
+++ b/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
@@ -59,8 +59,6 @@ import javax.annotation.Nullable;
  */
 final class ControlPlaneClient {
 
-  public static final String CLOSED_BY_SERVER_AFTER_RECEIVING_A_RESPONSE =
-      "Closed by server after receiving a response";
   private final SynchronizationContext syncContext;
   private final InternalLogId logId;
   private final XdsLogger logger;
@@ -401,21 +399,20 @@ final class ControlPlaneClient {
         // close streams for various reasons during normal operation, such as load balancing or
         // underlying connection hitting its max connection age limit  (see gRFC A9).
         if (!status.isOk()) {
-          newStatus = Status.OK.withDescription(
-              CLOSED_BY_SERVER_AFTER_RECEIVING_A_RESPONSE);
+          newStatus = Status.OK;
           logger.log( XdsLogLevel.DEBUG, "ADS stream closed with error {0}: {1}. However, a "
-              + "response was received, so this will not be treated as an error. Cause: {2}.",
+              + "response was received, so this will not be treated as an error. Cause: {2}",
               status.getCode(), status.getDescription(), status.getCause());
         } else {
           logger.log(XdsLogLevel.DEBUG,
-              "ADS stream closed by server after responses received.");
+              "ADS stream closed by server after a response was received");
         }
       } else {
         // If the ADS stream is closed without ever having received a response from the server, then
         // the XdsClient should consider that a connectivity error (see gRFC A57).
         if (status.isOk()) {
           newStatus = Status.UNAVAILABLE.withDescription(
-              "ADS stream failed, because connection was closed before receiving a response.");
+              "ADS stream closed with OK before receiving a response");
         }
         logger.log(
             XdsLogLevel.ERROR, "ADS stream failed with status {0}: {1}. Cause: {2}",

--- a/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
+++ b/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
@@ -408,7 +408,7 @@ final class ControlPlaneClient {
               status.getCode(), status.getDescription(), status.getCause());
         } else {
           logger.log(XdsLogLevel.DEBUG,
-              "ADS stream closed by server after responses received status {0}: {1}. Cause: {2}");
+              "ADS stream closed by server after responses received.");
         }
       } else {
         // If the ADS stream is closed without ever having received a response from the server, then
@@ -417,14 +417,11 @@ final class ControlPlaneClient {
           newStatus = Status.UNAVAILABLE.withDescription(
               "ADS stream failed, because connection was closed before receiving a response.");
         }
-      }
-
-      if (!newStatus.isOk() && !(newStatus.getDescription() != null
-          && newStatus.getDescription().contains(CLOSED_BY_SERVER_AFTER_RECEIVING_A_RESPONSE))) {
         logger.log(
             XdsLogLevel.ERROR, "ADS stream failed with status {0}: {1}. Cause: {2}",
             newStatus.getCode(), newStatus.getDescription(), newStatus.getCause());
       }
+
       closed = true;
       xdsResponseHandler.handleStreamClosed(newStatus);
       cleanUp();

--- a/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
+++ b/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
@@ -401,7 +401,7 @@ final class ControlPlaneClient {
         // close streams for various reasons during normal operation, such as load balancing or
         // underlying connection hitting its max connection age limit  (see gRFC A9).
         if (!status.isOk()) {
-          newStatus = Status.UNAVAILABLE.withDescription(
+          newStatus = Status.OK.withDescription(
               CLOSED_BY_SERVER_AFTER_RECEIVING_A_RESPONSE);
           logger.log( XdsLogLevel.DEBUG, "ADS stream closed with error {0}: {1}. However, a "
               + "response was received, so this will not be treated as an error. Cause: {2}.",

--- a/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
+++ b/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
@@ -16,7 +16,6 @@
 
 package io.grpc.xds.client;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
@@ -358,11 +357,7 @@ final class ControlPlaneClient {
     @Override
     public void onStatusReceived(final Status status) {
       syncContext.execute(() -> {
-        if (status.isOk()) {
-          handleRpcStreamClosed(Status.UNAVAILABLE.withDescription(CLOSED_BY_SERVER));
-        } else {
-          handleRpcStreamClosed(status);
-        }
+        handleRpcStreamClosed(status);
       });
     }
 
@@ -381,7 +376,7 @@ final class ControlPlaneClient {
       processingTracker.onComplete();
     }
 
-    private void handleRpcStreamClosed(Status error) {
+    private void handleRpcStreamClosed(Status status) {
       if (closed) {
         return;
       }
@@ -399,15 +394,33 @@ final class ControlPlaneClient {
       rpcRetryTimer = syncContext.schedule(
           new RpcRetryTask(), delayNanos, TimeUnit.NANOSECONDS, timeService);
 
-      checkArgument(!error.isOk(), "unexpected OK status");
-      String errorMsg = error.getDescription() != null
-          && error.getDescription().equals(CLOSED_BY_SERVER)
-              ? "ADS stream closed with status {0}: {1}. Cause: {2}"
-              : "ADS stream failed with status {0}: {1}. Cause: {2}";
-      logger.log(
-          XdsLogLevel.ERROR, errorMsg, error.getCode(), error.getDescription(), error.getCause());
+      Status newStatus = status;
+      if (responseReceived) {
+        // A closed ADS stream after a successful response is not considered an error. Servers may
+        // close streams for various reasons during normal operation, such as load balancing or
+        // underlying connection hitting its max connection age limit  (see gRFC A9).
+        if (!status.isOk()) {
+          newStatus = Status.OK.withDescription(CLOSED_BY_SERVER);
+          logger.log( XdsLogLevel.INFO, "ADS stream closed with error {0}: {1}. However, a "
+              + "response was received, so this will not be treated as an error. Cause: {2}.",
+              status.getCode(), status.getDescription(), status.getCause());
+        }
+      } else {
+        // If the ADS stream is closed without ever having received a response from the server, then
+        // the XdsClient should consider that a connectivity error (see gRFC A57).
+        if (status.isOk()) {
+          newStatus = Status.UNAVAILABLE.withDescription(
+              "ADS stream failed due to connectivity error");
+        }
+      }
+
+      if (!newStatus.isOk()) {
+        logger.log(
+            XdsLogLevel.ERROR, "ADS stream failed with status {0}: {1}. Cause: {2}",
+            status.getCode(), status.getDescription(), status.getCause());
+      }
       closed = true;
-      xdsResponseHandler.handleStreamClosed(error);
+      xdsResponseHandler.handleStreamClosed(status);
       cleanUp();
 
       logger.log(XdsLogLevel.INFO, "Retry ADS stream in {0} ns", delayNanos);

--- a/xds/src/main/java/io/grpc/xds/client/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/client/XdsClientImpl.java
@@ -19,7 +19,6 @@ package io.grpc.xds.client;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.grpc.xds.client.Bootstrapper.XDSTP_SCHEME;
-import static io.grpc.xds.client.ControlPlaneClient.CLOSED_BY_SERVER_AFTER_RECEIVING_A_RESPONSE;
 import static io.grpc.xds.client.XdsResourceType.ParsedResource;
 import static io.grpc.xds.client.XdsResourceType.ValidatedResourceUpdate;
 
@@ -145,8 +144,7 @@ public final class XdsClientImpl extends XdsClient implements XdsResponseHandler
     cleanUpResourceTimers();
     // Resource subscribers are not notified when the server closes the stream after a
     // response is received.
-    if (!error.isOk() && !(error.getDescription() != null
-        && error.getDescription().contains(CLOSED_BY_SERVER_AFTER_RECEIVING_A_RESPONSE))) {
+    if (!error.isOk()) {
       for (Map<String, ResourceSubscriber<? extends ResourceUpdate>> subscriberMap :
           resourceSubscribers.values()) {
         for (ResourceSubscriber<? extends ResourceUpdate> subscriber : subscriberMap.values()) {

--- a/xds/src/main/java/io/grpc/xds/client/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/client/XdsClientImpl.java
@@ -141,12 +141,14 @@ public final class XdsClientImpl extends XdsClient implements XdsResponseHandler
   @Override
   public void handleStreamClosed(Status error) {
     syncContext.throwIfNotInThisSynchronizationContext();
-    cleanUpResourceTimers();
-    for (Map<String, ResourceSubscriber<? extends ResourceUpdate>> subscriberMap :
-        resourceSubscribers.values()) {
-      for (ResourceSubscriber<? extends ResourceUpdate> subscriber : subscriberMap.values()) {
-        if (!subscriber.hasResult()) {
-          subscriber.onError(error, null);
+    if (!error.isOk()) {
+      cleanUpResourceTimers();
+      for (Map<String, ResourceSubscriber<? extends ResourceUpdate>> subscriberMap :
+          resourceSubscribers.values()) {
+        for (ResourceSubscriber<? extends ResourceUpdate> subscriber : subscriberMap.values()) {
+          if (!subscriber.hasResult()) {
+            subscriber.onError(error, null);
+          }
         }
       }
     }

--- a/xds/src/main/java/io/grpc/xds/client/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/client/XdsClientImpl.java
@@ -142,8 +142,6 @@ public final class XdsClientImpl extends XdsClient implements XdsResponseHandler
   public void handleStreamClosed(Status error) {
     syncContext.throwIfNotInThisSynchronizationContext();
     cleanUpResourceTimers();
-    // Resource subscribers are not notified when the server closes the stream after a
-    // response is received.
     if (!error.isOk()) {
       for (Map<String, ResourceSubscriber<? extends ResourceUpdate>> subscriberMap :
           resourceSubscribers.values()) {

--- a/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplTestBase.java
@@ -3342,10 +3342,10 @@ public abstract class GrpcXdsClientImplTestBase {
     verify(ldsResourceWatcher, Mockito.timeout(1000).times(1))
         .onError(errorCaptor.capture());
     verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNAVAILABLE,
-        "ADS stream failed, because connection was closed before receiving a response.");
+        "ADS stream closed with OK before receiving a response");
     verify(rdsResourceWatcher).onError(errorCaptor.capture());
     verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNAVAILABLE,
-        "ADS stream failed, because connection was closed before receiving a response.");
+        "ADS stream closed with OK before receiving a response");
   }
 
   @Test


### PR DESCRIPTION
According to [gRFC A57](https://github.com/grpc/proposal/blob/master/A57-xds-client-failure-mode-behavior.md#handling-ads-stream-termination):
> If the ADS stream is closed without ever having received a response from the server, then the XdsClient should consider that a connectivity error. It should log the error and report the error to all watchers of resources that were subscribed to on that stream.

For `status == OK`, updated the new status to `Status.UNAVAILABLE` with description "ADS stream closed with OK before receiving a response".

> Note that we do not consider it an error if the ADS stream was closed after having received a response on the stream. This is because there are legitimate reasons why the server may need to close the stream during normal operations, such as needing to rebalance load or the underlying connection hitting its max connection age limit (see [gRFC A9](https://github.com/grpc/proposal/blob/master/A9-server-side-conn-mgt.md)).

For `status != OK`, updated new status to `Status.OK`.

Updated `handleStreamClosed` to clean up resources and report error to all watchers of resources that were subscribed to on that stream for `status != OK`.