### PR TITLE
Remove java.util.logging from AsyncServletOutputStreamWriter.Log

### DIFF
--- a/servlet/src/main/java/io/grpc/servlet/AsyncServletOutputStreamWriter.java
+++ b/servlet/src/main/java/io/grpc/servlet/AsyncServletOutputStreamWriter.java
@@ -32,7 +32,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
@@ -88,8 +87,8 @@ final class AsyncServletOutputStreamWriter {
     Logger logger = Logger.getLogger(AsyncServletOutputStreamWriter.class.getName());
     this.log = new Log() {
       @Override
-      public boolean isLoggable(Level level) {
-        return logger.isLoggable(level);
+      public boolean isFinestLoggable() {
+        return logger.isLoggable(FINEST);
       }
 
       @Override
@@ -111,7 +110,7 @@ final class AsyncServletOutputStreamWriter {
     this.writeAction = (byte[] bytes, Integer numBytes) -> () -> {
       outputStream.write(bytes, 0, numBytes);
       transportState.runOnTransportThread(() -> transportState.onSentBytes(numBytes));
-      if (log.isLoggable(Level.FINEST)) {
+      if (log.isFinestLoggable()) {
         log.finest("outbound data: length={0}, bytes={1}", numBytes, toHexString(bytes, numBytes));
       }
     };
@@ -253,7 +252,7 @@ final class AsyncServletOutputStreamWriter {
 
   @VisibleForTesting // Lincheck test can not run with java.util.logging dependency.
   interface Log {
-    default boolean isLoggable(Level level) {
+    default boolean isFinestLoggable() {
       return false; 
     }
 


### PR DESCRIPTION
Comments suggest that this API cannot be referenced, but a new method in the interface still used it.

It is possible that only the Logger interface itself can't be referenced for some reason, in which case this won't help - I can't seem to cause the apparent Lincheck issue from the Gradle tests.