### PR TITLE
xds: Fix XDS control plane client retry timer backoff duration when connection closes after results are received

### DIFF
--- a/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
+++ b/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
@@ -451,12 +451,9 @@ final class ControlPlaneClient {
       // FakeClock in tests isn't thread-safe. Schedule the retry timer before notifying callbacks
       // to avoid TSAN races, since tests may wait until callbacks are called but then would run
       // concurrently with the stopwatch and schedule.
-
-      long elapsed = stopwatch.elapsed(TimeUnit.NANOSECONDS);
-      long delayNanos = Math.max(0, retryBackoffPolicy.nextBackoffNanos() - elapsed);
-
       rpcRetryTimer =
-          syncContext.schedule(new RpcRetryTask(), delayNanos, TimeUnit.NANOSECONDS, timeService);
+          syncContext.schedule(new RpcRetryTask(), retryBackoffPolicy.nextBackoffNanos(),
+              TimeUnit.NANOSECONDS, timeService);
 
       Status newStatus = status;
       if (responseReceived) {

--- a/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplTestBase.java
@@ -3524,6 +3524,7 @@ public abstract class GrpcXdsClientImplTestBase {
     call.verifyRequest(EDS, EDS_RESOURCE, "", "", NODE);
 
     // Management server closes the RPC stream with an error.
+    fakeClock.forwardNanos(1000L); // Make sure retry isn't based on stopwatch 0
     call.sendError(Status.UNKNOWN.asException());
     verify(ldsResourceWatcher, Mockito.timeout(1000).times(1))
         .onError(errorCaptor.capture());


### PR DESCRIPTION
The backoffPolicy was calculating time since last attempt, but if the stream had been successfully connected and received responses it should delay from the current time (i.e. reset the stopwatch).  Changed test so that stopwatch wasn't always 0, which masked the problem.