### PR TITLE
examples: Remove references to maven-central.storage-download.googleapis.com

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -7,8 +7,6 @@ plugins {
 }
 
 repositories {
-    maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/maven2/" }
     mavenCentral()
     mavenLocal()
 }

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -7,9 +7,6 @@ plugins {
 }
 
 repositories {
-    maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/maven2/"
-    }
     mavenCentral()
     mavenLocal()
 }

--- a/examples/example-alts/settings.gradle
+++ b/examples/example-alts/settings.gradle
@@ -1,8 +1,5 @@
 pluginManagement {
     repositories {
-        maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/maven2/"
-        }
         gradlePluginPortal()
     }
 }

--- a/examples/example-debug/build.gradle
+++ b/examples/example-debug/build.gradle
@@ -9,8 +9,6 @@ plugins {
 }
 
 repositories {
-    maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/maven2/" }
     mavenCentral()
     mavenLocal()
 }

--- a/examples/example-dualstack/build.gradle
+++ b/examples/example-dualstack/build.gradle
@@ -9,8 +9,6 @@ plugins {
 }
 
 repositories {
-    maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/maven2/" }
     mavenCentral()
     mavenLocal()
 }

--- a/examples/example-dualstack/settings.gradle
+++ b/examples/example-dualstack/settings.gradle
@@ -1,8 +1,5 @@
 pluginManagement {
     repositories {
-        maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/maven2/"
-        }
         gradlePluginPortal()
     }
 }

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -7,9 +7,6 @@ plugins {
 }
 
 repositories {
-    maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/maven2/"
-    }
     mavenCentral()
     mavenLocal()
 }

--- a/examples/example-gauth/settings.gradle
+++ b/examples/example-gauth/settings.gradle
@@ -1,8 +1,5 @@
 pluginManagement {
     repositories {
-        maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/maven2/"
-        }
         gradlePluginPortal()
     }
 }

--- a/examples/example-gcp-csm-observability/build.gradle
+++ b/examples/example-gcp-csm-observability/build.gradle
@@ -8,9 +8,6 @@ plugins {
 }
 
 repositories {
-    maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/maven2/"
-    }
     mavenCentral()
     mavenLocal()
 }

--- a/examples/example-gcp-observability/build.gradle
+++ b/examples/example-gcp-observability/build.gradle
@@ -8,9 +8,6 @@ plugins {
 }
 
 repositories {
-    maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/maven2/"
-    }
     mavenCentral()
     mavenLocal()
 }

--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -7,8 +7,6 @@ plugins {
 }
 
 repositories {
-    maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/maven2/" }
     mavenCentral()
     mavenLocal()
 }

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -7,9 +7,7 @@ plugins {
 }
 
 repositories {
-    maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/maven2/"
-    }
+    mavenCentral()
     mavenLocal()
 }
 

--- a/examples/example-jwt-auth/settings.gradle
+++ b/examples/example-jwt-auth/settings.gradle
@@ -1,8 +1,5 @@
 pluginManagement {
     repositories {
-        maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/maven2/"
-        }
         gradlePluginPortal()
     }
 }

--- a/examples/example-oauth/build.gradle
+++ b/examples/example-oauth/build.gradle
@@ -7,9 +7,7 @@ plugins {
 }
 
 repositories {
-    maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/maven2/"
-    }
+    mavenCentral()
     mavenLocal()
 }
 

--- a/examples/example-oauth/settings.gradle
+++ b/examples/example-oauth/settings.gradle
@@ -1,8 +1,5 @@
 pluginManagement {
     repositories {
-        maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/maven2/"
-        }
         gradlePluginPortal()
     }
 }

--- a/examples/example-opentelemetry/build.gradle
+++ b/examples/example-opentelemetry/build.gradle
@@ -7,9 +7,6 @@ plugins {
 }
 
 repositories {
-    maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/maven2/"
-    }
     mavenCentral()
     mavenLocal()
 }

--- a/examples/example-orca/build.gradle
+++ b/examples/example-orca/build.gradle
@@ -7,8 +7,6 @@ plugins {
 }
 
 repositories {
-    maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/maven2/" }
     mavenCentral()
     mavenLocal()
 }

--- a/examples/example-reflection/build.gradle
+++ b/examples/example-reflection/build.gradle
@@ -7,8 +7,6 @@ plugins {
 }
 
 repositories {
-    maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/maven2/" }
     mavenCentral()
     mavenLocal()
 }

--- a/examples/example-servlet/build.gradle
+++ b/examples/example-servlet/build.gradle
@@ -6,8 +6,7 @@ plugins {
 }
 
 repositories {
-    maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/maven2/" }
+    mavenCentral()
     mavenLocal()
 }
 

--- a/examples/example-servlet/settings.gradle
+++ b/examples/example-servlet/settings.gradle
@@ -1,8 +1,5 @@
 pluginManagement {
     repositories {
-        maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/maven2/"
-        }
         gradlePluginPortal()
     }
 }

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -7,9 +7,6 @@ plugins {
 }
 
 repositories {
-    maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/maven2/"
-    }
     mavenCentral()
     mavenLocal()
 }

--- a/examples/example-tls/settings.gradle
+++ b/examples/example-tls/settings.gradle
@@ -1,8 +1,5 @@
 pluginManagement {
     repositories {
-        maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/maven2/"
-        }
         gradlePluginPortal()
     }
 }

--- a/examples/example-xds/build.gradle
+++ b/examples/example-xds/build.gradle
@@ -7,8 +7,6 @@ plugins {
 }
 
 repositories {
-    maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/maven2/" }
     mavenCentral()
     mavenLocal()
 }

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -1,8 +1,5 @@
 pluginManagement {
     repositories {
-        maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/maven2/"
-        }
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
As stated [on its main page][index], it isn't officially supported, so we shouldn't include it in our examples.

[index]: https://maven-central.storage-download.googleapis.com/index.html