### PR TITLE
services: Don't track code coverage of reflection.v1 gencode

### DIFF
--- a/services/build.gradle
+++ b/services/build.gradle
@@ -58,6 +58,7 @@ tasks.named("jacocoTestReport").configure {
                 '**/io/grpc/binarylog/v1/**',
                 '**/io/grpc/channelz/v1/**',
                 '**/io/grpc/health/v1/**',
+                '**/io/grpc/reflection/v1/**',
                 '**/io/grpc/reflection/v1alpha/**',
         ])
     }


### PR DESCRIPTION
Generated code for v1alpha was ignored, but not v1. Ignoring v1 reduces lines being checked from 16,145 to 6,303, significantly improving the overall code coverage and removing noise. This was noticed because there was a very clear drop at 0aa976c4 visible in the coveralls.io coverage graph, the point when v1 was introduced.