### PR TITLE
Ensure hostname is ascii

### DIFF
--- a/okhttp/third_party/okhttp/main/java/io/grpc/okhttp/internal/OkHostnameVerifier.java
+++ b/okhttp/third_party/okhttp/main/java/io/grpc/okhttp/internal/OkHostnameVerifier.java
@@ -63,6 +63,9 @@ public final class OkHostnameVerifier implements HostnameVerifier {
 
   @Override
   public boolean verify(String host, SSLSession session) {
+    if (!isAscii(host)) {
+      return false;
+    }
     try {
       Certificate[] certificates = session.getPeerCertificates();
       return verify(host, (X509Certificate) certificates[0]);
@@ -253,5 +256,14 @@ public final class OkHostnameVerifier implements HostnameVerifier {
 
     // hostName matches pattern
     return true;
+  }
+
+  private static boolean isAscii(String input) {
+    try {
+      // All only ascii characters are 1 byte in utf8
+      return input.getBytes("UTF-8").length == input.length();
+    } catch (java.io.UnsupportedEncodingException e) {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
Implement fix to address potential security issue related to certificate validation in OkHttp

grpc-java is susceptible to [CVE-2021-0341](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-0341)

This mirrors the okhttp patch for this exploit available in https://github.com/square/okhttp/pull/6353