### PR TITLE
gae-interop-testing: Remove duplicate repositories

### DIFF
--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -14,10 +14,6 @@
 
 buildscript {
     // Configuration for building
-    repositories {
-        maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/maven2/" }
-    }
     dependencies {
         classpath 'com.squareup.okhttp:okhttp:2.7.4'
     }
@@ -32,13 +28,6 @@ plugins {
 }
 
 description = 'gRPC: gae interop testing (jdk8)'
-
-repositories {
-    // repositories for Jar's you access in your code
-    mavenLocal()
-    maven { // The google mirror is less flaky than mavenCentral()
-        url "https://maven-central.storage-download.googleapis.com/maven2/" }
-}
 
 dependencies {
     providedCompile group: 'javax.servlet', name: 'servlet-api', version:'2.5'


### PR DESCRIPTION
These repositories are already included from the main build.gradle, so they don't do anything. Much less do they need to be defined twice in the same file.