### PR TITLE
xds: Preserve nonce when unsubscribing type (1.69.x backport)

### DIFF
--- a/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplTestBase.java
@@ -2899,10 +2899,9 @@ public abstract class GrpcXdsClientImplTestBase {
     verifySubscribedResourcesMetadataSizes(0, 0, 0, 0);
     call.verifyRequest(EDS, Arrays.asList(), VERSION_1, "0000", NODE);
 
-    // When re-subscribing, the version and nonce were properly forgotten, so the request is the
-    // same as the initial request
+    // When re-subscribing, the version was forgotten but not the nonce
     xdsClient.watchXdsResource(XdsEndpointResource.getInstance(), "A.1", edsResourceWatcher);
-    call.verifyRequest(EDS, "A.1", "", "", NODE, Mockito.timeout(2000).times(2));
+    call.verifyRequest(EDS, "A.1", "", "0000", NODE, Mockito.timeout(2000));
   }
 
   @Test


### PR DESCRIPTION
This fixes a regression introduced in 19c9b998.

b/374697875

Backport of #11796