### PR TITLE
xds: fixed unsupported unsigned 32 bits issue for circuit breaker (1.68.x backport)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsClusterResource.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClusterResource.java
@@ -208,7 +208,7 @@ class XdsClusterResource extends XdsResourceType<CdsUpdate> {
           continue;
         }
         if (threshold.hasMaxRequests()) {
-          maxConcurrentRequests = (long) threshold.getMaxRequests().getValue();
+          maxConcurrentRequests = Integer.toUnsignedLong(threshold.getMaxRequests().getValue());
         }
       }
     }

--- a/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplTestBase.java
@@ -3765,6 +3765,25 @@ public abstract class GrpcXdsClientImplTestBase {
   }
 
   @Test
+  public void circuitBreakingConversionOf32bitIntTo64bitLongForMaxRequestNegativeValue() {
+    DiscoveryRpcCall call = startResourceWatcher(XdsClusterResource.getInstance(), CDS_RESOURCE,
+        cdsResourceWatcher);
+    Any clusterCircuitBreakers = Any.pack(
+        mf.buildEdsCluster(CDS_RESOURCE, null, "round_robin", null, null, false, null,
+            "envoy.transport_sockets.tls", mf.buildCircuitBreakers(50, -1), null));
+    call.sendResponse(CDS, clusterCircuitBreakers, VERSION_1, "0000");
+
+    // Client sent an ACK CDS request.
+    call.verifyRequest(CDS, CDS_RESOURCE, VERSION_1, "0000", NODE);
+    verify(cdsResourceWatcher).onChanged(cdsUpdateCaptor.capture());
+    CdsUpdate cdsUpdate = cdsUpdateCaptor.getValue();
+
+    assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
+    assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.EDS);
+    assertThat(cdsUpdate.maxConcurrentRequests()).isEqualTo(4294967295L);
+  }
+
+  @Test
   public void sendToNonexistentServer() throws Exception {
     // Setup xdsClient to fail on stream creation
     // The Windows CI takes ~11 seconds to resolve "doesnotexist.invalid.". That seems broken, since


### PR DESCRIPTION
Added change for circuit breaking by converting signed 32-bit Int to Unsigned 64-bit Long For MaxRequest negative value ( -1)

Fixes https://github.com/grpc/grpc-java/issues/11695

Backport of #11735