### PR TITLE
chore: Make MetaData#isEmpty a public method

### DIFF
--- a/api/src/main/java/io/grpc/Metadata.java
+++ b/api/src/main/java/io/grpc/Metadata.java
@@ -212,7 +212,7 @@ public final class Metadata {
   }
 
   /** checks when {@link #namesAndValues} is null or has no elements. */
-  private boolean isEmpty() {
+  public boolean isEmpty() {
     return size == 0;
   }
 


### PR DESCRIPTION
Motivation:
I need to check this instead of `MetaData.keys().isEmpty`, I think this shortcut is helpful fo rusers.

Fixes #11686