### PR TITLE
feat[ServletAdapter]: Ability remove context path when get method name

### DIFF
--- a/examples/example-servlet/src/main/java/io/grpc/servlet/examples/helloworld/HelloWorldServlet.java
+++ b/examples/example-servlet/src/main/java/io/grpc/servlet/examples/helloworld/HelloWorldServlet.java
@@ -64,7 +64,7 @@ public class HelloWorldServlet extends HttpServlet {
   protected void doPost(HttpServletRequest request, HttpServletResponse response)
       throws IOException {
     if (ServletAdapter.isGrpc(request)) {
-      servletAdapter.doPost(request, response);
+      servletAdapter.doPost("helloworld.Greeter/SayHello", request, response);
     } else {
       response.setContentType("text/html");
       response.getWriter().println("<p>Hello non-gRPC client!</p>");

--- a/servlet/src/main/java/io/grpc/servlet/GrpcServlet.java
+++ b/servlet/src/main/java/io/grpc/servlet/GrpcServlet.java
@@ -36,6 +36,7 @@ import javax.servlet.http.HttpServletResponse;
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/5066")
 public class GrpcServlet extends HttpServlet {
   private static final long serialVersionUID = 1L;
+  public static final String REMOVE_CONTEXT_PATH = "REMOVE_CONTEXT_PATH";
 
   private final ServletAdapter servletAdapter;
 
@@ -58,6 +59,15 @@ public class GrpcServlet extends HttpServlet {
     return serverBuilder.buildServletAdapter();
   }
 
+  private String getMethod(HttpServletRequest req) {
+    Boolean removeContextPath = Boolean.parseBoolean(getInitParameter(REMOVE_CONTEXT_PATH));
+    String method = req.getRequestURI();
+    if (removeContextPath) {
+      method = method.substring(req.getContextPath().length()); // remove Context Path from application server
+    }
+    return method.substring(1); // remove the leading "/"
+  }
+
   @Override
   protected final void doGet(HttpServletRequest request, HttpServletResponse response)
       throws IOException {
@@ -67,7 +77,7 @@ public class GrpcServlet extends HttpServlet {
   @Override
   protected final void doPost(HttpServletRequest request, HttpServletResponse response)
       throws IOException {
-    servletAdapter.doPost(request, response);
+    servletAdapter.doPost(getMethod(request), request, response);
   }
 
   @Override

--- a/servlet/src/main/java/io/grpc/servlet/GrpcServlet.java
+++ b/servlet/src/main/java/io/grpc/servlet/GrpcServlet.java
@@ -63,7 +63,8 @@ public class GrpcServlet extends HttpServlet {
     Boolean removeContextPath = Boolean.parseBoolean(getInitParameter(REMOVE_CONTEXT_PATH));
     String method = req.getRequestURI();
     if (removeContextPath) {
-      method = method.substring(req.getContextPath().length()); // remove Context Path from application server
+      // remove context path used in application server
+      method = method.substring(req.getContextPath().length());
     }
     return method.substring(1); // remove the leading "/"
   }

--- a/servlet/src/main/java/io/grpc/servlet/ServletAdapter.java
+++ b/servlet/src/main/java/io/grpc/servlet/ServletAdapter.java
@@ -59,10 +59,11 @@ import javax.servlet.http.HttpServletResponse;
  * process it, and transforms the gRPC response into {@link HttpServletResponse}. An adapter can be
  * instantiated by {@link ServletServerBuilder#buildServletAdapter()}.
  *
- * <p>In a servlet, calling {@link #doPost(HttpServletRequest, HttpServletResponse)} inside {@link
- * javax.servlet.http.HttpServlet#doPost(HttpServletRequest, HttpServletResponse)} makes the servlet
- * backed by the gRPC server associated with the adapter. The servlet must support Asynchronous
- * Processing and must be deployed to a container that supports servlet 4.0 and enables HTTP/2.
+ * <p>In a servlet, calling {@link #doPost(String, HttpServletRequest, HttpServletResponse)} inside 
+ * {@link javax.servlet.http.HttpServlet#doPost(HttpServletRequest, HttpServletResponse)} makes
+ * the servlet backed by the gRPC server associated with the adapter. The servlet must support 
+ * Asynchronous Processing and must be deployed to a container that supports servlet 4.0
+ * and enables HTTP/2.
  *
  * <p>The API is experimental. The authors would like to know more about the real usecases. Users
  * are welcome to provide feedback by commenting on

--- a/servlet/src/main/java/io/grpc/servlet/ServletAdapter.java
+++ b/servlet/src/main/java/io/grpc/servlet/ServletAdapter.java
@@ -159,7 +159,7 @@ public final class ServletAdapter {
     asyncCtx.addListener(new GrpcAsyncListener(stream, logId));
   }
 
-  private static String getMethod(HttpServletRequest req) {
+  private String getMethod(HttpServletRequest req) {
     Boolean removeContextPath = Boolean.parseBoolean(getInitParameter(REMOVE_CONTEXT_PATH));
     String method = req.getRequestURI();
     if (removeContextPath) {

--- a/servlet/src/main/java/io/grpc/servlet/ServletAdapter.java
+++ b/servlet/src/main/java/io/grpc/servlet/ServletAdapter.java
@@ -111,7 +111,8 @@ public final class ServletAdapter {
    * <p>Do not modify {@code req} and {@code resp} before or after calling this method. However,
    * calling {@code resp.setBufferSize()} before invocation is allowed.
    */
-  public void doPost(String method, HttpServletRequest req, HttpServletResponse resp) throws IOException {
+  public void doPost(String method, HttpServletRequest req, HttpServletResponse resp)
+      throws IOException {
     checkArgument(req.isAsyncSupported(), "servlet does not support asynchronous operation");
     checkArgument(ServletAdapter.isGrpc(req), "the request is not a gRPC request");
 

--- a/servlet/src/test/java/io/grpc/servlet/ServletServerBuilderTest.java
+++ b/servlet/src/test/java/io/grpc/servlet/ServletServerBuilderTest.java
@@ -78,7 +78,7 @@ public class ServletServerBuilderTest {
     ServletServerBuilder serverBuilder =
         new ServletServerBuilder().scheduledExecutorService(scheduler);
     ServletAdapter servletAdapter = serverBuilder.buildServletAdapter();
-    servletAdapter.doPost(verify(request).getRequestURI().substring(1), request, response);
+    servletAdapter.doPost("hello/world", request, response);
 
     verify(asyncContext).setTimeout(1);
 

--- a/servlet/src/test/java/io/grpc/servlet/ServletServerBuilderTest.java
+++ b/servlet/src/test/java/io/grpc/servlet/ServletServerBuilderTest.java
@@ -78,7 +78,7 @@ public class ServletServerBuilderTest {
     ServletServerBuilder serverBuilder =
         new ServletServerBuilder().scheduledExecutorService(scheduler);
     ServletAdapter servletAdapter = serverBuilder.buildServletAdapter();
-    servletAdapter.doPost(request, response);
+    servletAdapter.doPost(req.getRequestURI().substring(1), request, response);
 
     verify(asyncContext).setTimeout(1);
 

--- a/servlet/src/test/java/io/grpc/servlet/ServletServerBuilderTest.java
+++ b/servlet/src/test/java/io/grpc/servlet/ServletServerBuilderTest.java
@@ -78,7 +78,7 @@ public class ServletServerBuilderTest {
     ServletServerBuilder serverBuilder =
         new ServletServerBuilder().scheduledExecutorService(scheduler);
     ServletAdapter servletAdapter = serverBuilder.buildServletAdapter();
-    servletAdapter.doPost(request.getRequestURI().substring(1), request, response);
+    servletAdapter.doPost(verify(request).getRequestURI().substring(1), request, response);
 
     verify(asyncContext).setTimeout(1);
 

--- a/servlet/src/test/java/io/grpc/servlet/ServletServerBuilderTest.java
+++ b/servlet/src/test/java/io/grpc/servlet/ServletServerBuilderTest.java
@@ -78,7 +78,7 @@ public class ServletServerBuilderTest {
     ServletServerBuilder serverBuilder =
         new ServletServerBuilder().scheduledExecutorService(scheduler);
     ServletAdapter servletAdapter = serverBuilder.buildServletAdapter();
-    servletAdapter.doPost(req.getRequestURI().substring(1), request, response);
+    servletAdapter.doPost(request.getRequestURI().substring(1), request, response);
 
     verify(asyncContext).setTimeout(1);
 


### PR DESCRIPTION
Refs: #5066

Complex application may have many `war`-s and do not allow monopolize root context path(`/`). Add ability to remove context path(usual it's `war` name) from application server use `@WebInitParam` or just override `getInitParameter` for parameter `GrpcServlet.REMOVE_CONTEXT_PATH`

```
requestURI = contextPath + servletPath + pathInfo
```

https://stackoverflow.com/a/42706412