### PR TITLE
util: Remove resolvedAddresses from MultiChildLb.ChildLbState

### DIFF
--- a/core/src/main/java/io/grpc/internal/PickFirstLoadBalancerProvider.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLoadBalancerProvider.java
@@ -36,7 +36,7 @@ public final class PickFirstLoadBalancerProvider extends LoadBalancerProvider {
   public static final String GRPC_PF_USE_HAPPY_EYEBALLS = "GRPC_PF_USE_HAPPY_EYEBALLS";
   private static final String SHUFFLE_ADDRESS_LIST_KEY = "shuffleAddressList";
 
-  private static boolean enableNewPickFirst =
+  static boolean enableNewPickFirst =
       GrpcUtil.getFlag("GRPC_EXPERIMENTAL_ENABLE_NEW_PICK_FIRST", false);
 
   public static boolean isEnabledHappyEyeballs() {

--- a/core/src/testFixtures/java/io/grpc/internal/PickFirstLoadBalancerProviderAccessor.java
+++ b/core/src/testFixtures/java/io/grpc/internal/PickFirstLoadBalancerProviderAccessor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+/**
+ * Accessor for PickFirstLoadBalancerProvider, allowing access only during tests.
+ */
+public final class PickFirstLoadBalancerProviderAccessor {
+  private PickFirstLoadBalancerProviderAccessor() {}
+
+  public static void setEnableNewPickFirst(boolean enableNewPickFirst) {
+    PickFirstLoadBalancerProvider.enableNewPickFirst = enableNewPickFirst;
+  }
+}

--- a/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/MultiChildLoadBalancer.java
@@ -191,7 +191,6 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
       }
       newChildLbStates.add(childLbState);
       if (entry.getValue() != null) {
-        childLbState.setResolvedAddresses(entry.getValue()); // update child
         childLbState.lb.handleResolvedAddresses(entry.getValue()); // update child LB
       }
     }
@@ -262,8 +261,6 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
    */
   public class ChildLbState {
     private final Object key;
-    private ResolvedAddresses resolvedAddresses;
-
     private final LoadBalancer lb;
     private ConnectivityState currentState;
     private SubchannelPicker currentPicker = new FixedResultPicker(PickResult.withNoResult());
@@ -319,16 +316,6 @@ public abstract class MultiChildLoadBalancer extends LoadBalancer {
 
     protected final void setCurrentPicker(SubchannelPicker newPicker) {
       currentPicker = newPicker;
-    }
-
-    protected final void setResolvedAddresses(ResolvedAddresses newAddresses) {
-      checkNotNull(newAddresses, "Missing address list for child");
-      resolvedAddresses = newAddresses;
-    }
-
-    @VisibleForTesting
-    public final ResolvedAddresses getResolvedAddresses() {
-      return resolvedAddresses;
     }
 
     /**

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
@@ -950,10 +950,6 @@ public class RingHashLoadBalancerTest {
     }
     inOrder.verify(helper, times(0)).updateBalancingState(eq(READY), any(SubchannelPicker.class));
 
-
-    healthListeners.get(subchannel0).onSubchannelState(
-        ConnectivityStateInfo.forTransientFailure(Status.UNAVAILABLE.withDescription("oh no")));
-
     // Health results lets subchannels go READY
     healthListeners.get(subchannel0).onSubchannelState(ConnectivityStateInfo.forNonError(READY));
     healthListeners.get(subchannel1).onSubchannelState(ConnectivityStateInfo.forNonError(READY));


### PR DESCRIPTION
It isn't actually used by MultiChildLb, and using the health API gives us more confidence that health is properly plumbed.