### PR TITLE
gcp-observability: Fixed the slowness issue of GcpObservabilityTest.enableObservability test.

### DIFF
--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
@@ -195,10 +195,11 @@ public class GcpObservabilityTest {
       InternalLoggingServerInterceptor.Factory serverInterceptorFactory =
           mock(InternalLoggingServerInterceptor.Factory.class);
       when(serverInterceptorFactory.create()).thenReturn(serverInterceptor);
-      GcpObservability gcpObservability = null;
       try {
-        gcpObservability = GcpObservability.grpcInit(
+        GcpObservability gcpObservability = GcpObservability.grpcInit(
             sink, config, channelInterceptorFactory, serverInterceptorFactory);
+        // Added the assert statement to fix the build warnings.
+        assertThat(gcpObservability).isNotNull();
         List<?> configurators = InternalConfiguratorRegistry.getConfigurators();
         assertThat(configurators).hasSize(1);
         ObservabilityConfigurator configurator = (ObservabilityConfigurator) configurators.get(0);

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
@@ -195,10 +195,9 @@ public class GcpObservabilityTest {
       InternalLoggingServerInterceptor.Factory serverInterceptorFactory =
           mock(InternalLoggingServerInterceptor.Factory.class);
       when(serverInterceptorFactory.create()).thenReturn(serverInterceptor);
-
-      try (GcpObservability unused =
-          GcpObservability.grpcInit(
-              sink, config, channelInterceptorFactory, serverInterceptorFactory)) {
+      try {
+        GcpObservability observability = GcpObservability.grpcInit(
+            sink, config, channelInterceptorFactory, serverInterceptorFactory);
         List<?> configurators = InternalConfiguratorRegistry.getConfigurators();
         assertThat(configurators).hasSize(1);
         ObservabilityConfigurator configurator = (ObservabilityConfigurator) configurators.get(0);

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
@@ -195,8 +195,9 @@ public class GcpObservabilityTest {
       InternalLoggingServerInterceptor.Factory serverInterceptorFactory =
           mock(InternalLoggingServerInterceptor.Factory.class);
       when(serverInterceptorFactory.create()).thenReturn(serverInterceptor);
+      GcpObservability gcpObservability = null;
       try {
-        GcpObservability observability = GcpObservability.grpcInit(
+        gcpObservability = GcpObservability.grpcInit(
             sink, config, channelInterceptorFactory, serverInterceptorFactory);
         List<?> configurators = InternalConfiguratorRegistry.getConfigurators();
         assertThat(configurators).hasSize(1);


### PR DESCRIPTION
gcp-observability: Fixed the slowness issue of GcpObservabilityTest.enableObservability test. 

Fixes https://github.com/grpc/grpc-java/issues/10146