### PR TITLE
Validate that ASCII Metadata values contain only printable ASCII Characters

### DIFF
--- a/api/src/main/java/io/grpc/Metadata.java
+++ b/api/src/main/java/io/grpc/Metadata.java
@@ -94,15 +94,19 @@ public final class Metadata {
    * Simple metadata marshaller that encodes strings as is.
    *
    * <p>This should be used with ASCII strings that only contain the characters listed in the class
-   * comment of {@link AsciiMarshaller}. Otherwise the output may be considered invalid and
-   * discarded by the transport, or the call may fail.
+   * comment of {@link AsciiMarshaller}. Otherwise an {@link IllegalArgumentException} will be
+   * thrown.
    */
   public static final AsciiMarshaller<String> ASCII_STRING_MARSHALLER =
       new AsciiMarshaller<String>() {
 
         @Override
         public String toAsciiString(String value) {
-          return value;
+          checkArgument(
+              value.chars().allMatch(c -> c >= 0x20 && c <= 0x7E),
+              "String \"%s\" contains non-printable ASCII characters",
+              value);
+          return value.trim();
         }
 
         @Override

--- a/api/src/test/java/io/grpc/MetadataTest.java
+++ b/api/src/test/java/io/grpc/MetadataTest.java
@@ -478,6 +478,17 @@ public class MetadataTest {
     assertSame(anotherSalmon, h2.get(KEY_IMMUTABLE));
   }
 
+  @Test
+  public void failNonPrintableAsciiCharacters() {
+    String value = "José";
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("String \"" + value + "\" contains non-printable ASCII characters");
+
+    Metadata metadata = new Metadata();
+    metadata.put(Metadata.Key.of("test-non-printable", Metadata.ASCII_STRING_MARSHALLER), value);
+  }
+
   private static final class Fish {
     private String name;
 

--- a/core/src/test/java/io/grpc/internal/TransportFrameUtilTest.java
+++ b/core/src/test/java/io/grpc/internal/TransportFrameUtilTest.java
@@ -71,7 +71,6 @@ public class TransportFrameUtilTest {
     Metadata headers = new Metadata();
     headers.put(PLAIN_STRING, COMPLIANT_ASCII_STRING);
     headers.put(BINARY_STRING, NONCOMPLIANT_ASCII_STRING);
-    headers.put(BINARY_STRING_WITHOUT_SUFFIX, NONCOMPLIANT_ASCII_STRING);
     byte[][] http2Headers = TransportFrameUtil.toHttp2Headers(headers);
     // BINARY_STRING_WITHOUT_SUFFIX should not get in because it contains non-compliant ASCII
     // characters but doesn't have "-bin" in the name.
@@ -96,7 +95,6 @@ public class TransportFrameUtilTest {
     Metadata headers = new Metadata();
     headers.put(PLAIN_STRING, COMPLIANT_ASCII_STRING);
     headers.put(BINARY_STRING, NONCOMPLIANT_ASCII_STRING);
-    headers.put(BINARY_STRING_WITHOUT_SUFFIX, NONCOMPLIANT_ASCII_STRING);
     byte[][] http2Headers = TransportFrameUtil.toHttp2Headers(headers);
     byte[][] rawSerialized = TransportFrameUtil.toRawSerializedHeaders(http2Headers);
     Metadata recoveredHeaders = InternalMetadata.newMetadata(rawSerialized);


### PR DESCRIPTION
To tackle grpc/grpc-go#468, in grpc/grpc-go#4886, a stricter validation on ASCII Metadata values was introduced to throw if the value contains any non-printable ASCII characters, that is characters outside of the range 0x20 to 0x7E. 

The current grpc-java behavior regarding that is:
* When putting entries to a `Metadata` instance:
  * Any non ASCII character is silently replaced with `?`; 
  * Any ASCII character is kept and marshaled as it is, this includes non-printable ones like `\t` for example.
* When sending the `Metadata` instance:
  * Entires where the value contains non-printable ASCII are logged and dropped.


This pull request fixes the inconsistent behavior among grpc-java and grpc-go and closes grpc/grpc-java#11679.

Notice that with this pull request, previously passing ASCII Metadata values, will now observe `IllegalArgumentException`s therefore this is a breaking change. 