### PR TITLE
Update binderDied() error description to spell out the possibilities for those unfamiliar with Android internals.

### DIFF
--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -299,7 +299,7 @@ public abstract class BinderTransport
 
   @Override
   public synchronized void binderDied() {
-    shutdownInternal(Status.UNAVAILABLE.withDescription("binderDied"), true);
+    shutdownInternal(Status.UNAVAILABLE.withDescription("Peer crashed, exited or was killed (binderDied)"), true);
   }
 
   @GuardedBy("this")

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -299,7 +299,7 @@ public abstract class BinderTransport
 
   @Override
   public synchronized void binderDied() {
-    shutdownInternal(Status.UNAVAILABLE.withDescription("Peer crashed, exited or was killed (binderDied)"), true);
+    shutdownInternal(Status.UNAVAILABLE.withDescription("Peer process crashed, exited or was killed (binderDied)"), true);
   }
 
   @GuardedBy("this")


### PR DESCRIPTION
Callers are frequently confused by this message and waste time looking for problems in the client when the root cause is a server crash. See b/371447460 for more context.