### PR TITLE
Fix tsan error

### DIFF
--- a/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
+++ b/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
@@ -238,7 +238,7 @@ final class ControlPlaneClient {
    */
   // Must be synchronized.
   void readyHandler(boolean shouldSendInitialRequest) {
-    if (shouldSendInitialRequest) {
+    if (!shutdown && shouldSendInitialRequest) {
       sendDiscoveryRequests();
     }
   }

--- a/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
+++ b/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
@@ -238,7 +238,7 @@ final class ControlPlaneClient {
    */
   // Must be synchronized.
   void readyHandler(boolean shouldSendInitialRequest) {
-    if (!shutdown && shouldSendInitialRequest) {
+    if (shouldSendInitialRequest) {
       sendDiscoveryRequests();
     }
   }

--- a/xds/src/test/java/io/grpc/xds/XdsClientFallbackTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientFallbackTest.java
@@ -428,7 +428,7 @@ public class XdsClientFallbackTest {
 
   @Test
   public void testGoodUrlFollowedByBadUrl() {
-    // Setup xdsClient to fail on stream creation
+    // xdsClient should succeed in stream creation as it doesn't need to use the bad url
     String garbageUri = "some. garbage";
     String validUri = "localhost:" + mainXdsServer.getServer().getPort();
 
@@ -437,7 +437,6 @@ public class XdsClientFallbackTest {
         new ExponentialBackoffPolicy.Provider(), MessagePrinter.INSTANCE, xdsClientMetricReporter);
 
     client.watchXdsResource(XdsListenerResource.getInstance(), MAIN_SERVER, ldsWatcher);
-    fakeClock.forwardTime(20, TimeUnit.SECONDS);
     verify(ldsWatcher, timeout(5000)).onChanged(
         XdsListenerResource.LdsUpdate.forApiListener(
             MAIN_HTTP_CONNECTION_MANAGER));


### PR DESCRIPTION
Eliminate unneeded fakeClock.forwardTime() that was causing the conflict.

```
  Read of size 8 at 0x00008eea4e28 by thread T24:
    #0 io.grpc.internal.FakeClock$ScheduledExecutorImpl.schedule(Lio/grpc/internal/FakeClock$ScheduledTask;JLjava/util/concurrent/TimeUnit;)V FakeClock.java:140 
    #1 io.grpc.internal.FakeClock$ScheduledExecutorImpl.schedule(Ljava/lang/Runnable;JLjava/util/concurrent/TimeUnit;)Ljava/util/concurrent/ScheduledFuture; FakeClock.java:150 
    #2 io.grpc.SynchronizationContext.schedule(Ljava/lang/Runnable;JLjava/util/concurrent/TimeUnit;Ljava/util/concurrent/ScheduledExecutorService;)Lio/grpc/SynchronizationContext$ScheduledHandle; SynchronizationContext.java:153 
    #3 io.grpc.xds.client.XdsClientImpl$ResourceSubscriber.restartTimer()V XdsClientImpl.java:779 
    #4 io.grpc.xds.client.XdsClientImpl.startMissingResourceTimers(Ljava/util/Collection;Lio/grpc/xds/client/XdsResourceType;)V XdsClientImpl.java:213 
    #5 io.grpc.xds.client.ControlPlaneClient.adjustResourceSubscription(Lio/grpc/xds/client/XdsResourceType;)V ControlPlaneClient.java:167 
    #6 io.grpc.xds.client.ControlPlaneClient.sendDiscoveryRequests()V ControlPlaneClient.java:281 
    #7 io.grpc.xds.client.ControlPlaneClient.readyHandler(Z)V ControlPlaneClient.java:242 
    #8 io.grpc.xds.client.ControlPlaneClient$AdsStream.lambda$onReady$0()V ControlPlaneClient.java:384 
    #9 io.grpc.xds.client.ControlPlaneClient$AdsStream$$Lambda+0x0000000100468a90.run()V ?? 
    #10 io.grpc.SynchronizationContext.drain()V SynchronizationContext.java:96 
    #11 io.grpc.SynchronizationContext.execute(Ljava/lang/Runnable;)V SynchronizationContext.java:128 
    #12 io.grpc.xds.client.ControlPlaneClient$AdsStream.onReady()V ControlPlaneClient.java:373 
```

```
  Previous write of size 8 at 0x00008eea4e28 by thread T4 (mutexes: write M0, write M1, write M2, write M3):
    #0 io.grpc.internal.FakeClock.forwardTime(JLjava/util/concurrent/TimeUnit;)I FakeClock.java:368 
    #1 io.grpc.xds.XdsClientFallbackTest.testGoodUrlFollowedByBadUrl()V XdsClientFallbackTest.java:440 
```