### PR TITLE
s2a: Don't allow S2AStub to be set

### DIFF
--- a/s2a/src/main/java/io/grpc/s2a/S2AChannelCredentials.java
+++ b/s2a/src/main/java/io/grpc/s2a/S2AChannelCredentials.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.grpc.Channel;
 import io.grpc.ChannelCredentials;
@@ -110,6 +111,7 @@ public final class S2AChannelCredentials {
      * Sets the stub to use to communicate with S2A. This is only used for testing that the
      * stream to S2A gets closed.
      */
+    @VisibleForTesting
     Builder setStub(S2AStub stub) {
       checkNotNull(stub);
       this.stub = stub;

--- a/s2a/src/main/java/io/grpc/s2a/S2AChannelCredentials.java
+++ b/s2a/src/main/java/io/grpc/s2a/S2AChannelCredentials.java
@@ -110,7 +110,7 @@ public final class S2AChannelCredentials {
      * Sets the stub to use to communicate with S2A. This is only used for testing that the
      * stream to S2A gets closed.
      */
-    public Builder setStub(S2AStub stub) {
+    Builder setStub(S2AStub stub) {
       checkNotNull(stub);
       this.stub = stub;
       return this;

--- a/s2a/src/main/java/io/grpc/s2a/internal/handshaker/S2AStub.java
+++ b/s2a/src/main/java/io/grpc/s2a/internal/handshaker/S2AStub.java
@@ -44,7 +44,8 @@ public class S2AStub implements AutoCloseable {
   private boolean doneWriting = false;
   private boolean isClosed = false;
 
-  static S2AStub newInstance(S2AServiceGrpc.S2AServiceStub serviceStub) {
+  @VisibleForTesting
+  public static S2AStub newInstance(S2AServiceGrpc.S2AServiceStub serviceStub) {
     checkNotNull(serviceStub);
     return new S2AStub(serviceStub);
   }

--- a/s2a/src/test/java/io/grpc/s2a/IntegrationTest.java
+++ b/s2a/src/test/java/io/grpc/s2a/IntegrationTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.grpc.s2a.internal.handshaker;
+package io.grpc.s2a;
 
 import static com.google.common.truth.Truth.assertThat;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -37,6 +37,8 @@ import io.grpc.netty.NettyServerBuilder;
 import io.grpc.s2a.S2AChannelCredentials;
 import io.grpc.s2a.internal.channel.S2AHandshakerServiceChannel;
 import io.grpc.s2a.internal.handshaker.FakeS2AServer;
+import io.grpc.s2a.internal.handshaker.S2AServiceGrpc;
+import io.grpc.s2a.internal.handshaker.S2AStub;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.protobuf.SimpleRequest;
 import io.grpc.testing.protobuf.SimpleResponse;


### PR DESCRIPTION
S2AStub is an internal API and shouldn't be used outside of s2a. It is still available for tests.

@rmehta19, could you review?