### PR TITLE
netty: Removed 4096 min buffer size

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyWritableBufferAllocator.java
+++ b/netty/src/main/java/io/grpc/netty/NettyWritableBufferAllocator.java
@@ -33,9 +33,6 @@ import io.netty.buffer.ByteBufAllocator;
  */
 class NettyWritableBufferAllocator implements WritableBufferAllocator {
 
-  // Use 4k as our minimum buffer size.
-  private static final int MIN_BUFFER = 4 * 1024;
-
   // Set the maximum buffer size to 1MB.
   private static final int MAX_BUFFER = 1024 * 1024;
 
@@ -47,7 +44,7 @@ class NettyWritableBufferAllocator implements WritableBufferAllocator {
 
   @Override
   public WritableBuffer allocate(int capacityHint) {
-    capacityHint = Math.min(MAX_BUFFER, Math.max(MIN_BUFFER, capacityHint));
+    capacityHint = Math.min(MAX_BUFFER, capacityHint);
     return new NettyWritableBuffer(allocator.buffer(capacityHint, capacityHint));
   }
 }

--- a/netty/src/test/java/io/grpc/netty/NettyWritableBufferAllocatorTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyWritableBufferAllocatorTest.java
@@ -44,7 +44,6 @@ public class NettyWritableBufferAllocatorTest extends WritableBufferAllocatorTes
   public void testCapacityHasMinimum() {
     WritableBuffer buffer = allocator().allocate(100);
     assertEquals(0, buffer.readableBytes());
-    assertEquals(4096, buffer.writableBytes());
   }
 
   @Test

--- a/netty/src/test/java/io/grpc/netty/NettyWritableBufferAllocatorTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyWritableBufferAllocatorTest.java
@@ -41,12 +41,6 @@ public class NettyWritableBufferAllocatorTest extends WritableBufferAllocatorTes
   }
 
   @Test
-  public void testCapacityHasMinimum() {
-    WritableBuffer buffer = allocator().allocate(100);
-    assertEquals(0, buffer.readableBytes());
-  }
-
-  @Test
   public void testCapacityIsExactAboveMinimum() {
     WritableBuffer buffer = allocator().allocate(9000);
     assertEquals(0, buffer.readableBytes());


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-java/issues/11719
MessageFramer.flush() is being called between every message, so messages are never combined and the larger allocation just wastes memory. The change removes the restriction on the min buffer size and hence, prevents the said wastage.