### PR TITLE
core: Alternate ipV4 and ipV6 addresses for Happy Eyeballs in PickFirstLeafLoadBalancer 

### DIFF
--- a/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
@@ -62,7 +62,7 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
   static final int CONNECTION_DELAY_INTERVAL_MS = 250;
   private final Helper helper;
   private final Map<SocketAddress, SubchannelData> subchannels = new HashMap<>();
-  private final IndexI addressIndex = IndexI.create(ImmutableList.of());
+  private final Index addressIndex = Index.create(ImmutableList.of());
   private int numTf = 0;
   private boolean firstPass = true;
   @Nullable
@@ -611,8 +611,8 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
     }
   }
 
-  interface IndexI {
-    static IndexI create(List<EquivalentAddressGroup> groups) {
+  interface Index {
+    static Index create(List<EquivalentAddressGroup> groups) {
       if (PickFirstLoadBalancerProvider.isEnabledHappyEyeballs()) {
         return new IndexHappyEyeballs(groups);
       } else {
@@ -659,7 +659,7 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
    * All updates should be done in a synchronization context.
    */
   @VisibleForTesting
-  private static class IndexNonHE implements IndexI {
+  private static final class IndexNonHE implements Index {
     private List<EquivalentAddressGroup> addressGroups;
     private int size;
     private int groupIndex;
@@ -772,7 +772,7 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
     }
   }
 
-  private static final class IndexHappyEyeballs implements IndexI {
+  private static final class IndexHappyEyeballs implements Index {
     private List<EquivalentAddressGroup> addressGroups;
     private List<InterleavedEntry> interleavedAddresses = new ArrayList<>();
     private int interleavedIndex = 0;

--- a/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
@@ -34,6 +34,8 @@ import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
 import io.grpc.Status;
 import io.grpc.SynchronizationContext.ScheduledHandle;
+import java.net.Inet4Address;
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -60,7 +62,7 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
   static final int CONNECTION_DELAY_INTERVAL_MS = 250;
   private final Helper helper;
   private final Map<SocketAddress, SubchannelData> subchannels = new HashMap<>();
-  private final Index addressIndex = new Index(ImmutableList.of());
+  private final IndexI addressIndex = IndexI.create(ImmutableList.of());
   private int numTf = 0;
   private boolean firstPass = true;
   @Nullable
@@ -609,26 +611,71 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
     }
   }
 
+  interface IndexI {
+    static IndexI create(List<EquivalentAddressGroup> groups) {
+      if (PickFirstLoadBalancerProvider.isEnabledHappyEyeballs()) {
+        return new IndexHappyEyeballs(groups);
+      } else {
+        return new IndexNonHE(groups);
+      }
+    }
+
+    boolean isValid();
+
+    boolean isAtBeginning();
+
+    /**
+     * Move to next address in group.  If last address in group move to first address of next group.
+     *
+     * @return false if went off end of the list, otherwise true
+     */
+    boolean increment();
+
+    void reset();
+
+    SocketAddress getCurrentAddress();
+
+    Attributes getCurrentEagAttributes();
+
+    List<EquivalentAddressGroup> getCurrentEagAsList();
+
+    /**
+     * Update to new groups, resetting the current index.
+     */
+    void updateGroups(List<EquivalentAddressGroup> newGroups);
+
+    /**
+     * Returns false if the needle was not found and the current index was left unchanged.
+     */
+    boolean seekTo(SocketAddress needle);
+
+    int size();
+
+    int getGroupIndex();
+  }
+
   /**
-   * Index as in 'i', the pointer to an entry. Not a "search index."
+   * IndexNonHE as in 'i', the pointer to an entry. Not a "search index."
    * All updates should be done in a synchronization context.
    */
   @VisibleForTesting
-  static final class Index {
+  private static class IndexNonHE implements IndexI {
     private List<EquivalentAddressGroup> addressGroups;
     private int size;
     private int groupIndex;
     private int addressIndex;
 
-    public Index(List<EquivalentAddressGroup> groups) {
+    public IndexNonHE(List<EquivalentAddressGroup> groups) {
       updateGroups(groups);
     }
 
+    @Override
     public boolean isValid() {
       // Is invalid if empty or has incremented off the end
       return groupIndex < addressGroups.size();
     }
 
+    @Override
     public boolean isAtBeginning() {
       return groupIndex == 0 && addressIndex == 0;
     }
@@ -637,6 +684,7 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
      * Move to next address in group.  If last address in group move to first address of next group.
      * @return false if went off end of the list, otherwise true
      */
+    @Override
     public boolean increment() {
       if (!isValid()) {
         return false;
@@ -653,11 +701,13 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
       return true;
     }
 
+    @Override
     public void reset() {
       groupIndex = 0;
       addressIndex = 0;
     }
 
+    @Override
     public SocketAddress getCurrentAddress() {
       if (!isValid()) {
         throw new IllegalStateException("Index is past the end of the address group list");
@@ -665,6 +715,7 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
       return addressGroups.get(groupIndex).getAddresses().get(addressIndex);
     }
 
+    @Override
     public Attributes getCurrentEagAttributes() {
       if (!isValid()) {
         throw new IllegalStateException("Index is off the end of the address group list");
@@ -672,6 +723,7 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
       return addressGroups.get(groupIndex).getAttributes();
     }
 
+    @Override
     public List<EquivalentAddressGroup> getCurrentEagAsList() {
       return Collections.singletonList(
           new EquivalentAddressGroup(getCurrentAddress(), getCurrentEagAttributes()));
@@ -680,6 +732,7 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
     /**
      * Update to new groups, resetting the current index.
      */
+    @Override
     public void updateGroups(List<EquivalentAddressGroup> newGroups) {
       addressGroups = checkNotNull(newGroups, "newGroups");
       reset();
@@ -693,6 +746,7 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
     /**
      * Returns false if the needle was not found and the current index was left unchanged.
      */
+    @Override
     public boolean seekTo(SocketAddress needle) {
       for (int i = 0; i < addressGroups.size(); i++) {
         EquivalentAddressGroup group = addressGroups.get(i);
@@ -707,14 +761,171 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
       return false;
     }
 
+    @Override
     public int size() {
       return size;
+    }
+
+    @Override
+    public int getGroupIndex() {
+      return groupIndex;
+    }
+  }
+
+  private static final class IndexHappyEyeballs implements IndexI {
+    private List<EquivalentAddressGroup> addressGroups;
+    private List<InterleavedEntry> interleavedAddresses = new ArrayList<>();
+    private int interleavedIndex = 0;
+
+    public IndexHappyEyeballs(List<EquivalentAddressGroup> groups) {
+      updateGroups(groups);
+    }
+
+    @Override
+    public boolean increment() {
+      if (!isValid()) {
+        return false;
+      }
+
+      interleavedIndex++;
+
+      return isValid();
+    }
+
+    @Override
+    public boolean isValid() {
+      return interleavedIndex < interleavedAddresses.size();
+    }
+
+    @Override
+    public boolean isAtBeginning() {
+      return interleavedIndex == 0;
+    }
+
+    @Override
+    public void reset() {
+      interleavedIndex = 0;
+    }
+
+    @Override
+    public SocketAddress getCurrentAddress() {
+      if (!isValid()) {
+        throw new IllegalStateException("Index is past the end of the address group list");
+      }
+      return interleavedAddresses.get(interleavedIndex).address;
+    }
+
+    @Override
+    public Attributes getCurrentEagAttributes() {
+      return getCurrentEag().getAttributes();
+    }
+
+    @Override
+    public List<EquivalentAddressGroup> getCurrentEagAsList() {
+      return Collections.singletonList(getCurrentEag());
+    }
+
+    @Override
+    public int getGroupIndex() {
+      if (!isValid()) {
+        throw new IllegalStateException("Index is past the end of the address group list");
+      }
+      return interleavedAddresses.get(interleavedIndex).addressGroup;
+    }
+
+    private EquivalentAddressGroup getCurrentEag() {
+      if (!isValid()) {
+        throw new IllegalStateException("Index is past the end of the address group list");
+      }
+      return addressGroups.get(interleavedAddresses.get(interleavedIndex).addressGroup);
+    }
+
+    @Override
+    public void updateGroups(List<EquivalentAddressGroup> newGroups) {
+      addressGroups = checkNotNull(newGroups, "newGroups");
+      Boolean firstIsV6 = null;
+      List<InterleavedEntry> v4Entries = new ArrayList<>();
+      List<InterleavedEntry> v6Entries = new ArrayList<>();
+      for (int g = 0; g <  newGroups.size(); g++) {
+        EquivalentAddressGroup eag = newGroups.get(g);
+        for (int a = 0; a < eag.getAddresses().size(); a++) {
+          SocketAddress addr = eag.getAddresses().get(a);
+          boolean isIpV4 = addr instanceof InetSocketAddress
+              && ((InetSocketAddress) addr).getAddress() instanceof Inet4Address;
+          if (isIpV4) {
+            if (firstIsV6 == null) {
+              firstIsV6 = false;
+            }
+            v4Entries.add(new InterleavedEntry(g, addr));
+          } else {
+            if (firstIsV6 == null) {
+              firstIsV6 = true;
+            }
+            v6Entries.add(new InterleavedEntry(g, addr));
+          }
+        }
+      }
+
+      this.interleavedAddresses =
+          firstIsV6 != null && firstIsV6
+          ? interleave(v6Entries, v4Entries)
+          : interleave(v4Entries, v6Entries);
+
+      reset();
+    }
+
+    private static List<InterleavedEntry> interleave(List<InterleavedEntry> firstFamily,
+                                                     List<InterleavedEntry> secondFamily) {
+      if (firstFamily.isEmpty()) {
+        return secondFamily;
+      }
+      if (secondFamily.isEmpty()) {
+        return firstFamily;
+      }
+
+      List<InterleavedEntry> result = new ArrayList<>();
+      for (int i = 0; i < Math.max(firstFamily.size(), secondFamily.size()); i++) {
+        if (i < firstFamily.size()) {
+          result.add(firstFamily.get(i));
+        }
+        if (i < secondFamily.size()) {
+          result.add(secondFamily.get(i));
+        }
+      }
+      return result;
+    }
+
+    @Override
+    public boolean seekTo(SocketAddress needle) {
+      checkNotNull(needle, "needle");
+      for (int i = 0; i < interleavedAddresses.size(); i++) {
+        if (interleavedAddresses.get(i).address.equals(needle)) {
+          this.interleavedIndex = i;
+          return true;
+        }
+      }
+      return false;
+    }
+
+    @Override
+    public int size() {
+      return interleavedAddresses.size();
+    }
+
+    private static final class InterleavedEntry {
+      private final int addressGroup;
+      private final SocketAddress address;
+
+      public InterleavedEntry(int addressGroup, SocketAddress address) {
+        this.addressGroup = addressGroup;
+        this.address = address;
+      }
     }
   }
 
   @VisibleForTesting
   int getGroupIndex() {
-    return addressIndex.groupIndex;
+    return addressIndex.getGroupIndex();
   }
 
   @VisibleForTesting
@@ -778,4 +989,5 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
       this.randomSeed = randomSeed;
     }
   }
+
 }

--- a/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
@@ -752,11 +752,7 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
       return orderedAddresses.size();
     }
 
-    int getActiveElement() {
-      return activeElement;
-    }
-
-    private final class UnwrappedEag {
+    private static final class UnwrappedEag {
       private final Attributes attributes;
       private final SocketAddress address;
 

--- a/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
@@ -757,7 +757,7 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
         return firstFamily;
       }
 
-      List<UnwrappedEag> result = new ArrayList<>();
+      List<UnwrappedEag> result = new ArrayList<>(firstFamily.size() + secondFamily.size());
       for (int i = 0; i < Math.max(firstFamily.size(), secondFamily.size()); i++) {
         if (i < firstFamily.size()) {
           result.add(firstFamily.get(i));

--- a/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
@@ -622,6 +622,14 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
       updateGroups(groups);
     }
 
+    public boolean isValid() {
+      return activeElement < orderedAddresses.size();
+    }
+
+    public boolean isAtBeginning() {
+      return activeElement == 0;
+    }
+
     boolean increment() {
       if (!isValid()) {
         return false;
@@ -630,14 +638,6 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
       activeElement++;
 
       return isValid();
-    }
-
-    boolean isValid() {
-      return activeElement < orderedAddresses.size();
-    }
-
-    boolean isAtBeginning() {
-      return activeElement == 0;
     }
 
     void reset() {

--- a/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
@@ -611,6 +611,10 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
     }
   }
 
+  /**
+   * This contains both an ordered list of addresses and a pointer(i.e. index) to the current entry
+   * All updates should be done in a synchronization context.
+   */
   @VisibleForTesting
   static final class Index {
     private List<UnwrappedEag> orderedAddresses = new ArrayList<>();
@@ -630,6 +634,10 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
       return activeElement == 0;
     }
 
+    /**
+     * Move to next address in group.  If last address in group move to first address of next group.
+     * @return false if went off end of the list, otherwise true
+     */
     public boolean increment() {
       if (!isValid()) {
         return false;
@@ -666,6 +674,9 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
       return orderedAddresses.get(activeElement).asEag();
     }
 
+    /**
+     * Update to new groups, resetting the current index.
+     */
     public void updateGroups(List<EquivalentAddressGroup> newGroups) {
       checkNotNull(newGroups, "newGroups");
       orderedAddresses = enableHappyEyeballs
@@ -674,7 +685,10 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
       reset();
     }
 
-    boolean seekTo(SocketAddress needle) {
+    /**
+     * Returns false if the needle was not found and the current index was left unchanged.
+     */
+    public boolean seekTo(SocketAddress needle) {
       checkNotNull(needle, "needle");
       for (int i = 0; i < orderedAddresses.size(); i++) {
         if (orderedAddresses.get(i).address.equals(needle)) {
@@ -685,7 +699,7 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
       return false;
     }
 
-    int size() {
+    public int size() {
       return orderedAddresses.size();
     }
 

--- a/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
@@ -612,12 +612,12 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
   }
 
   /**
-   * This contains both an ordered list of addresses and a pointer(i.e. index) to the current entry
+   * This contains both an ordered list of addresses and a pointer(i.e. index) to the current entry.
    * All updates should be done in a synchronization context.
    */
   @VisibleForTesting
   static final class Index {
-    private List<UnwrappedEag> orderedAddresses = new ArrayList<>();
+    private List<UnwrappedEag> orderedAddresses;
     private int activeElement = 0;
     private boolean enableHappyEyeballs;
 
@@ -660,6 +660,9 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
     }
 
     public Attributes getCurrentEagAttributes() {
+      if (!isValid()) {
+        throw new IllegalStateException("Index is off the end of the address group list");
+      }
       return orderedAddresses.get(activeElement).attributes;
     }
 

--- a/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
@@ -630,7 +630,7 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
       return activeElement == 0;
     }
 
-    boolean increment() {
+    public boolean increment() {
       if (!isValid()) {
         return false;
       }
@@ -640,22 +640,22 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
       return isValid();
     }
 
-    void reset() {
+    public void reset() {
       activeElement = 0;
     }
 
-    SocketAddress getCurrentAddress() {
+    public SocketAddress getCurrentAddress() {
       if (!isValid()) {
         throw new IllegalStateException("Index is past the end of the address group list");
       }
       return orderedAddresses.get(activeElement).address;
     }
 
-    Attributes getCurrentEagAttributes() {
+    public Attributes getCurrentEagAttributes() {
       return orderedAddresses.get(activeElement).attributes;
     }
 
-    private List<EquivalentAddressGroup> getCurrentEagAsList() {
+    public List<EquivalentAddressGroup> getCurrentEagAsList() {
       return Collections.singletonList(getCurrentEag());
     }
 
@@ -666,12 +666,27 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
       return orderedAddresses.get(activeElement).asEag();
     }
 
-    void updateGroups(List<EquivalentAddressGroup> newGroups) {
+    public void updateGroups(List<EquivalentAddressGroup> newGroups) {
       checkNotNull(newGroups, "newGroups");
       orderedAddresses = enableHappyEyeballs
                              ? updateGroupsHE(newGroups)
                              : updateGroupsNonHE(newGroups);
       reset();
+    }
+
+    boolean seekTo(SocketAddress needle) {
+      checkNotNull(needle, "needle");
+      for (int i = 0; i < orderedAddresses.size(); i++) {
+        if (orderedAddresses.get(i).address.equals(needle)) {
+          this.activeElement = i;
+          return true;
+        }
+      }
+      return false;
+    }
+
+    int size() {
+      return orderedAddresses.size();
     }
 
     private List<UnwrappedEag> updateGroupsNonHE(List<EquivalentAddressGroup> newGroups) {
@@ -735,21 +750,6 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
         }
       }
       return result;
-    }
-
-    boolean seekTo(SocketAddress needle) {
-      checkNotNull(needle, "needle");
-      for (int i = 0; i < orderedAddresses.size(); i++) {
-        if (orderedAddresses.get(i).address.equals(needle)) {
-          this.activeElement = i;
-          return true;
-        }
-      }
-      return false;
-    }
-
-    int size() {
-      return orderedAddresses.size();
     }
 
     private static final class UnwrappedEag {

--- a/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
@@ -60,17 +60,17 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
   private static final Logger log = Logger.getLogger(PickFirstLeafLoadBalancer.class.getName());
   @VisibleForTesting
   static final int CONNECTION_DELAY_INTERVAL_MS = 250;
+  private final boolean enableHappyEyeballs = !isSerializingRetries()
+      && PickFirstLoadBalancerProvider.isEnabledHappyEyeballs();
   private final Helper helper;
   private final Map<SocketAddress, SubchannelData> subchannels = new HashMap<>();
-  private final Index addressIndex = Index.create(ImmutableList.of());
+  private final Index addressIndex = new Index(ImmutableList.of(), this.enableHappyEyeballs);
   private int numTf = 0;
   private boolean firstPass = true;
   @Nullable
   private ScheduledHandle scheduleConnectionTask = null;
   private ConnectivityState rawConnectivityState = IDLE;
   private ConnectivityState concludedState = IDLE;
-  private final boolean enableHappyEyeballs = !isSerializingRetries()
-      && PickFirstLoadBalancerProvider.isEnabledHappyEyeballs();
   private boolean notAPetiolePolicy = true; // means not under a petiole policy
   private final BackoffPolicy.Provider bkoffPolProvider = new ExponentialBackoffPolicy.Provider();
   private BackoffPolicy reconnectPolicy;
@@ -611,241 +611,86 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
     }
   }
 
-  interface Index {
-    static Index create(List<EquivalentAddressGroup> groups) {
-      if (PickFirstLoadBalancerProvider.isEnabledHappyEyeballs()) {
-        return new IndexHappyEyeballs(groups);
-      } else {
-        return new IndexNonHE(groups);
-      }
-    }
-
-    boolean isValid();
-
-    boolean isAtBeginning();
-
-    /**
-     * Move to next address in group.  If last address in group move to first address of next group.
-     *
-     * @return false if went off end of the list, otherwise true
-     */
-    boolean increment();
-
-    void reset();
-
-    SocketAddress getCurrentAddress();
-
-    Attributes getCurrentEagAttributes();
-
-    List<EquivalentAddressGroup> getCurrentEagAsList();
-
-    /**
-     * Update to new groups, resetting the current index.
-     */
-    void updateGroups(List<EquivalentAddressGroup> newGroups);
-
-    /**
-     * Returns false if the needle was not found and the current index was left unchanged.
-     */
-    boolean seekTo(SocketAddress needle);
-
-    int size();
-
-    int getGroupIndex();
-  }
-
-  /**
-   * IndexNonHE as in 'i', the pointer to an entry. Not a "search index."
-   * All updates should be done in a synchronization context.
-   */
   @VisibleForTesting
-  private static final class IndexNonHE implements Index {
-    private List<EquivalentAddressGroup> addressGroups;
-    private int size;
-    private int groupIndex;
-    private int addressIndex;
+  static final class Index {
+    private List<UnwrappedEag> orderedAddresses = new ArrayList<>();
+    private int activeElement = 0;
+    private boolean enableHappyEyeballs;
 
-    public IndexNonHE(List<EquivalentAddressGroup> groups) {
+    Index(List<EquivalentAddressGroup> groups, boolean enableHappyEyeballs) {
+      this.enableHappyEyeballs = enableHappyEyeballs;
       updateGroups(groups);
     }
 
-    @Override
-    public boolean isValid() {
-      // Is invalid if empty or has incremented off the end
-      return groupIndex < addressGroups.size();
-    }
-
-    @Override
-    public boolean isAtBeginning() {
-      return groupIndex == 0 && addressIndex == 0;
-    }
-
-    /**
-     * Move to next address in group.  If last address in group move to first address of next group.
-     * @return false if went off end of the list, otherwise true
-     */
-    @Override
-    public boolean increment() {
+    boolean increment() {
       if (!isValid()) {
         return false;
       }
 
-      EquivalentAddressGroup group = addressGroups.get(groupIndex);
-      addressIndex++;
-      if (addressIndex >= group.getAddresses().size()) {
-        groupIndex++;
-        addressIndex = 0;
-        return groupIndex < addressGroups.size();
-      }
-
-      return true;
-    }
-
-    @Override
-    public void reset() {
-      groupIndex = 0;
-      addressIndex = 0;
-    }
-
-    @Override
-    public SocketAddress getCurrentAddress() {
-      if (!isValid()) {
-        throw new IllegalStateException("Index is past the end of the address group list");
-      }
-      return addressGroups.get(groupIndex).getAddresses().get(addressIndex);
-    }
-
-    @Override
-    public Attributes getCurrentEagAttributes() {
-      if (!isValid()) {
-        throw new IllegalStateException("Index is off the end of the address group list");
-      }
-      return addressGroups.get(groupIndex).getAttributes();
-    }
-
-    @Override
-    public List<EquivalentAddressGroup> getCurrentEagAsList() {
-      return Collections.singletonList(
-          new EquivalentAddressGroup(getCurrentAddress(), getCurrentEagAttributes()));
-    }
-
-    /**
-     * Update to new groups, resetting the current index.
-     */
-    @Override
-    public void updateGroups(List<EquivalentAddressGroup> newGroups) {
-      addressGroups = checkNotNull(newGroups, "newGroups");
-      reset();
-      int size = 0;
-      for (EquivalentAddressGroup eag : newGroups) {
-        size += eag.getAddresses().size();
-      }
-      this.size = size;
-    }
-
-    /**
-     * Returns false if the needle was not found and the current index was left unchanged.
-     */
-    @Override
-    public boolean seekTo(SocketAddress needle) {
-      for (int i = 0; i < addressGroups.size(); i++) {
-        EquivalentAddressGroup group = addressGroups.get(i);
-        int j = group.getAddresses().indexOf(needle);
-        if (j == -1) {
-          continue;
-        }
-        this.groupIndex = i;
-        this.addressIndex = j;
-        return true;
-      }
-      return false;
-    }
-
-    @Override
-    public int size() {
-      return size;
-    }
-
-    @Override
-    public int getGroupIndex() {
-      return groupIndex;
-    }
-  }
-
-  private static final class IndexHappyEyeballs implements Index {
-    private List<EquivalentAddressGroup> addressGroups;
-    private List<InterleavedEntry> interleavedAddresses = new ArrayList<>();
-    private int interleavedIndex = 0;
-
-    public IndexHappyEyeballs(List<EquivalentAddressGroup> groups) {
-      updateGroups(groups);
-    }
-
-    @Override
-    public boolean increment() {
-      if (!isValid()) {
-        return false;
-      }
-
-      interleavedIndex++;
+      activeElement++;
 
       return isValid();
     }
 
-    @Override
-    public boolean isValid() {
-      return interleavedIndex < interleavedAddresses.size();
+    boolean isValid() {
+      return activeElement < orderedAddresses.size();
     }
 
-    @Override
-    public boolean isAtBeginning() {
-      return interleavedIndex == 0;
+    boolean isAtBeginning() {
+      return activeElement == 0;
     }
 
-    @Override
-    public void reset() {
-      interleavedIndex = 0;
+    void reset() {
+      activeElement = 0;
     }
 
-    @Override
-    public SocketAddress getCurrentAddress() {
+    SocketAddress getCurrentAddress() {
       if (!isValid()) {
         throw new IllegalStateException("Index is past the end of the address group list");
       }
-      return interleavedAddresses.get(interleavedIndex).address;
+      return orderedAddresses.get(activeElement).address;
     }
 
-    @Override
-    public Attributes getCurrentEagAttributes() {
-      return getCurrentEag().getAttributes();
+    Attributes getCurrentEagAttributes() {
+      return orderedAddresses.get(activeElement).attributes;
     }
 
-    @Override
-    public List<EquivalentAddressGroup> getCurrentEagAsList() {
+    private List<EquivalentAddressGroup> getCurrentEagAsList() {
       return Collections.singletonList(getCurrentEag());
-    }
-
-    @Override
-    public int getGroupIndex() {
-      if (!isValid()) {
-        throw new IllegalStateException("Index is past the end of the address group list");
-      }
-      return interleavedAddresses.get(interleavedIndex).addressGroup;
     }
 
     private EquivalentAddressGroup getCurrentEag() {
       if (!isValid()) {
         throw new IllegalStateException("Index is past the end of the address group list");
       }
-      return addressGroups.get(interleavedAddresses.get(interleavedIndex).addressGroup);
+      return orderedAddresses.get(activeElement).asEag();
     }
 
-    @Override
-    public void updateGroups(List<EquivalentAddressGroup> newGroups) {
-      addressGroups = checkNotNull(newGroups, "newGroups");
+    void updateGroups(List<EquivalentAddressGroup> newGroups) {
+      checkNotNull(newGroups, "newGroups");
+      orderedAddresses = enableHappyEyeballs
+                             ? updateGroupsHE(newGroups)
+                             : updateGroupsNonHE(newGroups);
+      reset();
+    }
+
+    private List<UnwrappedEag> updateGroupsNonHE(List<EquivalentAddressGroup> newGroups) {
+      List<UnwrappedEag> entries = new ArrayList<>();
+      for (int g = 0; g < newGroups.size(); g++) {
+        EquivalentAddressGroup eag = newGroups.get(g);
+        for (int a = 0; a < eag.getAddresses().size(); a++) {
+          SocketAddress addr = eag.getAddresses().get(a);
+          entries.add(new UnwrappedEag(eag.getAttributes(), addr));
+        }
+      }
+
+      return entries;
+    }
+
+    private List<UnwrappedEag> updateGroupsHE(List<EquivalentAddressGroup> newGroups) {
       Boolean firstIsV6 = null;
-      List<InterleavedEntry> v4Entries = new ArrayList<>();
-      List<InterleavedEntry> v6Entries = new ArrayList<>();
+      List<UnwrappedEag> v4Entries = new ArrayList<>();
+      List<UnwrappedEag> v6Entries = new ArrayList<>();
       for (int g = 0; g <  newGroups.size(); g++) {
         EquivalentAddressGroup eag = newGroups.get(g);
         for (int a = 0; a < eag.getAddresses().size(); a++) {
@@ -856,26 +701,23 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
             if (firstIsV6 == null) {
               firstIsV6 = false;
             }
-            v4Entries.add(new InterleavedEntry(g, addr));
+            v4Entries.add(new UnwrappedEag(eag.getAttributes(), addr));
           } else {
             if (firstIsV6 == null) {
               firstIsV6 = true;
             }
-            v6Entries.add(new InterleavedEntry(g, addr));
+            v6Entries.add(new UnwrappedEag(eag.getAttributes(), addr));
           }
         }
       }
 
-      this.interleavedAddresses =
-          firstIsV6 != null && firstIsV6
+      return firstIsV6 != null && firstIsV6
           ? interleave(v6Entries, v4Entries)
           : interleave(v4Entries, v6Entries);
-
-      reset();
     }
 
-    private static List<InterleavedEntry> interleave(List<InterleavedEntry> firstFamily,
-                                                     List<InterleavedEntry> secondFamily) {
+    private List<UnwrappedEag> interleave(List<UnwrappedEag> firstFamily,
+                                          List<UnwrappedEag> secondFamily) {
       if (firstFamily.isEmpty()) {
         return secondFamily;
       }
@@ -883,7 +725,7 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
         return firstFamily;
       }
 
-      List<InterleavedEntry> result = new ArrayList<>();
+      List<UnwrappedEag> result = new ArrayList<>();
       for (int i = 0; i < Math.max(firstFamily.size(), secondFamily.size()); i++) {
         if (i < firstFamily.size()) {
           result.add(firstFamily.get(i));
@@ -895,37 +737,43 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
       return result;
     }
 
-    @Override
-    public boolean seekTo(SocketAddress needle) {
+    boolean seekTo(SocketAddress needle) {
       checkNotNull(needle, "needle");
-      for (int i = 0; i < interleavedAddresses.size(); i++) {
-        if (interleavedAddresses.get(i).address.equals(needle)) {
-          this.interleavedIndex = i;
+      for (int i = 0; i < orderedAddresses.size(); i++) {
+        if (orderedAddresses.get(i).address.equals(needle)) {
+          this.activeElement = i;
           return true;
         }
       }
       return false;
     }
 
-    @Override
-    public int size() {
-      return interleavedAddresses.size();
+    int size() {
+      return orderedAddresses.size();
     }
 
-    private static final class InterleavedEntry {
-      private final int addressGroup;
+    int getActiveElement() {
+      return activeElement;
+    }
+
+    private final class UnwrappedEag {
+      private final Attributes attributes;
       private final SocketAddress address;
 
-      public InterleavedEntry(int addressGroup, SocketAddress address) {
-        this.addressGroup = addressGroup;
+      public UnwrappedEag(Attributes attributes, SocketAddress address) {
+        this.attributes = attributes;
         this.address = address;
+      }
+
+      private EquivalentAddressGroup asEag() {
+        return new EquivalentAddressGroup(address, attributes);
       }
     }
   }
 
   @VisibleForTesting
-  int getGroupIndex() {
-    return addressIndex.getGroupIndex();
+  int getIndexLocation() {
+    return addressIndex.activeElement;
   }
 
   @VisibleForTesting

--- a/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
@@ -2636,7 +2636,7 @@ public class PickFirstLeafLoadBalancerTest {
     SocketAddress addr3 = new FakeSocketAddress("addr3");
     SocketAddress addr4 = new FakeSocketAddress("addr4");
     SocketAddress addr5 = new FakeSocketAddress("addr5");
-    PickFirstLeafLoadBalancer.IndexI index = PickFirstLeafLoadBalancer.IndexI.create(Arrays.asList(
+    PickFirstLeafLoadBalancer.Index index = PickFirstLeafLoadBalancer.Index.create(Arrays.asList(
         new EquivalentAddressGroup(Arrays.asList(addr1, addr2), attr1),
         new EquivalentAddressGroup(Arrays.asList(addr3), attr2),
         new EquivalentAddressGroup(Arrays.asList(addr4, addr5), attr3)));
@@ -2696,7 +2696,7 @@ public class PickFirstLeafLoadBalancerTest {
     SocketAddress addr1 = new FakeSocketAddress("addr1");
     SocketAddress addr2 = new FakeSocketAddress("addr2");
     SocketAddress addr3 = new FakeSocketAddress("addr3");
-    PickFirstLeafLoadBalancer.IndexI index = PickFirstLeafLoadBalancer.IndexI.create(Arrays.asList(
+    PickFirstLeafLoadBalancer.Index index = PickFirstLeafLoadBalancer.Index.create(Arrays.asList(
         new EquivalentAddressGroup(Arrays.asList(addr1)),
         new EquivalentAddressGroup(Arrays.asList(addr2, addr3))));
     index.increment();
@@ -2713,7 +2713,7 @@ public class PickFirstLeafLoadBalancerTest {
     SocketAddress addr1 = new FakeSocketAddress("addr1");
     SocketAddress addr2 = new FakeSocketAddress("addr2");
     SocketAddress addr3 = new FakeSocketAddress("addr3");
-    PickFirstLeafLoadBalancer.IndexI index = PickFirstLeafLoadBalancer.IndexI.create(Arrays.asList(
+    PickFirstLeafLoadBalancer.Index index = PickFirstLeafLoadBalancer.Index.create(Arrays.asList(
         new EquivalentAddressGroup(Arrays.asList(addr1, addr2)),
         new EquivalentAddressGroup(Arrays.asList(addr3))));
     assertThat(index.seekTo(addr3)).isTrue();
@@ -2736,7 +2736,7 @@ public class PickFirstLeafLoadBalancerTest {
     InetSocketAddress addr4_4 = new InetSocketAddress("10.1.1.4", 1234);
     InetSocketAddress addr4_6 = new InetSocketAddress("f38:1:4", 1234);
 
-    PickFirstLeafLoadBalancer.IndexI index = PickFirstLeafLoadBalancer.IndexI.create(Arrays.asList(
+    PickFirstLeafLoadBalancer.Index index = PickFirstLeafLoadBalancer.Index.create(Arrays.asList(
         new EquivalentAddressGroup(Arrays.asList(addr1_4, addr1_6)),
         new EquivalentAddressGroup(Arrays.asList(addr2_4)),
         new EquivalentAddressGroup(Arrays.asList(addr3_4)),

--- a/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
@@ -67,6 +68,7 @@ import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.SynchronizationContext;
 import io.grpc.internal.PickFirstLeafLoadBalancer.PickFirstLeafLoadBalancerConfig;
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2634,7 +2636,7 @@ public class PickFirstLeafLoadBalancerTest {
     SocketAddress addr3 = new FakeSocketAddress("addr3");
     SocketAddress addr4 = new FakeSocketAddress("addr4");
     SocketAddress addr5 = new FakeSocketAddress("addr5");
-    PickFirstLeafLoadBalancer.Index index = new PickFirstLeafLoadBalancer.Index(Arrays.asList(
+    PickFirstLeafLoadBalancer.IndexI index = PickFirstLeafLoadBalancer.IndexI.create(Arrays.asList(
         new EquivalentAddressGroup(Arrays.asList(addr1, addr2), attr1),
         new EquivalentAddressGroup(Arrays.asList(addr3), attr2),
         new EquivalentAddressGroup(Arrays.asList(addr4, addr5), attr3)));
@@ -2694,7 +2696,7 @@ public class PickFirstLeafLoadBalancerTest {
     SocketAddress addr1 = new FakeSocketAddress("addr1");
     SocketAddress addr2 = new FakeSocketAddress("addr2");
     SocketAddress addr3 = new FakeSocketAddress("addr3");
-    PickFirstLeafLoadBalancer.Index index = new PickFirstLeafLoadBalancer.Index(Arrays.asList(
+    PickFirstLeafLoadBalancer.IndexI index = PickFirstLeafLoadBalancer.IndexI.create(Arrays.asList(
         new EquivalentAddressGroup(Arrays.asList(addr1)),
         new EquivalentAddressGroup(Arrays.asList(addr2, addr3))));
     index.increment();
@@ -2711,7 +2713,7 @@ public class PickFirstLeafLoadBalancerTest {
     SocketAddress addr1 = new FakeSocketAddress("addr1");
     SocketAddress addr2 = new FakeSocketAddress("addr2");
     SocketAddress addr3 = new FakeSocketAddress("addr3");
-    PickFirstLeafLoadBalancer.Index index = new PickFirstLeafLoadBalancer.Index(Arrays.asList(
+    PickFirstLeafLoadBalancer.IndexI index = PickFirstLeafLoadBalancer.IndexI.create(Arrays.asList(
         new EquivalentAddressGroup(Arrays.asList(addr1, addr2)),
         new EquivalentAddressGroup(Arrays.asList(addr3))));
     assertThat(index.seekTo(addr3)).isTrue();
@@ -2723,6 +2725,73 @@ public class PickFirstLeafLoadBalancerTest {
     index.seekTo(new FakeSocketAddress("addr4"));
     // Failed seekTo doesn't change the index
     assertThat(index.getCurrentAddress()).isSameInstanceAs(addr2);
+  }
+
+  @Test
+  public void index_interleaving() {
+    InetSocketAddress addr1_6 = new InetSocketAddress("f38:1:1", 1234);
+    InetSocketAddress addr1_4 = new InetSocketAddress("10.1.1.1", 1234);
+    InetSocketAddress addr2_4 = new InetSocketAddress("10.1.1.2", 1234);
+    InetSocketAddress addr3_4 = new InetSocketAddress("10.1.1.3", 1234);
+    InetSocketAddress addr4_4 = new InetSocketAddress("10.1.1.4", 1234);
+    InetSocketAddress addr4_6 = new InetSocketAddress("f38:1:4", 1234);
+
+    PickFirstLeafLoadBalancer.IndexI index = PickFirstLeafLoadBalancer.IndexI.create(Arrays.asList(
+        new EquivalentAddressGroup(Arrays.asList(addr1_4, addr1_6)),
+        new EquivalentAddressGroup(Arrays.asList(addr2_4)),
+        new EquivalentAddressGroup(Arrays.asList(addr3_4)),
+        new EquivalentAddressGroup(Arrays.asList(addr4_4, addr4_6))));
+
+    assertThat(index.getCurrentAddress()).isSameInstanceAs(addr1_4);
+    assertThat(index.isAtBeginning()).isTrue();
+
+    index.increment();
+    assertThat(index.getCurrentAddress()).isSameInstanceAs(addr1_6);
+    assertThat(index.isAtBeginning()).isFalse();
+    assertThat(index.isValid()).isTrue();
+    assertThat(index.getGroupIndex()).isEqualTo(0);
+
+    index.increment();
+    assertThat(index.getCurrentAddress()).isSameInstanceAs(addr2_4);
+    assertThat(index.getGroupIndex()).isEqualTo(1);
+
+    index.increment();
+    if (enableHappyEyeballs) {
+      assertThat(index.getCurrentAddress()).isSameInstanceAs(addr4_6);
+      assertThat(index.getGroupIndex()).isEqualTo(3);
+    } else {
+      assertThat(index.getCurrentAddress()).isSameInstanceAs(addr3_4);
+      assertThat(index.getGroupIndex()).isEqualTo(2);
+    }
+
+    index.increment();
+    if (enableHappyEyeballs) {
+      assertThat(index.getCurrentAddress()).isSameInstanceAs(addr3_4);
+      assertThat(index.getGroupIndex()).isEqualTo(2);
+    } else {
+      assertThat(index.getCurrentAddress()).isSameInstanceAs(addr4_4);
+      assertThat(index.getGroupIndex()).isEqualTo(3);
+    }
+
+    // Move to last entry
+    assertThat(index.increment()).isTrue();
+    assertThat(index.isValid()).isTrue();
+    assertThat(index.getGroupIndex()).isEqualTo(3);
+
+    // Move off of the end
+    assertThat(index.increment()).isFalse();
+    assertThat(index.isValid()).isFalse();
+    assertThrows(IllegalStateException.class, index::getCurrentAddress);
+
+    // Reset
+    index.reset();
+    assertThat(index.getCurrentAddress()).isSameInstanceAs(addr1_4);
+    assertThat(index.isAtBeginning()).isTrue();
+    assertThat(index.isValid()).isTrue();
+
+    // Seek to an address
+    assertThat(index.seekTo(addr4_4)).isTrue();
+    assertThat(index.getCurrentAddress()).isSameInstanceAs(addr4_4);
   }
 
   private static class FakeSocketAddress extends SocketAddress {


### PR DESCRIPTION
The gRFC A61 states that addresses should be alternated in the Happy Eyeballs case rather than purely going in the specified order.