### PR TITLE
interop-test: add interop test open telemetry tracing flags

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -82,6 +82,7 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -229,9 +230,9 @@ public class TestServiceClient {
       } else if ("use_open_telemetry_tracing".equals(key)) {
         useOpenTelemetryTracing = Boolean.parseBoolean(value);
       } else if ("open_telemetry_propagator".equals(key)) {
-        if (value.toLowerCase().contains("w3c")) {
+        if (value.toLowerCase(Locale.ROOT).contains("w3c")) {
           textMapPropagator = W3CTraceContextPropagator.getInstance();
-        } else if (value.toLowerCase().contains("grpc-trace-bin")) {
+        } else if (value.toLowerCase(Locale.ROOT).contains("grpc-trace-bin")) {
           textMapPropagator = GrpcTraceBinContextPropagator.defaultInstance();
         } else {
           System.err.println("Unsupported text map propagator, use 'w3c' or 'grpc-trace-bin'");

--- a/opentelemetry/src/main/java/io/grpc/opentelemetry/MetadataSetter.java
+++ b/opentelemetry/src/main/java/io/grpc/opentelemetry/MetadataSetter.java
@@ -20,6 +20,7 @@ package io.grpc.opentelemetry;
 import com.google.common.io.BaseEncoding;
 import io.grpc.Metadata;
 import io.opentelemetry.context.propagation.TextMapSetter;
+import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
@@ -40,6 +41,8 @@ final class MetadataSetter implements TextMapSetter<Metadata> {
 
   @Override
   public void set(@Nullable Metadata carrier, String key, String value) {
+    logger.log(Level.FINE, "Setting text trace header key={0} value={1}",
+        new Object[]{key, value});
     if (carrier == null) {
       logger.log(Level.FINE, "Carrier is null, setting no data");
       return;
@@ -57,6 +60,8 @@ final class MetadataSetter implements TextMapSetter<Metadata> {
   }
 
   void set(@Nullable Metadata carrier, String key, byte[] value) {
+    logger.log(Level.FINE, "Setting binary trace header key={0} value={1}",
+        new Object[]{key, Arrays.toString(value)});
     if (carrier == null) {
       logger.log(Level.FINE, "Carrier is null, setting no data");
       return;


### PR DESCRIPTION
This is a quick change to unblock benchmark test: go/c2p-w3c-benchmark
Usage:

revision1: 
`./run-test-client.sh  --use_tls=false --use_open_telemetry_tracing=true --open_telemetry_propagator=w3c`

`./run-test-client.sh  --use_tls=false --use_open_telemetry_tracing=true --open_telemetry_propagator=grpc-trace-bin`

revision2:
use  w3c: `JAVA_OPTS=-Dotel.propagators=tracecontext ./run-test-client.sh --use_tls=false --use_open_telemetry_tracing=true`
use grpc-trace-bin(do not set otel.propagator): `./run-test-client.sh --use_tls=false --use_open_telemetry_tracing=true`



cc. @yashykt 