### PR TITLE
Update proto-google-common-protos to 2.48.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ cronet-api = "org.chromium.net:cronet-api:119.6045.31"
 cronet-embedded = "org.chromium.net:cronet-embedded:119.6045.31"
 errorprone-annotations = "com.google.errorprone:error_prone_annotations:2.28.0"
 errorprone-core = "com.google.errorprone:error_prone_core:2.28.0"
-google-api-protos = "com.google.api.grpc:proto-google-common-protos:2.41.0"
+google-api-protos = "com.google.api.grpc:proto-google-common-protos:2.48.0"
 google-auth-credentials = "com.google.auth:google-auth-library-credentials:1.23.0"
 google-auth-oauth2Http = "com.google.auth:google-auth-library-oauth2-http:1.23.0"
 # Release notes: https://cloud.google.com/logging/docs/release-notes


### PR DESCRIPTION
Update proto-google-common-protos to the recent version. 
It aligns the underlying `protobuf-java` version with the one that `grpc-protobuf` depends on.

It should make maven-enforcer-plugin happy in the projects that use it:

```
[ERROR] Dependency convergence error for com.google.protobuf:protobuf-java:jar:3.25.5 paths to dependency are:
[ERROR] +-snip:0.0.1-SNAPSHOT
[ERROR]   +-io.grpc:grpc-protobuf:jar:1.68.1:compile
[ERROR]     +-com.google.protobuf:protobuf-java:jar:3.25.5:compile
[ERROR] and
[ERROR] +-snip:0.0.1-SNAPSHOT
[ERROR]   +-io.grpc:grpc-protobuf:jar:1.68.1:compile
[ERROR]     +-com.google.api.grpc:proto-google-common-protos:jar:2.41.0:compile
[ERROR]       +-com.google.protobuf:protobuf-java:jar:3.25.3:compile
```