### PR TITLE
xds: Envoy proto sync to 2024-10-23

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -141,10 +141,10 @@ def grpc_java_repositories(bzlmod = False):
     if not native.existing_rule("envoy_api"):
         http_archive(
             name = "envoy_api",
-            sha256 = "cb7cd388eaa297320d392c872ceb82571dee71f4b6f1c4546b0c0a399636f523",
-            strip_prefix = "data-plane-api-874e3aa8c3aa5086b6bffa2166e0e0077bb32f71",
+            sha256 = "f439add0cc01f718d53d6feb4d0972ac0d48b3e145c18b53439a3b5148a0cb6e",
+            strip_prefix = "data-plane-api-55f8b2351962d84c84a6534da67da1dd9f671c50",
             urls = [
-                "https://github.com/envoyproxy/data-plane-api/archive/874e3aa8c3aa5086b6bffa2166e0e0077bb32f71.tar.gz",
+                "https://github.com/envoyproxy/data-plane-api/archive/55f8b2351962d84c84a6534da67da1dd9f671c50.tar.gz",
             ],
         )
 

--- a/xds/third_party/envoy/import.sh
+++ b/xds/third_party/envoy/import.sh
@@ -17,7 +17,7 @@
 
 set -e
 # import VERSION from the google internal copybara_version.txt for Envoy
-VERSION=ab911ac2ff971f805ec822ad4d4ff6b42a61cc7c
+VERSION=742a3b02e3b2a9dfb877a7e378607c6ed0c2aa53
 DOWNLOAD_URL="https://github.com/envoyproxy/envoy/archive/${VERSION}.tar.gz"
 DOWNLOAD_BASE_DIR="envoy-${VERSION}"
 SOURCE_PROTO_BASE_DIR="${DOWNLOAD_BASE_DIR}/api"

--- a/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/cluster.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/cluster/v3/cluster.proto
@@ -45,7 +45,7 @@ message ClusterCollection {
 }
 
 // Configuration for a single upstream cluster.
