### PR TITLE
api: Use package-private IgnoreJRERequirement

### DIFF
--- a/api/BUILD.bazel
+++ b/api/BUILD.bazel
@@ -13,6 +13,5 @@ java_library(
         artifact("com.google.errorprone:error_prone_annotations"),
         artifact("com.google.guava:failureaccess"),  # future transitive dep of Guava. See #5214
         artifact("com.google.guava:guava"),
-        artifact("org.codehaus.mojo:animal-sniffer-annotations"),
     ],
 )

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -36,7 +36,6 @@ tasks.named("jar").configure {
 dependencies {
     compileOnly sourceSets.context.output
     api libraries.jsr305,
-            libraries.animalsniffer.annotations,
             libraries.errorprone.annotations
     implementation libraries.guava
 
@@ -59,6 +58,10 @@ dependencies {
             extension = "signature"
         }
     }
+}
+
+animalsniffer {
+    annotation = 'io.grpc.IgnoreJRERequirement'
 }
 
 tasks.named("javadoc").configure {

--- a/api/src/main/java/io/grpc/IgnoreJRERequirement.java
+++ b/api/src/main/java/io/grpc/IgnoreJRERequirement.java
@@ -16,17 +16,15 @@
 
 package io.grpc;
 
-import java.time.Duration;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
 
-final class TimeUtils {
-  private TimeUtils() {}
-
-  @IgnoreJRERequirement
-  static long convertToNanos(Duration duration) {
-    try {
-      return duration.toNanos();
-    } catch (ArithmeticException tooBig) {
-      return duration.isNegative() ? Long.MIN_VALUE : Long.MAX_VALUE;
-    }
-  }
-}
+/**
+ * Disables Animal Sniffer's signature checking. This is our own package-private version to avoid
+ * dependening on animalsniffer-annotations.
+ *
+ * <p>FIELD is purposefully not supported, as Android wouldn't be able to ignore a field. Instead,
+ * the entire class would need to be avoided on Android.
+ */
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE})
+@interface IgnoreJRERequirement {}

--- a/api/src/test/java/io/grpc/CallOptionsTest.java
+++ b/api/src/test/java/io/grpc/CallOptionsTest.java
@@ -34,7 +34,6 @@ import io.grpc.ClientStreamTracer.StreamInfo;
 import io.grpc.internal.SerializingExecutor;
 import java.time.Duration;
 import java.util.concurrent.Executor;
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/api/src/test/java/io/grpc/SynchronizationContextTest.java
+++ b/api/src/test/java/io/grpc/SynchronizationContextTest.java
@@ -36,7 +36,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;

--- a/api/src/test/java/io/grpc/TimeUtilsTest.java
+++ b/api/src/test/java/io/grpc/TimeUtilsTest.java
@@ -19,7 +19,6 @@ package io.grpc;
 import static org.junit.Assert.assertEquals;
 
 import java.time.Duration;
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/buildscripts/checkstyle.xml
+++ b/buildscripts/checkstyle.xml
@@ -38,6 +38,12 @@
         <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
     </module>
 
+    <module name="SuppressionSingleFilter">
+        <!-- Prefer using the same name as in Animal Sniffer -->
+        <property name="checks" value="AbbreviationAsWordInName"/>
+        <property name="files" value="IgnoreJRERequirement.java"/>
+    </module>
+
     <module name="TreeWalker">
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -17,6 +17,7 @@ tasks.named("jar").configure {
 
 dependencies {
     api project(':grpc-api'),
+            libraries.animalsniffer.annotations,
             libraries.netty.codec.http2
     implementation project(':grpc-core'),
             libs.netty.handler.proxy,

--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -16,6 +16,7 @@ tasks.named("jar").configure {
 
 dependencies {
     api project(':grpc-api'),
+        libraries.animalsniffer.annotations,
         libraries.guava
     implementation libraries.errorprone.annotations
     testImplementation libraries.truth,


### PR DESCRIPTION
This avoids the dependency on animalsniffer-annotations. grpc-api, and particularly grpc-context, are used many low-level places and it is beneficial for them to be very low dependency. This brings grpc-context back to zero-dependency.

CC @kannanjgithub 