### PR TITLE
s2a: Restore static token state mutated in tests

### DIFF
--- a/s2a/src/main/java/io/grpc/s2a/internal/handshaker/tokenmanager/SingleTokenFetcher.java
+++ b/s2a/src/main/java/io/grpc/s2a/internal/handshaker/tokenmanager/SingleTokenFetcher.java
@@ -41,6 +41,11 @@ public final class SingleTokenFetcher implements TokenFetcher {
     accessToken = token;
   }
 
+  @VisibleForTesting
+  public static String getAccessToken() {
+    return accessToken;
+  }
+
   private SingleTokenFetcher(String token) {
     this.token = token;
   }

--- a/s2a/src/test/java/io/grpc/s2a/internal/handshaker/GetAuthenticationMechanismsTest.java
+++ b/s2a/src/test/java/io/grpc/s2a/internal/handshaker/GetAuthenticationMechanismsTest.java
@@ -20,6 +20,7 @@ import com.google.common.truth.Expect;
 import io.grpc.s2a.internal.handshaker.S2AIdentity;
 import io.grpc.s2a.internal.handshaker.tokenmanager.SingleTokenFetcher;
 import java.util.Optional;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -31,11 +32,18 @@ import org.junit.runners.JUnit4;
 public final class GetAuthenticationMechanismsTest {
   @Rule public final Expect expect = Expect.create();
   private static final String TOKEN = "access_token";
+  private static String originalAccessToken;
 
   @BeforeClass
   public static void setUpClass() {
+    originalAccessToken = SingleTokenFetcher.getAccessToken();
     // Set the token that the client will use to authenticate to the S2A.
     SingleTokenFetcher.setAccessToken(TOKEN);
+  }
+
+  @AfterClass
+  public static void tearDownClass() {
+    SingleTokenFetcher.setAccessToken(originalAccessToken);
   }
 
   @Test

--- a/s2a/src/test/java/io/grpc/s2a/internal/handshaker/tokenmanager/SingleTokenAccessTokenManagerTest.java
+++ b/s2a/src/test/java/io/grpc/s2a/internal/handshaker/tokenmanager/SingleTokenAccessTokenManagerTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import io.grpc.s2a.internal.handshaker.S2AIdentity;
 import java.util.Optional;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,9 +31,17 @@ public final class SingleTokenAccessTokenManagerTest {
   private static final S2AIdentity IDENTITY = S2AIdentity.fromSpiffeId("spiffe_id");
   private static final String TOKEN = "token";
 
+  private String originalAccessToken;
+
   @Before
   public void setUp() {
+    originalAccessToken = SingleTokenFetcher.getAccessToken();
     SingleTokenFetcher.setAccessToken(null);
+  }
+
+  @After
+  public void tearDown() {
+    SingleTokenFetcher.setAccessToken(originalAccessToken);
   }
 
   @Test


### PR DESCRIPTION
This is the easy-to-fix state, but GetAuthenticationMechanisms can save these temporary states used in tests, so more fixes will be necessary.

CC @rmehta19 