### PR TITLE
gcp-csm-o11y: Get mesh_id from environment variable

### DIFF
--- a/gcp-csm-observability/src/test/java/io/grpc/gcp/csm/observability/CsmObservabilityTest.java
+++ b/gcp-csm-observability/src/test/java/io/grpc/gcp/csm/observability/CsmObservabilityTest.java
@@ -77,17 +77,14 @@ public final class CsmObservabilityTest {
 
   @Test
   public void unknownDataExchange() throws Exception {
-    String xdsBootstrap = "";
     MetadataExchanger clientExchanger = new MetadataExchanger(
         Attributes.builder().build(),
-        ImmutableMap.<String, String>of()::get,
-        () -> xdsBootstrap);
+        ImmutableMap.<String, String>of()::get);
     CsmObservability.Builder clientCsmBuilder = new CsmObservability.Builder(clientExchanger)
         .sdk(openTelemetryTesting.getOpenTelemetry());
     MetadataExchanger serverExchanger = new MetadataExchanger(
         Attributes.builder().build(),
-        ImmutableMap.<String, String>of()::get,
-        () -> xdsBootstrap);
+        ImmutableMap.<String, String>of()::get);
     CsmObservability.Builder serverCsmBuilder = new CsmObservability.Builder(serverExchanger)
         .sdk(openTelemetryTesting.getOpenTelemetry());
 
