### PR TITLE
Populate the pb::java feature extension to gprc proto plugin

### DIFF
--- a/compiler/src/java_plugin/cpp/java_plugin.cpp
+++ b/compiler/src/java_plugin/cpp/java_plugin.cpp
@@ -23,6 +23,7 @@
 
 #include "java_generator.h"
 #include <google/protobuf/compiler/code_generator.h>
+#include <google/protobuf/compiler/java/java_features.pb.h>
 #include <google/protobuf/compiler/plugin.h>
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/io/zero_copy_stream.h>
@@ -56,6 +57,10 @@ class JavaGrpcGenerator : public protobuf::compiler::CodeGenerator {
   }
   protobuf::Edition GetMaximumEdition() const override {
     return protobuf::Edition::EDITION_2023;
+  }
+  std::vector<const protobuf::FieldDescriptor*> GetFeatureExtensions()
+      const override {
+    return {GetExtensionReflection(pb::java)};
   }
 #else
   uint64_t GetSupportedFeatures() const override {


### PR DESCRIPTION
The plugin interacts with the Java Protobuf names API, which requires Java feature set defaults to be fully resolved.

Question:

How should I import this change to the google internal repo (google3)?