### PR TITLE
core: updates the backoff range as per the A6 redefinition

### DIFF
--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -1066,7 +1066,8 @@ abstract class RetriableStream<ReqT> implements ClientStream {
         if (pushbackMillis == null) {
           if (isRetryableStatusCode) {
             shouldRetry = true;
-            backoffNanos = (long) (nextBackoffIntervalNanos * random.nextDouble());
+            // Apply jitter by multiplying with a random factor between 0.8 and 1.2
+            backoffNanos = (long) (nextBackoffIntervalNanos * (0.8 + random.nextDouble() * 0.4));
             nextBackoffIntervalNanos = Math.min(
                 (long) (nextBackoffIntervalNanos * retryPolicy.backoffMultiplier),
                 retryPolicy.maxBackoffNanos);

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -846,12 +846,11 @@ abstract class RetriableStream<ReqT> implements ClientStream {
     }
   }
 
-  private static boolean isExperimentalRetryJitterEnabled() {
-    return GrpcUtil.getFlag("GRPC_EXPERIMENTAL_RETRY_JITTER", true);
-  }
+  private static final boolean isExperimentalRetryJitterEnabled = GrpcUtil
+          .getFlag("GRPC_EXPERIMENTAL_XDS_RLS_LB", true);
 
   public static long intervalWithJitter(long intervalNanos) {
-    double inverseJitterFactor = isExperimentalRetryJitterEnabled()
+    double inverseJitterFactor = isExperimentalRetryJitterEnabled
             ? 0.8 * random.nextDouble() + 0.4 : random.nextDouble();
     return (long) (intervalNanos * inverseJitterFactor);
   }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -3875,7 +3875,7 @@ public class ManagedChannelImplTest {
         Status.UNAVAILABLE, PROCESSED, new Metadata());
 
     // in backoff
-    timer.forwardTime(5, TimeUnit.SECONDS);
+    timer.forwardTime(6, TimeUnit.SECONDS);
     assertThat(timer.getPendingTasks()).hasSize(1);
     verify(mockStream2, never()).start(any(ClientStreamListener.class));
 
@@ -3894,7 +3894,7 @@ public class ManagedChannelImplTest {
     assertEquals("Channel shutdown invoked", statusCaptor.getValue().getDescription());
 
     // backoff ends
-    timer.forwardTime(5, TimeUnit.SECONDS);
+    timer.forwardTime(6, TimeUnit.SECONDS);
     assertThat(timer.getPendingTasks()).isEmpty();
     verify(mockStream2).start(streamListenerCaptor.capture());
     verify(mockLoadBalancer, never()).shutdown();

--- a/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
@@ -147,6 +147,27 @@ public class RetriableStreamTest {
   private final ChannelBufferMeter channelBufferUsed = new ChannelBufferMeter();
   private final FakeClock fakeClock = new FakeClock();
 
+  private static double calculateJitterFactor() {
+    return (0.8 + FAKE_RANDOM * 0.4);
+  }
+
+  private static long calculateInitialBackoff() {
+    return (long) (INITIAL_BACKOFF_IN_SECONDS * calculateJitterFactor());
+  }
+
+  private static long calculateBackoff() {
+    return (long) (INITIAL_BACKOFF_IN_SECONDS * BACKOFF_MULTIPLIER * calculateJitterFactor());
+  }
+
+  private static long calculateBackoffSquared() {
+    return (long) (INITIAL_BACKOFF_IN_SECONDS * BACKOFF_MULTIPLIER * BACKOFF_MULTIPLIER
+            * calculateJitterFactor());
+  }
+
+  private static long calculateMaxBackoff() {
+    return (long) (MAX_BACKOFF_IN_SECONDS * calculateJitterFactor());
+  }
+
   private final class RecordedRetriableStream extends RetriableStream<String> {
     RecordedRetriableStream(MethodDescriptor<String, ?> method, Metadata headers,
         ChannelBufferMeter channelBufferUsed, long perRpcBufferLimit, long channelBufferLimit,
@@ -307,7 +328,7 @@ public class RetriableStreamTest {
     retriableStream.sendMessage("msg1 during backoff1");
     retriableStream.sendMessage("msg2 during backoff1");
 
-    fakeClock.forwardTime((long) (INITIAL_BACKOFF_IN_SECONDS * FAKE_RANDOM) - 1L, TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateInitialBackoff() - 1L, TimeUnit.SECONDS);
     inOrder.verifyNoMoreInteractions();
     assertEquals(1, fakeClock.numPendingTasks());
     fakeClock.forwardTime(1L, TimeUnit.SECONDS);
@@ -364,9 +385,7 @@ public class RetriableStreamTest {
     retriableStream.sendMessage("msg2 during backoff2");
     retriableStream.sendMessage("msg3 during backoff2");
 
-    fakeClock.forwardTime(
-        (long) (INITIAL_BACKOFF_IN_SECONDS * BACKOFF_MULTIPLIER * FAKE_RANDOM) - 1L,
-        TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateBackoff() - 1L, TimeUnit.SECONDS);
     inOrder.verifyNoMoreInteractions();
     assertEquals(1, fakeClock.numPendingTasks());
     fakeClock.forwardTime(1L, TimeUnit.SECONDS);
@@ -459,7 +478,7 @@ public class RetriableStreamTest {
     sublistenerCaptor1.getValue().closed(
         Status.fromCode(RETRIABLE_STATUS_CODE_1), PROCESSED, new Metadata());
     assertEquals(1, fakeClock.numPendingTasks());
-    fakeClock.forwardTime((long) (INITIAL_BACKOFF_IN_SECONDS * FAKE_RANDOM), TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateInitialBackoff(), TimeUnit.SECONDS);
 
     ArgumentCaptor<ClientStreamListener> sublistenerCaptor2 =
         ArgumentCaptor.forClass(ClientStreamListener.class);
@@ -518,7 +537,7 @@ public class RetriableStreamTest {
     doReturn(mockStream2).when(retriableStreamRecorder).newSubstream(1);
     sublistenerCaptor1.getValue().closed(
         Status.fromCode(RETRIABLE_STATUS_CODE_1), PROCESSED, new Metadata());
-    fakeClock.forwardTime((long) (INITIAL_BACKOFF_IN_SECONDS * FAKE_RANDOM), TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateInitialBackoff(), TimeUnit.SECONDS);
 
     ArgumentCaptor<ClientStreamListener> sublistenerCaptor2 =
         ArgumentCaptor.forClass(ClientStreamListener.class);
@@ -584,7 +603,7 @@ public class RetriableStreamTest {
     doReturn(mockStream2).when(retriableStreamRecorder).newSubstream(1);
     sublistenerCaptor1.getValue().closed(
         Status.fromCode(RETRIABLE_STATUS_CODE_1), PROCESSED, new Metadata());
-    fakeClock.forwardTime((long) (INITIAL_BACKOFF_IN_SECONDS * FAKE_RANDOM), TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateInitialBackoff(), TimeUnit.SECONDS);
 
     ArgumentCaptor<ClientStreamListener> sublistenerCaptor2 =
         ArgumentCaptor.forClass(ClientStreamListener.class);
@@ -687,7 +706,7 @@ public class RetriableStreamTest {
     doReturn(mockStream2).when(retriableStreamRecorder).newSubstream(1);
     sublistenerCaptor1.getValue().closed(
         Status.fromCode(RETRIABLE_STATUS_CODE_1), PROCESSED, new Metadata());
-    fakeClock.forwardTime((long) (INITIAL_BACKOFF_IN_SECONDS * FAKE_RANDOM), TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateInitialBackoff(), TimeUnit.SECONDS);
 
     ArgumentCaptor<ClientStreamListener> sublistenerCaptor2 =
         ArgumentCaptor.forClass(ClientStreamListener.class);
@@ -821,7 +840,7 @@ public class RetriableStreamTest {
     // send more requests during backoff
     retriableStream.request(789);
 
-    fakeClock.forwardTime((long) (INITIAL_BACKOFF_IN_SECONDS * FAKE_RANDOM), TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateInitialBackoff(), TimeUnit.SECONDS);
 
     inOrder.verify(mockStream2).start(sublistenerCaptor2.get());
     inOrder.verify(mockStream2).request(3);
@@ -875,7 +894,7 @@ public class RetriableStreamTest {
     doReturn(mockStream2).when(retriableStreamRecorder).newSubstream(1);
     sublistenerCaptor1.getValue().closed(
         Status.fromCode(RETRIABLE_STATUS_CODE_1), PROCESSED, new Metadata());
-    fakeClock.forwardTime((long) (INITIAL_BACKOFF_IN_SECONDS * FAKE_RANDOM), TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateInitialBackoff(), TimeUnit.SECONDS);
 
     inOrder.verify(mockStream2).start(sublistenerCaptor2.capture());
     inOrder.verify(mockStream2).request(3);
@@ -920,7 +939,7 @@ public class RetriableStreamTest {
     doReturn(mockStream2).when(retriableStreamRecorder).newSubstream(1);
     sublistenerCaptor1.getValue().closed(
         Status.fromCode(RETRIABLE_STATUS_CODE_1), PROCESSED, new Metadata());
-    fakeClock.forwardTime((long) (INITIAL_BACKOFF_IN_SECONDS * FAKE_RANDOM), TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateInitialBackoff(), TimeUnit.SECONDS);
 
     inOrder.verify(mockStream2).start(sublistenerCaptor2.capture());
     inOrder.verify(retriableStreamRecorder).postCommit();
@@ -1028,7 +1047,7 @@ public class RetriableStreamTest {
     retriableStream.request(789);
     readiness.add(retriableStream.isReady()); // expected false b/c in backoff
 
-    fakeClock.forwardTime((long) (INITIAL_BACKOFF_IN_SECONDS * FAKE_RANDOM), TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateInitialBackoff(), TimeUnit.SECONDS);
 
     verify(mockStream2).start(any(ClientStreamListener.class));
     readiness.add(retriableStream.isReady()); // expected true
@@ -1110,7 +1129,7 @@ public class RetriableStreamTest {
     doReturn(mockStream2).when(retriableStreamRecorder).newSubstream(1);
     sublistenerCaptor1.getValue().closed(
             Status.fromCode(RETRIABLE_STATUS_CODE_1), PROCESSED, new Metadata());
-    fakeClock.forwardTime((long) (INITIAL_BACKOFF_IN_SECONDS * FAKE_RANDOM), TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateInitialBackoff(), TimeUnit.SECONDS);
 
     ArgumentCaptor<ClientStreamListener> sublistenerCaptor2 =
             ArgumentCaptor.forClass(ClientStreamListener.class);
@@ -1160,13 +1179,12 @@ public class RetriableStreamTest {
     listener1.closed(
         Status.fromCode(RETRIABLE_STATUS_CODE_1), PROCESSED, new Metadata());
     assertEquals(1, fakeClock.numPendingTasks());
-    fakeClock.forwardTime((long) (INITIAL_BACKOFF_IN_SECONDS * FAKE_RANDOM), TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateInitialBackoff(), TimeUnit.SECONDS);
     assertEquals(1, fakeClock.numPendingTasks());
 
     // send requests during backoff
     retriableStream.request(3);
-    fakeClock.forwardTime(
-        (long) (INITIAL_BACKOFF_IN_SECONDS * BACKOFF_MULTIPLIER * FAKE_RANDOM), TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateBackoff(), TimeUnit.SECONDS);
 
     retriableStream.request(1);
     verify(mockStream1, never()).request(anyInt());
@@ -1207,7 +1225,7 @@ public class RetriableStreamTest {
     // retry
     listener1.closed(
         Status.fromCode(RETRIABLE_STATUS_CODE_1), PROCESSED, new Metadata());
-    fakeClock.forwardTime((long) (INITIAL_BACKOFF_IN_SECONDS * FAKE_RANDOM), TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateInitialBackoff(), TimeUnit.SECONDS);
 
     verify(mockStream2).start(any(ClientStreamListener.class));
     verify(retriableStreamRecorder).postCommit();
@@ -1260,7 +1278,7 @@ public class RetriableStreamTest {
     bufferSizeTracer.outboundWireSize(2);
     verify(retriableStreamRecorder, never()).postCommit();
 
-    fakeClock.forwardTime((long) (INITIAL_BACKOFF_IN_SECONDS * FAKE_RANDOM), TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateInitialBackoff(), TimeUnit.SECONDS);
     verify(mockStream2).start(any(ClientStreamListener.class));
     verify(mockStream2).isReady();
 
@@ -1332,7 +1350,7 @@ public class RetriableStreamTest {
     sublistenerCaptor1.getValue().closed(
         Status.fromCode(RETRIABLE_STATUS_CODE_1), PROCESSED, new Metadata());
     assertEquals(1, fakeClock.numPendingTasks());
-    fakeClock.forwardTime((long) (INITIAL_BACKOFF_IN_SECONDS * FAKE_RANDOM) - 1L, TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateInitialBackoff() - 1L, TimeUnit.SECONDS);
     assertEquals(1, fakeClock.numPendingTasks());
     fakeClock.forwardTime(1L, TimeUnit.SECONDS);
     assertEquals(0, fakeClock.numPendingTasks());
@@ -1347,9 +1365,7 @@ public class RetriableStreamTest {
     sublistenerCaptor2.getValue().closed(
         Status.fromCode(RETRIABLE_STATUS_CODE_2), PROCESSED, new Metadata());
     assertEquals(1, fakeClock.numPendingTasks());
-    fakeClock.forwardTime(
-        (long) (INITIAL_BACKOFF_IN_SECONDS * BACKOFF_MULTIPLIER * FAKE_RANDOM) - 1L,
-        TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateBackoff() - 1L, TimeUnit.SECONDS);
     assertEquals(1, fakeClock.numPendingTasks());
     fakeClock.forwardTime(1L, TimeUnit.SECONDS);
     assertEquals(0, fakeClock.numPendingTasks());
@@ -1364,10 +1380,7 @@ public class RetriableStreamTest {
     sublistenerCaptor3.getValue().closed(
         Status.fromCode(RETRIABLE_STATUS_CODE_1), PROCESSED, new Metadata());
     assertEquals(1, fakeClock.numPendingTasks());
-    fakeClock.forwardTime(
-        (long) (INITIAL_BACKOFF_IN_SECONDS * BACKOFF_MULTIPLIER * BACKOFF_MULTIPLIER * FAKE_RANDOM)
-            - 1L,
-        TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateBackoffSquared() - 1L, TimeUnit.SECONDS);
     assertEquals(1, fakeClock.numPendingTasks());
     fakeClock.forwardTime(1L, TimeUnit.SECONDS);
     assertEquals(0, fakeClock.numPendingTasks());
@@ -1382,7 +1395,7 @@ public class RetriableStreamTest {
     sublistenerCaptor4.getValue().closed(
         Status.fromCode(RETRIABLE_STATUS_CODE_2), PROCESSED, new Metadata());
     assertEquals(1, fakeClock.numPendingTasks());
-    fakeClock.forwardTime((long) (MAX_BACKOFF_IN_SECONDS * FAKE_RANDOM) - 1L, TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateMaxBackoff() - 1L, TimeUnit.SECONDS);
     assertEquals(1, fakeClock.numPendingTasks());
     fakeClock.forwardTime(1L, TimeUnit.SECONDS);
     assertEquals(0, fakeClock.numPendingTasks());
@@ -1397,7 +1410,7 @@ public class RetriableStreamTest {
     sublistenerCaptor5.getValue().closed(
         Status.fromCode(RETRIABLE_STATUS_CODE_2), PROCESSED, new Metadata());
     assertEquals(1, fakeClock.numPendingTasks());
-    fakeClock.forwardTime((long) (MAX_BACKOFF_IN_SECONDS * FAKE_RANDOM) - 1L, TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateMaxBackoff() - 1L, TimeUnit.SECONDS);
     assertEquals(1, fakeClock.numPendingTasks());
     fakeClock.forwardTime(1L, TimeUnit.SECONDS);
     assertEquals(0, fakeClock.numPendingTasks());
@@ -1480,7 +1493,7 @@ public class RetriableStreamTest {
     sublistenerCaptor3.getValue().closed(
         Status.fromCode(RETRIABLE_STATUS_CODE_1), PROCESSED, new Metadata());
     assertEquals(1, fakeClock.numPendingTasks());
-    fakeClock.forwardTime((long) (INITIAL_BACKOFF_IN_SECONDS * FAKE_RANDOM) - 1L, TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateInitialBackoff() - 1L, TimeUnit.SECONDS);
     assertEquals(1, fakeClock.numPendingTasks());
     fakeClock.forwardTime(1L, TimeUnit.SECONDS);
     assertEquals(0, fakeClock.numPendingTasks());
@@ -1495,9 +1508,7 @@ public class RetriableStreamTest {
     sublistenerCaptor4.getValue().closed(
         Status.fromCode(RETRIABLE_STATUS_CODE_2), PROCESSED, new Metadata());
     assertEquals(1, fakeClock.numPendingTasks());
-    fakeClock.forwardTime(
-        (long) (INITIAL_BACKOFF_IN_SECONDS * BACKOFF_MULTIPLIER * FAKE_RANDOM) - 1L,
-        TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateBackoff() - 1L, TimeUnit.SECONDS);
     assertEquals(1, fakeClock.numPendingTasks());
     fakeClock.forwardTime(1L, TimeUnit.SECONDS);
     assertEquals(0, fakeClock.numPendingTasks());
@@ -1512,10 +1523,7 @@ public class RetriableStreamTest {
     sublistenerCaptor5.getValue().closed(
         Status.fromCode(RETRIABLE_STATUS_CODE_2), PROCESSED, new Metadata());
     assertEquals(1, fakeClock.numPendingTasks());
-    fakeClock.forwardTime(
-        (long) (INITIAL_BACKOFF_IN_SECONDS * BACKOFF_MULTIPLIER * BACKOFF_MULTIPLIER * FAKE_RANDOM)
-            - 1L,
-        TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateBackoffSquared() - 1L, TimeUnit.SECONDS);
     assertEquals(1, fakeClock.numPendingTasks());
     fakeClock.forwardTime(1L, TimeUnit.SECONDS);
     assertEquals(0, fakeClock.numPendingTasks());
@@ -1804,7 +1812,7 @@ public class RetriableStreamTest {
         .closed(Status.fromCode(RETRIABLE_STATUS_CODE_1), REFUSED, new Metadata());
 
     assertEquals(1, fakeClock.numPendingTasks());
-    fakeClock.forwardTime((long) (INITIAL_BACKOFF_IN_SECONDS * FAKE_RANDOM), TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateInitialBackoff(), TimeUnit.SECONDS);
     inOrder.verify(retriableStreamRecorder).newSubstream(1);
     ArgumentCaptor<ClientStreamListener> sublistenerCaptor3 =
         ArgumentCaptor.forClass(ClientStreamListener.class);
@@ -1907,7 +1915,7 @@ public class RetriableStreamTest {
         .closed(Status.fromCode(RETRIABLE_STATUS_CODE_1), PROCESSED, new Metadata());
 
     assertEquals(1, fakeClock.numPendingTasks());
-    fakeClock.forwardTime((long) (INITIAL_BACKOFF_IN_SECONDS * FAKE_RANDOM), TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateInitialBackoff(), TimeUnit.SECONDS);
     inOrder.verify(retriableStreamRecorder).newSubstream(1);
     ArgumentCaptor<ClientStreamListener> sublistenerCaptor2 =
         ArgumentCaptor.forClass(ClientStreamListener.class);
@@ -1923,8 +1931,7 @@ public class RetriableStreamTest {
         .closed(Status.fromCode(RETRIABLE_STATUS_CODE_1), REFUSED, new Metadata());
 
     assertEquals(1, fakeClock.numPendingTasks());
-    fakeClock.forwardTime(
-        (long) (INITIAL_BACKOFF_IN_SECONDS * BACKOFF_MULTIPLIER * FAKE_RANDOM), TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateBackoff(), TimeUnit.SECONDS);
     inOrder.verify(retriableStreamRecorder).newSubstream(2);
     ArgumentCaptor<ClientStreamListener> sublistenerCaptor3 =
         ArgumentCaptor.forClass(ClientStreamListener.class);
@@ -1960,7 +1967,7 @@ public class RetriableStreamTest {
         .closed(Status.fromCode(RETRIABLE_STATUS_CODE_1), PROCESSED, new Metadata());
 
     assertEquals(1, fakeClock.numPendingTasks());
-    fakeClock.forwardTime((long) (INITIAL_BACKOFF_IN_SECONDS * FAKE_RANDOM), TimeUnit.SECONDS);
+    fakeClock.forwardTime(calculateInitialBackoff(), TimeUnit.SECONDS);
     inOrder.verify(retriableStreamRecorder).newSubstream(1);
     ArgumentCaptor<ClientStreamListener> sublistenerCaptor2 =
         ArgumentCaptor.forClass(ClientStreamListener.class);

--- a/interop-testing/src/test/java/io/grpc/testing/integration/RetryTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/RetryTest.java
@@ -303,7 +303,7 @@ public class RetryTest {
     serverCall.close(
         Status.UNAVAILABLE.withDescription("original attempt failed"),
         new Metadata());
-    elapseBackoff(10, SECONDS);
+    elapseBackoff(12, SECONDS);
     // 2nd attempt received
     serverCall = serverCalls.poll(5, SECONDS);
     serverCall.request(2);
@@ -348,7 +348,7 @@ public class RetryTest {
         Status.UNAVAILABLE.withDescription("original attempt failed"),
         new Metadata());
     assertRpcStatusRecorded(Status.Code.UNAVAILABLE, 1000, 1);
-    elapseBackoff(10, SECONDS);
+    elapseBackoff(12, SECONDS);
     assertRpcStartedRecorded();
     assertOutboundMessageRecorded();
     serverCall = serverCalls.poll(5, SECONDS);
@@ -366,7 +366,7 @@ public class RetryTest {
     call.request(1);
     assertInboundMessageRecorded();
     assertInboundWireSizeRecorded(1);
-    assertRpcStatusRecorded(Status.Code.OK, 12000, 2);
+    assertRpcStatusRecorded(Status.Code.OK, 14000, 2);
     assertRetryStatsRecorded(1, 0, 0);
   }
 
@@ -418,7 +418,7 @@ public class RetryTest {
         Status.UNAVAILABLE.withDescription("original attempt failed"),
         new Metadata());
     assertRpcStatusRecorded(Code.UNAVAILABLE, 5000, 1);
-    elapseBackoff(10, SECONDS);
+    elapseBackoff(12, SECONDS);
     assertRpcStartedRecorded();
     assertOutboundMessageRecorded();
     serverCall = serverCalls.poll(5, SECONDS);
@@ -431,7 +431,7 @@ public class RetryTest {
     streamClosedLatch.countDown();
     // The call listener is closed.
     verify(mockCallListener, timeout(5000)).onClose(any(Status.class), any(Metadata.class));
-    assertRpcStatusRecorded(Code.CANCELLED, 17_000, 1);
+    assertRpcStatusRecorded(Code.CANCELLED, 19_000, 1);
     assertRetryStatsRecorded(1, 0, 0);
   }
 

--- a/netty/src/main/java/io/grpc/netty/NettyWritableBufferAllocator.java
+++ b/netty/src/main/java/io/grpc/netty/NettyWritableBufferAllocator.java
@@ -33,9 +33,6 @@ import io.netty.buffer.ByteBufAllocator;
  */
 class NettyWritableBufferAllocator implements WritableBufferAllocator {
 
-  // Use 4k as our minimum buffer size.
-  private static final int MIN_BUFFER = 4 * 1024;
-
   // Set the maximum buffer size to 1MB.
   private static final int MAX_BUFFER = 1024 * 1024;
 
@@ -47,7 +44,7 @@ class NettyWritableBufferAllocator implements WritableBufferAllocator {
 
   @Override
   public WritableBuffer allocate(int capacityHint) {
-    capacityHint = Math.min(MAX_BUFFER, Math.max(MIN_BUFFER, capacityHint));
+    capacityHint = Math.min(MAX_BUFFER, capacityHint);
     return new NettyWritableBuffer(allocator.buffer(capacityHint, capacityHint));
   }
 }

--- a/netty/src/test/java/io/grpc/netty/NettyWritableBufferAllocatorTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyWritableBufferAllocatorTest.java
@@ -41,13 +41,6 @@ public class NettyWritableBufferAllocatorTest extends WritableBufferAllocatorTes
   }
 
   @Test
-  public void testCapacityHasMinimum() {
-    WritableBuffer buffer = allocator().allocate(100);
-    assertEquals(0, buffer.readableBytes());
-    assertEquals(4096, buffer.writableBytes());
-  }
-
-  @Test
   public void testCapacityIsExactAboveMinimum() {
     WritableBuffer buffer = allocator().allocate(9000);
     assertEquals(0, buffer.readableBytes());

--- a/xds/src/main/java/io/grpc/xds/FaultFilter.java
+++ b/xds/src/main/java/io/grpc/xds/FaultFilter.java
@@ -190,94 +190,102 @@ final class FaultFilter implements Filter, ClientInterceptorBuilder {
       config = overrideConfig;
     }
     FaultConfig faultConfig = (FaultConfig) config;
-    Long delayNanos = null;
-    Status abortStatus = null;
-    if (faultConfig.maxActiveFaults() == null
-        || activeFaultCounter.get() < faultConfig.maxActiveFaults()) {
-      Metadata headers = args.getHeaders();
-      if (faultConfig.faultDelay() != null) {
-        delayNanos = determineFaultDelayNanos(faultConfig.faultDelay(), headers);
-      }
-      if (faultConfig.faultAbort() != null) {
-        abortStatus = determineFaultAbortStatus(faultConfig.faultAbort(), headers);
-      }
-    }
-    if (delayNanos == null && abortStatus == null) {
-      return null;
-    }
-    final Long finalDelayNanos = delayNanos;
-    final Status finalAbortStatus = getAbortStatusWithDescription(abortStatus);
 
     final class FaultInjectionInterceptor implements ClientInterceptor {
       @Override
       public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
           final MethodDescriptor<ReqT, RespT> method, final CallOptions callOptions,
           final Channel next) {
-        Executor callExecutor = callOptions.getExecutor();
-        if (callExecutor == null) { // This should never happen in practice because
-          // ManagedChannelImpl.ConfigSelectingClientCall always provides CallOptions with
-          // a callExecutor.
-          // TODO(https://github.com/grpc/grpc-java/issues/7868)
-          callExecutor = MoreExecutors.directExecutor();
+        boolean checkFault = false;
+        if (faultConfig.maxActiveFaults() == null
+            || activeFaultCounter.get() < faultConfig.maxActiveFaults()) {
+          checkFault = faultConfig.faultDelay() != null || faultConfig.faultAbort() != null;
         }
-        if (finalDelayNanos != null) {
-          Supplier<? extends ClientCall<ReqT, RespT>> callSupplier;
-          if (finalAbortStatus != null) {
-            callSupplier = Suppliers.ofInstance(
-                new FailingClientCall<ReqT, RespT>(finalAbortStatus, callExecutor));
-          } else {
-            callSupplier = new Supplier<ClientCall<ReqT, RespT>>() {
-              @Override
-              public ClientCall<ReqT, RespT> get() {
-                return next.newCall(method, callOptions);
-              }
-            };
-          }
-          final DelayInjectedCall<ReqT, RespT> delayInjectedCall = new DelayInjectedCall<>(
-              finalDelayNanos, callExecutor, scheduler, callOptions.getDeadline(), callSupplier);
+        if (!checkFault) {
+          return next.newCall(method, callOptions);
+        }
+        final class DeadlineInsightForwardingCall extends ForwardingClientCall<ReqT, RespT> {
+          private ClientCall<ReqT, RespT> delegate;
 
-          final class DeadlineInsightForwardingCall extends ForwardingClientCall<ReqT, RespT> {
-            @Override
-            protected ClientCall<ReqT, RespT> delegate() {
-              return delayInjectedCall;
+          @Override
+          protected ClientCall<ReqT, RespT> delegate() {
+            return delegate;
+          }
+
+          @Override
+          public void start(Listener<RespT> listener, Metadata headers) {
+            Executor callExecutor = callOptions.getExecutor();
+            if (callExecutor == null) { // This should never happen in practice because
+              // ManagedChannelImpl.ConfigSelectingClientCall always provides CallOptions with
+              // a callExecutor.
+              // TODO(https://github.com/grpc/grpc-java/issues/7868)
+              callExecutor = MoreExecutors.directExecutor();
             }
 
-            @Override
-            public void start(Listener<RespT> listener, Metadata headers) {
-              Listener<RespT> finalListener =
-                  new SimpleForwardingClientCallListener<RespT>(listener) {
-                    @Override
-                    public void onClose(Status status, Metadata trailers) {
-                      if (status.getCode().equals(Code.DEADLINE_EXCEEDED)) {
-                        // TODO(zdapeng:) check effective deadline locally, and
-                        //   do the following only if the local deadline is exceeded.
-                        //   (If the server sends DEADLINE_EXCEEDED for its own deadline, then the
-                        //   injected delay does not contribute to the error, because the request is
-                        //   only sent out after the delay. There could be a race between local and
-                        //   remote, but it is rather rare.)
-                        String description = String.format(
-                            Locale.US,
-                            "Deadline exceeded after up to %d ns of fault-injected delay",
-                            finalDelayNanos);
-                        if (status.getDescription() != null) {
-                          description = description + ": " + status.getDescription();
-                        }
-                        status = Status.DEADLINE_EXCEEDED
-                            .withDescription(description).withCause(status.getCause());
-                        // Replace trailers to prevent mixing sources of status and trailers.
-                        trailers = new Metadata();
+            Long delayNanos;
+            Status abortStatus = null;
+            if (faultConfig.faultDelay() != null) {
+              delayNanos = determineFaultDelayNanos(faultConfig.faultDelay(), headers);
+            } else {
+              delayNanos = null;
+            }
+            if (faultConfig.faultAbort() != null) {
+              abortStatus = getAbortStatusWithDescription(
+                  determineFaultAbortStatus(faultConfig.faultAbort(), headers));
+            }
+
+            Supplier<? extends ClientCall<ReqT, RespT>> callSupplier;
+            if (abortStatus != null) {
+              callSupplier = Suppliers.ofInstance(
+                  new FailingClientCall<ReqT, RespT>(abortStatus, callExecutor));
+            } else {
+              callSupplier = new Supplier<ClientCall<ReqT, RespT>>() {
+                @Override
+                public ClientCall<ReqT, RespT> get() {
+                  return next.newCall(method, callOptions);
+                }
+              };
+            }
+            if (delayNanos == null) {
+              delegate = callSupplier.get();
+              delegate().start(listener, headers);
+              return;
+            }
+
+            delegate = new DelayInjectedCall<>(
+                delayNanos, callExecutor, scheduler, callOptions.getDeadline(), callSupplier);
+
+            Listener<RespT> finalListener =
+                new SimpleForwardingClientCallListener<RespT>(listener) {
+                  @Override
+                  public void onClose(Status status, Metadata trailers) {
+                    if (status.getCode().equals(Code.DEADLINE_EXCEEDED)) {
+                      // TODO(zdapeng:) check effective deadline locally, and
+                      //   do the following only if the local deadline is exceeded.
+                      //   (If the server sends DEADLINE_EXCEEDED for its own deadline, then the
+                      //   injected delay does not contribute to the error, because the request is
+                      //   only sent out after the delay. There could be a race between local and
+                      //   remote, but it is rather rare.)
+                      String description = String.format(
+                          Locale.US,
+                          "Deadline exceeded after up to %d ns of fault-injected delay",
+                          delayNanos);
+                      if (status.getDescription() != null) {
+                        description = description + ": " + status.getDescription();
                       }
-                      delegate().onClose(status, trailers);
+                      status = Status.DEADLINE_EXCEEDED
+                          .withDescription(description).withCause(status.getCause());
+                      // Replace trailers to prevent mixing sources of status and trailers.
+                      trailers = new Metadata();
                     }
-                  };
-              delegate().start(finalListener, headers);
-            }
+                    delegate().onClose(status, trailers);
+                  }
+                };
+            delegate().start(finalListener, headers);
           }
-
-          return new DeadlineInsightForwardingCall();
-        } else {
-          return new FailingClientCall<>(finalAbortStatus, callExecutor);
         }
+
+        return new DeadlineInsightForwardingCall();
       }
     }
 


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-java/issues/11700
Updates the backoff range from [0, 1] to [0.8, 1.2] as per the A6 redefinition