### PR TITLE
Use more Bazel module dependencies

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -47,33 +47,21 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
 # GRPC_DEPS_END
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
-bazel_dep(name = "googleapis", repo_name = "com_google_googleapis", version = "0.0.0-20240326-1c8d509c5")
+bazel_dep(name = "googleapis", repo_name = "com_google_googleapis", version = "0.0.0-20240819-fe8ba054a")
 # CEL Spec may be removed when cncf/xds MODULE is no longer using protobuf 27.x
 bazel_dep(name = "cel-spec", repo_name = "dev_cel", version = "0.15.0")
+bazel_dep(name = "envoy_api", version = "0.0.0-20241214-918efc9")
 bazel_dep(name = "grpc", repo_name = "com_github_grpc_grpc", version = "1.56.3.bcr.1")
 bazel_dep(name = "grpc-proto", repo_name = "io_grpc_grpc_proto", version = "0.0.0-20240627-ec30f58")
+bazel_dep(name = "opencensus-proto", repo_name = "opencensus_proto", version = "0.4.1")
 bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "23.1")
+bazel_dep(name = "protoc-gen-validate", repo_name = "com_envoyproxy_protoc_gen_validate", version = "1.0.4.bcr.2")
 bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "rules_java", version = "5.3.5")
 bazel_dep(name = "rules_go", repo_name = "io_bazel_rules_go", version = "0.46.0")
 bazel_dep(name = "rules_jvm_external", version = "6.0")
 bazel_dep(name = "rules_proto", version = "5.3.0-21.7")
-
-non_module_deps = use_extension("//:repositories.bzl", "grpc_java_repositories_extension")
-
-use_repo(
-    non_module_deps,
-    "com_github_cncf_xds",
-    "envoy_api",
-)
-
-grpc_repo_deps_ext = use_extension("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_repo_deps_ext")
-
-use_repo(
-    grpc_repo_deps_ext,
-    "com_envoyproxy_protoc_gen_validate",
-    "opencensus_proto",
-)
+bazel_dep(name = "xds", repo_name = "com_github_cncf_xds", version = "0.0.0-20240423-555b57e")
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 


### PR DESCRIPTION
This allows bzlmod version resolution and avoids ODR violations when importing the same dependency multiple times in different modules.