### PR TITLE
examples: Updated the deleted reference attachHeaders to newAttachHeadersInterceptor in HeaderClientInterceptor for header example

### DIFF
--- a/examples/src/main/java/io/grpc/examples/header/HeaderClientInterceptor.java
+++ b/examples/src/main/java/io/grpc/examples/header/HeaderClientInterceptor.java
@@ -50,6 +50,11 @@ public class HeaderClientInterceptor implements ClientInterceptor {
         super.start(new SimpleForwardingClientCallListener<RespT>(responseListener) {
           @Override
           public void onHeaders(Metadata headers) {
+            /**
+             * if you don't need receive header from server,
+             * you can use {@link io.grpc.stub.MetadataUtils#newAttachHeadersInterceptor}
+             * directly to send header
+             */
             logger.info("header received from server:" + headers);
             super.onHeaders(headers);
           }

--- a/examples/src/main/java/io/grpc/examples/header/HeaderClientInterceptor.java
+++ b/examples/src/main/java/io/grpc/examples/header/HeaderClientInterceptor.java
@@ -50,11 +50,6 @@ public class HeaderClientInterceptor implements ClientInterceptor {
         super.start(new SimpleForwardingClientCallListener<RespT>(responseListener) {
           @Override
           public void onHeaders(Metadata headers) {
-            /**
-             * if you don't need receive header from server,
-             * you can use {@link io.grpc.stub.MetadataUtils#attachHeaders}
-             * directly to send header
-             */
             logger.info("header received from server:" + headers);
             super.onHeaders(headers);
           }


### PR DESCRIPTION
Updated the deleted reference attachHeaders to newAttachHeadersInterceptor in HeaderClientInterceptor for header example

Fixes https://github.com/grpc/grpc-java/issues/11693