### PR TITLE
examples: added gradle's java platform plugin in root examples project and used reference in child module example-alts

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -30,18 +30,20 @@ def protobufVersion = '3.25.5'
 def protocVersion = protobufVersion
 
 dependencies {
+    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
+    runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
+}
+
+dependencies {
     constraints {
         api "io.grpc:grpc-protobuf:${grpcVersion}"
         api "io.grpc:grpc-services:${grpcVersion}"
         api "io.grpc:grpc-stub:${grpcVersion}"
-        compileOnly "org.apache.tomcat:annotations-api:6.0.53"
-
+        api "io.grpc:grpc-inprocess:${grpcVersion}"
         // examples/advanced need this for JsonFormat
         api "com.google.protobuf:protobuf-java-util:${protobufVersion}"
-        runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
         api "io.grpc:grpc-testing:${grpcVersion}"
-        api "io.grpc:grpc-inprocess:${grpcVersion}"
         api "junit:junit:4.13.2"
         api "org.mockito:mockito-core:4.4.0"
     }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,9 +1,13 @@
 plugins {
     // Provide convenience executables for trying out the examples.
-    id 'application'
+    id 'java-platform'
     id 'com.google.protobuf' version '0.9.4'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
+}
+
+javaPlatform {
+    allowDependencies() // Allows using external BOMs like grpc-bom
 }
 
 repositories {
@@ -26,20 +30,21 @@ def protobufVersion = '3.25.5'
 def protocVersion = protobufVersion
 
 dependencies {
-    implementation "io.grpc:grpc-protobuf:${grpcVersion}"
-    implementation "io.grpc:grpc-services:${grpcVersion}"
-    implementation "io.grpc:grpc-stub:${grpcVersion}"
-    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
+    constraints {
+        api "io.grpc:grpc-protobuf:${grpcVersion}"
+        api "io.grpc:grpc-services:${grpcVersion}"
+        api "io.grpc:grpc-stub:${grpcVersion}"
+        compileOnly "org.apache.tomcat:annotations-api:6.0.53"
 
-    // examples/advanced need this for JsonFormat
-    implementation "com.google.protobuf:protobuf-java-util:${protobufVersion}"
+        // examples/advanced need this for JsonFormat
+        api "com.google.protobuf:protobuf-java-util:${protobufVersion}"
+        runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
-    runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
-
-    testImplementation "io.grpc:grpc-testing:${grpcVersion}"
-    testImplementation "io.grpc:grpc-inprocess:${grpcVersion}"
-    testImplementation "junit:junit:4.13.2"
-    testImplementation "org.mockito:mockito-core:4.4.0"
+        api "io.grpc:grpc-testing:${grpcVersion}"
+        api "io.grpc:grpc-inprocess:${grpcVersion}"
+        api "junit:junit:4.13.2"
+        api "org.mockito:mockito-core:4.4.0"
+    }
 }
 
 protobuf {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -30,18 +30,15 @@ def protobufVersion = '3.25.5'
 def protocVersion = protobufVersion
 
 dependencies {
-    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
-    runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
-}
-
-dependencies {
     constraints {
         api "io.grpc:grpc-protobuf:${grpcVersion}"
         api "io.grpc:grpc-services:${grpcVersion}"
         api "io.grpc:grpc-stub:${grpcVersion}"
+        api "io.grpc:grpc-netty-shaded:${grpcVersion}"
         api "io.grpc:grpc-inprocess:${grpcVersion}"
         // examples/advanced need this for JsonFormat
         api "com.google.protobuf:protobuf-java-util:${protobufVersion}"
+        api "org.apache.tomcat:annotations-api:6.0.53"
 
         api "io.grpc:grpc-testing:${grpcVersion}"
         api "junit:junit:4.13.2"

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -15,10 +15,10 @@ repositories {
     mavenLocal()
 }
 
-java {
+/*java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
-}
+}*/
 
 // IMPORTANT: You probably want the non-SNAPSHOT version of gRPC. Make sure you
 // are looking at a tagged version of the example and not "master"!

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     // Provide convenience executables for trying out the examples.
-    id 'application'
+    id 'java'
     id 'com.google.protobuf' version '0.9.4'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
@@ -21,16 +21,17 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.71.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.25.5'
+//def grpcVersion = '1.71.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+//def protocVersion = '3.25.5'
 
 dependencies {
     // grpc-alts transitively depends on grpc-netty-shaded, grpc-protobuf, and grpc-stub
-    implementation "io.grpc:grpc-alts:${grpcVersion}"
-    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
+    //implementation "io.grpc:grpc-alts:${grpcVersion}"
+    implementation platform('io.grpc:examples:1.71.0-SNAPSHOT')
+    compileOnly "org.apache.tomcat:annotations-api"
 }
 
-protobuf {
+/*protobuf {
     protoc { artifact = "com.google.protobuf:protoc:${protocVersion}" }
     plugins {
         grpc { artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}" }
@@ -38,7 +39,7 @@ protobuf {
     generateProtoTasks {
         all()*.plugins { grpc {} }
     }
-}
+}*/
 
 // Inform IDEs like IntelliJ IDEA, Eclipse or NetBeans about the generated code.
 sourceSets {


### PR DESCRIPTION
examples: added gradle's java platform plugin in root examples project and used reference in child module example-alts

Fixes https://github.com/grpc/grpc-java/issues/5530