### PR TITLE
bazel: Restore DoNotCall ErrorProne check

### DIFF
--- a/api/BUILD.bazel
+++ b/api/BUILD.bazel
@@ -6,7 +6,6 @@ java_library(
         "src/main/java/**/*.java",
         "src/context/java/**/*.java",
     ]),
-    javacopts = ["-Xep:DoNotCall:OFF"],  # Remove once requiring Bazel 3.4.0+; allows non-final
     visibility = ["//visibility:public"],
     deps = [
         artifact("com.google.code.findbugs:jsr305"),

--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -17,7 +17,6 @@ java_library(
     srcs = glob([
         "src/main/java/io/grpc/internal/*.java",
     ]),
-    javacopts = ["-Xep:DoNotCall:OFF"],  # Remove once requiring Bazel 3.4.0+; allows non-final
     resources = glob([
         "src/bazel-internal/resources/**",
     ]),


### PR DESCRIPTION
In e08b9db20 we added `@DoNotCall` annotations to some call sites, but Bazel used an older version of ErrorProne that complained at times it shouldn't. The minimum version of Bazel we test/support is now Bazel 6, well past Bazel 3.4+.