### PR TITLE
Let AndroidComponentAddress specify a target UserHandle

### DIFF
--- a/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
+++ b/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
@@ -244,6 +244,14 @@ public final class AndroidComponentAddress extends SocketAddress {
     }
 
     /**
+     * See {@link Intent#addCategory(String)}.
+     */
+    public Builder addCategory(String category) {
+      bindIntent.addCategory(category);
+      return this;
+    }
+
+    /**
      * See {@link Intent#setAction(String)}.
      */
     public Builder setAction(String action) {

--- a/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
+++ b/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
@@ -236,14 +236,6 @@ public final class AndroidComponentAddress extends SocketAddress {
     }
 
     /**
-     * See {@link Intent#setClassName(String, String)}.
-     */
-    public Builder setClassName(String packageName, String className) {
-      bindIntent.setClassName(packageName, className);
-      return this;
-    }
-
-    /**
      * See {@link Intent#setComponent(ComponentName)}.
      */
     public Builder setComponent(ComponentName component) {

--- a/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
+++ b/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
@@ -151,6 +151,9 @@ public final class AndroidComponentAddress extends SocketAddress {
   /**
    * Returns this address as an explicit {@link Intent} suitable for passing to {@link
    * Context#bindService}.
+   *
+   * <p>NB: The returned Intent does not specify a target Android user. If {@link #getTargetUser()}
+   * is non-null, {@link Context#bindServiceAsUser} should be called instead.
    */
   public Intent asBindIntent() {
     return bindIntent.cloneFilter(); // Intent is mutable so return a copy.

--- a/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
+++ b/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
@@ -25,6 +25,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.UserHandle;
 import com.google.common.base.Objects;
+import io.grpc.ExperimentalApi;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
 
@@ -214,6 +215,7 @@ public final class AndroidComponentAddress extends SocketAddress {
    * <p>Returns the {@link UserHandle}, or null which means that the Android user hosting the
    * current process will be used.
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/10173")
   @Nullable
   public UserHandle getTargetUser() {
     return targetUser;
@@ -273,6 +275,7 @@ public final class AndroidComponentAddress extends SocketAddress {
     /**
      * See {@link AndroidComponentAddress#getTargetUser()}.
      */
+    @ExperimentalApi("https://github.com/grpc/grpc-java/issues/10173")
     public Builder setTargetUser(@Nullable UserHandle targetUser) {
       this.targetUser = targetUser;
       return this;

--- a/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
+++ b/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
@@ -18,6 +18,7 @@ package io.grpc.binder;
 
 import static android.content.Intent.URI_ANDROID_APP_SCHEME;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 
 import android.content.ComponentName;
 import android.content.Context;
@@ -226,7 +227,7 @@ public final class AndroidComponentAddress extends SocketAddress {
 
   /** Fluently builds instances of {@link AndroidComponentAddress}. */
   public static class Builder {
-    Intent bindIntent = new Intent(ApiConstants.ACTION_BIND);
+    Intent bindIntent;
     UserHandle targetUser;
 
     /**
@@ -259,6 +260,7 @@ public final class AndroidComponentAddress extends SocketAddress {
     public AndroidComponentAddress build() {
       // We clone any incoming mutable intent in the setter, not here. AndroidComponentAddress
       // itself is immutable so multiple instances built from here can safely share 'bindIntent'.
+      checkState(bindIntent != null, "Required property 'bindIntent' unset");
       return new AndroidComponentAddress(bindIntent, targetUser);
     }
   }

--- a/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
@@ -236,20 +236,28 @@ public final class BinderChannelBuilder extends ForwardingChannelBuilder<BinderC
   }
 
   /**
-   * Provides the target {@UserHandle} of the remote Android service.
+   * Specifies the {@link UserHandle} to be searched for the remote Android Service by default.
    *
-   * <p>When targetUserHandle is set, Context.bindServiceAsUser will used and additional Android
-   * permissions will be required. If your usage does not require cross-user communications, please
-   * do not set this field. It is the caller's responsibility to make sure that it holds the
-   * corresponding permissions.
+   * <p>Used only as a fallback if the direct or resolved {@link AndroidComponentAddress} doesn't
+   * specify a {@link UserHandle}. If neither the Channel nor the {@link AndroidComponentAddress}
+   * specifies a target user, the {@link UserHandle} of the current process will be used.
    *
+   * <p>Targeting a Service in a different Android user is uncommon and requires special permissions
+   * normally reserved for system apps. See {@link android.content.Context#bindServiceAsUser} for
+   * details.
+   *
+   * @deprecated This method's name is confusing since it implies impersonation. It's also no longer
+   *     necessary since the target user is now part of the {@link AndroidComponentAddress}. Prefer
+   *     to specify your target there instead, either as a direct address or via a
+   *     {@link io.grpc.NameResolverProvider}.
    * @param targetUserHandle the target user to bind into.
    * @return this
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/10173")
   @RequiresApi(30)
+  @Deprecated
   public BinderChannelBuilder bindAsUser(UserHandle targetUserHandle) {
-    transportFactoryBuilder.setTargetUserHandle(targetUserHandle);
+    transportFactoryBuilder.setDefaultTargetUserHandle(targetUserHandle);
     return this;
   }
 

--- a/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
@@ -246,10 +246,10 @@ public final class BinderChannelBuilder extends ForwardingChannelBuilder<BinderC
    * normally reserved for system apps. See {@link android.content.Context#bindServiceAsUser} for
    * details.
    *
-   * @deprecated This method's name is confusing since it implies impersonation. It's also no longer
-   *     necessary since the target user is now part of the {@link AndroidComponentAddress}. Prefer
-   *     to specify your target there instead, either as a direct address or via a
-   *     {@link io.grpc.NameResolverProvider}.
+   * @deprecated This method's name is misleading because it implies an impersonated client identity
+   *     when it's actually specifying part of the server's location. It's also no longer necessary
+   *     since the target user is part of {@link AndroidComponentAddress}. Prefer to specify target
+   *     user in the address instead, either directly or via a {@link io.grpc.NameResolverProvider}.
    * @param targetUserHandle the target user to bind into.
    * @return this
    */

--- a/binder/src/main/java/io/grpc/binder/internal/BinderClientTransportFactory.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderClientTransportFactory.java
@@ -50,7 +50,7 @@ public final class BinderClientTransportFactory implements ClientTransportFactor
   final ObjectPool<ScheduledExecutorService> scheduledExecutorPool;
   final ObjectPool<? extends Executor> offloadExecutorPool;
   final SecurityPolicy securityPolicy;
-  @Nullable final UserHandle targetUserHandle;
+  @Nullable final UserHandle defaultTargetUserHandle;
   final BindServiceFlags bindServiceFlags;
   final InboundParcelablePolicy inboundParcelablePolicy;
   final OneWayBinderProxy.Decorator binderDecorator;
@@ -70,7 +70,7 @@ public final class BinderClientTransportFactory implements ClientTransportFactor
     scheduledExecutorPool = checkNotNull(builder.scheduledExecutorPool);
     offloadExecutorPool = checkNotNull(builder.offloadExecutorPool);
     securityPolicy = checkNotNull(builder.securityPolicy);
-    targetUserHandle = builder.targetUserHandle;
+    defaultTargetUserHandle = builder.defaultTargetUserHandle;
     bindServiceFlags = checkNotNull(builder.bindServiceFlags);
     inboundParcelablePolicy = checkNotNull(builder.inboundParcelablePolicy);
     binderDecorator = checkNotNull(builder.binderDecorator);
@@ -123,7 +123,7 @@ public final class BinderClientTransportFactory implements ClientTransportFactor
     ObjectPool<ScheduledExecutorService> scheduledExecutorPool =
         SharedResourcePool.forResource(GrpcUtil.TIMER_SERVICE);
     SecurityPolicy securityPolicy = SecurityPolicies.internalOnly();
-    @Nullable UserHandle targetUserHandle;
+    @Nullable UserHandle defaultTargetUserHandle;
     BindServiceFlags bindServiceFlags = BindServiceFlags.DEFAULTS;
     InboundParcelablePolicy inboundParcelablePolicy = InboundParcelablePolicy.DEFAULT;
     OneWayBinderProxy.Decorator binderDecorator = OneWayBinderProxy.IDENTITY_DECORATOR;
@@ -165,8 +165,8 @@ public final class BinderClientTransportFactory implements ClientTransportFactor
       return this;
     }
 
-    public Builder setTargetUserHandle(@Nullable UserHandle targetUserHandle) {
-      this.targetUserHandle = targetUserHandle;
+    public Builder setDefaultTargetUserHandle(@Nullable UserHandle defaultTargetUserHandle) {
+      this.defaultTargetUserHandle = defaultTargetUserHandle;
       return this;
     }
 

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -299,7 +299,10 @@ public abstract class BinderTransport
 
   @Override
   public synchronized void binderDied() {
-    shutdownInternal(Status.UNAVAILABLE.withDescription("Peer process crashed, exited or was killed (binderDied)"), true);
+    shutdownInternal(
+        Status.UNAVAILABLE.withDescription(
+            "Peer process crashed, exited or was killed (binderDied)"),
+        true);
   }
 
   @GuardedBy("this")
@@ -611,7 +614,9 @@ public abstract class BinderTransport
               factory.sourceContext,
               factory.channelCredentials,
               targetAddress.asBindIntent(),
-              factory.targetUserHandle,
+              targetAddress.getTargetUser() != null
+                  ? targetAddress.getTargetUser()
+                  : factory.defaultTargetUserHandle,
               factory.bindServiceFlags.toInteger(),
               this);
     }

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -299,10 +299,7 @@ public abstract class BinderTransport
 
   @Override
   public synchronized void binderDied() {
-    shutdownInternal(
-        Status.UNAVAILABLE.withDescription(
-            "Peer process crashed, exited or was killed (binderDied)"),
-        true);
+    shutdownInternal(Status.UNAVAILABLE.withDescription("Peer process crashed, exited or was killed (binderDied)"), true);
   }
 
   @GuardedBy("this")

--- a/binder/src/test/java/io/grpc/binder/AndroidComponentAddressTest.java
+++ b/binder/src/test/java/io/grpc/binder/AndroidComponentAddressTest.java
@@ -18,6 +18,7 @@ package io.grpc.binder;
 
 import static android.content.Intent.URI_ANDROID_APP_SCHEME;
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import android.content.ComponentName;
 import android.content.Context;
@@ -100,6 +101,15 @@ public final class AndroidComponentAddressTest {
         AndroidComponentAddress.newBuilder().setBindIntent(bindIntent).build();
     bindIntent.setAction("bar-action");
     assertThat(addr.asBindIntent().getAction()).isEqualTo("foo-action");
+  }
+
+  @Test
+  public void testBuilderMissingRequired() {
+    IllegalStateException ise =
+        assertThrows(
+            IllegalStateException.class,
+            () -> AndroidComponentAddress.newBuilder().setTargetUser(newUserHandle(123)).build());
+    assertThat(ise.getMessage()).contains("bindIntent");
   }
 
   @Test

--- a/binder/src/test/java/io/grpc/binder/AndroidComponentAddressTest.java
+++ b/binder/src/test/java/io/grpc/binder/AndroidComponentAddressTest.java
@@ -86,6 +86,23 @@ public final class AndroidComponentAddressTest {
   }
 
   @Test
+  public void testPostCreateIntentMutation() {
+    Intent bindIntent = new Intent().setAction("foo-action").setComponent(hostComponent);
+    AndroidComponentAddress addr = AndroidComponentAddress.forBindIntent(bindIntent);
+    bindIntent.setAction("bar-action");
+    assertThat(addr.asBindIntent().getAction()).isEqualTo("foo-action");
+  }
+
+  @Test
+  public void testPostBuildIntentMutation() {
+    Intent bindIntent = new Intent().setAction("foo-action").setComponent(hostComponent);
+    AndroidComponentAddress addr =
+        AndroidComponentAddress.newBuilder().setBindIntent(bindIntent).build();
+    bindIntent.setAction("bar-action");
+    assertThat(addr.asBindIntent().getAction()).isEqualTo("foo-action");
+  }
+
+  @Test
   @Config(sdk = 30)
   public void testAsAndroidAppUriSdk30() throws URISyntaxException {
     AndroidComponentAddress addr =

--- a/binder/src/test/java/io/grpc/binder/AndroidComponentAddressTest.java
+++ b/binder/src/test/java/io/grpc/binder/AndroidComponentAddressTest.java
@@ -121,7 +121,7 @@ public final class AndroidComponentAddressTest {
             AndroidComponentAddress.forRemoteComponent(
                 appContext.getPackageName(), appContext.getClass().getName()),
             AndroidComponentAddress.newBuilder()
-                .setComponent(hostComponent)
+                .setBindIntentFromComponent(hostComponent)
                 .setTargetUser(null)
                 .build())
         .addEqualityGroup(
@@ -131,8 +131,7 @@ public final class AndroidComponentAddressTest {
             AndroidComponentAddress.forBindIntent(
                 new Intent().setAction("custom-action").setComponent(hostComponent)),
             AndroidComponentAddress.newBuilder()
-                .setAction("custom-action")
-                .setComponent(hostComponent)
+                .setBindIntent(new Intent().setAction("custom-action").setComponent(hostComponent))
                 .setTargetUser(null)
                 .build())
         .addEqualityGroup(
@@ -149,21 +148,23 @@ public final class AndroidComponentAddressTest {
     new EqualsTester()
         .addEqualityGroup(
             AndroidComponentAddress.newBuilder()
-                .setPackage("com.foo")
+                .setBindIntentFromComponent(hostComponent)
                 .setTargetUser(newUserHandle(10))
                 .build(),
             AndroidComponentAddress.newBuilder()
-                .setPackage("com.foo")
+                .setBindIntentFromComponent(hostComponent)
                 .setTargetUser(newUserHandle(10))
                 .build())
         .addEqualityGroup(
             AndroidComponentAddress.newBuilder()
-                .setPackage("com.foo")
+                .setBindIntentFromComponent(hostComponent)
                 .setTargetUser(newUserHandle(11))
                 .build())
         .addEqualityGroup(
-            AndroidComponentAddress.newBuilder().setPackage("com.foo").setTargetUser(null).build(),
-            AndroidComponentAddress.newBuilder().setPackage("com.foo").build())
+            AndroidComponentAddress.newBuilder()
+                .setBindIntentFromComponent(hostComponent)
+                .setTargetUser(null)
+                .build())
         .testEquals();
   }
 


### PR DESCRIPTION
The target UserHandle is best modeled as part of the SocketAddress since it's part of the server's location.

This change allows a NameResolver to select different target users over time within a single Channel.