### PR TITLE
testing: enabled smallLatency test

### DIFF
--- a/interop-testing/src/test/java/io/grpc/testing/integration/ProxyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/ProxyTest.java
@@ -62,7 +62,6 @@ public class ProxyTest {
   }
 
   @Test
-  @org.junit.Ignore // flaky. latency commonly too high
   public void smallLatency() throws Exception {
     server = new Server();
     int serverPort = server.init();


### PR DESCRIPTION
Enabled smallLatency() test which was ignored earlier and its working as Expected as I don't see any latency issue here.

Fixes https://github.com/grpc/grpc-java/issues/2951