-// [#next-free-field: 57]
+// [#next-free-field: 59]
 message Cluster {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Cluster";
 
@@ -754,13 +754,13 @@ message Cluster {
 
   reserved "hosts", "tls_context", "extension_protocol_options";
 
-  // Configuration to use different transport sockets for different endpoints.  The entry of
+  // Configuration to use different transport sockets for different endpoints. The entry of
   // ``envoy.transport_socket_match`` in the :ref:`LbEndpoint.Metadata
   // <envoy_v3_api_field_config.endpoint.v3.LbEndpoint.metadata>` is used to match against the
   // transport sockets as they appear in the list. If a match is not found, the search continues in
   // :ref:`LocalityLbEndpoints.Metadata
-  // <envoy_v3_api_field_config.endpoint.v3.LocalityLbEndpoints.metadata>`.  The first :ref:`match
-  // <envoy_v3_api_msg_config.cluster.v3.Cluster.TransportSocketMatch>` is used.  For example, with
+  // <envoy_v3_api_field_config.endpoint.v3.LocalityLbEndpoints.metadata>`. The first :ref:`match
+  // <envoy_v3_api_msg_config.cluster.v3.Cluster.TransportSocketMatch>` is used. For example, with
   // the following match
   //
   // .. code-block:: yaml
@@ -956,6 +956,17 @@ message Cluster {
   google.protobuf.Duration dns_refresh_rate = 16
       [(validate.rules).duration = {gt {nanos: 1000000}}];
 
+  // DNS jitter can be optionally specified if the cluster type is either
+  // :ref:`STRICT_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.STRICT_DNS>`,
+  // or :ref:`LOGICAL_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.LOGICAL_DNS>`.
+  // DNS jitter causes the cluster to refresh DNS entries later by a random amount of time to avoid a
+  // stampede of DNS requests. This value sets the upper bound (exclusive) for the random amount.
+  // There will be no jitter if this value is omitted. For cluster types other than
+  // :ref:`STRICT_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.STRICT_DNS>`
+  // and :ref:`LOGICAL_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.LOGICAL_DNS>`
+  // this setting is ignored.
+  google.protobuf.Duration dns_jitter = 58;
+
   // If the DNS failure refresh rate is specified and the cluster type is either
   // :ref:`STRICT_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.STRICT_DNS>`,
   // or :ref:`LOGICAL_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.LOGICAL_DNS>`,
@@ -1150,6 +1161,23 @@ message Cluster {
   // maybe by allowing LRS to go on the ADS stream, or maybe by moving some of the negotiation
   // from the LRS stream here.]
   core.v3.ConfigSource lrs_server = 42;
+
+  // A list of metric names from :ref:`ORCA load reports <envoy_v3_api_msg_.xds.data.orca.v3.OrcaLoadReport>` to propagate to LRS.
+  //
+  // If not specified, then ORCA load reports will not be propagated to LRS.
+  //
+  // For map fields in the ORCA proto, the string will be of the form ``<map_field_name>.<map_key>``.
+  // For example, the string ``named_metrics.foo`` will mean to look for the key ``foo`` in the ORCA
+  // :ref:`named_metrics <envoy_v3_api_field_.xds.data.orca.v3.OrcaLoadReport.named_metrics>` field.
+  //
+  // The special map key ``*`` means to report all entries in the map (e.g., ``named_metrics.*`` means to
+  // report all entries in the ORCA named_metrics field). Note that this should be used only with trusted
+  // backends.
+  //
+  // The metric names in LRS will follow the same semantics as this field. In other words, if this field
+  // contains ``named_metrics.foo``, then the LRS load report will include the data with that same string
+  // as the key.
+  repeated string lrs_report_endpoint_metrics = 57;
 
   // If track_timeout_budgets is true, the :ref:`timeout budget histograms
   // <config_cluster_manager_cluster_stats_timeout_budgets>` will be published for each

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/protocol.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/protocol.proto
@@ -39,24 +39,21 @@ message QuicKeepAliveSettings {
   //
   // If zero, disable keepalive probing.
   // If absent, use the QUICHE default interval to probe.
-  google.protobuf.Duration max_interval = 1 [(validate.rules).duration = {
-    lte {}
-    gte {seconds: 1}
-  }];
+  google.protobuf.Duration max_interval = 1;
 
   // The interval to send the first few keep-alive probing packets to prevent connection from hitting the idle timeout. Subsequent probes will be sent, each one with an interval exponentially longer than previous one, till it reaches :ref:`max_interval <envoy_v3_api_field_config.core.v3.QuicKeepAliveSettings.max_interval>`. And the probes afterwards will always use :ref:`max_interval <envoy_v3_api_field_config.core.v3.QuicKeepAliveSettings.max_interval>`.
   //
   // The value should be smaller than :ref:`connection idle_timeout <envoy_v3_api_field_config.listener.v3.QuicProtocolOptions.idle_timeout>` to prevent idle timeout and smaller than max_interval to take effect.
   //
-  // If absent or zero, disable keepalive probing for a server connection. For a client connection, if :ref:`max_interval <envoy_v3_api_field_config.core.v3.QuicKeepAliveSettings.max_interval>`  is also zero, do not keepalive, otherwise use max_interval or QUICHE default to probe all the time.
+  // If absent, disable keepalive probing for a server connection. For a client connection, if :ref:`max_interval <envoy_v3_api_field_config.core.v3.QuicKeepAliveSettings.max_interval>` is zero, do not keepalive, otherwise use max_interval or QUICHE default to probe all the time.
   google.protobuf.Duration initial_interval = 2 [(validate.rules).duration = {
     lte {}
-    gte {seconds: 1}
+    gte {nanos: 1000000}
   }];
 }
 
 // QUIC protocol options which apply to both downstream and upstream connections.
-// [#next-free-field: 9]
+// [#next-free-field: 10]
 message QuicProtocolOptions {
   // Maximum number of streams that the client can negotiate per connection. 100
   // if not specified.
@@ -111,6 +108,10 @@ message QuicProtocolOptions {
     lte {seconds: 600}
     gte {seconds: 1}
   }];
+
+  // Maximum packet length for QUIC connections. It refers to the largest size of a QUIC packet that can be transmitted over the connection.
+  // If not specified, one of the `default values in QUICHE <https://github.com/google/quiche/blob/main/quiche/quic/core/quic_constants.h>`_ is used.
+  google.protobuf.UInt64Value max_packet_length = 9;
 }
 
 message UpstreamHttpProtocolOptions {
@@ -205,7 +206,7 @@ message AlternateProtocolsCacheOptions {
   repeated string canonical_suffixes = 5;
 }
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message HttpProtocolOptions {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.core.HttpProtocolOptions";
@@ -249,17 +250,36 @@ message HttpProtocolOptions {
   google.protobuf.Duration idle_timeout = 1;
 
   // The maximum duration of a connection. The duration is defined as a period since a connection
-  // was established. If not set, there is no max duration. When max_connection_duration is reached
-  // and if there are no active streams, the connection will be closed. If the connection is a
-  // downstream connection and there are any active streams, the drain sequence will kick-in,
-  // and the connection will be force-closed after the drain period. See :ref:`drain_timeout
+  // was established. If not set, there is no max duration. When max_connection_duration is reached,
+  // the drain sequence will kick-in. The connection will be closed after the drain timeout period
+  // if there are no active streams. See :ref:`drain_timeout
   // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.drain_timeout>`.
   google.protobuf.Duration max_connection_duration = 3;
 
-  // The maximum number of headers. If unconfigured, the default
-  // maximum number of request headers allowed is 100. Requests that exceed this limit will receive
-  // a 431 response for HTTP/1.x and cause a stream reset for HTTP/2.
+  // The maximum number of headers (request headers if configured on HttpConnectionManager,
+  // response headers when configured on a cluster).
+  // If unconfigured, the default maximum number of headers allowed is 100.
+  // The default value for requests can be overridden by setting runtime key ``envoy.reloadable_features.max_request_headers_count``.
+  // The default value for responses can be overridden by setting runtime key ``envoy.reloadable_features.max_response_headers_count``.
+  // Downstream requests that exceed this limit will receive a 431 response for HTTP/1.x and cause a stream
+  // reset for HTTP/2.
+  // Upstream responses that exceed this limit will result in a 503 response.
   google.protobuf.UInt32Value max_headers_count = 2 [(validate.rules).uint32 = {gte: 1}];
+
+  // The maximum size of response headers.
+  // If unconfigured, the default is 60 KiB, except for HTTP/1 response headers which have a default
+  // of 80KiB.
+  // The default value can be overridden by setting runtime key ``envoy.reloadable_features.max_response_headers_size_kb``.
+  // Responses that exceed this limit will result in a 503 response.
+  // In Envoy, this setting is only valid when configured on an upstream cluster, not on the
+  // :ref:`HTTP Connection Manager
+  // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.common_http_protocol_options>`.
+  //
+  // Note: currently some protocol codecs impose limits on the maximum size of a single header:
+  //   HTTP/2 (when using nghttp2) limits a single header to around 100kb.
+  //   HTTP/3 limits a single header to around 1024kb.
+  google.protobuf.UInt32Value max_response_headers_kb = 7
+      [(validate.rules).uint32 = {lte: 8192 gt: 0}];
 
   // Total duration to keep alive an HTTP request/response stream. If the time limit is reached the stream will be
   // reset independent of any other timeouts. If not specified, this value is not set.

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/socket_cmsg_headers.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/socket_cmsg_headers.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+package envoy.config.core.v3;
+
+import "google/protobuf/wrappers.proto";
+
+import "udpa/annotations/status.proto";
+
+option java_package = "io.envoyproxy.envoy.config.core.v3";
+option java_outer_classname = "SocketCmsgHeadersProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/envoy/config/core/v3;corev3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Socket CMSG headers]
+
+// Configuration for socket cmsg headers.
+// See `:ref:CMSG <https://man7.org/linux/man-pages/man3/cmsg.3.html>`_ for further information.
+message SocketCmsgHeaders {
+  // cmsg level. Default is unset.
+  google.protobuf.UInt32Value level = 1;
+
+  // cmsg type. Default is unset.
+  google.protobuf.UInt32Value type = 2;
+
+  // Expected size of cmsg value. Default is zero.
+  uint32 expected_size = 3;
+}

--- a/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/socket_option.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/core/v3/socket_option.proto
@@ -36,7 +36,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // :ref:`admin's <envoy_v3_api_field_config.bootstrap.v3.Admin.socket_options>` socket_options etc.
 //
 // It should be noted that the name or level may have different values on different platforms.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message SocketOption {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.core.SocketOption";
 
@@ -49,6 +49,29 @@ message SocketOption {
 
     // Socket options are applied after calling listen()
     STATE_LISTENING = 2;
+  }
+
+  // The `socket type <https://linux.die.net/man/2/socket>`_ to apply the socket option to.
+  // Only one field should be set. If multiple fields are set, the precedence order will determine
+  // the selected one. If none of the fields is set, the socket option will be applied to all socket types.
+  //
+  // For example:
+  // If :ref:`stream <envoy_v3_api_field_config.core.v3.SocketOption.SocketType.stream>` is set,
+  // it takes precedence over :ref:`datagram <envoy_v3_api_field_config.core.v3.SocketOption.SocketType.datagram>`.
+  message SocketType {
+    // The stream socket type.
+    message Stream {
+    }
+
+    // The datagram socket type.
+    message Datagram {
+    }
+
+    // Apply the socket option to the stream socket type.
+    Stream stream = 1;
+
+    // Apply the socket option to the datagram socket type.
+    Datagram datagram = 2;
   }
 
   // An optional name to give this socket option for debugging, etc.
@@ -74,6 +97,10 @@ message SocketOption {
   // The state in which the option will be applied. When used in BindConfig
   // STATE_PREBIND is currently the only valid value.
   SocketState state = 6 [(validate.rules).enum = {defined_only: true}];
+
+  // Apply the socket option to the specified `socket type <https://linux.die.net/man/2/socket>`_.
+  // If not specified, the socket option will be applied to all socket types.
+  SocketType type = 7;
 }
 
 message SocketOptionsOverride {

--- a/xds/third_party/envoy/src/main/proto/envoy/config/endpoint/v3/load_report.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/endpoint/v3/load_report.proto
@@ -25,7 +25,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // These are stats Envoy reports to the management server at a frequency defined by
 // :ref:`LoadStatsResponse.load_reporting_interval<envoy_v3_api_field_service.load_stats.v3.LoadStatsResponse.load_reporting_interval>`.
 // Stats per upstream region/zone and optionally per subzone.
-// [#next-free-field: 12]
+// [#next-free-field: 15]
 message UpstreamLocalityStats {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.endpoint.UpstreamLocalityStats";
@@ -75,7 +75,20 @@ message UpstreamLocalityStats {
   // [#not-implemented-hide:]
   uint64 total_fail_connections = 11 [(xds.annotations.v3.field_status).work_in_progress = true];
 
-  // Stats for multi-dimensional load balancing.
+  // CPU utilization stats for multi-dimensional load balancing.
+  // This typically comes from endpoint metrics reported via ORCA.
+  UnnamedEndpointLoadMetricStats cpu_utilization = 12;
+
+  // Memory utilization for multi-dimensional load balancing.
+  // This typically comes from endpoint metrics reported via ORCA.
+  UnnamedEndpointLoadMetricStats mem_utilization = 13;
+
+  // Blended application-defined utilization for multi-dimensional load balancing.
+  // This typically comes from endpoint metrics reported via ORCA.
+  UnnamedEndpointLoadMetricStats application_utilization = 14;
+
+  // Named stats for multi-dimensional load balancing.
+  // These typically come from endpoint metrics reported via ORCA.
   repeated EndpointLoadMetricStats load_metric_stats = 5;
 
   // Endpoint granularity stats information for this locality. This information
@@ -143,6 +156,16 @@ message EndpointLoadMetricStats {
   // Sum of metric values across all calls that finished with this metric for
   // load_reporting_interval.
   double total_metric_value = 3;
+}
+
+// Same as EndpointLoadMetricStats, except without the metric_name field.
+message UnnamedEndpointLoadMetricStats {
+  // Number of calls that finished and included this metric.
+  uint64 num_requests_finished_with_metric = 1;
+
+  // Sum of metric values across all calls that finished with this metric for
+  // load_reporting_interval.
+  double total_metric_value = 2;
 }
 
 // Per cluster load stats. Envoy reports these stats a management server in a

--- a/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/quic_config.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/listener/v3/quic_config.proto
@@ -5,6 +5,7 @@ package envoy.config.listener.v3;
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/extension.proto";
 import "envoy/config/core/v3/protocol.proto";
+import "envoy/config/core/v3/socket_cmsg_headers.proto";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
@@ -24,7 +25,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#protodoc-title: QUIC listener config]
 
 // Configuration specific to the UDP QUIC listener.
-// [#next-free-field: 12]
+// [#next-free-field: 14]
 message QuicProtocolOptions {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.listener.QuicProtocolOptions";
@@ -86,4 +87,16 @@ message QuicProtocolOptions {
   // If not specified, no debug visitor will be attached to connections.
   // [#extension-category: envoy.quic.connection_debug_visitor]
   core.v3.TypedExtensionConfig connection_debug_visitor_config = 11;
+
+  // Configure a type of UDP cmsg to pass to listener filters via QuicReceivedPacket.
+  // Both level and type must be specified for cmsg to be saved.
+  // Cmsg may be truncated or omitted if expected size is not set.
+  // If not specified, no cmsg will be saved to QuicReceivedPacket.
+  repeated core.v3.SocketCmsgHeaders save_cmsg_config = 12
+      [(validate.rules).repeated = {max_items: 1}];
+
+  // If true, the listener will reject connection-establishing packets at the
+  // QUIC layer by replying with an empty version negotiation packet to the
+  // client.
+  bool reject_new_connections = 13;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/config/route/v3/route_components.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/route/v3/route_components.proto
@@ -17,7 +17,6 @@ import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
-import "xds/annotations/v3/status.proto";
 import "xds/type/matcher/v3/matcher.proto";
 
 import "envoy/annotations/deprecation.proto";
@@ -92,13 +91,12 @@ message VirtualHost {
   // The list of routes that will be matched, in order, for incoming requests.
   // The first route that matches will be used.
   // Only one of this and ``matcher`` can be specified.
-  repeated Route routes = 3;
+  repeated Route routes = 3 [(udpa.annotations.field_migrate).oneof_promotion = "route_selection"];
 
-  // [#next-major-version: This should be included in a oneof with routes wrapped in a message.]
   // The match tree to use when resolving route actions for incoming requests. Only one of this and ``routes``
   // can be specified.
   xds.type.matcher.v3.Matcher matcher = 21
-      [(xds.annotations.v3.field_status).work_in_progress = true];
+      [(udpa.annotations.field_migrate).oneof_promotion = "route_selection"];
 
   // Specifies the type of TLS enforcement the virtual host expects. If this option is not
   // specified, there is no TLS requirement for the virtual host.

--- a/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/datadog.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/datadog.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.config.trace.v3;
 
+import "google/protobuf/duration.proto";
+
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -15,6 +17,13 @@ option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.trace
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Datadog tracer]
+
+// Configuration for the Remote Configuration feature.
+message DatadogRemoteConfig {
+  // Frequency at which new configuration updates are queried.
+  // If no value is provided, the default value is delegated to the Datadog tracing library.
+  google.protobuf.Duration polling_interval = 1;
+}
 
 // Configuration for the Datadog tracer.
 // [#extension: envoy.tracers.datadog]
@@ -31,4 +40,11 @@ message DatadogConfig {
   // Optional hostname to use when sending spans to the collector_cluster. Useful for collectors
   // that require a specific hostname. Defaults to :ref:`collector_cluster <envoy_v3_api_field_config.trace.v3.DatadogConfig.collector_cluster>` above.
   string collector_hostname = 3;
+
+  // Enables and configures remote configuration.
+  // Remote Configuration allows to configure the tracer from Datadog's user interface.
+  // This feature can drastically increase the number of connections to the Datadog Agent.
+  // Each tracer regularly polls for configuration updates, and the number of tracers is the product
+  // of the number of listeners and worker threads.
+  DatadogRemoteConfig remote_config = 4;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/dynamic_ot.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/config/trace/v3/dynamic_ot.proto
@@ -20,10 +20,10 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Dynamically loadable OpenTracing tracer]
 
-// DynamicOtConfig is used to dynamically load a tracer from a shared library
+// DynamicOtConfig was used to dynamically load a tracer from a shared library
 // that implements the `OpenTracing dynamic loading API
 // <https://github.com/opentracing/opentracing-cpp>`_.
-// [#extension: envoy.tracers.dynamic_ot]
+// [#not-implemented-hide:]
 message DynamicOtConfig {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.trace.v2.DynamicOtConfig";

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -37,7 +37,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 // [#extension: envoy.filters.network.http_connection_manager]
 
-// [#next-free-field: 58]
+// [#next-free-field: 59]
 message HttpConnectionManager {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager";
@@ -58,9 +58,8 @@ message HttpConnectionManager {
     // Prior knowledge is allowed).
     HTTP2 = 2;
 
-    // [#not-implemented-hide:] QUIC implementation is not production ready yet. Use this enum with
-    // caution to prevent accidental execution of QUIC code. I.e. `!= HTTP2` is no longer sufficient
-    // to distinguish HTTP1 and HTTP2 traffic.
+    // The connection manager will assume that the client is speaking HTTP/3.
+    // This needs to be consistent with listener and transport socket config.
     HTTP3 = 3;
   }
 
@@ -447,6 +446,21 @@ message HttpConnectionManager {
   config.core.v3.HttpProtocolOptions common_http_protocol_options = 35
       [(udpa.annotations.security).configure_for_untrusted_downstream = true];
 
+  // If set to true, Envoy will not start a drain timer for downstream HTTP1 connections after
+  // :ref:`common_http_protocol_options.max_connection_duration
+  // <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.max_connection_duration>` passes.
+  // Instead, Envoy will wait for the next downstream request, add connection:close to the response
+  // headers, then close the connection after the stream ends.
+  //
+  // This behavior is compliant with `RFC 9112 section 9.6 <https://www.rfc-editor.org/rfc/rfc9112#name-tear-down>`_
+  //
+  // If set to false, ``max_connection_duration`` will cause Envoy to enter the normal drain
+  // sequence for HTTP1 with Envoy eventually closing the connection (once there are no active
+  // streams).
+  //
+  // Has no effect if ``max_connection_duration`` is unset. Defaults to false.
+  bool http1_safe_max_connection_duration = 58;
+
   // Additional HTTP/1 settings that are passed to the HTTP/1 codec.
   // [#comment:TODO: The following fields are ignored when the
   // :ref:`header validation configuration <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.typed_header_validation_config>`
@@ -459,7 +473,6 @@ message HttpConnectionManager {
       [(udpa.annotations.security).configure_for_untrusted_downstream = true];
 
   // Additional HTTP/3 settings that are passed directly to the HTTP/3 codec.
-  // [#not-implemented-hide:]
   config.core.v3.Http3ProtocolOptions http3_protocol_options = 44;
 
   // An optional override that the connection manager will write to the server
@@ -480,7 +493,12 @@ message HttpConnectionManager {
 
   // The maximum request headers size for incoming connections.
   // If unconfigured, the default max request headers allowed is 60 KiB.
+  // The default value can be overridden by setting runtime key ``envoy.reloadable_features.max_request_headers_size_kb``.
   // Requests that exceed this limit will receive a 431 response.
+  //
+  // Note: currently some protocol codecs impose limits on the maximum size of a single header:
+  //   HTTP/2 (when using nghttp2) limits a single header to around 100kb.
+  //   HTTP/3 limits a single header to around 1024kb.
   google.protobuf.UInt32Value max_request_headers_kb = 29
       [(validate.rules).uint32 = {lte: 8192 gt: 0}];
 
@@ -547,9 +565,10 @@ message HttpConnectionManager {
   // race with the final GOAWAY frame. During this grace period, Envoy will
   // continue to accept new streams. After the grace period, a final GOAWAY
   // frame is sent and Envoy will start refusing new streams. Draining occurs
-  // both when a connection hits the idle timeout or during general server
-  // draining. The default grace period is 5000 milliseconds (5 seconds) if this
-  // option is not specified.
+  // either when a connection hits the idle timeout, when :ref:`max_connection_duration
+  // <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.max_connection_duration>`
+  // is reached, or during general server draining. The default grace period is
+  // 5000 milliseconds (5 seconds) if this option is not specified.
   google.protobuf.Duration drain_timeout = 12;
 
   // The delayed close timeout is for downstream connections managed by the HTTP connection manager.
@@ -588,26 +607,33 @@ message HttpConnectionManager {
   // emitted by the connection manager.
   repeated config.accesslog.v3.AccessLog access_log = 13;
 
+  // The interval to flush the above access logs.
+  //
   // .. attention::
-  // This field is deprecated in favor of
-  // :ref:`access_log_flush_interval
-  // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.HcmAccessLogOptions.access_log_flush_interval>`.
-  // Note that if both this field and :ref:`access_log_flush_interval
-  // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.HcmAccessLogOptions.access_log_flush_interval>`
-  // are specified, the former (deprecated field) is ignored.
+  //
+  //   This field is deprecated in favor of
+  //   :ref:`access_log_flush_interval
+  //   <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.HcmAccessLogOptions.access_log_flush_interval>`.
+  //   Note that if both this field and :ref:`access_log_flush_interval
+  //   <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.HcmAccessLogOptions.access_log_flush_interval>`
+  //   are specified, the former (deprecated field) is ignored.
   google.protobuf.Duration access_log_flush_interval = 54 [
     deprecated = true,
     (validate.rules).duration = {gte {nanos: 1000000}},
     (envoy.annotations.deprecated_at_minor_version) = "3.0"
   ];
 
+  // If set to true, HCM will flush an access log once when a new HTTP request is received, after the request
+  // headers have been evaluated, and before iterating through the HTTP filter chain.
+  //
   // .. attention::
-  // This field is deprecated in favor of
-  // :ref:`flush_access_log_on_new_request
-  // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.HcmAccessLogOptions.flush_access_log_on_new_request>`.
-  // Note that if both this field and :ref:`flush_access_log_on_new_request
-  // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.HcmAccessLogOptions.flush_access_log_on_new_request>`
-  // are specified, the former (deprecated field) is ignored.
+  //
+  //   This field is deprecated in favor of
+  //   :ref:`flush_access_log_on_new_request
+  //   <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.HcmAccessLogOptions.flush_access_log_on_new_request>`.
+  //   Note that if both this field and :ref:`flush_access_log_on_new_request
+  //   <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.HcmAccessLogOptions.flush_access_log_on_new_request>`
+  //   are specified, the former (deprecated field) is ignored.
   bool flush_access_log_on_new_request = 55
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
@@ -663,6 +689,34 @@ message HttpConnectionManager {
   // purposes. If unspecified, only RFC1918 IP addresses will be considered internal.
   // See the documentation for :ref:`config_http_conn_man_headers_x-envoy-internal` for more
   // information about internal/external addresses.
+  //
+  // .. warning::
+  //     In the next release, no IP addresses will be considered trusted. If you have tooling such as probes
+  //     on your private network which need to be treated as trusted (e.g. changing arbitrary x-envoy headers)
+  //     you will have to manually include those addresses or CIDR ranges like:
+  //
+  // .. validated-code-block:: yaml
+  //   :type-name: envoy.extensions.filters.network.http_connection_manager.v3.InternalAddressConfig
+  //
+  //   cidr_ranges:
+  //       address_prefix: 10.0.0.0
+  //       prefix_len: 8
+  //   cidr_ranges:
+  //       address_prefix: 192.168.0.0
+  //       prefix_len: 16
+  //   cidr_ranges:
+  //       address_prefix: 172.16.0.0
+  //       prefix_len: 12
+  //   cidr_ranges:
+  //       address_prefix: 127.0.0.1
+  //       prefix_len: 32
+  //   cidr_ranges:
+  //       address_prefix: fd00::
+  //       prefix_len: 8
+  //   cidr_ranges:
+  //       address_prefix: ::1
+  //       prefix_len: 128
+  //
   InternalAddressConfig internal_address_config = 25;
 
   // If set, Envoy will not append the remote address to the

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
@@ -15,7 +15,7 @@ option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/loa
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Client-Side Weighted Round Robin Load Balancing Policy]
-// [#not-implemented-hide:]
+// [#extension: envoy.load_balancing_policies.client_side_weighted_round_robin]
 
 // Configuration for the client_side_weighted_round_robin LB policy.
 //
@@ -30,11 +30,12 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // regardless of result. Only failed queries count toward eps. A config
 // parameter error_utilization_penalty controls the penalty to adjust endpoint
 // weights using eps and qps. The weight of a given endpoint is computed as:
-//   qps / (utilization + eps/qps * error_utilization_penalty)
+// ``qps / (utilization + eps/qps * error_utilization_penalty)``.
 //
-// See the :ref:`load balancing architecture overview<arch_overview_load_balancing_types>` for more information.
+// See the :ref:`load balancing architecture
+// overview<arch_overview_load_balancing_types>` for more information.
 //
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message ClientSideWeightedRoundRobin {
   // Whether to enable out-of-band utilization reporting collection from
   // the endpoints. By default, per-request utilization reporting is used.
@@ -68,4 +69,10 @@ message ClientSideWeightedRoundRobin {
   // calculated as eps/qps. Configuration is rejected if this value is negative.
   // Default is 1.0.
   google.protobuf.FloatValue error_utilization_penalty = 6 [(validate.rules).float = {gte: 0.0}];
+
+  // By default, endpoint weight is computed based on the :ref:`application_utilization <envoy_v3_api_field_.xds.data.orca.v3.OrcaLoadReport.application_utilization>` field reported by the endpoint.
+  // If that field is not set, then utilization will instead be computed by taking the max of the values of the metrics specified here.
+  // For map fields in the ORCA proto, the string will be of the form ``<map_field_name>.<map_key>``. For example, the string ``named_metrics.foo`` will mean to look for the key ``foo`` in the ORCA :ref:`named_metrics <envoy_v3_api_field_.xds.data.orca.v3.OrcaLoadReport.named_metrics>` field.
+  // If none of the specified metrics are present in the load report, then :ref:`cpu_utilization <envoy_v3_api_field_.xds.data.orca.v3.OrcaLoadReport.cpu_utilization>` is used instead.
+  repeated string metric_names_for_computing_utilization = 7;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -290,12 +290,12 @@ message TlsSessionTicketKeys {
 // respect to the TLS handshake.
 // [#not-implemented-hide:]
 message CertificateProviderPluginInstance {
-  // Provider instance name. If not present, defaults to "default".
+  // Provider instance name.
   //
   // Instance names should generally be defined not in terms of the underlying provider
   // implementation (e.g., "file_watcher") but rather in terms of the function of the
   // certificates (e.g., "foo_deployment_identity").
-  string instance_name = 1;
+  string instance_name = 1 [(validate.rules).string = {min_len: 1}];
 
   // Opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
   // a root-certificate (validation context) or "example.com" to specify a certificate for a

--- a/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -63,7 +63,7 @@ message UpstreamTlsContext {
   google.protobuf.BoolValue enforce_rsa_key_usage = 5;
 }
 
-// [#next-free-field: 11]
+// [#next-free-field: 12]
 message DownstreamTlsContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.auth.DownstreamTlsContext";
@@ -140,6 +140,11 @@ message DownstreamTlsContext {
   // If the client provides SNI but no such cert matched, it will decide to full scan certificates or not based on this config.
   // Defaults to false. See more details in :ref:`Multiple TLS certificates <arch_overview_ssl_cert_select>`.
   google.protobuf.BoolValue full_scan_certs_on_sni_mismatch = 9;
+
+  // By default, Envoy as a server uses its preferred cipher during the handshake.
+  // Setting this to true would allow the downstream client's preferred cipher to be used instead.
+  // Has no effect when using TLSv1_3.
+  bool prefer_client_ciphers = 11;
 }
 
 // TLS key log configuration.
@@ -158,7 +163,7 @@ message TlsKeyLog {
 }
 
 // TLS context shared by both client and server TLS contexts.
-// [#next-free-field: 16]
+// [#next-free-field: 17]
 message CommonTlsContext {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.auth.CommonTlsContext";
 
@@ -268,6 +273,13 @@ message CommonTlsContext {
   // are ignored.
   // [#not-implemented-hide:]
   CertificateProviderPluginInstance tls_certificate_provider_instance = 14;
+
+  // Custom TLS certificate selector.
+  //
+  // Select TLS certificate based on TLS client hello.
+  // If empty, defaults to native TLS certificate selection behavior:
+  // DNS SANs or Subject Common Name in TLS certificates is extracted as server name pattern to match SNI.
+  config.core.v3.TypedExtensionConfig custom_tls_certificate_selector = 16;
 
   // Certificate provider for fetching TLS certificates.
   // [#not-implemented-hide:]


### PR DESCRIPTION
envoyproxy/envoy: Sync protos to the latest imported version https://github.com/envoyproxy/envoy/commit/742a3b02e3b2a9dfb877a7e378607c6ed0c2aa53 (commit 2024-10-23, cl/692906546).

Should be a noop, just a routine xDS proto update to make upcoming GCP_Auth_Filter related imports simpler.