### PR TITLE
interop-testing: Add concurrency condition to the soak test using existing blocking api 

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1794,7 +1794,7 @@ public abstract class AbstractInteropTest {
       threads[threadInd].start();
     }
     for (Thread thread : threads) {
-          thread.join();
+      thread.join();
     }
 
     int totalFailures = 0;
@@ -1802,7 +1802,7 @@ public abstract class AbstractInteropTest {
     Histogram latencies = new Histogram(4);
     for (ThreadResults threadResult :threadResultsList) {
       totalFailures += threadResult.getThreadFailures();
-      iterationsDone += (threadResult.getIterationsDone());
+      iterationsDone += threadResult.getIterationsDone();
       latencies.add(threadResult.getLatencies());
     }
     System.err.println(
@@ -1845,11 +1845,12 @@ public abstract class AbstractInteropTest {
       channel.awaitTermination(10, TimeUnit.SECONDS);
     }
   }
+
   protected ManagedChannel createNewChannel(ManagedChannel currentChannel) {
     try {
-        shutdownChannel(currentChannel);
-        return createChannel();
-      } catch (InterruptedException e) {
+      shutdownChannel(currentChannel);
+      return createChannel();
+    } catch (InterruptedException e) {
       throw new RuntimeException("Interrupted while creating a new channel", e);
     }
   }
@@ -1865,7 +1866,7 @@ public abstract class AbstractInteropTest {
       String serverUri,
       ThreadResults threadResults,
       ManagedChannel sharedChannel,
-      Function<ManagedChannel, ManagedChannel> maybeCreateChannel) throws InterruptedException{
+      Function<ManagedChannel, ManagedChannel> maybeCreateChannel) throws InterruptedException {
     ManagedChannel currentChannel = sharedChannel;
     TestServiceGrpc.TestServiceBlockingStub stub = TestServiceGrpc
         .newBlockingStub(currentChannel)
@@ -1880,15 +1881,17 @@ public abstract class AbstractInteropTest {
 
       currentChannel = maybeCreateChannel.apply(currentChannel);
       TestServiceGrpc.TestServiceBlockingStub currentStub = TestServiceGrpc
-          .newBlockingStub(currentChannel).
-          withInterceptors(recordClientCallInterceptor(clientCallCapture));
-      SoakIterationResult result = performOneSoakIteration(currentStub, soakRequestSize, soakResponseSize);
+          .newBlockingStub(currentChannel)
+              .withInterceptors(recordClientCallInterceptor(clientCallCapture));
+      SoakIterationResult result = performOneSoakIteration(currentStub,
+          soakRequestSize, soakResponseSize);
       SocketAddress peer = clientCallCapture
           .get().getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
       StringBuilder logStr = new StringBuilder(
           String.format(
               Locale.US,
-              "thread id: %d soak iteration: %d elapsed_ms: %d peer: %s server_uri: %s", Thread.currentThread().getId(),
+              "thread id: %d soak iteration: %d elapsed_ms: %d peer: %s server_uri: %s",
+              Thread.currentThread().getId(),
               i, result.getLatencyMs(), peer != null ? peer.toString() : "null", serverUri));
       if (!result.getStatus().equals(Status.OK)) {
         threadResults.threadFailures++;

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -112,13 +112,11 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
@@ -690,7 +688,8 @@ public abstract class AbstractInteropTest {
                     .setSize(31415))
             .addResponseParameters(
                 ResponseParameters.newBuilder()
-                    .setCompressed(BoolValue.newBuilder().setValue(false)))
+                    .setCompressed(BoolValue.newBuilder().setValue(false))
+                    .setSize(92653))
             .build();
     final List<StreamingOutputCallResponse> goldenResponses =
         Arrays.asList(

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1789,8 +1789,7 @@ public abstract class AbstractInteropTest {
               maybeCreateNewChannel);
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
-          System.err.println("Thread interrupted: " + e.getMessage());
-          // throw new RuntimeException("Thread interrupted: " + e.getMessage());
+          throw new RuntimeException("Thread interrupted: " + e.getMessage(), e);
         }
       });
       threads[threadInd].start();

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1868,10 +1868,6 @@ public abstract class AbstractInteropTest {
       ManagedChannel sharedChannel,
       Function<ManagedChannel, ManagedChannel> maybeCreateChannel) throws InterruptedException {
     ManagedChannel currentChannel = sharedChannel;
-    TestServiceGrpc.TestServiceBlockingStub stub = TestServiceGrpc
-        .newBlockingStub(currentChannel)
-        .withInterceptors(recordClientCallInterceptor(clientCallCapture));
-
     for (int i = 0; i < soakIterationsPerThread; i++) {
       if (System.nanoTime() - startNs >= TimeUnit.SECONDS.toNanos(overallTimeoutSeconds)) {
         break;

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -690,8 +690,7 @@ public abstract class AbstractInteropTest {
                     .setSize(31415))
             .addResponseParameters(
                 ResponseParameters.newBuilder()
-                    .setCompressed(BoolValue.newBuilder().setValue(false))
-                    .setSize(92653))
+                    .setCompressed(BoolValue.newBuilder().setValue(false)))
             .build();
     final List<StreamingOutputCallResponse> goldenResponses =
         Arrays.asList(
@@ -1776,7 +1775,7 @@ public abstract class AbstractInteropTest {
       final int currentThreadInd = threadInd;
       threads[threadInd] = new Thread(() -> {
         try {
-          executeSoakTestInThreads(
+          executeSoakTestInThread(
               soakIterationsPerThread,
               startNs,
               minTimeMsBetweenRpcs,
@@ -1791,6 +1790,7 @@ public abstract class AbstractInteropTest {
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           System.err.println("Thread interrupted: " + e.getMessage());
+          // throw new RuntimeException("Thread interrupted: " + e.getMessage());
         }
       });
       threads[threadInd].start();
@@ -1856,7 +1856,7 @@ public abstract class AbstractInteropTest {
     return currentChannel;
   }
 
-  private void executeSoakTestInThreads(
+  private void executeSoakTestInThread(
       int soakIterationsPerThread,
       long startNs,
       int minTimeMsBetweenRpcs,

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1850,7 +1850,7 @@ public abstract class AbstractInteropTest {
         shutdownChannel(currentChannel);
         return createChannel();
       } catch (InterruptedException e) {
-      throw new RuntimeException("Interrupted while creating a new channel", e)
+      throw new RuntimeException("Interrupted while creating a new channel", e);
     }
   }
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1757,7 +1757,7 @@ public abstract class AbstractInteropTest {
       int soakRequestSize,
       int soakResponseSize,
       int numThreads,
-      Function<ManagedChannel, ManagedChannel> maybeCreateNewChannel)
+      Function<ManagedChannel, ManagedChannel> createNewChannel)
       throws InterruptedException {
     if (soakIterations % numThreads != 0) {
       throw new IllegalArgumentException("soakIterations must be evenly divisible by numThreads.");
@@ -1785,7 +1785,7 @@ public abstract class AbstractInteropTest {
               serverUri,
               threadResultsList.get(currentThreadInd),
               sharedChannel,
-              maybeCreateNewChannel);
+              createNewChannel);
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           throw new RuntimeException("Thread interrupted: " + e.getMessage(), e);
@@ -1845,15 +1845,11 @@ public abstract class AbstractInteropTest {
       channel.awaitTermination(10, TimeUnit.SECONDS);
     }
   }
-  protected ManagedChannel maybeCreateNewChannel(ManagedChannel currentChannel,
-      boolean resetChannel) {
+  protected ManagedChannel createNewChannel(ManagedChannel currentChannel) {
     try {
-      if (resetChannel) {
         shutdownChannel(currentChannel);
         return createChannel();
-      }
-      return currentChannel;
-    } catch (InterruptedException e) {
+      } catch (InterruptedException e) {
       throw new RuntimeException("Interrupted while creating a new channel", e)
     }
   }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1799,11 +1799,11 @@ public abstract class AbstractInteropTest {
     }
 
     int totalFailures = 0;
-    AtomicInteger iterationsDone = new AtomicInteger(0);
+    int iterationsDone = 0;
     Histogram latencies = new Histogram(4);
     for (ThreadResults threadResult :threadResultsList) {
       totalFailures += threadResult.getThreadFailures();
-      iterationsDone.addAndGet(threadResult.getIterationsDone());
+      iterationsDone += (threadResult.getIterationsDone());
       latencies.add(threadResult.getLatencies());
     }
     System.err.println(
@@ -1847,12 +1847,16 @@ public abstract class AbstractInteropTest {
     }
   }
   protected ManagedChannel maybeCreateNewChannel(ManagedChannel currentChannel,
-      boolean resetChannel) throws InterruptedException {
-    if (resetChannel) {
-      shutdownChannel(currentChannel);
-      return createChannel();
+      boolean resetChannel) {
+    try {
+      if (resetChannel) {
+        shutdownChannel(currentChannel);
+        return createChannel();
+      }
+      return currentChannel;
+    } catch (InterruptedException e) {
+      throw new RuntimeException("Interrupted while creating a new channel", e)
     }
-    return currentChannel;
   }
 
   private void executeSoakTestInThread(

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestCases.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestCases.java
@@ -57,7 +57,11 @@ public enum TestCases {
   VERY_LARGE_REQUEST("very large request"),
   PICK_FIRST_UNARY("all requests are sent to one server despite multiple servers are resolved"),
   RPC_SOAK("sends 'soak_iterations' large_unary rpcs in a loop, each on the same channel"),
+  RPC_SOAK_CONCURRENT("sends 'soak_iterations' large_unary rpcs in a loop, each on the same channel,"
+      + " and using multiple threads concurrently"),
   CHANNEL_SOAK("sends 'soak_iterations' large_unary rpcs in a loop, each on a new channel"),
+  CHANNEL_SOAK_CONCURRENT("sends 'soak_iterations' large_unary rpcs in a loop, each on a new channel,"
+      + " and using multiple threads concurrently"),
   ORCA_PER_RPC("report backend metrics per query"),
   ORCA_OOB("report backend metrics out-of-band");
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestCases.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestCases.java
@@ -57,11 +57,7 @@ public enum TestCases {
   VERY_LARGE_REQUEST("very large request"),
   PICK_FIRST_UNARY("all requests are sent to one server despite multiple servers are resolved"),
   RPC_SOAK("sends 'soak_iterations' large_unary rpcs in a loop, each on the same channel"),
-  RPC_SOAK_CONCURRENT("sends 'soak_iterations' large_unary rpcs in a loop, each on the same channel,"
-      + " and using multiple threads concurrently"),
   CHANNEL_SOAK("sends 'soak_iterations' large_unary rpcs in a loop, each on a new channel"),
-  CHANNEL_SOAK_CONCURRENT("sends 'soak_iterations' large_unary rpcs in a loop, each on a new channel,"
-      + " and using multiple threads concurrently"),
   ORCA_PER_RPC("report backend metrics per query"),
   ORCA_OOB("report backend metrics out-of-band");
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -520,6 +520,22 @@ public class TestServiceClient {
         tester.performSoakTest(
             serverHost,
             false /* resetChannelPerIteration */,
+            false /* concurrent */,
+            soakIterations,
+            soakMaxFailures,
+            soakPerIterationMaxAcceptableLatencyMs,
+            soakMinTimeMsBetweenRpcs,
+            soakOverallTimeoutSeconds,
+            soakRequestSize,
+            soakResponseSize);
+        break;
+      }
+
+      case RPC_SOAK_CONCURRENT: {
+        tester.performSoakTest(
+            serverHost,
+            false /* resetChannelPerIteration */,
+            true /* concurrent */,
             soakIterations,
             soakMaxFailures,
             soakPerIterationMaxAcceptableLatencyMs,
@@ -534,6 +550,7 @@ public class TestServiceClient {
         tester.performSoakTest(
             serverHost,
             true /* resetChannelPerIteration */,
+            false /* concurrent */,
             soakIterations,
             soakMaxFailures,
             soakPerIterationMaxAcceptableLatencyMs,
@@ -542,7 +559,21 @@ public class TestServiceClient {
             soakRequestSize,
             soakResponseSize);
         break;
+      }
 
+      case CHANNEL_SOAK_CONCURRENT: {
+        tester.performSoakTest(
+            serverHost,
+            true /* resetChannelPerIteration */,
+            true /* concurrent */,
+            soakIterations,
+            soakMaxFailures,
+            soakPerIterationMaxAcceptableLatencyMs,
+            soakMinTimeMsBetweenRpcs,
+            soakOverallTimeoutSeconds,
+            soakRequestSize,
+            soakResponseSize);
+        break;
       }
 
       case ORCA_PER_RPC: {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -533,8 +533,7 @@ public class TestServiceClient {
             soakRequestSize,
             soakResponseSize,
             numThreads,
-            (currentChannel) -> tester.maybeCreateNewChannel(currentChannel, false)
-        );
+            (currentChannel) -> currentChannel);
         break;
       }
 
@@ -549,8 +548,7 @@ public class TestServiceClient {
             soakRequestSize,
             soakResponseSize,
             numThreads,
-            (currentChannel) -> tester.maybeCreateNewChannel(currentChannel, true)
-            );
+            (currentChannel) -> tester.createNewChannel(currentChannel));
         break;
       }
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -134,6 +134,7 @@ public class TestServiceClient {
       soakIterations * soakPerIterationMaxAcceptableLatencyMs / 1000;
   private int soakRequestSize = 271828;
   private int soakResponseSize = 314159;
+  private int numThreads = 1;
   private String additionalMetadata = "";
   private static LoadBalancerProvider customBackendMetricsLoadBalancerProvider;
 
@@ -214,6 +215,8 @@ public class TestServiceClient {
         soakRequestSize = Integer.parseInt(value);
       } else if ("soak_response_size".equals(key)) {
         soakResponseSize = Integer.parseInt(value);
+      }  else if ("soak_num_threads".equals(key)) {
+        numThreads = Integer.parseInt(value);
       } else if ("additional_metadata".equals(key)) {
         additionalMetadata = value;
       } else {
@@ -290,6 +293,9 @@ public class TestServiceClient {
           + "\n --soak_response_size "
           + "\n                              The response size in a soak RPC. Default "
             + c.soakResponseSize
+          + "\n --soak_num_threads           The number of threads for concurrent execution of the "
+          + "\n                              soak tests (rpc_soak or channel_soak). Default "
+            + c.numThreads
           + "\n --additional_metadata "
           + "\n                              Additional metadata to send in each request, as a "
           + "\n                              semicolon-separated list of key:value pairs. Default "
@@ -520,29 +526,14 @@ public class TestServiceClient {
         tester.performSoakTest(
             serverHost,
             false /* resetChannelPerIteration */,
-            false /* concurrent */,
             soakIterations,
             soakMaxFailures,
             soakPerIterationMaxAcceptableLatencyMs,
             soakMinTimeMsBetweenRpcs,
             soakOverallTimeoutSeconds,
             soakRequestSize,
-            soakResponseSize);
-        break;
-      }
-
-      case RPC_SOAK_CONCURRENT: {
-        tester.performSoakTest(
-            serverHost,
-            false /* resetChannelPerIteration */,
-            true /* concurrent */,
-            soakIterations,
-            soakMaxFailures,
-            soakPerIterationMaxAcceptableLatencyMs,
-            soakMinTimeMsBetweenRpcs,
-            soakOverallTimeoutSeconds,
-            soakRequestSize,
-            soakResponseSize);
+            soakResponseSize,
+            numThreads);
         break;
       }
 
@@ -550,29 +541,14 @@ public class TestServiceClient {
         tester.performSoakTest(
             serverHost,
             true /* resetChannelPerIteration */,
-            false /* concurrent */,
             soakIterations,
             soakMaxFailures,
             soakPerIterationMaxAcceptableLatencyMs,
             soakMinTimeMsBetweenRpcs,
             soakOverallTimeoutSeconds,
             soakRequestSize,
-            soakResponseSize);
-        break;
-      }
-
-      case CHANNEL_SOAK_CONCURRENT: {
-        tester.performSoakTest(
-            serverHost,
-            true /* resetChannelPerIteration */,
-            true /* concurrent */,
-            soakIterations,
-            soakMaxFailures,
-            soakPerIterationMaxAcceptableLatencyMs,
-            soakMinTimeMsBetweenRpcs,
-            soakOverallTimeoutSeconds,
-            soakRequestSize,
-            soakResponseSize);
+            soakResponseSize,
+            numThreads);
         break;
       }
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -525,7 +525,6 @@ public class TestServiceClient {
       case RPC_SOAK: {
         tester.performSoakTest(
             serverHost,
-            false /* resetChannelPerIteration */,
             soakIterations,
             soakMaxFailures,
             soakPerIterationMaxAcceptableLatencyMs,
@@ -533,14 +532,15 @@ public class TestServiceClient {
             soakOverallTimeoutSeconds,
             soakRequestSize,
             soakResponseSize,
-            numThreads);
+            numThreads,
+            (currentChannel) -> tester.maybeCreateNewChannel(currentChannel, false)
+        );
         break;
       }
 
       case CHANNEL_SOAK: {
         tester.performSoakTest(
             serverHost,
-            true /* resetChannelPerIteration */,
             soakIterations,
             soakMaxFailures,
             soakPerIterationMaxAcceptableLatencyMs,
@@ -548,7 +548,9 @@ public class TestServiceClient {
             soakOverallTimeoutSeconds,
             soakRequestSize,
             soakResponseSize,
-            numThreads);
+            numThreads,
+            (currentChannel) -> tester.maybeCreateNewChannel(currentChannel, true)
+            );
         break;
       }
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -533,13 +533,7 @@ public class TestServiceClient {
             soakRequestSize,
             soakResponseSize,
             numThreads,
-            (currentChannel) -> {
-              try {
-                return tester.maybeCreateNewChannel(currentChannel, false);
-              } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-              }
-            }
+            (currentChannel) -> tester.maybeCreateNewChannel(currentChannel, false)
         );
         break;
       }
@@ -555,13 +549,7 @@ public class TestServiceClient {
             soakRequestSize,
             soakResponseSize,
             numThreads,
-            (currentChannel) -> {
-              try {
-                return tester.maybeCreateNewChannel(currentChannel, true);
-              } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-              }
-            }
+            (currentChannel) -> tester.maybeCreateNewChannel(currentChannel, true)
             );
         break;
       }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -533,7 +533,13 @@ public class TestServiceClient {
             soakRequestSize,
             soakResponseSize,
             numThreads,
-            (currentChannel) -> tester.maybeCreateNewChannel(currentChannel, false)
+            (currentChannel) -> {
+              try {
+                return tester.maybeCreateNewChannel(currentChannel, false);
+              } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+              }
+            }
         );
         break;
       }
@@ -549,7 +555,13 @@ public class TestServiceClient {
             soakRequestSize,
             soakResponseSize,
             numThreads,
-            (currentChannel) -> tester.maybeCreateNewChannel(currentChannel, true)
+            (currentChannel) -> {
+              try {
+                return tester.maybeCreateNewChannel(currentChannel, true);
+              } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+              }
+            }
             );
         break;
       }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
@@ -259,8 +259,7 @@ public final class XdsFederationTestClient {
                 soakRequestSize,
                 soakResponseSize,
                 1,
-                (currentChannel) -> maybeCreateNewChannel(currentChannel, false)
-                );
+                (currentChannel) -> currentChannel);
           }
               break;
           case "channel_soak":{
@@ -274,8 +273,7 @@ public final class XdsFederationTestClient {
                 soakRequestSize,
                 soakResponseSize,
                 1,
-                (currentChannel) -> maybeCreateNewChannel(currentChannel, true)
-                );
+                (currentChannel) -> createNewChannel(currentChannel));
           }
             break;
           default:

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
@@ -259,13 +259,8 @@ public final class XdsFederationTestClient {
                 soakRequestSize,
                 soakResponseSize,
                 1,
-                (currentChannel) -> {
-                  try {
-                    return maybeCreateNewChannel(currentChannel, false);
-                  } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                  }
-                });
+                (currentChannel) -> maybeCreateNewChannel(currentChannel, false)
+                );
           }
               break;
           case "channel_soak":{
@@ -279,13 +274,8 @@ public final class XdsFederationTestClient {
                 soakRequestSize,
                 soakResponseSize,
                 1,
-                (currentChannel) -> {
-                  try {
-                    return maybeCreateNewChannel(currentChannel, true);
-                  } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                  }
-                });
+                (currentChannel) -> maybeCreateNewChannel(currentChannel, true)
+                );
           }
             break;
           default:

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
@@ -262,7 +262,7 @@ public final class XdsFederationTestClient {
                 (currentChannel) -> currentChannel);
           }
               break;
