### PR TITLE
Disable Gradle Module Metadata resolution

### DIFF
--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -7,7 +7,6 @@ description = 'gRPC: Android Integration Testing'
 
 repositories {
     google()
-    mavenCentral()
 }
 
 android {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,6 @@ android {
 
 repositories {
     google()
-    mavenCentral()
 }
 
 dependencies {

--- a/binder/build.gradle
+++ b/binder/build.gradle
@@ -32,7 +32,6 @@ android {
 
 repositories {
     google()
-    mavenCentral()
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,24 @@ subprojects {
 
     repositories {
         maven { // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/maven2/" }
-        mavenCentral()
-        mavenLocal()
+            url "https://maven-central.storage-download.googleapis.com/maven2/"
+            metadataSources {
+                mavenPom()
+                ignoreGradleMetadataRedirection()
+            }
+        }
+        mavenCentral() {
+            metadataSources {
+                mavenPom()
+                ignoreGradleMetadataRedirection()
+            }
+        }
+        mavenLocal() {
+            metadataSources {
+                mavenPom()
+                ignoreGradleMetadataRedirection()
+            }
+        }
     }
 
     tasks.withType(JavaCompile).configureEach {

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -8,7 +8,6 @@ description = "gRPC: Cronet Android"
 
 repositories {
     google()
-    mavenCentral()
 }
 
 android {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,7 +62,7 @@ jetty-servlet10 = "org.eclipse.jetty:jetty-servlet:10.0.20"
 jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
 junit = "junit:junit:4.13.2"
 # 2.17+ require Java 11+ (not mentioned in release notes)
-lincheck = "org.jetbrains.kotlinx:lincheck:2.16"
+lincheck = "org.jetbrains.kotlinx:lincheck-jvm:2.16"
 # Update notes / 2023-07-19 sergiitk:
 #    Couldn't update to 5.4.0, updated to the last in 4.x line. Version 5.x breaks some tests.
 #    Error log: https://github.com/grpc/grpc-java/pull/10359#issuecomment-1632834435


### PR DESCRIPTION
The module metadata in Guava causes the -jre version to be selected even when you choose the -android version. Gradle did not give any clues that this was happening, and while
`println(configurations.compileClasspath.resolve())` shows the different jar in use, most other diagonstics don't. dependencyInsight can show you this is happening, but only if you know which dependency has a problem and read Guava's module metadata first to understand the significance of the results.

You could argue this is a Guava-specific problem. I was able to get parts of our build working with attributes and resolutionStrategy configurations mentioned at
https://github.com/google/guava/releases/tag/v32.1.0 , so that only Guava would be changed. But it was fickle giving poor error messages or silently swapping back to the -jre version.

Given the weak debuggability, the added complexity, and the lack of value module metadata is providing us, disabling module metadata for our entire build seems prudent.

See https://github.com/google/guava/issues/7575

CC @kannanjgithub, @cpovirk 