### PR TITLE
xds: Rename grpc.xds.cluster to grpc.lb.backend_service (v1.70.x backport)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -385,7 +385,7 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
       public PickResult pickSubchannel(PickSubchannelArgs args) {
         args.getCallOptions().getOption(ClusterImplLoadBalancerProvider.FILTER_METADATA_CONSUMER)
             .accept(filterMetadata);
-        args.getPickDetailsConsumer().addOptionalLabel("grpc.xds.cluster", cluster);
+        args.getPickDetailsConsumer().addOptionalLabel("grpc.lb.backend_service", cluster);
         for (DropOverload dropOverload : dropPolicies) {
           int rand = random.nextInt(1_000_000);
           if (rand < dropOverload.dropsPerMillion()) {

--- a/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
@@ -298,7 +298,7 @@ public class ClusterImplLoadBalancerTest {
     // The value will be determined by the parent policy, so can be different than the value used in
     // makeAddress() for the test.
     verify(detailsConsumer).addOptionalLabel("grpc.lb.locality", locality.toString());
-    verify(detailsConsumer).addOptionalLabel("grpc.xds.cluster", CLUSTER);
+    verify(detailsConsumer).addOptionalLabel("grpc.lb.backend_service", CLUSTER);
   }
 
   @Test
@@ -322,7 +322,7 @@ public class ClusterImplLoadBalancerTest {
       TestMethodDescriptors.voidMethod(), new Metadata(), CallOptions.DEFAULT, detailsConsumer);
     PickResult result = currentPicker.pickSubchannel(pickSubchannelArgs);
     assertThat(result.getStatus().isOk()).isTrue();
-    verify(detailsConsumer).addOptionalLabel("grpc.xds.cluster", CLUSTER);
+    verify(detailsConsumer).addOptionalLabel("grpc.lb.backend_service", CLUSTER);
   }
 
   @Test


### PR DESCRIPTION
The name is being changed to allow the value to be used in more metrics where xds-specifics are awkward.

Backport of #11841