### PR TITLE
xds: Unexpected types in server_features should be ignored (1.69.x backport)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/client/BootstrapperImpl.java
+++ b/xds/src/main/java/io/grpc/xds/client/BootstrapperImpl.java
@@ -235,7 +235,9 @@ public abstract class BootstrapperImpl extends Bootstrapper {
       Object implSpecificConfig = getImplSpecificConfig(serverConfig, serverUri);
 
       boolean ignoreResourceDeletion = false;
-      List<String> serverFeatures = JsonUtil.getListOfStrings(serverConfig, "server_features");
+      // "For forward compatibility reasons, the client will ignore any entry in the list that it
+      // does not understand, regardless of type."
+      List<?> serverFeatures = JsonUtil.getList(serverConfig, "server_features");
       if (serverFeatures != null) {
         logger.log(XdsLogLevel.INFO, "Server features: {0}", serverFeatures);
         ignoreResourceDeletion = serverFeatures.contains(SERVER_FEATURE_IGNORE_RESOURCE_DELETION);

--- a/xds/src/test/java/io/grpc/xds/GrpcBootstrapperImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/GrpcBootstrapperImplTest.java
@@ -673,6 +673,26 @@ public class GrpcBootstrapperImplTest {
   }
 
   @Test
+  public void serverFeatures_ignoresUnknownValues() throws XdsInitializationException {
+    String rawData = "{\n"
+        + "  \"xds_servers\": [\n"
+        + "    {\n"
+        + "      \"server_uri\": \"" + SERVER_URI + "\",\n"
+        + "      \"channel_creds\": [\n"
+        + "        {\"type\": \"insecure\"}\n"
+        + "      ],\n"
+        + "      \"server_features\": [null, {}, 3, true, \"unexpected\", \"trusted_xds_server\"]\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+
+    bootstrapper.setFileReader(createFileReader(BOOTSTRAP_FILE_PATH, rawData));
+    BootstrapInfo info = bootstrapper.bootstrap();
+    ServerInfo serverInfo = Iterables.getOnlyElement(info.servers());
+    assertThat(serverInfo.isTrustedXdsServer()).isTrue();
+  }
+
+  @Test
   public void notFound() {
     bootstrapper.bootstrapPathFromEnvVar = null;
     bootstrapper.bootstrapPathFromSysProp = null;


### PR DESCRIPTION
It was clearly defined in gRFC A30. The relevant text was copied as a comment in the code.

As discovered due to grpc/grpc-go#7932

Backport of #11751