### PR TITLE
.github/workflows: Split Bazel into two jobs

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -77,8 +77,15 @@ jobs:
 
   bazel:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - bazel: 6.0.0
+            bzlmod: false
+          - bazel: 7.0.0
+            bzlmod: true
     env:
-      USE_BAZEL_VERSION: 6.0.0
+      USE_BAZEL_VERSION: ${{ matrix.bazel }}
 
     steps:
     - uses: actions/checkout@v4
@@ -97,19 +104,8 @@ jobs:
         key: ${{ runner.os }}-bazel-${{ env.USE_BAZEL_VERSION }}-${{ hashFiles('WORKSPACE', 'repositories.bzl') }}
 
     - name: Run bazel build
-      run: bazelisk build //... --enable_bzlmod=false
+      run: bazelisk build //... --enable_bzlmod=${{ matrix.bzlmod }}
 
     - name: Run example bazel build
-      run: bazelisk build //... --enable_bzlmod=false
-      working-directory: ./examples
-
-    - name: Run bazel build (bzlmod)
-      env:
-        USE_BAZEL_VERSION: 7.0.0
-      run: bazelisk build //... --enable_bzlmod=true
-
-    - name: Run example bazel build (bzlmod)
-      env:
-        USE_BAZEL_VERSION: 7.0.0
-      run: bazelisk build //... --enable_bzlmod=true
+      run: bazelisk build //... --enable_bzlmod=${{ matrix.bzlmod }}
       working-directory: ./examples

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -80,6 +80,7 @@ jobs:
     strategy:
       matrix:
         include:
+          # Test with and without bzlmod. Bazel 6 doesn't support bzlmod, so use Bazel 7 instead
           - bazel: 6.0.0
             bzlmod: false
           - bazel: 7.0.0


### PR DESCRIPTION
The two Bazel versions are completely separate; no need to run them serially.

----

We started testing against two versions because of bzlmod. Even when we drop 6.0.0 we're going to need to keep two runs, one with and one without bzlmod. I was noticing it was taking a while to run compared to our other GitHub Actions, and I think this makes it more clear what is going on anyway.