### PR TITLE
api: When forwarding from Listener onAddresses to Listener2 continue to use onResult (v1.68.x backport)

### DIFF
--- a/api/src/main/java/io/grpc/NameResolver.java
+++ b/api/src/main/java/io/grpc/NameResolver.java
@@ -219,13 +219,15 @@ public abstract class NameResolver {
     @Override
     @Deprecated
     @InlineMe(
-        replacement = "this.onResult2(ResolutionResult.newBuilder().setAddressesOrError("
+        replacement = "this.onResult(ResolutionResult.newBuilder().setAddressesOrError("
             + "StatusOr.fromValue(servers)).setAttributes(attributes).build())",
         imports = {"io.grpc.NameResolver.ResolutionResult", "io.grpc.StatusOr"})
     public final void onAddresses(
         List<EquivalentAddressGroup> servers, @ResolutionResultAttr Attributes attributes) {
       // TODO(jihuncho) need to promote Listener2 if we want to use ConfigOrError
-      onResult2(
+      // Calling onResult and not onResult2 because onResult2 can only be called from a
+      // synchronization context.
+      onResult(
           ResolutionResult.newBuilder().setAddressesOrError(
               StatusOr.fromValue(servers)).setAttributes(attributes).build());
     }


### PR DESCRIPTION
Backport of #11666 to v1.68.x.
---
When forwarding from Listener onAddresses to Listener2 continue to use onResult and not onResult2 because the latter requires to be called from within synchronization context and it breaks existing code that didn't need to do so when using the old Listener interface

Fixed #11662.