### PR TITLE
core: fix test flakiness in retriableStream hedging deadlock test

### DIFF
--- a/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
@@ -2592,9 +2592,7 @@ public class RetriableStreamTest {
               .closed(Status.fromCode(NON_FATAL_STATUS_CODE_1), REFUSED, new Metadata());
         } finally {
           transport2Lock.unlock();
-          if (transport1Lock.tryLock()) {
-            transport1Lock.unlock();
-          }
+          transport1Lock.unlock();
         }
       }
     }, "Thread-transport2");


### PR DESCRIPTION
The rootcause is reentrant lock has more than one hold count. In this case, lock1 is held when stream4 is created within sublistener.closed callback. It can just be released, no tryLock(), which increment the lock hold count in the current thread, and prevent thread1 from acquiring lock1.

Tested with blaze test `--runs_per_test=100`:
http://sponge2/caeee424-089f-456e-99de-eb82a35558ba


cc. @ejona86 
