### PR TITLE
experiment: using proto3 version of dev.cel

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,11 +27,13 @@ commons-math3 = "org.apache.commons:commons-math3:3.6.1"
 conscrypt = "org.conscrypt:conscrypt-openjdk-uber:2.5.2"
 cronet-api = "org.chromium.net:cronet-api:119.6045.31"
 cronet-embedded = "org.chromium.net:cronet-embedded:119.6045.31"
+#dev-cel-compiler = "dev.cel:compiler:0.9.0-proto3"
+dev-cel-runtime = "dev.cel:runtime:0.9.0-proto3"
 # error-prone 2.31.0+ blocked on https://github.com/grpc/grpc-java/issues/10152
 # It breaks Bazel (ArrayIndexOutOfBoundsException in turbine) and Dexing ("D8:
 # java.lang.NullPointerException"). We can trivially upgrade the Bazel CI to
 # 6.3.0+ (https://github.com/bazelbuild/bazel/issues/18743).
-errorprone-annotations = "com.google.errorprone:error_prone_annotations:2.30.0"
+errorprone-annotations = "com.google.errorprone:error_prone_annotations:2.36.0"
 # error-prone 2.32.0+ require Java 17+
 errorprone-core = "com.google.errorprone:error_prone_core:2.31.0"
 google-api-protos = "com.google.api.grpc:proto-google-common-protos:2.48.0"

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -53,6 +53,7 @@ dependencies {
             project(':grpc-auth'),
             project(path: ':grpc-alts', configuration: 'shadow'),
             libraries.guava,
+            libraries.dev.cel.runtime,
             libraries.gson,
             libraries.re2j,
             libraries.auto.value.annotations,


### PR DESCRIPTION
> [!CAUTION]
> Experiment, do not merge. 

> Maven version skew: com.google.errorprone:error_prone_annotations (2.30.0 != 2.36.0) Bad version dependency path: [:grpc-all, io.grpc:grpc-api:1.71.0-SNAPSHOT] Run './gradlew :grpc-all:dependencies --configuration runtimeClasspath' to diagnose