### PR TITLE
fix XdsTestServer/TestServiceServer listenAddresses conflict

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
@@ -180,18 +180,22 @@ public class TestServiceServer {
         break;
       case IPV4:
         SocketAddress v4Address = Util.getV4Address(port);
+        InetSocketAddress localV4Address = new InetSocketAddress("127.0.0.1", port);
         serverBuilder =
-            NettyServerBuilder.forAddress(new InetSocketAddress("127.0.0.1", port), serverCreds);
-        if (v4Address == null) {
+            NettyServerBuilder.forAddress(localV4Address, serverCreds);
+        if (v4Address != null && !v4Address.equals(localV4Address)) {
           ((NettyServerBuilder) serverBuilder).addListenAddress(v4Address);
         }
         break;
       case IPV6:
         List<SocketAddress> v6Addresses = Util.getV6Addresses(port);
+        InetSocketAddress localV6Address = new InetSocketAddress("::1", port);
         serverBuilder =
-            NettyServerBuilder.forAddress(new InetSocketAddress("::1", port), serverCreds);
+            NettyServerBuilder.forAddress(localV6Address, serverCreds);
         for (SocketAddress address : v6Addresses) {
-          ((NettyServerBuilder)serverBuilder).addListenAddress(address);
+          if (!address.equals(localV6Address)) {
+            ((NettyServerBuilder) serverBuilder).addListenAddress(address);
+          }
         }
         break;
       default:

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
@@ -242,18 +242,21 @@ public final class XdsTestServer {
           break;
         case IPV4:
           SocketAddress v4Address = Util.getV4Address(port);
+          InetSocketAddress localV4Address = new InetSocketAddress("127.0.0.1", port);
           serverBuilder = NettyServerBuilder.forAddress(
-              new InetSocketAddress("127.0.0.1", port), insecureServerCreds);
-          if (v4Address != null) {
+                  localV4Address, insecureServerCreds);
+          if (v4Address != null && !v4Address.equals(localV4Address) ) {
             ((NettyServerBuilder) serverBuilder).addListenAddress(v4Address);
           }
           break;
         case IPV6:
           List<SocketAddress> v6Addresses = Util.getV6Addresses(port);
-          serverBuilder = NettyServerBuilder.forAddress(
-                  new InetSocketAddress("::1", port), insecureServerCreds);
+          InetSocketAddress localV6Address = new InetSocketAddress("::1", port);
+          serverBuilder = NettyServerBuilder.forAddress(localV6Address, insecureServerCreds);
           for (SocketAddress address : v6Addresses) {
-            ((NettyServerBuilder)serverBuilder).addListenAddress(address);
+            if (!address.equals(localV6Address)) {
+              ((NettyServerBuilder) serverBuilder).addListenAddress(address);
+            }
           }
           break;
         default:


### PR DESCRIPTION

<img width="1287" alt="image" src="https://github.com/user-attachments/assets/2a3f23c1-381c-4384-b936-4dd01b60e184">

when i build `grpc-java` project.  i find a unit test error. 

reason：
`Util.getV4Address(port);`  obtained address conflicts with the local address

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/76a66a7f-bef9-4fa9-a311-458882866abd">

