### PR TITLE
gcp-observability : Fixed the slowness issue of GcpObservabilityTest.enableObservability test

### DIFF
--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
@@ -196,9 +196,11 @@ public class GcpObservabilityTest {
           mock(InternalLoggingServerInterceptor.Factory.class);
       when(serverInterceptorFactory.create()).thenReturn(serverInterceptor);
 
-      try (GcpObservability unused =
-          GcpObservability.grpcInit(
-              sink, config, channelInterceptorFactory, serverInterceptorFactory)) {
+      try {
+        GcpObservability gcpObservability = GcpObservability.grpcInit(
+            sink, config, channelInterceptorFactory, serverInterceptorFactory);
+        // Added the assert statement to fix the build warnings.
+        assertThat(gcpObservability).isNotNull();
         List<?> configurators = InternalConfiguratorRegistry.getConfigurators();
         assertThat(configurators).hasSize(1);
         ObservabilityConfigurator configurator = (ObservabilityConfigurator) configurators.get(0);

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
@@ -199,7 +199,7 @@ public class GcpObservabilityTest {
       try {
         GcpObservability gcpObservability = GcpObservability.grpcInit(
             sink, config, channelInterceptorFactory, serverInterceptorFactory);
-        // Added the assert statement to fix the build warnings.
+        // Added the assert statement to fix the PR build/check warnings.
         assertThat(gcpObservability).isNotNull();
         List<?> configurators = InternalConfiguratorRegistry.getConfigurators();
         assertThat(configurators).hasSize(1);


### PR DESCRIPTION
gcp-observability : Fixed the slowness issue of GcpObservabilityTest.enableObservability test.

Fixes https://github.com/grpc/grpc-java/issues/10146