### PR TITLE
xds: Remove xds authority label from metric registration (v1.69.x backport)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsClientMetricReporterImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClientMetricReporterImpl.java
@@ -90,7 +90,7 @@ final class XdsClientMetricReporterImpl implements XdsClientMetricReporter {
         Arrays.asList("grpc.target", "grpc.xds.server"), Collections.emptyList(), false);
     RESOURCES_GAUGE = metricInstrumentRegistry.registerLongGauge("grpc.xds_client.resources",
         "EXPERIMENTAL.  Number of xDS resources.", "{resource}",
-        Arrays.asList("grpc.target", "grpc.xds.authority", "grpc.xds.cache_state",
+        Arrays.asList("grpc.target", "grpc.xds.cache_state",
             "grpc.xds.resource_type"), Collections.emptyList(), false);
   }
 

--- a/xds/src/test/java/io/grpc/xds/XdsClientMetricReporterImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientMetricReporterImplTest.java
@@ -17,6 +17,7 @@
 package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -83,13 +84,13 @@ public class XdsClientMetricReporterImplTest {
   public final MockitoRule mocks = MockitoJUnit.rule();
 
   @Mock
-  private MetricRecorder mockMetricRecorder;
-  @Mock
   private XdsClient mockXdsClient;
-  @Mock
-  private BatchRecorder mockBatchRecorder;
   @Captor
   private ArgumentCaptor<BatchCallback> gaugeBatchCallbackCaptor;
+  private MetricRecorder mockMetricRecorder = mock(MetricRecorder.class,
+      delegatesTo(new MetricRecorderImpl()));
+  private BatchRecorder mockBatchRecorder = mock(BatchRecorder.class,
+      delegatesTo(new BatchRecorderImpl()));
 
   private XdsClientMetricReporterImpl reporter;
 
@@ -370,6 +371,12 @@ public class XdsClientMetricReporterImplTest {
         return instrument.getName().equals(name);
       }
     });
+  }
+
+  static class MetricRecorderImpl implements MetricRecorder {
+  }
+
+  static class BatchRecorderImpl implements BatchRecorder {
   }
 
   static class TestlogHandler extends Handler {


### PR DESCRIPTION
XdsClient metrics were added in #11661. It is missing `grpc.xds.authority` label for `grpc.xds_client.resources` gauge. 

While label value is absent, label got added while registering the gauge. This leads to `java.lang.IllegalArgumentException: Incorrect number of required labels provided.` on invoking callback.  Stack trace is added below:

```
00:25:09.808 [PeriodicMetricReader-1] WARN  i.o.s.m.i.state.CallbackRegistration - An exception occurred invoking callback for CallbackRegistration{instrumentDescriptors=[InstrumentDescriptor{name=grpc.xds_client.resources, description=EXPERIMENTAL.  Number of xDS resources., unit={resource}, type=OBSERVABLE_GAUGE, valueType=LONG, advice=Advice{explicitBucketBoundaries=null, attributes=null}}, InstrumentDescriptor{name=grpc.xds_client.connected, description=EXPERIMENTAL. Whether or not the xDS client currently has a working ADS stream to the xDS server. For a given server, this will be set to 1 when the stream is initially created. It will be set to 0 when we have a connectivity failure or when the ADS stream fails without seeing a response message, as per gRFC A57. Once set to 0, it will be reset to 1 when we receive the first response on an ADS stream., unit={bool}, type=OBSERVABLE_GAUGE, valueType=LONG, advice=Advice{explicitBucketBoundaries=null, attributes=null}}]}.
java.lang.IllegalArgumentException: Incorrect number of required labels provided. Expected: 4
    at com.google.common.base.Preconditions.checkArgument(Preconditions.java:191)
    at io.grpc.MetricRecorder$BatchRecorder.recordLongGauge(MetricRecorder.java:138)
    at io.grpc.internal.MetricRecorderImpl$BatchRecorderImpl.recordLongGauge(MetricRecorderImpl.java:199)
    at io.grpc.xds.XdsClientMetricReporterImpl$MetricReporterCallback.reportResourceCountGauge(XdsClientMetricReporterImpl.java:205)
    at io.grpc.xds.XdsClientMetricReporterImpl.lambda$computeAndReportResourceCounts$1(XdsClientMetricReporterImpl.java:172)
    at java.base/java.util.HashMap.forEach(HashMap.java:1337)
    at io.grpc.xds.XdsClientMetricReporterImpl.computeAndReportResourceCounts(XdsClientMetricReporterImpl.java:171)
    at io.grpc.xds.XdsClientMetricReporterImpl.reportCallbackMetrics(XdsClientMetricReporterImpl.java:146)
    at io.grpc.xds.XdsClientMetricReporterImpl$1.accept(XdsClientMetricReporterImpl.java:123)
    at io.grpc.internal.MetricRecorderImpl.lambda$registerBatchCallback$0(MetricRecorderImpl.java:177)
    at io.opentelemetry.sdk.metrics.internal.state.CallbackRegistration.invokeCallback(CallbackRegistration.java:84)
    at io.opentelemetry.sdk.metrics.SdkMeter.collectAll(SdkMeter.java:112)
    at io.opentelemetry.sdk.metrics.SdkMeterProvider$LeasedMetricProducer.produce(SdkMeterProvider.java:208)
    at io.opentelemetry.sdk.metrics.SdkMeterProvider$SdkCollectionRegistration.collectAllMetrics(SdkMeterProvider.java:232)
    at io.opentelemetry.sdk.metrics.export.PeriodicMetricReader$Scheduled.doRun(PeriodicMetricReader.java:161)
    at io.opentelemetry.sdk.metrics.export.PeriodicMetricReader$Scheduled.run(PeriodicMetricReader.java:153)
    at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
    at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
    at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.lang.Thread.run(Thread.java:829)
```

As a fix, we are removing the label from gauge registration until `gpc.xds.authority` label value is available.

Backport of #11760