### PR TITLE
core-test: updated the tolerance time to 1 second

### DIFF
--- a/core/src/test/java/io/grpc/internal/InstantTimeProviderTest.java
+++ b/core/src/test/java/io/grpc/internal/InstantTimeProviderTest.java
@@ -44,7 +44,7 @@ public class InstantTimeProviderTest {
           + instantNow.getNano();
 
     // Validate the time returned is close to the expected value within a tolerance
-    // (i,e 10 millisecond tolerance in nanoseconds).
-    assertThat(actualTimeNanos).isWithin(10_000_000L).of(expectedTimeNanos);
+    // (i,e 1000 millisecond (1 second) tolerance in nanoseconds).
+    assertThat(actualTimeNanos).isWithin(1000_000_000L).of(expectedTimeNanos);
   }
 }


### PR DESCRIPTION
Updated the tolerance time to 1 sec as per the latest discussion to fix the flaky test.

Fixes https://github.com/grpc/grpc-java/issues/11680