### PR TITLE
binder: Remove unnecessary uses of LooperMode(PAUSED)

### DIFF
--- a/binder/src/test/java/io/grpc/binder/internal/BinderServerTransportTest.java
+++ b/binder/src/test/java/io/grpc/binder/internal/BinderServerTransportTest.java
@@ -23,7 +23,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
 import static org.robolectric.Shadows.shadowOf;
-import static org.robolectric.annotation.LooperMode.Mode.PAUSED;
 
 import android.os.IBinder;
 import android.os.Looper;
@@ -44,14 +43,12 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.LooperMode;
 
 /**
  * Low-level server-side transport tests for binder channel. Like BinderChannelSmokeTest, this
  * convers edge cases not exercised by AbstractTransportTest, but it deals with the
  * binderTransport.BinderServerTransport directly.
  */
-@LooperMode(PAUSED)
 @RunWith(RobolectricTestRunner.class)
 public final class BinderServerTransportTest {
 

--- a/binder/src/test/java/io/grpc/binder/internal/ServiceBindingTest.java
+++ b/binder/src/test/java/io/grpc/binder/internal/ServiceBindingTest.java
@@ -21,7 +21,6 @@ import static android.os.Looper.getMainLooper;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 import static org.robolectric.Shadows.shadowOf;
-import static org.robolectric.annotation.LooperMode.Mode.PAUSED;
 
 import android.app.Application;
 import android.app.admin.DevicePolicyManager;
@@ -48,11 +47,9 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
-import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.shadows.ShadowDevicePolicyManager;
 
-@LooperMode(PAUSED)
 @RunWith(RobolectricTestRunner.class)
 public final class ServiceBindingTest {
 


### PR DESCRIPTION
PAUSED Looper mode has been the default for many years, maybe around robolectric 4.5 (9ae9f0b6a6). Explicitly specifying PAUSED Looper mode is not necessary.

cl/690684542

CC @hoisie

------

I did look up the robolectric 4.5 version, and we're on 4.13 so everything seems in-place.