### PR TITLE
xds: Change XdsClusterConfig to have children field instead of endpoint

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsConfig.java
+++ b/xds/src/main/java/io/grpc/xds/XdsConfig.java
@@ -109,7 +109,7 @@ final class XdsConfig {
     XdsClusterConfig(String clusterName, CdsUpdate clusterResource, ClusterChild details) {
       this.clusterName = checkNotNull(clusterName, "clusterName");
       this.clusterResource = checkNotNull(clusterResource, "clusterResource");
-      this.children = details;
+      this.children = checkNotNull(details, "details");
     }
 
     @Override
@@ -152,8 +152,9 @@ final class XdsConfig {
 
     interface ClusterChild {}
 
-    // Endpoint info for EDS and LOGICAL_DNS clusters.  If there was an
-    // error, endpoints will be null and resolution_note will be set.
+    /** Endpoint info for EDS and LOGICAL_DNS clusters.  If there was an
+     * error, endpoints will be null and resolution_note will be set.
+     */
     static final class EndpointConfig implements ClusterChild {
       private final StatusOr<EdsUpdate> endpoint;
 

--- a/xds/src/main/java/io/grpc/xds/XdsConfig.java
+++ b/xds/src/main/java/io/grpc/xds/XdsConfig.java
@@ -26,6 +26,7 @@ import io.grpc.xds.XdsListenerResource.LdsUpdate;
 import io.grpc.xds.XdsRouteConfigureResource.RdsUpdate;
 import java.io.Closeable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -103,19 +104,17 @@ final class XdsConfig {
   static final class XdsClusterConfig {
     private final String clusterName;
     private final CdsUpdate clusterResource;
-    private final StatusOr<EdsUpdate> endpoint; //Will be null for non-EDS clusters
+    private final ClusterChild children; // holds details
 
-    XdsClusterConfig(String clusterName, CdsUpdate clusterResource,
-                      StatusOr<EdsUpdate> endpoint) {
+    XdsClusterConfig(String clusterName, CdsUpdate clusterResource, ClusterChild details) {
       this.clusterName = checkNotNull(clusterName, "clusterName");
       this.clusterResource = checkNotNull(clusterResource, "clusterResource");
-      this.endpoint = endpoint;
+      this.children = details;
     }
 
     @Override
     public int hashCode() {
-      int endpointHash = (endpoint != null) ? endpoint.hashCode() : 0;
-      return clusterName.hashCode() + clusterResource.hashCode() + endpointHash;
+      return clusterName.hashCode() + clusterResource.hashCode() + children.hashCode();
     }
 
     @Override
@@ -126,7 +125,7 @@ final class XdsConfig {
       XdsClusterConfig o = (XdsClusterConfig) obj;
       return Objects.equals(clusterName, o.clusterName)
           && Objects.equals(clusterResource, o.clusterResource)
-          && Objects.equals(endpoint, o.endpoint);
+          && Objects.equals(children, o.children);
     }
 
     @Override
@@ -134,7 +133,8 @@ final class XdsConfig {
       StringBuilder builder = new StringBuilder();
       builder.append("XdsClusterConfig{clusterName=").append(clusterName)
           .append(", clusterResource=").append(clusterResource)
-          .append(", endpoint=").append(endpoint).append("}");
+          .append(", children={").append(children)
+          .append("}");
       return builder.toString();
     }
 
@@ -146,8 +146,59 @@ final class XdsConfig {
       return clusterResource;
     }
 
-    public StatusOr<EdsUpdate> getEndpoint() {
-      return endpoint;
+    public ClusterChild getChildren() {
+      return children;
+    }
+
+    interface ClusterChild {}
+
+    // Endpoint info for EDS and LOGICAL_DNS clusters.  If there was an
+    // error, endpoints will be null and resolution_note will be set.
+    static final class EndpointConfig implements ClusterChild {
+      private final StatusOr<EdsUpdate> endpoint;
+
+      public EndpointConfig(StatusOr<EdsUpdate> endpoint) {
+        this.endpoint = checkNotNull(endpoint, "endpoint");
+      }
+
+      @Override
+      public int hashCode() {
+        return endpoint.hashCode();
+      }
+
+      @Override
+      public boolean equals(Object obj) {
+        if (!(obj instanceof EndpointConfig)) {
+          return false;
+        }
+        return Objects.equals(endpoint, ((EndpointConfig)obj).endpoint);
+      }
+
+      public StatusOr<EdsUpdate> getEndpoint() {
+        return endpoint;
+      }
+    }
+
+    // The list of leaf clusters for an aggregate cluster.
+    static final class AggregateConfig implements ClusterChild {
+      private final List<String> leafNames;
+
+      public AggregateConfig(List<String> leafNames) {
+        this.leafNames = checkNotNull(leafNames, "leafNames");
+      }
+
+      @Override
+      public int hashCode() {
+        return leafNames.hashCode();
+      }
+
+      @Override
+      public boolean equals(Object obj) {
+        if (!(obj instanceof AggregateConfig)) {
+          return false;
+        }
+        return Objects.equals(leafNames, ((AggregateConfig) obj).leafNames);
+      }
     }
   }
 

--- a/xds/src/main/java/io/grpc/xds/XdsDependencyManager.java
+++ b/xds/src/main/java/io/grpc/xds/XdsDependencyManager.java
@@ -308,7 +308,7 @@ final class XdsDependencyManager implements XdsConfig.XdsClusterSubscriptionRegi
     List<String> topLevelClusters =
         cdsWatchers.values().stream()
             .filter(XdsDependencyManager::isTopLevelCluster)
-            .map(XdsWatcherBase::resourceName)
+            .map(w -> w.resourceName())
             .collect(Collectors.toList());
 
     // Flatten multi-level aggregates into lists of leaf clusters

--- a/xds/src/main/java/io/grpc/xds/XdsRouteConfigureResource.java
+++ b/xds/src/main/java/io/grpc/xds/XdsRouteConfigureResource.java
@@ -136,7 +136,7 @@ class XdsRouteConfigureResource extends XdsResourceType<RdsUpdate> {
         (RouteConfiguration) unpackedMessage, FilterRegistry.getDefaultRegistry(), args);
   }
 
-  private static RdsUpdate processRouteConfiguration(
+  static RdsUpdate processRouteConfiguration(
       RouteConfiguration routeConfig, FilterRegistry filterRegistry, XdsResourceType.Args args)
       throws ResourceInvalidException {
     return new RdsUpdate(extractVirtualHosts(routeConfig, filterRegistry, args));

--- a/xds/src/main/java/io/grpc/xds/XdsRouteConfigureResource.java
+++ b/xds/src/main/java/io/grpc/xds/XdsRouteConfigureResource.java
@@ -136,7 +136,7 @@ class XdsRouteConfigureResource extends XdsResourceType<RdsUpdate> {
         (RouteConfiguration) unpackedMessage, FilterRegistry.getDefaultRegistry(), args);
   }
 
-  static RdsUpdate processRouteConfiguration(
+  private static RdsUpdate processRouteConfiguration(
       RouteConfiguration routeConfig, FilterRegistry filterRegistry, XdsResourceType.Args args)
       throws ResourceInvalidException {
     return new RdsUpdate(extractVirtualHosts(routeConfig, filterRegistry, args));

--- a/xds/src/test/java/io/grpc/xds/XdsDependencyManagerTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsDependencyManagerTest.java
@@ -57,6 +57,8 @@ import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.internal.ExponentialBackoffPolicy;
 import io.grpc.internal.FakeClock;
 import io.grpc.testing.GrpcCleanupRule;
+import io.grpc.xds.XdsConfig.XdsClusterConfig;
+import io.grpc.xds.XdsEndpointResource.EdsUpdate;
 import io.grpc.xds.XdsListenerResource.LdsUpdate;
 import io.grpc.xds.client.CommonBootstrapperTestUtils;
 import io.grpc.xds.client.XdsClient;
@@ -219,26 +221,35 @@ public class XdsDependencyManagerTest {
     XdsTestUtils.setAggregateCdsConfig(controlPlaneService, serverName, rootName, childNames);
     inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(any());
 
-    Map<String, StatusOr<XdsConfig.XdsClusterConfig>> lastConfigClusters =
+    Map<String, StatusOr<XdsClusterConfig>> lastConfigClusters =
         testWatcher.lastConfig.getClusters();
     assertThat(lastConfigClusters).hasSize(childNames.size() + 1);
-    StatusOr<XdsConfig.XdsClusterConfig> rootC = lastConfigClusters.get(rootName);
+    StatusOr<XdsClusterConfig> rootC = lastConfigClusters.get(rootName);
     XdsClusterResource.CdsUpdate rootUpdate = rootC.getValue().getClusterResource();
     assertThat(rootUpdate.clusterType()).isEqualTo(AGGREGATE);
     assertThat(rootUpdate.prioritizedClusterNames()).isEqualTo(childNames);
 
     for (String childName : childNames) {
       assertThat(lastConfigClusters).containsKey(childName);
+      StatusOr<XdsClusterConfig> childConfigOr = lastConfigClusters.get(childName);
       XdsClusterResource.CdsUpdate childResource =
-          lastConfigClusters.get(childName).getValue().getClusterResource();
+          childConfigOr.getValue().getClusterResource();
       assertThat(childResource.clusterType()).isEqualTo(EDS);
       assertThat(childResource.edsServiceName()).isEqualTo(getEdsNameForCluster(childName));
 
-      StatusOr<XdsEndpointResource.EdsUpdate> endpoint =
-          lastConfigClusters.get(childName).getValue().getEndpoint();
+      StatusOr<EdsUpdate> endpoint = getEndpoint(childConfigOr);
       assertThat(endpoint.hasValue()).isTrue();
       assertThat(endpoint.getValue().clusterName).isEqualTo(getEdsNameForCluster(childName));
     }
+  }
+
+  private static StatusOr<EdsUpdate> getEndpoint(StatusOr<XdsClusterConfig> childConfigOr) {
+    XdsClusterConfig.ClusterChild clusterChild = childConfigOr.getValue()
+        .getChildren();
+    assertThat(clusterChild).isInstanceOf(XdsClusterConfig.EndpointConfig.class);
+    StatusOr<EdsUpdate> endpoint = ((XdsClusterConfig.EndpointConfig) clusterChild).getEndpoint();
+    assertThat(endpoint).isNotNull();
+    return endpoint;
   }
 
   @Test
@@ -289,7 +300,6 @@ public class XdsDependencyManagerTest {
     inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(defaultXdsConfig);
 
     String rootName1 = "root_c";
-    List<String> childNames = Arrays.asList("clusterC", "clusterB", "clusterA");
 
     Closeable subscription1 = xdsDependencyManager.subscribeToCluster(rootName1);
     assertThat(subscription1).isNotNull();
@@ -299,6 +309,7 @@ public class XdsDependencyManagerTest {
         StatusOr.fromStatus(Status.UNAVAILABLE.withDescription(
             "No " + toContextStr(CLUSTER_TYPE_NAME, rootName1))).toString());
 
+    List<String> childNames = Arrays.asList("clusterC", "clusterB", "clusterA");
     XdsTestUtils.addAggregateToExistingConfig(controlPlaneService, rootName1, childNames);
     inOrder.verify(xdsConfigWatcher).onUpdate(xdsConfigCaptor.capture());
     assertThat(xdsConfigCaptor.getValue().getClusters().get(rootName1).hasValue()).isTrue();
@@ -336,7 +347,7 @@ public class XdsDependencyManagerTest {
     fakeClock.forwardTime(16, TimeUnit.SECONDS);
     verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsConfigCaptor.capture());
 
-    List<StatusOr<XdsConfig.XdsClusterConfig>> returnedClusters = new ArrayList<>();
+    List<StatusOr<XdsClusterConfig>> returnedClusters = new ArrayList<>();
     for (String childName : childNames) {
       returnedClusters.add(xdsConfigCaptor.getValue().getClusters().get(childName));
     }
@@ -344,7 +355,7 @@ public class XdsDependencyManagerTest {
     // Check that missing cluster reported Status and the other 2 are present
     Status expectedClusterStatus = Status.UNAVAILABLE.withDescription(
         "No " + toContextStr(CLUSTER_TYPE_NAME, childNames.get(2)));
-    StatusOr<XdsConfig.XdsClusterConfig> missingCluster = returnedClusters.get(2);
+    StatusOr<XdsClusterConfig> missingCluster = returnedClusters.get(2);
     assertThat(missingCluster.getStatus().toString()).isEqualTo(expectedClusterStatus.toString());
     assertThat(returnedClusters.get(0).hasValue()).isTrue();
     assertThat(returnedClusters.get(1).hasValue()).isTrue();
@@ -352,9 +363,9 @@ public class XdsDependencyManagerTest {
     // Check that missing EDS reported Status, the other one is present and the garbage EDS is not
     Status expectedEdsStatus = Status.UNAVAILABLE.withDescription(
         "No " + toContextStr(ENDPOINT_TYPE_NAME, XdsTestUtils.EDS_NAME + 1));
-    assertThat(returnedClusters.get(0).getValue().getEndpoint().hasValue()).isTrue();
-    assertThat(returnedClusters.get(1).getValue().getEndpoint().hasValue()).isFalse();
-    assertThat(returnedClusters.get(1).getValue().getEndpoint().getStatus().toString())
+    assertThat(getEndpoint(returnedClusters.get(0)).hasValue()).isTrue();
+    assertThat(getEndpoint(returnedClusters.get(1)).hasValue()).isFalse();
+    assertThat(getEndpoint(returnedClusters.get(1)).getStatus().toString())
         .isEqualTo(expectedEdsStatus.toString());
 
     verify(xdsConfigWatcher, never()).onResourceDoesNotExist(any());
@@ -539,7 +550,7 @@ public class XdsDependencyManagerTest {
     controlPlaneService.setXdsConfig(
         ADS_TYPE_URL_RDS, ImmutableMap.of(XdsTestUtils.RDS_NAME, newRouteConfig));
     inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsConfigCaptor.capture());
-    assertThat(xdsConfigCaptor.getValue().getClusters().keySet().size()).isEqualTo(8);
+    assertThat(xdsConfigCaptor.getValue().getClusters().keySet().size()).isEqualTo(4);
 
     // Now that it is released, we should only have A11
     rootSub.close();
@@ -582,11 +593,9 @@ public class XdsDependencyManagerTest {
     assertThat(initialConfig.getClusters().keySet())
         .containsExactly("root", "clusterA", "clusterB");
 
-    XdsEndpointResource.EdsUpdate edsForA =
-        initialConfig.getClusters().get("clusterA").getValue().getEndpoint().getValue();
+    EdsUpdate edsForA = getEndpoint(initialConfig.getClusters().get("clusterA")).getValue();
     assertThat(edsForA.clusterName).isEqualTo(edsName);
-    XdsEndpointResource.EdsUpdate edsForB =
-        initialConfig.getClusters().get("clusterB").getValue().getEndpoint().getValue();
+    EdsUpdate edsForB = getEndpoint(initialConfig.getClusters().get("clusterB")).getValue();
     assertThat(edsForB.clusterName).isEqualTo(edsName);
     assertThat(edsForA).isEqualTo(edsForB);
     edsForA.localityLbEndpointsMap.values().forEach(
@@ -635,7 +644,7 @@ public class XdsDependencyManagerTest {
     inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsConfigCaptor.capture());
     XdsConfig config = xdsConfigCaptor.getValue();
     assertThat(config.getVirtualHost().name()).isEqualTo(newRdsName);
-    assertThat(config.getClusters().size()).isEqualTo(8);
+    assertThat(config.getClusters().size()).isEqualTo(4);
   }
 
   @Test
@@ -689,8 +698,7 @@ public class XdsDependencyManagerTest {
     // Verify that the config is updated as expected
     inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsConfigCaptor.capture());
     XdsConfig config = xdsConfigCaptor.getValue();
-    assertThat(config.getClusters().keySet()).containsExactly("root", "clusterA", "clusterA2",
-        "clusterA21", "clusterA22");
+    assertThat(config.getClusters().keySet()).containsExactly("root", "clusterA21", "clusterA22");
   }
 
   private Listener buildInlineClientListener(String rdsName, String clusterName) {

--- a/xds/src/test/java/io/grpc/xds/XdsTestUtils.java
+++ b/xds/src/test/java/io/grpc/xds/XdsTestUtils.java
@@ -57,6 +57,7 @@ import io.grpc.internal.JsonParser;
 import io.grpc.stub.StreamObserver;
 import io.grpc.xds.Endpoints.LbEndpoint;
 import io.grpc.xds.Endpoints.LocalityLbEndpoints;
+import io.grpc.xds.XdsConfig.XdsClusterConfig.EndpointConfig;
 import io.grpc.xds.client.Bootstrapper;
 import io.grpc.xds.client.Locality;
 import io.grpc.xds.client.XdsResourceType;
@@ -269,7 +270,7 @@ public class XdsTestUtils {
         CLUSTER_NAME, EDS_NAME, serverInfo, null, null, null)
         .lbPolicyConfig(getWrrLbConfigAsMap()).build();
     XdsConfig.XdsClusterConfig clusterConfig = new XdsConfig.XdsClusterConfig(
-        CLUSTER_NAME, cdsUpdate, StatusOr.fromValue(edsUpdate));
+        CLUSTER_NAME, cdsUpdate, new EndpointConfig(StatusOr.fromValue(edsUpdate)));
 
     builder
         .setListener(ldsUpdate)


### PR DESCRIPTION
children is a single object which is either a list of leaf names (AggregateConfig) or an EdsUpdate (EndpointConfig).  All intermediate aggregate nodes have been squashed.

Rebasing onto master pulled some of the commits from master into this PR.