### PR TITLE
Re-enable animalsniffer, fixing violations

### DIFF
--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -44,7 +44,11 @@ dependencies {
             classifier = "linux-x86_64"
         }
     }
-    signature libraries.signature.java
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 configureProtoCompilation()

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -36,6 +36,7 @@ tasks.named("jar").configure {
 dependencies {
     compileOnly sourceSets.context.output
     api libraries.jsr305,
+            libraries.animalsniffer.annotations,
             libraries.errorprone.annotations
     implementation libraries.guava
 
@@ -48,8 +49,18 @@ dependencies {
     testImplementation project(':grpc-testing')
     testImplementation libraries.guava.testlib
 
-    signature libraries.signature.java
-    signature libraries.signature.android
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
+    // Temporarily disabled until StatusException is fixed.
+    // Context: https://github.com/grpc/grpc-java/pull/11066
+    //signature (libraries.signature.android) {
+    //    artifact {
+    //        extension = "signature"
+    //    }
+    //}
 }
 
 tasks.named("javadoc").configure {

--- a/api/src/main/java/io/grpc/TimeUtils.java
+++ b/api/src/main/java/io/grpc/TimeUtils.java
@@ -17,10 +17,12 @@
 package io.grpc;
 
 import java.time.Duration;
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 final class TimeUtils {
   private TimeUtils() {}
 
+  @IgnoreJRERequirement
   static long convertToNanos(Duration duration) {
     try {
       return duration.toNanos();

--- a/api/src/test/java/io/grpc/CallOptionsTest.java
+++ b/api/src/test/java/io/grpc/CallOptionsTest.java
@@ -34,6 +34,7 @@ import io.grpc.ClientStreamTracer.StreamInfo;
 import io.grpc.internal.SerializingExecutor;
 import java.time.Duration;
 import java.util.concurrent.Executor;
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -152,6 +153,7 @@ public class CallOptionsTest {
   }
 
   @Test
+  @IgnoreJRERequirement
   public void withDeadlineAfterDuration() {
     Deadline actual = CallOptions.DEFAULT.withDeadlineAfter(Duration.ofMinutes(1L)).getDeadline();
     Deadline expected = Deadline.after(1, MINUTES);

--- a/api/src/test/java/io/grpc/SynchronizationContextTest.java
+++ b/api/src/test/java/io/grpc/SynchronizationContextTest.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -248,6 +249,7 @@ public class SynchronizationContextTest {
   }
 
   @Test
+  @IgnoreJRERequirement
   public void scheduleDuration() {
     MockScheduledExecutorService executorService = new MockScheduledExecutorService();
     ScheduledHandle handle =
@@ -265,6 +267,7 @@ public class SynchronizationContextTest {
   }
 
   @Test
+  @IgnoreJRERequirement
   public void scheduleWithFixedDelayDuration() {
     MockScheduledExecutorService executorService = new MockScheduledExecutorService();
     ScheduledHandle handle =

--- a/api/src/test/java/io/grpc/TimeUtilsTest.java
+++ b/api/src/test/java/io/grpc/TimeUtilsTest.java
@@ -19,12 +19,14 @@ package io.grpc;
 import static org.junit.Assert.assertEquals;
 
 import java.time.Duration;
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Unit tests for {@link TimeUtils}. */
 @RunWith(JUnit4.class)
+@IgnoreJRERequirement
 public class TimeUtilsTest {
 
   @Test

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -22,6 +22,14 @@ dependencies {
             project(':grpc-core'),
             project(":grpc-context"), // Override google-auth dependency with our newer version
             libraries.google.auth.oauth2Http
-    signature libraries.signature.java
-    signature libraries.signature.android
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
+    signature (libraries.signature.android) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }

--- a/authz/build.gradle
+++ b/authz/build.gradle
@@ -26,7 +26,11 @@ dependencies {
     shadow configurations.implementation.getDependencies().minus([xdsDependency])
     shadow project(path: ':grpc-xds', configuration: 'shadow')
 
-    signature libraries.signature.java
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 tasks.named("jar").configure {

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -43,7 +43,11 @@ dependencies {
     testImplementation libraries.junit,
             libraries.mockito.core
 
-    signature libraries.signature.java
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 import net.ltgt.gradle.errorprone.CheckSeverity

--- a/census/build.gradle
+++ b/census/build.gradle
@@ -27,8 +27,16 @@ dependencies {
             project(':grpc-testing'),
             libraries.opencensus.impl
 
-    signature libraries.signature.java
-    signature libraries.signature.android
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
+    signature (libraries.signature.android) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 tasks.named("javadoc").configure {

--- a/contextstorage/build.gradle
+++ b/contextstorage/build.gradle
@@ -16,8 +16,16 @@ dependencies {
             libraries.assertj.core
     testImplementation 'junit:junit:4.13.1'// opentelemetry.sdk.testing uses compileOnly for assertj
 
-    signature libraries.signature.java
-    signature libraries.signature.android
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
+    signature (libraries.signature.android) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 tasks.named("jar").configure {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -39,8 +39,16 @@ dependencies {
 
     jmh project(':grpc-testing')
 
-    signature libraries.signature.java
-    signature libraries.signature.android
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
+    signature (libraries.signature.android) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 tasks.named("javadoc").configure {

--- a/core/src/main/java/io/grpc/internal/SpiffeUtil.java
+++ b/core/src/main/java/io/grpc/internal/SpiffeUtil.java
@@ -23,13 +23,12 @@ import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Files;
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
@@ -188,8 +187,8 @@ public final class SpiffeUtil {
   }
 
   private static Map<String, ?> readTrustDomainsFromFile(String filePath) throws IOException {
-    Path path = Paths.get(checkNotNull(filePath, "trustBundleFile"));
-    String json = new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+    File file = new File(checkNotNull(filePath, "trustBundleFile"));
+    String json = new String(Files.toByteArray(file), StandardCharsets.UTF_8);
     Object jsonObject = JsonParser.parse(json);
     if (!(jsonObject instanceof Map)) {
       throw new IllegalArgumentException(

--- a/core/src/test/java/io/grpc/internal/ConcurrentTimeProviderTest.java
+++ b/core/src/test/java/io/grpc/internal/ConcurrentTimeProviderTest.java
@@ -18,7 +18,6 @@ package io.grpc.internal;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,10 +35,8 @@ public class ConcurrentTimeProviderTest {
     // Get the current time from the ConcurrentTimeProvider
     long actualTimeNanos = concurrentTimeProvider.currentTimeNanos();
 
-    // Get the current time from Instant for comparison
-    Instant instantNow = Instant.now();
-    long expectedTimeNanos = TimeUnit.SECONDS.toNanos(instantNow.getEpochSecond())
-        + instantNow.getNano();
+    // Get the current time from System for comparison
+    long expectedTimeNanos = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
 
     // Validate the time returned is close to the expected value within a tolerance
     // (i,e 10 millisecond tolerance in nanoseconds).

--- a/core/src/test/java/io/grpc/internal/InstantTimeProviderTest.java
+++ b/core/src/test/java/io/grpc/internal/InstantTimeProviderTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -28,6 +29,7 @@ import org.junit.runners.JUnit4;
  * Unit tests for {@link InstantTimeProvider}.
  */
 @RunWith(JUnit4.class)
+@IgnoreJRERequirement
 public class InstantTimeProviderTest {
   @Test
   public void testInstantCurrentTimeNanos() throws Exception {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -57,6 +57,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
@@ -1199,8 +1200,10 @@ public class ManagedChannelImplTest {
     // config simply gets ignored and not gets reassigned.
     resolver.resolved();
     timer.forwardNanos(1234);
-    assertThat(getStats(channel).channelTrace.events.stream().filter(
-        event -> event.description.equals("Service config changed")).count()).isEqualTo(0);
+    assertThat(Iterables.filter(
+          getStats(channel).channelTrace.events,
+          event -> event.description.equals("Service config changed")))
+        .isEmpty();
   }
 
   @Test

--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -53,7 +53,11 @@ dependencies {
     implementation libraries.junit
     implementation libraries.protobuf.java
     runtimeOnly libraries.netty.tcnative, libraries.netty.tcnative.classes
-    signature libraries.signature.java
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 tasks.named("compileJava").configure {

--- a/gcp-csm-observability/build.gradle
+++ b/gcp-csm-observability/build.gradle
@@ -28,5 +28,9 @@ dependencies {
             libraries.opentelemetry.sdk.testing,
             libraries.assertj.core // opentelemetry.sdk.testing uses compileOnly for this dep
 
-    signature libraries.signature.java
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }

--- a/gcp-observability/build.gradle
+++ b/gcp-observability/build.gradle
@@ -74,7 +74,11 @@ dependencies {
         exclude group: 'junit', module: 'junit'
     }
 
-    signature libraries.signature.java
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 configureProtoCompilation()

--- a/gcp-observability/interop/build.gradle
+++ b/gcp-observability/interop/build.gradle
@@ -10,7 +10,11 @@ dependencies {
     implementation project(':grpc-interop-testing'),
             project(':grpc-gcp-observability')
 
-    signature libraries.signature.java
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 application {

--- a/googleapis/build.gradle
+++ b/googleapis/build.gradle
@@ -21,5 +21,9 @@ dependencies {
                    libraries.guava.jre // JRE required by transitive protobuf-java-util
     testImplementation testFixtures(project(':grpc-core'))
 
-    signature libraries.signature.java
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }

--- a/grpclb/build.gradle
+++ b/grpclb/build.gradle
@@ -28,7 +28,11 @@ dependencies {
             project(':grpc-inprocess'),
             testFixtures(project(':grpc-core'))
 
-    signature libraries.signature.java
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 configureProtoCompilation()

--- a/inprocess/build.gradle
+++ b/inprocess/build.gradle
@@ -22,8 +22,16 @@ dependencies {
             testFixtures(project(':grpc-core'))
     testImplementation libraries.guava.testlib
 
-    signature libraries.signature.java
-    signature libraries.signature.android
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
+    signature (libraries.signature.android) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 tasks.named("javadoc").configure {

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -53,8 +53,16 @@ dependencies {
             libraries.mockito.core,
             libraries.okhttp
 
-    signature libraries.signature.java
-    signature libraries.signature.android
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
+    signature (libraries.signature.android) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 configureProtoCompilation()

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
@@ -78,6 +78,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 /** Client for xDS interop tests. */
 public final class XdsTestClient {
@@ -261,6 +262,7 @@ public final class XdsTestClient {
     }
   }
 
+  @IgnoreJRERequirement // OpenTelemetry uses Java 8+ APIs
   private void run() {
     if (enableCsmObservability) {
       csmObservability = CsmObservability.newBuilder()

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestServer.java
@@ -57,6 +57,7 @@ import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 /** Interop test server that implements the xDS testing service. */
 public final class XdsTestServer {
@@ -193,6 +194,7 @@ public final class XdsTestServer {
   }
 
   @SuppressWarnings("AddressSelection")
+  @IgnoreJRERequirement // OpenTelemetry uses Java 8+ APIs
   void start() throws Exception {
     if (enableCsmObservability) {
       csmObservability = CsmObservability.newBuilder()

--- a/istio-interop-testing/build.gradle
+++ b/istio-interop-testing/build.gradle
@@ -28,7 +28,11 @@ dependencies {
             libraries.junit,
             libraries.truth
 
-    signature libraries.signature.java
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 sourceSets {

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -65,8 +65,16 @@ dependencies {
             classifier = "linux-x86_64"
         }
     }
-    signature libraries.signature.java
-    signature libraries.signature.android
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
+    signature (libraries.signature.android) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 import net.ltgt.gradle.errorprone.CheckSeverity

--- a/netty/shaded/build.gradle
+++ b/netty/shaded/build.gradle
@@ -65,8 +65,16 @@ dependencies {
     shadow project(':grpc-netty').configurations.runtimeClasspath.allDependencies.matching {
         it.group != 'io.netty'
     }
-    signature libraries.signature.java
-    signature libraries.signature.android
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
+    signature (libraries.signature.android) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 tasks.named("jar").configure {

--- a/netty/src/main/java/io/grpc/netty/InternalProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/InternalProtocolNegotiators.java
@@ -16,6 +16,7 @@
 
 package io.grpc.netty;
 
+import com.google.common.base.Optional;
 import io.grpc.ChannelLogger;
 import io.grpc.internal.ObjectPool;
 import io.grpc.netty.ProtocolNegotiators.ClientTlsHandler;
@@ -24,7 +25,6 @@ import io.grpc.netty.ProtocolNegotiators.WaitUntilActiveHandler;
 import io.netty.channel.ChannelHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.util.AsciiString;
-import java.util.Optional;
 import java.util.concurrent.Executor;
 
 /**
@@ -72,7 +72,7 @@ public final class InternalProtocolNegotiators {
    * may happen immediately, even before the TLS Handshake is complete.
    */
   public static InternalProtocolNegotiator.ProtocolNegotiator tls(SslContext sslContext) {
-    return tls(sslContext, null, Optional.empty());
+    return tls(sslContext, null, Optional.absent());
   }
 
   /**
@@ -170,7 +170,7 @@ public final class InternalProtocolNegotiators {
       ChannelHandler next, SslContext sslContext, String authority,
       ChannelLogger negotiationLogger) {
     return new ClientTlsHandler(next, sslContext, authority, null, negotiationLogger,
-        Optional.empty());
+        Optional.absent());
   }
 
   public static class ProtocolNegotiationHandler

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -23,6 +23,7 @@ import static io.grpc.internal.GrpcUtil.DEFAULT_KEEPALIVE_TIMEOUT_NANOS;
 import static io.grpc.internal.GrpcUtil.KEEPALIVE_TIME_NANOS_DISABLED;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
 import com.google.common.base.Ticker;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.CheckReturnValue;
@@ -63,7 +64,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -652,7 +652,7 @@ public final class NettyChannelBuilder extends ForwardingChannelBuilder2<NettyCh
       case PLAINTEXT_UPGRADE:
         return ProtocolNegotiators.plaintextUpgrade();
       case TLS:
-        return ProtocolNegotiators.tls(sslContext, executorPool, Optional.empty());
+        return ProtocolNegotiators.tls(sslContext, executorPool, Optional.absent());
       default:
         throw new IllegalArgumentException("Unsupported negotiationType: " + negotiationType);
     }

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.errorprone.annotations.ForOverride;
 import io.grpc.Attributes;
@@ -72,7 +73,6 @@ import java.net.URI;
 import java.nio.channels.ClosedChannelException;
 import java.util.Arrays;
 import java.util.EnumSet;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.logging.Level;
@@ -82,6 +82,7 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSession;
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 /**
  * Common {@link ProtocolNegotiator}s used by gRPC.
@@ -601,6 +602,7 @@ final class ProtocolNegotiators {
     }
 
     @Override
+    @IgnoreJRERequirement
     protected void handlerAdded0(ChannelHandlerContext ctx) {
       SSLEngine sslEngine = sslContext.newEngine(ctx.alloc(), host, port);
       SSLParameters sslParams = sslEngine.getSSLParameters();
@@ -708,7 +710,7 @@ final class ProtocolNegotiators {
    * may happen immediately, even before the TLS Handshake is complete.
    */
   public static ProtocolNegotiator tls(SslContext sslContext) {
-    return tls(sslContext, null, Optional.empty());
+    return tls(sslContext, null, Optional.absent());
   }
 
   public static ProtocolNegotiator.ClientFactory tlsClientFactory(SslContext sslContext) {

--- a/netty/src/test/java/io/grpc/netty/NettyAdaptiveCumulatorTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyAdaptiveCumulatorTest.java
@@ -40,7 +40,6 @@ import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -55,7 +54,7 @@ import org.junit.runners.Parameterized.Parameters;
 public class NettyAdaptiveCumulatorTest {
 
   private static Collection<Object[]> cartesianProductParams(List<?>... lists) {
-    return Lists.cartesianProduct(lists).stream().map(List::toArray).collect(Collectors.toList());
+    return Lists.transform(Lists.cartesianProduct(lists), List::toArray);
   }
 
   @RunWith(JUnit4.class)

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -46,6 +46,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.Iterables;
 import com.google.common.io.BaseEncoding;
 import io.grpc.CallOptions;
 import io.grpc.InternalStatus;
@@ -239,11 +240,13 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
     // Get the CancelClientStreamCommand written to the queue. Above we verified that there is
     // only one CancelClientStreamCommand enqueued, and is the third enqueued command (create,
     // frame write failure, cancel).
-    CancelClientStreamCommand cancelCommand = Mockito.mockingDetails(writeQueue).getInvocations()
-        // Get enqueue() innovations only
-        .stream().filter(invocation -> invocation.getMethod().getName().equals("enqueue"))
+    CancelClientStreamCommand cancelCommand = Iterables.get(
+        Iterables.filter(
+          Mockito.mockingDetails(writeQueue).getInvocations(),
+          // Get enqueue() innovations only
+          invocation -> invocation.getMethod().getName().equals("enqueue")),
         // Get the third invocation of enqueue()
-        .skip(2).findFirst().get()
+        2)
         // Get the first argument (QueuedCommand command)
         .getArgument(0);
 

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -39,6 +39,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.base.Ticker;
 import com.google.common.io.ByteStreams;
@@ -105,7 +106,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -803,7 +803,7 @@ public class NettyClientTransportTest {
         .keyManager(clientCert, clientKey)
         .build();
     ProtocolNegotiator negotiator = ProtocolNegotiators.tls(clientContext, clientExecutorPool,
-        Optional.empty());
+        Optional.absent());
     // after starting the client, the Executor in the client pool should be used
     assertEquals(true, clientExecutorPool.isInUse());
     final NettyClientTransport transport = newTransport(negotiator);

--- a/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
+++ b/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.google.common.base.Optional;
 import io.grpc.Attributes;
 import io.grpc.CallCredentials;
 import io.grpc.ChannelCredentials;
@@ -120,7 +121,6 @@ import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -877,7 +877,7 @@ public class ProtocolNegotiatorsTest {
     DefaultEventLoopGroup elg = new DefaultEventLoopGroup(1);
 
     ClientTlsHandler handler = new ClientTlsHandler(grpcHandler, sslContext,
-        "authority", elg, noopLogger, Optional.empty());
+        "authority", elg, noopLogger, Optional.absent());
     pipeline.addLast(handler);
     pipeline.replace(SslHandler.class, null, goodSslHandler);
     pipeline.fireUserEventTriggered(ProtocolNegotiationEvent.DEFAULT);
@@ -915,7 +915,7 @@ public class ProtocolNegotiatorsTest {
         .applicationProtocolConfig(apn).build();
 
     ClientTlsHandler handler = new ClientTlsHandler(grpcHandler, sslContext,
-        "authority", elg, noopLogger, Optional.empty());
+        "authority", elg, noopLogger, Optional.absent());
     pipeline.addLast(handler);
     pipeline.replace(SslHandler.class, null, goodSslHandler);
     pipeline.fireUserEventTriggered(ProtocolNegotiationEvent.DEFAULT);
@@ -939,7 +939,7 @@ public class ProtocolNegotiatorsTest {
     DefaultEventLoopGroup elg = new DefaultEventLoopGroup(1);
 
     ClientTlsHandler handler = new ClientTlsHandler(grpcHandler, sslContext,
-        "authority", elg, noopLogger, Optional.empty());
+        "authority", elg, noopLogger, Optional.absent());
     pipeline.addLast(handler);
 
     final AtomicReference<Throwable> error = new AtomicReference<>();
@@ -967,7 +967,7 @@ public class ProtocolNegotiatorsTest {
   @Test
   public void clientTlsHandler_closeDuringNegotiation() throws Exception {
     ClientTlsHandler handler = new ClientTlsHandler(grpcHandler, sslContext,
-        "authority", null, noopLogger, Optional.empty());
+        "authority", null, noopLogger, Optional.absent());
     pipeline.addLast(new WriteBufferingAndExceptionHandler(handler));
     ChannelFuture pendingWrite = channel.writeAndFlush(NettyClientHandler.NOOP_MESSAGE);
 
@@ -1230,7 +1230,7 @@ public class ProtocolNegotiatorsTest {
     }
     FakeGrpcHttp2ConnectionHandler gh = FakeGrpcHttp2ConnectionHandler.newHandler();
     ClientTlsProtocolNegotiator pn = new ClientTlsProtocolNegotiator(clientSslContext,
-        null, Optional.empty());
+        null, Optional.absent());
     WriteBufferingAndExceptionHandler clientWbaeh =
         new WriteBufferingAndExceptionHandler(pn.newHandler(gh));
 

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -31,8 +31,16 @@ dependencies {
             project(':grpc-testing-proto'),
             libraries.netty.codec.http2,
             libraries.okhttp
-    signature libraries.signature.java
-    signature libraries.signature.android
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
+    signature (libraries.signature.android) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 project.sourceSets {

--- a/opentelemetry/build.gradle
+++ b/opentelemetry/build.gradle
@@ -23,8 +23,11 @@ dependencies {
 
     annotationProcessor libraries.auto.value
 
-    signature libraries.signature.java
-    signature libraries.signature.android
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 tasks.named("jar").configure {

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -17,8 +17,16 @@ dependencies {
 
     testImplementation project(':grpc-core')
 
-    signature libraries.signature.java
-    signature libraries.signature.android
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
+    signature (libraries.signature.android) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 tasks.named("jar").configure {

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -31,8 +31,16 @@ dependencies {
         exclude group: 'com.google.protobuf', module: 'protobuf-javalite'
     }
 
-    signature libraries.signature.java
-    signature libraries.signature.android
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
+    signature (libraries.signature.android) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 tasks.named("javadoc").configure {

--- a/rls/build.gradle
+++ b/rls/build.gradle
@@ -30,7 +30,11 @@ dependencies {
             project(':grpc-testing-proto'),
             testFixtures(project(':grpc-api')),
             testFixtures(project(':grpc-core'))
-    signature libraries.signature.java
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 tasks.named("compileJava").configure {

--- a/s2a/build.gradle
+++ b/s2a/build.gradle
@@ -62,7 +62,11 @@ dependencies {
         }
     }
 
-    signature libraries.signature.java
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 configureProtoCompilation()

--- a/s2a/src/main/java/io/grpc/s2a/internal/handshaker/S2AProtocolNegotiatorFactory.java
+++ b/s2a/src/main/java/io/grpc/s2a/internal/handshaker/S2AProtocolNegotiatorFactory.java
@@ -253,7 +253,7 @@ public final class S2AProtocolNegotiatorFactory {
                   InternalProtocolNegotiators.tls(
                           sslContext,
                           SharedResourcePool.forResource(GrpcUtil.SHARED_CHANNEL_EXECUTOR),
-                          Optional.of(new Runnable() {
+                          com.google.common.base.Optional.of(new Runnable() {
                             @Override
                             public void run() {
                               s2aStub.close();

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -39,7 +39,11 @@ dependencies {
             testFixtures(project(':grpc-core')),
             testFixtures(project(':grpc-api'))
     testCompileOnly libraries.javax.annotation
-    signature libraries.signature.java
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 configureProtoCompilation()

--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -22,8 +22,16 @@ dependencies {
             project(':grpc-inprocess'),
             project(':grpc-testing'),
             testFixtures(project(':grpc-api'))
-    signature libraries.signature.java
-    signature libraries.signature.android
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
+    signature (libraries.signature.android) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 tasks.named("javadoc").configure {

--- a/stub/src/main/java/io/grpc/stub/AbstractStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractStub.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 /**
  * Common base type for stub implementations. Stub configuration is immutable; changing the
@@ -152,6 +153,7 @@ public abstract class AbstractStub<S extends AbstractStub<S>> {
   }
 
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11657")
+  @IgnoreJRERequirement
   public final S withDeadlineAfter(Duration duration) {
     return withDeadlineAfter(convert(duration), TimeUnit.NANOSECONDS);
   }

--- a/stub/src/test/java/io/grpc/stub/AbstractStubTest.java
+++ b/stub/src/test/java/io/grpc/stub/AbstractStubTest.java
@@ -28,6 +28,7 @@ import io.grpc.Deadline;
 import io.grpc.stub.AbstractStub.StubFactory;
 import io.grpc.stub.AbstractStubTest.NoopStub;
 import java.time.Duration;
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -54,6 +55,7 @@ public class AbstractStubTest extends BaseAbstractStubTest<NoopStub> {
   }
 
   @Test
+  @IgnoreJRERequirement
   public void testDuration() {
     NoopStub stub = NoopStub.newStub(new StubFactory<NoopStub>() {
       @Override

--- a/testing-proto/build.gradle
+++ b/testing-proto/build.gradle
@@ -20,7 +20,11 @@ dependencies {
     compileOnly libraries.javax.annotation
     testImplementation libraries.truth
     testRuntimeOnly libraries.javax.annotation
-    signature libraries.signature.java
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 configureProtoCompilation()

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -24,8 +24,16 @@ dependencies {
     testImplementation project(':grpc-testing-proto'),
             testFixtures(project(':grpc-core'))
 
-    signature libraries.signature.java
-    signature libraries.signature.android
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
+    signature (libraries.signature.android) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 tasks.named("javadoc").configure { exclude 'io/grpc/internal/**' }

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -35,8 +35,16 @@ dependencies {
             project(':grpc-testing')
     jmh project(':grpc-testing')
 
-    signature libraries.signature.java
-    signature libraries.signature.android
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
+    signature (libraries.signature.android) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 animalsniffer {

--- a/util/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
@@ -685,7 +685,11 @@ public final class OutlierDetectionLoadBalancer extends LoadBalancer {
     /** Adds a new tracker for every given address. */
     void putNewTrackers(OutlierDetectionLoadBalancerConfig config,
         Set<Set<SocketAddress>> endpoints) {
-      endpoints.forEach(e -> trackerMap.putIfAbsent(e, new EndpointTracker(config)));
+      for (Set<SocketAddress> endpoint : endpoints) {
+        if (!trackerMap.containsKey(endpoint)) {
+          trackerMap.put(endpoint, new EndpointTracker(config));
+        }
+      }
     }
 
     /** Resets the call counters for all the trackers in the map. */

--- a/util/src/test/java/io/grpc/util/AdvancedTlsX509TrustManagerTest.java
+++ b/util/src/test/java/io/grpc/util/AdvancedTlsX509TrustManagerTest.java
@@ -44,6 +44,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import javax.net.ssl.SSLSocket;
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,6 +52,7 @@ import org.junit.runners.JUnit4;
 
 /** Unit tests for {@link AdvancedTlsX509TrustManager}. */
 @RunWith(JUnit4.class)
+@IgnoreJRERequirement
 public class AdvancedTlsX509TrustManagerTest {
 
   private static final String CA_PEM_FILE = "ca.pem";

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -81,7 +81,11 @@ dependencies {
     shadow configurations.implementation.getDependencies().minus([nettyDependency])
     shadow project(path: ':grpc-netty-shaded', configuration: 'shadow')
 
-    signature libraries.signature.java
+    signature (libraries.signature.java) {
+        artifact {
+            extension = "signature"
+        }
+    }
     testRuntimeOnly libraries.netty.tcnative,
             libraries.netty.tcnative.classes
     testRuntimeOnly (libraries.netty.tcnative) {


### PR DESCRIPTION
In 61f19d707a I swapped the signatures to use the version catalog. But I failed to preserve the `@signature` extension and it all seemed to work... But in fact all the animalsniffer tasks were completing as SKIPPED as they lacked signatures. The build.gradle changes in this commit are to fix that while still using version catalog.

But while it was broken violations crept in. Most violations weren't too important and we're not surprised went unnoticed. For example, Netty with TLS has long required the Java 8 API
`setEndpointIdentificationAlgorithm()`, so using `Optional` in the same code path didn't harm anything in particular. I still swapped it to Guava's `Optional` to avoid overuse of `@IgnoreJRERequirement`.

One important violation has not been fixed and instead I've disabled the android signature in api/build.gradle for the moment.  The violation is in StatusException using the `fillInStackTrace` overload of Exception. This problem [had been noticed][PR11066], but we couldn't figure out what was going on. AnimalSniffer is now noticing this and agreeing with the internal linter. There is still a question of why our interop tests failed to notice this, but given they are no longer running on pre-API level 24, that may forever be a mystery.

[PR11066]: https://github.com/grpc/grpc-java/pull/11066