### PR TITLE
servlet: Provide Gradle a filter version number

### DIFF
--- a/servlet/jakarta/build.gradle
+++ b/servlet/jakarta/build.gradle
@@ -47,6 +47,8 @@ def migrate(String name, String inputDir, SourceSet sourceSet) {
     def outputDir = layout.buildDirectory.dir('generated/sources/jakarta-' + name)
     sourceSet.java.srcDir tasks.register('migrateSources' + name.capitalize(), Sync) { task ->
         into(outputDir)
+	// Increment when changing the filter, to inform Gradle it needs to rebuild
+	inputs.property("filter-version", "1")
         from("$inputDir/io/grpc/servlet") {
             into('io/grpc/servlet/jakarta')
             filter { String line ->


### PR DESCRIPTION
The version number is simply a unique string per version.

CC @kannanjgithub 

----

FWIW, it is very rare to need to do something like this.