### PR TITLE
xds: Avoid depending on io.grpc.xds.Internal* classes

### DIFF
--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
@@ -88,7 +88,7 @@ final class CdsLoadBalancer2 extends LoadBalancer {
     }
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     this.resolvedAddresses = resolvedAddresses;
-    xdsClientPool = resolvedAddresses.getAttributes().get(InternalXdsAttributes.XDS_CLIENT_POOL);
+    xdsClientPool = resolvedAddresses.getAttributes().get(XdsAttributes.XDS_CLIENT_POOL);
     xdsClient = xdsClientPool.getObject();
     CdsConfig config = (CdsConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
     logger.log(XdsLogLevel.INFO, "Config: {0}", config);

--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -52,6 +52,7 @@ import io.grpc.xds.client.Locality;
 import io.grpc.xds.client.XdsClient;
 import io.grpc.xds.client.XdsLogger;
 import io.grpc.xds.client.XdsLogger.XdsLogLevel;
+import io.grpc.xds.internal.security.SecurityProtocolNegotiators;
 import io.grpc.xds.internal.security.SslContextProviderSupplier;
 import io.grpc.xds.orca.OrcaPerRequestUtil;
 import io.grpc.xds.orca.OrcaPerRequestUtil.OrcaPerRequestReportListener;
@@ -114,12 +115,12 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     Attributes attributes = resolvedAddresses.getAttributes();
     if (xdsClientPool == null) {
-      xdsClientPool = attributes.get(InternalXdsAttributes.XDS_CLIENT_POOL);
+      xdsClientPool = attributes.get(XdsAttributes.XDS_CLIENT_POOL);
       assert xdsClientPool != null;
       xdsClient = xdsClientPool.getObject();
     }
     if (callCounterProvider == null) {
-      callCounterProvider = attributes.get(InternalXdsAttributes.CALL_COUNTER_PROVIDER);
+      callCounterProvider = attributes.get(XdsAttributes.CALL_COUNTER_PROVIDER);
     }
 
     ClusterImplConfig config =
@@ -236,9 +237,9 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
           .set(ATTR_CLUSTER_LOCALITY, localityAtomicReference);
       if (GrpcUtil.getFlag("GRPC_EXPERIMENTAL_XDS_AUTHORITY_REWRITE", false)) {
         String hostname = args.getAddresses().get(0).getAttributes()
-            .get(InternalXdsAttributes.ATTR_ADDRESS_NAME);
+            .get(XdsAttributes.ATTR_ADDRESS_NAME);
         if (hostname != null) {
-          attrsBuilder.set(InternalXdsAttributes.ATTR_ADDRESS_NAME, hostname);
+          attrsBuilder.set(XdsAttributes.ATTR_ADDRESS_NAME, hostname);
         }
       }
       args = args.toBuilder().setAddresses(addresses).setAttributes(attrsBuilder.build()).build();
@@ -287,10 +288,10 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
       List<EquivalentAddressGroup> newAddresses = new ArrayList<>();
       for (EquivalentAddressGroup eag : addresses) {
         Attributes.Builder attrBuilder = eag.getAttributes().toBuilder().set(
-            InternalXdsAttributes.ATTR_CLUSTER_NAME, cluster);
+            XdsAttributes.ATTR_CLUSTER_NAME, cluster);
         if (sslContextProviderSupplier != null) {
           attrBuilder.set(
-              InternalXdsAttributes.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER,
+              SecurityProtocolNegotiators.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER,
               sslContextProviderSupplier);
         }
         newAddresses.add(new EquivalentAddressGroup(eag.getAddresses(), attrBuilder.build()));
@@ -299,8 +300,8 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
     }
 
     private ClusterLocality createClusterLocalityFromAttributes(Attributes addressAttributes) {
-      Locality locality = addressAttributes.get(InternalXdsAttributes.ATTR_LOCALITY);
-      String localityName = addressAttributes.get(InternalXdsAttributes.ATTR_LOCALITY_NAME);
+      Locality locality = addressAttributes.get(XdsAttributes.ATTR_LOCALITY);
+      String localityName = addressAttributes.get(XdsAttributes.ATTR_LOCALITY_NAME);
 
       // Endpoint addresses resolved by ClusterResolverLoadBalancer should always contain
       // attributes with its locality, including endpoints in LOGICAL_DNS clusters.
@@ -431,7 +432,7 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
             result = PickResult.withSubchannel(result.getSubchannel(),
                 result.getStreamTracerFactory(),
                 result.getSubchannel().getAttributes().get(
-                    InternalXdsAttributes.ATTR_ADDRESS_NAME));
+                    XdsAttributes.ATTR_ADDRESS_NAME));
           }
         }
         return result;

