### PR TITLE
util: Remove EAG conveniences from MultiChildLb

### DIFF
--- a/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
@@ -24,7 +24,6 @@ import static io.grpc.ConnectivityState.SHUTDOWN;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Objects;
 import com.google.common.collect.Maps;
 import io.grpc.Attributes;
 import io.grpc.ConnectivityState;
@@ -237,21 +236,6 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
     return childLbStates;
   }
 
-  @VisibleForTesting
-  public final ChildLbState getChildLbState(Object key) {
-    for (ChildLbState state : childLbStates) {
-      if (Objects.equal(state.getKey(), key)) {
-        return state;
-      }
-    }
-    return null;
-  }
-
-  @VisibleForTesting
-  public final ChildLbState getChildLbStateEag(EquivalentAddressGroup eag) {
-    return getChildLbState(new Endpoint(eag));
-  }
-
   /**
    * Filters out non-ready child load balancers (subchannels).
    */
@@ -335,13 +319,6 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
 
     protected final void setCurrentPicker(SubchannelPicker newPicker) {
       currentPicker = newPicker;
-    }
-
-    public final EquivalentAddressGroup getEag() {
-      if (resolvedAddresses == null || resolvedAddresses.getAddresses().isEmpty()) {
-        return null;
-      }
-      return resolvedAddresses.getAddresses().get(0);
     }
 
     protected final void setResolvedAddresses(ResolvedAddresses newAddresses) {

--- a/util/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
+++ b/util/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
@@ -61,7 +61,6 @@ import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -207,10 +206,6 @@ public class RoundRobinLoadBalancerTest {
       assertThat(childLbState.getResolvedAddresses().getAttributes().get(IS_PETIOLE_POLICY))
           .isTrue();
     }
-    assertThat(loadBalancer.getChildLbStateEag(removedEag).getCurrentPicker().pickSubchannel(null)
-        .getSubchannel()).isEqualTo(removedSubchannel);
-    assertThat(loadBalancer.getChildLbStateEag(oldEag1).getCurrentPicker().pickSubchannel(null)
-        .getSubchannel()).isEqualTo(oldSubchannel);
 
     // This time with Attributes
     List<EquivalentAddressGroup> latestServers = Lists.newArrayList(oldEag2, newEag);
@@ -225,12 +220,6 @@ public class RoundRobinLoadBalancerTest {
 
     deliverSubchannelState(newSubchannel, ConnectivityStateInfo.forNonError(READY));
 
-    assertThat(loadBalancer.getChildLbStates().size()).isEqualTo(2);
-    assertThat(loadBalancer.getChildLbStateEag(newEag).getCurrentPicker()
-        .pickSubchannel(null).getSubchannel()).isEqualTo(newSubchannel);
-    assertThat(loadBalancer.getChildLbStateEag(oldEag2).getCurrentPicker()
-        .pickSubchannel(null).getSubchannel()).isEqualTo(oldSubchannel);
-
     verify(mockHelper, times(6)).createSubchannel(any(CreateSubchannelArgs.class));
     inOrder.verify(mockHelper, times(2)).updateBalancingState(eq(READY), pickerCaptor.capture());
 
@@ -243,35 +232,35 @@ public class RoundRobinLoadBalancerTest {
   @Test
   public void pickAfterStateChange() throws Exception {
     InOrder inOrder = inOrder(mockHelper);
-    Status addressesAcceptanceStatus = acceptAddresses(servers, Attributes.EMPTY);
+    Status addressesAcceptanceStatus =
+        acceptAddresses(Arrays.asList(servers.get(0)), Attributes.EMPTY);
     assertThat(addressesAcceptanceStatus.isOk()).isTrue();
+    inOrder.verify(mockHelper).createSubchannel(any(CreateSubchannelArgs.class));
 
     // TODO figure out if this method testing the right things
 
-    ChildLbState childLbState = loadBalancer.getChildLbStates().iterator().next();
-    Subchannel subchannel = subchannels.get(Arrays.asList(childLbState.getEag()));
+    assertThat(subchannels).hasSize(1);
+    Subchannel subchannel = subchannels.values().iterator().next();
 
     inOrder.verify(mockHelper).updateBalancingState(eq(CONNECTING), eq(EMPTY_PICKER));
-    assertThat(childLbState.getCurrentState()).isEqualTo(CONNECTING);
 
     deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(READY));
     inOrder.verify(mockHelper).updateBalancingState(eq(READY), pickerCaptor.capture());
     assertThat(pickerCaptor.getValue()).isInstanceOf(ReadyPicker.class);
-    assertThat(childLbState.getCurrentState()).isEqualTo(READY);
 
     Status error = Status.UNKNOWN.withDescription("¯\\_(ツ)_//¯");
     deliverSubchannelState(subchannel,
         ConnectivityStateInfo.forTransientFailure(error));
-    assertThat(childLbState.getCurrentState()).isEqualTo(TRANSIENT_FAILURE);
-    AbstractTestHelper.refreshInvokedAndUpdateBS(inOrder, CONNECTING, mockHelper, pickerCaptor);
-    assertThat(pickerCaptor.getValue()).isEqualTo(EMPTY_PICKER);
+    AbstractTestHelper.refreshInvokedAndUpdateBS(
+        inOrder, TRANSIENT_FAILURE, mockHelper, pickerCaptor);
+    assertThat(pickerCaptor.getValue().pickSubchannel(mockArgs).getStatus()).isEqualTo(error);
 
     deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(IDLE));
     inOrder.verify(mockHelper).refreshNameResolution();
-    assertThat(childLbState.getCurrentState()).isEqualTo(TRANSIENT_FAILURE);
+    inOrder.verify(mockHelper, never())
+        .updateBalancingState(eq(TRANSIENT_FAILURE), any(SubchannelPicker.class));
 
     verify(subchannel, atLeastOnce()).requestConnection();
-    verify(mockHelper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
     AbstractTestHelper.verifyNoMoreMeaningfulInteractions(mockHelper);
   }
 
@@ -282,10 +271,10 @@ public class RoundRobinLoadBalancerTest {
     assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     inOrder.verify(mockHelper).updateBalancingState(eq(CONNECTING), eq(EMPTY_PICKER));
 
+    List<Subchannel> savedSubchannels = new ArrayList<>(subchannels.values());
     loadBalancer.shutdown();
-    for (ChildLbState child : loadBalancer.getChildLbStates()) {
-      Subchannel sc = child.getCurrentPicker().pickSubchannel(null).getSubchannel();
-      verify(child).shutdown();
+    for (Subchannel sc : savedSubchannels) {
+      verify(sc).shutdown();
       // When the subchannel is being shut down, a SHUTDOWN connectivity state is delivered
       // back to the subchannel state listener.
       deliverSubchannelState(sc, ConnectivityStateInfo.forNonError(SHUTDOWN));
@@ -300,34 +289,27 @@ public class RoundRobinLoadBalancerTest {
     Status addressesAcceptanceStatus = acceptAddresses(servers, Attributes.EMPTY);
     assertThat(addressesAcceptanceStatus.isOk()).isTrue();
 
+    inOrder.verify(mockHelper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
     inOrder.verify(mockHelper).updateBalancingState(eq(CONNECTING), eq(EMPTY_PICKER));
 
-    Map<ChildLbState, Subchannel> childToSubChannelMap = new HashMap<>();
     // Simulate state transitions for each subchannel individually.
-    for ( ChildLbState child : loadBalancer.getChildLbStates()) {
-      Subchannel sc = subchannels.get(Arrays.asList(child.getEag()));
-      childToSubChannelMap.put(child, sc);
+    for (Subchannel sc : subchannels.values()) {
       Status error = Status.UNKNOWN.withDescription("connection broken");
       deliverSubchannelState(
           sc,
           ConnectivityStateInfo.forTransientFailure(error));
-      assertEquals(TRANSIENT_FAILURE, child.getCurrentState());
       deliverSubchannelState(
           sc,
           ConnectivityStateInfo.forNonError(CONNECTING));
-      assertEquals(TRANSIENT_FAILURE, child.getCurrentState());
     }
     inOrder.verify(mockHelper).updateBalancingState(eq(TRANSIENT_FAILURE), isA(ReadyPicker.class));
     inOrder.verify(mockHelper, atLeast(0)).refreshNameResolution();
     inOrder.verifyNoMoreInteractions();
 
-    ChildLbState child = loadBalancer.getChildLbStates().iterator().next();
-    Subchannel subchannel = childToSubChannelMap.get(child);
+    Subchannel subchannel = subchannels.values().iterator().next();
     deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(READY));
-    assertThat(child.getCurrentState()).isEqualTo(READY);
     inOrder.verify(mockHelper).updateBalancingState(eq(READY), isA(ReadyPicker.class));
 
-    verify(mockHelper, times(3)).createSubchannel(any(CreateSubchannelArgs.class));
     inOrder.verify(mockHelper, atLeast(0)).refreshNameResolution();
     inOrder.verifyNoMoreInteractions();
   }
@@ -342,8 +324,7 @@ public class RoundRobinLoadBalancerTest {
     inOrder.verify(mockHelper).updateBalancingState(eq(CONNECTING), eq(EMPTY_PICKER));
 
     // Simulate state transitions for each subchannel individually.
-    for (ChildLbState child : loadBalancer.getChildLbStates()) {
-      Subchannel sc = subchannels.get(Arrays.asList(child.getEag()));
+    for (Subchannel sc : subchannels.values()) {
       verify(sc).requestConnection();
       deliverSubchannelState(sc, ConnectivityStateInfo.forNonError(CONNECTING));
       Status error = Status.UNKNOWN.withDescription("connection broken");

--- a/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancer.java
@@ -32,7 +32,6 @@ import io.grpc.Attributes;
 import io.grpc.ClientStreamTracer;
 import io.grpc.ClientStreamTracer.StreamInfo;
 import io.grpc.ConnectivityState;
-import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.Metadata;
@@ -155,7 +154,6 @@ final class LeastRequestLoadBalancer extends MultiChildLoadBalancer {
   static final class ReadyPicker extends SubchannelPicker {
     private final List<SubchannelPicker> childPickers; // non-empty
     private final List<AtomicInteger> childInFlights; // 1:1 with childPickers
-    private final List<EquivalentAddressGroup> childEags; // 1:1 with childPickers
     private final int choiceCount;
     private final ThreadSafeRandom random;
     private final int hashCode;
@@ -164,11 +162,9 @@ final class LeastRequestLoadBalancer extends MultiChildLoadBalancer {
       checkArgument(!childLbStates.isEmpty(), "empty list");
       this.childPickers = new ArrayList<>(childLbStates.size());
       this.childInFlights = new ArrayList<>(childLbStates.size());
-      this.childEags = new ArrayList<>(childLbStates.size());
       for (ChildLbState state : childLbStates) {
         childPickers.add(state.getCurrentPicker());
         childInFlights.add(getInFlights(state));
-        childEags.add(state.getEag());
       }
       this.choiceCount = choiceCount;
       this.random = checkNotNull(random, "random");
@@ -222,11 +218,6 @@ final class LeastRequestLoadBalancer extends MultiChildLoadBalancer {
     @VisibleForTesting
     List<SubchannelPicker> getChildPickers() {
       return childPickers;
-    }
-
-    @VisibleForTesting
-    List<EquivalentAddressGroup> getChildEags() {
-      return childEags;
     }
 
     @Override

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
@@ -177,13 +177,12 @@ public class RingHashLoadBalancerTest {
     assertThat(addressesAcceptanceStatus.isOk()).isTrue();
     verify(helper).updateBalancingState(eq(IDLE), pickerCaptor.capture());
 
-    ChildLbState childLbState = loadBalancer.getChildLbStates().iterator().next();
-    assertThat(subchannels.get(Collections.singletonList(childLbState.getEag()))).isNull();
+    assertThat(subchannels).isEmpty();
 
     // Picking subchannel triggers connection.
     PickSubchannelArgs args = getDefaultPickSubchannelArgs(hashFunc.hashVoid());
     pickerCaptor.getValue().pickSubchannel(args);
-    Subchannel subchannel = subchannels.get(Collections.singletonList(childLbState.getEag()));
+    Subchannel subchannel = subchannels.get(Collections.singletonList(servers.get(0)));
     InOrder inOrder = Mockito.inOrder(helper, subchannel);
     int expectedTimes = PickFirstLoadBalancerProvider.isEnabledHappyEyeballs()
                             || !PickFirstLoadBalancerProvider.isEnabledNewPickFirst() ? 2 : 1;
@@ -422,7 +421,7 @@ public class RingHashLoadBalancerTest {
     assertThat(addressesAcceptanceStatus.isOk()).isTrue();
 
     // Create subchannel for the first address
-    loadBalancer.getChildLbStateEag(servers.get(0)).getCurrentPicker()
+    loadBalancer.getChildLbStates().iterator().next().getCurrentPicker()
         .pickSubchannel(getDefaultPickSubchannelArgs(hashFunc.hashVoid()));
     verifyConnection(1);
 


### PR DESCRIPTION
This is a step toward removing ResolvedAddresses from ChildLbState, which isn't actually used by MultiChildLb. Most usages of the EAG usages can be served more directly without peering into MultiChildLb's internals or even accessing ChildLbStates, which make the tests less sensitive to implementation changes. Some changes do leverage the new behavior of MultiChildLb where it preserves the order of the entries.

This does fix an important bug in shutdown tests. The tests looped over the ChildLbStates after shutdown, but shutdown deleted all the children so it looped over an entry collection. Fixing that exposed that deliverSubchannelState() didn't function after shutdown, as the listener was removed from the map when the subchannel was shut down. Moving the listener onto the TestSubchannel allowed having access to the listener even after shutdown.

A few places in LeastRequestLb lines were just deleted, but that's because an existing assertion already provided the same check but without digging into MultiChildLb.