### PR TITLE
Fix for ipv6 link local with scope

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpProtocolNegotiator.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpProtocolNegotiator.java
@@ -19,6 +19,8 @@ package io.grpc.okhttp;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.net.HostAndPort;
+import com.google.common.net.InetAddresses;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.okhttp.internal.OptionalMethod;
 import io.grpc.okhttp.internal.Platform;
@@ -247,7 +249,9 @@ class OkHttpProtocolNegotiator {
           } else {
             SET_USE_SESSION_TICKETS.invokeOptionalWithoutCheckedException(sslSocket, true);
           }
-          if (SET_SERVER_NAMES != null && SNI_HOST_NAME != null) {
+          if (SET_SERVER_NAMES != null
+              && SNI_HOST_NAME != null
+              && !InetAddresses.isInetAddress(HostAndPort.fromString(hostname).getHost())) {
             SET_SERVER_NAMES
                 .invoke(sslParams, Collections.singletonList(SNI_HOST_NAME.newInstance(hostname)));
           } else {


### PR DESCRIPTION
With these changes scoped ipv6 link is supported.

This was previously attempted in #9326 but due to internal failures it was reverted. We now fixed the internal issues, so this should go seamlessly.

Fixes #9325 