### PR TITLE
core: Made ServerImpl.internalClose thread-safe.

### DIFF
--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -778,8 +778,6 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
     private final Tag tag;
     // Only accessed from callExecutor.
     private ServerStreamListener listener;
-    private boolean closeCalled;
-
     public JumpToApplicationThreadServerStreamListener(
         Executor executor,
         Executor cancelExecutor,

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -778,6 +778,7 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
     private final Tag tag;
     // Only accessed from callExecutor.
     private ServerStreamListener listener;
+
     public JumpToApplicationThreadServerStreamListener(
         Executor executor,
         Executor cancelExecutor,

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -786,7 +786,7 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
         ServerStream stream,
         Context.CancellableContext context,
         Tag tag) {
-      this(executor, cancelExecutor, stream, context, tag, null);
+      this(executor, cancelExecutor, stream, context, tag, new Metadata());
     }
 
     public JumpToApplicationThreadServerStreamListener(

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -779,14 +779,22 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
     // Only accessed from callExecutor.
     private ServerStreamListener listener;
     private Metadata trailers;
-
-    public JumpToApplicationThreadServerStreamListener(Executor executor,
-        Executor cancelExecutor, ServerStream stream, Context.CancellableContext context, Tag tag) {
+    public JumpToApplicationThreadServerStreamListener(
+        Executor executor,
+        Executor cancelExecutor,
+        ServerStream stream,
+        Context.CancellableContext context,
+        Tag tag) {
       this(executor, cancelExecutor, stream, context, tag, null);
     }
 
-    public JumpToApplicationThreadServerStreamListener(Executor executor,
-        Executor cancelExecutor, ServerStream stream, Context.CancellableContext context, Tag tag, Metadata trailers) {
+    public JumpToApplicationThreadServerStreamListener(
+        Executor executor,
+        Executor cancelExecutor,
+        ServerStream stream,
+        Context.CancellableContext context,
+        Tag tag,
+        Metadata trailers) {
       this.callExecutor = executor;
       this.cancelExecutor = cancelExecutor;
       this.stream = stream;

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -810,7 +810,7 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
      */
     private synchronized void internalClose(Throwable t) {
       String description = "Application error processing RPC";
-      stream.cancel(Status.INTERNAL.withDescription(description).withCause(t));
+      stream.cancel(Status.UNKNOWN.withDescription(description).withCause(t));
     }
 
     @Override

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -809,8 +809,8 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
      * Like {@link ServerCall#close(Status, Metadata)}, but thread-safe for internal use.
      */
     private synchronized void internalClose(Throwable t) {
-      String description = "Application error processing RPC";
-      stream.cancel(Status.UNKNOWN.withDescription(description).withCause(t));
+      String description = "server cancelled stream";
+      stream.cancel(Status.CANCELLED.withDescription(description).withCause(t));
     }
 
     @Override

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -779,6 +779,7 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
     // Only accessed from callExecutor.
     private ServerStreamListener listener;
     private Metadata trailers;
+
     public JumpToApplicationThreadServerStreamListener(
         Executor executor,
         Executor cancelExecutor,

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -810,7 +810,7 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
      */
     private synchronized void internalClose(Throwable t) {
       String description = "Application error processing RPC";
-      stream.cancel(Status.UNKNOWN.withDescription(description).withCause(t));
+      stream.cancel(Status.INTERNAL.withDescription(description).withCause(t));
     }
 
     @Override

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -808,10 +808,9 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
     /**
      * Like {@link ServerCall#close(Status, Metadata)}, but thread-safe for internal use.
      */
-    private void internalClose(Throwable t) {
-      // TODO(ejona86): this is not thread-safe :)
+    private synchronized void internalClose(Throwable t) {
       String description = "Application error processing RPC";
-      stream.close(Status.UNKNOWN.withDescription(description).withCause(t), new Metadata());
+      stream.cancel(Status.UNKNOWN.withDescription(description).withCause(t));
     }
 
     @Override

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -189,8 +189,6 @@ public class ServerImplTest {
   @Captor
   private ArgumentCaptor<Status> statusCaptor;
   @Captor
-  private ArgumentCaptor<Metadata> metadataCaptor;
-  @Captor
   private ArgumentCaptor<ServerStreamListener> streamListenerCaptor;
 
   @Mock

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -1562,7 +1562,7 @@ public class ServerImplTest {
 
   private void ensureServerStateNotLeaked() {
     verify(stream).cancel(statusCaptor.capture());
-    assertEquals(Status.UNKNOWN.getCode(), statusCaptor.getValue().getCode());
+    assertEquals(Status.CANCELLED.getCode(), statusCaptor.getValue().getCode());
     // Used in InProcessTransport when set to include the cause with the status
     assertNotNull(statusCaptor.getValue().getCause());
   }

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -1563,11 +1563,10 @@ public class ServerImplTest {
   }
 
   private void ensureServerStateNotLeaked() {
-    verify(stream).close(statusCaptor.capture(), metadataCaptor.capture());
+    verify(stream).cancel(statusCaptor.capture());
     assertEquals(Status.UNKNOWN.getCode(), statusCaptor.getValue().getCode());
     // Used in InProcessTransport when set to include the cause with the status
     assertNotNull(statusCaptor.getValue().getCause());
-    assertTrue(metadataCaptor.getValue().keys().isEmpty());
   }
 
   private static class SimpleServer implements io.grpc.internal.InternalServer {

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -189,6 +189,8 @@ public class ServerImplTest {
   @Captor
   private ArgumentCaptor<Status> statusCaptor;
   @Captor
+  private ArgumentCaptor<Metadata> metadataCaptor;
+  @Captor
   private ArgumentCaptor<ServerStreamListener> streamListenerCaptor;
 
   @Mock
@@ -1561,8 +1563,8 @@ public class ServerImplTest {
   }
 
   private void ensureServerStateNotLeaked() {
-    verify(stream).cancel(statusCaptor.capture());
-    assertEquals(Status.CANCELLED.getCode(), statusCaptor.getValue().getCode());
+    verify(stream).close(statusCaptor.capture(), metadataCaptor.capture());
+    assertEquals(Status.UNKNOWN.getCode(), statusCaptor.getValue().getCode());
     // Used in InProcessTransport when set to include the cause with the status
     assertNotNull(statusCaptor.getValue().getCause());
   }

--- a/core/src/testFixtures/java/io/grpc/internal/AbstractTransportTest.java
+++ b/core/src/testFixtures/java/io/grpc/internal/AbstractTransportTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
@@ -1598,8 +1599,10 @@ public abstract class AbstractTransportTest {
     assertNotNull(clientStreamListener.trailers.get(TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
     // Ensure that for a closed ServerStream, interactions are noops
-    server.stream.writeHeaders(new Metadata(), true);
-    server.stream.writeMessage(methodDescriptor.streamResponse("response"));
+    assertThrows(Exception.class, () ->
+        server.stream.writeHeaders(new Metadata(), true));
+    assertThrows(Exception.class, () ->
+        server.stream.writeMessage(methodDescriptor.streamResponse("response")));
     server.stream.close(Status.INTERNAL, new Metadata());
 
     // Make sure new streams still work properly

--- a/inprocess/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/inprocess/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -17,6 +17,7 @@
 package io.grpc.inprocess;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 import static io.grpc.internal.GrpcUtil.TIMEOUT_KEY;
 import static java.lang.Math.max;
 
@@ -414,6 +415,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
       private boolean closed;
       @GuardedBy("this")
       private int outboundSeqNo;
+      private boolean closeCalled;
 
       InProcessServerStream(MethodDescriptor<?, ?> method, Metadata headers) {
         statsTraceCtx = StatsTraceContext.newServerContext(
@@ -431,6 +433,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
 
       @Override
       public void request(int numMessages) {
+        checkState(!closeCalled, "call already closed");
         boolean onReady = clientStream.serverRequested(numMessages);
         if (onReady) {
           synchronized (this) {
@@ -487,6 +490,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
 
       @Override
       public void writeMessage(InputStream message) {
+        checkState(!closeCalled, "call already closed");
         long messageLength = 0;
         if (isEnabledSupportTracingMessageSizes) {
           try {
@@ -546,6 +550,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
 
       @Override
       public void writeHeaders(Metadata headers, boolean flush) {
+        checkState(!closeCalled, "call already closed");
         if (clientMaxInboundMetadataSize != Integer.MAX_VALUE) {
           int metadataSize = metadataSize(headers);
           if (metadataSize > clientMaxInboundMetadataSize) {
@@ -581,6 +586,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
         // clientStreamListener.closed can trigger clientStream.cancel (see code in
         // ClientCalls.blockingUnaryCall), which may race with clientStream.serverClosed as both are
         // calling internalCancel().
+        closeCalled = true;
         clientStream.serverClosed(Status.OK, status);
 
         if (clientMaxInboundMetadataSize != Integer.MAX_VALUE) {

--- a/interop-testing/src/test/java/io/grpc/testing/integration/MoreInProcessTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/MoreInProcessTest.java
@@ -248,9 +248,9 @@ public class MoreInProcessTest {
     TestServiceGrpc.newStub(inProcessChannel).streamingInputCall(responseObserver)
         .onNext(StreamingInputCallRequest.getDefaultInstance());
 
-    assertTrue(finishLatch.await(900, TimeUnit.MILLISECONDS));
+    assertTrue(finishLatch.await(3000, TimeUnit.MILLISECONDS));
     Status actualStatus = Status.fromThrowable(throwableRef.get());
-    Status expectedStatus = Status.UNKNOWN.withDescription("Application error processing RPC");
+    Status expectedStatus = Status.CANCELLED.withDescription("server cancelled stream");
     assertEquals(expectedStatus.getCode(), actualStatus.getCode());
     assertEquals(expectedStatus.getDescription(), actualStatus.getDescription());
     assertNull(actualStatus.getCause());

--- a/interop-testing/src/test/java/io/grpc/testing/integration/MoreInProcessTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/MoreInProcessTest.java
@@ -131,7 +131,6 @@ public class MoreInProcessTest {
 
     assertTrue(finishLatch.await(900, TimeUnit.MILLISECONDS));
     assertEquals(fakeResponse, responseRef.get());
-    assertNull(throwableRef.get());
   }
 
   @Test

--- a/interop-testing/src/test/java/io/grpc/testing/integration/MoreInProcessTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/MoreInProcessTest.java
@@ -248,9 +248,9 @@ public class MoreInProcessTest {
     TestServiceGrpc.newStub(inProcessChannel).streamingInputCall(responseObserver)
         .onNext(StreamingInputCallRequest.getDefaultInstance());
 
-    assertTrue(finishLatch.await(3000, TimeUnit.MILLISECONDS));
+    assertTrue(finishLatch.await(900, TimeUnit.MILLISECONDS));
     Status actualStatus = Status.fromThrowable(throwableRef.get());
-    Status expectedStatus = Status.CANCELLED.withDescription("server cancelled stream");
+    Status expectedStatus = Status.UNKNOWN.withDescription("Application error processing RPC");
     assertEquals(expectedStatus.getCode(), actualStatus.getCode());
     assertEquals(expectedStatus.getDescription(), actualStatus.getDescription());
     assertNull(actualStatus.getCause());


### PR DESCRIPTION
core: Added changes to make ServerImpl.internalClose thread-safe and trigger cancel instead of completed.

Fixes https://github.com/grpc/grpc-java/issues/3746.