### PR TITLE
interop-testing: fix peer extraction issue in soak test iterations

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1874,14 +1874,15 @@ public abstract class AbstractInteropTest {
       }
       long earliestNextStartNs = System.nanoTime()
           + TimeUnit.MILLISECONDS.toNanos(minTimeMsBetweenRpcs);
-      AtomicReference<ClientCall<?, ?>> threadClientCallCapture = new AtomicReference<>();
+      // recordClientCallInterceptor takes an AtomicReference
+      AtomicReference<ClientCall<?, ?>> soakThreadClientCallCapture = new AtomicReference<>();
       currentChannel = maybeCreateChannel.apply(currentChannel);
       TestServiceGrpc.TestServiceBlockingStub currentStub = TestServiceGrpc
           .newBlockingStub(currentChannel)
-              .withInterceptors(recordClientCallInterceptor(threadClientCallCapture));
+              .withInterceptors(recordClientCallInterceptor(soakThreadClientCallCapture));
       SoakIterationResult result = performOneSoakIteration(currentStub,
           soakRequestSize, soakResponseSize);
-      SocketAddress peer = threadClientCallCapture
+      SocketAddress peer = soakThreadClientCallCapture
           .get().getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
       StringBuilder logStr = new StringBuilder(
           String.format(

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1874,7 +1874,7 @@ public abstract class AbstractInteropTest {
       }
       long earliestNextStartNs = System.nanoTime()
           + TimeUnit.MILLISECONDS.toNanos(minTimeMsBetweenRpcs);
-      // recordClientCallInterceptor takes an AtomicReference
+      // recordClientCallInterceptor takes an AtomicReference.
       AtomicReference<ClientCall<?, ?>> soakThreadClientCallCapture = new AtomicReference<>();
       currentChannel = maybeCreateChannel.apply(currentChannel);
       TestServiceGrpc.TestServiceBlockingStub currentStub = TestServiceGrpc

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -167,7 +167,7 @@ public abstract class AbstractInteropTest {
       new AtomicReference<>();
   private final AtomicReference<ClientCall<?, ?>> clientCallCapture =
       new AtomicReference<>();
-  private final ThreadLocal<ClientCall<?, ?>> threadClientCallCapture =
+  private static final ThreadLocal<ClientCall<?, ?>> threadClientCallCapture =
       new ThreadLocal<>();
   private final AtomicReference<Metadata> requestHeadersCapture =
       new AtomicReference<>();


### PR DESCRIPTION
This PR resolves an issue with peer address extraction in the soak test. 

In current `TestServiceClient` implementation, the same `clientCallCapture` atomic is shared across threads, leading to incorrect peer extraction. This fix ensures that each thread uses a local variable for capturing the client call.
