### PR TITLE
xds: Add `grpc.target` value for xDS enabled server metrics

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsServerWrapper.java
+++ b/xds/src/main/java/io/grpc/xds/XdsServerWrapper.java
@@ -172,9 +172,7 @@ final class XdsServerWrapper extends Server {
 
   private void internalStart() {
     try {
-      // TODO(dnvindhya): Add "#server" as "grpc.target" attribute value for
-      // xDS enabled servers.
-      xdsClientPool = xdsClientPoolFactory.getOrCreate("", new MetricRecorder() {});
+      xdsClientPool = xdsClientPoolFactory.getOrCreate("#server", new MetricRecorder() {});
     } catch (Exception e) {
       StatusException statusException = Status.UNAVAILABLE.withDescription(
               "Failed to initialize xDS").withCause(e).asException();


### PR DESCRIPTION
According to gRFC [A71 xDS Fallback]( https://github.com/grpc/proposal/blob/master/A71-xds-fallback.md#update-csds-to-aggregate-configs-from-multiple-xdsclient-instances):

> Update CSDS to aggregate configs from multiple XdsClient instances.
>
> The CSDS RPC service will be changed to get data from all XdsClient instances. A new string field named client_scope will be added to the CSDS [ClientConfig](https://github.com/envoyproxy/envoy/blob/e61e461736a28e26b6fcf0ca25d34c47ed29b0fc/api/envoy/service/status/v3/csds.proto#L130) message to indicate the channel target the data is associated with. For gRPC clients, this field will contain the key channels use to lookup their XdsClient instance, such as dataplane target for client channels or special value **"#server" for xDS-enabled gRPC servers**.

Updated dataplane target value to "#server" for xDS enabled servers. 

The dataplane target value of "#server" will also be used as `grpc.target` attribute value for xDS client metrics implemented in #11661.