### PR TITLE
kokoro: Increase gradle mem in android-interop

### DIFF
--- a/buildscripts/kokoro/android-interop.sh
+++ b/buildscripts/kokoro/android-interop.sh
@@ -7,7 +7,6 @@ set -exu -o pipefail
 
 cd github/grpc-java
 
-export GRADLE_OPTS=-Xmx512m
 export LDFLAGS=-L/tmp/protobuf/lib
 export CXXFLAGS=-I/tmp/protobuf/include
 export LD_LIBRARY_PATH=/tmp/protobuf/lib
@@ -30,7 +29,7 @@ sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
 # Unset any existing JAVA_HOME env var to stop Gradle from using it
 unset JAVA_HOME
 
-GRADLE_FLAGS="-Pandroid.useAndroidX=true"
+GRADLE_FLAGS="-Pandroid.useAndroidX=true -Dorg.gradle.jvmargs=-Xmx1024m"
 
 ./gradlew $GRADLE_FLAGS :grpc-android-interop-testing:assembleDebug
 ./gradlew $GRADLE_FLAGS :grpc-android-interop-testing:assembleDebugAndroidTest


### PR DESCRIPTION
To try to aid failure when building android-interop-testing
```
The Daemon will expire after the build after running out of JVM heap space.
The project memory settings are likely not configured or are configured to an insufficient value.
The daemon will restart for the next build, which may increase subsequent build times.
These settings can be adjusted by setting 'org.gradle.jvmargs' in 'gradle.properties'.
The currently configured max heap space is '512 MiB' and the configured max metaspace is '384 MiB'.
...
Exception in thread "Daemon client event forwarder" java.lang.OutOfMemoryError: Java heap space
...
> Task :grpc-android-interop-testing:mergeDexDebug FAILED
ERROR:D8: java.lang.OutOfMemoryError: Java heap space
com.android.builder.dexing.DexArchiveMergerException: Error while merging dex archives:
```