### PR TITLE
[CSM] Use xds-enabled server and xds credentials in examples (v1.68.x backport)

### DIFF
--- a/examples/example-gcp-csm-observability/build.gradle
+++ b/examples/example-gcp-csm-observability/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-gcp-csm-observability:${grpcVersion}"
+    implementation "io.grpc:grpc-xds:${grpcVersion}"
     implementation "io.opentelemetry:opentelemetry-sdk:${openTelemetryVersion}"
     implementation "io.opentelemetry:opentelemetry-sdk-metrics:${openTelemetryVersion}"
     implementation "io.opentelemetry:opentelemetry-exporter-prometheus:${openTelemetryPrometheusVersion}"

--- a/examples/example-gcp-csm-observability/src/main/java/io/grpc/examples/csmobservability/CsmObservabilityClient.java
+++ b/examples/example-gcp-csm-observability/src/main/java/io/grpc/examples/csmobservability/CsmObservabilityClient.java
@@ -25,6 +25,7 @@ import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.grpc.gcp.csm.observability.CsmObservability;
+import io.grpc.xds.XdsChannelCredentials;
 import io.opentelemetry.exporter.prometheus.PrometheusHttpServer;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
@@ -127,8 +128,10 @@ public class CsmObservabilityClient {
     observability.registerGlobal();
 
     // Create a communication channel to the server, known as a Channel.
-    ManagedChannel channel = Grpc.newChannelBuilder(target, InsecureChannelCredentials.create())
-        .build();
+    ManagedChannel channel =
+        Grpc.newChannelBuilder(
+                target, XdsChannelCredentials.create(InsecureChannelCredentials.create()))
+            .build();
     CsmObservabilityClient client = new CsmObservabilityClient(channel);
 
     try {

--- a/examples/example-gcp-csm-observability/src/main/java/io/grpc/examples/csmobservability/CsmObservabilityServer.java
+++ b/examples/example-gcp-csm-observability/src/main/java/io/grpc/examples/csmobservability/CsmObservabilityServer.java
@@ -24,6 +24,8 @@ import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.grpc.gcp.csm.observability.CsmObservability;
 import io.grpc.stub.StreamObserver;
+import io.grpc.xds.XdsServerBuilder;
+import io.grpc.xds.XdsServerCredentials;
 import io.opentelemetry.exporter.prometheus.PrometheusHttpServer;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
@@ -40,10 +42,12 @@ public class CsmObservabilityServer {
 
   private Server server;
   private void start(int port) throws IOException {
-    server = Grpc.newServerBuilderForPort(port, InsecureServerCredentials.create())
-        .addService(new GreeterImpl())
-        .build()
-        .start();
+    server =
+        XdsServerBuilder.forPort(
+                port, XdsServerCredentials.create(InsecureServerCredentials.create()))
+            .addService(new GreeterImpl())
+            .build()
+            .start();
     logger.info("Server started, listening on " + port);
   }
 


### PR DESCRIPTION
Backport #11706 to v1.68.x