### PR TITLE
examples: added changes for grpc-bom to gradle's java platform plugin for example gradle project

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -4,6 +4,11 @@ plugins {
     id 'com.google.protobuf' version '0.9.4'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
+    id 'java-platform'
+}
+
+javaPlatform {
+    allowDependencies() // Allows using external BOMs or defining a platform
 }
 
 repositories {
@@ -28,20 +33,22 @@ def protobufVersion = '3.25.5'
 def protocVersion = protobufVersion
 
 dependencies {
-    implementation "io.grpc:grpc-protobuf:${grpcVersion}"
-    implementation "io.grpc:grpc-services:${grpcVersion}"
-    implementation "io.grpc:grpc-stub:${grpcVersion}"
-    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
+    constraints {
+        api 'io.grpc:grpc-protobuf:${grpcVersion}'
+        api 'io.grpc:grpc-services:${grpcVersion}'
+        api 'io.grpc:grpc-stub:${grpcVersion}'
+        compileOnly 'org.apache.tomcat:annotations-api:6.0.53'
 
-    // examples/advanced need this for JsonFormat
-    implementation "com.google.protobuf:protobuf-java-util:${protobufVersion}"
+        // examples/advanced need this for JsonFormat
+        api 'com.google.protobuf:protobuf-java-util:${protobufVersion}'
 
-    runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
+        runtimeOnly 'io.grpc:grpc-netty-shaded:${grpcVersion}'
 
-    testImplementation "io.grpc:grpc-testing:${grpcVersion}"
-    testImplementation "io.grpc:grpc-inprocess:${grpcVersion}"
-    testImplementation "junit:junit:4.13.2"
-    testImplementation "org.mockito:mockito-core:4.4.0"
+        api 'io.grpc:grpc-testing:${grpcVersion}'
+        api 'io.grpc:grpc-inprocess:${grpcVersion}'
+        api 'junit:junit:4.13.2'
+        api 'org.mockito:mockito-core:4.4.0'
+    }
 }
 
 protobuf {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'com.google.protobuf' version '0.9.4'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
-    id 'java-platform'
+    id 'java'
 }
 
 javaPlatform {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -7,9 +7,9 @@ plugins {
     id 'java'
 }
 
-javaPlatform {
+/*javaPlatform {
     allowDependencies() // Allows using external BOMs or defining a platform
-}
+}*/
 
 repositories {
     maven { // The google mirror is less flaky than mavenCentral()

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,15 +1,14 @@
 plugins {
     // Provide convenience executables for trying out the examples.
-    id 'application'
+    id 'java-platform'
     id 'com.google.protobuf' version '0.9.4'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
-    id 'java'
 }
 
-/*javaPlatform {
+javaPlatform {
     allowDependencies() // Allows using external BOMs or defining a platform
-}*/
+}
 
 repositories {
     maven { // The google mirror is less flaky than mavenCentral()
@@ -34,20 +33,20 @@ def protocVersion = protobufVersion
 
 dependencies {
     constraints {
-        api 'io.grpc:grpc-protobuf:${grpcVersion}'
-        api 'io.grpc:grpc-services:${grpcVersion}'
-        api 'io.grpc:grpc-stub:${grpcVersion}'
+        api "io.grpc:grpc-protobuf:${grpcVersion}"
+        api "io.grpc:grpc-services:${grpcVersion}"
+        api "io.grpc:grpc-stub:${grpcVersion}"
         compileOnly 'org.apache.tomcat:annotations-api:6.0.53'
 
         // examples/advanced need this for JsonFormat
-        api 'com.google.protobuf:protobuf-java-util:${protobufVersion}'
+        api "com.google.protobuf:protobuf-java-util:${protobufVersion}"
 
-        runtimeOnly 'io.grpc:grpc-netty-shaded:${grpcVersion}'
+        runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
-        api 'io.grpc:grpc-testing:${grpcVersion}'
-        api 'io.grpc:grpc-inprocess:${grpcVersion}'
-        api 'junit:junit:4.13.2'
-        api 'org.mockito:mockito-core:4.4.0'
+        api "io.grpc:grpc-testing:${grpcVersion}"
+        api "io.grpc:grpc-inprocess:${grpcVersion}"
+        api "junit:junit:4.13.2"
+        api "org.mockito:mockito-core:4.4.0"
     }
 }
 

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     // Provide convenience executables for trying out the examples.
-    id 'application'
+    id 'java'
     id 'com.google.protobuf' version '0.9.4'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
@@ -24,16 +24,17 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.69.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.25.5'
+//def grpcVersion = '1.69.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+//def protocVersion = '3.25.5'
 
 dependencies {
     // grpc-alts transitively depends on grpc-netty-shaded, grpc-protobuf, and grpc-stub
-    implementation "io.grpc:grpc-alts:${grpcVersion}"
-    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
+    //implementation "io.grpc:grpc-alts:${grpcVersion}"
+    implementation platform('io.grpc:examples:1.69.0-SNAPSHOT')
+    compileOnly "org.apache.tomcat:annotations-api"
 }
 
-protobuf {
+/*protobuf {
     protoc { artifact = "com.google.protobuf:protoc:${protocVersion}" }
     plugins {
         grpc { artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}" }
@@ -41,7 +42,7 @@ protobuf {
     generateProtoTasks {
         all()*.plugins { grpc {} }
     }
-}
+}*/
 
 // Inform IDEs like IntelliJ IDEA, Eclipse or NetBeans about the generated code.
 sourceSets {


### PR DESCRIPTION
Added changes for conversion of grpc-bom to gradle's java platform plugin for examples gradle project as root project and other modules specific examples as sharing the root project dependencies.

Fixes https://github.com/grpc/grpc-java/issues/5530