### PR TITLE
servlet: ignore IllegalStateException from AsyncContext.complete()

### DIFF
--- a/servlet/src/main/java/io/grpc/servlet/AsyncServletOutputStreamWriter.java
+++ b/servlet/src/main/java/io/grpc/servlet/AsyncServletOutputStreamWriter.java
@@ -124,7 +124,11 @@ final class AsyncServletOutputStreamWriter {
       transportState.runOnTransportThread(
           () -> {
             transportState.complete();
-            asyncContext.complete();
+            try {
+              asyncContext.complete();
+            } catch (IllegalStateException ignored) {
+              // Tomcat can throw "Calling [asyncComplete()] is not valid for a request with Async state [COMPLETING]"
+            }
             log.fine("call completed");
           });
     };
@@ -254,7 +258,7 @@ final class AsyncServletOutputStreamWriter {
   @VisibleForTesting // Lincheck test can not run with java.util.logging dependency.
   interface Log {
     default boolean isLoggable(Level level) {
-      return false; 
+      return false;
     }
 
     default void fine(String str, Object...params) {}

--- a/servlet/src/main/java/io/grpc/servlet/ServletServerStream.java
+++ b/servlet/src/main/java/io/grpc/servlet/ServletServerStream.java
@@ -300,7 +300,11 @@ final class ServletServerStream extends AbstractServerStream {
       close(Status.CANCELLED.withCause(status.asRuntimeException()), new Metadata());
       CountDownLatch countDownLatch = new CountDownLatch(1);
       transportState.runOnTransportThread(() -> {
-        asyncCtx.complete();
+        try {
+          asyncCtx.complete();
+        } catch (IllegalStateException ignored) {
+          // Tomcat can throw "Calling [asyncComplete()] is not valid for a request with Async state [COMPLETING]"
+        }
         countDownLatch.countDown();
       });
       try {


### PR DESCRIPTION
There are errors logged in case of DEADLINE_EXCEEDED which I would like to avoid.
```
2025-01-13 11:46:01.942 ERROR [grpc-timer-0]                 SerializingExecutor           Exception while executing runnable io.grpc.servlet.ServletServerStream$Sink$$Lambda$2200/0x0000000801a1cab0@3580f36e
java.lang.IllegalStateException: Calling [asyncComplete()] is not valid for a request with Async state [COMPLETING]
	at org.apache.coyote.AsyncStateMachine.asyncComplete(AsyncStateMachine.java:344)
	at org.apache.coyote.AbstractProcessor.action(AbstractProcessor.java:507)
	at org.apache.coyote.Request.action(Request.java:505)
	at org.apache.catalina.core.AsyncContextImpl.complete(AsyncContextImpl.java:92)
	at io.grpc.servlet.ServletServerStream$Sink.lambda$cancel$2(ServletServerStream.java:303)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
	at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:31)
	at io.grpc.internal.SerializingExecutor.schedule(SerializingExecutor.java:102)
	at io.grpc.internal.SerializingExecutor.execute(SerializingExecutor.java:95)
	at io.grpc.servlet.ServletServerStream$ServletTransportState.runOnTransportThread(ServletServerStream.java:146)
	at io.grpc.servlet.ServletServerStream$Sink.cancel(ServletServerStream.java:302)
	at io.grpc.internal.AbstractServerStream.cancel(AbstractServerStream.java:148)
	at io.grpc.internal.ServerImpl$ServerTransportListenerImpl$1HandleServerCall$1ServerStreamCancellationListener.cancelled(ServerImpl.java:632)
	at io.grpc.Context$ExecutableListener.run(Context.java:1065)
	at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:31)
	at io.grpc.Context$ExecutableListener.deliver(Context.java:1057)
	at io.grpc.Context$CancellableContext.notifyAndClearListeners(Context.java:860)
	at io.grpc.Context$CancellableContext.cancel(Context.java:833)
	at io.grpc.Context$CancellableContext$1CancelOnExpiration.run(Context.java:696)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```