--- a/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
@@ -119,7 +119,7 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
   public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
     logger.log(XdsLogLevel.DEBUG, "Received resolution result: {0}", resolvedAddresses);
     if (xdsClientPool == null) {
-      xdsClientPool = resolvedAddresses.getAttributes().get(InternalXdsAttributes.XDS_CLIENT_POOL);
+      xdsClientPool = resolvedAddresses.getAttributes().get(XdsAttributes.XDS_CLIENT_POOL);
       xdsClient = xdsClientPool.getObject();
     }
     ClusterResolverConfig config =
@@ -423,12 +423,12 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
                   String localityName = localityName(locality);
                   Attributes attr =
                       endpoint.eag().getAttributes().toBuilder()
-                          .set(InternalXdsAttributes.ATTR_LOCALITY, locality)
-                          .set(InternalXdsAttributes.ATTR_LOCALITY_NAME, localityName)
-                          .set(InternalXdsAttributes.ATTR_LOCALITY_WEIGHT,
+                          .set(XdsAttributes.ATTR_LOCALITY, locality)
+                          .set(XdsAttributes.ATTR_LOCALITY_NAME, localityName)
+                          .set(XdsAttributes.ATTR_LOCALITY_WEIGHT,
                               localityLbInfo.localityWeight())
-                          .set(InternalXdsAttributes.ATTR_SERVER_WEIGHT, weight)
-                          .set(InternalXdsAttributes.ATTR_ADDRESS_NAME, endpoint.hostname())
+                          .set(XdsAttributes.ATTR_SERVER_WEIGHT, weight)
+                          .set(XdsAttributes.ATTR_ADDRESS_NAME, endpoint.hostname())
                           .build();
                   EquivalentAddressGroup eag = new EquivalentAddressGroup(
                       endpoint.eag().getAddresses(), attr);
@@ -630,9 +630,9 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
                 // to handle such it.
                 String localityName = localityName(LOGICAL_DNS_CLUSTER_LOCALITY);
                 Attributes attr = eag.getAttributes().toBuilder()
-                    .set(InternalXdsAttributes.ATTR_LOCALITY, LOGICAL_DNS_CLUSTER_LOCALITY)
-                    .set(InternalXdsAttributes.ATTR_LOCALITY_NAME, localityName)
-                    .set(InternalXdsAttributes.ATTR_ADDRESS_NAME, dnsHostName)
+                    .set(XdsAttributes.ATTR_LOCALITY, LOGICAL_DNS_CLUSTER_LOCALITY)
+                    .set(XdsAttributes.ATTR_LOCALITY_NAME, localityName)
+                    .set(XdsAttributes.ATTR_ADDRESS_NAME, dnsHostName)
                     .build();
                 eag = new EquivalentAddressGroup(eag.getAddresses(), attr);
                 eag = AddressFilter.setPathFilter(eag, Arrays.asList(priorityName, localityName));

--- a/xds/src/main/java/io/grpc/xds/FilterChainMatchingProtocolNegotiators.java
+++ b/xds/src/main/java/io/grpc/xds/FilterChainMatchingProtocolNegotiators.java
@@ -17,8 +17,8 @@
 package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.grpc.xds.InternalXdsAttributes.ATTR_DRAIN_GRACE_NANOS;
-import static io.grpc.xds.InternalXdsAttributes.ATTR_FILTER_CHAIN_SELECTOR_MANAGER;
+import static io.grpc.xds.XdsAttributes.ATTR_DRAIN_GRACE_NANOS;
+import static io.grpc.xds.XdsAttributes.ATTR_FILTER_CHAIN_SELECTOR_MANAGER;
 import static io.grpc.xds.XdsServerWrapper.ATTR_SERVER_ROUTING_CONFIG;
 import static io.grpc.xds.internal.security.SecurityProtocolNegotiators.ATTR_SERVER_SSL_CONTEXT_PROVIDER_SUPPLIER;
 

--- a/xds/src/main/java/io/grpc/xds/GcpAuthenticationFilter.java
+++ b/xds/src/main/java/io/grpc/xds/GcpAuthenticationFilter.java
@@ -106,7 +106,7 @@ final class GcpAuthenticationFilter implements Filter, ClientInterceptorBuilder 
       public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
           MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
 
-        /*String clusterName = callOptions.getOption(InternalXdsAttributes.ATTR_CLUSTER_NAME);
+        /*String clusterName = callOptions.getOption(XdsAttributes.ATTR_CLUSTER_NAME);
         if (clusterName == null) {
           return next.newCall(method, callOptions);
         }*/

--- a/xds/src/main/java/io/grpc/xds/InternalXdsAttributes.java
+++ b/xds/src/main/java/io/grpc/xds/InternalXdsAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The gRPC Authors
+ * Copyright 2024 The gRPC Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,96 +18,19 @@ package io.grpc.xds;
 
 import io.grpc.Attributes;
 import io.grpc.EquivalentAddressGroup;
-import io.grpc.Grpc;
 import io.grpc.Internal;
-import io.grpc.NameResolver;
-import io.grpc.internal.ObjectPool;
-import io.grpc.xds.XdsNameResolverProvider.CallCounterProvider;
-import io.grpc.xds.client.Locality;
-import io.grpc.xds.client.XdsClient;
-import io.grpc.xds.internal.security.SslContextProviderSupplier;
 
 /**
  * Internal attributes used for xDS implementation. Do not use.
  */
 @Internal
 public final class InternalXdsAttributes {
-
-  // TODO(sanjaypujare): move to xds internal package.
-  /** Attribute key for SslContextProviderSupplier (used from client) for a subchannel. */
-  @Grpc.TransportAttr
-  public static final Attributes.Key<SslContextProviderSupplier>
-      ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER =
-          Attributes.Key.create("io.grpc.xds.internal.security.SslContextProviderSupplier");
-
-  /**
-   * Attribute key for passing around the XdsClient object pool across NameResolver/LoadBalancers.
-   */
-  @NameResolver.ResolutionResultAttr
-  static final Attributes.Key<ObjectPool<XdsClient>> XDS_CLIENT_POOL =
-      Attributes.Key.create("io.grpc.xds.InternalXdsAttributes.xdsClientPool");
-
-  /**
-   * Attribute key for obtaining the global provider that provides atomics for aggregating
-   * outstanding RPCs sent to each cluster.
-   */
-  @NameResolver.ResolutionResultAttr
-  static final Attributes.Key<CallCounterProvider> CALL_COUNTER_PROVIDER =
-      Attributes.Key.create("io.grpc.xds.InternalXdsAttributes.callCounterProvider");
-
-  /**
-   * Map from localities to their weights.
-   */
-  @NameResolver.ResolutionResultAttr
-  static final Attributes.Key<Integer> ATTR_LOCALITY_WEIGHT =
-      Attributes.Key.create("io.grpc.xds.InternalXdsAttributes.localityWeight");
-
   /**
    * Name of the cluster that provides this EquivalentAddressGroup.
    */
-  @Internal
   @EquivalentAddressGroup.Attr
   public static final Attributes.Key<String> ATTR_CLUSTER_NAME =
-      Attributes.Key.create("io.grpc.xds.InternalXdsAttributes.clusterName");
-
-  /**
-   * The locality that this EquivalentAddressGroup is in.
-   */
-  @EquivalentAddressGroup.Attr
-  static final Attributes.Key<Locality> ATTR_LOCALITY =
-      Attributes.Key.create("io.grpc.xds.InternalXdsAttributes.locality");
-
-  /**
-   * The name of the locality that this EquivalentAddressGroup is in.
-   */
-  @EquivalentAddressGroup.Attr
-  static final Attributes.Key<String> ATTR_LOCALITY_NAME =
-      Attributes.Key.create("io.grpc.xds.InternalXdsAttributes.localityName");
-
-  /**
-   * Endpoint weight for load balancing purposes.
-   */
-  @EquivalentAddressGroup.Attr
-  static final Attributes.Key<Long> ATTR_SERVER_WEIGHT =
-      Attributes.Key.create("io.grpc.xds.InternalXdsAttributes.serverWeight");
-
-  /** Name associated with individual address, if available (e.g., DNS name). */
-  @EquivalentAddressGroup.Attr
-  static final Attributes.Key<String> ATTR_ADDRESS_NAME =
-      Attributes.Key.create("io.grpc.xds.InternalXdsAttributes.addressName");
-
-  /**
-   * Filter chain match for network filters.
-   */
-  @Grpc.TransportAttr
-  static final Attributes.Key<FilterChainSelectorManager>
-          ATTR_FILTER_CHAIN_SELECTOR_MANAGER = Attributes.Key.create(
-          "io.grpc.xds.InternalXdsAttributes.filterChainSelectorManager");
-
-  /** Grace time to use when draining. Null for an infinite grace time. */
-  @Grpc.TransportAttr
-  static final Attributes.Key<Long> ATTR_DRAIN_GRACE_NANOS =
-      Attributes.Key.create("io.grpc.xds.InternalXdsAttributes.drainGraceTime");
+      XdsAttributes.ATTR_CLUSTER_NAME;
 
   private InternalXdsAttributes() {}
 }

--- a/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/RingHashLoadBalancer.java
@@ -102,7 +102,7 @@ final class RingHashLoadBalancer extends MultiChildLoadBalancer {
       Map<EquivalentAddressGroup, Long> serverWeights = new HashMap<>();
       long totalWeight = 0L;
       for (EquivalentAddressGroup eag : addrList) {
-        Long weight = eag.getAttributes().get(InternalXdsAttributes.ATTR_SERVER_WEIGHT);
+        Long weight = eag.getAttributes().get(XdsAttributes.ATTR_SERVER_WEIGHT);
         // Support two ways of server weighing: either multiple instances of the same address
         // or each address contains a per-address weight attribute. If a weight is not provided,
         // each occurrence of the address will be counted a weight value of one.
@@ -241,7 +241,7 @@ final class RingHashLoadBalancer extends MultiChildLoadBalancer {
 
     long totalWeight = 0;
     for (EquivalentAddressGroup eag : addrList) {
-      Long weight = eag.getAttributes().get(InternalXdsAttributes.ATTR_SERVER_WEIGHT);
+      Long weight = eag.getAttributes().get(XdsAttributes.ATTR_SERVER_WEIGHT);
 
       if (weight == null) {
         weight = 1L;

--- a/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancer.java
@@ -74,8 +74,8 @@ final class WrrLocalityLoadBalancer extends LoadBalancer {
     Map<String, Integer> localityWeights = new HashMap<>();
     for (EquivalentAddressGroup eag : resolvedAddresses.getAddresses()) {
       Attributes eagAttrs = eag.getAttributes();
-      String locality = eagAttrs.get(InternalXdsAttributes.ATTR_LOCALITY_NAME);
-      Integer localityWeight = eagAttrs.get(InternalXdsAttributes.ATTR_LOCALITY_WEIGHT);
+      String locality = eagAttrs.get(XdsAttributes.ATTR_LOCALITY_NAME);
+      Integer localityWeight = eagAttrs.get(XdsAttributes.ATTR_LOCALITY_WEIGHT);
 
       if (locality == null) {
         Status unavailableStatus = Status.UNAVAILABLE.withDescription(

--- a/xds/src/main/java/io/grpc/xds/XdsAttributes.java
+++ b/xds/src/main/java/io/grpc/xds/XdsAttributes.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import io.grpc.Attributes;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.Grpc;
+import io.grpc.NameResolver;
+import io.grpc.internal.ObjectPool;
+import io.grpc.xds.XdsNameResolverProvider.CallCounterProvider;
+import io.grpc.xds.client.Locality;
+import io.grpc.xds.client.XdsClient;
+
+/**
+ * Attributes used for xDS implementation.
+ */
+final class XdsAttributes {
+  /**
+   * Attribute key for passing around the XdsClient object pool across NameResolver/LoadBalancers.
+   */
+  @NameResolver.ResolutionResultAttr
+  static final Attributes.Key<ObjectPool<XdsClient>> XDS_CLIENT_POOL =
+      Attributes.Key.create("io.grpc.xds.XdsAttributes.xdsClientPool");
+
+  /**
+   * Attribute key for obtaining the global provider that provides atomics for aggregating
+   * outstanding RPCs sent to each cluster.
+   */
+  @NameResolver.ResolutionResultAttr
+  static final Attributes.Key<CallCounterProvider> CALL_COUNTER_PROVIDER =
+      Attributes.Key.create("io.grpc.xds.XdsAttributes.callCounterProvider");
+
+  /**
+   * Map from localities to their weights.
+   */
+  @NameResolver.ResolutionResultAttr
+  static final Attributes.Key<Integer> ATTR_LOCALITY_WEIGHT =
+      Attributes.Key.create("io.grpc.xds.XdsAttributes.localityWeight");
+
+  /**
+   * Name of the cluster that provides this EquivalentAddressGroup.
+   */
+  @EquivalentAddressGroup.Attr
+  public static final Attributes.Key<String> ATTR_CLUSTER_NAME =
+      Attributes.Key.create("io.grpc.xds.XdsAttributes.clusterName");
+
+  /**
+   * The locality that this EquivalentAddressGroup is in.
+   */
+  @EquivalentAddressGroup.Attr
+  static final Attributes.Key<Locality> ATTR_LOCALITY =
+      Attributes.Key.create("io.grpc.xds.XdsAttributes.locality");
+
+  /**
+   * The name of the locality that this EquivalentAddressGroup is in.
+   */
+  @EquivalentAddressGroup.Attr
+  static final Attributes.Key<String> ATTR_LOCALITY_NAME =
+      Attributes.Key.create("io.grpc.xds.XdsAttributes.localityName");
+
+  /**
+   * Endpoint weight for load balancing purposes.
+   */
+  @EquivalentAddressGroup.Attr
+  static final Attributes.Key<Long> ATTR_SERVER_WEIGHT =
+      Attributes.Key.create("io.grpc.xds.XdsAttributes.serverWeight");
+
+  /** Name associated with individual address, if available (e.g., DNS name). */
+  @EquivalentAddressGroup.Attr
+  static final Attributes.Key<String> ATTR_ADDRESS_NAME =
+      Attributes.Key.create("io.grpc.xds.XdsAttributes.addressName");
+
+  /**
+   * Filter chain match for network filters.
+   */
+  @Grpc.TransportAttr
+  static final Attributes.Key<FilterChainSelectorManager>
+          ATTR_FILTER_CHAIN_SELECTOR_MANAGER = Attributes.Key.create(
+          "io.grpc.xds.XdsAttributes.filterChainSelectorManager");
+
+  /** Grace time to use when draining. Null for an infinite grace time. */
+  @Grpc.TransportAttr
+  static final Attributes.Key<Long> ATTR_DRAIN_GRACE_NANOS =
+      Attributes.Key.create("io.grpc.xds.XdsAttributes.drainGraceTime");
+
+  private XdsAttributes() {}
+}

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -307,8 +307,8 @@ final class XdsNameResolver extends NameResolver {
     ConfigOrError parsedServiceConfig = serviceConfigParser.parseServiceConfig(rawServiceConfig);
     Attributes attrs =
         Attributes.newBuilder()
-            .set(InternalXdsAttributes.XDS_CLIENT_POOL, xdsClientPool)
-            .set(InternalXdsAttributes.CALL_COUNTER_PROVIDER, callCounterProvider)
+            .set(XdsAttributes.XDS_CLIENT_POOL, xdsClientPool)
+            .set(XdsAttributes.CALL_COUNTER_PROVIDER, callCounterProvider)
             .set(InternalConfigSelector.KEY, configSelector)
             .build();
     ResolutionResult result =

--- a/xds/src/main/java/io/grpc/xds/XdsServerBuilder.java
+++ b/xds/src/main/java/io/grpc/xds/XdsServerBuilder.java
@@ -19,8 +19,8 @@ package io.grpc.xds;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
-import static io.grpc.xds.InternalXdsAttributes.ATTR_DRAIN_GRACE_NANOS;
-import static io.grpc.xds.InternalXdsAttributes.ATTR_FILTER_CHAIN_SELECTOR_MANAGER;
+import static io.grpc.xds.XdsAttributes.ATTR_DRAIN_GRACE_NANOS;
+import static io.grpc.xds.XdsAttributes.ATTR_FILTER_CHAIN_SELECTOR_MANAGER;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.errorprone.annotations.DoNotCall;

--- a/xds/src/main/java/io/grpc/xds/internal/security/SecurityProtocolNegotiators.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/SecurityProtocolNegotiators.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.Attributes;
+import io.grpc.Grpc;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.ObjectPool;
 import io.grpc.netty.GrpcHttp2ConnectionHandler;
@@ -28,7 +29,6 @@ import io.grpc.netty.InternalProtocolNegotiator;
 import io.grpc.netty.InternalProtocolNegotiator.ProtocolNegotiator;
 import io.grpc.netty.InternalProtocolNegotiators;
 import io.grpc.netty.ProtocolNegotiationEvent;
-import io.grpc.xds.InternalXdsAttributes;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
@@ -62,6 +62,12 @@ public final class SecurityProtocolNegotiators {
   public static final Attributes.Key<SslContextProviderSupplier>
           ATTR_SERVER_SSL_CONTEXT_PROVIDER_SUPPLIER =
           Attributes.Key.create("io.grpc.xds.internal.security.server.sslContextProviderSupplier");
+
+  /** Attribute key for SslContextProviderSupplier (used from client) for a subchannel. */
+  @Grpc.TransportAttr
+  public static final Attributes.Key<SslContextProviderSupplier>
+      ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER =
+          Attributes.Key.create("io.grpc.xds.internal.security.SslContextProviderSupplier");
 
   /**
    * Returns a {@link InternalProtocolNegotiator.ClientFactory}.
@@ -130,8 +136,7 @@ public final class SecurityProtocolNegotiators {
     public ChannelHandler newHandler(GrpcHttp2ConnectionHandler grpcHandler) {
       // check if SslContextProviderSupplier was passed via attributes
       SslContextProviderSupplier localSslContextProviderSupplier =
-          grpcHandler.getEagAttributes().get(
-              InternalXdsAttributes.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER);
+          grpcHandler.getEagAttributes().get(ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER);
       if (localSslContextProviderSupplier == null) {
         checkNotNull(
             fallbackProtocolNegotiator, "No TLS config and no fallbackProtocolNegotiator!");

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
@@ -160,7 +160,7 @@ public class CdsLoadBalancer2Test {
             .setAttributes(
                 // Other attributes not used by cluster_resolver LB are omitted.
                 Attributes.newBuilder()
-                    .set(InternalXdsAttributes.XDS_CLIENT_POOL, xdsClientPool)
+                    .set(XdsAttributes.XDS_CLIENT_POOL, xdsClientPool)
                     .build())
             .setLoadBalancingPolicyConfig(new CdsConfig(CLUSTER))
             .build());

--- a/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
@@ -272,13 +272,13 @@ public class ClusterResolverLoadBalancerTest {
     // Endpoints in locality1 have no endpoint-level weight specified, so all endpoints within
     // locality1 are equally weighted.
     assertThat(addr1.getAddresses()).isEqualTo(endpoint1.getAddresses());
-    assertThat(addr1.getAttributes().get(InternalXdsAttributes.ATTR_SERVER_WEIGHT))
+    assertThat(addr1.getAttributes().get(XdsAttributes.ATTR_SERVER_WEIGHT))
         .isEqualTo(10);
     assertThat(addr2.getAddresses()).isEqualTo(endpoint2.getAddresses());
-    assertThat(addr2.getAttributes().get(InternalXdsAttributes.ATTR_SERVER_WEIGHT))
+    assertThat(addr2.getAttributes().get(XdsAttributes.ATTR_SERVER_WEIGHT))
         .isEqualTo(10);
     assertThat(addr3.getAddresses()).isEqualTo(endpoint3.getAddresses());
-    assertThat(addr3.getAttributes().get(InternalXdsAttributes.ATTR_SERVER_WEIGHT))
+    assertThat(addr3.getAttributes().get(XdsAttributes.ATTR_SERVER_WEIGHT))
         .isEqualTo(50 * 60);
     assertThat(childBalancer.name).isEqualTo(PRIORITY_POLICY_NAME);
     PriorityLbConfig priorityLbConfig = (PriorityLbConfig) childBalancer.config;
@@ -342,7 +342,7 @@ public class ClusterResolverLoadBalancerTest {
 
     assertThat(
         childBalancer.addresses.get(0).getAttributes()
-            .get(InternalXdsAttributes.ATTR_LOCALITY_WEIGHT)).isEqualTo(100);
+            .get(XdsAttributes.ATTR_LOCALITY_WEIGHT)).isEqualTo(100);
   }
 
   @Test
@@ -368,7 +368,7 @@ public class ClusterResolverLoadBalancerTest {
 
     assertThat(
         childBalancer.addresses.get(0).getAttributes()
-            .get(InternalXdsAttributes.ATTR_ADDRESS_NAME)).isEqualTo("hostname1");
+            .get(XdsAttributes.ATTR_ADDRESS_NAME)).isEqualTo("hostname1");
   }
 
 
@@ -468,16 +468,16 @@ public class ClusterResolverLoadBalancerTest {
     assertThat(childProvider3.getPolicyName()).isEqualTo("round_robin");
 
     for (EquivalentAddressGroup eag : childBalancer.addresses) {
-      if (eag.getAttributes().get(InternalXdsAttributes.ATTR_LOCALITY) == locality1) {
-        assertThat(eag.getAttributes().get(InternalXdsAttributes.ATTR_LOCALITY_WEIGHT))
+      if (eag.getAttributes().get(XdsAttributes.ATTR_LOCALITY) == locality1) {
+        assertThat(eag.getAttributes().get(XdsAttributes.ATTR_LOCALITY_WEIGHT))
             .isEqualTo(70);
       }
-      if (eag.getAttributes().get(InternalXdsAttributes.ATTR_LOCALITY) == locality2) {
-        assertThat(eag.getAttributes().get(InternalXdsAttributes.ATTR_LOCALITY_WEIGHT))
+      if (eag.getAttributes().get(XdsAttributes.ATTR_LOCALITY) == locality2) {
+        assertThat(eag.getAttributes().get(XdsAttributes.ATTR_LOCALITY_WEIGHT))
             .isEqualTo(10);
       }
-      if (eag.getAttributes().get(InternalXdsAttributes.ATTR_LOCALITY) == locality3) {
-        assertThat(eag.getAttributes().get(InternalXdsAttributes.ATTR_LOCALITY_WEIGHT))
+      if (eag.getAttributes().get(XdsAttributes.ATTR_LOCALITY) == locality3) {
+        assertThat(eag.getAttributes().get(XdsAttributes.ATTR_LOCALITY_WEIGHT))
             .isEqualTo(20);
       }
     }
@@ -659,7 +659,7 @@ public class ClusterResolverLoadBalancerTest {
 
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(childBalancers);
     for (EquivalentAddressGroup eag : childBalancer.addresses) {
-      assertThat(eag.getAttributes().get(InternalXdsAttributes.ATTR_LOCALITY)).isEqualTo(locality2);
+      assertThat(eag.getAttributes().get(XdsAttributes.ATTR_LOCALITY)).isEqualTo(locality2);
     }
   }
 
@@ -740,9 +740,9 @@ public class ClusterResolverLoadBalancerTest {
         Collections.<DropOverload>emptyList(), "pick_first");
     assertAddressesEqual(Arrays.asList(endpoint1, endpoint2), childBalancer.addresses);
     assertThat(childBalancer.addresses.get(0).getAttributes()
-        .get(InternalXdsAttributes.ATTR_ADDRESS_NAME)).isEqualTo(DNS_HOST_NAME);
+        .get(XdsAttributes.ATTR_ADDRESS_NAME)).isEqualTo(DNS_HOST_NAME);
     assertThat(childBalancer.addresses.get(1).getAttributes()
-        .get(InternalXdsAttributes.ATTR_ADDRESS_NAME)).isEqualTo(DNS_HOST_NAME);
+        .get(XdsAttributes.ATTR_ADDRESS_NAME)).isEqualTo(DNS_HOST_NAME);
 
   }
 
@@ -1068,7 +1068,7 @@ public class ClusterResolverLoadBalancerTest {
             .setAttributes(
                 // Other attributes not used by cluster_resolver LB are omitted.
                 Attributes.newBuilder()
-                    .set(InternalXdsAttributes.XDS_CLIENT_POOL, xdsClientPool)
+                    .set(XdsAttributes.XDS_CLIENT_POOL, xdsClientPool)
                     .build())
             .setLoadBalancingPolicyConfig(config)
             .build());

--- a/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/RingHashLoadBalancerTest.java
@@ -1084,7 +1084,7 @@ public class RingHashLoadBalancerTest {
     for (int i = 0; i < weights.length; i++) {
       SocketAddress addr = new FakeSocketAddress("server" + i);
       Attributes attr = Attributes.newBuilder().set(
-          InternalXdsAttributes.ATTR_SERVER_WEIGHT, weights[i]).build();
+          XdsAttributes.ATTR_SERVER_WEIGHT, weights[i]).build();
       EquivalentAddressGroup eag = new EquivalentAddressGroup(addr, attr);
       addrs.add(eag);
     }

--- a/xds/src/test/java/io/grpc/xds/WrrLocalityLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WrrLocalityLoadBalancerTest.java
@@ -185,7 +185,7 @@ public class WrrLocalityLoadBalancerTest {
     verify(mockWeightedTargetLb).handleResolvedAddresses(resolvedAddressesCaptor.capture());
 
     //assertThat(resolvedAddressesCaptor.getValue().getAttributes()
-    //    .get(InternalXdsAttributes.ATTR_LOCALITY_WEIGHTS)).isNull();
+    //    .get(XdsAttributes.ATTR_LOCALITY_WEIGHTS)).isNull();
   }
 
   @Test
@@ -254,9 +254,9 @@ public class WrrLocalityLoadBalancerTest {
     }
 
     Attributes.Builder attrBuilder = Attributes.newBuilder()
-        .set(InternalXdsAttributes.ATTR_LOCALITY_NAME, locality);
+        .set(XdsAttributes.ATTR_LOCALITY_NAME, locality);
     if (localityWeight != null) {
-      attrBuilder.set(InternalXdsAttributes.ATTR_LOCALITY_WEIGHT, localityWeight);
+      attrBuilder.set(XdsAttributes.ATTR_LOCALITY_WEIGHT, localityWeight);
     }
 
     EquivalentAddressGroup eag = new EquivalentAddressGroup(new FakeSocketAddress(name),

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -755,8 +755,8 @@ public class XdsNameResolverTest {
     assertServiceConfigForLoadBalancingConfig(
         Collections.singletonList(cluster2),
         (Map<String, ?>) result.getServiceConfig().getConfig());
-    assertThat(result.getAttributes().get(InternalXdsAttributes.XDS_CLIENT_POOL)).isNotNull();
-    assertThat(result.getAttributes().get(InternalXdsAttributes.CALL_COUNTER_PROVIDER)).isNotNull();
+    assertThat(result.getAttributes().get(XdsAttributes.XDS_CLIENT_POOL)).isNotNull();
+    assertThat(result.getAttributes().get(XdsAttributes.CALL_COUNTER_PROVIDER)).isNotNull();
     InternalConfigSelector configSelector = result.getAttributes().get(InternalConfigSelector.KEY);
     // Simulates making a call1 RPC.
     Result selectResult = configSelector.selectConfig(
@@ -1156,7 +1156,7 @@ public class XdsNameResolverTest {
     assertThat(result.getAddressesOrError().getValue()).isEmpty();
     assertServiceConfigForLoadBalancingConfig(
         Arrays.asList(cluster1, cluster2), (Map<String, ?>) result.getServiceConfig().getConfig());
-    assertThat(result.getAttributes().get(InternalXdsAttributes.XDS_CLIENT_POOL)).isNotNull();
+    assertThat(result.getAttributes().get(XdsAttributes.XDS_CLIENT_POOL)).isNotNull();
     InternalConfigSelector configSelector = result.getAttributes().get(InternalConfigSelector.KEY);
     assertCallSelectClusterResult(call1, configSelector, cluster2, 20.0);
     assertCallSelectClusterResult(call1, configSelector, cluster1, 20.0);
@@ -1207,7 +1207,7 @@ public class XdsNameResolverTest {
                 ImmutableList.of(ImmutableMap.of("rls_experimental", expectedRlsLbConfig)))));
     assertThat(clusterManagerLbConfig).isEqualTo(expectedClusterManagerLbConfig);
 
-    assertThat(result.getAttributes().get(InternalXdsAttributes.XDS_CLIENT_POOL)).isNotNull();
+    assertThat(result.getAttributes().get(XdsAttributes.XDS_CLIENT_POOL)).isNotNull();
     InternalConfigSelector configSelector = result.getAttributes().get(InternalConfigSelector.KEY);
     assertCallSelectRlsPluginResult(
         call1, configSelector, "rls-plugin-foo", 20.0);
@@ -1345,8 +1345,8 @@ public class XdsNameResolverTest {
     assertThat(result.getAddressesOrError().getValue()).isEmpty();
     assertServiceConfigForLoadBalancingConfig(
         Arrays.asList(cluster1, cluster2), (Map<String, ?>) result.getServiceConfig().getConfig());
-    assertThat(result.getAttributes().get(InternalXdsAttributes.XDS_CLIENT_POOL)).isNotNull();
-    assertThat(result.getAttributes().get(InternalXdsAttributes.CALL_COUNTER_PROVIDER)).isNotNull();
+    assertThat(result.getAttributes().get(XdsAttributes.XDS_CLIENT_POOL)).isNotNull();
+    assertThat(result.getAttributes().get(XdsAttributes.CALL_COUNTER_PROVIDER)).isNotNull();
     return result.getAttributes().get(InternalConfigSelector.KEY);
   }
 

--- a/xds/src/test/java/io/grpc/xds/XdsSecurityClientServerTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsSecurityClientServerTest.java
@@ -70,6 +70,7 @@ import io.grpc.xds.client.Bootstrapper;
 import io.grpc.xds.client.CommonBootstrapperTestUtils;
 import io.grpc.xds.internal.Matchers.HeaderMatcher;
 import io.grpc.xds.internal.security.CommonTlsContextTestsUtil;
+import io.grpc.xds.internal.security.SecurityProtocolNegotiators;
 import io.grpc.xds.internal.security.SslContextProviderSupplier;
 import io.grpc.xds.internal.security.TlsContextManagerImpl;
 import io.grpc.xds.internal.security.certprovider.FileWatcherCertificateProviderProvider;
@@ -653,7 +654,7 @@ public class XdsSecurityClientServerTest {
     Attributes attrs =
         (upstreamTlsContext != null)
             ? Attributes.newBuilder()
-                .set(InternalXdsAttributes.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER,
+                .set(SecurityProtocolNegotiators.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER,
                     new SslContextProviderSupplier(
                         upstreamTlsContext, tlsContextManagerForClient))
                 .build()

--- a/xds/src/test/java/io/grpc/xds/internal/security/SecurityProtocolNegotiatorsTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/security/SecurityProtocolNegotiatorsTest.java
@@ -47,7 +47,6 @@ import io.grpc.netty.InternalProtocolNegotiators;
 import io.grpc.netty.ProtocolNegotiationEvent;
 import io.grpc.xds.EnvoyServerProtoData.DownstreamTlsContext;
 import io.grpc.xds.EnvoyServerProtoData.UpstreamTlsContext;
-import io.grpc.xds.InternalXdsAttributes;
 import io.grpc.xds.TlsContextManager;
 import io.grpc.xds.client.Bootstrapper;
 import io.grpc.xds.client.CommonBootstrapperTestUtils;
@@ -134,7 +133,7 @@ public class SecurityProtocolNegotiatorsTest {
     when(mockHandler.getEagAttributes())
         .thenReturn(
             Attributes.newBuilder()
-                .set(InternalXdsAttributes.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER,
+                .set(SecurityProtocolNegotiators.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER,
                     new SslContextProviderSupplier(upstreamTlsContext, mockTlsContextManager))
                 .build());
     ChannelHandler newHandler = pn.newHandler(mockHandler);


### PR DESCRIPTION
Internal* classes should generally be accessors that are used outside of the package/project. Only one attribute was used outside of xds, so leave only that one attribute in InternalXdsAttributes. One attribute was used by the internal.security package, so move the definition to the same package to reduce the circular dependencies.

CC @danielzhaotongliu