@@ -140,11 +137,9 @@ public final class CsmObservabilityTest {
 
   @Test
   public void nonCsmServer() throws Exception {
-    String xdsBootstrap = "";
     MetadataExchanger clientExchanger = new MetadataExchanger(
         Attributes.builder().build(),
-        ImmutableMap.<String, String>of()::get,
-        () -> xdsBootstrap);
+        ImmutableMap.<String, String>of()::get);
     CsmObservability.Builder clientCsmBuilder = new CsmObservability.Builder(clientExchanger)
         .sdk(openTelemetryTesting.getOpenTelemetry());
 
@@ -205,19 +200,16 @@ public final class CsmObservabilityTest {
 
   @Test
   public void nonCsmClient() throws Exception {
-    String xdsBootstrap = "";
     MetadataExchanger clientExchanger = new MetadataExchanger(
         Attributes.builder()
             .put(stringKey("cloud.platform"), "gcp_kubernetes_engine")
             .build(),
-        ImmutableMap.<String, String>of()::get,
-        () -> xdsBootstrap);
+        ImmutableMap.<String, String>of()::get);
     CsmObservability.Builder clientCsmBuilder = new CsmObservability.Builder(clientExchanger)
         .sdk(openTelemetryTesting.getOpenTelemetry());
     MetadataExchanger serverExchanger = new MetadataExchanger(
         Attributes.builder().build(),
-        ImmutableMap.<String, String>of()::get,
-        () -> xdsBootstrap);
+        ImmutableMap.<String, String>of()::get);
     CsmObservability.Builder serverCsmBuilder = new CsmObservability.Builder(serverExchanger)
         .sdk(openTelemetryTesting.getOpenTelemetry());
 
@@ -262,11 +254,6 @@ public final class CsmObservabilityTest {
 
   @Test
   public void k8sExchange() throws Exception {
-    // Purposefully use a different project ID in the bootstrap than the resource, as the mesh could
-    // be in a different project than the running account.
-    String clientBootstrap = "{\"node\": {"
-        + "\"id\": \"projects/12/networks/mesh:mymesh/nodes/a6420022-cbc5-4e10-808c-507e3fc95f2e\""
-        + "}}";
     MetadataExchanger clientExchanger = new MetadataExchanger(
         Attributes.builder()
             .put(stringKey("cloud.platform"), "gcp_kubernetes_engine")
@@ -277,13 +264,10 @@ public final class CsmObservabilityTest {
             .build(),
         ImmutableMap.of(
             "CSM_CANONICAL_SERVICE_NAME", "canon-service-is-a-client",
-            "CSM_WORKLOAD_NAME", "best-client")::get,
-        () -> clientBootstrap);
+            "CSM_WORKLOAD_NAME", "best-client",
+            "CSM_MESH_ID", "mymesh")::get);
     CsmObservability.Builder clientCsmBuilder = new CsmObservability.Builder(clientExchanger)
         .sdk(openTelemetryTesting.getOpenTelemetry());
-    String serverBootstrap = "{\"node\": {"
-        + "\"id\": \"projects/34/networks/mesh:meshhh/nodes/4969ef19-24b6-44c0-baf3-86d188ff5967\""
-        + "}}";
     MetadataExchanger serverExchanger = new MetadataExchanger(
         Attributes.builder()
             .put(stringKey("cloud.platform"), "gcp_kubernetes_engine")
@@ -295,8 +279,8 @@ public final class CsmObservabilityTest {
             .build(),
         ImmutableMap.of(
             "CSM_CANONICAL_SERVICE_NAME", "server-has-a-single-name",
-            "CSM_WORKLOAD_NAME", "fast-server")::get,
-        () -> serverBootstrap);
+            "CSM_WORKLOAD_NAME", "fast-server",
+            "CSM_MESH_ID", "meshhh")::get);
     CsmObservability.Builder serverCsmBuilder = new CsmObservability.Builder(serverExchanger)
         .sdk(openTelemetryTesting.getOpenTelemetry());
 
@@ -366,11 +350,6 @@ public final class CsmObservabilityTest {
 
   @Test
   public void gceExchange() throws Exception {
-    // Purposefully use a different project ID in the bootstrap than the resource, as the mesh could
-    // be in a different project than the running account.
-    String clientBootstrap = "{\"node\": {"
-        + "\"id\": \"projects/12/networks/mesh:mymesh/nodes/a6420022-cbc5-4e10-808c-507e3fc95f2e\""
-        + "}}";
     MetadataExchanger clientExchanger = new MetadataExchanger(
         Attributes.builder()
             .put(stringKey("cloud.platform"), "gcp_compute_engine")
@@ -379,13 +358,10 @@ public final class CsmObservabilityTest {
             .build(),
         ImmutableMap.of(
             "CSM_CANONICAL_SERVICE_NAME", "canon-service-is-a-client",
-            "CSM_WORKLOAD_NAME", "best-client")::get,
-        () -> clientBootstrap);
+            "CSM_WORKLOAD_NAME", "best-client",
+            "CSM_MESH_ID", "mymesh")::get);
     CsmObservability.Builder clientCsmBuilder = new CsmObservability.Builder(clientExchanger)
         .sdk(openTelemetryTesting.getOpenTelemetry());
-    String serverBootstrap = "{\"node\": {"
-        + "\"id\": \"projects/34/networks/mesh:meshhh/nodes/4969ef19-24b6-44c0-baf3-86d188ff5967\""
-        + "}}";
     MetadataExchanger serverExchanger = new MetadataExchanger(
         Attributes.builder()
             .put(stringKey("cloud.platform"), "gcp_compute_engine")
@@ -395,8 +371,8 @@ public final class CsmObservabilityTest {
             .build(),
         ImmutableMap.of(
             "CSM_CANONICAL_SERVICE_NAME", "server-has-a-single-name",
-            "CSM_WORKLOAD_NAME", "fast-server")::get,
-        () -> serverBootstrap);
+            "CSM_WORKLOAD_NAME", "fast-server",
+            "CSM_MESH_ID", "meshhh")::get);
     CsmObservability.Builder serverCsmBuilder = new CsmObservability.Builder(serverExchanger)
         .sdk(openTelemetryTesting.getOpenTelemetry());
 
@@ -456,9 +432,6 @@ public final class CsmObservabilityTest {
 
   @Test
   public void trailersOnly() throws Exception {
-    String clientBootstrap = "{\"node\": {"
-        + "\"id\": \"projects/12/networks/mesh:mymesh/nodes/a6420022-cbc5-4e10-808c-507e3fc95f2e\""
-        + "}}";
     MetadataExchanger clientExchanger = new MetadataExchanger(
         Attributes.builder()
             .put(stringKey("cloud.platform"), "gcp_compute_engine")
@@ -467,13 +440,11 @@ public final class CsmObservabilityTest {
             .build(),
         ImmutableMap.of(
             "CSM_CANONICAL_SERVICE_NAME", "canon-service-is-a-client",
-            "CSM_WORKLOAD_NAME", "best-client")::get,
-        () -> clientBootstrap);
+            "CSM_WORKLOAD_NAME", "best-client",
+            "CSM_MESH_ID", "mymesh")::get);
     CsmObservability.Builder clientCsmBuilder = new CsmObservability.Builder(clientExchanger)
         .sdk(openTelemetryTesting.getOpenTelemetry());
-    String serverBootstrap = "{\"node\": {"
-        + "\"id\": \"projects/34/networks/mesh:meshhh/nodes/4969ef19-24b6-44c0-baf3-86d188ff5967\""
-        + "}}";
+
     MetadataExchanger serverExchanger = new MetadataExchanger(
         Attributes.builder()
             .put(stringKey("cloud.platform"), "gcp_compute_engine")
@@ -483,8 +454,8 @@ public final class CsmObservabilityTest {
             .build(),
         ImmutableMap.of(
             "CSM_CANONICAL_SERVICE_NAME", "server-has-a-single-name",
-            "CSM_WORKLOAD_NAME", "fast-server")::get,
-        () -> serverBootstrap);
+            "CSM_WORKLOAD_NAME", "fast-server",
+            "CSM_MESH_ID", "meshhh")::get);
     CsmObservability.Builder serverCsmBuilder = new CsmObservability.Builder(serverExchanger)
         .sdk(openTelemetryTesting.getOpenTelemetry());
 

--- a/gcp-csm-observability/src/test/java/io/grpc/gcp/csm/observability/MetadataExchangerTest.java
+++ b/gcp-csm-observability/src/test/java/io/grpc/gcp/csm/observability/MetadataExchangerTest.java
@@ -33,56 +33,11 @@ import org.junit.runners.JUnit4;
 /** Tests for {@link MetadataExchanger}. */
 @RunWith(JUnit4.class)
 public final class MetadataExchangerTest {
-  @Test
-  public void getMeshId_findsMeshId() {
-    assertThat(MetadataExchanger.getMeshId(() ->
-        "{\"node\":{\"id\":\"projects/12/networks/mesh:mine/nodes/uu-id\"}}"))
-        .isEqualTo("mine");
-    assertThat(MetadataExchanger.getMeshId(() ->
-          "{\"node\":{\"id\":\"projects/1234567890/networks/mesh:mine/nodes/uu-id\", "
-          + "\"unknown\": \"\"}, \"unknown\": \"\"}"))
-        .isEqualTo("mine");
-  }
-
-  @Test
-  public void getMeshId_returnsNullOnBadMeshId() {
-    assertThat(MetadataExchanger.getMeshId(
-            () -> "[\"node\"]"))
-        .isNull();
-    assertThat(MetadataExchanger.getMeshId(
-            () -> "{\"node\":[\"id\"]}}"))
-        .isNull();
-    assertThat(MetadataExchanger.getMeshId(
-            () -> "{\"node\":{\"id\":[\"projects/12/networks/mesh:mine/nodes/uu-id\"]}}"))
-        .isNull();
-
-    assertThat(MetadataExchanger.getMeshId(
-            () -> "{\"NODE\":{\"id\":\"projects/12/networks/mesh:mine/nodes/uu-id\"}}"))
-        .isNull();
-    assertThat(MetadataExchanger.getMeshId(
-            () -> "{\"node\":{\"ID\":\"projects/12/networks/mesh:mine/nodes/uu-id\"}}"))
-        .isNull();
-    assertThat(MetadataExchanger.getMeshId(
-            () -> "{\"node\":{\"id\":\"projects/12/networks/mesh:mine\"}}"))
-        .isNull();
-    assertThat(MetadataExchanger.getMeshId(
-            () -> "{\"node\":{\"id\":\"PROJECTS/12/networks/mesh:mine/nodes/uu-id\"}}"))
-        .isNull();
-    assertThat(MetadataExchanger.getMeshId(
-            () -> "{\"node\":{\"id\":\"projects/12/NETWORKS/mesh:mine/nodes/uu-id\"}}"))
-        .isNull();
-    assertThat(MetadataExchanger.getMeshId(
-            () -> "{\"node\":{\"id\":\"projects/12/networks/MESH:mine/nodes/uu-id\"}}"))
-        .isNull();
-    assertThat(MetadataExchanger.getMeshId(
-            () -> "{\"node\":{\"id\":\"projects/12/networks/mesh:mine/NODES/uu-id\"}}"))
-        .isNull();
-  }
 
   @Test
   public void enablePluginForChannel_matches() {
     MetadataExchanger exchanger =
-        new MetadataExchanger(Attributes.builder().build(), (name) -> null, () -> "");
+        new MetadataExchanger(Attributes.builder().build(), (name) -> null);
     assertThat(exchanger.enablePluginForChannel("xds:///testing")).isTrue();
     assertThat(exchanger.enablePluginForChannel("xds:/testing")).isTrue();
     assertThat(exchanger.enablePluginForChannel(
@@ -92,7 +47,7 @@ public final class MetadataExchangerTest {
   @Test
   public void enablePluginForChannel_doesNotMatch() {
     MetadataExchanger exchanger =
-        new MetadataExchanger(Attributes.builder().build(), (name) -> null, () -> "");
+        new MetadataExchanger(Attributes.builder().build(), (name) -> null);
     assertThat(exchanger.enablePluginForChannel("dns:///localhost")).isFalse();
     assertThat(exchanger.enablePluginForChannel("xds:///[]")).isFalse();
     assertThat(exchanger.enablePluginForChannel("xds://my-xds-server/testing")).isFalse();
@@ -101,7 +56,7 @@ public final class MetadataExchangerTest {
   @Test
   public void addLabels_receivedWrongType() {
     MetadataExchanger exchanger =
-        new MetadataExchanger(Attributes.builder().build(), (name) -> null, () -> "");
+        new MetadataExchanger(Attributes.builder().build(), (name) -> null);
     Metadata metadata = new Metadata();
     metadata.put(Metadata.Key.of("x-envoy-peer-metadata", Metadata.ASCII_STRING_MARSHALLER),
         BaseEncoding.base64().encode(Struct.newBuilder()
@@ -122,7 +77,7 @@ public final class MetadataExchangerTest {
   @Test
   public void addLabelsFromExchange_unknownGcpType() {
     MetadataExchanger exchanger =
-        new MetadataExchanger(Attributes.builder().build(), (name) -> null, () -> "");
+        new MetadataExchanger(Attributes.builder().build(), (name) -> null);
     Metadata metadata = new Metadata();
     metadata.put(Metadata.Key.of("x-envoy-peer-metadata", Metadata.ASCII_STRING_MARSHALLER),
         BaseEncoding.base64().encode(Struct.newBuilder()
@@ -153,8 +108,7 @@ public final class MetadataExchangerTest {
             .build(),
         ImmutableMap.of(
             "CSM_CANONICAL_SERVICE_NAME", "myservice1",
-            "CSM_WORKLOAD_NAME", "myworkload1")::get,
-        () -> "");
+            "CSM_WORKLOAD_NAME", "myworkload1")::get);
     Metadata metadata = new Metadata();
     exchanger.newClientCallPlugin().addMetadata(metadata);
 
@@ -182,8 +136,7 @@ public final class MetadataExchangerTest {
             .build(),
         ImmutableMap.of(
             "CSM_CANONICAL_SERVICE_NAME", "myservice1",
-            "CSM_WORKLOAD_NAME", "myworkload1")::get,
-        () -> "");
+            "CSM_WORKLOAD_NAME", "myworkload1")::get);
     Metadata metadata = new Metadata();
     exchanger.newClientCallPlugin().addMetadata(metadata);
 


### PR DESCRIPTION
This PR updates how the mesh_id local label is assigned.

Instead of deriving it from the bootstrap or parsing it from the bootstrap's node_id, the mesh_id will now be set using the `CSM_MESH_ID` environment variable.

CC  @yashykt 