### PR TITLE
Replace null check with has value check because proto fields can never be null

### DIFF
--- a/xds/src/main/java/io/grpc/xds/GcpAuthenticationFilter.java
+++ b/xds/src/main/java/io/grpc/xds/GcpAuthenticationFilter.java
@@ -72,8 +72,8 @@ final class GcpAuthenticationFilter implements Filter, ClientInterceptorBuilder 
 
     long cacheSize = 10;
     // Validate cache_config
-    TokenCacheConfig cacheConfig = gcpAuthnProto.getCacheConfig();
-    if (cacheConfig != null) {
+    if (gcpAuthnProto.hasCacheConfig()) {
+      TokenCacheConfig cacheConfig = gcpAuthnProto.getCacheConfig();
       cacheSize = cacheConfig.getCacheSize().getValue();
       if (cacheSize == 0) {
         return ConfigOrError.fromError(


### PR DESCRIPTION
Fixes failing checks (["ImpossibleNullError"](http://go/bugpattern/ImpossibleNullComparison)) during google3 import of GcpAuthenticationFilter from Github.