### PR TITLE
gcp-obsrevability : Fixed the slowness issue for GcpObservabilityTest.enableObservability test case.

### DIFF
--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
@@ -196,11 +196,9 @@ public class GcpObservabilityTest {
           mock(InternalLoggingServerInterceptor.Factory.class);
       when(serverInterceptorFactory.create()).thenReturn(serverInterceptor);
 
-      try {
-        GcpObservability gcpObservability = GcpObservability.grpcInit(
-            sink, config, channelInterceptorFactory, serverInterceptorFactory);
-        // Added the assert statement to fix the build warnings.
-        assertThat(gcpObservability).isNotNull();
+      try (GcpObservability unused =
+          GcpObservability.grpcInit(
+              sink, config, channelInterceptorFactory, serverInterceptorFactory)) {
         List<?> configurators = InternalConfiguratorRegistry.getConfigurators();
         assertThat(configurators).hasSize(1);
         ObservabilityConfigurator configurator = (ObservabilityConfigurator) configurators.get(0);

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
@@ -196,9 +196,12 @@ public class GcpObservabilityTest {
           mock(InternalLoggingServerInterceptor.Factory.class);
       when(serverInterceptorFactory.create()).thenReturn(serverInterceptor);
 
-      try (GcpObservability unused =
-          GcpObservability.grpcInit(
-              sink, config, channelInterceptorFactory, serverInterceptorFactory)) {
+      try {
+        GcpObservability gcpObservability = GcpObservability.grpcInit(
+            sink, config, channelInterceptorFactory, serverInterceptorFactory);
+        //Added the assert statement to fix the PR build/check warnings for unused
+        //variable in gcpObservability.
+        assertThat(gcpObservability).isNotNull();
         List<?> configurators = InternalConfiguratorRegistry.getConfigurators();
         assertThat(configurators).hasSize(1);
         ObservabilityConfigurator configurator = (ObservabilityConfigurator) configurators.get(0);

--- a/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
+++ b/gcp-observability/src/test/java/io/grpc/gcp/observability/GcpObservabilityTest.java
@@ -196,9 +196,11 @@ public class GcpObservabilityTest {
           mock(InternalLoggingServerInterceptor.Factory.class);
       when(serverInterceptorFactory.create()).thenReturn(serverInterceptor);
 
-      try (GcpObservability unused =
-          GcpObservability.grpcInit(
-              sink, config, channelInterceptorFactory, serverInterceptorFactory)) {
+      try {
+        GcpObservability gcpObservability = GcpObservability.grpcInit(
+            sink, config, channelInterceptorFactory, serverInterceptorFactory);
+        // Added the assert statement to fix the build warnings.
+        assertThat(gcpObservability).isNotNull();
         List<?> configurators = InternalConfiguratorRegistry.getConfigurators();
         assertThat(configurators).hasSize(1);
         ObservabilityConfigurator configurator = (ObservabilityConfigurator) configurators.get(0);


### PR DESCRIPTION
gcp-obsrevability : Fixed the slowness issue for GcpObservabilityTest.enableObservability test case.

Fixes https://github.com/grpc/grpc-java/issues/10146

**Snippet before fix as execuation time taking 1m 21sec** 

![10146-before-fix](https://github.com/user-attachments/assets/3b2fb504-06fd-4388-a9e4-173436af6b9c)

Snippet after fix as execuation time taking below 1sec 44msec.

![10146-after-fix](https://github.com/user-attachments/assets/d636f39a-4a4c-4590-be95-401f9dab2353)
