### PR TITLE
grpc-okhttp: Removed Annotation SuppressWarnings("GuardedBy")

### DIFF
--- a/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
@@ -151,13 +151,17 @@ class CronetClientTransport implements ConnectionClientTransport {
     return new StartCallback().clientStream;
   }
 
-  @SuppressWarnings("GuardedBy")
+  //@SuppressWarnings("GuardedBy")
   @GuardedBy("lock")
   private void startStream(CronetClientStream stream) {
-    streams.add(stream);
-    // TODO(b/145386688): This access should be guarded by 'stream.transportState().lock'; instead
-    // found: 'this.lock'
-    stream.transportState().start(streamFactory);
+    synchronized (lock) {
+      streams.add(stream);
+      // TODO(b/145386688): This access should be guarded by 'stream.transportState().lock'; instead
+      // found: 'this.lock'
+      synchronized (stream.transportState().lock) {
+        stream.transportState().start(streamFactory);
+      }
+    }
   }
 
   @Override

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -147,7 +147,7 @@ class OkHttpClientStream extends AbstractClientStream {
           useGet = true;
           defaultPath += "?" + BaseEncoding.base64().encode(payload);
         }
-        synchronized (state.lock) {
+        synchronized(OkHttpClientStream.this.state.lock) {
           state.streamReady(metadata, defaultPath);
         }
       }
@@ -178,7 +178,7 @@ class OkHttpClientStream extends AbstractClientStream {
     @Override
     public void cancel(Status reason) {
       try (TaskCloseable ignore = PerfMark.traceTask("OkHttpClientStream$Sink.cancel")) {
-        synchronized (state.lock) {
+        synchronized(OkHttpClientStream.this.state.lock) {
           state.cancel(reason, true, null);
         }
       }
@@ -236,16 +236,17 @@ class OkHttpClientStream extends AbstractClientStream {
       tag = PerfMark.createTag(methodName);
     }
 
-    @SuppressWarnings("GuardedBy")
+    //@SuppressWarnings("GuardedBy")
     @GuardedBy("lock")
     public void start(int streamId) {
-      checkState(id == ABSENT_ID, "the stream has been started with id %s", streamId);
-      id = streamId;
-      outboundFlowState = outboundFlow.createState(this, streamId);
-      // TODO(b/145386688): This access should be guarded by 'OkHttpClientStream.this.state.lock';
-      // instead found: 'this.lock'
-      state.onStreamAllocated();
-
+      synchronized(OkHttpClientStream.this.state.lock) {
+        checkState(id == ABSENT_ID, "the stream has been started with id %s", streamId);
+        id = streamId;
+        outboundFlowState = outboundFlow.createState(this, streamId);
+        // TODO(b/145386688): This access should be guarded by 'OkHttpClientStream.this.state.lock';
+        // instead found: 'this.lock'
+        state.onStreamAllocated();
+      }
       if (canStart) {
         // Only happens when the stream has neither been started nor cancelled.
         frameWriter.synStream(useGet, false, id, 0, requestHeaders);
@@ -352,28 +353,30 @@ class OkHttpClientStream extends AbstractClientStream {
       }
     }
 
-    @SuppressWarnings("GuardedBy")
+    //@SuppressWarnings("GuardedBy")
     @GuardedBy("lock")
     private void cancel(Status reason, boolean stopDelivery, Metadata trailers) {
-      if (cancelSent) {
-        return;
-      }
-      cancelSent = true;
-      if (canStart) {
-        // stream is pending.
-        // TODO(b/145386688): This access should be guarded by 'this.transport.lock'; instead found:
-        // 'this.lock'
-        transport.removePendingStream(OkHttpClientStream.this);
-        // release holding data, so they can be GCed or returned to pool earlier.
-        requestHeaders = null;
-        pendingData.clear();
-        canStart = false;
-        transportReportStatus(reason, true, trailers != null ? trailers : new Metadata());
-      } else {
-        // If pendingData is null, start must have already been called, which means synStream has
-        // been called as well.
-        transport.finishStream(
-            id(), reason, PROCESSED, stopDelivery, ErrorCode.CANCEL, trailers);
+      synchronized(transport.lock) {
+        if (cancelSent) {
+          return;
+        }
+        cancelSent = true;
+        if (canStart) {
+          // stream is pending.
+          // TODO(b/145386688): This access should be guarded by 'this.transport.lock'; instead found:
+          // 'this.lock'
+          transport.removePendingStream(OkHttpClientStream.this);
+          // release holding data, so they can be GCed or returned to pool earlier.
+          requestHeaders = null;
+          pendingData.clear();
+          canStart = false;
+          transportReportStatus(reason, true, trailers != null ? trailers : new Metadata());
+        } else {
+          // If pendingData is null, start must have already been called, which means synStream has
+          // been called as well.
+          transport.finishStream(
+              id(), reason, PROCESSED, stopDelivery, ErrorCode.CANCEL, trailers);
+        }
       }
     }
 
@@ -396,20 +399,22 @@ class OkHttpClientStream extends AbstractClientStream {
       }
     }
 
-    @SuppressWarnings("GuardedBy")
+    //@SuppressWarnings("GuardedBy")
     @GuardedBy("lock")
     private void streamReady(Metadata metadata, String path) {
-      requestHeaders =
-          Headers.createRequestHeaders(
-              metadata,
-              path,
-              authority,
-              userAgent,
-              useGet,
-              transport.isUsingPlaintext());
-      // TODO(b/145386688): This access should be guarded by 'this.transport.lock'; instead found:
-      // 'this.lock'
-      transport.streamReadyToStart(OkHttpClientStream.this);
+      synchronized (transport.lock) {
+        requestHeaders =
+            Headers.createRequestHeaders(
+                metadata,
+                path,
+                authority,
+                userAgent,
+                useGet,
+                transport.isUsingPlaintext());
+        // TODO(b/145386688): This access should be guarded by 'this.transport.lock'; instead found:
+        // 'this.lock'
+        transport.streamReadyToStart(OkHttpClientStream.this);
+      }
     }
 
     Tag tag() {

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -188,7 +188,7 @@ class OkHttpClientStream extends AbstractClientStream {
   class TransportState extends Http2ClientStreamTransportState
       implements OutboundFlowController.Stream {
     private final int initialWindowSize;
-    private final Object lock;
+    final Object lock;
     @GuardedBy("lock")
     private List<Header> requestHeaders;
     @GuardedBy("lock")

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -156,7 +156,7 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
   @GuardedBy("lock")
   private ExceptionHandlingFrameWriter frameWriter;
   private OutboundFlowController outboundFlow;
-  private final Object lock = new Object();
+  final Object lock = new Object();
   private final InternalLogId logId;
   @GuardedBy("lock")
   private int nextStreamId;


### PR DESCRIPTION
Removed the SuppressWarnings("GuardedBy") Annotation and Cleanup/tweak the code.

Fixes https://github.com/grpc/grpc-java/issues/6578