-          case "channel_soak":{
+          case "channel_soak": {
             performSoakTest(
                 serverUri,
                 soakIterations,
@@ -311,7 +311,14 @@ public final class XdsFederationTestClient {
     logger.info("Begin test case: " + testCase);
     ArrayList<Thread> threads = new ArrayList<>();
     for (InnerClient c : clients) {
-      Thread t = new Thread(c::run);
+      Thread t = new Thread(() -> {
+        try {
+          c.run();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt(); // Properly re-interrupt the thread
+          throw new RuntimeException("Thread was interrupted during execution", e);
+        }
+      });
       t.start();
       threads.add(t);
     }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
@@ -127,7 +127,7 @@ public final class XdsFederationTestClient {
         case "soak_request_size":
           soakRequestSize = Integer.parseInt(value);
           break;
-        case "":
+        case "soak_response_size":
           soakResponseSize = Integer.parseInt(value);
           break;
         default:

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
@@ -76,7 +76,6 @@ public final class XdsFederationTestClient {
   private int soakMinTimeMsBetweenRpcs = 0;
   private int soakRequestSize = 271828;
   private int soakResponseSize = 314159;
-  private int numThreads = 1;
   private String testCase = "rpc_soak";
   private final ArrayList<InnerClient> clients = new ArrayList<>();
 
@@ -130,9 +129,6 @@ public final class XdsFederationTestClient {
           break;
         case "":
           soakResponseSize = Integer.parseInt(value);
-          break;
-        case "soak_num_threads":
-          numThreads = Integer.parseInt(value);
           break;
         default:
           System.err.println("Unknown argument: " + key);
@@ -195,9 +191,6 @@ public final class XdsFederationTestClient {
           + "                                          The response size in a soak RPC. Default"
           + " "
           + c.soakResponseSize
-          + "\n --soak_num_threads           The number of threads for concurrent execution of the "
-          + "\n                              soak tests (rpc_soak or channel_soak). Default "
-          + c.numThreads
       );
       System.exit(1);
     }
@@ -265,7 +258,7 @@ public final class XdsFederationTestClient {
                 soakOverallTimeoutSeconds,
                 soakRequestSize,
                 soakResponseSize,
-                numThreads,
+                1,
                 (currentChannel) -> {
                   try {
                     return maybeCreateNewChannel(currentChannel, false);
@@ -285,7 +278,7 @@ public final class XdsFederationTestClient {
                 soakOverallTimeoutSeconds,
                 soakRequestSize,
                 soakResponseSize,
-                numThreads,
+                1,
                 (currentChannel) -> {
                   try {
                     return maybeCreateNewChannel(currentChannel, true);

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsFederationTestClient.java
@@ -307,7 +307,7 @@ public final class XdsFederationTestClient {
     }
   }
 
-  private void run() throws Exception {
+  private void run() throws InterruptedException {
     logger.info("Begin test case: " + testCase);
     ArrayList<Thread> threads = new ArrayList<>();
     for (InnerClient c : clients) {


### PR DESCRIPTION
The goal of this PR is to increase the test coverage of the C2P E2E load test by improving the rpc_soak and channel_soak tests to support concurrency.

**rpc_soak:**
The client performs many large_unary RPCs in sequence over the same channel. The test can run in either a concurrent or non-concurrent mode, depending on the number of threads specified (soak_num_threads):
  - Non-Concurrent Mode: When soak_num_threads = 1, all RPCs are performed sequentially on a single thread.
  - Concurrent Mode: When soak_num_threads > 1, the client uses multiple threads to distribute the workload. Each thread performs a portion of the total soak_iterations, executing its own set of RPCs concurrently.

**channel_soak:**
Similar to rpc_soak, but this time each RPC is performed on a new channel. The channel is created just before each RPC and is destroyed just after. Note on Concurrent Execution and Channel Creation: In a concurrent execution setting (i.e., when soak_num_threads > 1), each thread performs a portion of the total soak_iterations and creates and destroys its own channel for each RPC iteration.
- createNewChannel Function: In channel_soak, the createNewChannel function is used by each thread to create a new channel before every RPC. This function ensures that each RPC has a separate channel, preventing race conditions by isolating channels between threads. It shuts down the previous channel (if any) and creates a new one for each iteration, ensuring accurate latency measurement per RPC.

- Thread-specific logs will include the thread_id, helping to track performance across threads, especially when each thread is managing its own channel lifecycle.

PTAL @apolcyn 
@DNVindhya 