### PR TITLE
xds: Remove Bazel dependency on xds v2

### DIFF
--- a/xds/BUILD.bazel
+++ b/xds/BUILD.bazel
@@ -27,9 +27,7 @@ java_library(
     ]),
     visibility = ["//visibility:public"],
     deps = [
-        ":envoy_service_discovery_v2_java_grpc",
         ":envoy_service_discovery_v3_java_grpc",
-        ":envoy_service_load_stats_v2_java_grpc",
         ":envoy_service_load_stats_v3_java_grpc",
         ":envoy_service_status_v3_java_grpc",
         ":orca",
@@ -64,20 +62,11 @@ java_proto_library(
     name = "xds_protos_java",
     deps = [
         "@com_github_cncf_xds//udpa/type/v1:pkg",
-        "@com_github_cncf_xds//xds/data/orca/v3:pkg",
-        "@com_github_cncf_xds//xds/service/orca/v3:pkg",
         "@com_github_cncf_xds//xds/type/v3:pkg",
         "@envoy_api//envoy/admin/v3:pkg",
-        "@envoy_api//envoy/api/v2:pkg",
-        "@envoy_api//envoy/api/v2/core:pkg",
-        "@envoy_api//envoy/api/v2/endpoint:pkg",
-        "@envoy_api//envoy/config/cluster/aggregate/v2alpha:pkg",
         "@envoy_api//envoy/config/cluster/v3:pkg",
         "@envoy_api//envoy/config/core/v3:pkg",
         "@envoy_api//envoy/config/endpoint/v3:pkg",
-        "@envoy_api//envoy/config/filter/http/fault/v2:pkg",
-        "@envoy_api//envoy/config/filter/http/router/v2:pkg",
-        "@envoy_api//envoy/config/filter/network/http_connection_manager/v2:pkg",
         "@envoy_api//envoy/config/listener/v3:pkg",
         "@envoy_api//envoy/config/rbac/v3:pkg",
         "@envoy_api//envoy/config/route/v3:pkg",
@@ -94,9 +83,7 @@ java_proto_library(
         "@envoy_api//envoy/extensions/load_balancing_policies/round_robin/v3:pkg",
         "@envoy_api//envoy/extensions/load_balancing_policies/wrr_locality/v3:pkg",
         "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg",
-        "@envoy_api//envoy/service/discovery/v2:pkg",
         "@envoy_api//envoy/service/discovery/v3:pkg",
-        "@envoy_api//envoy/service/load_stats/v2:pkg",
         "@envoy_api//envoy/service/load_stats/v3:pkg",
         "@envoy_api//envoy/service/status/v3:pkg",
         "@envoy_api//envoy/type/matcher/v3:pkg",
@@ -105,20 +92,8 @@ java_proto_library(
 )
 
 java_grpc_library(
-    name = "envoy_service_discovery_v2_java_grpc",
-    srcs = ["@envoy_api//envoy/service/discovery/v2:pkg"],
-    deps = [":xds_protos_java"],
-)
-
-java_grpc_library(
     name = "envoy_service_discovery_v3_java_grpc",
     srcs = ["@envoy_api//envoy/service/discovery/v3:pkg"],
-    deps = [":xds_protos_java"],
-)
-
-java_grpc_library(
-    name = "envoy_service_load_stats_v2_java_grpc",
-    srcs = ["@envoy_api//envoy/service/load_stats/v2:pkg"],
     deps = [":xds_protos_java"],
 )
 


### PR DESCRIPTION
feab4e54 removed xds v2 for the Gradle build. Testing with a deploy.jar, I see the same 4 MB size reduction (31 -> 27 MB) here.

While an orca dependency is deleted in this commit, it is only a direct dependency. It remains in the :orca target, so doesn't contribute a size reduction.

CC @sergiitk