### PR TITLE
examples: Simplify graceful shutdown in Hostname example

### DIFF
--- a/examples/example-hostname/src/main/java/io/grpc/examples/hostname/HostnameServer.java
+++ b/examples/example-hostname/src/main/java/io/grpc/examples/hostname/HostnameServer.java
@@ -64,17 +64,17 @@ public final class HostnameServer {
         // Start graceful shutdown
         server.shutdown();
         try {
-          // Wait for RPCs to complete processing
-          if (!server.awaitTermination(30, TimeUnit.SECONDS)) {
-            // That was plenty of time. Let's cancel the remaining RPCs
-            server.shutdownNow();
-            // shutdownNow isn't instantaneous, so give a bit of time to clean resources up
-            // gracefully. Normally this will be well under a second.
-            server.awaitTermination(5, TimeUnit.SECONDS);
-          }
+          // Wait up to 30 seconds for RPCs to complete processing.
+          server.awaitTermination(30, TimeUnit.SECONDS);
         } catch (InterruptedException ex) {
-          server.shutdownNow();
+          Thread.currentThread().interrupt();
         }
+        // Cancel any remaining RPCs. If awaitTermination() returned true above, then there are no
+        // RPCs and the server is already terminated. But it is safe to call even when terminated.
+        server.shutdownNow();
+        // shutdownNow isn't instantaneous, so you want an additional awaitTermination() to give
+        // time to clean resources up gracefully. Normally it will return in well under a second. In
+        // this example, the server.awaitTermination() in main() provides that delay.
       }
     });
     // This would normally be tied to the service's dependencies. For example, if HostnameGreeter


### PR DESCRIPTION
I've slept since I wrote the original code, so now I see a less repetitive implementation.

------

Is this better? I figured we'd want to make it any nicer before we copy it to any other examples.

I changed the first comment to make it clearer that awaitTermination() doesn't sleep the full 30 seconds if it doesn't need to.